### PR TITLE
[ML] prevent APIs from being called when upgrade mode is set

### DIFF
--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MlUpgradeModeActionFilter.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MlUpgradeModeActionFilter.java
@@ -26,6 +26,8 @@ import org.elasticsearch.xpack.core.ml.action.DeleteForecastAction;
 import org.elasticsearch.xpack.core.ml.action.DeleteJobAction;
 import org.elasticsearch.xpack.core.ml.action.DeleteModelSnapshotAction;
 import org.elasticsearch.xpack.core.ml.action.DeleteTrainedModelAction;
+import org.elasticsearch.xpack.core.ml.action.DeleteTrainedModelAliasAction;
+import org.elasticsearch.xpack.core.ml.action.ExplainDataFrameAnalyticsAction;
 import org.elasticsearch.xpack.core.ml.action.FinalizeJobExecutionAction;
 import org.elasticsearch.xpack.core.ml.action.FlushJobAction;
 import org.elasticsearch.xpack.core.ml.action.ForecastJobAction;
@@ -40,6 +42,7 @@ import org.elasticsearch.xpack.core.ml.action.PutDatafeedAction;
 import org.elasticsearch.xpack.core.ml.action.PutFilterAction;
 import org.elasticsearch.xpack.core.ml.action.PutJobAction;
 import org.elasticsearch.xpack.core.ml.action.PutTrainedModelAction;
+import org.elasticsearch.xpack.core.ml.action.PutTrainedModelAliasAction;
 import org.elasticsearch.xpack.core.ml.action.RevertModelSnapshotAction;
 import org.elasticsearch.xpack.core.ml.action.StartDataFrameAnalyticsAction;
 import org.elasticsearch.xpack.core.ml.action.StartDatafeedAction;
@@ -51,6 +54,7 @@ import org.elasticsearch.xpack.core.ml.action.UpdateFilterAction;
 import org.elasticsearch.xpack.core.ml.action.UpdateJobAction;
 import org.elasticsearch.xpack.core.ml.action.UpdateModelSnapshotAction;
 import org.elasticsearch.xpack.core.ml.action.UpdateProcessAction;
+import org.elasticsearch.xpack.core.ml.action.UpgradeJobModelSnapshotAction;
 
 import java.util.Collections;
 import java.util.Objects;
@@ -85,6 +89,7 @@ class MlUpgradeModeActionFilter extends ActionFilter.Simple {
             RevertModelSnapshotAction.NAME,
             UpdateModelSnapshotAction.NAME,
             DeleteModelSnapshotAction.NAME,
+            UpgradeJobModelSnapshotAction.NAME,
 
             PutDatafeedAction.NAME,
             UpdateDatafeedAction.NAME,
@@ -114,9 +119,12 @@ class MlUpgradeModeActionFilter extends ActionFilter.Simple {
             DeleteDataFrameAnalyticsAction.NAME,
             StartDataFrameAnalyticsAction.NAME,
             StopDataFrameAnalyticsAction.NAME,
+            ExplainDataFrameAnalyticsAction.NAME,
 
+            PutTrainedModelAliasAction.NAME,
             PutTrainedModelAction.NAME,
-            DeleteTrainedModelAction.NAME
+            DeleteTrainedModelAction.NAME,
+            DeleteTrainedModelAliasAction.NAME
         ));
 
     private static final Set<String> RESET_MODE_EXEMPTIONS =


### PR DESCRIPTION
Some APIs have been added recently that should not be callable while in upgrade mode.

This commit adds the following actions to not be allowed during upgrade mode.

`UpgradeJobModelSnapshotAction`
`ExplainDataFrameAnalyticsAction`
`PutTrainedModelAliasAction`
`DeleteTrainedModelAliasAction`