### PR TITLE
Adjust numeric and boolean representation in YAML tests

### DIFF
--- a/modules/aggs-matrix-stats/src/yamlRestTest/resources/rest-api-spec/test/stats/20_empty_bucket.yml
+++ b/modules/aggs-matrix-stats/src/yamlRestTest/resources/rest-api-spec/test/stats/20_empty_bucket.yml
@@ -5,7 +5,7 @@
         index: empty_bucket_idx
         body:
           settings:
-            number_of_shards: "3"
+            number_of_shards: 3
           mappings:
             "properties":
               "value":

--- a/modules/lang-painless/src/yamlRestTest/resources/rest-api-spec/test/painless/30_search.yml
+++ b/modules/lang-painless/src/yamlRestTest/resources/rest-api-spec/test/painless/30_search.yml
@@ -419,7 +419,7 @@
             index: test
             body:
               settings:
-                number_of_shards: "1"
+                number_of_shards: 1
 
     - do:
         index:

--- a/modules/reindex/src/yamlRestTest/resources/rest-api-spec/test/reindex/70_throttle.yml
+++ b/modules/reindex/src/yamlRestTest/resources/rest-api-spec/test/reindex/70_throttle.yml
@@ -7,8 +7,8 @@
         index: source
         body:
           settings:
-            number_of_shards: "1"
-            number_of_replicas: "0"
+            number_of_shards: 1
+            number_of_replicas: 0
   - do:
       index:
         index:   source
@@ -53,8 +53,8 @@
         index: source
         body:
           settings:
-            number_of_shards: "1"
-            number_of_replicas: "0"
+            number_of_shards: 1
+            number_of_replicas: 0
   - do:
       index:
         index:   source
@@ -99,8 +99,8 @@
         index: source
         body:
           settings:
-            number_of_shards: "1"
-            number_of_replicas: "0"
+            number_of_shards: 1
+            number_of_replicas: 0
   - do:
       index:
         index:   source
@@ -151,8 +151,8 @@
         index: source
         body:
           settings:
-            number_of_shards: "1"
-            number_of_replicas: "0"
+            number_of_shards: 1
+            number_of_replicas: 0
   - do:
       index:
         index:   source

--- a/modules/reindex/src/yamlRestTest/resources/rest-api-spec/test/reindex/90_remote.yml
+++ b/modules/reindex/src/yamlRestTest/resources/rest-api-spec/test/reindex/90_remote.yml
@@ -392,8 +392,8 @@
         index: source
         body:
           settings:
-            number_of_shards: "1"
-            number_of_replicas: "0"
+            number_of_shards: 1
+            number_of_replicas: 0
   - do:
       index:
         index:   source

--- a/plugins/mapper-annotated-text/src/yamlRestTest/resources/rest-api-spec/test/mapper_annotatedtext/10_basic.yml
+++ b/plugins/mapper-annotated-text/src/yamlRestTest/resources/rest-api-spec/test/mapper_annotatedtext/10_basic.yml
@@ -8,8 +8,8 @@
         index: annotated
         body:
           settings:
-            number_of_shards: "1"
-            number_of_replicas: "0"
+            number_of_shards: 1
+            number_of_replicas: 0
           mappings:
             properties:
               text:
@@ -81,8 +81,8 @@
         index: annotated
         body:
           settings:
-            number_of_shards: "5"
-            number_of_replicas: "0"
+            number_of_shards: 5
+            number_of_replicas: 0
           mappings:
             properties:
               my_field:
@@ -180,8 +180,8 @@
         index: annotated
         body:
           settings:
-            number_of_shards: "1"
-            number_of_replicas: "0"
+            number_of_shards: 1
+            number_of_replicas: 0
           mappings:
             properties:
               my_field:
@@ -221,8 +221,8 @@
         index: annotated
         body:
           settings:
-            number_of_shards: "1"
-            number_of_replicas: "0"
+            number_of_shards: 1
+            number_of_replicas: 0
             index.highlight.max_analyzed_offset: 20
           mappings:
             properties:
@@ -260,8 +260,8 @@
         index: annotated
         body:
           settings:
-            number_of_shards: "1"
-            number_of_replicas: "0"
+            number_of_shards: 1
+            number_of_replicas: 0
             index.highlight.max_analyzed_offset: 20
           mappings:
             properties:

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/cat.aliases/40_hidden.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/cat.aliases/40_hidden.yml
@@ -9,8 +9,8 @@
         index: test
         body:
           settings:
-            number_of_shards: "1"
-            number_of_replicas: "0"
+            number_of_shards: 1
+            number_of_replicas: 0
             index:
               hidden: true
           aliases:
@@ -66,8 +66,8 @@
         index: test
         body:
           settings:
-            number_of_shards: "1"
-            number_of_replicas: "0"
+            number_of_shards: 1
+            number_of_replicas: 0
             index:
               hidden: true
           aliases:
