### PR TITLE
Add integration tests for filters (backport of #69439)

### DIFF
--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/README.asciidoc
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/README.asciidoc
@@ -388,7 +388,9 @@ match all of those selectors. The following selectors are supported:
 
 - `version`: Only nodes who's version is within the range will receive the
 request. The syntax for the pattern is the same as when `version` is within
-`skip`.
+`skip` but also supports `current` which selects nodes of the current version.
+`current` is useful when running mixed version tests if the results vary based
+on the version of the node that received the request.
 - `attribute`: Only nodes that have an attribute matching the name and value
 of the provided attribute match.
 Looks like:

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.aggregation/220_filters_bucket.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.aggregation/220_filters_bucket.yml
@@ -275,23 +275,26 @@ setup:
 
 
 ---
-"cache":
+"cache busting":
   - skip:
       version: " - 7.10.99"
       reason:  cache fixed in 7.11.0
+      features: node_selector
 
   - do:
-       bulk:
-         refresh: true
-         body:
-           - index:
-               _index: test_1
-               _id:    100
-           - int_field: 1
-             double_field: 1.0
-             string_field: foo bar
+      bulk:
+        refresh: true
+        body:
+          - index:
+              _index: test_1
+              _id:    100
+          - int_field: 1
+            double_field: 1.0
+            string_field: foo bar
 
   - do:
+      node_selector:
+        version: current # the version of the node that parsed the request is part of the cache key.
       search:
         index: test_1
         body:
@@ -323,6 +326,8 @@ setup:
 
   # This should be entirely fresh because updating the mapping busted the cache.
   - do:
+      node_selector:
+        version: current # the version of the node that parsed the request is part of the cache key.
       search:
         index: test_1
         body:
@@ -392,3 +397,110 @@ nested:
   - match: { hits.total.value: 1 }
   - length: { aggregations.f.buckets: 1 }
   - match: { aggregations.f.buckets.foo.doc_count: 1 }
+
+---
+"cache hits":
+  - skip:
+      features: node_selector
+
+  - do:
+      indices.create:
+          index: test
+          body:
+            settings:
+              number_of_shards: 1
+              number_of_replicas: 0
+            mappings:
+              properties:
+                mentions:
+                  type: keyword
+                notifications:
+                  type: keyword
+
+  - do:
+      bulk:
+        refresh: true
+        index: test
+        body: |
+          {"index":{"_id": "foo|bar|baz0"}}
+          {"notifications" : ["abc"]}
+          {"index":{"_id": "foo|bar|baz1"}}
+          {"mentions" : ["abc"]}
+
+  - do:
+      node_selector:
+        version: current # the version of the node that parsed the request is part of the cache key.
+      search:
+        rest_total_hits_as_int: true
+        size: 0
+        request_cache: true
+        index: test
+        body:
+          aggs:
+            itemsNotify:
+              filters:
+                filters:
+                  lookup:
+                    terms:
+                      mentions:
+                        index: test
+                        id: foo|bar|baz0
+                        path: notifications
+                  std:
+                    terms:
+                      mentions: ["abc"]
+              aggs:
+                mentions:
+                  terms:
+                    field: mentions
+
+  # validate result
+  - match: { hits.total: 2 }
+  - match: { aggregations.itemsNotify.buckets.lookup.doc_count: 1 }
+  - match: { aggregations.itemsNotify.buckets.std.doc_count: 1 }
+
+  # The first request will miss the cache
+  - do:
+      indices.stats: { index: test, metric: request_cache}
+  - match: { _shards.total: 1 }
+  - match: { indices.test.total.request_cache.hit_count: 0 }
+  - match: { indices.test.total.request_cache.miss_count: 1 }
+
+  - do:
+      node_selector:
+        version: current # the version of the node that parsed the request is part of the cache key.
+      search:
+        rest_total_hits_as_int: true
+        size: 0
+        request_cache: true
+        index: test
+        body:
+          aggs:
+            itemsNotify:
+              filters:
+                filters:
+                  lookup:
+                    terms:
+                      mentions:
+                        index: test
+                        id: foo|bar|baz0
+                        path: notifications
+                  std:
+                    terms:
+                      mentions: ["abc"]
+              aggs:
+                mentions:
+                  terms:
+                    field: mentions
+
+  # validate result
+  - match: { hits.total: 2 }
+  - match: { aggregations.itemsNotify.buckets.lookup.doc_count: 1 }
+  - match: { aggregations.itemsNotify.buckets.std.doc_count: 1 }
+
+  # The second result with hit the cache
+  - do:
+      indices.stats: { index: test, metric: request_cache}
+  - match: { _shards.total: 1 }
+  - match: { indices.test.total.request_cache.hit_count: 1 }
+  - match: { indices.test.total.request_cache.miss_count: 1 }

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.aggregation/50_filter.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.aggregation/50_filter.yml
@@ -14,67 +14,156 @@ setup:
                   type: keyword
 
   - do:
-      index:
+      bulk:
+        refresh: true
         index: test
-        id: foo|bar|baz0
-        body: { "notifications" : ["abc"] }
-
-  - do:
-      index:
-        index: test
-        id: foo|bar|baz1
-        body: { "mentions" : ["abc"] }
-
-  - do:
-      indices.refresh: {}
+        body: |
+          {"index":{"_id": "foo|bar|baz0"}}
+          {"notifications" : ["abc"]}
+          {"index":{"_id": "foo|bar|baz1"}}
+          {"mentions" : ["abc"]}
 
 ---
-"Filter aggs with terms lookup and ensure it's cached":
-  # Because the filter agg rewrites the terms lookup in the rewrite phase the request can be cached
+"Terms lookup gets cached":
   - skip:
-      version: " - 6.99.99"
-      reason: types are required in requests before 7.0.0
+      features: node_selector
 
   - do:
+      node_selector:
+        version: current # the version of the node that parsed the request is part of the cache key.
       search:
         rest_total_hits_as_int: true
         size: 0
         request_cache: true
-        body: {"aggs": { "itemsNotify": { "filter": { "terms": { "mentions": { "index": "test", "id": "foo|bar|baz0", "path": "notifications"}}}, "aggs": { "mentions" : {"terms" : { "field" : "mentions" }}}}}}
+        body:
+          aggs:
+            itemsNotify:
+              filter:
+                terms:
+                  mentions:
+                    index: test
+                    id: foo|bar|baz0
+                    path: notifications
+              aggs:
+                mentions:
+                  terms:
+                    field: mentions
 
   # validate result
   - match: { hits.total: 2 }
   - match: { aggregations.itemsNotify.doc_count: 1 }
   - length: { aggregations.itemsNotify.mentions.buckets: 1 }
   - match: { aggregations.itemsNotify.mentions.buckets.0.key: "abc" }
-  # we are using a lookup - this should not cache
+
+  # The first request will miss the cache
   - do:
       indices.stats: { index: test, metric: request_cache}
   - match: { _shards.total: 1 }
-  - match: { _all.total.request_cache.hit_count: 0 }
-  - match: { _all.total.request_cache.miss_count: 1 }
-  - is_true: indices.test
+  - match: { indices.test.total.request_cache.hit_count: 0 }
+  - match: { indices.test.total.request_cache.miss_count: 1 }
 
----
-"Filter aggs no lookup and ensure it's cached":
-  # now run without lookup and ensure we get cached or at least do the lookup
   - do:
+      node_selector:
+        version: current # the version of the node that parsed the request is part of the cache key.
       search:
         rest_total_hits_as_int: true
         size: 0
         request_cache: true
-        body: {"aggs": { "itemsNotify": { "filter": { "terms": { "mentions": ["abc"]}}, "aggs": { "mentions" : {"terms" : { "field" : "mentions" }}}}}}
+        body:
+          aggs:
+            itemsNotify:
+              filter:
+                terms:
+                  mentions:
+                    index: test
+                    id: foo|bar|baz0
+                    path: notifications
+              aggs:
+                mentions:
+                  terms:
+                    field: mentions
 
+  # validate result
   - match: { hits.total: 2 }
   - match: { aggregations.itemsNotify.doc_count: 1 }
   - length: { aggregations.itemsNotify.mentions.buckets: 1 }
   - match: { aggregations.itemsNotify.mentions.buckets.0.key: "abc" }
+
+  # The second result with hit the cache
   - do:
       indices.stats: { index: test, metric: request_cache}
   - match: { _shards.total: 1 }
-  - match: { _all.total.request_cache.hit_count: 0 }
-  - match: { _all.total.request_cache.miss_count: 1 }
+  - match: { indices.test.total.request_cache.hit_count: 1 }
+  - match: { indices.test.total.request_cache.miss_count: 1 }
+
+---
+"Standard queries get cached":
+  - skip:
+      features: node_selector
+
+  - do:
+      node_selector:
+        version: current # the version of the node that parsed the request is part of the cache key.
+      search:
+        rest_total_hits_as_int: true
+        size: 0
+        request_cache: true
+        body:
+          aggs:
+            itemsNotify:
+              filter:
+                terms:
+                  mentions: ["abc"]
+              aggs:
+                mentions:
+                  terms:
+                    field: mentions
+
+  # Validate result
+  - match: { hits.total: 2 }
+  - match: { aggregations.itemsNotify.doc_count: 1 }
+  - length: { aggregations.itemsNotify.mentions.buckets: 1 }
+  - match: { aggregations.itemsNotify.mentions.buckets.0.key: "abc" }
+
+  # The first request will miss the cache
+  - do:
+      indices.stats: { index: test, metric: request_cache}
+  - match: { _shards.total: 1 }
+  - match: { indices.test.total.request_cache.hit_count: 0 }
+  - match: { indices.test.total.request_cache.miss_count: 1 }
   - is_true: indices.test
+
+  # Try again - it'll cache
+  - do:
+      node_selector:
+        version: current # the version of the node that parsed the request is part of the cache key.
+      search:
+        rest_total_hits_as_int: true
+        size: 0
+        request_cache: true
+        body:
+          aggs:
+            itemsNotify:
+              filter:
+                terms:
+                  mentions: ["abc"]
+              aggs:
+                mentions:
+                  terms:
+                    field: mentions
+
+  # Validate result
+  - match: { hits.total: 2 }
+  - match: { aggregations.itemsNotify.doc_count: 1 }
+  - length: { aggregations.itemsNotify.mentions.buckets: 1 }
+  - match: { aggregations.itemsNotify.mentions.buckets.0.key: "abc" }
+
+  # The first request will miss the cache
+  - do:
+      indices.stats: { index: test, metric: request_cache}
+  - match: { _shards.total: 1 }
+  - match: { indices.test.total.request_cache.hit_count: 1 }
+  - match: { indices.test.total.request_cache.miss_count: 1 }
 
 ---
 "As a child of terms":

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.aggregation/70_adjacency_matrix.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.aggregation/70_adjacency_matrix.yml
@@ -70,7 +70,19 @@ setup:
   - skip:
       version: " - 7.8.99"
       reason:  fixed in 7.9.0
+      features: node_selector
 
+  - do:
+      indices.create:
+          index: lookup
+          body:
+            settings:
+              number_of_shards: 1
+              number_of_replicas: 0
+            mappings:
+              properties:
+                num:
+                  type: long
   - do:
       bulk:
         index: lookup
@@ -83,6 +95,8 @@ setup:
           { "index": {"_id": 4} }
           { "num": [4] }
   - do:
+      node_selector:
+        version: current # the version of the node that parsed the request is part of the cache key.
       search:
         index: test
         body:
@@ -125,3 +139,45 @@ setup:
 
   - match: { aggregations.conns.buckets.3.doc_count: 1 }
   - match: { aggregations.conns.buckets.3.key: "4" }
+
+  - do:
+      indices.stats: { index: test, metric: request_cache}
+  - match: { _shards.total: 1 }
+  - match: { indices.test.total.request_cache.hit_count: 0 }
+  - match: { indices.test.total.request_cache.miss_count: 1 }
+
+  # The second request should hit the cache
+  - do:
+      node_selector:
+        version: current # the version of the node that parsed the request is part of the cache key.
+      search:
+        index: test
+        body:
+          size: 0
+          aggs:
+            conns:
+              adjacency_matrix:
+                filters:
+                  1:
+                    terms:
+                      num:
+                        index: lookup
+                        id: "1"
+                        path: num
+                  2:
+                    terms:
+                      num:
+                        index: lookup
+                        id: "2"
+                        path: num
+                  4:
+                    terms:
+                      num:
+                        index: lookup
+                        id: "4"
+                        path: num
+  - do:
+      indices.stats: { index: test, metric: request_cache}
+  - match: { _shards.total: 1 }
+  - match: { indices.test.total.request_cache.hit_count: 1 }
+  - match: { indices.test.total.request_cache.miss_count: 1 }

--- a/server/src/main/java/org/elasticsearch/indices/IndicesRequestCache.java
+++ b/server/src/main/java/org/elasticsearch/indices/IndicesRequestCache.java
@@ -252,6 +252,19 @@ public final class IndicesRequestCache implements RemovalListener<IndicesRequest
             result = 31 * result + value.hashCode();
             return result;
         }
