### PR TITLE
[7.x] [DOCS] Move JSON encoding section (#71508)

### DIFF
--- a/docs/reference/api-conventions.asciidoc
+++ b/docs/reference/api-conventions.asciidoc
@@ -1,9 +1,7 @@
 [[api-conventions]]
 == API conventions
 
-The {es} REST APIs are exposed using JSON over HTTP. The JSON request body must
-be UTF-8 encoded. {es} ignores any other encoding headings sent with a request.
-Responses are also UTF-8 encoded.
+The {es} REST APIs are exposed over HTTP.
 
 The conventions listed in this chapter can be applied throughout the REST
 API, unless otherwise specified.
@@ -685,7 +683,7 @@ should also be passed with a media type value that indicates the format
 of the source, such as `application/json`.
 
 [discrete]
-==== Content-Type Requirements
+==== Content-type requirements
 
 The type of the content sent in a request body must be specified using
 the `Content-Type` header. The value of this header must map to one of
@@ -693,9 +691,11 @@ the supported formats that the API supports. Most APIs support JSON,
 YAML, CBOR, and SMILE. The bulk and multi-search APIs support NDJSON,
 JSON, and SMILE; other types will result in an error response.
 
-Additionally, when using the `source` query string parameter, the
-content type must be specified using the `source_content_type` query
-string parameter.
+When using the `source` query string parameter, the content type must be
+specified using the `source_content_type` query string parameter.
+
+{es} only supports UTF-8-encoded JSON. {es} ignores any other encoding headings
+sent with a request. Responses are also UTF-8 encoded.
 
 [[url-access-control]]
 === URL-based access control


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [DOCS] Move JSON encoding section (#71508)