### PR TITLE
Fix testFrozenAndNormalIndependent

### DIFF
--- a/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/SearchableSnapshotsShardLimitIntegTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/SearchableSnapshotsShardLimitIntegTests.java
@@ -55,7 +55,7 @@ public class SearchableSnapshotsShardLimitIntegTests extends BaseSearchableSnaps
         createFullSnapshot(fsRepoName, snapshotName);
 
         final Settings.Builder indexSettingsBuilder = Settings.builder();
-        final int initialCopies = between(1, MAX_FROZEN);
+        final int initialCopies = between(1, MAX_FROZEN - 1);
         indexSettingsBuilder.put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, initialCopies - 1);
         mount(indexSettingsBuilder, MountSearchableSnapshotRequest.Storage.SHARED_CACHE);
 


### PR DESCRIPTION
Test would fail one out of 20 runs due to off by one error.

Discovered during backport of #71392 in #71760, where the fix is already contained so this only goes to 8.0