### PR TITLE
[DOCS] Add runtime_mappings to update datafeed API in HLRC

### DIFF
--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/MlClientDocumentationIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/MlClientDocumentationIT.java
@@ -772,6 +772,7 @@ public class MlClientDocumentationIT extends ESRestHighLevelClientTestCase {
         {
             AggregatorFactories.Builder aggs = AggregatorFactories.builder();
             List<SearchSourceBuilder.ScriptField> scriptFields = Collections.emptyList();
+            Map<String, Object> runtimeMappings = Collections.emptyMap();
             // tag::update-datafeed-config
             DatafeedUpdate.Builder datafeedUpdateBuilder = new DatafeedUpdate.Builder(datafeedId) // <1>
                 .setAggregations(aggs) // <2>
@@ -782,6 +783,7 @@ public class MlClientDocumentationIT extends ESRestHighLevelClientTestCase {
                 .setQueryDelay(TimeValue.timeValueMinutes(1)) // <7>
                 .setScriptFields(scriptFields) // <8>
                 .setScrollSize(1000); // <9>
+                .setRuntimeMappings(runtimeMappings); // <10>
             // end::update-datafeed-config
 
             // Clearing aggregation to avoid complex validation rules

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/MlClientDocumentationIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/MlClientDocumentationIT.java
@@ -782,7 +782,7 @@ public class MlClientDocumentationIT extends ESRestHighLevelClientTestCase {
                 .setQuery(QueryBuilders.matchAllQuery()) // <6>
                 .setQueryDelay(TimeValue.timeValueMinutes(1)) // <7>
                 .setScriptFields(scriptFields) // <8>
-                .setScrollSize(1000); // <9>
+                .setScrollSize(1000) // <9>
                 .setRuntimeMappings(runtimeMappings); // <10>
             // end::update-datafeed-config
 

--- a/docs/java-rest/high-level/ml/put-datafeed.asciidoc
+++ b/docs/java-rest/high-level/ml/put-datafeed.asciidoc
@@ -93,7 +93,7 @@ include-tagged::{doc-tests-file}[{api}-config-set-scroll-size]
 --------------------------------------------------
 include-tagged::{doc-tests-file}[{api}-config-set-runtime-mappings]
 --------------------------------------------------
-<1> Set the runtime mappings used in the searches.
+<1> The runtime fields used in the datafeed.
 
 include::../execution.asciidoc[]
 

--- a/docs/java-rest/high-level/ml/update-datafeed.asciidoc
+++ b/docs/java-rest/high-level/ml/update-datafeed.asciidoc
@@ -43,6 +43,7 @@ datafeed runs in real time.
 <7> Optional, the time interval behind real time that data is queried.
 <8> Optional, allows the use of script fields.
 <9> Optional, the `size` parameter used in the searches.
+<10> Optional, the runtime fields used in the datafeed.
 
 include::../execution.asciidoc[]
 


### PR DESCRIPTION
Related to https://github.com/elastic/elasticsearch/pull/71707

This PR updates the Java High Level REST Client documentation to include the runtime mappings option in the [update datafeeds API](https://www.elastic.co/guide/en/elasticsearch/client/java-rest/master/java-rest-high-x-pack-ml-update-datafeed.html), similar to how it was added to the [create datafeeds API](https://www.elastic.co/guide/en/elasticsearch/client/java-rest/master/java-rest-high-x-pack-ml-put-datafeed.html).