### PR TITLE
[Transform] finish backport: adapt versions to 7.13 and re-enable BWC tests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -190,9 +190,9 @@ tasks.register("verifyVersions") {
  * after the backport of the backcompat code is complete.
  */
 
-boolean bwc_tests_enabled = false
+boolean bwc_tests_enabled = true
 // place a PR link here when committing bwc changes:
-String bwc_tests_disabled_issue = "https://github.com/elastic/elasticsearch/pull/71835"
+String bwc_tests_disabled_issue = ""
 /*
  * FIPS 140-2 behavior was fixed in 7.11.0. Before that there is no way to run elasticsearch in a
  * JVM that is properly configured to be in fips mode with BCFIPS. For now we need to disable

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/TransformFeatureSetUsage.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/TransformFeatureSetUsage.java
@@ -17,7 +17,6 @@ import org.elasticsearch.xpack.core.transform.transforms.TransformIndexerStats;
 import org.elasticsearch.xpack.core.XPackField;
 
 import java.io.IOException;
-import java.util.Collections;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Objects;

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/TransformFeatureSetUsage.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/TransformFeatureSetUsage.java
@@ -33,11 +33,7 @@ public class TransformFeatureSetUsage extends Usage {
     public TransformFeatureSetUsage(StreamInput in) throws IOException {
         super(in);
         this.transformCountByState = in.readMap(StreamInput::readString, StreamInput::readLong);
-        if (in.getVersion().onOrAfter(Version.V_8_0_0)) {  // TODO: V_7_13_0
-            this.transformCountByFeature = in.readMap(StreamInput::readString, StreamInput::readLong);
-        } else {
-            this.transformCountByFeature = Collections.emptyMap();
-        }
+        this.transformCountByFeature = in.readMap(StreamInput::readString, StreamInput::readLong);
         this.accumulatedStats = new TransformIndexerStats(in);
     }
 
@@ -59,9 +55,7 @@ public class TransformFeatureSetUsage extends Usage {
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
         out.writeMap(transformCountByState, StreamOutput::writeString, StreamOutput::writeLong);
-        if (out.getVersion().onOrAfter(Version.V_8_0_0)) {  // TODO: V_7_13_0
-            out.writeMap(transformCountByFeature, StreamOutput::writeString, StreamOutput::writeLong);
-        }
+        out.writeMap(transformCountByFeature, StreamOutput::writeString, StreamOutput::writeLong);
         accumulatedStats.writeTo(out);
     }
 


### PR DESCRIPTION
finalize the integration of https://github.com/elastic/elasticsearch/pull/71607

Relates #68461

