### PR TITLE
Avoid spinning up test fixtures during compilation

### DIFF
--- a/x-pack/qa/saml-idp-tests/build.gradle
+++ b/x-pack/qa/saml-idp-tests/build.gradle
@@ -41,9 +41,10 @@ def setupPorts = tasks.register("setupPorts") {
   }
 }
 
-project.sourceSets.test.output.dir(outputDir, builtBy: [copyIdpFiles, setupPorts])
+project.sourceSets.test.output.dir(outputDir, builtBy: [copyIdpFiles])
 
 tasks.named("integTest").configure {
+  dependsOn setupPorts
   onlyIf { idpFixtureProject.postProcessFixture.state.skipped == false && Architecture.current() == Architecture.X64 }
 }
 


### PR DESCRIPTION
Some task dependencies were reworked as part of #71377. This had the unintentional side effect of making a simple compile depend on building the Elasticsearch docker image and spinning up a Docker Compose test fixture. This ends up adding a ton of time to something like `./gradlew precommit`.