### PR TITLE
Update version constants for API key metadata

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/CreateApiKeyRequest.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/CreateApiKeyRequest.java
@@ -174,7 +174,7 @@ public final class CreateApiKeyRequest extends ActionRequest {
         out.writeOptionalTimeValue(expiration);
         out.writeList(roleDescriptors);
         refreshPolicy.writeTo(out);
-        if (out.getVersion().onOrAfter(Version.V_8_0_0)) {
+        if (out.getVersion().onOrAfter(Version.V_7_13_0)) {
             out.writeMap(metadata);
         }
     }

--- a/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/mixed_cluster/120_api_key.yml
+++ b/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/mixed_cluster/120_api_key.yml
@@ -30,7 +30,7 @@
 
   - do:
       node_selector:
-        version: "8.0.0 - "
+        version: " 7.13.0 - "
       security.create_api_key:
         body:  >
           {

--- a/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/upgraded_cluster/120_api_key.yml
+++ b/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/upgraded_cluster/120_api_key.yml
@@ -49,7 +49,4 @@
   - length: { api_keys: 1 }
 
   - match: { api_keys.0.name: "my-mixed-api-key-2" }
-# We cannot assert metadata for this API key because it is possible
-# that the security index is on an old node and the metadata is dropped
-# when transfer through the wire. But at least the key will be created
-# and retrieved successfully
+  - match: { api_keys.0.metadata: {"foo": "bar"} }


### PR DESCRIPTION
This PR updates the version constants for API key metadata to be `7.13.0` since #70956 is backported.