### PR TITLE
Add new predefined reserved roles

### DIFF
--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/SecurityDocumentationIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/SecurityDocumentationIT.java
@@ -691,7 +691,7 @@ public class SecurityDocumentationIT extends ESRestHighLevelClientTestCase {
             List<Role> roles = response.getRoles();
             assertNotNull(response);
             // 29 system roles plus the three we created
-            assertThat(roles.size(), equalTo(29 + 3));
+            assertThat(roles.size(), equalTo(31 + 3));
         }
 
         {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStore.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStore.java
@@ -336,7 +336,91 @@ public class ReservedRolesStore implements BiConsumer<Set<String>, ActionListene
                             .indices(".enrich-*")
                             .privileges("manage", "read", "write")
                             .build() }, null, MetadataUtils.DEFAULT_RESERVED_METADATA))
+                .put("viewer", buildViewerRoleDescriptor())
+                .put("editor", buildEditorRoleDescriptor())
                 .immutableMap();
+    }
+
+    private static RoleDescriptor buildViewerRoleDescriptor() {
+        return new RoleDescriptor("viewer",
+            new String[] {},
+            new RoleDescriptor.IndicesPrivileges[] {
+                // Stack
+                RoleDescriptor.IndicesPrivileges.builder()
+                    .indices("/~(([.]|ilm-history-).*)/")
+                    .privileges("read", "view_index_metadata").build(),
+                // Security
+                RoleDescriptor.IndicesPrivileges.builder().indices(".siem-signals-*").privileges("read", "view_index_metadata").build() },
+            new RoleDescriptor.ApplicationResourcePrivileges[] {
+                RoleDescriptor.ApplicationResourcePrivileges.builder().application("kibana-.kibana").resources("*").privileges(
+                    "feature_discover.read",
+                    "feature_dashboard.read",
+                    "feature_canvas.read",
+                    "feature_maps.read",
+                    "feature_ml.read",
+                    "feature_graph.read",
+                    "feature_visualize.read",
+                    "feature_logs.read",
+                    "feature_infrastructure.read",
+                    "feature_apm.read",
+                    "feature_uptime.read",
+                    "feature_siem.read",
+                    "feature_dev_tools.read",
+                    "feature_advancedSettings.read",
+                    "feature_indexPatterns.read",
+                    "feature_savedObjectsManagement.read",
+                    "feature_savedObjectsTagging.read",
+                    "feature_fleet.read",
+                    "feature_actions.read",
+                    "feature_stackAlerts.read").build() },
+            null,
+            null,
+            MetadataUtils.DEFAULT_RESERVED_METADATA,
+            null);
+    }
+
+    private static RoleDescriptor buildEditorRoleDescriptor() {
+        return new RoleDescriptor("editor",
+            new String[] {},
+            new RoleDescriptor.IndicesPrivileges[] {
+                // Stack
+                RoleDescriptor.IndicesPrivileges.builder()
+                    .indices("/~(([.]|ilm-history-).*)/")
+                    .privileges("read", "view_index_metadata").build(),
+                // Observability
+                RoleDescriptor.IndicesPrivileges.builder()
+                    .indices("observability-annotations")
+                    .privileges("read", "view_index_metadata", "write").build(),
+                // Security
+                RoleDescriptor.IndicesPrivileges.builder()
+                    .indices(".siem-signals-*", ".lists-*", ".items-*")
+                    .privileges("read", "view_index_metadata", "write", "maintenance").build() },
+            new RoleDescriptor.ApplicationResourcePrivileges[] {
+                RoleDescriptor.ApplicationResourcePrivileges.builder().application("kibana-.kibana").resources("*").privileges(
+                    "feature_discover.all",
+                    "feature_dashboard.all",
+                    "feature_canvas.all",
+                    "feature_maps.all",
+                    "feature_ml.all",
+                    "feature_graph.all",
+                    "feature_visualize.all",
+                    "feature_logs.all",
+                    "feature_infrastructure.all",
+                    "feature_apm.all",
+                    "feature_uptime.all",
+                    "feature_siem.all",
+                    "feature_dev_tools.all",
+                    "feature_advancedSettings.all",
+                    "feature_indexPatterns.all",
+                    "feature_savedObjectsManagement.all",
+                    "feature_savedObjectsTagging.all",
+                    "feature_fleet.all",
+                    "feature_actions.all",
+                    "feature_stackAlerts.all").build() },
+            null,
+            null,
+            MetadataUtils.DEFAULT_RESERVED_METADATA,
+            null);
     }
 
     private static RoleDescriptor kibanaAdminUser(String name, Map<String, Object> metadata) {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStore.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStore.java
@@ -342,7 +342,8 @@ public class ReservedRolesStore implements BiConsumer<Set<String>, ActionListene
     }
 
     private static RoleDescriptor buildViewerRoleDescriptor() {
-        return new RoleDescriptor("viewer",
+        return new RoleDescriptor(
+            "viewer",
             new String[] {},
             new RoleDescriptor.IndicesPrivileges[] {
                 // Stack
@@ -352,27 +353,10 @@ public class ReservedRolesStore implements BiConsumer<Set<String>, ActionListene
                 // Security
                 RoleDescriptor.IndicesPrivileges.builder().indices(".siem-signals-*").privileges("read", "view_index_metadata").build() },
             new RoleDescriptor.ApplicationResourcePrivileges[] {
-                RoleDescriptor.ApplicationResourcePrivileges.builder().application("kibana-.kibana").resources("*").privileges(
-                    "feature_discover.read",
-                    "feature_dashboard.read",
-                    "feature_canvas.read",
-                    "feature_maps.read",
-                    "feature_ml.read",
-                    "feature_graph.read",
-                    "feature_visualize.read",
-                    "feature_logs.read",
-                    "feature_infrastructure.read",
-                    "feature_apm.read",
-                    "feature_uptime.read",
-                    "feature_siem.read",
-                    "feature_dev_tools.read",
-                    "feature_advancedSettings.read",
-                    "feature_indexPatterns.read",
-                    "feature_savedObjectsManagement.read",
-                    "feature_savedObjectsTagging.read",
-                    "feature_fleet.read",
-                    "feature_actions.read",
-                    "feature_stackAlerts.read").build() },
+                RoleDescriptor.ApplicationResourcePrivileges.builder()
+                    .application("kibana-.kibana")
+                    .resources("*")
+                    .privileges("read").build() },
             null,
             null,
             MetadataUtils.DEFAULT_RESERVED_METADATA,
@@ -396,27 +380,10 @@ public class ReservedRolesStore implements BiConsumer<Set<String>, ActionListene
                     .indices(".siem-signals-*", ".lists-*", ".items-*")
                     .privileges("read", "view_index_metadata", "write", "maintenance").build() },
             new RoleDescriptor.ApplicationResourcePrivileges[] {
-                RoleDescriptor.ApplicationResourcePrivileges.builder().application("kibana-.kibana").resources("*").privileges(
-                    "feature_discover.all",
-                    "feature_dashboard.all",
-                    "feature_canvas.all",
-                    "feature_maps.all",
-                    "feature_ml.all",
-                    "feature_graph.all",
-                    "feature_visualize.all",
-                    "feature_logs.all",
-                    "feature_infrastructure.all",
-                    "feature_apm.all",
-                    "feature_uptime.all",
-                    "feature_siem.all",
-                    "feature_dev_tools.all",
-                    "feature_advancedSettings.all",
-                    "feature_indexPatterns.all",
-                    "feature_savedObjectsManagement.all",
-                    "feature_savedObjectsTagging.all",
-                    "feature_fleet.all",
-                    "feature_actions.all",
-                    "feature_stackAlerts.all").build() },
+                RoleDescriptor.ApplicationResourcePrivileges.builder()
+                    .application("kibana-.kibana")
+                    .resources("*")
+                    .privileges("all").build() },
             null,
             null,
             MetadataUtils.DEFAULT_RESERVED_METADATA,

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStoreTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStoreTests.java
@@ -1700,26 +1700,8 @@ public class ReservedRolesStoreTests extends ESTestCase {
         assertNoAccessAllowed(role, "." + randomAlphaOfLengthBetween(6, 10));
         assertNoAccessAllowed(role, "ilm-history-" + randomIntBetween(0, 5));
         // Check application privileges
-        assertKibanaFeatureReadButNotAll(role, "feature_discover");
-        assertKibanaFeatureReadButNotAll(role, "feature_dashboard");
-        assertKibanaFeatureReadButNotAll(role, "feature_canvas");
-        assertKibanaFeatureReadButNotAll(role, "feature_maps");
-        assertKibanaFeatureReadButNotAll(role, "feature_ml");
-        assertKibanaFeatureReadButNotAll(role, "feature_graph");
-        assertKibanaFeatureReadButNotAll(role, "feature_visualize");
-        assertKibanaFeatureReadButNotAll(role, "feature_logs");
-        assertKibanaFeatureReadButNotAll(role, "feature_infrastructure");
-        assertKibanaFeatureReadButNotAll(role, "feature_apm");
-        assertKibanaFeatureReadButNotAll(role, "feature_uptime");
-        assertKibanaFeatureReadButNotAll(role, "feature_siem");
-        assertKibanaFeatureReadButNotAll(role, "feature_dev_tools");
-        assertKibanaFeatureReadButNotAll(role, "feature_advancedSettings");
-        assertKibanaFeatureReadButNotAll(role, "feature_indexPatterns");
-        assertKibanaFeatureReadButNotAll(role, "feature_savedObjectsManagement");
-        assertKibanaFeatureReadButNotAll(role, "feature_savedObjectsTagging");
-        assertKibanaFeatureReadButNotAll(role, "feature_fleet");
-        assertKibanaFeatureReadButNotAll(role, "feature_actions");
-        assertKibanaFeatureReadButNotAll(role, "feature_stackAlerts");
+        assertThat(role.application().grants(new ApplicationPrivilege("kibana-.kibana", "kibana-read", "read"), "*"), is(true));
+        assertThat(role.application().grants(new ApplicationPrivilege("kibana-.kibana", "kibana-all", "all"), "*"), is(false));
 
         assertThat(role.runAs().check(randomAlphaOfLengthBetween(1, 20)), is(false));
     }
