### PR TITLE
[7.x] Enhanced segment files sizes information in Nodes Stats/Indices Stats APIs

### DIFF
--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.stats/30_segments.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.stats/30_segments.yml
@@ -61,3 +61,42 @@ setup:
         forbid_closed_indices: false
 
   - match: { indices.test.primaries.segments.count: $num_segments_after_flush }
+
+
+---
+"Indices Stats API with extended files stats":
+
+  - skip:
+      version: " - 7.99.99"
+      reason: segment files stats extended in 8.0.0
+
+  - do:
+      index:
+        index: test
+        id:    1
+        body:  { "foo": "bar" }
+
+  - do:
+      indices.flush:
+        index: test
+
+  - do:
+      indices.stats:
+        metric: [ segments ]
+        include_segment_file_sizes: true
+
+  - is_true: _all.total.segments.file_sizes
+  - is_true: _all.total.segments.file_sizes.si
+  - gt: { _all.total.segments.file_sizes.si.count: 0 }
+  - gt: { _all.total.segments.file_sizes.si.size_in_bytes: 0 }
+  - gt: { _all.total.segments.file_sizes.si.min_size_in_bytes: 0 }
+  - gt: { _all.total.segments.file_sizes.si.max_size_in_bytes: 0 }
+  - gt: { _all.total.segments.file_sizes.si.average_size_in_bytes: 0 }
+
+  - is_true: indices.test.primaries.segments.file_sizes
+  - is_true: indices.test.primaries.segments.file_sizes.si
+  - gt: { indices.test.primaries.segments.file_sizes.si.count: 0 }
+  - gt: { indices.test.primaries.segments.file_sizes.si.size_in_bytes: 0 }
+  - gt: { indices.test.primaries.segments.file_sizes.si.min_size_in_bytes: 0 }
+  - gt: { indices.test.primaries.segments.file_sizes.si.max_size_in_bytes: 0 }
+  - gt: { indices.test.primaries.segments.file_sizes.si.average_size_in_bytes: 0 }

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.stats/30_segments.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.stats/30_segments.yml
@@ -67,8 +67,8 @@ setup:
 "Indices Stats API with extended files stats":
 
   - skip:
-      version: " - 7.99.99"
-      reason: segment files stats extended in 8.0.0
+      version: " - 7.12.99"
+      reason: segment files stats extended in 7.13.0
 
   - do:
       index:

--- a/server/src/internalClusterTest/java/org/elasticsearch/indices/stats/IndexStatsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/indices/stats/IndexStatsIT.java
@@ -8,6 +8,7 @@
 
 package org.elasticsearch.indices.stats;
 
+import com.carrotsearch.hppc.cursors.ObjectObjectCursor;
 import org.apache.lucene.util.LuceneTestCase.SuppressCodecs;
 import org.elasticsearch.action.DocWriteResponse;
 import org.elasticsearch.action.admin.cluster.node.stats.NodesStatsResponse;
@@ -39,6 +40,7 @@ import org.elasticsearch.index.MergePolicyConfig;
 import org.elasticsearch.index.MergeSchedulerConfig;
 import org.elasticsearch.index.VersionType;
 import org.elasticsearch.index.cache.query.QueryCacheStats;
+import org.elasticsearch.index.engine.SegmentsStats;
 import org.elasticsearch.index.engine.VersionConflictEngineException;
 import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.index.shard.IndexShard;
