### PR TITLE
Add doc on rank_feature(s) negative score impact

### DIFF
--- a/docs/reference/mapping/types/rank-feature.asciidoc
+++ b/docs/reference/mapping/types/rank-feature.asciidoc
@@ -58,10 +58,3 @@ the <<query-dsl-rank-feature-query,`rank_feature`>> query to modify the scoring 
 in such a way that the score decreases with the value of the feature instead of
 increasing. For instance in web search, the url length is a commonly used
 feature which correlates negatively with scores.
-
-With `positive_score_impact` set to `false` for a `rank_feature` field,
-we recommend that every document that participates in a query
-has a value for this field. Otherwise, a document that has the negative feature
-would contribute to a higher score than a document that doesn't have the feature,
-which is counter-intuitive as we want documents with negative features
-to be ranked lower.

--- a/docs/reference/mapping/types/rank-feature.asciidoc
+++ b/docs/reference/mapping/types/rank-feature.asciidoc
@@ -58,3 +58,10 @@ the <<query-dsl-rank-feature-query,`rank_feature`>> query to modify the scoring 
 in such a way that the score decreases with the value of the feature instead of
 increasing. For instance in web search, the url length is a commonly used
 feature which correlates negatively with scores.
+
+With `positive_score_impact` set to `false` for a `rank_feature` field,
+we recommend that every document that participates in a query
+has a value for this field. Otherwise, a document that has the negative feature
+would contribute to a higher score than a document that doesn't have the feature,
+which is counter-intuitive as we want documents with negative features
+to be ranked lower.

--- a/docs/reference/mapping/types/rank-features.asciidoc
+++ b/docs/reference/mapping/types/rank-features.asciidoc
@@ -93,10 +93,3 @@ Rank features that correlate negatively with the score should set
 the <<query-dsl-rank-feature-query,`rank_feature`>> query to modify the scoring formula
 in such a way that the score decreases with the value of the feature instead of
 increasing.
-
-With `positive_score_impact` set to `false` for a `rank_features` field,
-we recommend that every document that participates in a query
-has a value for this field. Otherwise, a document that has the negative feature
-would contribute to a higher score than a document that doesn't have the feature,
-which is counter-intuitive as we want documents with negative features
-to be ranked lower.

--- a/docs/reference/mapping/types/rank-features.asciidoc
+++ b/docs/reference/mapping/types/rank-features.asciidoc
@@ -94,3 +94,9 @@ the <<query-dsl-rank-feature-query,`rank_feature`>> query to modify the scoring 
 in such a way that the score decreases with the value of the feature instead of
 increasing.
 
+With `positive_score_impact` set to `false` for a `rank_features` field,
+we recommend that every document that participates in a query
+has a value for this field. Otherwise, a document that has the negative feature
+would contribute to a higher score than a document that doesn't have the feature,
+which is counter-intuitive as we want documents with negative features
+to be ranked lower.

--- a/docs/reference/query-dsl/rank-feature-query.asciidoc
+++ b/docs/reference/query-dsl/rank-feature-query.asciidoc
@@ -12,6 +12,15 @@ The `rank_feature` query is typically used in the `should` clause of a
 <<query-dsl-bool-query,`bool`>> query so its relevance scores are added to other
 scores from the `bool` query.
 
+With `positive_score_impact` set to `false` for a `rank_feature` or
+`rank_features` field, we recommend that every document that participates
+in a query has a value for this field. Otherwise, if a `rank_feature` query
+is used in the should clause, it doesn't add anything to a score of
+a document with a missing value, but adds some boost for a document
+containing a feature. This is contrary to what we want – as we consider these
+features negative, we want to rank documents containing them lower than documents
+missing them.
+
 Unlike the <<query-dsl-function-score-query,`function_score`>> query or other
 ways to change <<relevance-scores,relevance scores>>, the
 `rank_feature` query efficiently skips non-competitive hits when the


### PR DESCRIPTION
Add a warning about consequences of negative score impact
for documents that don't have values for rank_feature(s)
fields.

Related to #69994