@@ -113,8 +113,8 @@
         index: test
         body:
           settings:
-            number_of_shards: "1"
-            number_of_replicas: "0"
+            number_of_shards: 1
+            number_of_replicas: 0
           aliases:
             test_alias:
               is_hidden: true

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/cat.fielddata/10_basic.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/cat.fielddata/10_basic.yml
@@ -25,7 +25,7 @@
         index:  index
         body:
           settings:
-            number_of_shards: "1"
+            number_of_shards: 1
           mappings:
             properties:
               foo:

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/cat.indices/10_basic.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/cat.indices/10_basic.yml
@@ -15,8 +15,8 @@
         index: index1
         body:
           settings:
-            number_of_shards: "1"
-            number_of_replicas: "0"
+            number_of_shards: 1
+            number_of_replicas: 0
   - do:
       cat.indices: {}
 
@@ -150,14 +150,14 @@
         index: foo
         body:
           settings:
-            number_of_shards: "1"
-            number_of_replicas: "0"
+            number_of_shards: 1
+            number_of_replicas: 0
   - do:
       indices.create:
         index: bar
         body:
           settings:
-            number_of_shards: "1"
+            number_of_shards: 1
             number_of_replicas: $count
 
   - do:
@@ -186,24 +186,24 @@
         index: foo
         body:
           settings:
-            number_of_shards: "1"
-            number_of_replicas: "0"
+            number_of_shards: 1
+            number_of_replicas: 0
 
   - do:
       indices.create:
         index: bar
         body:
           settings:
-            number_of_shards: "1"
-            number_of_replicas: "0"
+            number_of_shards: 1
+            number_of_replicas: 0
 
   - do:
       indices.create:
         index: baz
         body:
           settings:
-            number_of_shards: "1"
-            number_of_replicas: "0"
+            number_of_shards: 1
+            number_of_replicas: 0
 
   - do:
       cat.indices:
@@ -235,24 +235,24 @@
         index: foo
         body:
           settings:
-            number_of_shards: "1"
-            number_of_replicas: "0"
+            number_of_shards: 1
+            number_of_replicas: 0
 
   - do:
       indices.create:
         index: bar
         body:
           settings:
-            number_of_shards: "1"
-            number_of_replicas: "0"
+            number_of_shards: 1
+            number_of_replicas: 0
 
   - do:
       indices.create:
         index: baz
         body:
           settings:
-            number_of_shards: "1"
-            number_of_replicas: "0"
+            number_of_shards: 1
+            number_of_replicas: 0
 
   - do:
       indices.close:
@@ -295,8 +295,8 @@
         index: foo
         body:
           settings:
-            number_of_shards: "1"
-            number_of_replicas: "0"
+            number_of_shards: 1
+            number_of_replicas: 0
 
   - do:
       catch: bad_request

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/cat.indices/20_hidden.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/cat.indices/20_hidden.yml
@@ -8,8 +8,8 @@
         index: index1
         body:
           settings:
-            number_of_shards: "1"
-            number_of_replicas: "0"
+            number_of_shards: 1
+            number_of_replicas: 0
             index:
               hidden: true
   - do:
@@ -46,8 +46,8 @@
         index: .index1
         body:
           settings:
-            number_of_shards: "1"
-            number_of_replicas: "0"
+            number_of_shards: 1
+            number_of_replicas: 0
             index:
               hidden: true
   - do:
@@ -85,8 +85,8 @@
         index: index1
         body:
           settings:
-            number_of_shards: "1"
-            number_of_replicas: "0"
+            number_of_shards: 1
+            number_of_replicas: 0
             index:
               hidden: true
           aliases:
@@ -147,8 +147,8 @@
         index: index1
         body:
           settings:
-            number_of_shards: "1"
-            number_of_replicas: "0"
+            number_of_shards: 1
+            number_of_replicas: 0
             index:
               hidden: true
           aliases:
@@ -207,8 +207,8 @@
         index: index1
         body:
           settings:
-            number_of_shards: "1"
-            number_of_replicas: "0"
+            number_of_shards: 1
+            number_of_replicas: 0
             index:
               hidden: true
           aliases:

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/cat.segments/10_basic.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/cat.segments/10_basic.yml
@@ -37,8 +37,8 @@
         index: index1
         body:
           settings:
-            number_of_shards: "3"
-            number_of_replicas: "0"
+            number_of_shards: 3
+            number_of_replicas: 0
   - do:
       index:
         index: index1
@@ -56,8 +56,8 @@
         index: index2
         body:
           settings:
-            number_of_shards: "3"
-            number_of_replicas: "0"
+            number_of_shards: 3
+            number_of_replicas: 0
   - do:
       index:
         index: index2
@@ -91,8 +91,8 @@
         index: index1
         body:
           settings:
-            number_of_shards: "1"
-            number_of_replicas: "0"
+            number_of_shards: 1
+            number_of_replicas: 0
 
   - do:
       indices.close:
