### PR TITLE
[7.x] Deprecate legacy index template API endpoints

### DIFF
--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/IndicesClientIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/IndicesClientIT.java
@@ -1566,7 +1566,7 @@ public class IndicesClientIT extends ESRestHighLevelClientTestCase {
 
         AcknowledgedResponse putTemplateResponse = execute(putTemplateRequest,
             highLevelClient().indices()::putTemplate, highLevelClient().indices()::putTemplateAsync,
-            expectWarnings(RestPutIndexTemplateAction.TYPES_DEPRECATION_MESSAGE)
+            expectWarnings(RestPutIndexTemplateAction.TYPES_DEPRECATION_MESSAGE, RestPutIndexTemplateAction.DEPRECATION_WARNING)
             );
         assertThat(putTemplateResponse.isAcknowledged(), equalTo(true));
 
@@ -1623,7 +1623,10 @@ public class IndicesClientIT extends ESRestHighLevelClientTestCase {
         AcknowledgedResponse putTemplateResponse = execute(putTemplateRequest,
             highLevelClient().indices()::putTemplate,
             highLevelClient().indices()::putTemplateAsync,
-            expectWarnings("Deprecated field [template] used, replaced by [index_patterns]"));
+            expectWarnings(
+                RestPutIndexTemplateAction.DEPRECATION_WARNING,
+                "Deprecated field [template] used, replaced by [index_patterns]"
+            ));
         assertThat(putTemplateResponse.isAcknowledged(), equalTo(true));
 
         Map<String, Object> templates = getAsMap("/_template/my-template");
@@ -1683,7 +1686,7 @@ public class IndicesClientIT extends ESRestHighLevelClientTestCase {
 
         AcknowledgedResponse putTemplateResponse = execute(putTemplateRequest,
             highLevelClient().indices()::putTemplate, highLevelClient().indices()::putTemplateAsync,
-            expectWarnings(RestPutIndexTemplateAction.TYPES_DEPRECATION_MESSAGE)
+            expectWarnings(RestPutIndexTemplateAction.TYPES_DEPRECATION_MESSAGE, RestPutIndexTemplateAction.DEPRECATION_WARNING)
             );
         assertThat(putTemplateResponse.isAcknowledged(), equalTo(true));
 
@@ -1781,8 +1784,8 @@ public class IndicesClientIT extends ESRestHighLevelClientTestCase {
         org.elasticsearch.action.admin.indices.template.put.PutIndexTemplateRequest putTemplate1 =
             new org.elasticsearch.action.admin.indices.template.put.PutIndexTemplateRequest().name("template-1")
             .patterns(Arrays.asList("pattern-1", "name-1")).alias(new Alias("alias-1"));
-        assertThat(execute(putTemplate1, client.indices()::putTemplate, client.indices()::putTemplateAsync
-                , expectWarnings(RestPutIndexTemplateAction.TYPES_DEPRECATION_MESSAGE))
+        assertThat(execute(putTemplate1, client.indices()::putTemplate, client.indices()::putTemplateAsync,
+            expectWarnings(RestPutIndexTemplateAction.TYPES_DEPRECATION_MESSAGE, RestPutIndexTemplateAction.DEPRECATION_WARNING))
             .isAcknowledged(), equalTo(true));
         org.elasticsearch.action.admin.indices.template.put.PutIndexTemplateRequest putTemplate2 =
             new org.elasticsearch.action.admin.indices.template.put.PutIndexTemplateRequest().name("template-2")
@@ -1790,7 +1793,7 @@ public class IndicesClientIT extends ESRestHighLevelClientTestCase {
             .mapping("custom_doc_type", "name", "type=text")
             .settings(Settings.builder().put("number_of_shards", "2").put("number_of_replicas", "0"));
         assertThat(execute(putTemplate2, client.indices()::putTemplate, client.indices()::putTemplateAsync,
-                expectWarnings(RestPutIndexTemplateAction.TYPES_DEPRECATION_MESSAGE))
+                expectWarnings(RestPutIndexTemplateAction.TYPES_DEPRECATION_MESSAGE, RestPutIndexTemplateAction.DEPRECATION_WARNING))
                 .isAcknowledged(), equalTo(true));
 
         org.elasticsearch.action.admin.indices.template.get.GetIndexTemplatesResponse getTemplate1 = execute(
@@ -1847,17 +1850,19 @@ public class IndicesClientIT extends ESRestHighLevelClientTestCase {
 
         assertThat(execute(new GetIndexTemplatesRequest("template-*"),
             client.indices()::getTemplate, client.indices()::getTemplateAsync,
-              expectWarnings(RestGetIndexTemplateAction.TYPES_DEPRECATION_MESSAGE)).getIndexTemplates(), hasSize(1));
+              expectWarnings(RestGetIndexTemplateAction.TYPES_DEPRECATION_MESSAGE))
+            .getIndexTemplates(), hasSize(1));
         assertThat(execute(new GetIndexTemplatesRequest("template-*"),
             client.indices()::getTemplate, client.indices()::getTemplateAsync,
-              expectWarnings(RestGetIndexTemplateAction.TYPES_DEPRECATION_MESSAGE)).getIndexTemplates()
-                .get(0).name(), equalTo("template-2"));
+              expectWarnings(RestGetIndexTemplateAction.TYPES_DEPRECATION_MESSAGE))
+            .getIndexTemplates().get(0).name(), equalTo("template-2"));
 
         assertTrue(execute(new DeleteIndexTemplateRequest("template-*"),
             client.indices()::deleteTemplate, client.indices()::deleteTemplateAsync).isAcknowledged());
         assertThat(expectThrows(ElasticsearchException.class, () -> execute(new GetIndexTemplatesRequest("template-*"),
             client.indices()::getTemplate, client.indices()::getTemplateAsync,
-              expectWarnings(RestGetIndexTemplateAction.TYPES_DEPRECATION_MESSAGE))).status(), equalTo(RestStatus.NOT_FOUND));
+              expectWarnings(RestGetIndexTemplateAction.TYPES_DEPRECATION_MESSAGE)))
+            .status(), equalTo(RestStatus.NOT_FOUND));
     }
 
 

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/IndicesClientDocumentationIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/IndicesClientDocumentationIT.java
@@ -58,21 +58,21 @@ import org.elasticsearch.client.indices.DeleteAliasRequest;
 import org.elasticsearch.client.indices.DeleteComposableIndexTemplateRequest;
 import org.elasticsearch.client.indices.DetailAnalyzeResponse;
 import org.elasticsearch.client.indices.FreezeIndexRequest;
+import org.elasticsearch.client.indices.GetComposableIndexTemplateRequest;
+import org.elasticsearch.client.indices.GetComposableIndexTemplatesResponse;
 import org.elasticsearch.client.indices.GetFieldMappingsRequest;
 import org.elasticsearch.client.indices.GetFieldMappingsResponse;
 import org.elasticsearch.client.indices.GetIndexRequest;
 import org.elasticsearch.client.indices.GetIndexResponse;
-import org.elasticsearch.client.indices.GetComposableIndexTemplateRequest;
 import org.elasticsearch.client.indices.GetIndexTemplatesRequest;
 import org.elasticsearch.client.indices.GetIndexTemplatesResponse;
