### PR TITLE
[7.x] Close CacheDecayTask when FrozenCacheService is closed

### DIFF
--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/cache/shared/FrozenCacheService.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/cache/shared/FrozenCacheService.java
@@ -519,6 +519,7 @@ public class FrozenCacheService implements Releasable {
     @Override
     public void close() {
         sharedBytes.decRef();
+        decayTask.close();
     }
 
     class CacheDecayTask extends AbstractAsyncTask {


### PR DESCRIPTION
CacheDecayTask is scheduled when the FrozenCacheService
is instantiated but it should also be closed accordingly when
the service is closed.

Backport of #71693