### PR TITLE
[ML] Fix error when a nested field is also incompatible

### DIFF
--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/extractor/ExtractedFieldsDetector.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/extractor/ExtractedFieldsDetector.java
@@ -253,13 +253,12 @@ public class ExtractedFieldsDetector {
         Iterator<String> fieldsIterator = fields.iterator();
         while (fieldsIterator.hasNext()) {
             String field = fieldsIterator.next();
-            if (hasCompatibleType(field) == false) {
-                addExcludedField(field, "unsupported type; supported types are " + getSupportedTypes(), fieldSelection);
-                fieldsIterator.remove();
-            }
             Optional<String> matchingNestedFieldPattern = findMatchingNestedFieldPattern(field);
             if (matchingNestedFieldPattern.isPresent()) {
                 addExcludedNestedPattern(matchingNestedFieldPattern.get(), fieldSelection);
+                fieldsIterator.remove();
+            } else if (hasCompatibleType(field) == false) {
+                addExcludedField(field, "unsupported type; supported types are " + getSupportedTypes(), fieldSelection);
                 fieldsIterator.remove();
             }
         }


### PR DESCRIPTION
This fixes a bug that was introduced in #71400.

The bug occurs when the _explain API is called for a
data frame analytics job and there are nested fields
that are also incompatible. In particular, we end
up calling `iterator.remove()` twice which throws
`IllegalStateException`.

I also took the chance to move the nested field check
first as I think it's more informative to explain a
field is not included due to being nested than because
it has an incompatible type in this case.

The PR is marked as `non-issue` as this has not been
released yet.
