### PR TITLE
Make ActionListener#wrap more Efficient in Common Use Case

### DIFF
--- a/modules/lang-mustache/src/main/java/org/elasticsearch/script/mustache/TransportMultiSearchTemplateAction.java
+++ b/modules/lang-mustache/src/main/java/org/elasticsearch/script/mustache/TransportMultiSearchTemplateAction.java
@@ -68,7 +68,7 @@ public class TransportMultiSearchTemplateAction extends HandledTransportAction<M
             }
         }
 
-        client.multiSearch(multiSearchRequest, ActionListener.wrap(r -> {
+        client.multiSearch(multiSearchRequest, listener.wrap((l, r) -> {
             for (int i = 0; i < r.getResponses().length; i++) {
                 MultiSearchResponse.Item item = r.getResponses()[i];
                 int originalSlot = originalSlots.get(i);
@@ -78,7 +78,7 @@ public class TransportMultiSearchTemplateAction extends HandledTransportAction<M
                     items[originalSlot].getResponse().setResponse(item.getResponse());
                 }
             }
-            listener.onResponse(new MultiSearchTemplateResponse(items, r.getTook().millis()));
-        }, listener::onFailure));
+            l.onResponse(new MultiSearchTemplateResponse(items, r.getTook().millis()));
+        }));
     }
 }

--- a/modules/reindex/src/main/java/org/elasticsearch/index/reindex/TransportRethrottleAction.java
+++ b/modules/reindex/src/main/java/org/elasticsearch/index/reindex/TransportRethrottleAction.java
@@ -69,12 +69,11 @@ public class TransportRethrottleAction extends TransportTasksAction<BulkByScroll
             subRequest.setParentTaskId(new TaskId(localNodeId, task.getId()));
             logger.debug("rethrottling children of task [{}] to [{}] requests per second", task.getId(),
                 subRequest.getRequestsPerSecond());
-            client.execute(RethrottleAction.INSTANCE, subRequest, ActionListener.wrap(
-                r -> {
+            client.execute(RethrottleAction.INSTANCE, subRequest, listener.wrap(
+                (l, r) -> {
                     r.rethrowFailures("Rethrottle");
-                    listener.onResponse(task.taskInfoGivenSubtaskInfo(localNodeId, r.getTasks()));
-                },
-                listener::onFailure));
+                    l.onResponse(task.taskInfoGivenSubtaskInfo(localNodeId, r.getTasks()));
+                }));
         } else {
             logger.debug("children of task [{}] are already finished, nothing to rethrottle", task.getId());
             listener.onResponse(task.taskInfo(localNodeId, true));

--- a/plugins/examples/security-authorization-engine/src/main/java/org/elasticsearch/example/CustomAuthorizationEngine.java
+++ b/plugins/examples/security-authorization-engine/src/main/java/org/elasticsearch/example/CustomAuthorizationEngine.java
@@ -82,15 +82,15 @@ public class CustomAuthorizationEngine implements AuthorizationEngine {
                                      Map<String, IndexAbstraction> aliasOrIndexLookup,
                                      ActionListener<IndexAuthorizationResult> listener) {
         if (isSuperuser(requestInfo.getAuthentication().getUser())) {
-            indicesAsyncSupplier.getAsync(ActionListener.wrap(resolvedIndices -> {
+            indicesAsyncSupplier.getAsync(listener.wrap((l, resolvedIndices) -> {
                 Map<String, IndexAccessControl> indexAccessControlMap = new HashMap<>();
                 for (String name : resolvedIndices.getLocal()) {
                     indexAccessControlMap.put(name, new IndexAccessControl(true, FieldPermissions.DEFAULT, null));
                 }
                 IndicesAccessControl indicesAccessControl =
                     new IndicesAccessControl(true, Collections.unmodifiableMap(indexAccessControlMap));
-                listener.onResponse(new IndexAuthorizationResult(true, indicesAccessControl));
-            }, listener::onFailure));
+                l.onResponse(new IndexAuthorizationResult(true, indicesAccessControl));
+            }));
         } else {
             listener.onResponse(new IndexAuthorizationResult(true, IndicesAccessControl.DENIED));
         }

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/reroute/TransportClusterRerouteAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/reroute/TransportClusterRerouteAction.java
@@ -86,9 +86,7 @@ public class TransportClusterRerouteAction extends TransportMasterNodeAction<Clu
         Map<String, List<AbstractAllocateAllocationCommand>> stalePrimaryAllocations) {
         transportService.sendRequest(transportService.getLocalNode(), IndicesShardStoresAction.NAME,
             new IndicesShardStoresRequest().indices(stalePrimaryAllocations.keySet().toArray(Strings.EMPTY_ARRAY)),
-            new ActionListenerResponseHandler<>(
-                ActionListener.wrap(
-                    response -> {
+            new ActionListenerResponseHandler<>(listener.wrap((l, response) -> {
                         ImmutableOpenMap<String, ImmutableOpenIntMap<List<IndicesShardStoresResponse.StoreStatus>>> status =
                             response.getStoreStatuses();
                         Exception e = null;
@@ -119,12 +117,11 @@ public class TransportClusterRerouteAction extends TransportMasterNodeAction<Clu
                             }
                         }
                         if (e == null) {
-                            submitStateUpdate(request, listener);
+                            submitStateUpdate(request, l);
                         } else {
-                            listener.onFailure(e);
+                            l.onFailure(e);
                         }
-                    }, listener::onFailure
-                ), IndicesShardStoresResponse::new));
+                }), IndicesShardStoresResponse::new));
     }
 
     private void submitStateUpdate(final ClusterRerouteRequest request, final ActionListener<ClusterRerouteResponse> listener) {

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/shards/TransportIndicesShardStoresAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/shards/TransportIndicesShardStoresAction.java
@@ -146,8 +146,7 @@ public class TransportIndicesShardStoresAction
         private void listStartedShards(ShardId shardId, String customDataPath, DiscoveryNode[] nodes,
                                        ActionListener<BaseNodesResponse<NodeGatewayStartedShards>> listener) {
             var request = new TransportNodesListGatewayStartedShards.Request(shardId, customDataPath, nodes);
-            client.executeLocally(TransportNodesListGatewayStartedShards.TYPE, request,
-                ActionListener.wrap(listener::onResponse, listener::onFailure));
+            client.executeLocally(TransportNodesListGatewayStartedShards.TYPE, request, listener.wrap((l, r) -> l.onResponse(r)));
         }
 
         private class InternalAsyncFetch extends AsyncShardFetch<NodeGatewayStartedShards> {

--- a/server/src/main/java/org/elasticsearch/action/bulk/TransportSingleItemBulkWriteAction.java
+++ b/server/src/main/java/org/elasticsearch/action/bulk/TransportSingleItemBulkWriteAction.java
@@ -43,16 +43,16 @@ public abstract class TransportSingleItemBulkWriteAction<
 
     public static <Response extends ReplicationResponse & WriteResponse>
     ActionListener<BulkResponse> wrapBulkResponse(ActionListener<Response> listener) {
-        return ActionListener.wrap(bulkItemResponses -> {
+        return listener.wrap((l, bulkItemResponses) -> {
             assert bulkItemResponses.getItems().length == 1 : "expected only one item in bulk request";
             BulkItemResponse bulkItemResponse = bulkItemResponses.getItems()[0];
             if (bulkItemResponse.isFailed() == false) {
                 final DocWriteResponse response = bulkItemResponse.getResponse();
-                listener.onResponse((Response) response);
+                l.onResponse((Response) response);
             } else {
-                listener.onFailure(bulkItemResponse.getFailure().getCause());
+                l.onFailure(bulkItemResponse.getFailure().getCause());
             }
-        }, listener::onFailure);
+        });
     }
 
     public static BulkRequest toSingleItemBulkRequest(ReplicatedWriteRequest<?> request) {

--- a/server/src/main/java/org/elasticsearch/action/ingest/PutPipelineTransportAction.java
+++ b/server/src/main/java/org/elasticsearch/action/ingest/PutPipelineTransportAction.java
@@ -58,13 +58,13 @@ public class PutPipelineTransportAction extends AcknowledgedTransportMasterNodeA
         NodesInfoRequest nodesInfoRequest = new NodesInfoRequest();
         nodesInfoRequest.clear()
             .addMetric(NodesInfoRequest.Metric.INGEST.metricName());
-        client.admin().cluster().nodesInfo(nodesInfoRequest, ActionListener.wrap(nodeInfos -> {
+        client.admin().cluster().nodesInfo(nodesInfoRequest, listener.wrap((l, nodeInfos) -> {
             Map<DiscoveryNode, IngestInfo> ingestInfos = new HashMap<>();
             for (NodeInfo nodeInfo : nodeInfos.getNodes()) {
                 ingestInfos.put(nodeInfo.getNode(), nodeInfo.getInfo(IngestInfo.class));
             }
-            ingestService.putPipeline(ingestInfos, request, listener);
-        }, listener::onFailure));
+            ingestService.putPipeline(ingestInfos, request, l);
+        }));
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/action/search/ClearScrollController.java
+++ b/server/src/main/java/org/elasticsearch/action/search/ClearScrollController.java
@@ -98,8 +98,7 @@ public final class ClearScrollController implements Runnable {
     }
 
     void cleanScrollIds(List<SearchContextIdForNode> contextIds) {
-        SearchScrollAsyncAction.collectNodesAndRun(contextIds, nodes, searchTransportService, ActionListener.wrap(
-            lookup -> {
+        SearchScrollAsyncAction.collectNodesAndRun(contextIds, nodes, searchTransportService, listener.wrap(lookup -> {
                 for (SearchContextIdForNode target : contextIds) {
                     final DiscoveryNode node = lookup.apply(target.getClusterAlias(), target.getNode());
                     if (node == null) {
@@ -114,7 +113,7 @@ public final class ClearScrollController implements Runnable {
                         }
                     }
                 }
-            }, listener::onFailure));
+        }));
     }
 
     private void onFreedContext(boolean freed) {

--- a/server/src/main/java/org/elasticsearch/action/search/SearchScrollAsyncAction.java
+++ b/server/src/main/java/org/elasticsearch/action/search/SearchScrollAsyncAction.java
@@ -82,8 +82,7 @@ abstract class SearchScrollAsyncAction<T extends SearchPhaseResult> implements R
         if (context.length == 0) {
             listener.onFailure(new SearchPhaseExecutionException("query", "no nodes to search on", ShardSearchFailure.EMPTY_ARRAY));
         } else {
-            collectNodesAndRun(Arrays.asList(context), nodes, searchTransportService, ActionListener.wrap(lookup -> run(lookup, context),
-                listener::onFailure));
+            collectNodesAndRun(Arrays.asList(context), nodes, searchTransportService, listener.wrap(lookup -> run(lookup, context)));
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/cluster/action/index/MappingUpdatedAction.java
+++ b/server/src/main/java/org/elasticsearch/cluster/action/index/MappingUpdatedAction.java
@@ -103,8 +103,7 @@ public class MappingUpdatedAction {
         putMappingRequest.source(mappingUpdate.toString(), XContentType.JSON);
         putMappingRequest.masterNodeTimeout(dynamicMappingUpdateTimeout);
         putMappingRequest.timeout(TimeValue.ZERO);
-        client.execute(AutoPutMappingAction.INSTANCE, putMappingRequest,
-                ActionListener.wrap(r -> listener.onResponse(null), listener::onFailure));
+        client.execute(AutoPutMappingAction.INSTANCE, putMappingRequest, listener.wrap((l, r) -> l.onResponse(null)));
     }
 
     static class AdjustableSemaphore extends Semaphore {

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataCreateIndexService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataCreateIndexService.java
@@ -257,7 +257,7 @@ public class MetadataCreateIndexService {
     public void createIndex(final CreateIndexClusterStateUpdateRequest request,
                             final ActionListener<ShardsAcknowledgedResponse> listener) {
         logger.trace("createIndex[{}]", request);
-        onlyCreateIndex(request, ActionListener.wrap(response -> {
+        onlyCreateIndex(request, listener.wrap((l, response) -> {
             if (response.isAcknowledged()) {
                 logger.trace("[{}] index creation acknowledged, waiting for active shards [{}]",
                     request.index(), request.waitForActiveShards());
@@ -269,13 +269,13 @@ public class MetadataCreateIndexService {
                         } else {
                             logger.trace("[{}] index created and shards acknowledged", request.index());
                         }
-                        listener.onResponse(ShardsAcknowledgedResponse.of(true, shardsAcknowledged));
-                    }, listener::onFailure);
+                        l.onResponse(ShardsAcknowledgedResponse.of(true, shardsAcknowledged));
+                    }, l::onFailure);
             } else {
                 logger.trace("index creation not acknowledged for [{}]", request);
-                listener.onResponse(ShardsAcknowledgedResponse.NOT_ACKNOWLEDGED);
+                l.onResponse(ShardsAcknowledgedResponse.NOT_ACKNOWLEDGED);
             }
-        }, listener::onFailure));
+        }));
     }
 
     private void onlyCreateIndex(final CreateIndexClusterStateUpdateRequest request,

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataIndexStateService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataIndexStateService.java
@@ -152,8 +152,7 @@ public class MetadataIndexStateService {
                     } else {
                         assert blockedIndices.isEmpty() == false : "List of blocked indices is empty but cluster state was changed";
                         threadPool.executor(ThreadPool.Names.MANAGEMENT)
-                            .execute(new WaitForClosedBlocksApplied(blockedIndices, request,
-                                ActionListener.wrap(verifyResults ->
+                            .execute(new WaitForClosedBlocksApplied(blockedIndices, request, listener.wrap((l, verifyResults) ->
                                     clusterService.submitStateUpdateTask("close-indices", new ClusterStateUpdateTask(Priority.URGENT) {
                                         private final List<IndexResult> indices = new ArrayList<>();
 
@@ -168,7 +167,7 @@ public class MetadataIndexStateService {
 
                                         @Override
                                         public void onFailure(final String source, final Exception e) {
-                                            listener.onFailure(e);
+                                            l.onFailure(e);
                                         }
 
                                         @Override
@@ -193,15 +192,13 @@ public class MetadataIndexStateService {
                                                         // we maintain a kind of coherency by overriding the shardsAcknowledged value
                                                         // (see ShardsAcknowledgedResponse constructor)
                                                         boolean shardsAcked = acknowledged ? shardsAcknowledged : false;
-                                                        listener.onResponse(new CloseIndexResponse(acknowledged, shardsAcked, indices));
-                                                    }, listener::onFailure);
+                                                        l.onResponse(new CloseIndexResponse(acknowledged, shardsAcked, indices));
+                                                    }, l::onFailure);
                                             } else {
-                                                listener.onResponse(new CloseIndexResponse(acknowledged, false, indices));
+                                                l.onResponse(new CloseIndexResponse(acknowledged, false, indices));
                                             }
                                         }
-                                    }),
-                                    listener::onFailure)
-                                )
+                                })))
                             );
                     }
                 }
@@ -400,9 +397,8 @@ public class MetadataIndexStateService {
                         listener.onResponse(new AddIndexBlockResponse(true, false, Collections.emptyList()));
                     } else {
                         assert blockedIndices.isEmpty() == false : "List of blocked indices is empty but cluster state was changed";
-                        threadPool.executor(ThreadPool.Names.MANAGEMENT)
-                            .execute(new WaitForBlocksApplied(blockedIndices, request,
-                                    ActionListener.wrap(verifyResults ->
+                        threadPool.executor(ThreadPool.Names.MANAGEMENT).execute(new WaitForBlocksApplied(blockedIndices, request,
+                                listener.wrap((l, verifyResults) ->
                                             clusterService.submitStateUpdateTask("finalize-index-block-[" + request.getBlock().name +
                                                     "]-[" + blockedIndices.keySet().stream().map(Index::getName)
                                                         .collect(Collectors.joining(", ")) + "]",
@@ -420,7 +416,7 @@ public class MetadataIndexStateService {
 
                                                 @Override
                                                 public void onFailure(final String source, final Exception e) {
-                                                    listener.onFailure(e);
+                                                    l.onFailure(e);
                                                 }
 
                                                 @Override
@@ -430,11 +426,9 @@ public class MetadataIndexStateService {
 
                                                     final boolean acknowledged = indices.stream().noneMatch(
                                                         AddBlockResult::hasFailures);
-                                                    listener.onResponse(new AddIndexBlockResponse(acknowledged, acknowledged, indices));
+                                                    l.onResponse(new AddIndexBlockResponse(acknowledged, acknowledged, indices));
                                                 }
-                                            }),
-                                        listener::onFailure)
-                                )
+                                    })))
                             );
                     }
                 }
