### PR TITLE
Fix fetch_fields yaml test result order

### DIFF
--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search/330_fetch_fields.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search/330_fetch_fields.yml
@@ -564,6 +564,7 @@ Test nested field inside object structure:
         search:
            index: test
            body:
+              sort: "obj.other_obj_field"
               _source: false
               fields: ["obj.products.manufacturer"]
   - match:
@@ -579,6 +580,7 @@ Test nested field inside object structure:
         search:
            index: test
            body:
+              sort: "obj.other_obj_field"
               _source: false
               fields: ["obj.pro*ts.manufacturer"]
   - match:


### PR DESCRIPTION
The test failing in #71685 does so because under rare circumstance the result
order for match_all can be different. If we want to make assertions on specific
entries in the result, we should sort by a field that imposes a fixed result
ordering.

Closes #71685