### PR TITLE
Adjust bwc for percentage based frozen autoscaling

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -190,9 +190,9 @@ tasks.register("verifyVersions") {
  * after the backport of the backcompat code is complete.
  */
 
-boolean bwc_tests_enabled = false
+boolean bwc_tests_enabled = true
 // place a PR link here when committing bwc changes:
-String bwc_tests_disabled_issue = "https://github.com/elastic/elasticsearch/pull/71922"
+String bwc_tests_disabled_issue = ""
 /*
  * FIPS 140-2 behavior was fixed in 7.11.0. Before that there is no way to run elasticsearch in a
  * JVM that is properly configured to be in fips mode with BCFIPS. For now we need to disable

--- a/server/src/main/java/org/elasticsearch/cluster/ClusterInfo.java
+++ b/server/src/main/java/org/elasticsearch/cluster/ClusterInfo.java
@@ -35,7 +35,7 @@ import java.util.Optional;
  */
 public class ClusterInfo implements ToXContentFragment, Writeable {
 
-    public static final Version DATA_SET_SIZE_SIZE_VERSION = Version.V_8_0_0; // todo: Version.V_7_13_0;
+    public static final Version DATA_SET_SIZE_SIZE_VERSION = Version.V_7_13_0;
 
     private final ImmutableOpenMap<String, DiskUsage> leastAvailableSpaceUsage;
     private final ImmutableOpenMap<String, DiskUsage> mostAvailableSpaceUsage;


### PR DESCRIPTION
Re-enables BWC tests and completes the backport of #71756
