### PR TITLE
[7.x] Network direction processor addition

### DIFF
--- a/docs/reference/ingest/processors/network-direction.asciidoc
+++ b/docs/reference/ingest/processors/network-direction.asciidoc
@@ -21,14 +21,17 @@ only the `internal_networks` option must be specified.
 | `source_ip`        | no       | `source.ip`   | Field containing the source IP address.
 | `destination_ip`   | no       | `destination.ip` | Field containing the destination IP address.
 | `target_field`     | no       | `network.direction` | Output field for the network direction.
-| `internal_networks`| yes      |               | List of internal networks. Supports IPv4 and
-IPv6 addresses and ranges in CIDR notation. Also supports the named ranges listed below.
+| `internal_networks`| yes *    |               | List of internal networks. Supports IPv4 and
+IPv6 addresses and ranges in CIDR notation. Also supports the named ranges listed below. These may be constructed with <<template-snippets,template snippets>>. * Must specify only one of `internal_networks` or `internal_networks_field`.
+| `internal_networks_field`| no      |               | A field on the given document to read the `internal_networks` configuration from.
 | `ignore_missing`   | no       | `true`        | If `true` and any required fields are missing,
 the processor quietly exits without modifying the document.
 
 
 include::common-options.asciidoc[]
 |======
+
+One of either `internal_networks` or `internal_networks_field` must be specified. If `internal_networks_field` is specified, it follows the behavior specified by `ignore_missing`.
 
 [float]
 [[supported-named-network-ranges]]

--- a/modules/ingest-common/src/main/java/org/elasticsearch/ingest/common/IngestCommonPlugin.java
+++ b/modules/ingest-common/src/main/java/org/elasticsearch/ingest/common/IngestCommonPlugin.java
@@ -80,7 +80,7 @@ public class IngestCommonPlugin extends Plugin implements ActionPlugin, IngestPl
                 entry(HtmlStripProcessor.TYPE, new HtmlStripProcessor.Factory()),
                 entry(CsvProcessor.TYPE, new CsvProcessor.Factory()),
                 entry(UriPartsProcessor.TYPE, new UriPartsProcessor.Factory()),
-                entry(NetworkDirectionProcessor.TYPE, new NetworkDirectionProcessor.Factory()),
+                entry(NetworkDirectionProcessor.TYPE, new NetworkDirectionProcessor.Factory(parameters.scriptService)),
                 entry(CommunityIdProcessor.TYPE, new CommunityIdProcessor.Factory()),
                 entry(FingerprintProcessor.TYPE, new FingerprintProcessor.Factory())
             );

--- a/modules/ingest-common/src/main/java/org/elasticsearch/ingest/common/NetworkDirectionProcessor.java
+++ b/modules/ingest-common/src/main/java/org/elasticsearch/ingest/common/NetworkDirectionProcessor.java
@@ -14,12 +14,17 @@ import org.elasticsearch.ingest.AbstractProcessor;
 import org.elasticsearch.ingest.ConfigurationUtils;
 import org.elasticsearch.ingest.IngestDocument;
 import org.elasticsearch.ingest.Processor;
+import org.elasticsearch.script.ScriptService;
+import org.elasticsearch.script.TemplateScript;
 
 import java.net.InetAddress;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
