### PR TITLE
Rename string_field script context to keyword_field (#71854)

### DIFF
--- a/modules/lang-painless/src/main/resources/org/elasticsearch/painless/spi/org.elasticsearch.script.keyword_field.txt
+++ b/modules/lang-painless/src/main/resources/org/elasticsearch/painless/spi/org.elasticsearch.script.keyword_field.txt
@@ -6,7 +6,7 @@
 # Side Public License, v 1.
 #
 
-# The whitelist for string-valued runtime fields
+# The whitelist for keyword runtime fields
 
 # These two whitelists are required for painless to find the classes
 class org.elasticsearch.script.StringFieldScript @no_import {

--- a/modules/lang-painless/src/test/java/org/elasticsearch/painless/action/PainlessExecuteApiTests.java
+++ b/modules/lang-painless/src/test/java/org/elasticsearch/painless/action/PainlessExecuteApiTests.java
@@ -242,7 +242,7 @@ public class PainlessExecuteApiTests extends ESSingleNodeTestCase {
         assertArrayEquals((long[])response.getResult(), new long[] {-1000L, 0L, 1L, 3L, 10L, 20000000000L});
     }
 
-    public void testStringFieldExecutionContext() throws IOException {
+    public void testKeywordFieldExecutionContext() throws IOException {
         ScriptService scriptService = getInstanceFromNode(ScriptService.class);
         IndexService indexService = createIndex("index", Settings.EMPTY, "doc", "test_point", "type=geo_point");
 
@@ -252,7 +252,7 @@ public class PainlessExecuteApiTests extends ESSingleNodeTestCase {
         Request request = new Request(new Script(ScriptType.INLINE, "painless",
                 "emit(doc['test_point'].value.lat.toString().substring(0, 5)); " +
                         "emit(doc['test_point'].value.lon.toString().substring(0, 5));", emptyMap()),
-                "string_field", contextSetup);
+                "keyword_field", contextSetup);
         Response response = innerShardOperation(request, scriptService, indexService);
         assertArrayEquals((String[])response.getResult(), new String[] {"30.19", "40.19"});
 
@@ -260,7 +260,7 @@ public class PainlessExecuteApiTests extends ESSingleNodeTestCase {
         contextSetup.setXContentType(XContentType.JSON);
         request = new Request(new Script(ScriptType.INLINE, "painless",
                 "emit(\"test\"); emit(\"baz was not here\"); emit(\"Data\"); emit(\"-10\"); emit(\"20\"); emit(\"9\");",
-                emptyMap()), "string_field", contextSetup);
+                emptyMap()), "keyword_field", contextSetup);
         response = innerShardOperation(request, scriptService, indexService);
         assertArrayEquals((String[])response.getResult(), new String[] {"-10", "20", "9", "Data", "baz was not here", "test"});
     }

--- a/modules/lang-painless/src/yamlRestTest/resources/rest-api-spec/test/painless/120_stored_scripts.yml
+++ b/modules/lang-painless/src/yamlRestTest/resources/rest-api-spec/test/painless/120_stored_scripts.yml
@@ -16,10 +16,6 @@
 ---
 
 "Test runtime field contexts not allowed as stored script":
-  - skip:
-      version:     " - 8.99.99"
-      reason:      Script while the string_field script context gets renamed
-
   - do:
       catch: bad_request
       put_script:
@@ -107,8 +103,8 @@
   - do:
       catch: bad_request
       put_script:
-        id: string_field_script
-        context: string_field
+        id: keyword_field_script
+        context: keyword_field
         body:
           script:
             source: "'should not reach compilation or this will error''"
@@ -116,4 +112,4 @@
 
   - match: { error.root_cause.0.type: "illegal_argument_exception" }
   - match: { error.type: "illegal_argument_exception" }
-  - match: { error.caused_by.reason: "cannot store a script for context [string_field]" }
+  - match: { error.caused_by.reason: "cannot store a script for context [keyword_field]" }

--- a/modules/lang-painless/src/yamlRestTest/resources/rest-api-spec/test/painless/70_execute_painless_scripts.yml
+++ b/modules/lang-painless/src/yamlRestTest/resources/rest-api-spec/test/painless/70_execute_painless_scripts.yml
@@ -265,17 +265,13 @@ setup:
   - match: { result: [ -90, 0, 20, 20, 35 ] }
 
 ---
-"Execute with string field context (single-value)":
-  - skip:
-      version:     " - 8.99.99"
-      reason:      Script while the script context gets renamed
-
+"Execute with keyword field context (single-value)":
   - do:
       scripts_painless_execute:
         body:
           script:
             source: "emit(doc['point'].value.lat.toString().substring(0, 5));"
-          context: "string_field"
+          context: "keyword_field"
           context_setup:
             document:
               point: "30.2,40.2"
@@ -283,18 +279,14 @@ setup:
   - match: { result.0: "30.19" }
 
 ---
-"Execute with string field context (multi-value)":
-  - skip:
-      version:     " - 8.99.99"
-      reason:      Script while the script context gets renamed
-
+"Execute with keyword field context (multi-value)":
   - do:
       scripts_painless_execute:
         body:
           script:
             source: "emit(doc['point'].value.lat.toString().substring(0, 5));
                      emit(doc['point'].value.lon.toString().substring(0, 5) + 'test');"
-          context: "string_field"
+          context: "keyword_field"
           context_setup:
             document:
               point: "30.2,40.2"

--- a/server/src/main/java/org/elasticsearch/script/StringFieldScript.java
+++ b/server/src/main/java/org/elasticsearch/script/StringFieldScript.java
@@ -24,7 +24,7 @@ public abstract class StringFieldScript extends AbstractFieldScript {
      */
     public static final long MAX_CHARS = 1024 * 1024;
 
-    public static final ScriptContext<Factory> CONTEXT = newContext("string_field", Factory.class);
+    public static final ScriptContext<Factory> CONTEXT = newContext("keyword_field", Factory.class);
 
     @SuppressWarnings("unused")
     public static final String[] PARAMETERS = {};


### PR DESCRIPTION
Up until now, the name of the script contexts that runtime fields use was internal only. They recently got exposed through the painless execute API. This commit fixes the discrepancy between the field type used to define a runtime field of type keyword and the script context needed to simulate its corresponding script: string_field should be keyword_field.