### PR TITLE
Service Accounts - auditing tests for existing fields (#71668)

### DIFF
--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/audit/logfile/LoggingAuditTrailTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/audit/logfile/LoggingAuditTrailTests.java
@@ -84,6 +84,7 @@ import org.elasticsearch.xpack.core.security.authz.RoleDescriptor;
 import org.elasticsearch.xpack.core.security.authz.privilege.ApplicationPrivilegeDescriptor;
 import org.elasticsearch.xpack.core.security.authz.privilege.ConfigurableClusterPrivilege;
 import org.elasticsearch.xpack.core.security.authz.privilege.ConfigurableClusterPrivileges;
+import org.elasticsearch.xpack.core.security.support.ValidationTests;
 import org.elasticsearch.xpack.core.security.user.AnonymousUser;
 import org.elasticsearch.xpack.core.security.user.AsyncSearchUser;
 import org.elasticsearch.xpack.core.security.user.SystemUser;
@@ -2048,7 +2049,6 @@ public class LoggingAuditTrailTests extends ESTestCase {
                 .put("xpack.security.audit.logfile.events.include", "_all")
                 .build();
         auditTrail = new LoggingAuditTrail(settings, clusterService, logger, threadContext);
-        final User user = new User("_username", new String[] { "r1" });
         final AuthorizationInfo authorizationInfo =
             () -> Collections.singletonMap(PRINCIPAL_ROLES_FIELD_NAME, new String[] { randomAlphaOfLengthBetween(1, 6) });
         final String realm = randomAlphaOfLengthBetween(1, 6);
@@ -2216,17 +2216,35 @@ public class LoggingAuditTrailTests extends ESTestCase {
         final RealmRef lookedUpBy;
         final RealmRef authBy;
         final User user;
-        if (randomBoolean()) {
-            user = new User(randomAlphaOfLength(4), new String[] { "r1" }, new User("authenticated_username", new String[] { "r2" }));
-            lookedUpBy = new RealmRef(randomAlphaOfLength(4), "lookup", "by");
-            authBy = new RealmRef("authRealm", "auth", "foo");
-        } else {
-            user = new User(randomAlphaOfLength(4), new String[] { "r1" });
-            lookedUpBy = null;
-            authBy = new RealmRef(randomAlphaOfLength(4), "auth", "by");
+        final AuthenticationType authenticationType;
+        final Map<String, Object> authMetadata;
+        switch (randomIntBetween(0, 2)) {
+            case 0:
+                user = new User(randomAlphaOfLength(4), new String[] { "r1" }, new User("authenticated_username", "r2"));
+                lookedUpBy = new RealmRef(randomAlphaOfLength(4), "lookup", "by");
+                authBy = new RealmRef("authRealm", "auth", "foo");
+                authenticationType= randomFrom(AuthenticationType.REALM, AuthenticationType.TOKEN,
+                    AuthenticationType.INTERNAL, AuthenticationType.ANONYMOUS);
+                authMetadata = Map.of();
+                break;
+            case 1:
+                user = new User(randomAlphaOfLength(4), "r1");
+                lookedUpBy = null;
+                authBy = new RealmRef(randomAlphaOfLength(4), "auth", "by");
+                authenticationType= randomFrom(AuthenticationType.REALM, AuthenticationType.TOKEN,
+                    AuthenticationType.INTERNAL, AuthenticationType.ANONYMOUS);
+                authMetadata = Map.of();
+                break;
+            default:  // service account
+                final String principal = randomAlphaOfLengthBetween(3, 8) + "/" + randomAlphaOfLengthBetween(3, 8);
+                user = new User(principal, Strings.EMPTY_ARRAY, "Service account - " + principal, null,
+                    Map.of("_elastic_service_account", true), true);
+                lookedUpBy = null;
+                authBy = new RealmRef("service_account", "service_account", randomAlphaOfLengthBetween(3, 8));
+                authenticationType = AuthenticationType.TOKEN;
+                authMetadata = Map.of("_token_name", ValidationTests.randomTokenName());
         }
-        return new Authentication(user, authBy, lookedUpBy, Version.CURRENT, randomFrom(AuthenticationType.REALM,
-                AuthenticationType.TOKEN, AuthenticationType.INTERNAL, AuthenticationType.ANONYMOUS), Collections.emptyMap());
+        return new Authentication(user, authBy, lookedUpBy, Version.CURRENT, authenticationType, authMetadata);
     }
 
     private ClusterSettings mockClusterSettings() {

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/audit/logfile/LoggingAuditTrailTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/audit/logfile/LoggingAuditTrailTests.java
@@ -2225,7 +2225,7 @@ public class LoggingAuditTrailTests extends ESTestCase {
                 authBy = new RealmRef("authRealm", "auth", "foo");
                 authenticationType= randomFrom(AuthenticationType.REALM, AuthenticationType.TOKEN,
                     AuthenticationType.INTERNAL, AuthenticationType.ANONYMOUS);
-                authMetadata = Map.of();
+                authMetadata = org.elasticsearch.common.collect.Map.of();
                 break;
             case 1:
                 user = new User(randomAlphaOfLength(4), "r1");
@@ -2233,16 +2233,16 @@ public class LoggingAuditTrailTests extends ESTestCase {
                 authBy = new RealmRef(randomAlphaOfLength(4), "auth", "by");
                 authenticationType= randomFrom(AuthenticationType.REALM, AuthenticationType.TOKEN,
                     AuthenticationType.INTERNAL, AuthenticationType.ANONYMOUS);
-                authMetadata = Map.of();
+                authMetadata = org.elasticsearch.common.collect.Map.of();
                 break;
             default:  // service account
                 final String principal = randomAlphaOfLengthBetween(3, 8) + "/" + randomAlphaOfLengthBetween(3, 8);
                 user = new User(principal, Strings.EMPTY_ARRAY, "Service account - " + principal, null,
-                    Map.of("_elastic_service_account", true), true);
+                    org.elasticsearch.common.collect.Map.of("_elastic_service_account", true), true);
                 lookedUpBy = null;
                 authBy = new RealmRef("service_account", "service_account", randomAlphaOfLengthBetween(3, 8));
                 authenticationType = AuthenticationType.TOKEN;
-                authMetadata = Map.of("_token_name", ValidationTests.randomTokenName());
+                authMetadata = org.elasticsearch.common.collect.Map.of("_token_name", ValidationTests.randomTokenName());
         }
         return new Authentication(user, authBy, lookedUpBy, Version.CURRENT, authenticationType, authMetadata);
     }

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/AuthenticationServiceTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/AuthenticationServiceTests.java
@@ -13,6 +13,7 @@ import org.apache.lucene.util.ArrayUtil;
 import org.apache.lucene.util.SetOnce;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.ElasticsearchSecurityException;
+import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.get.GetAction;
 import org.elasticsearch.action.get.GetRequest;
@@ -80,6 +81,7 @@ import org.elasticsearch.xpack.core.security.authc.support.Hasher;
 import org.elasticsearch.xpack.core.security.authc.support.UsernamePasswordToken;
 import org.elasticsearch.xpack.core.security.authz.AuthorizationEngine.EmptyAuthorizationInfo;
 import org.elasticsearch.xpack.core.security.index.RestrictedIndicesNames;
+import org.elasticsearch.xpack.core.security.support.ValidationTests;
 import org.elasticsearch.xpack.core.security.user.AnonymousUser;
 import org.elasticsearch.xpack.core.security.user.SystemUser;
 import org.elasticsearch.xpack.core.security.user.User;
@@ -89,6 +91,7 @@ import org.elasticsearch.xpack.security.audit.AuditUtil;
 import org.elasticsearch.xpack.security.authc.AuthenticationService.Authenticator;
 import org.elasticsearch.xpack.security.authc.esnative.ReservedRealm;
 import org.elasticsearch.xpack.security.authc.service.ServiceAccountService;
+import org.elasticsearch.xpack.security.authc.service.ServiceAccountToken;
 import org.elasticsearch.xpack.security.operator.OperatorPrivileges;
 import org.elasticsearch.xpack.security.support.CacheInvalidatorRegistry;
 import org.elasticsearch.xpack.security.support.SecurityIndexManager;
@@ -1911,8 +1914,14 @@ public class AuthenticationServiceTests extends ESTestCase {
         Mockito.reset(serviceAccountService);
         final Authentication authentication = new Authentication(
             new User("elastic/fleet-server"),
-            new RealmRef("service_account", "service_account", "foo"), null);
+            new RealmRef("service_account", "service_account", "foo"), null,
+            Version.CURRENT, AuthenticationType.TOKEN, Map.of("_token_name", ValidationTests.randomTokenName()));
         try (ThreadContext.StoredContext ignored = threadContext.newStoredContext(false)) {
+            boolean requestIdAlreadyPresent = randomBoolean();
+            SetOnce<String> reqId = new SetOnce<>();
+            if (requestIdAlreadyPresent) {
+                reqId.set(AuditUtil.getOrGenerateRequestId(threadContext));
+            }
             threadContext.putHeader("Authorization", "Bearer AAEAAWVsYXN0aWMvZmxlZXQtc2VydmVyL3Rva2VuMTpyNXdkYmRib1FTZTl2R09Ld2FKR0F3");
             doAnswer(invocationOnMock -> {
                 @SuppressWarnings("unchecked")
@@ -1920,27 +1929,46 @@ public class AuthenticationServiceTests extends ESTestCase {
                 listener.onResponse(authentication);
                 return null;
             }).when(serviceAccountService).authenticateToken(any(), any(), any());
-            final PlainActionFuture<Authentication> future = new PlainActionFuture<>();
-            service.authenticate("_action", transportRequest, false, future);
-            assertThat(future.get(), is(authentication));
+            final Tuple<Authentication, String> result = authenticateBlocking("_action", transportRequest, null);
+            if (requestIdAlreadyPresent) {
+                assertThat(expectAuditRequestId(threadContext), is(reqId.get()));
+            }
+            assertThat(expectAuditRequestId(threadContext), is(result.v2()));
+            assertThat(result.v1(), is(authentication));
+            verify(auditTrail).authenticationSuccess(eq(result.v2()), same(authentication), eq("_action"), same(transportRequest));
+            verify(operatorPrivilegesService).maybeMarkOperatorUser(eq(result.v1()), eq(threadContext));
+            verifyNoMoreInteractions(auditTrail);
         }
     }
 
-    public void testServiceAccountFailureWillNotFallthrough() {
+    public void testServiceAccountFailureWillNotFallthrough() throws IOException {
         Mockito.reset(serviceAccountService);
-        final RuntimeException bailOut = new RuntimeException("bail out");
+        final ElasticsearchSecurityException bailOut = new ElasticsearchSecurityException("bail out", RestStatus.UNAUTHORIZED);
         try (ThreadContext.StoredContext ignored = threadContext.newStoredContext(false)) {
-            threadContext.putHeader("Authorization", "Bearer AAEAAWVsYXN0aWMvZmxlZXQtc2VydmVyL3Rva2VuMTpyNXdkYmRib1FTZTl2R09Ld2FKR0F3");
+            boolean requestIdAlreadyPresent = randomBoolean();
+            SetOnce<String> reqId = new SetOnce<>();
+            if (requestIdAlreadyPresent) {
+                reqId.set(AuditUtil.getOrGenerateRequestId(threadContext));
+            }
+            final String bearerString = "AAEAAWVsYXN0aWMvZmxlZXQtc2VydmVyL3Rva2VuMTpyNXdkYmRib1FTZTl2R09Ld2FKR0F3";
+            threadContext.putHeader("Authorization", "Bearer " + bearerString);
             doAnswer(invocationOnMock -> {
                 @SuppressWarnings("unchecked")
                 final ActionListener<Authentication> listener = (ActionListener<Authentication>) invocationOnMock.getArguments()[2];
                 listener.onFailure(bailOut);
                 return null;
             }).when(serviceAccountService).authenticateToken(any(), any(), any());
-            final PlainActionFuture<Authentication> future = new PlainActionFuture<>();
-            service.authenticate("_action", transportRequest, false, future);
-            final ExecutionException e = expectThrows(ExecutionException.class, () -> future.get());
-            assertThat(e.getCause().getCause(), is(bailOut));
+            final ElasticsearchSecurityException e = expectThrows(ElasticsearchSecurityException.class,
+                () -> authenticateBlocking("_action", transportRequest, null));
+            if (requestIdAlreadyPresent) {
+                assertThat(expectAuditRequestId(threadContext), is(reqId.get()));
+            } else {
+                reqId.set(expectAuditRequestId(threadContext));
+            }
+            assertThat(e, sameInstance(bailOut));
+            verifyZeroInteractions(operatorPrivilegesService);
+            final ServiceAccountToken serviceToken = ServiceAccountToken.fromBearerString(new SecureString(bearerString.toCharArray()));
+            verify(auditTrail).authenticationFailed(eq(reqId.get()), eq(serviceToken), eq("_action"), eq(transportRequest));
         }
     }
 

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/AuthenticationServiceTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/AuthenticationServiceTests.java
@@ -1915,7 +1915,8 @@ public class AuthenticationServiceTests extends ESTestCase {
         final Authentication authentication = new Authentication(
             new User("elastic/fleet-server"),
             new RealmRef("service_account", "service_account", "foo"), null,
-            Version.CURRENT, AuthenticationType.TOKEN, Map.of("_token_name", ValidationTests.randomTokenName()));
+            Version.CURRENT, AuthenticationType.TOKEN,
+            org.elasticsearch.common.collect.Map.of("_token_name", ValidationTests.randomTokenName()));
         try (ThreadContext.StoredContext ignored = threadContext.newStoredContext(false)) {
             boolean requestIdAlreadyPresent = randomBoolean();
             SetOnce<String> reqId = new SetOnce<>();


### PR DESCRIPTION
This PR ensure existing auditing tests cover service account authentication.
It makes sure compatible existing fields also work for service accounts.