### PR TITLE
Remove assertion from DatabaseRegistry

### DIFF
--- a/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/DatabaseRegistry.java
+++ b/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/DatabaseRegistry.java
@@ -349,7 +349,7 @@ public final class DatabaseRegistry implements Closeable {
                     // This makes the code easier to understand and maintain.
                     SearchResponse searchResponse = client.search(searchRequest).actionGet();
                     SearchHit[] hits = searchResponse.getHits().getHits();
-                    assert hits.length == 1 : "expected 1 hit, but instead got [" + hits.length + "]";
+
                     if (searchResponse.getHits().getHits().length == 0) {
                         failureHandler.accept(new ResourceNotFoundException("chunk document with id [" + id + "] not found"));
                         return;

--- a/qa/os/src/test/java/org/elasticsearch/packaging/util/ServerUtils.java
+++ b/qa/os/src/test/java/org/elasticsearch/packaging/util/ServerUtils.java
@@ -42,6 +42,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
 
 import static java.nio.file.StandardOpenOption.APPEND;
 import static java.nio.file.StandardOpenOption.CREATE;
@@ -253,6 +254,11 @@ public class ServerUtils {
 
     public static void disableGeoIpDownloader(Installation installation) throws IOException {
         List<String> yaml = Collections.singletonList("ingest.geoip.downloader.enabled: false");
-        Files.write(installation.config("elasticsearch.yml"), yaml, CREATE, APPEND);
+        Path yml = installation.config("elasticsearch.yml");
+        try (Stream<String> lines = Files.readAllLines(yml).stream()) {
+            if (lines.noneMatch(s -> s.startsWith("ingest.geoip.downloader.enabled"))) {
+                Files.write(installation.config("elasticsearch.yml"), yaml, CREATE, APPEND);
+            }
+        }
     }
 }


### PR DESCRIPTION
This change removes assertion from `DatabaseRegistry` - we can easily loose `.geoip_databases` index with persistent task state still in cluster state, this is not assertion failing, this is usual failure and should be signalled as one.

This also tries to fix packaging tests by avoiding duplicates in `elasticsearch.yml`.

Closes #71762