@@ -601,11 +603,23 @@ public class IndexStatsIT extends ESIntegTestCase {
         client().admin().indices().prepareFlush().get();
         client().admin().indices().prepareForceMerge().setMaxNumSegments(1).execute().actionGet();
         client().admin().indices().prepareRefresh().get();
-        stats = client().admin().indices().prepareStats().setSegments(true).get();
+
+        final boolean includeSegmentFileSizes = randomBoolean();
+        stats = client().admin().indices().prepareStats().setSegments(true).setIncludeSegmentFileSizes(includeSegmentFileSizes).get();
 
         assertThat(stats.getTotal().getSegments(), notNullValue());
         assertThat(stats.getTotal().getSegments().getCount(), equalTo((long) test1.totalNumShards));
         assertThat(stats.getTotal().getSegments().getMemoryInBytes(), greaterThan(0L));
+        if (includeSegmentFileSizes) {
+            assertThat(stats.getTotal().getSegments().getFiles().size(), greaterThan(0));
+            for (ObjectObjectCursor<String, SegmentsStats.FileStats> cursor : stats.getTotal().getSegments().getFiles()) {
+                assertThat(cursor.value.getExt(), notNullValue());
+                assertThat(cursor.value.getTotal(), greaterThan(0L));
+                assertThat(cursor.value.getCount(), greaterThan(0L));
+                assertThat(cursor.value.getMin(), greaterThan(0L));
+                assertThat(cursor.value.getMax(), greaterThan(0L));
+            }
+        }
     }
 
     public void testAllFlags() throws Exception {

--- a/server/src/main/java/org/elasticsearch/index/engine/Engine.java
+++ b/server/src/main/java/org/elasticsearch/index/engine/Engine.java
@@ -25,8 +25,6 @@ import org.apache.lucene.search.QueryCachingPolicy;
 import org.apache.lucene.search.ReferenceManager;
 import org.apache.lucene.search.similarities.Similarity;
 import org.apache.lucene.store.AlreadyClosedException;
-import org.apache.lucene.store.Directory;
-import org.apache.lucene.store.IOContext;
 import org.apache.lucene.util.Accountable;
 import org.apache.lucene.util.Accountables;
 import org.apache.lucene.util.SetOnce;
@@ -69,10 +67,8 @@ import org.elasticsearch.index.translog.TranslogStats;
 import org.elasticsearch.search.suggest.completion.CompletionStats;
 
 import java.io.Closeable;
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.UncheckedIOException;
-import java.nio.file.NoSuchFileException;
 import java.util.Arrays;
 import java.util.Base64;
 import java.util.Comparator;
@@ -139,7 +135,7 @@ public abstract class Engine implements Closeable {
         this.store = engineConfig.getStore();
         // we use the engine class directly here to make sure all subclasses have the same logger name
         this.logger = Loggers.getLogger(Engine.class,
-                engineConfig.getShardId());
+            engineConfig.getShardId());
         this.eventListener = engineConfig.getEventListener();
     }
 
@@ -182,7 +178,7 @@ public abstract class Engine implements Closeable {
         // when indexing but not refreshing in general. Yet, if a refresh happens the internal searcher is refresh as well so we are
         // safe here.
         try (Searcher searcher = acquireSearcher("docStats", SearcherScope.INTERNAL)) {
-           return docsStats(searcher.getIndexReader());
+            return docsStats(searcher.getIndexReader());
         }
     }
 
