### PR TITLE
[Test] Fix comparison for long value (#71513)

### DIFF
--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/action/ApiKeyTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/action/ApiKeyTests.java
@@ -46,9 +46,9 @@ public class ApiKeyTests extends ESTestCase {
 
         assertThat(map.get("name"), equalTo(name));
         assertThat(map.get("id"), equalTo(id));
-        assertThat(map.get("creation"), equalTo(creation.toEpochMilli()));
+        assertThat(Long.valueOf(map.get("creation").toString()), equalTo(creation.toEpochMilli()));
         if (expiration != null) {
-            assertThat(map.get("expiration"), equalTo(expiration.toEpochMilli()));
+            assertThat(Long.valueOf(map.get("expiration").toString()), equalTo(expiration.toEpochMilli()));
         } else {
             assertThat(map.containsKey("expiration"), is(false));
         }


### PR DESCRIPTION
The epochMillis value is always a long value. Hence the test should convert
the actual value to long first before comparison.
