### PR TITLE
Cleanup SnapshotsInProgress for Readability (#71620)

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/SnapshotDeletionsInProgress.java
+++ b/server/src/main/java/org/elasticsearch/cluster/SnapshotDeletionsInProgress.java
@@ -72,14 +72,6 @@ public class SnapshotDeletionsInProgress extends AbstractNamedDiffable<Custom> i
     }
 
     /**
-     * Returns a new instance of {@link SnapshotDeletionsInProgress} with the given
-     * {@link Entry} added.
-     */
-    public static SnapshotDeletionsInProgress newInstance(Entry entry) {
-        return new SnapshotDeletionsInProgress(Collections.singletonList(entry));
-    }
-
-    /**
      * Returns a new instance of {@link SnapshotDeletionsInProgress} which adds
      * the given {@link Entry} to the invoking instance.
      */

--- a/server/src/main/java/org/elasticsearch/cluster/SnapshotsInProgress.java
+++ b/server/src/main/java/org/elasticsearch/cluster/SnapshotsInProgress.java
@@ -59,6 +59,67 @@ public class SnapshotsInProgress extends AbstractNamedDiffable<Custom> implement
 
     public static final String ABORTED_FAILURE_TEXT = "Snapshot was aborted by deletion";
 
+    private final List<Entry> entries;
+
+    public static SnapshotsInProgress of(List<Entry> entries) {
+        if (entries.isEmpty()) {
+            return EMPTY;
+        }
+        return new SnapshotsInProgress(Collections.unmodifiableList(entries));
+    }
+
+    public SnapshotsInProgress(StreamInput in) throws IOException {
+        this(in.readList(SnapshotsInProgress.Entry::new));
+    }
+
+    private SnapshotsInProgress(List<Entry> entries) {
+        this.entries = entries;
+        assert assertConsistentEntries(entries);
+    }
+
+    public List<Entry> entries() {
+        return this.entries;
+    }
+
+    public Entry snapshot(final Snapshot snapshot) {
+        for (Entry entry : entries) {
+            final Snapshot curr = entry.snapshot();
+            if (curr.equals(snapshot)) {
+                return entry;
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public String getWriteableName() {
+        return TYPE;
+    }
+
+    @Override
+    public Version getMinimalSupportedVersion() {
+        return Version.CURRENT.minimumCompatibilityVersion();
+    }
+
+    public static NamedDiff<Custom> readDiffFrom(StreamInput in) throws IOException {
+        return readDiffFrom(Custom.class, TYPE, in);
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeList(entries);
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, ToXContent.Params params) throws IOException {
+        builder.startArray("snapshots");
+        for (Entry entry : entries) {
+            entry.toXContent(builder, params);
+        }
+        builder.endArray();
+        return builder;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
@@ -88,8 +149,9 @@ public class SnapshotsInProgress extends AbstractNamedDiffable<Custom> implement
      * will be in state {@link State#SUCCESS} right away otherwise it will be in state {@link State#STARTED}.
      */
     public static Entry startedEntry(Snapshot snapshot, boolean includeGlobalState, boolean partial, List<IndexId> indices,
-        List<String> dataStreams, long startTime, long repositoryStateId, ImmutableOpenMap<ShardId, ShardSnapshotStatus> shards,
-        Map<String, Object> userMetadata, Version version, List<SnapshotFeatureInfo> featureStates) {
+                                     List<String> dataStreams, long startTime, long repositoryStateId,
+                                     ImmutableOpenMap<ShardId, ShardSnapshotStatus> shards,
+                                     Map<String, Object> userMetadata, Version version, List<SnapshotFeatureInfo> featureStates) {
         return new SnapshotsInProgress.Entry(snapshot, includeGlobalState, partial,
                 completed(shards.values()) ? State.SUCCESS : State.STARTED,
                 indices, dataStreams, featureStates, startTime, repositoryStateId, shards, null, userMetadata, version);
@@ -109,8 +171,294 @@ public class SnapshotsInProgress extends AbstractNamedDiffable<Custom> implement
     public static Entry startClone(Snapshot snapshot, SnapshotId source, List<IndexId> indices, long startTime,
                                    long repositoryStateId, Version version) {
         return new SnapshotsInProgress.Entry(snapshot, true, false, State.STARTED, indices, Collections.emptyList(),
-            Collections.emptyList(), startTime, repositoryStateId, ImmutableOpenMap.of(), null, Collections.emptyMap(), version, source,
-            ImmutableOpenMap.of());
+            Collections.emptyList(), startTime, repositoryStateId, ImmutableOpenMap.of(), null, Collections.emptyMap(), version,
+            source, ImmutableOpenMap.of());
+    }
+
+    /**
+     * Checks if all shards in the list have completed
+     *
+     * @param shards list of shard statuses
+     * @return true if all shards have completed (either successfully or failed), false otherwise
+     */
+    public static boolean completed(ObjectContainer<ShardSnapshotStatus> shards) {
+        for (ObjectCursor<ShardSnapshotStatus> status : shards) {
+            if (status.value.state().completed == false) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static boolean hasFailures(ImmutableOpenMap<RepositoryShardId, ShardSnapshotStatus> clones) {
+        for (ObjectCursor<ShardSnapshotStatus> value : clones.values()) {
+            if (value.value.state().failed()) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static boolean assertConsistentEntries(List<Entry> entries) {
+        final Map<String, Set<Tuple<String, Integer>>> assignedShardsByRepo = new HashMap<>();
+        final Map<String, Set<Tuple<String, Integer>>> queuedShardsByRepo = new HashMap<>();
+        for (Entry entry : entries) {
+            for (ObjectObjectCursor<ShardId, ShardSnapshotStatus> shard : entry.shards()) {
+                final ShardId sid = shard.key;
+                assert assertShardStateConsistent(entries, assignedShardsByRepo, queuedShardsByRepo, entry, sid.getIndexName(), sid.id(),
+                        shard.value);
+            }
+            for (ObjectObjectCursor<RepositoryShardId, ShardSnapshotStatus> shard : entry.clones()) {
+                final RepositoryShardId sid = shard.key;
+                assert assertShardStateConsistent(entries, assignedShardsByRepo, queuedShardsByRepo, entry, sid.indexName(), sid.shardId(),
+                        shard.value);
+            }
+        }
+        for (String repoName : assignedShardsByRepo.keySet()) {
+            // make sure in-flight-shard-states can be built cleanly for the entries without tripping assertions
+            InFlightShardSnapshotStates.forRepo(repoName, entries);
+        }
+        return true;
+    }
+
+    private static boolean assertShardStateConsistent(List<Entry> entries, Map<String, Set<Tuple<String, Integer>>> assignedShardsByRepo,
+                                                      Map<String, Set<Tuple<String, Integer>>> queuedShardsByRepo, Entry entry,
+                                                      String indexName, int shardId, ShardSnapshotStatus shardSnapshotStatus) {
+        if (shardSnapshotStatus.isActive()) {
+            Tuple<String, Integer> plainShardId = Tuple.tuple(indexName, shardId);
+            assert assignedShardsByRepo.computeIfAbsent(entry.repository(), k -> new HashSet<>())
+                    .add(plainShardId) : "Found duplicate shard assignments in " + entries;
+            assert queuedShardsByRepo.getOrDefault(entry.repository(), Collections.emptySet()).contains(plainShardId) == false
+                    : "Found active shard assignments after queued shard assignments in " + entries;
+        } else if (shardSnapshotStatus.state() == ShardState.QUEUED) {
+            queuedShardsByRepo.computeIfAbsent(entry.repository(), k -> new HashSet<>()).add(Tuple.tuple(indexName, shardId));
+        }
+        return true;
+    }
+
+    public enum ShardState {
+        INIT((byte) 0, false, false),
+        SUCCESS((byte) 2, true, false),
+        FAILED((byte) 3, true, true),
+        ABORTED((byte) 4, false, true),
+        MISSING((byte) 5, true, true),
+        /**
+         * Shard snapshot is waiting for the primary to snapshot to become available.
+         */
+        WAITING((byte) 6, false, false),
+        /**
+         * Shard snapshot is waiting for another shard snapshot for the same shard and to the same repository to finish.
+         */
+        QUEUED((byte) 7, false, false);
+
+        private final byte value;
+
+        private final boolean completed;
+
+        private final boolean failed;
+
+        ShardState(byte value, boolean completed, boolean failed) {
+            this.value = value;
+            this.completed = completed;
+            this.failed = failed;
+        }
+
+        public boolean completed() {
+            return completed;
+        }
+
+        public boolean failed() {
+            return failed;
+        }
+
+        public static ShardState fromValue(byte value) {
+            switch (value) {
+                case 0:
+                    return INIT;
+                case 2:
+                    return SUCCESS;
+                case 3:
+                    return FAILED;
+                case 4:
+                    return ABORTED;
+                case 5:
+                    return MISSING;
+                case 6:
+                    return WAITING;
+                case 7:
+                    return QUEUED;
+                default:
+                    throw new IllegalArgumentException("No shard snapshot state for value [" + value + "]");
+            }
+        }
+    }
+
+    public enum State {
+        INIT((byte) 0, false),
+        STARTED((byte) 1, false),
+        SUCCESS((byte) 2, true),
+        FAILED((byte) 3, true),
+        ABORTED((byte) 4, false);
+
+        private final byte value;
+
+        private final boolean completed;
+
+        State(byte value, boolean completed) {
+            this.value = value;
+            this.completed = completed;
+        }
+
+        public byte value() {
+            return value;
+        }
+
+        public boolean completed() {
+            return completed;
+        }
+
+        public static State fromValue(byte value) {
+            switch (value) {
+                case 0:
+                    return INIT;
+                case 1:
+                    return STARTED;
+                case 2:
+                    return SUCCESS;
+                case 3:
+                    return FAILED;
+                case 4:
+                    return ABORTED;
+                default:
+                    throw new IllegalArgumentException("No snapshot state for value [" + value + "]");
+            }
+        }
+    }
+
+    public static class ShardSnapshotStatus implements Writeable {
+
+        /**
+         * Shard snapshot status for shards that are waiting for another operation to finish before they can be assigned to a node.
+         */
+        public static final ShardSnapshotStatus UNASSIGNED_QUEUED =
+            new SnapshotsInProgress.ShardSnapshotStatus(null, ShardState.QUEUED, null);
+
+        /**
+         * Shard snapshot status for shards that could not be snapshotted because their index was deleted from before the shard snapshot
+         * started.
+         */
+        public static final ShardSnapshotStatus MISSING =
+            new SnapshotsInProgress.ShardSnapshotStatus(null, ShardState.MISSING, "missing index", null);
+
+        private final ShardState state;
+
+        @Nullable
+        private final String nodeId;
+
+        @Nullable
+        private final String generation;
+
+        @Nullable
+        private final String reason;
+
+        public ShardSnapshotStatus(String nodeId, String generation) {
+            this(nodeId, ShardState.INIT, generation);
+        }
+
+        public ShardSnapshotStatus(@Nullable String nodeId, ShardState state, @Nullable String generation) {
+            this(nodeId, state, null, generation);
+        }
+
+        public ShardSnapshotStatus(@Nullable String nodeId, ShardState state, String reason, @Nullable String generation) {
+            this.nodeId = nodeId;
+            this.state = state;
+            this.reason = reason;
+            this.generation = generation;
+            assert assertConsistent();
+        }
+
+        private boolean assertConsistent() {
+            // If the state is failed we have to have a reason for this failure
+            assert state.failed() == false || reason != null;
+            assert (state != ShardState.INIT && state != ShardState.WAITING) || nodeId != null : "Null node id for state [" + state + "]";
+            return true;
+        }
+
+        public static ShardSnapshotStatus readFrom(StreamInput in) throws IOException {
+            String nodeId = in.readOptionalString();
+            final ShardState state = ShardState.fromValue(in.readByte());
+            final String generation;
+            if (SnapshotsService.useShardGenerations(in.getVersion())) {
+                generation = in.readOptionalString();
+            } else {
+                generation = null;
+            }
+            final String reason = in.readOptionalString();
+            if (state == ShardState.QUEUED) {
+                return UNASSIGNED_QUEUED;
+            }
+            return new ShardSnapshotStatus(nodeId, state, reason, generation);
+        }
+
+        public ShardState state() {
+            return state;
+        }
+
+        @Nullable
+        public String nodeId() {
+            return nodeId;
+        }
+
+        @Nullable
+        public String generation() {
+            return this.generation;
+        }
+
+        public String reason() {
+            return reason;
+        }
+
+        /**
+         * Checks if this shard snapshot is actively executing.
+         * A shard is defined as actively executing if it either is in a state that may write to the repository
+         * ({@link ShardState#INIT} or {@link ShardState#ABORTED}) or about to write to it in state {@link ShardState#WAITING}.
+         */
+        public boolean isActive() {
+            return state == ShardState.INIT || state == ShardState.ABORTED || state == ShardState.WAITING;
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            out.writeOptionalString(nodeId);
+            out.writeByte(state.value);
+            if (SnapshotsService.useShardGenerations(out.getVersion())) {
+                out.writeOptionalString(generation);
+            }
+            out.writeOptionalString(reason);
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            ShardSnapshotStatus status = (ShardSnapshotStatus) o;
+            return Objects.equals(nodeId, status.nodeId) && Objects.equals(reason, status.reason)
+                    && Objects.equals(generation, status.generation) && state == status.state;
+        }
+
+        @Override
+        public int hashCode() {
+            int result = state != null ? state.hashCode() : 0;
+            result = 31 * result + (nodeId != null ? nodeId.hashCode() : 0);
+            result = 31 * result + (reason != null ? reason.hashCode() : 0);
+            result = 31 * result + (generation != null ? generation.hashCode() : 0);
+            return result;
+        }
+
+        @Override
+        public String toString() {
+            return "ShardSnapshotStatus[state=" + state + ", nodeId=" + nodeId + ", reason=" + reason + ", generation=" + generation + "]";
+        }
     }
 
     public static class Entry implements Writeable, ToXContent, RepositoryOperation {
@@ -127,7 +475,6 @@ public class SnapshotsInProgress extends AbstractNamedDiffable<Custom> implement
         private final List<SnapshotFeatureInfo> featureStates;
         private final long startTime;
         private final long repositoryStateId;
-        // see #useShardGenerations
         private final Version version;
 
         /**
@@ -151,7 +498,7 @@ public class SnapshotsInProgress extends AbstractNamedDiffable<Custom> implement
                      ImmutableOpenMap<ShardId, ShardSnapshotStatus> shards, String failure, Map<String, Object> userMetadata,
                      Version version) {
             this(snapshot, includeGlobalState, partial, state, indices, dataStreams, featureStates, startTime, repositoryStateId, shards,
-                failure, userMetadata, version, null, ImmutableOpenMap.of());
+                    failure, userMetadata, version, null, ImmutableOpenMap.of());
         }
 
         private Entry(Snapshot snapshot, boolean includeGlobalState, boolean partial, State state, List<IndexId> indices,
@@ -272,7 +619,7 @@ public class SnapshotsInProgress extends AbstractNamedDiffable<Custom> implement
             assert newRepoGen > repositoryStateId : "Updated repository generation [" + newRepoGen
                     + "] must be higher than current generation [" + repositoryStateId + "]";
             return new Entry(snapshot, includeGlobalState, partial, state, indices, dataStreams, featureStates, startTime, newRepoGen,
-                shards, failure, userMetadata, version, source, clones);
+                    shards, failure, userMetadata, version, source, clones);
         }
 
         public Entry withClones(ImmutableOpenMap<RepositoryShardId, ShardSnapshotStatus> updatedClones) {
@@ -282,7 +629,7 @@ public class SnapshotsInProgress extends AbstractNamedDiffable<Custom> implement
             return new Entry(snapshot, includeGlobalState, partial,
                     completed(updatedClones.values()) ? (hasFailures(updatedClones) ? State.FAILED : State.SUCCESS) :
                             state, indices, dataStreams, featureStates, startTime, repositoryStateId, shards, failure, userMetadata,
-                            version, source, updatedClones);
+                    version, source, updatedClones);
         }
 
         /**
@@ -319,7 +666,7 @@ public class SnapshotsInProgress extends AbstractNamedDiffable<Custom> implement
 
         public Entry fail(ImmutableOpenMap<ShardId, ShardSnapshotStatus> shards, State state, String failure) {
             return new Entry(snapshot, includeGlobalState, partial, state, indices, dataStreams, featureStates, startTime,
-                repositoryStateId, shards, failure, userMetadata, version, source, clones);
+                    repositoryStateId, shards, failure, userMetadata, version, source, clones);
         }
 
         /**
@@ -333,7 +680,7 @@ public class SnapshotsInProgress extends AbstractNamedDiffable<Custom> implement
         public Entry withShardStates(ImmutableOpenMap<ShardId, ShardSnapshotStatus> shards) {
             if (completed(shards.values())) {
                 return new Entry(snapshot, includeGlobalState, partial, State.SUCCESS, indices, dataStreams, featureStates,
-                    startTime, repositoryStateId, shards, failure, userMetadata, version);
+                        startTime, repositoryStateId, shards, failure, userMetadata, version);
             }
             return withStartedShards(shards);
         }
@@ -344,7 +691,7 @@ public class SnapshotsInProgress extends AbstractNamedDiffable<Custom> implement
          */
         public Entry withStartedShards(ImmutableOpenMap<ShardId, ShardSnapshotStatus> shards) {
             final SnapshotsInProgress.Entry updated = new Entry(snapshot, includeGlobalState, partial, state, indices, dataStreams,
-                featureStates, startTime, repositoryStateId, shards, failure, userMetadata, version);
+                    featureStates, startTime, repositoryStateId, shards, failure, userMetadata, version);
             assert updated.state().completed() == false && completed(updated.shards().values()) == false
                     : "Only running snapshots allowed but saw [" + updated + "]";
             return updated;
@@ -478,38 +825,30 @@ public class SnapshotsInProgress extends AbstractNamedDiffable<Custom> implement
         @Override
         public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
             builder.startObject();
-            builder.field(REPOSITORY, snapshot.getRepository());
-            builder.field(SNAPSHOT, snapshot.getSnapshotId().getName());
-            builder.field(UUID, snapshot.getSnapshotId().getUUID());
-            builder.field(INCLUDE_GLOBAL_STATE, includeGlobalState());
-            builder.field(PARTIAL, partial);
-            builder.field(STATE, state);
-            builder.startArray(INDICES);
+            builder.field("repository", snapshot.getRepository());
+            builder.field("snapshot", snapshot.getSnapshotId().getName());
+            builder.field("uuid", snapshot.getSnapshotId().getUUID());
+            builder.field("include_global_state", includeGlobalState());
+            builder.field("partial", partial);
+            builder.field("state", state);
+            builder.startArray("indices");
             {
                 for (IndexId index : indices) {
                     index.toXContent(builder, params);
                 }
             }
             builder.endArray();
-            builder.timeField(START_TIME_MILLIS, START_TIME, startTime);
-            builder.field(REPOSITORY_STATE_ID, repositoryStateId);
-            builder.startArray(SHARDS);
+            builder.timeField("start_time_millis", "start_time", startTime);
+            builder.field("repository_state_id", repositoryStateId);
+            builder.startArray("shards");
             {
                 for (ObjectObjectCursor<ShardId, ShardSnapshotStatus> shardEntry : shards) {
                     ShardId shardId = shardEntry.key;
-                    ShardSnapshotStatus status = shardEntry.value;
-                    builder.startObject();
-                    {
-                        builder.field(INDEX, shardId.getIndex());
-                        builder.field(SHARD, shardId.getId());
-                        builder.field(STATE, status.state());
-                        builder.field(NODE, status.nodeId());
-                    }
-                    builder.endObject();
+                    writeShardSnapshotStatus(builder, shardId.getIndex(), shardId.getId(), shardEntry.value);
                 }
             }
             builder.endArray();
-            builder.startArray(FEATURE_STATES);
+            builder.startArray("feature_states");
             {
                 for (SnapshotFeatureInfo featureState : featureStates) {
                     featureState.toXContent(builder, params);
@@ -517,27 +856,29 @@ public class SnapshotsInProgress extends AbstractNamedDiffable<Custom> implement
             }
             builder.endArray();
             if (isClone()) {
-                builder.field(SOURCE, source);
-                builder.startArray(CLONES);
+                builder.field("source", source);
+                builder.startArray("clones");
                 {
                     for (ObjectObjectCursor<RepositoryShardId, ShardSnapshotStatus> shardEntry : clones) {
                         RepositoryShardId shardId = shardEntry.key;
-                        ShardSnapshotStatus status = shardEntry.value;
-                        builder.startObject();
-                        {
-                            builder.field(INDEX, shardId.index());
-                            builder.field(SHARD, shardId.shardId());
-                            builder.field(STATE, status.state());
-                            builder.field(NODE, status.nodeId());
-                        }
-                        builder.endObject();
+                        writeShardSnapshotStatus(builder, shardId.index(), shardId.shardId(), shardEntry.value);
                     }
                 }
                 builder.endArray();
             }
-            builder.array(DATA_STREAMS, dataStreams.toArray(new String[0]));
+            builder.array("data_streams", dataStreams.toArray(new String[0]));
             builder.endObject();
             return builder;
+        }
+
+        private void writeShardSnapshotStatus(XContentBuilder builder, ToXContent indexId, int shardId,
+                                              ShardSnapshotStatus status) throws IOException {
+            builder.startObject();
+            builder.field("index", indexId);
+            builder.field("shard", shardId);
+            builder.field("state", status.state());
+            builder.field("node", status.nodeId());
+            builder.endObject();
         }
 
         @Override
@@ -574,373 +915,6 @@ public class SnapshotsInProgress extends AbstractNamedDiffable<Custom> implement
         @Override
         public boolean isFragment() {
             return false;
-        }
-    }
-
-    /**
-     * Checks if all shards in the list have completed
-     *
-     * @param shards list of shard statuses
-     * @return true if all shards have completed (either successfully or failed), false otherwise
-     */
-    public static boolean completed(ObjectContainer<ShardSnapshotStatus> shards) {
-        for (ObjectCursor<ShardSnapshotStatus> status : shards) {
-            if (status.value.state().completed == false) {
-                return false;
-            }
-        }
-        return true;
-    }
-
-    private static boolean hasFailures(ImmutableOpenMap<RepositoryShardId, ShardSnapshotStatus> clones) {
-        for (ObjectCursor<ShardSnapshotStatus> value : clones.values()) {
-            if (value.value.state().failed()) {
-                return true;
-            }
-        }
-        return false;
-    }
-
-    public static class ShardSnapshotStatus implements Writeable {
-
-        /**
-         * Shard snapshot status for shards that are waiting for another operation to finish before they can be assigned to a node.
-         */
-        public static final ShardSnapshotStatus UNASSIGNED_QUEUED =
-                new SnapshotsInProgress.ShardSnapshotStatus(null, ShardState.QUEUED, null);
-
-        /**
-         * Shard snapshot status for shards that could not be snapshotted because their index was deleted from before the shard snapshot
-         * started.
-         */
-        public static final ShardSnapshotStatus MISSING =
-                new SnapshotsInProgress.ShardSnapshotStatus(null, ShardState.MISSING, "missing index", null);
-
-        private final ShardState state;
-
-        @Nullable
-        private final String nodeId;
-
-        @Nullable
-        private final String generation;
-
-        @Nullable
-        private final String reason;
-
-        public ShardSnapshotStatus(String nodeId, String generation) {
-            this(nodeId, ShardState.INIT, generation);
-        }
-
-        public ShardSnapshotStatus(@Nullable String nodeId, ShardState state, @Nullable String generation) {
-            this(nodeId, state, null, generation);
-        }
-
-        public ShardSnapshotStatus(@Nullable String nodeId, ShardState state, String reason, @Nullable String generation) {
-            this.nodeId = nodeId;
-            this.state = state;
-            this.reason = reason;
-            this.generation = generation;
-            assert assertConsistent();
-        }
-
-        private boolean assertConsistent() {
-            // If the state is failed we have to have a reason for this failure
-            assert state.failed() == false || reason != null;
-            assert (state != ShardState.INIT && state != ShardState.WAITING) || nodeId != null : "Null node id for state [" + state + "]";
-            return true;
-        }
-
-        public static ShardSnapshotStatus readFrom(StreamInput in) throws IOException {
-            String nodeId = in.readOptionalString();
-            final ShardState state = ShardState.fromValue(in.readByte());
-            final String generation;
-            if (SnapshotsService.useShardGenerations(in.getVersion())) {
-                generation = in.readOptionalString();
-            } else {
-                generation = null;
-            }
-            final String reason = in.readOptionalString();
-            if (state == ShardState.QUEUED) {
-                return UNASSIGNED_QUEUED;
-            }
-            return new ShardSnapshotStatus(nodeId, state, reason, generation);
-        }
-
-        public ShardState state() {
-            return state;
-        }
-
-        @Nullable
-        public String nodeId() {
-            return nodeId;
-        }
-
-        @Nullable
-        public String generation() {
-            return this.generation;
-        }
-
-        public String reason() {
-            return reason;
-        }
-
-        /**
-         * Checks if this shard snapshot is actively executing.
-         * A shard is defined as actively executing if it either is in a state that may write to the repository
-         * ({@link ShardState#INIT} or {@link ShardState#ABORTED}) or about to write to it in state {@link ShardState#WAITING}.
-         */
-        public boolean isActive() {
-            return state == ShardState.INIT || state == ShardState.ABORTED || state == ShardState.WAITING;
-        }
-
-        @Override
-        public void writeTo(StreamOutput out) throws IOException {
-            out.writeOptionalString(nodeId);
-            out.writeByte(state.value);
-            if (SnapshotsService.useShardGenerations(out.getVersion())) {
-                out.writeOptionalString(generation);
-            }
-            out.writeOptionalString(reason);
-        }
-
-        @Override
-        public boolean equals(Object o) {
-            if (this == o) return true;
-            if (o == null || getClass() != o.getClass()) return false;
-            ShardSnapshotStatus status = (ShardSnapshotStatus) o;
-            return Objects.equals(nodeId, status.nodeId) && Objects.equals(reason, status.reason)
-                && Objects.equals(generation, status.generation) && state == status.state;
-        }
-
-        @Override
-        public int hashCode() {
-            int result = state != null ? state.hashCode() : 0;
-            result = 31 * result + (nodeId != null ? nodeId.hashCode() : 0);
-            result = 31 * result + (reason != null ? reason.hashCode() : 0);
-            result = 31 * result + (generation != null ? generation.hashCode() : 0);
-            return result;
-        }
-
-        @Override
-        public String toString() {
-            return "ShardSnapshotStatus[state=" + state + ", nodeId=" + nodeId + ", reason=" + reason + ", generation=" + generation + "]";
-        }
-    }
-
-    public enum State {
-        INIT((byte) 0, false),
-        STARTED((byte) 1, false),
-        SUCCESS((byte) 2, true),
-        FAILED((byte) 3, true),
-        ABORTED((byte) 4, false);
-
-        private final byte value;
-
-        private final boolean completed;
-
-        State(byte value, boolean completed) {
-            this.value = value;
-            this.completed = completed;
-        }
-
-        public byte value() {
-            return value;
-        }
-
-        public boolean completed() {
-            return completed;
-        }
-
-        public static State fromValue(byte value) {
-            switch (value) {
-                case 0:
-                    return INIT;
-                case 1:
-                    return STARTED;
-                case 2:
-                    return SUCCESS;
-                case 3:
-                    return FAILED;
-                case 4:
-                    return ABORTED;
-                default:
-                    throw new IllegalArgumentException("No snapshot state for value [" + value + "]");
-            }
-        }
-    }
-
-    private final List<Entry> entries;
-
-    private static boolean assertConsistentEntries(List<Entry> entries) {
-        final Map<String, Set<Tuple<String, Integer>>> assignedShardsByRepo = new HashMap<>();
-        final Map<String, Set<Tuple<String, Integer>>> queuedShardsByRepo = new HashMap<>();
-        for (Entry entry : entries) {
-            for (ObjectObjectCursor<ShardId, ShardSnapshotStatus> shard : entry.shards()) {
-                final ShardId sid = shard.key;
-                assert assertShardStateConsistent(entries, assignedShardsByRepo, queuedShardsByRepo, entry, sid.getIndexName(), sid.id(),
-                        shard.value);
-            }
-            for (ObjectObjectCursor<RepositoryShardId, ShardSnapshotStatus> shard : entry.clones()) {
-                final RepositoryShardId sid = shard.key;
-                assert assertShardStateConsistent(entries, assignedShardsByRepo, queuedShardsByRepo, entry, sid.indexName(), sid.shardId(),
-                        shard.value);
-            }
-        }
-        for (String repoName : assignedShardsByRepo.keySet()) {
-            // make sure in-flight-shard-states can be built cleanly for the entries without tripping assertions
-            InFlightShardSnapshotStates.forRepo(repoName, entries);
-        }
-        return true;
-    }
-
-    private static boolean assertShardStateConsistent(List<Entry> entries, Map<String, Set<Tuple<String, Integer>>> assignedShardsByRepo,
-                                                      Map<String, Set<Tuple<String, Integer>>> queuedShardsByRepo, Entry entry,
-                                                      String indexName, int shardId, ShardSnapshotStatus shardSnapshotStatus) {
-        if (shardSnapshotStatus.isActive()) {
-            Tuple<String, Integer> plainShardId = Tuple.tuple(indexName, shardId);
-            assert assignedShardsByRepo.computeIfAbsent(entry.repository(), k -> new HashSet<>())
-                    .add(plainShardId) : "Found duplicate shard assignments in " + entries;
-            assert queuedShardsByRepo.getOrDefault(entry.repository(), Collections.emptySet()).contains(plainShardId) == false
-                    : "Found active shard assignments after queued shard assignments in " + entries;
-        } else if (shardSnapshotStatus.state() == ShardState.QUEUED) {
-            queuedShardsByRepo.computeIfAbsent(entry.repository(), k -> new HashSet<>()).add(Tuple.tuple(indexName, shardId));
-        }
-        return true;
-    }
-
-    public static SnapshotsInProgress of(List<Entry> entries) {
-        if (entries.isEmpty()) {
-            return EMPTY;
-        }
-        return new SnapshotsInProgress(Collections.unmodifiableList(entries));
-    }
-
-    private SnapshotsInProgress(List<Entry> entries) {
-        this.entries = entries;
-        assert assertConsistentEntries(entries);
-    }
-
-    public List<Entry> entries() {
-        return this.entries;
-    }
-
-    public Entry snapshot(final Snapshot snapshot) {
-        for (Entry entry : entries) {
-            final Snapshot curr = entry.snapshot();
-            if (curr.equals(snapshot)) {
-                return entry;
-            }
-        }
-        return null;
-    }
-
-    @Override
-    public String getWriteableName() {
-        return TYPE;
-    }
-
-    @Override
-    public Version getMinimalSupportedVersion() {
-        return Version.CURRENT.minimumCompatibilityVersion();
-    }
-
-    public static NamedDiff<Custom> readDiffFrom(StreamInput in) throws IOException {
-        return readDiffFrom(Custom.class, TYPE, in);
-    }
-
-    public SnapshotsInProgress(StreamInput in) throws IOException {
-        this.entries = in.readList(SnapshotsInProgress.Entry::new);
-    }
-
-    @Override
-    public void writeTo(StreamOutput out) throws IOException {
-        out.writeList(entries);
-    }
-
-    private static final String REPOSITORY = "repository";
-    private static final String SNAPSHOTS = "snapshots";
-    private static final String SNAPSHOT = "snapshot";
-    private static final String UUID = "uuid";
-    private static final String INCLUDE_GLOBAL_STATE = "include_global_state";
-    private static final String PARTIAL = "partial";
-    private static final String STATE = "state";
-    private static final String INDICES = "indices";
-    private static final String DATA_STREAMS = "data_streams";
-    private static final String SOURCE = "source";
-    private static final String CLONES = "clones";
-    private static final String START_TIME_MILLIS = "start_time_millis";
-    private static final String START_TIME = "start_time";
-    private static final String REPOSITORY_STATE_ID = "repository_state_id";
-    private static final String SHARDS = "shards";
-    private static final String INDEX = "index";
-    private static final String SHARD = "shard";
-    private static final String NODE = "node";
-    private static final String FEATURE_STATES = "feature_states";
-
-    @Override
-    public XContentBuilder toXContent(XContentBuilder builder, ToXContent.Params params) throws IOException {
-        builder.startArray(SNAPSHOTS);
-        for (Entry entry : entries) {
-            entry.toXContent(builder, params);
-        }
-        builder.endArray();
-        return builder;
-    }
-
-    public enum ShardState {
-        INIT((byte) 0, false, false),
-        SUCCESS((byte) 2, true, false),
-        FAILED((byte) 3, true, true),
-        ABORTED((byte) 4, false, true),
-        MISSING((byte) 5, true, true),
-        /**
-         * Shard snapshot is waiting for the primary to snapshot to become available.
-         */
-        WAITING((byte) 6, false, false),
-        /**
-         * Shard snapshot is waiting for another shard snapshot for the same shard and to the same repository to finish.
-         */
-        QUEUED((byte) 7, false, false);
-
-        private final byte value;
-
-        private final boolean completed;
-
-        private final boolean failed;
-
-        ShardState(byte value, boolean completed, boolean failed) {
-            this.value = value;
-            this.completed = completed;
-            this.failed = failed;
-        }
-
-        public boolean completed() {
-            return completed;
-        }
-
-        public boolean failed() {
-            return failed;
-        }
-
-        public static ShardState fromValue(byte value) {
-            switch (value) {
-                case 0:
-                    return INIT;
-                case 2:
-                    return SUCCESS;
-                case 3:
-                    return FAILED;
-                case 4:
-                    return ABORTED;
-                case 5:
-                    return MISSING;
-                case 6:
-                    return WAITING;
-                case 7:
-                    return QUEUED;
-                default:
-                    throw new IllegalArgumentException("No shard snapshot state for value [" + value + "]");
-            }
         }
     }
 }

--- a/server/src/main/java/org/elasticsearch/snapshots/SnapshotsService.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/SnapshotsService.java
@@ -1336,7 +1336,7 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
                 }
                 final ClusterState res = readyDeletions(
                         changed ? ClusterState.builder(currentState).putCustom(
-                                SnapshotsInProgress.TYPE, SnapshotsInProgress.of(unmodifiableList(updatedSnapshotEntries))).build() :
+                                SnapshotsInProgress.TYPE, SnapshotsInProgress.of(updatedSnapshotEntries)).build() :
                                 currentState).v1();
                 for (SnapshotDeletionsInProgress.Entry delete
                         : res.custom(SnapshotDeletionsInProgress.TYPE, SnapshotDeletionsInProgress.EMPTY).getEntries()) {
@@ -1863,8 +1863,7 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
             }
         }
         if (changed) {
-            result = ClusterState.builder(state).putCustom(
-                    SnapshotsInProgress.TYPE, SnapshotsInProgress.of(unmodifiableList(entries))).build();
+            result = ClusterState.builder(state).putCustom(SnapshotsInProgress.TYPE, SnapshotsInProgress.of(entries)).build();
         }
         return readyDeletions(result).v1();
     }

--- a/server/src/test/java/org/elasticsearch/cluster/SnapshotDeletionsInProgressTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/SnapshotDeletionsInProgressTests.java
@@ -22,8 +22,8 @@ import static org.hamcrest.Matchers.equalTo;
 public class SnapshotDeletionsInProgressTests extends ESTestCase {
     public void testXContent() throws IOException {
         SnapshotDeletionsInProgress sdip =
-            SnapshotDeletionsInProgress.newInstance(new SnapshotDeletionsInProgress.Entry(Collections.emptyList(),
-                "repo", 736694267638L, 0, SnapshotDeletionsInProgress.State.STARTED));
+            SnapshotDeletionsInProgress.of(Collections.singletonList(new SnapshotDeletionsInProgress.Entry(Collections.emptyList(),
+                    "repo", 736694267638L, 0, SnapshotDeletionsInProgress.State.STARTED)));
 
         try (XContentBuilder builder = jsonBuilder()) {
             builder.humanReadable(true);


### PR DESCRIPTION
* Formatting `SnapshotsInProgress` in a more reasonable way instead of mixing nested class, fields and methods.
* Removing pointless constants for the x-content serialization.
* Cleaning up double wrapping in `unmodifiableList`.
* Removing unused and incorrectly documented constructor from `SnapshotDeletionsInProgress`

backport of #71620