### PR TITLE
Close CacheDecayTask when FrozenCacheService is closed

### DIFF
--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/cache/shared/FrozenCacheService.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/cache/shared/FrozenCacheService.java
@@ -16,7 +16,6 @@ import org.elasticsearch.action.StepListener;
 import org.elasticsearch.cluster.node.DiscoveryNodeRole;
 import org.elasticsearch.common.lease.Releasable;
 import org.elasticsearch.common.lease.Releasables;
-import org.elasticsearch.common.logging.DeprecationLogger;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.settings.SettingsException;
@@ -162,7 +161,6 @@ public class FrozenCacheService implements Releasable {
     );
 
     private static final Logger logger = LogManager.getLogger(FrozenCacheService.class);
-    private static final DeprecationLogger deprecationLogger = DeprecationLogger.getLogger(FrozenCacheService.class);
 
     private final ConcurrentHashMap<RegionKey, Entry<CacheFileRegion>> keyMapping;
 
@@ -499,6 +497,7 @@ public class FrozenCacheService implements Releasable {
     @Override
     public void close() {
         sharedBytes.decRef();
+        decayTask.close();
     }
 
     class CacheDecayTask extends AbstractAsyncTask {


### PR DESCRIPTION
`CacheDecayTask` is scheduled when the `FrozenCacheService` is instantiated but it should also be closed accordingly when the service is closed.