### PR TITLE
[ML] Store compressed model definitions in ByteReferences

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/InferenceToXContentCompressor.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/InferenceToXContentCompressor.java
@@ -11,7 +11,6 @@ import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.common.CheckedFunction;
 import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.common.breaker.CircuitBreakingException;
-import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.unit.ByteSizeValue;
@@ -29,8 +28,6 @@ import org.elasticsearch.xpack.core.ml.inference.utils.SimpleBoundedInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.nio.charset.StandardCharsets;
-import java.util.Base64;
 import java.util.Map;
 import java.util.zip.GZIPInputStream;
 import java.util.zip.GZIPOutputStream;
@@ -47,24 +44,24 @@ public final class InferenceToXContentCompressor {
 
     private InferenceToXContentCompressor() {}
 
-    public static <T extends ToXContentObject> String deflate(T objectToCompress) throws IOException {
+    public static <T extends ToXContentObject> BytesReference deflate(T objectToCompress) throws IOException {
         BytesReference reference = XContentHelper.toXContent(objectToCompress, XContentType.JSON, false);
         return deflate(reference);
     }
 
-    public static <T> T inflate(String compressedString,
+    public static <T> T inflate(BytesReference compressedBytes,
                                 CheckedFunction<XContentParser, T, IOException> parserFunction,
                                 NamedXContentRegistry xContentRegistry) throws IOException {
-        return inflate(compressedString, parserFunction, xContentRegistry, MAX_INFLATED_BYTES);
+        return inflate(compressedBytes, parserFunction, xContentRegistry, MAX_INFLATED_BYTES);
     }
 
-    static <T> T inflate(String compressedString,
+    static <T> T inflate(BytesReference compressedBytes,
                          CheckedFunction<XContentParser, T, IOException> parserFunction,
                          NamedXContentRegistry xContentRegistry,
                          long maxBytes) throws IOException {
         try(XContentParser parser = JsonXContent.jsonXContent.createParser(xContentRegistry,
             LoggingDeprecationHandler.INSTANCE,
-            inflate(compressedString, maxBytes))) {
+            inflate(compressedBytes, maxBytes))) {
             return parserFunction.apply(parser);
         } catch (XContentParseException parseException) {
             SimpleBoundedInputStream.StreamSizeExceededException streamSizeCause =
@@ -82,32 +79,31 @@ public final class InferenceToXContentCompressor {
         }
     }
 
-    static Map<String, Object> inflateToMap(String compressedString) throws IOException {
+    static Map<String, Object> inflateToMap(BytesReference compressedBytes) throws IOException {
         // Don't need the xcontent registry as we are not deflating named objects.
         try(XContentParser parser = JsonXContent.jsonXContent.createParser(NamedXContentRegistry.EMPTY,
             LoggingDeprecationHandler.INSTANCE,
-            inflate(compressedString, MAX_INFLATED_BYTES))) {
+            inflate(compressedBytes, MAX_INFLATED_BYTES))) {
             return parser.mapOrdered();
         }
     }
 
-    static InputStream inflate(String compressedString, long streamSize) throws IOException {
-        byte[] compressedBytes = Base64.getDecoder().decode(compressedString.getBytes(StandardCharsets.UTF_8));
+    static InputStream inflate(BytesReference compressedBytes, long streamSize) throws IOException {
         // If the compressed length is already too large, it make sense that the inflated length would be as well
         // In the extremely small string case, the compressed data could actually be longer than the compressed stream
-        if (compressedBytes.length > Math.max(100L, streamSize)) {
+        if (compressedBytes.length() > Math.max(100L, streamSize)) {
             throw new CircuitBreakingException("compressed stream is longer than maximum allowed bytes [" + streamSize + "]",
                 CircuitBreaker.Durability.PERMANENT);
         }
-        InputStream gzipStream = new GZIPInputStream(new BytesArray(compressedBytes).streamInput(), BUFFER_SIZE);
+        InputStream gzipStream = new GZIPInputStream(compressedBytes.streamInput(), BUFFER_SIZE);
         return new SimpleBoundedInputStream(gzipStream, streamSize);
     }
 
-    private static String deflate(BytesReference reference) throws IOException {
+    private static BytesReference deflate(BytesReference reference) throws IOException {
         BytesStreamOutput out = new BytesStreamOutput();
         try (OutputStream compressedOutput = new GZIPOutputStream(out, BUFFER_SIZE)) {
             reference.writeTo(compressedOutput);
         }
-        return new String(Base64.getEncoder().encode(BytesReference.toBytes(out.bytes())), StandardCharsets.UTF_8);
+        return out.bytes();
     }
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/TrainedModelConfig.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/TrainedModelConfig.java
@@ -256,7 +256,7 @@ public class TrainedModelConfig implements ToXContentObject, Writeable {
         if (definition == null) {
             return null;
         }
-        return definition.compressedRepresentation;
+        return definition.getCompressedDefinition();
     }
 
     public void clearCompressed() {
@@ -352,7 +352,7 @@ public class TrainedModelConfig implements ToXContentObject, Writeable {
             if (params.paramAsBoolean(DECOMPRESS_DEFINITION, false)) {
                 builder.field(DEFINITION.getPreferredName(), definition);
             } else {
-                builder.field(COMPRESSED_DEFINITION.getPreferredName(), definition.compressedRepresentation);
+                builder.field(COMPRESSED_DEFINITION.getPreferredName(), definition.getCompressedDefinition());
             }
         }
         builder.field(TAGS.getPreferredName(), tags);
@@ -803,6 +803,13 @@ public class TrainedModelConfig implements ToXContentObject, Writeable {
             }
             this.compressedRepresentation = compressedRepresentation;
             this.parsedDefinition = trainedModelDefinition;
+        }
+
+        public BytesReference getCompressedDefinition() throws IOException {
+            if (compressedRepresentation == null) {
+                compressedRepresentation = InferenceToXContentCompressor.deflate(parsedDefinition);
+            }
+            return compressedRepresentation;
         }
 
         public void ensureParsedDefinition(NamedXContentRegistry xContentRegistry) throws IOException {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/TrainedModelConfig.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/TrainedModelConfig.java
@@ -12,6 +12,8 @@ import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.bytes.BytesArray;
+import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
@@ -36,8 +38,10 @@ import org.elasticsearch.xpack.core.ml.utils.MlStrings;
 import org.elasticsearch.xpack.core.ml.utils.ToXContentParams;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.util.Arrays;
+import java.util.Base64;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -248,15 +252,15 @@ public class TrainedModelConfig implements ToXContentObject, Writeable {
     }
 
     @Nullable
-    public String getCompressedDefinition() throws IOException {
+    public BytesReference getCompressedDefinition() throws IOException {
         if (definition == null) {
             return null;
         }
-        return definition.getCompressedString();
+        return definition.compressedRepresentation;
     }
 
     public void clearCompressed() {
-        definition.compressedString = null;
+        definition.compressedRepresentation = null;
     }
 
     public TrainedModelConfig ensureParsedDefinition(NamedXContentRegistry xContentRegistry) throws IOException {
@@ -348,7 +352,7 @@ public class TrainedModelConfig implements ToXContentObject, Writeable {
             if (params.paramAsBoolean(DECOMPRESS_DEFINITION, false)) {
                 builder.field(DEFINITION.getPreferredName(), definition);
             } else {
-                builder.field(COMPRESSED_DEFINITION.getPreferredName(), definition.getCompressedString());
+                builder.field(COMPRESSED_DEFINITION.getPreferredName(), definition.compressedRepresentation);
             }
         }
         builder.field(TAGS.getPreferredName(), tags);
@@ -564,11 +568,11 @@ public class TrainedModelConfig implements ToXContentObject, Writeable {
             return this;
         }
 
-        public Builder setDefinitionFromString(String definitionFromString) {
-            if (definitionFromString == null) {
+        public Builder setDefinitionFromBytes(BytesReference definition) {
+            if (definition == null) {
                 return this;
             }
-            this.definition = LazyModelDefinition.fromCompressedString(definitionFromString);
+            this.definition = LazyModelDefinition.fromCompressedData(definition);
             return this;
         }
 
@@ -605,7 +609,7 @@ public class TrainedModelConfig implements ToXContentObject, Writeable {
                     DEFINITION.getPreferredName())
                     .getFormattedMessage());
             }
-            this.definition = LazyModelDefinition.fromCompressedString(compressedString);
+            this.definition = LazyModelDefinition.fromBase64String(compressedString);
             return this;
         }
 
@@ -762,54 +766,61 @@ public class TrainedModelConfig implements ToXContentObject, Writeable {
 
     public static class LazyModelDefinition implements ToXContentObject, Writeable {
 
-        private String compressedString;
+        private BytesReference compressedRepresentation;
         private TrainedModelDefinition parsedDefinition;
 
         public static LazyModelDefinition fromParsedDefinition(TrainedModelDefinition definition) {
             return new LazyModelDefinition(null, definition);
         }
 
-        public static LazyModelDefinition fromCompressedString(String compressedString) {
-            return new LazyModelDefinition(compressedString, null);
+        public static LazyModelDefinition fromCompressedData(BytesReference compressed) {
+            return new LazyModelDefinition(compressed, null);
+        }
+
+        public static LazyModelDefinition fromBase64String(String base64String) {
+            byte[] decodedBytes = Base64.getDecoder().decode(base64String);
+            return new LazyModelDefinition(new BytesArray(decodedBytes), null);
         }
 
         public static LazyModelDefinition fromStreamInput(StreamInput input) throws IOException {
-            return new LazyModelDefinition(input.readString(), null);
+            if (input.getVersion().onOrAfter(Version.V_8_0_0)) { // TODO adjust on backport
+                return new LazyModelDefinition(input.readBytesReference(), null);
+            } else {
+                return fromBase64String(input.readString());
+            }
         }
 
         private LazyModelDefinition(LazyModelDefinition definition) {
             if (definition != null) {
-                this.compressedString = definition.compressedString;
+                this.compressedRepresentation = definition.compressedRepresentation;
                 this.parsedDefinition = definition.parsedDefinition;
             }
         }
 
-        private LazyModelDefinition(String compressedString, TrainedModelDefinition trainedModelDefinition) {
-            if (compressedString == null && trainedModelDefinition == null) {
+        private LazyModelDefinition(BytesReference compressedRepresentation, TrainedModelDefinition trainedModelDefinition) {
+            if (compressedRepresentation == null && trainedModelDefinition == null) {
                 throw new IllegalArgumentException("unexpected null model definition");
             }
-            this.compressedString = compressedString;
+            this.compressedRepresentation = compressedRepresentation;
             this.parsedDefinition = trainedModelDefinition;
         }
 
         public void ensureParsedDefinition(NamedXContentRegistry xContentRegistry) throws IOException {
             if (parsedDefinition == null) {
-                parsedDefinition = InferenceToXContentCompressor.inflate(compressedString,
+                parsedDefinition = InferenceToXContentCompressor.inflate(compressedRepresentation,
                     parser -> TrainedModelDefinition.fromXContent(parser, true).build(),
                     xContentRegistry);
             }
         }
 
-        public String getCompressedString() throws IOException {
-            if (compressedString == null) {
-                compressedString = InferenceToXContentCompressor.deflate(parsedDefinition);
-            }
-            return compressedString;
-        }
-
         @Override
         public void writeTo(StreamOutput out) throws IOException {
-            out.writeString(getCompressedString());
+            if (out.getVersion().onOrAfter(Version.V_8_0_0)) { // TODO adjust on backport
+                out.writeBytesReference(compressedRepresentation);
+            } else {
+                String base64String = new String(Base64.getEncoder().encode(compressedRepresentation.array()), StandardCharsets.UTF_8);
+                out.writeString(base64String);
+            }
         }
 
         @Override
@@ -817,7 +828,7 @@ public class TrainedModelConfig implements ToXContentObject, Writeable {
             if (parsedDefinition != null) {
                 return parsedDefinition.toXContent(builder, params);
             }
-            Map<String, Object> map = InferenceToXContentCompressor.inflateToMap(compressedString);
+            Map<String, Object> map = InferenceToXContentCompressor.inflateToMap(compressedRepresentation);
             return builder.map(map);
         }
 
@@ -826,13 +837,13 @@ public class TrainedModelConfig implements ToXContentObject, Writeable {
             if (this == o) return true;
             if (o == null || getClass() != o.getClass()) return false;
             LazyModelDefinition that = (LazyModelDefinition) o;
-            return Objects.equals(compressedString, that.compressedString) &&
+            return Objects.equals(compressedRepresentation, that.compressedRepresentation) &&
                 Objects.equals(parsedDefinition, that.parsedDefinition);
         }
 
         @Override
         public int hashCode() {
-            return Objects.hash(compressedString, parsedDefinition);
+            return Objects.hash(compressedRepresentation, parsedDefinition);
         }
 
     }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/persistence/InferenceIndexConstants.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/persistence/InferenceIndexConstants.java
@@ -30,7 +30,7 @@ public final class InferenceIndexConstants {
      * version: UNKNOWN_MERGED_ON_FEATURE_BRANCH: 000004   TODO
      *  - adds binary_definition for TrainedModelDefinitionDoc
      */
-    public static final String INDEX_VERSION = "000003";
+    public static final String INDEX_VERSION = "000004";
     public static final String INDEX_NAME_PREFIX = ".ml-inference-";
     public static final String INDEX_PATTERN = INDEX_NAME_PREFIX + "*";
     public static final String LATEST_INDEX_NAME = INDEX_NAME_PREFIX + INDEX_VERSION;

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/persistence/InferenceIndexConstants.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/persistence/InferenceIndexConstants.java
@@ -26,6 +26,9 @@ public final class InferenceIndexConstants {
      *
      * version: 7.10.0: 000003
      *  - adds trained_model_metadata object
+     *
+     * version: UNKNOWN_MERGED_ON_FEATURE_BRANCH: 000004   TODO
+     *  - adds binary_definition for TrainedModelDefinitionDoc
      */
     public static final String INDEX_VERSION = "000003";
     public static final String INDEX_NAME_PREFIX = ".ml-inference-";

--- a/x-pack/plugin/core/src/main/resources/org/elasticsearch/xpack/core/ml/inference_index_mappings.json
+++ b/x-pack/plugin/core/src/main/resources/org/elasticsearch/xpack/core/ml/inference_index_mappings.json
@@ -44,6 +44,9 @@
       "definition": {
         "enabled": false
       },
+      "binary_definition": {
+        "type": "binary"
+      },
       "compression_version": {
         "type": "long"
       },
@@ -135,7 +138,7 @@
           "supplied": {
             "type": "boolean"
           }
-        } 
+        }
       }
     }
   }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/InferenceToXContentCompressorTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/InferenceToXContentCompressorTests.java
@@ -8,6 +8,8 @@ package org.elasticsearch.xpack.core.ml.inference;
 
 import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.common.breaker.CircuitBreakingException;
+import org.elasticsearch.common.bytes.BytesArray;
+import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.io.Streams;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 import org.elasticsearch.test.ESTestCase;
@@ -16,7 +18,6 @@ import org.elasticsearch.xpack.core.ml.inference.preprocessing.OneHotEncodingTes
 import org.elasticsearch.xpack.core.ml.inference.preprocessing.TargetMeanEncodingTests;
 
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -27,7 +28,7 @@ public class InferenceToXContentCompressorTests extends ESTestCase {
     public void testInflateAndDeflate() throws IOException {
         for(int i = 0; i < 10; i++) {
             TrainedModelDefinition definition = TrainedModelDefinitionTests.createRandomBuilder().build();
-            String firstDeflate = InferenceToXContentCompressor.deflate(definition);
+            BytesReference firstDeflate = InferenceToXContentCompressor.deflate(definition);
             TrainedModelDefinition inflatedDefinition = InferenceToXContentCompressor.inflate(firstDeflate,
                 parser -> TrainedModelDefinition.fromXContent(parser, false).build(),
                 xContentRegistry());
@@ -45,8 +46,8 @@ public class InferenceToXContentCompressorTests extends ESTestCase {
                 .limit(100)
                 .collect(Collectors.toList()))
             .build();
-        String firstDeflate = InferenceToXContentCompressor.deflate(definition);
-        int max = firstDeflate.getBytes(StandardCharsets.UTF_8).length + 10;
+        BytesReference firstDeflate = InferenceToXContentCompressor.deflate(definition);
+        int max = firstDeflate.length() + 10;
         IOException ex = expectThrows(IOException.class,
             () -> Streams.readFully(InferenceToXContentCompressor.inflate(firstDeflate, max)));
         assertThat(ex.getMessage(), equalTo("" +
@@ -54,7 +55,8 @@ public class InferenceToXContentCompressorTests extends ESTestCase {
     }
 
     public void testInflateGarbage() {
-        expectThrows(IOException.class, () -> Streams.readFully(InferenceToXContentCompressor.inflate(randomAlphaOfLength(10), 100L)));
+        expectThrows(IOException.class, () -> Streams.readFully(
+            InferenceToXContentCompressor.inflate(new BytesArray(randomByteArrayOfLength(10)), 100L)));
     }
 
     public void testInflateParsingTooLargeStream() throws IOException {
@@ -65,8 +67,8 @@ public class InferenceToXContentCompressorTests extends ESTestCase {
                 .limit(100)
                 .collect(Collectors.toList()))
             .build();
-        String compressedString = InferenceToXContentCompressor.deflate(definition);
-        int max = compressedString.getBytes(StandardCharsets.UTF_8).length + 10;
+        BytesReference compressedString = InferenceToXContentCompressor.deflate(definition);
+        int max = compressedString.length() + 10;
 
         CircuitBreakingException e = expectThrows(CircuitBreakingException.class, ()-> InferenceToXContentCompressor.inflate(
             compressedString,

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/TrainedModelConfigTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/TrainedModelConfigTests.java
@@ -115,8 +115,7 @@ public class TrainedModelConfigTests extends AbstractBWCSerializationTestCase<Tr
 
     @Override
     protected NamedWriteableRegistry getNamedWriteableRegistry() {
-        List<NamedWriteableRegistry.Entry> entries = new ArrayList<>();
-        entries.addAll(new MlInferenceNamedXContentProvider().getNamedWriteables());
+        List<NamedWriteableRegistry.Entry> entries = new ArrayList<>(new MlInferenceNamedXContentProvider().getNamedWriteables());
         return new NamedWriteableRegistry(entries);
     }
 
@@ -170,7 +169,7 @@ public class TrainedModelConfigTests extends AbstractBWCSerializationTestCase<Tr
         assertThat(reference.utf8ToString(), containsString("\"definition\""));
         assertThat(reference.utf8ToString(), not(containsString("compressed_definition")));
     }
-    
+
     public void testParseWithBothDefinitionAndCompressedSupplied() throws IOException {
         TrainedModelConfig.LazyModelDefinition lazyModelDefinition = TrainedModelConfig.LazyModelDefinition
             .fromParsedDefinition(TrainedModelDefinitionTests.createRandomBuilder().build());
@@ -263,9 +262,9 @@ public class TrainedModelConfigTests extends AbstractBWCSerializationTestCase<Tr
         xContentTester(this::createParser,
             () -> {
             try {
-                String compressedString = InferenceToXContentCompressor.deflate(TrainedModelDefinitionTests.createRandomBuilder().build());
+                BytesReference bytes = InferenceToXContentCompressor.deflate(TrainedModelDefinitionTests.createRandomBuilder().build());
                 return createTestInstance(randomAlphaOfLength(10))
-                    .setDefinitionFromString(compressedString)
+                    .setDefinitionFromBytes(bytes)
                     .build();
             } catch (IOException ex) {
                 fail(ex.getMessage());
@@ -294,10 +293,10 @@ public class TrainedModelConfigTests extends AbstractBWCSerializationTestCase<Tr
         xContentTester(this::createParser,
             () -> {
                 try {
-                    String compressedString =
+                    BytesReference bytes =
                         InferenceToXContentCompressor.deflate(TrainedModelDefinitionTests.createRandomBuilder().build());
                     return createTestInstance(randomAlphaOfLength(10))
-                        .setDefinitionFromString(compressedString)
+                        .setDefinitionFromBytes(bytes)
                         .build();
                 } catch (IOException ex) {
                     fail(ex.getMessage());

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/inference/InferenceDefinitionTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/inference/InferenceDefinitionTests.java
@@ -7,6 +7,7 @@
 
 package org.elasticsearch.xpack.core.ml.inference.trainedmodel.inference;
 
+import com.unboundid.util.Base64;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.DeprecationHandler;
@@ -24,6 +25,7 @@ import org.elasticsearch.xpack.core.ml.inference.results.ClassificationInference
 import org.elasticsearch.xpack.core.ml.inference.trainedmodel.ClassificationConfig;
 
 import java.io.IOException;
+import java.text.ParseException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -59,7 +61,7 @@ public class InferenceDefinitionTests extends ESTestCase {
         assertThat(definition.getTrainedModel().getClass(), equalTo(TreeInferenceModel.class));
     }
 
-    public void testMultiClassIrisInference() throws IOException {
+    public void testMultiClassIrisInference() throws IOException, ParseException {
         // Fairly simple, random forest classification model built to fit in our format
         // Trained on the well known Iris dataset
         String compressedDef = "H4sIAPbiMl4C/+1b246bMBD9lVWet8jjG3b/oN9QVYgmToLEkghIL6r23wukl90" +
@@ -83,7 +85,8 @@ public class InferenceDefinitionTests extends ESTestCase {
             "aLbAYWcAdpeweKa2IfIT2jz5QzXxD6AoP+DrdXtxeluV7pdWrvkcKqPp7rjS19d+wp/fff/5Ez3FPjzFNy" +
             "fdpTi9JB0sDp2JR7b309mn5HuPkEAAA==";
 
-        InferenceDefinition definition = InferenceToXContentCompressor.inflate(compressedDef,
+        byte[] bytes = Base64.decode(compressedDef);
+        InferenceDefinition definition = InferenceToXContentCompressor.inflate(new BytesArray(bytes),
             InferenceDefinition::fromXContent,
             xContentRegistry());
 

--- a/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/ChunkedTrainedModelPersisterIT.java
+++ b/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/ChunkedTrainedModelPersisterIT.java
@@ -47,7 +47,6 @@ import org.elasticsearch.xpack.ml.notifications.DataFrameAnalyticsAuditor;
 import org.junit.Before;
 
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Base64;
@@ -96,7 +95,8 @@ public class ChunkedTrainedModelPersisterIT extends MlSingleNodeTestCase {
         ModelSizeInfo modelSizeInfo = ModelSizeInfoTests.createRandom();
         persister.createAndIndexInferenceModelConfig(modelSizeInfo, configBuilder.getModelType());
         for (int i = 0; i < base64Chunks.size(); i++) {
-            persister.createAndIndexInferenceModelDoc(new TrainedModelDefinitionChunk(base64Chunks.get(i), i, i == (base64Chunks.size() - 1)));
+            persister.createAndIndexInferenceModelDoc(
+                new TrainedModelDefinitionChunk(base64Chunks.get(i), i, i == (base64Chunks.size() - 1)));
         }
         ModelMetadata modelMetadata = new ModelMetadata(Stream.generate(TotalFeatureImportanceTests::randomInstance)
             .limit(randomIntBetween(1, 10))

--- a/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/ChunkedTrainedModelPersisterIT.java
+++ b/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/ChunkedTrainedModelPersisterIT.java
@@ -10,6 +10,7 @@ import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.Version;
 import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.collect.Tuple;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 import org.elasticsearch.license.License;
@@ -27,8 +28,8 @@ import org.elasticsearch.xpack.core.ml.inference.TrainedModelInputTests;
 import org.elasticsearch.xpack.core.ml.inference.TrainedModelType;
 import org.elasticsearch.xpack.core.ml.inference.trainedmodel.TargetType;
 import org.elasticsearch.xpack.core.ml.inference.trainedmodel.metadata.FeatureImportanceBaselineTests;
-import org.elasticsearch.xpack.core.ml.inference.trainedmodel.metadata.TotalFeatureImportanceTests;
 import org.elasticsearch.xpack.core.ml.inference.trainedmodel.metadata.HyperparametersTests;
+import org.elasticsearch.xpack.core.ml.inference.trainedmodel.metadata.TotalFeatureImportanceTests;
 import org.elasticsearch.xpack.core.ml.inference.trainedmodel.metadata.TrainedModelMetadata;
 import org.elasticsearch.xpack.ml.MlSingleNodeTestCase;
 import org.elasticsearch.xpack.ml.dataframe.process.ChunkedTrainedModelPersister;
@@ -46,7 +47,9 @@ import org.elasticsearch.xpack.ml.notifications.DataFrameAnalyticsAuditor;
 import org.junit.Before;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.Base64;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -78,7 +81,9 @@ public class ChunkedTrainedModelPersisterIT extends MlSingleNodeTestCase {
             .build();
         List<ExtractedField> extractedFieldList = Collections.singletonList(new DocValueField("foo", Collections.emptySet()));
         TrainedModelConfig.Builder configBuilder = buildTrainedModelConfigBuilder(modelId);
-        String compressedDefinition = configBuilder.build().getCompressedDefinition();
+        // TODO where does the compressed def come from is parse set??
+        BytesReference bytes = configBuilder.build().getCompressedDefinition();
+        String compressedDefinition = new String(Base64.getEncoder().encode(bytes.array()), StandardCharsets.UTF_8);
         int totalSize = compressedDefinition.length();
         List<String> chunks = chunkStringWithSize(compressedDefinition, totalSize/3);
 

--- a/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/TrainedModelProviderIT.java
+++ b/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/TrainedModelProviderIT.java
@@ -228,7 +228,7 @@ public class TrainedModelProviderIT extends MlSingleNodeTestCase {
 
         TrainedModelDefinitionDoc truncatedDoc = new TrainedModelDefinitionDoc.Builder()
             .setDocNum(0)
-            .setBinaryData(config.getCompressedDefinition().slice(0, config.getCompressedDefinition().length() - 10).array())
+            .setBinaryData(config.getCompressedDefinition().slice(0, config.getCompressedDefinition().length() - 10))
             .setCompressionVersion(TrainedModelConfig.CURRENT_DEFINITION_COMPRESSION_VERSION)
             .setDefinitionLength(config.getCompressedDefinition().length())
             .setTotalDefinitionLength(config.getCompressedDefinition().length())
@@ -352,14 +352,15 @@ public class TrainedModelProviderIT extends MlSingleNodeTestCase {
     }
 
     private List<TrainedModelDefinitionDoc.Builder> createModelDefinitionDocs(BytesReference compressedDefinition, String modelId) {
-        List<byte[]> chunks = TrainedModelProvider.chunkDefinitionWithSize(compressedDefinition, compressedDefinition.length()/3);
+        List<BytesReference> chunks = TrainedModelProvider.chunkDefinitionWithSize(compressedDefinition, compressedDefinition.length()/3);
 
         return IntStream.range(0, chunks.size())
             .mapToObj(i -> new TrainedModelDefinitionDoc.Builder()
                 .setDocNum(i)
                 .setBinaryData(chunks.get(i))
                 .setCompressionVersion(TrainedModelConfig.CURRENT_DEFINITION_COMPRESSION_VERSION)
-                .setDefinitionLength(chunks.get(i).length)
+                .setDefinitionLength(chunks.get(i).length())
+                .setTotalDefinitionLength(compressedDefinition.length())
                 .setEos(i == chunks.size() - 1)
                 .setModelId(modelId))
             .collect(Collectors.toList());

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/persistence/TrainedModelDefinitionDoc.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/persistence/TrainedModelDefinitionDoc.java
@@ -17,6 +17,8 @@ import org.elasticsearch.xpack.core.ml.inference.persistence.InferenceIndexConst
 import org.elasticsearch.xpack.core.ml.utils.ExceptionsHelper;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
 import java.util.Objects;
 
 /**
@@ -31,6 +33,7 @@ public class TrainedModelDefinitionDoc implements ToXContentObject {
 
     public static final ParseField DOC_NUM = new ParseField("doc_num");
     public static final ParseField DEFINITION = new ParseField("definition");
+    public static final ParseField BINARY_DEFINITION = new ParseField("binary_definition");
     public static final ParseField COMPRESSION_VERSION = new ParseField("compression_version");
     public static final ParseField TOTAL_DEFINITION_LENGTH = new ParseField("total_definition_length");
     public static final ParseField DEFINITION_LENGTH = new ParseField("definition_length");
@@ -47,6 +50,8 @@ public class TrainedModelDefinitionDoc implements ToXContentObject {
         parser.declareString((a, b) -> {}, InferenceIndexConstants.DOC_TYPE);  // type is hard coded but must be parsed
         parser.declareString(TrainedModelDefinitionDoc.Builder::setModelId, TrainedModelConfig.MODEL_ID);
         parser.declareString(TrainedModelDefinitionDoc.Builder::setCompressedString, DEFINITION);
+        parser.declareField(TrainedModelDefinitionDoc.Builder::setBinaryData, (p, c) -> p.binaryValue(),
+            BINARY_DEFINITION, ObjectParser.ValueType.VALUE_ARRAY);
         parser.declareInt(TrainedModelDefinitionDoc.Builder::setDocNum, DOC_NUM);
         parser.declareInt(TrainedModelDefinitionDoc.Builder::setCompressionVersion, COMPRESSION_VERSION);
         parser.declareLong(TrainedModelDefinitionDoc.Builder::setDefinitionLength, DEFINITION_LENGTH);
@@ -64,7 +69,7 @@ public class TrainedModelDefinitionDoc implements ToXContentObject {
         return NAME + "-" + modelId + "-" + docNum;
     }
 
-    private final String compressedString;
+    private final byte[] binaryData;
     private final String modelId;
     private final int docNum;
     // for bwc
@@ -73,14 +78,14 @@ public class TrainedModelDefinitionDoc implements ToXContentObject {
     private final int compressionVersion;
     private final boolean eos;
 
-    private TrainedModelDefinitionDoc(String compressedString,
+    private TrainedModelDefinitionDoc(byte[] binaryData,
                                       String modelId,
                                       int docNum,
                                       Long totalDefinitionLength,
                                       long definitionLength,
                                       int compressionVersion,
                                       boolean eos) {
-        this.compressedString = ExceptionsHelper.requireNonNull(compressedString, DEFINITION);
+        this.binaryData = ExceptionsHelper.requireNonNull(binaryData, BINARY_DEFINITION);
         this.modelId = ExceptionsHelper.requireNonNull(modelId, TrainedModelConfig.MODEL_ID);
         if (docNum < 0) {
             throw new IllegalArgumentException("[doc_num] must be greater than or equal to 0");
@@ -98,8 +103,8 @@ public class TrainedModelDefinitionDoc implements ToXContentObject {
         this.eos = eos;
     }
 
-    public String getCompressedString() {
-        return compressedString;
+    public byte[] getBinaryData() {
+        return binaryData;
     }
 
     public String getModelId() {
@@ -141,7 +146,7 @@ public class TrainedModelDefinitionDoc implements ToXContentObject {
             builder.field(TOTAL_DEFINITION_LENGTH.getPreferredName(), totalDefinitionLength);
         }
         builder.field(COMPRESSION_VERSION.getPreferredName(), compressionVersion);
-        builder.field(DEFINITION.getPreferredName(), compressedString);
+        builder.field(BINARY_DEFINITION.getPreferredName(), binaryData);
         builder.field(EOS.getPreferredName(), eos);
         builder.endObject();
         return builder;
@@ -163,18 +168,18 @@ public class TrainedModelDefinitionDoc implements ToXContentObject {
             Objects.equals(totalDefinitionLength, that.totalDefinitionLength) &&
             Objects.equals(compressionVersion, that.compressionVersion) &&
             Objects.equals(eos, that.eos) &&
-            Objects.equals(compressedString, that.compressedString);
+            Objects.equals(binaryData, that.binaryData);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(modelId, docNum, definitionLength, totalDefinitionLength, compressionVersion, compressedString, eos);
+        return Objects.hash(modelId, docNum, definitionLength, totalDefinitionLength, compressionVersion, binaryData, eos);
     }
 
     public static class Builder {
 
         private String modelId;
-        private String compressedString;
+        private byte[] binaryData;
         private int docNum;
         private Long totalDefinitionLength;
         private long definitionLength;
@@ -187,7 +192,12 @@ public class TrainedModelDefinitionDoc implements ToXContentObject {
         }
 
         public Builder setCompressedString(String compressedString) {
-            this.compressedString = compressedString;
+            this.binaryData = Base64.getDecoder().decode(compressedString.getBytes(StandardCharsets.UTF_8));
+            return this;
+        }
+
+        public Builder setBinaryData(byte [] binaryData) {
+            this.binaryData = binaryData;
             return this;
         }
 
@@ -218,7 +228,7 @@ public class TrainedModelDefinitionDoc implements ToXContentObject {
 
         public TrainedModelDefinitionDoc build() {
             return new TrainedModelDefinitionDoc(
-                this.compressedString,
+                this.binaryData,
                 this.modelId,
                 this.docNum,
                 this.totalDefinitionLength,

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/persistence/TrainedModelProvider.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/persistence/TrainedModelProvider.java
@@ -1091,7 +1091,7 @@ public class TrainedModelProvider {
                                                         String modelId) throws ElasticsearchException {
 
         BytesReference[] bb = new BytesReference[docs.size()];
-        for (int i=0; i<docs.size(); i++) {
+        for (int i = 0; i < docs.size(); i++) {
             bb[i] = docs.get(i).getBinaryData();
         }
         BytesReference bytes = CompositeBytesReference.of(bb);
@@ -1104,7 +1104,7 @@ public class TrainedModelProvider {
 
         TrainedModelDefinitionDoc lastDoc = docs.get(docs.size() - 1);
         // Either we are missing the last doc, or some previous doc
-        if(lastDoc.isEos() == false || lastDoc.getDocNum() != docs.size() - 1) {
+        if (lastDoc.isEos() == false || lastDoc.getDocNum() != docs.size() - 1) {
             throw ExceptionsHelper.serverError(Messages.getMessage(Messages.MODEL_DEFINITION_TRUNCATED, modelId));
         }
         return bytes;

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/persistence/TrainedModelProvider.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/persistence/TrainedModelProvider.java
@@ -1096,18 +1096,16 @@ public class TrainedModelProvider {
         }
         BytesReference bytes = CompositeBytesReference.of(bb);
 
-        // BWC for when we tracked the total definition length
-        // TODO: remove in 9
         if (docs.get(0).getTotalDefinitionLength() != null) {
             if (bytes.length() != docs.get(0).getTotalDefinitionLength()) {
                 throw ExceptionsHelper.serverError(Messages.getMessage(Messages.MODEL_DEFINITION_TRUNCATED, modelId));
             }
-        } else {
-            TrainedModelDefinitionDoc lastDoc = docs.get(docs.size() - 1);
-            // Either we are missing the last doc, or some previous doc
-            if(lastDoc.isEos() == false || lastDoc.getDocNum() != docs.size() - 1) {
-                throw ExceptionsHelper.serverError(Messages.getMessage(Messages.MODEL_DEFINITION_TRUNCATED, modelId));
-            }
+        }
+
+        TrainedModelDefinitionDoc lastDoc = docs.get(docs.size() - 1);
+        // Either we are missing the last doc, or some previous doc
+        if(lastDoc.isEos() == false || lastDoc.getDocNum() != docs.size() - 1) {
+            throw ExceptionsHelper.serverError(Messages.getMessage(Messages.MODEL_DEFINITION_TRUNCATED, modelId));
         }
         return bytes;
     }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/persistence/TrainedModelProvider.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/persistence/TrainedModelProvider.java
@@ -113,9 +113,9 @@ public class TrainedModelProvider {
     public static final Set<String> MODELS_STORED_AS_RESOURCE = Collections.singleton("lang_ident_model_1");
     private static final String MODEL_RESOURCE_PATH = "/org/elasticsearch/xpack/ml/inference/persistence/";
     private static final String MODEL_RESOURCE_FILE_EXT = ".json";
-    private static final int COMPRESSED_STRING_CHUNK_SIZE = 16 * 1024 * 1024;
+    private static final int COMPRESSED_MODEL_CHUNK_SIZE = 16 * 1024 * 1024;
     private static final int MAX_NUM_DEFINITION_DOCS = 100;
-    private static final int MAX_COMPRESSED_STRING_SIZE = COMPRESSED_STRING_CHUNK_SIZE * MAX_NUM_DEFINITION_DOCS;
+    private static final int MAX_COMPRESSED_MODEL_SIZE = COMPRESSED_MODEL_CHUNK_SIZE * MAX_NUM_DEFINITION_DOCS;
 
     private static final Logger logger = LogManager.getLogger(TrainedModelProvider.class);
     private final Client client;
@@ -293,15 +293,15 @@ public class TrainedModelProvider {
         List<TrainedModelDefinitionDoc> trainedModelDefinitionDocs = new ArrayList<>();
         try {
             BytesReference compressedDefinition = trainedModelConfig.getCompressedDefinition();
-            if (compressedDefinition.length() > MAX_COMPRESSED_STRING_SIZE) {
+            if (compressedDefinition.length() > MAX_COMPRESSED_MODEL_SIZE) {
                 listener.onFailure(
                     ExceptionsHelper.badRequestException(
-                        "Unable to store model as compressed definition has length [{}] the limit is [{}]",
+                        "Unable to store model as compressed definition of size [{}] bytes the limit is [{}] bytes",
                         compressedDefinition.length(),
-                        MAX_COMPRESSED_STRING_SIZE));
+                        MAX_COMPRESSED_MODEL_SIZE));
                 return;
             }
-            List<BytesReference> chunkedDefinition = chunkDefinitionWithSize(compressedDefinition, COMPRESSED_STRING_CHUNK_SIZE);
+            List<BytesReference> chunkedDefinition = chunkDefinitionWithSize(compressedDefinition, COMPRESSED_MODEL_CHUNK_SIZE);
             for(int i = 0; i < chunkedDefinition.size(); ++i) {
                 trainedModelDefinitionDocs.add(new TrainedModelDefinitionDoc.Builder()
                     .setDocNum(i)

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/pytorch/process/PyTorchStateStreamer.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/pytorch/process/PyTorchStateStreamer.java
@@ -19,8 +19,6 @@ import org.elasticsearch.xpack.ml.inference.persistence.TrainedModelDefinitionDo
 import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.ByteBuffer;
-import java.nio.charset.StandardCharsets;
-import java.util.Base64;
 import java.util.Locale;
 import java.util.Objects;
 import java.util.concurrent.ExecutorService;
@@ -82,9 +80,7 @@ public class PyTorchStateStreamer {
             modelSizeWritten = true;
         }
 
-        byte[] rawBytes = Base64.getDecoder().decode(doc.getCompressedString().getBytes(StandardCharsets.UTF_8));
-        outputStream.write(rawBytes);
-
+        outputStream.write(doc.getBinaryData());
         return true;
     }
 

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/pytorch/process/PyTorchStateStreamer.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/pytorch/process/PyTorchStateStreamer.java
@@ -80,7 +80,9 @@ public class PyTorchStateStreamer {
             modelSizeWritten = true;
         }
 
-        outputStream.write(doc.getBinaryData());
+        // The array backing the BytesReference may be bigger than what is
+        // referred to so write only what is after the offset
+        outputStream.write(doc.getBinaryData().array(), doc.getBinaryData().arrayOffset(), doc.getBinaryData().length());
         return true;
     }
 

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/persistence/TrainedModelDefinitionDocTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/persistence/TrainedModelDefinitionDocTests.java
@@ -19,7 +19,7 @@ public class TrainedModelDefinitionDocTests extends AbstractXContentTestCase<Tra
 
     private final boolean isLenient = randomBoolean();
 
-    public void testParsingDocWithCompressedString() throws IOException {
+    public void testParsingDocWithCompressedStringDefinition() throws IOException {
         byte[] bytes = randomByteArrayOfLength(50);
         String base64 = Base64.getEncoder().encodeToString(bytes);
 

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/persistence/TrainedModelDefinitionDocTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/persistence/TrainedModelDefinitionDocTests.java
@@ -7,6 +7,7 @@
 
 package org.elasticsearch.xpack.ml.inference.persistence;
 
+import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.test.AbstractXContentTestCase;
 
@@ -14,7 +15,7 @@ import java.io.IOException;
 
 public class TrainedModelDefinitionDocTests extends AbstractXContentTestCase<TrainedModelDefinitionDoc> {
 
-    private boolean isLenient = randomBoolean();
+    private final boolean isLenient = randomBoolean();
 
     @Override
     protected TrainedModelDefinitionDoc doParseInstance(XContentParser parser) throws IOException {
@@ -28,12 +29,13 @@ public class TrainedModelDefinitionDocTests extends AbstractXContentTestCase<Tra
 
     @Override
     protected TrainedModelDefinitionDoc createTestInstance() {
-        int length = randomIntBetween(1, 10);
+        int length = randomIntBetween(4, 10);
+
         return new TrainedModelDefinitionDoc.Builder()
             .setModelId(randomAlphaOfLength(6))
             .setDefinitionLength(length)
             .setTotalDefinitionLength(randomIntBetween(length, length *2))
-            .setCompressedString(randomAlphaOfLength(length))
+            .setBinaryData(new BytesArray(randomByteArrayOfLength(length)))
             .setDocNum(randomIntBetween(0, 10))
             .setCompressionVersion(randomIntBetween(1, 5))
             .setEos(randomBoolean())


### PR DESCRIPTION
Binary data is stored in lucene base64 encoded, the same data stored in a Java string uses 2 bytes (UTF16) to represent each base64 character consuming twice the amount of memory required. This change uses ByteReferences to hold the binary data which is not base64 encoded, encoding must take place the bytes can be persisted and this is performed by the XContent classes.

For BWC I've added a new field mapping `binary_definition` to .ml-inference-* which means the index version has to be incremented.

Compatibility for HLRC and REST API users is preserved as the `compressed_definition` field still contains the base64 encoded rep.