### PR TITLE
[DOCS] Adds backticks to xpack.ml.use_auto_machine_memory_percent

### DIFF
--- a/docs/reference/settings/ml-settings.asciidoc
+++ b/docs/reference/settings/ml-settings.asciidoc
@@ -192,7 +192,7 @@ specified by this setting then the process is assumed to have failed. When the
 {operator-feature} is enabled, this setting can be updated only by operator
 users. The minimum value is `5s`. Defaults to `10s`.
 
-xpack.ml.use_auto_machine_memory_percent::
+`xpack.ml.use_auto_machine_memory_percent`::
 (<<cluster-update-settings,Dynamic>>) If this setting is `true`, the
 `xpack.ml.max_machine_memory_percent` setting is ignored. Instead, the maximum
 percentage of the machine's memory that can be used for running {ml} analytics


### PR DESCRIPTION
## Overview

This PR adds backticks around the xpack.ml.use_auto_machine_memory_percent setting in ml-settings.asciidoc.

### Preview

[ML settings in ES](https://elasticsearch_71814.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/ml-settings.html)