@@ -113,8 +113,8 @@
         index: foo
         body:
           settings:
-            number_of_shards: "1"
-            number_of_replicas: "0"
+            number_of_shards: 1
+            number_of_replicas: 0
 
   - do:
       index:
@@ -127,8 +127,8 @@
         index: bar
         body:
           settings:
-            number_of_shards: "1"
-            number_of_replicas: "0"
+            number_of_shards: 1
+            number_of_replicas: 0
 
   - do:
       index:
@@ -141,8 +141,8 @@
         index: baz
         body:
           settings:
-            number_of_shards: "1"
-            number_of_replicas: "0"
+            number_of_shards: 1
+            number_of_replicas: 0
 
   - do:
       index:

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/cat.shards/10_basic.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/cat.shards/10_basic.yml
@@ -100,8 +100,8 @@
         index: index1
         body:
           settings:
-            number_of_shards: "5"
-            number_of_replicas: "1"
+            number_of_shards: 5
+            number_of_replicas: 1
   - do:
       cat.shards: {}
 
@@ -114,8 +114,8 @@
         index: index2
         body:
           settings:
-            number_of_shards: "5"
-            number_of_replicas: "0"
+            number_of_shards: 5
+            number_of_replicas: 0
 
   - do:
       cat.shards: {}
@@ -138,24 +138,24 @@
         index: foo
         body:
           settings:
-            number_of_shards: "1"
-            number_of_replicas: "0"
+            number_of_shards: 1
+            number_of_replicas: 0
 
   - do:
       indices.create:
         index: bar
         body:
           settings:
-            number_of_shards: "1"
-            number_of_replicas: "0"
+            number_of_shards: 1
+            number_of_replicas: 0
 
   - do:
       indices.create:
         index: baz
         body:
           settings:
-            number_of_shards: "1"
-            number_of_replicas: "0"
+            number_of_shards: 1
+            number_of_replicas: 0
 
   - do:
       cat.shards:
@@ -184,16 +184,16 @@
         index: foo
         body:
           settings:
-            number_of_shards: "1"
-            number_of_replicas: "0"
+            number_of_shards: 1
+            number_of_replicas: 0
 
   - do:
       indices.create:
         index: bar
         body:
           settings:
-            number_of_shards: "1"
-            number_of_replicas: "0"
+            number_of_shards: 1
+            number_of_replicas: 0
 
   - do:
       index:

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/cat.snapshots/10_basic.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/cat.snapshots/10_basic.yml
@@ -51,15 +51,15 @@
         index: index1
         body:
           settings:
-            number_of_shards: "1"
-            number_of_replicas: "0"
+            number_of_shards: 1
+            number_of_replicas: 0
   - do:
       indices.create:
         index: index2
         body:
           settings:
-            number_of_shards: "1"
-            number_of_replicas: "0"
+            number_of_shards: 1
+            number_of_replicas: 0
   - do:
        cluster.health:
          wait_for_status: green

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/cluster.reroute/11_explain.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/cluster.reroute/11_explain.yml
@@ -4,8 +4,8 @@ setup:
         index: test_index
         body:
           settings:
-            number_of_shards: "1"
-            number_of_replicas: "0"
+            number_of_shards: 1
+            number_of_replicas: 0
 
   - do:
       cluster.health:

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/cluster.state/30_expand_wildcards.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/cluster.state/30_expand_wildcards.yml
@@ -7,16 +7,16 @@ setup:
         index: test_close_index
         body:
           settings:
-            number_of_shards: "1"
-            number_of_replicas: "0"
+            number_of_shards: 1
+            number_of_replicas: 0
 
   - do:
       indices.create:
         index: test_open_index
         body:
           settings:
-            number_of_shards: "1"
-            number_of_replicas: "0"
+            number_of_shards: 1
+            number_of_replicas: 0
 
   - do:
       cluster.health:

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/delete/11_shard_header.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/delete/11_shard_header.yml
@@ -8,8 +8,8 @@
         index: foobar
         body:
           settings:
-            number_of_shards: "1"
-            number_of_replicas: "0"
+            number_of_shards: 1
+            number_of_replicas: 0
 
  - do:
       cluster.health:

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.clone/30_copy_settings.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.clone/30_copy_settings.yml
@@ -56,6 +56,6 @@
         index: "copy-settings-target"
 
   # settings should be copied
-  - match: { copy-settings-target.settings.index.merge.scheduler.max_merge_count: "4" }
-  - match: { copy-settings-target.settings.index.merge.scheduler.max_thread_count: "2" }
-  - match: { copy-settings-target.settings.index.blocks.write: "true" }
+  - match: { copy-settings-target.settings.index.merge.scheduler.max_merge_count: 4 }
+  - match: { copy-settings-target.settings.index.merge.scheduler.max_thread_count: 2 }
+  - match: { copy-settings-target.settings.index.blocks.write: true }

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.create/10_basic.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.create/10_basic.yml
@@ -23,13 +23,13 @@
         index: test_index
         body:
           settings:
