### PR TITLE
Fix overlapping task outputs with test-with-dep gradle plugin (7.x backport)

### DIFF
--- a/buildSrc/src/main/java/org/elasticsearch/gradle/test/TestWithDependenciesPlugin.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/test/TestWithDependenciesPlugin.java
@@ -53,7 +53,7 @@ public class TestWithDependenciesPlugin implements Plugin<Project> {
     }
 
     private static void addPluginResources(final Project project, final Project pluginProject) {
-        final File outputDir = new File(project.getBuildDir(), "/generated-resources/" + pluginProject.getName());
+        final File outputDir = new File(project.getBuildDir(), "/generated-test-resources/" + pluginProject.getName());
         String camelProjectName = stream(pluginProject.getName().split("-")).map(t -> StringUtils.capitalize(t))
             .collect(Collectors.joining());
         String taskName = "copy" + camelProjectName + "Metadata";


### PR DESCRIPTION
backports #70339 to 7.x branch