@@ -750,7 +744,7 @@ public class MetadataIndexStateService {
 
     public void openIndex(final OpenIndexClusterStateUpdateRequest request,
                           final ActionListener<ShardsAcknowledgedResponse> listener) {
-        onlyOpenIndex(request, ActionListener.wrap(response -> {
+        onlyOpenIndex(request, listener.wrap((l, response) -> {
             if (response.isAcknowledged()) {
                 String[] indexNames = Arrays.stream(request.indices()).map(Index::getName).toArray(String[]::new);
                 activeShardsObserver.waitForActiveShards(indexNames, request.waitForActiveShards(), request.ackTimeout(),
@@ -759,12 +753,12 @@ public class MetadataIndexStateService {
                             logger.debug("[{}] indices opened, but the operation timed out while waiting for " +
                                 "enough shards to be started.", Arrays.toString(indexNames));
                         }
-                        listener.onResponse(ShardsAcknowledgedResponse.of(true, shardsAcknowledged));
-                    }, listener::onFailure);
+                        l.onResponse(ShardsAcknowledgedResponse.of(true, shardsAcknowledged));
+                    }, l::onFailure);
             } else {
-                listener.onResponse(ShardsAcknowledgedResponse.NOT_ACKNOWLEDGED);
+                l.onResponse(ShardsAcknowledgedResponse.NOT_ACKNOWLEDGED);
             }
-        }, listener::onFailure));
+        }));
     }
 
     private void onlyOpenIndex(final OpenIndexClusterStateUpdateRequest request,

--- a/server/src/main/java/org/elasticsearch/gateway/GatewayAllocator.java
+++ b/server/src/main/java/org/elasticsearch/gateway/GatewayAllocator.java
@@ -245,8 +245,7 @@ public class GatewayAllocator implements ExistingShardsAllocator {
         private void listStartedShards(ShardId shardId, String customDataPath, DiscoveryNode[] nodes,
                                        ActionListener<BaseNodesResponse<NodeGatewayStartedShards>> listener) {
             var request = new TransportNodesListGatewayStartedShards.Request(shardId, customDataPath, nodes);
-            client.executeLocally(TransportNodesListGatewayStartedShards.TYPE, request,
-                ActionListener.wrap(listener::onResponse, listener::onFailure));
+            client.executeLocally(TransportNodesListGatewayStartedShards.TYPE, request, listener.wrap((l, r) -> l.onResponse(r)));
         }
     }
 
@@ -276,8 +275,7 @@ public class GatewayAllocator implements ExistingShardsAllocator {
         private void listStoreFilesMetadata(ShardId shardId, String customDataPath, DiscoveryNode[] nodes,
                                             ActionListener<BaseNodesResponse<NodeStoreFilesMetadata>> listener) {
             var request = new TransportNodesListShardStoreMetadata.Request(shardId, customDataPath, nodes);
-            client.executeLocally(TransportNodesListShardStoreMetadata.TYPE, request,
-                ActionListener.wrap(listener::onResponse, listener::onFailure));
+            client.executeLocally(TransportNodesListShardStoreMetadata.TYPE, request, listener.wrap((l, r) -> l.onResponse(r)));
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/index/query/AbstractGeometryQueryBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/AbstractGeometryQueryBuilder.java
@@ -461,10 +461,10 @@ public abstract class AbstractGeometryQueryBuilder<QB extends AbstractGeometryQu
             queryRewriteContext.registerAsyncAction((client, listener) -> {
                 GetRequest getRequest = new GetRequest(indexedShapeIndex, indexedShapeId);
                 getRequest.routing(indexedShapeRouting);
-                fetch(client, getRequest, indexedShapePath, ActionListener.wrap(builder-> {
+                fetch(client, getRequest, indexedShapePath, listener.wrap((l, builder)-> {
                     supplier.set(builder);
-                    listener.onResponse(null);
-                }, listener::onFailure));
+                    l.onResponse(null);
+                }));
             });
             return newShapeQueryBuilder(this.fieldName, supplier::get, this.indexedShapeId).relation(relation);
         }

--- a/server/src/main/java/org/elasticsearch/index/query/Rewriteable.java
+++ b/server/src/main/java/org/elasticsearch/index/query/Rewriteable.java
@@ -95,8 +95,8 @@ public interface Rewriteable<T> {
                 if (context.hasAsyncActions()) {
                     T finalBuilder = builder;
                     final int currentIterationNumber = iteration;
-                    context.executeAsyncActions(ActionListener.wrap(n -> rewriteAndFetch(finalBuilder, context, rewriteResponse,
-                        currentIterationNumber), rewriteResponse::onFailure));
+                    context.executeAsyncActions(
+                            rewriteResponse.wrap((l, n) -> rewriteAndFetch(finalBuilder, context, l, currentIterationNumber)));
                     return;
                 }
             }

--- a/server/src/main/java/org/elasticsearch/index/seqno/ReplicationTracker.java
+++ b/server/src/main/java/org/elasticsearch/index/seqno/ReplicationTracker.java
@@ -1376,10 +1376,10 @@ public class ReplicationTracker extends AbstractIndexShardComponent implements L
     public synchronized void createMissingPeerRecoveryRetentionLeases(ActionListener<Void> listener) {
         if (hasAllPeerRecoveryRetentionLeases == false) {
             final List<ShardRouting> shardRoutings = routingTable.assignedShards();
-            final GroupedActionListener<ReplicationResponse> groupedActionListener = new GroupedActionListener<>(ActionListener.wrap(vs -> {
+            final GroupedActionListener<ReplicationResponse> groupedActionListener = new GroupedActionListener<>(listener.wrap((l, vs) -> {
                 setHasAllPeerRecoveryRetentionLeases();
-                listener.onResponse(null);
-            }, listener::onFailure), shardRoutings.size());
+                l.onResponse(null);
+            }), shardRoutings.size());
             for (ShardRouting shardRouting : shardRoutings) {
                 if (retentionLeases.contains(getPeerRecoveryRetentionLeaseId(shardRouting))) {
                     groupedActionListener.onResponse(null);

--- a/server/src/main/java/org/elasticsearch/indices/recovery/RecoverySourceHandler.java
+++ b/server/src/main/java/org/elasticsearch/indices/recovery/RecoverySourceHandler.java
@@ -814,10 +814,10 @@ public class RecoverySourceHandler {
                 logger.trace("performing relocation hand-off");
                 // this acquires all IndexShard operation permits and will thus delay new recoveries until it is done
                 cancellableThreads.execute(() -> shard.relocated(request.targetAllocationId(), recoveryTarget::handoffPrimaryContext,
-                        ActionListener.wrap(v -> {
+                        listener.wrap((l, v) -> {
                             cancellableThreads.checkForCancel();
-                            completeFinalizationListener(listener, stopWatch);
-                        }, listener::onFailure)));
+                            completeFinalizationListener(l, stopWatch);
+                        })));
                 /*
                  * if the recovery process fails after disabling primary mode on the source shard, both relocation source and
                  * target are failed (see {@link IndexShard#updateRoutingEntry}).

--- a/server/src/main/java/org/elasticsearch/repositories/blobstore/FileRestoreContext.java
+++ b/server/src/main/java/org/elasticsearch/repositories/blobstore/FileRestoreContext.java
@@ -144,16 +144,15 @@ public abstract class FileRestoreContext {
                     }
                 }
 
-                restoreFiles(filesToRecover, store, ActionListener.wrap(
-                    v -> {
+                restoreFiles(filesToRecover, store, listener.wrap((l, v) -> {
                         store.incRef();
                         try {
                             afterRestore(snapshotFiles, store, restoredSegmentsFile);
-                            listener.onResponse(null);
+                            l.onResponse(null);
                         } finally {
                             store.decRef();
                         }
-                    }, listener::onFailure));
+                    }));
             } catch (IOException ex) {
                 throw new IndexShardRestoreFailedException(shardId, "Failed to recover index", ex);
             }

--- a/server/src/main/java/org/elasticsearch/rest/action/cat/RestIndicesAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/cat/RestIndicesAction.java
@@ -117,11 +117,11 @@ public class RestIndicesAction extends AbstractCatAction {
                     // This behavior can be ensured by letting the cluster state, cluster health and indices stats requests re-resolve the
                     // index names with the same indices options that we used for the initial cluster state request (strictExpand).
                     sendIndicesStatsRequest(indices, subRequestIndicesOptions, includeUnloadedSegments, client,
-                        ActionListener.wrap(groupedListener::onResponse, groupedListener::onFailure));
+                        groupedListener.wrap((l, r) -> l.onResponse(r)));
                     sendClusterStateRequest(indices, subRequestIndicesOptions, masterNodeTimeout, client,
-                        ActionListener.wrap(groupedListener::onResponse, groupedListener::onFailure));
+                        groupedListener.wrap((l, r) -> l.onResponse(r)));
                     sendClusterHealthRequest(indices, subRequestIndicesOptions, masterNodeTimeout, client,
-                        ActionListener.wrap(groupedListener::onResponse, groupedListener::onFailure));
+                        groupedListener.wrap((l, r) -> l.onResponse(r)));
                 }
             });
         };

--- a/server/src/main/java/org/elasticsearch/search/SearchService.java
+++ b/server/src/main/java/org/elasticsearch/search/SearchService.java
@@ -1282,14 +1282,14 @@ public class SearchService extends AbstractLifecycleComponent implements IndexEv
     }
 
     private void rewriteAndFetchShardRequest(IndexShard shard, ShardSearchRequest request, ActionListener<ShardSearchRequest> listener) {
-        ActionListener<Rewriteable> actionListener = ActionListener.wrap(r -> {
+        ActionListener<Rewriteable> actionListener = listener.wrap((l, r) -> {
             if (request.readerId() != null) {
-                listener.onResponse(request);
+                l.onResponse(request);
             } else {
                 // now we need to check if there is a pending refresh and register
-                shard.awaitShardSearchActive(b -> listener.onResponse(request));
+                shard.awaitShardSearchActive(b -> l.onResponse(request));
             }
-        }, listener::onFailure);
+        });
         // we also do rewrite on the coordinating node (TransportSearchService) but we also need to do it here for BWC as well as
         // AliasFilters that might need to be rewritten. These are edge-cases but we are every efficient doing the rewrite here so it's not
         // adding a lot of overhead

--- a/server/src/main/java/org/elasticsearch/snapshots/SnapshotsService.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/SnapshotsService.java
@@ -204,7 +204,7 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
      * @param listener snapshot completion listener
      */
     public void executeSnapshot(final CreateSnapshotRequest request, final ActionListener<SnapshotInfo> listener) {
-        createSnapshot(request, ActionListener.wrap(snapshot -> addListener(snapshot, listener.map(Tuple::v2)), listener::onFailure));
+        createSnapshot(request, listener.wrap((l, snapshot) -> addListener(snapshot, l.map(Tuple::v2))));
     }
 
     /**
@@ -444,7 +444,7 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
             @Override
             public void clusterStateProcessed(String source, ClusterState oldState, final ClusterState newState) {
                 logger.info("snapshot clone [{}] started", snapshot);
-                addListener(snapshot, ActionListener.wrap(r -> listener.onResponse(null), listener::onFailure));
+                addListener(snapshot, listener.wrap((l, r) -> l.onResponse(null)));
                 startCloning(repository, newEntry);
             }
         }, "clone_snapshot [" + request.source() + "][" + snapshotName + ']', listener::onFailure);

--- a/server/src/main/java/org/elasticsearch/transport/RemoteClusterAwareClient.java
+++ b/server/src/main/java/org/elasticsearch/transport/RemoteClusterAwareClient.java
@@ -34,7 +34,7 @@ final class RemoteClusterAwareClient extends AbstractClient {
     @Override
     protected <Request extends ActionRequest, Response extends ActionResponse>
     void doExecute(ActionType<Response> action, Request request, ActionListener<Response> listener) {
-        remoteClusterService.ensureConnected(clusterAlias, ActionListener.wrap(v -> {
+        remoteClusterService.ensureConnected(clusterAlias, listener.wrap((l, v) -> {
             Transport.Connection connection;
             if (request instanceof RemoteClusterAwareRequest) {
                 DiscoveryNode preferredTargetNode = ((RemoteClusterAwareRequest) request).getPreferredTargetNode();
@@ -43,9 +43,8 @@ final class RemoteClusterAwareClient extends AbstractClient {
                 connection = remoteClusterService.getConnection(clusterAlias);
             }
             service.sendRequest(connection, action.name(), request, TransportRequestOptions.EMPTY,
-                new ActionListenerResponseHandler<>(listener, action.getResponseReader()));
-        },
-        listener::onFailure));
+                new ActionListenerResponseHandler<>(l, action.getResponseReader()));
+        }));
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/transport/RemoteClusterConnection.java
+++ b/server/src/main/java/org/elasticsearch/transport/RemoteClusterConnection.java
@@ -144,7 +144,7 @@ final class RemoteClusterConnection implements Closeable {
             // we can't proceed with a search on a cluster level.
             // in the future we might want to just skip the remote nodes in such a case but that can already be implemented on the
             // caller end since they provide the listener.
-            ensureConnected(ActionListener.wrap((x) -> runnable.run(), listener::onFailure));
+            ensureConnected(listener.wrap(x -> runnable.run()));
         } catch (Exception ex) {
             listener.onFailure(ex);
         }

--- a/server/src/test/java/org/elasticsearch/action/admin/indices/close/TransportVerifyShardBeforeCloseActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/close/TransportVerifyShardBeforeCloseActionTests.java
@@ -134,12 +134,10 @@ public class TransportVerifyShardBeforeCloseActionTests extends ESTestCase {
         final TransportVerifyShardBeforeCloseAction.ShardRequest request =
             new TransportVerifyShardBeforeCloseAction.ShardRequest(indexShard.shardId(), clusterBlock, phase1, taskId);
         final PlainActionFuture<Void> res = PlainActionFuture.newFuture();
-        action.shardOperationOnPrimary(request, indexShard, ActionListener.wrap(
-            r -> {
+        action.shardOperationOnPrimary(request, indexShard, res.wrap((l, r) -> {
                 assertNotNull(r);
-                res.onResponse(null);
-            },
-            res::onFailure
+                l.onResponse(null);
+            }
         ));
         try {
             res.get();

--- a/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/action/AnalyticsUsageTransportAction.java
+++ b/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/action/AnalyticsUsageTransportAction.java
@@ -40,8 +40,7 @@ public class AnalyticsUsageTransportAction extends XPackUsageFeatureTransportAct
                                    ActionListener<XPackUsageFeatureResponse> listener) {
         AnalyticsStatsAction.Request statsRequest = new AnalyticsStatsAction.Request();
         statsRequest.setParentTask(clusterService.localNode().getId(), task.getId());
-        client.execute(AnalyticsStatsAction.INSTANCE, statsRequest, ActionListener.wrap(r ->
-                listener.onResponse(new XPackUsageFeatureResponse(new AnalyticsFeatureSetUsage(true, true, r))),
-            listener::onFailure));
+        client.execute(AnalyticsStatsAction.INSTANCE, statsRequest, listener.wrap((l, r) ->
+            l.onResponse(new XPackUsageFeatureResponse(new AnalyticsFeatureSetUsage(true, true, r)))));
     }
 }

--- a/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/TransportCcrStatsAction.java
+++ b/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/TransportCcrStatsAction.java
@@ -84,7 +84,7 @@ public class TransportCcrStatsAction extends TransportMasterNodeAction<CcrStatsA
         };
         FollowStatsAction.StatsRequest statsRequest = new FollowStatsAction.StatsRequest();
         statsRequest.setParentTask(clusterService.localNode().getId(), task.getId());
-        client.execute(FollowStatsAction.INSTANCE, statsRequest, ActionListener.wrap(handler, listener::onFailure));
+        client.execute(FollowStatsAction.INSTANCE, statsRequest, listener.wrap(handler::accept));
     }
 
     @Override

--- a/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/TransportPutFollowAction.java
+++ b/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/TransportPutFollowAction.java
@@ -257,13 +257,11 @@ public final class TransportPutFollowAction
         ResumeFollowAction.Request resumeFollowRequest = new ResumeFollowAction.Request();
         resumeFollowRequest.setFollowerIndex(request.getFollowerIndex());
         resumeFollowRequest.setParameters(new FollowParameters(parameters));
-        client.execute(ResumeFollowAction.INSTANCE, resumeFollowRequest, ActionListener.wrap(
-            r -> activeShardsObserver.waitForActiveShards(new String[]{request.getFollowerIndex()},
+        client.execute(ResumeFollowAction.INSTANCE, resumeFollowRequest, listener.wrap((l, r) ->
+            activeShardsObserver.waitForActiveShards(new String[]{request.getFollowerIndex()},
                 request.waitForActiveShards(), request.timeout(), result ->
-                    listener.onResponse(new PutFollowAction.Response(true, result, r.isAcknowledged())),
-                listener::onFailure),
-            listener::onFailure
-        ));
+                    l.onResponse(new PutFollowAction.Response(true, result, r.isAcknowledged())),
+            l::onFailure)));
     }
 
     static DataStream updateLocalDataStream(Index backingIndexToFollow,

--- a/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/repository/CcrRepository.java
+++ b/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/repository/CcrRepository.java
@@ -384,11 +384,11 @@ public class CcrRepository extends AbstractLifecycleComponent implements Reposit
             //  response, we should be able to retry by creating a new session.
             final RestoreSession restoreSession = openSession(metadata.name(), remoteClient, leaderShardId, shardId, recoveryState);
             toClose.addFirst(restoreSession); // Some tests depend on closing session before cancelling retention lease renewal
-            restoreSession.restoreFiles(store, ActionListener.wrap(v -> {
+            restoreSession.restoreFiles(store, restoreListener.wrap((l, v) -> {
                 logger.trace("[{}] completed CCR restore", shardId);
                 updateMappings(remoteClient, leaderIndex, restoreSession.mappingVersion, client, shardId.getIndex());
-                restoreListener.onResponse(null);
-            }, restoreListener::onFailure));
+                l.onResponse(null);
+            }));
         } catch (Exception e) {
             restoreListener.onFailure(e);
         }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/DataTiersUsageTransportAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/DataTiersUsageTransportAction.java
@@ -60,7 +60,7 @@ public class DataTiersUsageTransportAction extends XPackUsageFeatureTransportAct
         client.admin().cluster().prepareNodesStats()
             .all()
             .setIndices(CommonStatsFlags.ALL)
-            .execute(ActionListener.wrap(nodesStatsResponse -> {
+            .execute(listener.wrap((l, nodesStatsResponse) -> {
                 final RoutingNodes routingNodes = state.getRoutingNodes();
 
                 // First separate the nodes into separate tiers, note that nodes *may* be duplicated
@@ -70,8 +70,8 @@ public class DataTiersUsageTransportAction extends XPackUsageFeatureTransportAct
                 Map<String, DataTiersFeatureSetUsage.TierSpecificStats> tierSpecificStats = tierSpecificNodeStats.entrySet()
                     .stream().collect(Collectors.toMap(Map.Entry::getKey, ns -> calculateStats(ns.getValue(), routingNodes)));
 
-                listener.onResponse(new XPackUsageFeatureResponse(new DataTiersFeatureSetUsage(tierSpecificStats)));
-            }, listener::onFailure));
+                l.onResponse(new XPackUsageFeatureResponse(new DataTiersFeatureSetUsage(tierSpecificStats)));
+            }));
     }
 
     // Visible for testing

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/action/TransportXPackInfoAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/action/TransportXPackInfoAction.java
@@ -68,8 +68,7 @@ public class TransportXPackInfoAction extends HandledTransportAction<XPackInfoRe
             var featureSets = new HashSet<FeatureSet>();
             for (var infoAction : infoActions) {
                 // local actions are executed directly, not on a separate thread, so no thread safe collection is necessary
-                client.executeLocally(infoAction, request,
-                    ActionListener.wrap(response -> featureSets.add(response.getInfo()), listener::onFailure));
+                client.executeLocally(infoAction, request, listener.wrap(response -> featureSets.add(response.getInfo())));
             }
             featureSetsInfo = new FeatureSetsInfo(featureSets);
         }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/async/DeleteAsyncResultsService.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/async/DeleteAsyncResultsService.java
@@ -89,7 +89,7 @@ public class DeleteAsyncResultsService {
                     deleteResponseFromIndex(searchId, false, listener);
                 } else {
                     store.ensureAuthenticatedUserCanDeleteFromIndex(searchId,
-                        ActionListener.wrap(res -> deleteResponseFromIndex(searchId, false, listener), listener::onFailure));
+                        listener.wrap((l, res) -> deleteResponseFromIndex(searchId, false, l)));
                 }
             }
         } catch (Exception exc) {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/common/validation/SourceDestValidator.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/common/validation/SourceDestValidator.java
@@ -315,19 +315,19 @@ public final class SourceDestValidator {
             license
         );
 
-        ActionListener<Context> validationListener = ActionListener.wrap(c -> {
+        ActionListener<Context> validationListener = listener.wrap((l, c) -> {
             if (c.getValidationException() != null) {
-                listener.onFailure(c.getValidationException());
+                l.onFailure(c.getValidationException());
             } else {
-                listener.onResponse(true);
+                l.onResponse(true);
             }
-        }, listener::onFailure);
+        });
 
         // We traverse the validations in reverse order as we chain the listeners from back to front
         for (int i = validations.size() - 1; i >= 0; i--) {
             SourceDestValidation validation = validations.get(i);
             final ActionListener<Context> previousValidationListener = validationListener;
-            validationListener = ActionListener.wrap(c -> validation.validate(c, previousValidationListener), listener::onFailure);
+            validationListener = listener.wrap(c -> validation.validate(c, previousValidationListener));
         }
 
         validationListener.onResponse(context);

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/persistence/ElasticsearchMappings.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/persistence/ElasticsearchMappings.java
@@ -164,15 +164,14 @@ public class ElasticsearchMappings {
                 PutMappingRequest putMappingRequest = new PutMappingRequest(indicesThatRequireAnUpdate);
                 putMappingRequest.source(mapping, XContentType.JSON);
                 putMappingRequest.origin(ML_ORIGIN);
-                executeAsyncWithOrigin(client, ML_ORIGIN, PutMappingAction.INSTANCE, putMappingRequest,
-                    ActionListener.wrap(response -> {
-                        if (response.isAcknowledged()) {
-                            listener.onResponse(true);
-                        } else {
-                            listener.onFailure(new ElasticsearchException("Attempt to put missing mapping in indices "
+                executeAsyncWithOrigin(client, ML_ORIGIN, PutMappingAction.INSTANCE, putMappingRequest, listener.wrap((l, response) -> {
+                    if (response.isAcknowledged()) {
+                        listener.onResponse(true);
+                    } else {
+                        listener.onFailure(new ElasticsearchException("Attempt to put missing mapping in indices "
                                 + Arrays.toString(indicesThatRequireAnUpdate) + " was not acknowledged"));
-                        }
-                    }, listener::onFailure));
+                    }
+                }));
             } catch (IOException e) {
                 listener.onFailure(e);
             }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/utils/MlIndexAndAliasTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/utils/MlIndexAndAliasTests.java
@@ -143,7 +143,9 @@ public class MlIndexAndAliasTests extends ESTestCase {
             "/org/elasticsearch/xpack/core/ml/notifications_index_template.json", Version.CURRENT.id, "xpack.ml.version",
             Collections.singletonMap("xpack.ml.version.id", String.valueOf(Version.CURRENT.id)));
 
-        MlIndexAndAlias.installIndexTemplateIfRequired(clusterState, client, notificationsTemplate, listener);
+        // wrapped to enable using non-static wrap logic in production code that is called
+        MlIndexAndAlias.installIndexTemplateIfRequired(clusterState, client, notificationsTemplate,
+                ActionListener.wrap(listener::onResponse, listener::onFailure));
         InOrder inOrder = inOrder(indicesAdminClient, listener);
         inOrder.verify(indicesAdminClient).putTemplate(any(), any());
         inOrder.verify(listener).onResponse(true);

--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/TransportDeprecationInfoAction.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/TransportDeprecationInfoAction.java
@@ -75,7 +75,7 @@ public class TransportDeprecationInfoAction extends TransportMasterNodeReadActio
         NodesDeprecationCheckRequest nodeDepReq = new NodesDeprecationCheckRequest("_all");
         ClientHelper.executeAsyncWithOrigin(client, ClientHelper.DEPRECATION_ORIGIN,
             NodesDeprecationCheckAction.INSTANCE, nodeDepReq,
-            ActionListener.wrap(response -> {
+            listener.wrap((l, response) -> {
             if (response.hasFailures()) {
                 List<String> failedNodeIds = response.failures().stream()
                     .map(failure -> failure.nodeId() + ": " + failure.getMessage())
@@ -91,15 +91,11 @@ public class TransportDeprecationInfoAction extends TransportMasterNodeReadActio
                 settings,
                 new OriginSettingClient(client, ClientHelper.DEPRECATION_ORIGIN)
             );
-            pluginSettingIssues(PLUGIN_CHECKERS, components, ActionListener.wrap(
-                deprecationIssues -> listener.onResponse(
+            pluginSettingIssues(PLUGIN_CHECKERS, components, l.wrap((ll, deprecationIssues) -> ll.onResponse(
                     DeprecationInfoAction.Response.from(state, indexNameExpressionResolver,
-                        request, response, INDEX_SETTINGS_CHECKS, CLUSTER_SETTINGS_CHECKS,
-                        deprecationIssues)),
-                listener::onFailure
+                        request, response, INDEX_SETTINGS_CHECKS, CLUSTER_SETTINGS_CHECKS, deprecationIssues))
             ));
-
-        }, listener::onFailure));
+        }));
     }
 
     static void pluginSettingIssues(List<DeprecationChecker> checkers,
@@ -113,12 +109,9 @@ public class TransportDeprecationInfoAction extends TransportMasterNodeReadActio
             listener.onResponse(Collections.emptyMap());
             return;
         }
-        GroupedActionListener<DeprecationChecker.CheckResult> groupedActionListener = new GroupedActionListener<>(ActionListener.wrap(
-            checkResults -> listener.onResponse(checkResults
-                    .stream()
-                    .collect(Collectors.toMap(DeprecationChecker.CheckResult::getCheckerName, DeprecationChecker.CheckResult::getIssues))),
-            listener::onFailure
-        ), enabledCheckers.size());
+        GroupedActionListener<DeprecationChecker.CheckResult> groupedActionListener = new GroupedActionListener<>(
+            listener.wrap((l, checkResults) -> l.onResponse(checkResults.stream().collect(Collectors.toMap(
+                DeprecationChecker.CheckResult::getCheckerName, DeprecationChecker.CheckResult::getIssues)))), enabledCheckers.size());
         for(DeprecationChecker checker : checkers) {
             checker.check(components, groupedActionListener);
         }

--- a/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/action/TransportDeleteEnrichPolicyAction.java
+++ b/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/action/TransportDeleteEnrichPolicyAction.java
@@ -142,9 +142,9 @@ public class TransportDeleteEnrichPolicyAction extends AcknowledgedTransportMast
         // as the setting 'action.destructive_requires_name' may be set to true
         DeleteIndexRequest deleteRequest = new DeleteIndexRequest().indices(indices).indicesOptions(LENIENT_OPTIONS);
 
-        new OriginSettingClient(client, ENRICH_ORIGIN).admin().indices().delete(deleteRequest, ActionListener.wrap((response) -> {
+        new OriginSettingClient(client, ENRICH_ORIGIN).admin().indices().delete(deleteRequest, listener.wrap((l, response) -> {
             if (response.isAcknowledged() == false) {
-                listener.onFailure(
+                l.onFailure(
                     new ElasticsearchStatusException(
                         "Could not fetch indices to delete during policy delete of [{}]",
                         RestStatus.INTERNAL_SERVER_ERROR,
@@ -152,9 +152,9 @@ public class TransportDeleteEnrichPolicyAction extends AcknowledgedTransportMast
                     )
                 );
             } else {
-                deletePolicy(name, listener);
+                deletePolicy(name, l);
             }
-        }, (error) -> listener.onFailure(error)));
+        }));
     }
 
     private void deletePolicy(String name, ActionListener<AcknowledgedResponse> listener) {

--- a/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/action/TransportEnrichStatsAction.java
+++ b/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/action/TransportEnrichStatsAction.java
@@ -64,7 +64,7 @@ public class TransportEnrichStatsAction extends TransportMasterNodeAction<Enrich
         ActionListener<EnrichStatsAction.Response> listener
     ) throws Exception {
         EnrichCoordinatorStatsAction.Request statsRequest = new EnrichCoordinatorStatsAction.Request();
-        ActionListener<EnrichCoordinatorStatsAction.Response> statsListener = ActionListener.wrap(response -> {
+        ActionListener<EnrichCoordinatorStatsAction.Response> statsListener = listener.wrap((l, response) -> {
             if (response.hasFailures()) {
                 // Report failures even if some node level requests succeed:
                 Exception failure = null;
@@ -75,7 +75,7 @@ public class TransportEnrichStatsAction extends TransportMasterNodeAction<Enrich
                         failure.addSuppressed(nodeFailure);
                     }
                 }
-                listener.onFailure(failure);
+                l.onFailure(failure);
                 return;
             }
 
@@ -92,8 +92,8 @@ public class TransportEnrichStatsAction extends TransportMasterNodeAction<Enrich
                 .map(t -> new ExecutingPolicy(t.getDescription(), t))
                 .sorted(Comparator.comparing(ExecutingPolicy::getName))
                 .collect(Collectors.toList());
-            listener.onResponse(new EnrichStatsAction.Response(policyExecutionTasks, coordinatorStats));
-        }, listener::onFailure);
+            l.onResponse(new EnrichStatsAction.Response(policyExecutionTasks, coordinatorStats));
+        });
         client.execute(EnrichCoordinatorStatsAction.INSTANCE, statsRequest, statsListener);
     }
 

--- a/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/action/TransportPutEnrichPolicyAction.java
+++ b/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/action/TransportPutEnrichPolicyAction.java
@@ -89,11 +89,11 @@ public class TransportPutEnrichPolicyAction extends AcknowledgedTransportMasterN
             privRequest.clusterPrivileges(Strings.EMPTY_ARRAY);
             privRequest.indexPrivileges(privileges);
 
-            ActionListener<HasPrivilegesResponse> wrappedListener = ActionListener.wrap(r -> {
+            ActionListener<HasPrivilegesResponse> wrappedListener = listener.wrap((l, r) -> {
                 if (r.isCompleteMatch()) {
-                    putPolicy(request, listener);
+                    putPolicy(request, l);
                 } else {
-                    listener.onFailure(
+                    l.onFailure(
                         Exceptions.authorizationError(
                             "unable to store policy because no indices match with the " + "specified index patterns {}",
                             request.getPolicy().getIndices(),
@@ -101,7 +101,7 @@ public class TransportPutEnrichPolicyAction extends AcknowledgedTransportMasterN
                         )
                     );
                 }
-            }, listener::onFailure);
+            });
             client.execute(HasPrivilegesAction.INSTANCE, privRequest, wrappedListener);
         } else {
             putPolicy(request, listener);

--- a/x-pack/plugin/eql/src/internalClusterTest/java/org/elasticsearch/xpack/eql/action/AbstractEqlBlockingIntegTestCase.java
+++ b/x-pack/plugin/eql/src/internalClusterTest/java/org/elasticsearch/xpack/eql/action/AbstractEqlBlockingIntegTestCase.java
@@ -210,17 +210,14 @@ public abstract class AbstractEqlBlockingIntegTestCase extends AbstractEqlIntegT
                             logger.trace("unblocking field caps on " + nodeId);
                         };
                         final Thread originalThread = Thread.currentThread();
-                        chain.proceed(task, action, request,
-                            ActionListener.wrap(
-                                resp -> {
+                        chain.proceed(task, action, request, listener.wrap(resp -> {
                                     if (originalThread == Thread.currentThread()) {
                                         // async if we never exited the original thread
                                         executorService.execute(() -> actionWrapper.accept(resp));
                                     } else {
                                         actionWrapper.accept(resp);
                                     }
-                                },
-                                listener::onFailure)
+                                })
                         );
                     } else {
                         chain.proceed(task, action, request, listener);

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/EqlUsageTransportAction.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/EqlUsageTransportAction.java
@@ -50,7 +50,7 @@ public class EqlUsageTransportAction extends XPackUsageFeatureTransportAction {
         EqlStatsRequest eqlRequest = new EqlStatsRequest();
         eqlRequest.includeStats(true);
         eqlRequest.setParentTask(clusterService.localNode().getId(), task.getId());
-        client.execute(EqlStatsAction.INSTANCE, eqlRequest, ActionListener.wrap(r -> {
+        client.execute(EqlStatsAction.INSTANCE, eqlRequest, listener.wrap((l, r) -> {
             List<Counters> countersPerNode = r.getNodes()
                 .stream()
                 .map(EqlStatsResponse.NodeStatsResponse::getStats)
@@ -58,7 +58,7 @@ public class EqlUsageTransportAction extends XPackUsageFeatureTransportAction {
                 .collect(Collectors.toList());
             Counters mergedCounters = Counters.merge(countersPerNode);
             EqlFeatureSetUsage usage = new EqlFeatureSetUsage(mergedCounters.toNestedMap());
-            listener.onResponse(new XPackUsageFeatureResponse(usage));
-        }, listener::onFailure));
+            l.onResponse(new XPackUsageFeatureResponse(usage));
+        }));
     }
 }

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/execution/search/BasicQueryClient.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/execution/search/BasicQueryClient.java
@@ -151,11 +151,11 @@ public class BasicQueryClient implements QueryClient {
             multiSearchBuilder.add(search);
         }
 
-        search(multiSearchBuilder.request(), ActionListener.wrap(r -> {
+        search(multiSearchBuilder.request(), listener.wrap((l, r) -> {
             for (MultiSearchResponse.Item item : r.getResponses()) {
                 // check for failures
                 if (item.isFailure()) {
-                    listener.onFailure(item.getFailure());
+                    l.onFailure(item.getFailure());
                     return;
                 }
                 // otherwise proceed
@@ -173,7 +173,7 @@ public class BasicQueryClient implements QueryClient {
                     });
                 }
             }
-            listener.onResponse(seq);
-        }, listener::onFailure));
+            l.onResponse(seq);
+        }));
     }
 }

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/execution/search/PITAwareQueryClient.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/execution/search/PITAwareQueryClient.java
@@ -135,11 +135,10 @@ public class PITAwareQueryClient extends BasicQueryClient {
             null,
             null
         );
-        client.execute(OpenPointInTimeAction.INSTANCE, request, wrap(r -> {
-                pitId = r.getSearchContextId();
-                runnable.run();
-            },
-            listener::onFailure));
+        client.execute(OpenPointInTimeAction.INSTANCE, request, listener.wrap(r -> {
+            pitId = r.getSearchContextId();
+            runnable.run();
+        }));
     }
 
     @Override

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/execution/search/RuntimeUtils.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/execution/search/RuntimeUtils.java
@@ -50,21 +50,21 @@ public final class RuntimeUtils {
     private RuntimeUtils() {}
 
     public static ActionListener<SearchResponse> searchLogListener(ActionListener<SearchResponse> listener, Logger log) {
-        return ActionListener.wrap(response -> {
+        return listener.wrap((l, response) -> {
             ShardSearchFailure[] failures = response.getShardFailures();
             if (CollectionUtils.isEmpty(failures) == false) {
-                listener.onFailure(new EqlIllegalArgumentException(failures[0].reason(), failures[0].getCause()));
+                l.onFailure(new EqlIllegalArgumentException(failures[0].reason(), failures[0].getCause()));
                 return;
             }
             if (log.isTraceEnabled()) {
                 logSearchResponse(response, log);
             }
-            listener.onResponse(response);
-        }, listener::onFailure);
+            l.onResponse(response);
+        });
     }
 
     public static ActionListener<MultiSearchResponse> multiSearchLogListener(ActionListener<MultiSearchResponse> listener, Logger log) {
-        return ActionListener.wrap(items -> {
+        return listener.wrap((l, items) -> {
             for (MultiSearchResponse.Item item : items) {
                 Exception failure = item.getFailure();
                 SearchResponse response = item.getResponse();
@@ -76,15 +76,15 @@ public final class RuntimeUtils {
                     }
                 }
                 if (failure != null) {
-                    listener.onFailure(failure);
+                    l.onFailure(failure);
                     return;
                 }
                 if (log.isTraceEnabled()) {
                     logSearchResponse(response, log);
                 }
             }
-            listener.onResponse(items);
-        }, listener::onFailure);
+            l.onResponse(items);
+        });
     }
 
     private static void logSearchResponse(SearchResponse response, Logger logger) {

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/execution/sequence/TumblingWindow.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/execution/sequence/TumblingWindow.java
@@ -33,7 +33,6 @@ import java.util.Map;
 import java.util.Set;
 
 import static java.util.stream.Collectors.toList;
-import static org.elasticsearch.action.ActionListener.wrap;
 import static org.elasticsearch.xpack.eql.execution.search.RuntimeUtils.searchHits;
 
 /**
@@ -181,7 +180,7 @@ public class TumblingWindow implements Executable {
         log.trace("{}", matcher);
         log.trace("Querying base stage [{}] {}", stage, base.queryRequest());
 
-        client.query(base.queryRequest(), wrap(p -> baseCriterion(stage, p, listener), listener::onFailure));
+        client.query(base.queryRequest(), listener.wrap((l, p) -> baseCriterion(stage, p, l)));
     }
 
     /**
@@ -344,7 +343,7 @@ public class TumblingWindow implements Executable {
 
         log.trace("Querying until stage {}", request);
 
-        client.query(request, wrap(r -> {
+        client.query(request, listener.wrap((l, r) -> {
             List<SearchHit> hits = searchHits(r);
 
             log.trace("Found [{}] hits", hits.size());
@@ -357,15 +356,14 @@ public class TumblingWindow implements Executable {
 
             // keep running the query runs out of the results (essentially returns less than what we want)
             if (hits.size() == windowSize && request.after().before(window.end)) {
-                untilCriterion(window, listener, next);
+                untilCriterion(window, l, next);
             }
             // looks like this stage is done, move on
             else {
                 // to the next query
                 next.run();
             }
-
-        }, listener::onFailure));
+        }));
     }
 
     private void secondaryCriterion(WindowInfo window, int currentStage, ActionListener<Payload> listener) {
@@ -376,7 +374,7 @@ public class TumblingWindow implements Executable {
 
         log.trace("Querying (secondary) stage [{}] {}", criterion.stage(), request);
 
-        client.query(request, wrap(r -> {
+        client.query(request, listener.wrap((l, r) -> {
             List<SearchHit> hits = searchHits(r);
 
             // filter hits that are escaping the window (same timestamp but different tiebreaker)
@@ -410,7 +408,7 @@ public class TumblingWindow implements Executable {
 
                 // if the limit has been reached, return what's available
                 if (matcher.match(criterion.stage(), wrapValues(criterion, hits)) == false) {
-                    payload(listener);
+                    payload(l);
                     return;
                 }
 
@@ -428,19 +426,19 @@ public class TumblingWindow implements Executable {
             // keep running the query runs out of the results (essentially returns less than what we want)
             // however check if the window has been fully consumed
             if (hits.size() == windowSize && request.after().before(window.end)) {
-                secondaryCriterion(window, currentStage, listener);
+                secondaryCriterion(window, currentStage, l);
             }
             // looks like this stage is done, move on
             else {
                 // but first check is there are still candidates within the current window
                 if (currentStage + 1 < maxStages && matcher.hasFollowingCandidates(criterion.stage())) {
-                    secondaryCriterion(window, currentStage + 1, listener);
+                    secondaryCriterion(window, currentStage + 1, l);
                 } else {
                     // otherwise, advance it
-                    tumbleWindow(window.baseStage, listener);
+                    tumbleWindow(window.baseStage, l);
                 }
             }
-        }, listener::onFailure));
+        }));
     }
 
     /**

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/plugin/TransportEqlAsyncGetResultAction.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/plugin/TransportEqlAsyncGetResultAction.java
@@ -65,16 +65,13 @@ public class TransportEqlAsyncGetResultAction extends HandledTransportAction<Get
     protected void doExecute(Task task, GetAsyncResultRequest request, ActionListener<EqlSearchResponse> listener) {
         DiscoveryNode node = resultsService.getNode(request.getId());
         if (node == null || resultsService.isLocalNode(node)) {
-            resultsService.retrieveResult(request, ActionListener.wrap(
-                r -> {
+            resultsService.retrieveResult(request, listener.wrap((l, r) -> {
                     if (r.getException() != null) {
-                        listener.onFailure(r.getException());
+                        l.onFailure(r.getException());
                     } else {
-                        listener.onResponse(r.getResponse());
+                        l.onResponse(r.getResponse());
                     }
-                },
-                listener::onFailure
-            ));
+            }));
         } else {
             transportService.sendRequest(node, EqlAsyncActionNames.EQL_ASYNC_GET_RESULT_ACTION_NAME, request,
                 new ActionListenerResponseHandler<>(listener, EqlSearchResponse::new, ThreadPool.Names.SAME));

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/session/EqlSession.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/session/EqlSession.java
@@ -25,7 +25,6 @@ import org.elasticsearch.xpack.ql.expression.function.FunctionRegistry;
 import org.elasticsearch.xpack.ql.index.IndexResolver;
 import org.elasticsearch.xpack.ql.plan.logical.LogicalPlan;
 
-import static org.elasticsearch.action.ActionListener.wrap;
 import static org.elasticsearch.xpack.ql.util.ActionListeners.map;
 
 public class EqlSession {
@@ -67,7 +66,7 @@ public class EqlSession {
     }
 
     public void eql(String eql, ParserParams params, ActionListener<Results> listener) {
-        eqlExecutable(eql, params, wrap(e -> e.execute(this, map(listener, Results::fromPayload)), listener::onFailure));
+        eqlExecutable(eql, params, listener.wrap((l, e) -> e.execute(this, map(l, Results::fromPayload))));
     }
 
     public void eqlExecutable(String eql, ParserParams params, ActionListener<PhysicalPlan> listener) {

--- a/x-pack/plugin/identity-provider/src/internalClusterTest/java/org/elasticsearch/xpack/idp/saml/sp/SamlServiceProviderIndexTests.java
+++ b/x-pack/plugin/identity-provider/src/internalClusterTest/java/org/elasticsearch/xpack/idp/saml/sp/SamlServiceProviderIndexTests.java
@@ -191,10 +191,8 @@ public class SamlServiceProviderIndexTests extends ESSingleNodeTestCase {
 
     private Set<SamlServiceProviderDocument> getAllDocs() {
         final PlainActionFuture<Set<SamlServiceProviderDocument>> future = new PlainActionFuture<>();
-        serviceProviderIndex.findAll(assertListenerIsOnlyCalledOnce(ActionListener.wrap(
-            set -> future.onResponse(set.stream().map(doc -> doc.document.get()).collect(Collectors.toUnmodifiableSet())),
-            future::onFailure
-        )));
+        serviceProviderIndex.findAll(assertListenerIsOnlyCalledOnce(future.wrap((f, set) ->
+                f.onResponse(set.stream().map(doc -> doc.document.get()).collect(Collectors.toUnmodifiableSet())))));
         return future.actionGet();
     }
 
@@ -214,9 +212,8 @@ public class SamlServiceProviderIndexTests extends ESSingleNodeTestCase {
 
     private DeleteResponse deleteDocument(SamlServiceProviderDocument doc) {
         final PlainActionFuture<DeleteResponse> future = new PlainActionFuture<>();
-        serviceProviderIndex.readDocument(doc.docId, assertListenerIsOnlyCalledOnce(ActionListener.wrap(
-            info -> serviceProviderIndex.deleteDocument(info.version, WriteRequest.RefreshPolicy.IMMEDIATE, future),
-            future::onFailure)));
+        serviceProviderIndex.readDocument(doc.docId, assertListenerIsOnlyCalledOnce(future.wrap((f, info) ->
+                serviceProviderIndex.deleteDocument(info.version, WriteRequest.RefreshPolicy.IMMEDIATE, f))));
         return future.actionGet();
     }
 
@@ -228,10 +225,8 @@ public class SamlServiceProviderIndexTests extends ESSingleNodeTestCase {
 
     private Set<SamlServiceProviderDocument> findAllByEntityId(String entityId) {
         final PlainActionFuture<Set<SamlServiceProviderDocument>> future = new PlainActionFuture<>();
-        serviceProviderIndex.findByEntityId(entityId, assertListenerIsOnlyCalledOnce(ActionListener.wrap(
-            set -> future.onResponse(set.stream().map(doc -> doc.document.get()).collect(Collectors.toUnmodifiableSet())),
-            future::onFailure
-        )));
+        serviceProviderIndex.findByEntityId(entityId, assertListenerIsOnlyCalledOnce(future.wrap((f, set) ->
+                f.onResponse(set.stream().map(doc -> doc.document.get()).collect(Collectors.toUnmodifiableSet())))));
         return future.actionGet();
     }
 

--- a/x-pack/plugin/identity-provider/src/main/java/org/elasticsearch/xpack/idp/action/TransportDeleteSamlServiceProviderAction.java
+++ b/x-pack/plugin/identity-provider/src/main/java/org/elasticsearch/xpack/idp/action/TransportDeleteSamlServiceProviderAction.java
@@ -40,24 +40,23 @@ public class TransportDeleteSamlServiceProviderAction
     protected void doExecute(Task task, final DeleteSamlServiceProviderRequest request,
                              final ActionListener<DeleteSamlServiceProviderResponse> listener) {
         final String entityId = request.getEntityId();
-        index.findByEntityId(entityId, ActionListener.wrap(matchingDocuments -> {
+        index.findByEntityId(entityId, listener.wrap((l, matchingDocuments) -> {
             if (matchingDocuments.isEmpty()) {
-                listener.onResponse(new DeleteSamlServiceProviderResponse(null, entityId));
+                l.onResponse(new DeleteSamlServiceProviderResponse(null, entityId));
             } else if (matchingDocuments.size() == 1) {
                 final SamlServiceProviderIndex.DocumentSupplier docInfo = Iterables.get(matchingDocuments, 0);
                 final SamlServiceProviderDocument existingDoc = docInfo.getDocument();
                 assert existingDoc.docId != null : "Loaded document with no doc id";
                 assert existingDoc.entityId.equals(entityId) : "Loaded document with non-matching entity-id";
                 logger.info("Deleting Service Provider [{}]", existingDoc);
-                index.deleteDocument(docInfo.version, request.getRefreshPolicy(), ActionListener.wrap(
-                    deleteResponse -> listener.onResponse(new DeleteSamlServiceProviderResponse(deleteResponse, entityId)),
-                    listener::onFailure
+                index.deleteDocument(docInfo.version, request.getRefreshPolicy(),
+                    l.wrap((ll, deleteResponse) -> ll.onResponse(new DeleteSamlServiceProviderResponse(deleteResponse, entityId))
                 ));
             } else {
                 logger.warn("Found multiple existing service providers in [{}] with entity id [{}] - [{}]",
                     index, entityId, matchingDocuments.stream().map(d -> d.getDocument().docId).collect(Collectors.joining(",")));
-                listener.onFailure(new IllegalStateException("Multiple service providers exist with entity id [" + entityId + "]"));
+                l.onFailure(new IllegalStateException("Multiple service providers exist with entity id [" + entityId + "]"));
             }
-        }, listener::onFailure));
+        }));
     }
 }

--- a/x-pack/plugin/identity-provider/src/main/java/org/elasticsearch/xpack/idp/action/TransportSamlInitiateSingleSignOnAction.java
+++ b/x-pack/plugin/identity-provider/src/main/java/org/elasticsearch/xpack/idp/action/TransportSamlInitiateSingleSignOnAction.java
@@ -116,17 +116,15 @@ public class TransportSamlInitiateSingleSignOnAction
                                              ActionListener<UserServiceAuthentication> listener) {
         User user = secondaryAuthentication.getUser();
         secondaryAuthentication.execute(ignore -> {
-                privilegeResolver.resolve(serviceProvider.getPrivileges(), ActionListener.wrap(
-                    userPrivileges -> {
+                privilegeResolver.resolve(serviceProvider.getPrivileges(), listener.wrap((l, userPrivileges) -> {
                         if (userPrivileges.hasAccess == false) {
-                            listener.onResponse(null);
+                            l.onResponse(null);
                         } else {
                             logger.debug("Resolved [{}] for [{}]", userPrivileges, user);
-                            listener.onResponse(new UserServiceAuthentication(user.principal(), user.fullName(), user.email(),
+                            l.onResponse(new UserServiceAuthentication(user.principal(), user.fullName(), user.email(),
                                 userPrivileges.roles, serviceProvider));
                         }
-                    },
-                    listener::onFailure
+                    }
                 ));
                 return null;
             }

--- a/x-pack/plugin/identity-provider/src/main/java/org/elasticsearch/xpack/idp/privileges/ApplicationActionsResolver.java
+++ b/x-pack/plugin/identity-provider/src/main/java/org/elasticsearch/xpack/idp/privileges/ApplicationActionsResolver.java
@@ -120,17 +120,14 @@ public class ApplicationActionsResolver extends AbstractLifecycleComponent {
     private void loadActions(String applicationName, ActionListener<Set<String>> listener) {
         final GetPrivilegesRequest request = new GetPrivilegesRequest();
         request.application(applicationName);
-        this.client.execute(GetPrivilegesAction.INSTANCE, request, ActionListener.wrap(
-            response -> {
+        this.client.execute(GetPrivilegesAction.INSTANCE, request, listener.wrap((l, response) -> {
                 final Set<String> fixedActions = Stream.of(response.privileges())
                     .map(p -> p.getActions())
                     .flatMap(Collection::stream)
                     .filter(s -> s.indexOf('*') == -1)
                     .collect(Collectors.toUnmodifiableSet());
                 cache.put(applicationName, fixedActions);
-                listener.onResponse(fixedActions);
-            },
-            listener::onFailure
-        ));
+                l.onResponse(fixedActions);
+        }));
     }
 }

--- a/x-pack/plugin/identity-provider/src/main/java/org/elasticsearch/xpack/idp/saml/idp/SamlIdentityProvider.java
+++ b/x-pack/plugin/identity-provider/src/main/java/org/elasticsearch/xpack/idp/saml/idp/SamlIdentityProvider.java
@@ -119,21 +119,18 @@ public class SamlIdentityProvider {
      */
     public void resolveServiceProvider(String spEntityId, @Nullable String acs, boolean allowDisabled,
                                        ActionListener<SamlServiceProvider> listener) {
-        serviceProviderResolver.resolve(spEntityId, ActionListener.wrap(
-            sp -> {
+        serviceProviderResolver.resolve(spEntityId, listener.wrap((l, sp) -> {
                 if (sp == null) {
                     logger.debug("No explicitly registered service provider exists for entityId [{}]", spEntityId);
-                    resolveWildcardService(spEntityId, acs, listener);
+                    resolveWildcardService(spEntityId, acs, l);
                 } else if (allowDisabled == false && sp.isEnabled() == false) {
                     logger.info("Service provider [{}][{}] is not enabled", spEntityId, sp.getName());
-                    listener.onResponse(null);
+                    l.onResponse(null);
                 } else {
                     logger.debug("Service provider for [{}] is [{}]", spEntityId, sp);
-                    listener.onResponse(sp);
+                    l.onResponse(sp);
                 }
-            },
-            listener::onFailure
-        ));
+        }));
     }
 
     private void resolveWildcardService(String entityId, String acs, ActionListener<SamlServiceProvider> listener) {

--- a/x-pack/plugin/identity-provider/src/main/java/org/elasticsearch/xpack/idp/saml/sp/SamlServiceProviderIndex.java
+++ b/x-pack/plugin/identity-provider/src/main/java/org/elasticsearch/xpack/idp/saml/sp/SamlServiceProviderIndex.java
@@ -209,10 +209,10 @@ public class SamlServiceProviderIndex implements Closeable {
         }
         final String template = TemplateUtils.loadTemplate(TEMPLATE_RESOURCE, Version.CURRENT.toString(), TEMPLATE_VERSION_SUBSTITUTE);
         final PutIndexTemplateRequest request = new PutIndexTemplateRequest(TEMPLATE_NAME).source(template, XContentType.JSON);
-        client.admin().indices().putTemplate(request, ActionListener.wrap(response -> {
+        client.admin().indices().putTemplate(request, listener.wrap((l, response) -> {
             logger.info("Installed template [{}]", TEMPLATE_NAME);
-            listener.onResponse(true);
-        }, listener::onFailure));
+            l.onResponse(true);
+        }));
     }
 
     private boolean isTemplateUpToDate(ClusterState state) {
@@ -225,10 +225,10 @@ public class SamlServiceProviderIndex implements Closeable {
             .setIfSeqNo(version.seqNo)
             .setIfPrimaryTerm(version.primaryTerm)
             .setRefreshPolicy(refreshPolicy);
-        client.delete(request, ActionListener.wrap(response -> {
+        client.delete(request, listener.wrap((l, response) -> {
             logger.debug("Deleted service provider document [{}] ({})", version.id, response.getResult());
-            listener.onResponse(response);
-        }, listener::onFailure));
+            l.onResponse(response);
+        }));
     }
 
     public void writeDocument(SamlServiceProviderDocument document, DocWriteRequest.OpType opType,
@@ -242,8 +242,7 @@ public class SamlServiceProviderIndex implements Closeable {
         if (templateInstalled) {
             _writeDocument(document, opType, refreshPolicy, listener);
         } else {
-            installIndexTemplate(ActionListener.wrap(installed ->
-                _writeDocument(document, opType, refreshPolicy, listener), listener::onFailure));
+            installIndexTemplate(listener.wrap((l, installed) -> _writeDocument(document, opType, refreshPolicy, l)));
         }
     }
 
@@ -260,11 +259,11 @@ public class SamlServiceProviderIndex implements Closeable {
                 .source(xContentBuilder)
                 .id(document.docId)
                 .setRefreshPolicy(refreshPolicy);
-            client.index(request, ActionListener.wrap(response -> {
+            client.index(request, listener.wrap((l, response) -> {
                 logger.debug("Wrote service provider [{}][{}] as document [{}] ({})",
                     document.name, document.entityId, response.getId(), response.getResult());
-                listener.onResponse(response);
-            }, listener::onFailure));
+                l.onResponse(response);
+            }));
         } catch (IOException e) {
             listener.onFailure(e);
         }
@@ -272,15 +271,14 @@ public class SamlServiceProviderIndex implements Closeable {
 
     public void readDocument(String documentId, ActionListener<DocumentSupplier> listener) {
         final GetRequest request = new GetRequest(ALIAS_NAME, documentId);
-        client.get(request, ActionListener.wrap(response -> {
+        client.get(request, listener.wrap((l, response) -> {
             if (response.isExists()) {
-                listener.onResponse(
-                    new DocumentSupplier(new DocumentVersion(response), () -> toDocument(documentId, response.getSourceAsBytesRef()))
-                );
+                l.onResponse(
+                        new DocumentSupplier(new DocumentVersion(response), () -> toDocument(documentId, response.getSourceAsBytesRef())));
             } else {
-                listener.onResponse(null);
+                l.onResponse(null);
             }
-        }, listener::onFailure));
+        }));
     }
 
     public void findByEntityId(String entityId, ActionListener<Set<DocumentSupplier>> listener) {
@@ -294,8 +292,7 @@ public class SamlServiceProviderIndex implements Closeable {
     }
 
     public void refresh(ActionListener<Void> listener) {
-        client.admin().indices().refresh(new RefreshRequest(ALIAS_NAME), ActionListener.wrap(
-            response -> listener.onResponse(null), listener::onFailure));
+        client.admin().indices().refresh(new RefreshRequest(ALIAS_NAME), listener.wrap((l, response) -> l.onResponse(null)));
     }
 
     private void findDocuments(QueryBuilder query, ActionListener<Set<DocumentSupplier>> listener) {

--- a/x-pack/plugin/logstash/src/main/java/org/elasticsearch/xpack/logstash/action/TransportGetPipelineAction.java
+++ b/x-pack/plugin/logstash/src/main/java/org/elasticsearch/xpack/logstash/action/TransportGetPipelineAction.java
@@ -150,12 +150,7 @@ public class TransportGetPipelineAction extends HandledTransportAction<GetPipeli
         } else {
             client.prepareSearchScroll(searchResponse.getScrollId())
                 .setScroll(TimeValue.timeValueMinutes(1L))
-                .execute(
-                    ActionListener.wrap(
-                        searchResponse1 -> handleSearchResponse(searchResponse1, pipelineSources, clearScroll, listener),
-                        listener::onFailure
-                    )
-                );
+                .execute(listener.wrap((l, searchResponse1) -> handleSearchResponse(searchResponse1, pipelineSources, clearScroll, l)));
         }
     }
 

--- a/x-pack/plugin/logstash/src/main/java/org/elasticsearch/xpack/logstash/action/TransportPutPipelineAction.java
+++ b/x-pack/plugin/logstash/src/main/java/org/elasticsearch/xpack/logstash/action/TransportPutPipelineAction.java
@@ -36,11 +36,6 @@ public class TransportPutPipelineAction extends HandledTransportAction<PutPipeli
             .setId(request.id())
             .setSource(request.source(), request.xContentType())
             .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE)
-            .execute(
-                ActionListener.wrap(
-                    indexResponse -> listener.onResponse(new PutPipelineResponse(indexResponse.status())),
-                    listener::onFailure
-                )
-            );
+            .execute(listener.wrap((l, indexResponse) -> l.onResponse(new PutPipelineResponse(indexResponse.status()))));
     }
 }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportDeleteCalendarEventAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportDeleteCalendarEventAction.java
@@ -54,36 +54,33 @@ public class TransportDeleteCalendarEventAction extends HandledTransportAction<D
                              ActionListener<AcknowledgedResponse> listener) {
         final String eventId = request.getEventId();
 
-        ActionListener<Calendar> calendarListener = ActionListener.wrap(
-                calendar -> {
+        ActionListener<Calendar> calendarListener = listener.wrap((l, calendar) -> {
                     GetRequest getRequest = new GetRequest(MlMetaIndex.indexName(), eventId);
-                    executeAsyncWithOrigin(client, ML_ORIGIN, GetAction.INSTANCE, getRequest, ActionListener.wrap(
-                            getResponse -> {
+                    executeAsyncWithOrigin(client, ML_ORIGIN, GetAction.INSTANCE, getRequest, l.wrap((ll, getResponse) -> {
                                 if (getResponse.isExists() == false) {
-                                    listener.onFailure(new ResourceNotFoundException("No event with id [" + eventId + "]"));
+                                    ll.onFailure(new ResourceNotFoundException("No event with id [" + eventId + "]"));
                                     return;
                                 }
 
                                 Map<String, Object> source = getResponse.getSourceAsMap();
                                 String calendarId = (String) source.get(Calendar.ID.getPreferredName());
                                 if (calendarId == null) {
-                                    listener.onFailure(ExceptionsHelper.badRequestException("Event [" + eventId + "] does not have a valid "
+                                    ll.onFailure(ExceptionsHelper.badRequestException("Event [" + eventId + "] does not have a valid "
                                             + Calendar.ID.getPreferredName()));
                                     return;
                                 }
 
                                 if (calendarId.equals(request.getCalendarId()) == false) {
-                                    listener.onFailure(ExceptionsHelper.badRequestException(
+                                    ll.onFailure(ExceptionsHelper.badRequestException(
                                             "Event [" + eventId + "] has " + Calendar.ID.getPreferredName()
                                                     + " [" + calendarId + "] which does not match the request "
                                                     + Calendar.ID.getPreferredName() + " [" + request.getCalendarId() + "]"));
                                     return;
                                 }
 
-                                deleteEvent(eventId, calendar, listener);
-                            }, listener::onFailure)
-                    );
-                }, listener::onFailure);
+                                deleteEvent(eventId, calendar, ll);
+                    }));
+            });
 
         // Get the calendar first so we check the calendar exists before checking the event exists
         jobResultsProvider.calendar(request.getCalendarId(), calendarListener);
@@ -101,10 +98,8 @@ public class TransportDeleteCalendarEventAction extends HandledTransportAction<D
                         if (response.status() == RestStatus.NOT_FOUND) {
                             listener.onFailure(new ResourceNotFoundException("No event with id [" + eventId + "]"));
                         } else {
-                            jobManager.updateProcessOnCalendarChanged(calendar.getJobIds(), ActionListener.wrap(
-                                    r -> listener.onResponse(AcknowledgedResponse.TRUE),
-                                    listener::onFailure
-                            ));
+                            jobManager.updateProcessOnCalendarChanged(calendar.getJobIds(),
+                                    listener.wrap((l, r) -> l.onResponse(AcknowledgedResponse.TRUE)));
                         }
                     }
 

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportDeleteFilterAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportDeleteFilterAction.java
@@ -53,19 +53,15 @@ public class TransportDeleteFilterAction extends HandledTransportAction<DeleteFi
     @Override
     protected void doExecute(Task task, DeleteFilterAction.Request request, ActionListener<AcknowledgedResponse> listener) {
         final String filterId = request.getFilterId();
-        jobConfigProvider.findJobsWithCustomRules(ActionListener.wrap(
-                jobs-> {
+        jobConfigProvider.findJobsWithCustomRules(listener.wrap((l, jobs) -> {
                     List<String> currentlyUsedBy = findJobsUsingFilter(jobs, filterId);
                     if (currentlyUsedBy.isEmpty() == false) {
-                        listener.onFailure(ExceptionsHelper.conflictStatusException(
+                        l.onFailure(ExceptionsHelper.conflictStatusException(
                                 Messages.getMessage(Messages.FILTER_CANNOT_DELETE, filterId, currentlyUsedBy)));
                     } else {
-                        deleteFilter(filterId, listener);
+                        deleteFilter(filterId, l);
                     }
-                },
-                listener::onFailure
-            )
-        );
+        }));
     }
 
     private static List<String> findJobsUsingFilter(List<Job> jobs, String filterId) {

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportDeleteTrainedModelAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportDeleteTrainedModelAction.java
@@ -104,17 +104,11 @@ public class TransportDeleteTrainedModelAction
             }
         }
 
-        ActionListener<AcknowledgedResponse> nameDeletionListener = ActionListener.wrap(
-            ack -> trainedModelProvider.deleteTrainedModel(request.getId(), ActionListener.wrap(
-                    r -> {
+        ActionListener<AcknowledgedResponse> nameDeletionListener = listener.wrap((l, ack) ->
+                trainedModelProvider.deleteTrainedModel(request.getId(), l.wrap((ll, r) -> {
                         auditor.info(request.getId(), "trained model deleted");
-                        listener.onResponse(AcknowledgedResponse.TRUE);
-                    },
-                    listener::onFailure
-            )),
-
-            listener::onFailure
-        );
+                        ll.onResponse(AcknowledgedResponse.TRUE);
+                })));
 
         // No reason to update cluster state, simply delete the model
         if (modelAliases.isEmpty()) {

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportEvaluateDataFrameAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportEvaluateDataFrameAction.java
@@ -64,13 +64,11 @@ public class TransportEvaluateDataFrameAction extends HandledTransportAction<Eva
     protected void doExecute(Task task,
                              EvaluateDataFrameAction.Request request,
                              ActionListener<EvaluateDataFrameAction.Response> listener) {
-        ActionListener<List<Void>> resultsListener = ActionListener.wrap(
-            unused -> {
+        ActionListener<List<Void>> resultsListener = listener.wrap((l, unused) -> {
                 EvaluateDataFrameAction.Response response =
                     new EvaluateDataFrameAction.Response(request.getEvaluation().getName(), request.getEvaluation().getResults());
-                listener.onResponse(response);
-            },
-            listener::onFailure
+                l.onResponse(response);
+            }
         );
 
         // Create an immutable collection of parameters to be used by evaluation metrics.
@@ -123,15 +121,13 @@ public class TransportEvaluateDataFrameAction extends HandledTransportAction<Eva
                     () -> client.execute(
                         SearchAction.INSTANCE,
                         searchRequest,
-                        ActionListener.wrap(
-                            searchResponse -> {
+                        listener.wrap((l, searchResponse) -> {
                                 evaluation.process(searchResponse);
                                 if (evaluation.hasAllResults() == false) {
                                     add(nextTask());
                                 }
-                                listener.onResponse(null);
-                            },
-                            listener::onFailure)));
+                                l.onResponse(null);
+                        })));
             };
         }
     }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportExplainDataFrameAnalyticsAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportExplainDataFrameAnalyticsAction.java
@@ -127,21 +127,12 @@ public class TransportExplainDataFrameAnalyticsAction
                     .setHeaders(filterSecurityHeaders(threadPool.getThreadContext().getHeaders()))
                     .build();
                 extractedFieldsDetectorFactory.createFromSource(
-                    config,
-                    ActionListener.wrap(
-                        extractedFieldsDetector -> explain(task, config, extractedFieldsDetector, listener),
-                        listener::onFailure
-                    )
-                );
+                        config, listener.wrap((l, extractedFieldsDetector) -> explain(task, config, extractedFieldsDetector, l)));
             });
         } else {
             extractedFieldsDetectorFactory.createFromSource(
                 request.getConfig(),
-                ActionListener.wrap(
-                    extractedFieldsDetector -> explain(task, request.getConfig(), extractedFieldsDetector, listener),
-                    listener::onFailure
-                )
-            );
+                listener.wrap((l, extractedFieldsDetector) -> explain(task, request.getConfig(), extractedFieldsDetector, l)));
         }
     }
 