-            number_of_replicas: "0"
+            number_of_replicas: 0
 
   - do:
       indices.get_settings:
         index: test_index
 
-  - match: { test_index.settings.index.number_of_replicas: "0"}
+  - match: { test_index.settings.index.number_of_replicas: 0}
 
 ---
 "Create index":
@@ -50,7 +50,7 @@
         wait_for_active_shards: all
         body:
           settings:
-            number_of_replicas: "0"
+            number_of_replicas: 0
 
   - match: { acknowledged: true }
   - match: { shards_acknowledged: true }

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.get_settings/10_basic.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.get_settings/10_basic.yml
@@ -21,10 +21,10 @@ setup:
  - do:
     indices.get_settings: {}
 
- - match: { test_1.settings.index.number_of_shards: "5"}
- - match: { test_1.settings.index.number_of_replicas: "1"}
- - match: { test_2.settings.index.number_of_shards: "3"}
- - match: { test_2.settings.index.number_of_replicas: "0"}
+ - match: { test_1.settings.index.number_of_shards: 5}
+ - match: { test_1.settings.index.number_of_replicas: 1}
+ - match: { test_2.settings.index.number_of_shards: 3}
+ - match: { test_2.settings.index.number_of_replicas: 0}
 
 ---
 "Get /{index}/_settings":
@@ -33,8 +33,8 @@ setup:
     indices.get_settings:
         index: test_1
 
- - match: { test_1.settings.index.number_of_shards: "5"}
- - match: { test_1.settings.index.number_of_replicas: "1"}
+ - match: { test_1.settings.index.number_of_shards: 5}
+ - match: { test_1.settings.index.number_of_replicas: 1}
  - is_false: test_2
 
 
@@ -46,8 +46,8 @@ setup:
         index: test_1
         name:  _all
 
- - match: { test_1.settings.index.number_of_shards: "5"}
- - match: { test_1.settings.index.number_of_replicas: "1"}
+ - match: { test_1.settings.index.number_of_shards: 5}
+ - match: { test_1.settings.index.number_of_replicas: 1}
  - is_false: test_2
 
 ---
@@ -58,8 +58,8 @@ setup:
         index: test_1
         name:  '*'
 
- - match: { test_1.settings.index.number_of_shards: "5"}
- - match: { test_1.settings.index.number_of_replicas: "1"}
+ - match: { test_1.settings.index.number_of_shards: 5}
+ - match: { test_1.settings.index.number_of_replicas: 1}
  - is_false: test_2
 
 ---
@@ -70,7 +70,7 @@ setup:
         index: test_1
         name:  index.number_of_shards
 
- - match: { test_1.settings.index.number_of_shards: "5"}
+ - match: { test_1.settings.index.number_of_shards: 5}
  - is_false: test_1.settings.index.number_of_replicas
  - is_false: test_2
 
@@ -82,8 +82,8 @@ setup:
         index: test_1
         name:  index.number_of_shards,index.number_of_replicas
 
- - match: { test_1.settings.index.number_of_shards: "5"}
- - match: { test_1.settings.index.number_of_replicas: "1"}
+ - match: { test_1.settings.index.number_of_shards: 5}
+ - match: { test_1.settings.index.number_of_replicas: 1}
  - is_false: test_2
 
 ---
@@ -94,7 +94,7 @@ setup:
         index: test_1
         name:  'index.number_of_s*'
 
- - match: { test_1.settings.index.number_of_shards: "5"}
+ - match: { test_1.settings.index.number_of_shards: 5}
  - is_false: test_1.settings.index.number_of_replicas
  - is_false: test_2
 
@@ -105,8 +105,8 @@ setup:
     indices.get_settings:
         name: index.number_of_shards
 
- - match: { test_1.settings.index.number_of_shards: "5"}
- - match: { test_2.settings.index.number_of_shards: "3"}
+ - match: { test_1.settings.index.number_of_shards: 5}
+ - match: { test_2.settings.index.number_of_shards: 3}
  - is_false: test_1.settings.index.number_of_replicas
  - is_false: test_2.settings.index.number_of_replicas
 
@@ -118,8 +118,8 @@ setup:
         index: _all
         name: index.number_of_shards
 
- - match: { test_1.settings.index.number_of_shards: "5"}
- - match: { test_2.settings.index.number_of_shards: "3"}
+ - match: { test_1.settings.index.number_of_shards: 5}
+ - match: { test_2.settings.index.number_of_shards: 3}
  - is_false: test_1.settings.index.number_of_replicas
  - is_false: test_2.settings.index.number_of_replicas
 
@@ -132,8 +132,8 @@ setup:
         index: '*'
         name: index.number_of_shards
 
