### PR TITLE
Remove experimental status from frozen tier docs

### DIFF
--- a/docs/reference/datatiers.asciidoc
+++ b/docs/reference/datatiers.asciidoc
@@ -85,8 +85,6 @@ For resiliency, indices in the cold tier can rely on
 [[frozen-tier]]
 === Frozen tier
 
-experimental::[]
-
 Once data is no longer being queried, or being queried rarely, it may move from
 the cold tier to the frozen tier where it stays for the rest of its life.
 

--- a/docs/reference/searchable-snapshots/apis/mount-snapshot.asciidoc
+++ b/docs/reference/searchable-snapshots/apis/mount-snapshot.asciidoc
@@ -48,9 +48,6 @@ include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=master-timeout]
 Defaults to `false`.
 
 `storage`::
-+
-experimental::[]
-+
 (Optional, string) Selects the kind of local storage used to accelerate
 searches of the mounted index. If `full_copy`, each node holding a shard of the
 searchable snapshot index makes a full copy of the shard to its local storage.

--- a/docs/reference/searchable-snapshots/index.asciidoc
+++ b/docs/reference/searchable-snapshots/index.asciidoc
@@ -80,6 +80,7 @@ Use any of the following repository types with searchable snapshots:
 * {plugins}/repository-azure.html[Azure Blob Storage]
 * {plugins}/repository-hdfs.html[Hadoop Distributed File Store (HDFS)]
 * <<snapshots-filesystem-repository,Shared filesystems>> such as NFS
+* <<snapshots-read-only-repository,URL repositories>>
 
 You can also use alternative implementations of these repository types, for
 instance
@@ -135,9 +136,6 @@ recovery.
 
 [[shared-cache]]
 Shared cache::
-+
-experimental::[]
-+
 Uses a local cache containing only recently searched parts of the snapshotted
 index's data. {ilm-init} uses this option by default in the `frozen` phase and
 corresponding frozen tier.

--- a/docs/reference/snapshot-restore/register-repository.asciidoc
+++ b/docs/reference/snapshot-restore/register-repository.asciidoc
@@ -190,9 +190,6 @@ repositories.url.allowed_urls: ["http://www.example.org/root/*", "https://*.mydo
 NOTE: URLs using the `ftp`, `http`, `https`, or `jar` protocols do not need to
 be registered in the `path.repo` setting.
 
-NOTE: Read-only URL repositories do not support
-<<searchable-snapshots,searchable snapshots>>.
-
 [discrete]
 [role="xpack"]
 [testenv="basic"]

--- a/docs/reference/tab-widgets/data-tiers.asciidoc
+++ b/docs/reference/tab-widgets/data-tiers.asciidoc
@@ -8,7 +8,7 @@ page.
 
 . To enable a data tier, click **Add capacity**.
 
-experimental:[] **Frozen tier** 
+**Frozen tier**
 
 The frozen tier is not yet available on {ess}. However, you can follow these
 steps to effectively recreate a frozen tier in your deployment:
@@ -61,7 +61,7 @@ node.roles: [ data_cold ]
 node.roles: [ data_frozen ]
 ----
 
-experimental:[] For nodes in the frozen tier, set
+For nodes in the frozen tier, set
 <<searchable-snapshots-shared-cache,`xpack.searchable.snapshot.shared_cache.size`>>
 to up to 90% of the node's available disk space. The frozen tier uses this space
 to create a <<shared-cache,shared, fixed-size cache>> for


### PR DESCRIPTION
Removes the experimental status for the frozen tier / shared_cache searchable snapshots for the 7.13 release. Also adapts docs that URL repositories are now supported in 7.13 for searchable snapshots.