### PR TITLE
Adding backticks to xpack.ml.use_auto_machine_memory_percent

### DIFF
--- a/docs/reference/settings/ml-settings.asciidoc
+++ b/docs/reference/settings/ml-settings.asciidoc
@@ -178,7 +178,7 @@ assumed to have failed. When the {operator-feature} is enabled, this setting can
 be updated only by operator users. Defaults to `10s`. The minimum value for this 
 setting is `5s`. 
 
-xpack.ml.use_auto_machine_memory_percent::
+`xpack.ml.use_auto_machine_memory_percent`::
 (<<cluster-update-settings,Dynamic>>) If this setting is `true`, the
 `xpack.ml.max_machine_memory_percent` setting is ignored. Instead, the maximum
 percentage of the machine's memory that can be used for running {ml} analytics


### PR DESCRIPTION
The filed xpack.ml.use_auto_machine_memory_percent was not enclosed in backticks and was rendered as bold.

<!--
Thank you for your interest in and contributing to Elasticsearch! There
are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.
-->

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/elasticsearch/blob/master/CONTRIBUTING.md)?
- If submitting code, have you built your formula locally prior to submission with `gradle check`?
- If submitting code, is your pull request against master? Unless there is a good reason otherwise, we prefer pull requests against master and will backport as needed.
- If submitting code, have you checked that your submission is for an [OS and architecture that we support](https://www.elastic.co/support/matrix#show_os)?
- If you are submitting this code for a class then read our [policy](https://github.com/elastic/elasticsearch/blob/master/CONTRIBUTING.md#contributing-as-part-of-a-class) for that.
