### PR TITLE
Add shardSnapshotResult to SnapshotShardStatus#equals etc

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/SnapshotsInProgress.java
+++ b/server/src/main/java/org/elasticsearch/cluster/SnapshotsInProgress.java
@@ -369,6 +369,7 @@ public class SnapshotsInProgress extends AbstractNamedDiffable<Custom> implement
         public ShardSnapshotStatus(@Nullable String nodeId, ShardState state, String reason, @Nullable String generation) {
             this(nodeId, assertNotSuccess(state), reason, generation, null);
         }
+
         private ShardSnapshotStatus(
                 @Nullable String nodeId,
                 ShardState state,
@@ -463,8 +464,11 @@ public class SnapshotsInProgress extends AbstractNamedDiffable<Custom> implement
             if (this == o) return true;
             if (o == null || getClass() != o.getClass()) return false;
             ShardSnapshotStatus status = (ShardSnapshotStatus) o;
-            return Objects.equals(nodeId, status.nodeId) && Objects.equals(reason, status.reason)
-                    && Objects.equals(generation, status.generation) && state == status.state;
+            return Objects.equals(nodeId, status.nodeId)
+                    && Objects.equals(reason, status.reason)
+                    && Objects.equals(generation, status.generation)
+                    && state == status.state
+                    && Objects.equals(shardSnapshotResult, status.shardSnapshotResult);
         }
 
         @Override
@@ -473,12 +477,14 @@ public class SnapshotsInProgress extends AbstractNamedDiffable<Custom> implement
             result = 31 * result + (nodeId != null ? nodeId.hashCode() : 0);
             result = 31 * result + (reason != null ? reason.hashCode() : 0);
             result = 31 * result + (generation != null ? generation.hashCode() : 0);
+            result = 31 * result + (shardSnapshotResult != null ? shardSnapshotResult.hashCode() : 0);
             return result;
         }
 
         @Override
         public String toString() {
-            return "ShardSnapshotStatus[state=" + state + ", nodeId=" + nodeId + ", reason=" + reason + ", generation=" + generation + "]";
+            return "ShardSnapshotStatus[state=" + state + ", nodeId=" + nodeId + ", reason=" + reason + ", generation=" + generation +
+                    ", shardSnapshotResult=" + shardSnapshotResult + "]";
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/repositories/ShardSnapshotResult.java
+++ b/server/src/main/java/org/elasticsearch/repositories/ShardSnapshotResult.java
@@ -73,4 +73,26 @@ public class ShardSnapshotResult implements Writeable {
         size.writeTo(out);
         out.writeVInt(segmentCount);
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        ShardSnapshotResult that = (ShardSnapshotResult) o;
+        return segmentCount == that.segmentCount && generation.equals(that.generation) && size.equals(that.size);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(generation, size, segmentCount);
+    }
+
+    @Override
+    public String toString() {
+        return "ShardSnapshotResult{" +
+                "generation='" + generation + '\'' +
+                ", size=" + size +
+                ", segmentCount=" + segmentCount +
+                '}';
+    }
 }

