### PR TITLE
Adjust BWC for tracking snapshot index details

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -190,9 +190,9 @@ tasks.register("verifyVersions") {
  * after the backport of the backcompat code is complete.
  */
 
-boolean bwc_tests_enabled = false
+boolean bwc_tests_enabled = true
 // place a PR link here when committing bwc changes:
-String bwc_tests_disabled_issue = "https://github.com/elastic/elasticsearch/pull/71902"
+String bwc_tests_disabled_issue = ""
 /*
  * FIPS 140-2 behavior was fixed in 7.11.0. Before that there is no way to run elasticsearch in a
  * JVM that is properly configured to be in fips mode with BCFIPS. For now we need to disable

--- a/rest-api-spec/build.gradle
+++ b/rest-api-spec/build.gradle
@@ -313,6 +313,7 @@ tasks.named("yamlRestCompatTest").configure {
     'snapshot.get/10_basic/Get snapshot info contains include_global_state',
     'snapshot.get/10_basic/Get snapshot info when verbose is false',
     'snapshot.get/10_basic/Get snapshot info with metadata',
+    'snapshot.get/10_basic/Get snapshot info with index details',
     'suggest/20_completion/Suggestions with source should work',
     'termvectors/11_basic_with_types/Basic tests for termvector get',
     'termvectors/20_issue7121/Term vector API should return \'found: false\' for docs between index and refresh',

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/snapshot.get/10_basic.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/snapshot.get/10_basic.yml
@@ -225,18 +225,18 @@ setup:
   - do:
       snapshot.create:
         repository: test_repo_get_1
-        snapshot: test_snapshot_with_metadata
+        snapshot: test_snapshot_with_index_details
         wait_for_completion: true
 
   - do:
       snapshot.get:
         repository: test_repo_get_1
-        snapshot: test_snapshot_with_metadata
+        snapshot: test_snapshot_with_index_details
         index_details: true
         human: true
 
   - is_true: responses.0.snapshots
-  - match: { responses.0.snapshots.0.snapshot: test_snapshot_with_metadata }
+  - match: { responses.0.snapshots.0.snapshot: test_snapshot_with_index_details }
   - match: { responses.0.snapshots.0.state: SUCCESS }
   - gt:  { responses.0.snapshots.0.index_details.test_index.shard_count: 0 }
   - gt:  { responses.0.snapshots.0.index_details.test_index.size_in_bytes: 0 }
@@ -246,4 +246,4 @@ setup:
   - do:
       snapshot.delete:
         repository: test_repo_get_1
-        snapshot: test_snapshot_with_metadata
+        snapshot: test_snapshot_with_index_details

--- a/server/src/internalClusterTest/java/org/elasticsearch/snapshots/SnapshotStatusApisIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/snapshots/SnapshotStatusApisIT.java
@@ -260,7 +260,14 @@ public class SnapshotStatusApisIT extends AbstractSnapshotIntegTestCase {
         }, 30L, TimeUnit.SECONDS);
 
         unblockAllDataNodes(repoName);
-        assertThat(responseSnapshotTwo.get().getSnapshotInfo().state(), is(SnapshotState.SUCCESS));
+        final SnapshotInfo snapshotInfo = responseSnapshotTwo.get().getSnapshotInfo();
+        assertThat(snapshotInfo.state(), is(SnapshotState.SUCCESS));
+
+        assertTrue(snapshotInfo.indexSnapshotDetails().toString(), snapshotInfo.indexSnapshotDetails().containsKey(indexOne));
+        final SnapshotInfo.IndexSnapshotDetails indexSnapshotDetails = snapshotInfo.indexSnapshotDetails().get(indexOne);
+        assertThat(indexSnapshotDetails.toString(), indexSnapshotDetails.getShardCount(), equalTo(1));
+        assertThat(indexSnapshotDetails.toString(), indexSnapshotDetails.getMaxSegmentsPerShard(), greaterThanOrEqualTo(1));
+        assertThat(indexSnapshotDetails.toString(), indexSnapshotDetails.getSize().getBytes(), greaterThan(0L));
     }
 
     public void testGetSnapshotsNoRepos() {

--- a/server/src/main/java/org/elasticsearch/cluster/SnapshotsInProgress.java
+++ b/server/src/main/java/org/elasticsearch/cluster/SnapshotsInProgress.java
@@ -409,12 +409,7 @@ public class SnapshotsInProgress extends AbstractNamedDiffable<Custom> implement
             final ShardState state = ShardState.fromValue(in.readByte());
             final String generation = in.readOptionalString();
             final String reason = in.readOptionalString();
-            final ShardSnapshotResult shardSnapshotResult;
-            if (in.getVersion().onOrAfter(Version.V_8_0_0)) {
-                shardSnapshotResult = in.readOptionalWriteable(ShardSnapshotResult::new);
-            } else {
-                shardSnapshotResult = null;
-            }
+            final ShardSnapshotResult shardSnapshotResult = in.readOptionalWriteable(ShardSnapshotResult::new);
             if (state == ShardState.QUEUED) {
                 return UNASSIGNED_QUEUED;
             }
@@ -460,9 +455,7 @@ public class SnapshotsInProgress extends AbstractNamedDiffable<Custom> implement
             out.writeByte(state.value);
             out.writeOptionalString(generation);
             out.writeOptionalString(reason);
-            if (out.getVersion().onOrAfter(Version.V_8_0_0)) {
-                out.writeOptionalWriteable(shardSnapshotResult);
-            }
+            out.writeOptionalWriteable(shardSnapshotResult);
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/snapshots/SnapshotInfo.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/SnapshotInfo.java
@@ -421,11 +421,7 @@ public final class SnapshotInfo implements Comparable<SnapshotInfo>, ToXContent,
         userMetadata = in.readMap();
         dataStreams = in.readStringList();
         featureStates = Collections.unmodifiableList(in.readList(SnapshotFeatureInfo::new));
-        if (in.getVersion().onOrAfter(Version.V_8_0_0)) {
-            this.indexSnapshotDetails = in.readMap(StreamInput::readString, IndexSnapshotDetails::new);
-        } else {
-            this.indexSnapshotDetails = Collections.emptyMap();
-        }
+        indexSnapshotDetails = in.readMap(StreamInput::readString, IndexSnapshotDetails::new);
     }
 
     /**
@@ -898,9 +894,7 @@ public final class SnapshotInfo implements Comparable<SnapshotInfo>, ToXContent,
         out.writeStringCollection(dataStreams);
         out.writeList(featureStates);
 
-        if (out.getVersion().onOrAfter(Version.V_8_0_0)) {
-            out.writeMap(indexSnapshotDetails, StreamOutput::writeString, (stream, value) -> value.writeTo(stream));
-        }
+        out.writeMap(indexSnapshotDetails, StreamOutput::writeString, (stream, value) -> value.writeTo(stream));
     }
 
     private static SnapshotState snapshotState(final String reason, final List<SnapshotShardFailure> shardFailures) {


### PR DESCRIPTION
Re-enables BWC tests and completes the backport of #71754