### PR TITLE
Prevent OutboundHandler Slowlog on Serialization Exception

### DIFF
--- a/server/src/main/java/org/elasticsearch/transport/OutboundHandler.java
+++ b/server/src/main/java/org/elasticsearch/transport/OutboundHandler.java
@@ -203,11 +203,14 @@ final class OutboundHandler {
         }
 
         private void maybeLogSlowMessage() {
-            final long took = threadPool.relativeTimeInMillis() - startTime;
             final long logThreshold = slowLogThresholdMs;
-            if (logThreshold > 0 && took > logThreshold) {
-                logger.warn("sending transport message [{}] of size [{}] on [{}] took [{}ms] which is above the warn threshold of [{}ms]",
-                        messageSupplier, messageSize, channel, took, logThreshold);
+            if (logThreshold > 0 && messageSize >= 0) {
+                final long took = threadPool.relativeTimeInMillis() - startTime;
+                if (took > logThreshold) {
+                    logger.warn(
+                            "sending transport message [{}] of size [{}] on [{}] took [{}ms] which is above the warn threshold of [{}ms]",
+                            messageSupplier, messageSize, channel, took, logThreshold);
+                }
             }
         }
 


### PR DESCRIPTION
If a message fails to serialize would log bogus `took` values equal to `ThreadPool#relativeTimeInMillis`.
We can detect that the message never serialized by just checking the message size.
