### PR TITLE
Service Accounts - CLI to delete and list file tokens (#71380)

### DIFF
--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/service/FileTokensTool.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/service/FileTokensTool.java
@@ -15,19 +15,20 @@ import org.elasticsearch.cli.LoggingAwareMultiCommand;
 import org.elasticsearch.cli.Terminal;
 import org.elasticsearch.cli.UserException;
 import org.elasticsearch.common.Strings;
-import org.elasticsearch.common.collect.Tuple;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.env.Environment;
 import org.elasticsearch.xpack.core.XPackSettings;
 import org.elasticsearch.xpack.core.security.authc.support.Hasher;
 import org.elasticsearch.xpack.core.security.support.Validation;
 import org.elasticsearch.xpack.security.authc.service.ServiceAccount.ServiceAccountId;
+import org.elasticsearch.xpack.security.authc.service.ServiceAccountToken.ServiceAccountTokenId;
 import org.elasticsearch.xpack.security.support.FileAttributesChecker;
 
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
+import java.util.function.Predicate;
 
 public class FileTokensTool extends LoggingAwareMultiCommand {
 
@@ -38,7 +39,7 @@ public class FileTokensTool extends LoggingAwareMultiCommand {
     public FileTokensTool() {
         super("Manages elasticsearch service account file-tokens");
         subcommands.put("create", newCreateFileTokenCommand());
-        subcommands.put("remove", newRemoveFileTokenCommand());
+        subcommands.put("delete", newDeleteFileTokenCommand());
         subcommands.put("list", newListFileTokenCommand());
     }
 
@@ -46,8 +47,8 @@ public class FileTokensTool extends LoggingAwareMultiCommand {
         return new CreateFileTokenCommand();
     }
 
-    protected RemoveFileTokenCommand newRemoveFileTokenCommand() {
-        return new RemoveFileTokenCommand();
+    protected DeleteFileTokenCommand newDeleteFileTokenCommand() {
+        return new DeleteFileTokenCommand();
     }
 
     protected ListFileTokenCommand newListFileTokenCommand() {
@@ -65,23 +66,14 @@ public class FileTokensTool extends LoggingAwareMultiCommand {
 
         @Override
         protected void execute(Terminal terminal, OptionSet options, Environment env) throws Exception {
-            final Tuple<String, String> tuple = parsePrincipalAndTokenName(arguments.values(options), env.settings());
-            final String principal = tuple.v1();
-            final String tokenName = tuple.v2();
-            if (false == ServiceAccountService.isServiceAccountPrincipal(principal)) {
-                throw new UserException(ExitCodes.NO_USER, "Unknown service account principal: [" + principal + "]. Must be one of ["
-                    + Strings.collectionToDelimitedString(ServiceAccountService.getServiceAccountPrincipals(), ",") + "]");
-            }
-            if (false == Validation.isValidServiceAccountTokenName(tokenName)) {
-                throw new UserException(ExitCodes.CODE_ERROR, Validation.INVALID_SERVICE_ACCOUNT_TOKEN_NAME_MESSAGE);
-            }
+            final ServiceAccountTokenId accountTokenId = parsePrincipalAndTokenName(arguments.values(options), env.settings());
             final Hasher hasher = Hasher.resolve(XPackSettings.SERVICE_TOKEN_HASHING_ALGORITHM.get(env.settings()));
             final Path serviceTokensFile = FileServiceAccountsTokenStore.resolveFile(env);
 
             FileAttributesChecker attributesChecker = new FileAttributesChecker(serviceTokensFile);
             final Map<String, char[]> tokenHashes = new TreeMap<>(FileServiceAccountsTokenStore.parseFile(serviceTokensFile, null));
 
-            try (ServiceAccountToken token = ServiceAccountToken.newToken(ServiceAccountId.fromPrincipal(principal), tokenName)) {
+            try (ServiceAccountToken token = ServiceAccountToken.newToken(accountTokenId.getAccountId(), accountTokenId.getTokenName())) {
                 if (tokenHashes.containsKey(token.getQualifiedName())) {
                     throw new UserException(ExitCodes.CODE_ERROR, "Service token [" + token.getQualifiedName() + "] already exists");
                 }
@@ -93,41 +85,92 @@ public class FileTokensTool extends LoggingAwareMultiCommand {
             attributesChecker.check(terminal);
         }
 
-        static Tuple<String, String> parsePrincipalAndTokenName(List<String> arguments, Settings settings) throws UserException {
-            if (arguments.isEmpty()) {
-                throw new UserException(ExitCodes.USAGE, "Missing service-account-principal and token-name arguments");
-            } else if (arguments.size() == 1) {
-                throw new UserException(ExitCodes.USAGE, "Missing token-name argument");
-            } else if (arguments.size() > 2) {
-                throw new UserException(
-                    ExitCodes.USAGE,
-                    "Expected two arguments, service-account-principal and token-name, found extra: " + arguments.toString());
-            }
-            return new Tuple<>(arguments.get(0), arguments.get(1));
-        }
     }
 
-    static class RemoveFileTokenCommand extends EnvironmentAwareCommand {
+    static class DeleteFileTokenCommand extends EnvironmentAwareCommand {
 
-        RemoveFileTokenCommand() {
+        private final OptionSpec<String> arguments;
+
+        DeleteFileTokenCommand() {
             super("Remove a file token for specified service account and token name");
+            this.arguments = parser.nonOptions("service-account-principal token-name");
         }
 
         @Override
         protected void execute(Terminal terminal, OptionSet options, Environment env) throws Exception {
-            throw new UnsupportedOperationException("remove command not implemented yet");
+            final ServiceAccountTokenId accountTokenId = parsePrincipalAndTokenName(arguments.values(options), env.settings());
+            final String qualifiedName = accountTokenId.getQualifiedName();
+            final Path serviceTokensFile = FileServiceAccountsTokenStore.resolveFile(env);
+
+            FileAttributesChecker attributesChecker = new FileAttributesChecker(serviceTokensFile);
+            final Map<String, char[]> tokenHashes = new TreeMap<>(FileServiceAccountsTokenStore.parseFile(serviceTokensFile, null));
+
+            if (tokenHashes.remove(qualifiedName) == null) {
+                throw new UserException(ExitCodes.CODE_ERROR, "Service token [" + qualifiedName + "] does not exist");
+            } else {
+                FileServiceAccountsTokenStore.writeFile(serviceTokensFile, tokenHashes);
+            }
+            attributesChecker.check(terminal);
         }
     }
 
     static class ListFileTokenCommand extends EnvironmentAwareCommand {
 
+        private final OptionSpec<String> arguments;
+
         ListFileTokenCommand() {
             super("List file tokens for the specified service account");
+            this.arguments = parser.nonOptions("service-account-principal");
         }
 
         @Override
         protected void execute(Terminal terminal, OptionSet options, Environment env) throws Exception {
-            throw new UnsupportedOperationException("list command not implemented yet");
+            final List<String> args = arguments.values(options);
+            if (args.size() > 1) {
+                throw new UserException(
+                    ExitCodes.USAGE,
+                    "Expected at most one argument, service-account-principal, found extra: ["
+                        + Strings.collectionToCommaDelimitedString(args) + "]");
+            }
+            Predicate<String> filter = k -> true;
+            if (args.size() == 1) {
+                final String principal = args.get(0);
+                if (false == ServiceAccountService.isServiceAccountPrincipal(principal)) {
+                    throw new UserException(ExitCodes.NO_USER, "Unknown service account principal: [" + principal + "]. Must be one of ["
+                        + Strings.collectionToDelimitedString(ServiceAccountService.getServiceAccountPrincipals(), ",") + "]");
+                }
+                filter = filter.and(k -> k.startsWith(principal + "/"));
+            }
+            final Path serviceTokensFile = FileServiceAccountsTokenStore.resolveFile(env);
+            final Map<String, char[]> tokenHashes = new TreeMap<>(FileServiceAccountsTokenStore.parseFile(serviceTokensFile, null));
+            for (String key : tokenHashes.keySet()) {
+                if (filter.test(key)) {
+                    terminal.println(key);
+                }
+            }
         }
+    }
+
+    static ServiceAccountTokenId parsePrincipalAndTokenName(List<String> arguments, Settings settings) throws UserException {
+        if (arguments.isEmpty()) {
+            throw new UserException(ExitCodes.USAGE, "Missing service-account-principal and token-name arguments");
+        } else if (arguments.size() == 1) {
+            throw new UserException(ExitCodes.USAGE, "Missing token-name argument");
+        } else if (arguments.size() > 2) {
+            throw new UserException(
+                ExitCodes.USAGE,
+                "Expected two arguments, service-account-principal and token-name, found extra: ["
+                    + Strings.collectionToCommaDelimitedString(arguments) + "]");
+        }
+        final String principal = arguments.get(0);
+        final String tokenName = arguments.get(1);
+        if (false == ServiceAccountService.isServiceAccountPrincipal(principal)) {
+            throw new UserException(ExitCodes.NO_USER, "Unknown service account principal: [" + principal + "]. Must be one of ["
+                + Strings.collectionToDelimitedString(ServiceAccountService.getServiceAccountPrincipals(), ",") + "]");
+        }
+        if (false == Validation.isValidServiceAccountTokenName(tokenName)) {
+            throw new UserException(ExitCodes.CODE_ERROR, Validation.INVALID_SERVICE_ACCOUNT_TOKEN_NAME_MESSAGE);
+        }
+        return new ServiceAccountTokenId(ServiceAccountId.fromPrincipal(principal), tokenName);
     }
 }

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/service/IndexServiceAccountsTokenStore.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/service/IndexServiceAccountsTokenStore.java
@@ -48,6 +48,7 @@ import org.elasticsearch.xpack.core.security.action.service.TokenInfo;
 import org.elasticsearch.xpack.core.security.authc.Authentication;
 import org.elasticsearch.xpack.core.security.authc.support.Hasher;
 import org.elasticsearch.xpack.security.authc.service.ServiceAccount.ServiceAccountId;
+import org.elasticsearch.xpack.security.authc.service.ServiceAccountToken.ServiceAccountTokenId;
 import org.elasticsearch.xpack.security.support.CacheInvalidatorRegistry;
 import org.elasticsearch.xpack.security.support.SecurityIndexManager;
 
@@ -175,7 +176,8 @@ public class IndexServiceAccountsTokenStore extends CachingServiceAccountsTokenS
                 listener.onResponse(false);
                 return;
             }
-            final String qualifiedTokenName = ServiceAccountToken.buildQualifiedName(accountId, request.getTokenName());
+            final ServiceAccountTokenId accountTokenId = new ServiceAccountTokenId(accountId, request.getTokenName());
+            final String qualifiedTokenName = accountTokenId.getQualifiedName();
             securityIndex.checkIndexVersionThenExecute(listener::onFailure, () -> {
                 final DeleteRequest deleteRequest =
                     client.prepareDelete(SECURITY_MAIN_ALIAS, SINGLE_MAPPING_NAME, docIdForToken(qualifiedTokenName)).request();

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/service/ServiceAccountToken.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/service/ServiceAccountToken.java
@@ -32,8 +32,7 @@ import java.util.Objects;
  * A decoded credential that may be used to authenticate a {@link ServiceAccount}.
  * It consists of:
  * <ol>
- *   <li>A {@link #getAccountId() service account id}</li>
- *   <li>The {@link #getTokenName() name of the token} to be used</li>
+ *   <li>A {@link #getTokenId() service account token ID}</li>
  *   <li>The {@link #getSecret() secret credential} for that token</li>
  * </ol>
  */
@@ -47,34 +46,33 @@ public class ServiceAccountToken implements AuthenticationToken, Closeable {
 
     private static final Logger logger = LogManager.getLogger(ServiceAccountToken.class);
 
-    private final ServiceAccountId accountId;
-    private final String tokenName;
+    private final ServiceAccountTokenId tokenId;
     private final SecureString secret;
 
     // pkg private for testing
     ServiceAccountToken(ServiceAccountId accountId, String tokenName, SecureString secret) {
-        this.accountId = Objects.requireNonNull(accountId, "service account ID cannot be null");
-        if (false == Validation.isValidServiceAccountTokenName(tokenName)) {
-            throw new IllegalArgumentException(Validation.INVALID_SERVICE_ACCOUNT_TOKEN_NAME_MESSAGE);
-        }
-        this.tokenName = tokenName;
+        tokenId = new ServiceAccountTokenId(accountId, tokenName);
         this.secret = Objects.requireNonNull(secret, "service account token secret cannot be null");
     }
 
-    public ServiceAccountId getAccountId() {
-        return accountId;
-    }
-
-    public String getTokenName() {
-        return tokenName;
+    public ServiceAccountTokenId getTokenId() {
+        return tokenId;
     }
 
     public SecureString getSecret() {
         return secret;
     }
 
+    public ServiceAccountId getAccountId() {
+        return tokenId.getAccountId();
+    }
+
+    public String getTokenName() {
+        return tokenId.getTokenName();
+    }
+
     public String getQualifiedName() {
-        return buildQualifiedName(getAccountId(), tokenName);
+        return tokenId.getQualifiedName();
     }
 
     public SecureString asBearerString() throws IOException {
@@ -86,10 +84,6 @@ public class ServiceAccountToken implements AuthenticationToken, Closeable {
             final String base64 = Base64.getEncoder().withoutPadding().encodeToString(out.toByteArray());
             return new SecureString(base64.toCharArray());
         }
-    }
-
-    public static String buildQualifiedName(ServiceAccountId accountId, String tokenName) {
-        return accountId.asPrincipal() + "/" + tokenName;
     }
 
     public static ServiceAccountToken fromBearerString(SecureString bearerString) throws IOException {
@@ -138,12 +132,12 @@ public class ServiceAccountToken implements AuthenticationToken, Closeable {
         if (o == null || getClass() != o.getClass())
             return false;
         ServiceAccountToken that = (ServiceAccountToken) o;
-        return accountId.equals(that.accountId) && tokenName.equals(that.tokenName) && secret.equals(that.secret);
+        return tokenId.equals(that.tokenId) && secret.equals(that.secret);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(accountId, tokenName, secret);
+        return Objects.hash(tokenId, secret);
     }
 
     public static ServiceAccountToken newToken(ServiceAccountId accountId, String tokenName) {
@@ -152,7 +146,7 @@ public class ServiceAccountToken implements AuthenticationToken, Closeable {
 
     @Override
     public String principal() {
-        return accountId.asPrincipal();
+        return tokenId.getAccountId().asPrincipal();
     }
 
     @Override
@@ -165,4 +159,48 @@ public class ServiceAccountToken implements AuthenticationToken, Closeable {
         close();
     }
 
+    public static class ServiceAccountTokenId {
+        private final ServiceAccountId accountId;
+        private final String tokenName;
+
+        public ServiceAccountTokenId(ServiceAccountId accountId, String tokenName) {
+            this.accountId = Objects.requireNonNull(accountId, "service account ID cannot be null");
+            if (false == Validation.isValidServiceAccountTokenName(tokenName)) {
+                throw new IllegalArgumentException(Validation.INVALID_SERVICE_ACCOUNT_TOKEN_NAME_MESSAGE);
+            }
+            this.tokenName = Objects.requireNonNull(tokenName, "service account token name cannot be null");
+        }
+
+        public ServiceAccountId getAccountId() {
+            return accountId;
+        }
+
+        public String getTokenName() {
+            return tokenName;
+        }
+
+        public String getQualifiedName() {
+            return accountId.asPrincipal() + "/" + tokenName;
+        }
+
+        @Override
+        public String toString() {
+            return getQualifiedName();
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o)
+                return true;
+            if (o == null || getClass() != o.getClass())
+                return false;
+            ServiceAccountTokenId that = (ServiceAccountTokenId) o;
+            return accountId.equals(that.accountId) && tokenName.equals(that.tokenName);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(accountId, tokenName);
+        }
+    }
 }

--- a/x-pack/qa/security-tools-tests/src/test/java/org/elasticsearch/xpack/security/authc/service/FileTokensToolTests.java
+++ b/x-pack/qa/security-tools-tests/src/test/java/org/elasticsearch/xpack/security/authc/service/FileTokensToolTests.java
@@ -13,7 +13,6 @@ import org.elasticsearch.cli.Command;
 import org.elasticsearch.cli.CommandTestCase;
 import org.elasticsearch.cli.UserException;
 import org.elasticsearch.common.UUIDs;
-import org.elasticsearch.common.collect.Tuple;
 import org.elasticsearch.common.io.PathUtilsForTesting;
 import org.elasticsearch.common.settings.SecureString;
 import org.elasticsearch.common.settings.Settings;
@@ -22,7 +21,7 @@ import org.elasticsearch.env.Environment;
 import org.elasticsearch.xpack.core.security.authc.support.Hasher;
 import org.elasticsearch.xpack.core.security.support.Validation;
 import org.elasticsearch.xpack.core.security.support.ValidationTests;
-import org.elasticsearch.xpack.security.authc.service.FileTokensTool.CreateFileTokenCommand;
+import org.elasticsearch.xpack.security.authc.service.ServiceAccountToken.ServiceAccountTokenId;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -37,6 +36,8 @@ import java.util.Map;
 
 import static org.elasticsearch.test.SecurityIntegTestCase.getFastStoredHashAlgoForTests;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.emptyString;
+import static org.hamcrest.Matchers.is;
 
 public class FileTokensToolTests extends CommandTestCase {
 
@@ -103,28 +104,48 @@ public class FileTokensToolTests extends CommandTestCase {
                     }
                 };
             }
+
+            @Override
+            protected DeleteFileTokenCommand newDeleteFileTokenCommand() {
+                return new DeleteFileTokenCommand() {
+                    @Override
+                    protected Environment createEnv(Map<String, String> settings) throws UserException {
+                        return new Environment(FileTokensToolTests.this.settings, confDir);
+                    }
+                };
+            }
+
+            @Override
+            protected ListFileTokenCommand newListFileTokenCommand() {
+                return new ListFileTokenCommand() {
+                    @Override
+                    protected Environment createEnv(Map<String, String> settings) throws UserException {
+                        return new Environment(FileTokensToolTests.this.settings, confDir);
+                    }
+                };
+            }
         };
     }
 
     public void testParsePrincipalAndTokenName() throws UserException {
         final String tokenName1 = randomAlphaOfLengthBetween(3, 8);
-        final Tuple<String, String> tuple1 =
-            CreateFileTokenCommand.parsePrincipalAndTokenName(
+        final ServiceAccountTokenId accountTokenId =
+            FileTokensTool.parsePrincipalAndTokenName(
                 org.elasticsearch.common.collect.List.of("elastic/fleet-server", tokenName1), Settings.EMPTY);
-        assertEquals("elastic/fleet-server", tuple1.v1());
-        assertEquals(tokenName1, tuple1.v2());
+        assertEquals("elastic/fleet-server", accountTokenId.getAccountId().asPrincipal());
+        assertEquals(tokenName1, accountTokenId.getTokenName());
 
         final UserException e2 = expectThrows(UserException.class,
-            () -> CreateFileTokenCommand.parsePrincipalAndTokenName(
+            () -> FileTokensTool.parsePrincipalAndTokenName(
                 org.elasticsearch.common.collect.List.of(randomAlphaOfLengthBetween(6, 16)), Settings.EMPTY));
         assertThat(e2.getMessage(), containsString("Missing token-name argument"));
 
         final UserException e3 = expectThrows(UserException.class,
-            () -> CreateFileTokenCommand.parsePrincipalAndTokenName(org.elasticsearch.common.collect.List.of(), Settings.EMPTY));
+            () -> FileTokensTool.parsePrincipalAndTokenName(org.elasticsearch.common.collect.List.of(), Settings.EMPTY));
         assertThat(e3.getMessage(), containsString("Missing service-account-principal and token-name arguments"));
 
         final UserException e4 = expectThrows(UserException.class,
-            () -> CreateFileTokenCommand.parsePrincipalAndTokenName(
+            () -> FileTokensTool.parsePrincipalAndTokenName(
                 org.elasticsearch.common.collect.List.of(randomAlphaOfLengthBetween(6, 16),
                     randomAlphaOfLengthBetween(3, 8), randomAlphaOfLengthBetween(3, 8)),
                 Settings.EMPTY));
@@ -167,6 +188,91 @@ public class FileTokensToolTests extends CommandTestCase {
                 randomAlphaOfLengthBetween(3, 8)));
         assertThat(e.getMessage(), containsString("Unknown service account principal: "));
         assertThat(e.getMessage(), containsString("Must be one of "));
+    }
+
+    public void testDeleteToken() throws Exception {
+        final String tokenName = randomFrom("server_1", "server_2", "server_3");
+        final String principal = "elastic/fleet-server";
+        final String qualifiedName = principal + "/" + tokenName;
+        assertServiceTokenExists(qualifiedName);
+        execute("delete", pathHomeParameter, principal, tokenName);
+        assertServiceTokenNotExists(qualifiedName);
+    }
+
+    public void testDeleteTokenIncorrect() throws IOException {
+        // Invalid principal
+        final UserException e1 = expectThrows(UserException.class,
+            () -> execute("delete", pathHomeParameter,
+                randomFrom("elastic/foo", "foo/fleet-server", randomAlphaOfLengthBetween(6, 16)),
+                randomAlphaOfLengthBetween(3, 8)));
+        assertThat(e1.getMessage(), containsString("Unknown service account principal: "));
+        assertThat(e1.getMessage(), containsString("Must be one of "));
+
+        // Invalid token name
+        final String tokenName2 = ValidationTests.randomInvalidTokenName();
+        final String[] args = tokenName2.startsWith("-") ?
+            new String[] { "delete", pathHomeParameter, "elastic/fleet-server", "--", tokenName2 } :
+            new String[] { "delete", pathHomeParameter, "elastic/fleet-server", tokenName2 };
+        final UserException e2 = expectThrows(UserException.class, () -> execute(args));
+        assertThat(e2.getMessage(), containsString(Validation.INVALID_SERVICE_ACCOUNT_TOKEN_NAME_MESSAGE));
+
+        // Non-exist token
+        final Path serviceTokensFile = confDir.resolve("service_tokens");
+        final boolean fileDeleted = randomBoolean();
+        if (fileDeleted) {
+            Files.delete(serviceTokensFile);
+        }
+        final String tokenName3 = randomAlphaOfLengthBetween(3, 8);
+        final UserException e3 = expectThrows(UserException.class,
+            () -> execute("delete", pathHomeParameter, "elastic/fleet-server", tokenName3));
+        assertThat(e3.getMessage(), containsString("Service token [elastic/fleet-server/" + tokenName3 + "] does not exist"));
+        if (fileDeleted) {
+            // The file should not be created if not exists in the first place
+            assertThat(Files.notExists(serviceTokensFile), is(true));
+        }
+    }
+
+    public void testListTokens() throws Exception {
+        execute("list", pathHomeParameter);
+        final String output = terminal.getOutput();
+        assertThat(output, containsString("elastic/fleet-server/server_1\n" +
+            "elastic/fleet-server/server_2\n" +
+            "elastic/fleet-server/server_3"));
+    }
+
+    public void testListTokensByPrincipal() throws Exception {
+        execute("list", pathHomeParameter, "elastic/fleet-server");
+        final String output = terminal.getOutput();
+        assertThat(output, containsString("elastic/fleet-server/server_1\n" +
+            "elastic/fleet-server/server_2\n" +
+            "elastic/fleet-server/server_3"));
+    }
+
+    public void testListTokensNonExist() throws Exception {
+        // Invalid principal
+        final UserException e1 = expectThrows(UserException.class,
+            () -> execute("list", pathHomeParameter,
+                randomFrom("elastic/foo", "foo/fleet-server", randomAlphaOfLengthBetween(6, 16))));
+        assertThat(e1.getMessage(), containsString("Unknown service account principal: "));
+        assertThat(e1.getMessage(), containsString("Must be one of "));
+
+        // Delete all tokens
+        execute("delete", pathHomeParameter, "elastic/fleet-server", "server_1");
+        execute("delete", pathHomeParameter, "elastic/fleet-server", "server_2");
+        execute("delete", pathHomeParameter, "elastic/fleet-server", "server_3");
+        execute("list", pathHomeParameter, "elastic/fleet-server");
+        final String output = terminal.getOutput();
+        assertThat(output, is(emptyString()));
+    }
+
+    public void testListTokensFileNotExists() throws Exception {
+        final Path serviceTokensFile = confDir.resolve("service_tokens");
+        Files.delete(serviceTokensFile);
+        execute("list", pathHomeParameter, "elastic/fleet-server");
+        final String output = terminal.getOutput();
+        assertThat(output, is(emptyString()));
+        // List should not create the file
+        assertThat(Files.notExists(serviceTokensFile), is(true));
     }
 
     private void assertServiceTokenExists(String key) throws IOException {


### PR DESCRIPTION
This PR adds the implementations for deleting and listing file tokens using
the elasticsearch-service-tokens CLI tool.
