### PR TITLE
Service Accounts - Get service account API (#71315)

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/service/GetServiceAccountAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/service/GetServiceAccountAction.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.core.security.action.service;
+
+import org.elasticsearch.action.ActionType;
+
+public class GetServiceAccountAction extends ActionType<GetServiceAccountResponse> {
+
+    public static final String NAME = "cluster:admin/xpack/security/service_account/get";
+    public static final GetServiceAccountAction INSTANCE = new GetServiceAccountAction();
+
+    public GetServiceAccountAction() {
+        super(NAME, GetServiceAccountResponse::new);
+    }
+}

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/service/GetServiceAccountRequest.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/service/GetServiceAccountRequest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.core.security.action.service;
+
+import org.elasticsearch.action.ActionRequest;
+import org.elasticsearch.action.ActionRequestValidationException;
+import org.elasticsearch.common.Nullable;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+
+import java.io.IOException;
+import java.util.Objects;
+
+public class GetServiceAccountRequest extends ActionRequest {
+
+    @Nullable
+    private final String namespace;
+    @Nullable
+    private final String serviceName;
+
+    public GetServiceAccountRequest(@Nullable String namespace, @Nullable String serviceName) {
+        this.namespace = namespace;
+        this.serviceName = serviceName;
+    }
+
+    public GetServiceAccountRequest(StreamInput in) throws IOException {
+        super(in);
+        this.namespace = in.readOptionalString();
+        this.serviceName = in.readOptionalString();
+    }
+
+    public String getNamespace() {
+        return namespace;
+    }
+
+    public String getServiceName() {
+        return serviceName;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o)
+            return true;
+        if (o == null || getClass() != o.getClass())
+            return false;
+        GetServiceAccountRequest that = (GetServiceAccountRequest) o;
+        return Objects.equals(namespace, that.namespace) && Objects.equals(serviceName, that.serviceName);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(namespace, serviceName);
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        super.writeTo(out);
+        out.writeOptionalString(namespace);
+        out.writeOptionalString(serviceName);
+    }
+
+    @Override
+    public ActionRequestValidationException validate() {
+        return null;
+    }
+}

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/service/GetServiceAccountResponse.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/service/GetServiceAccountResponse.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.core.security.action.service;
+
+import org.elasticsearch.action.ActionResponse;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.xcontent.ToXContentObject;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Objects;
+
+public class GetServiceAccountResponse extends ActionResponse implements ToXContentObject {
+
+    private final ServiceAccountInfo[] serviceAccountInfos;
+
+    public GetServiceAccountResponse(ServiceAccountInfo[] serviceAccountInfos) {
+        this.serviceAccountInfos = Objects.requireNonNull(serviceAccountInfos);
+    }
+
+    public GetServiceAccountResponse(StreamInput in) throws IOException {
+        super(in);
+        this.serviceAccountInfos = in.readArray(ServiceAccountInfo::new, ServiceAccountInfo[]::new);
+    }
+
+    public ServiceAccountInfo[] getServiceAccountInfos() {
+        return serviceAccountInfos;
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeArray(serviceAccountInfos);
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.startObject();
+        for (ServiceAccountInfo info : serviceAccountInfos) {
+            info.toXContent(builder, params);
+        }
+        builder.endObject();
+        return builder;
+    }
+
+    @Override
+    public String toString() {
+        return "GetServiceAccountResponse{" + "serviceAccountInfos=" + Arrays.toString(serviceAccountInfos) + '}';
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o)
+            return true;
+        if (o == null || getClass() != o.getClass())
+            return false;
+        GetServiceAccountResponse that = (GetServiceAccountResponse) o;
+        return Arrays.equals(serviceAccountInfos, that.serviceAccountInfos);
+    }
+
+    @Override
+    public int hashCode() {
+        return Arrays.hashCode(serviceAccountInfos);
+    }
+}

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/service/ServiceAccountInfo.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/service/ServiceAccountInfo.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.core.security.action.service;
+
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.common.xcontent.ToXContent;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.xpack.core.security.authz.RoleDescriptor;
+
+import java.io.IOException;
+import java.util.Objects;
+
+public class ServiceAccountInfo implements Writeable, ToXContent {
+
+    private final String principal;
+    private final RoleDescriptor roleDescriptor;
+
+    public ServiceAccountInfo(String principal, RoleDescriptor roleDescriptor) {
+        this.principal = Objects.requireNonNull(principal, "service account principal cannot be null");
+        this.roleDescriptor = Objects.requireNonNull(roleDescriptor, "service account descriptor cannot be null");
+    }
+
+    public ServiceAccountInfo(StreamInput in) throws IOException {
+        this.principal = in.readString();
+        this.roleDescriptor = new RoleDescriptor(in);
+    }
+
+    public String getPrincipal() {
+        return principal;
+    }
+
+    public RoleDescriptor getRoleDescriptor() {
+        return roleDescriptor;
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeString(principal);
+        roleDescriptor.writeTo(out);
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.startObject(principal);
+        builder.field("role_descriptor");
+        roleDescriptor.toXContent(builder, params);
+        builder.endObject();
+        return builder;
+    }
+
+    @Override
+    public String toString() {
+        return "ServiceAccountInfo{" + "principal='" + principal + '\'' + ", roleDescriptor=" + roleDescriptor + '}';
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o)
+            return true;
+        if (o == null || getClass() != o.getClass())
+            return false;
+        ServiceAccountInfo that = (ServiceAccountInfo) o;
+        return principal.equals(that.principal) && roleDescriptor.equals(that.roleDescriptor);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(principal, roleDescriptor);
+    }
+}

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/action/service/GetServiceAccountRequestTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/action/service/GetServiceAccountRequestTests.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.core.security.action.service;
+
+import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.test.AbstractWireSerializingTestCase;
+
+import java.io.IOException;
+
+public class GetServiceAccountRequestTests extends AbstractWireSerializingTestCase<GetServiceAccountRequest> {
+
+    @Override
+    protected Writeable.Reader<GetServiceAccountRequest> instanceReader() {
+        return GetServiceAccountRequest::new;
+    }
+
+    @Override
+    protected GetServiceAccountRequest createTestInstance() {
+        return new GetServiceAccountRequest(randomFrom(randomAlphaOfLengthBetween(3, 8), null),
+            randomFrom(randomAlphaOfLengthBetween(3, 8), null));
+    }
+
+    @Override
+    protected GetServiceAccountRequest mutateInstance(GetServiceAccountRequest instance) throws IOException {
+        if (randomBoolean()) {
+            return new GetServiceAccountRequest(
+                randomValueOtherThan(instance.getNamespace(), () -> randomFrom(randomAlphaOfLengthBetween(3, 8), null)),
+                instance.getServiceName());
+        } else {
+            return new GetServiceAccountRequest(
+                instance.getNamespace(),
+                randomValueOtherThan(instance.getServiceName(), () -> randomFrom(randomAlphaOfLengthBetween(3, 8), null)));
+        }
+    }
+}

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/action/service/GetServiceAccountResponseTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/action/service/GetServiceAccountResponseTests.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.core.security.action.service;
+
+import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.common.xcontent.ToXContent;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentFactory;
+import org.elasticsearch.common.xcontent.XContentHelper;
+import org.elasticsearch.common.xcontent.XContentType;
+import org.elasticsearch.test.AbstractWireSerializingTestCase;
+import org.elasticsearch.test.XContentTestUtils;
+import org.elasticsearch.xpack.core.security.authz.RoleDescriptor;
+
+import java.io.IOException;
+import java.util.Map;
+
+import static org.hamcrest.Matchers.anEmptyMap;
+import static org.hamcrest.Matchers.equalTo;
+
+public class GetServiceAccountResponseTests extends AbstractWireSerializingTestCase<GetServiceAccountResponse> {
+
+    @Override
+    protected Writeable.Reader<GetServiceAccountResponse> instanceReader() {
+        return GetServiceAccountResponse::new;
+    }
+
+    @Override
+    protected GetServiceAccountResponse createTestInstance() {
+        final String principal = randomPrincipal();
+        return new GetServiceAccountResponse(randomBoolean()
+            ? new ServiceAccountInfo[]{new ServiceAccountInfo(principal, getRoleDescriptorFor(principal))}
+            : new ServiceAccountInfo[0]);
+    }
+
+    @Override
+    protected GetServiceAccountResponse mutateInstance(GetServiceAccountResponse instance) throws IOException {
+        if (instance.getServiceAccountInfos().length == 0) {
+            final String principal = randomPrincipal();
+            return new GetServiceAccountResponse(new ServiceAccountInfo[]{
+                new ServiceAccountInfo(principal, getRoleDescriptorFor(principal))});
+        } else {
+            return new GetServiceAccountResponse(new ServiceAccountInfo[0]);
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    public void testToXContent() throws IOException {
+        final GetServiceAccountResponse response = createTestInstance();
+        XContentBuilder builder = XContentFactory.jsonBuilder();
+        response.toXContent(builder, ToXContent.EMPTY_PARAMS);
+        final Map<String, Object> responseMap = XContentHelper.convertToMap(
+            BytesReference.bytes(builder),
+            false, builder.contentType()).v2();
+        final ServiceAccountInfo[] serviceAccountInfos = response.getServiceAccountInfos();
+        if (serviceAccountInfos.length == 0) {
+            assertThat(responseMap, anEmptyMap());
+        } else {
+            assertThat(responseMap.size(), equalTo(serviceAccountInfos.length));
+            for (int i = 0; i < serviceAccountInfos.length - 1; i++) {
+                final String key = serviceAccountInfos[i].getPrincipal();
+                assertRoleDescriptorEquals((Map<String, Object>) responseMap.get(key), serviceAccountInfos[i].getRoleDescriptor());
+            }
+        }
+    }
+
+    private String randomPrincipal() {
+        return randomAlphaOfLengthBetween(3, 8) + "/" + randomAlphaOfLengthBetween(3, 8);
+    }
+
+    private RoleDescriptor getRoleDescriptorFor(String name) {
+        return new RoleDescriptor(name,
+            new String[] { "monitor", "manage_own_api_key" },
+            new RoleDescriptor.IndicesPrivileges[] {
+            RoleDescriptor.IndicesPrivileges.builder()
+                .indices("logs-*", "metrics-*", "traces-*")
+                .privileges("write", "create_index", "auto_configure").build() },
+            null,
+            null,
+            null,
+            null,
+            null);
+    }
+
+    private void assertRoleDescriptorEquals(Map<String, Object> responseFragment, RoleDescriptor roleDescriptor) throws IOException {
+        @SuppressWarnings("unchecked")
+        final Map<String, Object> descriptorMap = (Map<String, Object>) responseFragment.get("role_descriptor");
+        assertThat(RoleDescriptor.parse(roleDescriptor.getName(),
+            XContentTestUtils.convertToXContent(descriptorMap, XContentType.JSON), false, XContentType.JSON),
+            equalTo(roleDescriptor));
+    }
+}

--- a/x-pack/plugin/security/qa/operator-privileges-tests/src/javaRestTest/java/org/elasticsearch/xpack/security/operator/Constants.java
+++ b/x-pack/plugin/security/qa/operator-privileges-tests/src/javaRestTest/java/org/elasticsearch/xpack/security/operator/Constants.java
@@ -190,6 +190,7 @@ public class Constants {
         "cluster:admin/xpack/security/saml/invalidate",
         "cluster:admin/xpack/security/saml/logout",
         "cluster:admin/xpack/security/saml/prepare",
+        "cluster:admin/xpack/security/service_account/get",
         "cluster:admin/xpack/security/service_account/token/create",
         "cluster:admin/xpack/security/service_account/token/get",
         "cluster:admin/xpack/security/token/create",

--- a/x-pack/plugin/security/qa/service-account/src/javaRestTest/java/org/elasticsearch/xpack/security/authc/service/ServiceAccountIT.java
+++ b/x-pack/plugin/security/qa/service-account/src/javaRestTest/java/org/elasticsearch/xpack/security/authc/service/ServiceAccountIT.java
@@ -354,7 +354,7 @@ public class ServiceAccountIT extends ESRestTestCase {
                                                     String serviceAccountPrincipal,
                                                     String roleDescriptorString) throws IOException {
         final Map<String, Object> responseMap = responseAsMap(response);
-        assertThat(responseMap, hasEntry(serviceAccountPrincipal, Map.of("role_descriptor",
+        assertThat(responseMap, hasEntry(serviceAccountPrincipal, org.elasticsearch.common.collect.Map.of("role_descriptor",
             XContentHelper.convertToMap(new BytesArray(roleDescriptorString), false, XContentType.JSON).v2())));
     }
 }

--- a/x-pack/plugin/security/qa/service-account/src/javaRestTest/java/org/elasticsearch/xpack/security/authc/service/ServiceAccountIT.java
+++ b/x-pack/plugin/security/qa/service-account/src/javaRestTest/java/org/elasticsearch/xpack/security/authc/service/ServiceAccountIT.java
@@ -30,6 +30,7 @@ import java.util.List;
 import java.util.Map;
 
 import static org.elasticsearch.xpack.core.security.authc.support.UsernamePasswordToken.basicAuthHeaderValue;
+import static org.hamcrest.Matchers.anEmptyMap;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasEntry;
@@ -61,6 +62,36 @@ public class ServiceAccountIT extends ESRestTestCase {
         + "  \"authentication_type\": \"token\"\n"
         + "}\n";
 
+    private static final String ELASTIC_FLEET_ROLE_DESCRIPTOR = ""
+        + "{\n"
+        + "      \"cluster\": [\n"
+        + "        \"monitor\",\n"
+        + "        \"manage_own_api_key\"\n"
+        + "      ],\n"
+        + "      \"indices\": [\n"
+        + "        {\n"
+        + "          \"names\": [\n"
+        + "            \"logs-*\",\n"
+        + "            \"metrics-*\",\n"
+        + "            \"traces-*\"\n"
+        + "          ],\n"
+        + "          \"privileges\": [\n"
+        + "            \"write\",\n"
+        + "            \"create_index\",\n"
+        + "            \"auto_configure\"\n"
+        + "          ],\n"
+        + "          \"allow_restricted_indices\": false\n"
+        + "        }\n"
+        + "      ],\n"
+        + "      \"applications\": [],\n"
+        + "      \"run_as\": [],\n"
+        + "      \"metadata\": {},\n"
+        + "      \"transient_metadata\": {\n"
+        + "        \"enabled\": true\n"
+        + "      }\n"
+        + "    }\n"
+        + "  }";
+
     @BeforeClass
     public static void init() throws URISyntaxException, FileNotFoundException {
         URL resource = ServiceAccountIT.class.getResource("/ssl/ca.crt");
@@ -82,6 +113,32 @@ public class ServiceAccountIT extends ESRestTestCase {
         return Settings.builder().put(ThreadContext.PREFIX + ".Authorization", token)
             .put(CERTIFICATE_AUTHORITIES, caPath)
             .build();
+    }
+
+    public void testGetServiceAccount() throws IOException {
+        final Request getServiceAccountRequest1 = new Request("GET", "_security/service");
+        final Response getServiceAccountResponse1 = client().performRequest(getServiceAccountRequest1);
+        assertOK(getServiceAccountResponse1);
+        assertServiceAccountRoleDescriptor(getServiceAccountResponse1,
+            "elastic/fleet-server", ELASTIC_FLEET_ROLE_DESCRIPTOR);
+
+        final Request getServiceAccountRequest2 = new Request("GET", "_security/service/elastic");
+        final Response getServiceAccountResponse2 = client().performRequest(getServiceAccountRequest2);
+        assertOK(getServiceAccountResponse2);
+        assertServiceAccountRoleDescriptor(getServiceAccountResponse2,
+            "elastic/fleet-server", ELASTIC_FLEET_ROLE_DESCRIPTOR);
+
+        final Request getServiceAccountRequest3 = new Request("GET", "_security/service/elastic/fleet-server");
+        final Response getServiceAccountResponse3 = client().performRequest(getServiceAccountRequest3);
+        assertOK(getServiceAccountResponse3);
+        assertServiceAccountRoleDescriptor(getServiceAccountResponse3,
+            "elastic/fleet-server", ELASTIC_FLEET_ROLE_DESCRIPTOR);
+
+        final String requestPath = "_security/service/" + randomFrom("foo", "elastic/foo", "foo/bar");
+        final Request getServiceAccountRequest4 = new Request("GET", requestPath);
+        final Response getServiceAccountResponse4 = client().performRequest(getServiceAccountRequest4);
+        assertOK(getServiceAccountResponse4);
+        assertThat(responseAsMap(getServiceAccountResponse4), anEmptyMap());
     }
 
     public void testAuthenticate() throws IOException {
@@ -291,5 +348,13 @@ public class ServiceAccountIT extends ESRestTestCase {
         assertThat(apiKey.get("username"), equalTo("elastic/fleet-server"));
         assertThat(apiKey.get("realm"), equalTo("service_account"));
         assertThat(apiKey.get("invalidated"), is(invalidated));
+    }
+
+    private void assertServiceAccountRoleDescriptor(Response response,
+                                                    String serviceAccountPrincipal,
+                                                    String roleDescriptorString) throws IOException {
+        final Map<String, Object> responseMap = responseAsMap(response);
+        assertThat(responseMap, hasEntry(serviceAccountPrincipal, Map.of("role_descriptor",
+            XContentHelper.convertToMap(new BytesArray(roleDescriptorString), false, XContentType.JSON).v2())));
     }
 }

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/Security.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/Security.java
@@ -113,6 +113,7 @@ import org.elasticsearch.xpack.core.security.action.saml.SamlLogoutAction;
 import org.elasticsearch.xpack.core.security.action.saml.SamlPrepareAuthenticationAction;
 import org.elasticsearch.xpack.core.security.action.saml.SamlSpMetadataAction;
 import org.elasticsearch.xpack.core.security.action.service.CreateServiceAccountTokenAction;
+import org.elasticsearch.xpack.core.security.action.service.GetServiceAccountAction;
 import org.elasticsearch.xpack.core.security.action.service.GetServiceAccountTokensAction;
 import org.elasticsearch.xpack.core.security.action.token.CreateTokenAction;
 import org.elasticsearch.xpack.core.security.action.token.InvalidateTokenAction;
@@ -182,6 +183,7 @@ import org.elasticsearch.xpack.security.action.saml.TransportSamlLogoutAction;
 import org.elasticsearch.xpack.security.action.saml.TransportSamlPrepareAuthenticationAction;
 import org.elasticsearch.xpack.security.action.saml.TransportSamlSpMetadataAction;
 import org.elasticsearch.xpack.security.action.service.TransportCreateServiceAccountTokenAction;
+import org.elasticsearch.xpack.security.action.service.TransportGetServiceAccountAction;
 import org.elasticsearch.xpack.security.action.service.TransportGetServiceAccountTokensAction;
 import org.elasticsearch.xpack.security.action.token.TransportCreateTokenAction;
 import org.elasticsearch.xpack.security.action.token.TransportInvalidateTokenAction;
@@ -264,6 +266,7 @@ import org.elasticsearch.xpack.security.rest.action.saml.RestSamlLogoutAction;
 import org.elasticsearch.xpack.security.rest.action.saml.RestSamlPrepareAuthenticationAction;
 import org.elasticsearch.xpack.security.rest.action.saml.RestSamlSpMetadataAction;
 import org.elasticsearch.xpack.security.rest.action.service.RestCreateServiceAccountTokenAction;
+import org.elasticsearch.xpack.security.rest.action.service.RestGetServiceAccountAction;
 import org.elasticsearch.xpack.security.rest.action.service.RestGetServiceAccountTokensAction;
 import org.elasticsearch.xpack.security.rest.action.user.RestChangePasswordAction;
 import org.elasticsearch.xpack.security.rest.action.user.RestDeleteUserAction;
@@ -911,7 +914,8 @@ public class Security extends Plugin implements SystemIndexPlugin, IngestPlugin,
                 new ActionHandler<>(GetApiKeyAction.INSTANCE, TransportGetApiKeyAction.class),
                 new ActionHandler<>(DelegatePkiAuthenticationAction.INSTANCE, TransportDelegatePkiAuthenticationAction.class),
                 new ActionHandler<>(CreateServiceAccountTokenAction.INSTANCE, TransportCreateServiceAccountTokenAction.class),
-                new ActionHandler<>(GetServiceAccountTokensAction.INSTANCE, TransportGetServiceAccountTokensAction.class)
+                new ActionHandler<>(GetServiceAccountTokensAction.INSTANCE, TransportGetServiceAccountTokensAction.class),
+                new ActionHandler<>(GetServiceAccountAction.INSTANCE, TransportGetServiceAccountAction.class)
         );
     }
 
@@ -975,7 +979,8 @@ public class Security extends Plugin implements SystemIndexPlugin, IngestPlugin,
                 new RestGetApiKeyAction(settings, getLicenseState()),
                 new RestDelegatePkiAuthenticationAction(settings, getLicenseState()),
                 new RestCreateServiceAccountTokenAction(settings, getLicenseState()),
-                new RestGetServiceAccountTokensAction(settings, getLicenseState())
+                new RestGetServiceAccountTokensAction(settings, getLicenseState()),
+                new RestGetServiceAccountAction(settings, getLicenseState())
         );
     }
 

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/service/TransportGetServiceAccountAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/service/TransportGetServiceAccountAction.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.security.action.service;
+
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.support.ActionFilters;
+import org.elasticsearch.action.support.HandledTransportAction;
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.tasks.Task;
+import org.elasticsearch.transport.TransportService;
+import org.elasticsearch.xpack.core.security.action.service.GetServiceAccountAction;
+import org.elasticsearch.xpack.core.security.action.service.GetServiceAccountRequest;
+import org.elasticsearch.xpack.core.security.action.service.GetServiceAccountResponse;
+import org.elasticsearch.xpack.core.security.action.service.ServiceAccountInfo;
+import org.elasticsearch.xpack.security.authc.service.ServiceAccount;
+import org.elasticsearch.xpack.security.authc.service.ServiceAccountService;
+import org.elasticsearch.xpack.security.authc.support.HttpTlsRuntimeCheck;
+
+import java.util.function.Predicate;
+
+public class TransportGetServiceAccountAction extends HandledTransportAction<GetServiceAccountRequest, GetServiceAccountResponse> {
+
+    private final HttpTlsRuntimeCheck httpTlsRuntimeCheck;
+
+    @Inject
+    public TransportGetServiceAccountAction(TransportService transportService, ActionFilters actionFilters,
+                                            HttpTlsRuntimeCheck httpTlsRuntimeCheck) {
+        super(GetServiceAccountAction.NAME, transportService, actionFilters, GetServiceAccountRequest::new);
+        this.httpTlsRuntimeCheck = httpTlsRuntimeCheck;
+    }
+
+    @Override
+    protected void doExecute(Task task, GetServiceAccountRequest request, ActionListener<GetServiceAccountResponse> listener) {
+        httpTlsRuntimeCheck.checkTlsThenExecute(listener::onFailure, "get service accounts", () -> {
+            Predicate<ServiceAccount> filter = v -> true;
+            if (request.getNamespace() != null) {
+                filter = filter.and( v -> v.id().namespace().equals(request.getNamespace()) );
+            } 
+            if (request.getServiceName() != null) {
+                filter = filter.and( v -> v.id().serviceName().equals(request.getServiceName()) );
+            }
+            final ServiceAccountInfo[] serviceAccountInfos = ServiceAccountService.getServiceAccounts()
+                .values()
+                .stream()
+                .filter(filter)
+                .map(v -> new ServiceAccountInfo(v.id().asPrincipal(), v.roleDescriptor()))
+                .toArray(ServiceAccountInfo[]::new);
+            listener.onResponse(new GetServiceAccountResponse(serviceAccountInfos));
+        });
+    }
+}

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/service/ServiceAccountService.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/service/ServiceAccountService.java
@@ -22,6 +22,7 @@ import org.elasticsearch.xpack.security.authc.service.ServiceAccount.ServiceAcco
 import org.elasticsearch.xpack.security.authc.support.HttpTlsRuntimeCheck;
 
 import java.util.Collection;
+import java.util.Map;
 
 import static org.elasticsearch.xpack.security.authc.service.ElasticServiceAccounts.ACCOUNTS;
 
@@ -53,7 +54,7 @@ public class ServiceAccountService {
     }
 
     public static Map<String, ServiceAccount> getServiceAccounts() {
-        return Map.copyOf(ACCOUNTS);
+        return org.elasticsearch.common.collect.Map.copyOf(ACCOUNTS);
     }
 
     /**

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/service/ServiceAccountService.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/service/ServiceAccountService.java
@@ -52,6 +52,10 @@ public class ServiceAccountService {
         return ACCOUNTS.keySet();
     }
 
+    public static Map<String, ServiceAccount> getServiceAccounts() {
+        return Map.copyOf(ACCOUNTS);
+    }
+
     /**
      * Parses a token object from the content of a {@link ServiceAccountToken#asBearerString()} bearer string}.
      * This bearer string would typically be

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/rest/action/service/RestGetServiceAccountAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/rest/action/service/RestGetServiceAccountAction.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.security.rest.action.service;
+
+import org.elasticsearch.client.node.NodeClient;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.license.XPackLicenseState;
+import org.elasticsearch.rest.RestRequest;
+import org.elasticsearch.rest.action.RestToXContentListener;
+import org.elasticsearch.xpack.core.security.action.service.GetServiceAccountAction;
+import org.elasticsearch.xpack.core.security.action.service.GetServiceAccountRequest;
+import org.elasticsearch.xpack.security.rest.action.SecurityBaseRestHandler;
+
+import java.io.IOException;
+import java.util.List;
+
+import static org.elasticsearch.rest.RestRequest.Method.GET;
+
+public class RestGetServiceAccountAction extends SecurityBaseRestHandler {
+
+    public RestGetServiceAccountAction(Settings settings, XPackLicenseState licenseState) {
+        super(settings, licenseState);
+    }
+
+    @Override
+    public List<Route> routes() {
+        return List.of(
+            new Route(GET, "/_security/service"),
+            new Route(GET, "/_security/service/{namespace}"),
+            new Route(GET, "/_security/service/{namespace}/{service}")
+        );
+    }
+
+    @Override
+    public String getName() {
+        return "xpack_security_get_service_account";
+    }
+
+    @Override
+    protected RestChannelConsumer innerPrepareRequest(RestRequest request, NodeClient client) throws IOException {
+        final String namespace = request.param("namespace");
+        final String serviceName = request.param("service");
+        final GetServiceAccountRequest getServiceAccountRequest = new GetServiceAccountRequest(namespace, serviceName);
+        return channel -> client.execute(GetServiceAccountAction.INSTANCE, getServiceAccountRequest,
+            new RestToXContentListener<>(channel));
+    }
+}

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/rest/action/service/RestGetServiceAccountAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/rest/action/service/RestGetServiceAccountAction.java
@@ -29,7 +29,7 @@ public class RestGetServiceAccountAction extends SecurityBaseRestHandler {
 
     @Override
     public List<Route> routes() {
-        return List.of(
+        return org.elasticsearch.common.collect.List.of(
             new Route(GET, "/_security/service"),
             new Route(GET, "/_security/service/{namespace}"),
             new Route(GET, "/_security/service/{namespace}/{service}")

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/action/service/TransportGetServiceAccountActionTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/action/service/TransportGetServiceAccountActionTests.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.security.action.service;
+
+import org.elasticsearch.action.support.ActionFilters;
+import org.elasticsearch.action.support.PlainActionFuture;
+import org.elasticsearch.tasks.Task;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.transport.TransportService;
+import org.elasticsearch.xpack.core.security.action.service.GetServiceAccountRequest;
+import org.elasticsearch.xpack.core.security.action.service.GetServiceAccountResponse;
+import org.elasticsearch.xpack.security.authc.support.HttpTlsRuntimeCheck;
+import org.junit.Before;
+
+import java.util.Collections;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+
+public class TransportGetServiceAccountActionTests extends ESTestCase {
+
+    private HttpTlsRuntimeCheck httpTlsRuntimeCheck;
+    private TransportGetServiceAccountAction transportGetServiceAccountAction;
+
+    @Before
+    public void init() {
+        httpTlsRuntimeCheck = mock(HttpTlsRuntimeCheck.class);
+        transportGetServiceAccountAction = new TransportGetServiceAccountAction(
+            mock(TransportService.class), new ActionFilters(Collections.emptySet()), httpTlsRuntimeCheck);
+
+        doAnswer(invocationOnMock -> {
+            final Object[] arguments = invocationOnMock.getArguments();
+            ((Runnable) arguments[2]).run();
+            return null;
+        }).when(httpTlsRuntimeCheck).checkTlsThenExecute(any(), any(), any());
+    }
+
+    public void testDoExecute() {
+        final GetServiceAccountRequest request1 = randomFrom(
+            new GetServiceAccountRequest(null, null),
+            new GetServiceAccountRequest("elastic", null),
+            new GetServiceAccountRequest("elastic", "fleet-server"));
+        final PlainActionFuture<GetServiceAccountResponse> future1 = new PlainActionFuture<>();
+        transportGetServiceAccountAction.doExecute(mock(Task.class), request1, future1);
+        final GetServiceAccountResponse getServiceAccountResponse1 = future1.actionGet();
+        assertThat(getServiceAccountResponse1.getServiceAccountInfos().length, equalTo(1));
+        assertThat(getServiceAccountResponse1.getServiceAccountInfos()[0].getPrincipal(), equalTo("elastic/fleet-server"));
+
+        final GetServiceAccountRequest request2 = randomFrom(
+            new GetServiceAccountRequest("foo", null),
+            new GetServiceAccountRequest("elastic", "foo"),
+            new GetServiceAccountRequest("foo", "bar"));
+        final PlainActionFuture<GetServiceAccountResponse> future2 = new PlainActionFuture<>();
+        transportGetServiceAccountAction.doExecute(mock(Task.class), request2, future2);
+        final GetServiceAccountResponse getServiceAccountResponse2 = future2.actionGet();
+        assertThat(getServiceAccountResponse2.getServiceAccountInfos().length, equalTo(0));
+    }
+}


### PR DESCRIPTION
This PR adds a new API endpoint to retrieve service accounts. Depends on the
request parameters, it returns either all accounts, accounts belong to a
namespace, a specific account, or an empty map if nothing is found.