@@ -158,10 +149,8 @@ public class TransportExplainDataFrameAnalyticsAction
             return;
         }
 
-        ActionListener<MemoryEstimation> memoryEstimationListener = ActionListener.wrap(
-            memoryEstimation -> listener.onResponse(new ExplainDataFrameAnalyticsAction.Response(fieldExtraction.v2(), memoryEstimation)),
-            listener::onFailure
-        );
+        ActionListener<MemoryEstimation> memoryEstimationListener = listener.wrap(
+            (l, memoryEstimation) -> l.onResponse(new ExplainDataFrameAnalyticsAction.Response(fieldExtraction.v2(), memoryEstimation)));
 
         estimateMemoryUsage(task, config, fieldExtraction.v1(), memoryEstimationListener);
     }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportFinalizeJobExecutionAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportFinalizeJobExecutionAction.java
@@ -70,21 +70,14 @@ public class TransportFinalizeJobExecutionAction extends AcknowledgedTransportMa
             updateRequest.doc(update);
             updateRequest.setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE);
 
-            voidChainTaskExecutor.add(chainedListener -> {
-                executeAsyncWithOrigin(client, ML_ORIGIN, UpdateAction.INSTANCE, updateRequest, ActionListener.wrap(
-                        updateResponse -> chainedListener.onResponse(null),
-                        chainedListener::onFailure
-                ));
-            });
+            voidChainTaskExecutor.add(chainedListener -> executeAsyncWithOrigin(client, ML_ORIGIN, UpdateAction.INSTANCE, updateRequest,
+                chainedListener.wrap((l, updateResponse) -> l.onResponse(null))));
         }
 
