### PR TITLE
[7.x] Searchable Snapshots Cache Stats API should check the license is valid

### DIFF
--- a/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/SearchableSnapshotsLicenseIntegTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/SearchableSnapshotsLicenseIntegTests.java
@@ -17,6 +17,7 @@ package org.elasticsearch.xpack.searchablesnapshots;
 import org.elasticsearch.ElasticsearchSecurityException;
 import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.action.ActionFuture;
+import org.elasticsearch.action.FailedNodeException;
 import org.elasticsearch.action.admin.cluster.snapshots.restore.RestoreSnapshotResponse;
 import org.elasticsearch.action.support.DefaultShardOperationFailedException;
 import org.elasticsearch.cluster.ClusterState;
@@ -43,6 +44,7 @@ import org.elasticsearch.xpack.searchablesnapshots.action.ClearSearchableSnapsho
 import org.elasticsearch.xpack.searchablesnapshots.action.SearchableSnapshotsStatsAction;
 import org.elasticsearch.xpack.searchablesnapshots.action.SearchableSnapshotsStatsRequest;
 import org.elasticsearch.xpack.searchablesnapshots.action.SearchableSnapshotsStatsResponse;
+import org.elasticsearch.xpack.searchablesnapshots.action.cache.TransportSearchableSnapshotsNodeCachesStatsAction;
 import org.junit.Before;
 
 import java.util.concurrent.ExecutionException;
@@ -162,5 +164,23 @@ public class SearchableSnapshotsLicenseIntegTests extends BaseSearchableSnapshot
         assertEquals(PostStartTrialResponse.Status.UPGRADED_TO_TRIAL, resp.getStatus());
         // check if cluster goes green again after valid license has been put in place
         ensureGreen(indexName);
+    }
+
+    public void testCachesStatsRequiresLicense() throws Exception {
+        final ActionFuture<TransportSearchableSnapshotsNodeCachesStatsAction.NodesCachesStatsResponse> future = client().execute(
+            TransportSearchableSnapshotsNodeCachesStatsAction.TYPE,
+            new TransportSearchableSnapshotsNodeCachesStatsAction.NodesRequest(Strings.EMPTY_ARRAY)
+        );
+
+        final TransportSearchableSnapshotsNodeCachesStatsAction.NodesCachesStatsResponse response = future.get();
+        assertThat(response.failures().size(), equalTo(internalCluster().numDataNodes()));
+        assertTrue(response.hasFailures());
+
+        for (FailedNodeException nodeException : response.failures()) {
+            final Throwable cause = ExceptionsHelper.unwrap(nodeException.getCause(), ElasticsearchSecurityException.class);
+            assertThat(cause, notNullValue());
+            assertThat(cause, instanceOf(ElasticsearchSecurityException.class));
+            assertThat(cause.getMessage(), containsString("current license is non-compliant for [searchable-snapshots]"));
+        }
     }
 }

--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/action/cache/TransportSearchableSnapshotsNodeCachesStatsAction.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/action/cache/TransportSearchableSnapshotsNodeCachesStatsAction.java
@@ -26,6 +26,8 @@ import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.xcontent.ToXContentFragment;
 import org.elasticsearch.common.xcontent.ToXContentObject;
 import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.license.XPackLicenseState;
+import org.elasticsearch.tasks.Task;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.xpack.searchablesnapshots.SearchableSnapshots;
@@ -50,6 +52,7 @@ public class TransportSearchableSnapshotsNodeCachesStatsAction extends Transport
     public static final ActionType<NodesCachesStatsResponse> TYPE = new ActionType<>(ACTION_NAME, NodesCachesStatsResponse::new);
 
     private final Supplier<FrozenCacheService> frozenCacheService;
+    private final XPackLicenseState licenseState;
 
     @Inject
     public TransportSearchableSnapshotsNodeCachesStatsAction(
@@ -57,7 +60,8 @@ public class TransportSearchableSnapshotsNodeCachesStatsAction extends Transport
         ClusterService clusterService,
         TransportService transportService,
         ActionFilters actionFilters,
-        SearchableSnapshots.FrozenCacheServiceSupplier frozenCacheService
+        SearchableSnapshots.FrozenCacheServiceSupplier frozenCacheService,
+        XPackLicenseState licenseState
     ) {
         super(
             ACTION_NAME,
@@ -72,6 +76,7 @@ public class TransportSearchableSnapshotsNodeCachesStatsAction extends Transport
             NodeCachesStatsResponse.class
         );
         this.frozenCacheService = frozenCacheService;
+        this.licenseState = licenseState;
     }
 
     @Override
@@ -111,6 +116,7 @@ public class TransportSearchableSnapshotsNodeCachesStatsAction extends Transport
 
     @Override
     protected NodeCachesStatsResponse nodeOperation(NodeRequest request) {
+        SearchableSnapshots.ensureValidLicense(licenseState);
         final FrozenCacheService.Stats frozenCacheStats;
         if (frozenCacheService.get() != null) {
             frozenCacheStats = frozenCacheService.get().getStats();

--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/action/cache/TransportSearchableSnapshotsNodeCachesStatsAction.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/action/cache/TransportSearchableSnapshotsNodeCachesStatsAction.java
@@ -27,7 +27,6 @@ import org.elasticsearch.common.xcontent.ToXContentFragment;
 import org.elasticsearch.common.xcontent.ToXContentObject;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.license.XPackLicenseState;
-import org.elasticsearch.tasks.Task;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.xpack.searchablesnapshots.SearchableSnapshots;


### PR DESCRIPTION
Node level cache stats introduced in #71701 should ensure
that the license is valid for searchable snapshots.

Backport of #71935