### PR TITLE
Track index details in SnapshotInfo

### DIFF
--- a/docs/reference/snapshot-restore/apis/get-snapshot-api.asciidoc
+++ b/docs/reference/snapshot-restore/apis/get-snapshot-api.asciidoc
@@ -86,9 +86,17 @@ If `true`, the request ignores snapshots that are unavailable, such as those tha
 
 `verbose`::
 (Optional, Boolean)
-If `true`, returns all available information about a snapshot. Defaults to `true`.
-+
-If `false`, omits additional information about the snapshot, such as version information, start and end times, and the number of snapshotted shards.
+If `true`, returns additional information about each snapshot such as the
+version of Elasticsearch which took the snapshot, the start and end times of
+the snapshot, and the number of shards snapshotted. Defaults to `true`. If
+`false`, omits the additional information.
+
+`index_details`::
+(Optional, Boolean)
+If `true`, returns additional information about each index in the snapshot
+comprising the number of shards in the index, the total size of the index in
+bytes, and the maximum number of segments per shard in the index. Defaults to
+`false`, meaning that this information is omitted.
 
 [role="child_attributes"]
 [[get-snapshot-api-response-body]]
@@ -113,6 +121,33 @@ Build ID of the {es} version used to create the snapshot.
 `indices`::
 (array)
 List of indices included in the snapshot.
+
+`index_details`::
+(object)
+Details of each index in the snapshot, keyed by index name. Only present if the
+`?index_details` query parameter is set, and only contains details for indices
+that were completely snapshotted in a sufficiently recent version of {es}.
++
+.Properties of `index_details`
+[%collapsible%open]
+====
+`shard_count`::
+(integer)
+Number of shards in this index.
+
+`size`::
+(string)
+Total size of all shards in this index. Only present if the `?human` query
+paramter is set.
+
+`size_in_bytes`::
+(long)
+Total size of all shards in this index, in bytes.
+
+`max_segments_per_shard`::
+(integer)
+Maximum number of segments per shard in this index snapshot.
+====
 
 `data_streams`::
 (array)

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/snapshot.get.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/snapshot.get.json
@@ -38,6 +38,10 @@
         "type":"boolean",
         "description":"Whether to ignore unavailable snapshots, defaults to false which means a SnapshotMissingException is thrown"
       },
