### PR TITLE
IndexFeatureStats to implement ToXContentObject

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/stats/IndexFeatureStats.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/stats/IndexFeatureStats.java
@@ -11,7 +11,7 @@ package org.elasticsearch.action.admin.cluster.stats;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
-import org.elasticsearch.common.xcontent.ToXContent;
+import org.elasticsearch.common.xcontent.ToXContentObject;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 
 import java.io.IOException;
@@ -20,7 +20,7 @@ import java.util.Objects;
 /**
  * Statistics about an index feature.
  */
-public class IndexFeatureStats implements ToXContent, Writeable {
+public class IndexFeatureStats implements ToXContentObject, Writeable {
 
     final String name;
     int count;

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/stats/IndexFeatureStatsTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/stats/IndexFeatureStatsTests.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.action.admin.cluster.stats;
+
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.test.AbstractWireSerializingTestCase;
+
+public class IndexFeatureStatsTests extends AbstractWireSerializingTestCase<IndexFeatureStats> {
+    @Override
+    protected Writeable.Reader<IndexFeatureStats> instanceReader() {
+        return IndexFeatureStats::new;
+    }
+
+    @Override
+    protected IndexFeatureStats createTestInstance() {
+        IndexFeatureStats indexFeatureStats = new IndexFeatureStats(randomAlphaOfLengthBetween(3, 10));
+        indexFeatureStats.indexCount = randomIntBetween(0, Integer.MAX_VALUE);
+        indexFeatureStats.count = randomIntBetween(0, Integer.MAX_VALUE);
+        return indexFeatureStats;
+    }
+
+    public void testToXContent() {
+        IndexFeatureStats testInstance = createTestInstance();
+        assertEquals("{\"name\":\"" + testInstance.name +
+            "\",\"count\":" + testInstance.count +
+            ",\"index_count\":" + testInstance.indexCount + "}", Strings.toString(testInstance));
+    }
+}


### PR DESCRIPTION
IndexFeatureStats prints out a whole object, hence it should be a ToXContentObject. This way consumers like Strings#toString automatically know not to wrap it into a new object when printing it out.
