### PR TITLE
Speed up terms agg when not force merged (backport of #71241)

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/fielddata/ordinals/GlobalOrdinalMapping.java
+++ b/server/src/main/java/org/elasticsearch/index/fielddata/ordinals/GlobalOrdinalMapping.java
@@ -17,7 +17,8 @@ import org.apache.lucene.util.LongValues;
 import java.io.IOException;
 
 /**
- * A {@link SortedSetDocValues} implementation that returns ordinals that are global.
+ * A {@link SortedSetDocValues} implementation that returns global ordinals
+ * instead of segment ordinals.
  */
 final class GlobalOrdinalMapping extends SortedSetDocValues {
 

--- a/server/src/main/java/org/elasticsearch/index/fielddata/ordinals/GlobalOrdinalsIndexFieldData.java
+++ b/server/src/main/java/org/elasticsearch/index/fielddata/ordinals/GlobalOrdinalsIndexFieldData.java
@@ -218,8 +218,14 @@ public final class GlobalOrdinalsIndexFieldData implements IndexOrdinalsFieldDat
                         // segment ordinals match global ordinals
                         return values;
                     }
-                    final TermsEnum[] atomicLookups = getOrLoadTermsEnums();
-                    return new GlobalOrdinalMapping(ordinalMap, values, atomicLookups, context.ord);
+                    TermsEnum[] atomicLookups = getOrLoadTermsEnums();
+                    SortedSetDocValues singleton = SingletonGlobalOrdinalMapping.singletonIfPossible(
+                        ordinalMap,
+                        values,
+                        atomicLookups,
+                        context.ord
+                    );
+                    return singleton == null ? new GlobalOrdinalMapping(ordinalMap, values, atomicLookups, context.ord) : singleton;
                 }
 
                 @Override

--- a/server/src/main/java/org/elasticsearch/index/fielddata/ordinals/SingletonGlobalOrdinalMapping.java
+++ b/server/src/main/java/org/elasticsearch/index/fielddata/ordinals/SingletonGlobalOrdinalMapping.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+package org.elasticsearch.index.fielddata.ordinals;
+
+import org.apache.lucene.index.DocValues;
+import org.apache.lucene.index.OrdinalMap;
+import org.apache.lucene.index.SortedDocValues;
+import org.apache.lucene.index.SortedSetDocValues;
+import org.apache.lucene.index.TermsEnum;
+import org.apache.lucene.util.BytesRef;
+import org.apache.lucene.util.LongValues;
+
+import java.io.IOException;
+
+/**
+ * {@link SortedDocValues} implementation that returns global ordinals instead
+ * of segment ordinals.
+ */
+class SingletonGlobalOrdinalMapping extends SortedDocValues {
+    /**
+     * Build a {@link SortedDocValues singleton doc values} if possible
+     * Lots of other code tries to unwrap the singleton with
+     * {@link DocValues#unwrapSingleton} and it'll take a fast path if
+     * it gets a singleton. This'll return a singleton that can be
+     * unwrapped or {@code null} if the {@link OrdinalMap} and
+     * {@link SortedSetDocValues} aren't compatible with {@link SortedDocValues}.
+     */
+    static SortedSetDocValues singletonIfPossible(OrdinalMap ordinalMap, SortedSetDocValues values, TermsEnum[] lookups, int segmentIndex) {
+        /*
+         * We can manage a singleton if the total value count
+         * fits in an `int` *and* the segment ords are a singleton.
+         * We need the first one just because SortedDocValues
+         * returns `int` instead of `long`
+         */
+        if (ordinalMap.getValueCount() > Integer.MAX_VALUE) {
+            return null;
+        }
+        SortedDocValues singleton = DocValues.unwrapSingleton(values);
+        if (singleton == null) {
+            return null;
+        }
+        return DocValues.singleton(new SingletonGlobalOrdinalMapping(ordinalMap, singleton, lookups, segmentIndex));
+    }
+
+    private final SortedDocValues values;
+    private final OrdinalMap ordinalMap;
+    private final LongValues mapping;
+    private final TermsEnum[] lookups;
+
+    private SingletonGlobalOrdinalMapping(OrdinalMap ordinalMap, SortedDocValues values, TermsEnum[] lookups, int segmentIndex) {
+        this.values = values;
+        this.lookups = lookups;
+        this.ordinalMap = ordinalMap;
+        this.mapping = ordinalMap.getGlobalOrds(segmentIndex);
+    }
+
+    @Override
+    public int getValueCount() {
+        return (int) ordinalMap.getValueCount();
+    }
+
+    @Override
+    public int ordValue() throws IOException {
+        return (int) mapping.get(values.ordValue());
+    }
+
+    @Override
+    public boolean advanceExact(int target) throws IOException {
+        return values.advanceExact(target);
+    }
+
+    @Override
+    public BytesRef lookupOrd(int globalOrd) throws IOException {
+        final long segmentOrd = ordinalMap.getFirstSegmentOrd(globalOrd);
+        int readerIndex = ordinalMap.getFirstSegmentNumber(globalOrd);
+        lookups[readerIndex].seekExact(segmentOrd);
+        return lookups[readerIndex].term();
+    }
+
+    @Override
+    public int docID() {
+        return values.docID();
+    }
+
+    @Override
+    public int nextDoc() throws IOException {
+        return values.nextDoc();
+    }
+
+    @Override
+    public int advance(int target) throws IOException {
+        return values.advance(target);
+    }
+
+    @Override
+    public long cost() {
+        return values.cost();
+    }
+}

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/DeferringBucketCollector.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/DeferringBucketCollector.java
@@ -19,6 +19,7 @@ import org.elasticsearch.search.sort.SortOrder;
 
 import java.io.IOException;
 import java.util.Iterator;
