### PR TITLE
NodeIndicesStats#statsByShard is never null

### DIFF
--- a/server/src/main/java/org/elasticsearch/indices/NodeIndicesStats.java
+++ b/server/src/main/java/org/elasticsearch/indices/NodeIndicesStats.java
@@ -179,7 +179,7 @@ public class NodeIndicesStats implements Writeable, ToXContentFragment {
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         stats.writeTo(out);
-        if (out.getVersion().onOrAfter(Version.V_8_0_0)) {
+        if (out.getVersion().before(Version.V_8_0_0)) {
             out.writeBoolean(true);
         }
         out.writeVInt(statsByShard.size());


### PR DESCRIPTION
Today we support serializing `NodeIndicesStats` with a null
`statsByShard` field, but in practice it is always present (since at
least 5.6). If it were absent, we either throw NPEs or treat it as an
empty map. This commit removes the option for this field to be null on
the wire.

Spotted while researching #71670.