-import org.elasticsearch.client.indices.GetComposableIndexTemplatesResponse;
 import org.elasticsearch.client.indices.GetMappingsRequest;
 import org.elasticsearch.client.indices.GetMappingsResponse;
 import org.elasticsearch.client.indices.IndexTemplateMetadata;
 import org.elasticsearch.client.indices.IndexTemplatesExistRequest;
 import org.elasticsearch.client.indices.PutComponentTemplateRequest;
-import org.elasticsearch.client.indices.PutIndexTemplateRequest;
 import org.elasticsearch.client.indices.PutComposableIndexTemplateRequest;
+import org.elasticsearch.client.indices.PutIndexTemplateRequest;
 import org.elasticsearch.client.indices.PutMappingRequest;
 import org.elasticsearch.client.indices.ReloadAnalyzersRequest;
 import org.elasticsearch.client.indices.ReloadAnalyzersResponse;
@@ -110,6 +110,7 @@ import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
+import static org.elasticsearch.client.IndicesClientIT.LEGACY_TEMPLATE_OPTIONS;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
@@ -2183,7 +2184,7 @@ public class IndicesClientDocumentationIT extends ESRestHighLevelClientTestCase 
                     "}",
                 XContentType.JSON);
             // end::put-template-request-mappings-json
-            assertTrue(client.indices().putTemplate(request, RequestOptions.DEFAULT).isAcknowledged());
+            assertTrue(client.indices().putTemplate(request, LEGACY_TEMPLATE_OPTIONS).isAcknowledged());
         }
         {
             //tag::put-template-request-mappings-map
@@ -2199,7 +2200,7 @@ public class IndicesClientDocumentationIT extends ESRestHighLevelClientTestCase 
             }
             request.mapping(jsonMap); // <1>
             //end::put-template-request-mappings-map
-            assertTrue(client.indices().putTemplate(request, RequestOptions.DEFAULT).isAcknowledged());
+            assertTrue(client.indices().putTemplate(request, LEGACY_TEMPLATE_OPTIONS).isAcknowledged());
         }
         {
             //tag::put-template-request-mappings-xcontent
@@ -2219,7 +2220,7 @@ public class IndicesClientDocumentationIT extends ESRestHighLevelClientTestCase 
             builder.endObject();
             request.mapping(builder); // <1>
             //end::put-template-request-mappings-xcontent
-            assertTrue(client.indices().putTemplate(request, RequestOptions.DEFAULT).isAcknowledged());
+            assertTrue(client.indices().putTemplate(request, LEGACY_TEMPLATE_OPTIONS).isAcknowledged());
         }
 
         // tag::put-template-request-aliases
@@ -2271,7 +2272,7 @@ public class IndicesClientDocumentationIT extends ESRestHighLevelClientTestCase 
         request.create(false); // make test happy
 
         // tag::put-template-execute
-        AcknowledgedResponse putTemplateResponse = client.indices().putTemplate(request, RequestOptions.DEFAULT);
+        AcknowledgedResponse putTemplateResponse = client.indices().putTemplate(request, LEGACY_TEMPLATE_OPTIONS);
         // end::put-template-execute
 
         // tag::put-template-response
@@ -2299,7 +2300,7 @@ public class IndicesClientDocumentationIT extends ESRestHighLevelClientTestCase 
         listener = new LatchedActionListener<>(listener, latch);
 
         // tag::put-template-execute-async
-        client.indices().putTemplateAsync(request, RequestOptions.DEFAULT, listener); // <1>
+        client.indices().putTemplateAsync(request, LEGACY_TEMPLATE_OPTIONS, listener); // <1>
         // end::put-template-execute-async
 
         assertTrue(latch.await(30L, TimeUnit.SECONDS));
@@ -2314,7 +2315,7 @@ public class IndicesClientDocumentationIT extends ESRestHighLevelClientTestCase 
             putRequest.mapping("{ \"properties\": { \"message\": { \"type\": \"text\" } } }",
                 XContentType.JSON
             );
-            assertTrue(client.indices().putTemplate(putRequest, RequestOptions.DEFAULT).isAcknowledged());
+            assertTrue(client.indices().putTemplate(putRequest, LEGACY_TEMPLATE_OPTIONS).isAcknowledged());
         }
 
         // tag::get-templates-request
@@ -2705,9 +2706,9 @@ public class IndicesClientDocumentationIT extends ESRestHighLevelClientTestCase 
     public void testTemplatesExist() throws Exception {
         final RestHighLevelClient client = highLevelClient();
         {
-            final PutIndexTemplateRequest putRequest = new PutIndexTemplateRequest("my-template");
-            putRequest.patterns(Collections.singletonList("foo"));
-            assertTrue(client.indices().putTemplate(putRequest, RequestOptions.DEFAULT).isAcknowledged());
+            final PutIndexTemplateRequest putRequest = new PutIndexTemplateRequest("my-template")
+                .patterns(org.elasticsearch.common.collect.List.of("foo"));
+            assertTrue(client.indices().putTemplate(putRequest, LEGACY_TEMPLATE_OPTIONS).isAcknowledged());
         }
 
         {
@@ -3118,7 +3119,7 @@ public class IndicesClientDocumentationIT extends ESRestHighLevelClientTestCase 
             PutIndexTemplateRequest putRequest = new PutIndexTemplateRequest("my-template");
             putRequest.patterns(Arrays.asList("pattern-1", "log-*"));
             putRequest.settings(Settings.builder().put("index.number_of_shards", 3));
-            assertTrue(client.indices().putTemplate(putRequest, RequestOptions.DEFAULT).isAcknowledged());
+            assertTrue(client.indices().putTemplate(putRequest, LEGACY_TEMPLATE_OPTIONS).isAcknowledged());
         }
 
         // tag::delete-template-request
@@ -3144,7 +3145,7 @@ public class IndicesClientDocumentationIT extends ESRestHighLevelClientTestCase 
             PutIndexTemplateRequest putRequest = new PutIndexTemplateRequest("my-template");
             putRequest.patterns(Arrays.asList("pattern-1", "log-*"));
             putRequest.settings(Settings.builder().put("index.number_of_shards", 3));
-            assertTrue(client.indices().putTemplate(putRequest, RequestOptions.DEFAULT).isAcknowledged());
+            assertTrue(client.indices().putTemplate(putRequest, LEGACY_TEMPLATE_OPTIONS).isAcknowledged());
         }
         // tag::delete-template-execute-listener
         ActionListener<AcknowledgedResponse> listener =

--- a/modules/transport-netty4/src/javaRestTest/java/org/elasticsearch/rest/Netty4HeadBodyIsEmptyIT.java
+++ b/modules/transport-netty4/src/javaRestTest/java/org/elasticsearch/rest/Netty4HeadBodyIsEmptyIT.java
@@ -12,6 +12,7 @@ import org.elasticsearch.client.Request;
 import org.elasticsearch.client.Response;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.rest.action.admin.indices.RestPutIndexTemplateAction;
 import org.elasticsearch.test.rest.ESRestTestCase;
 import org.hamcrest.Matcher;
 
