### PR TITLE
[TEST] Temporarily skip painless execute script field tests

### DIFF
--- a/modules/lang-painless/src/yamlRestTest/resources/rest-api-spec/test/painless/120_stored_scripts.yml
+++ b/modules/lang-painless/src/yamlRestTest/resources/rest-api-spec/test/painless/120_stored_scripts.yml
@@ -16,6 +16,9 @@
 ---
 
 "Test runtime field contexts not allowed as stored script":
+  - skip:
+      version:     " - 8.99.99"
+      reason:      Script while the string_field script context gets renamed
 
   - do:
       catch: bad_request

--- a/modules/lang-painless/src/yamlRestTest/resources/rest-api-spec/test/painless/70_execute_painless_scripts.yml
+++ b/modules/lang-painless/src/yamlRestTest/resources/rest-api-spec/test/painless/70_execute_painless_scripts.yml
@@ -266,6 +266,10 @@ setup:
 
 ---
 "Execute with string field context (single-value)":
+  - skip:
+      version:     " - 8.99.99"
+      reason:      Script while the script context gets renamed
+
   - do:
       scripts_painless_execute:
         body:
@@ -280,6 +284,10 @@ setup:
 
 ---
 "Execute with string field context (multi-value)":
+  - skip:
+      version:     " - 8.99.99"
+      reason:      Script while the script context gets renamed
+
   - do:
       scripts_painless_execute:
         body:


### PR DESCRIPTION
The script context is being renamed as part of #71854, which is not a breaking change as we have not released a public version that supports such new context in the painless execute API. We will re-enable these tests once the linked PR is merged.