### PR TITLE
[ML] Fixing edge cases in TransportMlInfoActionTests

### DIFF
--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/action/TransportMlInfoActionTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/action/TransportMlInfoActionTests.java
@@ -133,9 +133,9 @@ public class TransportMlInfoActionTests extends ESTestCase {
 
     public void testCalculateEffectiveMaxModelMemoryLimitSmallMlNodesButMaxMlNodeSizeBiggerAndLazyNodesExhausted() {
 
-        int mlMemoryPercent = randomIntBetween(5, 90);
+        int mlMemoryPercent = randomIntBetween(10, 90);
         long mlMaxNodeSize = randomLongBetween(2000000000L, 100000000000L);
-        long mlMachineMemory = mlMaxNodeSize / randomLongBetween(3, 5);
+        long mlMachineMemory = mlMaxNodeSize / randomLongBetween(3, 4);
         int numMlNodes = randomIntBetween(2, 10);
         int numNonMlNodes = randomIntBetween(0, 10);
         ClusterSettings clusterSettings = new ClusterSettings(


### PR DESCRIPTION
Certain combinations of random numbers could cause the
tests to fail if the amount of memory available to ML
ended up less than the process overhead, with no
possibility to add more ML nodes to the cluster.

This is an unlikely scenario (basically inappropriate
configuration of ML nodes), so not worth complicating
the test logic for.  (In this situation we say the
effective model memory limit is zero, and no ML job
can be started.)

This change adjusts the random numbers so that the
extreme situation doesn't make the test hard to understand.