--- a/server/src/test/java/org/elasticsearch/snapshots/ShardSnapshotResultWireSerializationTests.java
+++ b/server/src/test/java/org/elasticsearch/snapshots/ShardSnapshotResultWireSerializationTests.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.snapshots;
+
+import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.common.unit.ByteSizeValue;
+import org.elasticsearch.repositories.ShardSnapshotResult;
+import org.elasticsearch.test.AbstractWireSerializingTestCase;
+
+import java.io.IOException;
+
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.containsString;
+
+public class ShardSnapshotResultWireSerializationTests extends AbstractWireSerializingTestCase<ShardSnapshotResult> {
+
+    @Override
+    protected Writeable.Reader<ShardSnapshotResult> instanceReader() {
+        return ShardSnapshotResult::new;
+    }
+
+    @Override
+    protected ShardSnapshotResult createTestInstance() {
+        return randomShardSnapshotResult();
+    }
+
+    @Override
+    protected ShardSnapshotResult mutateInstance(ShardSnapshotResult instance) throws IOException {
+        return mutateShardSnapshotResult(instance);
+    }
+
+    public void testToString() {
+        final ShardSnapshotResult testInstance = randomShardSnapshotResult();
+        assertThat(testInstance.toString(), allOf(
+                containsString(testInstance.getGeneration()),
+                containsString(testInstance.getSize().toString()),
+                containsString(Integer.toString(testInstance.getSegmentCount()))));
+    }
+
+    static ShardSnapshotResult randomShardSnapshotResult() {
+        return new ShardSnapshotResult(randomAlphaOfLength(5), new ByteSizeValue(randomNonNegativeLong()), between(0, 1000));
+    }
+
+    static ShardSnapshotResult mutateShardSnapshotResult(ShardSnapshotResult instance) {
+        switch (between(1, 3)) {
+            case 1:
+                return new ShardSnapshotResult(
+                        randomAlphaOfLength(11 - instance.getGeneration().length()),
+                        instance.getSize(),
+                        instance.getSegmentCount());
+            case 2:
+                return new ShardSnapshotResult(
+                        instance.getGeneration(),
+                        randomValueOtherThan(instance.getSize(), () -> new ByteSizeValue(randomNonNegativeLong())),
+                        instance.getSegmentCount());
+
+            case 3:
+                return new ShardSnapshotResult(
+                        instance.getGeneration(),
+                        instance.getSize(),
+                        randomValueOtherThan(instance.getSegmentCount(), () -> between(0, 1000)));
+        }
+        throw new AssertionError("invalid mutation");
+    }
+
+}
+