+
+        @Override
+        public String toString() {
+            return "Key(mappingKey=["
+                + mappingCacheKey
+                + "],readerKey=["
+                + readerCacheKey
+                + "],entityKey=["
+                + entity.getCacheIdentity()
+                + ",value=" // BytesRef's toString already has [] so we don't add it here
+                + value.toBytesRef() // BytesRef has a readable toString
+                + ")";
+        }
     }
 
     private class CleanupKey implements IndexReader.ClosedListener {

--- a/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/section/DoSection.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/section/DoSection.java
@@ -562,7 +562,9 @@ public class DoSection implements ExecutableSection {
         if (false == parser.currentToken().isValue()) {
             throw new XContentParseException(parser.getTokenLocation(), "expected [version] to be a value");
         }
-        List<VersionRange> skipVersionRanges = SkipSection.parseVersionRanges(parser.text());
+        List<VersionRange> skipVersionRanges = parser.text().equals("current")
+            ? org.elasticsearch.common.collect.List.of(new VersionRange(Version.CURRENT, Version.CURRENT))
+            : SkipSection.parseVersionRanges(parser.text());
         return new NodeSelector() {
             @Override
             public void select(Iterable<Node> nodes) {

--- a/test/framework/src/test/java/org/elasticsearch/test/rest/yaml/section/DoSectionTests.java
+++ b/test/framework/src/test/java/org/elasticsearch/test/rest/yaml/section/DoSectionTests.java
@@ -629,6 +629,29 @@ public class DoSectionTests extends AbstractClientYamlTestFragmentParserTestCase
         }
     }
 
+    public void testNodeSelectorCurrentVersion() throws IOException {
+        parser = createParser(YamlXContent.yamlXContent,
+                "node_selector:\n" +
+                "    version: current\n" +
+                "indices.get_field_mapping:\n" +
+                "    index: test_index"
+        );
+
+        DoSection doSection = DoSection.parse(parser);
+        assertNotSame(NodeSelector.ANY, doSection.getApiCallSection().getNodeSelector());
+        Node v170 = nodeWithVersion("1.7.0");
+        Node v521 = nodeWithVersion("5.2.1");
+        Node v550 = nodeWithVersion("5.5.0");
+        Node current = nodeWithVersion(Version.CURRENT.toString());
+        List<Node> nodes = new ArrayList<>();
+        nodes.add(v170);
+        nodes.add(v521);
+        nodes.add(v550);
+        nodes.add(current);
+        doSection.getApiCallSection().getNodeSelector().select(nodes);
+        assertEquals(List.of(current), nodes);
+    }
+
     private static Node nodeWithVersion(String version) {
         return new Node(new HttpHost("dummy"), null, null, version, null, null);
     }

--- a/test/framework/src/test/java/org/elasticsearch/test/rest/yaml/section/DoSectionTests.java
+++ b/test/framework/src/test/java/org/elasticsearch/test/rest/yaml/section/DoSectionTests.java
@@ -649,7 +649,7 @@ public class DoSectionTests extends AbstractClientYamlTestFragmentParserTestCase
         nodes.add(v550);
         nodes.add(current);
         doSection.getApiCallSection().getNodeSelector().select(nodes);
-        assertEquals(List.of(current), nodes);
+        assertEquals(org.elasticsearch.common.collect.List.of(current), nodes);
     }
 
     private static Node nodeWithVersion(String version) {

--- a/x-pack/qa/runtime-fields/build.gradle
+++ b/x-pack/qa/runtime-fields/build.gradle
@@ -58,13 +58,13 @@ subprojects {
           'search.aggregation/40_range/Date range', //source only date field should also emit values for numbers, it expects strings only
           'search/115_multiple_field_collapsing/two levels fields collapsing', // Field collapsing on a runtime field does not work
           'field_caps/30_filter/Field caps with index filter', // We don't support filtering field caps on runtime fields. What should we do?
-          'search.aggregation/220_filters_bucket/cache', // runtime keyword does not support split_queries_on_whitespace
+          'search.aggregation/220_filters_bucket/cache busting', // runtime keyword does not support split_queries_on_whitespace
           'search/140_pre_filter_search_shards/pre_filter_shard_size with shards that have no hit',
           //completion suggester does not return options when the context field is a geo_point runtime field
           'suggest/30_context/Multi contexts should work',
 
           //there is something wrong when using dotted document syntax here, passes in main yaml tests
-	        'search/330_fetch_fields/Test nested field inside object structure',
+          'search/330_fetch_fields/Test nested field inside object structure',
           /////// TO FIX ///////
 
           /////// NOT SUPPORTED ///////


### PR DESCRIPTION
Revamps the integration tests for the `filter` agg to be more clear and
builds integration tests for the `fitlers` agg. Both of these
integration tests are fairly basic but they do assert that the aggs
work.
