### PR TITLE
re-factor top-metrics to use a generic multi value output interface

### DIFF
--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/InternalMultiValueAggregation.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/InternalMultiValueAggregation.java
@@ -9,12 +9,20 @@
 package org.elasticsearch.search.aggregations.metrics;
 
 import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.aggregations.InternalAggregation;
+import org.elasticsearch.search.aggregations.support.AggregationPath;
 
 import java.io.IOException;
+import java.util.Iterator;
 import java.util.Map;
+import java.util.Objects;
 
 public abstract class InternalMultiValueAggregation extends InternalAggregation implements MultiValueAggregation {
+
+    private static final DocValueFormat DEFAULT_FORMAT = DocValueFormat.RAW;
+
+    protected DocValueFormat format = DEFAULT_FORMAT;
 
     protected InternalMultiValueAggregation(String name, Map<String, Object> metadata) {
         super(name, metadata);
@@ -28,7 +36,27 @@ public abstract class InternalMultiValueAggregation extends InternalAggregation 
     }
 
     @Override
+    public final double sortValue(AggregationPath.PathElement head, Iterator<AggregationPath.PathElement> tail) {
+        throw new IllegalArgumentException("Metrics aggregations cannot have sub-aggregations (at [>" + head + "]");
+    }
+
+    @Override
     protected boolean mustReduceOnSingleInternalAgg() {
         return false;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), format);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) return true;
+        if (obj == null || getClass() != obj.getClass()) return false;
+        if (super.equals(obj) == false) return false;
+
+        InternalMultiValueAggregation other = (InternalMultiValueAggregation) obj;
+        return Objects.equals(format, other.format);
     }
 }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/InternalMultiValueAggregation.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/InternalMultiValueAggregation.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.search.aggregations.metrics;
+
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.search.aggregations.InternalAggregation;
+
+import java.io.IOException;
+import java.util.Map;
+
+public abstract class InternalMultiValueAggregation extends InternalAggregation implements MultiValueAggregation {
+
+    protected InternalMultiValueAggregation(String name, Map<String, Object> metadata) {
+        super(name, metadata);
+    }
+
+    /**
+     * Read from a stream.
+     */
+    protected InternalMultiValueAggregation(StreamInput in) throws IOException {
+        super(in);
+    }
+
+    @Override
+    protected boolean mustReduceOnSingleInternalAgg() {
+        return false;
+    }
+}

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/InternalMultiValueAggregation.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/InternalMultiValueAggregation.java
@@ -9,20 +9,14 @@
 package org.elasticsearch.search.aggregations.metrics;
 
 import org.elasticsearch.common.io.stream.StreamInput;
-import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.aggregations.InternalAggregation;
 import org.elasticsearch.search.aggregations.support.AggregationPath;
 
 import java.io.IOException;
 import java.util.Iterator;
 import java.util.Map;
