### PR TITLE
Disallow multifields on mappers with index-time scripts

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/mapper/BooleanFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/BooleanFieldMapper.java
@@ -93,6 +93,9 @@ public class BooleanFieldMapper extends FieldMapper {
                 if (s != null && indexed.get() == false && docValues.get() == false) {
                     throw new MapperParsingException("Cannot define script on field with index:false and doc_values:false");
                 }
+                if (s != null && multiFieldsBuilder.hasMultiFields()) {
+                    throw new MapperParsingException("Cannot define multifields on a field with a script");
+                }
             });
         }
 

--- a/server/src/main/java/org/elasticsearch/index/mapper/FieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/FieldMapper.java
@@ -426,6 +426,10 @@ public abstract class FieldMapper extends Mapper implements Cloneable {
                 return this;
             }
 
+            public boolean hasMultiFields() {
+                return mapperBuilders.isEmpty() == false;
+            }
+
             public MultiFields build(Mapper.Builder mainFieldBuilder, ContentPath contentPath) {
                 if (mapperBuilders.isEmpty()) {
                     return empty();

--- a/server/src/main/java/org/elasticsearch/index/mapper/NumberFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/NumberFieldMapper.java
@@ -114,6 +114,9 @@ public class NumberFieldMapper extends FieldMapper {
                 if (s != null && indexed.get() == false && hasDocValues.get() == false) {
                     throw new MapperParsingException("Cannot define script on field with index:false and doc_values:false");
                 }
+                if (s != null && multiFieldsBuilder.hasMultiFields()) {
+                    throw new MapperParsingException("Cannot define multifields on a field with a script");
+                }
             });
         }
 

--- a/test/framework/src/main/java/org/elasticsearch/index/mapper/MapperScriptTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/mapper/MapperScriptTestCase.java
@@ -95,6 +95,17 @@ public abstract class MapperScriptTestCase<FactoryType> extends MapperServiceTes
         assertThat(e.getMessage(), containsString("Cannot define script on field with index:false and doc_values:false"));
     }
 
+    public final void testMultiFieldsNotPermitted() {
+        Exception e = expectThrows(MapperParsingException.class, () -> createDocumentMapper(fieldMapping(b -> {
+            b.field("type", type());
+            b.field("script", "serializer_test");
+            b.startObject("fields");
+            b.startObject("subfield").field("type", "keyword").endObject();
+            b.endObject();
+        })));
+        assertThat(e.getMessage(), containsString("Cannot define multifields on a field with a script"));
+    }
+
     public final void testOnScriptErrorParameterRequiresScript() {
         Exception e = expectThrows(MapperParsingException.class, () -> createDocumentMapper(fieldMapping(b -> {
             b.field("type", type());


### PR DESCRIPTION
Multifields are built at the same time as their parent fields, using
a positioned xcontent parser to read information.  Fields with index
time scripts are built entirely differently, and it does not make sense
to combine the two.

This commit adds a base test to MapperScriptTestCase that ensures
a field mapper defined with both multifields and a script parameter 
throws a parse error.