### PR TITLE
Clarify timeout and terminate_after docs

### DIFF
--- a/docs/reference/rest-api/common-parms.asciidoc
+++ b/docs/reference/rest-api/common-parms.asciidoc
@@ -1081,8 +1081,10 @@ tag::terminate_after[]
 query reaches this limit, {es} terminates the query early. {es} collects
 documents before sorting.
 +
-IMPORTANT: We do not recommend specifying this parameter. When possible, {es}
-performs early termination automatically.
+IMPORTANT: Use with caution. {es} applies this parameter to each shard handling
+the request. When possible, let {es} perform early termination automatically.
+Avoid specifying this parameter for requests that target data streams with
+backing indices across multiple data tiers.
 end::terminate_after[]
 
 tag::time[]

--- a/docs/reference/rest-api/common-parms.asciidoc
+++ b/docs/reference/rest-api/common-parms.asciidoc
@@ -1077,10 +1077,12 @@ end::term_statistics[]
 
 tag::terminate_after[]
 `terminate_after`::
-(Optional, integer) The maximum number of documents to collect for each shard,
-upon reaching which the query execution will terminate early. Documents are collected
-before sorting. Early termination is done automatically when possible, so this setting
-is not recommended.
+(Optional, integer) Maximum number of documents to collect for each shard. If a
+query reaches this limit, {es} terminates the query early. {es} collects
+documents before sorting.
++
+IMPORTANT: We do not recommend specifying this parameter. When possible, {es}
+performs early termination automatically.
 end::terminate_after[]
 
 tag::time[]

--- a/docs/reference/rest-api/common-parms.asciidoc
+++ b/docs/reference/rest-api/common-parms.asciidoc
@@ -1078,7 +1078,9 @@ end::term_statistics[]
 tag::terminate_after[]
 `terminate_after`::
 (Optional, integer) The maximum number of documents to collect for each shard,
-upon reaching which the query execution will terminate early.
+upon reaching which the query execution will terminate early. Documents are collected
+before sorting. Early termination is done automatically when possible, so this setting
+is not recommended.
 end::terminate_after[]
 
 tag::time[]

--- a/docs/reference/search/search-your-data/search-your-data.asciidoc
+++ b/docs/reference/search/search-your-data/search-your-data.asciidoc
@@ -236,11 +236,11 @@ results from each shard before returning a response.
 
 While <<async-search-intro,async search>> is designed for long-running
 searches, you can also use the `timeout` parameter to specify a duration you'd
-like to wait on each shard to complete. Each shard will collect hits
-within the specified time and bail with the hits accumulated up to that
-point when expired. The overall latency of the search request will depend on
-the number of shards that participate in the query and the number of shard
-requests that executed concurrently.
+like to wait on each shard to complete. Each shard collects hits within the
+specified time period. If collection isn't finished when the period ends, {es}
+uses only the hits accumulated up to that point. The overall latency of a search
+request depends on the number of shards needed for the search and the number of
+concurrent shard requests.
 
 [source,console]
 ----

--- a/docs/reference/search/search-your-data/search-your-data.asciidoc
+++ b/docs/reference/search/search-your-data/search-your-data.asciidoc
@@ -232,12 +232,15 @@ results for a long-running search now and get complete results later.
 === Search timeout
 
 By default, search requests don't time out. The request waits for complete
-results before returning a response.
+results from each shard before returning a response.
 
 While <<async-search-intro,async search>> is designed for long-running
 searches, you can also use the `timeout` parameter to specify a duration you'd
-like to wait for a search to complete. If no response is received before this
-period ends, the request fails and returns an error.
+like to wait on each shard to complete. Each shard will collect hits
+within the specified time and bail with the hits accumulated up to that
+point when expired. The overall latency of the search request will depend on
+the number of shards that participate in the query and the number of shard
+requests that executed concurrently.
 
 [source,console]
 ----

--- a/docs/reference/search/search.asciidoc
+++ b/docs/reference/search/search.asciidoc
@@ -66,7 +66,7 @@ Defaults to `true`.
 [[search-partial-responses]]
 `allow_partial_search_results`::
 (Optional, Boolean)
-If `true`, returns partial results if there are request timeouts or
+If `true`, returns partial results if there are shard request timeouts or
 <<shard-failures,shard failures>>. If `false`, returns an error with
 no partial results. Defaults to `true`.
 +
@@ -287,7 +287,7 @@ Defaults to `0`, which does not terminate query execution early.
 
 `timeout`::
 (Optional, <<time-units, time units>>) Specifies the period of time to wait
-for a response. If no response is received before the timeout expires, the
+for a response from each shard. If no response is received before the timeout expires, the
 request fails and returns an error. Defaults to no timeout.
 
 `track_scores`::
@@ -567,7 +567,7 @@ Defaults to `0`, which does not terminate query execution early.
 
 `timeout`::
 (Optional, <<time-units, time units>>) Specifies the period of time to wait
-for a response. If no response is received before the timeout expires, the
+for a response from each shard. If no response is received before the timeout expires, the
 request fails and returns an error. Defaults to no timeout.
 
 [[request-body-search-version]]


### PR DESCRIPTION
It looks like @jimczi started an effort to rename the `timeout` setting to `shard_timeout`, which included a docs update. This PR takes just the docs updates and re-applies them, with a few tweaks due to changes since that PR was originally opened.

Reference PR: https://github.com/elastic/elasticsearch/pull/51858/

Closes https://github.com/elastic/elasticsearch/issues/47716