### PR TITLE
DOCS: update `delete_searchable_snapshot` option documentation

### DIFF
--- a/docs/reference/ilm/actions/ilm-delete.asciidoc
+++ b/docs/reference/ilm/actions/ilm-delete.asciidoc
@@ -14,7 +14,7 @@ Permanently removes the index.
 Deletes the searchable snapshot created in a previous phase.
 Defaults to `true`.
 This option is applicable when the <<ilm-searchable-snapshot,searchable
-snapshot>> action is used in a previous phase.
+snapshot>> action is used in any previous phase.
 
 [[ilm-delete-action-ex]]
 ==== Example

--- a/docs/reference/ilm/actions/ilm-delete.asciidoc
+++ b/docs/reference/ilm/actions/ilm-delete.asciidoc
@@ -14,7 +14,7 @@ Permanently removes the index.
 Deletes the searchable snapshot created in a previous phase.
 Defaults to `true`.
 This option is applicable when the <<ilm-searchable-snapshot,searchable
-snapshot>> action is used in the cold phase.
+snapshot>> action is used in a previous phase.
 
 [[ilm-delete-action-ex]]
 ==== Example


### PR DESCRIPTION
If enabled, the `delete_searchable_snapshot` option will attempt to delete the
index snapshot generated in any previous phase, for the purpose of mounting the
index as a searchable snapshot.