### PR TITLE
[7.x] Tests: add support for close_to assertion (#71590)

### DIFF
--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.aggregation/390_geo_bounds_centroid.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.aggregation/390_geo_bounds_centroid.yml
@@ -1,0 +1,76 @@
+setup:
+  - skip:
+      features: close_to
+
+  - do:
+      indices.create:
+        index: test_1
+        body:
+          settings:
+            number_of_replicas: 0
+          mappings:
+            properties:
+              location:
+                type: geo_point
+
+---
+"Basic test":
+  - do:
+      bulk:
+        refresh: true
+        body:
+          - index:
+              _index: test_1
+              _id:    1
+          - location: "52.374081,4.912350"
+          - index:
+              _index: test_1
+              _id:    2
+          - location: "52.369219,4.901618"
+          - index:
+              _index: test_1
+              _id:    3
+          - location: "52.371667,4.914722"
+          - index:
+              _index: test_1
+              _id:    4
+          - location: "51.222900,4.405200"
+          - index:
+              _index: test_1
+              _id:    5
+          - location: "48.861111,2.336389"
+          - index:
+              _index: test_1
+              _id:    6
+          - location: "48.860000,2.327000"
+
+  - do:
+      search:
+        rest_total_hits_as_int: true
+        body:
+          aggregations:
+            view_port:
+              geo_bounds:
+                field: location
+                wrap_longitude: true
+
+
+  - match: { hits.total: 6 }
+  - close_to: { aggregations.view_port.bounds.top_left.lat: { value: 52.374081, error: 0.00001 } }
+  - close_to: { aggregations.view_port.bounds.top_left.lon: { value: 2.327000, error: 0.00001 } }
+  - close_to: { aggregations.view_port.bounds.bottom_right.lat: { value: 48.860000, error: 0.00001 } }
+  - close_to: { aggregations.view_port.bounds.bottom_right.lon: { value: 4.914722, error: 0.00001 } }
+
+
+  - do:
+      search:
+        rest_total_hits_as_int: true
+        body:
+          aggregations:
+            centroid:
+              geo_centroid:
+                field: location
+
+  - match: { hits.total: 6 }
+  - close_to: { aggregations.centroid.location.lat: { value: 51.00982967, error: 0.00001 } }
+  - close_to: { aggregations.centroid.location.lon: { value: 3.966213167, error: 0.00001 } }

--- a/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/Features.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/Features.java
@@ -41,7 +41,8 @@ public final class Features {
             "transform_and_set",
             "arbitrary_key",
             "allowed_warnings",
-            "allowed_warnings_regex"));
+            "allowed_warnings_regex",
+            "close_to"));
     private static final String SPI_ON_CLASSPATH_SINCE_JDK_9 = "spi_on_classpath_jdk9";
 
     private Features() {

--- a/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/section/ClientYamlTestSuite.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/section/ClientYamlTestSuite.java
@@ -200,6 +200,13 @@ public class ClientYamlTestSuite {
                 + "[\"skip\": \"features\": \"headers\"] so runners that do not support the [headers] section can skip the test at " +
                 "line [" + section.getLocation().lineNumber + "]"));
 
+        errors = Stream.concat(errors, sections.stream()
+            .filter(section -> section instanceof CloseToAssertion)
+            .filter(section -> false == hasSkipFeature("close_to", testSection, setupSection, teardownSection))
+            .map(section -> "attempted to add a [close_to] assertion " +
+                "without a corresponding [\"skip\": \"features\": \"close_to\"] so runners that do not support the " +
+                "[close_to] assertion can skip the test at line [" + section.getLocation().lineNumber + "]"));
+
         return errors;
     }
 

--- a/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/section/CloseToAssertion.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/section/CloseToAssertion.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+package org.elasticsearch.test.rest.yaml.section;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.elasticsearch.common.collect.Tuple;
+import org.elasticsearch.common.xcontent.XContentLocation;
+import org.elasticsearch.common.xcontent.XContentParser;
+
+import java.io.IOException;
+import java.util.Map;
+
+import static org.hamcrest.Matchers.closeTo;
+import static org.junit.Assert.assertThat;
+
+/**
+ * Represents a close_to assert section:
+ *
+ *   - close_to:   { get.fields._routing: { value: 5.1, error: 0.00001 } }
+ *
+ */
+public class CloseToAssertion extends Assertion {
+    public static CloseToAssertion parse(XContentParser parser) throws IOException {
+        XContentLocation location = parser.getTokenLocation();
+        Tuple<String,Object> fieldValueTuple = ParserUtils.parseTuple(parser);
+        if (fieldValueTuple.v2() instanceof Map) {
+            @SuppressWarnings("unchecked")
+            Map<String, Object> map = (Map<String, Object>) fieldValueTuple.v2();
+            if (map.size() != 2) {
+                throw new IllegalArgumentException("expected a map with value and error but got a map with " + map.size() + " fields");
+            }
+            Object valObj = map.get("value");
+            if (valObj instanceof Number == false) {
+                throw new IllegalArgumentException("value is missing or not a number");
+            }
+            Object errObj = map.get("error");
+            if (errObj instanceof Number == false) {
+                throw new IllegalArgumentException("error is missing or not a number");
+            }
+            return new CloseToAssertion(location, fieldValueTuple.v1(), ((Number)valObj).doubleValue(), ((Number)errObj).doubleValue());
+        } else {
+            throw new IllegalArgumentException("expected a map with value and error but got " +
+                fieldValueTuple.v2().getClass().getSimpleName());
+        }
+
+    }
+
+    private static final Logger logger = LogManager.getLogger(CloseToAssertion.class);
+
+    private final double error;
+
+    public CloseToAssertion(XContentLocation location, String field, Double expectedValue, Double error) {
+        super(location, field, expectedValue);
+        this.error = error;
+    }
+
+    public final double getError() {
+        return error;
+    }
+
+    @Override
+    protected void doAssert(Object actualValue, Object expectedValue) {
+        logger.trace("assert that [{}] is close to [{}] with error [{}] (field [{}])", actualValue, expectedValue, error, getField());
+        if (actualValue instanceof Number) {
+            assertThat(((Number) expectedValue).doubleValue(), closeTo((Double) expectedValue, error));
+        } else {
+            throw new AssertionError("excpected a value close to " + expectedValue + " but got " + actualValue + ", which is not a number");
+        }
+    }
+}