+      "index_details":{
+        "type":"boolean",
+        "description":"Whether to include details of each index in the snapshot, if those details are available. Defaults to false."
+      },
       "verbose":{
         "type":"boolean",
         "description":"Whether to show verbose snapshot info or only show the basic info found in the repository index blob"

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/snapshot.get/10_basic.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/snapshot.get/10_basic.yml
@@ -195,12 +195,17 @@ setup:
       snapshot.get:
         repository: test_repo_get_1
         snapshot: test_snapshot_with_metadata
+        human: true
 
   - is_true: responses.0.snapshots
   - match: { responses.0.snapshots.0.snapshot: test_snapshot_with_metadata }
   - match: { responses.0.snapshots.0.state: SUCCESS }
   - match: { responses.0.snapshots.0.metadata.taken_by: test }
   - match: { responses.0.snapshots.0.metadata.foo.bar: baz }
+  - gt:  { responses.0.snapshots.0.index_details.test_index.shard_count: 0 }
+  - gt:  { responses.0.snapshots.0.index_details.test_index.size_in_bytes: 0 }
+  - gte: { responses.0.snapshots.0.index_details.test_index.max_segments_per_shard: 0 }
+  - is_true: responses.0.snapshots.0.index_details.test_index.size
 
   - do:
       snapshot.delete:

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/snapshot.get/10_basic.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/snapshot.get/10_basic.yml
@@ -195,7 +195,6 @@ setup:
       snapshot.get:
         repository: test_repo_get_1
         snapshot: test_snapshot_with_metadata
-        human: true
 
   - is_true: responses.0.snapshots
   - match: { responses.0.snapshots.0.snapshot: test_snapshot_with_metadata }

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/snapshot.get/10_basic.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/snapshot.get/10_basic.yml
@@ -202,6 +202,43 @@ setup:
   - match: { responses.0.snapshots.0.state: SUCCESS }
   - match: { responses.0.snapshots.0.metadata.taken_by: test }
   - match: { responses.0.snapshots.0.metadata.foo.bar: baz }
+  - is_false: responses.0.snapshots.0.index_details
+
+  - do:
+      snapshot.delete:
+        repository: test_repo_get_1
+        snapshot: test_snapshot_with_metadata
+
+---
+"Get snapshot info with index details":
+  - skip:
+      version: " - 7.99.99"
+      reason: "8.0 changes get snapshots response format"
+
+  - do:
+      indices.create:
+        index: test_index
+        body:
+          settings:
+            number_of_shards:   1
+            number_of_replicas: 0
+
+  - do:
+      snapshot.create:
+        repository: test_repo_get_1
+        snapshot: test_snapshot_with_metadata
+        wait_for_completion: true
+
+  - do:
+      snapshot.get:
+        repository: test_repo_get_1
+        snapshot: test_snapshot_with_metadata
+        index_details: true
+        human: true
+
+  - is_true: responses.0.snapshots
+  - match: { responses.0.snapshots.0.snapshot: test_snapshot_with_metadata }
+  - match: { responses.0.snapshots.0.state: SUCCESS }
   - gt:  { responses.0.snapshots.0.index_details.test_index.shard_count: 0 }
   - gt:  { responses.0.snapshots.0.index_details.test_index.size_in_bytes: 0 }
   - gte: { responses.0.snapshots.0.index_details.test_index.max_segments_per_shard: 0 }

--- a/server/src/internalClusterTest/java/org/elasticsearch/snapshots/CloneSnapshotIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/snapshots/CloneSnapshotIT.java
@@ -19,6 +19,7 @@ import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.util.MockBigArrays;
 import org.elasticsearch.index.IndexNotFoundException;
 import org.elasticsearch.repositories.RepositoryData;
+import org.elasticsearch.repositories.ShardSnapshotResult;
 import org.elasticsearch.snapshots.mockstore.MockRepository;
 import org.elasticsearch.test.ESIntegTestCase;
 
@@ -82,8 +83,9 @@ public class CloneSnapshotIT extends AbstractSnapshotIntegTestCase {
         } else {
             currentShardGen = repositoryData.shardGenerations().getShardGen(indexId, shardId);
         }
-        final String newShardGeneration = PlainActionFuture.get(f -> repository.cloneShardSnapshot(
+        final ShardSnapshotResult shardSnapshotResult = PlainActionFuture.get(f -> repository.cloneShardSnapshot(
                 sourceSnapshotInfo.snapshotId(), targetSnapshotId, repositoryShardId, currentShardGen, f));
+        final String newShardGeneration = shardSnapshotResult.getGeneration();
 
         if (useBwCFormat) {
             final long gen = Long.parseLong(newShardGeneration);
@@ -107,9 +109,11 @@ public class CloneSnapshotIT extends AbstractSnapshotIntegTestCase {
         assertTrue(snapshotFiles.get(0).isSame(snapshotFiles.get(1)));
 
         // verify that repeated cloning is idempotent
-        final String newShardGeneration2 = PlainActionFuture.get(f -> repository.cloneShardSnapshot(
+        final ShardSnapshotResult shardSnapshotResult2 = PlainActionFuture.get(f -> repository.cloneShardSnapshot(
                 sourceSnapshotInfo.snapshotId(), targetSnapshotId, repositoryShardId, newShardGeneration, f));
-        assertEquals(newShardGeneration, newShardGeneration2);
+        assertEquals(newShardGeneration, shardSnapshotResult2.getGeneration());
+        assertEquals(shardSnapshotResult.getSegmentCount(), shardSnapshotResult2.getSegmentCount());
+        assertEquals(shardSnapshotResult.getSize(), shardSnapshotResult2.getSize());
     }
 
     public void testCloneSnapshotIndex() throws Exception {

--- a/server/src/internalClusterTest/java/org/elasticsearch/snapshots/RepositoryFilterUserMetadataIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/snapshots/RepositoryFilterUserMetadataIT.java
@@ -27,6 +27,7 @@ import org.elasticsearch.repositories.IndexId;
 import org.elasticsearch.repositories.Repository;
 import org.elasticsearch.repositories.RepositoryData;
 import org.elasticsearch.repositories.ShardGenerations;
+import org.elasticsearch.repositories.ShardSnapshotResult;
 import org.elasticsearch.repositories.fs.FsRepository;
 import org.elasticsearch.test.ESIntegTestCase;
 
@@ -90,7 +91,7 @@ public class RepositoryFilterUserMetadataIT extends ESIntegTestCase {
                     public void snapshotShard(Store store, MapperService mapperService, SnapshotId snapshotId, IndexId indexId,
                                               IndexCommit snapshotIndexCommit, String shardStateIdentifier,
                                               IndexShardSnapshotStatus snapshotStatus, Version repositoryMetaVersion,
-                                              Map<String, Object> userMetadata, ActionListener<String> listener) {
+                                              Map<String, Object> userMetadata, ActionListener<ShardSnapshotResult> listener) {
                         assertThat(userMetadata, is(Collections.singletonMap(MOCK_FILTERED_META, initialMetaValue)));
                         super.snapshotShard(store, mapperService, snapshotId, indexId, snapshotIndexCommit, shardStateIdentifier,
                             snapshotStatus, repositoryMetaVersion, userMetadata, listener);

--- a/server/src/internalClusterTest/java/org/elasticsearch/snapshots/SnapshotStatusApisIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/snapshots/SnapshotStatusApisIT.java
@@ -20,6 +20,7 @@ import org.elasticsearch.action.admin.cluster.snapshots.status.SnapshotsStatusRe
 import org.elasticsearch.action.admin.cluster.snapshots.status.SnapshotsStatusResponse;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.cluster.SnapshotsInProgress;
+import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.ByteSizeUnit;
@@ -41,8 +42,10 @@ import java.util.stream.Collectors;
 
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.anEmptyMap;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
@@ -170,6 +173,7 @@ public class SnapshotStatusApisIT extends AbstractSnapshotIntegTestCase {
         final SnapshotInfo found = snapshotInfos.get(0);
         assertThat(found.snapshotId(), is(snapshotInfo.snapshotId()));
         assertThat(found.state(), is(SnapshotState.SUCCESS));
+        assertThat(found.indexSnapshotDetails(), anEmptyMap());
     }
 
     /**
@@ -281,6 +285,8 @@ public class SnapshotStatusApisIT extends AbstractSnapshotIntegTestCase {
         logger.info("--> create an index and index some documents");
         final String indexName = "test-idx";
         createIndexWithRandomDocs(indexName, 10);
+        final int numberOfShards = IndexMetadata.INDEX_NUMBER_OF_SHARDS_SETTING.get(
+            client.admin().indices().prepareGetSettings(indexName).get().getIndexToSettings().get(indexName));
 
         for (int repoIndex = 0; repoIndex < randomIntBetween(2, 5); repoIndex++) {
             final String repoName = "repo" + repoIndex;
@@ -307,7 +313,13 @@ public class SnapshotStatusApisIT extends AbstractSnapshotIntegTestCase {
                         .setWaitForCompletion(true)
                         .setIndices(indexName)
                         .get();
-                assertThat(createSnapshotResponse.getSnapshotInfo().successfulShards(), greaterThan(0));
+                final SnapshotInfo snapshotInfo = createSnapshotResponse.getSnapshotInfo();
+                assertThat(snapshotInfo.successfulShards(), greaterThan(0));
+                assertTrue(snapshotInfo.indexSnapshotDetails().containsKey(indexName));
+                final SnapshotInfo.IndexSnapshotDetails indexSnapshotDetails = snapshotInfo.indexSnapshotDetails().get(indexName);
+                assertThat(indexSnapshotDetails.getShardCount(), equalTo(numberOfShards));
+                assertThat(indexSnapshotDetails.getMaxSegmentsPerShard(), greaterThanOrEqualTo(1));
+                assertThat(indexSnapshotDetails.getSize().getBytes(), greaterThan(0L));
                 snapshotNames.add(snapshotName);
             }
         }

--- a/server/src/main/java/org/elasticsearch/index/snapshots/blobstore/BlobStoreIndexShardSnapshot.java
+++ b/server/src/main/java/org/elasticsearch/index/snapshots/blobstore/BlobStoreIndexShardSnapshot.java
@@ -444,6 +444,10 @@ public class BlobStoreIndexShardSnapshot implements ToXContentFragment {
      * Returns total size of all files that where snapshotted
      */
     public long totalSize() {
+        return totalSize(indexFiles);
+    }
+
+    public static long totalSize(List<FileInfo> indexFiles) {
         return indexFiles.stream().mapToLong(fi -> fi.metadata().length()).sum();
     }
 

--- a/server/src/main/java/org/elasticsearch/index/snapshots/blobstore/SnapshotFiles.java
+++ b/server/src/main/java/org/elasticsearch/index/snapshots/blobstore/SnapshotFiles.java
@@ -117,6 +117,10 @@ public class SnapshotFiles {
         return physicalFiles.get(physicalName);
     }
 
+    public long totalSize() {
+        return BlobStoreIndexShardSnapshot.totalSize(indexFiles);
+    }
+
     @Override
     public String toString() {
         return "SnapshotFiles{snapshot=[" + snapshot + "], shardStateIdentifier=[" + shardStateIdentifier + "], indexFiles=" + indexFiles

--- a/server/src/main/java/org/elasticsearch/repositories/FilterRepository.java
+++ b/server/src/main/java/org/elasticsearch/repositories/FilterRepository.java
@@ -116,7 +116,8 @@ public class FilterRepository implements Repository {
     @Override
     public void snapshotShard(Store store, MapperService mapperService, SnapshotId snapshotId, IndexId indexId,
                               IndexCommit snapshotIndexCommit, String shardStateIdentifier, IndexShardSnapshotStatus snapshotStatus,
-                              Version repositoryMetaVersion, Map<String, Object> userMetadata, ActionListener<String> listener) {
+                              Version repositoryMetaVersion, Map<String, Object> userMetadata,
+                              ActionListener<ShardSnapshotResult> listener) {
         in.snapshotShard(store, mapperService, snapshotId, indexId, snapshotIndexCommit, shardStateIdentifier, snapshotStatus,
             repositoryMetaVersion, userMetadata, listener);
     }
@@ -144,7 +145,7 @@ public class FilterRepository implements Repository {
 
     @Override
     public void cloneShardSnapshot(SnapshotId source, SnapshotId target, RepositoryShardId shardId, String shardGeneration,
-                                   ActionListener<String> listener) {
+                                   ActionListener<ShardSnapshotResult> listener) {
         in.cloneShardSnapshot(source, target, shardId, shardGeneration, listener);
     }
 

--- a/server/src/main/java/org/elasticsearch/repositories/Repository.java
+++ b/server/src/main/java/org/elasticsearch/repositories/Repository.java
@@ -202,9 +202,17 @@ public interface Repository extends LifecycleComponent {
      * @param userMetadata          user metadata of the snapshot found in {@link SnapshotsInProgress.Entry#userMetadata()}
      * @param listener              listener invoked on completion
      */
-    void snapshotShard(Store store, MapperService mapperService, SnapshotId snapshotId, IndexId indexId, IndexCommit snapshotIndexCommit,
-                       @Nullable String shardStateIdentifier, IndexShardSnapshotStatus snapshotStatus, Version repositoryMetaVersion,
-                       Map<String, Object> userMetadata, ActionListener<String> listener);
+    void snapshotShard(
+            Store store,
+            MapperService mapperService,
+            SnapshotId snapshotId,
+            IndexId indexId,
+            IndexCommit snapshotIndexCommit,
+            @Nullable String shardStateIdentifier,
+            IndexShardSnapshotStatus snapshotStatus,
+            Version repositoryMetaVersion,
+            Map<String, Object> userMetadata,
+            ActionListener<ShardSnapshotResult> listener);
 
     /**
      * Restores snapshot of the shard.
@@ -262,8 +270,12 @@ public interface Repository extends LifecycleComponent {
      * @param shardGeneration shard generation in repo
      * @param listener        listener to complete with new shard generation once clone has completed
      */
-    void cloneShardSnapshot(SnapshotId source, SnapshotId target, RepositoryShardId shardId, @Nullable String shardGeneration,
-                            ActionListener<String> listener);
+    void cloneShardSnapshot(
+            SnapshotId source,
+            SnapshotId target,
+            RepositoryShardId shardId,
+            @Nullable String shardGeneration,
+            ActionListener<ShardSnapshotResult> listener);
 
     /**
      * Hook that allows a repository to filter the user supplied snapshot metadata in {@link SnapshotsInProgress.Entry#userMetadata()}

--- a/server/src/main/java/org/elasticsearch/repositories/ShardSnapshotResult.java
+++ b/server/src/main/java/org/elasticsearch/repositories/ShardSnapshotResult.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.repositories;
+
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.common.unit.ByteSizeValue;
+
+import java.io.IOException;
+import java.util.Objects;
+
+/**
+ * The details of a successful shard-level snapshot that are used to build the overall snapshot during finalization.
+ */
+public class ShardSnapshotResult implements Writeable {
+
+    private final String generation;
+
+    private final ByteSizeValue size;
+
+    private final int segmentCount;
+
+    /**
+     * @param generation   the shard generation UUID, which uniquely identifies the specific snapshot of the shard
+     * @param size         the total size of all the blobs that make up the shard snapshot, or equivalently, the size of the shard when
+     *                     restored
+     * @param segmentCount the number of segments in this shard snapshot
+     */
+    public ShardSnapshotResult(String generation, ByteSizeValue size, int segmentCount) {
+        this.generation = Objects.requireNonNull(generation);
+        this.size = Objects.requireNonNull(size);
+        assert segmentCount >= 0;
+        this.segmentCount = segmentCount;
+    }
+
+    public ShardSnapshotResult(StreamInput in) throws IOException {
+        generation = in.readString();
+        size = new ByteSizeValue(in);
+        segmentCount = in.readVInt();
+    }
+
+    /**
+     * @return the shard generation UUID, which uniquely identifies the specific snapshot of the shard
+     */
+    public String getGeneration() {
+        return generation;
+    }
+
+    /**
+     * @return the total size of all the blobs that make up the shard snapshot, or equivalently, the size of the shard when restored
+     */
+    public ByteSizeValue getSize() {
+        return size;
+    }
+
+    /**
+     * @return the number of segments in this shard snapshot
+     */
+    public int getSegmentCount() {
+        return segmentCount;
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeString(generation);
+        size.writeTo(out);
+        out.writeVInt(segmentCount);
+    }
+}

--- a/server/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
+++ b/server/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
@@ -103,6 +103,7 @@ import org.elasticsearch.repositories.RepositoryShardId;
 import org.elasticsearch.repositories.RepositoryStats;
 import org.elasticsearch.repositories.RepositoryVerificationException;
 import org.elasticsearch.repositories.ShardGenerations;
+import org.elasticsearch.repositories.ShardSnapshotResult;
 import org.elasticsearch.snapshots.AbortedSnapshotException;
 import org.elasticsearch.snapshots.SnapshotException;
 import org.elasticsearch.snapshots.SnapshotId;
@@ -416,7 +417,7 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
 
     @Override
     public void cloneShardSnapshot(SnapshotId source, SnapshotId target, RepositoryShardId shardId,
-                                   @Nullable String shardGeneration, ActionListener<String> listener) {
+                                   @Nullable String shardGeneration, ActionListener<ShardSnapshotResult> listener) {
         if (isReadOnly()) {
             listener.onFailure(new RepositoryException(metadata.name(), "cannot clone shard snapshot on a readonly repository"));
             return;
@@ -460,7 +461,9 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
             }
             if (existingTargetFiles != null) {
                 if (existingTargetFiles.isSame(sourceFiles)) {
-                    return existingShardGen;
+                    return new ShardSnapshotResult(existingShardGen,
+                            getTotalSize(existingTargetFiles.indexFiles()),
+                            getSegmentInfoFileCount(existingTargetFiles.indexFiles()));
                 }
                 throw new RepositoryException(metadata.name(), "Can't create clone of [" + shardId + "] for snapshot ["
                         + target + "]. A snapshot by that name already exists for this shard.");
@@ -472,8 +475,17 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
                     shardContainer, target.getUUID(), compress, bigArrays);
             INDEX_SHARD_SNAPSHOTS_FORMAT.write(existingSnapshots.withClone(source.getName(), target.getName()), shardContainer, newGen,
                     compress, bigArrays);
-            return newGen;
+            return new ShardSnapshotResult(newGen, getTotalSize(sourceMeta.indexFiles()), getSegmentInfoFileCount(sourceMeta.indexFiles()));
         }));
+    }
+
+    private static ByteSizeValue getTotalSize(List<BlobStoreIndexShardSnapshot.FileInfo> indexFiles) {
+        return ByteSizeValue.ofBytes(indexFiles.stream().mapToLong(BlobStoreIndexShardSnapshot.FileInfo::length).sum());
+    }
+
+    private static int getSegmentInfoFileCount(List<BlobStoreIndexShardSnapshot.FileInfo> indexFiles) {
+        //noinspection ConstantConditions
+        return Math.toIntExact(Math.min(Integer.MAX_VALUE, indexFiles.stream().filter(fi -> fi.physicalName().endsWith(".si")).count()));
     }
 
     // Inspects all cluster state elements that contain a hint about what the current repository generation is and updates
@@ -2089,7 +2101,8 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
     @Override
     public void snapshotShard(Store store, MapperService mapperService, SnapshotId snapshotId, IndexId indexId,
                               IndexCommit snapshotIndexCommit, String shardStateIdentifier, IndexShardSnapshotStatus snapshotStatus,
-                              Version repositoryMetaVersion, Map<String, Object> userMetadata, ActionListener<String> listener) {
+                              Version repositoryMetaVersion, Map<String, Object> userMetadata,
+                              ActionListener<ShardSnapshotResult> listener) {
         if (isReadOnly()) {
             listener.onFailure(new RepositoryException(metadata.name(), "cannot snapshot shard on a readonly repository"));
             return;
@@ -2281,8 +2294,12 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
                     throw new IndexShardSnapshotFailedException(shardId, "Failed to write commit point", e);
                 }
                 afterWriteSnapBlob.run();
-                snapshotStatus.moveToDone(threadPool.absoluteTimeInMillis(), indexGeneration);
-                listener.onResponse(indexGeneration);
+                final ShardSnapshotResult shardSnapshotResult = new ShardSnapshotResult(
+                        indexGeneration,
+                        getTotalSize(indexCommitPointFiles),
+                        snapshotIndexCommit.getSegmentCount());
+                snapshotStatus.moveToDone(threadPool.absoluteTimeInMillis(), shardSnapshotResult);
+                listener.onResponse(shardSnapshotResult);
             }, listener::onFailure);
             if (indexIncrementalFileCount == 0) {
                 allFilesUploadedListener.onResponse(Collections.emptyList());

--- a/server/src/main/java/org/elasticsearch/rest/action/admin/cluster/RestGetSnapshotsAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/admin/cluster/RestGetSnapshotsAction.java
@@ -16,10 +16,13 @@ import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.rest.action.RestToXContentListener;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 
 import static org.elasticsearch.client.Requests.getSnapshotsRequest;
 import static org.elasticsearch.rest.RestRequest.Method.GET;
+import static org.elasticsearch.snapshots.SnapshotInfo.INDEX_DETAILS_XCONTENT_PARAM;
 
 /**
  * Returns information about snapshot
@@ -34,6 +37,11 @@ public class RestGetSnapshotsAction extends BaseRestHandler {
     @Override
     public String getName() {
         return "get_snapshots_action";
+    }
+
+    @Override
+    protected Set<String> responseParams() {
+        return Collections.singleton(INDEX_DETAILS_XCONTENT_PARAM);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/snapshots/SnapshotInfo.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/SnapshotInfo.java
@@ -17,9 +17,11 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.time.DateFormatter;
+import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.xcontent.ObjectParser;
 import org.elasticsearch.common.xcontent.ToXContent;
+import org.elasticsearch.common.xcontent.ToXContentObject;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.XContentParserUtils;
@@ -32,6 +34,7 @@ import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -70,6 +73,7 @@ public final class SnapshotInfo implements Comparable<SnapshotInfo>, ToXContent,
     private static final String INCLUDE_GLOBAL_STATE = "include_global_state";
     private static final String USER_METADATA = "metadata";
     private static final String FEATURE_STATES = "feature_states";
+    private static final String INDEX_DETAILS = "index_details";
 
     private static final Comparator<SnapshotInfo> COMPARATOR =
         Comparator.comparing(SnapshotInfo::startTime).thenComparing(SnapshotInfo::snapshotId);
@@ -172,7 +176,7 @@ public final class SnapshotInfo implements Comparable<SnapshotInfo>, ToXContent,
             }
 
             return new SnapshotInfo(snapshotId, indices, dataStreams, featureStates, reason, version, startTime, endTime, totalShards,
-                successfulShards, shardFailures, includeGlobalState, userMetadata, snapshotState
+                successfulShards, shardFailures, includeGlobalState, userMetadata, snapshotState, Collections.emptyMap()
             );
         }
     }
@@ -259,36 +263,127 @@ public final class SnapshotInfo implements Comparable<SnapshotInfo>, ToXContent,
 
     private final List<SnapshotShardFailure> shardFailures;
 
-    public SnapshotInfo(SnapshotId snapshotId, List<String> indices, List<String> dataStreams, List<SnapshotFeatureInfo> featureStates,
-                        SnapshotState state) {
-        this(snapshotId, indices, dataStreams, featureStates, null, null, 0L, 0L, 0, 0, Collections.emptyList(), null, null, state);
+    private final Map<String, IndexSnapshotDetails> indexSnapshotDetails;
+
+    public SnapshotInfo(
+            SnapshotId snapshotId,
+            List<String> indices,
+            List<String> dataStreams,
+            List<SnapshotFeatureInfo> featureStates,
+            SnapshotState state) {
+        this(
+                snapshotId,
+                indices,
+                dataStreams,
+                featureStates,
+                null,
+                null,
+                0L,
+                0L,
+                0,
+                0,
+                Collections.emptyList(),
+                null,
+                null,
+                state,
+                Collections.emptyMap()
+        );
     }
 
-    public SnapshotInfo(SnapshotId snapshotId, List<String> indices, List<String> dataStreams, List<SnapshotFeatureInfo> featureStates,
-                        Version version, SnapshotState state) {
-        this(snapshotId, indices, dataStreams, featureStates, null, version, 0L, 0L, 0, 0, Collections.emptyList(), null, null, state);
+    public SnapshotInfo(
+            SnapshotId snapshotId,
+            List<String> indices,
+            List<String> dataStreams,
+            List<SnapshotFeatureInfo> featureStates,
+            Version version,
+            SnapshotState state) {
+        this(
+                snapshotId,
+                indices,
+                dataStreams,
+                featureStates,
+                null,
+                version,
+                0L,
+                0L,
+                0,
+                0,
+                Collections.emptyList(),
+                null,
+                null,
+                state,
+                Collections.emptyMap()
+        );
     }
 
     public SnapshotInfo(SnapshotsInProgress.Entry entry) {
-        this(entry.snapshot().getSnapshotId(),
-            entry.indices().stream().map(IndexId::getName).collect(Collectors.toList()), entry.dataStreams(), entry.featureStates(),
-            null, Version.CURRENT, entry.startTime(), 0L, 0, 0, Collections.emptyList(), entry.includeGlobalState(), entry.userMetadata(),
-            SnapshotState.IN_PROGRESS
+        this(
+                entry.snapshot().getSnapshotId(),
+                entry.indices().stream().map(IndexId::getName).collect(Collectors.toList()),
+                entry.dataStreams(),
+                entry.featureStates(),
+                null,
+                Version.CURRENT,
+                entry.startTime(),
+                0L,
+                0,
+                0,
+                Collections.emptyList(),
+                entry.includeGlobalState(),
+                entry.userMetadata(),
+                SnapshotState.IN_PROGRESS,
+                Collections.emptyMap()
         );
     }
 
-    public SnapshotInfo(SnapshotId snapshotId, List<String> indices, List<String> dataStreams, List<SnapshotFeatureInfo> featureStates,
-                        String reason, long endTime, int totalShards, List<SnapshotShardFailure> shardFailures, Boolean includeGlobalState,
-                        Map<String, Object> userMetadata, long startTime) {
-        this(snapshotId, indices, dataStreams, featureStates, reason, Version.CURRENT, startTime, endTime, totalShards,
-            totalShards - shardFailures.size(), shardFailures, includeGlobalState, userMetadata, snapshotState(reason, shardFailures)
+    public SnapshotInfo(
+            SnapshotId snapshotId,
+            List<String> indices,
+            List<String> dataStreams,
+            List<SnapshotFeatureInfo> featureStates,
+            String reason,
+            long endTime,
+            int totalShards,
+            List<SnapshotShardFailure> shardFailures,
+            Boolean includeGlobalState,
+            Map<String, Object> userMetadata,
+            long startTime,
+            Map<String, IndexSnapshotDetails> indexSnapshotDetails) {
+        this(
+                snapshotId,
+                indices,
+                dataStreams,
+                featureStates,
+                reason,
+                Version.CURRENT,
+                startTime,
+                endTime,
+                totalShards,
+                totalShards - shardFailures.size(),
+                shardFailures,
+                includeGlobalState,
+                userMetadata,
+                snapshotState(reason, shardFailures),
+                indexSnapshotDetails
         );
     }
 
-    SnapshotInfo(SnapshotId snapshotId, List<String> indices, List<String> dataStreams, List<SnapshotFeatureInfo> featureStates,
-                 String reason, Version version, long startTime, long endTime, int totalShards, int successfulShards,
-                 List<SnapshotShardFailure> shardFailures, Boolean includeGlobalState, Map<String, Object> userMetadata,
-                 SnapshotState state) {
+    SnapshotInfo(
+            SnapshotId snapshotId,
+            List<String> indices,
+            List<String> dataStreams,
+            List<SnapshotFeatureInfo> featureStates,
+            String reason,
+            Version version,
+            long startTime,
+            long endTime,
+            int totalShards,
+            int successfulShards,
+            List<SnapshotShardFailure> shardFailures,
+            Boolean includeGlobalState,
+            Map<String, Object> userMetadata,
+            SnapshotState state,
+            Map<String, IndexSnapshotDetails> indexSnapshotDetails) {
         this.snapshotId = Objects.requireNonNull(snapshotId);
         this.indices = Collections.unmodifiableList(Objects.requireNonNull(indices));
         this.dataStreams = Collections.unmodifiableList(Objects.requireNonNull(dataStreams));
@@ -303,6 +398,7 @@ public final class SnapshotInfo implements Comparable<SnapshotInfo>, ToXContent,
         this.shardFailures = Objects.requireNonNull(shardFailures);
         this.includeGlobalState = includeGlobalState;
         this.userMetadata = userMetadata;
+        this.indexSnapshotDetails = Collections.unmodifiableMap(Objects.requireNonNull(indexSnapshotDetails));
     }
 
     /**
@@ -323,6 +419,11 @@ public final class SnapshotInfo implements Comparable<SnapshotInfo>, ToXContent,
         userMetadata = in.readMap();
         dataStreams = in.readStringList();
         featureStates = Collections.unmodifiableList(in.readList(SnapshotFeatureInfo::new));
+        if (in.getVersion().onOrAfter(Version.V_8_0_0)) {
+            this.indexSnapshotDetails = in.readMap(StreamInput::readString, IndexSnapshotDetails::new);
+        } else {
+            this.indexSnapshotDetails = Collections.emptyMap();
+        }
     }
 
     /**
@@ -467,6 +568,13 @@ public final class SnapshotInfo implements Comparable<SnapshotInfo>, ToXContent,
     }
 
     /**
+     * @return details of each index in the snapshot, if available, or an empty map otherwise.
+     */
+    public Map<String, IndexSnapshotDetails> indexSnapshotDetails() {
+        return indexSnapshotDetails;
+    }
+
+    /**
      * Compares two snapshots by their start time; if the start times are the same, then
      * compares the two snapshots by their snapshot ids.
      */
@@ -490,6 +598,7 @@ public final class SnapshotInfo implements Comparable<SnapshotInfo>, ToXContent,
             ", version=" + version +
             ", shardFailures=" + shardFailures +
             ", featureStates=" + featureStates +
+            ", indexSnapshotDetails=" + indexSnapshotDetails +
             '}';
     }
 
@@ -528,6 +637,16 @@ public final class SnapshotInfo implements Comparable<SnapshotInfo>, ToXContent,
             builder.value(index);
         }
         builder.endArray();
+
+        if (indexSnapshotDetails.isEmpty() == false) {
+            builder.startObject(INDEX_DETAILS);
+            for (Map.Entry<String, IndexSnapshotDetails> entry : indexSnapshotDetails.entrySet()) {
+                builder.field(entry.getKey());
+                entry.getValue().toXContent(builder, params);
+            }
+            builder.endObject();
+        }
+
         builder.startArray(DATA_STREAMS);
         for (String dataStream : dataStreams) {
             builder.value(dataStream);
@@ -619,6 +738,13 @@ public final class SnapshotInfo implements Comparable<SnapshotInfo>, ToXContent,
         }
         builder.endArray();
 
+        builder.startObject(INDEX_DETAILS);
+        for (Map.Entry<String, IndexSnapshotDetails> entry : indexSnapshotDetails.entrySet()) {
+            builder.field(entry.getKey());
+            entry.getValue().toXContent(builder, params);
+        }
+        builder.endObject();
+
         builder.endObject();
         return builder;
     }
@@ -644,6 +770,7 @@ public final class SnapshotInfo implements Comparable<SnapshotInfo>, ToXContent,
         Map<String, Object> userMetadata = null;
         List<SnapshotShardFailure> shardFailures = Collections.emptyList();
         List<SnapshotFeatureInfo> featureStates = Collections.emptyList();
+        Map<String, IndexSnapshotDetails> indexSnapshotDetails = null;
         if (parser.currentToken() == null) { // fresh parser? move to the first token
             parser.nextToken();
         }
@@ -711,6 +838,8 @@ public final class SnapshotInfo implements Comparable<SnapshotInfo>, ToXContent,
                     } else if (token == XContentParser.Token.START_OBJECT) {
                         if (USER_METADATA.equals(currentFieldName)) {
                             userMetadata = parser.map();
+                        } else if (INDEX_DETAILS.equals(currentFieldName)) {
+                            indexSnapshotDetails = parser.map(HashMap::new, IndexSnapshotDetails::fromXContent);
                         } else {
                             // It was probably created by newer version - ignoring
                             parser.skipChildren();
@@ -736,8 +865,8 @@ public final class SnapshotInfo implements Comparable<SnapshotInfo>, ToXContent,
                                 shardFailures,
                                 includeGlobalState,
                                 userMetadata,
-                                state
-        );
+                                state,
+                                indexSnapshotDetails == null ? Collections.emptyMap() : indexSnapshotDetails);
     }
 
     @Override
@@ -766,6 +895,10 @@ public final class SnapshotInfo implements Comparable<SnapshotInfo>, ToXContent,
         out.writeMap(userMetadata);
         out.writeStringCollection(dataStreams);
         out.writeList(featureStates);
+
+        if (out.getVersion().onOrAfter(Version.V_8_0_0)) {
+            out.writeMap(indexSnapshotDetails, StreamOutput::writeString, (stream, value) -> value.writeTo(stream));
+        }
     }
 
     private static SnapshotState snapshotState(final String reason, final List<SnapshotShardFailure> shardFailures) {
@@ -798,14 +931,124 @@ public final class SnapshotInfo implements Comparable<SnapshotInfo>, ToXContent,
             Objects.equals(version, that.version) &&
             Objects.equals(shardFailures, that.shardFailures) &&
             Objects.equals(userMetadata, that.userMetadata) &&
-            Objects.equals(featureStates, that.featureStates);
+            Objects.equals(featureStates, that.featureStates) &&
+            Objects.equals(indexSnapshotDetails, that.indexSnapshotDetails);
     }
 
     @Override
     public int hashCode() {
         return Objects.hash(snapshotId, state, reason, indices, dataStreams, startTime, endTime,
                 totalShards, successfulShards, includeGlobalState, version, shardFailures, userMetadata,
-            featureStates);
+                featureStates, indexSnapshotDetails);
+    }
+
+    public static class IndexSnapshotDetails implements ToXContentObject, Writeable {
+        private static final String SHARD_COUNT = "shard_count";
+        private static final String SIZE = "size_in_bytes";
+        private static final String MAX_SEGMENTS_PER_SHARD = "max_segments_per_shard";
+
+        private final int shardCount;
+        private final ByteSizeValue size;
+        private final int maxSegmentsPerShard;
+
+        public IndexSnapshotDetails(int shardCount, ByteSizeValue size, int maxSegmentsPerShard) {
+            this.shardCount = shardCount;
+            this.size = Objects.requireNonNull(size);
+            this.maxSegmentsPerShard = maxSegmentsPerShard;
+        }
+
+        public IndexSnapshotDetails(StreamInput in) throws IOException {
+            shardCount = in.readVInt();
+            size = new ByteSizeValue(in);
+            maxSegmentsPerShard = in.readVInt();
+        }
+
+        public int getShardCount() {
+            return shardCount;
+        }
+
+        public ByteSizeValue getSize() {
+            return size;
+        }
+
+        public int getMaxSegmentsPerShard() {
+            return maxSegmentsPerShard;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            IndexSnapshotDetails that = (IndexSnapshotDetails) o;
+            return shardCount == that.shardCount && maxSegmentsPerShard == that.maxSegmentsPerShard && size.equals(that.size);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(shardCount, size, maxSegmentsPerShard);
+        }
+
+        @Override
+        public String toString() {
+            return "IndexSnapshotDetails{" +
+                    "shardCount=" + shardCount +
+                    ", size=" + size +
+                    ", maxSegmentsPerShard=" + maxSegmentsPerShard +
+                    '}';
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            out.writeVInt(shardCount);
+            size.writeTo(out);
+            out.writeVInt(maxSegmentsPerShard);
+        }
+
+        @Override
+        public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+            builder.startObject();
+            builder.field(SHARD_COUNT, shardCount);
+            builder.humanReadableField(SIZE, "size", size);
+            builder.field(MAX_SEGMENTS_PER_SHARD, maxSegmentsPerShard);
+            builder.endObject();
+            return builder;
+        }
+
+        public static IndexSnapshotDetails fromXContent(XContentParser parser) throws IOException {
+            XContentParserUtils.ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.currentToken(), parser);
+            int shardCount = -1;
+            ByteSizeValue size = null;
+            int maxSegmentsPerShard = -1;
+            String currentFieldName;
+            while (parser.nextToken() != XContentParser.Token.END_OBJECT) {
+                XContentParserUtils.ensureExpectedToken(XContentParser.Token.FIELD_NAME, parser.currentToken(), parser);
+                currentFieldName = parser.currentName();
+                XContentParserUtils.ensureExpectedToken(XContentParser.Token.VALUE_NUMBER, parser.nextToken(), parser);
+                switch (currentFieldName) {
+                    case SHARD_COUNT:
+                        shardCount = parser.intValue();
+                        break;
+                    case SIZE:
+                        size = new ByteSizeValue(parser.longValue());
+                        break;
+                    case MAX_SEGMENTS_PER_SHARD:
+                        maxSegmentsPerShard = parser.intValue();
+                        break;
+                }
+            }
+
+            if (shardCount < 1) {
+                throw new IllegalArgumentException("field [" + SHARD_COUNT + "] missing or invalid: " + shardCount);
+            }
+            if (size == null) {
+                throw new IllegalArgumentException("field [" + SIZE + "] missing");
+            }
+            if (maxSegmentsPerShard < 0) {
+                throw new IllegalArgumentException("field [" + MAX_SEGMENTS_PER_SHARD + "] missing or invalid: " + maxSegmentsPerShard);
+            }
+
+            return new IndexSnapshotDetails(shardCount, size, maxSegmentsPerShard);
+        }
     }
 
 }

--- a/server/src/main/java/org/elasticsearch/snapshots/SnapshotInfo.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/SnapshotInfo.java
@@ -47,6 +47,8 @@ public final class SnapshotInfo implements Comparable<SnapshotInfo>, ToXContent,
 
     public static final String CONTEXT_MODE_PARAM = "context_mode";
     public static final String CONTEXT_MODE_SNAPSHOT = "SNAPSHOT";
+    public static final String INDEX_DETAILS_XCONTENT_PARAM = "index_details";
+
     private static final DateFormatter DATE_TIME_FORMATTER = DateFormatter.forPattern("strict_date_optional_time");
     private static final String SNAPSHOT = "snapshot";
     private static final String UUID = "uuid";
@@ -638,7 +640,7 @@ public final class SnapshotInfo implements Comparable<SnapshotInfo>, ToXContent,
         }
         builder.endArray();
 