+import java.util.function.BiConsumer;
 
 /**
  * A {@link BucketCollector} that records collected doc IDs and buckets and
@@ -85,6 +86,12 @@ public abstract class DeferringBucketCollector extends BucketCollector {
         @Override
         public InternalAggregation buildEmptyAggregation() {
             return in.buildEmptyAggregation();
+        }
+
+        @Override
+        public void collectDebugInfo(BiConsumer<String, Object> add) {
+            super.collectDebugInfo(add);
+            in.collectDebugInfo(add);
         }
 
         @Override

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/range/RangeAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/range/RangeAggregatorTests.java
@@ -508,7 +508,7 @@ public class RangeAggregatorTests extends AggregatorTestCase {
                     )
                 );
             }
-        }, (InternalRange<?, ?> r, Class<? extends Aggregator> impl, Map<String, Object> debug) -> {
+        }, (InternalRange<?, ?> r, Class<? extends Aggregator> impl, Map<String, Map<String, Object>> debug) -> {
             assertThat(
                 r.getBuckets().stream().map(InternalRange.Bucket::getKey).collect(toList()),
                 equalTo(org.elasticsearch.common.collect.List.of("0.0-1.0", "1.0-2.0", "2.0-3.0"))
@@ -518,7 +518,8 @@ public class RangeAggregatorTests extends AggregatorTestCase {
                 equalTo(org.elasticsearch.common.collect.List.of(totalDocs, 0L, 0L))
             );
             assertThat(impl, equalTo(RangeAggregator.FromFilters.class));
-            Map<?, ?> delegateDebug = (Map<?, ?>) debug.get("delegate_debug");
+            Map<?, ?> topLevelDebug = (Map<?, ?>) debug.get("r");
+            Map<?, ?> delegateDebug = (Map<?, ?>) topLevelDebug.get("delegate_debug");
             assertThat(delegateDebug, hasEntry("estimated_cost", totalDocs));
             assertThat(delegateDebug, hasEntry("max_cost", totalDocs));
         }, new NumberFieldMapper.NumberFieldType(NUMBER_FIELD_NAME, NumberFieldMapper.NumberType.INTEGER));

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/terms/TermsAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/terms/TermsAggregatorTests.java
@@ -50,6 +50,7 @@ import org.elasticsearch.index.mapper.KeywordFieldMapper.KeywordField;
 import org.elasticsearch.index.mapper.KeywordFieldMapper.KeywordFieldType;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.NumberFieldMapper;
+import org.elasticsearch.index.mapper.NumberFieldMapper.NumberFieldType;
 import org.elasticsearch.index.mapper.ObjectMapper;
 import org.elasticsearch.index.mapper.RangeFieldMapper;
 import org.elasticsearch.index.mapper.RangeType;
@@ -1389,6 +1390,43 @@ public class TermsAggregatorTests extends AggregatorTestCase {
         }
     }
 
+    public void testManySegmentsStillSingleton() throws IOException {
+        NumberFieldType nFt = new NumberFieldType("n", NumberFieldMapper.NumberType.LONG);
+        KeywordFieldType strFt = new KeywordFieldType("str", true, true, Collections.emptyMap());
+        AggregationBuilder builder = new TermsAggregationBuilder("n").field("n")
+            .subAggregation(new TermsAggregationBuilder("str").field("str"));
+        withNonMergingIndex(iw -> {
+            iw.addDocument(
+                List.of(
+                    new SortedNumericDocValuesField("n", 1),
+                    new LongPoint("n", 1),
+                    new SortedSetDocValuesField("str", new BytesRef("sheep")),
+                    new Field("str", new BytesRef("sheep"), KeywordFieldMapper.Defaults.FIELD_TYPE)
+                )
+            );
+            iw.commit();   // Force two segments
+            iw.addDocument(
+                List.of(
+                    new SortedNumericDocValuesField("n", 1),
+                    new LongPoint("n", 1),
+                    new SortedSetDocValuesField("str", new BytesRef("cow")),
+                    new Field("str", new BytesRef("sheep"), KeywordFieldMapper.Defaults.FIELD_TYPE)
+                )
+            );
+        }, searcher -> debugTestCase(
+            builder,
+            new MatchAllDocsQuery(),
+            searcher,
+            (LongTerms result, Class<? extends Aggregator> impl, Map<String, Map<String, Object>> debug) -> {
+                Map<String, Object> subDebug = debug.get("n.str");
+                assertThat(subDebug, hasEntry("segments_with_single_valued_ords", 2));
+                assertThat(subDebug, hasEntry("segments_with_multi_valued_ords", 0));
+            },
+            nFt,
+            strFt
+        ));
+    }
+
     public void testNumberToStringValueScript() throws IOException {
         MappedFieldType fieldType
             = new NumberFieldMapper.NumberFieldType("number", NumberFieldMapper.NumberType.INTEGER);
@@ -1788,7 +1826,7 @@ public class TermsAggregatorTests extends AggregatorTestCase {
                     )
                 );
             }
-        }, (StringTerms r, Class<? extends Aggregator> impl, Map<String, Object> debug) -> {
+        }, (StringTerms r, Class<? extends Aggregator> impl, Map<String, Map<String, Object>> debug) -> {
             assertThat(
                 r.getBuckets().stream().map(StringTerms.Bucket::getKey).collect(toList()),
                 equalTo(org.elasticsearch.common.collect.List.of("more_stuff", "stuff", "other_stuff"))
@@ -1798,7 +1836,8 @@ public class TermsAggregatorTests extends AggregatorTestCase {
                 equalTo(org.elasticsearch.common.collect.List.of(167L, 167L, 166L))
             );
             assertThat(impl, equalTo(StringTermsAggregatorFromFilters.class));
-            Map<?, ?> delegateDebug = (Map<?, ?>) debug.get("delegate_debug");
+            Map<?, ?> topLevelDebug = (Map<?, ?>) debug.get("t");
+            Map<?, ?> delegateDebug = (Map<?, ?>) topLevelDebug.get("delegate_debug");
             // We don't estimate the cost here so these shouldn't show up
             assertThat(delegateDebug, not(hasKey("estimated_cost")));
             assertThat(delegateDebug, not(hasKey("max_cost")));

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/terms/TermsAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/terms/TermsAggregatorTests.java
@@ -1397,7 +1397,7 @@ public class TermsAggregatorTests extends AggregatorTestCase {
             .subAggregation(new TermsAggregationBuilder("str").field("str"));
         withNonMergingIndex(iw -> {
             iw.addDocument(
-                List.of(
+                org.elasticsearch.common.collect.List.of(
                     new SortedNumericDocValuesField("n", 1),
                     new LongPoint("n", 1),
                     new SortedSetDocValuesField("str", new BytesRef("sheep")),
@@ -1406,7 +1406,7 @@ public class TermsAggregatorTests extends AggregatorTestCase {
             );
             iw.commit();   // Force two segments
             iw.addDocument(
-                List.of(
+                org.elasticsearch.common.collect.List.of(
                     new SortedNumericDocValuesField("n", 1),
                     new LongPoint("n", 1),
                     new SortedSetDocValuesField("str", new BytesRef("cow")),

--- a/test/framework/src/main/java/org/elasticsearch/search/aggregations/AggregatorTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/search/aggregations/AggregatorTestCase.java
@@ -22,6 +22,7 @@ import org.apache.lucene.index.DirectoryReader;
 import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.IndexReaderContext;
 import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.index.NoMergePolicy;
 import org.apache.lucene.index.RandomIndexWriter;
 import org.apache.lucene.search.AssertingIndexSearcher;
 import org.apache.lucene.search.Collector;
@@ -35,6 +36,7 @@ import org.apache.lucene.search.Weight;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.util.Accountable;
 import org.apache.lucene.util.BytesRef;
+import org.apache.lucene.util.LuceneTestCase;
 import org.apache.lucene.util.NumericUtils;
 import org.elasticsearch.Version;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
@@ -553,6 +555,38 @@ public abstract class AggregatorTestCase extends ESTestCase {
         }
     }
 
+    protected void withIndex(
+        CheckedConsumer<RandomIndexWriter, IOException> buildIndex,
+        CheckedConsumer<IndexSearcher, IOException> consume
+    ) throws IOException {
+        try (Directory directory = newDirectory()) {
+            RandomIndexWriter iw = new RandomIndexWriter(random(), directory);
+            buildIndex.accept(iw);
+            iw.close();
+            try (DirectoryReader unwrapped = DirectoryReader.open(directory); IndexReader indexReader = wrapDirectoryReader(unwrapped)) {
+                consume.accept(newIndexSearcher(indexReader));
+            }
+        }
+    }
+
+    protected void withNonMergingIndex(
+        CheckedConsumer<RandomIndexWriter, IOException> buildIndex,
+        CheckedConsumer<IndexSearcher, IOException> consume
+    ) throws IOException {
+        try (Directory directory = newDirectory()) {
+            RandomIndexWriter iw = new RandomIndexWriter(
+                random(),
+                directory,
+                LuceneTestCase.newIndexWriterConfig(random(), new StandardAnalyzer()).setMergePolicy(NoMergePolicy.INSTANCE)
+            );
+            buildIndex.accept(iw);
+            iw.close();
+            try (DirectoryReader unwrapped = DirectoryReader.open(directory); IndexReader indexReader = wrapDirectoryReader(unwrapped)) {
+                consume.accept(newIndexSearcher(indexReader));
+            }
+        }
+    }
+
     /**
      * Execute and aggregation and collect its {@link Aggregator#collectDebugInfo debug}
      * information. Unlike {@link #testCase} this doesn't randomly create an
@@ -563,49 +597,65 @@ public abstract class AggregatorTestCase extends ESTestCase {
         AggregationBuilder builder,
         Query query,
         CheckedConsumer<RandomIndexWriter, IOException> buildIndex,
-        TriConsumer<R, Class<? extends Aggregator>, Map<String, Object>> verify,
+        TriConsumer<R, Class<? extends Aggregator>, Map<String, Map<String, Object>>> verify,
         MappedFieldType... fieldTypes
     ) throws IOException {
-        try (Directory directory = newDirectory()) {
-            RandomIndexWriter indexWriter = new RandomIndexWriter(random(), directory);
-            buildIndex.accept(indexWriter);
-            indexWriter.close();
+        withIndex(buildIndex, searcher -> debugTestCase(builder, query, searcher, verify, fieldTypes));
+    }
 
-            try (DirectoryReader unwrapped = DirectoryReader.open(directory); IndexReader indexReader = wrapDirectoryReader(unwrapped)) {
-                IndexSearcher searcher = newIndexSearcher(indexReader);
-                // Don't use searchAndReduce because we only want a single aggregator.
-                IndexReaderContext ctx = searcher.getTopReaderContext();
-                CircuitBreakerService breakerService = new NoneCircuitBreakerService();
-                AggregationContext context = createAggregationContext(
-                    searcher,
-                    createIndexSettings(),
-                    searcher.rewrite(query),
-                    breakerService,
-                    builder.bytesToPreallocate(),
-                    DEFAULT_MAX_BUCKETS,
-                    fieldTypes
-                );
-                Aggregator aggregator = createAggregator(builder, context);
-                aggregator.preCollection();
-                searcher.search(context.query(), aggregator);
-                aggregator.postCollection();
-                InternalAggregation r = aggregator.buildTopLevel();
-                r = r.reduce(
-                    org.elasticsearch.common.collect.List.of(r),
-                    ReduceContext.forFinalReduction(
-                        context.bigArrays(),
-                        getMockScriptService(),
-                        context.multiBucketConsumer(),
-                        builder.buildPipelineTree()
-                    )
-                );
-                @SuppressWarnings("unchecked") // We'll get a cast error in the test if we're wrong here and that is ok
-                R result = (R) r;
-                Map<String, Object> debug = new HashMap<>();
-                aggregator.collectDebugInfo(debug::put);
-                verify.apply(result, aggregator.getClass(), debug);
-                verifyOutputFieldNames(builder, result);
-            }
+    /**
+     * Execute and aggregation and collect its {@link Aggregator#collectDebugInfo debug}
+     * information. Unlike {@link #testCase} this doesn't randomly create an
+     * {@link Aggregator} per leaf and perform partial reductions. It always
+     * creates a single {@link Aggregator} so we can get consistent debug info.
+     */
+    protected <R extends InternalAggregation> void debugTestCase(
+        AggregationBuilder builder,
+        Query query,
+        IndexSearcher searcher,
+        TriConsumer<R, Class<? extends Aggregator>, Map<String, Map<String, Object>>> verify,
+        MappedFieldType... fieldTypes
+    ) throws IOException {
+        // Don't use searchAndReduce because we only want a single aggregator.
+        IndexReaderContext ctx = searcher.getTopReaderContext();
+        CircuitBreakerService breakerService = new NoneCircuitBreakerService();
+        AggregationContext context = createAggregationContext(
+            searcher,
+            createIndexSettings(),
+            searcher.rewrite(query),
+            breakerService,
+            builder.bytesToPreallocate(),
+            DEFAULT_MAX_BUCKETS,
+            fieldTypes
+        );
+        Aggregator aggregator = createAggregator(builder, context);
+        aggregator.preCollection();
+        searcher.search(context.query(), aggregator);
+        aggregator.postCollection();
+        InternalAggregation r = aggregator.buildTopLevel();
+        r = r.reduce(
+            List.of(r),
+            ReduceContext.forFinalReduction(
+                context.bigArrays(),
+                getMockScriptService(),
+                context.multiBucketConsumer(),
+                builder.buildPipelineTree()
+            )
+        );
+        @SuppressWarnings("unchecked") // We'll get a cast error in the test if we're wrong here and that is ok
+        R result = (R) r;
+        Map<String, Map<String, Object>> debug = new HashMap<>();
+        collectDebugInfo("", aggregator, debug);
+        verify.apply(result, aggregator.getClass(), debug);
+        verifyOutputFieldNames(builder, result);
+    }
+
+    private void collectDebugInfo(String prefix, Aggregator aggregator, Map<String, Map<String, Object>> allDebug) {
+        Map<String, Object> debug = new HashMap<>();
+        aggregator.collectDebugInfo(debug::put);
+        allDebug.put(prefix + aggregator.name(), debug);
+        for (Aggregator sub : aggregator.subAggregators()) {
+            collectDebugInfo(aggregator.name() + ".", sub, allDebug);
         }
     }
 

