### PR TITLE
[DOCS] Updates cross link to avoid redirected page

### DIFF
--- a/x-pack/docs/en/security/authentication/oidc-realm.asciidoc
+++ b/x-pack/docs/en/security/authentication/oidc-realm.asciidoc
@@ -16,4 +16,4 @@ should also configure another realm, such as the <<native-realm, native realm>>
 in your authentication chain.
 
 In order to simplify the process of configuring OpenID Connect authentication
-within the {stack}, there is a step-by-step guide: <<oidc-guide>>.
+within the {stack}, there is a step-by-step guide: <<oidc-guide-stack>>.


### PR DESCRIPTION
Instead of linking users to a redirected OIDC page, this link points users directly to the renamed page for [configuring OIDC](https://www.elastic.co/guide/en/elasticsearch/reference/7.12/oidc-guide-stack.html).

Preview link: https://elasticsearch_71951.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/7.12/oidc-realm.html