### PR TITLE
Remove `--illegal-access` option in test base plugin

### DIFF
--- a/buildSrc/src/main/java/org/elasticsearch/gradle/ElasticsearchTestBasePlugin.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/ElasticsearchTestBasePlugin.java
@@ -93,7 +93,6 @@ public class ElasticsearchTestBasePlugin implements Plugin<Project> {
             test.jvmArgs(
                 "-Xmx" + System.getProperty("tests.heap.size", "512m"),
                 "-Xms" + System.getProperty("tests.heap.size", "512m"),
-                "--illegal-access=warn",
                 "-XX:+HeapDumpOnOutOfMemoryError"
             );
 


### PR DESCRIPTION
The `--illegal-access` JVM option is deprecated and will be removed in
a future release. The default going forwards is `deny`.
