### PR TITLE
Only clear cache for frozen tier shards

### DIFF
--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/action/TransportClearSearchableSnapshotsCacheAction.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/action/TransportClearSearchableSnapshotsCacheAction.java
@@ -81,7 +81,7 @@ public class TransportClearSearchableSnapshotsCacheAction extends AbstractTransp
         ShardRouting shardRouting,
         SearchableSnapshotDirectory directory
     ) {
-        directory.clearCache();
+        directory.clearCache(false, true);
         return EmptyResult.INSTANCE;
     }
 }

--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/store/SearchableSnapshotDirectory.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/store/SearchableSnapshotDirectory.java
@@ -353,11 +353,15 @@ public class SearchableSnapshotDirectory extends BaseDirectory {
         }
     }
 
-    public void clearCache() {
+    public void clearCache(boolean clearCacheService, boolean clearFrozenCacheService) {
         for (BlobStoreIndexShardSnapshot.FileInfo file : files()) {
             final CacheKey cacheKey = createCacheKey(file.physicalName());
-            cacheService.removeFromCache(cacheKey);
-            frozenCacheService.removeFromCache(cacheKey);
+            if (clearCacheService) {
+                cacheService.removeFromCache(cacheKey);
+            }
+            if (clearFrozenCacheService) {
+                frozenCacheService.removeFromCache(cacheKey);
+            }
         }
     }
 

--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/store/SearchableSnapshotDirectory.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/store/SearchableSnapshotDirectory.java
@@ -255,7 +255,7 @@ public class SearchableSnapshotDirectory extends BaseDirectory {
         return snapshot;
     }
 
-    private List<BlobStoreIndexShardSnapshot.FileInfo> files() {
+    public List<BlobStoreIndexShardSnapshot.FileInfo> files() {
         if (loaded == false) {
             return List.of();
         }
@@ -356,7 +356,6 @@ public class SearchableSnapshotDirectory extends BaseDirectory {
     public void clearCache() {
         for (BlobStoreIndexShardSnapshot.FileInfo file : files()) {
             final CacheKey cacheKey = createCacheKey(file.physicalName());
-            cacheService.removeFromCache(cacheKey);
             frozenCacheService.removeFromCache(cacheKey);
         }
     }

--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/store/SearchableSnapshotDirectory.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/store/SearchableSnapshotDirectory.java
@@ -255,7 +255,7 @@ public class SearchableSnapshotDirectory extends BaseDirectory {
         return snapshot;
     }
 
-    public List<BlobStoreIndexShardSnapshot.FileInfo> files() {
+    private List<BlobStoreIndexShardSnapshot.FileInfo> files() {
         if (loaded == false) {
             return List.of();
         }
@@ -356,6 +356,7 @@ public class SearchableSnapshotDirectory extends BaseDirectory {
     public void clearCache() {
         for (BlobStoreIndexShardSnapshot.FileInfo file : files()) {
             final CacheKey cacheKey = createCacheKey(file.physicalName());
+            cacheService.removeFromCache(cacheKey);
             frozenCacheService.removeFromCache(cacheKey);
         }
     }

--- a/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/AbstractSearchableSnapshotsRestTestCase.java
+++ b/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/AbstractSearchableSnapshotsRestTestCase.java
@@ -38,6 +38,7 @@ import java.util.function.Function;
 import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
 import static org.hamcrest.Matchers.notNullValue;
 
@@ -260,7 +261,7 @@ public abstract class AbstractSearchableSnapshotsRestTestCase extends ESRestTest
 
             assertBusy(() -> {
                 final long bytesInCacheAfterSearch = sumCachedBytesWritten.apply(searchableSnapshotStats(restoredIndexName));
-                assertThat(bytesInCacheAfterSearch, greaterThan(bytesInCacheBeforeClear));
+                assertThat(bytesInCacheAfterSearch, greaterThanOrEqualTo(bytesInCacheBeforeClear));
             });
         });
     }

--- a/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/store/SearchableSnapshotDirectoryTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/store/SearchableSnapshotDirectoryTests.java
@@ -76,7 +76,6 @@ import org.elasticsearch.index.snapshots.blobstore.BlobStoreIndexShardSnapshot;
 import org.elasticsearch.index.store.Store;
 import org.elasticsearch.index.store.StoreFileMetadata;
 import org.elasticsearch.repositories.ShardSnapshotResult;
-import org.elasticsearch.xpack.searchablesnapshots.cache.common.CacheKey;
 import org.elasticsearch.xpack.searchablesnapshots.cache.common.TestUtils;
 import org.elasticsearch.xpack.searchablesnapshots.store.input.ChecksumBlobContainerIndexInput;
 import org.elasticsearch.index.translog.Translog;
@@ -787,12 +786,7 @@ public class SearchableSnapshotDirectoryTests extends AbstractSearchableSnapshot
                     }
                     assertListOfFiles(cacheDir, allOf(greaterThan(0), lessThanOrEqualTo(nbRandomFiles)), greaterThan(0L));
                     if (randomBoolean()) {
-                        directory.clearCache(); // should not clear CacheService cache
-                        assertBusy(() -> assertListOfFiles(cacheDir, greaterThan(0), greaterThan(0L)));
-                        for (BlobStoreIndexShardSnapshot.FileInfo file : directory.files()) {
-                            final CacheKey cacheKey = directory.createCacheKey(file.physicalName());
-                            cacheService.removeFromCache(cacheKey);
-                        }
+                        directory.clearCache();
                         assertBusy(() -> assertListOfFiles(cacheDir, equalTo(0), equalTo(0L)));
                     }
                 }

--- a/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/store/SearchableSnapshotDirectoryTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/store/SearchableSnapshotDirectoryTests.java
@@ -786,7 +786,7 @@ public class SearchableSnapshotDirectoryTests extends AbstractSearchableSnapshot
                     }
                     assertListOfFiles(cacheDir, allOf(greaterThan(0), lessThanOrEqualTo(nbRandomFiles)), greaterThan(0L));
                     if (randomBoolean()) {
-                        directory.clearCache();
+                        directory.clearCache(true, true);
                         assertBusy(() -> assertListOfFiles(cacheDir, equalTo(0), equalTo(0L)));
                     }
                 }


### PR DESCRIPTION
Makes it so that the experimental searchable snapshot clear cache API only clears the shared cache (`FrozenCacheService`), leaving `CacheService` unchanged.

This API is only useful to measure how much shared_cache a query might take (take cache stats, reset the cache, then run the query, the check cache stats again). Running this API against the cold tier would dramatically mess with query performance there, as it undoes the pre-warming, so this PR removes that effect.