### PR TITLE
Convert parent-join example script to runtime field (backport of #71423)

### DIFF
--- a/docs/reference/mapping/types/parent-join.asciidoc
+++ b/docs/reference/mapping/types/parent-join.asciidoc
@@ -273,7 +273,7 @@ and scripts, and may be queried with the
 <<query-dsl-parent-id-query, `parent_id` query>>:
 
 [source,console]
---------------------------
+----
 GET my-index-000001/_search
 {
   "query": {
@@ -290,21 +290,72 @@ GET my-index-000001/_search
       }
     }
   },
-  "script_fields": {
+  "runtime_mappings": {
     "parent": {
-      "script": {
-         "source": "doc['my_join_field#question']" <3>
-      }
+      "type": "long",
+      "script": """
+        emit(Integer.parseInt(doc['my_join_field#question'].value)) <3>
+      """
     }
-  }
+  },
+  "fields": [
+    { "field": "parent" }
+  ]
 }
---------------------------
+----
 // TEST[continued]
-
+// TEST[s/_search/_search?filter_path=aggregations,hits.hits&sort=my_id/]
 <1> Querying the `parent id` field (also see the <<query-dsl-has-parent-query,`has_parent` query>> and the <<query-dsl-has-child-query,`has_child` query>>)
 <2> Aggregating on the `parent id` field (also see the <<search-aggregations-bucket-children-aggregation,`children`>> aggregation)
-<3> Accessing the parent id` field in scripts
+<3> Accessing the `parent id` field in scripts. 
 
+////
+[source,console-result]
+----
+{
+  "aggregations": {
+    "parents": {
+      "doc_count_error_upper_bound": 0,
+      "sum_other_doc_count": 0,
+      "buckets": [
+        {
+          "key": "1",
+          "doc_count": 2
+        }
+      ]
+    }
+  },
+  "hits": {
+    "hits": [
+      {
+        "_id": "3",
+        "_index": "my-index-000001",
+        "_type": "_doc",
+        "_score": null,
+        "_routing": "1",
+        "_source": $body.hits.hits.0._source,
+        "fields": {
+          "parent": [1]
+        },
+        "sort": ["3"]
+      },
+      {
+        "_id": "4",
+        "_index": "my-index-000001",
+        "_type": "_doc",
+        "_score": null,
+        "_routing": "1",
+        "_source": $body.hits.hits.1._source,
+        "fields": {
+          "parent": [1]
+        },
+        "sort": ["4"]
+      }
+    ]
+  }
+}
+----
+////
 
 ==== Global ordinals
 


### PR DESCRIPTION
Runtime fields are much more flexible than script_fields because you
can filter and aggregate on them so we hope folks use them! This
converts the example of using a `parent_join` field in a script to a
runtime field so folks get used to seeing them and hopefully using them.

While I was editing this I took the opportunity to replace the script
with a real-ish example. Scripts that just load the field value are nice
and short but I hope no one uses them in real life because they just add
overhead when compared to accessing the field directly. So I made the
script do something.

Relates to #69291
