### PR TITLE
[DOC] Fix typos

### DIFF
--- a/docs/reference/query-dsl.asciidoc
+++ b/docs/reference/query-dsl.asciidoc
@@ -31,18 +31,18 @@ Allow expensive queries::
 Certain types of queries will generally execute slowly due to the way they are implemented, which can affect
 the stability of the cluster. Those queries can be categorised as follows:
 * Queries that need to do linear scans to identify matches:
-** <<query-dsl-script-query, `script queries`>>
+** <<query-dsl-script-query,`script` queries>>
 * Queries that have a high up-front cost :
-** <<query-dsl-fuzzy-query,`fuzzy queries`>> (except on <<wildcard-field-type, `wildcard`>> fields)
-** <<query-dsl-regexp-query,`regexp queries`>> (except on <<wildcard-field-type, `wildcard`>> fields)
-** <<query-dsl-prefix-query,`prefix queries`>>  (except on <<wildcard-field-type, `wildcard`>> fields or those without <<index-prefixes, `index_prefixes`>>)
-** <<query-dsl-wildcard-query, `wildcard queries`>> (except on <<wildcard-field-type, `wildcard`>> fields)
-** <<query-dsl-range-query, `range queries`>> on <<text, `text`>> and <<keyword, `keyword`>> fields
-* <<joining-queries, `Joining queries`>>
-* Queries on <<prefix-trees, deprecated geo shapes>>
+** <<query-dsl-fuzzy-query,`fuzzy` queries>> (except on <<wildcard-field-type,`wildcard`>> fields)
+** <<query-dsl-regexp-query,`regexp` queries>> (except on <<wildcard-field-type,`wildcard`>> fields)
+** <<query-dsl-prefix-query,`prefix` queries>>  (except on <<wildcard-field-type,`wildcard`>> fields or those without <<index-prefixes, `index_prefixes`>>)
+** <<query-dsl-wildcard-query,`wildcard` queries>> (except on <<wildcard-field-type,`wildcard`>> fields)
+** <<query-dsl-range-query,`range` queries>> on <<text,`text`>> and <<keyword,`keyword`>> fields
+* <<joining-queries,Joining queries>>
+* Queries on <<prefix-trees,deprecated geo-shapes>>
 * Queries that may have a high per-document cost:
-** <<query-dsl-script-score-query, `script score queries`>>
-** <<query-dsl-percolate-query, `percolate queries`>>
+** <<query-dsl-script-score-query,`script_score` queries>>
+** <<query-dsl-percolate-query,`percolate` queries>>
 
 The execution of such queries can be prevented by setting the value of the `search.allow_expensive_queries`
 setting to `false` (defaults to `true`).

--- a/docs/reference/query-dsl.asciidoc
+++ b/docs/reference/query-dsl.asciidoc
@@ -30,16 +30,27 @@ Query clauses behave differently depending on whether they are used in
 Allow expensive queries::
 Certain types of queries will generally execute slowly due to the way they are implemented, which can affect
 the stability of the cluster. Those queries can be categorised as follows:
+
 * Queries that need to do linear scans to identify matches:
 ** <<query-dsl-script-query,`script` queries>>
-* Queries that have a high up-front cost :
-** <<query-dsl-fuzzy-query,`fuzzy` queries>> (except on <<wildcard-field-type,`wildcard`>> fields)
-** <<query-dsl-regexp-query,`regexp` queries>> (except on <<wildcard-field-type,`wildcard`>> fields)
-** <<query-dsl-prefix-query,`prefix` queries>>  (except on <<wildcard-field-type,`wildcard`>> fields or those without <<index-prefixes, `index_prefixes`>>)
-** <<query-dsl-wildcard-query,`wildcard` queries>> (except on <<wildcard-field-type,`wildcard`>> fields)
-** <<query-dsl-range-query,`range` queries>> on <<text,`text`>> and <<keyword,`keyword`>> fields
+
+* Queries that have a high up-front cost:
+** <<query-dsl-fuzzy-query,`fuzzy` queries>> (except on
+   <<wildcard-field-type,`wildcard`>> fields)
+** <<query-dsl-regexp-query,`regexp` queries>> (except on
+   <<wildcard-field-type,`wildcard`>> fields)
+** <<query-dsl-prefix-query,`prefix` queries>>  (except on
+   <<wildcard-field-type,`wildcard`>> fields or those without
+   <<index-prefixes,`index_prefixes`>>)
+** <<query-dsl-wildcard-query,`wildcard` queries>> (except on
+   <<wildcard-field-type,`wildcard`>> fields)
+** <<query-dsl-range-query,`range` queries>> on <<text,`text`>> and
+   <<keyword,`keyword`>> fields
+
 * <<joining-queries,Joining queries>>
+
 * Queries on <<prefix-trees,deprecated geo-shapes>>
+
 * Queries that may have a high per-document cost:
 ** <<query-dsl-script-score-query,`script_score` queries>>
 ** <<query-dsl-percolate-query,`percolate` queries>>

--- a/docs/reference/query-dsl.asciidoc
+++ b/docs/reference/query-dsl.asciidoc
@@ -37,7 +37,7 @@ the stability of the cluster. Those queries can be categorised as follows:
 ** <<query-dsl-regexp-query,`regexp queries`>> (except on <<wildcard-field-type, `wildcard`>> fields)
 ** <<query-dsl-prefix-query,`prefix queries`>>  (except on <<wildcard-field-type, `wildcard`>> fields or those without <<index-prefixes, `index_prefixes`>>)
 ** <<query-dsl-wildcard-query, `wildcard queries`>> (except on <<wildcard-field-type, `wildcard`>> fields)
-** <<query-dsl-range-query, `range queries>> on <<text, `text`>> and <<keyword, `keyword`>> fields
+** <<query-dsl-range-query, `range queries`>> on <<text, `text`>> and <<keyword, `keyword`>> fields
 * <<joining-queries, `Joining queries`>>
 * Queries on <<prefix-trees, deprecated geo shapes>>
 * Queries that may have a high per-document cost:


### PR DESCRIPTION
Fixes several typos on the query DSL overview page.