### PR TITLE
Disable module inference in Eclipse

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -343,6 +343,7 @@ allprojects {
   }
 
   plugins.withType(JavaBasePlugin) {
+    java.modularity.inferModulePath.set(false)
     eclipse.classpath.file.whenMerged { classpath ->
       /*
        * give each source folder a unique corresponding output folder


### PR DESCRIPTION
We recently upgrade to gradle 7.0 (#69096) which turned on module
inference by default. I'm sure that's lovely, but its broken eclipse. We
should probably support modules one day, but that day ain't today. This
turns off module inference for eclipse so it can continue compiling
things just like it did yesterday.

Closes #71648
