### PR TITLE
[ML] using feature reset API for integration test clean up: external multi-node

### DIFF
--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/AutodetectMemoryLimitIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/AutodetectMemoryLimitIT.java
@@ -56,7 +56,6 @@ public class AutodetectMemoryLimitIT extends MlNativeAutodetectIntegTestCase {
         AnalysisLimits limits = new AnalysisLimits(30L, null);
         job.setAnalysisLimits(limits);
 
-        registerJob(job);
         putJob(job);
         openJob(job.getId());
 
@@ -102,7 +101,6 @@ public class AutodetectMemoryLimitIT extends MlNativeAutodetectIntegTestCase {
         AnalysisLimits limits = new AnalysisLimits(30L, null);
         job.setAnalysisLimits(limits);
 
-        registerJob(job);
         putJob(job);
         openJob(job.getId());
 
@@ -148,7 +146,6 @@ public class AutodetectMemoryLimitIT extends MlNativeAutodetectIntegTestCase {
         AnalysisLimits limits = new AnalysisLimits(30L, null);
         job.setAnalysisLimits(limits);
 
-        registerJob(job);
         putJob(job);
         openJob(job.getId());
 
@@ -196,7 +193,6 @@ public class AutodetectMemoryLimitIT extends MlNativeAutodetectIntegTestCase {
         AnalysisLimits limits = new AnalysisLimits(110L, null);
         job.setAnalysisLimits(limits);
 
-        registerJob(job);
         putJob(job);
         openJob(job.getId());
 

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/AutoscalingIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/AutoscalingIT.java
@@ -172,7 +172,6 @@ public class AutoscalingIT extends MlNativeAutodetectIntegTestCase {
                     new DataDescription.Builder()
                         .setTimeFormat("epoch"));
 
-        registerJob(job);
         putJob(job);
     }
 }

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/BasicRenormalizationIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/BasicRenormalizationIT.java
@@ -97,7 +97,6 @@ public class BasicRenormalizationIT extends MlNativeAutodetectIntegTestCase {
         if (renormalizationWindow != null) {
             job.setRenormalizationWindowDays(renormalizationWindow);
         }
-        registerJob(job);
         putJob(job);
         return job;
     }

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/BulkFailureRetryIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/BulkFailureRetryIT.java
@@ -104,10 +104,8 @@ public class BulkFailureRetryIT extends MlNativeAutodetectIntegTestCase {
         DatafeedConfig.Builder datafeedConfigBuilder =
             createDatafeedBuilder(job.getId() + "-datafeed", job.getId(), Collections.singletonList(index));
         DatafeedConfig datafeedConfig = datafeedConfigBuilder.build();
-        registerJob(job);
         putJob(job);
         openJob(job.getId());
-        registerDatafeed(datafeedConfig);
         putDatafeed(datafeedConfig);
         long twoDaysAgo = now - 2 * DAY;
         startDatafeed(datafeedConfig.getId(), 0L, twoDaysAgo);

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/CategorizationIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/CategorizationIT.java
@@ -111,7 +111,6 @@ public class CategorizationIT extends MlNativeAutodetectIntegTestCase {
 
     public void testBasicCategorization() throws Exception {
         Job.Builder job = newJobBuilder("categorization", Collections.emptyList(), false);
-        registerJob(job);
         putJob(job);
         openJob(job.getId());
 
@@ -119,7 +118,7 @@ public class CategorizationIT extends MlNativeAutodetectIntegTestCase {
         DatafeedConfig.Builder datafeedConfig = new DatafeedConfig.Builder(datafeedId, job.getId());
         datafeedConfig.setIndices(Collections.singletonList(DATA_INDEX));
         DatafeedConfig datafeed = datafeedConfig.build();
-        registerDatafeed(datafeed);
+
         putDatafeed(datafeed);
         startDatafeed(datafeedId, 0, nowMillis);
         waitUntilJobIsClosed(job.getId());
@@ -169,7 +168,6 @@ public class CategorizationIT extends MlNativeAutodetectIntegTestCase {
 
     public void testPerPartitionCategorization() throws Exception {
         Job.Builder job = newJobBuilder("per-partition-categorization", Collections.emptyList(), true);
-        registerJob(job);
         putJob(job);
         openJob(job.getId());
 
@@ -177,7 +175,7 @@ public class CategorizationIT extends MlNativeAutodetectIntegTestCase {
         DatafeedConfig.Builder datafeedConfig = new DatafeedConfig.Builder(datafeedId, job.getId());
         datafeedConfig.setIndices(Collections.singletonList(DATA_INDEX));
         DatafeedConfig datafeed = datafeedConfig.build();
-        registerDatafeed(datafeed);
+
         putDatafeed(datafeed);
         startDatafeed(datafeedId, 0, nowMillis);
         waitUntilJobIsClosed(job.getId());
@@ -248,7 +246,6 @@ public class CategorizationIT extends MlNativeAutodetectIntegTestCase {
 
     public void testCategorizationWithFilters() throws Exception {
         Job.Builder job = newJobBuilder("categorization-with-filters", Collections.singletonList("\\[.*\\]"), false);
-        registerJob(job);
         putJob(job);
         openJob(job.getId());
 
@@ -256,7 +253,7 @@ public class CategorizationIT extends MlNativeAutodetectIntegTestCase {
         DatafeedConfig.Builder datafeedConfig = new DatafeedConfig.Builder(datafeedId, job.getId());
         datafeedConfig.setIndices(Collections.singletonList(DATA_INDEX));
         DatafeedConfig datafeed = datafeedConfig.build();
-        registerDatafeed(datafeed);
+
         putDatafeed(datafeed);
         startDatafeed(datafeedId, 0, nowMillis);
         waitUntilJobIsClosed(job.getId());
@@ -278,7 +275,6 @@ public class CategorizationIT extends MlNativeAutodetectIntegTestCase {
 
     public void testCategorizationStatePersistedOnSwitchToRealtime() throws Exception {
         Job.Builder job = newJobBuilder("categorization-swtich-to-realtime", Collections.emptyList(), false);
-        registerJob(job);
         putJob(job);
         openJob(job.getId());
 
@@ -286,7 +282,7 @@ public class CategorizationIT extends MlNativeAutodetectIntegTestCase {
         DatafeedConfig.Builder datafeedConfig = new DatafeedConfig.Builder(datafeedId, job.getId());
         datafeedConfig.setIndices(Collections.singletonList(DATA_INDEX));
         DatafeedConfig datafeed = datafeedConfig.build();
-        registerDatafeed(datafeed);
+
         putDatafeed(datafeed);
         startDatafeed(datafeedId, 0, null);
 
@@ -355,7 +351,6 @@ public class CategorizationIT extends MlNativeAutodetectIntegTestCase {
 
         String jobId = "categorization-performance";
         Job.Builder job = newJobBuilder(jobId, Collections.emptyList(), false);
-        registerJob(job);
         putJob(job);
         openJob(job.getId());
 
@@ -382,7 +377,6 @@ public class CategorizationIT extends MlNativeAutodetectIntegTestCase {
 
         String jobId = "categorization-stop-on-warn";
         Job.Builder job = newJobBuilder(jobId, Collections.emptyList(), true);
-        registerJob(job);
         putJob(job);
         openJob(job.getId());
 
@@ -526,7 +520,6 @@ public class CategorizationIT extends MlNativeAutodetectIntegTestCase {
         assertThat(bulkResponse.hasFailures(), is(false));
 
         Job.Builder job = newJobBuilder("categorization-with-preferred-categories", Collections.emptyList(), false);
-        registerJob(job);
         putJob(job);
         openJob(job.getId());
 
@@ -534,7 +527,7 @@ public class CategorizationIT extends MlNativeAutodetectIntegTestCase {
         DatafeedConfig.Builder datafeedConfig = new DatafeedConfig.Builder(datafeedId, job.getId());
         datafeedConfig.setIndices(Collections.singletonList(index));
         DatafeedConfig datafeed = datafeedConfig.build();
-        registerDatafeed(datafeed);
+
         putDatafeed(datafeed);
         startDatafeed(datafeedId, 0, nowMillis + 1);
         waitUntilJobIsClosed(job.getId());

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/DatafeedJobsRestIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/DatafeedJobsRestIT.java
@@ -1232,10 +1232,7 @@ public class DatafeedJobsRestIT extends ESRestTestCase {
     public void clearMlState() throws Exception {
         new MlRestTestStateCleaner(logger, adminClient()).clearMlMetadata();
         // Don't check rollup jobs because we clear them in the superclass.
-        // Don't check analytics jobs as they are independent of anomaly detection jobs and should not be created by this test.
-        waitForPendingTasks(
-            adminClient(),
-            taskName -> taskName.startsWith(RollupJob.NAME) || taskName.contains(MlTasks.DATA_FRAME_ANALYTICS_TASK_NAME));
+        waitForPendingTasks(adminClient(), taskName -> taskName.startsWith(RollupJob.NAME));
     }
 
     private static class DatafeedBuilder {

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/DatafeedWithAggsIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/DatafeedWithAggsIT.java
@@ -101,9 +101,8 @@ public class DatafeedWithAggsIT extends MlNativeAutodetectIntegTestCase {
         DatafeedConfig datafeed = datafeedBuilder.build();
 
         // Create stuff and open job
-        registerJob(jobBuilder);
         putJob(jobBuilder);
-        registerDatafeed(datafeed);
+
         putDatafeed(datafeed);
         openJob(jobId);
 

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/DelayedDataDetectorIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/DelayedDataDetectorIT.java
@@ -71,11 +71,10 @@ public class DelayedDataDetectorIT extends MlNativeAutodetectIntegTestCase {
             createDatafeedBuilder(job.getId() + "-datafeed", job.getId(), Collections.singletonList(index));
         datafeedConfigBuilder.setDelayedDataCheckConfig(DelayedDataCheckConfig.enabledDelayedDataCheckConfig(TimeValue.timeValueHours(12)));
         DatafeedConfig datafeedConfig = datafeedConfigBuilder.build();
-        registerJob(job);
         putJob(job);
         openJob(job.getId());
 
-        registerDatafeed(datafeedConfig);
+
         putDatafeed(datafeedConfig);
         startDatafeed(datafeedConfig.getId(), 0L, now);
         waitUntilJobIsClosed(jobId);
@@ -109,11 +108,10 @@ public class DelayedDataDetectorIT extends MlNativeAutodetectIntegTestCase {
         datafeedConfigBuilder.setDelayedDataCheckConfig(DelayedDataCheckConfig.enabledDelayedDataCheckConfig(TimeValue.timeValueHours(12)));
         DatafeedConfig datafeedConfig = datafeedConfigBuilder.build();
 
-        registerJob(job);
         putJob(job);
         openJob(job.getId());
 
-        registerDatafeed(datafeedConfig);
+
         putDatafeed(datafeedConfig);
 
         startDatafeed(datafeedConfig.getId(), 0L, now);
@@ -165,11 +163,10 @@ public class DelayedDataDetectorIT extends MlNativeAutodetectIntegTestCase {
         datafeedConfigBuilder.setDelayedDataCheckConfig(DelayedDataCheckConfig.enabledDelayedDataCheckConfig(TimeValue.timeValueHours(12)));
 
         DatafeedConfig datafeedConfig = datafeedConfigBuilder.build();
-        registerJob(job);
         putJob(job);
         openJob(job.getId());
 
-        registerDatafeed(datafeedConfig);
+
         putDatafeed(datafeedConfig);
         startDatafeed(datafeedConfig.getId(), 0L, now);
         waitUntilJobIsClosed(jobId);

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/DeleteExpiredDataIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/DeleteExpiredDataIT.java
@@ -157,17 +157,18 @@ public class DeleteExpiredDataIT extends MlNativeAutodetectIntegTestCase {
             bulkRequestBuilder.add(indexRequest);
         }
         ActionFuture<BulkResponse> indexUnusedStateDocsResponse = bulkRequestBuilder.execute();
+        List<Job.Builder> jobs = new ArrayList<>();
 
         // These jobs don't thin out model state; ModelSnapshotRetentionIT tests that
-        registerJob(newJobBuilder("no-retention")
+        jobs.add(newJobBuilder("no-retention")
             .setResultsRetentionDays(null).setModelSnapshotRetentionDays(1000L).setDailyModelSnapshotRetentionAfterDays(1000L));
-        registerJob(newJobBuilder("results-retention")
+        jobs.add(newJobBuilder("results-retention")
             .setResultsRetentionDays(1L).setModelSnapshotRetentionDays(1000L).setDailyModelSnapshotRetentionAfterDays(1000L));
-        registerJob(newJobBuilder("snapshots-retention")
+        jobs.add(newJobBuilder("snapshots-retention")
             .setResultsRetentionDays(null).setModelSnapshotRetentionDays(2L).setDailyModelSnapshotRetentionAfterDays(2L));
-        registerJob(newJobBuilder("snapshots-retention-with-retain")
+        jobs.add(newJobBuilder("snapshots-retention-with-retain")
             .setResultsRetentionDays(null).setModelSnapshotRetentionDays(2L).setDailyModelSnapshotRetentionAfterDays(2L));
-        registerJob(newJobBuilder("results-and-snapshots-retention")
+        jobs.add(newJobBuilder("results-and-snapshots-retention")
             .setResultsRetentionDays(1L).setModelSnapshotRetentionDays(2L).setDailyModelSnapshotRetentionAfterDays(2L));
 
         List<String> shortExpiryForecastIds = new ArrayList<>();
@@ -176,14 +177,14 @@ public class DeleteExpiredDataIT extends MlNativeAutodetectIntegTestCase {
         long oneDayAgo = now - TimeValue.timeValueHours(48).getMillis() - 1;
 
         // Start all jobs
-        for (Job.Builder job : getJobs()) {
+        for (Job.Builder job : jobs) {
             putJob(job);
 
             String datafeedId = job.getId() + "-feed";
             DatafeedConfig.Builder datafeedConfig = new DatafeedConfig.Builder(datafeedId, job.getId());
             datafeedConfig.setIndices(Collections.singletonList(DATA_INDEX));
             DatafeedConfig datafeed = datafeedConfig.build();
-            registerDatafeed(datafeed);
+
             putDatafeed(datafeed);
 
             // Run up to a day ago
@@ -192,11 +193,11 @@ public class DeleteExpiredDataIT extends MlNativeAutodetectIntegTestCase {
         }
 
         // Now let's wait for all jobs to be closed
-        for (Job.Builder job : getJobs()) {
+        for (Job.Builder job : jobs) {
             waitUntilJobIsClosed(job.getId());
         }
 
-        for (Job.Builder job : getJobs()) {
+        for (Job.Builder job : jobs) {
             assertThat(getBuckets(job.getId()).size(), is(greaterThanOrEqualTo(47)));
             assertThat(getRecords(job.getId()).size(), equalTo(2));
             List<ModelSnapshot> modelSnapshots = getModelSnapshots(job.getId());
@@ -231,7 +232,7 @@ public class DeleteExpiredDataIT extends MlNativeAutodetectIntegTestCase {
         long before = System.currentTimeMillis() / 1000;
         assertBusy(() -> assertNotEquals(before, System.currentTimeMillis() / 1000), 1, TimeUnit.SECONDS);
 
-        for (Job.Builder job : getJobs()) {
+        for (Job.Builder job : jobs) {
             // Run up to now
             startDatafeed(job.getId() + "-feed", 0, now);
             waitUntilJobIsClosed(job.getId());
@@ -254,7 +255,7 @@ public class DeleteExpiredDataIT extends MlNativeAutodetectIntegTestCase {
 
         // Verify forecasts were created
         List<ForecastRequestStats> forecastStats = getForecastStats();
-        assertThat(forecastStats.size(), equalTo(getJobs().size() * 3));
+        assertThat(forecastStats.size(), equalTo(jobs.size() * 3));
         for (ForecastRequestStats forecastStat : forecastStats) {
             assertThat(countForecastDocs(forecastStat.getJobId(), forecastStat.getForecastId()), equalTo(forecastStat.getRecordCount()));
         }
@@ -303,11 +304,11 @@ public class DeleteExpiredDataIT extends MlNativeAutodetectIntegTestCase {
 
         // Verify short expiry forecasts were deleted only
         forecastStats = getForecastStats();
-        assertThat(forecastStats.size(), equalTo(getJobs().size() * 2));
+        assertThat(forecastStats.size(), equalTo(jobs.size() * 2));
         for (ForecastRequestStats forecastStat : forecastStats) {
             assertThat(countForecastDocs(forecastStat.getJobId(), forecastStat.getForecastId()), equalTo(forecastStat.getRecordCount()));
         }
-        for (Job.Builder job : getJobs()) {
+        for (Job.Builder job : jobs) {
             for (String forecastId : shortExpiryForecastIds) {
                 assertThat(countForecastDocs(job.getId(), forecastId), equalTo(0L));
             }

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/DeleteJobIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/DeleteJobIT.java
@@ -97,7 +97,7 @@ public class DeleteJobIT extends MlNativeAutodetectIntegTestCase {
             .setAnalysisConfig(analysisConfig)
             .setDataDescription(dataDescription);
 
-                putJob(job);
+        putJob(job);
 
         DatafeedConfig.Builder datafeedConfig = new DatafeedConfig.Builder(datafeedId, jobId);
         datafeedConfig.setIndices(Collections.singletonList(DATA_INDEX));

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/DeleteJobIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/DeleteJobIT.java
@@ -97,13 +97,12 @@ public class DeleteJobIT extends MlNativeAutodetectIntegTestCase {
             .setAnalysisConfig(analysisConfig)
             .setDataDescription(dataDescription);
 
-        registerJob(job);
-        putJob(job);
+                putJob(job);
 
         DatafeedConfig.Builder datafeedConfig = new DatafeedConfig.Builder(datafeedId, jobId);
         datafeedConfig.setIndices(Collections.singletonList(DATA_INDEX));
         DatafeedConfig datafeedA = datafeedConfig.build();
-        registerDatafeed(datafeedA);
+
         putDatafeed(datafeedA);
 
         openJob(jobId);

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/DetectionRulesIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/DetectionRulesIT.java
@@ -67,7 +67,7 @@ public class DetectionRulesIT extends MlNativeAutodetectIntegTestCase {
         job.setAnalysisConfig(analysisConfig);
         job.setDataDescription(dataDescription);
 
-                putJob(job);
+        putJob(job);
         openJob(job.getId());
 
         long timestamp = 1491004800000L;
@@ -139,7 +139,7 @@ public class DetectionRulesIT extends MlNativeAutodetectIntegTestCase {
         job.setAnalysisConfig(analysisConfig);
         job.setDataDescription(dataDescription);
 
-                putJob(job);
+        putJob(job);
         openJob(job.getId());
 
         long timestamp = 1509062400000L;
@@ -253,7 +253,7 @@ public class DetectionRulesIT extends MlNativeAutodetectIntegTestCase {
         job.setAnalysisConfig(analysisConfig);
         job.setDataDescription(dataDescription);
 
-                putJob(job);
+        putJob(job);
         openJob(job.getId());
 
         long timestamp = 1509062400000L;

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/DetectionRulesIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/DetectionRulesIT.java
@@ -67,8 +67,7 @@ public class DetectionRulesIT extends MlNativeAutodetectIntegTestCase {
         job.setAnalysisConfig(analysisConfig);
         job.setDataDescription(dataDescription);
 
-        registerJob(job);
-        putJob(job);
+                putJob(job);
         openJob(job.getId());
 
         long timestamp = 1491004800000L;
@@ -140,8 +139,7 @@ public class DetectionRulesIT extends MlNativeAutodetectIntegTestCase {
         job.setAnalysisConfig(analysisConfig);
         job.setDataDescription(dataDescription);
 
-        registerJob(job);
-        putJob(job);
+                putJob(job);
         openJob(job.getId());
 
         long timestamp = 1509062400000L;
@@ -255,8 +253,7 @@ public class DetectionRulesIT extends MlNativeAutodetectIntegTestCase {
         job.setAnalysisConfig(analysisConfig);
         job.setDataDescription(dataDescription);
 
-        registerJob(job);
-        putJob(job);
+                putJob(job);
         openJob(job.getId());
 
         long timestamp = 1509062400000L;

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/ForecastIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/ForecastIT.java
@@ -56,8 +56,7 @@ public class ForecastIT extends MlNativeAutodetectIntegTestCase {
         job.setAnalysisConfig(analysisConfig);
         job.setDataDescription(dataDescription);
 
-        registerJob(job);
-        putJob(job);
+                putJob(job);
         openJob(job.getId());
 
         long now = Instant.now().getEpochSecond();
@@ -157,8 +156,7 @@ public class ForecastIT extends MlNativeAutodetectIntegTestCase {
         job.setAnalysisConfig(analysisConfig);
         job.setDataDescription(dataDescription);
 
-        registerJob(job);
-        putJob(job);
+                putJob(job);
         openJob(job.getId());
         ElasticsearchException e = expectThrows(ElasticsearchException.class,() -> forecast(job.getId(),
                 TimeValue.timeValueMinutes(10), null));
@@ -178,8 +176,7 @@ public class ForecastIT extends MlNativeAutodetectIntegTestCase {
         job.setAnalysisConfig(analysisConfig);
         job.setDataDescription(dataDescription);
 
-        registerJob(job);
-        putJob(job);
+                putJob(job);
         openJob(job.getId());
         ElasticsearchException e = expectThrows(ElasticsearchException.class,
                 () -> forecast(job.getId(), TimeValue.timeValueMinutes(120), null));
@@ -204,7 +201,7 @@ public class ForecastIT extends MlNativeAutodetectIntegTestCase {
         AnalysisLimits limits = new AnalysisLimits(30L, null);
         job.setAnalysisLimits(limits);
 
-        registerJob(job);
+
         putJob(job);
         openJob(job.getId());
         createDataWithLotsOfClientIps(bucketSpan, job);
@@ -230,7 +227,7 @@ public class ForecastIT extends MlNativeAutodetectIntegTestCase {
         job.setAnalysisConfig(analysisConfig);
         job.setDataDescription(dataDescription);
 
-        registerJob(job);
+
         putJob(job);
         openJob(job.getId());
         createDataWithLotsOfClientIps(bucketSpan, job);
@@ -297,7 +294,7 @@ public class ForecastIT extends MlNativeAutodetectIntegTestCase {
         job.setAnalysisConfig(analysisConfig);
         job.setDataDescription(dataDescription);
 
-        registerJob(job);
+
         putJob(job);
         openJob(job.getId());
 
@@ -365,7 +362,7 @@ public class ForecastIT extends MlNativeAutodetectIntegTestCase {
         job.setAnalysisConfig(analysisConfig);
         job.setDataDescription(dataDescription);
 
-        registerJob(job);
+
         putJob(job);
         openJob(job.getId());
 
@@ -429,7 +426,7 @@ public class ForecastIT extends MlNativeAutodetectIntegTestCase {
             otherJob.setAnalysisConfig(analysisConfig);
             otherJob.setDataDescription(dataDescription);
 
-            registerJob(otherJob);
+            ;
             putJob(otherJob);
             DeleteForecastAction.Request request = new DeleteForecastAction.Request(otherJob.getId(), Metadata.ALL);
             AcknowledgedResponse response = client().execute(DeleteForecastAction.INSTANCE, request).actionGet();
@@ -441,7 +438,7 @@ public class ForecastIT extends MlNativeAutodetectIntegTestCase {
             otherJob.setAnalysisConfig(analysisConfig);
             otherJob.setDataDescription(dataDescription);
 
-            registerJob(otherJob);
+            ;
             putJob(otherJob);
 
             DeleteForecastAction.Request request = new DeleteForecastAction.Request(otherJob.getId(), Metadata.ALL);
@@ -466,7 +463,7 @@ public class ForecastIT extends MlNativeAutodetectIntegTestCase {
         job.setDataDescription(dataDescription);
         String jobId = job.getId();
 
-        registerJob(job);
+
         putJob(job);
         openJob(job.getId());
 
@@ -510,7 +507,7 @@ public class ForecastIT extends MlNativeAutodetectIntegTestCase {
         job.setAnalysisConfig(analysisConfig);
         job.setDataDescription(dataDescription);
 
-        registerJob(job);
+
         putJob(job);
         openJob(job.getId());
 

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/ForecastIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/ForecastIT.java
@@ -56,7 +56,7 @@ public class ForecastIT extends MlNativeAutodetectIntegTestCase {
         job.setAnalysisConfig(analysisConfig);
         job.setDataDescription(dataDescription);
 
-                putJob(job);
+        putJob(job);
         openJob(job.getId());
 
         long now = Instant.now().getEpochSecond();
@@ -92,7 +92,7 @@ public class ForecastIT extends MlNativeAutodetectIntegTestCase {
         List<ForecastRequestStats> forecastStats = getForecastStats();
         assertThat(forecastStats.size(), equalTo(3));
         Map<String, ForecastRequestStats> idToForecastStats = new HashMap<>();
-        forecastStats.stream().forEach(f -> idToForecastStats.put(f.getForecastId(), f));
+        forecastStats.forEach(f -> idToForecastStats.put(f.getForecastId(), f));
 
         {
             ForecastRequestStats forecastDefaultDurationDefaultExpiry = idToForecastStats.get(forecastIdDefaultDurationDefaultExpiry);
@@ -156,7 +156,7 @@ public class ForecastIT extends MlNativeAutodetectIntegTestCase {
         job.setAnalysisConfig(analysisConfig);
         job.setDataDescription(dataDescription);
 
-                putJob(job);
+        putJob(job);
         openJob(job.getId());
         ElasticsearchException e = expectThrows(ElasticsearchException.class,() -> forecast(job.getId(),
                 TimeValue.timeValueMinutes(10), null));
@@ -176,7 +176,7 @@ public class ForecastIT extends MlNativeAutodetectIntegTestCase {
         job.setAnalysisConfig(analysisConfig);
         job.setDataDescription(dataDescription);
 
-                putJob(job);
+        putJob(job);
         openJob(job.getId());
         ElasticsearchException e = expectThrows(ElasticsearchException.class,
                 () -> forecast(job.getId(), TimeValue.timeValueMinutes(120), null));
@@ -200,7 +200,6 @@ public class ForecastIT extends MlNativeAutodetectIntegTestCase {
         // Set the memory limit to 30MB
         AnalysisLimits limits = new AnalysisLimits(30L, null);
         job.setAnalysisLimits(limits);
-
 
         putJob(job);
         openJob(job.getId());
@@ -226,7 +225,6 @@ public class ForecastIT extends MlNativeAutodetectIntegTestCase {
         job.setAnalysisLimits(limits);
         job.setAnalysisConfig(analysisConfig);
         job.setDataDescription(dataDescription);
-
 
         putJob(job);
         openJob(job.getId());
@@ -293,7 +291,6 @@ public class ForecastIT extends MlNativeAutodetectIntegTestCase {
         Job.Builder job = new Job.Builder("forecast-it-test-delete-wildcard");
         job.setAnalysisConfig(analysisConfig);
         job.setDataDescription(dataDescription);
-
 
         putJob(job);
         openJob(job.getId());
@@ -362,7 +359,6 @@ public class ForecastIT extends MlNativeAutodetectIntegTestCase {
         job.setAnalysisConfig(analysisConfig);
         job.setDataDescription(dataDescription);
 
-
         putJob(job);
         openJob(job.getId());
 
@@ -426,7 +422,6 @@ public class ForecastIT extends MlNativeAutodetectIntegTestCase {
             otherJob.setAnalysisConfig(analysisConfig);
             otherJob.setDataDescription(dataDescription);
 
-            ;
             putJob(otherJob);
             DeleteForecastAction.Request request = new DeleteForecastAction.Request(otherJob.getId(), Metadata.ALL);
             AcknowledgedResponse response = client().execute(DeleteForecastAction.INSTANCE, request).actionGet();
@@ -438,7 +433,6 @@ public class ForecastIT extends MlNativeAutodetectIntegTestCase {
             otherJob.setAnalysisConfig(analysisConfig);
             otherJob.setDataDescription(dataDescription);
 
-            ;
             putJob(otherJob);
 
             DeleteForecastAction.Request request = new DeleteForecastAction.Request(otherJob.getId(), Metadata.ALL);
@@ -462,7 +456,6 @@ public class ForecastIT extends MlNativeAutodetectIntegTestCase {
         job.setAnalysisConfig(analysisConfig);
         job.setDataDescription(dataDescription);
         String jobId = job.getId();
-
 
         putJob(job);
         openJob(job.getId());
@@ -506,7 +499,6 @@ public class ForecastIT extends MlNativeAutodetectIntegTestCase {
         Job.Builder job = new Job.Builder("forecast-it-test-single-series");
         job.setAnalysisConfig(analysisConfig);
         job.setDataDescription(dataDescription);
-
 
         putJob(job);
         openJob(job.getId());

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/InterimResultsDeletedAfterReopeningJobIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/InterimResultsDeletedAfterReopeningJobIT.java
@@ -50,7 +50,6 @@ public class InterimResultsDeletedAfterReopeningJobIT extends MlNativeAutodetect
         job.setAnalysisConfig(analysisConfig);
         job.setDataDescription(dataDescription);
 
-        registerJob(job);
         putJob(job);
         openJob(job.getId());
 

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/InterimResultsIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/InterimResultsIT.java
@@ -50,7 +50,6 @@ public class InterimResultsIT extends MlNativeAutodetectIntegTestCase {
         job.setAnalysisConfig(analysisConfig);
         job.setDataDescription(dataDescription);
 
-
         putJob(job);
         openJob(job.getId());
 
@@ -117,7 +116,6 @@ public class InterimResultsIT extends MlNativeAutodetectIntegTestCase {
         Job.Builder job = new Job.Builder(jobId);
         job.setAnalysisConfig(analysisConfig);
         job.setDataDescription(dataDescription);
-
 
         putJob(job);
         openJob(job.getId());

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/InterimResultsIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/InterimResultsIT.java
@@ -50,7 +50,7 @@ public class InterimResultsIT extends MlNativeAutodetectIntegTestCase {
         job.setAnalysisConfig(analysisConfig);
         job.setDataDescription(dataDescription);
 
-        registerJob(job);
+
         putJob(job);
         openJob(job.getId());
 
@@ -118,7 +118,7 @@ public class InterimResultsIT extends MlNativeAutodetectIntegTestCase {
         job.setAnalysisConfig(analysisConfig);
         job.setDataDescription(dataDescription);
 
-        registerJob(job);
+
         putJob(job);
         openJob(job.getId());
 

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/JobAndDatafeedResilienceIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/JobAndDatafeedResilienceIT.java
@@ -75,11 +75,11 @@ public class JobAndDatafeedResilienceIT extends MlNativeAutodetectIntegTestCase 
         DatafeedConfig.Builder datafeedConfigBuilder =
             createDatafeedBuilder(job.getId() + "-datafeed", job.getId(), Collections.singletonList(index));
         DatafeedConfig datafeedConfig = datafeedConfigBuilder.build();
-        registerJob(job);
+
         putJob(job);
         openJob(job.getId());
 
-        registerDatafeed(datafeedConfig);
+
         putDatafeed(datafeedConfig);
         startDatafeed(datafeedConfig.getId(), 0L, null);
 
@@ -117,7 +117,7 @@ public class JobAndDatafeedResilienceIT extends MlNativeAutodetectIntegTestCase 
 
         putJob(job1);
         openJob(job1.getId());
-        registerJob(job2);
+        ;
         putJob(job2);
         openJob(job2.getId());
 
@@ -155,10 +155,10 @@ public class JobAndDatafeedResilienceIT extends MlNativeAutodetectIntegTestCase 
         Job.Builder job1 = createJob(jobId1, TimeValue.timeValueMinutes(5), "count", null);
         Job.Builder job2 = createJob(jobId2, TimeValue.timeValueMinutes(5), "count", null);
 
-        registerJob(job1);
+        ;
         putJob(job1);
         openJob(job1.getId());
-        registerJob(job2);
+        ;
         putJob(job2);
         openJob(job2.getId());
 

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/JobAndDatafeedResilienceIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/JobAndDatafeedResilienceIT.java
@@ -79,7 +79,6 @@ public class JobAndDatafeedResilienceIT extends MlNativeAutodetectIntegTestCase 
         putJob(job);
         openJob(job.getId());
 
-
         putDatafeed(datafeedConfig);
         startDatafeed(datafeedConfig.getId(), 0L, null);
 
@@ -92,7 +91,6 @@ public class JobAndDatafeedResilienceIT extends MlNativeAutodetectIntegTestCase 
             client().execute(StopDatafeedAction.INSTANCE, request).actionGet();
         });
         assertThat(ex.getMessage(), equalTo("No datafeed with id [job-with-missing-datafeed-with-config-datafeed] exists"));
-
 
         forceStopDatafeed(datafeedConfig.getId());
         assertBusy(() ->
@@ -117,7 +115,6 @@ public class JobAndDatafeedResilienceIT extends MlNativeAutodetectIntegTestCase 
 
         putJob(job1);
         openJob(job1.getId());
-        ;
         putJob(job2);
         openJob(job2.getId());
 
@@ -155,10 +152,8 @@ public class JobAndDatafeedResilienceIT extends MlNativeAutodetectIntegTestCase 
         Job.Builder job1 = createJob(jobId1, TimeValue.timeValueMinutes(5), "count", null);
         Job.Builder job2 = createJob(jobId2, TimeValue.timeValueMinutes(5), "count", null);
 
-        ;
         putJob(job1);
         openJob(job1.getId());
-        ;
         putJob(job2);
         openJob(job2.getId());
 

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/MlDailyMaintenanceServiceIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/MlDailyMaintenanceServiceIT.java
@@ -112,7 +112,7 @@ public class MlDailyMaintenanceServiceIT extends MlNativeAutodetectIntegTestCase
                     new DataDescription.Builder()
                         .setTimeFormat("epoch"));
 
-        registerJob(job);
+
         putJob(job);
     }
 

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/MlDailyMaintenanceServiceIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/MlDailyMaintenanceServiceIT.java
@@ -112,7 +112,6 @@ public class MlDailyMaintenanceServiceIT extends MlNativeAutodetectIntegTestCase
                     new DataDescription.Builder()
                         .setTimeFormat("epoch"));
 
-
         putJob(job);
     }
 

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/MlNativeAutodetectIntegTestCase.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/MlNativeAutodetectIntegTestCase.java
@@ -6,6 +6,8 @@
  */
 package org.elasticsearch.xpack.ml.integration;
 
+import org.elasticsearch.action.admin.cluster.snapshots.features.ResetFeatureStateAction;
+import org.elasticsearch.action.admin.cluster.snapshots.features.ResetFeatureStateRequest;
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.support.IndicesOptions;
@@ -86,69 +88,6 @@ import static org.hamcrest.Matchers.notNullValue;
  * Base class of ML integration tests that use a native autodetect process
  */
 abstract class MlNativeAutodetectIntegTestCase extends MlNativeIntegTestCase {
-
-    private final List<Job.Builder> jobs = new ArrayList<>();
-    private final List<DatafeedConfig> datafeeds = new ArrayList<>();
-
-    @Override
-    protected void cleanUpResources() {
-        cleanUpDatafeeds();
-        cleanUpJobs();
-    }
-
-    private void cleanUpDatafeeds() {
-        for (DatafeedConfig datafeed : datafeeds) {
-            cleanupDatafeed(datafeed.getId());
-        }
-    }
-
-    void cleanupDatafeed(String datafeedId) {
-        try {
-            stopDatafeed(datafeedId);
-        } catch (Exception e) {
-            // ignore
-        }
-        try {
-            deleteDatafeed(datafeedId);
-        } catch (Exception e) {
-            // ignore
-        }
-    }
-
-    private void cleanUpJobs() {
-        for (Job.Builder job : jobs) {
-            cleanupJob(job.getId());
-        }
-    }
-
-    void cleanupJob(String jobId) {
-        try {
-            closeJob(jobId);
-        } catch (Exception e) {
-            // ignore
-        }
-        try {
-            deleteJob(jobId);
-        } catch (Exception e) {
-            // ignore
-        }
-    }
-
-    protected void registerJob(Job.Builder job) {
-        if (jobs.add(job) == false) {
-            throw new IllegalArgumentException("job [" + job.getId() + "] is already registered");
-        }
-    }
-
-    protected void registerDatafeed(DatafeedConfig datafeed) {
-        if (datafeeds.add(datafeed) == false) {
-            throw new IllegalArgumentException("datafeed [" + datafeed.getId() + "] is already registered");
-        }
-    }
-
-    protected List<Job.Builder> getJobs() {
-        return jobs;
-    }
 
     protected PutJobAction.Response putJob(Job.Builder job) {
         PutJobAction.Request request = new PutJobAction.Request(job);

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/MlNativeAutodetectIntegTestCase.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/MlNativeAutodetectIntegTestCase.java
@@ -6,8 +6,6 @@
  */
 package org.elasticsearch.xpack.ml.integration;
 
-import org.elasticsearch.action.admin.cluster.snapshots.features.ResetFeatureStateAction;
-import org.elasticsearch.action.admin.cluster.snapshots.features.ResetFeatureStateRequest;
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.support.IndicesOptions;

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/MlNativeDataFrameAnalyticsIntegTestCase.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/MlNativeDataFrameAnalyticsIntegTestCase.java
@@ -6,7 +6,6 @@
  */
 package org.elasticsearch.xpack.ml.integration;
 
-import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.elasticsearch.action.admin.indices.get.GetIndexAction;
 import org.elasticsearch.action.admin.indices.get.GetIndexRequest;
 import org.elasticsearch.action.admin.indices.refresh.RefreshAction;
@@ -16,7 +15,6 @@ import org.elasticsearch.action.search.SearchAction;
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.search.SearchRequestBuilder;
 import org.elasticsearch.action.search.SearchResponse;
-import org.elasticsearch.action.support.master.AcknowledgedResponse;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.Strings;
@@ -28,7 +26,6 @@ import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.search.sort.SortOrder;
 import org.elasticsearch.tasks.TaskInfo;
 import org.elasticsearch.xpack.core.ml.MlTasks;
-import org.elasticsearch.xpack.core.ml.action.DeleteDataFrameAnalyticsAction;
 import org.elasticsearch.xpack.core.ml.action.EvaluateDataFrameAction;
 import org.elasticsearch.xpack.core.ml.action.ExplainDataFrameAnalyticsAction;
 import org.elasticsearch.xpack.core.ml.action.PreviewDataFrameAnalyticsAction;
@@ -56,7 +53,6 @@ import org.elasticsearch.xpack.ml.dataframe.StoredProgress;
 import org.hamcrest.Matcher;
 import org.hamcrest.Matchers;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -84,44 +80,7 @@ import static org.hamcrest.Matchers.nullValue;
  */
 abstract class MlNativeDataFrameAnalyticsIntegTestCase extends MlNativeIntegTestCase {
 
-    private final List<DataFrameAnalyticsConfig> analytics = new ArrayList<>();
-
-    @Override
-    protected void cleanUpResources() {
-        cleanUpAnalytics();
-    }
-
-    private void cleanUpAnalytics() {
-        stopAnalyticsAndForceStopOnError();
-
-        for (DataFrameAnalyticsConfig config : analytics) {
-            try {
-                assertThat(deleteAnalytics(config.getId()).isAcknowledged(), is(true));
-            } catch (Exception e) {
-                // just log and ignore
-                logger.error(new ParameterizedMessage("[{}] Could not clean up analytics job config", config.getId()), e);
-            }
-        }
-    }
-
-    private void stopAnalyticsAndForceStopOnError() {
-        try {
-            assertThat(stopAnalytics("*").isStopped(), is(true));
-        } catch (Exception e) {
-            logger.error("Failed to stop data frame analytics jobs; trying force", e);
-            try {
-                assertThat(forceStopAnalytics("*").isStopped(), is(true));
-            } catch (Exception e2) {
-                logger.error("Force-stopping data frame analytics jobs failed", e2);
-            }
-            throw new RuntimeException("Had to resort to force-stopping jobs, something went wrong?", e);
-        }
-    }
-
     protected PutDataFrameAnalyticsAction.Response putAnalytics(DataFrameAnalyticsConfig config) {
-        if (analytics.add(config) == false) {
-            throw new IllegalArgumentException("analytics config [" + config.getId() + "] is already registered");
-        }
         PutDataFrameAnalyticsAction.Request request = new PutDataFrameAnalyticsAction.Request(config);
         return client().execute(PutDataFrameAnalyticsAction.INSTANCE, request).actionGet();
     }
@@ -129,11 +88,6 @@ abstract class MlNativeDataFrameAnalyticsIntegTestCase extends MlNativeIntegTest
     protected PutDataFrameAnalyticsAction.Response updateAnalytics(DataFrameAnalyticsConfigUpdate update) {
         UpdateDataFrameAnalyticsAction.Request request = new UpdateDataFrameAnalyticsAction.Request(update);
         return client().execute(UpdateDataFrameAnalyticsAction.INSTANCE, request).actionGet();
-    }
-
-    protected AcknowledgedResponse deleteAnalytics(String id) {
-        DeleteDataFrameAnalyticsAction.Request request = new DeleteDataFrameAnalyticsAction.Request(id);
-        return client().execute(DeleteDataFrameAnalyticsAction.INSTANCE, request).actionGet();
     }
 
     protected NodeAcknowledgedResponse startAnalytics(String id) {

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/ModelPlotsIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/ModelPlotsIT.java
@@ -74,11 +74,11 @@ public class ModelPlotsIT extends MlNativeAutodetectIntegTestCase {
     public void testPartitionFieldWithoutTerms() throws Exception {
         Job.Builder job = jobWithPartitionUser("model-plots-it-test-partition-field-without-terms");
         job.setModelPlotConfig(new ModelPlotConfig());
-        registerJob(job);
+
         putJob(job);
         String datafeedId = job.getId() + "-feed";
         DatafeedConfig datafeed = newDatafeed(datafeedId, job.getId());
-        registerDatafeed(datafeed);
+
         putDatafeed(datafeed);
         openJob(job.getId());
         startDatafeed(datafeedId, 0, System.currentTimeMillis());
@@ -96,11 +96,11 @@ public class ModelPlotsIT extends MlNativeAutodetectIntegTestCase {
     public void testPartitionFieldWithTerms() throws Exception {
         Job.Builder job = jobWithPartitionUser("model-plots-it-test-partition-field-with-terms");
         job.setModelPlotConfig(new ModelPlotConfig(true, "user_2,user_3", false));
-        registerJob(job);
+
         putJob(job);
         String datafeedId = job.getId() + "-feed";
         DatafeedConfig datafeed = newDatafeed(datafeedId, job.getId());
-        registerDatafeed(datafeed);
+
         putDatafeed(datafeed);
         openJob(job.getId());
         startDatafeed(datafeedId, 0, System.currentTimeMillis());
@@ -118,11 +118,11 @@ public class ModelPlotsIT extends MlNativeAutodetectIntegTestCase {
     public void testByFieldWithTerms() throws Exception {
         Job.Builder job = jobWithByUser("model-plots-it-test-by-field-with-terms");
         job.setModelPlotConfig(new ModelPlotConfig(true, "user_2,user_3", false));
-        registerJob(job);
+
         putJob(job);
         String datafeedId = job.getId() + "-feed";
         DatafeedConfig datafeed = newDatafeed(datafeedId, job.getId());
-        registerDatafeed(datafeed);
+
         putDatafeed(datafeed);
         openJob(job.getId());
         startDatafeed(datafeedId, 0, System.currentTimeMillis());

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/ModelPlotsIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/ModelPlotsIT.java
@@ -74,11 +74,9 @@ public class ModelPlotsIT extends MlNativeAutodetectIntegTestCase {
     public void testPartitionFieldWithoutTerms() throws Exception {
         Job.Builder job = jobWithPartitionUser("model-plots-it-test-partition-field-without-terms");
         job.setModelPlotConfig(new ModelPlotConfig());
-
         putJob(job);
         String datafeedId = job.getId() + "-feed";
         DatafeedConfig datafeed = newDatafeed(datafeedId, job.getId());
-
         putDatafeed(datafeed);
         openJob(job.getId());
         startDatafeed(datafeedId, 0, System.currentTimeMillis());
@@ -96,11 +94,9 @@ public class ModelPlotsIT extends MlNativeAutodetectIntegTestCase {
     public void testPartitionFieldWithTerms() throws Exception {
         Job.Builder job = jobWithPartitionUser("model-plots-it-test-partition-field-with-terms");
         job.setModelPlotConfig(new ModelPlotConfig(true, "user_2,user_3", false));
-
         putJob(job);
         String datafeedId = job.getId() + "-feed";
         DatafeedConfig datafeed = newDatafeed(datafeedId, job.getId());
-
         putDatafeed(datafeed);
         openJob(job.getId());
         startDatafeed(datafeedId, 0, System.currentTimeMillis());
@@ -118,11 +114,9 @@ public class ModelPlotsIT extends MlNativeAutodetectIntegTestCase {
     public void testByFieldWithTerms() throws Exception {
         Job.Builder job = jobWithByUser("model-plots-it-test-by-field-with-terms");
         job.setModelPlotConfig(new ModelPlotConfig(true, "user_2,user_3", false));
-
         putJob(job);
         String datafeedId = job.getId() + "-feed";
         DatafeedConfig datafeed = newDatafeed(datafeedId, job.getId());
-
         putDatafeed(datafeed);
         openJob(job.getId());
         startDatafeed(datafeedId, 0, System.currentTimeMillis());

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/OverallBucketsIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/OverallBucketsIT.java
@@ -49,7 +49,6 @@ public class OverallBucketsIT extends MlNativeAutodetectIntegTestCase {
         job.setAnalysisConfig(analysisConfig);
         job.setDataDescription(dataDescription);
 
-        registerJob(job);
         putJob(job);
         openJob(job.getId());
 

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/PersistJobIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/PersistJobIT.java
@@ -216,9 +216,7 @@ public class PersistJobIT extends MlNativeAutodetectIntegTestCase {
         Job.Builder job = new Job.Builder(jobId);
         job.setAnalysisConfig(analysisConfig);
         job.setDataDescription(new DataDescription.Builder());
-
         putJob(job);
-
         openJob(job.getId());
     }
 

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/PersistJobIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/PersistJobIT.java
@@ -216,7 +216,7 @@ public class PersistJobIT extends MlNativeAutodetectIntegTestCase {
         Job.Builder job = new Job.Builder(jobId);
         job.setAnalysisConfig(analysisConfig);
         job.setDataDescription(new DataDescription.Builder());
-        registerJob(job);
+
         putJob(job);
 
         openJob(job.getId());

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/ReopenJobWithGapIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/ReopenJobWithGapIT.java
@@ -48,7 +48,6 @@ public class ReopenJobWithGapIT extends MlNativeAutodetectIntegTestCase {
         job.setAnalysisConfig(analysisConfig);
         job.setDataDescription(dataDescription);
 
-        registerJob(job);
         putJob(job);
         openJob(job.getId());
 

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/RestoreModelSnapshotIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/RestoreModelSnapshotIT.java
@@ -91,7 +91,6 @@ public class RestoreModelSnapshotIT extends MlNativeAutodetectIntegTestCase {
         job.setAnalysisConfig(analysisConfig);
         DataDescription.Builder dataDescription = new DataDescription.Builder();
         job.setDataDescription(dataDescription);
-
         putJob(job);
         return job;
     }

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/RestoreModelSnapshotIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/RestoreModelSnapshotIT.java
@@ -91,7 +91,7 @@ public class RestoreModelSnapshotIT extends MlNativeAutodetectIntegTestCase {
         job.setAnalysisConfig(analysisConfig);
         DataDescription.Builder dataDescription = new DataDescription.Builder();
         job.setDataDescription(dataDescription);
-        registerJob(job);
+
         putJob(job);
         return job;
     }

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/RevertModelSnapshotIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/RevertModelSnapshotIT.java
@@ -225,7 +225,7 @@ public class RevertModelSnapshotIT extends MlNativeAutodetectIntegTestCase {
         job.setAnalysisConfig(analysisConfig);
         DataDescription.Builder dataDescription = new DataDescription.Builder();
         job.setDataDescription(dataDescription);
-        registerJob(job);
+
         putJob(job);
         return job;
     }

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/RevertModelSnapshotIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/RevertModelSnapshotIT.java
@@ -225,7 +225,6 @@ public class RevertModelSnapshotIT extends MlNativeAutodetectIntegTestCase {
         job.setAnalysisConfig(analysisConfig);
         DataDescription.Builder dataDescription = new DataDescription.Builder();
         job.setDataDescription(dataDescription);
-
         putJob(job);
         return job;
     }

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/ScheduledEventsIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/ScheduledEventsIT.java
@@ -393,8 +393,6 @@ public class ScheduledEventsIT extends MlNativeAutodetectIntegTestCase {
         DataDescription.Builder dataDescription = new DataDescription.Builder();
         job.setDataDescription(dataDescription);
         putJob(job);
-        // register for clean up
-
 
         return job;
     }

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/ScheduledEventsIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/ScheduledEventsIT.java
@@ -394,7 +394,7 @@ public class ScheduledEventsIT extends MlNativeAutodetectIntegTestCase {
         job.setDataDescription(dataDescription);
         putJob(job);
         // register for clean up
-        registerJob(job);
+
 
         return job;
     }

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/SetUpgradeModeIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/SetUpgradeModeIT.java
@@ -122,7 +122,6 @@ public class SetUpgradeModeIT extends MlNativeAutodetectIntegTestCase {
     public void testJobOpenActionInUpgradeMode() {
         String jobId = "job-should-not-open";
         Job.Builder job = createScheduledJob(jobId);
-
         putJob(job);
 
         setUpgradeModeTo(true);
@@ -172,13 +171,11 @@ public class SetUpgradeModeIT extends MlNativeAutodetectIntegTestCase {
         indexDocs(logger, "data", numDocs1, lastWeek, now);
 
         Job.Builder job = createScheduledJob(jobId);
-
         putJob(job);
         openJob(job.getId());
         assertBusy(() -> assertEquals(getJobStats(job.getId()).get(0).getState(), JobState.OPENED));
 
         DatafeedConfig datafeedConfig = createDatafeed(job.getId() + "-datafeed", job.getId(), Collections.singletonList("data"));
-
         putDatafeed(datafeedConfig);
         startDatafeed(datafeedConfig.getId(), 0L, null);
         assertBusy(() -> {

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/SetUpgradeModeIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/SetUpgradeModeIT.java
@@ -122,7 +122,7 @@ public class SetUpgradeModeIT extends MlNativeAutodetectIntegTestCase {
     public void testJobOpenActionInUpgradeMode() {
         String jobId = "job-should-not-open";
         Job.Builder job = createScheduledJob(jobId);
-        registerJob(job);
+
         putJob(job);
 
         setUpgradeModeTo(true);
@@ -172,13 +172,13 @@ public class SetUpgradeModeIT extends MlNativeAutodetectIntegTestCase {
         indexDocs(logger, "data", numDocs1, lastWeek, now);
 
         Job.Builder job = createScheduledJob(jobId);
-        registerJob(job);
+
         putJob(job);
         openJob(job.getId());
         assertBusy(() -> assertEquals(getJobStats(job.getId()).get(0).getState(), JobState.OPENED));
 
         DatafeedConfig datafeedConfig = createDatafeed(job.getId() + "-datafeed", job.getId(), Collections.singletonList("data"));
-        registerDatafeed(datafeedConfig);
+
         putDatafeed(datafeedConfig);
         startDatafeed(datafeedConfig.getId(), 0L, null);
         assertBusy(() -> {

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/TestFeatureResetIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/TestFeatureResetIT.java
@@ -52,10 +52,37 @@ public class TestFeatureResetIT extends MlNativeAutodetectIntegTestCase {
     private final Set<String> jobIds = new HashSet<>();
     private final Set<String> datafeedIds = new HashSet<>();
 
+    void cleanupDatafeed(String datafeedId) {
+        try {
+            stopDatafeed(datafeedId);
+        } catch (Exception e) {
+            // ignore
+        }
+        try {
+            deleteDatafeed(datafeedId);
+        } catch (Exception e) {
+            // ignore
+        }
+    }
+
+    void cleanupJob(String jobId) {
+        try {
+            closeJob(jobId);
+        } catch (Exception e) {
+            // ignore
+        }
+        try {
+            deleteJob(jobId);
+        } catch (Exception e) {
+            // ignore
+        }
+    }
+
     @Override
     // The extra work of the original native clean up causes the indices to be recreated
     // It can complicate the logging and make it difficult to determine if the reset feature API cleaned up all the indices appropriately
     protected void cleanUpResources() {
+        super.cleanUpResources();
         for (String jobId : jobIds) {
             cleanupJob(jobId);
         }


### PR DESCRIPTION
In machine learning integration tests there is logic for cleaning up created anomaly jobs, datafeeds and data frame analytics
jobs.

This commit removes all that logic and makes sure the integration tests are cleaned up with the feature state reset API.