+import static org.elasticsearch.ingest.ConfigurationUtils.newConfigurationException;
 import static org.elasticsearch.ingest.ConfigurationUtils.readBooleanProperty;
 
 public class NetworkDirectionProcessor extends AbstractProcessor {
@@ -48,7 +53,8 @@ public class NetworkDirectionProcessor extends AbstractProcessor {
     private final String sourceIpField;
     private final String destinationIpField;
     private final String targetField;
-    private final List<String> internalNetworks;
+    private final List<TemplateScript.Factory> internalNetworks;
+    private final String internalNetworksField;
     private final boolean ignoreMissing;
 
     NetworkDirectionProcessor(
@@ -57,7 +63,8 @@ public class NetworkDirectionProcessor extends AbstractProcessor {
         String sourceIpField,
         String destinationIpField,
         String targetField,
-        List<String> internalNetworks,
+        List<TemplateScript.Factory> internalNetworks,
+        String internalNetworksField,
         boolean ignoreMissing
     ) {
         super(tag, description);
@@ -65,6 +72,7 @@ public class NetworkDirectionProcessor extends AbstractProcessor {
         this.destinationIpField = destinationIpField;
         this.targetField = targetField;
         this.internalNetworks = internalNetworks;
+        this.internalNetworksField = internalNetworksField;
         this.ignoreMissing = ignoreMissing;
     }
 
@@ -80,8 +88,12 @@ public class NetworkDirectionProcessor extends AbstractProcessor {
         return targetField;
     }
 
-    public List<String> getInternalNetworks() {
+    public List<TemplateScript.Factory> getInternalNetworks() {
         return internalNetworks;
+    }
+
+    public String getInternalNetworksField() {
+        return internalNetworksField;
     }
 
     public boolean getIgnoreMissing() {
@@ -103,9 +115,18 @@ public class NetworkDirectionProcessor extends AbstractProcessor {
         return ingestDocument;
     }
 
-    private String getDirection(IngestDocument d) {
-        if (internalNetworks == null) {
-            return null;
+    private String getDirection(IngestDocument d) throws Exception {
+        List<String> networks = new ArrayList<>();
+
+        if (internalNetworksField != null) {
+            @SuppressWarnings("unchecked")
+            List<String> stringList = d.getFieldValue(internalNetworksField, networks.getClass(), ignoreMissing);
+            if (stringList == null) {
+                return null;
+            }
+            networks.addAll(stringList);
+        } else {
+            networks = internalNetworks.stream().map(network -> d.renderTemplate(network)).collect(Collectors.toList());
         }
 
         String sourceIpAddrString = d.getFieldValue(sourceIpField, String.class, ignoreMissing);
@@ -118,8 +139,8 @@ public class NetworkDirectionProcessor extends AbstractProcessor {
             return null;
         }
 
-        boolean sourceInternal = isInternal(sourceIpAddrString);
-        boolean destinationInternal = isInternal(destIpAddrString);
+        boolean sourceInternal = isInternal(networks, sourceIpAddrString);
+        boolean destinationInternal = isInternal(networks, destIpAddrString);
 
         if (sourceInternal && destinationInternal) {
             return DIRECTION_INTERNAL;
@@ -133,8 +154,8 @@ public class NetworkDirectionProcessor extends AbstractProcessor {
         return DIRECTION_EXTERNAL;
     }
 
-    private boolean isInternal(String ip) {
-        for (String network : internalNetworks) {
+    private boolean isInternal(List<String> networks, String ip) {
+        for (String network : networks) {
             if (inNetwork(ip, network)) {
                 return true;
             }
@@ -227,10 +248,14 @@ public class NetworkDirectionProcessor extends AbstractProcessor {
     }
 
     public static final class Factory implements Processor.Factory {
-
+        private final ScriptService scriptService;
         static final String DEFAULT_SOURCE_IP = "source.ip";
         static final String DEFAULT_DEST_IP = "destination.ip";
         static final String DEFAULT_TARGET = "network.direction";
+
+        public Factory(ScriptService scriptService) {
+            this.scriptService = scriptService;
+        }
 
         @Override
         public NetworkDirectionProcessor create(
@@ -239,19 +264,44 @@ public class NetworkDirectionProcessor extends AbstractProcessor {
             String description,
             Map<String, Object> config
         ) throws Exception {
-            String sourceIpField = ConfigurationUtils.readStringProperty(TYPE, processorTag, config, "source_ip", DEFAULT_SOURCE_IP);
-            String destIpField = ConfigurationUtils.readStringProperty(TYPE, processorTag, config, "destination_ip", DEFAULT_DEST_IP);
-            String targetField = ConfigurationUtils.readStringProperty(TYPE, processorTag, config, "target_field", DEFAULT_TARGET);
-            List<String> internalNetworks = ConfigurationUtils.readList(TYPE, processorTag, config, "internal_networks");
-            boolean ignoreMissing = readBooleanProperty(TYPE, processorTag, config, "ignore_missing", true);
+            final String sourceIpField = ConfigurationUtils.readStringProperty(TYPE, processorTag, config, "source_ip", DEFAULT_SOURCE_IP);
+            final String destIpField = ConfigurationUtils.readStringProperty(TYPE, processorTag, config, "destination_ip", DEFAULT_DEST_IP);
+            final String targetField = ConfigurationUtils.readStringProperty(TYPE, processorTag, config, "target_field", DEFAULT_TARGET);
+            final boolean ignoreMissing = readBooleanProperty(TYPE, processorTag, config, "ignore_missing", true);
 
+            final List<String> internalNetworks = ConfigurationUtils.readOptionalList(TYPE, processorTag, config, "internal_networks");
+            final String internalNetworksField = ConfigurationUtils.readOptionalStringProperty(
+                TYPE,
+                processorTag,
+                config,
+                "internal_networks_field"
+            );
+
+            if (internalNetworks == null && internalNetworksField == null) {
+                throw newConfigurationException(TYPE, processorTag, "internal_networks", "or [internal_networks_field] must be specified");
+            }
+            if (internalNetworks != null && internalNetworksField != null) {
+                throw newConfigurationException(
+                    TYPE,
+                    processorTag,
+                    "internal_networks", "and [internal_networks_field] cannot both be used in the same processor"
+                );
+            }
+
+            List<TemplateScript.Factory> internalNetworkTemplates = null;
+            if (internalNetworks != null) {
+                internalNetworkTemplates = internalNetworks.stream()
+                    .map(n -> ConfigurationUtils.compileTemplate(TYPE, processorTag, "internal_networks", n, scriptService))
+                    .collect(Collectors.toList());
+            }
             return new NetworkDirectionProcessor(
                 processorTag,
                 description,
                 sourceIpField,
                 destIpField,
                 targetField,
-                internalNetworks,
+                internalNetworkTemplates,
+                internalNetworksField,
                 ignoreMissing
             );
         }

--- a/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/NetworkDirectionProcessorTests.java
+++ b/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/NetworkDirectionProcessorTests.java
@@ -10,14 +10,16 @@ package org.elasticsearch.ingest.common;
 
 import org.elasticsearch.ingest.IngestDocument;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.ingest.TestTemplateService;
+import org.elasticsearch.ElasticsearchParseException;
+import org.elasticsearch.ingest.TestTemplateService;
 
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
+import java.util.ArrayList;
 import java.util.Map;
 
-import static org.elasticsearch.ingest.common.NetworkDirectionProcessor.Factory.DEFAULT_DEST_IP;
-import static org.elasticsearch.ingest.common.NetworkDirectionProcessor.Factory.DEFAULT_SOURCE_IP;
 import static org.elasticsearch.ingest.common.NetworkDirectionProcessor.Factory.DEFAULT_TARGET;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
@@ -49,8 +51,11 @@ public class NetworkDirectionProcessorTests extends ESTestCase {
     }
 
     public void testNoInternalNetworks() throws Exception {
-        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> testNetworkDirectionProcessor(buildEvent(), null));
-        assertThat(e.getMessage(), containsString("unable to calculate network direction from document"));
+        ElasticsearchParseException e = expectThrows(
+            ElasticsearchParseException.class,
+            () -> testNetworkDirectionProcessor(buildEvent(), null)
+        );
+        assertThat(e.getMessage(), containsString("[internal_networks] or [internal_networks_field] must be specified"));
     }
 
     public void testNoSource() throws Exception {
@@ -130,6 +135,50 @@ public class NetworkDirectionProcessorTests extends ESTestCase {
         testNetworkDirectionProcessor(source, internalNetworks, expectedDirection, false);
     }
 
+    public void testReadFromField() throws Exception {
+        String processorTag = randomAlphaOfLength(10);
+        Map<String, Object> source = buildEvent("192.168.1.1", "192.168.1.2");
+        ArrayList<String> networks = new ArrayList<>();
+        networks.add("public");
+        source.put("some_field", networks);
+
+        Map<String, Object> config = new HashMap<>();
+        config.put("internal_networks_field", "some_field");
+        NetworkDirectionProcessor processor = new NetworkDirectionProcessor.Factory(TestTemplateService.instance()).create(
+            null,
+            processorTag,
+            null,
+            config
+        );
+        IngestDocument input = new IngestDocument(source, Map.of());
+        IngestDocument output = processor.execute(input);
+        String hash = output.getFieldValue(DEFAULT_TARGET, String.class);
+        assertThat(hash, equalTo("external"));
+    }
+
+    public void testInternalNetworksAndField() throws Exception {
+        String processorTag = randomAlphaOfLength(10);
+        Map<String, Object> source = buildEvent("192.168.1.1", "192.168.1.2");
+        ArrayList<String> networks = new ArrayList<>();
+        networks.add("public");
+        source.put("some_field", networks);
+        Map<String, Object> config = new HashMap<>();
+        config.put("internal_networks_field", "some_field");
+        config.put("internal_networks", networks);
+        ElasticsearchParseException e = expectThrows(
+            ElasticsearchParseException.class,
+            () -> new NetworkDirectionProcessor.Factory(TestTemplateService.instance()).create(
+                null,
+                processorTag,
+                null,
+                config
+            )
+        );
+        assertThat(e.getMessage(), containsString(
+            "[internal_networks] and [internal_networks_field] cannot both be used in the same processor"
+        ));
+    }
+
     private void testNetworkDirectionProcessor(
         Map<String, Object> source,
         String[] internalNetworks,
@@ -140,17 +189,18 @@ public class NetworkDirectionProcessorTests extends ESTestCase {
 
         if (internalNetworks != null) networks = Arrays.asList(internalNetworks);
 
-        NetworkDirectionProcessor processor = new NetworkDirectionProcessor(
+        String processorTag = randomAlphaOfLength(10);
+        Map<String, Object> config = new HashMap<>();
+        config.put("internal_networks", networks);
+        config.put("ignore_missing", ignoreMissing);
+        NetworkDirectionProcessor processor = new NetworkDirectionProcessor.Factory(TestTemplateService.instance()).create(
             null,
+            processorTag,
             null,
-            DEFAULT_SOURCE_IP,
-            DEFAULT_DEST_IP,
-            DEFAULT_TARGET,
-            networks,
-            ignoreMissing
+            config
         );
 
-        IngestDocument input = new IngestDocument(source, org.elasticsearch.common.collect.Map.of());
+        IngestDocument input = new IngestDocument(source, Map.of());
         IngestDocument output = processor.execute(input);
 
         String hash = output.getFieldValue(DEFAULT_TARGET, String.class, ignoreMissing);

--- a/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/NetworkDirectionProcessorTests.java
+++ b/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/NetworkDirectionProcessorTests.java
@@ -8,16 +8,15 @@
 
 package org.elasticsearch.ingest.common;
 
-import org.elasticsearch.ingest.IngestDocument;
-import org.elasticsearch.test.ESTestCase;
-import org.elasticsearch.ingest.TestTemplateService;
 import org.elasticsearch.ElasticsearchParseException;
+import org.elasticsearch.ingest.IngestDocument;
 import org.elasticsearch.ingest.TestTemplateService;
+import org.elasticsearch.test.ESTestCase;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
-import java.util.ArrayList;
 import java.util.Map;
 
 import static org.elasticsearch.ingest.common.NetworkDirectionProcessor.Factory.DEFAULT_TARGET;
@@ -150,7 +149,7 @@ public class NetworkDirectionProcessorTests extends ESTestCase {
             null,
             config
         );
-        IngestDocument input = new IngestDocument(source, Map.of());
+        IngestDocument input = new IngestDocument(source, org.elasticsearch.common.collect.Map.of());
         IngestDocument output = processor.execute(input);
         String hash = output.getFieldValue(DEFAULT_TARGET, String.class);
         assertThat(hash, equalTo("external"));
@@ -200,7 +199,7 @@ public class NetworkDirectionProcessorTests extends ESTestCase {
             config
         );
 
-        IngestDocument input = new IngestDocument(source, Map.of());
+        IngestDocument input = new IngestDocument(source, org.elasticsearch.common.collect.Map.of());
         IngestDocument output = processor.execute(input);
 
         String hash = output.getFieldValue(DEFAULT_TARGET, String.class, ignoreMissing);


### PR DESCRIPTION
This adds some functionality to the new `network_direction` processor that allows the processor to use templates for specifying `internal_networks` or to read the values as an array from a given field. This is important because it allows for dynamic processor execution based on the contents of a given field. We actually use this internally in a number of beats modules where we pass configuration from a configuration file up to a pipeline on the document being ingested--the processor then gets executed based off of that extra configuration context prior to the fields being dropped.

One of my first desired use cases is in the cisco umbrella filebeat module where I'm planning to add the following to the pipeline:

```
  - network_direction:
      internal_networks_field: _conf.internal_networks
      ignore_missing: true
```

Backport of #68712