### PR TITLE
[Transform] disable bwc for backporting telemetry for transform features

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -190,9 +190,9 @@ tasks.register("verifyVersions") {
  * after the backport of the backcompat code is complete.
  */
 
-boolean bwc_tests_enabled = true
+boolean bwc_tests_enabled = false
 // place a PR link here when committing bwc changes:
-String bwc_tests_disabled_issue = ""
+String bwc_tests_disabled_issue = "https://github.com/elastic/elasticsearch/pull/71835"
 /*
  * FIPS 140-2 behavior was fixed in 7.11.0. Before that there is no way to run elasticsearch in a
  * JVM that is properly configured to be in fips mode with BCFIPS. For now we need to disable


### PR DESCRIPTION
disable bwc to integrate https://github.com/elastic/elasticsearch/pull/71835

Relates #68461

