### PR TITLE
Fix mount frozen index during rolling upgrade

### DIFF
--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/action/TransportMountSearchableSnapshotAction.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/action/TransportMountSearchableSnapshotAction.java
@@ -8,6 +8,7 @@
 package org.elasticsearch.xpack.searchablesnapshots.action;
 
 import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.StepListener;
 import org.elasticsearch.action.admin.cluster.snapshots.restore.RestoreSnapshotRequest;
@@ -126,7 +127,8 @@ public class TransportMountSearchableSnapshotAction extends TransportMasterNodeA
         String repoName,
         SnapshotId snapshotId,
         IndexId indexId,
-        MountSearchableSnapshotRequest.Storage storage
+        MountSearchableSnapshotRequest.Storage storage,
+        Version minNodeVersion
     ) {
         final Settings.Builder settings = Settings.builder();
 
@@ -145,9 +147,17 @@ public class TransportMountSearchableSnapshotAction extends TransportMasterNodeA
             .put(INDEX_RECOVERY_TYPE_SETTING.getKey(), SearchableSnapshotsConstants.SNAPSHOT_RECOVERY_STATE_FACTORY_KEY);
 
         if (storage == MountSearchableSnapshotRequest.Storage.SHARED_CACHE) {
+            if (minNodeVersion.before(Version.V_7_12_0)) {
+                throw new IllegalArgumentException("shared cache searchable snapshots require minimum node version " + Version.V_7_12_0);
+            }
             settings.put(SearchableSnapshotsConstants.SNAPSHOT_PARTIAL_SETTING.getKey(), true)
-                .put(DiskThresholdDecider.SETTING_IGNORE_DISK_WATERMARKS.getKey(), true)
-                .put(ShardLimitValidator.INDEX_SETTING_SHARD_LIMIT_GROUP.getKey(), ShardLimitValidator.FROZEN_GROUP);
+                .put(DiskThresholdDecider.SETTING_IGNORE_DISK_WATERMARKS.getKey(), true);
+
+            // we cannot apply this setting during rolling upgrade.
+            // todo: update version after backport
+            if (minNodeVersion.onOrAfter(Version.V_8_0_0)) {
+                settings.put(ShardLimitValidator.INDEX_SETTING_SHARD_LIMIT_GROUP.getKey(), ShardLimitValidator.FROZEN_GROUP);
+            }
         }
 
         return settings.build();
@@ -228,7 +238,16 @@ public class TransportMountSearchableSnapshotAction extends TransportMasterNodeA
                 .put(IndexMetadata.SETTING_AUTO_EXPAND_REPLICAS, false) // can be overridden
                 .put(DataTierAllocationDecider.INDEX_ROUTING_PREFER, getDataTiersPreference(request.storage()))
                 .put(request.indexSettings())
-                .put(buildIndexSettings(repoData.getUuid(), request.repositoryName(), snapshotId, indexId, request.storage()))
+                .put(
+                    buildIndexSettings(
+                        repoData.getUuid(),
+                        request.repositoryName(),
+                        snapshotId,
+                        indexId,
+                        request.storage(),
+                        state.nodes().getMinNodeVersion()
+                    )
+                )
                 .build();
 
             // todo: restore archives bad settings, for now we verify just the data tiers, since we know their dependencies are available


### PR DESCRIPTION
If master ends up on a newer version than other cluster members, we
cannot apply the new index setting for shard limits. We skip doing so
for now.

Relates #71392

Will integrate into original 7.x backport in #71760

Will follow-up with a conversion when all nodes in cluster are upgraded to new version (now available in #71781, depending on this PR).