-        voidChainTaskExecutor.execute(ActionListener.wrap(
-                aVoids ->  {
+        voidChainTaskExecutor.execute(listener.wrap((l, aVoids) ->  {
                     logger.debug("finalized job [{}]", jobIdString);
-                    listener.onResponse(AcknowledgedResponse.TRUE);
-                },
-                listener::onFailure
-        ));
+                    l.onResponse(AcknowledgedResponse.TRUE);
+        }));
     }
 
     @Override

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportFlushJobAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportFlushJobAction.java
@@ -47,11 +47,7 @@ public class TransportFlushJobAction extends TransportJobTaskAction<FlushJobActi
             timeRangeBuilder.endTime(request.getEnd());
         }
         paramsBuilder.forTimeRange(timeRangeBuilder.build());
-        processManager.flushJob(task, paramsBuilder.build(), ActionListener.wrap(
-                flushAcknowledgement -> {
-                    listener.onResponse(new FlushJobAction.Response(true,
-                            flushAcknowledgement == null ? null : flushAcknowledgement.getLastFinalizedBucketEnd()));
-                }, listener::onFailure
-        ));
+        processManager.flushJob(task, paramsBuilder.build(), listener.wrap((l, flushAcknowledgement) -> l.onResponse(
+            new FlushJobAction.Response(true, flushAcknowledgement == null ? null : flushAcknowledgement.getLastFinalizedBucketEnd()))));
     }
 }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportForecastJobAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportForecastJobAction.java
@@ -72,8 +72,7 @@ public class TransportForecastJobAction extends TransportJobTaskAction<ForecastJ
 
     @Override
     protected void taskOperation(ForecastJobAction.Request request, JobTask task, ActionListener<ForecastJobAction.Response> listener) {
-        jobManager.getJob(task.getJobId(), ActionListener.wrap(
-                job -> {
+        jobManager.getJob(task.getJobId(), listener.wrap((l, job) -> {
                     validate(job, request);
 
                     ForecastParams.Builder paramsBuilder = ForecastParams.builder();
@@ -105,14 +104,12 @@ public class TransportForecastJobAction extends TransportJobTaskAction<ForecastJ
                     ForecastParams params = paramsBuilder.build();
                     processManager.forecastJob(task, params, e -> {
                         if (e == null) {
-                            getForecastRequestStats(request.getJobId(), params.getForecastId(), listener);
+                            getForecastRequestStats(request.getJobId(), params.getForecastId(), l);
                         } else {
-                            listener.onFailure(e);
+                            l.onFailure(e);
                         }
                     });
-                },
-                listener::onFailure
-        ));
+        }));
     }
 
     private void getForecastRequestStats(String jobId, String forecastId, ActionListener<ForecastJobAction.Response> listener) {

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetBucketsAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetBucketsAction.java
@@ -35,8 +35,7 @@ public class TransportGetBucketsAction extends HandledTransportAction<GetBuckets
 
     @Override
     protected void doExecute(Task task, GetBucketsAction.Request request, ActionListener<GetBucketsAction.Response> listener) {
-        jobManager.jobExists(request.getJobId(), ActionListener.wrap(
-                ok -> {
+        jobManager.jobExists(request.getJobId(), listener.wrap((l, ok) -> {
                     BucketsQueryBuilder query =
                             new BucketsQueryBuilder().expand(request.isExpand())
                                     .includeInterim(request.isExcludeInterim() == false)
@@ -57,11 +56,7 @@ public class TransportGetBucketsAction extends HandledTransportAction<GetBuckets
                         query.end(request.getEnd());
                     }
                     jobResultsProvider.buckets(request.getJobId(), query, q ->
-                            listener.onResponse(new GetBucketsAction.Response(q)), listener::onFailure, client);
-
-                },
-                listener::onFailure
-
-        ));
+                        l.onResponse(new GetBucketsAction.Response(q)), l::onFailure, client);
+        }));
     }
 }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetDataFrameAnalyticsAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetDataFrameAnalyticsAction.java
@@ -60,10 +60,7 @@ public class TransportGetDataFrameAnalyticsAction extends AbstractTransportGetRe
     @Override
     protected void doExecute(Task task, GetDataFrameAnalyticsAction.Request request,
                              ActionListener<GetDataFrameAnalyticsAction.Response> listener) {
-        searchResources(request, ActionListener.wrap(
-            queryPage -> listener.onResponse(new GetDataFrameAnalyticsAction.Response(queryPage)),
-            listener::onFailure
-        ));
+        searchResources(request, listener.wrap((l, queryPage) -> l.onResponse(new GetDataFrameAnalyticsAction.Response(queryPage))));
     }
 
     @Nullable

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetDatafeedsAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetDatafeedsAction.java
@@ -62,12 +62,12 @@ public class TransportGetDatafeedsAction extends TransportMasterNodeReadAction<G
         Map<String, DatafeedConfig> clusterStateConfigs =
                 expandClusterStateDatafeeds(request.getDatafeedId(), request.allowNoMatch(), state);
 