- - match: { test_1.settings.index.number_of_shards: "5"}
- - match: { test_2.settings.index.number_of_shards: "3"}
+ - match: { test_1.settings.index.number_of_shards: 5}
+ - match: { test_2.settings.index.number_of_shards: 3}
  - is_false: test_1.settings.index.number_of_replicas
  - is_false: test_2.settings.index.number_of_replicas
 
@@ -145,8 +145,8 @@ setup:
         index: test_1,test_2
         name: index.number_of_shards
 
- - match: { test_1.settings.index.number_of_shards: "5"}
- - match: { test_2.settings.index.number_of_shards: "3"}
+ - match: { test_1.settings.index.number_of_shards: 5}
+ - match: { test_2.settings.index.number_of_shards: 3}
  - is_false: test_1.settings.index.number_of_replicas
  - is_false: test_2.settings.index.number_of_replicas
 
@@ -158,7 +158,7 @@ setup:
         index: '*2'
         name: index.number_of_shards
 
- - match: { test_2.settings.index.number_of_shards: "3"}
+ - match: { test_2.settings.index.number_of_shards: 3}
  - is_false: test_1
  - is_false: test_2.settings.index.number_of_replicas
 

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.get_settings/20_aliases.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.get_settings/20_aliases.yml
@@ -20,7 +20,7 @@
       indices.get_settings:
         index: test-alias
 
-  - match: { test-index.settings.index.number_of_replicas: "3" }
-  - match: { test-index.settings.index.number_of_shards: "2" }
-  - match: { test-index.settings.index.refresh_interval: "-1" }
+  - match: { test-index.settings.index.number_of_replicas: 3 }
+  - match: { test-index.settings.index.number_of_shards: 2 }
+  - match: { test-index.settings.index.refresh_interval: -1 }
 

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.put_index_template/15_composition.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.put_index_template/15_composition.yml
@@ -74,9 +74,9 @@
       indices.get:
         index: bar-baz
 
-  - match: {bar-baz.settings.index.number_of_shards: "2"}
-  - match: {bar-baz.settings.index.number_of_replicas: "0"}
-  - match: {bar-baz.settings.index.priority: "17"}
+  - match: {bar-baz.settings.index.number_of_shards: 2}
+  - match: {bar-baz.settings.index.number_of_replicas: 0}
+  - match: {bar-baz.settings.index.priority: 17}
   - match: {bar-baz.mappings.properties.field1: {type: text}}
   - match: {bar-baz.mappings.properties.field2: {type: keyword}}
   - match: {bar-baz.mappings.properties.field3: {type: integer}}
@@ -126,7 +126,7 @@
       indices.get:
         index: bar-baz
 
-  - match: {bar-baz.settings.index.number_of_shards: "3"}
+  - match: {bar-baz.settings.index.number_of_shards: 3}
 
 ---
 "Component template only composition":
@@ -199,7 +199,7 @@
       indices.get:
         index: eggplant
 
-  - match: {eggplant.settings.index.number_of_shards: "3"}
+  - match: {eggplant.settings.index.number_of_shards: 3}
 
 ---
 "Index template mapping merging":

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.put_settings/10_basic.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.put_settings/10_basic.yml
@@ -15,7 +15,7 @@ setup:
         flat_settings: true
 
   - match:
-      test-index.settings.index\.number_of_replicas: "0"
+      test-index.settings.index\.number_of_replicas: 0
 
   - do:
       indices.put_settings:
@@ -27,7 +27,7 @@ setup:
         flat_settings: false
 
   - match:
-      test-index.settings.index.number_of_replicas: "1"
+      test-index.settings.index.number_of_replicas: 1
 
 ---
 "Test indices settings ignore_unavailable":
@@ -42,7 +42,7 @@ setup:
       indices.get_settings: {}
 
   - match:
-      test-index.settings.index.number_of_replicas: "1"
+      test-index.settings.index.number_of_replicas: 1
 
 ---
 "Test indices settings allow_no_indices":
@@ -70,7 +70,7 @@ setup:
         flat_settings: false
 
   - match:
-      test-index.settings.index.number_of_replicas: "0"
+      test-index.settings.index.number_of_replicas: 0
 
   - do:
       indices.put_settings:
@@ -85,7 +85,7 @@ setup:
         flat_settings: false
 
   - match:
-      test-index.settings.index.number_of_replicas: "0"
+      test-index.settings.index.number_of_replicas: 0
   - match:
       test-index.settings.index.translog.durability: "async"
 

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.segments/10_basic.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.segments/10_basic.yml
@@ -20,8 +20,8 @@
         index: index1
         body:
           settings:
-            number_of_shards: "1"
-            number_of_replicas: "0"
+            number_of_shards: 1
+            number_of_replicas: 0
   - do:
       index:
         index: index1
@@ -50,8 +50,8 @@
         index: index1
         body:
           settings:
-            number_of_shards: "1"
-            number_of_replicas: "0"
+            number_of_shards: 1
+            number_of_replicas: 0
   - do:
       index:
         index: index1

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.shard_stores/10_basic.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.shard_stores/10_basic.yml
@@ -19,8 +19,8 @@
         index: index1
         body:
           settings:
-            number_of_shards: "1"
-            number_of_replicas: "0"
+            number_of_shards: 1
+            number_of_replicas: 0
   - do:
       index:
         index: index1
@@ -46,15 +46,15 @@
         index: index1
         body:
           settings:
-            number_of_shards: "1"
-            number_of_replicas: "0"
+            number_of_shards: 1
+            number_of_replicas: 0
   - do:
       indices.create:
         index: index2
         body:
           settings:
-            number_of_shards: "2"
-            number_of_replicas: "0"
+            number_of_shards: 2
+            number_of_replicas: 0
   - do:
       index:
         index: index1

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.shrink/30_copy_settings.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.shrink/30_copy_settings.yml
@@ -55,7 +55,7 @@
         index: "copy-settings-target"
 
   # settings should be copied
-  - match: { copy-settings-target.settings.index.merge.scheduler.max_merge_count: "4" }
-  - match: { copy-settings-target.settings.index.merge.scheduler.max_thread_count: "2" }
-  - match: { copy-settings-target.settings.index.blocks.write: "true" }
+  - match: { copy-settings-target.settings.index.merge.scheduler.max_merge_count: 4 }
+  - match: { copy-settings-target.settings.index.merge.scheduler.max_thread_count: 2 }
+  - match: { copy-settings-target.settings.index.blocks.write: true }
   - match: { copy-settings-target.settings.index.routing.allocation.include._id: $node_id }

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.simulate_index_template/10_basic.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.simulate_index_template/10_basic.yml
@@ -23,8 +23,8 @@
       indices.simulate_index_template:
         name: test
 
-  - match: {template.settings.index.number_of_shards: "1"}
-  - match: {template.settings.index.number_of_replicas: "0"}
+  - match: {template.settings.index.number_of_shards: 1}
+  - match: {template.settings.index.number_of_replicas: 0}
   - match: {template.mappings.properties.field.type: "keyword"}
   - match: {overlapping: []}
 
@@ -75,8 +75,8 @@
               test_alias: {}
           composed_of: ["ct"]
 
-  - match: {template.settings.index.blocks.write: "true"}
-  - match: {template.settings.index.number_of_replicas: "2"}
+  - match: {template.settings.index.blocks.write: true}
+  - match: {template.settings.index.number_of_replicas: 2}
   - match: {template.mappings.properties.ct_field.type: "keyword"}
   - match: {overlapping.0.name: existing_test}
   - match: {overlapping.0.index_patterns: ["te*"]}
@@ -168,8 +168,8 @@
       indices.simulate_index_template:
         name: test
 
-  - match: {template.settings.index.number_of_shards: "1"}
-  - match: {template.settings.index.number_of_replicas: "0"}
+  - match: {template.settings.index.number_of_shards: 1}
+  - match: {template.settings.index.number_of_replicas: 0}
   - match: {template.mappings.properties.field.type: "keyword"}
   - match: {overlapping.0.name: v1_template}
   - match: {overlapping.0.index_patterns: ["t*", "t1*"]}

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.simulate_template/10_basic.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.simulate_template/10_basic.yml
@@ -23,8 +23,8 @@
       indices.simulate_template:
         name: my-template
 
-  - match: {template.settings.index.number_of_shards: "1"}
-  - match: {template.settings.index.number_of_replicas: "0"}
+  - match: {template.settings.index.number_of_shards: 1}
+  - match: {template.settings.index.number_of_replicas: 0}
   - match: {template.mappings.properties.field.type: "keyword"}
   - match: {overlapping: []}
 
@@ -74,8 +74,8 @@
               test_alias: {}
           composed_of: ["ct"]
 
-  - match: {template.settings.index.blocks.write: "true"}
-  - match: {template.settings.index.number_of_replicas: "2"}
+  - match: {template.settings.index.blocks.write: true}
+  - match: {template.settings.index.number_of_replicas: 2}
   - match: {template.mappings.properties.ct_field.type: "keyword"}
   - match: {overlapping.0.name: existing_test}
   - match: {overlapping.0.index_patterns: ["te*"]}
@@ -137,8 +137,8 @@
       indices.simulate_template:
         name: winning_v2_template
 
-  - match: {template.settings.index.number_of_shards: "1"}
-  - match: {template.settings.index.number_of_replicas: "0"}
+  - match: {template.settings.index.number_of_shards: 1}
+  - match: {template.settings.index.number_of_replicas: 0}
   - match: {template.mappings.properties.field.type: "keyword"}
   - match: {overlapping.0.name: v1_template}
   - match: {overlapping.0.index_patterns: ["t*", "t1*"]}
@@ -192,8 +192,8 @@
               test_alias: {}
           composed_of: ["ct"]
 