@@ -289,12 +285,14 @@ public abstract class Engine implements Closeable {
 
     /**
      * Returns the <code>true</code> iff this engine is currently under index throttling.
+     *
      * @see #getIndexThrottleTimeInMillis()
      */
     public abstract boolean isThrottled();
 
     /**
      * Trims translog for terms below <code>belowTerm</code> and seq# above <code>aboveSeqNo</code>
+     *
      * @see Translog#trimOperations(long, long)
      */
     public abstract void trimOperationsFromTranslog(long belowTerm, long aboveSeqNo) throws EngineException;
@@ -819,86 +817,38 @@ public abstract class Engine implements Closeable {
         stats.addNormsMemoryInBytes(guardedRamBytesUsed(segmentReader.getNormsReader()));
         stats.addPointsMemoryInBytes(guardedRamBytesUsed(segmentReader.getPointsReader()));
         stats.addDocValuesMemoryInBytes(guardedRamBytesUsed(segmentReader.getDocValuesReader()));
-
         if (includeSegmentFileSizes) {
-            // TODO: consider moving this to StoreStats
-            stats.addFileSizes(getSegmentFileSizes(segmentReader));
+            stats.addFiles(getSegmentFileSizes(segmentReader));
         }
     }
 
-    private ImmutableOpenMap<String, Long> getSegmentFileSizes(SegmentReader segmentReader) {
-        Directory directory = null;
-        SegmentCommitInfo segmentCommitInfo = segmentReader.getSegmentInfo();
-        boolean useCompoundFile = segmentCommitInfo.info.getUseCompoundFile();
-        if (useCompoundFile) {
-            try {
-                directory = engineConfig.getCodec().compoundFormat().getCompoundReader(segmentReader.directory(),
-                    segmentCommitInfo.info, IOContext.READ);
-            } catch (IOException e) {
-                logger.warn(() -> new ParameterizedMessage("Error when opening compound reader for Directory [{}] and " +
-                    "SegmentCommitInfo [{}]", segmentReader.directory(), segmentCommitInfo), e);
-
-                return ImmutableOpenMap.of();
+    private ImmutableOpenMap<String, SegmentsStats.FileStats> getSegmentFileSizes(SegmentReader segmentReader) {
+        try {
+            final ImmutableOpenMap.Builder<String, SegmentsStats.FileStats> files = ImmutableOpenMap.builder();
+            final SegmentCommitInfo segmentCommitInfo = segmentReader.getSegmentInfo();
+            for (String fileName : segmentCommitInfo.files()) {
+                String fileExtension = IndexFileNames.getExtension(fileName);
+                if (fileExtension != null) {
+                    try {
+                        long fileLength = segmentReader.directory().fileLength(fileName);
+                        files.put(fileExtension, new SegmentsStats.FileStats(fileExtension, fileLength, 1L, fileLength, fileLength));
+                    } catch (IOException ioe) {
+                        logger.warn(() ->
+                            new ParameterizedMessage("Error when retrieving file length for [{}]", fileName), ioe);
+                    } catch (AlreadyClosedException ace) {
+                        logger.warn(() ->
+                            new ParameterizedMessage("Error when retrieving file length for [{}], directory is closed", fileName), ace);
+                        return ImmutableOpenMap.of();
+                    }
+                }
             }
-        } else {
-            directory = segmentReader.directory();
+            return files.build();
+        } catch (IOException e) {
+            logger.warn(() ->
+                new ParameterizedMessage("Error when listing files for segment reader [{}] and segment info [{}]",
+                    segmentReader, segmentReader.getSegmentInfo()), e);
+            return ImmutableOpenMap.of();
         }
-
-        assert directory != null;
-
-        String[] files;
-        if (useCompoundFile) {
-            try {
-                files = directory.listAll();
-            } catch (IOException e) {
-                final Directory finalDirectory = directory;
-                logger.warn(() ->
-                    new ParameterizedMessage("Couldn't list Compound Reader Directory [{}]", finalDirectory), e);
-                return ImmutableOpenMap.of();
-            }
-        } else {
-            try {
-                files = segmentReader.getSegmentInfo().files().toArray(new String[]{});
-            } catch (IOException e) {
-                logger.warn(() ->
-                    new ParameterizedMessage("Couldn't list Directory from SegmentReader [{}] and SegmentInfo [{}]",
-                        segmentReader, segmentReader.getSegmentInfo()), e);
-                return ImmutableOpenMap.of();
-            }
-        }
-
-        ImmutableOpenMap.Builder<String, Long> map = ImmutableOpenMap.builder();
-        for (String file : files) {
-            String extension = IndexFileNames.getExtension(file);
-            long length = 0L;
-            try {
-                length = directory.fileLength(file);
-            } catch (NoSuchFileException | FileNotFoundException e) {
-                final Directory finalDirectory = directory;
-                logger.warn(() -> new ParameterizedMessage("Tried to query fileLength but file is gone [{}] [{}]",
-                    finalDirectory, file), e);
-            } catch (IOException e) {
-                final Directory finalDirectory = directory;
-                logger.warn(() -> new ParameterizedMessage("Error when trying to query fileLength [{}] [{}]",
-                    finalDirectory, file), e);
-            }
-            if (length == 0L) {
-                continue;
-            }
-            map.put(extension, length);
-        }
-
-        if (useCompoundFile) {
-            try {
-                directory.close();
-            } catch (IOException e) {
-                final Directory finalDirectory = directory;
-                logger.warn(() -> new ParameterizedMessage("Error when closing compound reader on Directory [{}]",
-                    finalDirectory), e);
-            }
-        }
-
-        return map.build();
     }
 
     protected void writerSegmentStats(SegmentsStats stats) {

--- a/server/src/main/java/org/elasticsearch/index/engine/NoOpEngine.java
+++ b/server/src/main/java/org/elasticsearch/index/engine/NoOpEngine.java
@@ -110,7 +110,7 @@ public final class NoOpEngine extends ReadOnlyEngine {
             final SegmentsStats stats = new SegmentsStats();
             stats.add(this.segmentsStats);
             if (includeSegmentFileSizes == false) {
-                stats.clearFileSizes();
+                stats.clearFiles();
             }
             return stats;
         } else {

--- a/server/src/main/java/org/elasticsearch/index/engine/SegmentsStats.java
+++ b/server/src/main/java/org/elasticsearch/index/engine/SegmentsStats.java
@@ -356,7 +356,7 @@ public class SegmentsStats implements Writeable, ToXContentFragment {
         private final long max;
 
         FileStats(StreamInput in) throws IOException {
-            if (in.getVersion().onOrAfter(Version.V_8_0_0)) {
+            if (in.getVersion().onOrAfter(Version.V_7_13_0)) {
                 this.ext = in.readString();
                 this.total = in.readVLong();
                 this.count = in.readVLong();
@@ -401,7 +401,7 @@ public class SegmentsStats implements Writeable, ToXContentFragment {
 
         @Override
         public void writeTo(StreamOutput out) throws IOException {
-            if (out.getVersion().onOrAfter(Version.V_8_0_0)) {
+            if (out.getVersion().onOrAfter(Version.V_7_13_0)) {
                 out.writeString(ext);
                 out.writeVLong(total);
                 out.writeVLong(count);

--- a/server/src/main/java/org/elasticsearch/index/engine/SegmentsStats.java
+++ b/server/src/main/java/org/elasticsearch/index/engine/SegmentsStats.java
@@ -8,7 +8,10 @@
 
 package org.elasticsearch.index.engine;
 
+import com.carrotsearch.hppc.cursors.ObjectCursor;
 import com.carrotsearch.hppc.cursors.ObjectObjectCursor;
+import org.elasticsearch.Version;
+import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.collect.ImmutableOpenMap;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -34,9 +37,10 @@ public class SegmentsStats implements Writeable, ToXContentFragment {
     private long versionMapMemoryInBytes;
     private long maxUnsafeAutoIdTimestamp = Long.MIN_VALUE;
     private long bitsetMemoryInBytes;
-    private ImmutableOpenMap<String, Long> fileSizes = ImmutableOpenMap.of();
+    private ImmutableOpenMap<String, FileStats> files = ImmutableOpenMap.of();
 
-    public SegmentsStats() {}
+    public SegmentsStats() {
+    }
 
     public SegmentsStats(StreamInput in) throws IOException {
         count = in.readVLong();
@@ -52,14 +56,13 @@ public class SegmentsStats implements Writeable, ToXContentFragment {
         bitsetMemoryInBytes = in.readLong();
         maxUnsafeAutoIdTimestamp = in.readLong();
 
-        int size = in.readVInt();
-        ImmutableOpenMap.Builder<String, Long> map = ImmutableOpenMap.builder(size);
+        final int size = in.readVInt();
+        final ImmutableOpenMap.Builder<String, FileStats> files = ImmutableOpenMap.builder(size);
         for (int i = 0; i < size; i++) {
-            String key = in.readString();
-            Long value = in.readLong();
-            map.put(key, value);
+            FileStats file = new FileStats(in);
+            files.put(file.getExt(), file);
         }
-        fileSizes = map.build();
+        this.files = files.build();
     }
 
     public void add(long count, long memoryInBytes) {
@@ -107,19 +110,18 @@ public class SegmentsStats implements Writeable, ToXContentFragment {
         this.bitsetMemoryInBytes += bitsetMemoryInBytes;
     }
 
-    public void addFileSizes(ImmutableOpenMap<String, Long> fileSizes) {
-        ImmutableOpenMap.Builder<String, Long> map = ImmutableOpenMap.builder(this.fileSizes);
-
-        for (ObjectObjectCursor<String, Long> entry : fileSizes) {
-            if (map.containsKey(entry.key)) {
-                Long oldValue = map.get(entry.key);
-                map.put(entry.key, oldValue + entry.value);
+    public void addFiles(ImmutableOpenMap<String, FileStats> files) {
+        final ImmutableOpenMap.Builder<String, FileStats> map = ImmutableOpenMap.builder(this.files);
+        for (ObjectObjectCursor<String, FileStats> entry : files) {
+            final String extension = entry.key;
+            if (map.containsKey(extension)) {
+                FileStats previous = map.get(extension);
+                map.put(extension, FileStats.merge(previous, entry.value));
             } else {
-                map.put(entry.key, entry.value);
+                map.put(extension, entry.value);
             }
         }
-
-        this.fileSizes = map.build();
+        this.files = map.build();
     }
 
     public void add(SegmentsStats mergeStats) {
@@ -137,7 +139,7 @@ public class SegmentsStats implements Writeable, ToXContentFragment {
         addIndexWriterMemoryInBytes(mergeStats.indexWriterMemoryInBytes);
         addVersionMapMemoryInBytes(mergeStats.versionMapMemoryInBytes);
         addBitsetMemoryInBytes(mergeStats.bitsetMemoryInBytes);
-        addFileSizes(mergeStats.fileSizes);
+        addFiles(mergeStats.files);
     }
 
     /**
@@ -257,8 +259,8 @@ public class SegmentsStats implements Writeable, ToXContentFragment {
         return new ByteSizeValue(bitsetMemoryInBytes);
     }
 
-    public ImmutableOpenMap<String, Long> getFileSizes() {
-        return fileSizes;
+    public ImmutableOpenMap<String, FileStats> getFiles() {
+        return files;
     }
 
     /**
@@ -285,12 +287,8 @@ public class SegmentsStats implements Writeable, ToXContentFragment {
         builder.humanReadableField(Fields.FIXED_BIT_SET_MEMORY_IN_BYTES, Fields.FIXED_BIT_SET, getBitsetMemory());
         builder.field(Fields.MAX_UNSAFE_AUTO_ID_TIMESTAMP, maxUnsafeAutoIdTimestamp);
         builder.startObject(Fields.FILE_SIZES);
-        for (ObjectObjectCursor<String, Long> entry : fileSizes) {
-            builder.startObject(entry.key);
-            builder.humanReadableField(Fields.SIZE_IN_BYTES, Fields.SIZE, new ByteSizeValue(entry.value));
-            LuceneFilesExtensions extension = LuceneFilesExtensions.fromExtension(entry.key);
-            builder.field(Fields.DESCRIPTION, extension != null ? extension.getDescription() : "Others");
-            builder.endObject();
+        for (ObjectObjectCursor<String, FileStats> entry : files) {
+            entry.value.toXContent(builder, params);
         }
         builder.endObject();
         builder.endObject();
@@ -322,9 +320,6 @@ public class SegmentsStats implements Writeable, ToXContentFragment {
         static final String FIXED_BIT_SET = "fixed_bit_set";
         static final String FIXED_BIT_SET_MEMORY_IN_BYTES = "fixed_bit_set_memory_in_bytes";
         static final String FILE_SIZES = "file_sizes";
-        static final String SIZE = "size";
-        static final String SIZE_IN_BYTES = "size_in_bytes";
-        static final String DESCRIPTION = "description";
     }
 
     @Override
@@ -342,14 +337,117 @@ public class SegmentsStats implements Writeable, ToXContentFragment {
         out.writeLong(bitsetMemoryInBytes);
         out.writeLong(maxUnsafeAutoIdTimestamp);
 
-        out.writeVInt(fileSizes.size());
-        for (ObjectObjectCursor<String, Long> entry : fileSizes) {
-            out.writeString(entry.key);
-            out.writeLong(entry.value);
+        out.writeVInt(files.size());
+        for (ObjectCursor<FileStats> file : files.values()) {
+            file.value.writeTo(out);
         }
     }
 
-    public void clearFileSizes() {
-        fileSizes = ImmutableOpenMap.of();
+    public void clearFiles() {
+        files = ImmutableOpenMap.of();
+    }
+
+    public static class FileStats implements Writeable, ToXContentFragment {
+
+        private final String ext;
+        private final long total;
+        private final long count;
+        private final long min;
+        private final long max;
+
+        FileStats(StreamInput in) throws IOException {
+            if (in.getVersion().onOrAfter(Version.V_8_0_0)) {
+                this.ext = in.readString();
+                this.total = in.readVLong();
+                this.count = in.readVLong();
+                this.min = in.readVLong();
+                this.max = in.readVLong();
+            } else {
+                this.ext = in.readString();
+                this.total = in.readLong();
+                this.count = 0L;
+                this.min = 0L;
+                this.max = 0L;
+            }
+        }
+
+        public FileStats(String ext, long total, long count, long min, long max) {
+            this.ext = ext;
+            this.total = total;
+            this.count = count;
+            this.min = min;
+            this.max = max;
+        }
+
+        public String getExt() {
+            return ext;
+        }
+
+        public long getCount() {
+            return count;
+        }
+
+        public long getTotal() {
+            return total;
+        }
+
+        public long getMin() {
+            return min;
+        }
+
+        public long getMax() {
+            return max;
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            if (out.getVersion().onOrAfter(Version.V_8_0_0)) {
+                out.writeString(ext);
+                out.writeVLong(total);
+                out.writeVLong(count);
+                out.writeVLong(min);
+                out.writeVLong(max);
+            } else {
+                out.writeString(ext);
+                out.writeLong(total);
+            }
+        }
+
+        @Override
+        public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+            final long roundedAverage = count > 0L ? Math.round((double) total / (double) count) : 0L;
+            final LuceneFilesExtensions extension = LuceneFilesExtensions.fromExtension(ext);
+            final String name = extension != null ? extension.getExtension() : "others";
+            final String desc = extension != null ? extension.getDescription() : "Others";
+            builder.startObject(name);
+            {
+                builder.field("description", desc);
+                builder.humanReadableField("size_in_bytes", "size", ByteSizeValue.ofBytes(total));
+                builder.humanReadableField("min_size_in_bytes", "min_size", ByteSizeValue.ofBytes(min));
+                builder.humanReadableField("max_size_in_bytes", "max_size", ByteSizeValue.ofBytes(max));
+                builder.humanReadableField("average_size_in_bytes", "average_size", ByteSizeValue.ofBytes(roundedAverage));
+                builder.field("count", count);
+            }
+            builder.endObject();
+            return builder;
+        }
+
+        public static FileStats merge(FileStats o1, FileStats o2) {
+            assert o1 != null && o1.ext != null : o1;
+            assert o2 != null && o2.ext != null : o2;
+            assert o1.ext.equals(o2.ext) : o1 + " vs " + o2;
+            return new FileStats(
+                o1.ext,
+                Math.addExact(o1.total, o2.total),
+                Math.addExact(o1.count, o2.count),
+                Math.min(o1.min, o2.min),
+                Math.max(o1.max, o2.max)
+            );
+        }
+
+        @Override
+        public String toString() {
+            return Strings.toString(this);
+        }
     }
 }

--- a/server/src/test/java/org/elasticsearch/index/engine/InternalEngineTests.java
+++ b/server/src/test/java/org/elasticsearch/index/engine/InternalEngineTests.java
@@ -8,6 +8,7 @@
 
 package org.elasticsearch.index.engine;
 
+import com.carrotsearch.hppc.cursors.ObjectCursor;
 import com.carrotsearch.hppc.cursors.ObjectObjectCursor;
 import com.carrotsearch.randomizedtesting.generators.RandomNumbers;
 import org.apache.logging.log4j.Level;
@@ -191,7 +192,6 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.emptyArray;
 import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.everyItem;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.hasItem;
@@ -586,23 +586,33 @@ public class InternalEngineTests extends EngineTestCase {
     public void testSegmentsStatsIncludingFileSizes() throws Exception {
         try (Store store = createStore();
              Engine engine = createEngine(defaultSettings, store, createTempDir(), NoMergePolicy.INSTANCE)) {
-            assertThat(engine.segmentsStats(true, false).getFileSizes().size(), equalTo(0));
+            assertThat(engine.segmentsStats(true, false).getFiles().size(), equalTo(0));
 
             ParsedDocument doc = testParsedDocument("1", null, testDocumentWithTextField(), B_1, null);
             engine.index(indexForDoc(doc));
             engine.refresh("test");
 
-            SegmentsStats stats = engine.segmentsStats(true, false);
-            assertThat(stats.getFileSizes().size(), greaterThan(0));
-            assertThat(() -> stats.getFileSizes().valuesIt(), everyItem(greaterThan(0L)));
-
-            ObjectObjectCursor<String, Long> firstEntry = stats.getFileSizes().iterator().next();
+            final SegmentsStats stats1 = engine.segmentsStats(true, false);
+            assertThat(stats1.getFiles().size(), greaterThan(0));
+            for (ObjectObjectCursor<String, SegmentsStats.FileStats> fileStats : stats1.getFiles()) {
+                assertThat(fileStats.value.getTotal(), greaterThan(0L));
+                assertThat(fileStats.value.getCount(), greaterThan(0L));
+                assertThat(fileStats.value.getMin(), greaterThan(0L));
+                assertThat(fileStats.value.getMax(), greaterThan(0L));
+            }
 
             ParsedDocument doc2 = testParsedDocument("2", null, testDocumentWithTextField(), B_2, null);
             engine.index(indexForDoc(doc2));
             engine.refresh("test");
 
-            assertThat(engine.segmentsStats(true, false).getFileSizes().get(firstEntry.key), greaterThan(firstEntry.value));
+            final SegmentsStats stats2 = engine.segmentsStats(true, false);
+            for (ObjectCursor<String> cursor : stats1.getFiles().keys()) {
+                final String extension = cursor.value;
+                assertThat(stats2.getFiles().get(extension).getTotal(), greaterThan((stats1.getFiles().get(extension).getTotal())));
+                assertThat(stats2.getFiles().get(extension).getCount(), greaterThan((stats1.getFiles().get(extension).getCount())));
+                assertThat(stats2.getFiles().get(extension).getMin(), greaterThan((0L)));
+                assertThat(stats2.getFiles().get(extension).getMax(), greaterThan((0L)));
+            }
         }
     }
 

--- a/server/src/test/java/org/elasticsearch/index/engine/NoOpEngineTests.java
+++ b/server/src/test/java/org/elasticsearch/index/engine/NoOpEngineTests.java
@@ -146,10 +146,10 @@ public class NoOpEngineTests extends EngineTestCase {
                 assertEquals(expectedDocStats.getTotalSizeInBytes(), noOpEngine.docStats().getTotalSizeInBytes());
                 assertEquals(expectedSegmentStats.getCount(), noOpEngine.segmentsStats(includeFileSize, true).getCount());
                 // don't compare memory in bytes since we load the index with term-dict off-heap
-                assertEquals(expectedSegmentStats.getFileSizes().size(),
-                    noOpEngine.segmentsStats(includeFileSize, true).getFileSizes().size());
+                assertEquals(expectedSegmentStats.getFiles().size(),
+                    noOpEngine.segmentsStats(includeFileSize, true).getFiles().size());
 
-                assertEquals(0, noOpEngine.segmentsStats(includeFileSize, false).getFileSizes().size());
+                assertEquals(0, noOpEngine.segmentsStats(includeFileSize, false).getFiles().size());
                 assertEquals(0, noOpEngine.segmentsStats(includeFileSize, false).getMemoryInBytes());
             } catch (AssertionError e) {
                 logger.error(config.getMergePolicy());

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/index/engine/FrozenEngine.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/index/engine/FrozenEngine.java
@@ -254,7 +254,7 @@ public final class FrozenEngine extends ReadOnlyEngine {
             final SegmentsStats stats = new SegmentsStats();
             stats.add(this.segmentsStats);
             if (includeSegmentFileSizes == false) {
-                stats.clearFileSizes();
+                stats.clearFiles();
             }
             return stats;
         } else {

--- a/x-pack/plugin/searchable-snapshots/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/indices_stats.yml
+++ b/x-pack/plugin/searchable-snapshots/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/indices_stats.yml
@@ -1,8 +1,8 @@
 ---
 setup:
   - skip:
-      version: " - 7.99.99"
-      reason: segment files stats enhanced in 8.0.0
+      version: " - 7.12.99"
+      reason: segment files stats enhanced in 7.13.0
 
   - do:
       indices.create:

--- a/x-pack/plugin/searchable-snapshots/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/indices_stats.yml
+++ b/x-pack/plugin/searchable-snapshots/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/indices_stats.yml
@@ -1,0 +1,156 @@
+---
+setup:
+  - skip:
+      version: " - 7.99.99"
+      reason: segment files stats enhanced in 8.0.0
+
+  - do:
+      indices.create:
+        index: docs
+        body:
+          settings:
+            number_of_shards:   1
+            number_of_replicas: 0
+
+  - do:
+      bulk:
+        body:
+          - index:
+              _index: docs
+              _id:    1
+          - field: foo
+          - index:
+              _index: docs
+              _id:    2
+          - field: bar
+          - index:
+              _index: docs
+              _id:    3
+          - field: baz
+
+  - do:
+      snapshot.create_repository:
+        repository: repository-fs
+        body:
+          type: fs
+          settings:
+            location: "repository-fs"
+
+  # Remove the snapshot if a previous test failed to delete it.
+  # Useful for third party tests that runs the test against a real external service.
+  - do:
+      snapshot.delete:
+        repository: repository-fs
+        snapshot: snapshot
+        ignore: 404
+
+  - do:
+      snapshot.create:
+        repository: repository-fs
+        snapshot: snapshot
+        wait_for_completion: true
+
+  - do:
+      indices.delete:
+        index: docs
+---
+teardown:
+
+  - do:
+      snapshot.delete:
+        repository: repository-fs
+        snapshot: snapshot
+        ignore: 404
+
+  - do:
+      snapshot.delete_repository:
+        repository: repository-fs
+
+---
+"Tests Indices Stats API for snapshot backed indices":
+
+  - do:
+      searchable_snapshots.mount:
+        repository: repository-fs
+        snapshot: snapshot
+        wait_for_completion: true
+        body:
+          index: docs
+          renamed_index: cold-docs
+
+  - match: { snapshot.snapshot: snapshot }
+  - match: { snapshot.shards.failed: 0 }
+  - match: { snapshot.shards.successful: 1 }
+
+  - do:
+      searchable_snapshots.mount:
+        repository: repository-fs
+        snapshot: snapshot
+        wait_for_completion: true
+        storage: shared_cache
+        body:
+          index: docs
+          renamed_index: frozen-docs
+
+  - match: { snapshot.snapshot: snapshot }
+  - match: { snapshot.shards.failed: 0 }
+  - match: { snapshot.shards.successful: 1 }
+
+  - do:
+      indices.stats:
+        index: "*-docs"
+        metric: [ segments ]
+        include_segment_file_sizes: true
+
+  - is_true: _all.total.segments.file_sizes
+  - is_true: _all.total.segments.file_sizes.si
+  - gt: { _all.total.segments.file_sizes.si.count: 0 }
+  - gt: { _all.total.segments.file_sizes.si.size_in_bytes: 0 }
+  - gt: { _all.total.segments.file_sizes.si.min_size_in_bytes: 0 }
+  - gt: { _all.total.segments.file_sizes.si.max_size_in_bytes: 0 }
+  - gt: { _all.total.segments.file_sizes.si.average_size_in_bytes: 0 }
+
+  - is_true: indices.cold-docs.primaries.segments.file_sizes
+  - is_true: indices.cold-docs.primaries.segments.file_sizes.si
+  - gt: { indices.cold-docs.primaries.segments.file_sizes.si.count: 0 }
+  - gt: { indices.cold-docs.primaries.segments.file_sizes.si.size_in_bytes: 0 }
+  - gt: { indices.cold-docs.primaries.segments.file_sizes.si.min_size_in_bytes: 0 }
+  - gt: { indices.cold-docs.primaries.segments.file_sizes.si.max_size_in_bytes: 0 }
+  - gt: { indices.cold-docs.primaries.segments.file_sizes.si.average_size_in_bytes: 0 }
+  - match: { indices.cold-docs.primaries.segments.file_sizes.si.description: "Segment Info" }
+
+  - is_true: indices.frozen-docs.primaries.segments.file_sizes
+  - is_false: indices.frozen-docs.primaries.segments.file_sizes.si
+
+  - do:
+      indices.stats:
+        index: "*-docs"
+        metric: [ segments ]
+        include_segment_file_sizes: true
+        include_unloaded_segments: true
+
+  - is_true: _all.total.segments.file_sizes
+  - is_true: _all.total.segments.file_sizes.si
+  - gt: { _all.total.segments.file_sizes.si.count: 0 }
+  - gt: { _all.total.segments.file_sizes.si.size_in_bytes: 0 }
+  - gt: { _all.total.segments.file_sizes.si.min_size_in_bytes: 0 }
+  - gt: { _all.total.segments.file_sizes.si.max_size_in_bytes: 0 }
+  - gt: { _all.total.segments.file_sizes.si.average_size_in_bytes: 0 }
+
+  - is_true: indices.cold-docs.primaries.segments.file_sizes
+  - is_true: indices.cold-docs.primaries.segments.file_sizes.si
+  - gt: { indices.cold-docs.primaries.segments.file_sizes.si.count: 0 }
+  - gt: { indices.cold-docs.primaries.segments.file_sizes.si.size_in_bytes: 0 }
+  - gt: { indices.cold-docs.primaries.segments.file_sizes.si.min_size_in_bytes: 0 }
+  - gt: { indices.cold-docs.primaries.segments.file_sizes.si.max_size_in_bytes: 0 }
+  - gt: { indices.cold-docs.primaries.segments.file_sizes.si.average_size_in_bytes: 0 }
+  - match: { indices.cold-docs.primaries.segments.file_sizes.si.description: "Segment Info" }
+
+  - is_true: indices.frozen-docs.primaries.segments.file_sizes
+  - is_true: indices.frozen-docs.primaries.segments.file_sizes.si
+  - gt: { indices.frozen-docs.primaries.segments.file_sizes.si.count: 0 }
+  - gt: { indices.frozen-docs.primaries.segments.file_sizes.si.size_in_bytes: 0 }
+  - gt: { indices.frozen-docs.primaries.segments.file_sizes.si.min_size_in_bytes: 0 }
+  - gt: { indices.frozen-docs.primaries.segments.file_sizes.si.max_size_in_bytes: 0 }
+  - gt: { indices.frozen-docs.primaries.segments.file_sizes.si.average_size_in_bytes: 0 }
+  - match: { indices.frozen-docs.primaries.segments.file_sizes.si.description: "Segment Info" }


### PR DESCRIPTION
Since #16661 it is possible to know the total sizes for some Lucene segment files 
by using the Node Stats or Indices Stats API with the include_segment_file_sizes 
parameter, and the list of file extensions has been extended in #71416.

This commit adds a bit more information about file sizes like the number of files 
(count), the min, max and average file sizes in bytes that share the same extension.

Here is a sample:
"cfs" : {
  "description" : "Compound Files",
  "size_in_bytes" : 2260,
  "min_size_in_bytes" : 2260,
  "max_size_in_bytes" : 2260,
  "average_size_in_bytes" : 2260,
  "count" : 1
}

This commit also simplifies how compound file sizes were computed: before 
compound segment files were extracted and sizes aggregated with regular 
non-compound files sizes (which can be confusing and out of the scope of 
the original issue #6728), now CFS/CFE files appears as distinct files.

These new information are provided to give a better view of the segment 
files and are useful in many cases, specially with frozen searchable snapshots 
whose segment stats can now be introspected thanks to the 
include_unloaded_segments parameter.

Backport of #71643