### PR TITLE
Fix ignored spock build tools integ tests

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -112,9 +112,24 @@ dependencies {
   testImplementation 'com.github.tomakehurst:wiremock-jre8-standalone:2.23.2'
   testImplementation 'org.mockito:mockito-core:1.9.5'
   testImplementation "org.hamcrest:hamcrest:${props.getProperty('hamcrest')}"
-  integTestImplementation('org.spockframework:spock-core:2.0-M5-groovy-3.0') {
+
+  integTestImplementation(platform("org.junit:junit-bom:${props.getProperty('junit5')}"))
+  integTestImplementation("org.junit.jupiter:junit-jupiter") {
+    because 'allows to write and run Jupiter tests'
+  }
+  integTestRuntimeOnly("org.junit.vintage:junit-vintage-engine") {
+    because 'allows JUnit 3 and JUnit 4 tests to run'
+  }
+
+  integTestRuntimeOnly("org.junit.platform:junit-platform-launcher") {
+    because 'allows tests to run from IDEs that bundle older version of launcher'
+  }
+
+  integTestImplementation platform("org.spockframework:spock-bom:2.0-M5-groovy-3.0")
+  integTestImplementation("org.spockframework:spock-core") {
     exclude module: "groovy"
   }
+  integTestImplementation "org.spockframework:spock-junit4"  // you can remove this if your code does not rely on old JUnit 4 rules
   integTestImplementation "org.xmlunit:xmlunit-core:2.8.2"
 }
 
@@ -230,6 +245,7 @@ if (project != rootProject) {
     systemProperty 'test.version_under_test', version
     testClassesDirs = sourceSets.integTest.output.classesDirs
     classpath = sourceSets.integTest.runtimeClasspath
+    useJUnitPlatform()
   }
   tasks.named("check").configure { dependsOn("integTest") }
 

--- a/buildSrc/src/integTest/groovy/org/elasticsearch/gradle/PublishPluginFuncTest.groovy
+++ b/buildSrc/src/integTest/groovy/org/elasticsearch/gradle/PublishPluginFuncTest.groovy
@@ -39,7 +39,7 @@ class PublishPluginFuncTest extends AbstractGradleFuncTest {
         file("build/distributions/hello-world-1.0.pom").exists()
         assertXmlEquals(file("build/distributions/hello-world-1.0.pom").text, """
             <project xmlns="http://maven.apache.org/POM/4.0.0" 
-                     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" 
+                     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd" 
                      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
               <modelVersion>4.0.0</modelVersion>
               <groupId>org.acme</groupId>
@@ -96,7 +96,7 @@ class PublishPluginFuncTest extends AbstractGradleFuncTest {
         file("build/distributions/hello-world-plugin-1.0.pom").exists()
         assertXmlEquals(file("build/distributions/hello-world-plugin-1.0.pom").text, """
             <project xmlns="http://maven.apache.org/POM/4.0.0" 
-                     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" 
+                     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd" 
                      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
               <modelVersion>4.0.0</modelVersion>
               <groupId>org.acme</groupId>
@@ -141,7 +141,7 @@ class PublishPluginFuncTest extends AbstractGradleFuncTest {
         file("build/distributions/hello-world-plugin-1.0.pom").exists()
         assertXmlEquals(file("build/distributions/hello-world-plugin-1.0.pom").text, """
             <project xmlns="http://maven.apache.org/POM/4.0.0" 
-                     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" 
+                     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd" 
                      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
               <modelVersion>4.0.0</modelVersion>
               <groupId>org.acme</groupId>
@@ -202,7 +202,7 @@ class PublishPluginFuncTest extends AbstractGradleFuncTest {
         file("build/distributions/hello-world-1.0.pom").exists()
         assertXmlEquals(file("build/distributions/hello-world-1.0.pom").text, """
             <project xmlns="http://maven.apache.org/POM/4.0.0" 
-                     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" 
+                     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd" 
                      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
               <modelVersion>4.0.0</modelVersion>
               <groupId>org.acme</groupId>

--- a/buildSrc/version.properties
+++ b/buildSrc/version.properties
@@ -34,6 +34,7 @@ bouncycastle=1.64
 # test dependencies
 randomizedrunner  = 2.7.7
 junit             = 4.12
+junit5            = 5.7.1
 httpclient        = 4.5.10
 httpcore          = 4.4.12
 httpasyncclient   = 4.1.4


### PR DESCRIPTION
Gradle 7.0 forced us to update to spock2 because we need a groovy 3 compatible
spock framework version. Spock2 requires junit5 to be executed. We use the junit5 platform
but provide the vintage runner to be able to execute junit4 implemented IT tests too