### PR TITLE
[Transform] Add telemetry support for transform features

### DIFF
--- a/docs/reference/rest-api/usage.asciidoc
+++ b/docs/reference/rest-api/usage.asciidoc
@@ -270,18 +270,7 @@ GET /_xpack/usage
   },
   "transform" : {
     "available" : true,
-    "enabled" : true,
-    "transforms": {
-      "_all": 9,
-      "stopped": 7,
-      "started": 2
-    },
-    "feature_counts": {
-      "pivot": 8,
-      "latest": 1,
-      "sync": 5,
-      "retention_policy": 2
-    }
+    "enabled" : true
   },
   "vectors" : {
     "available" : true,

--- a/docs/reference/rest-api/usage.asciidoc
+++ b/docs/reference/rest-api/usage.asciidoc
@@ -270,7 +270,18 @@ GET /_xpack/usage
   },
   "transform" : {
     "available" : true,
-    "enabled" : true
+    "enabled" : true,
+    "transforms": {
+      "_all": 9,
+      "stopped": 7,
+      "started": 2
+    },
+    "feature_counts": {
+      "pivot": 8,
+      "latest": 1,
+      "sync": 5,
+      "retention_policy": 2
+    }
   },
   "vectors" : {
     "available" : true,

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/TransformFeatureSetUsage.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/TransformFeatureSetUsage.java
@@ -17,25 +17,36 @@ import org.elasticsearch.xpack.core.transform.transforms.TransformIndexerStats;
 import org.elasticsearch.xpack.core.XPackField;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Objects;
 
 public class TransformFeatureSetUsage extends Usage {
 
+    private static final String FEATURE_COUNTS = "feature_counts";
+
     private final Map<String, Long> transformCountByState;
+    private final Map<String, Long> transformCountByFeature;
     private final TransformIndexerStats accumulatedStats;
 
     public TransformFeatureSetUsage(StreamInput in) throws IOException {
         super(in);
         this.transformCountByState = in.readMap(StreamInput::readString, StreamInput::readLong);
+        if (in.getVersion().onOrAfter(Version.CURRENT)) {  // TODO: V_7_13_0
+            this.transformCountByFeature = in.readMap(StreamInput::readString, StreamInput::readLong);
+        } else {
+            this.transformCountByFeature = Collections.emptyMap();
+        }
         this.accumulatedStats = new TransformIndexerStats(in);
     }
 
     public TransformFeatureSetUsage(Map<String, Long> transformCountByState,
-            TransformIndexerStats accumulatedStats) {
+                                    Map<String, Long> transformCountByFeature,
+                                    TransformIndexerStats accumulatedStats) {
         super(XPackField.TRANSFORM, true, true);
         this.transformCountByState = Objects.requireNonNull(transformCountByState);
+        this.transformCountByFeature = Objects.requireNonNull(transformCountByFeature);
         this.accumulatedStats = Objects.requireNonNull(accumulatedStats);
     }
 
@@ -48,6 +59,9 @@ public class TransformFeatureSetUsage extends Usage {
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
         out.writeMap(transformCountByState, StreamOutput::writeString, StreamOutput::writeLong);
+        if (out.getVersion().onOrAfter(Version.CURRENT)) {  // TODO: V_7_13_0
+            out.writeMap(transformCountByFeature, StreamOutput::writeString, StreamOutput::writeLong);
+        }
         accumulatedStats.writeTo(out);
     }
 
@@ -55,14 +69,18 @@ public class TransformFeatureSetUsage extends Usage {
     protected void innerXContent(XContentBuilder builder, Params params) throws IOException {
         super.innerXContent(builder, params);
         if (transformCountByState.isEmpty() == false) {
+            // Transforms by state
             builder.startObject(TransformField.TRANSFORMS.getPreferredName());
             long all = 0L;
             for (Entry<String, Long> entry : transformCountByState.entrySet()) {
                 builder.field(entry.getKey(), entry.getValue());
-                all+=entry.getValue();
+                all += entry.getValue();
             }
             builder.field(Metadata.ALL, all);
             builder.endObject();
+
+            // Transform count for each feature
+            builder.field(FEATURE_COUNTS, transformCountByFeature);
 
             // if there are no transforms, do not show any stats
             builder.field(TransformField.STATS_FIELD.getPreferredName(), accumulatedStats);
@@ -71,7 +89,7 @@ public class TransformFeatureSetUsage extends Usage {
 
     @Override
     public int hashCode() {
-        return Objects.hash(enabled, available, transformCountByState, accumulatedStats);
+        return Objects.hash(enabled, available, transformCountByState, transformCountByFeature, accumulatedStats);
     }
 
     @Override
@@ -85,6 +103,7 @@ public class TransformFeatureSetUsage extends Usage {
         TransformFeatureSetUsage other = (TransformFeatureSetUsage) obj;
         return Objects.equals(name, other.name) && available == other.available && enabled == other.enabled
                 && Objects.equals(transformCountByState, other.transformCountByState)
+                && Objects.equals(transformCountByFeature, other.transformCountByFeature)
                 && Objects.equals(accumulatedStats, other.accumulatedStats);
     }
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/TransformFeatureSetUsage.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/TransformFeatureSetUsage.java
@@ -33,7 +33,7 @@ public class TransformFeatureSetUsage extends Usage {
     public TransformFeatureSetUsage(StreamInput in) throws IOException {
         super(in);
         this.transformCountByState = in.readMap(StreamInput::readString, StreamInput::readLong);
-        if (in.getVersion().onOrAfter(Version.CURRENT)) {  // TODO: V_7_13_0
+        if (in.getVersion().onOrAfter(Version.V_8_0_0)) {  // TODO: V_7_13_0
             this.transformCountByFeature = in.readMap(StreamInput::readString, StreamInput::readLong);
         } else {
             this.transformCountByFeature = Collections.emptyMap();
@@ -59,7 +59,7 @@ public class TransformFeatureSetUsage extends Usage {
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
         out.writeMap(transformCountByState, StreamOutput::writeString, StreamOutput::writeLong);
-        if (out.getVersion().onOrAfter(Version.CURRENT)) {  // TODO: V_7_13_0
+        if (out.getVersion().onOrAfter(Version.V_8_0_0)) {  // TODO: V_7_13_0
             out.writeMap(transformCountByFeature, StreamOutput::writeString, StreamOutput::writeLong);
         }
         accumulatedStats.writeTo(out);

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/TransformField.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/TransformField.java
@@ -10,7 +10,7 @@ package org.elasticsearch.xpack.core.transform;
 import org.elasticsearch.common.ParseField;
 
 /*
- * Utility class to hold common fields and strings for data frame.
+ * Utility class to hold common fields and strings for transform.
  */
 public final class TransformField {
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/transforms/TransformConfig.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/transforms/TransformConfig.java
@@ -35,6 +35,7 @@ import java.io.IOException;
 import java.time.Instant;
 import java.util.Collections;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 
@@ -51,10 +52,20 @@ public class TransformConfig extends AbstractDiffable<TransformConfig> implement
     /** Version in which {@code FieldCapabilitiesRequest.runtime_fields} field was introduced. */
     private static final Version FIELD_CAPS_RUNTIME_MAPPINGS_INTRODUCED_VERSION = Version.V_7_12_0;
 
-    // types of transforms
-    public static final ParseField PIVOT_TRANSFORM = new ParseField("pivot");
-    public static final ParseField LATEST_TRANSFORM = new ParseField("latest");
+    /** Specifies all the possible transform functions. */
+    public enum Function {
+        PIVOT, LATEST;
 
+        private final ParseField parseField;
+
+        Function() {
+            this.parseField = new ParseField(name().toLowerCase(Locale.ROOT));
+        }
+
+        public ParseField getParseField() {
+            return parseField;
+        }
+    }
     private static final ConstructingObjectParser<TransformConfig, String> STRICT_PARSER = createParser(false);
     private static final ConstructingObjectParser<TransformConfig, String> LENIENT_PARSER = createParser(true);
     static final int MAX_DESCRIPTION_LENGTH = 1_000;
@@ -149,8 +160,8 @@ public class TransformConfig extends AbstractDiffable<TransformConfig> implement
         parser.declareNamedObject(optionalConstructorArg(), (p, c, n) -> p.namedObject(SyncConfig.class, n, c), TransformField.SYNC);
         parser.declareString(optionalConstructorArg(), TransformField.INDEX_DOC_TYPE);
         parser.declareObject(optionalConstructorArg(), (p, c) -> p.mapStrings(), HEADERS);
-        parser.declareObject(optionalConstructorArg(), (p, c) -> PivotConfig.fromXContent(p, lenient), PIVOT_TRANSFORM);
-        parser.declareObject(optionalConstructorArg(), (p, c) -> LatestConfig.fromXContent(p, lenient), LATEST_TRANSFORM);
+        parser.declareObject(optionalConstructorArg(), (p, c) -> PivotConfig.fromXContent(p, lenient), Function.PIVOT.getParseField());
+        parser.declareObject(optionalConstructorArg(), (p, c) -> LatestConfig.fromXContent(p, lenient), Function.LATEST.getParseField());
         parser.declareString(optionalConstructorArg(), TransformField.DESCRIPTION);
         parser.declareObject(optionalConstructorArg(), (p, c) -> SettingsConfig.fromXContent(p, lenient), TransformField.SETTINGS);
         parser.declareNamedObject(
@@ -429,10 +440,10 @@ public class TransformConfig extends AbstractDiffable<TransformConfig> implement
             builder.endObject();
         }
         if (pivotConfig != null) {
-            builder.field(PIVOT_TRANSFORM.getPreferredName(), pivotConfig);
+            builder.field(Function.PIVOT.getParseField().getPreferredName(), pivotConfig);
         }
         if (latestConfig != null) {
-            builder.field(LATEST_TRANSFORM.getPreferredName(), latestConfig);
+            builder.field(Function.LATEST.getParseField().getPreferredName(), latestConfig);
         }
         if (description != null) {
             builder.field(TransformField.DESCRIPTION.getPreferredName(), description);

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/transforms/persistence/TransformInternalIndexConstants.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/transforms/persistence/TransformInternalIndexConstants.java
@@ -31,8 +31,8 @@ public final class TransformInternalIndexConstants {
     public static final String TRANSFORM_PREFIX_DEPRECATED = ".data-frame-";
 
     // version is not a rollover pattern, however padded because sort is string based
-    public static final Version INDEX_VERSION_LAST_CHANGED = Version.V_7_12_0;
-    public static final String INDEX_VERSION = "006";
+    public static final Version INDEX_VERSION_LAST_CHANGED = Version.V_7_13_0;
+    public static final String INDEX_VERSION = "007";
     public static final String INDEX_PATTERN = TRANSFORM_PREFIX + "internal-";
     public static final String LATEST_INDEX_VERSIONED_NAME = INDEX_PATTERN + INDEX_VERSION;
     public static final String LATEST_INDEX_NAME = LATEST_INDEX_VERSIONED_NAME;

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/transform/TransformFeatureSetUsageTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/transform/TransformFeatureSetUsageTests.java
@@ -10,27 +10,30 @@ package org.elasticsearch.xpack.core.transform;
 import org.elasticsearch.common.io.stream.Writeable.Reader;
 import org.elasticsearch.test.AbstractWireSerializingTestCase;
 import org.elasticsearch.xpack.core.indexing.IndexerState;
+import org.elasticsearch.xpack.core.transform.transforms.TransformIndexerStats;
 import org.elasticsearch.xpack.core.transform.transforms.TransformIndexerStatsTests;
 
-import java.util.HashMap;
+import java.util.Arrays;
 import java.util.Map;
+
+import static java.util.stream.Collectors.toMap;
 
 public class TransformFeatureSetUsageTests extends AbstractWireSerializingTestCase<TransformFeatureSetUsage> {
 
     @Override
     protected TransformFeatureSetUsage createTestInstance() {
-        Map<String, Long> transformCountByState = new HashMap<>();
-
-        if (randomBoolean()) {
-            transformCountByState.put(randomFrom(IndexerState.values()).toString(), randomLong());
-        }
-
-        return new TransformFeatureSetUsage(transformCountByState, TransformIndexerStatsTests.randomStats());
+        Map<String, Long> transformCountByState =
+            randomSubsetOf(Arrays.asList(IndexerState.values())).stream()
+                .collect(toMap(state -> state.value(), state -> randomLong()));
+        Map<String, Long> transformCountByFeature =
+            randomList(10, () -> randomAlphaOfLength(10)).stream()
+                .collect(toMap(f -> f, f -> randomLong()));
+        TransformIndexerStats accumulatedStats = TransformIndexerStatsTests.randomStats();
+        return new TransformFeatureSetUsage(transformCountByState, transformCountByFeature, accumulatedStats);
     }
 
     @Override
     protected Reader<TransformFeatureSetUsage> instanceReader() {
         return TransformFeatureSetUsage::new;
     }
-
 }

--- a/x-pack/plugin/transform/qa/single-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/TransformRestTestCase.java
+++ b/x-pack/plugin/transform/qa/single-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/TransformRestTestCase.java
@@ -247,8 +247,6 @@ public abstract class TransformRestTestCase extends ESRestTestCase {
 
     protected void createContinuousPivotReviewsTransform(String transformId, String transformIndex, String authHeader) throws IOException {
 
-        final Request createTransformRequest = createRequestWithAuth("PUT", getTransformEndpoint() + transformId, authHeader);
-
         String config = "{ \"dest\": {\"index\":\"" + transformIndex + "\"}," + " \"source\": {\"index\":\"" + REVIEWS_INDEX_NAME + "\"},"
         // Set frequency high for testing
             + " \"sync\": {\"time\":{\"field\": \"timestamp\", \"delay\": \"15m\"}},"
@@ -266,10 +264,7 @@ public abstract class TransformRestTestCase extends ESRestTestCase {
             + " } } } }"
             + "}";
 
-        createTransformRequest.setJsonEntity(config);
-
-        Map<String, Object> createTransformResponse = entityAsMap(client().performRequest(createTransformRequest));
-        assertThat(createTransformResponse.get("acknowledged"), equalTo(Boolean.TRUE));
+        createReviewsTransform(transformId, authHeader, config);
     }
 
     protected void createPivotReviewsTransform(
@@ -280,8 +275,6 @@ public abstract class TransformRestTestCase extends ESRestTestCase {
         String authHeader,
         String sourceIndex
     ) throws IOException {
-        final Request createTransformRequest = createRequestWithAuth("PUT", getTransformEndpoint() + transformId, authHeader);
-
         String config = "{";
 
         if (pipeline != null) {
@@ -315,6 +308,25 @@ public abstract class TransformRestTestCase extends ESRestTestCase {
             + "\"frequency\":\"1s\""
             + "}";
 
+        createReviewsTransform(transformId, authHeader, config);
+    }
+
+    protected void createLatestReviewsTransform(String transformId, String transformIndex) throws IOException {
+        String config = "{"
+            + " \"dest\": {\"index\":\"" + transformIndex + "\"},"
+            + " \"source\": {\"index\":\"" + REVIEWS_INDEX_NAME + "\"},"
+            + " \"latest\": {"
+            + "   \"unique_key\": [ \"user_id\" ],"
+            + "   \"sort\": \"@timestamp\""
+            + " },"
+            + "\"frequency\":\"1s\""
+            + "}";
+
+        createReviewsTransform(transformId, null, config);
+    }
+
+    private void createReviewsTransform(String transformId, String authHeader, String config) throws IOException {
+        final Request createTransformRequest = createRequestWithAuth("PUT", getTransformEndpoint() + transformId, authHeader);
         createTransformRequest.setJsonEntity(config);
 
         Map<String, Object> createTransformResponse = entityAsMap(client().performRequest(createTransformRequest));

--- a/x-pack/plugin/transform/qa/single-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/TransformUsageIT.java
+++ b/x-pack/plugin/transform/qa/single-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/TransformUsageIT.java
@@ -55,7 +55,7 @@ public class TransformUsageIT extends TransformRestTestCase {
         assertEquals(4, XContentMapValues.extractValue("transform.transforms.stopped", usageAsMap));
         assertEquals(3, XContentMapValues.extractValue("transform.feature_counts.pivot", usageAsMap));
         assertEquals(1, XContentMapValues.extractValue("transform.feature_counts.latest", usageAsMap));
-        assertNull(XContentMapValues.extractValue("transform.feature_counts.retention_policy", usageAsMap));
+        assertEquals(0, XContentMapValues.extractValue("transform.feature_counts.retention_policy", usageAsMap));
         assertEquals(1, XContentMapValues.extractValue("transform.feature_counts.sync", usageAsMap));
 
         startAndWaitForTransform("test_usage", "pivot_reviews");
@@ -111,7 +111,7 @@ public class TransformUsageIT extends TransformRestTestCase {
             assertEquals(1, XContentMapValues.extractValue("transform.transforms.started", statsMap));
             assertEquals(3, XContentMapValues.extractValue("transform.feature_counts.pivot", statsMap));
             assertEquals(1, XContentMapValues.extractValue("transform.feature_counts.latest", statsMap));
-            assertNull(XContentMapValues.extractValue("transform.feature_counts.retention_policy", statsMap));
+            assertEquals(0, XContentMapValues.extractValue("transform.feature_counts.retention_policy", statsMap));
             assertEquals(1, XContentMapValues.extractValue("transform.feature_counts.sync", statsMap));
             for (String statName : PROVIDED_STATS) {
                 // the trigger count can be off: e.g. if the scheduler kicked in before usage has been called,
@@ -144,7 +144,7 @@ public class TransformUsageIT extends TransformRestTestCase {
         assertEquals(4, XContentMapValues.extractValue("transform.transforms.stopped", usageAsMap));
         assertEquals(3, XContentMapValues.extractValue("transform.feature_counts.pivot", usageAsMap));
         assertEquals(1, XContentMapValues.extractValue("transform.feature_counts.latest", usageAsMap));
-        assertNull(XContentMapValues.extractValue("transform.feature_counts.retention_policy", usageAsMap));
+        assertEquals(0, XContentMapValues.extractValue("transform.feature_counts.retention_policy", usageAsMap));
         assertEquals(1, XContentMapValues.extractValue("transform.feature_counts.sync", usageAsMap));
     }
 

--- a/x-pack/plugin/transform/qa/single-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/TransformUsageIT.java
+++ b/x-pack/plugin/transform/qa/single-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/TransformUsageIT.java
@@ -41,7 +41,7 @@ public class TransformUsageIT extends TransformRestTestCase {
         assertTrue((boolean) XContentMapValues.extractValue("transform.enabled", usageAsMap));
         // no transforms, no stats
         assertNull(XContentMapValues.extractValue("transform.transforms", usageAsMap));
-        assertNull(XContentMapValues.extractValue("transform.functions", usageAsMap));
+        assertNull(XContentMapValues.extractValue("transform.feature_counts", usageAsMap));
         assertNull(XContentMapValues.extractValue("transform.stats", usageAsMap));
 
         // create transforms
@@ -53,9 +53,10 @@ public class TransformUsageIT extends TransformRestTestCase {
         usageAsMap = entityAsMap(usageResponse);
         assertEquals(4, XContentMapValues.extractValue("transform.transforms._all", usageAsMap));
         assertEquals(4, XContentMapValues.extractValue("transform.transforms.stopped", usageAsMap));
-        assertEquals(4, XContentMapValues.extractValue("transform.functions._all", usageAsMap));
-        assertEquals(3, XContentMapValues.extractValue("transform.functions.pivot", usageAsMap));
-        assertEquals(1, XContentMapValues.extractValue("transform.functions.latest", usageAsMap));
+        assertEquals(3, XContentMapValues.extractValue("transform.feature_counts.pivot", usageAsMap));
+        assertEquals(1, XContentMapValues.extractValue("transform.feature_counts.latest", usageAsMap));
+        assertNull(XContentMapValues.extractValue("transform.feature_counts.retention_policy", usageAsMap));
+        assertEquals(1, XContentMapValues.extractValue("transform.feature_counts.sync", usageAsMap));
 
         startAndWaitForTransform("test_usage", "pivot_reviews");
         stopTransform("test_usage", false);
@@ -108,9 +109,10 @@ public class TransformUsageIT extends TransformRestTestCase {
             assertEquals(4, XContentMapValues.extractValue("transform.transforms._all", statsMap));
             assertEquals(3, XContentMapValues.extractValue("transform.transforms.stopped", statsMap));
             assertEquals(1, XContentMapValues.extractValue("transform.transforms.started", statsMap));
-            assertEquals(4, XContentMapValues.extractValue("transform.functions._all", statsMap));
-            assertEquals(3, XContentMapValues.extractValue("transform.functions.pivot", statsMap));
-            assertEquals(1, XContentMapValues.extractValue("transform.functions.latest", statsMap));
+            assertEquals(3, XContentMapValues.extractValue("transform.feature_counts.pivot", statsMap));
+            assertEquals(1, XContentMapValues.extractValue("transform.feature_counts.latest", statsMap));
+            assertNull(XContentMapValues.extractValue("transform.feature_counts.retention_policy", statsMap));
+            assertEquals(1, XContentMapValues.extractValue("transform.feature_counts.sync", statsMap));
             for (String statName : PROVIDED_STATS) {
                 // the trigger count can be off: e.g. if the scheduler kicked in before usage has been called,
                 // or if the scheduler triggered later, but state hasn't been persisted (by design)
@@ -140,9 +142,10 @@ public class TransformUsageIT extends TransformRestTestCase {
 
         assertEquals(4, XContentMapValues.extractValue("transform.transforms._all", usageAsMap));
         assertEquals(4, XContentMapValues.extractValue("transform.transforms.stopped", usageAsMap));
-        assertEquals(4, XContentMapValues.extractValue("transform.functions._all", usageAsMap));
-        assertEquals(3, XContentMapValues.extractValue("transform.functions.pivot", usageAsMap));
-        assertEquals(1, XContentMapValues.extractValue("transform.functions.latest", usageAsMap));
+        assertEquals(3, XContentMapValues.extractValue("transform.feature_counts.pivot", usageAsMap));
+        assertEquals(1, XContentMapValues.extractValue("transform.feature_counts.latest", usageAsMap));
+        assertNull(XContentMapValues.extractValue("transform.feature_counts.retention_policy", usageAsMap));
+        assertEquals(1, XContentMapValues.extractValue("transform.feature_counts.sync", usageAsMap));
     }
 
     private static double extractStatsAsDouble(Object statsObject) {

--- a/x-pack/plugin/transform/qa/single-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/TransformUsageIT.java
+++ b/x-pack/plugin/transform/qa/single-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/TransformUsageIT.java
@@ -40,17 +40,22 @@ public class TransformUsageIT extends TransformRestTestCase {
         assertTrue((boolean) XContentMapValues.extractValue("transform.available", usageAsMap));
         assertTrue((boolean) XContentMapValues.extractValue("transform.enabled", usageAsMap));
         // no transforms, no stats
-        assertEquals(null, XContentMapValues.extractValue("transform.transforms", usageAsMap));
-        assertEquals(null, XContentMapValues.extractValue("transform.stats", usageAsMap));
+        assertNull(XContentMapValues.extractValue("transform.transforms", usageAsMap));
+        assertNull(XContentMapValues.extractValue("transform.functions", usageAsMap));
+        assertNull(XContentMapValues.extractValue("transform.stats", usageAsMap));
 
         // create transforms
         createPivotReviewsTransform("test_usage", "pivot_reviews", null);
         createPivotReviewsTransform("test_usage_no_stats", "pivot_reviews_no_stats", null);
         createContinuousPivotReviewsTransform("test_usage_continuous", "pivot_reviews_continuous", null);
+        createLatestReviewsTransform("test_usage_latest", "latest_reviews");
         usageResponse = client().performRequest(new Request("GET", "_xpack/usage"));
         usageAsMap = entityAsMap(usageResponse);
-        assertEquals(3, XContentMapValues.extractValue("transform.transforms._all", usageAsMap));
-        assertEquals(3, XContentMapValues.extractValue("transform.transforms.stopped", usageAsMap));
+        assertEquals(4, XContentMapValues.extractValue("transform.transforms._all", usageAsMap));
+        assertEquals(4, XContentMapValues.extractValue("transform.transforms.stopped", usageAsMap));
+        assertEquals(4, XContentMapValues.extractValue("transform.functions._all", usageAsMap));
+        assertEquals(3, XContentMapValues.extractValue("transform.functions.pivot", usageAsMap));
+        assertEquals(1, XContentMapValues.extractValue("transform.functions.latest", usageAsMap));
 
         startAndWaitForTransform("test_usage", "pivot_reviews");
         stopTransform("test_usage", false);
@@ -100,9 +105,12 @@ public class TransformUsageIT extends TransformRestTestCase {
             Response response = client().performRequest(new Request("GET", "_xpack/usage"));
             Map<String, Object> statsMap = entityAsMap(response);
             // we should see some stats
-            assertEquals(3, XContentMapValues.extractValue("transform.transforms._all", statsMap));
-            assertEquals(2, XContentMapValues.extractValue("transform.transforms.stopped", statsMap));
+            assertEquals(4, XContentMapValues.extractValue("transform.transforms._all", statsMap));
+            assertEquals(3, XContentMapValues.extractValue("transform.transforms.stopped", statsMap));
             assertEquals(1, XContentMapValues.extractValue("transform.transforms.started", statsMap));
+            assertEquals(4, XContentMapValues.extractValue("transform.functions._all", statsMap));
+            assertEquals(3, XContentMapValues.extractValue("transform.functions.pivot", statsMap));
+            assertEquals(1, XContentMapValues.extractValue("transform.functions.latest", statsMap));
             for (String statName : PROVIDED_STATS) {
                 // the trigger count can be off: e.g. if the scheduler kicked in before usage has been called,
                 // or if the scheduler triggered later, but state hasn't been persisted (by design)
@@ -130,11 +138,14 @@ public class TransformUsageIT extends TransformRestTestCase {
         usageResponse = client().performRequest(new Request("GET", "_xpack/usage"));
         usageAsMap = entityAsMap(usageResponse);
 
-        assertEquals(3, XContentMapValues.extractValue("transform.transforms._all", usageAsMap));
-        assertEquals(3, XContentMapValues.extractValue("transform.transforms.stopped", usageAsMap));
+        assertEquals(4, XContentMapValues.extractValue("transform.transforms._all", usageAsMap));
+        assertEquals(4, XContentMapValues.extractValue("transform.transforms.stopped", usageAsMap));
+        assertEquals(4, XContentMapValues.extractValue("transform.functions._all", usageAsMap));
+        assertEquals(3, XContentMapValues.extractValue("transform.functions.pivot", usageAsMap));
+        assertEquals(1, XContentMapValues.extractValue("transform.functions.latest", usageAsMap));
     }
 
-    private double extractStatsAsDouble(Object statsObject) {
+    private static double extractStatsAsDouble(Object statsObject) {
         if (statsObject instanceof Integer) {
             return ((Integer) statsObject).doubleValue();
         } else if (statsObject instanceof Double) {

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/TransformUsageTransportAction.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/TransformUsageTransportAction.java
@@ -129,9 +129,7 @@ public class TransformUsageTransportAction extends XPackUsageFeatureTransportAct
             }
             long totalTransforms = transformCountSuccess.getHits().getTotalHits().value;
             if (totalTransforms == 0) {
-                transformsCountByFeature.set(Collections.emptyMap());
-                var usage =
-                    new TransformFeatureSetUsage(transformsCountByState, transformsCountByFeature.get(), new TransformIndexerStats());
+                var usage = new TransformFeatureSetUsage(transformsCountByState, Collections.emptyMap(), new TransformIndexerStats());
                 listener.onResponse(new XPackUsageFeatureResponse(usage));
                 return;
             }

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/persistence/TransformInternalIndex.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/persistence/TransformInternalIndex.java
@@ -34,6 +34,7 @@ import org.elasticsearch.xpack.core.transform.TransformField;
 import org.elasticsearch.xpack.core.transform.transforms.DestConfig;
 import org.elasticsearch.xpack.core.transform.transforms.SourceConfig;
 import org.elasticsearch.xpack.core.transform.transforms.TransformCheckpoint;
+import org.elasticsearch.xpack.core.transform.transforms.TransformConfig;
 import org.elasticsearch.xpack.core.transform.transforms.TransformIndexerStats;
 import org.elasticsearch.xpack.core.transform.transforms.TransformProgress;
 import org.elasticsearch.xpack.core.transform.transforms.TransformState;
@@ -65,6 +66,7 @@ public final class TransformInternalIndex {
      *                  checkpoint::checkpoint
      * version 5 (7.7): stats::processing_time_in_ms, stats::processing_total
      * version 6 (7.12):stats::delete_time_in_ms, stats::documents_deleted
+     * version 7 (7.13):add mapping for config::pivot, config::latest, config::retention_policy and config::sync
      */
 
     // constants for mappings
@@ -84,6 +86,7 @@ public final class TransformInternalIndex {
     public static final String LONG = "long";
     public static final String KEYWORD = "keyword";
     public static final String BOOLEAN = "boolean";
+    public static final String FLATTENED = "flattened";
 
     public static SystemIndexDescriptor getSystemIndexDescriptor() throws IOException {
         return SystemIndexDescriptor.builder()
@@ -319,6 +322,18 @@ public final class TransformInternalIndex {
             .endObject()
             .startObject(TransformField.CREATE_TIME.getPreferredName())
                 .field(TYPE, DATE)
+            .endObject()
+            .startObject(TransformConfig.Function.PIVOT.getParseField().getPreferredName())
+                .field(TYPE, FLATTENED)
+            .endObject()
+            .startObject(TransformConfig.Function.LATEST.getParseField().getPreferredName())
+                .field(TYPE, FLATTENED)
+            .endObject()
+            .startObject(TransformField.RETENTION_POLICY.getPreferredName())
+                .field(TYPE, FLATTENED)
+            .endObject()
+            .startObject(TransformField.SYNC.getPreferredName())
+                .field(TYPE, FLATTENED)
             .endObject();
     }
 

--- a/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/upgraded_cluster/80_transform_jobs_crud.yml
+++ b/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/upgraded_cluster/80_transform_jobs_crud.yml
@@ -298,11 +298,11 @@ setup:
 
   - do:
       warnings:
-        - "this request accesses system indices: [.transform-internal-006], but in a future major version, direct access to system indices will be prevented by default"
+        - "this request accesses system indices: [.transform-internal-007], but in a future major version, direct access to system indices will be prevented by default"
       indices.get_mapping:
-        index: .transform-internal-006
-  - match: { \.transform-internal-006.mappings.dynamic: "false" }
-  - match: { \.transform-internal-006.mappings.properties.id.type: "keyword" }
+        index: .transform-internal-007
+  - match: { \.transform-internal-007.mappings.dynamic: "false" }
+  - match: { \.transform-internal-007.mappings.properties.id.type: "keyword" }
   - do:
       indices.get_mapping:
         index: .transform-notifications-000002


### PR DESCRIPTION
This PR adds telemetry for transform features, i.e.: the number of existing transforms using each feature.
This PR adds support for 4 features: `pivot`, `latest`, `sync` and `retention_policy` but the code is generic enough to handle other features too.

Example response from `_xpack/usage`:
```
{
  ...
  "transform": {
    "enabled": true,
    "available": true,
    "transforms": {
      "_all": 4,
      "stopped": 2,
      "started": 2
    },
    "feature_counts": {
      "pivot": 3,
      "latest": 1,
      "sync": 2,
      "retention_policy": 1,
    },
    "stats": {
      ...
    }
  }
  ...
}
```

Relates https://github.com/elastic/elasticsearch/issues/68461