### PR TITLE
Use ByteBufferStreamInput to Stream Byte Arrays (#71538)

### DIFF
--- a/benchmarks/src/main/java/org/elasticsearch/common/bytes/BytesArrayReadLongBenchmark.java
+++ b/benchmarks/src/main/java/org/elasticsearch/common/bytes/BytesArrayReadLongBenchmark.java
@@ -9,6 +9,8 @@ package org.elasticsearch.common.bytes;
 
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.unit.ByteSizeUnit;
+import org.elasticsearch.common.unit.ByteSizeValue;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Fork;
@@ -30,35 +32,36 @@ import java.util.concurrent.TimeUnit;
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
 @State(Scope.Thread)
 @Fork(value = 1)
-public class PagedBytesReferenceReadVLongBenchmark {
+public class BytesArrayReadLongBenchmark {
 
-    @Param(value = { "10000000" })
-    int entries;
+    @Param(value = { "1" })
+    private int dataMb;
+
+    private BytesReference bytesArray;
 
     private StreamInput streamInput;
 
     @Setup
     public void initResults() throws IOException {
         final BytesStreamOutput tmp = new BytesStreamOutput();
-        for (int i = 0; i < entries / 2; i++) {
-            tmp.writeVLong(i);
+        final long bytes = new ByteSizeValue(dataMb, ByteSizeUnit.MB).getBytes();
+        for (int i = 0; i < bytes / 8; i++) {
+            tmp.writeLong(i);
         }
-        for (int i = 0; i < entries / 2; i++) {
-            tmp.writeVLong(Long.MAX_VALUE - i);
+        bytesArray = tmp.copyBytes();
+        if (bytesArray instanceof BytesArray == false) {
+            throw new AssertionError("expected BytesArray but saw [" + bytesArray.getClass() + "]");
         }
-        BytesReference pagedBytes = tmp.bytes();
-        if (pagedBytes instanceof PagedBytesReference == false) {
-            throw new AssertionError("expected PagedBytesReference but saw [" + pagedBytes.getClass() + "]");
-        }
-        this.streamInput = pagedBytes.streamInput();
+        streamInput = bytesArray.streamInput();
     }
 
     @Benchmark
-    public long readVLong() throws IOException {
-        long res = 0;
+    public long readLong() throws IOException {
+        long res = 0L;
         streamInput.reset();
-        for (int i = 0; i < entries; i++) {
-            res = res ^ streamInput.readVLong();
+        final int reads = bytesArray.length() / 8;
+        for (int i = 0; i < reads; i++) {
+            res = res ^ streamInput.readLong();
         }
         return res;
     }

--- a/benchmarks/src/main/java/org/elasticsearch/common/bytes/BytesArrayReadVLongBenchmark.java
+++ b/benchmarks/src/main/java/org/elasticsearch/common/bytes/BytesArrayReadVLongBenchmark.java
@@ -30,7 +30,7 @@ import java.util.concurrent.TimeUnit;
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
 @State(Scope.Thread)
 @Fork(value = 1)
-public class PagedBytesReferenceReadVLongBenchmark {
+public class BytesArrayReadVLongBenchmark {
 
     @Param(value = { "10000000" })
     int entries;
@@ -46,11 +46,11 @@ public class PagedBytesReferenceReadVLongBenchmark {
         for (int i = 0; i < entries / 2; i++) {
             tmp.writeVLong(Long.MAX_VALUE - i);
         }
-        BytesReference pagedBytes = tmp.bytes();
-        if (pagedBytes instanceof PagedBytesReference == false) {
-            throw new AssertionError("expected PagedBytesReference but saw [" + pagedBytes.getClass() + "]");
+        BytesReference bytesArray = tmp.copyBytes();
+        if (bytesArray instanceof BytesArray == false) {
+            throw new AssertionError("expected BytesArray but saw [" + bytesArray.getClass() + "]");
         }
-        this.streamInput = pagedBytes.streamInput();
+        this.streamInput = bytesArray.streamInput();
     }
 
     @Benchmark

--- a/benchmarks/src/main/java/org/elasticsearch/common/bytes/PagedBytesReferenceReadLongBenchmark.java
+++ b/benchmarks/src/main/java/org/elasticsearch/common/bytes/PagedBytesReferenceReadLongBenchmark.java
@@ -39,6 +39,8 @@ public class PagedBytesReferenceReadLongBenchmark {
 
     private BytesReference pagedBytes;
 
+    private StreamInput streamInput;
+
     @Setup
     public void initResults() throws IOException {
         final BytesStreamOutput tmp = new BytesStreamOutput();
@@ -48,18 +50,18 @@ public class PagedBytesReferenceReadLongBenchmark {
         }
         pagedBytes = tmp.bytes();
         if (pagedBytes instanceof PagedBytesReference == false) {
-            throw new AssertionError("expected paged PagedBytesReference but saw [" + pagedBytes.getClass() + "]");
+            throw new AssertionError("expected PagedBytesReference but saw [" + pagedBytes.getClass() + "]");
         }
+        this.streamInput = pagedBytes.streamInput();
     }
 
     @Benchmark
     public long readLong() throws IOException {
         long res = 0L;
+        streamInput.reset();
         final int reads = pagedBytes.length() / 8;
-        try (StreamInput streamInput = pagedBytes.streamInput()) {
-            for (int i = 0; i < reads; i++) {
-                res = res ^ streamInput.readLong();
-            }
+        for (int i = 0; i < reads; i++) {
+            res = res ^ streamInput.readLong();
         }
         return res;
     }

--- a/server/src/main/java/org/elasticsearch/common/io/stream/ByteBufferStreamInput.java
+++ b/server/src/main/java/org/elasticsearch/common/io/stream/ByteBufferStreamInput.java
@@ -17,7 +17,7 @@ public class ByteBufferStreamInput extends StreamInput {
     private final ByteBuffer buffer;
 
     public ByteBufferStreamInput(ByteBuffer buffer) {
-        this.buffer = buffer;
+        this.buffer = (ByteBuffer) buffer.mark();
     }
 
     @Override
@@ -30,10 +30,11 @@ public class ByteBufferStreamInput extends StreamInput {
 
     @Override
     public byte readByte() throws IOException {
-        if (buffer.hasRemaining() == false) {
-            throw new EOFException();
+        try {
+            return buffer.get();
+        } catch (BufferUnderflowException ex) {
+            throw newEOFException(ex);
         }
-        return buffer.get();
     }
 
     @Override
@@ -49,10 +50,10 @@ public class ByteBufferStreamInput extends StreamInput {
 
     @Override
     public long skip(long n) throws IOException {
-        if (n > buffer.remaining()) {
-            int ret = buffer.position();
+        int remaining = buffer.remaining();
+        if (n > remaining) {
             buffer.position(buffer.limit());
-            return ret;
+            return remaining;
         }
         buffer.position((int) (buffer.position() + n));
         return n;
@@ -60,10 +61,11 @@ public class ByteBufferStreamInput extends StreamInput {
 
     @Override
     public void readBytes(byte[] b, int offset, int len) throws IOException {
-        if (buffer.remaining() < len) {
-            throw new EOFException();
+        try {
+            buffer.get(b, offset, len);
+        } catch (BufferUnderflowException ex) {
+            throw newEOFException(ex);
         }
-        buffer.get(b, offset, len);
     }
 
     @Override
@@ -71,9 +73,7 @@ public class ByteBufferStreamInput extends StreamInput {
         try {
             return buffer.getShort();
         } catch (BufferUnderflowException ex) {
-            EOFException eofException = new EOFException();
-            eofException.initCause(ex);
-            throw eofException;
+            throw newEOFException(ex);
         }
     }
 
@@ -82,9 +82,7 @@ public class ByteBufferStreamInput extends StreamInput {
         try {
             return buffer.getInt();
         } catch (BufferUnderflowException ex) {
-            EOFException eofException = new EOFException();
-            eofException.initCause(ex);
-            throw eofException;
+            throw newEOFException(ex);
         }
     }
 
@@ -93,18 +91,14 @@ public class ByteBufferStreamInput extends StreamInput {
         try {
             return buffer.getLong();
         } catch (BufferUnderflowException ex) {
-            EOFException eofException = new EOFException();
-            eofException.initCause(ex);
-            throw eofException;
+            throw newEOFException(ex);
         }
     }
 
-    public void position(int newPosition) throws IOException {
-        buffer.position(newPosition);
-    }
-
-    public int position() throws IOException {
-        return buffer.position();
+    private EOFException newEOFException(RuntimeException ex) {
+        EOFException eofException = new EOFException();
+        eofException.initCause(ex);
+        return eofException;
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/common/io/stream/StreamInput.java
+++ b/server/src/main/java/org/elasticsearch/common/io/stream/StreamInput.java
@@ -35,13 +35,13 @@ import org.elasticsearch.common.util.concurrent.EsRejectedExecutionException;
 import org.elasticsearch.script.JodaCompatibleZonedDateTime;
 import org.joda.time.DateTimeZone;
 
-import java.io.ByteArrayInputStream;
 import java.io.EOFException;
 import java.io.FileNotFoundException;
 import java.io.FilterInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.math.BigInteger;
+import java.nio.ByteBuffer;
 import java.nio.file.AccessDeniedException;
 import java.nio.file.AtomicMoveNotSupportedException;
 import java.nio.file.DirectoryNotEmptyException;
@@ -1320,7 +1320,7 @@ public abstract class StreamInput extends InputStream {
     }
 
     public static StreamInput wrap(byte[] bytes, int offset, int length) {
-        return new InputStreamStreamInput(new ByteArrayInputStream(bytes, offset, length), length);
+        return new ByteBufferStreamInput(ByteBuffer.wrap(bytes, offset, length));
     }
 
     /**

--- a/server/src/test/java/org/elasticsearch/common/io/stream/BytesStreamsTests.java
+++ b/server/src/test/java/org/elasticsearch/common/io/stream/BytesStreamsTests.java
@@ -789,7 +789,7 @@ public class BytesStreamsTests extends ESTestCase {
                     assertEquals(i, ints[i]);
                 }
                 EOFException eofException = expectThrows(EOFException.class, () -> streamInput.readIntArray());
-                assertEquals("tried to read: 100 bytes but this stream is limited to: 82", eofException.getMessage());
+                assertEquals("tried to read: 100 bytes but only 40 remaining", eofException.getMessage());
             }
         }
     }


### PR DESCRIPTION
For bulk operations that fall back to hotspot intrinsic code (reading short, int, long)
using this stream brings a massive speedup. The added benchmark for reading `long` values
sees a ~100x speedup in local benchmarking and the vLong read benchmark still sees a slightly
under ~10x speedup.
Also, this PR moves creation of the `StreamInput` out of the hot benchmark loop for all the bytes
reference benchmarks to make the benchmark less noisy and more practically useful.
(the `readLong` case using intrinsic operations is so fast that it wouldn't even show up in a profile relative to
instantiating the stream otherwise).

Relates work in #71181

backport of #71538