### PR TITLE
Fix Missing Datanode Block in SearchableSnapshotsCanMatchOnCoordinatorIntegTests (#71819)

### DIFF
--- a/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/SearchableSnapshotsCanMatchOnCoordinatorIntegTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/SearchableSnapshotsCanMatchOnCoordinatorIntegTests.java
@@ -250,7 +250,7 @@ public class SearchableSnapshotsCanMatchOnCoordinatorIntegTests extends BaseSear
 
         // Block the repository for the node holding the searchable snapshot shards
         // to delay its restore
-        blockDataNode(repositoryName, dataNodeHoldingSearchableSnapshot);
+        blockNodeOnAnyFiles(repositoryName, dataNodeHoldingSearchableSnapshot);
 
         // Force the searchable snapshot to be allocated in a particular node
         Settings restoredIndexSettings = Settings.builder()


### PR DESCRIPTION
We can't use `blockDataNode` because that only blocks on data files.
In the corner case of having no documents in a shard (e.g. if test randomizes to 3 shards and 2 documents)
this won't prevent the shard from being recovered because the empty segments file will be read
from a repository metadata blob.

-> fixed by blocking on any file

closes #70501

backport of #71819