### PR TITLE
Searchable Snapshots Cache Stats API should check the license is valid

### DIFF
--- a/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/SearchableSnapshotsLicenseIntegTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/SearchableSnapshotsLicenseIntegTests.java
@@ -35,7 +35,6 @@ import org.elasticsearch.license.PostStartTrialAction;
 import org.elasticsearch.license.PostStartTrialRequest;
 import org.elasticsearch.license.PostStartTrialResponse;
 import org.elasticsearch.protocol.xpack.license.DeleteLicenseRequest;
-import org.elasticsearch.rest.action.RestToXContentListener;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.elasticsearch.xpack.core.searchablesnapshots.MountSearchableSnapshotAction;
 import org.elasticsearch.xpack.core.searchablesnapshots.MountSearchableSnapshotRequest;
@@ -46,7 +45,6 @@ import org.elasticsearch.xpack.searchablesnapshots.action.SearchableSnapshotsSta
 import org.elasticsearch.xpack.searchablesnapshots.action.SearchableSnapshotsStatsRequest;
 import org.elasticsearch.xpack.searchablesnapshots.action.SearchableSnapshotsStatsResponse;
 import org.elasticsearch.xpack.searchablesnapshots.action.cache.TransportSearchableSnapshotsNodeCachesStatsAction;
-import org.elasticsearch.xpack.searchablesnapshots.action.cache.TransportSearchableSnapshotsNodeCachesStatsAction.NodeCachesStatsResponse;
 import org.junit.Before;
 
 import java.util.concurrent.ExecutionException;

--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/action/cache/TransportSearchableSnapshotsNodeCachesStatsAction.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/action/cache/TransportSearchableSnapshotsNodeCachesStatsAction.java
@@ -25,6 +25,7 @@ import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.xcontent.ToXContentFragment;
 import org.elasticsearch.common.xcontent.ToXContentObject;
 import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.license.XPackLicenseState;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportRequest;
@@ -52,6 +53,7 @@ public class TransportSearchableSnapshotsNodeCachesStatsAction extends Transport
     public static final ActionType<NodesCachesStatsResponse> TYPE = new ActionType<>(ACTION_NAME, NodesCachesStatsResponse::new);
 
     private final Supplier<FrozenCacheService> frozenCacheService;
+    private final XPackLicenseState licenseState;
 
     @Inject
     public TransportSearchableSnapshotsNodeCachesStatsAction(
@@ -59,7 +61,8 @@ public class TransportSearchableSnapshotsNodeCachesStatsAction extends Transport
         ClusterService clusterService,
         TransportService transportService,
         ActionFilters actionFilters,
-        SearchableSnapshots.FrozenCacheServiceSupplier frozenCacheService
+        SearchableSnapshots.FrozenCacheServiceSupplier frozenCacheService,
+        XPackLicenseState licenseState
     ) {
         super(
             ACTION_NAME,
@@ -74,6 +77,7 @@ public class TransportSearchableSnapshotsNodeCachesStatsAction extends Transport
             NodeCachesStatsResponse.class
         );
         this.frozenCacheService = frozenCacheService;
+        this.licenseState = licenseState;
     }
 
     @Override
@@ -114,6 +118,7 @@ public class TransportSearchableSnapshotsNodeCachesStatsAction extends Transport
 
     @Override
     protected NodeCachesStatsResponse nodeOperation(NodeRequest request, Task task) {
+        SearchableSnapshots.ensureValidLicense(licenseState);
         final FrozenCacheService.Stats frozenCacheStats;
         if (frozenCacheService.get() != null) {
             frozenCacheStats = frozenCacheService.get().getStats();


### PR DESCRIPTION
Node level cache stats introduced in #71701 should ensure that the license is valid for searchable snapshots.