### PR TITLE
Vector Tiles: add a more generic way of building meta layer

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/util/Maps.java
+++ b/server/src/main/java/org/elasticsearch/common/util/Maps.java
@@ -11,8 +11,10 @@ package org.elasticsearch.common.util;
 import org.elasticsearch.Assertions;
 
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
+import java.util.TreeMap;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -125,4 +127,23 @@ public class Maps {
                 .allMatch(e -> right.containsKey(e.getKey()) && Objects.deepEquals(e.getValue(), right.get(e.getKey())));
     }
 
+    public static Map<String, Object> flatten(Map<String, Object> map, boolean ordered) {
+        return flatten(map, ordered, null);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Map<String, Object> flatten(Map<String, Object> map, boolean ordered, String parentPath) {
+        Map<String, Object> flatMap = ordered ? new TreeMap() : new HashMap<>();
+        String prefix = parentPath != null ? parentPath + "." : "";
+
+        for (Map.Entry<String, Object> entry : map.entrySet()) {
+            if (entry.getValue() instanceof Map) {
+                flatMap.putAll(flatten((Map<String, Object>) entry.getValue(), ordered, prefix + entry.getKey()));
+            } else {
+                flatMap.put(prefix + entry.getKey(), entry.getValue());
+            }
+        }
+
+        return flatMap;
+    }
 }

--- a/x-pack/plugin/spatial/src/yamlRestTest/java/org/elasticsearch/xpack/spatial/VectorTileRestIT.java
+++ b/x-pack/plugin/spatial/src/yamlRestTest/java/org/elasticsearch/xpack/spatial/VectorTileRestIT.java
@@ -132,7 +132,7 @@ public class VectorTileRestIT extends ESRestTestCase {
         assertThat(tile.getLayersCount(), Matchers.equalTo(3));
         assertLayer(tile, HITS_LAYER, 4096, 33, 1);
         assertLayer(tile, AGGS_LAYER, 4096, 1, 1);
-        assertLayer(tile, META_LAYER, 4096, 1, 7);
+        assertLayer(tile, META_LAYER, 4096, 1, 11);
 
     }
 
