### PR TITLE
Test: Handle order change (backport of #70427)

### DIFF
--- a/server/src/test/java/org/elasticsearch/search/aggregations/metrics/TopHitsTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/metrics/TopHitsTests.java
@@ -8,7 +8,9 @@
 
 package org.elasticsearch.search.aggregations.metrics;
 
+import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.common.xcontent.json.JsonXContent;
 import org.elasticsearch.search.aggregations.AggregationInitializationException;
 import org.elasticsearch.search.aggregations.AggregatorFactories;
@@ -19,7 +21,9 @@ import org.elasticsearch.search.sort.ScriptSortBuilder.ScriptSortType;
 import org.elasticsearch.search.sort.SortBuilders;
 import org.elasticsearch.search.sort.SortOrder;
 import org.elasticsearch.test.AbstractQueryTestCase;
+import org.elasticsearch.test.hamcrest.ElasticsearchAssertions;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -189,4 +193,13 @@ public class TopHitsTests extends BaseAggregationTestCase<TopHitsAggregationBuil
         assertThat(e.toString(), containsString("Aggregator [top_tags_hits] of type [top_hits] cannot accept sub-aggregations"));
     }
 
+    @Override
+    protected void assertToXContentAfterSerialization(TopHitsAggregationBuilder original, TopHitsAggregationBuilder deserialized)
+        throws IOException {
+        ElasticsearchAssertions.assertToXContentEquivalent(
+            XContentHelper.toXContent(original, XContentType.JSON, false),
+            XContentHelper.toXContent(deserialized, XContentType.JSON, false),
+            XContentType.JSON
+        );
+    }
 }

--- a/test/framework/src/main/java/org/elasticsearch/search/aggregations/BaseAggregationTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/search/aggregations/BaseAggregationTestCase.java
@@ -145,10 +145,18 @@ public abstract class BaseAggregationTestCase<AB extends AbstractAggregationBuil
                 assertEquals(testAgg, deserialized);
                 assertEquals(testAgg.hashCode(), deserialized.hashCode());
                 assertNotSame(testAgg, deserialized);
-                // Make sure serialization preserves toXContent.
-                assertEquals(Strings.toString(testAgg), Strings.toString(deserialized));
+                @SuppressWarnings("unchecked") // They are .equal so its safe
+                AB castDeserialized = (AB) deserialized;
+                assertToXContentAfterSerialization(testAgg, castDeserialized);
             }
         }
+    }
+
+    /**
+     * Make sure serialization preserves toXContent.
+     */
+    protected void assertToXContentAfterSerialization(AB original, AB deserialized) throws IOException {
+        assertEquals(Strings.toString(original), Strings.toString(deserialized));
     }
 
     public void testEqualsAndHashcode() throws IOException {


### PR DESCRIPTION
Fixes a error in `TopHitsTests` introduced in #70318 where we were too
strict in our round trip tests. We asserted that serialization produced
exactly the same `.toString` which is true of most aggregations, but not
`top_hits`. In `top_hits` it shuffles some map keys. Which is just fine.
We should not consider that a failure.

Closes #71635