@@ -1773,40 +1755,9 @@ public class ReservedRolesStoreTests extends ESTestCase {
         assertNoAccessAllowed(role, "ilm-history-" + randomIntBetween(0, 5));
 
         // Check application privileges
-        assertKibanaFeatureAll(role, "feature_discover");
-        assertKibanaFeatureAll(role, "feature_dashboard");
-        assertKibanaFeatureAll(role, "feature_canvas");
-        assertKibanaFeatureAll(role, "feature_maps");
-        assertKibanaFeatureAll(role, "feature_ml");
-        assertKibanaFeatureAll(role, "feature_graph");
-        assertKibanaFeatureAll(role, "feature_visualize");
-        assertKibanaFeatureAll(role, "feature_logs");
-        assertKibanaFeatureAll(role, "feature_infrastructure");
-        assertKibanaFeatureAll(role, "feature_apm");
-        assertKibanaFeatureAll(role, "feature_uptime");
-        assertKibanaFeatureAll(role, "feature_siem");
-        assertKibanaFeatureAll(role, "feature_dev_tools");
-        assertKibanaFeatureAll(role, "feature_advancedSettings");
-        assertKibanaFeatureAll(role, "feature_indexPatterns");
-        assertKibanaFeatureAll(role, "feature_savedObjectsManagement");
-        assertKibanaFeatureAll(role, "feature_savedObjectsTagging");
-        assertKibanaFeatureAll(role, "feature_fleet");
-        assertKibanaFeatureAll(role, "feature_actions");
-        assertKibanaFeatureAll(role, "feature_stackAlerts");
+        assertThat(role.application().grants(new ApplicationPrivilege("kibana-.kibana", "kibana-all", "all"), "*"), is(true));
 
         assertThat(role.runAs().check(randomAlphaOfLengthBetween(1, 20)), is(false));
-    }
-
-    private void assertKibanaFeatureReadButNotAll(Role role, String featureName) {
-        assertThat(role.application()
-            .grants(new ApplicationPrivilege("kibana-.kibana", "kibana-" + featureName + ".read", featureName + ".read"), "*"), is(true));
-        assertThat(role.application()
-            .grants(new ApplicationPrivilege("kibana-.kibana", "kibana-" + featureName + ".all", featureName + ".all"), "*"), is(false));
-    }
-
-    private void assertKibanaFeatureAll(Role role, String featureName) {
-        assertThat(role.application()
-            .grants(new ApplicationPrivilege("kibana-.kibana", "kibana-" + featureName + ".all", featureName + ".all"), "*"), is(true));
     }
 
     private void assertReadWriteDocsAndMaintenanceButNotDeleteIndexAllowed(Role role, String index) {

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStoreTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStoreTests.java
@@ -1697,6 +1697,8 @@ public class ReservedRolesStoreTests extends ESTestCase {
         assertOnlyReadAllowed(role, randomAlphaOfLength(5));
 
         assertNoAccessAllowed(role, RestrictedIndicesNames.RESTRICTED_NAMES);
+        assertNoAccessAllowed(role, "." + randomAlphaOfLengthBetween(6, 10));
+        assertNoAccessAllowed(role, "ilm-history-" + randomIntBetween(0, 5));
         // Check application privileges
         assertKibanaFeatureReadButNotAll(role, "feature_discover");
         assertKibanaFeatureReadButNotAll(role, "feature_dashboard");
@@ -1718,6 +1720,8 @@ public class ReservedRolesStoreTests extends ESTestCase {
         assertKibanaFeatureReadButNotAll(role, "feature_fleet");
         assertKibanaFeatureReadButNotAll(role, "feature_actions");
         assertKibanaFeatureReadButNotAll(role, "feature_stackAlerts");
+
+        assertThat(role.runAs().check(randomAlphaOfLengthBetween(1, 20)), is(false));
     }
 
     public void testPredefinedEditorRole() {
@@ -1765,6 +1769,8 @@ public class ReservedRolesStoreTests extends ESTestCase {
         assertReadWriteDocsButNotDeleteIndexAllowed(role, "observability-annotations");
 
         assertNoAccessAllowed(role, RestrictedIndicesNames.RESTRICTED_NAMES);
+        assertNoAccessAllowed(role, "." + randomAlphaOfLengthBetween(6, 10));
+        assertNoAccessAllowed(role, "ilm-history-" + randomIntBetween(0, 5));
 
         // Check application privileges
         assertKibanaFeatureAll(role, "feature_discover");
@@ -1787,6 +1793,8 @@ public class ReservedRolesStoreTests extends ESTestCase {
         assertKibanaFeatureAll(role, "feature_fleet");
         assertKibanaFeatureAll(role, "feature_actions");
         assertKibanaFeatureAll(role, "feature_stackAlerts");
+
+        assertThat(role.runAs().check(randomAlphaOfLengthBetween(1, 20)), is(false));
     }
 
     private void assertKibanaFeatureReadButNotAll(Role role, String featureName) {

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStoreTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStoreTests.java
@@ -230,8 +230,8 @@ public class ReservedRolesStoreTests extends ESTestCase {
         assertThat(ReservedRolesStore.isReserved("snapshot_user"), is(true));
         assertThat(ReservedRolesStore.isReserved("code_admin"), is(false));
         assertThat(ReservedRolesStore.isReserved("code_user"), is(false));
-        assertThat(ReservedRolesStore.isReserved("viewer"), is(false));
-        assertThat(ReservedRolesStore.isReserved("editor"), is(false));
+        assertThat(ReservedRolesStore.isReserved("viewer"), is(true));
+        assertThat(ReservedRolesStore.isReserved("editor"), is(true));
     }
 
     public void testSnapshotUserRole() {


### PR DESCRIPTION
This change adds two new reserved roles in Elasticsearch, `viewer`
and `editor`
Solutions will use these roles in order to provide,out of the box,
 a role for full access to data and configuration with no access to
cluster management(editor) and a role for read only access to data
again with no access to cluster management (viewer).