-        datafeedConfigProvider.expandDatafeedConfigs(request.getDatafeedId(), request.allowNoMatch(), ActionListener.wrap(
-                datafeedBuilders -> {
+        datafeedConfigProvider.expandDatafeedConfigs(request.getDatafeedId(), request.allowNoMatch(), listener.wrap(
+                (l, datafeedBuilders) -> {
                     // Check for duplicate datafeeds
                     for (DatafeedConfig.Builder datafeed : datafeedBuilders) {
                         if (clusterStateConfigs.containsKey(datafeed.getId())) {
-                            listener.onFailure(new IllegalStateException("Datafeed [" + datafeed.getId() + "] configuration " +
+                            l.onFailure(new IllegalStateException("Datafeed [" + datafeed.getId() + "] configuration " +
                                     "exists in both clusterstate and index"));
                             return;
                         }
@@ -81,11 +81,9 @@ public class TransportGetDatafeedsAction extends TransportMasterNodeReadAction<G
 
                     datafeeds.addAll(clusterStateConfigs.values());
                     Collections.sort(datafeeds, Comparator.comparing(DatafeedConfig::getId));
-                    listener.onResponse(new GetDatafeedsAction.Response(new QueryPage<>(datafeeds, datafeeds.size(),
+                    l.onResponse(new GetDatafeedsAction.Response(new QueryPage<>(datafeeds, datafeeds.size(),
                             DatafeedConfig.RESULTS_FIELD)));
-                },
-                listener::onFailure
-        ));
+        }));
     }
 
     Map<String, DatafeedConfig> expandClusterStateDatafeeds(String datafeedExpression, boolean allowNoMatch, ClusterState clusterState) {

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetFiltersAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetFiltersAction.java
@@ -42,10 +42,7 @@ public class TransportGetFiltersAction extends AbstractTransportGetResourcesActi
     @Override
     protected void doExecute(Task task, GetFiltersAction.Request request, ActionListener<GetFiltersAction.Response> listener) {
         request.setAllowNoResources(true);
-        searchResources(request, ActionListener.wrap(
-            filters -> listener.onResponse(new GetFiltersAction.Response(filters)),
-            listener::onFailure
-        ));
+        searchResources(request, listener.wrap((l, filters) -> l.onResponse(new GetFiltersAction.Response(filters))));
     }
 
     @Override

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetInfluencersAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetInfluencersAction.java
@@ -35,8 +35,7 @@ public class TransportGetInfluencersAction extends HandledTransportAction<GetInf
 
     @Override
     protected void doExecute(Task task, GetInfluencersAction.Request request, ActionListener<GetInfluencersAction.Response> listener) {
-        jobManager.jobExists(request.getJobId(), ActionListener.wrap(
-                jobExists -> {
+        jobManager.jobExists(request.getJobId(), listener.wrap((l, jobExists) -> {
                     InfluencersQueryBuilder.InfluencersQuery query = new InfluencersQueryBuilder()
                             .includeInterim(request.isExcludeInterim() == false)
                             .start(request.getStart())
@@ -47,9 +46,7 @@ public class TransportGetInfluencersAction extends HandledTransportAction<GetInf
                             .sortField(request.getSort())
                             .sortDescending(request.isDescending()).build();
                     jobResultsProvider.influencers(request.getJobId(), query,
-                            page -> listener.onResponse(new GetInfluencersAction.Response(page)), listener::onFailure, client);
-                },
-                listener::onFailure)
-        );
+                            page -> l.onResponse(new GetInfluencersAction.Response(page)), l::onFailure, client);
+        }));
     }
 }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetJobsAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetJobsAction.java
@@ -43,12 +43,8 @@ public class TransportGetJobsAction extends TransportMasterNodeReadAction<GetJob
     protected void masterOperation(Task task, GetJobsAction.Request request, ClusterState state,
                                    ActionListener<GetJobsAction.Response> listener) {
         logger.debug("Get job '{}'", request.getJobId());
-        jobManager.expandJobs(request.getJobId(), request.allowNoMatch(), ActionListener.wrap(
-                jobs -> {
-                    listener.onResponse(new GetJobsAction.Response(jobs));
-                },
-                listener::onFailure
-        ));
+        jobManager.expandJobs(request.getJobId(), request.allowNoMatch(),
+                listener.wrap((l, jobs) -> l.onResponse(new GetJobsAction.Response(jobs))));
     }
 
     @Override

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetModelSnapshotsAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetModelSnapshotsAction.java
@@ -55,10 +55,7 @@ public class TransportGetModelSnapshotsAction extends HandledTransportAction<Get
             getModelSnapshots(request, listener);
             return;
         }
-        jobManager.jobExists(request.getJobId(), ActionListener.wrap(
-            ok -> getModelSnapshots(request, listener),
-            listener::onFailure
-        ));
+        jobManager.jobExists(request.getJobId(), listener.wrap((l, ok) -> getModelSnapshots(request, l)));
     }
 
     private void getModelSnapshots(GetModelSnapshotsAction.Request request, ActionListener<GetModelSnapshotsAction.Response> listener) {

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetRecordsAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetRecordsAction.java
@@ -36,8 +36,7 @@ public class TransportGetRecordsAction extends HandledTransportAction<GetRecords
     @Override
     protected void doExecute(Task task, GetRecordsAction.Request request, ActionListener<GetRecordsAction.Response> listener) {
 
-        jobManager.jobExists(request.getJobId(), ActionListener.wrap(
-                jobExists -> {
+        jobManager.jobExists(request.getJobId(), listener.wrap((l, jobExists) -> {
                     RecordsQueryBuilder query = new RecordsQueryBuilder()
                             .includeInterim(request.isExcludeInterim() == false)
                             .epochStart(request.getStart())
@@ -48,9 +47,8 @@ public class TransportGetRecordsAction extends HandledTransportAction<GetRecords
                             .sortField(request.getSort())
                             .sortDescending(request.isDescending());
                     jobResultsProvider.records(request.getJobId(), query, page ->
-                            listener.onResponse(new GetRecordsAction.Response(page)), listener::onFailure, client);
-                },
-                listener::onFailure
+                            l.onResponse(new GetRecordsAction.Response(page)), l::onFailure, client);
+                }
         ));
     }
 }

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/dataframe/DestinationIndexTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/dataframe/DestinationIndexTests.java
@@ -366,7 +366,7 @@ public class DestinationIndexTests extends ESTestCase {
             expectThrows(
                 ElasticsearchStatusException.class,
                 () -> DestinationIndex.updateMappingsToDestIndex(
-                    client, config, getIndexResponse, ActionListener.wrap(Assert::fail)));
+                    client, config, getIndexResponse, ActionListener.wrap((Runnable) Assert::fail)));
         assertThat(
             e.getMessage(),
             equalTo("A field that matches the dest.results_field [ml] already exists; please set a different results_field"));

--- a/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/exporter/ExportBulk.java
+++ b/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/exporter/ExportBulk.java
@@ -126,13 +126,13 @@ public abstract class ExportBulk {
 
         private static ActionListener<Void> newExceptionHandlingListener(SetOnce<ExportException> exceptionRef,
                                                                          ActionListener<Void> listener) {
-            return ActionListener.wrap(r -> {
+            return listener.wrap((l, r) -> {
                 if (exceptionRef.get() == null) {
-                    listener.onResponse(null);
+                    l.onResponse(null);
                 } else {
-                    listener.onFailure(exceptionRef.get());
+                    l.onFailure(exceptionRef.get());
                 }
-            }, listener::onFailure);
+            });
         }
     }
 

--- a/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/exporter/Exporters.java
+++ b/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/exporter/Exporters.java
@@ -254,13 +254,13 @@ public class Exporters extends AbstractLifecycleComponent {
         if (this.lifecycleState() != Lifecycle.State.STARTED) {
             listener.onFailure(new ExportException("Export service is not started"));
         } else if (docs != null && docs.size() > 0) {
-            wrapExportBulk(ActionListener.wrap(bulk -> {
+            wrapExportBulk(listener.wrap((l, bulk) -> {
                 if (bulk != null) {
-                    doExport(bulk, docs, listener);
+                    doExport(bulk, docs, l);
                 } else {
-                    listener.onResponse(null);
+                    l.onResponse(null);
                 }
-            }, listener::onFailure));
+            }));
         } else {
             listener.onResponse(null);
         }

--- a/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/MonitoringServiceTests.java
+++ b/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/MonitoringServiceTests.java
@@ -184,14 +184,14 @@ public class MonitoringServiceTests extends ESTestCase {
 
         @Override
         public void export(Collection<MonitoringDoc> docs, ActionListener<Void> listener) {
-            super.export(docs, ActionListener.wrap(r -> {
+            super.export(docs, listener.wrap((l, r) -> {
                 try {
                     latch.await();
-                    listener.onResponse(null);
+                    l.onResponse(null);
                 } catch (InterruptedException e) {
-                    listener.onFailure(new ExportException("BlockingExporter failed", e));
+                    l.onFailure(new ExportException("BlockingExporter failed", e));
                 }
-            }, listener::onFailure));
+            }));
 
         }
 

--- a/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/exporter/http/AsyncHttpResourceHelper.java
+++ b/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/exporter/http/AsyncHttpResourceHelper.java
@@ -36,7 +36,7 @@ class AsyncHttpResourceHelper {
 
     static <T> ActionListener<T> wrapMockListener(ActionListener<T> mock) {
         // wraps the mock listener so that default functions on the ActionListener interface can be used
-        return mock.wrap((l, r) -> l.onResponse(r));
+        return ActionListener.wrap(mock::onResponse, mock::onFailure);
     }
 
     static void whenPerformRequestAsyncWith(final RestClient client, final Response response) {

--- a/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/exporter/http/AsyncHttpResourceHelper.java
+++ b/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/exporter/http/AsyncHttpResourceHelper.java
@@ -36,7 +36,7 @@ class AsyncHttpResourceHelper {
 
     static <T> ActionListener<T> wrapMockListener(ActionListener<T> mock) {
         // wraps the mock listener so that default functions on the ActionListener interface can be used
-        return ActionListener.wrap(mock::onResponse, mock::onFailure);
+        return mock.wrap((l, r) -> l.onResponse(r));
     }
 
     static void whenPerformRequestAsyncWith(final RestClient client, final Response response) {

--- a/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/index/IndexResolver.java
+++ b/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/index/IndexResolver.java
@@ -228,9 +228,7 @@ public class IndexResolver {
             }
 
             client.admin().indices().getIndex(indexRequest,
-                wrap(response -> filterResults(javaRegex, aliases, response, retrieveIndices, retrieveFrozenIndices, listener),
-                    listener::onFailure));
-
+                listener.wrap((l, response) -> filterResults(javaRegex, aliases, response, retrieveIndices, retrieveFrozenIndices, l)));
         } else {
             filterResults(javaRegex, aliases, null, false, false, listener);
         }

--- a/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/util/ActionListeners.java
+++ b/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/util/ActionListeners.java
@@ -21,6 +21,6 @@ public class ActionListeners {
      * Combination of {@link ActionListener#wrap(CheckedConsumer, Consumer)} and {@link ActionListener#map}
      */
     public static <T, Response> ActionListener<Response> map(ActionListener<T> delegate, CheckedFunction<Response, T, Exception> fn) {
-        return ActionListener.wrap(r -> delegate.onResponse(fn.apply(r)), delegate::onFailure);
+        return delegate.wrap((l, r) -> l.onResponse(fn.apply(r)));
     }
 }

--- a/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/action/TransportPutRollupJobAction.java
+++ b/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/action/TransportPutRollupJobAction.java
@@ -228,8 +228,7 @@ public class TransportPutRollupJobAction extends AcknowledgedTransportMasterNode
             PutMappingRequest request = new PutMappingRequest(indexName);
             request.source(newMapping);
             client.execute(PutMappingAction.INSTANCE, request,
-                    ActionListener.wrap(putMappingResponse -> startPersistentTask(job, listener, persistentTasksService),
-                            listener::onFailure));
+                listener.wrap((l, putMappingResponse) -> startPersistentTask(job, l, persistentTasksService)));
         };
 
         GetMappingsRequest request = new GetMappingsRequest();

--- a/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/action/TransportRollupSearchAction.java
+++ b/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/action/TransportRollupSearchAction.java
@@ -106,11 +106,11 @@ public class TransportRollupSearchAction extends TransportAction<SearchRequest, 
 
         MultiSearchRequest msearch = createMSearchRequest(request, registry, rollupSearchContext);
 
-        client.multiSearch(msearch, ActionListener.wrap(msearchResponse -> {
+        client.multiSearch(msearch, listener.wrap((l, msearchResponse) -> {
             InternalAggregation.ReduceContext context = InternalAggregation.ReduceContext.forPartialReduction(
                     bigArrays, scriptService, () -> PipelineAggregator.PipelineTree.EMPTY);
-            listener.onResponse(processResponses(rollupSearchContext, msearchResponse, context));
-        }, listener::onFailure));
+            l.onResponse(processResponses(rollupSearchContext, msearchResponse, context));
+        }));
     }
 
     static SearchResponse processResponses(RollupSearchContext rollupContext, MultiSearchResponse msearchResponse,

--- a/x-pack/plugin/rollup/src/test/java/org/elasticsearch/xpack/rollup/job/RollupIndexerStateTests.java
+++ b/x-pack/plugin/rollup/src/test/java/org/elasticsearch/xpack/rollup/job/RollupIndexerStateTests.java
@@ -271,9 +271,7 @@ public class RollupIndexerStateTests extends ESTestCase {
             DelayedEmptyRollupIndexer indexer = new DelayedEmptyRollupIndexer(threadPool, job, state, null) {
                 @Override
                 protected void onFinish(ActionListener<Void> listener) {
-                    super.onFinish(ActionListener.wrap(r -> {
-                        listener.onResponse(r);
-                    }, listener::onFailure));
+                    super.onFinish(listener.wrap((l, r) -> l.onResponse(r)));
                 }
 
                 @Override
@@ -330,10 +328,10 @@ public class RollupIndexerStateTests extends ESTestCase {
                 new DelayedEmptyRollupIndexer(threadPool, job, state, null, spyStats) {
                 @Override
                 protected void onFinish(ActionListener<Void> listener) {
-                    super.onFinish(ActionListener.wrap(r -> {
-                        listener.onResponse(r);
+                    super.onFinish(listener.wrap((l, r) -> {
+                        l.onResponse(r);
                         isFinished.set(true);
-                    }, listener::onFailure));
+                    }));
                 }
             };
             final CountDownLatch latch = indexer.newLatch();

--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/cache/common/CacheFile.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/cache/common/CacheFile.java
@@ -434,12 +434,12 @@ public class CacheFile {
         FileChannelReference reference,
         Releasable releasable
     ) {
-        return ActionListener.runAfter(ActionListener.wrap(success -> {
+        return ActionListener.runAfter(future.wrap((f, success) -> {
             final int read = reader.onRangeAvailable(reference.fileChannel);
             assert read == rangeToRead.length()
                 : "partial read [" + read + "] does not match the range to read [" + rangeToRead.end() + '-' + rangeToRead.start() + ']';
-            future.onResponse(read);
-        }, future::onFailure), releasable::close);
+            f.onResponse(read);
+        }), releasable::close);
     }
 
     /**

--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/cache/shared/FrozenCacheService.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/cache/shared/FrozenCacheService.java
@@ -700,7 +700,7 @@ public class FrozenCacheService implements Releasable {
             ActionListener<Integer> listener,
             SharedBytes.IO fileChannel
         ) {
-            return ActionListener.wrap(success -> {
+            return listener.wrap((l, success) -> {
                 final long physicalStartOffset = physicalStartOffset();
                 assert regionOwners[sharedBytesPos].get() == CacheFileRegion.this;
                 final int read = reader.onRangeAvailable(
@@ -717,8 +717,8 @@ public class FrozenCacheService implements Releasable {
                         + '-'
                         + rangeToRead.start()
                         + ']';
-                listener.onResponse(read);
-            }, listener::onFailure);
+                l.onResponse(read);
+            });
         }
 
         private void releaseAndFail(ActionListener<Integer> listener, Releasable decrementRef, Exception e) {

--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/store/SearchableSnapshotDirectory.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/store/SearchableSnapshotDirectory.java
@@ -496,10 +496,10 @@ public class SearchableSnapshotDirectory extends BaseDirectory {
         final BlockingQueue<Tuple<ActionListener<Void>, CheckedRunnable<Exception>>> queue = new LinkedBlockingQueue<>();
         final Executor executor = prewarmExecutor();
 
-        final GroupedActionListener<Void> completionListener = new GroupedActionListener<>(ActionListener.wrap(voids -> {
+        final GroupedActionListener<Void> completionListener = new GroupedActionListener<>(listener.wrap((l, voids) -> {
             recoveryState.setPreWarmComplete();
-            listener.onResponse(null);
-        }, listener::onFailure), snapshot().totalFileCount());
+            l.onResponse(null);
+        }), snapshot().totalFileCount());
 
         for (BlobStoreIndexShardSnapshot.FileInfo file : snapshot().indexFiles()) {
             if (file.metadata().hashEqualsContents() || isExcludedFromCache(file.physicalName())) {

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/SecurityUsageTransportAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/SecurityUsageTransportAction.java
@@ -99,24 +99,21 @@ public class SecurityUsageTransportAction extends XPackUsageFeatureTransportActi
             }
         };
 
-        final ActionListener<Map<String, Object>> rolesStoreUsageListener =
-                ActionListener.wrap(rolesStoreUsage -> {
-                    rolesUsageRef.set(rolesStoreUsage);
-                    doCountDown.run();
-                }, listener::onFailure);
+        final ActionListener<Map<String, Object>> rolesStoreUsageListener = listener.wrap(rolesStoreUsage -> {
+            rolesUsageRef.set(rolesStoreUsage);
+            doCountDown.run();
+        });
 
-        final ActionListener<Map<String, Object>> roleMappingStoreUsageListener =
-                ActionListener.wrap(nativeRoleMappingStoreUsage -> {
-                    Map<String, Object> usage = singletonMap("native", nativeRoleMappingStoreUsage);
-                    roleMappingUsageRef.set(usage);
-                    doCountDown.run();
-                }, listener::onFailure);
+        final ActionListener<Map<String, Object>> roleMappingStoreUsageListener = listener.wrap(nativeRoleMappingStoreUsage -> {
+            Map<String, Object> usage = singletonMap("native", nativeRoleMappingStoreUsage);
+            roleMappingUsageRef.set(usage);
+            doCountDown.run();
+        });
 
-        final ActionListener<Map<String, Object>> realmsUsageListener =
-            ActionListener.wrap(realmsUsage -> {
-                realmsUsageRef.set(realmsUsage);
-                doCountDown.run();
-            }, listener::onFailure);
+        final ActionListener<Map<String, Object>> realmsUsageListener = listener.wrap(realmsUsage -> {
+            realmsUsageRef.set(realmsUsage);
+            doCountDown.run();
+        });
 
         if (rolesStore == null || enabled == false) {
             rolesStoreUsageListener.onResponse(Collections.emptyMap());

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/TransportDelegatePkiAuthenticationAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/TransportDelegatePkiAuthenticationAction.java
@@ -83,11 +83,11 @@ public final class TransportDelegatePkiAuthenticationAction
                     ActionListener.wrap(authentication -> {
                         assert authentication != null : "authentication should never be null at this point";
                         tokenService.createOAuth2Tokens(authentication, delegateeAuthentication, Map.of(), false,
-                                ActionListener.wrap(tokenResult -> {
+                                listener.wrap((l, tokenResult) -> {
                                     final TimeValue expiresIn = tokenService.getExpirationDelay();
-                                    listener.onResponse(new DelegatePkiAuthenticationResponse(tokenResult.getAccessToken(), expiresIn,
+                                    l.onResponse(new DelegatePkiAuthenticationResponse(tokenResult.getAccessToken(), expiresIn,
                                         authentication));
-                                }, listener::onFailure));
+                                }));
                     }, e -> {
                         logger.debug((Supplier<?>) () -> new ParameterizedMessage("Delegated x509Token [{}] could not be authenticated",
                                 x509DelegatedToken), e);

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/TransportGrantApiKeyAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/TransportGrantApiKeyAction.java
@@ -61,10 +61,8 @@ public final class TransportGrantApiKeyAction extends HandledTransportAction<Gra
     @Override
     protected void doExecute(Task task, GrantApiKeyRequest request, ActionListener<CreateApiKeyResponse> listener) {
         try (ThreadContext.StoredContext ignore = threadContext.stashContext()) {
-            resolveAuthentication(request.getGrant(), request, ActionListener.wrap(
-                authentication -> generator.generateApiKey(authentication, request.getApiKeyRequest(), listener),
-                listener::onFailure
-            ));
+            resolveAuthentication(request.getGrant(), request, listener.wrap(
+                (l, authentication) -> generator.generateApiKey(authentication, request.getApiKeyRequest(), l)));
         } catch (Exception e) {
             listener.onFailure(e);
         }

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/oidc/TransportOpenIdConnectAuthenticateAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/oidc/TransportOpenIdConnectAuthenticateAction.java
@@ -73,11 +73,11 @@ public class TransportOpenIdConnectAuthenticateAction
                     @SuppressWarnings("unchecked") final Map<String, Object> tokenMetadata = (Map<String, Object>) result.getMetadata()
                         .get(OpenIdConnectRealm.CONTEXT_TOKEN_DATA);
                     tokenService.createOAuth2Tokens(authentication, originatingAuthentication, tokenMetadata, true,
-                        ActionListener.wrap(tokenResult -> {
+                            listener.wrap((l, tokenResult) -> {
                             final TimeValue expiresIn = tokenService.getExpirationDelay();
-                            listener.onResponse(new OpenIdConnectAuthenticateResponse(authentication, tokenResult.getAccessToken(),
+                            l.onResponse(new OpenIdConnectAuthenticateResponse(authentication, tokenResult.getAccessToken(),
                                 tokenResult.getRefreshToken(), expiresIn));
-                        }, listener::onFailure));
+                        }));
                 }, e -> {
                     logger.debug(() -> new ParameterizedMessage("OpenIDConnectToken [{}] could not be authenticated", token), e);
                     listener.onFailure(e);

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/privilege/TransportDeletePrivilegesAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/privilege/TransportDeletePrivilegesAction.java
@@ -42,10 +42,7 @@ public class TransportDeletePrivilegesAction extends HandledTransportAction<Dele
             return;
         }
         final Set<String> names = Sets.newHashSet(request.privileges());
-        this.privilegeStore.deletePrivileges(request.application(), names, request.getRefreshPolicy(), ActionListener.wrap(
-                privileges -> listener.onResponse(
-                        new DeletePrivilegesResponse(privileges.getOrDefault(request.application(), Collections.emptyList()))
-                ), listener::onFailure
-        ));
+        this.privilegeStore.deletePrivileges(request.application(), names, request.getRefreshPolicy(), listener.wrap((l, privileges) ->
+            l.onResponse(new DeletePrivilegesResponse(privileges.getOrDefault(request.application(), Collections.emptyList())))));
     }
 }

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/privilege/TransportGetPrivilegesAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/privilege/TransportGetPrivilegesAction.java
@@ -49,10 +49,8 @@ public class TransportGetPrivilegesAction extends HandledTransportAction<GetPriv
         }
 
         final Collection<String> applications = isNullOrEmpty(request.application()) ? null : Collections.singleton(request.application());
-        this.privilegeStore.getPrivileges(applications, names, ActionListener.wrap(
-            privileges -> listener.onResponse(new GetPrivilegesResponse(privileges)),
-            listener::onFailure
-        ));
+        this.privilegeStore.getPrivileges(applications, names, listener.wrap((l, privileges) ->
+                l.onResponse(new GetPrivilegesResponse(privileges))));
     }
 
 }

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/privilege/TransportPutPrivilegesAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/privilege/TransportPutPrivilegesAction.java
@@ -38,10 +38,8 @@ public class TransportPutPrivilegesAction extends HandledTransportAction<PutPriv
         if (request.getPrivileges() == null || request.getPrivileges().size() == 0) {
             listener.onResponse(new PutPrivilegesResponse(Collections.emptyMap()));
         } else {
-            this.privilegeStore.putPrivileges(request.getPrivileges(), request.getRefreshPolicy(), ActionListener.wrap(
-                created -> listener.onResponse(new PutPrivilegesResponse(created)),
-                listener::onFailure
-            ));
+            this.privilegeStore.putPrivileges(request.getPrivileges(), request.getRefreshPolicy(),
+                    listener.wrap((l, created) -> l.onResponse(new PutPrivilegesResponse(created))));
         }
     }
 }

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/role/TransportGetRolesAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/role/TransportGetRolesAction.java
@@ -66,14 +66,14 @@ public class TransportGetRolesAction extends HandledTransportAction<GetRolesRequ
             // specific roles were requested but they were built in only, no need to hit the store
             listener.onResponse(new GetRolesResponse(roles.toArray(new RoleDescriptor[roles.size()])));
         } else {
-            nativeRolesStore.getRoleDescriptors(rolesToSearchFor, ActionListener.wrap((retrievalResult) -> {
+            nativeRolesStore.getRoleDescriptors(rolesToSearchFor, listener.wrap((l, retrievalResult) -> {
                 if (retrievalResult.isSuccess()) {
                     roles.addAll(retrievalResult.getDescriptors());
-                    listener.onResponse(new GetRolesResponse(roles.toArray(new RoleDescriptor[roles.size()])));
+                    l.onResponse(new GetRolesResponse(roles.toArray(new RoleDescriptor[roles.size()])));
                 } else {
-                    listener.onFailure(retrievalResult.getFailure());
+                    l.onFailure(retrievalResult.getFailure());
                 }
-            }, listener::onFailure));
+            }));
         }
     }
 }

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/rolemapping/TransportGetRoleMappingsAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/rolemapping/TransportGetRoleMappingsAction.java
@@ -42,14 +42,10 @@ public class TransportGetRoleMappingsAction
         } else {
             names = new HashSet<>(Arrays.asList(request.getNames()));
         }
-        this.roleMappingStore.getRoleMappings(names, ActionListener.wrap(
-                mappings -> {
-                    ExpressionRoleMapping[] array = mappings.toArray(
-                            new ExpressionRoleMapping[mappings.size()]
-                    );
-                    listener.onResponse(new GetRoleMappingsResponse(array));
-                },
-                listener::onFailure
+        this.roleMappingStore.getRoleMappings(names, listener.wrap((l, mappings) -> {
+                    ExpressionRoleMapping[] array = mappings.toArray(new ExpressionRoleMapping[mappings.size()]);
+                    l.onResponse(new GetRoleMappingsResponse(array));
+                }
         ));
     }
 }

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/rolemapping/TransportPutRoleMappingAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/rolemapping/TransportPutRoleMappingAction.java
@@ -31,9 +31,6 @@ public class TransportPutRoleMappingAction
 
     @Override
     protected void doExecute(Task task, final PutRoleMappingRequest request, final ActionListener<PutRoleMappingResponse> listener) {
-        roleMappingStore.putRoleMapping(request, ActionListener.wrap(
-                created -> listener.onResponse(new PutRoleMappingResponse(created)),
-                listener::onFailure
-        ));
+        roleMappingStore.putRoleMapping(request, listener.wrap((l, created) -> l.onResponse(new PutRoleMappingResponse(created))));
     }
 }

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/saml/TransportSamlAuthenticateAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/saml/TransportSamlAuthenticateAction.java
@@ -66,12 +66,12 @@ public final class TransportSamlAuthenticateAction extends HandledTransportActio
                 assert authentication != null : "authentication should never be null at this point";
                 final Map<String, Object> tokenMeta = (Map<String, Object>) result.getMetadata().get(SamlRealm.CONTEXT_TOKEN_DATA);
                 tokenService.createOAuth2Tokens(authentication, originatingAuthentication,
-                        tokenMeta, true, ActionListener.wrap(tokenResult -> {
+                        tokenMeta, true, listener.wrap((l, tokenResult) -> {
                             final TimeValue expiresIn = tokenService.getExpirationDelay();
-                            listener.onResponse(
+                            l.onResponse(
                                 new SamlAuthenticateResponse(authentication, tokenResult.getAccessToken(), tokenResult.getRefreshToken(),
                                     expiresIn));
-                        }, listener::onFailure));
+                        }));
             }, e -> {
                 logger.debug(() -> new ParameterizedMessage("SamlToken [{}] could not be authenticated", saml), e);
                 listener.onFailure(e);

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/service/TransportDeleteServiceAccountTokenAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/service/TransportDeleteServiceAccountTokenAction.java
@@ -37,10 +37,8 @@ public class TransportDeleteServiceAccountTokenAction
     @Override
     protected void doExecute(Task task, DeleteServiceAccountTokenRequest request,
                              ActionListener<DeleteServiceAccountTokenResponse> listener) {
-        httpTlsRuntimeCheck.checkTlsThenExecute(listener::onFailure, "create service account token", () -> {
-            indexServiceAccountsTokenStore.deleteToken(request, ActionListener.wrap(found -> {
-                listener.onResponse(new DeleteServiceAccountTokenResponse(found));
-            }, listener::onFailure));
-        });
+        httpTlsRuntimeCheck.checkTlsThenExecute(listener::onFailure, "create service account token", () ->
+                indexServiceAccountsTokenStore.deleteToken(request, listener.wrap((l, found) ->
+                        l.onResponse(new DeleteServiceAccountTokenResponse(found)))));
     }
 }

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/token/TransportCreateTokenAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/token/TransportCreateTokenAction.java
@@ -139,14 +139,14 @@ public final class TransportCreateTokenAction extends HandledTransportAction<Cre
     private void createToken(GrantType grantType, CreateTokenRequest request, Authentication authentication, Authentication originatingAuth,
             boolean includeRefreshToken, ActionListener<CreateTokenResponse> listener) {
         tokenService.createOAuth2Tokens(authentication, originatingAuth, Collections.emptyMap(), includeRefreshToken,
-                ActionListener.wrap(tokenResult -> {
+                listener.wrap((l, tokenResult) -> {
                     final String scope = getResponseScopeValue(request.getScope());
                     final String base64AuthenticateResponse = (grantType == GrantType.KERBEROS) ? extractOutToken() : null;
                     final CreateTokenResponse response = new CreateTokenResponse(tokenResult.getAccessToken(),
                         tokenService.getExpirationDelay(), scope, tokenResult.getRefreshToken(), base64AuthenticateResponse,
                         authentication);
-                    listener.onResponse(response);
-                }, listener::onFailure));
+                    l.onResponse(response);
+                }));
     }
 
     private String extractOutToken() {

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/token/TransportInvalidateTokenAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/token/TransportInvalidateTokenAction.java
@@ -35,8 +35,7 @@ public final class TransportInvalidateTokenAction extends HandledTransportAction
     @Override
     protected void doExecute(Task task, InvalidateTokenRequest request, ActionListener<InvalidateTokenResponse> listener) {
         final ActionListener<TokensInvalidationResult> invalidateListener =
-            ActionListener.wrap(tokensInvalidationResult ->
-                listener.onResponse(new InvalidateTokenResponse(tokensInvalidationResult)), listener::onFailure);
+                listener.wrap((l, tokensInvalidationResult) -> l.onResponse(new InvalidateTokenResponse(tokensInvalidationResult)));
         if (Strings.hasText(request.getUserName()) || Strings.hasText(request.getRealmName())) {
             tokenService.invalidateActiveTokensForRealmAndUser(request.getRealmName(), request.getUserName(), invalidateListener);
         } else if (request.getTokenType() == InvalidateTokenRequest.Type.ACCESS_TOKEN) {

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/token/TransportRefreshTokenAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/token/TransportRefreshTokenAction.java
@@ -31,12 +31,12 @@ public class TransportRefreshTokenAction extends HandledTransportAction<CreateTo
 
     @Override
     protected void doExecute(Task task, CreateTokenRequest request, ActionListener<CreateTokenResponse> listener) {
-        tokenService.refreshToken(request.getRefreshToken(), ActionListener.wrap(tokenResult -> {
+        tokenService.refreshToken(request.getRefreshToken(), listener.wrap((l, tokenResult) -> {
             final String scope = getResponseScopeValue(request.getScope());
             final CreateTokenResponse response =
                 new CreateTokenResponse(tokenResult.getAccessToken(), tokenService.getExpirationDelay(), scope,
                     tokenResult.getRefreshToken(), null, tokenResult.getAuthentication());
-            listener.onResponse(response);
-        }, listener::onFailure));
+            l.onResponse(response);
+        }));
     }
 }

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/user/TransportGetUsersAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/user/TransportGetUsersAction.java
@@ -64,10 +64,10 @@ public class TransportGetUsersAction extends HandledTransportAction<GetUsersRequ
             }
         }
 
-        final ActionListener<Collection<Collection<User>>> sendingListener = ActionListener.wrap((userLists) -> {
+        final ActionListener<Collection<Collection<User>>> sendingListener = listener.wrap((l, userLists) -> {
                 users.addAll(userLists.stream().flatMap(Collection::stream).filter(Objects::nonNull).collect(Collectors.toList()));
-                listener.onResponse(new GetUsersResponse(users));
-            }, listener::onFailure);
+                l.onResponse(new GetUsersResponse(users));
+            });
         final GroupedActionListener<Collection<User>> groupListener =
                 new GroupedActionListener<>(sendingListener, 2);
         // We have two sources for the users object, the reservedRealm and the usersStore, we query both at the same time with a

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/user/TransportHasPrivilegesAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/user/TransportHasPrivilegesAction.java
@@ -78,9 +78,8 @@ public class TransportHasPrivilegesAction extends HandledTransportAction<HasPriv
             }
         }
 
-        resolveApplicationPrivileges(request, ActionListener.wrap(applicationPrivilegeDescriptors ->
-                authorizationService.checkPrivileges(authentication, request, applicationPrivilegeDescriptors, listener),
-            listener::onFailure));
+        resolveApplicationPrivileges(request, listener.wrap((l, applicationPrivilegeDescriptors) ->
+                authorizationService.checkPrivileges(authentication, request, applicationPrivilegeDescriptors, l)));
     }
 
     private void resolveApplicationPrivileges(HasPrivilegesRequest request,

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/ApiKeyService.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/ApiKeyService.java
@@ -275,13 +275,10 @@ public class ApiKeyService {
 
             securityIndex.prepareIndexIfNeededThenExecute(listener::onFailure, () ->
                 executeAsyncWithOrigin(client, SECURITY_ORIGIN, BulkAction.INSTANCE, bulkRequest,
-                    TransportSingleItemBulkWriteAction.<IndexResponse>wrapBulkResponse(ActionListener.wrap(
-                        indexResponse -> {
+                    TransportSingleItemBulkWriteAction.<IndexResponse>wrapBulkResponse(listener.wrap((l, indexResponse) -> {
                             assert request.getId().equals(indexResponse.getId());
-                            listener.onResponse(
-                                    new CreateApiKeyResponse(request.getName(), request.getId(), apiKey, expiration));
-                        },
-                        listener::onFailure))));
+                            l.onResponse(new CreateApiKeyResponse(request.getName(), request.getId(), apiKey, expiration));
+                        }))));
         } catch (IOException e) {
             listener.onFailure(e);
         }

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/esnative/NativeRealm.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/esnative/NativeRealm.java
@@ -53,12 +53,10 @@ public class NativeRealm extends CachingUsernamePasswordRealm {
 
     @Override
     public void usageStats(ActionListener<Map<String, Object>> listener) {
-        super.usageStats(ActionListener.wrap(stats ->
-            userStore.getUserCount(ActionListener.wrap(size -> {
-                stats.put("size", size);
-                listener.onResponse(stats);
-            }, listener::onFailure))
-        , listener::onFailure));
+        super.usageStats(listener.wrap((l, stats) -> userStore.getUserCount(l.wrap((ll, size) -> {
+            stats.put("size", size);
+            ll.onResponse(stats);
+        }))));
     }
 
     // method is used for testing to verify cache expiration since expireAll is final

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/esnative/NativeUsersStore.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/esnative/NativeUsersStore.java
@@ -93,9 +93,7 @@ public class NativeUsersStore {
      * Blocking version of {@code getUser} that blocks until the User is returned
      */
     public void getUser(String username, ActionListener<User> listener) {
-        getUserAndPassword(username, ActionListener.wrap((uap) -> {
-            listener.onResponse(uap == null ? null : uap.user());
-        }, listener::onFailure));
+        getUserAndPassword(username, listener.wrap((l, uap) -> l.onResponse(uap == null ? null : uap.user())));
     }
 
     /**
@@ -450,15 +448,15 @@ public class NativeUsersStore {
      * @param password the plaintext password to verify
      */
     void verifyPassword(String username, final SecureString password, ActionListener<AuthenticationResult> listener) {
-        getUserAndPassword(username, ActionListener.wrap((userAndPassword) -> {
+        getUserAndPassword(username, listener.wrap((l, userAndPassword) -> {
             if (userAndPassword == null || userAndPassword.passwordHash() == null) {
-                listener.onResponse(AuthenticationResult.notHandled());
+                l.onResponse(AuthenticationResult.notHandled());
             } else if (userAndPassword.verifyPassword(password)) {
-                listener.onResponse(AuthenticationResult.success(userAndPassword.user()));
+                l.onResponse(AuthenticationResult.success(userAndPassword.user()));
             } else {
-                listener.onResponse(AuthenticationResult.unsuccessful("Password authentication failed for " + username, null));
+                l.onResponse(AuthenticationResult.unsuccessful("Password authentication failed for " + username, null));
             }
-        }, listener::onFailure));
+        }));
     }
 
     void getReservedUserInfo(String username, ActionListener<ReservedUserInfo> listener) {

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/esnative/ReservedRealm.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/esnative/ReservedRealm.java
@@ -93,7 +93,7 @@ public class ReservedRealm extends CachingUsernamePasswordRealm {
         } else if (ClientReservedRealm.isReserved(token.principal(), config.settings()) == false) {
             listener.onResponse(AuthenticationResult.notHandled());
         } else {
-            getUserInfo(token.principal(), ActionListener.wrap((userInfo) -> {
+            getUserInfo(token.principal(), listener.wrap((l, userInfo) -> {
                 AuthenticationResult result;
                 if (userInfo != null) {
                     try {
@@ -114,8 +114,8 @@ public class ReservedRealm extends CachingUsernamePasswordRealm {
                     result = AuthenticationResult.terminate("failed to authenticate user [" + token.principal() + "]", null);
                 }
                 // we want the finally block to clear out the chars before we proceed further so we handle the result here
-                listener.onResponse(result);
-            }, listener::onFailure));
+                l.onResponse(result);
+            }));
         }
     }
 
@@ -132,14 +132,14 @@ public class ReservedRealm extends CachingUsernamePasswordRealm {
         } else if (AnonymousUser.isAnonymousUsername(username, config.settings())) {
             listener.onResponse(anonymousEnabled ? anonymousUser : null);
         } else {
-            getUserInfo(username, ActionListener.wrap((userInfo) -> {
+            getUserInfo(username, listener.wrap((l, userInfo) -> {
                 if (userInfo != null) {
-                    listener.onResponse(getUser(username, userInfo));
+                    l.onResponse(getUser(username, userInfo));
                 } else {
                     // this was a reserved username - don't allow this to go to another realm...
-                    listener.onFailure(Exceptions.authenticationError("failed to lookup user [{}]", username));
+                    l.onFailure(Exceptions.authenticationError("failed to lookup user [{}]", username));
                 }
-            }, listener::onFailure));
+            }));
         }
     }
 

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/file/FileRealm.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/file/FileRealm.java
@@ -56,10 +56,10 @@ public class FileRealm extends CachingUsernamePasswordRealm {
 
     @Override
     public void usageStats(ActionListener<Map<String, Object>> listener) {
-        super.usageStats(ActionListener.wrap(stats -> {
+        super.usageStats(listener.wrap((l, stats) -> {
             stats.put("size", userPasswdStore.usersCount());
-            listener.onResponse(stats);
-        }, listener::onFailure));
+            l.onResponse(stats);
+        }));
     }
 
 }

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/kerberos/KerberosRealm.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/kerberos/KerberosRealm.java
@@ -227,13 +227,13 @@ public final class KerberosRealm extends Realm implements CachingRealm {
 
     private void buildUser(final String username, final Map<String, Object> metadata, final ActionListener<AuthenticationResult> listener) {
         final UserRoleMapper.UserData userData = new UserRoleMapper.UserData(username, null, Set.of(), metadata, this.config);
-        userRoleMapper.resolveRoles(userData, ActionListener.wrap(roles -> {
+        userRoleMapper.resolveRoles(userData, listener.wrap((l, roles) -> {
             final User computedUser = new User(username, roles.toArray(new String[roles.size()]), null, null, userData.getMetadata(), true);
             if (userPrincipalNameToUserCache != null) {
                 userPrincipalNameToUserCache.put(username, computedUser);
             }
-            listener.onResponse(AuthenticationResult.success(computedUser));
-        }, listener::onFailure));
+            l.onResponse(AuthenticationResult.success(computedUser));
+        }));
     }
 
     @Override

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/ldap/LdapRealm.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/ldap/LdapRealm.java
@@ -141,9 +141,8 @@ public final class LdapRealm extends CachingUsernamePasswordRealm {
         if (sessionFactory.supportsUnauthenticatedSession()) {
             // we submit to the threadpool because authentication using LDAP will execute blocking I/O for a bind request and we don't want
             // network threads stuck waiting for a socket to connect. After the bind, then all interaction with LDAP should be async
-            final ActionListener<AuthenticationResult> sessionListener = ActionListener.wrap(
-                    result -> userActionListener.onResponse(result.getUser()),
-                    userActionListener::onFailure);
+            final ActionListener<AuthenticationResult> sessionListener =
+                    userActionListener.wrap((l, result) -> l.onResponse(result.getUser()));
             final CancellableLdapRunnable<User> cancellableLdapRunnable = new CancellableLdapRunnable<>(userActionListener, e -> null,
                     () -> sessionFactory.unauthenticatedSession(username,
                             contextPreservingListener(new LdapSessionActionListener("lookup", username, sessionListener))), logger);

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/ldap/LdapUserSearchSessionFactory.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/ldap/LdapUserSearchSessionFactory.java
@@ -77,17 +77,17 @@ class LdapUserSearchSessionFactory extends PoolingSessionFactory {
      */
     @Override
     void getSessionWithPool(LDAPConnectionPool connectionPool, String user, SecureString password, ActionListener<LdapSession> listener) {
-        findUser(user, connectionPool, ActionListener.wrap((entry) -> {
+        findUser(user, connectionPool, listener.wrap((l, entry) -> {
             if (entry == null) {
-                listener.onResponse(null);
+                l.onResponse(null);
             } else {
                 final String dn = entry.getDN();
                 final byte[] passwordBytes = CharArrays.toUtf8Bytes(password.getChars());
                 final SimpleBindRequest bind = new SimpleBindRequest(dn, passwordBytes);
-                LdapUtils.maybeForkThenBindAndRevert(connectionPool, bind, threadPool, ActionRunnable.supply(listener, () ->
+                LdapUtils.maybeForkThenBindAndRevert(connectionPool, bind, threadPool, ActionRunnable.supply(l, () ->
                     new LdapSession(logger, config, connectionPool, dn, groupResolver, metadataResolver, timeout, entry.getAttributes())));
             }
-        }, listener::onFailure));
+        }));
     }
 
     /**
@@ -167,16 +167,16 @@ class LdapUserSearchSessionFactory extends PoolingSessionFactory {
 
     @Override
     void getUnauthenticatedSessionWithPool(LDAPConnectionPool connectionPool, String user, ActionListener<LdapSession> listener) {
-        findUser(user, connectionPool, ActionListener.wrap((entry) -> {
+        findUser(user, connectionPool, listener.wrap((l, entry) -> {
             if (entry == null) {
-                listener.onResponse(null);
+                l.onResponse(null);
             } else {
                 final String dn = entry.getDN();
                 LdapSession session = new LdapSession(logger, config, connectionPool, dn, groupResolver, metadataResolver, timeout,
                         entry.getAttributes());
-                listener.onResponse(session);
+                l.onResponse(session);
             }
-        }, listener::onFailure));
+        }));
     }
 
     @Override

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/ldap/UserAttributeGroupsResolver.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/ldap/UserAttributeGroupsResolver.java
@@ -54,13 +54,13 @@ class UserAttributeGroupsResolver implements GroupsResolver {
             listener.onResponse(groups);
         } else {
             searchForEntry(connection, userDn, SearchScope.BASE, OBJECT_CLASS_PRESENCE_FILTER, Math.toIntExact(timeout.seconds()),
-                    ignoreReferralErrors, ActionListener.wrap((entry) -> {
+                    ignoreReferralErrors, listener.wrap((l, entry) -> {
                         if (entry == null || entry.hasAttribute(attribute) == false) {
-                            listener.onResponse(List.of());
+                            l.onResponse(List.of());
                         } else {
-                            listener.onResponse(List.of(entry.getAttributeValues(attribute)));
+                            l.onResponse(List.of(entry.getAttributeValues(attribute)));
                         }
-                    }, listener::onFailure), attribute);
+                    }), attribute);
         }
     }
 

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/ldap/support/LdapMetadataResolver.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/ldap/support/LdapMetadataResolver.java
@@ -8,7 +8,6 @@ package org.elasticsearch.xpack.security.authc.ldap.support;
 
 import com.unboundid.ldap.sdk.Attribute;
 import com.unboundid.ldap.sdk.LDAPInterface;
-import com.unboundid.ldap.sdk.SearchResultEntry;
 import com.unboundid.ldap.sdk.SearchScope;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.action.ActionListener;
@@ -57,13 +56,13 @@ public class LdapMetadataResolver {
         } else {
             searchForEntry(connection, userDn, SearchScope.BASE, OBJECT_CLASS_PRESENCE_FILTER,
                     Math.toIntExact(timeout.seconds()), ignoreReferralErrors,
-                    ActionListener.wrap((SearchResultEntry entry) -> {
+                    listener.wrap((l, entry) -> {
                         if (entry == null) {
-                            listener.onResponse(Map.of());
+                            l.onResponse(Map.of());
                         } else {
-                            listener.onResponse(toMap(entry::getAttribute));
+                            l.onResponse(toMap(entry::getAttribute));
                         }
-                    }, listener::onFailure), this.attributeNames);
+                    }), this.attributeNames);
         }
     }
 

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/ldap/support/LdapSession.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/ldap/support/LdapSession.java
@@ -99,17 +99,13 @@ public class LdapSession implements Releasable {
 
     public void resolve(ActionListener<LdapUserData> listener) {
         logger.debug("Resolving LDAP groups + meta-data for user [{}]", userDn);
-        groups(ActionListener.wrap(
-                groups -> {
-                    logger.debug("Resolved {} LDAP groups [{}] for user [{}]",  groups.size(), groups, userDn);
-                    metadata(ActionListener.wrap(
-                            meta -> {
-                                logger.debug("Resolved {} meta-data fields [{}] for user [{}]",  meta.size(), meta, userDn);
-                                listener.onResponse(new LdapUserData(groups, meta));
-                            },
-                            listener::onFailure));
-                },
-                listener::onFailure));
+        groups(listener.wrap((l, groups) -> {
+            logger.debug("Resolved {} LDAP groups [{}] for user [{}]", groups.size(), groups, userDn);
+            metadata(l.wrap((ll, meta) -> {
+                logger.debug("Resolved {} meta-data fields [{}] for user [{}]", meta.size(), meta, userDn);
+                ll.onResponse(new LdapUserData(groups, meta));
+            }));
+        }));
     }
 
     public static class LdapUserData {

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/oidc/OpenIdConnectAuthenticator.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/oidc/OpenIdConnectAuthenticator.java
@@ -191,12 +191,12 @@ public class OpenIdConnectAuthenticator {
             validateResponseType(response);
             if (rpConfig.getResponseType().impliesCodeFlow()) {
                 final AuthorizationCode code = response.getAuthorizationCode();
-                exchangeCodeForToken(code, ActionListener.wrap(tokens -> {
+                exchangeCodeForToken(code, listener.wrap((l, tokens) -> {
                     final AccessToken accessToken = tokens.v1();
                     final JWT idToken = tokens.v2();
                     validateAccessToken(accessToken, idToken);
-                    getUserClaims(accessToken, idToken, expectedNonce, true, listener);
-                }, listener::onFailure));
+                    getUserClaims(accessToken, idToken, expectedNonce, true, l);
+                }));
             } else {
                 final JWT idToken = response.getIDToken();
                 final AccessToken accessToken = response.getAccessToken();

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/oidc/OpenIdConnectRealm.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/oidc/OpenIdConnectRealm.java
@@ -197,15 +197,15 @@ public class OpenIdConnectRealm extends Realm implements Releasable {
 
         final Map<String, Object> tokenMetadata = new HashMap<>();
         tokenMetadata.put("id_token_hint", claims.getClaim("id_token_hint"));
-        ActionListener<AuthenticationResult> wrappedAuthResultListener = ActionListener.wrap(auth -> {
+        ActionListener<AuthenticationResult> wrappedAuthResultListener = authResultListener.wrap((l, auth) -> {
             if (auth.isAuthenticated()) {
                 // Add the ID Token as metadata on the authentication, so that it can be used for logout requests
                 Map<String, Object> metadata = new HashMap<>(auth.getMetadata());
                 metadata.put(CONTEXT_TOKEN_DATA, tokenMetadata);
                 auth = AuthenticationResult.success(auth.getUser(), metadata);
             }
-            authResultListener.onResponse(auth);
-        }, authResultListener::onFailure);
+            l.onResponse(auth);
+        });
 
         if (delegatedRealms.hasDelegation()) {
             delegatedRealms.resolve(principal, wrappedAuthResultListener);
@@ -225,10 +225,10 @@ public class OpenIdConnectRealm extends Realm implements Releasable {
         final String mail = mailAttribute.getClaimValue(claims);
         final String name = nameAttribute.getClaimValue(claims);
         UserRoleMapper.UserData userData = new UserRoleMapper.UserData(principal, dn, groups, userMetadata, config);
-        roleMapper.resolveRoles(userData, ActionListener.wrap(roles -> {
+        roleMapper.resolveRoles(userData, wrappedAuthResultListener.wrap((l, roles) -> {
             final User user = new User(principal, roles.toArray(Strings.EMPTY_ARRAY), name, mail, userMetadata, true);
-            wrappedAuthResultListener.onResponse(AuthenticationResult.success(user));
-        }, wrappedAuthResultListener::onFailure));
+            l.onResponse(AuthenticationResult.success(user));
+        }));
 
     }
 

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/service/CachingServiceAccountsTokenStore.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/service/CachingServiceAccountsTokenStore.java
@@ -79,17 +79,17 @@ public abstract class CachingServiceAccountsTokenStore implements ServiceAccount
                 return new ListenableFuture<>();
             });
             if (valueAlreadyInCache.get()) {
-                listenableCacheEntry.addListener(ActionListener.wrap(result -> {
+                listenableCacheEntry.addListener(listener.wrap((l, result) -> {
                     if (result.success) {
-                        listener.onResponse(result.verify(token));
+                        l.onResponse(result.verify(token));
                     } else if (result.verify(token)) {
                         // same wrong token
-                        listener.onResponse(false);
+                        l.onResponse(false);
                     } else {
                         cache.invalidate(token.getQualifiedName(), listenableCacheEntry);
-                        authenticateWithCache(token, listener);
+                        authenticateWithCache(token, l);
                     }
-                }, listener::onFailure), threadPool.generic(), threadPool.getThreadContext());
+                }), threadPool.generic(), threadPool.getThreadContext());
             } else {
                 doAuthenticate(token, ActionListener.wrap(success -> {
                     logger.trace("cache service token [{}] authentication result", token.getQualifiedName());

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/service/ServiceAccountService.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/service/ServiceAccountService.java
@@ -84,9 +84,8 @@ public class ServiceAccountService {
     }
 
     public void findTokensFor(ServiceAccountId accountId, String nodeName, ActionListener<GetServiceAccountTokensResponse> listener) {
-        serviceAccountsTokenStore.findTokensFor(accountId, ActionListener.wrap(tokenInfos -> {
-            listener.onResponse(new GetServiceAccountTokensResponse(accountId.asPrincipal(), nodeName, tokenInfos));
-        }, listener::onFailure));
+        serviceAccountsTokenStore.findTokensFor(accountId, listener.wrap((l, tokenInfos) ->
+                l.onResponse(new GetServiceAccountTokensResponse(accountId.asPrincipal(), nodeName, tokenInfos))));
     }
 
     public void authenticateToken(ServiceAccountToken serviceAccountToken, String nodeName, ActionListener<Authentication> listener) {
@@ -106,15 +105,15 @@ public class ServiceAccountService {
                 return;
             }
 
-            serviceAccountsTokenStore.authenticate(serviceAccountToken, ActionListener.wrap(success -> {
+            serviceAccountsTokenStore.authenticate(serviceAccountToken, listener.wrap((l, success) -> {
                 if (success) {
-                    listener.onResponse(createAuthentication(account, serviceAccountToken, nodeName));
+                    l.onResponse(createAuthentication(account, serviceAccountToken, nodeName));
                 } else {
                     final ElasticsearchSecurityException e = createAuthenticationException(serviceAccountToken);
                     logger.debug(e.getMessage());
-                    listener.onFailure(e);
+                    l.onFailure(e);
                 }
-            }, listener::onFailure));
+            }));
         });
     }
 

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/support/ApiKeyGenerator.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/support/ApiKeyGenerator.java
@@ -41,19 +41,17 @@ public class ApiKeyGenerator {
         }
         apiKeyService.ensureEnabled();
         rolesStore.getRoleDescriptors(new HashSet<>(Arrays.asList(authentication.getUser().roles())),
-            ActionListener.wrap(roleDescriptors -> {
-                    for (RoleDescriptor rd : roleDescriptors) {
-                        try {
-                            DLSRoleQueryValidator.validateQueryField(rd.getIndicesPrivileges(), xContentRegistry);
-                        } catch (ElasticsearchException | IllegalArgumentException e) {
-                            listener.onFailure(e);
-                            return;
-                        }
+            listener.wrap((l, roleDescriptors) -> {
+                for (RoleDescriptor rd : roleDescriptors) {
+                    try {
+                        DLSRoleQueryValidator.validateQueryField(rd.getIndicesPrivileges(), xContentRegistry);
+                    } catch (ElasticsearchException | IllegalArgumentException e) {
+                        l.onFailure(e);
+                        return;
                     }
-                    apiKeyService.createApiKey(authentication, request, roleDescriptors, listener);
-                },
-                listener::onFailure));
-
+                }
+                apiKeyService.createApiKey(authentication, request, roleDescriptors, l);
+        }));
     }
 
 }

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/support/DelegatedAuthorizationSupport.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/support/DelegatedAuthorizationSupport.java
@@ -95,16 +95,16 @@ public class DelegatedAuthorizationSupport {
                 "No [" + DelegatedAuthorizationSettings.AUTHZ_REALMS_SUFFIX + "] have been configured", null));
             return;
         }
-        ActionListener<Tuple<User, Realm>> userListener = ActionListener.wrap(tuple -> {
+        ActionListener<Tuple<User, Realm>> userListener = resultListener.wrap((l, tuple) -> {
             if (tuple != null) {
                 logger.trace("Found user " + tuple.v1() + " in realm " + tuple.v2());
-                resultListener.onResponse(AuthenticationResult.success(tuple.v1()));
+                l.onResponse(AuthenticationResult.success(tuple.v1()));
             } else {
-                resultListener.onResponse(AuthenticationResult.unsuccessful("the principal [" + username
+                l.onResponse(AuthenticationResult.unsuccessful("the principal [" + username
                     + "] was authenticated, but no user could be found in realms [" + collectionToDelimitedString(lookup.getRealms(), ",")
                     + "]", null));
             }
-        }, resultListener::onFailure);
+        });
         lookup.lookup(username, userListener);
     }
 

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/support/RealmUserLookup.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/support/RealmUserLookup.java
@@ -45,16 +45,13 @@ public class RealmUserLookup {
     public void lookup(String principal, ActionListener<Tuple<User, Realm>> listener) {
         final IteratingActionListener<Tuple<User, Realm>, ? extends Realm> userLookupListener =
             new IteratingActionListener<>(listener,
-                (realm, lookupUserListener) -> realm.lookupUser(principal,
-                    ActionListener.wrap(foundUser -> {
+                (realm, lookupUserListener) -> realm.lookupUser(principal, lookupUserListener.wrap((l, foundUser) -> {
                             if (foundUser != null) {
-                                lookupUserListener.onResponse(new Tuple<>(foundUser, realm));
+                                l.onResponse(new Tuple<>(foundUser, realm));
                             } else {
-                                lookupUserListener.onResponse(null);
+                                l.onResponse(null);
                             }
-                        },
-                        lookupUserListener::onFailure)),
-                realms, threadContext);
+                })), realms, threadContext);
         try {
             userLookupListener.run();
         } catch (Exception e) {

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/support/SecondaryAuthenticator.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/support/SecondaryAuthenticator.java
@@ -76,13 +76,12 @@ public class SecondaryAuthenticator {
       // Use cases for secondary authentication are far more likely to want to fall back to the primary authentication if no secondary
       // auth is provided, so in that case we do no want to set anything in the context
       authenticate(authListener -> authenticationService.authenticate(request, false, authListener),
-          ActionListener.wrap(secondaryAuthentication -> {
+              listener.wrap((l, secondaryAuthentication) -> {
                   if (secondaryAuthentication != null) {
                       secondaryAuthentication.writeToContext(threadContext);
                   }
-                  listener.onResponse(secondaryAuthentication);
-              },
-              listener::onFailure));
+                  l.onResponse(secondaryAuthentication);
+              }));
   }
 
     private void authenticate(Consumer<ActionListener<Authentication>> authenticate, ActionListener<SecondaryAuthentication> listener) {

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/support/mapper/CompositeRoleMapper.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/support/mapper/CompositeRoleMapper.java
@@ -41,9 +41,8 @@ public class CompositeRoleMapper implements UserRoleMapper {
 
     @Override
     public void resolveRoles(UserData user, ActionListener<Set<String>> listener) {
-        GroupedActionListener<Set<String>> groupListener = new GroupedActionListener<>(ActionListener.wrap(
-                composite -> listener.onResponse(composite.stream().flatMap(Set::stream).collect(Collectors.toSet())), listener::onFailure
-        ), delegates.size());
+        GroupedActionListener<Set<String>> groupListener = new GroupedActionListener<>(listener.wrap((l, composite) ->
+                l.onResponse(composite.stream().flatMap(Set::stream).collect(Collectors.toSet()))), delegates.size());
         this.delegates.forEach(mapper -> mapper.resolveRoles(user, groupListener));
     }
 

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/interceptor/IndicesAliasesRequestInterceptor.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/interceptor/IndicesAliasesRequestInterceptor.java
@@ -88,17 +88,17 @@ public final class IndicesAliasesRequestInterceptor implements RequestIntercepto
                     return list;
                 }));
             authorizationEngine.validateIndexPermissionsAreSubset(requestInfo, authorizationInfo, indexToAliasesMap,
-                wrapPreservingContext(ActionListener.wrap(authzResult -> {
+                wrapPreservingContext(listener.wrap((l, authzResult) -> {
                     if (authzResult.isGranted()) {
                         // do not audit success again
-                        listener.onResponse(null);
+                        l.onResponse(null);
                     } else {
                         auditTrail.accessDenied(AuditUtil.extractRequestId(threadContext), requestInfo.getAuthentication(),
                             requestInfo.getAction(), request, authorizationInfo);
-                        listener.onFailure(Exceptions.authorizationError("Adding an alias is not allowed when the alias " +
+                        l.onFailure(Exceptions.authorizationError("Adding an alias is not allowed when the alias " +
                             "has more permissions than any of the indices"));
                     }
-                }, listener::onFailure), threadContext));
+                }), threadContext));
             } else {
                 listener.onResponse(null);
             }

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/interceptor/ResizeRequestInterceptor.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/interceptor/ResizeRequestInterceptor.java
@@ -67,18 +67,18 @@ public final class ResizeRequestInterceptor implements RequestInterceptor {
 
                 authorizationEngine.validateIndexPermissionsAreSubset(requestInfo, authorizationInfo,
                     Collections.singletonMap(request.getSourceIndex(), Collections.singletonList(request.getTargetIndexRequest().index())),
-                    wrapPreservingContext(ActionListener.wrap(authzResult -> {
+                    wrapPreservingContext(listener.wrap((l, authzResult) -> {
                         if (authzResult.isGranted()) {
-                            listener.onResponse(null);
+                            l.onResponse(null);
                         } else {
                             if (authzResult.isAuditable()) {
                                 auditTrail.accessDenied(extractRequestId(threadContext), requestInfo.getAuthentication(),
                                     requestInfo.getAction(), request, authorizationInfo);
                             }
-                            listener.onFailure(Exceptions.authorizationError("Resizing an index is not allowed when the target index " +
+                            l.onFailure(Exceptions.authorizationError("Resizing an index is not allowed when the target index " +
                                 "has more permissions than the source index"));
                         }
-                    }, listener::onFailure), threadContext));
+                    }), threadContext));
             } else {
                 listener.onResponse(null);
             }

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/transport/ServerTransportFilter.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/transport/ServerTransportFilter.java
@@ -100,22 +100,22 @@ final class ServerTransportFilter {
         }
 
         final Version version = transportChannel.getVersion();
-        authcService.authenticate(securityAction, request, true, ActionListener.wrap((authentication) -> {
+        authcService.authenticate(securityAction, request, true, listener.wrap((l, authentication) -> {
             if (authentication != null) {
                 if (securityAction.equals(TransportService.HANDSHAKE_ACTION_NAME) &&
-                    SystemUser.is(authentication.getUser()) == false) {
+                        SystemUser.is(authentication.getUser()) == false) {
                     securityContext.executeAsUser(SystemUser.INSTANCE, (ctx) -> {
                         final Authentication replaced = securityContext.getAuthentication();
-                        authzService.authorize(replaced, securityAction, request, listener);
+                        authzService.authorize(replaced, securityAction, request, l);
                     }, version);
                 } else {
-                    authzService.authorize(authentication, securityAction, request, listener);
+                    authzService.authorize(authentication, securityAction, request, l);
                 }
             } else if (licenseState.isSecurityEnabled() == false) {
-                listener.onResponse(null);
+                l.onResponse(null);
             } else {
-                listener.onFailure(new IllegalStateException("no authentication present but auth is allowed"));
+                l.onFailure(new IllegalStateException("no authentication present but auth is allowed"));
             }
-        }, listener::onFailure));
+        }));
     }
 }

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/IndicesAndAliasesResolverTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/IndicesAndAliasesResolverTests.java
@@ -259,8 +259,7 @@ public class IndicesAndAliasesResolverTests extends ESTestCase {
             }, null));
         final FieldPermissionsCache fieldPermissionsCache = new FieldPermissionsCache(Settings.EMPTY);
         doAnswer((i) -> {
-            ActionListener callback =
-                    (ActionListener) i.getArguments()[1];
+            ActionListener<Role> callback = (ActionListener<Role>) i.getArguments()[1];
             Set<String> names = (Set<String>) i.getArguments()[0];
             assertNotNull(names);
             Set<RoleDescriptor> roleDescriptors = new HashSet<>();
@@ -275,8 +274,7 @@ public class IndicesAndAliasesResolverTests extends ESTestCase {
                 callback.onResponse(Role.EMPTY);
             } else {
                 CompositeRolesStore.buildRoleFromDescriptors(roleDescriptors, fieldPermissionsCache, null,
-                        ActionListener.wrap(r -> callback.onResponse(r), callback::onFailure)
-                );
+                    callback.wrap((l, r) -> l.onResponse(r)));
             }
             return Void.TYPE;
         }).when(rolesStore).roles(any(Set.class), any(ActionListener.class));

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/action/SpatialUsageTransportAction.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/action/SpatialUsageTransportAction.java
@@ -41,8 +41,7 @@ public class SpatialUsageTransportAction extends XPackUsageFeatureTransportActio
                                    ActionListener<XPackUsageFeatureResponse> listener) {
         SpatialStatsAction.Request statsRequest = new SpatialStatsAction.Request();
         statsRequest.setParentTask(clusterService.localNode().getId(), task.getId());
-        client.execute(SpatialStatsAction.INSTANCE, statsRequest, ActionListener.wrap(r ->
-                listener.onResponse(new XPackUsageFeatureResponse(new SpatialFeatureSetUsage(r))),
-            listener::onFailure));
+        client.execute(SpatialStatsAction.INSTANCE, statsRequest,
+                listener.wrap((l, r) -> l.onResponse(new XPackUsageFeatureResponse(new SpatialFeatureSetUsage(r)))));
     }
 }

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/SqlUsageTransportAction.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/SqlUsageTransportAction.java
@@ -51,7 +51,7 @@ public class SqlUsageTransportAction extends XPackUsageFeatureTransportAction {
         SqlStatsRequest sqlRequest = new SqlStatsRequest();
         sqlRequest.includeStats(true);
         sqlRequest.setParentTask(clusterService.localNode().getId(), task.getId());
-        client.execute(SqlStatsAction.INSTANCE, sqlRequest, ActionListener.wrap(r -> {
+        client.execute(SqlStatsAction.INSTANCE, sqlRequest, listener.wrap((l, r) -> {
             List<Counters> countersPerNode = r.getNodes()
                 .stream()
                 .map(SqlStatsResponse.NodeStatsResponse::getStats)
@@ -59,7 +59,7 @@ public class SqlUsageTransportAction extends XPackUsageFeatureTransportAction {
                 .collect(Collectors.toList());
             Counters mergedCounters = Counters.merge(countersPerNode);
             SqlFeatureSetUsage usage = new SqlFeatureSetUsage(mergedCounters.toNestedMap());
-            listener.onResponse(new XPackUsageFeatureResponse(usage));
-        }, listener::onFailure));
+            l.onResponse(new XPackUsageFeatureResponse(usage));
+        }));
     }
 }

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/execution/PlanExecutor.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/execution/PlanExecutor.java
@@ -71,10 +71,10 @@ public class PlanExecutor {
             ActionListener<SearchSourceBuilder> listener) {
         metrics.translate();
 
-        newSession(cfg).sqlExecutable(sql, params, wrap(exec -> {
+        newSession(cfg).sqlExecutable(sql, params, listener.wrap((l, exec) -> {
             if (exec instanceof EsQueryExec) {
                 EsQueryExec e = (EsQueryExec) exec;
-                listener.onResponse(SourceGenerator.sourceBuilder(e.queryContainer(), cfg.filter(), cfg.pageSize()));
+                l.onResponse(SourceGenerator.sourceBuilder(e.queryContainer(), cfg.filter(), cfg.pageSize()));
             }
             // try to provide a better resolution of what failed
             else {
@@ -88,9 +88,9 @@ public class PlanExecutor {
                 } else {
                     message = "Cannot generate a query DSL";
                 }
-                listener.onFailure(new PlanningException(message + ", sql statement: [{}]", sql));
+                l.onFailure(new PlanningException(message + ", sql statement: [{}]", sql));
             }
-        }, listener::onFailure));
+        }));
     }
 
     public void sql(SqlConfiguration cfg, String sql, List<SqlTypedParamValue> params, ActionListener<Page> listener) {

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/execution/search/Querier.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/execution/search/Querier.java
@@ -83,7 +83,6 @@ import java.util.function.BiFunction;
 import java.util.function.Supplier;
 
 import static java.util.Collections.singletonList;
-import static org.elasticsearch.action.ActionListener.wrap;
 import static org.elasticsearch.xpack.ql.execution.search.QlSourceBuilder.SWITCH_TO_FIELDS_API_VERSION;
 
 // TODO: add retry/back-off
@@ -481,8 +480,7 @@ public class Querier {
             }
 
             ScrollCursor.handle(response, () -> new SchemaSearchHitRowSet(schema, exts, mask, query.limit(), response),
-                    p -> listener.onResponse(p),
-                    p -> clear(response.getScrollId(), wrap(success -> listener.onResponse(p), listener::onFailure)), schema);
+                    listener::onResponse, p -> clear(response.getScrollId(), listener.wrap((l, success) -> l.onResponse(p))), schema);
         }
 
         private HitExtractor createExtractor(FieldExtraction ref) {

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/plan/logical/command/Debug.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/plan/logical/command/Debug.java
@@ -30,7 +30,6 @@ import java.util.Map.Entry;
 import java.util.Objects;
 
 import static java.util.Collections.singletonList;
-import static org.elasticsearch.action.ActionListener.wrap;
 
 public class Debug extends Command {
 
@@ -79,11 +78,11 @@ public class Debug extends Command {
     public void execute(SqlSession session, ActionListener<Page> listener) {
         switch (type) {
             case ANALYZED:
-                session.debugAnalyzedPlan(plan, wrap(i -> handleInfo(i, listener), listener::onFailure));
+                session.debugAnalyzedPlan(plan, listener.wrap((l, i) -> handleInfo(i, l)));
                 break;
             case OPTIMIZED:
                 session.analyzedPlan(plan, true,
-                        wrap(analyzedPlan -> handleInfo(session.optimizer().debugOptimize(analyzedPlan), listener), listener::onFailure));
+                    listener.wrap((l,analyzedPlan) -> handleInfo(session.optimizer().debugOptimize(analyzedPlan), l)));
                 break;
             default:
                 break;

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/plan/logical/command/Explain.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/plan/logical/command/Explain.java
@@ -30,7 +30,6 @@ import java.util.Objects;
 
 import static java.util.Collections.singletonList;
 import static java.util.Collections.unmodifiableMap;
-import static org.elasticsearch.action.ActionListener.wrap;
 
 public class Explain extends Command {
 
@@ -94,54 +93,54 @@ public class Explain extends Command {
         }
 
         // to avoid duplicating code, the type/verification filtering happens inside the listeners instead of outside using a CASE
-        session.analyzedPlan(plan, verify, wrap(analyzedPlan -> {
+        session.analyzedPlan(plan, verify, listener.wrap((l, analyzedPlan) -> {
 
             if (type == Type.ANALYZED) {
-                listener.onResponse(Page.last(Rows.singleton(output(), formatPlan(format, analyzedPlan))));
+                l.onResponse(Page.last(Rows.singleton(output(), formatPlan(format, analyzedPlan))));
                 return;
             }
 
             Planner planner = session.planner();
             // verification is on, exceptions can be thrown
             if (verify) {
-                session.optimizedPlan(analyzedPlan, wrap(optimizedPlan -> {
+                session.optimizedPlan(analyzedPlan, l.wrap((ll, optimizedPlan) -> {
                     if (type == Type.OPTIMIZED) {
-                        listener.onResponse(Page.last(Rows.singleton(output(), formatPlan(format, optimizedPlan))));
+                        ll.onResponse(Page.last(Rows.singleton(output(), formatPlan(format, optimizedPlan))));
                         return;
                     }
 
                     PhysicalPlan mappedPlan = planner.mapPlan(optimizedPlan, verify);
                     if (type == Type.MAPPED) {
-                        listener.onResponse(Page.last(Rows.singleton(output(), formatPlan(format, mappedPlan))));
+                        ll.onResponse(Page.last(Rows.singleton(output(), formatPlan(format, mappedPlan))));
                         return;
                     }
 
                     PhysicalPlan executablePlan = planner.foldPlan(mappedPlan, verify);
                     if (type == Type.EXECUTABLE) {
-                        listener.onResponse(Page.last(Rows.singleton(output(), formatPlan(format, executablePlan))));
+                        ll.onResponse(Page.last(Rows.singleton(output(), formatPlan(format, executablePlan))));
                         return;
                     }
 
                     // Type.All
-                    listener.onResponse(Page.last(
+                    ll.onResponse(Page.last(
                             Rows.singleton(output(), printPlans(format, plan, analyzedPlan, optimizedPlan, mappedPlan, executablePlan))));
-                }, listener::onFailure));
+                }));
             }
 
             // check errors manually to see how far the plans work out
             else {
                 // no analysis failure, can move on
                 if (session.verifier().verifyFailures(analyzedPlan).isEmpty()) {
-                    session.optimizedPlan(analyzedPlan, wrap(optimizedPlan -> {
+                    session.optimizedPlan(analyzedPlan, l.wrap((ll, optimizedPlan) -> {
                         if (type == Type.OPTIMIZED) {
-                            listener.onResponse(Page.last(Rows.singleton(output(), formatPlan(format, optimizedPlan))));
+                            ll.onResponse(Page.last(Rows.singleton(output(), formatPlan(format, optimizedPlan))));
                             return;
                         }
 
                         PhysicalPlan mappedPlan = planner.mapPlan(optimizedPlan, verify);
 
                         if (type == Type.MAPPED) {
-                            listener.onResponse(Page.last(Rows.singleton(output(), formatPlan(format, mappedPlan))));
+                            ll.onResponse(Page.last(Rows.singleton(output(), formatPlan(format, mappedPlan))));
                             return;
                         }
 
@@ -149,34 +148,33 @@ public class Explain extends Command {
                             PhysicalPlan executablePlan = planner.foldPlan(mappedPlan, verify);
 
                             if (type == Type.EXECUTABLE) {
-                                listener.onResponse(Page.last(Rows.singleton(output(), formatPlan(format, executablePlan))));
+                                ll.onResponse(Page.last(Rows.singleton(output(), formatPlan(format, executablePlan))));
                                 return;
                             }
 
-                            listener.onResponse(Page.last(Rows.singleton(output(),
+                            ll.onResponse(Page.last(Rows.singleton(output(),
                                     printPlans(format, plan, analyzedPlan, optimizedPlan, mappedPlan, executablePlan))));
                             return;
                         }
                         // mapped failed
                         if (type != Type.ALL) {
-                            listener.onResponse(Page.last(Rows.singleton(output(), formatPlan(format, mappedPlan))));
+                            ll.onResponse(Page.last(Rows.singleton(output(), formatPlan(format, mappedPlan))));
                             return;
                         }
 
-                        listener.onResponse(Page
+                        ll.onResponse(Page
                                 .last(Rows.singleton(output(), printPlans(format, plan, analyzedPlan, optimizedPlan, mappedPlan, null))));
-                    }, listener::onFailure));
+                    }));
                     // cannot continue
                 } else {
                     if (type != Type.ALL) {
-                        listener.onResponse(Page.last(Rows.singleton(output(), formatPlan(format, analyzedPlan))));
-                    }
-                    else {
-                        listener.onResponse(Page.last(Rows.singleton(output(), printPlans(format, plan, analyzedPlan, null, null, null))));
+                        l.onResponse(Page.last(Rows.singleton(output(), formatPlan(format, analyzedPlan))));
+                    } else {
+                        l.onResponse(Page.last(Rows.singleton(output(), printPlans(format, plan, analyzedPlan, null, null, null))));
                     }
                 }
             }
-        }, listener::onFailure));
+        }));
     }
 
     private static String printPlans(Format format, LogicalPlan parsed, LogicalPlan analyzedPlan, LogicalPlan optimizedPlan,

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/plan/logical/command/ShowColumns.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/plan/logical/command/ShowColumns.java
@@ -68,16 +68,14 @@ public class ShowColumns extends Command {
         String regex = pattern != null ? pattern.asJavaRegex() : null;
 
         boolean withFrozen = includeFrozen || session.configuration().includeFrozen();
-        session.indexResolver().resolveAsMergedMapping(idx, regex, withFrozen, emptyMap(), ActionListener.wrap(
-                indexResult -> {
-                    List<List<?>> rows = emptyList();
-                    if (indexResult.isValid()) {
-                        rows = new ArrayList<>();
-                        fillInRows(indexResult.get().mapping(), null, rows);
-                    }
-                    listener.onResponse(of(session, rows));
-                },
-                listener::onFailure));
+        session.indexResolver().resolveAsMergedMapping(idx, regex, withFrozen, emptyMap(), listener.wrap((l, indexResult) -> {
+            List<List<?>> rows = emptyList();
+            if (indexResult.isValid()) {
+                rows = new ArrayList<>();
+                fillInRows(indexResult.get().mapping(), null, rows);
+            }
+            l.onResponse(of(session, rows));
+        }));
     }
 
     private void fillInRows(Map<String, EsField> mapping, String prefix, List<List<?>> rows) {

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/plan/logical/command/ShowTables.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/plan/logical/command/ShowTables.java
@@ -62,11 +62,8 @@ public class ShowTables extends Command {
         EnumSet<IndexType> withFrozen = session.configuration().includeFrozen() || includeFrozen ?
                 IndexType.VALID_INCLUDE_FROZEN : IndexType.VALID_REGULAR;
 
-        session.indexResolver().resolveNames(idx, regex, withFrozen, ActionListener.wrap(result -> {
-            listener.onResponse(of(session, result.stream()
-                 .map(t -> asList(t.name(), t.type().toSql(), t.type().toNative()))
-                .collect(toList())));
-        }, listener::onFailure));
+        session.indexResolver().resolveNames(idx, regex, withFrozen, listener.wrap((l, result) -> l.onResponse(of(session,
+                result.stream().map(t -> asList(t.name(), t.type().toSql(), t.type().toNative())).collect(toList())))));
     }
 
     @Override

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/plan/logical/command/sys/SysColumns.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/plan/logical/command/sys/SysColumns.java
@@ -130,27 +130,25 @@ public class SysColumns extends Command {
 
         // special case for '%' (translated to *)
         if ("*".equals(idx)) {
-            session.indexResolver().resolveAsSeparateMappings(idx, regex, includeFrozen, emptyMap(),
-                ActionListener.wrap(esIndices -> {
-                    List<List<?>> rows = new ArrayList<>();
-                    for (EsIndex esIndex : esIndices) {
-                        fillInRows(cluster, esIndex.name(), esIndex.mapping(), null, rows, columnMatcher, mode);
-                    }
-                listener.onResponse(ListCursor.of(Rows.schema(output), rows, session.configuration().pageSize()));
-            }, listener::onFailure));
+            session.indexResolver().resolveAsSeparateMappings(idx, regex, includeFrozen, emptyMap(), listener.wrap((l, esIndices) -> {
+                List<List<?>> rows = new ArrayList<>();
+                for (EsIndex esIndex : esIndices) {
+                    fillInRows(cluster, esIndex.name(), esIndex.mapping(), null, rows, columnMatcher, mode);
+                }
+                l.onResponse(ListCursor.of(Rows.schema(output), rows, session.configuration().pageSize()));
+            }));
         }
         // otherwise use a merged mapping
         else {
-            session.indexResolver().resolveAsMergedMapping(idx, regex, includeFrozen, emptyMap(),
-                ActionListener.wrap(r -> {
-                    List<List<?>> rows = new ArrayList<>();
-                    // populate the data only when a target is found
-                    if (r.isValid()) {
-                        EsIndex esIndex = r.get();
-                        fillInRows(cluster, indexName, esIndex.mapping(), null, rows, columnMatcher, mode);
-                    }
-                listener.onResponse(ListCursor.of(Rows.schema(output), rows, session.configuration().pageSize()));
-            }, listener::onFailure));
+            session.indexResolver().resolveAsMergedMapping(idx, regex, includeFrozen, emptyMap(), listener.wrap((l, r) -> {
+                List<List<?>> rows = new ArrayList<>();
+                // populate the data only when a target is found
+                if (r.isValid()) {
+                    EsIndex esIndex = r.get();
+                    fillInRows(cluster, indexName, esIndex.mapping(), null, rows, columnMatcher, mode);
+                }
+                l.onResponse(ListCursor.of(Rows.schema(output), rows, session.configuration().pageSize()));
+            }));
         }
     }
 

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/plan/logical/command/sys/SysTables.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/plan/logical/command/sys/SysTables.java
@@ -137,7 +137,7 @@ public class SysTables extends Command {
             }
         }
 
-        session.indexResolver().resolveNames(idx, regex, tableTypes, ActionListener.wrap(result -> listener.onResponse(
+        session.indexResolver().resolveNames(idx, regex, tableTypes, listener.wrap((l, result) -> l.onResponse(
                 of(session, result.stream()
                  // sort by type, then by name
                  .sorted(Comparator.<IndexInfo, String> comparing(i -> i.type().toSql())
@@ -152,8 +152,7 @@ public class SysTables extends Command {
                          null,
                          null,
                          null))
-                .collect(toList())))
-        , listener::onFailure));
+                .collect(toList())))));
     }
 
     @Override

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/plan/physical/CommandExec.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/plan/physical/CommandExec.java
@@ -17,8 +17,6 @@ import org.elasticsearch.xpack.sql.session.SqlSession;
 import java.util.List;
 import java.util.Objects;
 
-import static org.elasticsearch.action.ActionListener.wrap;
-
 public class CommandExec extends LeafExec {
 
     private final Command command;
@@ -39,7 +37,7 @@ public class CommandExec extends LeafExec {
 
     @Override
     public void execute(SqlSession session, ActionListener<Page> listener) {
-        command.execute(session, wrap(listener::onResponse, listener::onFailure));
+        command.execute(session, listener.wrap((l, r) -> l.onResponse(r)));
     }
 
     @Override

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/plugin/TextFormatterCursor.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/plugin/TextFormatterCursor.java
@@ -18,7 +18,6 @@ import org.elasticsearch.xpack.sql.session.Cursor;
 import java.io.IOException;
 import java.util.Objects;
 
-import static org.elasticsearch.action.ActionListener.wrap;
 /**
  * The cursor that wraps all necessary information for textual representation of the result table
  */
@@ -51,11 +50,10 @@ public class TextFormatterCursor implements Cursor {
     @Override
     public void nextPage(SqlConfiguration cfg, Client client, NamedWriteableRegistry registry, ActionListener<Page> listener) {
         // keep wrapping the text formatter
-        delegate.nextPage(cfg, client, registry,
-                wrap(p -> {
-                    Cursor next = p.next();
-                    listener.onResponse(next == Cursor.EMPTY ? p : new Page(p.rowSet(), new TextFormatterCursor(next, formatter)));
-                }, listener::onFailure));
+        delegate.nextPage(cfg, client, registry, listener.wrap((l, p) -> {
+            Cursor next = p.next();
+            l.onResponse(next == Cursor.EMPTY ? p : new Page(p.rowSet(), new TextFormatterCursor(next, formatter)));
+        }));
     }
 
     @Override

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/plugin/TransportSqlClearCursorAction.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/plugin/TransportSqlClearCursorAction.java
@@ -50,8 +50,7 @@ public class TransportSqlClearCursorAction extends HandledTransportAction<SqlCle
                 new SqlConfiguration(DateUtils.UTC, Protocol.FETCH_SIZE, Protocol.REQUEST_TIMEOUT, Protocol.PAGE_TIMEOUT, null,
                         emptyMap(), request.mode(), StringUtils.EMPTY, request.version(), StringUtils.EMPTY, StringUtils.EMPTY,
                         Protocol.FIELD_MULTI_VALUE_LENIENCY, Protocol.INDEX_INCLUDE_FROZEN),
-                cursor, ActionListener.wrap(
-                success -> listener.onResponse(new SqlClearCursorResponse(success)), listener::onFailure));
+                cursor, listener.wrap((l, success) -> l.onResponse(new SqlClearCursorResponse(success))));
     }
 }
 

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/plugin/TransportSqlQueryAction.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/plugin/TransportSqlQueryAction.java
@@ -101,8 +101,7 @@ public class TransportSqlQueryAction extends HandledTransportAction<SqlQueryRequ
         } else {
             Tuple<Cursor, ZoneId> decoded = Cursors.decodeFromStringWithZone(request.cursor());
             planExecutor.nextPage(cfg, decoded.v1(),
-                    wrap(p -> listener.onResponse(createResponse(request, decoded.v2(), null, p)),
-                            listener::onFailure));
+                listener.wrap((l, p) -> l.onResponse(createResponse(request, decoded.v2(), null, p))));
         }
     }
 

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/plugin/TransportSqlTranslateAction.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/plugin/TransportSqlTranslateAction.java
@@ -59,7 +59,7 @@ public class TransportSqlTranslateAction extends HandledTransportAction<SqlTrans
                 username(securityContext), clusterName(clusterService), Protocol.FIELD_MULTI_VALUE_LENIENCY,
                 Protocol.INDEX_INCLUDE_FROZEN);
 
-        planExecutor.searchSource(cfg, request.query(), request.params(), ActionListener.wrap(
-                searchSourceBuilder -> listener.onResponse(new SqlTranslateResponse(searchSourceBuilder)), listener::onFailure));
+        planExecutor.searchSource(cfg, request.query(), request.params(),
+                listener.wrap((l, searchSourceBuilder) -> l.onResponse(new SqlTranslateResponse(searchSourceBuilder))));
     }
 }

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/session/SqlSession.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/session/SqlSession.java
@@ -32,8 +32,6 @@ import org.elasticsearch.xpack.sql.session.Cursor.Page;
 import java.util.List;
 import java.util.function.Function;
 
-import static org.elasticsearch.action.ActionListener.wrap;
-
 public class SqlSession implements Session {
 
     private final Client client;
@@ -142,7 +140,7 @@ public class SqlSession implements Session {
 
             boolean includeFrozen = configuration.includeFrozen() || tableInfo.isFrozen();
             indexResolver.resolveAsMergedMapping(table.index(), null, includeFrozen, configuration.runtimeMappings(),
-                    wrap(indexResult -> listener.onResponse(action.apply(indexResult)), listener::onFailure));
+                listener.wrap((l, indexResult) -> l.onResponse(action.apply(indexResult))));
         } else {
             try {
                 // occurs when dealing with local relations (SELECT 5+2)
@@ -154,15 +152,15 @@ public class SqlSession implements Session {
     }
 
     public void optimizedPlan(LogicalPlan verified, ActionListener<LogicalPlan> listener) {
-        analyzedPlan(verified, true, wrap(v -> listener.onResponse(optimizer.optimize(v)), listener::onFailure));
+        analyzedPlan(verified, true, listener.wrap((l, v) -> l.onResponse(optimizer.optimize(v))));
     }
 
     public void physicalPlan(LogicalPlan optimized, boolean verify, ActionListener<PhysicalPlan> listener) {
-        optimizedPlan(optimized, wrap(o -> listener.onResponse(planner.plan(o, verify)), listener::onFailure));
+        optimizedPlan(optimized, listener.wrap((l, o) -> l.onResponse(planner.plan(o, verify))));
     }
 
     public void sql(String sql, List<SqlTypedParamValue> params, ActionListener<Page> listener) {
-        sqlExecutable(sql, params, wrap(e -> e.execute(this, listener), listener::onFailure));
+        sqlExecutable(sql, params, listener.wrap((l, e) -> e.execute(this, l)));
     }
 
     public void sqlExecutable(String sql, List<SqlTypedParamValue> params, ActionListener<PhysicalPlan> listener) {

--- a/x-pack/plugin/transform/src/internalClusterTest/java/org/elasticsearch/xpack/transform/checkpoint/TransformCheckpointServiceNodeTests.java
+++ b/x-pack/plugin/transform/src/internalClusterTest/java/org/elasticsearch/xpack/transform/checkpoint/TransformCheckpointServiceNodeTests.java
@@ -368,10 +368,8 @@ public class TransformCheckpointServiceNodeTests extends TransformSingleNodeTest
         TransformProgress nextCheckpointProgress,
         ActionListener<TransformCheckpointingInfo> listener
     ) {
-        ActionListener<TransformCheckpointingInfoBuilder> checkPointInfoListener = ActionListener.wrap(
-            infoBuilder -> { listener.onResponse(infoBuilder.build()); },
-            listener::onFailure
-        );
+        ActionListener<TransformCheckpointingInfoBuilder> checkPointInfoListener =
+                listener.wrap((l, infoBuilder) -> l.onResponse(infoBuilder.build()));
         transformCheckpointService.getCheckpointingInfo(
             mockClientForCheckpointing,
             transformId,

--- a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/WatcherUsageTransportAction.java
+++ b/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/WatcherUsageTransportAction.java
@@ -63,7 +63,7 @@ public class WatcherUsageTransportAction extends XPackUsageFeatureTransportActio
                 WatcherStatsRequest statsRequest = new WatcherStatsRequest();
                 statsRequest.includeStats(true);
                 statsRequest.setParentTask(clusterService.localNode().getId(), task.getId());
-                client.execute(WatcherStatsAction.INSTANCE, statsRequest, ActionListener.wrap(r -> {
+                client.execute(WatcherStatsAction.INSTANCE, statsRequest, listener.wrap((l, r) -> {
                     List<Counters> countersPerNode = r.getNodes()
                         .stream()
                         .map(WatcherStatsResponse.Node::getStats)
@@ -72,8 +72,8 @@ public class WatcherUsageTransportAction extends XPackUsageFeatureTransportActio
                     Counters mergedCounters = Counters.merge(countersPerNode);
                     WatcherFeatureSetUsage usage =
                         new WatcherFeatureSetUsage(licenseState.isAllowed(Feature.WATCHER), true, mergedCounters.toNestedMap());
-                    listener.onResponse(new XPackUsageFeatureResponse(usage));
-                }, listener::onFailure));
+                    l.onResponse(new XPackUsageFeatureResponse(usage));
+                }));
             }
         } else {
             WatcherFeatureSetUsage usage =

--- a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/transport/actions/TransportDeleteWatchAction.java
+++ b/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/transport/actions/TransportDeleteWatchAction.java
@@ -44,10 +44,10 @@ public class TransportDeleteWatchAction extends HandledTransportAction<DeleteWat
         DeleteRequest deleteRequest = new DeleteRequest(Watch.INDEX, request.getId());
         deleteRequest.setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE);
         executeAsyncWithOrigin(client.threadPool().getThreadContext(), WATCHER_ORIGIN, deleteRequest,
-                ActionListener.<DeleteResponse>wrap(deleteResponse -> {
+                listener.<DeleteResponse>wrap((l, deleteResponse) -> {
                     boolean deleted = deleteResponse.getResult() == DocWriteResponse.Result.DELETED;
                     DeleteWatchResponse response = new DeleteWatchResponse(deleteResponse.getId(), deleteResponse.getVersion(), deleted);
-                    listener.onResponse(response);
-                }, listener::onFailure), client::delete);
+                    l.onResponse(response);
+                }), client::delete);
     }
 }

--- a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/transport/actions/TransportExecuteWatchAction.java
+++ b/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/transport/actions/TransportExecuteWatchAction.java
@@ -87,16 +87,16 @@ public class TransportExecuteWatchAction extends WatcherTransportAction<ExecuteW
                     .preference(Preference.LOCAL.type()).realtime(true);
 
             executeAsyncWithOrigin(client.threadPool().getThreadContext(), WATCHER_ORIGIN, getRequest,
-                    ActionListener.<GetResponse>wrap(response -> {
+                listener.<GetResponse>wrap((l, response) -> {
                         if (response.isExists()) {
                             Watch watch = watchParser.parse(request.getId(), true, response.getSourceAsBytesRef(),
                                 request.getXContentType(), response.getSeqNo(), response.getPrimaryTerm());
                             watch.status().version(response.getVersion());
-                            executeWatch(request, listener, watch, true);
+                            executeWatch(request, l, watch, true);
                         } else {
-                            listener.onFailure(new ResourceNotFoundException("Watch with id [{}] does not exist", request.getId()));
+                            l.onFailure(new ResourceNotFoundException("Watch with id [{}] does not exist", request.getId()));
                         }
-                    }, listener::onFailure), client::get);
+                    }), client::get);
         } else if (request.getWatchSource() != null) {
             try {
                 assert request.isRecordExecution() == false;

--- a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/transport/actions/TransportPutWatchAction.java
+++ b/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/transport/actions/TransportPutWatchAction.java
@@ -103,23 +103,21 @@ public class TransportPutWatchAction extends WatcherTransportAction<PutWatchRequ
                     updateRequest.doc(builder);
 
                     executeAsyncWithOrigin(client.threadPool().getThreadContext(), WATCHER_ORIGIN, updateRequest,
-                            ActionListener.<UpdateResponse>wrap(response -> {
+                            listener.<UpdateResponse>wrap((l, response) -> {
                                 boolean created = response.getResult() == DocWriteResponse.Result.CREATED;
-                                listener.onResponse(new PutWatchResponse(response.getId(), response.getVersion(),
+                                l.onResponse(new PutWatchResponse(response.getId(), response.getVersion(),
                                     response.getSeqNo(), response.getPrimaryTerm(), created));
-                            }, listener::onFailure),
-                            client::update);
+                            }), client::update);
                 } else {
                     IndexRequest indexRequest = new IndexRequest(Watch.INDEX).id(request.getId());
                     indexRequest.source(builder);
                     indexRequest.setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE);
                     executeAsyncWithOrigin(client.threadPool().getThreadContext(), WATCHER_ORIGIN, indexRequest,
-                        ActionListener.<IndexResponse>wrap(response -> {
+                            listener.<IndexResponse>wrap((l, response) -> {
                             boolean created = response.getResult() == DocWriteResponse.Result.CREATED;
-                            listener.onResponse(new PutWatchResponse(response.getId(), response.getVersion(),
+                            l.onResponse(new PutWatchResponse(response.getId(), response.getVersion(),
                                 response.getSeqNo(), response.getPrimaryTerm(), created));
-                        }, listener::onFailure),
-                        client::index);
+                        }), client::index);
                 }
             }
         } catch (Exception e) {

--- a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/transport/actions/TransportQueryWatchesAction.java
+++ b/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/transport/actions/TransportQueryWatchesAction.java
@@ -59,7 +59,7 @@ public class TransportQueryWatchesAction extends WatcherTransportAction<QueryWat
     protected void doExecute(QueryWatchesAction.Request request, ActionListener<QueryWatchesAction.Response> listener) {
         SearchRequest searchRequest = createSearchRequest(request);
         executeAsyncWithOrigin(client.threadPool().getThreadContext(), WATCHER_ORIGIN, searchRequest,
-            ActionListener.<SearchResponse>wrap(r -> transformResponse(r, listener), listener::onFailure), client::search);
+            listener.<SearchResponse>wrap((l, r) -> transformResponse(r, l)), client::search);
     }
 
     SearchRequest createSearchRequest(QueryWatchesAction.Request request) {

--- a/x-pack/qa/security-example-spi-extension/src/main/java/org/elasticsearch/example/realm/CustomRoleMappingRealm.java
+++ b/x-pack/qa/security-example-spi-extension/src/main/java/org/elasticsearch/example/realm/CustomRoleMappingRealm.java
@@ -68,10 +68,7 @@ public class CustomRoleMappingRealm extends Realm implements CachingRealm {
             return;
         }
         if (USERNAME.equals(username)) {
-            buildUser(username, ActionListener.wrap(
-                u -> listener.onResponse(cache.computeIfAbsent(username, k -> u)),
-                listener::onFailure
-            ));
+            buildUser(username, listener.wrap((l, u) -> l.onResponse(cache.computeIfAbsent(username, k -> u))));
         } else {
             listener.onResponse(null);
         }
@@ -79,10 +76,7 @@ public class CustomRoleMappingRealm extends Realm implements CachingRealm {
 
     private void buildUser(String username, ActionListener<User> listener) {
         final UserRoleMapper.UserData data = new UserRoleMapper.UserData(username, null, List.of(USER_GROUP), Map.of(), super.config);
-        roleMapper.resolveRoles(data, ActionListener.wrap(
-            roles -> listener.onResponse(new User(username, roles.toArray(String[]::new))),
-            listener::onFailure
-        ));
+        roleMapper.resolveRoles(data, listener.wrap((l, roles) -> listener.onResponse(new User(username, roles.toArray(String[]::new)))));
     }
 
     @Override


### PR DESCRIPTION
We very often just use this method with `listener::wrap` as the failure callback.
When also using the listener reference in the response callback, this needlessly
captures the listener in both callback instances. With this change we only capture
the wrapping listener once, making many response callback use cases non-capturing
lambdas (this might be nice for authentication in particular that heavily nests
these listeners via wrapping in seemingly somewhat hot code). Also, (IMO) this
change makes the code a lot more readable in many cases since the error catching
listener is easily identifiable now on first read, instead of having to look
for it after a lengthy response handler. This also makes the `onFailure` handling
for the callbacks stricter by forcing them to not throw themselves.

This only refactors a subset (the cases that I could easily track down via static refactoring)
of possible spots.