--- a/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/section/ExecutableSection.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/section/ExecutableSection.java
@@ -38,7 +38,8 @@ public interface ExecutableSection {
             new NamedXContentRegistry.Entry(ExecutableSection.class, new ParseField("lt"), LessThanAssertion::parse),
             new NamedXContentRegistry.Entry(ExecutableSection.class, new ParseField("lte"), LessThanOrEqualToAssertion::parse),
             new NamedXContentRegistry.Entry(ExecutableSection.class, new ParseField("contains"), ContainsAssertion::parse),
-            new NamedXContentRegistry.Entry(ExecutableSection.class, new ParseField("length"), LengthAssertion::parse)));
+            new NamedXContentRegistry.Entry(ExecutableSection.class, new ParseField("length"), LengthAssertion::parse),
+            new NamedXContentRegistry.Entry(ExecutableSection.class, new ParseField("close_to"), CloseToAssertion::parse)));
 
     /**
      * {@link NamedXContentRegistry} that parses the default list of

--- a/test/framework/src/test/java/org/elasticsearch/test/rest/yaml/section/AssertionTests.java
+++ b/test/framework/src/test/java/org/elasticsearch/test/rest/yaml/section/AssertionTests.java
@@ -159,4 +159,44 @@ public class AssertionTests extends AbstractClientYamlTestFragmentParserTestCase
         assertThat(o, instanceOf(String.class));
         assertThat(o.toString(), equalTo("bar"));
     }
+
+    public void testCloseTo() throws Exception {
+        parser = createParser(YamlXContent.yamlXContent,
+            "{ field: { value: 42.2, error: 0.001 } }"
+        );
+
+        CloseToAssertion closeToAssertion = CloseToAssertion.parse(parser);
+
+        assertThat(closeToAssertion, notNullValue());
+        assertThat(closeToAssertion.getField(), equalTo("field"));
+        assertThat(closeToAssertion.getExpectedValue(), instanceOf(Double.class));
+        assertThat((Double) closeToAssertion.getExpectedValue(), equalTo(42.2));
+        assertThat(closeToAssertion.getError(), equalTo(0.001));
+    }
+
+    public void testInvalidCloseTo() throws Exception {
+        parser = createParser(YamlXContent.yamlXContent,
+            "{ field: 42 }"
+        );
+        IllegalArgumentException exception = expectThrows(IllegalArgumentException.class, () ->  CloseToAssertion.parse(parser));
+        assertThat(exception.getMessage(), equalTo("expected a map with value and error but got Integer"));
+
+        parser = createParser(YamlXContent.yamlXContent,
+            "{ field: {  } }"
+        );
+        exception = expectThrows(IllegalArgumentException.class, () ->  CloseToAssertion.parse(parser));
+        assertThat(exception.getMessage(), equalTo("expected a map with value and error but got a map with 0 fields"));
+
+        parser = createParser(YamlXContent.yamlXContent,
+            "{ field: { foo: 13, value: 15 } }"
+        );
+        exception = expectThrows(IllegalArgumentException.class, () ->  CloseToAssertion.parse(parser));
+        assertThat(exception.getMessage(), equalTo("error is missing or not a number"));
+
+        parser = createParser(YamlXContent.yamlXContent,
+            "{ field: { foo: 13, bar: 15 } }"
+        );
+        exception = expectThrows(IllegalArgumentException.class, () ->  CloseToAssertion.parse(parser));
+        assertThat(exception.getMessage(), equalTo("value is missing or not a number"));
+    }
 }

--- a/test/framework/src/test/java/org/elasticsearch/test/rest/yaml/section/ClientYamlTestSuiteTests.java
+++ b/test/framework/src/test/java/org/elasticsearch/test/rest/yaml/section/ClientYamlTestSuiteTests.java
@@ -604,6 +604,17 @@ public class ClientYamlTestSuiteTests extends AbstractClientYamlTestFragmentPars
         createTestSuite(skipSection, containsAssertion).validate();
     }
 
+    public void testAddingCloseToWithSkip() {
+        int lineNumber = between(1, 10000);
+        SkipSection skipSection = new SkipSection(null, singletonList("close_to"), emptyList(), null);
+        CloseToAssertion closeToAssertion = new CloseToAssertion(
+            new XContentLocation(lineNumber, 0),
+            randomAlphaOfLength(randomIntBetween(3, 30)),
+            randomDouble(),
+            randomDouble());
+        createTestSuite(skipSection, closeToAssertion).validate();
+    }
+
     private static ClientYamlTestSuite createTestSuite(SkipSection skipSection, ExecutableSection executableSection) {
         final SetupSection setupSection;
         final TeardownSection teardownSection;


### PR DESCRIPTION
Adds support for close_to assertion to yaml tests. The assertion can be called
the following way:
```
  - close_to:   { get.fields._routing: { value: 5.1, error: 0.00001 } }
```
Closes #71303
