### PR TITLE
Rename on_script_error options to fail or continue (#71841)

### DIFF
--- a/docs/reference/mapping/runtime.asciidoc
+++ b/docs/reference/mapping/runtime.asciidoc
@@ -958,7 +958,7 @@ PUT my-index-00001/
       },
       "voltage_corrected": {
         "type": "double",
-        "on_script_error": "reject", <1>
+        "on_script_error": "fail", <1>
         "script": {
           "source": """
         emit(doc['voltage'].value * params['multiplier'])

--- a/docs/reference/mapping/types/boolean.asciidoc
+++ b/docs/reference/mapping/types/boolean.asciidoc
@@ -194,8 +194,8 @@ The following parameters are accepted by `boolean` fields:
 `on_script_error`::
 
     Defines what to do if the script defined by the `script` parameter
-    throws an error at indexing time. Accepts `reject` (default), which
-    will cause the entire document to be rejected, and `ignore`, which
+    throws an error at indexing time. Accepts `fail` (default), which
+    will cause the entire document to be rejected, and `continue`, which
     will register the field in the document's
     <<mapping-ignored-field,`_ignored`>> metadata field and continue
     indexing. This parameter can only be set if the `script` field is

--- a/docs/reference/mapping/types/date.asciidoc
+++ b/docs/reference/mapping/types/date.asciidoc
@@ -155,8 +155,8 @@ The following parameters are accepted by `date` fields:
 `on_script_error`::
 
     Defines what to do if the script defined by the `script` parameter
-    throws an error at indexing time. Accepts `reject` (default), which
-    will cause the entire document to be rejected, and `ignore`, which
+    throws an error at indexing time. Accepts `fail` (default), which
+    will cause the entire document to be rejected, and `continue`, which
     will register the field in the document's
     <<mapping-ignored-field,`_ignored`>> metadata field and continue
     indexing. This parameter can only be set if the `script` field is

--- a/docs/reference/mapping/types/keyword.asciidoc
+++ b/docs/reference/mapping/types/keyword.asciidoc
@@ -110,8 +110,8 @@ The following parameters are accepted by `keyword` fields:
 `on_script_error`::
 
     Defines what to do if the script defined by the `script` parameter
-    throws an error at indexing time. Accepts `reject` (default), which
-    will cause the entire document to be rejected, and `ignore`, which
+    throws an error at indexing time. Accepts `fail` (default), which
+    will cause the entire document to be rejected, and `continue`, which
     will register the field in the document's
     <<mapping-ignored-field,`_ignored`>> metadata field and continue
     indexing. This parameter can only be set if the `script` field is

--- a/docs/reference/mapping/types/numeric.asciidoc
+++ b/docs/reference/mapping/types/numeric.asciidoc
@@ -150,8 +150,8 @@ The following parameters are accepted by numeric types:
 `on_script_error`::
 
     Defines what to do if the script defined by the `script` parameter
-    throws an error at indexing time. Accepts `reject` (default), which
-    will cause the entire document to be rejected, and `ignore`, which
+    throws an error at indexing time. Accepts `fail` (default), which
+    will cause the entire document to be rejected, and `continue`, which
     will register the field in the document's
     <<mapping-ignored-field,`_ignored`>> metadata field and continue
     indexing. This parameter can only be set if the `script` field is

--- a/server/src/main/java/org/elasticsearch/index/mapper/FieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/FieldMapper.java
@@ -246,7 +246,7 @@ public abstract class FieldMapper extends Mapper implements Cloneable {
         try {
             indexScriptValues(searchLookup, readerContext, doc, parseContext);
         } catch (Exception e) {
-            if ("ignore".equals(onScriptError)) {
+            if ("continue".equals(onScriptError)) {
                 parseContext.addIgnoredField(name());
             } else {
                 throw new MapperParsingException("Error executing script on field [" + name() + "]", e);
@@ -988,7 +988,7 @@ public abstract class FieldMapper extends Mapper implements Cloneable {
                 "on_script_error",
                 true,
                 initializer,
-                "reject", "ignore").requiresParameters(dependentScriptParam);
+                "fail", "continue").requiresParameters(dependentScriptParam);
         }
     }
 

--- a/server/src/test/java/org/elasticsearch/index/mapper/IndexTimeScriptTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/IndexTimeScriptTests.java
@@ -137,7 +137,7 @@ public class IndexTimeScriptTests extends MapperServiceTestCase {
     public void testScriptErrorParameterRequiresScript() {
         Exception e = expectThrows(MapperParsingException.class, () -> createDocumentMapper(fieldMapping(b -> {
             b.field("type", "long");
-            b.field("on_script_error", "ignore");
+            b.field("on_script_error", "continue");
         })));
         assertThat(e.getMessage(),
             equalTo("Failed to parse mapping [_doc]: Field [on_script_error] requires field [script] to be configured"));
@@ -156,7 +156,7 @@ public class IndexTimeScriptTests extends MapperServiceTestCase {
             {
                 b.field("type", "long");
                 b.field("script", "throws");
-                b.field("on_script_error", "ignore");
+                b.field("on_script_error", "continue");
             }
             b.endObject();
         }));

--- a/server/src/test/java/org/elasticsearch/index/mapper/NumberFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/NumberFieldMapperTests.java
@@ -61,14 +61,14 @@ public abstract class NumberFieldMapperTests extends MapperTestCase {
                 b -> {
                     minimalMapping(b);
                     b.field("script", "test");
-                    b.field("on_script_error", "reject");
+                    b.field("on_script_error", "fail");
                 },
                 b -> {
                     minimalMapping(b);
                     b.field("script", "test");
-                    b.field("on_script_error", "ignore");
+                    b.field("on_script_error", "continue");
                 },
-                m -> assertThat((m).onScriptError, equalTo("ignore")));
+                m -> assertThat((m).onScriptError, equalTo("continue")));
         }
     }
 

--- a/test/framework/src/main/java/org/elasticsearch/index/mapper/MapperScriptTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/mapper/MapperScriptTestCase.java
@@ -122,20 +122,20 @@ public abstract class MapperScriptTestCase<FactoryType> extends MapperServiceTes
     public final void testOnScriptErrorParameterRequiresScript() {
         Exception e = expectThrows(MapperParsingException.class, () -> createDocumentMapper(fieldMapping(b -> {
             b.field("type", type());
-            b.field("on_script_error", "ignore");
+            b.field("on_script_error", "continue");
         })));
         assertThat(e.getMessage(),
             equalTo("Failed to parse mapping [_doc]: Field [on_script_error] requires field [script] to be configured"));
     }
 
-    public final void testIgnoreScriptErrors() throws IOException {
+    public final void testOnScriptErrorContinue() throws IOException {
         DocumentMapper mapper = createDocumentMapper(mapping(b -> {
             b.startObject("message").field("type", "keyword").endObject();
             b.startObject("message_error");
             {
                 b.field("type", type());
                 b.field("script", "throws");
-                b.field("on_script_error", "ignore");
+                b.field("on_script_error", "continue");
             }
             b.endObject();
         }));


### PR DESCRIPTION
As we started thinking about applying on_script_error to runtime fields, to handle script errors at search time, we would like to use the same parameter that was recently introduced for indexed fields. We decided that continue or fail gives a better indication of the behaviour compared to the current ignore or reject which is too specific to indexing documents.

This commit applies such rename.