-        if (indexSnapshotDetails.isEmpty() == false) {
+        if (params.paramAsBoolean(INDEX_DETAILS_XCONTENT_PARAM, false) && indexSnapshotDetails.isEmpty() == false) {
             builder.startObject(INDEX_DETAILS);
             for (Map.Entry<String, IndexSnapshotDetails> entry : indexSnapshotDetails.entrySet()) {
                 builder.field(entry.getKey());

--- a/server/src/main/java/org/elasticsearch/snapshots/SnapshotInfo.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/SnapshotInfo.java
@@ -947,6 +947,8 @@ public final class SnapshotInfo implements Comparable<SnapshotInfo>, ToXContent,
         private static final String SIZE = "size_in_bytes";
         private static final String MAX_SEGMENTS_PER_SHARD = "max_segments_per_shard";
 
+        public static final IndexSnapshotDetails SKIPPED = new IndexSnapshotDetails(0, ByteSizeValue.ZERO, 0);
+
         private final int shardCount;
         private final ByteSizeValue size;
         private final int maxSegmentsPerShard;

--- a/server/src/main/java/org/elasticsearch/snapshots/SnapshotShardsService.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/SnapshotShardsService.java
@@ -44,6 +44,7 @@ import org.elasticsearch.repositories.IndexId;
 import org.elasticsearch.repositories.RepositoriesService;
 import org.elasticsearch.repositories.Repository;
 import org.elasticsearch.repositories.ShardGenerations;
+import org.elasticsearch.repositories.ShardSnapshotResult;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportException;
 import org.elasticsearch.action.ResultDeduplicator;
@@ -250,7 +251,8 @@ public class SnapshotShardsService extends AbstractLifecycleComponent implements
                 snapshot(shardId, snapshot, indexId, entry.userMetadata(), snapshotStatus, entry.version(),
                     new ActionListener<>() {
                         @Override
-                        public void onResponse(String newGeneration) {
+                        public void onResponse(ShardSnapshotResult shardSnapshotResult) {
+                            final String newGeneration = shardSnapshotResult.getGeneration();
                             assert newGeneration != null;
                             assert newGeneration.equals(snapshotStatus.generation());
                             if (logger.isDebugEnabled()) {
@@ -258,7 +260,7 @@ public class SnapshotShardsService extends AbstractLifecycleComponent implements
                                 logger.debug("[{}][{}] completed snapshot to [{}] with status [{}] at generation [{}]",
                                     shardId, snapshot, snapshot.getRepository(), lastSnapshotStatus, snapshotStatus.generation());
                             }
-                            notifySuccessfulSnapshotShard(snapshot, shardId, newGeneration);
+                            notifySuccessfulSnapshotShard(snapshot, shardId, shardSnapshotResult);
                         }
 
                         @Override
@@ -308,7 +310,7 @@ public class SnapshotShardsService extends AbstractLifecycleComponent implements
      * @param snapshotStatus snapshot status
      */
     private void snapshot(final ShardId shardId, final Snapshot snapshot, final IndexId indexId, final Map<String, Object> userMetadata,
-                          final IndexShardSnapshotStatus snapshotStatus, Version version, ActionListener<String> listener) {
+                          final IndexShardSnapshotStatus snapshotStatus, Version version, ActionListener<ShardSnapshotResult> listener) {
         try {
             final IndexShard indexShard = indicesService.indexServiceSafe(shardId.getIndex()).getShardOrNull(shardId.id());
             if (indexShard.routingEntry().primary() == false) {
@@ -395,7 +397,7 @@ public class SnapshotShardsService extends AbstractLifecycleComponent implements
                                 // but we think the shard is done - we need to make new master know that the shard is done
                                 logger.debug("[{}] new master thinks the shard [{}] is not completed but the shard is done locally, " +
                                              "updating status on the master", snapshot.snapshot(), shardId);
-                                notifySuccessfulSnapshotShard(snapshot.snapshot(), shardId, localShard.getValue().generation());
+                                notifySuccessfulSnapshotShard(snapshot.snapshot(), shardId, localShard.getValue().getShardSnapshotResult());
 
                             } else if (stage == Stage.FAILURE) {
                                 // but we think the shard failed - we need to make new master know that the shard failed
@@ -411,10 +413,10 @@ public class SnapshotShardsService extends AbstractLifecycleComponent implements
     }
 
     /** Notify the master node that the given shard has been successfully snapshotted **/
-    private void notifySuccessfulSnapshotShard(final Snapshot snapshot, final ShardId shardId, String generation) {
-        assert generation != null;
-        sendSnapshotShardUpdate(snapshot, shardId,
-            new ShardSnapshotStatus(clusterService.localNode().getId(), ShardState.SUCCESS, generation));
+    private void notifySuccessfulSnapshotShard(final Snapshot snapshot, final ShardId shardId, ShardSnapshotResult shardSnapshotResult) {
+        assert shardSnapshotResult != null;
+        assert shardSnapshotResult.getGeneration() != null;
+        sendSnapshotShardUpdate(snapshot, shardId, ShardSnapshotStatus.success(clusterService.localNode().getId(), shardSnapshotResult));
     }
 
     /** Notify the master node that the given shard failed to be snapshotted **/

--- a/server/src/main/java/org/elasticsearch/snapshots/SnapshotsService.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/SnapshotsService.java
@@ -1260,7 +1260,7 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
                         final Map<String, SnapshotInfo.IndexSnapshotDetails> indexSnapshotDetails = new HashMap<>(finalIndices.size());
                         for (ObjectObjectCursor<ShardId, ShardSnapshotStatus> shardEntry : entry.shards()) {
                             indexSnapshotDetails.compute(shardEntry.key.getIndexName(), (indexName, current) -> {
-                                if (current != null && current.getShardCount() == 0) {
+                                if (current == SnapshotInfo.IndexSnapshotDetails.SKIPPED) {
                                     // already found an unsuccessful shard in this index, skip this shard
                                     return current;
                                 }
@@ -1268,13 +1268,13 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
                                 final ShardSnapshotStatus shardSnapshotStatus = shardEntry.value;
                                 if (shardSnapshotStatus.state() != ShardState.SUCCESS) {
                                     // first unsuccessful shard in this index found, record that this index should be skipped
-                                    return new SnapshotInfo.IndexSnapshotDetails(0, ByteSizeValue.ZERO, 0);
+                                    return SnapshotInfo.IndexSnapshotDetails.SKIPPED;
                                 }
 
                                 final ShardSnapshotResult result = shardSnapshotStatus.shardSnapshotResult();
                                 if (result == null) {
                                     // detailed result not recorded, skip this index
-                                    return new SnapshotInfo.IndexSnapshotDetails(0, ByteSizeValue.ZERO, 0);
+                                    return SnapshotInfo.IndexSnapshotDetails.SKIPPED;
                                 }
 
                                 if (current == null) {

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/snapshots/create/CreateSnapshotResponseTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/snapshots/create/CreateSnapshotResponseTests.java
@@ -20,6 +20,7 @@ import org.elasticsearch.test.AbstractXContentTestCase;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
 import java.util.function.Predicate;
@@ -65,7 +66,7 @@ public class CreateSnapshotResponseTests extends AbstractXContentTestCase<Create
 
         return new CreateSnapshotResponse(
             new SnapshotInfo(snapshotId, indices, dataStreams, featureStates, reason, endTime, totalShards, shardFailures,
-                globalState, SnapshotInfoTestUtils.randomUserMetadata(), startTime
+                globalState, SnapshotInfoTestUtils.randomUserMetadata(), startTime, Collections.emptyMap()
             ));
     }
 

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/snapshots/get/GetSnapshotsResponseTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/snapshots/get/GetSnapshotsResponseTests.java
@@ -75,8 +75,7 @@ public class GetSnapshotsResponseTests extends ESTestCase {
             List<SnapshotFeatureInfo> featureInfos = randomList(0, () -> randomSnapshotFeatureInfo());
             snapshots.add(new SnapshotInfo(snapshotId, Arrays.asList("index1", "index2"), Collections.singletonList("ds"),
                 featureInfos, reason, System.currentTimeMillis(), randomIntBetween(2, 3), shardFailures, randomBoolean(),
-                SnapshotInfoTestUtils.randomUserMetadata(), System.currentTimeMillis()
-            ));
+                SnapshotInfoTestUtils.randomUserMetadata(), System.currentTimeMillis(), Collections.emptyMap()));
 
         }
         return snapshots;

--- a/server/src/test/java/org/elasticsearch/repositories/RepositoriesServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/repositories/RepositoriesServiceTests.java
@@ -253,7 +253,8 @@ public class RepositoriesServiceTests extends ESTestCase {
         @Override
         public void snapshotShard(Store store, MapperService mapperService, SnapshotId snapshotId, IndexId indexId,
                                   IndexCommit snapshotIndexCommit, String shardStateIdentifier, IndexShardSnapshotStatus snapshotStatus,
-                                  Version repositoryMetaVersion, Map<String, Object> userMetadata, ActionListener<String> listener) {
+                                  Version repositoryMetaVersion, Map<String, Object> userMetadata,
+                                  ActionListener<ShardSnapshotResult> listener) {
 
         }
 
@@ -279,7 +280,7 @@ public class RepositoriesServiceTests extends ESTestCase {
 
         @Override
         public void cloneShardSnapshot(SnapshotId source, SnapshotId target, RepositoryShardId shardId, String shardGeneration,
-                                       ActionListener<String> listener) {
+                                       ActionListener<ShardSnapshotResult> listener) {
 
         }
 

--- a/server/src/test/java/org/elasticsearch/repositories/blobstore/BlobStoreRepositoryRestoreTests.java
+++ b/server/src/test/java/org/elasticsearch/repositories/blobstore/BlobStoreRepositoryRestoreTests.java
@@ -184,7 +184,8 @@ public class BlobStoreRepositoryRestoreTests extends IndexShardTestCase {
                         Collections.emptyList(),
                         true,
                         Collections.emptyMap(),
-                        0L
+                        0L,
+                        Collections.emptyMap()
                     ),
                     Version.CURRENT, Function.identity(), f));
             IndexShardSnapshotFailedException isfe = expectThrows(IndexShardSnapshotFailedException.class,

--- a/server/src/test/java/org/elasticsearch/snapshots/SnapshotInfoTestUtils.java
+++ b/server/src/test/java/org/elasticsearch/snapshots/SnapshotInfoTestUtils.java
@@ -8,6 +8,7 @@
 
 package org.elasticsearch.snapshots;
 
+import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.test.ESTestCase;
 
@@ -54,6 +55,8 @@ public class SnapshotInfoTestUtils {
 
         final List<SnapshotFeatureInfo> snapshotFeatureInfos = randomSnapshotFeatureInfos();
 
+        final Map<String, SnapshotInfo.IndexSnapshotDetails> indexSnapshotDetails = randomIndexSnapshotDetails();
+
         return new SnapshotInfo(
                 snapshotId,
                 indices,
@@ -65,8 +68,21 @@ public class SnapshotInfoTestUtils {
                 shardFailures,
                 includeGlobalState,
                 userMetadata,
-                startTime
+                startTime,
+                indexSnapshotDetails
         );
+    }
+
+    private static Map<String, SnapshotInfo.IndexSnapshotDetails> randomIndexSnapshotDetails() {
+        final Map<String, SnapshotInfo.IndexSnapshotDetails> result = new HashMap<>();
+        final int size = between(0, 10);
+        while (result.size() < size) {
+            result.put(randomAlphaOfLengthBetween(5, 10), new SnapshotInfo.IndexSnapshotDetails(
+                    between(1, 10),
+                    new ByteSizeValue(between(0, Integer.MAX_VALUE)),
+                    between(1, 100)));
+        }
+        return result;
     }
 
     private static List<SnapshotShardFailure> randomShardFailures(int failedShards) {
@@ -110,7 +126,7 @@ public class SnapshotInfoTestUtils {
     }
 
     static SnapshotInfo mutateSnapshotInfo(SnapshotInfo instance) {
-        switch (randomIntBetween(0, 9)) {
+        switch (randomIntBetween(0, 10)) {
             case 0:
                 final String newName = randomValueOtherThan(instance.snapshotId().getName(), () -> randomAlphaOfLength(5));
                 final String newUuid = randomValueOtherThan(instance.snapshotId().getUUID(), () -> randomAlphaOfLength(5));
@@ -128,7 +144,8 @@ public class SnapshotInfoTestUtils {
                         instance.shardFailures(),
                         instance.includeGlobalState(),
                         instance.userMetadata(),
-                        instance.startTime()
+                        instance.startTime(),
+                        instance.indexSnapshotDetails()
                 );
             case 1:
                 final int indicesSize = randomValueOtherThan(instance.indices().size(), () -> randomIntBetween(1, 10));
@@ -145,7 +162,8 @@ public class SnapshotInfoTestUtils {
                         instance.shardFailures(),
                         instance.includeGlobalState(),
                         instance.userMetadata(),
-                        instance.startTime()
+                        instance.startTime(),
+                        instance.indexSnapshotDetails()
                 );
             case 2:
                 return new SnapshotInfo(
@@ -159,7 +177,8 @@ public class SnapshotInfoTestUtils {
                         instance.shardFailures(),
                         instance.includeGlobalState(),
                         instance.userMetadata(),
-                        randomValueOtherThan(instance.startTime(), ESTestCase::randomNonNegativeLong)
+                        randomValueOtherThan(instance.startTime(), ESTestCase::randomNonNegativeLong),
+                        instance.indexSnapshotDetails()
                 );
             case 3:
                 return new SnapshotInfo(
@@ -173,7 +192,8 @@ public class SnapshotInfoTestUtils {
                         instance.shardFailures(),
                         instance.includeGlobalState(),
                         instance.userMetadata(),
-                        instance.startTime()
+                        instance.startTime(),
+                        instance.indexSnapshotDetails()
                 );
             case 4:
                 return new SnapshotInfo(
@@ -187,7 +207,8 @@ public class SnapshotInfoTestUtils {
                         instance.shardFailures(),
                         instance.includeGlobalState(),
                         instance.userMetadata(),
-                        instance.startTime()
+                        instance.startTime(),
+                        instance.indexSnapshotDetails()
                 );
             case 5:
                 final int totalShards = randomValueOtherThan(instance.totalShards(), () -> randomIntBetween(0, 100));
@@ -203,7 +224,8 @@ public class SnapshotInfoTestUtils {
                         shardFailures,
                         instance.includeGlobalState(),
                         instance.userMetadata(),
-                        instance.startTime()
+                        instance.startTime(),
+                        instance.indexSnapshotDetails()
                 );
             case 6:
                 return new SnapshotInfo(
@@ -217,7 +239,8 @@ public class SnapshotInfoTestUtils {
                         instance.shardFailures(),
                         Boolean.FALSE.equals(instance.includeGlobalState()),
                         instance.userMetadata(),
-                        instance.startTime()
+                        instance.startTime(),
+                        instance.indexSnapshotDetails()
                 );
             case 7:
                 return new SnapshotInfo(
@@ -231,7 +254,8 @@ public class SnapshotInfoTestUtils {
                         instance.shardFailures(),
                         instance.includeGlobalState(),
                         randomValueOtherThan(instance.userMetadata(), SnapshotInfoTestUtils::randomUserMetadata),
-                        instance.startTime()
+                        instance.startTime(),
+                        instance.indexSnapshotDetails()
                 );
             case 8:
                 final List<String> dataStreams = randomValueOtherThan(instance.dataStreams(),
@@ -247,7 +271,8 @@ public class SnapshotInfoTestUtils {
                         instance.shardFailures(),
                         instance.includeGlobalState(),
                         instance.userMetadata(),
-                        instance.startTime()
+                        instance.startTime(),
+                        instance.indexSnapshotDetails()
                 );
             case 9:
                 return new SnapshotInfo(
@@ -261,7 +286,23 @@ public class SnapshotInfoTestUtils {
                         instance.shardFailures(),
                         instance.includeGlobalState(),
                         instance.userMetadata(),
-                        instance.startTime()
+                        instance.startTime(),
+                        instance.indexSnapshotDetails()
+                );
+            case 10:
+                return new SnapshotInfo(
+                        instance.snapshotId(),
+                        instance.indices(),
+                        instance.dataStreams(),
+                        instance.featureStates(),
+                        instance.reason(),
+                        instance.endTime(),
+                        instance.totalShards(),
+                        instance.shardFailures(),
+                        instance.includeGlobalState(),
+                        instance.userMetadata(),
+                        instance.startTime(),
+                        randomValueOtherThan(instance.indexSnapshotDetails(), SnapshotInfoTestUtils::randomIndexSnapshotDetails)
                 );
             default:
                 throw new IllegalArgumentException("invalid randomization case");

--- a/server/src/test/java/org/elasticsearch/snapshots/SnapshotsInProgressSerializationTests.java
+++ b/server/src/test/java/org/elasticsearch/snapshots/SnapshotsInProgressSerializationTests.java
@@ -20,11 +20,13 @@ import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.collect.ImmutableOpenMap;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.repositories.IndexId;
+import org.elasticsearch.repositories.ShardSnapshotResult;
 import org.elasticsearch.test.AbstractDiffableWireSerializationTestCase;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.VersionUtils;
@@ -72,19 +74,26 @@ public class SnapshotsInProgressSerializationTests extends AbstractDiffableWireS
         for (Index idx : esIndices) {
             int shardsCount = randomIntBetween(1, 10);
             for (int j = 0; j < shardsCount; j++) {
-                ShardId shardId = new ShardId(idx, j);
-                String nodeId = randomAlphaOfLength(10);
-                ShardState shardState = randomFrom(ShardState.values());
-                builder.put(shardId,
-                        shardState == ShardState.QUEUED ? SnapshotsInProgress.ShardSnapshotStatus.UNASSIGNED_QUEUED :
-                                new SnapshotsInProgress.ShardSnapshotStatus(nodeId, shardState,
-                                        shardState.failed() ? randomAlphaOfLength(10) : null, "1"));
+                builder.put(new ShardId(idx, j), randomShardSnapshotStatus(randomAlphaOfLength(10)));
             }
         }
         List<SnapshotFeatureInfo> featureStates = randomList(5, SnapshotFeatureInfoTests::randomSnapshotFeatureInfo);
         ImmutableOpenMap<ShardId, SnapshotsInProgress.ShardSnapshotStatus> shards = builder.build();
         return new Entry(snapshot, includeGlobalState, partial, randomState(shards), indices, dataStreams, featureStates,
             startTime, repositoryStateId, shards, null, SnapshotInfoTestUtils.randomUserMetadata(), VersionUtils.randomVersion(random()));
+    }
+
+    private SnapshotsInProgress.ShardSnapshotStatus randomShardSnapshotStatus(String nodeId) {
+        ShardState shardState = randomFrom(ShardState.values());
+        if (shardState == ShardState.QUEUED) {
+            return SnapshotsInProgress.ShardSnapshotStatus.UNASSIGNED_QUEUED;
+        } else if (shardState == ShardState.SUCCESS) {
+            final ShardSnapshotResult shardSnapshotResult = new ShardSnapshotResult("1", new ByteSizeValue(1L), 1);
+            return SnapshotsInProgress.ShardSnapshotStatus.success(nodeId, shardSnapshotResult);
+        } else {
+            final String reason = shardState.failed() ? randomAlphaOfLength(10) : null;
+            return new SnapshotsInProgress.ShardSnapshotStatus(nodeId, shardState, reason, "1");
+        }
     }
 
     @Override
@@ -194,13 +203,7 @@ public class SnapshotsInProgressSerializationTests extends AbstractDiffableWireS
                 Index index = new Index(indexId.getName(), randomAlphaOfLength(10));
                 int shardsCount = randomIntBetween(1, 10);
                 for (int j = 0; j < shardsCount; j++) {
-                    ShardId shardId = new ShardId(index, j);
-                    String nodeId = randomAlphaOfLength(10);
-                    ShardState shardState = randomFrom(ShardState.values());
-                    builder.put(shardId,
-                        shardState == ShardState.QUEUED ? SnapshotsInProgress.ShardSnapshotStatus.UNASSIGNED_QUEUED :
-                            new SnapshotsInProgress.ShardSnapshotStatus(nodeId, shardState,
-                                shardState.failed() ? randomAlphaOfLength(10) : null, "1"));
+                    builder.put(new ShardId(index, j), randomShardSnapshotStatus(randomAlphaOfLength(10)));
                 }
                 shards = builder.build();
                 return new Entry(entry.snapshot(), entry.includeGlobalState(), entry.partial(), randomState(shards), indices,
@@ -221,11 +224,10 @@ public class SnapshotsInProgressSerializationTests extends AbstractDiffableWireS
                 logger.error("randomizing feature states");
                 List<SnapshotFeatureInfo> featureStates = randomList(1, 5,
                     () -> randomValueOtherThanMany(entry.featureStates()::contains, SnapshotFeatureInfoTests::randomSnapshotFeatureInfo));
-                final Entry newEntry = new Entry(entry.snapshot(), entry.includeGlobalState(), entry.partial(), entry.state(),
+                return new Entry(entry.snapshot(), entry.includeGlobalState(), entry.partial(), entry.state(),
                     entry.indices(),
                     entry.dataStreams(), featureStates, entry.startTime(), entry.repositoryStateId(), entry.shards(), entry.failure(),
                     entry.userMetadata(), entry.version());
-                return newEntry;
             default:
                 throw new IllegalArgumentException("invalid randomization case");
         }
@@ -238,7 +240,8 @@ public class SnapshotsInProgressSerializationTests extends AbstractDiffableWireS
                 Collections.singletonList(new IndexId("index", "uuid")), Collections.emptyList(), Collections.emptyList(), 1234567, 0,
                 ImmutableOpenMap.<ShardId, SnapshotsInProgress.ShardSnapshotStatus>builder()
                     .fPut(new ShardId("index", "uuid", 0),
-                        new SnapshotsInProgress.ShardSnapshotStatus("nodeId", ShardState.SUCCESS, "reason", "generation"))
+                        SnapshotsInProgress.ShardSnapshotStatus.success("nodeId",
+                                new ShardSnapshotResult("generation", new ByteSizeValue(1L), 1)))
                     .build(), null, null, Version.CURRENT)));
 
         try (XContentBuilder builder = jsonBuilder()) {

--- a/server/src/test/java/org/elasticsearch/snapshots/SnapshotsServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/snapshots/SnapshotsServiceTests.java
@@ -22,10 +22,12 @@ import org.elasticsearch.cluster.routing.TestShardRouting;
 import org.elasticsearch.common.UUIDs;
 import org.elasticsearch.common.collect.ImmutableOpenMap;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.repositories.IndexId;
 import org.elasticsearch.repositories.RepositoryShardId;
+import org.elasticsearch.repositories.ShardSnapshotResult;
 import org.elasticsearch.test.ESTestCase;
 
 import java.util.Arrays;
@@ -395,7 +397,7 @@ public class SnapshotsServiceTests extends ESTestCase {
     }
 
     private static SnapshotsInProgress.ShardSnapshotStatus successfulShardStatus(String nodeId) {
-        return new SnapshotsInProgress.ShardSnapshotStatus(nodeId, SnapshotsInProgress.ShardState.SUCCESS, uuid());
+        return SnapshotsInProgress.ShardSnapshotStatus.success(nodeId, new ShardSnapshotResult(uuid(), new ByteSizeValue(1L), 1));
     }
 
     private static Snapshot snapshot(String repoName, String name) {

--- a/server/src/test/java/org/elasticsearch/snapshots/mockstore/MockEventuallyConsistentRepositoryTests.java
+++ b/server/src/test/java/org/elasticsearch/snapshots/mockstore/MockEventuallyConsistentRepositoryTests.java
@@ -147,16 +147,38 @@ public class MockEventuallyConsistentRepositoryTests extends ESTestCase {
             PlainActionFuture.<RepositoryData, Exception>get(f ->
                 // We try to write another snap- blob for "foo" in the next generation. It fails because the content differs.
                 repository.finalizeSnapshot(ShardGenerations.EMPTY, RepositoryData.EMPTY_REPO_GEN, Metadata.EMPTY_METADATA,
-                    new SnapshotInfo(snapshotId, Collections.emptyList(), Collections.emptyList(),
-                        Collections.emptyList(), null, 1L, 5, Collections.emptyList(), true, Collections.emptyMap(), 0L),
+                    new SnapshotInfo(
+                        snapshotId,
+                        Collections.emptyList(),
+                        Collections.emptyList(),
+                        Collections.emptyList(),
+                        null,
+                        1L,
+                        5,
+                        Collections.emptyList(),
+                        true,
+                        Collections.emptyMap(),
+                        0L,
+                        Collections.emptyMap()),
                     Version.CURRENT, Function.identity(), f));
 
             // We try to write another snap- blob for "foo" in the next generation. It fails because the content differs.
             final AssertionError assertionError = expectThrows(AssertionError.class,
                 () -> PlainActionFuture.<RepositoryData, Exception>get(f ->
                     repository.finalizeSnapshot(ShardGenerations.EMPTY, 0L, Metadata.EMPTY_METADATA,
-                        new SnapshotInfo(snapshotId, Collections.emptyList(), Collections.emptyList(),
-                            Collections.emptyList(), null, 1L, 6, Collections.emptyList(), true, Collections.emptyMap(), 0L),
+                        new SnapshotInfo(
+                            snapshotId,
+                            Collections.emptyList(),
+                            Collections.emptyList(),
+                            Collections.emptyList(),
+                            null,
+                            1L,
+                            6,
+                            Collections.emptyList(),
+                            true,
+                            Collections.emptyMap(),
+                            0L,
+                            Collections.emptyMap()),
                         Version.CURRENT, Function.identity(), f)));
             assertThat(assertionError.getMessage(), equalTo("\nExpected: <6>\n     but: was <5>"));
 
@@ -164,8 +186,18 @@ public class MockEventuallyConsistentRepositoryTests extends ESTestCase {
             // It passes cleanly because the content of the blob except for the timestamps.
             PlainActionFuture.<RepositoryData, Exception>get(f ->
                 repository.finalizeSnapshot(ShardGenerations.EMPTY, 0L, Metadata.EMPTY_METADATA,
-                    new SnapshotInfo(snapshotId, Collections.emptyList(), Collections.emptyList(),
-                        Collections.emptyList(), null, 2L, 5, Collections.emptyList(), true, Collections.emptyMap(), 0L),
+                    new SnapshotInfo(snapshotId,
+                        Collections.emptyList(),
+                        Collections.emptyList(),
+                        Collections.emptyList(),
+                        null,
+                        2L,
+                        5,
+                        Collections.emptyList(),
+                        true,
+                        Collections.emptyMap(),
+                        0L,
+                        Collections.emptyMap()),
                     Version.CURRENT, Function.identity(), f));
         }
     }

--- a/test/framework/src/main/java/org/elasticsearch/index/shard/IndexShardTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/shard/IndexShardTestCase.java
@@ -69,6 +69,7 @@ import org.elasticsearch.indices.recovery.RecoveryTarget;
 import org.elasticsearch.indices.recovery.StartRecoveryRequest;
 import org.elasticsearch.repositories.IndexId;
 import org.elasticsearch.repositories.Repository;
+import org.elasticsearch.repositories.ShardSnapshotResult;
 import org.elasticsearch.repositories.blobstore.ESBlobStoreRepositoryIntegTestCase;
 import org.elasticsearch.snapshots.Snapshot;
 import org.elasticsearch.test.DummyShardLock;
@@ -833,13 +834,13 @@ public abstract class IndexShardTestCase extends ESTestCase {
         final IndexShardSnapshotStatus snapshotStatus = IndexShardSnapshotStatus.newInitializing(
             ESBlobStoreRepositoryIntegTestCase.getRepositoryData(repository).shardGenerations().getShardGen(
                 indexId, shard.shardId().getId()));
-        final PlainActionFuture<String> future = PlainActionFuture.newFuture();
+        final PlainActionFuture<ShardSnapshotResult> future = PlainActionFuture.newFuture();
         final String shardGen;
         try (Engine.IndexCommitRef indexCommitRef = shard.acquireLastIndexCommit(true)) {
             repository.snapshotShard(shard.store(), shard.mapperService(), snapshot.getSnapshotId(), indexId,
                 indexCommitRef.getIndexCommit(), null, snapshotStatus, Version.CURRENT,
                 Collections.emptyMap(), future);
-            shardGen = future.actionGet();
+            shardGen = future.actionGet().getGeneration();
         }
 
         final IndexShardSnapshotStatus.Copy lastSnapshotStatus = snapshotStatus.asCopy();

--- a/test/framework/src/main/java/org/elasticsearch/index/shard/RestoreOnlyRepository.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/shard/RestoreOnlyRepository.java
@@ -26,6 +26,7 @@ import org.elasticsearch.repositories.Repository;
 import org.elasticsearch.repositories.RepositoryData;
 import org.elasticsearch.repositories.RepositoryShardId;
 import org.elasticsearch.repositories.ShardGenerations;
+import org.elasticsearch.repositories.ShardSnapshotResult;
 import org.elasticsearch.snapshots.SnapshotId;
 import org.elasticsearch.snapshots.SnapshotInfo;
 
@@ -135,7 +136,8 @@ public abstract class RestoreOnlyRepository extends AbstractLifecycleComponent i
     @Override
     public void snapshotShard(Store store, MapperService mapperService, SnapshotId snapshotId, IndexId indexId,
                               IndexCommit snapshotIndexCommit, String shardStateIdentifier, IndexShardSnapshotStatus snapshotStatus,
-                              Version repositoryMetaVersion, Map<String, Object> userMetadata, ActionListener<String> listener) {
+                              Version repositoryMetaVersion, Map<String, Object> userMetadata,
+                              ActionListener<ShardSnapshotResult> listener) {
     }
 
     @Override
@@ -159,7 +161,7 @@ public abstract class RestoreOnlyRepository extends AbstractLifecycleComponent i
 
     @Override
     public void cloneShardSnapshot(SnapshotId source, SnapshotId target, RepositoryShardId repositoryShardId, String shardGeneration,
-                                   ActionListener<String> listener) {
+                                   ActionListener<ShardSnapshotResult> listener) {
         throw new UnsupportedOperationException("Unsupported for restore-only repository");
     }
 }

--- a/test/framework/src/main/java/org/elasticsearch/snapshots/AbstractSnapshotIntegTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/snapshots/AbstractSnapshotIntegTestCase.java
@@ -435,10 +435,22 @@ public abstract class AbstractSnapshotIntegTestCase extends ESIntegTestCase {
         final Repository repo = getRepositoryOnMaster(repoName);
         final SnapshotId snapshotId = new SnapshotId(snapshotName, UUIDs.randomBase64UUID(random()));
         logger.info("--> adding old version FAILED snapshot [{}] to repository [{}]", snapshotId, repoName);
-        final SnapshotInfo snapshotInfo = new SnapshotInfo(snapshotId,
-                Collections.emptyList(), Collections.emptyList(),
-                Collections.emptyList(), "failed on purpose", SnapshotsService.OLD_SNAPSHOT_FORMAT, 0L, 0L, 0, 0, Collections.emptyList(),
-                randomBoolean(), metadata, SnapshotState.FAILED
+        final SnapshotInfo snapshotInfo = new SnapshotInfo(
+            snapshotId,
+            Collections.emptyList(),
+            Collections.emptyList(),
+            Collections.emptyList(),
+            "failed on purpose",
+            SnapshotsService.OLD_SNAPSHOT_FORMAT,
+            0L,
+            0L,
+            0,
+            0,
+            Collections.emptyList(),
+            randomBoolean(),
+            metadata,
+            SnapshotState.FAILED,
+            Collections.emptyMap()
         );
         PlainActionFuture.<RepositoryData, Exception>get(f -> repo.finalizeSnapshot(
                 ShardGenerations.EMPTY, getRepositoryData(repoName).getGenId(), state.metadata(), snapshotInfo,

--- a/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/repository/CcrRepository.java
+++ b/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/repository/CcrRepository.java
@@ -70,6 +70,7 @@ import org.elasticsearch.repositories.Repository;
 import org.elasticsearch.repositories.RepositoryData;
 import org.elasticsearch.repositories.RepositoryShardId;
 import org.elasticsearch.repositories.ShardGenerations;
+import org.elasticsearch.repositories.ShardSnapshotResult;
 import org.elasticsearch.repositories.blobstore.FileRestoreContext;
 import org.elasticsearch.snapshots.SnapshotId;
 import org.elasticsearch.snapshots.SnapshotInfo;
@@ -318,7 +319,8 @@ public class CcrRepository extends AbstractLifecycleComponent implements Reposit
     @Override
     public void snapshotShard(Store store, MapperService mapperService, SnapshotId snapshotId, IndexId indexId,
                               IndexCommit snapshotIndexCommit, String shardStateIdentifier, IndexShardSnapshotStatus snapshotStatus,
-                              Version repositoryMetaVersion, Map<String, Object> userMetadata, ActionListener<String> listener) {
+                              Version repositoryMetaVersion, Map<String, Object> userMetadata,
+                              ActionListener<ShardSnapshotResult> listener) {
         throw new UnsupportedOperationException("Unsupported for repository of type: " + TYPE);
     }
 
@@ -475,7 +477,7 @@ public class CcrRepository extends AbstractLifecycleComponent implements Reposit
 
     @Override
     public void cloneShardSnapshot(SnapshotId source, SnapshotId target, RepositoryShardId shardId, String shardGeneration,
-                                   ActionListener<String> listener) {
+                                   ActionListener<ShardSnapshotResult> listener) {
         throw new UnsupportedOperationException("Unsupported for repository of type: " + TYPE);
     }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/snapshots/SourceOnlySnapshotRepository.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/snapshots/SourceOnlySnapshotRepository.java
@@ -44,6 +44,7 @@ import org.elasticsearch.repositories.IndexId;
 import org.elasticsearch.repositories.Repository;
 import org.elasticsearch.repositories.RepositoryData;
 import org.elasticsearch.repositories.ShardGenerations;
+import org.elasticsearch.repositories.ShardSnapshotResult;
 
 import java.io.Closeable;
 import java.io.IOException;
@@ -127,7 +128,8 @@ public final class SourceOnlySnapshotRepository extends FilterRepository {
     @Override
     public void snapshotShard(Store store, MapperService mapperService, SnapshotId snapshotId, IndexId indexId,
                               IndexCommit snapshotIndexCommit, String shardStateIdentifier, IndexShardSnapshotStatus snapshotStatus,
-                              Version repositoryMetaVersion, Map<String, Object> userMetadata, ActionListener<String> listener) {
+                              Version repositoryMetaVersion, Map<String, Object> userMetadata,
+                              ActionListener<ShardSnapshotResult> listener) {
         if (mapperService.documentMapper() != null // if there is no mapping this is null
             && mapperService.documentMapper().sourceMapper().isComplete() == false) {
             listener.onFailure(

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/snapshots/SourceOnlySnapshotShardTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/snapshots/SourceOnlySnapshotShardTests.java
@@ -65,6 +65,7 @@ import org.elasticsearch.repositories.IndexId;
 import org.elasticsearch.repositories.Repository;
 import org.elasticsearch.repositories.RepositoryData;
 import org.elasticsearch.repositories.ShardGenerations;
+import org.elasticsearch.repositories.ShardSnapshotResult;
 import org.elasticsearch.repositories.blobstore.BlobStoreTestUtil;
 import org.elasticsearch.repositories.blobstore.ESBlobStoreRepositoryIntegTestCase;
 import org.elasticsearch.repositories.fs.FsRepository;
@@ -106,7 +107,7 @@ public class SourceOnlySnapshotShardTests extends IndexShardTestCase {
         repository.start();
         try (Engine.IndexCommitRef snapshotRef = shard.acquireLastIndexCommit(true)) {
             IndexShardSnapshotStatus indexShardSnapshotStatus = IndexShardSnapshotStatus.newInitializing("-1");
-            final PlainActionFuture<String> future = PlainActionFuture.newFuture();
+            final PlainActionFuture<ShardSnapshotResult> future = PlainActionFuture.newFuture();
             runAsSnapshot(shard.getThreadPool(), () -> repository.snapshotShard(shard.store(), shard.mapperService(), snapshotId, indexId,
                 snapshotRef.getIndexCommit(), null, indexShardSnapshotStatus, Version.CURRENT,
                 Collections.emptyMap(), future));
@@ -133,11 +134,11 @@ public class SourceOnlySnapshotShardTests extends IndexShardTestCase {
         try (Engine.IndexCommitRef snapshotRef = shard.acquireLastIndexCommit(true)) {
             IndexShardSnapshotStatus indexShardSnapshotStatus = IndexShardSnapshotStatus.newInitializing(null);
             SnapshotId snapshotId = new SnapshotId("test", "test");
-            final PlainActionFuture<String> future = PlainActionFuture.newFuture();
+            final PlainActionFuture<ShardSnapshotResult> future = PlainActionFuture.newFuture();
             runAsSnapshot(shard.getThreadPool(), () -> repository.snapshotShard(shard.store(), shard.mapperService(), snapshotId, indexId,
                 snapshotRef.getIndexCommit(), null, indexShardSnapshotStatus, Version.CURRENT,
                 Collections.emptyMap(), future));
-            shardGeneration = future.actionGet();
+            shardGeneration = future.actionGet().getGeneration();
             IndexShardSnapshotStatus.Copy copy = indexShardSnapshotStatus.asCopy();
             assertEquals(copy.getTotalFileCount(), copy.getIncrementalFileCount());
             totalFileCount = copy.getTotalFileCount();
@@ -150,11 +151,11 @@ public class SourceOnlySnapshotShardTests extends IndexShardTestCase {
             SnapshotId snapshotId = new SnapshotId("test_1", "test_1");
 
             IndexShardSnapshotStatus indexShardSnapshotStatus = IndexShardSnapshotStatus.newInitializing(shardGeneration);
-            final PlainActionFuture<String> future = PlainActionFuture.newFuture();
+            final PlainActionFuture<ShardSnapshotResult> future = PlainActionFuture.newFuture();
             runAsSnapshot(shard.getThreadPool(), () -> repository.snapshotShard(shard.store(), shard.mapperService(), snapshotId, indexId,
                 snapshotRef.getIndexCommit(), null, indexShardSnapshotStatus, Version.CURRENT,
                 Collections.emptyMap(), future));
-            shardGeneration = future.actionGet();
+            shardGeneration = future.actionGet().getGeneration();
             IndexShardSnapshotStatus.Copy copy = indexShardSnapshotStatus.asCopy();
             // we processed the segments_N file plus _1.si, _1.fnm, _1.fdx, _1.fdt, _1.fdm
             assertEquals(6, copy.getIncrementalFileCount());
@@ -167,7 +168,7 @@ public class SourceOnlySnapshotShardTests extends IndexShardTestCase {
             SnapshotId snapshotId = new SnapshotId("test_2", "test_2");
 
             IndexShardSnapshotStatus indexShardSnapshotStatus = IndexShardSnapshotStatus.newInitializing(shardGeneration);
-            final PlainActionFuture<String> future = PlainActionFuture.newFuture();
+            final PlainActionFuture<ShardSnapshotResult> future = PlainActionFuture.newFuture();
             runAsSnapshot(shard.getThreadPool(), () -> repository.snapshotShard(shard.store(), shard.mapperService(), snapshotId, indexId,
                 snapshotRef.getIndexCommit(), null, indexShardSnapshotStatus, Version.CURRENT,
                 Collections.emptyMap(), future));
@@ -215,7 +216,7 @@ public class SourceOnlySnapshotShardTests extends IndexShardTestCase {
         repository.start();
         try (Engine.IndexCommitRef snapshotRef = shard.acquireLastIndexCommit(true)) {
             IndexShardSnapshotStatus indexShardSnapshotStatus = IndexShardSnapshotStatus.newInitializing(null);
-            final PlainActionFuture<String> future = PlainActionFuture.newFuture();
+            final PlainActionFuture<ShardSnapshotResult> future = PlainActionFuture.newFuture();
             runAsSnapshot(shard.getThreadPool(), () -> {
                 repository.snapshotShard(shard.store(), shard.mapperService(), snapshotId, indexId, snapshotRef.getIndexCommit(),
                     null, indexShardSnapshotStatus, Version.CURRENT, Collections.emptyMap(), future);
@@ -227,11 +228,20 @@ public class SourceOnlySnapshotShardTests extends IndexShardTestCase {
                     shardGenerations,
                     ESBlobStoreRepositoryIntegTestCase.getRepositoryData(repository).getGenId(),
                     Metadata.builder().put(shard.indexSettings().getIndexMetadata(), false).build(),
-                    new SnapshotInfo(snapshotId,
+                    new SnapshotInfo(
+                        snapshotId,
                         shardGenerations.indices().stream()
-                        .map(IndexId::getName).collect(Collectors.toList()), Collections.emptyList(), Collections.emptyList(), null, 1L,
-                        shardGenerations.totalShards(), Collections.emptyList(), true, Collections.emptyMap(), 0L
-                    ),
+                                .map(IndexId::getName).collect(Collectors.toList()),
+                        Collections.emptyList(),
+                        Collections.emptyList(),
+                        null,
+                        1L,
+                        shardGenerations.totalShards(),
+                        Collections.emptyList(),
+                        true,
+                        Collections.emptyMap(),
+                        0L,
+                        Collections.emptyMap()),
                     Version.CURRENT, Function.identity(), finFuture);
                 finFuture.actionGet();
             });

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/slm/SnapshotRetentionConfigurationTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/slm/SnapshotRetentionConfigurationTests.java
@@ -285,10 +285,19 @@ public class SnapshotRetentionConfigurationTests extends ESTestCase {
         final Map<String, Object> meta = new HashMap<>();
         meta.put(SnapshotLifecyclePolicy.POLICY_ID_METADATA_FIELD, REPO);
         final int totalShards = between(1,20);
-        SnapshotInfo snapInfo = new SnapshotInfo(new SnapshotId("snap-" + randomAlphaOfLength(3), "uuid"),
+        SnapshotInfo snapInfo = new SnapshotInfo(
+            new SnapshotId("snap-" + randomAlphaOfLength(3), "uuid"),
             Collections.singletonList("foo"),
             Collections.singletonList("bar"),
-            Collections.emptyList(), null, startTime + between(1, 10000), totalShards, new ArrayList<>(), false, meta, startTime
+            Collections.emptyList(),
+            null,
+            startTime + between(1, 10000),
+            totalShards,
+            new ArrayList<>(),
+            false,
+            meta,
+            startTime,
+            Collections.emptyMap()
         );
         assertThat(snapInfo.state(), equalTo(SnapshotState.SUCCESS));
         return snapInfo;
@@ -312,11 +321,19 @@ public class SnapshotRetentionConfigurationTests extends ESTestCase {
             failures.add(new SnapshotShardFailure("nodeId", new ShardId("index-name", "index-uuid", i), "failed"));
         }
         assert failureCount == failures.size();
-        SnapshotInfo snapInfo = new SnapshotInfo(new SnapshotId("snap-fail-" + randomAlphaOfLength(3), "uuid-fail"),
+        SnapshotInfo snapInfo = new SnapshotInfo(
+            new SnapshotId("snap-fail-" + randomAlphaOfLength(3), "uuid-fail"),
             Collections.singletonList("foo-fail"),
             Collections.singletonList("bar-fail"),
             Collections.emptyList(),
-            "forced-failure", startTime + between(1, 10000), totalShards, failures, randomBoolean(), meta, startTime
+            "forced-failure",
+            startTime + between(1, 10000),
+            totalShards,
+            failures,
+            randomBoolean(),
+            meta,
+            startTime,
+            Collections.emptyMap()
         );
         assertThat(snapInfo.state(), equalTo(SnapshotState.FAILED));
         return snapInfo;
@@ -332,10 +349,19 @@ public class SnapshotRetentionConfigurationTests extends ESTestCase {
             failures.add(new SnapshotShardFailure("nodeId", new ShardId("index-name", "index-uuid", i), "failed"));
         }
         assert failureCount == failures.size();
-        SnapshotInfo snapInfo = new SnapshotInfo(new SnapshotId("snap-fail-" + randomAlphaOfLength(3), "uuid-fail"),
+        SnapshotInfo snapInfo = new SnapshotInfo(
+            new SnapshotId("snap-fail-" + randomAlphaOfLength(3), "uuid-fail"),
             Collections.singletonList("foo-fail"),
             Collections.singletonList("bar-fail"),
-            Collections.emptyList(), null, startTime + between(1, 10000), totalShards, failures, randomBoolean(), meta, startTime
+            Collections.emptyList(),
+            null,
+            startTime + between(1, 10000),
+            totalShards,
+            failures,
+            randomBoolean(),
+            meta,
+            startTime,
+            Collections.emptyMap()
         );
         assertThat(snapInfo.state(), equalTo(SnapshotState.PARTIAL));
         return snapInfo;

--- a/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/slm/SnapshotLifecycleTaskTests.java
+++ b/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/slm/SnapshotLifecycleTaskTests.java
@@ -247,7 +247,7 @@ public class SnapshotLifecycleTaskTests extends ESTestCase {
                              Collections.emptyList(),
                              Collections.emptyList(), "snapshot started", endTime, 3, Collections.singletonList(
                                  new SnapshotShardFailure("nodeId", new ShardId("index", "uuid", 0), "forced failure")),
-                             req.includeGlobalState(), req.userMetadata(), startTime
+                             req.includeGlobalState(), req.userMetadata(), startTime, Collections.emptyMap()
                          ));
                  })) {
             final AtomicBoolean historyStoreCalled = new AtomicBoolean(false);

--- a/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/slm/SnapshotRetentionTaskTests.java
+++ b/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/slm/SnapshotRetentionTaskTests.java
@@ -110,38 +110,100 @@ public class SnapshotRetentionTaskTests extends ESTestCase {
             Collections.singletonMap("repo", Collections.singletonList(i));
 
         // Test when user metadata is null
-        SnapshotInfo info = new SnapshotInfo(new SnapshotId("name", "uuid"), Collections.singletonList("index"),
-            Collections.emptyList(), Collections.emptyList(), null, 1L, 1, Collections.emptyList(), true, null, 0L);
+        SnapshotInfo info = new SnapshotInfo(
+            new SnapshotId("name", "uuid"),
+            Collections.singletonList("index"),
+            Collections.emptyList(),
+            Collections.emptyList(),
+            null,
+            1L,
+            1,
+            Collections.emptyList(),
+            true,
+            null,
+            0L,
+            Collections.emptyMap());
         assertThat(SnapshotRetentionTask.snapshotEligibleForDeletion(info, mkInfos.apply(info), policyMap), equalTo(false));
 
         // Test when no retention is configured
-        info = new SnapshotInfo(new SnapshotId("name", "uuid"), Collections.singletonList("index"), Collections.emptyList(),
-            Collections.emptyList(), null, 1L, 1, Collections.emptyList(), true, null, 0L);
+        info = new SnapshotInfo(
+            new SnapshotId("name", "uuid"),
+            Collections.singletonList("index"),
+            Collections.emptyList(),
+            Collections.emptyList(),
+            null,
+            1L,
+            1,
+            Collections.emptyList(),
+            true,
+            null,
+            0L,
+            Collections.emptyMap());
         assertThat(SnapshotRetentionTask.snapshotEligibleForDeletion(info, mkInfos.apply(info), policyWithNoRetentionMap), equalTo(false));
 
         // Test when user metadata is a map that doesn't contain "policy"
-        info = new SnapshotInfo(new SnapshotId("name", "uuid"), Collections.singletonList("index"), Collections.emptyList(),
-            Collections.emptyList(), null, 1L, 1, Collections.emptyList(), true, Collections.singletonMap("foo", "bar"), 0L);
+        info = new SnapshotInfo(
+            new SnapshotId("name", "uuid"),
+            Collections.singletonList("index"),
+            Collections.emptyList(),
+            Collections.emptyList(),
+            null,
+            1L,
+            1,
+            Collections.emptyList(),
+            true,
+            Collections.singletonMap("foo", "bar"),
+            0L,
+            Collections.emptyMap());
         assertThat(SnapshotRetentionTask.snapshotEligibleForDeletion(info, mkInfos.apply(info), policyMap), equalTo(false));
 
         // Test with an ancient snapshot that should be expunged
-        info = new SnapshotInfo(new SnapshotId("name", "uuid"), Collections.singletonList("index"), Collections.emptyList(),
-            Collections.emptyList(), null, 1L, 1, Collections.emptyList(), true, Collections.singletonMap("policy", "policy"), 0L);
+        info = new SnapshotInfo(
+            new SnapshotId("name", "uuid"),
+            Collections.singletonList("index"),
+            Collections.emptyList(),
+            Collections.emptyList(),
+            null,
+            1L,
+            1,
+            Collections.emptyList(),
+            true,
+            Collections.singletonMap("policy", "policy"),
+            0L,
+            Collections.emptyMap());
         assertThat(SnapshotRetentionTask.snapshotEligibleForDeletion(info, mkInfos.apply(info), policyMap), equalTo(true));
 
         // Test with a snapshot that's start date is old enough to be expunged (but the finish date is not)
         long time = System.currentTimeMillis() - TimeValue.timeValueDays(30).millis() - 1;
-        info = new SnapshotInfo(new SnapshotId("name", "uuid"), Collections.singletonList("index"), Collections.emptyList(),
-            Collections.emptyList(), null, time + TimeValue.timeValueDays(4).millis(), 1, Collections.emptyList(), true,
-            Collections.singletonMap("policy", "policy"), time
-        );
+        info = new SnapshotInfo(
+            new SnapshotId("name", "uuid"),
+            Collections.singletonList("index"),
+            Collections.emptyList(),
+            Collections.emptyList(),
+            null,
+            time + TimeValue.timeValueDays(4).millis(),
+            1,
+            Collections.emptyList(),
+            true,
+            Collections.singletonMap("policy", "policy"),
+            time,
+            Collections.emptyMap());
         assertThat(SnapshotRetentionTask.snapshotEligibleForDeletion(info, mkInfos.apply(info), policyMap), equalTo(true));
 
         // Test with a fresh snapshot that should not be expunged
-        info = new SnapshotInfo(new SnapshotId("name", "uuid"), Collections.singletonList("index"), Collections.emptyList(),
-            Collections.emptyList(), null, System.currentTimeMillis() + 1, 1, Collections.emptyList(), true,
-            Collections.singletonMap("policy", "policy"), System.currentTimeMillis()
-        );
+        info = new SnapshotInfo(
+            new SnapshotId("name", "uuid"),
+            Collections.singletonList("index"),
+            Collections.emptyList(),
+            Collections.emptyList(),
+            null,
+            System.currentTimeMillis() + 1,
+            1,
+            Collections.emptyList(),
+            true,
+            Collections.singletonMap("policy", "policy"),
+            System.currentTimeMillis(),
+            Collections.emptyMap());
         assertThat(SnapshotRetentionTask.snapshotEligibleForDeletion(info, mkInfos.apply(info), policyMap), equalTo(false));
     }
 
@@ -168,11 +230,20 @@ public class SnapshotRetentionTaskTests extends ESTestCase {
 
             final SnapshotInfo eligibleSnapshot = new SnapshotInfo(new SnapshotId("name", "uuid"), Collections.singletonList("index"),
                 Collections.emptyList(), Collections.emptyList(), null, 1L, 1, Collections.emptyList(), true,
-                Collections.singletonMap("policy", policyId), 0L);
-            final SnapshotInfo ineligibleSnapshot = new SnapshotInfo(new SnapshotId("name2", "uuid2"), Collections.singletonList("index"),
-                Collections.emptyList(), Collections.emptyList(), null, System.currentTimeMillis() + 1, 1, Collections.emptyList(), true,
-                Collections.singletonMap("policy", policyId), System.currentTimeMillis()
-            );
+                Collections.singletonMap("policy", policyId), 0L, Collections.emptyMap());
+            final SnapshotInfo ineligibleSnapshot = new SnapshotInfo(
+                new SnapshotId("name2", "uuid2"),
+                Collections.singletonList("index"),
+                Collections.emptyList(),
+                Collections.emptyList(),
+                null,
+                System.currentTimeMillis() + 1,
+                1,
+                Collections.emptyList(),
+                true,
+                Collections.singletonMap("policy", policyId),
+                System.currentTimeMillis(),
+                Collections.emptyMap());
 
             Set<SnapshotId> deleted = ConcurrentHashMap.newKeySet();
             Set<String> deletedSnapshotsInHistory = ConcurrentHashMap.newKeySet();

--- a/x-pack/plugin/repository-encrypted/src/main/java/org/elasticsearch/repositories/encrypted/EncryptedRepository.java
+++ b/x-pack/plugin/repository-encrypted/src/main/java/org/elasticsearch/repositories/encrypted/EncryptedRepository.java
@@ -46,6 +46,7 @@ import org.elasticsearch.repositories.RepositoryData;
 import org.elasticsearch.repositories.RepositoryException;
 import org.elasticsearch.repositories.RepositoryStats;
 import org.elasticsearch.repositories.ShardGenerations;
+import org.elasticsearch.repositories.ShardSnapshotResult;
 import org.elasticsearch.repositories.blobstore.BlobStoreRepository;
 import org.elasticsearch.snapshots.SnapshotId;
 import org.elasticsearch.snapshots.SnapshotInfo;
@@ -248,7 +249,7 @@ public class EncryptedRepository extends BlobStoreRepository {
         IndexShardSnapshotStatus snapshotStatus,
         Version repositoryMetaVersion,
         Map<String, Object> userMetadata,
-        ActionListener<String> listener
+        ActionListener<ShardSnapshotResult> listener
     ) {
         try {
             validateLocalRepositorySecret(userMetadata);

--- a/x-pack/plugin/repository-encrypted/src/test/java/org/elasticsearch/repositories/encrypted/LocalStateEncryptedRepositoryPlugin.java
+++ b/x-pack/plugin/repository-encrypted/src/test/java/org/elasticsearch/repositories/encrypted/LocalStateEncryptedRepositoryPlugin.java
@@ -21,6 +21,7 @@ import org.elasticsearch.index.store.Store;
 import org.elasticsearch.indices.recovery.RecoverySettings;
 import org.elasticsearch.license.XPackLicenseState;
 import org.elasticsearch.repositories.IndexId;
+import org.elasticsearch.repositories.ShardSnapshotResult;
 import org.elasticsearch.repositories.blobstore.BlobStoreRepository;
 import org.elasticsearch.snapshots.SnapshotId;
 import org.elasticsearch.xpack.core.LocalStateCompositeXPackPlugin;
@@ -104,7 +105,7 @@ public final class LocalStateEncryptedRepositoryPlugin extends LocalStateComposi
             IndexShardSnapshotStatus snapshotStatus,
             Version repositoryMetaVersion,
             Map<String, Object> userMetadata,
-            ActionListener<String> listener
+            ActionListener<ShardSnapshotResult> listener
         ) {
             snapshotShardLock.lock();
             try {

--- a/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/store/SearchableSnapshotDirectoryTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/store/SearchableSnapshotDirectoryTests.java
@@ -75,6 +75,7 @@ import org.elasticsearch.index.snapshots.IndexShardSnapshotStatus;
 import org.elasticsearch.index.snapshots.blobstore.BlobStoreIndexShardSnapshot;
 import org.elasticsearch.index.store.Store;
 import org.elasticsearch.index.store.StoreFileMetadata;
+import org.elasticsearch.repositories.ShardSnapshotResult;
 import org.elasticsearch.xpack.searchablesnapshots.cache.common.TestUtils;
 import org.elasticsearch.xpack.searchablesnapshots.store.input.ChecksumBlobContainerIndexInput;
 import org.elasticsearch.index.translog.Translog;
@@ -602,7 +603,7 @@ public class SearchableSnapshotDirectoryTests extends AbstractSearchableSnapshot
                 final SnapshotId snapshotId = new SnapshotId("_snapshot", UUIDs.randomBase64UUID(random()));
                 final IndexId indexId = new IndexId(indexSettings.getIndex().getName(), UUIDs.randomBase64UUID(random()));
 
-                final PlainActionFuture<String> future = PlainActionFuture.newFuture();
+                final PlainActionFuture<ShardSnapshotResult> future = PlainActionFuture.newFuture();
                 threadPool.generic().submit(() -> {
                     IndexShardSnapshotStatus snapshotStatus = IndexShardSnapshotStatus.newInitializing(null);
                     repository.snapshotShard(


### PR DESCRIPTION
This commit adds some per-index statistics to the `SnapshotInfo` blob:

- number of shards
- total size in bytes
- maximum number of segments per shard

It also exposes these statistics in the get snapshot API.