### PR TITLE
Service Accounts - delete index backed service account token (#71165)

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/service/DeleteServiceAccountTokenAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/service/DeleteServiceAccountTokenAction.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.core.security.action.service;
+
+import org.elasticsearch.action.ActionType;
+
+public class DeleteServiceAccountTokenAction extends ActionType<DeleteServiceAccountTokenResponse> {
+
+    public static final String NAME = "cluster:admin/xpack/security/service_account/token/delete";
+    public static final DeleteServiceAccountTokenAction INSTANCE = new DeleteServiceAccountTokenAction();
+
+    public DeleteServiceAccountTokenAction() {
+        super(NAME, DeleteServiceAccountTokenResponse::new);
+    }
+}

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/service/DeleteServiceAccountTokenRequest.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/service/DeleteServiceAccountTokenRequest.java
@@ -20,20 +20,20 @@ import java.util.Objects;
 
 import static org.elasticsearch.action.ValidateActions.addValidationError;
 
-public class CreateServiceAccountTokenRequest extends ActionRequest {
+public class DeleteServiceAccountTokenRequest extends ActionRequest {
 
     private final String namespace;
     private final String serviceName;
     private final String tokenName;
     private WriteRequest.RefreshPolicy refreshPolicy = WriteRequest.RefreshPolicy.WAIT_UNTIL;
 
-    public CreateServiceAccountTokenRequest(String namespace, String serviceName, String tokenName) {
+    public DeleteServiceAccountTokenRequest(String namespace, String serviceName, String tokenName) {
         this.namespace = namespace;
         this.serviceName = serviceName;
         this.tokenName = tokenName;
     }
 
-    public CreateServiceAccountTokenRequest(StreamInput in) throws IOException {
+    public DeleteServiceAccountTokenRequest(StreamInput in) throws IOException {
         super(in);
         this.namespace = in.readString();
         this.serviceName = in.readString();
@@ -67,7 +67,7 @@ public class CreateServiceAccountTokenRequest extends ActionRequest {
             return true;
         if (o == null || getClass() != o.getClass())
             return false;
-        CreateServiceAccountTokenRequest that = (CreateServiceAccountTokenRequest) o;
+        DeleteServiceAccountTokenRequest that = (DeleteServiceAccountTokenRequest) o;
         return Objects.equals(namespace, that.namespace) && Objects.equals(serviceName, that.serviceName)
             && Objects.equals(tokenName, that.tokenName) && refreshPolicy == that.refreshPolicy;
     }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/service/DeleteServiceAccountTokenResponse.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/service/DeleteServiceAccountTokenResponse.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.core.security.action.service;
+
+import org.elasticsearch.action.ActionResponse;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.xcontent.ToXContentObject;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+
+import java.io.IOException;
+import java.util.Objects;
+
+public class DeleteServiceAccountTokenResponse extends ActionResponse implements ToXContentObject {
+
+    private boolean found;
+
+    public DeleteServiceAccountTokenResponse(boolean found) {
+        this.found = found;
+    }
+
+    public DeleteServiceAccountTokenResponse(StreamInput in) throws IOException {
+        super(in);
+        this.found = in.readBoolean();
+    }
+
+    public boolean found() {
+        return this.found;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o)
+            return true;
+        if (o == null || getClass() != o.getClass())
+            return false;
+        DeleteServiceAccountTokenResponse that = (DeleteServiceAccountTokenResponse) o;
+        return found == that.found;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(found);
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.startObject().field("found", found).endObject();
+        return builder;
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeBoolean(found);
+    }
+}

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/support/Validation.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/support/Validation.java
@@ -14,6 +14,7 @@ import org.elasticsearch.xpack.core.security.authz.store.ReservedRolesStore;
 
 import java.util.Locale;
 import java.util.Set;
+import java.util.regex.Pattern;
 
 import static java.util.Collections.unmodifiableSet;
 
@@ -35,6 +36,12 @@ public final class Validation {
         "%1s names must be at least " + MIN_NAME_LENGTH + " and no more than " + MAX_NAME_LENGTH + " characters. " +
         "They can contain alphanumeric characters (a-z, A-Z, 0-9), spaces, punctuation, and printable symbols in the " +
         "Basic Latin (ASCII) block. Leading or trailing whitespace is not allowed.";
+
+    private static final Pattern VALID_SERVICE_ACCOUNT_TOKEN_NAME = Pattern.compile("^[a-zA-Z0-9-][a-zA-Z0-9_-]{0,255}$");
+
+    public static final String INVALID_SERVICE_ACCOUNT_TOKEN_NAME_MESSAGE = "service account token name must have at least 1 character " +
+        "and at most 256 characters that are alphanumeric (A-Z, a-z, 0-9) or hyphen (-) or underscore (_). " +
+        "It must not begin with an underscore (_).";
 
     private static boolean isValidUserOrRoleName(String name) {
         if (name.length() < MIN_NAME_LENGTH || name.length() > MAX_NAME_LENGTH) {
@@ -60,6 +67,10 @@ public final class Validation {
         }
 
         return true;
+    }
+
+    public static boolean isValidServiceAccountTokenName(String name) {
+        return name != null && VALID_SERVICE_ACCOUNT_TOKEN_NAME.matcher(name).matches();
     }
 
     public static final class Users {

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/action/service/CreateServiceAccountTokenResponseTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/action/service/CreateServiceAccountTokenResponseTests.java
@@ -7,11 +7,19 @@
 
 package org.elasticsearch.xpack.core.security.action.service;
 
+import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.settings.SecureString;
+import org.elasticsearch.common.xcontent.ToXContent;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentFactory;
+import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.test.AbstractWireSerializingTestCase;
 
 import java.io.IOException;
+import java.util.Map;
+
+import static org.hamcrest.Matchers.equalTo;
 
 public class CreateServiceAccountTokenResponseTests extends AbstractWireSerializingTestCase<CreateServiceAccountTokenResponse> {
 
@@ -35,5 +43,19 @@ public class CreateServiceAccountTokenResponseTests extends AbstractWireSerializ
             return CreateServiceAccountTokenResponse.created(instance.getName(),
                 randomValueOtherThan(instance.getValue(), () -> new SecureString(randomAlphaOfLength(22).toCharArray())));
         }
+    }
+
+    public void testToXContent() throws IOException {
+        final CreateServiceAccountTokenResponse response = createTestInstance();
+        XContentBuilder builder = XContentFactory.jsonBuilder();
+        response.toXContent(builder, ToXContent.EMPTY_PARAMS);
+        final Map<String, Object> responseMap = XContentHelper.convertToMap(
+            BytesReference.bytes(builder),
+            false, builder.contentType()).v2();
+
+        assertThat(responseMap, equalTo(Map.of(
+            "created", true,
+            "token", Map.of("name", response.getName(), "value", response.getValue().toString())
+            )));
     }
 }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/action/service/CreateServiceAccountTokenResponseTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/action/service/CreateServiceAccountTokenResponseTests.java
@@ -53,9 +53,9 @@ public class CreateServiceAccountTokenResponseTests extends AbstractWireSerializ
             BytesReference.bytes(builder),
             false, builder.contentType()).v2();
 
-        assertThat(responseMap, equalTo(Map.of(
+        assertThat(responseMap, equalTo(org.elasticsearch.common.collect.Map.of(
             "created", true,
-            "token", Map.of("name", response.getName(), "value", response.getValue().toString())
+            "token", org.elasticsearch.common.collect.Map.of("name", response.getName(), "value", response.getValue().toString())
             )));
     }
 }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/action/service/DeleteServiceAccountTokenRequestTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/action/service/DeleteServiceAccountTokenRequestTests.java
@@ -8,34 +8,50 @@
 package org.elasticsearch.xpack.core.security.action.service;
 
 import org.elasticsearch.action.ActionRequestValidationException;
-import org.elasticsearch.common.io.stream.BytesStreamOutput;
-import org.elasticsearch.common.io.stream.InputStreamStreamInput;
-import org.elasticsearch.common.io.stream.StreamInput;
-import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.test.AbstractWireSerializingTestCase;
 import org.elasticsearch.xpack.core.security.support.Validation;
 import org.elasticsearch.xpack.core.security.support.ValidationTests;
 
-import java.io.ByteArrayInputStream;
 import java.io.IOException;
 
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsString;
-import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.nullValue;
 
-public class CreateServiceAccountTokenRequestTests extends ESTestCase {
+public class DeleteServiceAccountTokenRequestTests extends AbstractWireSerializingTestCase<DeleteServiceAccountTokenRequest> {
 
-    public void testReadWrite() throws IOException {
-        final CreateServiceAccountTokenRequest request = new CreateServiceAccountTokenRequest(
-            randomAlphaOfLengthBetween(3, 8),
-            randomAlphaOfLengthBetween(3, 8),
-            randomAlphaOfLengthBetween(3, 8));
-        try (BytesStreamOutput out = new BytesStreamOutput()) {
-            request.writeTo(out);
-            try (StreamInput in = new InputStreamStreamInput(new ByteArrayInputStream(out.bytes().array()))) {
-                assertThat(new CreateServiceAccountTokenRequest(in), equalTo(request));
-            }
+    @Override
+    protected Writeable.Reader<DeleteServiceAccountTokenRequest> instanceReader() {
+        return DeleteServiceAccountTokenRequest::new;
+    }
+
+    @Override
+    protected DeleteServiceAccountTokenRequest createTestInstance() {
+        return new DeleteServiceAccountTokenRequest(
+            randomAlphaOfLengthBetween(3, 8), randomAlphaOfLengthBetween(3, 8), randomAlphaOfLengthBetween(3, 8));
+    }
+
+    @Override
+    protected DeleteServiceAccountTokenRequest mutateInstance(DeleteServiceAccountTokenRequest instance) throws IOException {
+        DeleteServiceAccountTokenRequest newInstance = instance;
+        if (randomBoolean()) {
+            newInstance = new DeleteServiceAccountTokenRequest(
+                randomValueOtherThan(newInstance.getNamespace(), () -> randomAlphaOfLengthBetween(3, 8)),
+                newInstance.getServiceName(), newInstance.getTokenName());
         }
+        if (randomBoolean()) {
+            newInstance = new DeleteServiceAccountTokenRequest(
+                newInstance.getNamespace(),
+                randomValueOtherThan(newInstance.getServiceName(), () -> randomAlphaOfLengthBetween(3, 8)),
+                newInstance.getTokenName());
+        }
+        if (newInstance == instance || randomBoolean()) {
+            newInstance = new DeleteServiceAccountTokenRequest(
+                newInstance.getNamespace(), newInstance.getServiceName(),
+                randomValueOtherThan(newInstance.getTokenName(), () -> randomAlphaOfLengthBetween(3, 8)));
+        }
+        return newInstance;
     }
 
     public void testValidation() {

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/action/service/DeleteServiceAccountTokenResponseTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/action/service/DeleteServiceAccountTokenResponseTests.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.core.security.action.service;
+
+import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.common.xcontent.ToXContent;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentFactory;
+import org.elasticsearch.common.xcontent.XContentHelper;
+import org.elasticsearch.test.AbstractWireSerializingTestCase;
+
+import java.io.IOException;
+import java.util.Map;
+
+import static org.hamcrest.Matchers.equalTo;
+
+public class DeleteServiceAccountTokenResponseTests extends AbstractWireSerializingTestCase<DeleteServiceAccountTokenResponse> {
+
+    @Override
+    protected Writeable.Reader<DeleteServiceAccountTokenResponse> instanceReader() {
+        return DeleteServiceAccountTokenResponse::new;
+    }
+
+    @Override
+    protected DeleteServiceAccountTokenResponse createTestInstance() {
+        return new DeleteServiceAccountTokenResponse(randomBoolean());
+    }
+
+    @Override
+    protected DeleteServiceAccountTokenResponse mutateInstance(DeleteServiceAccountTokenResponse instance) throws IOException {
+        return new DeleteServiceAccountTokenResponse(false == instance.found());
+    }
+
+    public void testToXContent() throws IOException {
+        final DeleteServiceAccountTokenResponse response = createTestInstance();
+        XContentBuilder builder = XContentFactory.jsonBuilder();
+        response.toXContent(builder, ToXContent.EMPTY_PARAMS);
+        final Map<String, Object> responseMap = XContentHelper.convertToMap(
+            BytesReference.bytes(builder),
+            false, builder.contentType()).v2();
+        assertThat(responseMap, equalTo(Map.of("found", response.found())));
+    }
+}

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/action/service/DeleteServiceAccountTokenResponseTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/action/service/DeleteServiceAccountTokenResponseTests.java
@@ -44,6 +44,6 @@ public class DeleteServiceAccountTokenResponseTests extends AbstractWireSerializ
         final Map<String, Object> responseMap = XContentHelper.convertToMap(
             BytesReference.bytes(builder),
             false, builder.contentType()).v2();
-        assertThat(responseMap, equalTo(Map.of("found", response.found())));
+        assertThat(responseMap, equalTo(org.elasticsearch.common.collect.Map.of("found", response.found())));
     }
 }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/support/ValidationTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/support/ValidationTests.java
@@ -32,7 +32,7 @@ public class ValidationTests extends ESTestCase {
         new Character[Validation.VALID_NAME_CHARS.size()]
     );
 
-    private static final Set<Character> VALID_SERVICE_ACCOUNT_TOKEN_NAME_CHARS = Set.of(
+    private static final Set<Character> VALID_SERVICE_ACCOUNT_TOKEN_NAME_CHARS = org.elasticsearch.common.collect.Set.of(
         '0', '1', '2', '3', '4', '5', '6', '7', '8', '9',
         'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M', 'N', 'O',
         'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z',
@@ -41,7 +41,7 @@ public class ValidationTests extends ESTestCase {
         '-', '_'
     );
 
-    private static final Set<Character> INVALID_SERVICE_ACCOUNT_TOKEN_NAME_CHARS = Set.of(
+    private static final Set<Character> INVALID_SERVICE_ACCOUNT_TOKEN_NAME_CHARS = org.elasticsearch.common.collect.Set.of(
         '!', '"', '#', '$', '%', '&', '\'', '(', ')', '*', '+', ',', '.', '/', ';', '<', '=', '>', '?', '@', '[',
         '\\', ']', '^', '`', '{', '|', '}', '~', ' ', '\t', '\n', '\r');
 

--- a/x-pack/plugin/security/qa/operator-privileges-tests/src/javaRestTest/java/org/elasticsearch/xpack/security/operator/Constants.java
+++ b/x-pack/plugin/security/qa/operator-privileges-tests/src/javaRestTest/java/org/elasticsearch/xpack/security/operator/Constants.java
@@ -192,6 +192,7 @@ public class Constants {
         "cluster:admin/xpack/security/saml/prepare",
         "cluster:admin/xpack/security/service_account/get",
         "cluster:admin/xpack/security/service_account/token/create",
+        "cluster:admin/xpack/security/service_account/token/delete",
         "cluster:admin/xpack/security/service_account/token/get",
         "cluster:admin/xpack/security/token/create",
         "cluster:admin/xpack/security/token/invalidate",

--- a/x-pack/plugin/security/qa/service-account/src/javaRestTest/java/org/elasticsearch/xpack/security/authc/service/ServiceAccountIT.java
+++ b/x-pack/plugin/security/qa/service-account/src/javaRestTest/java/org/elasticsearch/xpack/security/authc/service/ServiceAccountIT.java
@@ -288,6 +288,26 @@ public class ServiceAccountIT extends ESRestTestCase {
             "api-token-1", org.elasticsearch.common.collect.Map.of(),
             "api-token-2", org.elasticsearch.common.collect.Map.of()
         )));
+
+        final Request deleteTokenRequest1 = new Request("DELETE", "_security/service/elastic/fleet-server/credential/token/api-token-2");
+        final Response deleteTokenResponse1 = client().performRequest(deleteTokenRequest1);
+        assertOK(deleteTokenResponse1);
+        assertThat(responseAsMap(deleteTokenResponse1).get("found"), is(true));
+
+        final Response getTokensResponse3 = client().performRequest(getTokensRequest);
+        assertOK(getTokensResponse3);
+        final Map<String, Object> getTokensResponseMap3 = responseAsMap(getTokensResponse3);
+        assertThat(getTokensResponseMap3.get("service_account"), equalTo("elastic/fleet-server"));
+        assertThat(getTokensResponseMap3.get("count"), equalTo(2));
+        assertThat(getTokensResponseMap3.get("file_tokens"), equalTo(Map.of("token1", Map.of())));
+        assertThat(getTokensResponseMap3.get("tokens"), equalTo(Map.of(
+            "api-token-1", Map.of()
+        )));
+
+        final Request deleteTokenRequest2 = new Request("DELETE", "_security/service/elastic/fleet-server/credential/token/non-such-thing");
+        final Response deleteTokenResponse2 = client().performRequest(deleteTokenRequest2);
+        assertOK(deleteTokenResponse2);
+        assertThat(responseAsMap(deleteTokenResponse2).get("found"), is(false));
     }
 
     public void testManageOwnApiKey() throws IOException {

--- a/x-pack/plugin/security/qa/service-account/src/javaRestTest/java/org/elasticsearch/xpack/security/authc/service/ServiceAccountIT.java
+++ b/x-pack/plugin/security/qa/service-account/src/javaRestTest/java/org/elasticsearch/xpack/security/authc/service/ServiceAccountIT.java
@@ -299,9 +299,10 @@ public class ServiceAccountIT extends ESRestTestCase {
         final Map<String, Object> getTokensResponseMap3 = responseAsMap(getTokensResponse3);
         assertThat(getTokensResponseMap3.get("service_account"), equalTo("elastic/fleet-server"));
         assertThat(getTokensResponseMap3.get("count"), equalTo(2));
-        assertThat(getTokensResponseMap3.get("file_tokens"), equalTo(Map.of("token1", Map.of())));
-        assertThat(getTokensResponseMap3.get("tokens"), equalTo(Map.of(
-            "api-token-1", Map.of()
+        assertThat(getTokensResponseMap3.get("file_tokens"),
+            equalTo(org.elasticsearch.common.collect.Map.of("token1", org.elasticsearch.common.collect.Map.of())));
+        assertThat(getTokensResponseMap3.get("tokens"), equalTo(org.elasticsearch.common.collect.Map.of(
+            "api-token-1", org.elasticsearch.common.collect.Map.of()
         )));
 
         final Request deleteTokenRequest2 = new Request("DELETE", "_security/service/elastic/fleet-server/credential/token/non-such-thing");

--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/authc/service/ServiceAccountSingleNodeTests.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/authc/service/ServiceAccountSingleNodeTests.java
@@ -10,9 +10,17 @@ package org.elasticsearch.xpack.security.authc.service;
 import org.elasticsearch.Version;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.cache.Cache;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.concurrent.ListenableFuture;
 import org.elasticsearch.node.Node;
 import org.elasticsearch.test.SecuritySingleNodeTestCase;
+import org.elasticsearch.xpack.core.security.action.service.CreateServiceAccountTokenAction;
+import org.elasticsearch.xpack.core.security.action.service.CreateServiceAccountTokenRequest;
+import org.elasticsearch.xpack.core.security.action.service.CreateServiceAccountTokenResponse;
+import org.elasticsearch.xpack.core.security.action.service.DeleteServiceAccountTokenAction;
+import org.elasticsearch.xpack.core.security.action.service.DeleteServiceAccountTokenRequest;
+import org.elasticsearch.xpack.core.security.action.service.DeleteServiceAccountTokenResponse;
 import org.elasticsearch.xpack.core.security.action.user.AuthenticateAction;
 import org.elasticsearch.xpack.core.security.action.user.AuthenticateRequest;
 import org.elasticsearch.xpack.core.security.action.user.AuthenticateResponse;
@@ -21,6 +29,7 @@ import org.elasticsearch.xpack.core.security.user.User;
 
 import static org.elasticsearch.test.SecuritySettingsSource.addSSLSettingsForNodePEMFiles;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
 
 public class ServiceAccountSingleNodeTests extends SecuritySingleNodeTestCase {
 
@@ -57,17 +66,53 @@ public class ServiceAccountSingleNodeTests extends SecuritySingleNodeTestCase {
             createServiceAccountClient().execute(AuthenticateAction.INSTANCE, authenticateRequest).actionGet();
         final String nodeName = node().settings().get(Node.NODE_NAME_SETTING.getKey());
         assertThat(authenticateResponse.authentication(), equalTo(
-            new Authentication(
-                new User("elastic/fleet-server", Strings.EMPTY_ARRAY, "Service account - elastic/fleet-server", null,
-                    org.elasticsearch.common.collect.Map.of("_elastic_service_account", true), true),
-                new Authentication.RealmRef("service_account", "service_account", nodeName),
-                null, Version.CURRENT, Authentication.AuthenticationType.TOKEN,
-                org.elasticsearch.common.collect.Map.of("_token_name", "token1")
-            )
+           getExpectedAuthentication("token1")
         ));
     }
 
+    public void testApiServiceAccountToken() {
+        final IndexServiceAccountsTokenStore store = node().injector().getInstance(IndexServiceAccountsTokenStore.class);
+        final Cache<String, ListenableFuture<CachingServiceAccountsTokenStore.CachedResult>> cache = store.getCache();
+        final CreateServiceAccountTokenRequest createServiceAccountTokenRequest =
+            new CreateServiceAccountTokenRequest("elastic", "fleet-server", "api-token-1");
+        final CreateServiceAccountTokenResponse createServiceAccountTokenResponse =
+            client().execute(CreateServiceAccountTokenAction.INSTANCE, createServiceAccountTokenRequest).actionGet();
+        assertThat(createServiceAccountTokenResponse.getName(), equalTo("api-token-1"));
+        assertThat(cache.count(), equalTo(0));
+
+        final AuthenticateRequest authenticateRequest = new AuthenticateRequest("elastic/fleet-server");
+        final AuthenticateResponse authenticateResponse =
+            createServiceAccountClient(createServiceAccountTokenResponse.getValue().toString())
+                .execute(AuthenticateAction.INSTANCE, authenticateRequest).actionGet();
+        assertThat(authenticateResponse.authentication(), equalTo(getExpectedAuthentication("api-token-1")));
+        // cache is populated after authenticate
+        assertThat(cache.count(), equalTo(1));
+
+        final DeleteServiceAccountTokenRequest deleteServiceAccountTokenRequest =
+            new DeleteServiceAccountTokenRequest("elastic", "fleet-server", "api-token-1");
+        final DeleteServiceAccountTokenResponse deleteServiceAccountTokenResponse =
+            client().execute(DeleteServiceAccountTokenAction.INSTANCE, deleteServiceAccountTokenRequest).actionGet();
+        assertThat(deleteServiceAccountTokenResponse.found(), is(true));
+        // cache is cleared after token deletion
+        assertThat(cache.count(), equalTo(0));
+    }
+
     private Client createServiceAccountClient() {
-        return client().filterWithHeader(org.elasticsearch.common.collect.Map.of("Authorization", "Bearer " + BEARER_TOKEN));
+        return createServiceAccountClient(BEARER_TOKEN);
+    }
+
+    private Client createServiceAccountClient(String bearerString) {
+        return client().filterWithHeader(org.elasticsearch.common.collect.Map.of("Authorization", "Bearer " + bearerString));
+    }
+
+    private Authentication getExpectedAuthentication(String tokenName) {
+        final String nodeName = node().settings().get(Node.NODE_NAME_SETTING.getKey());
+        return new Authentication(
+            new User("elastic/fleet-server", Strings.EMPTY_ARRAY, "Service account - elastic/fleet-server", null,
+                org.elasticsearch.common.collect.Map.of("_elastic_service_account", true), true),
+            new Authentication.RealmRef("service_account", "service_account", nodeName),
+            null, Version.CURRENT, Authentication.AuthenticationType.TOKEN,
+            org.elasticsearch.common.collect.Map.of("_token_name", tokenName)
+        );
     }
 }

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/Security.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/Security.java
@@ -113,6 +113,7 @@ import org.elasticsearch.xpack.core.security.action.saml.SamlLogoutAction;
 import org.elasticsearch.xpack.core.security.action.saml.SamlPrepareAuthenticationAction;
 import org.elasticsearch.xpack.core.security.action.saml.SamlSpMetadataAction;
 import org.elasticsearch.xpack.core.security.action.service.CreateServiceAccountTokenAction;
+import org.elasticsearch.xpack.core.security.action.service.DeleteServiceAccountTokenAction;
 import org.elasticsearch.xpack.core.security.action.service.GetServiceAccountAction;
 import org.elasticsearch.xpack.core.security.action.service.GetServiceAccountTokensAction;
 import org.elasticsearch.xpack.core.security.action.token.CreateTokenAction;
@@ -183,6 +184,7 @@ import org.elasticsearch.xpack.security.action.saml.TransportSamlLogoutAction;
 import org.elasticsearch.xpack.security.action.saml.TransportSamlPrepareAuthenticationAction;
 import org.elasticsearch.xpack.security.action.saml.TransportSamlSpMetadataAction;
 import org.elasticsearch.xpack.security.action.service.TransportCreateServiceAccountTokenAction;
+import org.elasticsearch.xpack.security.action.service.TransportDeleteServiceAccountTokenAction;
 import org.elasticsearch.xpack.security.action.service.TransportGetServiceAccountAction;
 import org.elasticsearch.xpack.security.action.service.TransportGetServiceAccountTokensAction;
 import org.elasticsearch.xpack.security.action.token.TransportCreateTokenAction;
@@ -266,6 +268,7 @@ import org.elasticsearch.xpack.security.rest.action.saml.RestSamlLogoutAction;
 import org.elasticsearch.xpack.security.rest.action.saml.RestSamlPrepareAuthenticationAction;
 import org.elasticsearch.xpack.security.rest.action.saml.RestSamlSpMetadataAction;
 import org.elasticsearch.xpack.security.rest.action.service.RestCreateServiceAccountTokenAction;
+import org.elasticsearch.xpack.security.rest.action.service.RestDeleteServiceAccountTokenAction;
 import org.elasticsearch.xpack.security.rest.action.service.RestGetServiceAccountAction;
 import org.elasticsearch.xpack.security.rest.action.service.RestGetServiceAccountTokensAction;
 import org.elasticsearch.xpack.security.rest.action.user.RestChangePasswordAction;
@@ -914,6 +917,7 @@ public class Security extends Plugin implements SystemIndexPlugin, IngestPlugin,
                 new ActionHandler<>(GetApiKeyAction.INSTANCE, TransportGetApiKeyAction.class),
                 new ActionHandler<>(DelegatePkiAuthenticationAction.INSTANCE, TransportDelegatePkiAuthenticationAction.class),
                 new ActionHandler<>(CreateServiceAccountTokenAction.INSTANCE, TransportCreateServiceAccountTokenAction.class),
+                new ActionHandler<>(DeleteServiceAccountTokenAction.INSTANCE, TransportDeleteServiceAccountTokenAction.class),
                 new ActionHandler<>(GetServiceAccountTokensAction.INSTANCE, TransportGetServiceAccountTokensAction.class),
                 new ActionHandler<>(GetServiceAccountAction.INSTANCE, TransportGetServiceAccountAction.class)
         );
@@ -979,6 +983,7 @@ public class Security extends Plugin implements SystemIndexPlugin, IngestPlugin,
                 new RestGetApiKeyAction(settings, getLicenseState()),
                 new RestDelegatePkiAuthenticationAction(settings, getLicenseState()),
                 new RestCreateServiceAccountTokenAction(settings, getLicenseState()),
+                new RestDeleteServiceAccountTokenAction(settings, getLicenseState()),
                 new RestGetServiceAccountTokensAction(settings, getLicenseState()),
                 new RestGetServiceAccountAction(settings, getLicenseState())
         );

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/service/TransportDeleteServiceAccountTokenAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/service/TransportDeleteServiceAccountTokenAction.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.security.action.service;
+
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.support.ActionFilters;
+import org.elasticsearch.action.support.HandledTransportAction;
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.tasks.Task;
+import org.elasticsearch.transport.TransportService;
+import org.elasticsearch.xpack.core.security.action.service.DeleteServiceAccountTokenAction;
+import org.elasticsearch.xpack.core.security.action.service.DeleteServiceAccountTokenRequest;
+import org.elasticsearch.xpack.core.security.action.service.DeleteServiceAccountTokenResponse;
+import org.elasticsearch.xpack.security.authc.service.IndexServiceAccountsTokenStore;
+import org.elasticsearch.xpack.security.authc.support.HttpTlsRuntimeCheck;
+
+public class TransportDeleteServiceAccountTokenAction
+    extends HandledTransportAction<DeleteServiceAccountTokenRequest, DeleteServiceAccountTokenResponse> {
+
+    private final IndexServiceAccountsTokenStore indexServiceAccountsTokenStore;
+    private final HttpTlsRuntimeCheck httpTlsRuntimeCheck;
+
+    @Inject
+    public TransportDeleteServiceAccountTokenAction(TransportService transportService, ActionFilters actionFilters,
+                                                    IndexServiceAccountsTokenStore indexServiceAccountsTokenStore,
+                                                    HttpTlsRuntimeCheck httpTlsRuntimeCheck) {
+        super(DeleteServiceAccountTokenAction.NAME, transportService, actionFilters, DeleteServiceAccountTokenRequest::new);
+        this.indexServiceAccountsTokenStore = indexServiceAccountsTokenStore;
+        this.httpTlsRuntimeCheck = httpTlsRuntimeCheck;
+    }
+
+    @Override
+    protected void doExecute(Task task, DeleteServiceAccountTokenRequest request,
+                             ActionListener<DeleteServiceAccountTokenResponse> listener) {
+        httpTlsRuntimeCheck.checkTlsThenExecute(listener::onFailure, "create service account token", () -> {
+            indexServiceAccountsTokenStore.deleteToken(request, ActionListener.wrap(found -> {
+                listener.onResponse(new DeleteServiceAccountTokenResponse(found));
+            }, listener::onFailure));
+        });
+    }
+}

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/service/FileTokensTool.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/service/FileTokensTool.java
@@ -20,6 +20,7 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.env.Environment;
 import org.elasticsearch.xpack.core.XPackSettings;
 import org.elasticsearch.xpack.core.security.authc.support.Hasher;
+import org.elasticsearch.xpack.core.security.support.Validation;
 import org.elasticsearch.xpack.security.authc.service.ServiceAccount.ServiceAccountId;
 import org.elasticsearch.xpack.security.support.FileAttributesChecker;
 
@@ -71,8 +72,8 @@ public class FileTokensTool extends LoggingAwareMultiCommand {
                 throw new UserException(ExitCodes.NO_USER, "Unknown service account principal: [" + principal + "]. Must be one of ["
                     + Strings.collectionToDelimitedString(ServiceAccountService.getServiceAccountPrincipals(), ",") + "]");
             }
-            if (false == ServiceAccountToken.isValidTokenName(tokenName)) {
-                throw new UserException(ExitCodes.CODE_ERROR, ServiceAccountToken.INVALID_TOKEN_NAME_MESSAGE);
+            if (false == Validation.isValidServiceAccountTokenName(tokenName)) {
+                throw new UserException(ExitCodes.CODE_ERROR, Validation.INVALID_SERVICE_ACCOUNT_TOKEN_NAME_MESSAGE);
             }
             final Hasher hasher = Hasher.resolve(XPackSettings.SERVICE_TOKEN_HASHING_ALGORITHM.get(env.settings()));
             final Path serviceTokensFile = FileServiceAccountsTokenStore.resolveFile(env);

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/service/IndexServiceAccountsTokenStore.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/service/IndexServiceAccountsTokenStore.java
@@ -55,7 +55,6 @@ import java.io.IOException;
 import java.time.Clock;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.List;
 
 import static org.elasticsearch.action.bulk.TransportSingleItemBulkWriteAction.toSingleItemBulkRequest;
 import static org.elasticsearch.index.mapper.MapperService.SINGLE_MAPPING_NAME;

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/service/IndexServiceAccountsTokenStore.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/service/IndexServiceAccountsTokenStore.java
@@ -9,6 +9,8 @@ package org.elasticsearch.xpack.security.authc.service;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.message.ParameterizedMessage;
+import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.DocWriteRequest.OpType;
@@ -16,6 +18,8 @@ import org.elasticsearch.action.DocWriteResponse;
 import org.elasticsearch.action.bulk.BulkAction;
 import org.elasticsearch.action.bulk.BulkRequest;
 import org.elasticsearch.action.bulk.TransportSingleItemBulkWriteAction;
+import org.elasticsearch.action.delete.DeleteAction;
+import org.elasticsearch.action.delete.DeleteRequest;
 import org.elasticsearch.action.get.GetAction;
 import org.elasticsearch.action.get.GetRequest;
 import org.elasticsearch.action.get.GetResponse;
@@ -35,8 +39,11 @@ import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.xpack.core.XPackSettings;
 import org.elasticsearch.xpack.core.security.ScrollHelper;
+import org.elasticsearch.xpack.core.security.action.ClearSecurityCacheAction;
+import org.elasticsearch.xpack.core.security.action.ClearSecurityCacheRequest;
 import org.elasticsearch.xpack.core.security.action.service.CreateServiceAccountTokenRequest;
 import org.elasticsearch.xpack.core.security.action.service.CreateServiceAccountTokenResponse;
+import org.elasticsearch.xpack.core.security.action.service.DeleteServiceAccountTokenRequest;
 import org.elasticsearch.xpack.core.security.action.service.TokenInfo;
 import org.elasticsearch.xpack.core.security.authc.Authentication;
 import org.elasticsearch.xpack.core.security.authc.support.Hasher;
@@ -48,6 +55,7 @@ import java.io.IOException;
 import java.time.Clock;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.List;
 
 import static org.elasticsearch.action.bulk.TransportSingleItemBulkWriteAction.toSingleItemBulkRequest;
 import static org.elasticsearch.index.mapper.MapperService.SINGLE_MAPPING_NAME;
@@ -82,7 +90,7 @@ public class IndexServiceAccountsTokenStore extends CachingServiceAccountsTokenS
     @Override
     void doAuthenticate(ServiceAccountToken token, ActionListener<Boolean> listener) {
         final GetRequest getRequest = client
-            .prepareGet(SECURITY_MAIN_ALIAS, SINGLE_MAPPING_NAME, docIdForToken(token))
+            .prepareGet(SECURITY_MAIN_ALIAS, SINGLE_MAPPING_NAME, docIdForToken(token.getQualifiedName()))
             .setFetchSource(true)
             .request();
         securityIndex.checkIndexVersionThenExecute(listener::onFailure, () ->
@@ -108,7 +116,7 @@ public class IndexServiceAccountsTokenStore extends CachingServiceAccountsTokenS
         try (XContentBuilder builder = newDocument(authentication, token)) {
             final IndexRequest indexRequest =
                 client.prepareIndex(SECURITY_MAIN_ALIAS, SINGLE_MAPPING_NAME)
-                    .setId(docIdForToken(token))
+                    .setId(docIdForToken(token.getQualifiedName()))
                     .setSource(builder)
                     .setOpType(OpType.CREATE)
                     .setRefreshPolicy(request.getRefreshPolicy())
@@ -131,26 +139,69 @@ public class IndexServiceAccountsTokenStore extends CachingServiceAccountsTokenS
 
     @Override
     public void findTokensFor(ServiceAccountId accountId, ActionListener<Collection<TokenInfo>> listener) {
-        // TODO: wildcard support?
-        final BoolQueryBuilder query = QueryBuilders.boolQuery()
-            .filter(QueryBuilders.termQuery("doc_type", SERVICE_ACCOUNT_TOKEN_DOC_TYPE))
-            .must(QueryBuilders.termQuery("username", accountId.asPrincipal()));
-        final SearchRequest request = client.prepareSearch(SECURITY_MAIN_ALIAS)
-            .setScroll(DEFAULT_KEEPALIVE_SETTING.get(getSettings()))
-            .setQuery(query)
-            .setSize(1000)
-            .setFetchSource(false)
-            .request();
-        request.indicesOptions().ignoreUnavailable();
+        final SecurityIndexManager frozenSecurityIndex = this.securityIndex.freeze();
+        if (false == frozenSecurityIndex.indexExists()) {
+            listener.onResponse(org.elasticsearch.common.collect.List.of());
+        } else if (false == frozenSecurityIndex.isAvailable()) {
+            listener.onFailure(frozenSecurityIndex.getUnavailableReason());
+        } else {
+            // TODO: wildcard support?
+            final BoolQueryBuilder query = QueryBuilders.boolQuery()
+                .filter(QueryBuilders.termQuery("doc_type", SERVICE_ACCOUNT_TOKEN_DOC_TYPE))
+                .must(QueryBuilders.termQuery("username", accountId.asPrincipal()));
+            final SearchRequest request = client.prepareSearch(SECURITY_MAIN_ALIAS)
+                .setScroll(DEFAULT_KEEPALIVE_SETTING.get(getSettings()))
+                .setQuery(query)
+                .setSize(1000)
+                .setFetchSource(false)
+                .request();
+            request.indicesOptions().ignoreUnavailable();
 
-        logger.trace("Searching tokens for service account [{}]", accountId);
-        ScrollHelper.fetchAllByEntity(client, request,
-            new ContextPreservingActionListener<>(client.threadPool().getThreadContext().newRestorableContext(false), listener),
-            hit -> extractTokenInfo(hit.getId(), accountId));
+            logger.trace("Searching tokens for service account [{}]", accountId);
+            ScrollHelper.fetchAllByEntity(client, request,
+                new ContextPreservingActionListener<>(client.threadPool().getThreadContext().newRestorableContext(false), listener),
+                hit -> extractTokenInfo(hit.getId(), accountId));
+        }
     }
 
-    private String docIdForToken(ServiceAccountToken token) {
-        return SERVICE_ACCOUNT_TOKEN_DOC_TYPE + "-" + token.getQualifiedName();
+    public void deleteToken(DeleteServiceAccountTokenRequest request, ActionListener<Boolean> listener) {
+        final SecurityIndexManager frozenSecurityIndex = this.securityIndex.freeze();
+        if (false == frozenSecurityIndex.indexExists()) {
+            listener.onResponse(false);
+        } else if (false == frozenSecurityIndex.isAvailable()) {
+            listener.onFailure(frozenSecurityIndex.getUnavailableReason());
+        } else {
+            final ServiceAccountId accountId = new ServiceAccountId(request.getNamespace(), request.getServiceName());
+            if (false == ServiceAccountService.isServiceAccountPrincipal(accountId.asPrincipal())) {
+                listener.onResponse(false);
+                return;
+            }
+            final String qualifiedTokenName = ServiceAccountToken.buildQualifiedName(accountId, request.getTokenName());
+            securityIndex.checkIndexVersionThenExecute(listener::onFailure, () -> {
+                final DeleteRequest deleteRequest =
+                    client.prepareDelete(SECURITY_MAIN_ALIAS, SINGLE_MAPPING_NAME, docIdForToken(qualifiedTokenName)).request();
+                deleteRequest.setRefreshPolicy(request.getRefreshPolicy());
+                executeAsyncWithOrigin(client, SECURITY_ORIGIN, DeleteAction.INSTANCE, deleteRequest,
+                    ActionListener.wrap(deleteResponse -> {
+                        final ClearSecurityCacheRequest clearSecurityCacheRequest =
+                            new ClearSecurityCacheRequest().cacheName("index_service_account_token").keys(qualifiedTokenName);
+                        executeAsyncWithOrigin(client, SECURITY_ORIGIN, ClearSecurityCacheAction.INSTANCE, clearSecurityCacheRequest,
+                            ActionListener.wrap(clearSecurityCacheResponse -> {
+                                listener.onResponse(deleteResponse.getResult() == DocWriteResponse.Result.DELETED);
+                            }, e -> {
+                                final ParameterizedMessage message = new ParameterizedMessage(
+                                    "clearing the cache for service token [{}] failed. please clear the cache manually",
+                                    qualifiedTokenName);
+                                logger.error(message, e);
+                                listener.onFailure(new ElasticsearchException(message.getFormattedMessage(), e));
+                            }));
+                    }, listener::onFailure));
+            });
+        }
+    }
+
+    private String docIdForToken(String qualifiedTokenName) {
+        return SERVICE_ACCOUNT_TOKEN_DOC_TYPE + "-" + qualifiedTokenName;
     }
 
     private XContentBuilder newDocument(Authentication authentication, ServiceAccountToken serviceAccountToken) throws IOException {

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/service/ServiceAccountToken.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/service/ServiceAccountToken.java
@@ -17,6 +17,7 @@ import org.elasticsearch.common.hash.MessageDigests;
 import org.elasticsearch.common.settings.SecureString;
 import org.elasticsearch.xpack.core.security.authc.AuthenticationToken;
 import org.elasticsearch.xpack.core.security.authc.support.UsernamePasswordToken;
+import org.elasticsearch.xpack.core.security.support.Validation;
 import org.elasticsearch.xpack.security.authc.service.ServiceAccount.ServiceAccountId;
 
 import java.io.ByteArrayOutputStream;
@@ -26,7 +27,6 @@ import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Base64;
 import java.util.Objects;
-import java.util.regex.Pattern;
 
 /**
  * A decoded credential that may be used to authenticate a {@link ServiceAccount}.
@@ -38,12 +38,6 @@ import java.util.regex.Pattern;
  * </ol>
  */
 public class ServiceAccountToken implements AuthenticationToken, Closeable {
-
-    public static final String INVALID_TOKEN_NAME_MESSAGE = "service account token name must have at least 1 character " +
-        "and at most 256 characters that are alphanumeric (A-Z, a-z, 0-9) or hyphen (-) or underscore (_). " +
-        "It must not begin with an underscore (_).";
-
-    private static final Pattern VALID_TOKEN_NAME = Pattern.compile("^[a-zA-Z0-9-][a-zA-Z0-9_-]{0,255}$");
 
     public static final byte MAGIC_BYTE = '\0';
     public static final byte TOKEN_TYPE = '\1';
@@ -60,8 +54,8 @@ public class ServiceAccountToken implements AuthenticationToken, Closeable {
     // pkg private for testing
     ServiceAccountToken(ServiceAccountId accountId, String tokenName, SecureString secret) {
         this.accountId = Objects.requireNonNull(accountId, "service account ID cannot be null");
-        if (false == isValidTokenName(tokenName)) {
-            throw new IllegalArgumentException(INVALID_TOKEN_NAME_MESSAGE);
+        if (false == Validation.isValidServiceAccountTokenName(tokenName)) {
+            throw new IllegalArgumentException(Validation.INVALID_SERVICE_ACCOUNT_TOKEN_NAME_MESSAGE);
         }
         this.tokenName = tokenName;
         this.secret = Objects.requireNonNull(secret, "service account token secret cannot be null");
@@ -80,7 +74,7 @@ public class ServiceAccountToken implements AuthenticationToken, Closeable {
     }
 
     public String getQualifiedName() {
-        return getAccountId().asPrincipal() + "/" + tokenName;
+        return buildQualifiedName(getAccountId(), tokenName);
     }
 
     public SecureString asBearerString() throws IOException {
@@ -92,6 +86,10 @@ public class ServiceAccountToken implements AuthenticationToken, Closeable {
             final String base64 = Base64.getEncoder().withoutPadding().encodeToString(out.toByteArray());
             return new SecureString(base64.toCharArray());
         }
+    }
+
+    public static String buildQualifiedName(ServiceAccountId accountId, String tokenName) {
+        return accountId.asPrincipal() + "/" + tokenName;
     }
 
     public static ServiceAccountToken fromBearerString(SecureString bearerString) throws IOException {
@@ -167,7 +165,4 @@ public class ServiceAccountToken implements AuthenticationToken, Closeable {
         close();
     }
 
-    public static boolean isValidTokenName(String name) {
-        return name != null && VALID_TOKEN_NAME.matcher(name).matches();
-    }
 }

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/rest/action/service/RestDeleteServiceAccountTokenAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/rest/action/service/RestDeleteServiceAccountTokenAction.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.security.rest.action.service;
+
+import org.elasticsearch.action.support.WriteRequest;
+import org.elasticsearch.client.node.NodeClient;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.license.XPackLicenseState;
+import org.elasticsearch.rest.RestRequest;
+import org.elasticsearch.rest.action.RestToXContentListener;
+import org.elasticsearch.xpack.core.security.action.service.DeleteServiceAccountTokenAction;
+import org.elasticsearch.xpack.core.security.action.service.DeleteServiceAccountTokenRequest;
+import org.elasticsearch.xpack.security.rest.action.SecurityBaseRestHandler;
+
+import java.io.IOException;
+import java.util.List;
+
+import static org.elasticsearch.rest.RestRequest.Method.DELETE;
+
+public class RestDeleteServiceAccountTokenAction extends SecurityBaseRestHandler {
+
+    public RestDeleteServiceAccountTokenAction(Settings settings, XPackLicenseState licenseState) {
+        super(settings, licenseState);
+    }
+
+    @Override
+    public List<Route> routes() {
+        return List.of(
+            new Route(DELETE, "/_security/service/{namespace}/{service}/credential/token/{name}"));
+    }
+
+    @Override
+    public String getName() {
+        return "xpack_security_delete_service_account_token";
+    }
+
+    @Override
+    protected RestChannelConsumer innerPrepareRequest(RestRequest request, NodeClient client) throws IOException {
+        final DeleteServiceAccountTokenRequest deleteServiceAccountTokenRequest = new DeleteServiceAccountTokenRequest(
+                request.param("namespace"), request.param("service"), request.param("name"));
+        final String refreshPolicy = request.param("refresh");
+        if (refreshPolicy != null) {
+            deleteServiceAccountTokenRequest.setRefreshPolicy(WriteRequest.RefreshPolicy.parse(refreshPolicy));
+        }
+
+        return channel -> client.execute(DeleteServiceAccountTokenAction.INSTANCE,
+            deleteServiceAccountTokenRequest,
+            new RestToXContentListener<>(channel));
+    }
+}

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/rest/action/service/RestDeleteServiceAccountTokenAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/rest/action/service/RestDeleteServiceAccountTokenAction.java
@@ -30,7 +30,7 @@ public class RestDeleteServiceAccountTokenAction extends SecurityBaseRestHandler
 
     @Override
     public List<Route> routes() {
-        return List.of(
+        return org.elasticsearch.common.collect.List.of(
             new Route(DELETE, "/_security/service/{namespace}/{service}/credential/token/{name}"));
     }
 

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/action/service/TransportDeleteServiceAccountTokenActionTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/action/service/TransportDeleteServiceAccountTokenActionTests.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.security.action.service;
+
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.support.ActionFilters;
+import org.elasticsearch.tasks.Task;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.transport.TransportService;
+import org.elasticsearch.xpack.core.security.action.service.DeleteServiceAccountTokenRequest;
+import org.elasticsearch.xpack.security.authc.service.IndexServiceAccountsTokenStore;
+import org.elasticsearch.xpack.security.authc.support.HttpTlsRuntimeCheck;
+import org.junit.Before;
+
+import java.util.Collections;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+public class TransportDeleteServiceAccountTokenActionTests extends ESTestCase {
+
+    private IndexServiceAccountsTokenStore indexServiceAccountsTokenStore;
+    private HttpTlsRuntimeCheck httpTlsRuntimeCheck;
+    private TransportDeleteServiceAccountTokenAction transportDeleteServiceAccountTokenAction;
+
+    @Before
+    public void init() {
+        indexServiceAccountsTokenStore = mock(IndexServiceAccountsTokenStore.class);
+        httpTlsRuntimeCheck = mock(HttpTlsRuntimeCheck.class);
+        transportDeleteServiceAccountTokenAction = new TransportDeleteServiceAccountTokenAction(
+            mock(TransportService.class), new ActionFilters(Collections.emptySet()), indexServiceAccountsTokenStore, httpTlsRuntimeCheck);
+
+        doAnswer(invocationOnMock -> {
+            final Object[] arguments = invocationOnMock.getArguments();
+            ((Runnable) arguments[2]).run();
+            return null;
+        }).when(httpTlsRuntimeCheck).checkTlsThenExecute(any(), any(), any());
+    }
+
+    @SuppressWarnings("rawtypes")
+    public void testDoExecuteWillDelegate() {
+        final DeleteServiceAccountTokenRequest request = new DeleteServiceAccountTokenRequest(
+            randomAlphaOfLengthBetween(3, 8), randomAlphaOfLengthBetween(3, 8), randomAlphaOfLengthBetween(3, 8));
+        final ActionListener listener = mock(ActionListener.class);
+        transportDeleteServiceAccountTokenAction.doExecute(mock(Task.class), request, listener);
+        verify(indexServiceAccountsTokenStore).deleteToken(eq(request), any(ActionListener.class));
+    }
+
+}

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/service/IndexServiceAccountsTokenStoreTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/service/IndexServiceAccountsTokenStoreTests.java
@@ -8,6 +8,7 @@
 package org.elasticsearch.xpack.security.authc.service;
 
 import org.apache.lucene.search.TotalHits;
+import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ActionRequest;
@@ -17,6 +18,8 @@ import org.elasticsearch.action.DocWriteRequest.OpType;
 import org.elasticsearch.action.bulk.BulkItemResponse;
 import org.elasticsearch.action.bulk.BulkRequest;
 import org.elasticsearch.action.bulk.BulkResponse;
+import org.elasticsearch.action.delete.DeleteRequest;
+import org.elasticsearch.action.delete.DeleteResponse;
 import org.elasticsearch.action.get.GetRequest;
 import org.elasticsearch.action.get.GetResponse;
 import org.elasticsearch.action.index.IndexRequest;
@@ -28,6 +31,7 @@ import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.client.FilterClient;
+import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
 import org.elasticsearch.cluster.service.ClusterService;
@@ -43,23 +47,30 @@ import org.elasticsearch.search.internal.InternalSearchResponse;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.XContentTestUtils;
 import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.xpack.core.security.action.ClearSecurityCacheRequest;
+import org.elasticsearch.xpack.core.security.action.ClearSecurityCacheResponse;
 import org.elasticsearch.xpack.core.security.action.service.CreateServiceAccountTokenRequest;
 import org.elasticsearch.xpack.core.security.action.service.CreateServiceAccountTokenResponse;
+import org.elasticsearch.xpack.core.security.action.service.DeleteServiceAccountTokenRequest;
 import org.elasticsearch.xpack.core.security.action.service.TokenInfo;
 import org.elasticsearch.xpack.core.security.authc.Authentication;
 import org.elasticsearch.xpack.core.security.authc.support.Hasher;
+import org.elasticsearch.xpack.core.security.support.ValidationTests;
 import org.elasticsearch.xpack.core.security.user.User;
 import org.elasticsearch.xpack.security.authc.service.ServiceAccount.ServiceAccountId;
 import org.elasticsearch.xpack.security.support.CacheInvalidatorRegistry;
 import org.elasticsearch.xpack.security.support.SecurityIndexManager;
 import org.junit.Before;
+import org.mockito.Mockito;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.time.Clock;
 import java.util.Collection;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
@@ -87,6 +98,7 @@ public class IndexServiceAccountsTokenStoreTests extends ESTestCase {
     private final AtomicReference<ActionRequest> requestHolder = new AtomicReference<>();
     private final AtomicReference<BiConsumer<ActionRequest, ActionListener<ActionResponse>>> responseProviderHolder =
         new AtomicReference<>();
+    private SecurityIndexManager securityIndex;
 
     @Before
     public void init() {
@@ -111,7 +123,7 @@ public class IndexServiceAccountsTokenStoreTests extends ESTestCase {
         when(clusterService.state()).thenReturn(clusterState);
         cacheInvalidatorRegistry = mock(CacheInvalidatorRegistry.class);
 
-        SecurityIndexManager securityIndex = mock(SecurityIndexManager.class);
+        securityIndex = mock(SecurityIndexManager.class);
         when(securityIndex.isAvailable()).thenReturn(true);
         when(securityIndex.indexExists()).thenReturn(true);
         when(securityIndex.isIndexUpToDate()).thenReturn(true);
@@ -129,8 +141,7 @@ public class IndexServiceAccountsTokenStoreTests extends ESTestCase {
         store = new IndexServiceAccountsTokenStore(Settings.EMPTY,
             threadPool,
             Clock.systemUTC(),
-            client,
-            securityIndex,
+            client, securityIndex,
             clusterService,
             cacheInvalidatorRegistry);
     }
@@ -223,7 +234,7 @@ public class IndexServiceAccountsTokenStoreTests extends ESTestCase {
     public void testFindTokensFor() {
         final ServiceAccountId accountId = new ServiceAccountId(randomAlphaOfLengthBetween(3, 8), randomAlphaOfLengthBetween(3, 8));
         final int nhits = randomIntBetween(0, 10);
-        final String[] tokenNames = randomArray(nhits, nhits, String[]::new, ServiceAccountTokenTests::randomTokenName);
+        final String[] tokenNames = randomArray(nhits, nhits, String[]::new, ValidationTests::randomTokenName);
 
         responseProviderHolder.set((r, l) -> {
             if (r instanceof SearchRequest) {
@@ -245,6 +256,8 @@ public class IndexServiceAccountsTokenStoreTests extends ESTestCase {
                 l.onResponse(searchResponse);
             } else if (r instanceof ClearScrollRequest) {
                 l.onResponse(new ClearScrollResponse(true, 1));
+            } else {
+                fail("unexpected request " + r);
             }
         });
 
@@ -267,6 +280,81 @@ public class IndexServiceAccountsTokenStoreTests extends ESTestCase {
         store.findTokensFor(accountId, future);
         final RuntimeException e1 = expectThrows(RuntimeException.class, future::actionGet);
         assertThat(e1, is(e));
+    }
+
+    public void testDeleteToken() {
+        final AtomicBoolean cacheCleared = new AtomicBoolean(false);
+        responseProviderHolder.set((r, l) -> {
+            if (r instanceof DeleteRequest) {
+                final DeleteRequest dr = (DeleteRequest) r;
+                final boolean found = dr.id().equals(SERVICE_ACCOUNT_TOKEN_DOC_TYPE + "-elastic/fleet-server/token1");
+                l.onResponse(new DeleteResponse(mock(ShardId.class), randomAlphaOfLengthBetween(3, 8),
+                    randomLong(), randomLong(), randomLong(), found));
+            } else if (r instanceof ClearSecurityCacheRequest) {
+                cacheCleared.set(true);
+                l.onResponse(new ClearSecurityCacheResponse(mock(ClusterName.class),
+                    List.of(mock(ClearSecurityCacheResponse.Node.class)), List.of()));
+            } else {
+                fail("unexpected request " + r);
+            }
+        });
+
+        final DeleteServiceAccountTokenRequest deleteServiceAccountTokenRequest1 = new DeleteServiceAccountTokenRequest(
+            "elastic", "fleet-server", "token1");
+        final PlainActionFuture<Boolean> future1 = new PlainActionFuture<>();
+        store.deleteToken(deleteServiceAccountTokenRequest1, future1);
+        assertThat(future1.actionGet(), is(true));
+        assertThat(cacheCleared.get(), is(true));
+
+        // non-exist token name
+        final DeleteServiceAccountTokenRequest deleteServiceAccountTokenRequest2 = new DeleteServiceAccountTokenRequest(
+            "elastic", "fleet-server", randomAlphaOfLengthBetween(3, 8));
+        final PlainActionFuture<Boolean> future2 = new PlainActionFuture<>();
+        store.deleteToken(deleteServiceAccountTokenRequest2, future2);
+        assertThat(future2.actionGet(), is(false));
+
+        // Invalid service account
+        final DeleteServiceAccountTokenRequest deleteServiceAccountTokenRequest3 = new DeleteServiceAccountTokenRequest(
+            randomValueOtherThan("elastic", () -> randomAlphaOfLengthBetween(3, 8)), "fleet-server", "token1");
+        final PlainActionFuture<Boolean> future3 = new PlainActionFuture<>();
+        store.deleteToken(deleteServiceAccountTokenRequest3, future3);
+        assertThat(future3.actionGet(), is(false));
+    }
+
+    public void testIndexStateIssues() {
+        // Index not exists
+        Mockito.reset(securityIndex);
+        when(securityIndex.freeze()).thenReturn(securityIndex);
+        when(securityIndex.indexExists()).thenReturn(false);
+
+        final ServiceAccountId accountId = new ServiceAccountId(randomAlphaOfLengthBetween(3, 8), randomAlphaOfLengthBetween(3, 8));
+        final PlainActionFuture<Collection<TokenInfo>> future1 = new PlainActionFuture<>();
+        store.findTokensFor(accountId, future1);
+        assertThat(future1.actionGet(), equalTo(List.of()));
+
+        final DeleteServiceAccountTokenRequest deleteServiceAccountTokenRequest = new DeleteServiceAccountTokenRequest(
+            randomAlphaOfLengthBetween(3, 8), randomAlphaOfLengthBetween(3, 8), randomAlphaOfLengthBetween(3, 8));
+        final PlainActionFuture<Boolean> future2 = new PlainActionFuture<>();
+        store.deleteToken(deleteServiceAccountTokenRequest, future2);
+        assertThat(future2.actionGet(), is(false));
+
+        // Index exists but not available
+        Mockito.reset(securityIndex);
+        when(securityIndex.freeze()).thenReturn(securityIndex);
+        when(securityIndex.indexExists()).thenReturn(true);
+        when(securityIndex.isAvailable()).thenReturn(false);
+        final ElasticsearchException e = new ElasticsearchException("fail");
+        when(securityIndex.getUnavailableReason()).thenReturn(e);
+
+        final PlainActionFuture<Collection<TokenInfo>> future3 = new PlainActionFuture<>();
+        store.findTokensFor(accountId, future3);
+        final ElasticsearchException e3 = expectThrows(ElasticsearchException.class, future3::actionGet);
+        assertThat(e3, is(e));
+
+        final PlainActionFuture<Boolean> future4 = new PlainActionFuture<>();
+        store.deleteToken(deleteServiceAccountTokenRequest, future4);
+        final ElasticsearchException e4 = expectThrows(ElasticsearchException.class, future4::actionGet);
+        assertThat(e4, is(e));
     }
 
     private GetResponse createGetResponse(ServiceAccountToken serviceAccountToken, boolean exists) throws IOException {

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/service/IndexServiceAccountsTokenStoreTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/service/IndexServiceAccountsTokenStoreTests.java
@@ -67,7 +67,6 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.time.Clock;
 import java.util.Collection;
-import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -288,12 +287,13 @@ public class IndexServiceAccountsTokenStoreTests extends ESTestCase {
             if (r instanceof DeleteRequest) {
                 final DeleteRequest dr = (DeleteRequest) r;
                 final boolean found = dr.id().equals(SERVICE_ACCOUNT_TOKEN_DOC_TYPE + "-elastic/fleet-server/token1");
-                l.onResponse(new DeleteResponse(mock(ShardId.class), randomAlphaOfLengthBetween(3, 8),
+                l.onResponse(new DeleteResponse(mock(ShardId.class), randomAlphaOfLengthBetween(3, 8), randomAlphaOfLengthBetween(3, 8),
                     randomLong(), randomLong(), randomLong(), found));
             } else if (r instanceof ClearSecurityCacheRequest) {
                 cacheCleared.set(true);
                 l.onResponse(new ClearSecurityCacheResponse(mock(ClusterName.class),
-                    List.of(mock(ClearSecurityCacheResponse.Node.class)), List.of()));
+                    org.elasticsearch.common.collect.List.of(mock(ClearSecurityCacheResponse.Node.class)),
+                    org.elasticsearch.common.collect.List.of()));
             } else {
                 fail("unexpected request " + r);
             }
@@ -330,7 +330,7 @@ public class IndexServiceAccountsTokenStoreTests extends ESTestCase {
         final ServiceAccountId accountId = new ServiceAccountId(randomAlphaOfLengthBetween(3, 8), randomAlphaOfLengthBetween(3, 8));
         final PlainActionFuture<Collection<TokenInfo>> future1 = new PlainActionFuture<>();
         store.findTokensFor(accountId, future1);
-        assertThat(future1.actionGet(), equalTo(List.of()));
+        assertThat(future1.actionGet(), equalTo(org.elasticsearch.common.collect.List.of()));
 
         final DeleteServiceAccountTokenRequest deleteServiceAccountTokenRequest = new DeleteServiceAccountTokenRequest(
             randomAlphaOfLengthBetween(3, 8), randomAlphaOfLengthBetween(3, 8), randomAlphaOfLengthBetween(3, 8));

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/service/ServiceAccountServiceTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/service/ServiceAccountServiceTests.java
@@ -29,6 +29,7 @@ import org.elasticsearch.test.MockLogAppender;
 import org.elasticsearch.transport.Transport;
 import org.elasticsearch.xpack.core.security.authc.Authentication;
 import org.elasticsearch.xpack.core.security.authz.RoleDescriptor;
+import org.elasticsearch.xpack.core.security.support.ValidationTests;
 import org.elasticsearch.xpack.core.security.user.User;
 import org.elasticsearch.xpack.security.authc.service.ServiceAccount.ServiceAccountId;
 import org.elasticsearch.xpack.security.authc.support.HttpTlsRuntimeCheck;
@@ -190,7 +191,7 @@ public class ServiceAccountServiceTests extends ESTestCase {
             final SecureString bearerString4 = createBearerString(org.elasticsearch.common.collect.List.of(
                 magicBytes,
                 (randomAlphaOfLengthBetween(3, 8) + "/" + randomAlphaOfLengthBetween(3, 8)
-                    + "/" + randomValueOtherThanMany(n -> n.contains("/"), ServiceAccountTokenTests::randomInvalidTokenName)
+                    + "/" + randomValueOtherThanMany(n -> n.contains("/"), ValidationTests::randomInvalidTokenName)
                     + ":" + randomAlphaOfLengthBetween(10, 20)).getBytes(StandardCharsets.UTF_8)
             ));
             assertNull(ServiceAccountService.tryParseToken(bearerString4));
@@ -199,7 +200,7 @@ public class ServiceAccountServiceTests extends ESTestCase {
             // Everything is good
             final String namespace = randomAlphaOfLengthBetween(3, 8);
             final String serviceName = randomAlphaOfLengthBetween(3, 8);
-            final String tokenName = ServiceAccountTokenTests.randomTokenName();
+            final String tokenName = ValidationTests.randomTokenName();
             final ServiceAccountId accountId = new ServiceAccountId(namespace, serviceName);
             final String secret = randomAlphaOfLengthBetween(10, 20);
             final SecureString bearerString5 = createBearerString(org.elasticsearch.common.collect.List.of(

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/service/ServiceAccountTokenTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/service/ServiceAccountTokenTests.java
@@ -9,74 +9,45 @@ package org.elasticsearch.xpack.security.authc.service;
 
 import org.elasticsearch.common.settings.SecureString;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.core.security.support.Validation;
+import org.elasticsearch.xpack.core.security.support.ValidationTests;
 import org.elasticsearch.xpack.security.authc.service.ServiceAccount.ServiceAccountId;
 
 import java.io.IOException;
-import java.util.Arrays;
-import java.util.Set;
-import java.util.stream.Collectors;
-import java.util.stream.IntStream;
 
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.is;
 
 public class ServiceAccountTokenTests extends ESTestCase {
 
-    private static final Set<Character> VALID_TOKEN_NAME_CHARS = org.elasticsearch.common.collect.Set.of(
-        '0', '1', '2', '3', '4', '5', '6', '7', '8', '9',
-        'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M', 'N', 'O',
-        'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z',
-        'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n', 'o',
-        'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z',
-        '-', '_'
-    );
-
-    private static final Set<Character> INVALID_TOKEN_NAME_CHARS = org.elasticsearch.common.collect.Set.of(
-        '!', '"', '#', '$', '%', '&', '\'', '(', ')', '*', '+', ',', '.', '/', ';', '<', '=', '>', '?', '@', '[',
-        '\\', ']', '^', '`', '{', '|', '}', '~', ' ', '\t', '\n', '\r');
-
-    public void testIsValidTokenName() {
-        final String tokenName1 = randomTokenName();
-        assertThat(ServiceAccountToken.isValidTokenName(tokenName1), is(true));
-
-        final String tokenName2 = "_" + randomTokenName().substring(1);
-        assertThat(ServiceAccountToken.isValidTokenName(tokenName2), is(false));
-
-        assertThat(ServiceAccountToken.isValidTokenName(null), is(false));
-
-        final String tokenName3 = randomInvalidTokenName();
-        assertThat(ServiceAccountToken.isValidTokenName(tokenName3), is(false));
-    }
-
     public void testNewToken() {
         final ServiceAccountId accountId = new ServiceAccountId(randomAlphaOfLengthBetween(3, 8), randomAlphaOfLengthBetween(3, 8));
-        ServiceAccountToken.newToken(accountId, randomTokenName());
+        ServiceAccountToken.newToken(accountId, ValidationTests.randomTokenName());
 
-        final IllegalArgumentException e1 =
-            expectThrows(IllegalArgumentException.class, () -> ServiceAccountToken.newToken(accountId, randomInvalidTokenName()));
-        assertThat(e1.getMessage(), containsString(ServiceAccountToken.INVALID_TOKEN_NAME_MESSAGE));
+        final IllegalArgumentException e1 = expectThrows(IllegalArgumentException.class,
+            () -> ServiceAccountToken.newToken(accountId, ValidationTests.randomInvalidTokenName()));
+        assertThat(e1.getMessage(), containsString(Validation.INVALID_SERVICE_ACCOUNT_TOKEN_NAME_MESSAGE));
 
         final NullPointerException e2 =
-            expectThrows(NullPointerException.class, () -> ServiceAccountToken.newToken(null, randomTokenName()));
+            expectThrows(NullPointerException.class, () -> ServiceAccountToken.newToken(null, ValidationTests.randomTokenName()));
         assertThat(e2.getMessage(), containsString("service account ID cannot be null"));
     }
 
     public void testServiceAccountTokenNew() {
         final ServiceAccountId accountId = new ServiceAccountId(randomAlphaOfLengthBetween(3, 8), randomAlphaOfLengthBetween(3, 8));
         final SecureString secret = new SecureString(randomAlphaOfLength(20).toCharArray());
-        new ServiceAccountToken(accountId, randomTokenName(), secret);
+        new ServiceAccountToken(accountId, ValidationTests.randomTokenName(), secret);
 
         final NullPointerException e1 =
-            expectThrows(NullPointerException.class, () -> new ServiceAccountToken(null, randomTokenName(), secret));
+            expectThrows(NullPointerException.class, () -> new ServiceAccountToken(null, ValidationTests.randomTokenName(), secret));
         assertThat(e1.getMessage(), containsString("service account ID cannot be null"));
 
-        final IllegalArgumentException e2 =
-            expectThrows(IllegalArgumentException.class, () -> new ServiceAccountToken(accountId, randomInvalidTokenName(), secret));
-        assertThat(e2.getMessage(), containsString(ServiceAccountToken.INVALID_TOKEN_NAME_MESSAGE));
+        final IllegalArgumentException e2 = expectThrows(IllegalArgumentException.class,
+            () -> new ServiceAccountToken(accountId, ValidationTests.randomInvalidTokenName(), secret));
+        assertThat(e2.getMessage(), containsString(Validation.INVALID_SERVICE_ACCOUNT_TOKEN_NAME_MESSAGE));
 
         final NullPointerException e3 =
-            expectThrows(NullPointerException.class, () -> new ServiceAccountToken(accountId, randomTokenName(), null));
+            expectThrows(NullPointerException.class, () -> new ServiceAccountToken(accountId, ValidationTests.randomTokenName(), null));
         assertThat(e3.getMessage(), containsString("service account token secret cannot be null"));
     }
 
@@ -91,29 +62,7 @@ public class ServiceAccountTokenTests extends ESTestCase {
             equalTo(serviceAccountToken));
 
         final ServiceAccountId accountId = new ServiceAccountId(randomAlphaOfLengthBetween(3, 8), randomAlphaOfLengthBetween(3, 8));
-        final ServiceAccountToken serviceAccountToken1 = ServiceAccountToken.newToken(accountId, randomTokenName());
+        final ServiceAccountToken serviceAccountToken1 = ServiceAccountToken.newToken(accountId, ValidationTests.randomTokenName());
         assertThat(ServiceAccountToken.fromBearerString(serviceAccountToken1.asBearerString()), equalTo(serviceAccountToken1));
-    }
-
-    public static String randomTokenName() {
-        final Character[] chars = randomArray(
-            1,
-            256,
-            Character[]::new,
-            () -> randomFrom(VALID_TOKEN_NAME_CHARS));
-        final String name = Arrays.stream(chars).map(String::valueOf).collect(Collectors.joining());
-        return name.startsWith("_") ? randomAlphaOfLength(1) + name.substring(1) : name;
-    }
-
-    public static String randomInvalidTokenName() {
-        if (randomBoolean()) {
-            final String tokenName = randomTokenName();
-            final char[] chars = tokenName.toCharArray();
-            IntStream.rangeClosed(1, randomIntBetween(1, chars.length))
-                .forEach(i -> chars[randomIntBetween(0, chars.length - 1)] = randomFrom(INVALID_TOKEN_NAME_CHARS));
-            return new String(chars);
-        } else {
-            return randomFrom("", " ", randomAlphaOfLength(257));
-        }
     }
 }

--- a/x-pack/qa/security-tools-tests/src/test/java/org/elasticsearch/xpack/security/authc/service/FileTokensToolTests.java
+++ b/x-pack/qa/security-tools-tests/src/test/java/org/elasticsearch/xpack/security/authc/service/FileTokensToolTests.java
@@ -20,6 +20,8 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.internal.io.IOUtils;
 import org.elasticsearch.env.Environment;
 import org.elasticsearch.xpack.core.security.authc.support.Hasher;
+import org.elasticsearch.xpack.core.security.support.Validation;
+import org.elasticsearch.xpack.core.security.support.ValidationTests;
 import org.elasticsearch.xpack.security.authc.service.FileTokensTool.CreateFileTokenCommand;
 import org.junit.AfterClass;
 import org.junit.Before;
@@ -131,15 +133,15 @@ public class FileTokensToolTests extends CommandTestCase {
     }
 
     public void testCreateToken() throws Exception {
-        final String tokenName1 = randomValueOtherThanMany(n -> n.startsWith("-"), ServiceAccountTokenTests::randomTokenName);
+        final String tokenName1 = randomValueOtherThanMany(n -> n.startsWith("-"), ValidationTests::randomTokenName);
         execute("create", pathHomeParameter, "elastic/fleet-server", tokenName1);
         assertServiceTokenExists("elastic/fleet-server/" + tokenName1);
         final String tokenName2 = randomValueOtherThanMany(n -> n.startsWith("-") || n.equals(tokenName1),
-            ServiceAccountTokenTests::randomTokenName);
+            ValidationTests::randomTokenName);
         execute("create", pathHomeParameter, "elastic/fleet-server", tokenName2);
         assertServiceTokenExists("elastic/fleet-server/" + tokenName2);
         // token name with a leading hyphen requires an option terminator
-        final String tokenName3 = "-" + ServiceAccountTokenTests.randomTokenName().substring(1);
+        final String tokenName3 = "-" + ValidationTests.randomTokenName().substring(1);
         execute("create", pathHomeParameter, "elastic/fleet-server", "--", tokenName3);
         assertServiceTokenExists("elastic/fleet-server/" + tokenName3);
         final String output = terminal.getOutput();
@@ -149,13 +151,13 @@ public class FileTokensToolTests extends CommandTestCase {
     }
 
     public void testCreateTokenWithInvalidTokenName() throws Exception {
-        final String tokenName = ServiceAccountTokenTests.randomInvalidTokenName();
+        final String tokenName = ValidationTests.randomInvalidTokenName();
         final String[] args = tokenName.startsWith("-") ?
             new String[] { "create", pathHomeParameter, "elastic/fleet-server", "--", tokenName } :
             new String[] { "create", pathHomeParameter, "elastic/fleet-server", tokenName };
         final UserException e = expectThrows(UserException.class, () -> execute(args));
         assertServiceTokenNotExists("elastic/fleet-server/" + tokenName);
-        assertThat(e.getMessage(), containsString(ServiceAccountToken.INVALID_TOKEN_NAME_MESSAGE));
+        assertThat(e.getMessage(), containsString(Validation.INVALID_SERVICE_ACCOUNT_TOKEN_NAME_MESSAGE));
     }
 
     public void testCreateTokenWithInvalidServiceAccount() throws Exception {


### PR DESCRIPTION
This PR adds a new API to delete service account tokens that are backed
by the security index.

