### PR TITLE
[Fleet] Add local_metadata.packages to agent mappings

### DIFF
--- a/x-pack/plugin/core/src/main/resources/fleet-agents.json
+++ b/x-pack/plugin/core/src/main/resources/fleet-agents.json
@@ -3,7 +3,7 @@
     "auto_expand_replicas": "0-1"
   },
   "mappings": {
-    "_doc" : {
+    "_doc": {
       "dynamic": false,
       "_meta": {
         "version": "${fleet.version}"
@@ -86,6 +86,9 @@
                           "ignore_above": 16
                         }
                       }
+                    },
+                    "packages": {
+                      "type": "keyword"
                     }
                   }
                 }


### PR DESCRIPTION
## Description 

We introduced a new property in the `.fleet-agents` indice (here https://github.com/elastic/beats/pull/25070), that PR add the needed mappings.

Let me know if there is anything else that need to be modified 