-import java.util.Objects;
 
 public abstract class InternalMultiValueAggregation extends InternalAggregation implements MultiValueAggregation {
-
-    private static final DocValueFormat DEFAULT_FORMAT = DocValueFormat.RAW;
-
-    protected DocValueFormat format = DEFAULT_FORMAT;
 
     protected InternalMultiValueAggregation(String name, Map<String, Object> metadata) {
         super(name, metadata);
@@ -38,25 +32,5 @@ public abstract class InternalMultiValueAggregation extends InternalAggregation 
     @Override
     public final double sortValue(AggregationPath.PathElement head, Iterator<AggregationPath.PathElement> tail) {
         throw new IllegalArgumentException("Metrics aggregations cannot have sub-aggregations (at [>" + head + "]");
-    }
-
-    @Override
-    protected boolean mustReduceOnSingleInternalAgg() {
-        return false;
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(super.hashCode(), format);
-    }
-
-    @Override
-    public boolean equals(Object obj) {
-        if (this == obj) return true;
-        if (obj == null || getClass() != obj.getClass()) return false;
-        if (super.equals(obj) == false) return false;
-
-        InternalMultiValueAggregation other = (InternalMultiValueAggregation) obj;
-        return Objects.equals(format, other.format);
     }
 }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/MultiValueAggregation.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/MultiValueAggregation.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.search.aggregations.metrics;
+
+import org.elasticsearch.search.aggregations.Aggregation;
+
+public interface MultiValueAggregation extends Aggregation {
+
+    /**
+     * Return an iterable over all value names this multi value aggregation provides.
+     *
+     * The iterable might be created on the fly, if you need to call this multiple times, please
+     * cache the result in a variable on caller side..
+     *
+     * @return iterable over all value names
+     */
+    Iterable<String> valueNames();
+
+    /**
+     * Return an iterable over all results by name
+     *
+     * @param name of the value
+     * @return iterable over all values formatted as string
+     */
+    Iterable<String> getValuesAsStrings(String name);
+
+    /**
+     * Return the maximum number of results per value
+     *
+     * Note: A single result might not have `size()` values
+     *
+     * @return maximum number of results per value
+     */
+    int size();
+}

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/MultiValueAggregation.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/MultiValueAggregation.java
@@ -10,6 +10,8 @@ package org.elasticsearch.search.aggregations.metrics;
 
 import org.elasticsearch.search.aggregations.Aggregation;
 
+import java.util.List;
+
 public interface MultiValueAggregation extends Aggregation {
 
     /**
@@ -23,19 +25,10 @@ public interface MultiValueAggregation extends Aggregation {
     Iterable<String> valueNames();
 
     /**
-     * Return an iterable over all results with the specified name
+     * Return a list of all results with the specified name
      *
      * @param name of the value
-     * @return iterable over all values formatted as string
+     * @return list of all values formatted as string
      */
-    Iterable<String> getValuesAsStrings(String name);
-
-    /**
-     * Return the maximum number of results per value
-     *
-     * Note: A single result might not have `size()` values
-     *
-     * @return maximum number of results per value
-     */
-    int size();
+    List<String> getValuesAsStrings(String name);
 }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/MultiValueAggregation.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/MultiValueAggregation.java
@@ -23,7 +23,7 @@ public interface MultiValueAggregation extends Aggregation {
     Iterable<String> valueNames();
 
     /**
-     * Return an iterable over all results by name
+     * Return an iterable over all results with the specified name
      *
      * @param name of the value
      * @return iterable over all values formatted as string

--- a/test/framework/src/main/java/org/elasticsearch/search/aggregations/AggregatorTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/search/aggregations/AggregatorTestCase.java
@@ -104,6 +104,7 @@ import org.elasticsearch.search.aggregations.InternalAggregation.ReduceContext;
 import org.elasticsearch.search.aggregations.MultiBucketConsumerService.MultiBucketConsumer;
 import org.elasticsearch.search.aggregations.bucket.nested.NestedAggregationBuilder;
 import org.elasticsearch.search.aggregations.metrics.MetricsAggregator;
+import org.elasticsearch.search.aggregations.metrics.MultiValueAggregation;
 import org.elasticsearch.search.aggregations.metrics.NumericMetricsAggregation;
 import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator.PipelineTree;
@@ -674,12 +675,20 @@ public abstract class AggregatorTestCase extends ESTestCase {
             return;
         }
 
-        assert agg instanceof NumericMetricsAggregation.MultiValue : "only multi value aggs are supported";
-
-        NumericMetricsAggregation.MultiValue multiValueAgg = (NumericMetricsAggregation.MultiValue) agg;
         Set<String> valueNames = new HashSet<>();
-        for (String name : multiValueAgg.valueNames()) {
-            valueNames.add(name);
+
+        if (agg instanceof NumericMetricsAggregation.MultiValue) {
+            NumericMetricsAggregation.MultiValue multiValueAgg = (NumericMetricsAggregation.MultiValue) agg;
+            for (String name : multiValueAgg.valueNames()) {
+                valueNames.add(name);
+            }
+        } else if (agg instanceof MultiValueAggregation) {
+            MultiValueAggregation multiValueAgg = (MultiValueAggregation) agg;
+            for (String name : multiValueAgg.valueNames()) {
+                valueNames.add(name);
+            }
+        } else {
+            assert false : "only multi value aggs are supported";
         }
 
         assertEquals(aggregationBuilder.getOutputFieldNames().get(), valueNames);

--- a/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/topmetrics/InternalTopMetrics.java
+++ b/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/topmetrics/InternalTopMetrics.java
@@ -165,9 +165,9 @@ public class InternalTopMetrics extends InternalMultiValueAggregation {
 
     @Override
     public final double sortValue(String key) {
-        int index = metricNames.indexOf(name);
+        int index = metricNames.indexOf(key);
         if (index < 0) {
-            throw new IllegalArgumentException("unknown metric [" + name + "]");
+            throw new IllegalArgumentException("unknown metric [" + key + "]");
         }
         if (topMetrics.isEmpty()) {
             return Double.NaN;

--- a/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/topmetrics/InternalTopMetrics.java
+++ b/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/topmetrics/InternalTopMetrics.java
@@ -164,6 +164,26 @@ public class InternalTopMetrics extends InternalMultiValueAggregation {
     }
 
     @Override
+    public final double sortValue(String key) {
+        int index = metricNames.indexOf(name);
+        if (index < 0) {
+            throw new IllegalArgumentException("unknown metric [" + name + "]");
+        }
+        if (topMetrics.isEmpty()) {
+            return Double.NaN;
+        }
+
+        MetricValue value = topMetrics.get(0).metricValues.get(index);
+        if (value == null) {
+            return Double.NaN;
+        }
+
+        // TODO it'd probably be nicer to have "compareTo" instead of assuming a double.
+        // non-numeric fields always return NaN
+        return value.numberValue().doubleValue();
+    }
+
+    @Override
     public Iterable<String> getValuesAsStrings(String name) {
         int index = metricNames.indexOf(name);
         if (index < 0) {

--- a/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/topmetrics/InternalTopMetrics.java
+++ b/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/topmetrics/InternalTopMetrics.java
@@ -184,7 +184,7 @@ public class InternalTopMetrics extends InternalMultiValueAggregation {
     }
 
     @Override
-    public Iterable<String> getValuesAsStrings(String name) {
+    public List<String> getValuesAsStrings(String name) {
         int index = metricNames.indexOf(name);
         if (index < 0) {
             throw new IllegalArgumentException("unknown metric [" + name + "]");
@@ -199,11 +199,6 @@ public class InternalTopMetrics extends InternalMultiValueAggregation {
             }
             return value.getValue().format(value.getFormat());
         }).collect(Collectors.toList());
-    }
-
-    @Override
-    public int size() {
-        return size;
     }
 
     @Override

--- a/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/topmetrics/InternalTopMetrics.java
+++ b/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/topmetrics/InternalTopMetrics.java
@@ -211,6 +211,11 @@ public class InternalTopMetrics extends InternalMultiValueAggregation {
         return metricNames;
     }
 
+    @Override
+    protected boolean mustReduceOnSingleInternalAgg() {
+        return false;
+    }
+
     SortOrder getSortOrder() {
         return sortOrder;
     }

--- a/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/topmetrics/InternalTopMetricsTests.java
+++ b/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/topmetrics/InternalTopMetricsTests.java
@@ -231,7 +231,6 @@ public class InternalTopMetricsTests extends InternalAggregationTestCase<Interna
         assertThat(metrics.getValuesAsStrings("double"), equalTo(Collections.singletonList("5.0")));
         assertThat(metrics.getValuesAsStrings("bytes"), equalTo(Collections.singletonList("cat")));
         assertThat(metrics.getValuesAsStrings("null"), equalTo(Collections.singletonList("null")));
-        assertThat(metrics.size(), equalTo(1));
     }
 
     private InternalTopMetrics resultWithAllTypes() {

--- a/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/topmetrics/InternalTopMetricsTests.java
+++ b/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/topmetrics/InternalTopMetricsTests.java
@@ -225,12 +225,13 @@ public class InternalTopMetricsTests extends InternalAggregationTestCase<Interna
         assertThat((Double) metrics.getProperty("null"), notANumber());
     }
 
-    public void testValue() {
+    public void testGetValuesAsStrings() {
         InternalTopMetrics metrics = resultWithAllTypes();
-        assertThat(metrics.value("int"), equalTo(1.0));
-        assertThat(metrics.value("double"), equalTo(5.0));
-        assertThat(metrics.value("bytes"), notANumber());
-        assertThat(metrics.value("null"), notANumber());
+        assertThat(metrics.getValuesAsStrings("int"), equalTo(Collections.singletonList("1")));
+        assertThat(metrics.getValuesAsStrings("double"), equalTo(Collections.singletonList("5.0")));
+        assertThat(metrics.getValuesAsStrings("bytes"), equalTo(Collections.singletonList("cat")));
+        assertThat(metrics.getValuesAsStrings("null"), equalTo(Collections.singletonList("null")));
+        assertThat(metrics.size(), equalTo(1));
     }
 
     private InternalTopMetrics resultWithAllTypes() {


### PR DESCRIPTION
re-factor top-metrics to return generic(non-numeric) multi value
aggregation results

relates #71850


Motivation: top metrics implements `Internal`_Numeric_`MetricsAggregation.MultiValue`, however is not limited to returning numeric, but it can return an arbitrary type.

However, I kept the the numeric dependency on the builder side, which seems to be valid as sorting is based on it.

A big benefit of this change: The former multi-value inteface was limited to return the top 1, this interface will make it possible to return top-N.

/CC @nik9000 