### PR TITLE
[7.12] Fix typo in validation for destination port of community ID processor (#70883)

### DIFF
--- a/x-pack/plugin/ingest/src/main/java/org/elasticsearch/xpack/ingest/CommunityIdProcessor.java
+++ b/x-pack/plugin/ingest/src/main/java/org/elasticsearch/xpack/ingest/CommunityIdProcessor.java
@@ -177,7 +177,7 @@ public final class CommunityIdProcessor extends AbstractProcessor {
 
                 Object destinationPortValue = d.getFieldValue(destinationPortField, Object.class, ignoreMissing);
                 flow.destinationPort = parseIntFromObjectOrString(destinationPortValue, "destination port");
-                if (flow.destinationPort < 1 || flow.sourcePort > 65535) {
+                if (flow.destinationPort < 1 || flow.destinationPort > 65535) {
                     throw new IllegalArgumentException("invalid destination port [" + destinationPortValue + "]");
                 }
                 break;

--- a/x-pack/plugin/ingest/src/test/java/org/elasticsearch/xpack/ingest/CommunityIdProcessorTests.java
+++ b/x-pack/plugin/ingest/src/test/java/org/elasticsearch/xpack/ingest/CommunityIdProcessorTests.java
@@ -302,14 +302,14 @@ public class CommunityIdProcessorTests extends ESTestCase {
 
         event = buildEvent();
         @SuppressWarnings("unchecked")
-        var source3 = (Map<String, Object>) event.get("destination");
+        Map<String, Object> source3 = (Map<String, Object>) event.get("destination");
         source3.put("port", 0);
         e = expectThrows(IllegalArgumentException.class, () -> testCommunityIdProcessor(event, null));
         assertThat(e.getMessage(), containsString("invalid destination port [0]"));
 
         event = buildEvent();
         @SuppressWarnings("unchecked")
-        var source4 = (Map<String, Object>) event.get("destination");
+        Map<String, Object> source4 = (Map<String, Object>) event.get("destination");
         source4.put("port", 65536);
         e = expectThrows(IllegalArgumentException.class, () -> testCommunityIdProcessor(event, null));
         assertThat(e.getMessage(), containsString("invalid destination port [65536]"));

--- a/x-pack/plugin/ingest/src/test/java/org/elasticsearch/xpack/ingest/CommunityIdProcessorTests.java
+++ b/x-pack/plugin/ingest/src/test/java/org/elasticsearch/xpack/ingest/CommunityIdProcessorTests.java
@@ -299,6 +299,20 @@ public class CommunityIdProcessorTests extends ESTestCase {
         source2.put("port", 65536);
         e = expectThrows(IllegalArgumentException.class, () -> testCommunityIdProcessor(event, null));
         assertThat(e.getMessage(), containsString("invalid source port [65536]"));
+
+        event = buildEvent();
+        @SuppressWarnings("unchecked")
+        var source3 = (Map<String, Object>) event.get("destination");
+        source3.put("port", 0);
+        e = expectThrows(IllegalArgumentException.class, () -> testCommunityIdProcessor(event, null));
+        assertThat(e.getMessage(), containsString("invalid destination port [0]"));
+
+        event = buildEvent();
+        @SuppressWarnings("unchecked")
+        var source4 = (Map<String, Object>) event.get("destination");
+        source4.put("port", 65536);
+        e = expectThrows(IllegalArgumentException.class, () -> testCommunityIdProcessor(event, null));
+        assertThat(e.getMessage(), containsString("invalid destination port [65536]"));
     }
 
     public void testIgnoreMissing() throws Exception {


### PR DESCRIPTION
Backport of #70883
