### PR TITLE
[7.x] Fix GeoIpProcessorNonIngestNodeIT#testLazyLoading(...)

### DIFF
--- a/modules/ingest-geoip/src/internalClusterTest/java/org/elasticsearch/ingest/geoip/GeoIpProcessorNonIngestNodeIT.java
+++ b/modules/ingest-geoip/src/internalClusterTest/java/org/elasticsearch/ingest/geoip/GeoIpProcessorNonIngestNodeIT.java
@@ -9,7 +9,6 @@
 package org.elasticsearch.ingest.geoip;
 
 import org.apache.lucene.util.Constants;
-import org.apache.lucene.util.LuceneTestCase;
 import org.elasticsearch.action.index.IndexRequest;
 import org.elasticsearch.action.index.IndexResponse;
 import org.elasticsearch.action.ingest.PutPipelineRequest;
@@ -30,7 +29,6 @@ import static org.elasticsearch.test.NodeRoles.nonIngestNode;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.hamcrest.Matchers.equalTo;
 
-@LuceneTestCase.AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/71251")
 public class GeoIpProcessorNonIngestNodeIT extends AbstractGeoIpIT {
 
     @Override
@@ -103,7 +101,7 @@ public class GeoIpProcessorNonIngestNodeIT extends AbstractGeoIpIT {
         final IndexRequest indexRequest = new IndexRequest("index", "_doc");
         indexRequest.setPipeline("geoip");
         indexRequest.source(Collections.singletonMap("ip", "1.1.1.1"));
-        final IndexResponse indexResponse = client().index(indexRequest).actionGet();
+        final IndexResponse indexResponse = client(ingestNode).index(indexRequest).actionGet();
         assertThat(indexResponse.status(), equalTo(RestStatus.CREATED));
         // now the geo-IP database should be loaded on the ingest node
         assertDatabaseLoadStatus(ingestNode, true);


### PR DESCRIPTION
Backporting #71579 to 7.x branch.

Ensure that the index request is routed to the ingest,
so that the lazy loading occurs of geoip database
on ingest node (which is what is asserted later on)
Otherwise the database is lazy loaded on a different node.

(without this fix, this test fails reproducible with
`-Dtests.seed=2E234CC71CE96F4F`)

Closes #71251