### PR TITLE
Fit runtime field on line (backport of #71470)

### DIFF
--- a/docs/reference/search/search.asciidoc
+++ b/docs/reference/search/search.asciidoc
@@ -452,14 +452,50 @@ script has access to the entire context of a document, including the original
 Your script must include `emit` to return calculated values. For
 example:
 +
-[source,js]
+[source,js,indent=0]
 ----
-"script": {
-  "source": "emit(doc['@timestamp'].value.dayOfWeekEnum.getDisplayName(TextStyle.FULL, Locale.ROOT))"
-        }
+include::search.asciidoc[tag=runtime-script]
 ----
 // NOTCONSOLE
 ====
+
+////
+[source,console]
+----
+POST _search?size=1&filter_path=hits.hits
+{
+  "runtime_mappings": {
+    "dow": {
+      "type": "keyword",
+      // tag::runtime-script[]
+      "script": "emit(doc['@timestamp'].value.dayOfWeekEnum.toString())"
+      // end::runtime-script[]
+    }
+  },
+  "fields": [{"field": "dow"}]
+}
+----
+// TEST[setup:my_index]
+
+[source,console-result]
+----
+{
+  "hits": {
+    "hits": [
+      {
+        "_index": $body.hits.hits.0._index,
+        "_id": $body.hits.hits.0._id,
+        "_score": $body.hits.hits.0._score,
+        "_source": $body.hits.hits.0._source,
+        "fields": {
+          "dow": ["SUNDAY"]
+        }
+      }
+    ]
+  }
+}
+----
+////
 
 [[request-body-search-seq-no-primary-term]]
 `seq_no_primary_term`::

--- a/docs/reference/search/search.asciidoc
+++ b/docs/reference/search/search.asciidoc
@@ -484,6 +484,7 @@ POST _search?size=1&filter_path=hits.hits
     "hits": [
       {
         "_index": $body.hits.hits.0._index,
+        "_type": "_doc",
         "_id": $body.hits.hits.0._id,
         "_score": $body.hits.hits.0._score,
         "_source": $body.hits.hits.0._source,


### PR DESCRIPTION
This shrinks a runtime field definition so that it fits on the screen
without scrolling. It also converts the doc into a test so we can be
sure it continues to work.

Relates to #69291