-  - match: {template.settings.index.blocks.write: "true"}
-  - match: {template.settings.index.number_of_replicas: "3"}
+  - match: {template.settings.index.blocks.write: true}
+  - match: {template.settings.index.number_of_replicas: 3}
   - match: {template.mappings.properties.ct_field.type: "keyword"}
   - length: {template.aliases: 1}
   - is_true: template.aliases.test_alias

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.split/30_copy_settings.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.split/30_copy_settings.yml
@@ -57,7 +57,7 @@
         index: "copy-settings-target"
 
   # settings should be copied
-  - match: { copy-settings-target.settings.index.merge.scheduler.max_merge_count: "4" }
-  - match: { copy-settings-target.settings.index.merge.scheduler.max_thread_count: "2" }
-  - match: { copy-settings-target.settings.index.blocks.write: "true" }
+  - match: { copy-settings-target.settings.index.merge.scheduler.max_merge_count: 4 }
+  - match: { copy-settings-target.settings.index.merge.scheduler.max_thread_count: 2 }
+  - match: { copy-settings-target.settings.index.blocks.write: true }
   - match: { copy-settings-target.settings.index.routing.allocation.include._id: $node_id }

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.aggregation/30_sig_terms.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.aggregation/30_sig_terms.yml
@@ -5,7 +5,7 @@
           index:  goodbad
           body:
             settings:
-                number_of_shards: "1"
+                number_of_shards: 1
             mappings:
                 properties:
                     text:

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.aggregation/90_sig_text.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.aggregation/90_sig_text.yml
@@ -6,7 +6,7 @@
           index:  goodbad
           body:
             settings:
-                number_of_shards: "1"
+                number_of_shards: 1
             mappings:
                 properties:
                     text:
@@ -81,7 +81,7 @@
           index:  goodbad
           body:
             settings:
-                number_of_shards: "1"
+                number_of_shards: 1
             mappings:
                 properties:
                     text:

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/update/11_shard_header.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/update/11_shard_header.yml
@@ -8,8 +8,8 @@
         index: foobar
         body:
           settings:
-            number_of_shards: "1"
-            number_of_replicas: "0"
+            number_of_shards: 1
+            number_of_replicas: 0
 
  - do:
       cluster.health:

--- a/x-pack/plugin/async-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/async-search/10_deprecation.yml
+++ b/x-pack/plugin/async-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/async-search/10_deprecation.yml
@@ -4,21 +4,21 @@ setup:
         index: test-1
         body:
           settings:
-            number_of_shards: "2"
+            number_of_shards: 2
 
   - do:
       indices.create:
         index: test-2
         body:
           settings:
-            number_of_shards: "1"
+            number_of_shards: 1
 
   - do:
       indices.create:
         index: test-3
         body:
           settings:
-            number_of_shards: "3"
+            number_of_shards: 3
 
   - do:
       index:

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/async_search/10_basic.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/async_search/10_basic.yml
@@ -5,21 +5,21 @@
         index: test-1
         body:
           settings:
-            number_of_shards: "2"
+            number_of_shards: 2
 
   - do:
       indices.create:
         index: test-2
         body:
           settings:
-            number_of_shards: "1"
+            number_of_shards: 1
 
   - do:
       indices.create:
         index: test-3
         body:
           settings:
-            number_of_shards: "3"
+            number_of_shards: 3
 
   - do:
       index:

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/async_search/20-with-poin-in-time.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/async_search/20-with-poin-in-time.yml
@@ -8,21 +8,21 @@
         index: test-1
         body:
           settings:
-            number_of_shards: "2"
+            number_of_shards: 2
 
   - do:
       indices.create:
         index: test-2
         body:
           settings:
-            number_of_shards: "1"
+            number_of_shards: 1
 
   - do:
       indices.create:
         index: test-3
         body:
           settings:
-            number_of_shards: "3"
+            number_of_shards: 3
 
   - do:
       index:

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/data_stream/40_supported_apis.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/data_stream/40_supported_apis.yml
@@ -73,8 +73,8 @@ teardown:
           index_patterns: [simple-data-stream1]
           template:
             settings:
-              number_of_shards: "1"
-              number_of_replicas: "0"
+              number_of_shards: 1
+              number_of_replicas: 0
           data_stream: {}
 
   - do:

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/security/authz/14_cat_indices.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/security/authz/14_cat_indices.yml
@@ -33,24 +33,24 @@ setup:
         index: index1
         body:
           settings:
-            number_of_shards: "1"
-            number_of_replicas: "0"
+            number_of_shards: 1
+            number_of_replicas: 0
 
   - do:
       indices.create:
         index: index2
         body:
           settings:
-            number_of_shards: "1"
-            number_of_replicas: "0"
+            number_of_shards: 1
+            number_of_replicas: 0
 
   - do:
       indices.create:
         index: index3
         body:
           settings:
