### PR TITLE
Improve reusability of the cache invalidation counter (#66310)

### DIFF
--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/Security.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/Security.java
@@ -523,13 +523,13 @@ public class Security extends Plugin implements SystemIndexPlugin, IngestPlugin,
 
         securityIndex.get().addIndexStateListener(nativeRoleMappingStore::onSecurityIndexStateChange);
 
-        final NativePrivilegeStore privilegeStore = new NativePrivilegeStore(settings, client, securityIndex.get());
-        components.add(privilegeStore);
-        securityIndex.get().addIndexStateListener(privilegeStore::onSecurityIndexStateChange);
-
         final CacheInvalidatorRegistry cacheInvalidatorRegistry = new CacheInvalidatorRegistry();
         components.add(cacheInvalidatorRegistry);
-        securityIndex.get().addIndexStateListener(cacheInvalidatorRegistry::onSecurityIndexStageChange);
+        securityIndex.get().addIndexStateListener(cacheInvalidatorRegistry::onSecurityIndexStateChange);
+
+        final NativePrivilegeStore privilegeStore =
+            new NativePrivilegeStore(settings, client, securityIndex.get(), cacheInvalidatorRegistry);
+        components.add(privilegeStore);
 
         dlsBitsetCache.set(new DocumentSubsetBitsetCache(settings, threadPool));
         final FieldPermissionsCache fieldPermissionsCache = new FieldPermissionsCache(settings);

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/privilege/TransportClearPrivilegesCacheAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/privilege/TransportClearPrivilegesCacheAction.java
@@ -19,7 +19,7 @@ import org.elasticsearch.xpack.core.security.action.privilege.ClearPrivilegesCac
 import org.elasticsearch.xpack.core.security.action.privilege.ClearPrivilegesCacheRequest;
 import org.elasticsearch.xpack.core.security.action.privilege.ClearPrivilegesCacheResponse;
 import org.elasticsearch.xpack.security.authz.store.CompositeRolesStore;
-import org.elasticsearch.xpack.security.authz.store.NativePrivilegeStore;
+import org.elasticsearch.xpack.security.support.CacheInvalidatorRegistry;
 
 import java.io.IOException;
 import java.util.List;
@@ -27,8 +27,8 @@ import java.util.List;
 public class TransportClearPrivilegesCacheAction extends TransportNodesAction<ClearPrivilegesCacheRequest, ClearPrivilegesCacheResponse,
     ClearPrivilegesCacheRequest.Node, ClearPrivilegesCacheResponse.Node> {
 
-    private final NativePrivilegeStore privilegesStore;
     private final CompositeRolesStore rolesStore;
+    private final CacheInvalidatorRegistry cacheInvalidatorRegistry;
 
     @Inject
     public TransportClearPrivilegesCacheAction(
@@ -36,8 +36,8 @@ public class TransportClearPrivilegesCacheAction extends TransportNodesAction<Cl
         ClusterService clusterService,
         TransportService transportService,
         ActionFilters actionFilters,
-        NativePrivilegeStore privilegesStore,
-        CompositeRolesStore rolesStore) {
+        CompositeRolesStore rolesStore,
+        CacheInvalidatorRegistry cacheInvalidatorRegistry) {
         super(
             ClearPrivilegesCacheAction.NAME,
             threadPool,
@@ -48,8 +48,8 @@ public class TransportClearPrivilegesCacheAction extends TransportNodesAction<Cl
             ClearPrivilegesCacheRequest.Node::new,
             ThreadPool.Names.MANAGEMENT,
             ClearPrivilegesCacheResponse.Node.class);
-        this.privilegesStore = privilegesStore;
         this.rolesStore = rolesStore;
+        this.cacheInvalidatorRegistry = cacheInvalidatorRegistry;
     }
 
     @Override
@@ -71,9 +71,10 @@ public class TransportClearPrivilegesCacheAction extends TransportNodesAction<Cl
     @Override
     protected ClearPrivilegesCacheResponse.Node nodeOperation(ClearPrivilegesCacheRequest.Node request) {
         if (request.getApplicationNames() == null || request.getApplicationNames().length == 0) {
-            privilegesStore.invalidateAll();
+            cacheInvalidatorRegistry.invalidateCache("application_privileges");
         } else {
-            privilegesStore.invalidate(org.elasticsearch.common.collect.List.of(request.getApplicationNames()));
+            cacheInvalidatorRegistry.invalidateByKey("application_privileges",
+                org.elasticsearch.common.collect.List.of(request.getApplicationNames()));
         }
         if (request.clearRolesCache()) {
             rolesStore.invalidateAll();

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/ApiKeyService.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/ApiKeyService.java
@@ -89,10 +89,10 @@ import org.elasticsearch.xpack.core.security.authc.AuthenticationResult;
 import org.elasticsearch.xpack.core.security.authc.support.Hasher;
 import org.elasticsearch.xpack.core.security.authz.RoleDescriptor;
 import org.elasticsearch.xpack.core.security.user.User;
+import org.elasticsearch.xpack.security.support.LockingAtomicCounter;
 import org.elasticsearch.xpack.security.support.CacheInvalidatorRegistry;
 import org.elasticsearch.xpack.security.support.FeatureNotEnabledException;
 import org.elasticsearch.xpack.security.support.FeatureNotEnabledException.Feature;
-import org.elasticsearch.xpack.security.support.InvalidationCountingCacheWrapper;
 import org.elasticsearch.xpack.security.support.SecurityIndexManager;
 
 import javax.crypto.SecretKeyFactory;
@@ -675,7 +675,7 @@ public class ApiKeyService {
     }
 
     // pkg private for testing
-    InvalidationCountingCacheWrapper<String, CachedApiKeyDoc> getDocCache() {
+    Cache<String, CachedApiKeyDoc> getDocCache() {
         return apiKeyDocCache == null ? null : apiKeyDocCache.docCache;
     }
 
@@ -1301,16 +1301,15 @@ public class ApiKeyService {
     }
 
     private static final class ApiKeyDocCache {
-        private final InvalidationCountingCacheWrapper<String, ApiKeyService.CachedApiKeyDoc> docCache;
+        private final Cache<String, ApiKeyService.CachedApiKeyDoc> docCache;
         private final Cache<String, BytesReference> roleDescriptorsBytesCache;
+        private final LockingAtomicCounter lockingAtomicCounter;
 
         ApiKeyDocCache(TimeValue ttl, int maximumWeight) {
-            this.docCache = new InvalidationCountingCacheWrapper<>(
-                CacheBuilder.<String, ApiKeyService.CachedApiKeyDoc>builder()
-                    .setMaximumWeight(maximumWeight)
-                    .setExpireAfterWrite(ttl)
-                    .build()
-            );
+            this.docCache = CacheBuilder.<String, ApiKeyService.CachedApiKeyDoc>builder()
+                .setMaximumWeight(maximumWeight)
+                .setExpireAfterWrite(ttl)
+                .build();
             // We don't use the doc TTL because that TTL is very low to avoid the risk of
             // caching an invalidated API key. But role descriptors are immutable and may be shared between
             // multiple API keys, so we cache for longer and rely on the weight to manage the cache size.
@@ -1318,6 +1317,7 @@ public class ApiKeyService {
                 .setExpireAfterAccess(TimeValue.timeValueHours(1))
                 .setMaximumWeight(maximumWeight * 2)
                 .build();
+            this.lockingAtomicCounter = new LockingAtomicCounter();
         }
 
         public ApiKeyDoc get(String docId) {
@@ -1333,24 +1333,33 @@ public class ApiKeyService {
         }
 
         public long getInvalidationCount() {
-            return docCache.getInvalidationCount();
+            return lockingAtomicCounter.get();
         }
 
-        public void putIfNoInvalidationSince(String docId, ApiKeyDoc apiKeyDoc, long invalidationCount) throws ExecutionException {
+        public void putIfNoInvalidationSince(String docId, ApiKeyDoc apiKeyDoc, long invalidationCount) {
             final CachedApiKeyDoc cachedApiKeyDoc = apiKeyDoc.toCachedApiKeyDoc();
-            if (docCache.putIfNoInvalidationSince(docId, cachedApiKeyDoc, invalidationCount)) {
-                roleDescriptorsBytesCache.computeIfAbsent(
-                    cachedApiKeyDoc.roleDescriptorsHash, k -> apiKeyDoc.roleDescriptorsBytes);
-                roleDescriptorsBytesCache.computeIfAbsent(
-                    cachedApiKeyDoc.limitedByRoleDescriptorsHash, k -> apiKeyDoc.limitedByRoleDescriptorsBytes);
-            }
+            lockingAtomicCounter.compareAndRun(invalidationCount, () -> {
+                docCache.put(docId, cachedApiKeyDoc);
+                try {
+                    roleDescriptorsBytesCache.computeIfAbsent(
+                        cachedApiKeyDoc.roleDescriptorsHash, k -> apiKeyDoc.roleDescriptorsBytes);
+                    roleDescriptorsBytesCache.computeIfAbsent(
+                        cachedApiKeyDoc.limitedByRoleDescriptorsHash, k -> apiKeyDoc.limitedByRoleDescriptorsBytes);
+                } catch (ExecutionException e) {
+                    throw new RuntimeException(e);
+                }
+            });
         }
 
         public void invalidate(Collection<String> docIds) {
-            docCache.invalidate(docIds);
+            lockingAtomicCounter.increment();
+            logger.debug("Invalidating API key doc cache with ids: [{}]", Strings.collectionToCommaDelimitedString(docIds));
+            docIds.forEach(docCache::invalidate);
         }
 
         public void invalidateAll() {
+            lockingAtomicCounter.increment();
+            logger.debug("Invalidating all API key doc cache and descriptor cache");
             docCache.invalidateAll();
             roleDescriptorsBytesCache.invalidateAll();
         }

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/store/NativePrivilegeStore.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/store/NativePrivilegeStore.java
@@ -29,7 +29,6 @@ import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.util.CollectionUtils;
-import org.elasticsearch.common.util.concurrent.ReleasableLock;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.common.xcontent.LoggingDeprecationHandler;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
@@ -48,6 +47,8 @@ import org.elasticsearch.xpack.core.security.action.privilege.ClearPrivilegesCac
 import org.elasticsearch.xpack.core.security.action.privilege.ClearPrivilegesCacheRequest;
 import org.elasticsearch.xpack.core.security.action.privilege.ClearPrivilegesCacheResponse;
 import org.elasticsearch.xpack.core.security.authz.privilege.ApplicationPrivilegeDescriptor;
+import org.elasticsearch.xpack.security.support.CacheInvalidatorRegistry;
+import org.elasticsearch.xpack.security.support.LockingAtomicCounter;
 import org.elasticsearch.xpack.security.support.SecurityIndexManager;
 
 import java.io.IOException;
@@ -57,11 +58,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Set;
-import java.util.concurrent.atomic.AtomicLong;
-import java.util.concurrent.locks.ReadWriteLock;
-import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.function.Supplier;
 import java.util.stream.Collector;
 import java.util.stream.Collectors;
@@ -74,8 +71,6 @@ import static org.elasticsearch.xpack.core.ClientHelper.executeAsyncWithOrigin;
 import static org.elasticsearch.xpack.core.security.authz.privilege.ApplicationPrivilegeDescriptor.DOC_TYPE_VALUE;
 import static org.elasticsearch.xpack.core.security.authz.privilege.ApplicationPrivilegeDescriptor.Fields.APPLICATION;
 import static org.elasticsearch.xpack.core.security.index.RestrictedIndicesNames.SECURITY_MAIN_ALIAS;
-import static org.elasticsearch.xpack.security.support.SecurityIndexManager.isIndexDeleted;
-import static org.elasticsearch.xpack.security.support.SecurityIndexManager.isMoveFromRedToNonRed;
 
 /**
  * {@code NativePrivilegeStore} is a store that reads/writes {@link ApplicationPrivilegeDescriptor} objects,
@@ -102,36 +97,22 @@ public class NativePrivilegeStore {
     private final Settings settings;
     private final Client client;
     private final SecurityIndexManager securityIndexManager;
-    private final Cache<String, Set<ApplicationPrivilegeDescriptor>> descriptorsCache;
-    private final Cache<Set<String>, Set<String>> applicationNamesCache;
-    private final AtomicLong numInvalidation = new AtomicLong();
-    private final ReadWriteLock invalidationLock = new ReentrantReadWriteLock();
-    private final ReleasableLock invalidationReadLock = new ReleasableLock(invalidationLock.readLock());
-    private final ReleasableLock invalidationWriteLock = new ReleasableLock(invalidationLock.writeLock());
+    private final DescriptorsAndApplicationNamesCache descriptorsAndApplicationNamesCache;
 
 
-    public NativePrivilegeStore(Settings settings, Client client, SecurityIndexManager securityIndexManager) {
+    public NativePrivilegeStore(
+        Settings settings, Client client, SecurityIndexManager securityIndexManager, CacheInvalidatorRegistry cacheInvalidatorRegistry) {
         this.settings = settings;
         this.client = client;
         this.securityIndexManager = securityIndexManager;
         final TimeValue ttl = CACHE_TTL_SETTING.get(settings);
         if (ttl.getNanos() > 0) {
-            final int cacheSize = CACHE_MAX_APPLICATIONS_SETTING.get(settings);
-            descriptorsCache = CacheBuilder.<String, Set<ApplicationPrivilegeDescriptor>>builder()
-                .setMaximumWeight(cacheSize)
-                .weigher((k, v) -> v.size())
-                .setExpireAfterWrite(ttl).build();
-            applicationNamesCache = CacheBuilder.<Set<String>, Set<String>>builder()
-                .setMaximumWeight(cacheSize)
-                .weigher((k, v) -> k.size() + v.size())
-                .setExpireAfterWrite(ttl).build();
+            descriptorsAndApplicationNamesCache = new DescriptorsAndApplicationNamesCache(
+                ttl, CACHE_MAX_APPLICATIONS_SETTING.get(settings));
+            cacheInvalidatorRegistry.registerCacheInvalidator("application_privileges", descriptorsAndApplicationNamesCache);
         } else {
-            descriptorsCache = null;
-            applicationNamesCache = null;
+            descriptorsAndApplicationNamesCache = null;
         }
-        assert (descriptorsCache == null && applicationNamesCache == null)
-            || (descriptorsCache != null && applicationNamesCache != null)
-            : "descriptor and application names cache must be enabled or disabled together";
     }
 
     public void getPrivileges(Collection<String> applications, Collection<String> names,
@@ -142,7 +123,8 @@ public class NativePrivilegeStore {
 
         // Always fetch for the concrete application names even when the passed-in application names has no wildcard.
         // This serves as a negative lookup, i.e. when a passed-in non-wildcard application does not exist.
-        Set<String> concreteApplicationNames = applicationNamesCache == null ? null : applicationNamesCache.get(applicationNamesCacheKey);
+        Set<String> concreteApplicationNames = descriptorsAndApplicationNamesCache == null ? null
+            : descriptorsAndApplicationNamesCache.getConcreteApplicationNames(applicationNamesCacheKey);
 
         if (concreteApplicationNames != null && concreteApplicationNames.isEmpty()) {
             logger.debug("returning empty application privileges for [{}] as application names result in empty list",
@@ -155,21 +137,15 @@ public class NativePrivilegeStore {
                 logger.debug("All application privileges for [{}] found in cache", applicationNamesCacheKey);
                 listener.onResponse(filterDescriptorsForPrivilegeNames(cachedDescriptors, names));
             } else {
-                final long invalidationCounter = numInvalidation.get();
                 // Always fetch all privileges of an application for caching purpose
                 logger.debug("Fetching application privilege documents for: {}", applicationNamesCacheKey);
+                final long invalidationCount =
+                    descriptorsAndApplicationNamesCache == null ? -1 : descriptorsAndApplicationNamesCache.getInvalidationCount();
                 innerGetPrivileges(applicationNamesCacheKey, ActionListener.wrap(fetchedDescriptors -> {
                     final Map<String, Set<ApplicationPrivilegeDescriptor>> mapOfFetchedDescriptors = fetchedDescriptors.stream()
                         .collect(Collectors.groupingBy(ApplicationPrivilegeDescriptor::getApplication, Collectors.toSet()));
-                    if (descriptorsCache != null) {
-                        // Use RWLock and atomic counter to:
-                        // 1. Avoid caching potential stale results as much as possible
-                        // 2. If stale results are cached, ensure they will be invalidated as soon as possible
-                        try (ReleasableLock ignored = invalidationReadLock.acquire()) {
-                            if (invalidationCounter == numInvalidation.get()) {
-                                cacheFetchedDescriptors(applicationNamesCacheKey, mapOfFetchedDescriptors);
-                            }
-                        }
+                    if (invalidationCount != -1) {
+                        cacheFetchedDescriptors(applicationNamesCacheKey, mapOfFetchedDescriptors, invalidationCount);
                     }
                     listener.onResponse(filterDescriptorsForPrivilegeNames(fetchedDescriptors, names));
                 }, listener::onFailure));
@@ -277,7 +253,7 @@ public class NativePrivilegeStore {
      * name, this means any wildcard will result in null.
      */
     private Set<ApplicationPrivilegeDescriptor> cachedDescriptorsForApplicationNames(Set<String> applicationNames) {
-        if (descriptorsCache == null) {
+        if (descriptorsAndApplicationNamesCache == null) {
             return null;
         }
         final Set<ApplicationPrivilegeDescriptor> cachedDescriptors = new HashSet<>();
@@ -285,7 +261,8 @@ public class NativePrivilegeStore {
             if (applicationName.endsWith("*")) {
                 return null;
             } else {
-                final Set<ApplicationPrivilegeDescriptor> descriptors = descriptorsCache.get(applicationName);
+                final Set<ApplicationPrivilegeDescriptor> descriptors =
+                    descriptorsAndApplicationNamesCache.getApplicationDescriptors(applicationName);
                 if (descriptors == null) {
                     return null;
                 } else {
@@ -310,17 +287,10 @@ public class NativePrivilegeStore {
 
     // protected for tests
     protected void cacheFetchedDescriptors(Set<String> applicationNamesCacheKey,
-        Map<String, Set<ApplicationPrivilegeDescriptor>> mapOfFetchedDescriptors) {
-        final Set<String> fetchedApplicationNames = Collections.unmodifiableSet(mapOfFetchedDescriptors.keySet());
-        // Do not cache the names if expansion has no effect
-        if (fetchedApplicationNames.equals(applicationNamesCacheKey) == false) {
-            logger.debug("Caching application names query: {} = {}", applicationNamesCacheKey, fetchedApplicationNames);
-            applicationNamesCache.put(applicationNamesCacheKey, fetchedApplicationNames);
-        }
-        for (Map.Entry<String, Set<ApplicationPrivilegeDescriptor>> entry : mapOfFetchedDescriptors.entrySet()) {
-            logger.debug("Caching descriptors for application: {}", entry.getKey());
-            descriptorsCache.put(entry.getKey(), entry.getValue());
-        }
+                                           Map<String, Set<ApplicationPrivilegeDescriptor>> mapOfFetchedDescriptors,
+                                           long invalidationCount) {
+        descriptorsAndApplicationNamesCache.putIfNoInvalidationSince(applicationNamesCacheKey, mapOfFetchedDescriptors,
+            invalidationCount);
     }
 
     public void putPrivileges(Collection<ApplicationPrivilegeDescriptor> privileges, WriteRequest.RefreshPolicy refreshPolicy,
@@ -420,62 +390,92 @@ public class NativePrivilegeStore {
         return DOC_TYPE_VALUE + "_" + application + ":" + name;
     }
 
-    public void onSecurityIndexStateChange(SecurityIndexManager.State previousState, SecurityIndexManager.State currentState) {
-        if (isMoveFromRedToNonRed(previousState, currentState)
-            || isIndexDeleted(previousState, currentState)
-            || Objects.equals(previousState.indexUUID, currentState.indexUUID) == false
-            || previousState.isIndexUpToDate != currentState.isIndexUpToDate) {
-            invalidateAll();
-        }
-    }
-
-    public void invalidate(Collection<String> updatedApplicationNames) {
-        if (descriptorsCache == null) {
-            return;
-        }
-        // Increment the invalidation count to avoid caching stale results
-        // Release the lock as soon as we increment the counter so the actual invalidation
-        // does not have to block other threads. In theory, there could be very rare edge
-        // cases that we would invalidate more than necessary. But we consider less locking
-        // duration is overall better.
-        try (ReleasableLock ignored = invalidationWriteLock.acquire()) {
-            numInvalidation.incrementAndGet();
-        }
-        logger.debug("Invalidating application privileges caches for: {}", updatedApplicationNames);
-        final Set<String> uniqueNames = org.elasticsearch.common.collect.Set.copyOf(updatedApplicationNames);
-        // Always completely invalidate application names cache due to wildcard
-        applicationNamesCache.invalidateAll();
-        uniqueNames.forEach(descriptorsCache::invalidate);
-    }
-
-    public void invalidateAll() {
-        if (descriptorsCache == null) {
-            return;
-        }
-        try (ReleasableLock ignored = invalidationWriteLock.acquire()) {
-            numInvalidation.incrementAndGet();
-        }
-        logger.debug("Invalidating all application privileges caches");
-        applicationNamesCache.invalidateAll();
-        descriptorsCache.invalidateAll();
-    }
-
     private static boolean isEmpty(Collection<String> collection) {
         return collection == null || collection.isEmpty();
     }
 
     // Package private for tests
+    DescriptorsAndApplicationNamesCache getDescriptorsAndApplicationNamesCache() {
+        return descriptorsAndApplicationNamesCache;
+    }
+
+    // Package private for tests
     Cache<Set<String>, Set<String>> getApplicationNamesCache() {
-        return applicationNamesCache;
+        return descriptorsAndApplicationNamesCache == null ? null : descriptorsAndApplicationNamesCache.applicationNamesCache;
     }
 
     // Package private for tests
     Cache<String, Set<ApplicationPrivilegeDescriptor>> getDescriptorsCache() {
-        return descriptorsCache;
+        return descriptorsAndApplicationNamesCache == null ? null : descriptorsAndApplicationNamesCache.descriptorsCache;
     }
 
     // Package private for tests
-    AtomicLong getNumInvalidation() {
-        return numInvalidation;
+    long getNumInvalidation() {
+        return descriptorsAndApplicationNamesCache.getInvalidationCount();
+    }
+
+    static final class DescriptorsAndApplicationNamesCache implements CacheInvalidatorRegistry.CacheInvalidator {
+        private final Cache<String, Set<ApplicationPrivilegeDescriptor>> descriptorsCache;
+        private final Cache<Set<String>, Set<String>> applicationNamesCache;
+        private final LockingAtomicCounter lockingAtomicCounter;
+
+        DescriptorsAndApplicationNamesCache(TimeValue ttl, int cacheSize) {
+            this.descriptorsCache = CacheBuilder.<String, Set<ApplicationPrivilegeDescriptor>>builder()
+                .setMaximumWeight(cacheSize)
+                .weigher((k, v) -> v.size())
+                .setExpireAfterWrite(ttl)
+                .build();
+            this.applicationNamesCache = CacheBuilder.<Set<String>, Set<String>>builder()
+                .setMaximumWeight(cacheSize)
+                .weigher((k, v) -> k.size() + v.size())
+                .setExpireAfterWrite(ttl)
+                .build();
+            this.lockingAtomicCounter = new LockingAtomicCounter();
+        }
+
+        public Set<ApplicationPrivilegeDescriptor> getApplicationDescriptors(String applicationName) {
+            return descriptorsCache.get(applicationName);
+        }
+
+        public Set<String> getConcreteApplicationNames(Set<String> applicationNames) {
+            return applicationNamesCache.get(applicationNames);
+        }
+
+        public void putIfNoInvalidationSince(Set<String> applicationNamesCacheKey,
+                                             Map<String, Set<ApplicationPrivilegeDescriptor>> mapOfFetchedDescriptors,
+                                             long invalidationCount) {
+            lockingAtomicCounter.compareAndRun(invalidationCount, () -> {
+                final Set<String> fetchedApplicationNames = Collections.unmodifiableSet(mapOfFetchedDescriptors.keySet());
+                // Do not cache the names if expansion has no effect
+                if (fetchedApplicationNames.equals(applicationNamesCacheKey) == false) {
+                    logger.debug("Caching application names query: {} = {}", applicationNamesCacheKey, fetchedApplicationNames);
+                    applicationNamesCache.put(applicationNamesCacheKey, fetchedApplicationNames);
+                }
+                for (Map.Entry<String, Set<ApplicationPrivilegeDescriptor>> entry : mapOfFetchedDescriptors.entrySet()) {
+                    logger.debug("Caching descriptors for application: {}", entry.getKey());
+                    descriptorsCache.put(entry.getKey(), entry.getValue());
+                }
+            });
+        }
+
+        public long getInvalidationCount() {
+            return lockingAtomicCounter.get();
+        }
+
+        public void invalidate(Collection<String> updatedApplicationNames) {
+            lockingAtomicCounter.increment();
+            logger.debug("Invalidating application privileges caches for: {}", updatedApplicationNames);
+            final Set<String> uniqueNames = org.elasticsearch.common.collect.Set.copyOf(updatedApplicationNames);
+            // Always completely invalidate application names cache due to wildcard
+            applicationNamesCache.invalidateAll();
+            updatedApplicationNames.forEach(descriptorsCache::invalidate);
+        }
+
+        public void invalidateAll() {
+            lockingAtomicCounter.increment();
+            logger.debug("Invalidating all application privileges caches");
+            applicationNamesCache.invalidateAll();
+            descriptorsCache.invalidateAll();
+        }
     }
 }

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/rest/action/privilege/RestClearPrivilegesCacheAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/rest/action/privilege/RestClearPrivilegesCacheAction.java
@@ -12,8 +12,8 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.license.XPackLicenseState;
 import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.rest.action.RestActions.NodesResponseRestListener;
-import org.elasticsearch.xpack.core.security.action.privilege.ClearPrivilegesCacheAction;
-import org.elasticsearch.xpack.core.security.action.privilege.ClearPrivilegesCacheRequest;
+import org.elasticsearch.xpack.core.security.action.ClearSecurityCacheAction;
+import org.elasticsearch.xpack.core.security.action.ClearSecurityCacheRequest;
 import org.elasticsearch.xpack.security.rest.action.SecurityBaseRestHandler;
 
 import java.io.IOException;
@@ -40,8 +40,9 @@ public class RestClearPrivilegesCacheAction extends SecurityBaseRestHandler {
     @Override
     protected RestChannelConsumer innerPrepareRequest(RestRequest request, NodeClient client) throws IOException {
         String[] applicationNames = request.paramAsStringArrayOrEmptyIfAll("application");
-        final ClearPrivilegesCacheRequest req = new ClearPrivilegesCacheRequest().applicationNames(applicationNames);
-        return channel -> client.execute(ClearPrivilegesCacheAction.INSTANCE, req, new NodesResponseRestListener<>(channel));
+        final ClearSecurityCacheRequest req =
+            new ClearSecurityCacheRequest().cacheName("application_privileges").keys(applicationNames);
+        return channel -> client.execute(ClearSecurityCacheAction.INSTANCE, req, new NodesResponseRestListener<>(channel));
     }
 
 }

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/support/CacheInvalidatorRegistry.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/support/CacheInvalidatorRegistry.java
@@ -32,7 +32,7 @@ public class CacheInvalidatorRegistry {
         cacheInvalidators.put(name, cacheInvalidator);
     }
 
-    public void onSecurityIndexStageChange(SecurityIndexManager.State previousState, SecurityIndexManager.State currentState) {
+    public void onSecurityIndexStateChange(SecurityIndexManager.State previousState, SecurityIndexManager.State currentState) {
         if (isMoveFromRedToNonRed(previousState, currentState)
             || isIndexDeleted(previousState, currentState)
             || Objects.equals(previousState.indexUUID, currentState.indexUUID) == false

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/support/LockingAtomicCounter.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/support/LockingAtomicCounter.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+package org.elasticsearch.xpack.security.support;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.elasticsearch.common.util.concurrent.ReleasableLock;
+
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+
+/**
+ * An utility class that keeps an internal counter to ensure given runnable is only executed
+ * when the counter matches the expected value. It also ensures that the counter value
+ * do not change while the runnable is executing. This is done by applying a RW lock when
+ * reading and writing (increment) to the counter.
+ */
+public class LockingAtomicCounter {
+
+    private static final Logger logger = LogManager.getLogger(LockingAtomicCounter.class);
+
+    private final AtomicLong counter = new AtomicLong();
+    private final ReadWriteLock countingLock = new ReentrantReadWriteLock();
+    private final ReleasableLock countingReadLock = new ReleasableLock(countingLock.readLock());
+    private final ReleasableLock countingWriteLock = new ReleasableLock(countingLock.writeLock());
+
+    public long get() {
+        return counter.get();
+    }
+
+    /**
+     * Execute the given runnable if the internal counter matches the given count.
+     * The counter check is performed inside a read-locking block to prevent the counter
+     * value from changing (i.e. block the call to {@link LockingAtomicCounter#increment()}.
+     * This method is in concept similar to {@link AtomicLong#compareAndSet}. Instead of
+     * a single "setValue" operation, this method takes any Runnable and ensure that
+     * the counter value do not change while the runnable is executing.
+     *
+     * Because it uses a readLock, it does *not* block other invocations of
+     * {@link LockingAtomicCounter#compareAndRun}.
+     *
+     * @return true if the runnable is executed, other false.
+     */
+    public boolean compareAndRun(long count, Runnable runnable) {
+        assert count >= 0 : "Count must be non-negative";
+        try (ReleasableLock ignored = countingReadLock.acquire()) {
+            if (count == counter.get()) {
+                logger.debug("Count matches [{}], executing runnable", count);
+                runnable.run();
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Increment the internal counter in the writeLock so it will be blocked if any invocation
+     * of {@link LockingAtomicCounter#compareAndRun} is already underway.
+     */
+    public void increment() {
+        try (ReleasableLock ignored = countingWriteLock.acquire()) {
+            counter.incrementAndGet();
+        }
+    }
+}

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/store/NativePrivilegeStoreTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/store/NativePrivilegeStoreTests.java
@@ -40,6 +40,7 @@ import org.elasticsearch.test.client.NoOpClient;
 import org.elasticsearch.xpack.core.security.action.privilege.ClearPrivilegesCacheRequest;
 import org.elasticsearch.xpack.core.security.authz.privilege.ApplicationPrivilegeDescriptor;
 import org.elasticsearch.xpack.core.security.index.RestrictedIndicesNames;
+import org.elasticsearch.xpack.security.support.CacheInvalidatorRegistry;
 import org.elasticsearch.xpack.security.support.SecurityIndexManager;
 import org.junit.After;
 import org.junit.Before;
@@ -88,6 +89,7 @@ public class NativePrivilegeStoreTests extends ESTestCase {
     private AtomicReference<ActionListener> listener;
     private Client client;
     private SecurityIndexManager securityIndex;
+    private CacheInvalidatorRegistry cacheInvalidatorRegistry;
 
     @Before
     public void setup() {
@@ -117,7 +119,8 @@ public class NativePrivilegeStoreTests extends ESTestCase {
             ((Runnable) invocationOnMock.getArguments()[1]).run();
             return null;
         }).when(securityIndex).checkIndexVersionThenExecute(any(Consumer.class), any(Runnable.class));
-        store = new NativePrivilegeStore(Settings.EMPTY, client, securityIndex);
+        cacheInvalidatorRegistry = new CacheInvalidatorRegistry();
+        store = new NativePrivilegeStore(Settings.EMPTY, client, securityIndex, cacheInvalidatorRegistry);
     }
 
     @After
@@ -387,7 +390,7 @@ public class NativePrivilegeStoreTests extends ESTestCase {
         store.getPrivileges(null, null, future);
 
         // Before the results can be cached, invalidate the cache to simulate stale search results
-        store.invalidateAll();
+        store.getDescriptorsAndApplicationNamesCache().invalidateAll();
         final SearchHit[] hits = buildHits(sourcePrivileges);
         listener.get().onResponse(new SearchResponse(new SearchResponseSections(
             new SearchHits(hits, new TotalHits(hits.length, TotalHits.Relation.EQUAL_TO), 0f),
@@ -411,10 +414,12 @@ public class NativePrivilegeStoreTests extends ESTestCase {
         // Hence the cache invalidation will be block at acquiring the write lock.
         // This simulates the scenario when stale results are cached just before the invalidation call arrives.
         // In this case, we guarantee the cache will be invalidate and the stale results won't stay for long.
-        final NativePrivilegeStore store1 = new NativePrivilegeStore(Settings.EMPTY, client, securityIndex) {
+        final NativePrivilegeStore store1 =
+            new NativePrivilegeStore(Settings.EMPTY, client, securityIndex, new CacheInvalidatorRegistry()) {
             @Override
-            protected void cacheFetchedDescriptors(
-                Set<String> applicationNamesCacheKey, Map<String, Set<ApplicationPrivilegeDescriptor>> mapOfFetchedDescriptors) {
+            protected void cacheFetchedDescriptors(Set<String> applicationNamesCacheKey,
+                                                   Map<String, Set<ApplicationPrivilegeDescriptor>> mapOfFetchedDescriptors,
+                                                   long invalidationCount) {
                 getPrivilegeCountDown.countDown();
                 try {
                     // wait till the invalidation call is at the door step
@@ -422,7 +427,7 @@ public class NativePrivilegeStoreTests extends ESTestCase {
                 } catch (InterruptedException e) {
                     throw new RuntimeException(e);
                 }
-                super.cacheFetchedDescriptors(applicationNamesCacheKey, mapOfFetchedDescriptors);
+                super.cacheFetchedDescriptors(applicationNamesCacheKey, mapOfFetchedDescriptors, invalidationCount);
                 // Assert that cache is successful
                 assertEquals(1, getApplicationNamesCache().count());
                 assertEquals(1, getDescriptorsCache().count());
@@ -442,7 +447,7 @@ public class NativePrivilegeStoreTests extends ESTestCase {
         new Thread(() -> {
             // Let the caching proceed
             invalidationCountDown.countDown();
-            store.invalidateAll();
+            store.getDescriptorsAndApplicationNamesCache().invalidateAll();
         }).start();
         // The cache should be cleared
         assertEquals(0, store.getApplicationNamesCache().count());
@@ -543,7 +548,7 @@ public class NativePrivilegeStoreTests extends ESTestCase {
             singleton(new ApplicationPrivilegeDescriptor("app-1", "read", emptySet(), emptyMap())));
         store.getDescriptorsCache().put("app-2",
             singleton(new ApplicationPrivilegeDescriptor("app-2", "read", emptySet(), emptyMap())));
-        store.invalidate(singletonList("app-1"));
+        store.getDescriptorsAndApplicationNamesCache().invalidate(singletonList("app-1"));
         assertEquals(0, store.getApplicationNamesCache().count());
         assertEquals(1, store.getDescriptorsCache().count());
     }
@@ -554,7 +559,7 @@ public class NativePrivilegeStoreTests extends ESTestCase {
             singleton(new ApplicationPrivilegeDescriptor("app-1", "read", emptySet(), emptyMap())));
         store.getDescriptorsCache().put("app-2",
             singleton(new ApplicationPrivilegeDescriptor("app-2", "read", emptySet(), emptyMap())));
-        store.invalidateAll();
+        store.getDescriptorsAndApplicationNamesCache().invalidateAll();
         assertEquals(0, store.getApplicationNamesCache().count());
         assertEquals(0, store.getDescriptorsCache().count());
     }
@@ -563,39 +568,40 @@ public class NativePrivilegeStoreTests extends ESTestCase {
         final String securityIndexName = randomFrom(
             RestrictedIndicesNames.INTERNAL_SECURITY_MAIN_INDEX_6, RestrictedIndicesNames.INTERNAL_SECURITY_MAIN_INDEX_7);
 
-        long count = store.getNumInvalidation().get();
+        long count = store.getNumInvalidation();
 
         // Cache should be cleared when security is back to green
-        store.onSecurityIndexStateChange(
+        cacheInvalidatorRegistry.onSecurityIndexStateChange(
             dummyState(securityIndexName, true, randomFrom((ClusterHealthStatus) null, ClusterHealthStatus.RED)),
             dummyState(securityIndexName, true, randomFrom(ClusterHealthStatus.GREEN, ClusterHealthStatus.YELLOW)));
-        assertEquals(++count, store.getNumInvalidation().get());
+        assertEquals(++count, store.getNumInvalidation());
 
         // Cache should be cleared when security is deleted
-        store.onSecurityIndexStateChange(
+        cacheInvalidatorRegistry.onSecurityIndexStateChange(
             dummyState(securityIndexName, true, randomFrom(ClusterHealthStatus.values())),
             dummyState(securityIndexName, true, null));
-        assertEquals(++count, store.getNumInvalidation().get());
+        assertEquals(++count, store.getNumInvalidation());
 
         // Cache should be cleared if indexUpToDate changed
         final boolean isIndexUpToDate = randomBoolean();
         final List<ClusterHealthStatus> allPossibleHealthStatus =
                 CollectionUtils.appendToCopy(Arrays.asList(ClusterHealthStatus.values()), null);
-        store.onSecurityIndexStateChange(
+        cacheInvalidatorRegistry.onSecurityIndexStateChange(
             dummyState(securityIndexName, isIndexUpToDate, randomFrom(allPossibleHealthStatus)),
             dummyState(securityIndexName, isIndexUpToDate == false, randomFrom(allPossibleHealthStatus)));
-        assertEquals(++count, store.getNumInvalidation().get());
+        assertEquals(++count, store.getNumInvalidation());
     }
 
     public void testCacheWillBeDisabledWhenTtlIsZero() {
         final Settings settings = Settings.builder().put("xpack.security.authz.store.privileges.cache.ttl", 0).build();
-        final NativePrivilegeStore store1 = new NativePrivilegeStore(settings, client, securityIndex);
+        final NativePrivilegeStore store1 = new NativePrivilegeStore(settings, client, securityIndex, new CacheInvalidatorRegistry());
         assertNull(store1.getApplicationNamesCache());
         assertNull(store1.getDescriptorsCache());
     }
     public void testGetPrivilegesWorkWithoutCache() throws Exception {
         final Settings settings = Settings.builder().put("xpack.security.authz.store.privileges.cache.ttl", 0).build();
-        final NativePrivilegeStore store1 = new NativePrivilegeStore(settings, client, securityIndex);
+        final NativePrivilegeStore store1 = new NativePrivilegeStore(settings, client, securityIndex, new CacheInvalidatorRegistry());
+        assertNull(store1.getDescriptorsAndApplicationNamesCache());
         final List<ApplicationPrivilegeDescriptor> sourcePrivileges = Arrays.asList(
             new ApplicationPrivilegeDescriptor("myapp", "admin", newHashSet("action:admin/*", "action:login", "data:read/*"), emptyMap())
         );
@@ -608,9 +614,6 @@ public class NativePrivilegeStoreTests extends ESTestCase {
             "_scrollId1", 1, 1, 0, 1, null, null));
 
         assertResult(sourcePrivileges, future);
-        // They are no-op but should "work" (pass-through)
-        store1.invalidate(singleton("myapp"));
-        store1.invalidateAll();
     }
 
     private SecurityIndexManager.State dummyState(

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/support/CacheInvalidatorRegistryTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/support/CacheInvalidatorRegistryTests.java
@@ -50,7 +50,7 @@ public class CacheInvalidatorRegistryTests extends ESTestCase {
             Instant.now(), true, true, true, Version.CURRENT,
             ".security", ClusterHealthStatus.GREEN, IndexMetadata.State.OPEN, null, "my_uuid");
 
-        cacheInvalidatorRegistry.onSecurityIndexStageChange(previousState, currentState);
+        cacheInvalidatorRegistry.onSecurityIndexStateChange(previousState, currentState);
         verify(invalidator1).invalidateAll();
         verify(invalidator2).invalidateAll();
     }

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/support/LockingAtomicCounterTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/support/LockingAtomicCounterTests.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+package org.elasticsearch.xpack.security.support;
+
+import org.elasticsearch.test.ESTestCase;
+import org.junit.Before;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.stream.IntStream;
+
+import static org.hamcrest.Matchers.equalTo;
+
+public class LockingAtomicCounterTests extends ESTestCase {
+
+    private LockingAtomicCounter lockingAtomicCounter;
+
+    @Before
+    public void setup() {
+        lockingAtomicCounter = new LockingAtomicCounter();
+    }
+
+    public void testRunnableWillRunIfCountMatches() throws Exception {
+        final AtomicBoolean done = new AtomicBoolean();
+        final long invalidationCount = lockingAtomicCounter.get();
+        assertTrue(lockingAtomicCounter.compareAndRun(invalidationCount, () -> done.set(true)));
+        assertTrue(done.get());
+    }
+
+    public void testIncrementAndRun() {
+        final int loop = randomIntBetween(1, 5);
+        IntStream.range(0, loop).forEach((ignored) -> {
+            try {
+                lockingAtomicCounter.increment();
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        });
+        assertThat((long)loop, equalTo(lockingAtomicCounter.get()));
+    }
+
+    public void testRunnableWillNotRunIfCounterHasChanged() throws Exception {
+        final AtomicBoolean done = new AtomicBoolean();
+        final long invalidationCount = lockingAtomicCounter.get();
+        final CountDownLatch countDownLatch = new CountDownLatch(1);
+        new Thread(() -> {
+            try {
+                lockingAtomicCounter.increment();
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+            countDownLatch.countDown();
+        }).start();
+        countDownLatch.await();
+        assertFalse(lockingAtomicCounter.compareAndRun(invalidationCount, () -> done.set(true)));
+        assertFalse(done.get());
+    }
+}


### PR DESCRIPTION
This PR is a follow-up refactoring for #59376. It replaces
InvalidationCountingCacheWrapper with a simpler and more resuable
LockingAtomicCounter.

The change includes extracting the logic of "minimizing chance of caching stale
results" into a new class, which is now generic and not tied to any cache
related operations. This in turn allows it to be reused by different caches,
which often have subtle, important and anonying differences that make it
impossible (or at least cubersome and painful) to have a generic solution. So
this change of reducing the size of reusable code is the right move.

As an example of applying this new pattern, the caches for NativePrivilegeStore
are now migrated and managed by the centrialied CacheInvalidatorRegistry. The
clear privilege cache rest and transport actions are also updated to use the
new implementation. The Request/Response classes are intentionally untouched
and plan to have a separate PR to address them because they would involve user
visible deprecation changes.

Co-authored-by: Albert Zaharovits <albert.zaharovits@elastic.co>

<!--
Thank you for your interest in and contributing to Elasticsearch! There
are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.
-->

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/elasticsearch/blob/master/CONTRIBUTING.md)?
- If submitting code, have you built your formula locally prior to submission with `gradle check`?
- If submitting code, is your pull request against master? Unless there is a good reason otherwise, we prefer pull requests against master and will backport as needed.
- If submitting code, have you checked that your submission is for an [OS and architecture that we support](https://www.elastic.co/support/matrix#show_os)?
- If you are submitting this code for a class then read our [policy](https://github.com/elastic/elasticsearch/blob/master/CONTRIBUTING.md#contributing-as-part-of-a-class) for that.
