### PR TITLE
Fix NetworkUtilsTests#testNonExistingInterface

### DIFF
--- a/server/src/test/java/org/elasticsearch/common/network/NetworkUtilsTests.java
+++ b/server/src/test/java/org/elasticsearch/common/network/NetworkUtilsTests.java
@@ -83,9 +83,16 @@ public class NetworkUtilsTests extends ESTestCase {
         }
     }
 
-    public void testNonExistingInterface() {
+    public void testNonExistingInterface() throws Exception {
         final IllegalArgumentException exception = expectThrows(IllegalArgumentException.class,
-                () -> NetworkUtils.getAddressesForInterface("settingValue", ":suffix" , "non-existing"));
+            () -> NetworkUtils.getAddressesForInterface("settingValue", ":suffix", "non-existing"));
         assertThat(exception.getMessage(), containsString("setting [settingValue] matched no network interfaces; valid values include"));
+        final boolean atLeastOneInterfaceIsPresentInExceptionMessage = getInterfaces().stream()
+            .anyMatch(anInterface -> exception.getMessage().contains(anInterface.getName() + ":suffix"));
+
+        assertThat("Expected to get at least one interface name in the exception but got none: " + exception.getMessage(),
+            atLeastOneInterfaceIsPresentInExceptionMessage,
+            equalTo(true)
+        );
     }
 }

--- a/server/src/test/java/org/elasticsearch/common/network/NetworkUtilsTests.java
+++ b/server/src/test/java/org/elasticsearch/common/network/NetworkUtilsTests.java
@@ -83,15 +83,9 @@ public class NetworkUtilsTests extends ESTestCase {
         }
     }
 
-    public void testNonExistingInterface() throws Exception {
+    public void testNonExistingInterface() {
         final IllegalArgumentException exception = expectThrows(IllegalArgumentException.class,
                 () -> NetworkUtils.getAddressesForInterface("settingValue", ":suffix" , "non-existing"));
         assertThat(exception.getMessage(), containsString("setting [settingValue] matched no network interfaces; valid values include"));
-        for (NetworkInterface anInterface : getInterfaces()) {
-            // virtual interfaces might pop up or disappear while the test is running, so ignore them
-            if (anInterface.isVirtual() == false) {
-                assertThat(exception.getMessage(), containsString(anInterface.getName() + ":suffix"));
-            }
-        }
     }
 }


### PR DESCRIPTION
In Linux it's possible that different virtual network interfaces appear
and disappear during the test execution. NetworkInterface#isVirtual
only detects interfaces that are created as a child of a physical
interface, veth network interfaces appear as non-virtual interfaces.
This commit deletes the assertion that checks that all the interfaces
are listed in the exception message, since there's no way to get
a snapshot of the network interfaces that were available when the exception
message was generated.

Closes #66658
