### PR TITLE
Whitelist URL class

### DIFF
--- a/modules/lang-painless/src/main/resources/org/elasticsearch/painless/spi/org.elasticsearch.net.txt
+++ b/modules/lang-painless/src/main/resources/org/elasticsearch/painless/spi/org.elasticsearch.net.txt
@@ -6,6 +6,15 @@
 # Side Public License, v 1.
 #
 
+class java.net.URL {
+    (String)
+    String getHost()
+    String getPath()
+    int getPort()
+    String getProtocol()
+    String getRef()
+}
+
 class org.elasticsearch.painless.api.CIDR {
     (String)
     boolean contains(String)

--- a/modules/lang-painless/src/test/java/org/elasticsearch/painless/UrlTests.java
+++ b/modules/lang-painless/src/test/java/org/elasticsearch/painless/UrlTests.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.painless;
+
+import java.net.MalformedURLException;
+
+public class UrlTests extends ScriptTestCase {
+    public void testInvalidURLs() {
+        MalformedURLException e = expectScriptThrows(MalformedURLException.class, () -> exec("new URL('abc')"));
+        assertEquals("no protocol: abc", e.getMessage());
+
+        e = expectScriptThrows(MalformedURLException.class, () -> exec("new URL('')"));
+        assertEquals("no protocol: ", e.getMessage());
+
+        e = expectScriptThrows(MalformedURLException.class, () -> exec("new URL(null)"));
+        assertEquals("Cannot invoke \"String.length()\" because \"spec\" is null", e.getMessage());
+
+        e = expectScriptThrows(MalformedURLException.class, () -> exec("new URL('abc://www.test.com')"));
+        assertEquals("unknown protocol: abc", e.getMessage());
+    }
+
+    public void testGetHost() {
+        assertEquals("www.test.com", exec("URL url = new URL('https://www.test.com:8080/path?query#fragment'); url.getHost()"));
+
+        assertEquals("www.test2.org", exec("URL url = new URL('https://www.test2.org'); url.getHost()"));
+    }
+
+    public void testGetPath() {
+        assertEquals("/path", exec("URL url = new URL('https://www.test.com:8080/path?query#fragment'); url.getPath()"));
+
+        assertEquals("/docs/example", exec("URL url = new URL('https://www.test.com/docs/example'); url.getPath()"));
+    }
+
+    public void testGetPort() {
+        assertEquals(8080, exec("URL url = new URL('https://www.test.com:8080/path?query#fragment'); url.getPort()"));
+
+        assertEquals(3000, exec("URL url = new URL('https://www.test.com:3000'); url.getPort()"));
+    }
+
+    public void testGetProtocol() {
+        assertEquals("https", exec("URL url = new URL('https://www.test.com:8080/path?query#fragment'); url.getProtocol()"));
+
+        assertEquals("ftp", exec("URL url = new URL('ftp://www.test.eu'); url.getProtocol()"));
+    }
+
+    public void testGetReference() {
+        assertEquals("reference", exec("URL url = new URL('https://www.test.com:8080/path?query#reference'); url.getRef()"));
+
+        assertEquals("section1", exec("URL url = new URL('https://www.test.com#section1'); url.getRef()"));
+    }
+}

--- a/modules/lang-painless/src/test/java/org/elasticsearch/painless/UrlTests.java
+++ b/modules/lang-painless/src/test/java/org/elasticsearch/painless/UrlTests.java
@@ -19,7 +19,8 @@ public class UrlTests extends ScriptTestCase {
         assertEquals("no protocol: ", e.getMessage());
 
         e = expectScriptThrows(MalformedURLException.class, () -> exec("new URL(null)"));
-        assertEquals("Cannot invoke \"String.length()\" because \"spec\" is null", e.getMessage());
+        // Can't check error message because in Java 11 message is null (it's not null in Java 15)
+        assertNotNull(e);
 
         e = expectScriptThrows(MalformedURLException.class, () -> exec("new URL('abc://www.example.com')"));
         assertEquals("unknown protocol: abc", e.getMessage());

--- a/modules/lang-painless/src/test/java/org/elasticsearch/painless/UrlTests.java
+++ b/modules/lang-painless/src/test/java/org/elasticsearch/painless/UrlTests.java
@@ -21,37 +21,37 @@ public class UrlTests extends ScriptTestCase {
         e = expectScriptThrows(MalformedURLException.class, () -> exec("new URL(null)"));
         assertEquals("Cannot invoke \"String.length()\" because \"spec\" is null", e.getMessage());
 
-        e = expectScriptThrows(MalformedURLException.class, () -> exec("new URL('abc://www.test.com')"));
+        e = expectScriptThrows(MalformedURLException.class, () -> exec("new URL('abc://www.example.com')"));
         assertEquals("unknown protocol: abc", e.getMessage());
     }
 
     public void testGetHost() {
-        assertEquals("www.test.com", exec("URL url = new URL('https://www.test.com:8080/path?query#fragment'); url.getHost()"));
+        assertEquals("www.example.com", exec("URL url = new URL('https://www.example.com:8080/path?query#fragment'); url.getHost()"));
 
-        assertEquals("www.test2.org", exec("URL url = new URL('https://www.test2.org'); url.getHost()"));
+        assertEquals("www.example2.org", exec("URL url = new URL('https://www.example2.org'); url.getHost()"));
     }
 
     public void testGetPath() {
-        assertEquals("/path", exec("URL url = new URL('https://www.test.com:8080/path?query#fragment'); url.getPath()"));
+        assertEquals("/path", exec("URL url = new URL('https://www.example.com:8080/path?query#fragment'); url.getPath()"));
 
-        assertEquals("/docs/example", exec("URL url = new URL('https://www.test.com/docs/example'); url.getPath()"));
+        assertEquals("/docs/example", exec("URL url = new URL('https://www.example.com/docs/example'); url.getPath()"));
     }
 
     public void testGetPort() {
-        assertEquals(8080, exec("URL url = new URL('https://www.test.com:8080/path?query#fragment'); url.getPort()"));
+        assertEquals(8080, exec("URL url = new URL('https://www.example.com:8080/path?query#fragment'); url.getPort()"));
 
-        assertEquals(3000, exec("URL url = new URL('https://www.test.com:3000'); url.getPort()"));
+        assertEquals(3000, exec("URL url = new URL('https://www.example.com:3000'); url.getPort()"));
     }
 
     public void testGetProtocol() {
-        assertEquals("https", exec("URL url = new URL('https://www.test.com:8080/path?query#fragment'); url.getProtocol()"));
+        assertEquals("https", exec("URL url = new URL('https://www.example.com:8080/path?query#fragment'); url.getProtocol()"));
 
-        assertEquals("ftp", exec("URL url = new URL('ftp://www.test.eu'); url.getProtocol()"));
+        assertEquals("ftp", exec("URL url = new URL('ftp://www.example.eu'); url.getProtocol()"));
     }
 
     public void testGetReference() {
-        assertEquals("reference", exec("URL url = new URL('https://www.test.com:8080/path?query#reference'); url.getRef()"));
+        assertEquals("reference", exec("URL url = new URL('https://www.example.com:8080/path?query#reference'); url.getRef()"));
 
-        assertEquals("section1", exec("URL url = new URL('https://www.test.com#section1'); url.getRef()"));
+        assertEquals("section1", exec("URL url = new URL('https://www.example.com#section1'); url.getRef()"));
     }
 }


### PR DESCRIPTION
Exposes parts of the [java.net.URL](https://docs.oracle.com/javase/7/docs/api/java/net/URL.html) class in painless.

API:
```
class java.net.URL {
    (String)
    String getHost()
    String getPath()
    int getPort()
    String getProtocol()
    String getRef()
}
```

Closes: #60660
