### PR TITLE
Add utility methods to return runtime field values in doc value order

### DIFF
--- a/server/src/main/java/org/elasticsearch/script/AbstractLongFieldScript.java
+++ b/server/src/main/java/org/elasticsearch/script/AbstractLongFieldScript.java
@@ -12,9 +12,7 @@ import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.util.ArrayUtil;
 import org.elasticsearch.search.lookup.SearchLookup;
 
-import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.List;
 import java.util.Map;
 import java.util.function.LongConsumer;
 

--- a/server/src/main/java/org/elasticsearch/script/AbstractLongFieldScript.java
+++ b/server/src/main/java/org/elasticsearch/script/AbstractLongFieldScript.java
@@ -12,6 +12,9 @@ import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.util.ArrayUtil;
 import org.elasticsearch.search.lookup.SearchLookup;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
 import java.util.function.LongConsumer;
 
@@ -53,6 +56,17 @@ public abstract class AbstractLongFieldScript extends AbstractFieldScript {
      */
     public final long[] values() {
         return values;
+    }
+
+    /**
+     * Reorders the values from the last time {@link #values()} was called to
+     * how this would appear in doc-values order. Truncates garbage values
+     * based on {@link #count()}.
+     */
+    public final long[] asDocValues() {
+        long[] truncated = Arrays.copyOf(values, count());
+        Arrays.sort(truncated);
+        return truncated;
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/script/BooleanFieldScript.java
+++ b/server/src/main/java/org/elasticsearch/script/BooleanFieldScript.java
@@ -11,6 +11,7 @@ package org.elasticsearch.script;
 import org.apache.lucene.index.LeafReaderContext;
 import org.elasticsearch.search.lookup.SearchLookup;
 
+import java.util.Arrays;
 import java.util.Map;
 import java.util.function.Consumer;
 
@@ -66,6 +67,17 @@ public abstract class BooleanFieldScript extends AbstractFieldScript {
      */
     public final int falses() {
         return falses;
+    }
+
+    /**
+     * Reorders the values from the last time {@link #runForDoc(int)} was called to
+     * how this would appear in doc-values order.
+     */
+    public final boolean[] asDocValues() {
+        boolean[] values = new boolean[falses + trues];
+        Arrays.fill(values, 0, falses, false);
+        Arrays.fill(values, falses, falses + trues, true);
+        return values;
     }
 
     public final void emit(boolean v) {

--- a/server/src/main/java/org/elasticsearch/script/DoubleFieldScript.java
+++ b/server/src/main/java/org/elasticsearch/script/DoubleFieldScript.java
@@ -12,6 +12,7 @@ import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.util.ArrayUtil;
 import org.elasticsearch.search.lookup.SearchLookup;
 
+import java.util.Arrays;
 import java.util.Map;
 import java.util.function.DoubleConsumer;
 
@@ -63,6 +64,17 @@ public abstract class DoubleFieldScript extends AbstractFieldScript {
      */
     public final double[] values() {
         return values;
+    }
+
+    /**
+     * Reorders the values from the last time {@link #values()} was called to
+     * how this would appear in doc-values order. Truncates garbage values
+     * based on {@link #count()}.
+     */
+    public final double[] asDocValues() {
+        double[] truncated = Arrays.copyOf(values, count());
+        Arrays.sort(truncated);
+        return truncated;
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/script/IpFieldScript.java
+++ b/server/src/main/java/org/elasticsearch/script/IpFieldScript.java
@@ -19,6 +19,7 @@ import org.elasticsearch.search.lookup.SearchLookup;
 import java.net.Inet4Address;
 import java.net.Inet6Address;
 import java.net.InetAddress;
+import java.util.Arrays;
 import java.util.Map;
 
 /**
@@ -76,6 +77,17 @@ public abstract class IpFieldScript extends AbstractFieldScript {
      */
     public final BytesRef[] values() {
         return values;
+    }
+
+    /**
+     * Reorders the values from the last time {@link #values()} was called to
+     * how this would appear in doc-values order. Truncates garbage values
+     * based on {@link #count()}.
+     */
+    public final BytesRef[] asDocValues() {
+        BytesRef[] truncated = Arrays.copyOf(values, count());
+        Arrays.sort(truncated);
+        return truncated;
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/script/StringFieldScript.java
+++ b/server/src/main/java/org/elasticsearch/script/StringFieldScript.java
@@ -12,6 +12,7 @@ import org.apache.lucene.index.LeafReaderContext;
 import org.elasticsearch.search.lookup.SearchLookup;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -59,6 +60,17 @@ public abstract class StringFieldScript extends AbstractFieldScript {
 
     public final void runForDoc(int docId, Consumer<String> consumer) {
         resultsForDoc(docId).forEach(consumer);
+    }
+
+    /**
+     * Reorders the values from the last time {@link #resultsForDoc(int)} was called to
+     * how this would appear in doc-values order.
+     */
+    public final String[] asDocValues() {
+        String[] values = new String[results.size()];
+        results.toArray(values);
+        Arrays.sort(values);
+        return values;
     }
 
     public final void emit(String v) {

--- a/server/src/test/java/org/elasticsearch/index/mapper/BooleanFieldScriptTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/BooleanFieldScriptTests.java
@@ -45,6 +45,23 @@ public class BooleanFieldScriptTests extends FieldScriptTestCase<BooleanFieldScr
         return DUMMY;
     }
 
+    public void testAsDocValues() {
+        BooleanFieldScript script = new BooleanFieldScript(
+                "test",
+                Map.of(),
+                new SearchLookup(field -> null, (ft, lookup) -> null),
+                null
+        ) {
+            @Override
+            public void execute() {
+                emit(true); emit(false); emit(true); emit(true); emit(false);
+            }
+        };
+        script.execute();
+
+        assertArrayEquals(new boolean[] {false, false, true, true, true}, script.asDocValues());
+    }
+
     public void testTooManyValues() throws IOException {
         try (Directory directory = newDirectory(); RandomIndexWriter iw = new RandomIndexWriter(random(), directory)) {
             iw.addDocument(List.of(new StoredField("_source", new BytesRef("{}"))));

--- a/server/src/test/java/org/elasticsearch/index/mapper/BooleanFieldScriptTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/BooleanFieldScriptTests.java
@@ -54,7 +54,11 @@ public class BooleanFieldScriptTests extends FieldScriptTestCase<BooleanFieldScr
         ) {
             @Override
             public void execute() {
-                emit(true); emit(false); emit(true); emit(true); emit(false);
+                emit(true);
+                emit(false);
+                emit(true);
+                emit(true);
+                emit(false);
             }
         };
         script.execute();

--- a/server/src/test/java/org/elasticsearch/index/mapper/DateFieldScriptTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/DateFieldScriptTests.java
@@ -16,13 +16,11 @@ import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.time.DateFormatter;
 import org.elasticsearch.script.AbstractFieldScript;
 import org.elasticsearch.script.DateFieldScript;
-import org.elasticsearch.script.LongFieldScript;
 import org.elasticsearch.script.ScriptContext;
 import org.elasticsearch.search.lookup.SearchLookup;
 
 import java.io.IOException;
 import java.time.ZonedDateTime;
-import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.Map;
 

--- a/server/src/test/java/org/elasticsearch/index/mapper/DoubleFieldScriptTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/DoubleFieldScriptTests.java
@@ -15,6 +15,7 @@ import org.apache.lucene.store.Directory;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.script.AbstractFieldScript;
 import org.elasticsearch.script.DoubleFieldScript;
+import org.elasticsearch.script.LongFieldScript;
 import org.elasticsearch.script.ScriptContext;
 import org.elasticsearch.search.lookup.SearchLookup;
 
@@ -45,6 +46,23 @@ public class DoubleFieldScriptTests extends FieldScriptTestCase<DoubleFieldScrip
     @Override
     protected DoubleFieldScript.Factory dummyScript() {
         return DUMMY;
+    }
+
+    public void testAsDocValues() {
+        DoubleFieldScript script = new DoubleFieldScript(
+                "test",
+                Map.of(),
+                new SearchLookup(field -> null, (ft, lookup) -> null),
+                null
+        ) {
+            @Override
+            public void execute() {
+                emit(3.1); emit(2.29); emit(-12.47); emit(-12.46); emit(Double.MAX_VALUE); emit(0.0);
+            }
+        };
+        script.execute();
+
+        assertArrayEquals(new double[] {-12.47, -12.46, 0.0, 2.29, 3.1, Double.MAX_VALUE}, script.asDocValues(), 0.000000001);
     }
 
     public void testTooManyValues() throws IOException {

--- a/server/src/test/java/org/elasticsearch/index/mapper/DoubleFieldScriptTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/DoubleFieldScriptTests.java
@@ -15,7 +15,6 @@ import org.apache.lucene.store.Directory;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.script.AbstractFieldScript;
 import org.elasticsearch.script.DoubleFieldScript;
-import org.elasticsearch.script.LongFieldScript;
 import org.elasticsearch.script.ScriptContext;
 import org.elasticsearch.search.lookup.SearchLookup;
 
@@ -57,7 +56,12 @@ public class DoubleFieldScriptTests extends FieldScriptTestCase<DoubleFieldScrip
         ) {
             @Override
             public void execute() {
-                emit(3.1); emit(2.29); emit(-12.47); emit(-12.46); emit(Double.MAX_VALUE); emit(0.0);
+                emit(3.1);
+                emit(2.29);
+                emit(-12.47);
+                emit(-12.46);
+                emit(Double.MAX_VALUE);
+                emit(0.0);
             }
         };
         script.execute();

--- a/server/src/test/java/org/elasticsearch/index/mapper/GeoPointFieldScriptTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/GeoPointFieldScriptTests.java
@@ -13,12 +13,15 @@ import org.apache.lucene.index.DirectoryReader;
 import org.apache.lucene.index.RandomIndexWriter;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.time.DateFormatter;
 import org.elasticsearch.script.AbstractFieldScript;
+import org.elasticsearch.script.DateFieldScript;
 import org.elasticsearch.script.GeoPointFieldScript;
 import org.elasticsearch.script.ScriptContext;
 import org.elasticsearch.search.lookup.SearchLookup;
 
 import java.io.IOException;
+import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.Map;
 
@@ -45,6 +48,24 @@ public class GeoPointFieldScriptTests extends FieldScriptTestCase<GeoPointFieldS
     @Override
     protected GeoPointFieldScript.Factory dummyScript() {
         return DUMMY;
+    }
+
+    public void testAsDocValues() {
+        GeoPointFieldScript script = new GeoPointFieldScript(
+                "test",
+                Map.of(),
+                new SearchLookup(field -> null, (ft, lookup) -> null),
+                null
+        ) {
+            @Override
+            public void execute() {
+                emit(78.96, 12.12);
+                emit(13.45, 56.78);
+            }
+        };
+        script.execute();
+
+        assertArrayEquals(new long[] {1378381707499043786L, 8091971733044486384L}, script.asDocValues());
     }
 
     public void testTooManyValues() throws IOException {

--- a/server/src/test/java/org/elasticsearch/index/mapper/GeoPointFieldScriptTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/GeoPointFieldScriptTests.java
@@ -13,15 +13,12 @@ import org.apache.lucene.index.DirectoryReader;
 import org.apache.lucene.index.RandomIndexWriter;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.util.BytesRef;
-import org.elasticsearch.common.time.DateFormatter;
 import org.elasticsearch.script.AbstractFieldScript;
-import org.elasticsearch.script.DateFieldScript;
 import org.elasticsearch.script.GeoPointFieldScript;
 import org.elasticsearch.script.ScriptContext;
 import org.elasticsearch.search.lookup.SearchLookup;
 
 import java.io.IOException;
-import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.Map;
 

--- a/server/src/test/java/org/elasticsearch/index/mapper/IpFieldScriptTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/IpFieldScriptTests.java
@@ -15,7 +15,6 @@ import org.apache.lucene.store.Directory;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.script.AbstractFieldScript;
 import org.elasticsearch.script.IpFieldScript;
-import org.elasticsearch.script.LongFieldScript;
 import org.elasticsearch.script.ScriptContext;
 import org.elasticsearch.search.lookup.SearchLookup;
 
@@ -57,7 +56,10 @@ public class IpFieldScriptTests extends FieldScriptTestCase<IpFieldScript.Factor
         ) {
             @Override
             public void execute() {
-                emit("192.168.0.1"); emit("127.0.0.1"); emit("255.255.255.255"); emit("0.0.0.0");
+                emit("192.168.0.1");
+                emit("127.0.0.1");
+                emit("255.255.255.255");
+                emit("0.0.0.0");
             }
         };
         script.execute();

--- a/server/src/test/java/org/elasticsearch/index/mapper/IpFieldScriptTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/IpFieldScriptTests.java
@@ -15,6 +15,7 @@ import org.apache.lucene.store.Directory;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.script.AbstractFieldScript;
 import org.elasticsearch.script.IpFieldScript;
+import org.elasticsearch.script.LongFieldScript;
 import org.elasticsearch.script.ScriptContext;
 import org.elasticsearch.search.lookup.SearchLookup;
 
@@ -45,6 +46,29 @@ public class IpFieldScriptTests extends FieldScriptTestCase<IpFieldScript.Factor
     @Override
     protected IpFieldScript.Factory dummyScript() {
         return DUMMY;
+    }
+
+    public void testAsDocValues() {
+        IpFieldScript script = new IpFieldScript(
+                "test",
+                Map.of(),
+                new SearchLookup(field -> null, (ft, lookup) -> null),
+                null
+        ) {
+            @Override
+            public void execute() {
+                emit("192.168.0.1"); emit("127.0.0.1"); emit("255.255.255.255"); emit("0.0.0.0");
+            }
+        };
+        script.execute();
+
+        assertArrayEquals(new BytesRef[] {
+                new BytesRef(new byte[] {0,0,0,0,0,0,0,0,0,0,-1,-1,0,0,0,0}),
+                new BytesRef(new byte[] {0,0,0,0,0,0,0,0,0,0,-1,-1,127,0,0,1}),
+                new BytesRef(new byte[] {0,0,0,0,0,0,0,0,0,0,-1,-1,-64,-88,0,1}),
+                new BytesRef(new byte[] {0,0,0,0,0,0,0,0,0,0,-1,-1,-1,-1,-1,-1})},
+                script.asDocValues()
+        );
     }
 
     public void testTooManyValues() throws IOException {

--- a/server/src/test/java/org/elasticsearch/index/mapper/LongFieldScriptTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/LongFieldScriptTests.java
@@ -14,7 +14,6 @@ import org.apache.lucene.index.RandomIndexWriter;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.script.AbstractFieldScript;
-import org.elasticsearch.script.BooleanFieldScript;
 import org.elasticsearch.script.LongFieldScript;
 import org.elasticsearch.script.ScriptContext;
 import org.elasticsearch.search.lookup.SearchLookup;
@@ -57,7 +56,12 @@ public class LongFieldScriptTests extends FieldScriptTestCase<LongFieldScript.Fa
         ) {
             @Override
             public void execute() {
-                emit(3L); emit(1L); emit(20000000000L); emit(10L); emit(-1000L); emit(0L);
+                emit(3L);
+                emit(1L);
+                emit(20000000000L);
+                emit(10L);
+                emit(-1000L);
+                emit(0L);
             }
         };
         script.execute();

--- a/server/src/test/java/org/elasticsearch/index/mapper/LongFieldScriptTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/LongFieldScriptTests.java
@@ -14,6 +14,7 @@ import org.apache.lucene.index.RandomIndexWriter;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.script.AbstractFieldScript;
+import org.elasticsearch.script.BooleanFieldScript;
 import org.elasticsearch.script.LongFieldScript;
 import org.elasticsearch.script.ScriptContext;
 import org.elasticsearch.search.lookup.SearchLookup;
@@ -45,6 +46,23 @@ public class LongFieldScriptTests extends FieldScriptTestCase<LongFieldScript.Fa
     @Override
     protected LongFieldScript.Factory dummyScript() {
         return DUMMY;
+    }
+
+    public void testAsDocValues() {
+        LongFieldScript script = new LongFieldScript(
+                "test",
+                Map.of(),
+                new SearchLookup(field -> null, (ft, lookup) -> null),
+                null
+        ) {
+            @Override
+            public void execute() {
+                emit(3L); emit(1L); emit(20000000000L); emit(10L); emit(-1000L); emit(0L);
+            }
+        };
+        script.execute();
+
+        assertArrayEquals(new long[] {-1000L, 0L, 1L, 3L, 10L, 20000000000L}, script.asDocValues());
     }
 
     public void testTooManyValues() throws IOException {

--- a/server/src/test/java/org/elasticsearch/index/mapper/StringFieldScriptTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/StringFieldScriptTests.java
@@ -14,7 +14,6 @@ import org.apache.lucene.index.RandomIndexWriter;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.script.AbstractFieldScript;
-import org.elasticsearch.script.LongFieldScript;
 import org.elasticsearch.script.ScriptContext;
 import org.elasticsearch.script.StringFieldScript;
 import org.elasticsearch.search.lookup.SearchLookup;
@@ -57,7 +56,12 @@ public class StringFieldScriptTests extends FieldScriptTestCase<StringFieldScrip
         ) {
             @Override
             public void execute() {
-                emit("test"); emit("baz was not here"); emit("Data"); emit("-10"); emit("20"); emit("9");
+                emit("test");
+                emit("baz was not here");
+                emit("Data");
+                emit("-10");
+                emit("20");
+                emit("9");
             }
         };
         script.execute();


### PR DESCRIPTION
This adds utility methods to each type of runtime field to return the results of a document in an ordered array based on the same order that doc values are ordered in. This is useful for supporting execute api in this https://github.com/elastic/elasticsearch/pull/71374.