### PR TITLE
Make ActionListener runAfter and runBefore Chainable

### DIFF
--- a/plugins/repository-s3/src/main/java/org/elasticsearch/repositories/s3/S3Repository.java
+++ b/plugins/repository-s3/src/main/java/org/elasticsearch/repositories/s3/S3Repository.java
@@ -264,7 +264,7 @@ class S3Repository extends MeteredBlobStoreRepository {
      * See {@link #COOLDOWN_PERIOD} for details.
      */
     private <T> ActionListener<T> delayedListener(ActionListener<T> listener) {
-        final ActionListener<T> wrappedListener = ActionListener.runBefore(listener, () -> {
+        final ActionListener<T> wrappedListener = listener.runBefore(() -> {
             final Scheduler.Cancellable cancellable = finalizationFuture.getAndSet(null);
             assert cancellable != null;
         });

--- a/server/src/internalClusterTest/java/org/elasticsearch/action/support/replication/TransportReplicationActionRetryOnClosedNodeIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/action/support/replication/TransportReplicationActionRetryOnClosedNodeIT.java
@@ -175,10 +175,9 @@ public class TransportReplicationActionRetryOnClosedNodeIT extends ESIntegTestCa
         AtomicReference<Object> response = new AtomicReference<>();
         CountDownLatch doneLatch = new CountDownLatch(1);
         client(coordinator).execute(TestAction.TYPE, new Request(new ShardId(resolveIndex("test"), 0)),
-            ActionListener.runAfter(ActionListener.wrap(
+            ActionListener.<Response>wrap(
                 r -> assertTrue(response.compareAndSet(null, r)),
-                e -> assertTrue(response.compareAndSet(null, e))),
-                doneLatch::countDown));
+                e -> assertTrue(response.compareAndSet(null, e))).runAfter(doneLatch::countDown));
 
         assertTrue(primaryTestPlugin.actionRunningLatch.await(10, TimeUnit.SECONDS));
 

--- a/server/src/main/java/org/elasticsearch/action/ActionListener.java
+++ b/server/src/main/java/org/elasticsearch/action/ActionListener.java
@@ -317,11 +317,11 @@ public interface ActionListener<Response> {
     }
 
     /**
-     * Wraps a given listener and returns a new listener which executes the provided {@code runAfter}
+     * Wraps the current instance and returns a new listener which executes the provided {@code runAfter}
      * callback when the listener is notified via either {@code #onResponse} or {@code #onFailure}.
      */
-    static <Response> ActionListener<Response> runAfter(ActionListener<Response> delegate, Runnable runAfter) {
-        return new RunAfterActionListener<>(delegate, runAfter);
+    default ActionListener<Response> runAfter(Runnable runAfter) {
+        return new RunAfterActionListener<>(this, runAfter);
     }
 
     final class RunAfterActionListener<T> extends Delegating<T, T> {
@@ -358,13 +358,13 @@ public interface ActionListener<Response> {
     }
 
     /**
-     * Wraps a given listener and returns a new listener which executes the provided {@code runBefore}
+     * Wraps the current listener and returns a new listener which executes the provided {@code runBefore}
      * callback before the listener is notified via either {@code #onResponse} or {@code #onFailure}.
      * If the callback throws an exception then it will be passed to the listener's {@code #onFailure} and its {@code #onResponse} will
      * not be executed.
      */
-    static <Response> ActionListener<Response> runBefore(ActionListener<Response> delegate, CheckedRunnable<?> runBefore) {
-        return new RunBeforeActionListener<>(delegate, runBefore);
+    default ActionListener<Response> runBefore(CheckedRunnable<?> runBefore) {
+        return new RunBeforeActionListener<>(this, runBefore);
     }
 
     final class RunBeforeActionListener<T> extends Delegating<T, T> {

--- a/server/src/main/java/org/elasticsearch/action/bulk/BulkRequestHandler.java
+++ b/server/src/main/java/org/elasticsearch/action/bulk/BulkRequestHandler.java
@@ -48,7 +48,7 @@ public final class BulkRequestHandler {
             semaphore.acquire();
             toRelease = semaphore::release;
             CountDownLatch latch = new CountDownLatch(1);
-            retry.withBackoff(consumer, bulkRequest, ActionListener.runAfter(new ActionListener<BulkResponse>() {
+            retry.withBackoff(consumer, bulkRequest, new ActionListener<BulkResponse>() {
                 @Override
                 public void onResponse(BulkResponse response) {
                     listener.afterBulk(executionId, bulkRequest, response);
@@ -58,7 +58,7 @@ public final class BulkRequestHandler {
                 public void onFailure(Exception e) {
                     listener.afterBulk(executionId, bulkRequest, e);
                 }
-            }, () -> {
+            }.runAfter(() -> {
                 semaphore.release();
                 latch.countDown();
             }));

--- a/server/src/main/java/org/elasticsearch/action/bulk/TransportBulkAction.java
+++ b/server/src/main/java/org/elasticsearch/action/bulk/TransportBulkAction.java
@@ -152,7 +152,7 @@ public class TransportBulkAction extends HandledTransportAction<BulkRequest, Bul
         final long indexingBytes = bulkRequest.ramBytesUsed();
         final boolean isOnlySystem = isOnlySystem(bulkRequest, clusterService.state().metadata().getIndicesLookup(), systemIndices);
         final Releasable releasable = indexingPressure.markCoordinatingOperationStarted(indexingOps, indexingBytes, isOnlySystem);
-        final ActionListener<BulkResponse> releasingListener = ActionListener.runBefore(listener, releasable::close);
+        final ActionListener<BulkResponse> releasingListener = listener.runBefore(releasable::close);
         final String executorName = isOnlySystem ? Names.SYSTEM_WRITE : Names.WRITE;
         try {
             doInternalExecute(task, bulkRequest, executorName, releasingListener);

--- a/server/src/main/java/org/elasticsearch/action/bulk/TransportShardBulkAction.java
+++ b/server/src/main/java/org/elasticsearch/action/bulk/TransportShardBulkAction.java
@@ -304,7 +304,7 @@ public class TransportShardBulkAction extends TransportWriteAction<BulkShardRequ
                     public void onResponse(Void v) {
                         context.markAsRequiringMappingUpdate();
                         waitForMappingUpdate.accept(
-                            ActionListener.runAfter(new ActionListener<>() {
+                            new ActionListener<Void>() {
                                 @Override
                                 public void onResponse(Void v) {
                                     assert context.requiresWaitingForMappingUpdate();
@@ -315,7 +315,7 @@ public class TransportShardBulkAction extends TransportWriteAction<BulkShardRequ
                                 public void onFailure(Exception e) {
                                     context.failOnMappingUpdate(e);
                                 }
-                            }, () -> itemDoneListener.onResponse(null))
+                            }.runAfter(() -> itemDoneListener.onResponse(null))
                         );
                     }
 

--- a/server/src/main/java/org/elasticsearch/action/search/AbstractSearchAsyncAction.java
+++ b/server/src/main/java/org/elasticsearch/action/search/AbstractSearchAsyncAction.java
@@ -140,7 +140,7 @@ abstract class AbstractSearchAsyncAction<Result extends SearchPhaseResult> exten
         this.executor = executor;
         this.request = request;
         this.task = task;
-        this.listener = ActionListener.runAfter(listener, this::releaseContext);
+        this.listener = listener.runAfter(this::releaseContext);
         this.nodeIdToConnection = nodeIdToConnection;
         this.clusterState = clusterState;
         this.concreteIndexBoosts = concreteIndexBoosts;

--- a/server/src/main/java/org/elasticsearch/cluster/InternalClusterInfoService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/InternalClusterInfoService.java
@@ -161,7 +161,7 @@ public class InternalClusterInfoService implements ClusterInfoService, ClusterSt
             nodesStatsRequest.clear();
             nodesStatsRequest.addMetric(NodesStatsRequest.Metric.FS.metricName());
             nodesStatsRequest.timeout(fetchTimeout);
-            client.admin().cluster().nodesStats(nodesStatsRequest, ActionListener.runAfter(new ActionListener<>() {
+            client.admin().cluster().nodesStats(nodesStatsRequest, new ActionListener<NodesStatsResponse>() {
                 @Override
                 public void onResponse(NodesStatsResponse nodesStatsResponse) {
                     logger.trace("received node stats response");
@@ -193,14 +193,14 @@ public class InternalClusterInfoService implements ClusterInfoService, ClusterSt
                     leastAvailableSpaceUsages = ImmutableOpenMap.of();
                     mostAvailableSpaceUsages = ImmutableOpenMap.of();
                 }
-            }, this::onStatsProcessed));
+            }.runAfter(this::onStatsProcessed));
 
             final IndicesStatsRequest indicesStatsRequest = new IndicesStatsRequest();
             indicesStatsRequest.clear();
             indicesStatsRequest.store(true);
             indicesStatsRequest.indicesOptions(IndicesOptions.STRICT_EXPAND_OPEN_CLOSED_HIDDEN);
             indicesStatsRequest.timeout(fetchTimeout);
-            client.admin().indices().stats(indicesStatsRequest, ActionListener.runAfter(new ActionListener<>() {
+            client.admin().indices().stats(indicesStatsRequest, new ActionListener<IndicesStatsResponse>() {
                 @Override
                 public void onResponse(IndicesStatsResponse indicesStatsResponse) {
                     logger.trace("received indices stats response");
@@ -253,7 +253,7 @@ public class InternalClusterInfoService implements ClusterInfoService, ClusterSt
                     }
                     indicesStatsSummary = IndicesStatsSummary.EMPTY;
                 }
-            }, this::onStatsProcessed));
+            }.runAfter(this::onStatsProcessed));
         }
 
         private void onStatsProcessed() {

--- a/server/src/main/java/org/elasticsearch/cluster/action/index/MappingUpdatedAction.java
+++ b/server/src/main/java/org/elasticsearch/cluster/action/index/MappingUpdatedAction.java
@@ -82,7 +82,7 @@ public class MappingUpdatedAction {
         }
         boolean successFullySent = false;
         try {
-            sendUpdateMapping(index, mappingUpdate, ActionListener.runBefore(listener, release::run));
+            sendUpdateMapping(index, mappingUpdate, listener.runBefore(release::run));
             successFullySent = true;
         } finally {
             if (successFullySent == false) {

--- a/server/src/main/java/org/elasticsearch/index/shard/IndexShard.java
+++ b/server/src/main/java/org/elasticsearch/index/shard/IndexShard.java
@@ -698,8 +698,7 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
                         final ReplicationTracker.PrimaryContext primaryContext =
                                 replicationTracker.startRelocationHandoff(targetAllocationId);
                         // make sure we release all permits before we resolve the final listener
-                        final ActionListener<Void> wrappedInnerListener =
-                                ActionListener.runBefore(listener, Releasables.releaseOnce(releasable)::close);
+                        final ActionListener<Void> wrappedInnerListener = listener.runBefore(Releasables.releaseOnce(releasable)::close);
                         final ActionListener<Void> wrappedListener = new ActionListener<>() {
                             @Override
                             public void onResponse(Void unused) {
@@ -1911,7 +1910,7 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
         assert recoveryState.getRecoverySource().getType() == RecoverySource.Type.LOCAL_SHARDS : "invalid recovery type: " +
             recoveryState.getRecoverySource();
         final List<LocalShardSnapshot> snapshots = new ArrayList<>();
-        final ActionListener<Boolean> recoveryListener = ActionListener.runBefore(listener, () -> IOUtils.close(snapshots));
+        final ActionListener<Boolean> recoveryListener = listener.runBefore(() -> IOUtils.close(snapshots));
         boolean success = false;
         try {
             for (IndexShard shard : localShards) {

--- a/server/src/main/java/org/elasticsearch/indices/recovery/PeerRecoverySourceService.java
+++ b/server/src/main/java/org/elasticsearch/indices/recovery/PeerRecoverySourceService.java
@@ -139,7 +139,7 @@ public class PeerRecoverySourceService extends AbstractLifecycleComponent implem
         RecoverySourceHandler handler = ongoingRecoveries.addNewRecovery(request, shard);
         logger.trace("[{}][{}] starting recovery to {}", request.shardId().getIndex().getName(), request.shardId().id(),
             request.targetNode());
-        handler.recoverToTarget(ActionListener.runAfter(listener, () -> ongoingRecoveries.remove(shard, handler)));
+        handler.recoverToTarget(listener.runAfter(() -> ongoingRecoveries.remove(shard, handler)));
     }
 
     private void reestablish(ReestablishRecoveryRequest request, ActionListener<RecoveryResponse> listener) {

--- a/server/src/main/java/org/elasticsearch/indices/recovery/PeerRecoveryTargetService.java
+++ b/server/src/main/java/org/elasticsearch/indices/recovery/PeerRecoveryTargetService.java
@@ -306,8 +306,8 @@ public class PeerRecoveryTargetService implements IndexEventListener {
             boolean success = false;
             try {
                 recoveryRef.target().handoffPrimaryContext(request.primaryContext(),
-                        ActionListener.runBefore(new ChannelActionListener<>(channel, Actions.HANDOFF_PRIMARY_CONTEXT, request)
-                                .map(v -> TransportResponse.Empty.INSTANCE), recoveryRef::close));
+                    new ChannelActionListener<>(channel, Actions.HANDOFF_PRIMARY_CONTEXT, request).<Void>map(
+                        v -> TransportResponse.Empty.INSTANCE).runBefore(recoveryRef::close));
                 success = true;
             } finally {
                 if (success == false) {

--- a/server/src/main/java/org/elasticsearch/indices/recovery/RecoverySourceHandler.java
+++ b/server/src/main/java/org/elasticsearch/indices/recovery/RecoverySourceHandler.java
@@ -932,9 +932,8 @@ public class RecoverySourceHandler {
                 protected void executeChunkRequest(FileChunk request, ActionListener<Void> listener) {
                     cancellableThreads.checkForCancel();
                     final ReleasableBytesReference content = new ReleasableBytesReference(request.content, request);
-                    recoveryTarget.writeFileChunk(
-                        request.md, request.position, content, request.lastChunk,
-                            translogOps.getAsInt(), ActionListener.runBefore(listener, content::close));
+                    recoveryTarget.writeFileChunk(request.md, request.position, content, request.lastChunk, translogOps.getAsInt(),
+                        listener.runBefore(content::close));
                 }
 
                 @Override

--- a/server/src/main/java/org/elasticsearch/indices/recovery/RemoteRecoveryTargetHandler.java
+++ b/server/src/main/java/org/elasticsearch/indices/recovery/RemoteRecoveryTargetHandler.java
@@ -225,7 +225,7 @@ public class RemoteRecoveryTargetHandler implements RecoveryTargetHandler {
                                                                       TransportRequestOptions options, ActionListener<T> actionListener,
                                                                       Writeable.Reader<T> reader) {
         final Object key = new Object();
-        final ActionListener<T> removeListener = ActionListener.runBefore(actionListener, () -> onGoingRetryableActions.remove(key));
+        final ActionListener<T> removeListener = actionListener.runBefore(() -> onGoingRetryableActions.remove(key));
         final TimeValue initialDelay = TimeValue.timeValueMillis(200);
         final TimeValue timeout = recoverySettings.internalActionRetryTimeout();
         final RetryableAction<T> retryableAction = new RetryableAction<>(logger, threadPool, initialDelay, timeout, removeListener) {

--- a/server/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
+++ b/server/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
@@ -1786,8 +1786,7 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
             if (snapshotIdsWithoutVersion.isEmpty() == false) {
                 final Map<SnapshotId, Version> updatedVersionMap = new ConcurrentHashMap<>();
                 final GroupedActionListener<Void> loadAllVersionsListener = new GroupedActionListener<>(
-                    ActionListener.runAfter(
-                        new ActionListener<>() {
+                        new ActionListener<Collection<Void>>() {
                             @Override
                             public void onResponse(Collection<Void> voids) {
                                 logger.info("Successfully loaded all snapshot's version information for {} from snapshot metadata",
@@ -1799,7 +1798,7 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
                             public void onFailure(Exception e) {
                                 logger.warn("Failure when trying to load missing version information from snapshot metadata", e);
                             }
-                        }, () -> filterRepositoryDataStep.onResponse(repositoryData.withVersions(updatedVersionMap))),
+                        }.runAfter(() -> filterRepositoryDataStep.onResponse(repositoryData.withVersions(updatedVersionMap))),
                     snapshotIdsWithoutVersion.size());
                 for (SnapshotId snapshotId : snapshotIdsWithoutVersion) {
                     threadPool().executor(ThreadPool.Names.SNAPSHOT).execute(ActionRunnable.run(loadAllVersionsListener, () ->

--- a/server/src/main/java/org/elasticsearch/snapshots/SnapshotShardsService.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/SnapshotShardsService.java
@@ -332,7 +332,7 @@ public class SnapshotShardsService extends AbstractLifecycleComponent implements
                 final IndexCommit snapshotIndexCommit = snapshotRef.getIndexCommit();
                 repository.snapshotShard(indexShard.store(), indexShard.mapperService(), snapshot.getSnapshotId(), indexId,
                     snapshotRef.getIndexCommit(), getShardStateId(indexShard, snapshotIndexCommit), snapshotStatus, version, userMetadata,
-                    ActionListener.runBefore(listener, snapshotRef::close));
+                    listener.runBefore(snapshotRef::close));
             } catch (Exception e) {
                 IOUtils.close(snapshotRef);
                 throw e;

--- a/server/src/main/java/org/elasticsearch/snapshots/SnapshotsService.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/SnapshotsService.java
@@ -609,27 +609,25 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
             repository.cloneShardSnapshot(sourceSnapshot, targetSnapshot, repoShardId, shardStatusBefore.generation(), ActionListener.wrap(
                     generation -> innerUpdateSnapshotState(
                             new ShardSnapshotUpdate(target, repoShardId,
-                                    new ShardSnapshotStatus(localNodeId, ShardState.SUCCESS, generation)),
-                            ActionListener.runBefore(
-                                    ActionListener.wrap(
+                                    new ShardSnapshotStatus(localNodeId, ShardState.SUCCESS, generation)), ActionListener.<Void>wrap(
                                             v -> logger.trace("Marked [{}] as successfully cloned from [{}] to [{}]", repoShardId,
                                                     sourceSnapshot, targetSnapshot),
                                             e -> {
                                                 logger.warn("Cluster state update after successful shard clone [{}] failed", repoShardId);
                                                 failAllListenersOnMasterFailOver(e);
                                             }
-                                    ), () -> currentlyCloning.remove(repoShardId))
+                            ).runBefore(() -> currentlyCloning.remove(repoShardId))
                     ), e -> innerUpdateSnapshotState(
                             new ShardSnapshotUpdate(target, repoShardId,
                                     new ShardSnapshotStatus(localNodeId, ShardState.FAILED, "failed to clone shard snapshot", null)),
-                            ActionListener.runBefore(ActionListener.wrap(
+                            ActionListener.<Void>wrap(
                                     v -> logger.trace("Marked [{}] as failed clone from [{}] to [{}]", repoShardId,
                                             sourceSnapshot, targetSnapshot),
                                     ex -> {
                                         logger.warn("Cluster state update after failed shard clone [{}] failed", repoShardId);
                                         failAllListenersOnMasterFailOver(ex);
                                     }
-                            ), () -> currentlyCloning.remove(repoShardId)))));
+                            ).runBefore(() -> currentlyCloning.remove(repoShardId)))));
         }
     }
 

--- a/server/src/test/java/org/elasticsearch/action/ActionListenerTests.java
+++ b/server/src/test/java/org/elasticsearch/action/ActionListenerTests.java
@@ -148,13 +148,13 @@ public class ActionListenerTests extends ESTestCase {
     public void testRunAfter() {
         {
             AtomicBoolean afterSuccess = new AtomicBoolean();
-            ActionListener<Object> listener = ActionListener.runAfter(ActionListener.wrap(r -> {}, e -> {}), () -> afterSuccess.set(true));
+            ActionListener<Object> listener = ActionListener.wrap(r -> {}, e -> {}).runAfter(() -> afterSuccess.set(true));
             listener.onResponse(null);
             assertThat(afterSuccess.get(), equalTo(true));
         }
         {
             AtomicBoolean afterFailure = new AtomicBoolean();
-            ActionListener<Object> listener = ActionListener.runAfter(ActionListener.wrap(r -> {}, e -> {}), () -> afterFailure.set(true));
+            ActionListener<Object> listener = ActionListener.wrap(r -> {}, e -> {}).runAfter(() -> afterFailure.set(true));
             listener.onFailure(null);
             assertThat(afterFailure.get(), equalTo(true));
         }
@@ -163,15 +163,13 @@ public class ActionListenerTests extends ESTestCase {
     public void testRunBefore() {
         {
             AtomicBoolean afterSuccess = new AtomicBoolean();
-            ActionListener<Object> listener =
-                ActionListener.runBefore(ActionListener.wrap(r -> {}, e -> {}), () -> afterSuccess.set(true));
+            ActionListener<Object> listener = ActionListener.wrap(r -> {}, e -> {}).runBefore(() -> afterSuccess.set(true));
             listener.onResponse(null);
             assertThat(afterSuccess.get(), equalTo(true));
         }
         {
             AtomicBoolean afterFailure = new AtomicBoolean();
-            ActionListener<Object> listener =
-                ActionListener.runBefore(ActionListener.wrap(r -> {}, e -> {}), () -> afterFailure.set(true));
+            ActionListener<Object> listener = ActionListener.wrap(r -> {}, e -> {}).runBefore(() -> afterFailure.set(true));
             listener.onFailure(null);
             assertThat(afterFailure.get(), equalTo(true));
         }

--- a/server/src/test/java/org/elasticsearch/action/search/AbstractSearchAsyncActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/search/AbstractSearchAsyncActionTests.java
@@ -118,7 +118,7 @@ public class AbstractSearchAsyncActionTests extends ESTestCase {
     private void runTestTook(final boolean controlled) {
         final AtomicLong expected = new AtomicLong();
         AbstractSearchAsyncAction<SearchPhaseResult> action = createAction(new SearchRequest(),
-            new ArraySearchPhaseResults<>(10), null, controlled, expected);
+            new ArraySearchPhaseResults<>(10), ActionListener.wrap(() -> {}), controlled, expected);
         final long actual = action.buildTookInMillis();
         if (controlled) {
             // with a controlled clock, we can assert the exact took time
@@ -133,7 +133,7 @@ public class AbstractSearchAsyncActionTests extends ESTestCase {
         SearchRequest searchRequest = new SearchRequest().allowPartialSearchResults(randomBoolean());
         final AtomicLong expected = new AtomicLong();
         AbstractSearchAsyncAction<SearchPhaseResult> action = createAction(searchRequest,
-            new ArraySearchPhaseResults<>(10), null, false, expected);
+            new ArraySearchPhaseResults<>(10), ActionListener.wrap(() -> {}), false, expected);
         String clusterAlias = randomBoolean() ? null : randomAlphaOfLengthBetween(5, 10);
         SearchShardIterator iterator = new SearchShardIterator(clusterAlias, new ShardId(new Index("name", "foo"), 1),
             Collections.emptyList(), new OriginalIndices(new String[] {"name", "name1"}, IndicesOptions.strictExpand()));

--- a/server/src/test/java/org/elasticsearch/action/search/CanMatchPreFilterSearchPhaseTests.java
+++ b/server/src/test/java/org/elasticsearch/action/search/CanMatchPreFilterSearchPhaseTests.java
@@ -107,7 +107,7 @@ public class CanMatchPreFilterSearchPhaseTests extends ESTestCase {
             (clusterAlias, node) -> lookup.get(node),
             Collections.singletonMap("_na_", new AliasFilter(null, Strings.EMPTY_ARRAY)),
             Collections.emptyMap(), EsExecutors.newDirectExecutorService(),
-            searchRequest, null, shardsIter, timeProvider, ClusterState.EMPTY_STATE, null,
+            searchRequest, ActionListener.wrap(() -> {}), shardsIter, timeProvider, ClusterState.EMPTY_STATE, null,
             (iter) -> new SearchPhase("test") {
                     @Override
                     public void run() throws IOException {
@@ -175,7 +175,7 @@ public class CanMatchPreFilterSearchPhaseTests extends ESTestCase {
             (clusterAlias, node) -> lookup.get(node),
             Collections.singletonMap("_na_", new AliasFilter(null, Strings.EMPTY_ARRAY)),
             Collections.emptyMap(), EsExecutors.newDirectExecutorService(),
-            searchRequest, null, shardsIter, timeProvider, ClusterState.EMPTY_STATE, null,
+            searchRequest, ActionListener.wrap(() -> {}), shardsIter, timeProvider, ClusterState.EMPTY_STATE, null,
             (iter) -> new SearchPhase("test") {
                 @Override
                 public void run() throws IOException {
@@ -238,7 +238,7 @@ public class CanMatchPreFilterSearchPhaseTests extends ESTestCase {
             Collections.emptyMap(),
             EsExecutors.newDirectExecutorService(),
             searchRequest,
-            null,
+            ActionListener.wrap(() -> {}),
             shardsIter,
             timeProvider,
             ClusterState.EMPTY_STATE,
@@ -340,7 +340,7 @@ public class CanMatchPreFilterSearchPhaseTests extends ESTestCase {
                 (clusterAlias, node) -> lookup.get(node),
                 Collections.singletonMap("_na_", new AliasFilter(null, Strings.EMPTY_ARRAY)),
                 Collections.emptyMap(), EsExecutors.newDirectExecutorService(),
-                searchRequest, null, shardsIter, timeProvider, ClusterState.EMPTY_STATE, null,
+                searchRequest, ActionListener.wrap(() -> {}), shardsIter, timeProvider, ClusterState.EMPTY_STATE, null,
                 (iter) -> new SearchPhase("test") {
                     @Override
                     public void run() {
@@ -420,7 +420,7 @@ public class CanMatchPreFilterSearchPhaseTests extends ESTestCase {
                 (clusterAlias, node) -> lookup.get(node),
                 Collections.singletonMap("_na_", new AliasFilter(null, Strings.EMPTY_ARRAY)),
                 Collections.emptyMap(), EsExecutors.newDirectExecutorService(),
-                searchRequest, null, shardsIter, timeProvider, ClusterState.EMPTY_STATE, null,
+                searchRequest, ActionListener.wrap(() -> {}), shardsIter, timeProvider, ClusterState.EMPTY_STATE, null,
                 (iter) -> new SearchPhase("test") {
                     @Override
                     public void run() {
@@ -725,7 +725,7 @@ public class CanMatchPreFilterSearchPhaseTests extends ESTestCase {
             Collections.emptyMap(),
             EsExecutors.newDirectExecutorService(),
             searchRequest,
-            null,
+            ActionListener.wrap(() -> {}),
             shardsIter,
             timeProvider,
             ClusterState.EMPTY_STATE,

--- a/server/src/test/java/org/elasticsearch/action/search/SearchQueryThenFetchAsyncActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/search/SearchQueryThenFetchAsyncActionTests.java
@@ -157,7 +157,7 @@ public class SearchQueryThenFetchAsyncActionTests extends ESTestCase {
             searchTransportService, (clusterAlias, node) -> lookup.get(node),
             Collections.singletonMap("_na_", new AliasFilter(null, Strings.EMPTY_ARRAY)),
             Collections.emptyMap(), controller, executor,
-            resultConsumer, searchRequest, null, shardsIter, timeProvider, null,
+            resultConsumer, searchRequest, ActionListener.wrap(() -> {}), shardsIter, timeProvider, null,
             task, SearchResponse.Clusters.EMPTY) {
             @Override
             protected SearchPhase getNextPhase(SearchPhaseResults<SearchPhaseResult> results, SearchPhaseContext context) {
@@ -353,7 +353,7 @@ public class SearchQueryThenFetchAsyncActionTests extends ESTestCase {
             searchTransportService, (clusterAlias, node) -> lookup.get(node),
             Collections.singletonMap("_na_", new AliasFilter(null, Strings.EMPTY_ARRAY)),
             Collections.emptyMap(), controller, executor,
-            resultConsumer, searchRequest, null, shardsIter, timeProvider, null,
+            resultConsumer, searchRequest, ActionListener.wrap(() -> {}), shardsIter, timeProvider, null,
             task, SearchResponse.Clusters.EMPTY) {
             @Override
             protected SearchPhase getNextPhase(SearchPhaseResults<SearchPhaseResult> results, SearchPhaseContext context) {
@@ -454,7 +454,7 @@ public class SearchQueryThenFetchAsyncActionTests extends ESTestCase {
             searchTransportService, (clusterAlias, node) -> lookup.get(node),
             Collections.singletonMap("_na_", new AliasFilter(null, Strings.EMPTY_ARRAY)),
             Collections.emptyMap(), controller, executor,
-            resultConsumer, searchRequest, null, shardsIter, timeProvider, null,
+            resultConsumer, searchRequest, ActionListener.wrap(() -> {}), shardsIter, timeProvider, null,
             task, SearchResponse.Clusters.EMPTY) {
             @Override
             protected SearchPhase getNextPhase(SearchPhaseResults<SearchPhaseResult> results, SearchPhaseContext context) {

--- a/server/src/test/java/org/elasticsearch/common/util/CancellableSingleObjectCacheTests.java
+++ b/server/src/test/java/org/elasticsearch/common/util/CancellableSingleObjectCacheTests.java
@@ -181,8 +181,8 @@ public class CancellableSingleObjectCacheTests extends ESTestCase {
                     final StepListener<Integer> stepListener = new StepListener<>();
                     final AtomicBoolean isComplete = new AtomicBoolean();
                     final AtomicBoolean isCancelled = new AtomicBoolean();
-                    testCache.get(input, isCancelled::get, ActionListener.runBefore(stepListener,
-                            () -> assertTrue(isComplete.compareAndSet(false, true))));
+                    testCache.get(input, isCancelled::get,
+                        stepListener.runBefore(() -> assertTrue(isComplete.compareAndSet(false, true))));
 
                     final Runnable next = queue.poll();
                     if (next != null) {

--- a/server/src/test/java/org/elasticsearch/index/replication/IndexLevelReplicationTests.java
+++ b/server/src/test/java/org/elasticsearch/index/replication/IndexLevelReplicationTests.java
@@ -120,7 +120,7 @@ public class IndexLevelReplicationTests extends ESIndexLevelReplicationTestCase 
                     @Override
                     public void cleanFiles(int totalTranslogOps, long globalCheckpoint,
                                            Store.MetadataSnapshot sourceMetadata, ActionListener<Void> listener) {
-                        super.cleanFiles(totalTranslogOps, globalCheckpoint, sourceMetadata, ActionListener.runAfter(listener, () -> {
+                        super.cleanFiles(totalTranslogOps, globalCheckpoint, sourceMetadata, listener.runAfter(() -> {
                             latch.countDown();
                             try {
                                 latch.await();

--- a/server/src/test/java/org/elasticsearch/index/shard/IndexShardOperationPermitsTests.java
+++ b/server/src/test/java/org/elasticsearch/index/shard/IndexShardOperationPermitsTests.java
@@ -281,7 +281,7 @@ public class IndexShardOperationPermitsTests extends ESTestCase {
         CountDownLatch blockReleased = new CountDownLatch(1);
         boolean throwsException = randomBoolean();
         IndexShardClosedException exception = new IndexShardClosedException(new ShardId("blubb", "id", 0));
-        permits.blockOperations(ActionListener.runAfter(new ActionListener<>() {
+        permits.blockOperations(new ActionListener<Releasable>() {
             @Override
             public void onResponse(Releasable releasable) {
                 try (releasable) {
@@ -301,7 +301,7 @@ public class IndexShardOperationPermitsTests extends ESTestCase {
                     throw new RuntimeException(e);
                 }
             }
-        }, blockReleased::countDown), 1, TimeUnit.MINUTES, ThreadPool.Names.GENERIC);
+        }.runAfter(blockReleased::countDown), 1, TimeUnit.MINUTES, ThreadPool.Names.GENERIC);
         blockAcquired.await();
         return () -> {
             releaseBlock.countDown();

--- a/test/framework/src/main/java/org/elasticsearch/indices/recovery/AsyncRecoveryTarget.java
+++ b/test/framework/src/main/java/org/elasticsearch/indices/recovery/AsyncRecoveryTarget.java
@@ -71,7 +71,7 @@ public class AsyncRecoveryTarget implements RecoveryTargetHandler {
     public void writeFileChunk(StoreFileMetadata fileMetadata, long position, ReleasableBytesReference content,
                                boolean lastChunk, int totalTranslogOps, ActionListener<Void> listener) {
         final ReleasableBytesReference retained = content.retain();
-        final ActionListener<Void> wrappedListener = ActionListener.runBefore(listener, retained::close);
+        final ActionListener<Void> wrappedListener = listener.runBefore(retained::close);
         boolean success = false;
         try {
             executor.execute(() -> target.writeFileChunk(fileMetadata, position, retained, lastChunk, totalTranslogOps, wrappedListener));

--- a/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/bulk/TransportBulkShardOperationsAction.java
+++ b/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/bulk/TransportBulkShardOperationsAction.java
@@ -80,7 +80,7 @@ public class TransportBulkShardOperationsAction
         // This is executed on the follower coordinator node and we need to mark the bytes.
         Releasable releasable = indexingPressure.markCoordinatingOperationStarted(primaryOperationCount(request),
             primaryOperationSize(request), false);
-        ActionListener<BulkShardOperationsResponse> releasingListener = ActionListener.runBefore(listener, releasable::close);
+        ActionListener<BulkShardOperationsResponse> releasingListener = listener.runBefore(releasable::close);
         try {
             super.doExecute(task, request, releasingListener);
         } catch (Exception e) {

--- a/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/repository/CcrRepository.java
+++ b/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/repository/CcrRepository.java
@@ -327,9 +327,9 @@ public class CcrRepository extends AbstractLifecycleComponent implements Reposit
                              ActionListener<Void> listener) {
         final ShardId shardId = store.shardId();
         final LinkedList<Closeable> toClose = new LinkedList<>();
-        final ActionListener<Void> restoreListener = ActionListener.runBefore(listener.delegateResponse(
-            (l, e) -> l.onFailure(new IndexShardRestoreFailedException(shardId, "failed to restore snapshot [" + snapshotId + "]", e))),
-            () -> IOUtils.close(toClose));
+        final ActionListener<Void> restoreListener = listener.delegateResponse(
+            (l, e) -> l.onFailure(new IndexShardRestoreFailedException(shardId, "failed to restore snapshot [" + snapshotId + "]", e)))
+                .runBefore(() -> IOUtils.close(toClose));
         try {
             // TODO: Add timeouts to network calls / the restore process.
             createEmptyStore(store);

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/snapshots/SourceOnlySnapshotRepository.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/snapshots/SourceOnlySnapshotRepository.java
@@ -175,7 +175,7 @@ public final class SourceOnlySnapshotRepository extends FilterRepository {
             toClose.add(reader);
             IndexCommit indexCommit = reader.getIndexCommit();
             super.snapshotShard(tempStore, mapperService, snapshotId, indexId, indexCommit, shardStateIdentifier, snapshotStatus,
-                repositoryMetaVersion, userMetadata, ActionListener.runBefore(listener, () -> IOUtils.close(toClose)));
+                repositoryMetaVersion, userMetadata, listener.runBefore(() -> IOUtils.close(toClose)));
         } catch (IOException e) {
             try {
                 IOUtils.close(toClose);

--- a/x-pack/plugin/identity-provider/src/internalClusterTest/java/org/elasticsearch/xpack/idp/saml/sp/SamlServiceProviderIndexTests.java
+++ b/x-pack/plugin/identity-provider/src/internalClusterTest/java/org/elasticsearch/xpack/idp/saml/sp/SamlServiceProviderIndexTests.java
@@ -243,7 +243,7 @@ public class SamlServiceProviderIndexTests extends ESSingleNodeTestCase {
 
     private static <T> ActionListener<T> assertListenerIsOnlyCalledOnce(ActionListener<T> delegate) {
         final AtomicInteger callCount = new AtomicInteger(0);
-        return ActionListener.runBefore(delegate, () -> {
+        return delegate.runBefore(() -> {
             if (callCount.incrementAndGet() != 1) {
                 fail("Listener was called twice");
             }

--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/slm/SnapshotRetentionTask.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/slm/SnapshotRetentionTask.java
@@ -290,13 +290,12 @@ public class SnapshotRetentionTask implements SchedulerEngine.Listener {
         long startTime = nowNanoSupplier.getAsLong();
         final AtomicInteger deleted = new AtomicInteger(0);
         final AtomicInteger failed = new AtomicInteger(0);
-        final GroupedActionListener<Void> allDeletesListener =
-                new GroupedActionListener<>(ActionListener.runAfter(listener.map(v -> null),
-                        () -> {
-                            TimeValue totalElapsedTime = TimeValue.timeValueNanos(nowNanoSupplier.getAsLong() - startTime);
-                            logger.debug("total elapsed time for deletion of [{}] snapshots: {}", deleted, totalElapsedTime);
-                            slmStats.deletionTime(totalElapsedTime);
-                        }), snapshotsToDelete.size());
+        final GroupedActionListener<Void> allDeletesListener = new GroupedActionListener<>(
+                listener.<Collection<Void>>map(v -> null).runAfter(() -> {
+                    TimeValue totalElapsedTime = TimeValue.timeValueNanos(nowNanoSupplier.getAsLong() - startTime);
+                    logger.debug("total elapsed time for deletion of [{}] snapshots: {}", deleted, totalElapsedTime);
+                    slmStats.deletionTime(totalElapsedTime);
+                }), snapshotsToDelete.size());
         for (Map.Entry<String, List<Tuple<SnapshotId, String>>> entry : snapshotsToDelete.entrySet()) {
             String repo = entry.getKey();
             List<Tuple<SnapshotId, String>> snapshots = entry.getValue();
@@ -324,8 +323,7 @@ public class SnapshotRetentionTask implements SchedulerEngine.Listener {
                 final long deleteStartTime = nowNanoSupplier.getAsLong();
                 // TODO: Use snapshot multi-delete instead of this loop if all nodes in the cluster support it
                 //       i.e are newer or equal to SnapshotsService#MULTI_DELETE_VERSION
-                deleteSnapshot(policyId, repo, snapshotId, slmStats, ActionListener.runAfter(
-                        ActionListener.wrap(acknowledgedResponse -> {
+                deleteSnapshot(policyId, repo, snapshotId, slmStats, ActionListener.<AcknowledgedResponse>wrap(acknowledgedResponse -> {
                             deleted.incrementAndGet();
                             assert acknowledgedResponse.isAcknowledged();
                             historyStore.putAsync(SnapshotHistoryItem.deletionSuccessRecord(Instant.now().toEpochMilli(),
@@ -345,7 +343,7 @@ public class SnapshotRetentionTask implements SchedulerEngine.Listener {
                             } finally {
                                 allDeletesListener.onFailure(e);
                             }
-                        }), () -> {
+                        }).runAfter(() -> {
                             runningDeletions.remove(snapshotId);
                             long finishTime = nowNanoSupplier.getAsLong();
                             TimeValue deletionTime = TimeValue.timeValueNanos(finishTime - deleteStartTime);

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/utils/persistence/ResultsPersisterService.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/utils/persistence/ResultsPersisterService.java
@@ -202,10 +202,7 @@ public class ResultsPersisterService {
         }
         final PlainActionFuture<BulkResponse> getResponse = PlainActionFuture.newFuture();
         final Object key = new Object();
-        final ActionListener<BulkResponse> removeListener = ActionListener.runBefore(
-            getResponse,
-            () -> onGoingRetryableBulkActions.remove(key)
-        );
+        final ActionListener<BulkResponse> removeListener = getResponse.runBefore(() -> onGoingRetryableBulkActions.remove(key));
         BulkRetryableAction bulkRetryableAction = new BulkRetryableAction(
             jobId,
             new BulkRequestRewriter(bulkRequest),
@@ -230,10 +227,7 @@ public class ResultsPersisterService {
                                           Consumer<String> retryMsgHandler) {
         final PlainActionFuture<SearchResponse> getResponse = PlainActionFuture.newFuture();
         final Object key = new Object();
-        final ActionListener<SearchResponse> removeListener = ActionListener.runBefore(
-            getResponse,
-            () -> onGoingRetryableSearchActions.remove(key)
-        );
+        final ActionListener<SearchResponse> removeListener = getResponse.runBefore(() -> onGoingRetryableSearchActions.remove(key));
         SearchRetryableAction mlRetryableAction = new SearchRetryableAction(
             jobId,
             searchRequest,

--- a/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/action/TransportMonitoringMigrateAlertsAction.java
+++ b/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/action/TransportMonitoringMigrateAlertsAction.java
@@ -75,7 +75,7 @@ public class TransportMonitoringMigrateAlertsAction extends TransportMasterNodeA
         }
         try {
             // Wrap the listener to unblock resource installation before completing
-            listener = ActionListener.runBefore(listener, migrationCoordinator::unblockInstallationTasks);
+            listener = listener.runBefore(migrationCoordinator::unblockInstallationTasks);
             Settings.Builder decommissionAlertSetting = Settings.builder().put(Monitoring.MIGRATION_DECOMMISSION_ALERTS.getKey(), true);
             client.admin().cluster().prepareUpdateSettings().setPersistentSettings(decommissionAlertSetting)
                 .execute(completeOnManagementThread(listener));
@@ -226,7 +226,7 @@ public class TransportMonitoringMigrateAlertsAction extends TransportMasterNodeA
      */
     private void deleteAlertsFromDisabledExporter(Exporter.Config exporterConf, ActionListener<ExporterResourceStatus> listener) {
         Exporter disabledExporter = exporters.openExporter(exporterConf);
-        deleteAlertsFromOpenExporter(disabledExporter, ActionListener.runBefore(listener, disabledExporter::close));
+        deleteAlertsFromOpenExporter(disabledExporter, listener.runBefore(disabledExporter::close));
     }
 
     @Override

--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/allocation/SearchableSnapshotAllocator.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/allocation/SearchableSnapshotAllocator.java
@@ -314,7 +314,7 @@ public class SearchableSnapshotAllocator implements ExistingShardsAllocator {
             client.execute(
                 TransportSearchableSnapshotCacheStoresAction.TYPE,
                 new TransportSearchableSnapshotCacheStoresAction.Request(snapshotId, shardId, dataNodes),
-                ActionListener.runAfter(new ActionListener<>() {
+                new ActionListener<NodesCacheFilesMetadata>() {
                     @Override
                     public void onResponse(NodesCacheFilesMetadata nodesCacheFilesMetadata) {
                         final Map<DiscoveryNode, NodeCacheFilesMetadata> res = new HashMap<>(nodesCacheFilesMetadata.getNodesMap().size());
@@ -338,7 +338,7 @@ public class SearchableSnapshotAllocator implements ExistingShardsAllocator {
                         }
                         asyncFetch.addData(res);
                     }
-                }, () -> {
+                }.runAfter(() -> {
                     if (asyncFetch.data() != null) {
                         rerouteService.reroute("async_shard_cache_fetch", Priority.HIGH, REROUTE_LISTENER);
                     }

--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/cache/blob/BlobStoreCacheService.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/cache/blob/BlobStoreCacheService.java
@@ -219,7 +219,7 @@ public class BlobStoreCacheService extends AbstractLifecycleComponent {
                     listener.onFailure(new IllegalStateException("Blob cache service is closed"));
                     return;
                 }
-                final ActionListener<Void> wrappedListener = ActionListener.runAfter(listener, release);
+                final ActionListener<Void> wrappedListener = listener.runAfter(release);
                 client.index(request, new ActionListener<>() {
                     @Override
                     public void onResponse(IndexResponse indexResponse) {

--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/cache/common/CacheFile.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/cache/common/CacheFile.java
@@ -434,12 +434,12 @@ public class CacheFile {
         FileChannelReference reference,
         Releasable releasable
     ) {
-        return ActionListener.runAfter(ActionListener.wrap(success -> {
+        return ActionListener.<Void>wrap(success -> {
             final int read = reader.onRangeAvailable(reference.fileChannel);
             assert read == rangeToRead.length()
                 : "partial read [" + read + "] does not match the range to read [" + rangeToRead.end() + '-' + rangeToRead.start() + ']';
             future.onResponse(read);
-        }, future::onFailure), releasable::close);
+        }, future::onFailure).runAfter(releasable::close);
     }
 
     /**

--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/cache/common/SparseFileTracker.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/cache/common/SparseFileTracker.java
@@ -360,10 +360,7 @@ public class SparseFileTracker {
 
     private ActionListener<Void> wrapWithAssertions(ActionListener<Void> listener) {
         if (Assertions.ENABLED) {
-            return ActionListener.runAfter(
-                listener,
-                () -> { assert Thread.holdsLock(mutex) == false : "mutex unexpectedly held in listener"; }
-            );
+            return listener.runAfter(() -> { assert Thread.holdsLock(mutex) == false : "mutex unexpectedly held in listener"; });
         } else {
             return listener;
         }

--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/store/SearchableSnapshotDirectory.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/store/SearchableSnapshotDirectory.java
@@ -569,7 +569,7 @@ public class SearchableSnapshotDirectory extends BaseDirectory {
             if (next == null) {
                 return;
             }
-            executor.execute(ActionRunnable.run(ActionListener.runAfter(next.v1(), () -> prewarmNext(executor, queue)), next.v2()));
+            executor.execute(ActionRunnable.run(next.v1().runAfter(() -> prewarmNext(executor, queue)), next.v2()));
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
             logger.warn(() -> new ParameterizedMessage("{} prewarming worker has been interrupted", shardId), e);

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/action/token/TransportCreateTokenActionTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/action/token/TransportCreateTokenActionTests.java
@@ -300,7 +300,7 @@ public class TransportCreateTokenActionTests extends ESTestCase {
 
     private static <T> ActionListener<T> assertListenerIsOnlyCalledOnce(ActionListener<T> delegate) {
         final AtomicInteger callCount = new AtomicInteger(0);
-        return ActionListener.runBefore(delegate, () -> {
+        return delegate.runBefore(() -> {
             if (callCount.incrementAndGet() != 1) {
                 fail("Listener was called twice");
             }

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/esnative/ReservedRealmTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/esnative/ReservedRealmTests.java
@@ -464,7 +464,7 @@ public class ReservedRealmTests extends ESTestCase {
 
     private static <T> ActionListener<T> assertListenerIsOnlyCalledOnce(ActionListener<T> delegate) {
         final AtomicInteger callCount = new AtomicInteger(0);
-        return ActionListener.runBefore(delegate, () -> {
+        return delegate.runBefore(() -> {
             if (callCount.incrementAndGet() != 1) {
                 fail("Listener was called twice");
             }


### PR DESCRIPTION
Doing the same we did for `.map` and `.delegate` methods here
to make using these methods a little less verbose and align
the style of all the delegation types on `ActionListener`.
