### PR TITLE
[7.x] [DOCS] Document create stored script API (#71493)

### DIFF
--- a/docs/reference/rest-api/index.asciidoc
+++ b/docs/reference/rest-api/index.asciidoc
@@ -34,6 +34,7 @@ not be included yet.
 * <<indices-reload-analyzers,Reload search analyzers API>>
 * <<repositories-metering-apis,Repositories metering APIs>>
 * <<rollup-apis,Rollup APIs>>
+* <<script-apis,Script APIs>>
 * <<search, Search APIs>>
 * <<searchable-snapshots-apis, Searchable snapshots APIs>>
 * <<security-api,Security APIs>>
@@ -68,6 +69,7 @@ include::{es-repo-dir}/migration/migration.asciidoc[]
 include::{es-repo-dir}/indices/apis/reload-analyzers.asciidoc[]
 include::{es-repo-dir}/repositories-metering-api/repositories-metering-apis.asciidoc[]
 include::{es-repo-dir}/rollup/rollup-apis.asciidoc[]
+include::{es-repo-dir}/scripting/apis/script-apis.asciidoc[]
 include::{es-repo-dir}/search.asciidoc[]
 include::{es-repo-dir}/searchable-snapshots/apis/searchable-snapshots-apis.asciidoc[]
 include::{xes-repo-dir}/rest-api/security.asciidoc[]

--- a/docs/reference/scripting/apis/create-stored-script-api.asciidoc
+++ b/docs/reference/scripting/apis/create-stored-script-api.asciidoc
@@ -1,0 +1,115 @@
+[[create-stored-script-api]]
+=== Create or update stored script API
+++++
+<titleabbrev>Create or update stored script</titleabbrev>
+++++
+
+Creates or updates a <<script-stored-scripts,stored script>> or
+<<search-template,search template>>.
+
+[source,console]
+----
+PUT _scripts/my-stored-script
+{
+  "script": {
+    "lang": "painless",
+    "source": """
+      TimestampHour date =  doc['@timestamp'].value; 
+      return date.getHour()
+    """
+  }
+}
+----
+
+[[create-stored-script-api-request]]
+==== {api-request-title}
+
+`PUT _search/<script-id>`
+
+`POST _scripts/<script-id>`
+
+`PUT _search/<script-id>/<context>`
+
+`POST _scripts/<script-id>/<context>`
+
+[[create-stored-script-api-prereqs]]
+==== {api-prereq-title}
+
+* If the {es} {security-features} are enabled, you must have the `manage`
+<<privileges-list-cluster,cluster privilege>> to use this API.
+
+[[create-stored-script-api-path-params]]
+==== {api-path-parms-title}
+
+`<script-id>`::
+(Required, string)
+Name or identifier for the stored script or search template. Must be unique
+within the cluster.
+
+`<context>`::
+(Optional, string)
+Context in which the script or search template should run. To prevent errors,
+the API immediately compiles the script or template in this context.
+
+[[create-stored-script-api-query-params]]
+==== {api-query-parms-title}
+
+`context`::
+(Optional, string)
+Context in which the script or search template should run. To prevent errors,
+the API immediately compiles the script or template in this context.
++
+If you specify both this and the `<context>` request path parameter, the API
+uses the request path parameter.
+
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=timeoutparms]
+
+[role="child_attributes"]
+[[create-stored-script-api-request-body]]
+==== {api-request-body-title}
+
+`script`::
+(Required, object)
+Contains the script or search template, its parameters, and its language.
++
+.Properties of `script`
+[%collapsible%open]
+====
+`lang`::
+(Required, string)
+<<scripting-available-languages,Script language>>. For search templates, use
+`mustache`.
+
+`source`::
+(Required, string)
+Script or search template.
+
+`params`::
+(Optional, object)
+Parameters for the script or search template.
+====
+
+[[create-stored-script-api-example]]
+==== {api-examples-title}
+
+The following request stores a search template. Search templates must use a
+`lang` of `mustache`.
+
+[source,console]
+----
+PUT _scripts/my-search-template
+{
+  "script": {
+    "lang": "mustache",
+    "source": {
+      "from": "{{from}}{{^from}}0{{/from}}",
+      "size": "{{size}}{{^size}}10{{/size}}",
+      "query": {
+        "match": {
+          "content": "{{query_string}}"
+        }
+      }
+    }
+  }
+}
+----

--- a/docs/reference/scripting/apis/script-apis.asciidoc
+++ b/docs/reference/scripting/apis/script-apis.asciidoc
@@ -1,0 +1,35 @@
+[[script-apis]]
+== Script APIs
+
+NOTE: This list of script APIs is incomplete. We're working on adding more.
+
+Use following APIs to manage, store, and test your
+<<modules-scripting,scripts>>.
+
+[discrete]
+[[stored-script-apis]]
+=== Stored script APIs
+
+Use stored script APIs to manage <<script-stored-scripts,stored scripts>> and
+<<search-template,search templates>>.
+
+* <<create-stored-script-api>>
+
+////
+TODO: See https://github.com/elastic/elasticsearch/issues/71376
+
+[discrete]
+[[script-support-apis]]
+=== Script support API
+
+Use the script support APIs to get a list of supported script languages and
+contexts.
+
+[discrete]
+[[painless-apis]]
+=== Painless APIs
+
+Use the execute script API to safely test Painless scripts.
+////
+
+include::create-stored-script-api.asciidoc[]

--- a/docs/reference/search/search-template.asciidoc
+++ b/docs/reference/search/search-template.asciidoc
@@ -115,7 +115,8 @@ The API request body must contain the search definition template and its paramet
 [[pre-registered-templates]]
 ===== Store a search template
 
-You can store a search template using the stored scripts API.
+To store a search template, use the <<create-stored-script-api,create stored
+script API>>. Specify `mustache` as the `lang`.
 
 [source,console]
 ------------------------------------------


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [DOCS] Document create stored script API (#71493)