-            number_of_shards: "1"
-            number_of_replicas: "0"
+            number_of_shards: 1
+            number_of_replicas: 0
 
   - do:
       indices.close:
@@ -94,8 +94,8 @@ teardown:
         index: index_to_monitor
         body:
           settings:
-            number_of_shards: "1"
-            number_of_replicas: "0"
+            number_of_shards: 1
+            number_of_replicas: 0
 
   - do:
       headers: { Authorization: "Basic Y2F0X3VzZXI6Y2F0X3NlY3JldF9wYXNzd29yZA==" } # cat_user
@@ -183,16 +183,16 @@ teardown:
         index: index_to_monitor
         body:
           settings:
-            number_of_shards: "1"
-            number_of_replicas: "0"
+            number_of_shards: 1
+            number_of_replicas: 0
 
   - do:
       indices.create:
         index: this_index
         body:
           settings:
-            number_of_shards: "1"
-            number_of_replicas: "0"
+            number_of_shards: 1
+            number_of_replicas: 0
 
   - do:
       headers: { Authorization: "Basic Y2F0X3VzZXI6Y2F0X3NlY3JldF9wYXNzd29yZA==" } # cat_user
@@ -226,24 +226,24 @@ teardown:
         index: index_to_monitor
         body:
           settings:
-            number_of_shards: "1"
-            number_of_replicas: "0"
+            number_of_shards: 1
+            number_of_replicas: 0
 
   - do:
       indices.create:
         index: this_index
         body:
           settings:
-            number_of_shards: "1"
-            number_of_replicas: "0"
+            number_of_shards: 1
+            number_of_replicas: 0
 
   - do:
       indices.create:
         index: this_index_is_closed
         body:
           settings:
-            number_of_shards: "1"
-            number_of_replicas: "0"
+            number_of_shards: 1
+            number_of_replicas: 0
 
   - do:
       headers: { Authorization: "Basic Y2F0X3VzZXI6Y2F0X3NlY3JldF9wYXNzd29yZA==" } # cat_user
@@ -287,32 +287,32 @@ teardown:
         index: index_to_monitor
         body:
           settings:
-            number_of_shards: "1"
-            number_of_replicas: "0"
+            number_of_shards: 1
+            number_of_replicas: 0
 
   - do:
       indices.create:
         index: this_index
         body:
           settings:
-            number_of_shards: "1"
-            number_of_replicas: "0"
+            number_of_shards: 1
+            number_of_replicas: 0
 
   - do:
       indices.create:
         index: this_index_as_well
         body:
           settings:
-            number_of_shards: "1"
-            number_of_replicas: "0"
+            number_of_shards: 1
+            number_of_replicas: 0
 
   - do:
       indices.create:
         index: not_this_one_though
         body:
           settings:
-            number_of_shards: "1"
-            number_of_replicas: "0"
+            number_of_shards: 1
+            number_of_replicas: 0
 
   - do:
       headers: { Authorization: "Basic Y2F0X3VzZXI6Y2F0X3NlY3JldF9wYXNzd29yZA==" } # cat_user

--- a/x-pack/plugin/watcher/qa/rest/src/yamlRestCompatTest/resources/rest-api-spec/test/v7compat/stats/10_basic.yml
+++ b/x-pack/plugin/watcher/qa/rest/src/yamlRestCompatTest/resources/rest-api-spec/test/v7compat/stats/10_basic.yml
@@ -31,7 +31,7 @@ setup:
         - "[GET /_xpack/watcher/stats/{metric}] is deprecated! Use [GET /_watcher/stats/{metric}] instead."
       xpack-watcher.stats:
         metric: "all"
-        emit_stacktraces: "true"
+        emit_stacktraces: true
   - match: { "manually_stopped": false }
   - match: { "stats.0.watcher_state": "started" }
 

--- a/x-pack/plugin/watcher/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/watcher/execute_watch/20_transform.yml
+++ b/x-pack/plugin/watcher/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/watcher/execute_watch/20_transform.yml
@@ -73,8 +73,8 @@ setup:
         index: my_test_index
         body:
           settings:
-            number_of_shards: "2"
-            number_of_replicas: "0"
+            number_of_shards: 2
+            number_of_replicas: 0
 
   - do:
       index:


### PR DESCRIPTION
This PR changes the following properties in the YAML tests to be defined as numeric or boolean instead of the string notation. The string notation has an effect on downstream projects such as the types validation, as the "real" type is e.g. `integer` but by representing it with double quotes, a proper type can not be inferred. Example: https://github.com/elastic/elastic-client-generator/pull/330 

`"number_of_shards": "1"` must be defined without the double quotes `"number_of_shards": 1` for the downstream tooling to work as expected.

Adjusted the following properties:
* max_merge_count: int
* max_thread_count: int
* index.blocks.write boolean
* index.number_of_shards: int
* index.number_of_replicas: int
* index.priority: int
* watcher.emit_stacktraces: boolean