@@ -141,7 +141,7 @@ public class VectorTileRestIT extends ESRestTestCase {
         final Request mvtRequest = new Request(HttpGet.METHOD_NAME, INDEX_POINTS + "/_mvt/location/" + z + "/" + x + "/" + newY);
         final VectorTile.Tile tile = execute(mvtRequest);
         assertThat(tile.getLayersCount(), Matchers.equalTo(1));
-        assertLayer(tile, META_LAYER, 4096, 1, 7);
+        assertLayer(tile, META_LAYER, 4096, 1, 10);
     }
 
     public void testGridPrecision() throws Exception {
@@ -152,7 +152,7 @@ public class VectorTileRestIT extends ESRestTestCase {
             assertThat(tile.getLayersCount(), Matchers.equalTo(3));
             assertLayer(tile, HITS_LAYER, 4096, 33, 1);
             assertLayer(tile, AGGS_LAYER, 4096, 1, 1);
-            assertLayer(tile, META_LAYER, 4096, 1, 7);
+            assertLayer(tile, META_LAYER, 4096, 1, 11);
         }
         {
             final Request mvtRequest = new Request(HttpGet.METHOD_NAME, INDEX_POINTS + "/_mvt/location/" + z + "/" + x + "/" + y);
@@ -170,7 +170,7 @@ public class VectorTileRestIT extends ESRestTestCase {
             assertThat(tile.getLayersCount(), Matchers.equalTo(3));
             assertLayer(tile, HITS_LAYER, 4096, 33, 1);
             assertLayer(tile, AGGS_LAYER, 4096, 1, 1);
-            assertLayer(tile, META_LAYER, 4096, 1, 7);
+            assertLayer(tile, META_LAYER, 4096, 1, 11);
         }
         {
             final Request mvtRequest = new Request(HttpGet.METHOD_NAME, INDEX_POINTS + "/_mvt/location/" + z + "/" + x + "/" + y);
@@ -179,7 +179,7 @@ public class VectorTileRestIT extends ESRestTestCase {
             assertThat(tile.getLayersCount(), Matchers.equalTo(3));
             assertLayer(tile, HITS_LAYER, 4096, 33, 1);
             assertLayer(tile, AGGS_LAYER, 4096, 1, 1);
-            assertLayer(tile, META_LAYER, 4096, 1, 7);
+            assertLayer(tile, META_LAYER, 4096, 1, 11);
         }
         {
             final Request mvtRequest = new Request(HttpGet.METHOD_NAME, INDEX_POINTS + "/_mvt/location/" + z + "/" + x + "/" + y);
@@ -195,7 +195,7 @@ public class VectorTileRestIT extends ESRestTestCase {
         final VectorTile.Tile tile = execute(mvtRequest);
         assertThat(tile.getLayersCount(), Matchers.equalTo(2));
         assertLayer(tile, HITS_LAYER, 4096, 33, 1);
-        assertLayer(tile, META_LAYER, 4096, 1, 7);
+        assertLayer(tile, META_LAYER, 4096, 1, 11);
     }
 
     public void testNoHitsLayer() throws Exception {
@@ -204,7 +204,7 @@ public class VectorTileRestIT extends ESRestTestCase {
         final VectorTile.Tile tile = execute(mvtRequest);
         assertThat(tile.getLayersCount(), Matchers.equalTo(2));
         assertLayer(tile, AGGS_LAYER, 4096, 1, 1);
-        assertLayer(tile, META_LAYER, 4096, 1, 7);
+        assertLayer(tile, META_LAYER, 4096, 1, 10);
     }
 
     public void testBasicQueryGet() throws Exception {
@@ -222,7 +222,7 @@ public class VectorTileRestIT extends ESRestTestCase {
         assertThat(tile.getLayersCount(), Matchers.equalTo(3));
         assertLayer(tile, HITS_LAYER, 4096, 1, 1);
         assertLayer(tile, AGGS_LAYER, 4096, 1, 1);
-        assertLayer(tile, META_LAYER, 4096, 1, 7);
+        assertLayer(tile, META_LAYER, 4096, 1, 11);
     }
 
     public void testBasicShape() throws Exception {
@@ -231,7 +231,7 @@ public class VectorTileRestIT extends ESRestTestCase {
         assertThat(tile.getLayersCount(), Matchers.equalTo(3));
         assertLayer(tile, HITS_LAYER, 4096, 1, 1);
         assertLayer(tile, AGGS_LAYER, 4096, 256 * 256, 1);
-        assertLayer(tile, META_LAYER, 4096, 1, 7);
+        assertLayer(tile, META_LAYER, 4096, 1, 11);
     }
 
     public void testWithFields() throws Exception {
@@ -241,7 +241,7 @@ public class VectorTileRestIT extends ESRestTestCase {
         assertThat(tile.getLayersCount(), Matchers.equalTo(3));
         assertLayer(tile, HITS_LAYER, 4096, 1, 3);
         assertLayer(tile, AGGS_LAYER, 4096, 256 * 256, 1);
-        assertLayer(tile, META_LAYER, 4096, 1, 7);
+        assertLayer(tile, META_LAYER, 4096, 1, 11);
     }
 
     public void testMinAgg() throws Exception {
@@ -259,7 +259,7 @@ public class VectorTileRestIT extends ESRestTestCase {
         assertThat(tile.getLayersCount(), Matchers.equalTo(3));
         assertLayer(tile, HITS_LAYER, 4096, 1, 1);
         assertLayer(tile, AGGS_LAYER, 4096, 256 * 256, 2);
-        assertLayer(tile, META_LAYER, 4096, 1, 7);
+        assertLayer(tile, META_LAYER, 4096, 1, 11);
     }
 
     private void assertLayer(VectorTile.Tile tile, String name, int extent, int numFeatures, int numTags) {


### PR DESCRIPTION
Replaces a manual way of building the meta layer with a more generic way
of collecting unprocessed elements of the search response. That should get
us started. I will add a dedicated test for Maps.flatten method and support
for arrays in the next PR. 