--- a/test/framework/src/main/java/org/elasticsearch/search/aggregations/AggregatorTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/search/aggregations/AggregatorTestCase.java
@@ -634,7 +634,7 @@ public abstract class AggregatorTestCase extends ESTestCase {
         aggregator.postCollection();
         InternalAggregation r = aggregator.buildTopLevel();
         r = r.reduce(
-            List.of(r),
+            org.elasticsearch.common.collect.List.of(r),
             ReduceContext.forFinalReduction(
                 context.bigArrays(),
                 getMockScriptService(),


### PR DESCRIPTION
This speeds up the `terms` aggregation when it can't take the fancy
`filters` path, there is more than one segment, and any of those
segments have only a single value for the field. These three things are
super common.

Here are the performance change numbers:
```
|        50th percentile latency | date-histo-string-terms-via-global-ords | 3414.02 | 2632.01 | -782.015 | ms |
|        90th percentile latency | date-histo-string-terms-via-global-ords | 3470.91 | 2756.88 | -714.031 | ms |
|       100th percentile latency | date-histo-string-terms-via-global-ords | 3620.89 | 2875.79 | -745.102 | ms |
|   50th percentile service time | date-histo-string-terms-via-global-ords | 3410.15 | 2628.87 | -781.275 | ms |
|   90th percentile service time | date-histo-string-terms-via-global-ords | 3467.36 | 2752.43 | -714.933 | ms |   20%!!!!
|  100th percentile service time | date-histo-string-terms-via-global-ords | 3617.71 | 2871.63 | -746.083 | ms |
```

This works by hooking global ordinals into `DocValues.unwrapSingleton`.
Without this you could unwrap singletons *if* the segment's ordinals
aligned exactly with the global ordinals. If they didn't we'd return an
doc values iterator that you can't unwrap. Even if the segment ordinals
were singletons.

That speeds up the terms aggregator because we have a fast path we can
take if we have singletons. It was previously only working if we had a
single segment. Or if the segment's ordinals lined up exactly. Which,
for low cardinality fields is fairly common. So they might not benefit
from this quite as much as high cardinality fields.

Closes #71086
