### PR TITLE
[7.12] Templates match indices with date math expressions

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/metadata/IndexNameExpressionResolver.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/IndexNameExpressionResolver.java
@@ -428,7 +428,7 @@ public class IndexNameExpressionResolver {
      */
     public boolean hasIndexAbstraction(String indexAbstraction, ClusterState state) {
         Context context = new Context(state, IndicesOptions.lenientExpandOpen(), false, false, true, isSystemIndexAccessAllowed());
-        String resolvedAliasOrIndex = dateMathExpressionResolver.resolveExpression(indexAbstraction, context);
+        String resolvedAliasOrIndex = DateMathExpressionResolver.resolveExpression(indexAbstraction, context);
         return state.metadata().getIndicesLookup().containsKey(resolvedAliasOrIndex);
     }
 
@@ -438,7 +438,7 @@ public class IndexNameExpressionResolver {
     public String resolveDateMathExpression(String dateExpression) {
         // The data math expression resolver doesn't rely on cluster state or indices options, because
         // it just resolves the date math to an actual date.
-        return dateMathExpressionResolver.resolveExpression(dateExpression, new Context(null, null, isSystemIndexAccessAllowed()));
+        return DateMathExpressionResolver.resolveExpression(dateExpression, new Context(null, null, isSystemIndexAccessAllowed()));
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/IndexNameExpressionResolver.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/IndexNameExpressionResolver.java
@@ -442,6 +442,14 @@ public class IndexNameExpressionResolver {
     }
 
     /**
+     * @param time instant to consider when parsing the expression
+     * @return If the specified string is data math expression then this method returns the resolved expression.
+     */
+    public String resolveDateMathExpression(String dateExpression, long time) {
+        return DateMathExpressionResolver.resolveExpression(dateExpression, new Context(null, null, time, isSystemIndexAccessAllowed()));
+    }
+
+    /**
      * Resolve an array of expressions to the set of indices and aliases that these expressions match.
      */
     public Set<String> resolveExpressions(ClusterState state, String... expressions) {
@@ -1081,7 +1089,7 @@ public class IndexNameExpressionResolver {
         }
 
         @SuppressWarnings("fallthrough")
-        String resolveExpression(String expression, final Context context) {
+        static String resolveExpression(String expression, final Context context) {
             if (expression.startsWith(EXPRESSION_LEFT_BOUND) == false || expression.endsWith(EXPRESSION_RIGHT_BOUND) == false) {
                 return expression;
             }

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataIndexTemplateService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataIndexTemplateService.java
@@ -798,7 +798,9 @@ public class MetadataIndexTemplateService {
      *
      */
     public static List<IndexTemplateMetadata> findV1Templates(Metadata metadata, String indexName, @Nullable Boolean isHidden) {
-        final Predicate<String> patternMatchPredicate = pattern -> Regex.simpleMatch(pattern, indexName);
+        final String resolvedIndexName = IndexNameExpressionResolver.DateMathExpressionResolver
+            .resolveExpression(indexName, new IndexNameExpressionResolver.Context(null, null, null));
+        final Predicate<String> patternMatchPredicate = pattern -> Regex.simpleMatch(pattern, resolvedIndexName);
         final List<IndexTemplateMetadata> matchedTemplates = new ArrayList<>();
         for (ObjectCursor<IndexTemplateMetadata> cursor : metadata.templates().values()) {
             final IndexTemplateMetadata template = cursor.value;
@@ -822,8 +824,9 @@ public class MetadataIndexTemplateService {
         // this is complex but if the index is not hidden in the create request but is hidden as the result of template application,
         // then we need to exclude global templates
         if (isHidden == null) {
-            final Optional<IndexTemplateMetadata> templateWithHiddenSetting = matchedTemplates.stream()
-                .filter(template -> IndexMetadata.INDEX_HIDDEN_SETTING.exists(template.settings())).findFirst();
+            final Optional<IndexTemplateMetadata>
+                templateWithHiddenSetting =
+                matchedTemplates.stream().filter(template -> IndexMetadata.INDEX_HIDDEN_SETTING.exists(template.settings())).findFirst();
             if (templateWithHiddenSetting.isPresent()) {
                 final boolean templatedIsHidden = IndexMetadata.INDEX_HIDDEN_SETTING.get(templateWithHiddenSetting.get().settings());
                 if (templatedIsHidden) {
@@ -849,7 +852,9 @@ public class MetadataIndexTemplateService {
      */
     @Nullable
     public static String findV2Template(Metadata metadata, String indexName, boolean isHidden) {
-        final Predicate<String> patternMatchPredicate = pattern -> Regex.simpleMatch(pattern, indexName);
+        final String resolvedIndexName = IndexNameExpressionResolver.DateMathExpressionResolver
+            .resolveExpression(indexName, new IndexNameExpressionResolver.Context(null, null, null));
+        final Predicate<String> patternMatchPredicate = pattern -> Regex.simpleMatch(pattern, resolvedIndexName);
         final Map<ComposableIndexTemplate, String> matchedTemplates = new HashMap<>();
         for (Map.Entry<String, ComposableIndexTemplate> entry : metadata.templatesV2().entrySet()) {
             final String name = entry.getKey();

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataIndexTemplateService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataIndexTemplateService.java
@@ -799,7 +799,7 @@ public class MetadataIndexTemplateService {
      */
     public static List<IndexTemplateMetadata> findV1Templates(Metadata metadata, String indexName, @Nullable Boolean isHidden) {
         final String resolvedIndexName = IndexNameExpressionResolver.DateMathExpressionResolver
-            .resolveExpression(indexName, new IndexNameExpressionResolver.Context(null, null, null));
+            .resolveExpression(indexName, new IndexNameExpressionResolver.Context(null, null, false));
         final Predicate<String> patternMatchPredicate = pattern -> Regex.simpleMatch(pattern, resolvedIndexName);
         final List<IndexTemplateMetadata> matchedTemplates = new ArrayList<>();
         for (ObjectCursor<IndexTemplateMetadata> cursor : metadata.templates().values()) {
@@ -853,7 +853,7 @@ public class MetadataIndexTemplateService {
     @Nullable
     public static String findV2Template(Metadata metadata, String indexName, boolean isHidden) {
         final String resolvedIndexName = IndexNameExpressionResolver.DateMathExpressionResolver
-            .resolveExpression(indexName, new IndexNameExpressionResolver.Context(null, null, null));
+            .resolveExpression(indexName, new IndexNameExpressionResolver.Context(null, null, false));
         final Predicate<String> patternMatchPredicate = pattern -> Regex.simpleMatch(pattern, resolvedIndexName);
         final Map<ComposableIndexTemplate, String> matchedTemplates = new HashMap<>();
         for (Map.Entry<String, ComposableIndexTemplate> entry : metadata.templatesV2().entrySet()) {

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataIndexTemplateServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataIndexTemplateServiceTests.java
@@ -322,6 +322,15 @@ public class MetadataIndexTemplateServiceTests extends ESSingleNodeTestCase {
             .map(IndexTemplateMetadata::name).collect(Collectors.toList()), contains("sneaky-hidden"));
     }
 
+    public void testFindTemplatesWithDateMathIndex() throws Exception {
+        client().admin().indices().prepareDeleteTemplate("*").get(); // Delete all existing templates
+        putTemplateDetail(new PutRequest("testFindTemplatesWithDateMathIndex", "foo-1").patterns(singletonList("test-*")).order(1));
+        final ClusterState state = client().admin().cluster().prepareState().get().getState();
+
+        assertThat(MetadataIndexTemplateService.findV1Templates(state.metadata(), "<test-{now/d}>", false).stream()
+            .map(IndexTemplateMetadata::name).collect(Collectors.toList()), containsInAnyOrder("foo-1"));
+    }
+
     public void testPutGlobalTemplateWithIndexHiddenSetting() throws Exception {
         List<Throwable> errors = putTemplateDetail(new PutRequest("testPutGlobalTemplateWithIndexHiddenSetting", "sneaky-hidden")
             .patterns(singletonList("*")).settings(Settings.builder().put("index.hidden", true).build()));
@@ -716,6 +725,24 @@ public class MetadataIndexTemplateServiceTests extends ESSingleNodeTestCase {
         state = service.addIndexTemplateV2(state, true, "my-template2", it2);
 
         String result = MetadataIndexTemplateService.findV2Template(state.metadata(), "index", true);
+
+        assertThat(result, equalTo("my-template"));
+    }
+
+    public void testFindV2TemplatesForDateMathIndex() throws Exception {
+        String indexName = "<index-{now/d}>";
+        final MetadataIndexTemplateService service = getMetadataIndexTemplateService();
+        ClusterState state = ClusterState.EMPTY_STATE;
+        assertNull(MetadataIndexTemplateService.findV2Template(state.metadata(), indexName, true));
+
+        ComponentTemplate ct = ComponentTemplateTests.randomInstance();
+        state = service.addComponentTemplate(state, true, "ct", ct);
+        ComposableIndexTemplate it = new ComposableIndexTemplate(List.of("index-*"), null, List.of("ct"), 0L, 1L, null, null, null);
+        state = service.addIndexTemplateV2(state, true, "my-template", it);
+        ComposableIndexTemplate it2 = new ComposableIndexTemplate(List.of("*"), null, List.of("ct"), 10L, 2L, null, null, null);
+        state = service.addIndexTemplateV2(state, true, "my-template2", it2);
+
+        String result = MetadataIndexTemplateService.findV2Template(state.metadata(), indexName, true);
 
         assertThat(result, equalTo("my-template"));
     }

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataIndexTemplateServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataIndexTemplateServiceTests.java
@@ -737,9 +737,15 @@ public class MetadataIndexTemplateServiceTests extends ESSingleNodeTestCase {
 
         ComponentTemplate ct = ComponentTemplateTests.randomInstance();
         state = service.addComponentTemplate(state, true, "ct", ct);
-        ComposableIndexTemplate it = new ComposableIndexTemplate(List.of("index-*"), null, List.of("ct"), 0L, 1L, null, null, null);
+        ComposableIndexTemplate it = new ComposableIndexTemplate(
+            org.elasticsearch.common.collect.List.of("index-*"), null,
+            org.elasticsearch.common.collect.List.of("ct"), 0L, 1L, null, null, null
+        );
         state = service.addIndexTemplateV2(state, true, "my-template", it);
-        ComposableIndexTemplate it2 = new ComposableIndexTemplate(List.of("*"), null, List.of("ct"), 10L, 2L, null, null, null);
+        ComposableIndexTemplate it2 = new ComposableIndexTemplate(
+            org.elasticsearch.common.collect.List.of("*"), null,
+            org.elasticsearch.common.collect.List.of("ct"), 10L, 2L, null, null, null
+        );
         state = service.addIndexTemplateV2(state, true, "my-template2", it2);
 
         String result = MetadataIndexTemplateService.findV2Template(state.metadata(), indexName, true);


### PR DESCRIPTION
The root cause of the bug identified in #69727 (reported independently by several users) is that the `findV?Templates` methods in `MetadataIndexTemplateService` do not resolve index names with date math expressions before attempting to match them. The reproduction scenario in #69727 demonstrates one flavor of this problem. Before 7.9, an ingest pipeline with a date_index_name processor would (accidentally) work around that problem, but the simple statement below would fail to execute the final pipeline in any ES version (assuming a template that defines a final pipeline for an index pattern of `test-*`):

```
# url-encoded form of <test-{now/d}>
POST /%3Ctest-%7Bnow%2Fd%7D%3E/_doc 
{
  "field": "value"
}
```

A change to the way ingest pipelines work in 7.9 caused the date_index_name scenario to fail as well. This change resolves both problems.

Fixes #69727.

Backport of #71433.