--- a/server/src/test/java/org/elasticsearch/snapshots/ShardSnapshotStatusWireSerializationTests.java
+++ b/server/src/test/java/org/elasticsearch/snapshots/ShardSnapshotStatusWireSerializationTests.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.snapshots;
+
+import org.elasticsearch.cluster.SnapshotsInProgress;
+import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.test.AbstractWireSerializingTestCase;
+import org.hamcrest.Matchers;
+
+import java.io.IOException;
+
+import static org.elasticsearch.snapshots.ShardSnapshotResultWireSerializationTests.randomShardSnapshotResult;
+import static org.hamcrest.Matchers.containsString;
+
+public class ShardSnapshotStatusWireSerializationTests extends AbstractWireSerializingTestCase<SnapshotsInProgress.ShardSnapshotStatus> {
+    @Override
+    protected Writeable.Reader<SnapshotsInProgress.ShardSnapshotStatus> instanceReader() {
+        return SnapshotsInProgress.ShardSnapshotStatus::readFrom;
+    }
+
+    @Override
+    protected SnapshotsInProgress.ShardSnapshotStatus createTestInstance() {
+        final SnapshotsInProgress.ShardState shardState = randomFrom(SnapshotsInProgress.ShardState.values());
+        final String nodeId = randomAlphaOfLength(5);
+        if (shardState == SnapshotsInProgress.ShardState.QUEUED) {
+            return SnapshotsInProgress.ShardSnapshotStatus.UNASSIGNED_QUEUED;
+        } else if (shardState == SnapshotsInProgress.ShardState.SUCCESS) {
+            return SnapshotsInProgress.ShardSnapshotStatus.success(nodeId, randomShardSnapshotResult());
+        } else {
+            final String reason = shardState.failed() ? randomAlphaOfLength(10) : null;
+            return new SnapshotsInProgress.ShardSnapshotStatus(nodeId, shardState, reason, randomAlphaOfLength(5));
+        }
+    }
+
+    @Override
+    protected SnapshotsInProgress.ShardSnapshotStatus mutateInstance(SnapshotsInProgress.ShardSnapshotStatus instance) throws IOException {
+        if (instance.state() == SnapshotsInProgress.ShardState.QUEUED) {
+            assert instance == SnapshotsInProgress.ShardSnapshotStatus.UNASSIGNED_QUEUED;
+            return randomValueOtherThanMany(i -> i.state() == SnapshotsInProgress.ShardState.QUEUED, this::createTestInstance);
+        }
+
+        final SnapshotsInProgress.ShardState newState = randomFrom(SnapshotsInProgress.ShardState.values());
+        if (newState == SnapshotsInProgress.ShardState.QUEUED) {
+            return SnapshotsInProgress.ShardSnapshotStatus.UNASSIGNED_QUEUED;
+        } else if (newState == SnapshotsInProgress.ShardState.SUCCESS) {
+            if (instance.state() == SnapshotsInProgress.ShardState.SUCCESS) {
+                assert instance.shardSnapshotResult() != null;
+                if (randomBoolean()) {
+                    return SnapshotsInProgress.ShardSnapshotStatus.success(
+                            randomAlphaOfLength(11 - instance.nodeId().length()),
+                            instance.shardSnapshotResult());
+                } else {
+                    return SnapshotsInProgress.ShardSnapshotStatus.success(
+                            instance.nodeId(),
+                            ShardSnapshotResultWireSerializationTests.mutateShardSnapshotResult(instance.shardSnapshotResult()));
+                }
+            } else {
+                return SnapshotsInProgress.ShardSnapshotStatus.success(instance.nodeId(), randomShardSnapshotResult());
+            }
+        } else if (newState.failed() && instance.state().failed() && randomBoolean()) {
+            return new SnapshotsInProgress.ShardSnapshotStatus(
+                    instance.nodeId(),
+                    newState,
+                    randomAlphaOfLength(15 - instance.reason().length()),
+                    instance.generation());
+        } else {
+            final String reason = newState.failed() ? randomAlphaOfLength(10) : null;
+            if (newState != instance.state() && randomBoolean()) {
+                return new SnapshotsInProgress.ShardSnapshotStatus(
+                        instance.nodeId(),
+                        newState,
+                        reason,
+                        instance.generation());
+            } else if (randomBoolean()) {
+                return new SnapshotsInProgress.ShardSnapshotStatus(
+                        randomAlphaOfLength(11 - instance.nodeId().length()),
+                        newState,
+                        reason,
+                        instance.generation());
+            } else {
+                return new SnapshotsInProgress.ShardSnapshotStatus(
+                        instance.nodeId(),
+                        newState,
+                        reason,
+                        randomAlphaOfLength(11 - instance.generation().length()));
+            }
+        }
+    }
+
+    @Override
+    protected void assertEqualInstances(
+            SnapshotsInProgress.ShardSnapshotStatus expectedInstance,
+            SnapshotsInProgress.ShardSnapshotStatus newInstance) {
+        if (newInstance.state() == SnapshotsInProgress.ShardState.QUEUED) {
+            assertSame(newInstance, expectedInstance);
+        } else {
+            assertNotSame(newInstance, expectedInstance);
+        }
+        assertThat(expectedInstance, Matchers.equalTo(newInstance));
+        assertEquals(expectedInstance.hashCode(), newInstance.hashCode());
+    }
+
+    public void testToString() {
+        final SnapshotsInProgress.ShardSnapshotStatus testInstance = createTestInstance();
+        if (testInstance.nodeId() != null) {
+            assertThat(testInstance.toString(), containsString(testInstance.nodeId()));
+        }
+        if (testInstance.generation() != null) {
+            assertThat(testInstance.toString(), containsString(testInstance.generation()));
+        }
+        if (testInstance.state() == SnapshotsInProgress.ShardState.SUCCESS) {
+            assertThat(testInstance.toString(), containsString(testInstance.shardSnapshotResult().toString()));
+        }
+    }
+
+}

--- a/server/src/test/java/org/elasticsearch/snapshots/SnapshotsInProgressSerializationTests.java
+++ b/server/src/test/java/org/elasticsearch/snapshots/SnapshotsInProgressSerializationTests.java
@@ -221,7 +221,6 @@ public class SnapshotsInProgressSerializationTests extends AbstractDiffableWireS
                     entry.dataStreams(), entry.featureStates(), entry.startTime(), entry.repositoryStateId(), entry.shards(),
                     entry.failure(), userMetadata, entry.version());
             case 8:
-                logger.error("randomizing feature states");
                 List<SnapshotFeatureInfo> featureStates = randomList(1, 5,
                     () -> randomValueOtherThanMany(entry.featureStates()::contains, SnapshotFeatureInfoTests::randomSnapshotFeatureInfo));
                 return new Entry(entry.snapshot(), entry.includeGlobalState(), entry.partial(), entry.state(),


### PR DESCRIPTION
In #71754 we added a new field to the value object `SnapshotShardStatus`
but did not update its `equals()` and `hashCode()` methods to include
this new field. This commit addresses that oversight.