### PR TITLE
Service Accounts - token name in response to Authenticate API (#71382)

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authc/Authentication.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authc/Authentication.java
@@ -16,6 +16,7 @@ import org.elasticsearch.common.xcontent.ToXContentObject;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.xpack.core.security.authc.esnative.NativeRealmSettings;
 import org.elasticsearch.xpack.core.security.authc.file.FileRealmSettings;
+import org.elasticsearch.xpack.core.security.authc.service.ServiceAccountSettings;
 import org.elasticsearch.xpack.core.security.authc.support.AuthenticationContextSerializer;
 import org.elasticsearch.xpack.core.security.user.InternalUserSerializationHelper;
 import org.elasticsearch.xpack.core.security.user.User;
@@ -28,6 +29,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 
+import static org.elasticsearch.xpack.core.security.authc.service.ServiceAccountSettings.TOKEN_NAME_FIELD;
 import static org.elasticsearch.xpack.core.security.authz.privilege.ManageOwnApiKeyClusterPrivilege.API_KEY_ID_KEY;
 
 // TODO(hub-cap) Clean this up after moving User over - This class can re-inherit its field AUTHENTICATION_KEY in AuthenticationField.
@@ -109,6 +111,10 @@ public class Authentication implements ToXContentObject {
 
     public Map<String, Object> getMetadata() {
         return metadata;
+    }
+
+    public boolean isServiceAccount() {
+        return ServiceAccountSettings.REALM_TYPE.equals(getAuthenticatedBy().getType()) && null == getLookedUpBy();
     }
 
     /**
@@ -226,6 +232,11 @@ public class Authentication implements ToXContentObject {
         builder.array(User.Fields.ROLES.getPreferredName(), user.roles());
         builder.field(User.Fields.FULL_NAME.getPreferredName(), user.fullName());
         builder.field(User.Fields.EMAIL.getPreferredName(), user.email());
+        if (isServiceAccount()) {
+            final String tokenName = (String) getMetadata().get(TOKEN_NAME_FIELD);
+            assert tokenName != null : "token name cannot be null";
+            builder.field(User.Fields.TOKEN.getPreferredName(), Map.of("name", tokenName));
+        }
         builder.field(User.Fields.METADATA.getPreferredName(), user.metadata());
         builder.field(User.Fields.ENABLED.getPreferredName(), user.enabled());
         builder.startObject(User.Fields.AUTHENTICATION_REALM.getPreferredName());

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authc/Authentication.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authc/Authentication.java
@@ -235,7 +235,7 @@ public class Authentication implements ToXContentObject {
         if (isServiceAccount()) {
             final String tokenName = (String) getMetadata().get(TOKEN_NAME_FIELD);
             assert tokenName != null : "token name cannot be null";
-            builder.field(User.Fields.TOKEN.getPreferredName(), Map.of("name", tokenName));
+            builder.field(User.Fields.TOKEN.getPreferredName(), org.elasticsearch.common.collect.Map.of("name", tokenName));
         }
         builder.field(User.Fields.METADATA.getPreferredName(), user.metadata());
         builder.field(User.Fields.ENABLED.getPreferredName(), user.enabled());

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authc/service/ServiceAccountSettings.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authc/service/ServiceAccountSettings.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.core.security.authc.service;
+
+public final class ServiceAccountSettings {
+
+    public static final String REALM_TYPE = "service_account";
+    public static final String REALM_NAME = "service_account";
+    public static final String TOKEN_NAME_FIELD = "_token_name";
+
+    private ServiceAccountSettings() {}
+}

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/user/User.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/user/User.java
@@ -245,6 +245,7 @@ public class User implements ToXContentObject {
         ParseField REALM_TYPE = new ParseField("type");
         ParseField REALM_NAME = new ParseField("name");
         ParseField AUTHENTICATION_TYPE = new ParseField("authentication_type");
+        ParseField TOKEN = new ParseField("token");
     }
 }
 

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authc/AuthenticationTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authc/AuthenticationTests.java
@@ -14,6 +14,7 @@ import org.elasticsearch.xpack.core.security.authc.Authentication.Authentication
 import org.elasticsearch.xpack.core.security.authc.Authentication.RealmRef;
 import org.elasticsearch.xpack.core.security.authc.esnative.NativeRealmSettings;
 import org.elasticsearch.xpack.core.security.authc.file.FileRealmSettings;
+import org.elasticsearch.xpack.core.security.authc.service.ServiceAccountSettings;
 import org.elasticsearch.xpack.core.security.user.User;
 
 import java.util.Arrays;
@@ -22,6 +23,7 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 import static org.elasticsearch.xpack.core.security.authz.privilege.ManageOwnApiKeyClusterPrivilege.API_KEY_ID_KEY;
+import static org.hamcrest.Matchers.is;
 
 public class AuthenticationTests extends ESTestCase {
 
@@ -89,6 +91,32 @@ public class AuthenticationTests extends ESTestCase {
         final String apiKeyId2 = randomValueOtherThan(apiKeyId1, () -> randomAlphaOfLengthBetween(10, 20));
         assertCannotAccessResources(randomApiKeyAuthentication(randomFrom(user1, user2), apiKeyId1),
             randomApiKeyAuthentication(randomFrom(user1, user2), apiKeyId2));
+    }
+
+    public void testIsServiceAccount() {
+        final User user =
+            new User(randomAlphaOfLengthBetween(3, 8), randomArray(0, 3, String[]::new, () -> randomAlphaOfLengthBetween(3, 8)));
+        final Authentication.RealmRef authRealm;
+        final boolean authRealmIsForServiceAccount = randomBoolean();
+        if (authRealmIsForServiceAccount) {
+            authRealm = new Authentication.RealmRef(
+                ServiceAccountSettings.REALM_NAME,
+                ServiceAccountSettings.REALM_TYPE,
+                randomAlphaOfLengthBetween(3, 8));
+        } else {
+            authRealm = new Authentication.RealmRef(randomAlphaOfLengthBetween(3, 8), randomAlphaOfLengthBetween(3, 8),
+                randomAlphaOfLengthBetween(3, 8));
+        }
+        final Authentication.RealmRef lookupRealm = randomFrom(
+            new Authentication.RealmRef(randomAlphaOfLengthBetween(3, 8), randomAlphaOfLengthBetween(3, 8),
+            randomAlphaOfLengthBetween(3, 8)), null);
+        final Authentication authentication = new Authentication(user, authRealm, lookupRealm);
+
+        if (authRealmIsForServiceAccount && lookupRealm == null) {
+            assertThat(authentication.isServiceAccount(), is(true));
+        } else {
+            assertThat(authentication.isServiceAccount(), is(false));
+        }
     }
 
     private void checkCanAccessResources(Authentication authentication0, Authentication authentication1) {

--- a/x-pack/plugin/security/qa/service-account/src/javaRestTest/java/org/elasticsearch/xpack/security/authc/service/ServiceAccountIT.java
+++ b/x-pack/plugin/security/qa/service-account/src/javaRestTest/java/org/elasticsearch/xpack/security/authc/service/ServiceAccountIT.java
@@ -27,6 +27,7 @@ import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.file.Path;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 
 import static org.elasticsearch.xpack.core.security.authc.support.UsernamePasswordToken.basicAuthHeaderValue;
@@ -48,9 +49,13 @@ public class ServiceAccountIT extends ESRestTestCase {
         + "  \"roles\": [],\n"
         + "  \"full_name\": \"Service account - elastic/fleet-server\",\n"
         + "  \"email\": null,\n"
+        + "  \"token\": {\n"
+        + "    \"name\": \"%s\"\n"
+        + "  },\n"
         + "  \"metadata\": {\n"
         + "    \"_elastic_service_account\": true\n"
-        + "  },\n" + "  \"enabled\": true,\n"
+        + "  },\n"
+        + "  \"enabled\": true,\n"
         + "  \"authentication_realm\": {\n"
         + "    \"name\": \"service_account\",\n"
         + "    \"type\": \"service_account\"\n"
@@ -161,7 +166,9 @@ public class ServiceAccountIT extends ESRestTestCase {
         final Response response = client().performRequest(request);
         assertOK(response);
         assertThat(responseAsMap(response),
-            equalTo(XContentHelper.convertToMap(new BytesArray(AUTHENTICATE_RESPONSE), false, XContentType.JSON).v2()));
+            equalTo(XContentHelper.convertToMap(
+                new BytesArray(String.format(Locale.ROOT, AUTHENTICATE_RESPONSE, "token1")),
+                false, XContentType.JSON).v2()));
     }
 
     public void testAuthenticateShouldNotFallThroughInCaseOfFailure() throws IOException {
@@ -237,7 +244,9 @@ public class ServiceAccountIT extends ESRestTestCase {
         final Response response = client().performRequest(request);
         assertOK(response);
         assertThat(responseAsMap(response),
-            equalTo(XContentHelper.convertToMap(new BytesArray(AUTHENTICATE_RESPONSE), false, XContentType.JSON).v2()));
+            equalTo(XContentHelper.convertToMap(
+                new BytesArray(String.format(Locale.ROOT, AUTHENTICATE_RESPONSE, "api-token-1")),
+                false, XContentType.JSON).v2()));
     }
 
     public void testFileTokenAndApiTokenCanShareTheSameNameAndBothWorks() throws IOException {

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/service/ServiceAccountService.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/service/ServiceAccountService.java
@@ -16,6 +16,7 @@ import org.elasticsearch.common.settings.SecureString;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.xpack.core.security.action.service.GetServiceAccountTokensResponse;
 import org.elasticsearch.xpack.core.security.authc.Authentication;
+import org.elasticsearch.xpack.core.security.authc.service.ServiceAccountSettings;
 import org.elasticsearch.xpack.core.security.authz.RoleDescriptor;
 import org.elasticsearch.xpack.core.security.user.User;
 import org.elasticsearch.xpack.security.authc.service.ServiceAccount.ServiceAccountId;
@@ -24,12 +25,10 @@ import org.elasticsearch.xpack.security.authc.support.HttpTlsRuntimeCheck;
 import java.util.Collection;
 import java.util.Map;
 
+import static org.elasticsearch.xpack.core.security.authc.service.ServiceAccountSettings.TOKEN_NAME_FIELD;
 import static org.elasticsearch.xpack.security.authc.service.ElasticServiceAccounts.ACCOUNTS;
 
 public class ServiceAccountService {
-
-    public static final String REALM_TYPE = "service_account";
-    public static final String REALM_NAME = "service_account";
 
     private static final Logger logger = LogManager.getLogger(ServiceAccountService.class);
 
@@ -39,10 +38,6 @@ public class ServiceAccountService {
     public ServiceAccountService(ServiceAccountsTokenStore serviceAccountsTokenStore, HttpTlsRuntimeCheck httpTlsRuntimeCheck) {
         this.serviceAccountsTokenStore = serviceAccountsTokenStore;
         this.httpTlsRuntimeCheck = httpTlsRuntimeCheck;
-    }
-
-    public static boolean isServiceAccount(Authentication authentication) {
-        return REALM_TYPE.equals(authentication.getAuthenticatedBy().getType()) && null == authentication.getLookedUpBy();
     }
 
     public static boolean isServiceAccountPrincipal(String principal) {
@@ -119,7 +114,7 @@ public class ServiceAccountService {
     }
 
     public void getRoleDescriptor(Authentication authentication, ActionListener<RoleDescriptor> listener) {
-        assert isServiceAccount(authentication) : "authentication is not for service account: " + authentication;
+        assert authentication.isServiceAccount() : "authentication is not for service account: " + authentication;
         httpTlsRuntimeCheck.checkTlsThenExecute(listener::onFailure, "service account role descriptor resolving", () -> {
             final String principal = authentication.getUser().principal();
             final ServiceAccount account = ACCOUNTS.get(principal);
@@ -134,9 +129,10 @@ public class ServiceAccountService {
 
     private Authentication createAuthentication(ServiceAccount account, ServiceAccountToken token, String nodeName) {
         final User user = account.asUser();
-        final Authentication.RealmRef authenticatedBy = new Authentication.RealmRef(REALM_NAME, REALM_TYPE, nodeName);
+        final Authentication.RealmRef authenticatedBy =
+            new Authentication.RealmRef(ServiceAccountSettings.REALM_NAME, ServiceAccountSettings.REALM_TYPE, nodeName);
         return new Authentication(user, authenticatedBy, null, Version.CURRENT, Authentication.AuthenticationType.TOKEN,
-            org.elasticsearch.common.collect.Map.of("_token_name", token.getTokenName()));
+            org.elasticsearch.common.collect.Map.of(TOKEN_NAME_FIELD, token.getTokenName()));
     }
 
     private ElasticsearchSecurityException createAuthenticationException(ServiceAccountToken serviceAccountToken) {

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/store/CompositeRolesStore.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/store/CompositeRolesStore.java
@@ -229,7 +229,7 @@ public class CompositeRolesStore {
             return;
         }
 
-        if (ServiceAccountService.isServiceAccount(authentication)) {
+        if (authentication.isServiceAccount()) {
             getRolesForServiceAccount(authentication, roleActionListener);
         } else if (ApiKeyService.isApiKeyAuthentication(authentication)) {
             getRolesForApiKey(authentication, roleActionListener);

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/service/ServiceAccountServiceTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/service/ServiceAccountServiceTests.java
@@ -28,6 +28,7 @@ import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.MockLogAppender;
 import org.elasticsearch.transport.Transport;
 import org.elasticsearch.xpack.core.security.authc.Authentication;
+import org.elasticsearch.xpack.core.security.authc.service.ServiceAccountSettings;
 import org.elasticsearch.xpack.core.security.authz.RoleDescriptor;
 import org.elasticsearch.xpack.core.security.support.ValidationTests;
 import org.elasticsearch.xpack.core.security.user.User;
@@ -84,28 +85,6 @@ public class ServiceAccountServiceTests extends ESTestCase {
             new BoundTransportAddress(new TransportAddress[] { transportAddress }, transportAddress));
         serviceAccountService = new ServiceAccountService(serviceAccountsTokenStore,
             new HttpTlsRuntimeCheck(builder.build(), new SetOnce<>(transport)));
-    }
-
-    public void testIsServiceAccount() {
-        final User user =
-            new User(randomAlphaOfLengthBetween(3, 8), randomArray(0, 3, String[]::new, () -> randomAlphaOfLengthBetween(3, 8)));
-        final Authentication.RealmRef authRealm;
-        final boolean authRealmIsForServiceAccount = randomBoolean();
-        if (authRealmIsForServiceAccount) {
-            authRealm = new Authentication.RealmRef(ServiceAccountService.REALM_NAME,
-                ServiceAccountService.REALM_TYPE,
-                randomAlphaOfLengthBetween(3, 8));
-        } else {
-            authRealm = randomRealmRef();
-        }
-        final Authentication.RealmRef lookupRealm = randomFrom(randomRealmRef(), null);
-        final Authentication authentication = new Authentication(user, authRealm, lookupRealm);
-
-        if (authRealmIsForServiceAccount && lookupRealm == null) {
-            assertThat(ServiceAccountService.isServiceAccount(authentication), is(true));
-        } else {
-            assertThat(ServiceAccountService.isServiceAccount(authentication), is(false));
-        }
     }
 
     public void testGetServiceAccountPrincipals() {
@@ -266,12 +245,6 @@ public class ServiceAccountServiceTests extends ESTestCase {
         }
     }
 
-    private Authentication.RealmRef randomRealmRef() {
-        return new Authentication.RealmRef(randomAlphaOfLengthBetween(3, 8),
-            randomAlphaOfLengthBetween(3, 8),
-            randomAlphaOfLengthBetween(3, 8));
-    }
-
     public void testTryAuthenticateBearerToken() throws ExecutionException, InterruptedException {
         // Valid token
         final PlainActionFuture<Authentication> future5 = new PlainActionFuture<>();
@@ -290,7 +263,7 @@ public class ServiceAccountServiceTests extends ESTestCase {
             new Authentication(
                 new User("elastic/fleet-server", Strings.EMPTY_ARRAY, "Service account - elastic/fleet-server", null,
                     org.elasticsearch.common.collect.Map.of("_elastic_service_account", true), true),
-                new Authentication.RealmRef(ServiceAccountService.REALM_NAME, ServiceAccountService.REALM_TYPE, nodeName),
+                new Authentication.RealmRef(ServiceAccountSettings.REALM_NAME, ServiceAccountSettings.REALM_TYPE, nodeName),
                 null, Version.CURRENT, Authentication.AuthenticationType.TOKEN,
                 org.elasticsearch.common.collect.Map.of("_token_name", "token1")
             )
@@ -369,7 +342,7 @@ public class ServiceAccountServiceTests extends ESTestCase {
                     "Service account - elastic/fleet-server", null,
                     org.elasticsearch.common.collect.Map.of("_elastic_service_account", true),
                     true),
-                new Authentication.RealmRef(ServiceAccountService.REALM_NAME, ServiceAccountService.REALM_TYPE, nodeName),
+                new Authentication.RealmRef(ServiceAccountSettings.REALM_NAME, ServiceAccountSettings.REALM_TYPE, nodeName),
                 null, Version.CURRENT, Authentication.AuthenticationType.TOKEN,
                 org.elasticsearch.common.collect.Map.of("_token_name", token3.getTokenName())
             )));
@@ -402,7 +375,7 @@ public class ServiceAccountServiceTests extends ESTestCase {
                 org.elasticsearch.common.collect.Map.of("_elastic_service_account", true),
                 true),
             new Authentication.RealmRef(
-                ServiceAccountService.REALM_NAME, ServiceAccountService.REALM_TYPE, randomAlphaOfLengthBetween(3, 8)),
+                ServiceAccountSettings.REALM_NAME, ServiceAccountSettings.REALM_TYPE, randomAlphaOfLengthBetween(3, 8)),
             null,
             Version.CURRENT,
             Authentication.AuthenticationType.TOKEN,
@@ -420,7 +393,7 @@ public class ServiceAccountServiceTests extends ESTestCase {
             new User(username, Strings.EMPTY_ARRAY, "Service account - " + username, null,
                 org.elasticsearch.common.collect.Map.of("_elastic_service_account", true), true),
             new Authentication.RealmRef(
-                ServiceAccountService.REALM_NAME, ServiceAccountService.REALM_TYPE, randomAlphaOfLengthBetween(3, 8)),
+                ServiceAccountSettings.REALM_NAME, ServiceAccountSettings.REALM_TYPE, randomAlphaOfLengthBetween(3, 8)),
             null,
             Version.CURRENT,
             Authentication.AuthenticationType.TOKEN,
@@ -450,7 +423,8 @@ public class ServiceAccountServiceTests extends ESTestCase {
 
         final PlainActionFuture<RoleDescriptor> future2 = new PlainActionFuture<>();
         final Authentication authentication = new Authentication(mock(User.class),
-            new Authentication.RealmRef(ServiceAccountService.REALM_NAME, ServiceAccountService.REALM_TYPE,
+            new Authentication.RealmRef(
+                ServiceAccountSettings.REALM_NAME, ServiceAccountSettings.REALM_TYPE,
                 randomAlphaOfLengthBetween(3, 8)),
             null);
         service.getRoleDescriptor(authentication, future2);


### PR DESCRIPTION
This PR adds the service account token name in a new top level field, `token`, to the authenticate response. For now, this new field is only shown when the authentication is for a service account.