### PR TITLE
[7.x] Enhance the validation for alias when creating index template or index (#68807)

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/admin/indices/alias/Alias.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/alias/Alias.java
@@ -29,6 +29,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 
 /**
  * Represents an alias, to be associated with an index
@@ -244,6 +245,13 @@ public class Alias implements Writeable, ToXContentFragment {
         while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
             if (token == XContentParser.Token.FIELD_NAME) {
                 currentFieldName = parser.currentName();
+                // check if there are any unknown fields
+                Set<String> knownFieldNames = Set.of(FILTER.getPreferredName(), ROUTING.getPreferredName(),
+                    INDEX_ROUTING.getPreferredName(), SEARCH_ROUTING.getPreferredName(), IS_WRITE_INDEX.getPreferredName(),
+                    IS_HIDDEN.getPreferredName());
+                if (knownFieldNames.contains(currentFieldName) == false) {
+                    throw new IllegalArgumentException("Unknown field [" + currentFieldName + "] in alias [" + alias.name + "]");
+                }
             } else if (token == XContentParser.Token.START_OBJECT) {
                 if (FILTER.match(currentFieldName, parser.getDeprecationHandler())) {
                     Map<String, Object> filter = parser.mapOrdered();
@@ -263,6 +271,8 @@ public class Alias implements Writeable, ToXContentFragment {
                 } else if (IS_HIDDEN.match(currentFieldName, parser.getDeprecationHandler())) {
                     alias.isHidden(parser.booleanValue());
                 }
+            } else {
+                throw new IllegalArgumentException("Unknown token [" + token + "] in alias [" + alias.name + "]");
             }
         }
         return alias;

--- a/server/src/test/java/org/elasticsearch/action/admin/indices/create/CreateIndexRequestTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/create/CreateIndexRequestTests.java
@@ -34,6 +34,7 @@ import java.util.Set;
 import static org.elasticsearch.cluster.metadata.IndexMetadata.SETTING_NUMBER_OF_SHARDS;
 import static org.elasticsearch.common.xcontent.ToXContent.EMPTY_PARAMS;
 import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.Matchers.containsString;
 
 public class CreateIndexRequestTests extends ESTestCase {
 
@@ -193,6 +194,40 @@ public class CreateIndexRequestTests extends ESTestCase {
         CreateIndexRequest parsedCreateIndexRequest = new CreateIndexRequest();
         ElasticsearchParseException e = expectThrows(ElasticsearchParseException.class, () -> parsedCreateIndexRequest.source(builder));
         assertThat(e.getMessage(), equalTo("key [settings] must be an object"));
+    }
+
+    public void testAlias() throws IOException {
+        XContentBuilder aliases1 = XContentFactory.jsonBuilder().startObject()
+            .startObject("aliases")
+                .startObject("filtered-data")
+                    .startObject("bool")
+                        .startObject("filter")
+                            .startObject("term")
+                            .field("a", "b")
+                            .endObject()
+                        .endObject()
+                    .endObject()
+                .endObject()
+            .endObject()
+        .endObject();
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> new CreateIndexRequest().source(aliases1));
+        assertThat(e.getMessage(), containsString("Unknown field [bool] in alias [filtered-data]"));
+
+        XContentBuilder aliases2 = XContentFactory.jsonBuilder().startObject()
+            .startObject("aliases")
+                .startObject("filtered-data")
+                    .startArray("filter")
+                        .startObject()
+                            .startObject("term")
+                            .field("a", "b")
+                            .endObject()
+                        .endObject()
+                    .endArray()
+                .endObject()
+            .endObject()
+        .endObject();
+        e = expectThrows(IllegalArgumentException.class, () -> new CreateIndexRequest().source(aliases2));
+        assertThat(e.getMessage(), containsString("Unknown token [START_ARRAY] in alias [filtered-data]"));
     }
 
     public static void assertMappingsEqual(Map<String, String> expected, Map<String, String> actual) throws IOException {

--- a/server/src/test/java/org/elasticsearch/action/admin/indices/template/put/PutIndexTemplateRequestTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/template/put/PutIndexTemplateRequestTests.java
@@ -162,6 +162,38 @@ public class PutIndexTemplateRequestTests extends AbstractXContentTestCase<PutIn
         assertThat(actual.aliases(), equalTo(expected.aliases()));
         assertThat(actual.mappings(), equalTo(expected.mappings()));
         assertThat(actual.settings(), equalTo(expected.settings()));
+
+        XContentBuilder aliases1 = XContentFactory.jsonBuilder().startObject()
+            .startObject("aliases")
+                .startObject("filtered-data")
+                    .startObject("bool")
+                        .startObject("filter")
+                            .startObject("term")
+                            .field("a", "b")
+                            .endObject()
+                        .endObject()
+                    .endObject()
+                .endObject()
+            .endObject()
+        .endObject();
+        e = expectThrows(IllegalArgumentException.class, () -> new PutIndexTemplateRequest().source(aliases1));
+        assertThat(e.getCause().getMessage(), containsString("Unknown field [bool] in alias [filtered-data]"));
+
+        XContentBuilder aliases2 = XContentFactory.jsonBuilder().startObject()
+            .startObject("aliases")
+                .startObject("filtered-data")
+                    .startArray("filter")
+                        .startObject()
+                            .startObject("term")
+                            .field("a", "b")
+                            .endObject()
+                        .endObject()
+                    .endArray()
+                .endObject()
+            .endObject()
+        .endObject();
+        e = expectThrows(IllegalArgumentException.class, () -> new PutIndexTemplateRequest().source(aliases2));
+        assertThat(e.getCause().getMessage(), containsString("Unknown token [START_ARRAY] in alias [filtered-data]"));
     }
 
     @Override


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Enhance the validation for alias when creating index template or index (#68807)