### PR TITLE
Fix testCreateAndRestorePartialSearchableSnapshot

### DIFF
--- a/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/BaseSearchableSnapshotsIntegTestCase.java
+++ b/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/BaseSearchableSnapshotsIntegTestCase.java
@@ -84,8 +84,8 @@ public abstract class BaseSearchableSnapshotsIntegTestCase extends AbstractSnaps
                 FrozenCacheService.SNAPSHOT_CACHE_SIZE_SETTING.getKey(),
                 rarely()
                     ? randomBoolean()
-                        ? new ByteSizeValue(randomIntBetween(0, 10), ByteSizeUnit.KB)
-                        : new ByteSizeValue(randomIntBetween(0, 1000), ByteSizeUnit.BYTES)
+                        ? new ByteSizeValue(randomIntBetween(1, 10), ByteSizeUnit.KB)
+                        : new ByteSizeValue(randomIntBetween(1, 1000), ByteSizeUnit.BYTES)
                     : new ByteSizeValue(randomIntBetween(1, 10), ByteSizeUnit.MB)
             );
         }


### PR DESCRIPTION
Parts of the test(s) will fail without any frozen cache since shards then
cannot allocate (or move), changed tests to always have a minimal frozen
cache.

Closes #71665

We can also consider splitting the set of tests into the set requiring non-zero
frozen cache size and those that do if reviewers find that preferable.

Note to self: backports should unmute testCreateAndRestorePartialSearchableSnapshot