@@ -138,7 +139,10 @@ public class Netty4HeadBodyIsEmptyIT extends ESRestTestCase {
                     ".slm-history => [.slm-history-5*]," +
                     ".watch-history-13 => [.watcher-history-13*],ilm-history => [ilm-history-5*]," +
                     "logs => [logs-*-*],metrics => [metrics-*-*],synthetics => [synthetics-*-*]" +
-                    "); this template [template] may be ignored in favor of a composable template at index creation time"));
+                    "); this template [template] may be ignored in favor of a composable template at index creation time",
+                    RestPutIndexTemplateAction.DEPRECATION_WARNING));
+            } else {
+                request.setOptions(expectWarnings(RestPutIndexTemplateAction.DEPRECATION_WARNING));
             }
             request.setJsonEntity(Strings.toString(builder));
             client().performRequest(request);

--- a/qa/full-cluster-restart/src/test/java/org/elasticsearch/upgrades/FullClusterRestartIT.java
+++ b/qa/full-cluster-restart/src/test/java/org/elasticsearch/upgrades/FullClusterRestartIT.java
@@ -879,9 +879,9 @@ public class FullClusterRestartIT extends AbstractFullClusterRestartTestCase {
         createTemplateRequest.setJsonEntity(Strings.toString(templateBuilder));
         createTemplateRequest.setOptions(expectVersionSpecificWarnings(v -> {
             v.current(RestPutIndexTemplateAction.DEPRECATION_WARNING);
-            final String typesWarning = "[types removal] The parameter include_type_name should be explicitly specified in get indices " +
-                "requests to prepare for 7.0. In 7.0 include_type_name will default to 'false', which means responses will omit the type " +
-                "name in mapping definitions.";
+            final String typesWarning = "[types removal] The parameter include_type_name should be explicitly specified in put template " +
+                "requests to prepare for 7.0. In 7.0 include_type_name will default to 'false', and requests are expected to omit the " +
+                "type name in mapping definitions.";
             v.compatible(typesWarning);
         }));
 

--- a/qa/full-cluster-restart/src/test/java/org/elasticsearch/upgrades/FullClusterRestartIT.java
+++ b/qa/full-cluster-restart/src/test/java/org/elasticsearch/upgrades/FullClusterRestartIT.java
@@ -61,6 +61,7 @@ import org.elasticsearch.rest.action.document.RestGetAction;
 import org.elasticsearch.rest.action.document.RestIndexAction;
 import org.elasticsearch.rest.action.document.RestUpdateAction;
 import org.elasticsearch.rest.action.search.RestExplainAction;
+import org.elasticsearch.rest.action.admin.indices.RestPutIndexTemplateAction;
 import org.elasticsearch.test.NotEqualMessageBuilder;
 import org.elasticsearch.test.XContentTestUtils;
 import org.elasticsearch.test.rest.ESRestTestCase;
@@ -247,6 +248,7 @@ public class FullClusterRestartIT extends AbstractFullClusterRestartTestCase {
             mappingsAndSettings.endObject();
             Request createTemplate = new Request("PUT", "/_template/template_1");
             createTemplate.setJsonEntity(Strings.toString(mappingsAndSettings));
+            createTemplate.setOptions(expectWarnings(RestPutIndexTemplateAction.DEPRECATION_WARNING));
             client().performRequest(createTemplate);
             client().performRequest(new Request("PUT", "/" + index));
         }
@@ -875,7 +877,13 @@ public class FullClusterRestartIT extends AbstractFullClusterRestartTestCase {
         templateBuilder.endObject().endObject();
         Request createTemplateRequest = new Request("PUT", "/_template/test_template");
         createTemplateRequest.setJsonEntity(Strings.toString(templateBuilder));
-        createTemplateRequest.setOptions(allowTypesRemovalWarnings());
+        createTemplateRequest.setOptions(expectVersionSpecificWarnings(v -> {
+            v.current(RestPutIndexTemplateAction.DEPRECATION_WARNING);
+            final String typesWarning = "[types removal] The parameter include_type_name should be explicitly specified in get indices " +
+                "requests to prepare for 7.0. In 7.0 include_type_name will default to 'false', which means responses will omit the type " +
+                "name in mapping definitions.";
+            v.compatible(typesWarning);
+        }));
 
         client().performRequest(createTemplateRequest);
 

--- a/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestPutIndexTemplateAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestPutIndexTemplateAction.java
@@ -10,6 +10,7 @@ package org.elasticsearch.rest.action.admin.indices;
 
 import org.elasticsearch.action.admin.indices.template.put.PutIndexTemplateRequest;
 import org.elasticsearch.client.node.NodeClient;
+import org.elasticsearch.common.RestApiVersion;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.logging.DeprecationCategory;
 import org.elasticsearch.common.logging.DeprecationLogger;
@@ -24,13 +25,14 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
-import static java.util.Arrays.asList;
-import static java.util.Collections.unmodifiableList;
 import static org.elasticsearch.rest.RestRequest.Method.POST;
 import static org.elasticsearch.rest.RestRequest.Method.PUT;
 
 public class RestPutIndexTemplateAction extends BaseRestHandler {
 
+    public static final String DEPRECATION_WARNING = "Legacy index templates are deprecated and will be removed completely in a " +
+        "future version. Please use composable templates instead.";
+    private static final RestApiVersion DEPRECATION_VERSION = RestApiVersion.V_7;
     private static final DeprecationLogger deprecationLogger = DeprecationLogger.getLogger(RestPutIndexTemplateAction.class);
     public static final String TYPES_DEPRECATION_MESSAGE = "[types removal]" +
             " Specifying include_type_name in put index template requests is deprecated."+
@@ -38,9 +40,14 @@ public class RestPutIndexTemplateAction extends BaseRestHandler {
 
     @Override
     public List<Route> routes() {
-        return unmodifiableList(asList(
-            new Route(POST, "/_template/{name}"),
-            new Route(PUT, "/_template/{name}")));
+        return org.elasticsearch.common.collect.List.of(
+            Route.builder(POST, "/_template/{name}")
+                .deprecated(DEPRECATION_WARNING, DEPRECATION_VERSION)
+                .build(),
+            Route.builder(PUT, "/_template/{name}")
+                .deprecated(DEPRECATION_WARNING, DEPRECATION_VERSION)
+                .build()
+        );
     }
 
     @Override

--- a/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/ClientYamlTestExecutionContext.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/ClientYamlTestExecutionContext.java
@@ -45,13 +45,18 @@ public class ClientYamlTestExecutionContext {
 
     private final Stash stash = new Stash();
     private final ClientYamlTestClient clientYamlTestClient;
+    private final ClientYamlTestCandidate clientYamlTestCandidate;
 
     private ClientYamlTestResponse response;
 
     private final boolean randomizeContentType;
 
-    ClientYamlTestExecutionContext(ClientYamlTestClient clientYamlTestClient, boolean randomizeContentType) {
+    ClientYamlTestExecutionContext(
+        ClientYamlTestCandidate clientYamlTestCandidate,
+        ClientYamlTestClient clientYamlTestClient,
+        boolean randomizeContentType) {
         this.clientYamlTestClient = clientYamlTestClient;
+        this.clientYamlTestCandidate = clientYamlTestCandidate;
         this.randomizeContentType = randomizeContentType;
     }
 
@@ -258,5 +263,9 @@ public class ClientYamlTestExecutionContext {
 
     public String os() {
         return clientYamlTestClient.getOs();
+    }
+
+    public ClientYamlTestCandidate getClientYamlTestCandidate() {
+        return clientYamlTestCandidate;
     }
 }

--- a/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/ESClientYamlSuiteTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/ESClientYamlSuiteTestCase.java
@@ -135,8 +135,8 @@ public abstract class ESClientYamlSuiteTestCase extends ESRestTestCase {
                 os
             );
             clientYamlTestClient = initClientYamlTestClient(restSpec, client(), hosts, esVersion, masterVersion, os);
-            restTestExecutionContext = new ClientYamlTestExecutionContext(clientYamlTestClient, randomizeContentType());
-            adminExecutionContext = new ClientYamlTestExecutionContext(clientYamlTestClient, false);
+            restTestExecutionContext = new ClientYamlTestExecutionContext(testCandidate, clientYamlTestClient, randomizeContentType());
+            adminExecutionContext = new ClientYamlTestExecutionContext(testCandidate, clientYamlTestClient, false);
             final String[] blacklist = resolvePathsProperty(REST_TESTS_BLACKLIST, null);
             blacklistPathMatchers = new ArrayList<>();
             for (final String entry : blacklist) {

--- a/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/section/DoSection.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/section/DoSection.java
@@ -24,6 +24,7 @@ import org.elasticsearch.common.xcontent.XContentLocation;
 import org.elasticsearch.common.xcontent.XContentParseException;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.json.JsonXContent;
+import org.elasticsearch.rest.action.admin.indices.RestPutIndexTemplateAction;
 import org.elasticsearch.test.rest.yaml.ClientYamlTestExecutionContext;
 import org.elasticsearch.test.rest.yaml.ClientYamlTestResponse;
 import org.elasticsearch.test.rest.yaml.ClientYamlTestResponseException;
@@ -343,7 +344,10 @@ public class DoSection implements ExecutableSection {
                 }
                 fail(formatStatusCodeMessage(response, catchStatusCode));
             }
-            checkWarningHeaders(response.getWarningHeaders(), executionContext.masterVersion());
+            final String testPath = executionContext.getClientYamlTestCandidate() != null
+                ? executionContext.getClientYamlTestCandidate().getTestPath()
+                : null;
+            checkWarningHeaders(response.getWarningHeaders(), testPath);
         } catch(ClientYamlTestResponseException e) {
             ClientYamlTestResponse restTestResponse = e.getRestTestResponse();
             if (Strings.hasLength(catchParam) == false) {
@@ -366,10 +370,14 @@ public class DoSection implements ExecutableSection {
         }
     }
 
+    void checkWarningHeaders(final List<String> warningHeaders) {
+        checkWarningHeaders(warningHeaders, null);
+    }
+
     /**
      * Check that the response contains only the warning headers that we expect.
      */
-    void checkWarningHeaders(final List<String> warningHeaders, final Version masterVersion) {
+    void checkWarningHeaders(final List<String> warningHeaders, String testPath) {
         final List<String> unexpected = new ArrayList<>();
         final List<String> unmatched = new ArrayList<>();
         final List<String> missing = new ArrayList<>();
@@ -440,6 +448,18 @@ public class DoSection implements ExecutableSection {
         if (expectedRegex.isEmpty() == false) {
             for (final Pattern headerPattern : expectedRegex) {
                 missingRegex.add(headerPattern.pattern());
+            }
+        }
+
+        // Log and remove all deprecation warnings for legacy index templates as a shortcut to dealing with all the legacy
+        // templates used in YAML tests. Once they have all been migrated to composable templates, this should be removed.
+        for (Iterator<String> warnings = unexpected.iterator(); warnings.hasNext();) {
+            if (warnings.next().endsWith(RestPutIndexTemplateAction.DEPRECATION_WARNING + "\"")) {
+                logger.warn(
+                    "Test [{}] uses deprecated legacy index templates and should be updated to use composable templates",
+                    (testPath == null ? "<unknown>" : testPath) + ":" + getLocation().lineNumber
+                );
+                warnings.remove();
             }
         }
 

--- a/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/section/DoSection.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/section/DoSection.java
@@ -347,7 +347,7 @@ public class DoSection implements ExecutableSection {
             final String testPath = executionContext.getClientYamlTestCandidate() != null
                 ? executionContext.getClientYamlTestCandidate().getTestPath()
                 : null;
-            checkWarningHeaders(response.getWarningHeaders(), testPath);
+            checkWarningHeaders(response.getWarningHeaders(), testPath, executionContext.masterVersion());
         } catch(ClientYamlTestResponseException e) {
             ClientYamlTestResponse restTestResponse = e.getRestTestResponse();
             if (Strings.hasLength(catchParam) == false) {
@@ -370,14 +370,14 @@ public class DoSection implements ExecutableSection {
         }
     }
 
-    void checkWarningHeaders(final List<String> warningHeaders) {
-        checkWarningHeaders(warningHeaders, null);
+    void checkWarningHeaders(final List<String> warningHeaders, final Version masterVersion) {
+        checkWarningHeaders(warningHeaders, null, masterVersion);
     }
 
     /**
      * Check that the response contains only the warning headers that we expect.
      */
-    void checkWarningHeaders(final List<String> warningHeaders, String testPath) {
+    void checkWarningHeaders(final List<String> warningHeaders, String testPath, final Version masterVersion) {
         final List<String> unexpected = new ArrayList<>();
         final List<String> unmatched = new ArrayList<>();
         final List<String> missing = new ArrayList<>();

--- a/test/framework/src/test/java/org/elasticsearch/test/rest/yaml/ClientYamlTestExecutionContextTests.java
+++ b/test/framework/src/test/java/org/elasticsearch/test/rest/yaml/ClientYamlTestExecutionContextTests.java
@@ -28,7 +28,7 @@ public class ClientYamlTestExecutionContextTests extends ESTestCase {
         final AtomicReference<Map<String, String>> headersRef = new AtomicReference<>();
         final Version version = VersionUtils.randomVersion(random());
         final ClientYamlTestExecutionContext context =
-            new ClientYamlTestExecutionContext(null, randomBoolean()) {
+            new ClientYamlTestExecutionContext(null, null, randomBoolean()) {
                 @Override
                 ClientYamlTestResponse callApiInternal(String apiName, Map<String, String> params,
                         HttpEntity entity, Map<String, String> headers, NodeSelector nodeSelector) {
@@ -60,7 +60,7 @@ public class ClientYamlTestExecutionContextTests extends ESTestCase {
     public void testStashHeadersOnException() throws IOException {
         final Version version = VersionUtils.randomVersion(random());
         final ClientYamlTestExecutionContext context =
-            new ClientYamlTestExecutionContext(null, randomBoolean()) {
+            new ClientYamlTestExecutionContext(null, null, randomBoolean()) {
                 @Override
                 ClientYamlTestResponse callApiInternal(String apiName, Map<String, String> params,
                                                        HttpEntity entity, Map<String, String> headers, NodeSelector nodeSelector) {

--- a/test/framework/src/test/java/org/elasticsearch/test/rest/yaml/section/DoSectionTests.java
+++ b/test/framework/src/test/java/org/elasticsearch/test/rest/yaml/section/DoSectionTests.java
@@ -48,7 +48,7 @@ public class DoSectionTests extends AbstractClientYamlTestFragmentParserTestCase
             final DoSection section = new DoSection(new XContentLocation(1, 1));
 
             // No warning headers doesn't throw an exception
-            section.checkWarningHeaders(emptyList());
+            section.checkWarningHeaders(emptyList(), Version.CURRENT);
         }
 
         final String testHeader = HeaderWarning.formatWarning("test");
@@ -60,11 +60,11 @@ public class DoSectionTests extends AbstractClientYamlTestFragmentParserTestCase
             final DoSection section = new DoSection(new XContentLocation(1, 1));
 
             final AssertionError one = expectThrows(AssertionError.class, () ->
-                    section.checkWarningHeaders(singletonList(testHeader)));
+                    section.checkWarningHeaders(singletonList(testHeader), Version.CURRENT));
             assertEquals("got unexpected warning header [\n\t" + testHeader + "\n]\n", one.getMessage());
 
             final AssertionError multiple = expectThrows(AssertionError.class, () ->
-                    section.checkWarningHeaders(Arrays.asList(testHeader, anotherHeader, someMoreHeader)));
+                    section.checkWarningHeaders(Arrays.asList(testHeader, anotherHeader, someMoreHeader), Version.CURRENT));
             assertEquals(
                     "got unexpected warning headers [\n\t" +
                             testHeader + "\n\t" +
@@ -77,19 +77,19 @@ public class DoSectionTests extends AbstractClientYamlTestFragmentParserTestCase
         {
             final DoSection section = new DoSection(new XContentLocation(1, 1));
             section.setExpectedWarningHeaders(singletonList("test"));
-            section.checkWarningHeaders(singletonList(testHeader));
+            section.checkWarningHeaders(singletonList(testHeader), Version.CURRENT);
         }
         {
             final DoSection section = new DoSection(new XContentLocation(1, 1));
             section.setExpectedWarningHeaders(Arrays.asList("test", "another \"with quotes and \\ backslashes\"", "some more"));
-            section.checkWarningHeaders(Arrays.asList(testHeader, anotherHeader, someMoreHeader));
+            section.checkWarningHeaders(Arrays.asList(testHeader, anotherHeader, someMoreHeader), Version.CURRENT);
         }
 
         // But if you don't get some that you did expect, that is an error
         {
             final DoSection section = new DoSection(new XContentLocation(1, 1));
             section.setExpectedWarningHeaders(singletonList("test"));
-            final AssertionError e = expectThrows(AssertionError.class, () -> section.checkWarningHeaders(emptyList()));
+            final AssertionError e = expectThrows(AssertionError.class, () -> section.checkWarningHeaders(emptyList(), Version.CURRENT));
             assertEquals("did not get expected warning header [\n\ttest\n]\n", e.getMessage());
         }
         {
@@ -97,11 +97,11 @@ public class DoSectionTests extends AbstractClientYamlTestFragmentParserTestCase
             section.setExpectedWarningHeaders(Arrays.asList("test", "another", "some more"));
 
             final AssertionError multiple = expectThrows(AssertionError.class, () ->
-                    section.checkWarningHeaders(emptyList()));
+                    section.checkWarningHeaders(emptyList(), Version.CURRENT));
             assertEquals("did not get expected warning headers [\n\ttest\n\tanother\n\tsome more\n]\n", multiple.getMessage());
 
             final AssertionError one = expectThrows(AssertionError.class, () ->
-                    section.checkWarningHeaders(Arrays.asList(testHeader, someMoreHeader)));
+                    section.checkWarningHeaders(Arrays.asList(testHeader, someMoreHeader), Version.CURRENT));
             assertEquals("did not get expected warning header [\n\tanother\n]\n", one.getMessage());
         }
 
@@ -110,7 +110,7 @@ public class DoSectionTests extends AbstractClientYamlTestFragmentParserTestCase
             final DoSection section = new DoSection(new XContentLocation(1, 1));
             section.setExpectedWarningHeaders(Arrays.asList("test", "another", "some more"));
             final AssertionError e = expectThrows(AssertionError.class, () ->
-                    section.checkWarningHeaders(Arrays.asList(testHeader, catHeader)));
+                    section.checkWarningHeaders(Arrays.asList(testHeader, catHeader), Version.CURRENT));
             assertEquals("got unexpected warning header [\n\t" +
                             catHeader + "\n]\n" +
                             "did not get expected warning headers [\n\tanother\n\tsome more\n]\n",
@@ -121,9 +121,9 @@ public class DoSectionTests extends AbstractClientYamlTestFragmentParserTestCase
         {
             final DoSection section = new DoSection(new XContentLocation(1, 1));
             section.setAllowedWarningHeaders(singletonList("test"));
-            section.checkWarningHeaders(singletonList(testHeader));
+            section.checkWarningHeaders(singletonList(testHeader), Version.CURRENT);
             // and don't throw exceptions if we don't receive them
-            section.checkWarningHeaders(emptyList());
+            section.checkWarningHeaders(emptyList(), Version.CURRENT);
         }
     }
 
@@ -139,7 +139,7 @@ public class DoSectionTests extends AbstractClientYamlTestFragmentParserTestCase
         //require header and it matches (basic example)
         DoSection section = new DoSection(new XContentLocation(1, 1));
         section.setExpectedWarningHeadersRegex(singletonList(Pattern.compile(".*")));
-        section.checkWarningHeaders(singletonList(testHeader));
+        section.checkWarningHeaders(singletonList(testHeader), Version.CURRENT);
 
         //require header and it matches (realistic example)
         section = new DoSection(new XContentLocation(1, 1));
@@ -149,14 +149,14 @@ public class DoSectionTests extends AbstractClientYamlTestFragmentParserTestCase
             singletonList(Pattern.compile("^index template \\[(.+)\\] has index patterns \\[(.+)\\] matching patterns from existing " +
                 "older templates \\[(.+)\\] with patterns \\((.+)\\); this template \\[(.+)\\] will " +
                 "take precedence during new index creation$")));
-        section.checkWarningHeaders(singletonList(realisticTestHeader));
+        section.checkWarningHeaders(singletonList(realisticTestHeader), Version.CURRENT);
 
         //require header, but no headers returned
         section = new DoSection(new XContentLocation(1, 1));
         section.setExpectedWarningHeadersRegex(singletonList(Pattern.compile("junk")));
         DoSection finalSection = section;
         AssertionError error =
-            expectThrows(AssertionError.class, () -> finalSection.checkWarningHeaders(emptyList()));
+            expectThrows(AssertionError.class, () -> finalSection.checkWarningHeaders(emptyList(), Version.CURRENT));
         assertEquals("the following regular expression did not match any warning header [\n\tjunk\n]\n", error.getMessage());
 
         //require multiple header, but none returned (plural error message)
@@ -164,28 +164,28 @@ public class DoSectionTests extends AbstractClientYamlTestFragmentParserTestCase
         section.setExpectedWarningHeadersRegex(Arrays.asList(Pattern.compile("junk"), Pattern.compile("junk2")));
         DoSection finalSection2 = section;
         error =
-            expectThrows(AssertionError.class, () -> finalSection2.checkWarningHeaders(emptyList()));
+            expectThrows(AssertionError.class, () -> finalSection2.checkWarningHeaders(emptyList(), Version.CURRENT));
         assertEquals("the following regular expressions did not match any warning header [\n\tjunk\n\tjunk2\n]\n", error.getMessage());
 
         //require header, got one back, but not matched
         section = new DoSection(new XContentLocation(1, 1));
         section.setExpectedWarningHeadersRegex(singletonList(Pattern.compile("junk")));
         DoSection finalSection3 = section;
-        error = expectThrows(AssertionError.class, () -> finalSection3.checkWarningHeaders(singletonList(testHeader)));
+        error = expectThrows(AssertionError.class, () -> finalSection3.checkWarningHeaders(singletonList(testHeader), Version.CURRENT));
         assertTrue(error.getMessage().contains("got unexpected warning header") && error.getMessage().contains("test"));
         assertTrue(error.getMessage().contains("the following regular expression did not match any warning header [\n\tjunk\n]\n"));
 
         //allow header
         section = new DoSection(new XContentLocation(1, 1));
         section.setAllowedWarningHeadersRegex(singletonList(Pattern.compile("test")));
-        section.checkWarningHeaders(singletonList(testHeader));
+        section.checkWarningHeaders(singletonList(testHeader), Version.CURRENT);
 
         //allow only one header
         section = new DoSection(new XContentLocation(1, 1));
         section.setExpectedWarningHeadersRegex(singletonList(Pattern.compile("test")));
         DoSection finalSection4 = section;
         error = expectThrows(AssertionError.class, () ->
-            finalSection4.checkWarningHeaders(org.elasticsearch.common.collect.List.of(testHeader, realisticTestHeader)));
+            finalSection4.checkWarningHeaders(org.elasticsearch.common.collect.List.of(testHeader, realisticTestHeader), Version.CURRENT));
         assertTrue(error.getMessage().contains("got unexpected warning header") && error.getMessage().contains("precedence during"));
 
         //the non-regex version does not need to worry about escaping since it is an exact match, and the code ensures that both
@@ -200,7 +200,7 @@ public class DoSectionTests extends AbstractClientYamlTestFragmentParserTestCase
         section = new DoSection(new XContentLocation(1, 1));
         section.setAllowedWarningHeadersRegex(singletonList(
             Pattern.compile("^test \\\\\"with quotes and \\\\\\\\ backslashes\\\\\"$")));
-        section.checkWarningHeaders(singletonList(testHeaderWithQuotesAndBackslashes));
+        section.checkWarningHeaders(singletonList(testHeaderWithQuotesAndBackslashes), Version.CURRENT);
     }
 
     public void testIgnoreTypesWarnings() {
@@ -210,7 +210,7 @@ public class DoSectionTests extends AbstractClientYamlTestFragmentParserTestCase
 
         DoSection section = new DoSection(new XContentLocation(1, 1));
         section.setExpectedWarningHeaders(singletonList("warning"));
-        section.checkWarningHeaders(Arrays.asList(legitimateWarning, typesWarning));
+        section.checkWarningHeaders(Arrays.asList(legitimateWarning, typesWarning), Version.CURRENT);
     }
 
     public void testParseDoSectionNoBody() throws Exception {

--- a/test/framework/src/test/java/org/elasticsearch/test/rest/yaml/section/DoSectionTests.java
+++ b/test/framework/src/test/java/org/elasticsearch/test/rest/yaml/section/DoSectionTests.java
@@ -48,7 +48,7 @@ public class DoSectionTests extends AbstractClientYamlTestFragmentParserTestCase
             final DoSection section = new DoSection(new XContentLocation(1, 1));
 
             // No warning headers doesn't throw an exception
-            section.checkWarningHeaders(emptyList(), Version.CURRENT);
+            section.checkWarningHeaders(emptyList());
         }
 
         final String testHeader = HeaderWarning.formatWarning("test");
@@ -60,11 +60,11 @@ public class DoSectionTests extends AbstractClientYamlTestFragmentParserTestCase
             final DoSection section = new DoSection(new XContentLocation(1, 1));
 
             final AssertionError one = expectThrows(AssertionError.class, () ->
-                    section.checkWarningHeaders(singletonList(testHeader), Version.CURRENT));
+                    section.checkWarningHeaders(singletonList(testHeader)));
             assertEquals("got unexpected warning header [\n\t" + testHeader + "\n]\n", one.getMessage());
 
             final AssertionError multiple = expectThrows(AssertionError.class, () ->
-                    section.checkWarningHeaders(Arrays.asList(testHeader, anotherHeader, someMoreHeader), Version.CURRENT));
+                    section.checkWarningHeaders(Arrays.asList(testHeader, anotherHeader, someMoreHeader)));
             assertEquals(
                     "got unexpected warning headers [\n\t" +
                             testHeader + "\n\t" +
@@ -77,19 +77,19 @@ public class DoSectionTests extends AbstractClientYamlTestFragmentParserTestCase
         {
             final DoSection section = new DoSection(new XContentLocation(1, 1));
             section.setExpectedWarningHeaders(singletonList("test"));
-            section.checkWarningHeaders(singletonList(testHeader), Version.CURRENT);
+            section.checkWarningHeaders(singletonList(testHeader));
         }
         {
             final DoSection section = new DoSection(new XContentLocation(1, 1));
             section.setExpectedWarningHeaders(Arrays.asList("test", "another \"with quotes and \\ backslashes\"", "some more"));
-            section.checkWarningHeaders(Arrays.asList(testHeader, anotherHeader, someMoreHeader), Version.CURRENT);
+            section.checkWarningHeaders(Arrays.asList(testHeader, anotherHeader, someMoreHeader));
         }
 
         // But if you don't get some that you did expect, that is an error
         {
             final DoSection section = new DoSection(new XContentLocation(1, 1));
             section.setExpectedWarningHeaders(singletonList("test"));
-            final AssertionError e = expectThrows(AssertionError.class, () -> section.checkWarningHeaders(emptyList(), Version.CURRENT));
+            final AssertionError e = expectThrows(AssertionError.class, () -> section.checkWarningHeaders(emptyList()));
             assertEquals("did not get expected warning header [\n\ttest\n]\n", e.getMessage());
         }
         {
@@ -97,11 +97,11 @@ public class DoSectionTests extends AbstractClientYamlTestFragmentParserTestCase
             section.setExpectedWarningHeaders(Arrays.asList("test", "another", "some more"));
 
             final AssertionError multiple = expectThrows(AssertionError.class, () ->
-                    section.checkWarningHeaders(emptyList(), Version.CURRENT));
+                    section.checkWarningHeaders(emptyList()));
             assertEquals("did not get expected warning headers [\n\ttest\n\tanother\n\tsome more\n]\n", multiple.getMessage());
 
             final AssertionError one = expectThrows(AssertionError.class, () ->
-                    section.checkWarningHeaders(Arrays.asList(testHeader, someMoreHeader), Version.CURRENT));
+                    section.checkWarningHeaders(Arrays.asList(testHeader, someMoreHeader)));
             assertEquals("did not get expected warning header [\n\tanother\n]\n", one.getMessage());
         }
 
@@ -110,7 +110,7 @@ public class DoSectionTests extends AbstractClientYamlTestFragmentParserTestCase
             final DoSection section = new DoSection(new XContentLocation(1, 1));
             section.setExpectedWarningHeaders(Arrays.asList("test", "another", "some more"));
             final AssertionError e = expectThrows(AssertionError.class, () ->
-                    section.checkWarningHeaders(Arrays.asList(testHeader, catHeader), Version.CURRENT));
+                    section.checkWarningHeaders(Arrays.asList(testHeader, catHeader)));
             assertEquals("got unexpected warning header [\n\t" +
                             catHeader + "\n]\n" +
                             "did not get expected warning headers [\n\tanother\n\tsome more\n]\n",
@@ -121,9 +121,9 @@ public class DoSectionTests extends AbstractClientYamlTestFragmentParserTestCase
         {
             final DoSection section = new DoSection(new XContentLocation(1, 1));
             section.setAllowedWarningHeaders(singletonList("test"));
-            section.checkWarningHeaders(singletonList(testHeader), Version.CURRENT);
+            section.checkWarningHeaders(singletonList(testHeader));
             // and don't throw exceptions if we don't receive them
-            section.checkWarningHeaders(emptyList(), Version.CURRENT);
+            section.checkWarningHeaders(emptyList());
         }
     }
 
@@ -139,7 +139,7 @@ public class DoSectionTests extends AbstractClientYamlTestFragmentParserTestCase
         //require header and it matches (basic example)
         DoSection section = new DoSection(new XContentLocation(1, 1));
         section.setExpectedWarningHeadersRegex(singletonList(Pattern.compile(".*")));
-        section.checkWarningHeaders(singletonList(testHeader), Version.CURRENT);
+        section.checkWarningHeaders(singletonList(testHeader));
 
         //require header and it matches (realistic example)
         section = new DoSection(new XContentLocation(1, 1));
@@ -149,14 +149,14 @@ public class DoSectionTests extends AbstractClientYamlTestFragmentParserTestCase
             singletonList(Pattern.compile("^index template \\[(.+)\\] has index patterns \\[(.+)\\] matching patterns from existing " +
                 "older templates \\[(.+)\\] with patterns \\((.+)\\); this template \\[(.+)\\] will " +
                 "take precedence during new index creation$")));
-        section.checkWarningHeaders(singletonList(realisticTestHeader), Version.CURRENT);
+        section.checkWarningHeaders(singletonList(realisticTestHeader));
 
         //require header, but no headers returned
         section = new DoSection(new XContentLocation(1, 1));
         section.setExpectedWarningHeadersRegex(singletonList(Pattern.compile("junk")));
         DoSection finalSection = section;
         AssertionError error =
-            expectThrows(AssertionError.class, () -> finalSection.checkWarningHeaders(emptyList(), Version.CURRENT));
+            expectThrows(AssertionError.class, () -> finalSection.checkWarningHeaders(emptyList()));
         assertEquals("the following regular expression did not match any warning header [\n\tjunk\n]\n", error.getMessage());
 
         //require multiple header, but none returned (plural error message)
@@ -164,28 +164,28 @@ public class DoSectionTests extends AbstractClientYamlTestFragmentParserTestCase
         section.setExpectedWarningHeadersRegex(Arrays.asList(Pattern.compile("junk"), Pattern.compile("junk2")));
         DoSection finalSection2 = section;
         error =
-            expectThrows(AssertionError.class, () -> finalSection2.checkWarningHeaders(emptyList(), Version.CURRENT));
+            expectThrows(AssertionError.class, () -> finalSection2.checkWarningHeaders(emptyList()));
         assertEquals("the following regular expressions did not match any warning header [\n\tjunk\n\tjunk2\n]\n", error.getMessage());
 
         //require header, got one back, but not matched
         section = new DoSection(new XContentLocation(1, 1));
         section.setExpectedWarningHeadersRegex(singletonList(Pattern.compile("junk")));
         DoSection finalSection3 = section;
-        error = expectThrows(AssertionError.class, () -> finalSection3.checkWarningHeaders(singletonList(testHeader), Version.CURRENT));
+        error = expectThrows(AssertionError.class, () -> finalSection3.checkWarningHeaders(singletonList(testHeader)));
         assertTrue(error.getMessage().contains("got unexpected warning header") && error.getMessage().contains("test"));
         assertTrue(error.getMessage().contains("the following regular expression did not match any warning header [\n\tjunk\n]\n"));
 
         //allow header
         section = new DoSection(new XContentLocation(1, 1));
         section.setAllowedWarningHeadersRegex(singletonList(Pattern.compile("test")));
-        section.checkWarningHeaders(singletonList(testHeader), Version.CURRENT);
+        section.checkWarningHeaders(singletonList(testHeader));
 
         //allow only one header
         section = new DoSection(new XContentLocation(1, 1));
         section.setExpectedWarningHeadersRegex(singletonList(Pattern.compile("test")));
         DoSection finalSection4 = section;
         error = expectThrows(AssertionError.class, () ->
-            finalSection4.checkWarningHeaders(Arrays.asList(testHeader, realisticTestHeader), Version.CURRENT));
+            finalSection4.checkWarningHeaders(org.elasticsearch.common.collect.List.of(testHeader, realisticTestHeader)));
         assertTrue(error.getMessage().contains("got unexpected warning header") && error.getMessage().contains("precedence during"));
 
         //the non-regex version does not need to worry about escaping since it is an exact match, and the code ensures that both
@@ -200,7 +200,7 @@ public class DoSectionTests extends AbstractClientYamlTestFragmentParserTestCase
         section = new DoSection(new XContentLocation(1, 1));
         section.setAllowedWarningHeadersRegex(singletonList(
             Pattern.compile("^test \\\\\"with quotes and \\\\\\\\ backslashes\\\\\"$")));
-        section.checkWarningHeaders(singletonList(testHeaderWithQuotesAndBackslashes), Version.CURRENT);
+        section.checkWarningHeaders(singletonList(testHeaderWithQuotesAndBackslashes));
     }
 
     public void testIgnoreTypesWarnings() {
@@ -210,7 +210,7 @@ public class DoSectionTests extends AbstractClientYamlTestFragmentParserTestCase
 
         DoSection section = new DoSection(new XContentLocation(1, 1));
         section.setExpectedWarningHeaders(singletonList("warning"));
-        section.checkWarningHeaders(Arrays.asList(legitimateWarning, typesWarning), Version.CURRENT);
+        section.checkWarningHeaders(Arrays.asList(legitimateWarning, typesWarning));
     }
 
     public void testParseDoSectionNoBody() throws Exception {

--- a/x-pack/plugin/ilm/qa/multi-node/src/javaRestTest/java/org/elasticsearch/xpack/ilm/TimeSeriesLifecycleActionsIT.java
+++ b/x-pack/plugin/ilm/qa/multi-node/src/javaRestTest/java/org/elasticsearch/xpack/ilm/TimeSeriesLifecycleActionsIT.java
@@ -27,6 +27,7 @@ import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.common.xcontent.json.JsonXContent;
 import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.engine.EngineConfig;
+import org.elasticsearch.rest.action.admin.indices.RestPutIndexTemplateAction;
 import org.elasticsearch.snapshots.SnapshotState;
 import org.elasticsearch.test.rest.ESRestTestCase;
 import org.elasticsearch.xpack.core.ilm.AllocateAction;
@@ -461,6 +462,7 @@ public class TimeSeriesLifecycleActionsIT extends ESRestTestCase {
             "}", ContentType.APPLICATION_JSON);
         Request templateRequest = new Request("PUT", "_template/test");
         templateRequest.setEntity(template);
+        templateRequest.setOptions(expectWarnings(RestPutIndexTemplateAction.DEPRECATION_WARNING));
         client().performRequest(templateRequest);
 
         policy = randomAlphaOfLengthBetween(5,20);
@@ -636,6 +638,7 @@ public class TimeSeriesLifecycleActionsIT extends ESRestTestCase {
             "    \"index.write.wait_for_active_shards\": \"all\"\n" +
             "  }\n" +
             "}");
+        createIndexTemplate.setOptions(expectWarnings(RestPutIndexTemplateAction.DEPRECATION_WARNING));
         client().performRequest(createIndexTemplate);
 
         // index document to trigger rollover
@@ -662,6 +665,7 @@ public class TimeSeriesLifecycleActionsIT extends ESRestTestCase {
             "    \"index.lifecycle.rollover_alias\": \"" + alias + "\"\n" +
             "  }\n" +
             "}");
+        createIndexTemplate.setOptions(expectWarnings(RestPutIndexTemplateAction.DEPRECATION_WARNING));
         client().performRequest(createIndexTemplate);
 
         createIndexWithSettings(client(), index + "-1", alias, Settings.builder(), true);
@@ -765,6 +769,7 @@ public class TimeSeriesLifecycleActionsIT extends ESRestTestCase {
             "    \"index.lifecycle.rollover_alias\": \"" + alias + "\"\n" +
             "  }\n" +
             "}");
+        createIndexTemplate.setOptions(expectWarnings(RestPutIndexTemplateAction.DEPRECATION_WARNING));
         client().performRequest(createIndexTemplate);
 
         createIndexWithSettings(client(), index + "-1", alias,

--- a/x-pack/plugin/ilm/qa/multi-node/src/javaRestTest/java/org/elasticsearch/xpack/ilm/actions/RolloverActionIT.java
+++ b/x-pack/plugin/ilm/qa/multi-node/src/javaRestTest/java/org/elasticsearch/xpack/ilm/actions/RolloverActionIT.java
@@ -12,6 +12,7 @@ import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.unit.TimeValue;
+import org.elasticsearch.rest.action.admin.indices.RestPutIndexTemplateAction;
 import org.elasticsearch.test.rest.ESRestTestCase;
 import org.elasticsearch.xpack.core.ilm.LifecycleSettings;
 import org.elasticsearch.xpack.core.ilm.PhaseCompleteStep;
@@ -192,6 +193,7 @@ public class RolloverActionIT extends ESRestTestCase {
             "    \"index.lifecycle.rollover_alias\": \"" + alias + "\"\n" +
             "  }\n" +
             "}");
+        createIndexTemplate.setOptions(expectWarnings(RestPutIndexTemplateAction.DEPRECATION_WARNING));
         client().performRequest(createIndexTemplate);
 
         createIndexWithSettings(

--- a/x-pack/plugin/ilm/qa/multi-node/src/javaRestTest/java/org/elasticsearch/xpack/ilm/actions/ShrinkActionIT.java
+++ b/x-pack/plugin/ilm/qa/multi-node/src/javaRestTest/java/org/elasticsearch/xpack/ilm/actions/ShrinkActionIT.java
@@ -18,6 +18,7 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.json.JsonXContent;
+import org.elasticsearch.rest.action.admin.indices.RestPutIndexTemplateAction;
 import org.elasticsearch.test.rest.ESRestTestCase;
 import org.elasticsearch.xpack.cluster.routing.allocation.DataTierAllocationDecider;
 import org.elasticsearch.xpack.core.ilm.LifecycleAction;
@@ -186,6 +187,7 @@ public class ShrinkActionIT extends ESRestTestCase {
             "    \"index.lifecycle.rollover_alias\": \"" + alias + "\"\n" +
             "  }\n" +
             "}");
+        createTemplateRequest.setOptions(expectWarnings(RestPutIndexTemplateAction.DEPRECATION_WARNING));
         client().performRequest(createTemplateRequest);
 
         // then create the index and index a document to trigger rollover

--- a/x-pack/plugin/ilm/qa/with-security/src/javaRestTest/java/org/elasticsearch/xpack/security/PermissionsIT.java
+++ b/x-pack/plugin/ilm/qa/with-security/src/javaRestTest/java/org/elasticsearch/xpack/security/PermissionsIT.java
@@ -43,6 +43,7 @@ import org.elasticsearch.common.xcontent.json.JsonXContent;
 import org.elasticsearch.common.xcontent.support.XContentMapValues;
 import org.elasticsearch.repositories.fs.FsRepository;
 import org.elasticsearch.rest.RestStatus;
+import org.elasticsearch.rest.action.admin.indices.RestPutIndexTemplateAction;
 import org.elasticsearch.snapshots.SnapshotState;
 import org.elasticsearch.test.rest.ESRestTestCase;
 import org.elasticsearch.xpack.core.ilm.DeleteAction;
@@ -363,6 +364,7 @@ public class PermissionsIT extends ESRestTestCase {
                 "                   \"index.lifecycle.rollover_alias\": \""+alias+"\"\n" +
                 "                 }\n" +
                 "              }");
+        request.setOptions(expectWarnings(RestPutIndexTemplateAction.DEPRECATION_WARNING));
         assertOK(adminClient().performRequest(request));
     }
 

--- a/x-pack/plugin/transform/qa/single-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/TransformPivotRestSpecialCasesIT.java
+++ b/x-pack/plugin/transform/qa/single-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/TransformPivotRestSpecialCasesIT.java
@@ -13,6 +13,7 @@ import org.elasticsearch.client.Request;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.support.XContentMapValues;
+import org.elasticsearch.rest.action.admin.indices.RestPutIndexTemplateAction;
 import org.junit.Before;
 
 import java.io.IOException;
@@ -43,7 +44,6 @@ public class TransformPivotRestSpecialCasesIT extends TransformRestTestCase {
         indicesCreated = true;
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/71792")
     public void testIndexTemplateMappingClash() throws Exception {
         String transformId = "special_pivot_template_mappings_clash";
         String transformIndex = "special_pivot_template_mappings_clash";
@@ -64,6 +64,7 @@ public class TransformPivotRestSpecialCasesIT extends TransformRestTestCase {
             + "}";
 
         createIndexTemplateRequest.setJsonEntity(template);
+        createIndexTemplateRequest.setOptions(expectWarnings(RestPutIndexTemplateAction.DEPRECATION_WARNING));
         Map<String, Object> createIndexTemplateResponse = entityAsMap(client().performRequest(createIndexTemplateRequest));
         assertThat(createIndexTemplateResponse.get("acknowledged"), equalTo(Boolean.TRUE));
 


### PR DESCRIPTION
Closes #71307

Backport of #71309 and #71778
