### PR TITLE
SQL: Fix manifest version tag in Tableau connector

### DIFF
--- a/x-pack/plugin/sql/connectors/tableau/package.sh
+++ b/x-pack/plugin/sql/connectors/tableau/package.sh
@@ -58,8 +58,9 @@ function package() {
     rm -rfv $MY_WORKSPACE/$SRC_DIR
     cp -rv $MY_TOP_DIR/$SRC_DIR $MY_WORKSPACE
 
-    # patch version tag in manifest file, filtering out any -SNAPSHOT
-    echo -e "cd //connector-plugin/@version\nset ${TACO_VERSION%-*}\nsave" |\
+    # patch plugin-version tag in manifest file, filtering out any -SNAPSHOT
+    echo \
+    -e "cd //connector-plugin/@plugin-version\nset ${TACO_VERSION%-*}\nsave" |\
         xmllint --shell $MY_WORKSPACE/$SRC_DIR/manifest.xml
 
     # check out TDVT SDK


### PR DESCRIPTION
The version needs to be contained in the `plugin-version` tag, not `version` one.
