### PR TITLE
[Transform] remove deprecated endpoint from tests

### DIFF
--- a/x-pack/plugin/transform/qa/single-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/TransformGetAndGetStatsIT.java
+++ b/x-pack/plugin/transform/qa/single-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/TransformGetAndGetStatsIT.java
@@ -47,7 +47,6 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
-import static org.elasticsearch.xpack.core.security.authc.support.UsernamePasswordToken.basicAuthHeaderValue;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
@@ -80,14 +79,8 @@ public class TransformGetAndGetStatsIT extends TransformRestTestCase {
         createReviewsIndex();
         indicesCreated = true;
 
-        // at random test the old deprecated roles, to be removed in 9.0.0
-        if (useDeprecatedEndpoints() && randomBoolean()) {
-            setupUser(TEST_USER_NAME, Collections.singletonList("data_frame_transforms_user"));
-            setupUser(TEST_ADMIN_USER_NAME, Collections.singletonList("data_frame_transforms_admin"));
-        } else {
-            setupUser(TEST_USER_NAME, Collections.singletonList("transform_user"));
-            setupUser(TEST_ADMIN_USER_NAME, Collections.singletonList("transform_admin"));
-        }
+        setupUser(TEST_USER_NAME, Collections.singletonList("transform_user"));
+        setupUser(TEST_ADMIN_USER_NAME, Collections.singletonList("transform_admin"));
     }
 
     @After

--- a/x-pack/plugin/transform/qa/single-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/TransformPivotRestIT.java
+++ b/x-pack/plugin/transform/qa/single-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/TransformPivotRestIT.java
@@ -28,7 +28,6 @@ import java.util.Map;
 import java.util.Set;
 
 import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
-import static org.elasticsearch.xpack.core.security.authc.support.UsernamePasswordToken.basicAuthHeaderValue;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasEntry;
@@ -66,13 +65,7 @@ public class TransformPivotRestIT extends TransformRestTestCase {
         createReviewsIndexNano();
         indicesCreated = true;
         setupDataAccessRole(DATA_ACCESS_ROLE, REVIEWS_INDEX_NAME);
-
-        // at random test the old deprecated roles, to be removed in 9.0.0
-        if (useDeprecatedEndpoints() && randomBoolean()) {
-            setupUser(TEST_USER_NAME, Arrays.asList("data_frame_transforms_admin", DATA_ACCESS_ROLE));
-        } else {
-            setupUser(TEST_USER_NAME, Arrays.asList("transform_admin", DATA_ACCESS_ROLE));
-        }
+        setupUser(TEST_USER_NAME, Arrays.asList("transform_admin", DATA_ACCESS_ROLE));
     }
 
     public void testSimplePivot() throws Exception {

--- a/x-pack/plugin/transform/qa/single-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/TransformRestTestCase.java
+++ b/x-pack/plugin/transform/qa/single-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/TransformRestTestCase.java
@@ -7,7 +7,6 @@
 
 package org.elasticsearch.xpack.transform.integration;
 
-import org.apache.http.HttpHost;
 import org.apache.http.entity.ContentType;
 import org.apache.http.entity.StringEntity;
 import org.apache.logging.log4j.Level;
@@ -15,8 +14,6 @@ import org.elasticsearch.client.Request;
 import org.elasticsearch.client.RequestOptions;
 import org.elasticsearch.client.Response;
 import org.elasticsearch.client.ResponseException;
-import org.elasticsearch.client.RestClient;
-import org.elasticsearch.client.RestClientBuilder;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.settings.SecureString;
 import org.elasticsearch.common.settings.Settings;
@@ -29,7 +26,6 @@ import org.elasticsearch.xpack.core.transform.transforms.persistence.TransformIn
 import org.joda.time.Instant;
 import org.junit.After;
 import org.junit.AfterClass;
-import org.junit.BeforeClass;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -52,32 +48,9 @@ public abstract class TransformRestTestCase extends ESRestTestCase {
     protected static final String REVIEWS_INDEX_NAME = "reviews";
     protected static final String REVIEWS_DATE_NANO_INDEX_NAME = "reviews_nano";
 
-    private static boolean useDeprecatedEndpoints;
-
-    protected boolean useDeprecatedEndpoints() {
-        return useDeprecatedEndpoints;
-    }
-
-    @BeforeClass
-    public static void init() {
-        // randomly return the old or the new endpoints, old endpoints to be removed for 8.0.0
-        useDeprecatedEndpoints = randomBoolean();
-    }
-
     @Override
     protected Settings restClientSettings() {
         return Settings.builder().put(ThreadContext.PREFIX + ".Authorization", BASIC_AUTH_VALUE_SUPER_USER).build();
-    }
-
-    @Override
-    protected RestClient buildClient(Settings settings, HttpHost[] hosts) throws IOException {
-        if (useDeprecatedEndpoints) {
-            RestClientBuilder builder = RestClient.builder(hosts);
-            configureClient(builder, settings);
-            builder.setStrictDeprecationMode(false);
-            return builder.build();
-        }
-        return super.buildClient(settings, hosts);
     }
 
     protected void createReviewsIndex(
@@ -313,8 +286,12 @@ public abstract class TransformRestTestCase extends ESRestTestCase {
 
     protected void createLatestReviewsTransform(String transformId, String transformIndex) throws IOException {
         String config = "{"
-            + " \"dest\": {\"index\":\"" + transformIndex + "\"},"
-            + " \"source\": {\"index\":\"" + REVIEWS_INDEX_NAME + "\"},"
+            + " \"dest\": {\"index\":\""
+            + transformIndex
+            + "\"},"
+            + " \"source\": {\"index\":\""
+            + REVIEWS_INDEX_NAME
+            + "\"},"
             + " \"latest\": {"
             + "   \"unique_key\": [ \"user_id\" ],"
             + "   \"sort\": \"@timestamp\""
@@ -580,7 +557,7 @@ public abstract class TransformRestTestCase extends ESRestTestCase {
     }
 
     protected static String getTransformEndpoint() {
-        return useDeprecatedEndpoints ? TransformField.REST_BASE_PATH_TRANSFORMS_DEPRECATED : TransformField.REST_BASE_PATH_TRANSFORMS;
+        return TransformField.REST_BASE_PATH_TRANSFORMS;
     }
 
     @SuppressWarnings("unchecked")


### PR DESCRIPTION
remove the use of the deprecated _data_frame endpoint from rest test cases, because it can prevent detecting problems in PR builds

relates #71792


Notes:
 - the use of the deprecated endpoint hid another problem and caused build errors after merging
 - this change only removes the check for `8.x`, it will _not_ be backported to `7.x`
 - removing the deprecated endpoints is planned for `8.x` but out of scope for this PR 