### PR TITLE
SQL: Fix MIN, MAX, SUM aggs data type handling (backport of #71525)

### DIFF
--- a/x-pack/plugin/eql/src/main/resources/org/elasticsearch/xpack/eql/plugin/eql_whitelist.txt
+++ b/x-pack/plugin/eql/src/main/resources/org/elasticsearch/xpack/eql/plugin/eql_whitelist.txt
@@ -18,6 +18,7 @@ class org.elasticsearch.xpack.ql.expression.function.scalar.whitelist.InternalQl
   boolean nullSafeFilter(Boolean)
   double nullSafeSortNumeric(Number)
   String nullSafeSortString(Object)
+  Number nullSafeCastNumeric(Number, String)
 
 #
 # ASCII Functions

--- a/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/expression/function/scalar/ScalarFunction.java
+++ b/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/expression/function/scalar/ScalarFunction.java
@@ -16,14 +16,18 @@ import org.elasticsearch.xpack.ql.expression.FieldAttribute;
 import org.elasticsearch.xpack.ql.expression.function.Function;
 import org.elasticsearch.xpack.ql.expression.function.aggregate.AggregateFunction;
 import org.elasticsearch.xpack.ql.expression.function.grouping.GroupingFunction;
+import org.elasticsearch.xpack.ql.expression.gen.script.ParamsBuilder;
 import org.elasticsearch.xpack.ql.expression.gen.script.ScriptTemplate;
 import org.elasticsearch.xpack.ql.expression.gen.script.Scripts;
 import org.elasticsearch.xpack.ql.tree.Source;
+import org.elasticsearch.xpack.ql.type.DataType;
 import org.elasticsearch.xpack.ql.util.DateUtils;
 
 import static java.util.Collections.emptyList;
 import static org.elasticsearch.xpack.ql.expression.gen.script.ParamsBuilder.paramsBuilder;
+import static org.elasticsearch.xpack.ql.expression.gen.script.Scripts.PARAM;
 import static org.elasticsearch.xpack.ql.type.DataTypes.DATETIME;
+import static org.elasticsearch.xpack.ql.type.DataTypes.LONG;
 
 /**
  * A {@code ScalarFunction} is a {@code Function} that takes values from some
@@ -110,31 +114,42 @@ public abstract class ScalarFunction extends Function {
     }
 
     protected ScriptTemplate scriptWithAggregate(AggregateFunction aggregate) {
-        String template = basicTemplate(aggregate);
-        return new ScriptTemplate(processScript(template),
-                paramsBuilder().agg(aggregate).build(),
-                dataType());
+        String template = PARAM;
+        ParamsBuilder paramsBuilder = paramsBuilder().agg(aggregate);
+
+        DataType nullSafeCastDataType = null;
+        DataType dataType = aggregate.dataType();
+        if (dataType.name().equals("DATE") || dataType == DATETIME ||
+            // Aggregations on date_nanos are returned as string
+            aggregate.field().dataType() == DATETIME) {
+
+            template = "{sql}.asDateTime({})";
+        } else if (dataType.isInteger()) {
+            // MAX, MIN need to retain field's data type, so that possible operations on integral types (like division) work
+            // correctly -> perform a cast in the aggs filtering script, the bucket selector for HAVING.
+            // SQL function classes not available in QL: filter by name
+            String fn = aggregate.functionName();
+            if ("MAX".equals(fn) || "MIN".equals(fn)) {
+                nullSafeCastDataType = dataType;
+            } else if ("SUM".equals(fn)) {
+                // SUM(integral_type) requires returning a LONG value
+                nullSafeCastDataType = LONG;
+            }
+        }
+        if (nullSafeCastDataType != null) {
+            template = "{ql}.nullSafeCastNumeric({},{})";
+            paramsBuilder.variable(nullSafeCastDataType.name());
+        }
+        return new ScriptTemplate(processScript(template), paramsBuilder.build(), dataType());
     }
 
     // This method isn't actually used at the moment, since there is no grouping function (ie HISTOGRAM)
     // that currently results in a script being generated
     protected ScriptTemplate scriptWithGrouping(GroupingFunction grouping) {
-        String template = basicTemplate(grouping);
+        String template = PARAM;
         return new ScriptTemplate(processScript(template),
-                paramsBuilder().grouping(grouping).build(),
-                dataType());
-    }
-
-    // FIXME: this needs to be refactored to account for different datatypes in different projects (ie DATE from SQL)
-    private String basicTemplate(Function function) {
-        if (function.dataType().name().equals("DATE") || function.dataType() == DATETIME ||
-            // Aggregations on date_nanos are returned as string
-            (function instanceof AggregateFunction && ((AggregateFunction) function).field().dataType() == DATETIME)) {
-
-            return "{sql}.asDateTime({})";
-        } else {
-            return "{}";
-        }
+            paramsBuilder().grouping(grouping).build(),
+            dataType());
     }
 
     protected ScriptTemplate scriptWithField(FieldAttribute field) {

--- a/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/expression/function/scalar/whitelist/InternalQlScriptUtils.java
+++ b/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/expression/function/scalar/whitelist/InternalQlScriptUtils.java
@@ -22,6 +22,9 @@ import org.elasticsearch.xpack.ql.util.StringUtils;
 import java.util.List;
 import java.util.Map;
 
+import static org.elasticsearch.xpack.ql.type.DataTypeConverter.convert;
+import static org.elasticsearch.xpack.ql.type.DataTypes.fromTypeName;
+
 public class InternalQlScriptUtils {
 
     //
@@ -49,6 +52,10 @@ public class InternalQlScriptUtils {
 
     public static String nullSafeSortString(Object sort) {
         return sort == null ? StringUtils.EMPTY : sort.toString();
+    }
+
+    public static Number nullSafeCastNumeric(Number number, String typeName) {
+        return number == null || Double.isNaN(number.doubleValue()) ? null : (Number) convert(number, fromTypeName(typeName));
     }
 
 

--- a/x-pack/plugin/sql/qa/server/src/main/resources/agg-ordering.csv-spec
+++ b/x-pack/plugin/sql/qa/server/src/main/resources/agg-ordering.csv-spec
@@ -1,7 +1,7 @@
 aggSumWithColumnRepeatedWithOrderAsc
 SELECT gender AS g, gender, SUM(salary) AS s3, SUM(salary), SUM(salary) AS s5 FROM test_emp GROUP BY gender ORDER BY SUM(salary);
 
-g:s  | gender:s  | s3:i  | SUM(salary):i | s5:i
+g:s  | gender:s  | s3:l  | SUM(salary):l | s5:l
 null |null       |487605 |487605         |487605
 F    |F          |1666196|1666196        |1666196
 M    |M          |2671054|2671054        |2671054
@@ -10,7 +10,7 @@ M    |M          |2671054|2671054        |2671054
 aggSumWithAliasWithColumnRepeatedWithOrderDesc
 SELECT gender AS g, gender, SUM(salary) AS s3, SUM(salary), SUM(salary) AS s5 FROM test_emp GROUP BY g ORDER BY s5 DESC;
 
-g:s  | gender:s  | s3:i  | SUM(salary):i | s5:i
+g:s  | gender:s  | s3:l  | SUM(salary):l | s5:l
 M    |M          |2671054|2671054        |2671054
 F    |F          |1666196|1666196        |1666196
 null |null       |487605 |487605         |487605
@@ -19,7 +19,7 @@ null |null       |487605 |487605         |487605
 aggSumWithNumericRefWithColumnRepeatedWithOrderDesc
 SELECT gender AS g, gender, SUM(salary) AS s3, SUM(salary), SUM(salary) AS s5 FROM test_emp GROUP BY 2 ORDER BY 3 DESC;
 
-g:s  | gender:s  | s3:i  | SUM(salary):i | s5:i
+g:s  | gender:s  | s3:l  | SUM(salary):l | s5:l
 M    |M          |2671054|2671054        |2671054
 F    |F          |1666196|1666196        |1666196
 null |null       |487605 |487605         |487605

--- a/x-pack/plugin/sql/qa/server/src/main/resources/agg.csv-spec
+++ b/x-pack/plugin/sql/qa/server/src/main/resources/agg.csv-spec
@@ -133,8 +133,8 @@ M                    |10096.2232            |10092.362             |15.350877192
 sum
 SELECT SUM(salary) FROM test_emp;
 
-  SUM(salary)
----------------
+  SUM(salary):l
+----------------
 4824855
 ;
 
@@ -193,7 +193,7 @@ SELECT MAX(languages) max, MIN(languages) min, SUM(languages) sum, AVG(languages
        KURTOSIS(languages) kurtosis, SKEWNESS(languages) skewness  
        FROM test_emp GROUP BY languages ORDER BY languages ASC LIMIT 5;
 
-      max:bt   |      min:bt   |      sum:bt   |      avg:d   |    percent:d  | percent_rank:d|   kurtosis:d  |   skewness:d    
+      max:bt   |      min:bt   |      sum:l    |      avg:d   |    percent:d  | percent_rank:d|   kurtosis:d  |   skewness:d
 ---------------+---------------+---------------+--------------+---------------+---------------+---------------+---------------
 null           |null           |null           |null          |null           |null           |null           |null           
 1              |1              |15             |1             |1.0            |100.0          |NaN            |NaN            
@@ -205,7 +205,7 @@ null           |null           |null           |null          |null           |n
 aggSumWithColumnRepeated
 SELECT gender AS g, gender, SUM(salary) AS s3, SUM(salary), SUM(salary) AS s5 FROM test_emp GROUP BY gender;
 
-g:s  | gender:s  | s3:i  | SUM(salary):i | s5:i
+g:s  | gender:s  | s3:l  | SUM(salary):l | s5:l
 null |null       |487605 |487605         |487605
 F    |F          |1666196|1666196        |1666196
 M    |M          |2671054|2671054        |2671054
@@ -214,7 +214,7 @@ M    |M          |2671054|2671054        |2671054
 aggSumWithAliasWithColumnRepeated
 SELECT gender AS g, gender, SUM(salary) AS s3, SUM(salary), SUM(salary) AS s5 FROM test_emp GROUP BY g;
 
-g:s  | gender:s  | s3:i  | SUM(salary):i | s5:i
+g:s  | gender:s  | s3:l  | SUM(salary):l | s5:l
 null |null       |487605 |487605         |487605
 F    |F          |1666196|1666196        |1666196
 M    |M          |2671054|2671054        |2671054
@@ -223,7 +223,7 @@ M    |M          |2671054|2671054        |2671054
 aggSumWithNumericRefWithColumnRepeated
 SELECT gender AS g, gender, SUM(salary) AS s3, SUM(salary), SUM(salary) AS s5 FROM test_emp GROUP BY 2;
 
-g:s  | gender:s  | s3:i  | SUM(salary):i | s5:i
+g:s  | gender:s  | s3:l  | SUM(salary):l | s5:l
 null |null       |487605 |487605         |487605
 F    |F          |1666196|1666196        |1666196
 M    |M          |2671054|2671054        |2671054
@@ -232,7 +232,7 @@ M    |M          |2671054|2671054        |2671054
 sumLiteralWithTrueConditionAndHavingWithCount
 SELECT SUM(1) AS c FROM test_emp WHERE 'a'='a' HAVING COUNT(1) > 0;
 
-      c:i       
+      c:l
 ---------------
 100     
 ;       
@@ -272,7 +272,7 @@ Bezalel        |1
 sumFieldWithSumLiteralAsCondition
 SELECT first_name, last_name, SUM(salary) AS s, birth_date AS y, COUNT(1) FROM test_emp GROUP BY 1, 2, 4 HAVING ((SUM(1) >= 1) AND (SUM(1) <= 577)) AND ((SUM(salary) >= 35000) AND (SUM(salary) <= 45000));
 
-  first_name:s |   last_name:s |       s:i     |           y:ts         |   COUNT(1):l    
+  first_name:s |   last_name:s |       s:l     |           y:ts         |   COUNT(1):l
 ---------------+---------------+---------------+------------------------+---------------
 null           |Brender        |36051          |1959-10-01T00:00:00.000Z|1              
 null           |Joslin         |37716          |1959-01-27T00:00:00.000Z|1              
@@ -308,7 +308,7 @@ Zvonko         |Nyanchama      |42716          |null                    |1
 mirrorIifForNumericAggregate
 SELECT IIF(COUNT(1)=0, NULL, 123)+5, AVG(123), MIN(123)+5, IIF(COUNT(1)=0, NULL, 30*COUNT(1)), SUM(30) FROM test_emp;
 
-IIF(COUNT(1)=0, NULL, 123)+5:i|   AVG(123):d    |  MIN(123)+5:i   |IIF(COUNT(1)=0, NULL, 30*COUNT(1)):l|    SUM(30):l    
+IIF(COUNT(1)=0, NULL, 123)+5:i|   AVG(123):d    |  MIN(123)+5:i   |IIF(COUNT(1)=0, NULL, 30*COUNT(1)):l|    SUM(30):l
 ------------------------------+-----------------+-----------------+------------------------------------+---------------
 128                           |123              |128              |3000                                |3000           
 ;
@@ -1452,7 +1452,7 @@ null
 
 
 allZerosWithSum
-schema::SUM_AllZeros:i
+schema::SUM_AllZeros:l
 SELECT SUM(bytes_in) as "SUM_AllZeros" FROM logs WHERE bytes_in = 0;
 
  SUM_AllZeros  
@@ -1462,7 +1462,7 @@ SELECT SUM(bytes_in) as "SUM_AllZeros" FROM logs WHERE bytes_in = 0;
 
 
 allNullsWithSum
-schema::SUM_AllNulls:i
+schema::SUM_AllNulls:l
 SELECT SUM(bytes_out) as "SUM_AllNulls" FROM logs WHERE bytes_out IS NULL;
 
  SUM_AllNulls  
@@ -1671,7 +1671,7 @@ null
 ;
 
 nullsAndZerosCombined
-schema::COUNT(*):l|COUNT_AllZeros:l|COUNT_AllNulls:l|FIRST_AllZeros:i|FIRST_AllNulls:i|SUM_AllZeros:i|SUM_AllNulls:i
+schema::COUNT(*):l|COUNT_AllZeros:l|COUNT_AllNulls:l|FIRST_AllZeros:i|FIRST_AllNulls:i|SUM_AllZeros:l|SUM_AllNulls:l
 SELECT
     COUNT(*), 
     COUNT(bytes_in) AS "COUNT_AllZeros", 
@@ -1690,7 +1690,7 @@ WHERE bytes_in = 0 AND bytes_out IS NULL;
 
 
 groupedByNullsAndZeros
-schema::bytes_in:i|COUNT(*):l|SUM(bytes_in):i|MIN(bytes_in):i|MAX(bytes_in):i|AVG(bytes_in):d
+schema::bytes_in:i|COUNT(*):l|SUM(bytes_in):l|MIN(bytes_in):i|MAX(bytes_in):i|AVG(bytes_in):d
 SELECT
     bytes_in, 
     COUNT(*), 
@@ -1710,7 +1710,7 @@ null           |1              |null           |null           |null           |
 ;
 
 groupedByMultipleSumsWithNullsAndZeros
-schema::SUM(bytes_in):i|SUM(bytes_out):i|client_ip:s|c:l
+schema::SUM(bytes_in):l|SUM(bytes_out):l|client_ip:s|c:l
 SELECT
   SUM(bytes_in),
   SUM(bytes_out),

--- a/x-pack/plugin/sql/qa/server/src/main/resources/agg.sql-spec
+++ b/x-pack/plugin/sql/qa/server/src/main/resources/agg.sql-spec
@@ -322,6 +322,8 @@ aggMinWithAlias
 SELECT gender g, MIN(emp_no) m FROM "test_emp" GROUP BY g ORDER BY gender;
 aggMinOnDateTime
 SELECT gender, MIN(birth_date) m FROM "test_emp" GROUP BY gender ORDER BY gender;
+aggMinOnNull
+SELECT MIN(languages) AS min FROM test_emp WHERE languages IS NULL;
 aggMinOnDateTimeCastAsDate
 SELECT gender, YEAR(CAST(MIN(birth_date) AS DATE)) m FROM "test_emp" GROUP BY gender ORDER BY gender;
 
@@ -340,6 +342,10 @@ aggMinWithMultipleHavingBetween
 SELECT gender g, MIN(emp_no) m FROM "test_emp" GROUP BY g HAVING m BETWEEN 10 AND 99999 ORDER BY g LIMIT 1;
 aggMinWithMultipleHavingOnAliasAndFunction
 SELECT gender g, MIN(emp_no) m FROM "test_emp" GROUP BY g HAVING m > 10 AND MIN(emp_no) < 99999 ORDER BY gender;
+aggMinWithHavingOnIntegralDivision
+SELECT MIN(salary)/100 AS min FROM test_emp HAVING min <= 253;
+aggMinWithHavingAndNull
+SELECT MIN(languages) AS min FROM test_emp GROUP BY languages HAVING min < 2;
 
 aggMinWithHavingGroupMultiGroupBy
 SELECT gender g, languages l, MIN(emp_no) m FROM "test_emp" GROUP BY g, l HAVING MIN(emp_no) > 10 ORDER BY gender, languages;
@@ -380,6 +386,8 @@ aggMaxWithAlias
 SELECT gender g, MAX(emp_no) m FROM "test_emp" GROUP BY g ORDER BY gender;
 aggMaxOnDateTime
 SELECT gender, MAX(birth_date) m FROM "test_emp" GROUP BY gender ORDER BY gender;
+aggMaxOnNull
+SELECT MAX(languages) AS max FROM test_emp WHERE languages IS NULL;
 aggMaxOnDateTimeCastAsDate
 SELECT gender, YEAR(CAST(MAX(birth_date) AS DATE)) m FROM "test_emp" GROUP BY gender ORDER BY gender;
 aggAvgAndMaxWithLikeFilter
@@ -400,6 +408,10 @@ aggMaxWithMultipleHavingBetweenWithLimit
 SELECT gender g, MAX(emp_no) m FROM "test_emp" GROUP BY g HAVING m BETWEEN 10 AND 99999 ORDER BY g LIMIT 1;
 aggMaxWithMultipleHavingOnAliasAndFunction
 SELECT gender g, MAX(emp_no) m FROM "test_emp" GROUP BY g HAVING m > 10 AND MAX(emp_no) < 99999 ORDER BY gender;
+aggMaxWithHavingOnIntegralDivision
+SELECT MAX(salary)/100 AS max FROM test_emp HAVING max > 749;
+aggMaxWithHavingAndNull
+SELECT MAX(languages) AS max FROM test_emp GROUP BY languages HAVING max < 2;
 
 // SUM
 aggSumImplicitWithCast
@@ -418,6 +430,8 @@ aggSumWithCastAndCountWithFilterAndLimit
 SELECT gender g, CAST(SUM(emp_no) AS BIGINT) s, COUNT(1) c FROM "test_emp" WHERE emp_no > 10000 GROUP BY g ORDER BY g LIMIT 1;
 aggSumWithAlias
 SELECT gender g, CAST(SUM(emp_no) AS BIGINT) s FROM "test_emp" GROUP BY g ORDER BY gender;
+aggSumOnNull
+SELECT SUM(languages) AS sum FROM test_emp WHERE languages IS NULL;
 
 // Conditional SUM
 aggSumWithHaving
@@ -434,6 +448,11 @@ aggSumWithMultipleHavingBetweenWithLimit
 SELECT gender g, CAST(SUM(emp_no) AS INT) s FROM "test_emp" GROUP BY g HAVING s BETWEEN 10 AND 10000000 ORDER BY g LIMIT 1;
 aggSumWithMultipleHavingOnAliasAndFunction
 SELECT gender g, CAST(SUM(emp_no) AS INT) s FROM "test_emp" GROUP BY g HAVING s > 10 AND SUM(emp_no) > 10000000 ORDER BY gender;
+aggSumWithHavingOnIntegralDivision
+SELECT SUM(salary)/100 AS sum FROM test_emp HAVING sum <= 48248;
+// AwaitsFix https://github.com/elastic/elasticsearch/issues/45251
+aggSumWithHavingOnNull-Ignore
+SELECT SUM(languages) AS sum FROM test_emp GROUP BY languages HAVING sum < 20 ORDER BY sum;
 
 // AVG
 aggAvgImplicitWithCast
@@ -595,6 +614,8 @@ selectLangGroupByLangHavingNotEquality
 SELECT languages, COUNT(*) c FROM test_emp GROUP BY languages HAVING NOT COUNT(*) = 1 ORDER BY languages DESC;
 selectLangGroupByLangHavingDifferent
 SELECT languages, COUNT(*) c FROM test_emp GROUP BY languages HAVING COUNT(*) <> 1 ORDER BY languages DESC;
+selectNullValueLangWithAgg
+SELECT MAX(languages) AS max FROM test_emp GROUP BY languages HAVING max < 2;
 
 
 // filter with IN
@@ -602,6 +623,16 @@ aggMultiWithHavingUsingInAndNullHandling
 SELECT MIN(salary) min, MAX(salary) max, gender g, COUNT(*) c FROM "test_emp" WHERE languages > 0 GROUP BY g HAVING max IN(74999, null, 74600) ORDER BY gender;
 aggMultiGroupByMultiWithHavingUsingInAndNullHandling
 SELECT MIN(salary) min, MAX(salary) max, gender g, languages l, COUNT(*) c FROM "test_emp" WHERE languages > 0 GROUP BY g, languages HAVING max IN (74500, null, 74600) ORDER BY gender, languages;
+
+// aggs filtering with integral types
+maxIntegralAggFiltering
+SELECT MAX(salary)/100 AS max FROM test_emp HAVING max > 749;
+minIntegralAggFiltering
+SELECT MIN(salary)/100 AS min FROM test_emp HAVING min <= 253;
+sumIntegralAggFiltering
+SELECT SUM(salary)/100 AS sum FROM test_emp HAVING sum <= 48248;
+nullIntegralAggFiltering
+SELECT MAX(languages) AS max FROM test_emp GROUP BY languages HAVING max < 2;
 
 // group by with literal
 implicitGroupByWithLiteral

--- a/x-pack/plugin/sql/qa/server/src/main/resources/constant-keyword.csv-spec
+++ b/x-pack/plugin/sql/qa/server/src/main/resources/constant-keyword.csv-spec
@@ -69,7 +69,7 @@ Female         |24.5
 aggSumWithAliasWithColumnRepeatedWithOrderDesc
 SELECT extra_gender AS g, extra_gender, SUM(salary) AS s3, SUM(salary), SUM(salary) AS s5 FROM test_emp_copy GROUP BY extra_gender;
 
-       g:s     | extra_gender:s |      s3:i     | SUM(salary):i |      s5:i       
+       g:s     | extra_gender:s |      s3:l     | SUM(salary):l |      s5:l
 ---------------+----------------+---------------+---------------+---------------
 Female         |Female          |4824855        |4824855        |4824855      
 ;

--- a/x-pack/plugin/sql/qa/server/src/main/resources/datetime.csv-spec
+++ b/x-pack/plugin/sql/qa/server/src/main/resources/datetime.csv-spec
@@ -134,7 +134,7 @@ SELECT WEEK(birth_date) week, birth_date FROM test_emp ORDER BY WEEK(birth_date)
 isoDayOfWeek
 SELECT ISO_DAY_OF_WEEK(birth_date) AS d, SUM(salary) s FROM test_emp GROUP BY d ORDER BY d DESC;
 
-      d:i      |      s:i       
+      d:i      |      s:l
 ---------------+---------------
 7              |386466       
 6              |643304       

--- a/x-pack/plugin/sql/qa/server/src/main/resources/docs/docs.csv-spec
+++ b/x-pack/plugin/sql/qa/server/src/main/resources/docs/docs.csv-spec
@@ -676,9 +676,9 @@ SELECT gender AS g, ROUND((MIN(salary) / 100)) AS salary FROM emp GROUP BY gende
 
        g       |    salary     
 ---------------+---------------
-null           |253            
-F              |260            
-M              |259        
+null           |253
+F              |259
+M              |259
 // end::groupByAndAggExpression
 ;
 

--- a/x-pack/plugin/sql/qa/server/src/main/resources/pivot.csv-spec
+++ b/x-pack/plugin/sql/qa/server/src/main/resources/pivot.csv-spec
@@ -186,7 +186,7 @@ null           |48396.28571428572|62140.666666666664
 ;
 
 sumWithoutSubquery
-schema::birth_date:ts|emp_no:i|first_name:s|gender:s|hire_date:ts|last_name:s|name:s|1:i|2:i
+schema::birth_date:ts|emp_no:i|first_name:s|gender:s|hire_date:ts|last_name:s|name:s|1:l|2:l
 // tag::sumWithoutSubquery
 SELECT * FROM test_emp PIVOT (SUM(salary) FOR languages IN (1, 2)) LIMIT 5;
 
@@ -205,7 +205,7 @@ SELECT *
 FROM (SELECT client_ip, status, bytes_in FROM logs WHERE NVL(bytes_in, 0) = 0)
 PIVOT (SUM(bytes_in) FOR status IN ('OK','Error'));
 
-   client_ip   |     'OK'      |    'Error'    
+   client_ip:s |     'OK':l    |    'Error':l
 ---------------+---------------+---------------
 10.0.1.199     |0              |null           
 10.0.1.205     |0              |null           

--- a/x-pack/plugin/sql/qa/server/src/main/resources/slow/frozen.csv-spec
+++ b/x-pack/plugin/sql/qa/server/src/main/resources/slow/frozen.csv-spec
@@ -49,7 +49,7 @@ M              |57
 sum
 SELECT SUM(salary) FROM FROZEN frozen_emp;
 
-  SUM(salary)
+  SUM(salary):l
 ---------------
 4824855
 ;

--- a/x-pack/plugin/sql/qa/server/src/main/resources/subselect.sql-spec
+++ b/x-pack/plugin/sql/qa/server/src/main/resources/subselect.sql-spec
@@ -186,7 +186,7 @@ filterOnAggregateInFunction
 SELECT * FROM (
     SELECT gender, MAX(salary) / 100 AS max FROM test_emp WHERE languages > 1 GROUP BY gender
 )
-WHERE max > 746 AND gender IS NOT NULL ORDER BY gender
+WHERE max > 745 AND gender IS NOT NULL ORDER BY gender
 ;
 
 // AwaitsFix : https://github.com/elastic/elasticsearch/issues/71394

--- a/x-pack/plugin/sql/qa/server/src/main/resources/wildcard.csv-spec
+++ b/x-pack/plugin/sql/qa/server/src/main/resources/wildcard.csv-spec
@@ -95,7 +95,7 @@ AP             |10062.0        |2
 aggSumWithAliasWithColumnRepeatedWithOrderDesc
 SELECT wildcard_name AS g, wildcard_name, SUM(salary) AS s3, SUM(salary), SUM(salary) AS s5 FROM test_emp_copy GROUP BY wildcard_name LIMIT 10;
 
-          g:s        |   wildcard_name:s   |      s3:i     | SUM(salary):i |      s5:i       
+          g:s        |   wildcard_name:s   |      s3:l     | SUM(salary):l |      s5:l
 ---------------------+---------------------+---------------+---------------+---------------
 null                 |null                 |473020         |473020         |473020         
 Alejandro McAlpine   |Alejandro McAlpine   |44307          |44307          |44307          

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/execution/search/Querier.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/execution/search/Querier.java
@@ -420,7 +420,7 @@ public class Querier {
 
             if (ref instanceof MetricAggRef) {
                 MetricAggRef r = (MetricAggRef) ref;
-                return new MetricAggExtractor(r.name(), r.property(), r.innerKey(), cfg.zoneId(), r.isDateTimeBased());
+                return new MetricAggExtractor(r.name(), r.property(), r.innerKey(), cfg.zoneId(), r.dataType());
             }
 
             if (ref instanceof TopHitsAggRef) {

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/execution/search/extractor/MetricAggExtractor.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/execution/search/extractor/MetricAggExtractor.java
@@ -6,6 +6,7 @@
  */
 package org.elasticsearch.xpack.sql.execution.search.extractor;
 
+import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.search.aggregations.InternalAggregation;
@@ -22,9 +23,11 @@ import org.elasticsearch.search.aggregations.metrics.InternalSum;
 import org.elasticsearch.search.aggregations.metrics.InternalTDigestPercentileRanks;
 import org.elasticsearch.search.aggregations.metrics.InternalTDigestPercentiles;
 import org.elasticsearch.xpack.ql.execution.search.extractor.BucketExtractor;
+import org.elasticsearch.xpack.ql.type.DataType;
 import org.elasticsearch.xpack.sql.SqlIllegalArgumentException;
 import org.elasticsearch.xpack.sql.common.io.SqlStreamInput;
 import org.elasticsearch.xpack.sql.querydsl.agg.Aggs;
+import org.elasticsearch.xpack.sql.type.SqlDataTypes;
 import org.elasticsearch.xpack.sql.util.DateUtils;
 import java.io.IOException;
 import java.time.ZoneId;
@@ -33,6 +36,8 @@ import java.util.Objects;
 
 import static org.elasticsearch.search.aggregations.matrix.stats.MatrixAggregationInspectionHelper.hasValue;
 import static org.elasticsearch.search.aggregations.support.AggregationInspectionHelper.hasValue;
+import static org.elasticsearch.xpack.sql.type.SqlDataTypeConverter.convert;
+import static org.elasticsearch.xpack.sql.type.SqlDataTypes.isDateBased;
 
 public class MetricAggExtractor implements BucketExtractor {
 
@@ -41,22 +46,31 @@ public class MetricAggExtractor implements BucketExtractor {
     private final String name;
     private final String property;
     private final String innerKey;
-    private final boolean isDateTimeBased;
+    private final DataType dataType;
     private final ZoneId zoneId;
 
-    public MetricAggExtractor(String name, String property, String innerKey, ZoneId zoneId, boolean isDateTimeBased) {
+    public MetricAggExtractor(String name, String property, String innerKey, ZoneId zoneId, @Nullable DataType dataType) {
         this.name = name;
         this.property = property;
         this.innerKey = innerKey;
-        this.isDateTimeBased = isDateTimeBased;
         this.zoneId = zoneId;
+        this.dataType = dataType;
+    }
+
+    public MetricAggExtractor(String name, String property, String innerKey, ZoneId zoneId) {
+        this(name, property, innerKey, zoneId, null);
     }
 
     MetricAggExtractor(StreamInput in) throws IOException {
         name = in.readString();
         property = in.readString();
         innerKey = in.readOptionalString();
-        isDateTimeBased = in.readBoolean();
+        String typeName = in.readOptionalString();
+        if (typeName != null) {
+            dataType = SqlDataTypes.fromTypeName(typeName);
+        } else {
+            dataType = null;
+        }
 
         zoneId = SqlStreamInput.asSqlStream(in).zoneId();
     }
@@ -66,7 +80,7 @@ public class MetricAggExtractor implements BucketExtractor {
         out.writeString(name);
         out.writeString(property);
         out.writeOptionalString(innerKey);
-        out.writeBoolean(isDateTimeBased);
+        out.writeOptionalString(dataType == null ? null : dataType.name());
     }
 
     String name() {
@@ -106,7 +120,7 @@ public class MetricAggExtractor implements BucketExtractor {
             //if (innerKey == null) {
             //    throw new SqlIllegalArgumentException("Invalid innerKey {} specified for aggregation {}", innerKey, name);
             //}
-            return handleDateTime(((InternalNumericMetricsAggregation.MultiValue) agg).value(property));
+            return handleTargetType(((InternalNumericMetricsAggregation.MultiValue) agg).value(property));
         } else if (agg instanceof InternalFilter) {
             // COUNT(expr) and COUNT(ALL expr) uses this type of aggregation to account for non-null values only
             return ((InternalFilter) agg).getDocCount();
@@ -115,17 +129,17 @@ public class MetricAggExtractor implements BucketExtractor {
         }
 
         Object v = agg.getProperty(property);
-        return handleDateTime(innerKey != null && v instanceof Map ? ((Map<?, ?>) v).get(innerKey) : v);
+        return handleTargetType(innerKey != null && v instanceof Map ? ((Map<?, ?>) v).get(innerKey) : v);
     }
 
-    private Object handleDateTime(Object object) {
-        if (isDateTimeBased) {
-            if (object == null) {
-                return object;
-            } else if (object instanceof Number) {
+    private Object handleTargetType(Object object) {
+        if (object instanceof Number && dataType != null) {
+            if (isDateBased(dataType)) {
                 return DateUtils.asDateTimeWithMillis(((Number) object).longValue(), zoneId);
-            } else {
-                throw new SqlIllegalArgumentException("Invalid date key returned: {}", object);
+            } else if (dataType.isInteger()) {
+                // MIN and MAX need to return the same type as field's and SUM a long for integral types, but ES returns them always as
+                // floating points -> convert them in the the SELECT pipeline, if needed
+                return convert(object, dataType);
             }
         }
         return object;

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/aggregate/Sum.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/aggregate/Sum.java
@@ -14,6 +14,9 @@ import org.elasticsearch.xpack.ql.type.DataType;
 
 import java.util.List;
 
+import static org.elasticsearch.xpack.ql.type.DataTypes.DOUBLE;
+import static org.elasticsearch.xpack.ql.type.DataTypes.LONG;
+
 /**
  * Sum all values of a field in matching documents.
  */
@@ -35,7 +38,7 @@ public class Sum extends NumericAggregate implements EnclosedAgg {
 
     @Override
     public DataType dataType() {
-        return field().dataType();
+        return field().dataType().isInteger() ? LONG : DOUBLE;
     }
 
     @Override

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/planner/QueryFolder.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/planner/QueryFolder.java
@@ -650,7 +650,7 @@ class QueryFolder extends RuleExecutor<PhysicalPlan> {
                 // COUNT(<field_name>)
                 } else if (c.distinct() == false) {
                     LeafAgg leafAgg = toAgg(functionId, f);
-                    AggPathInput a = new AggPathInput(f, new MetricAggRef(leafAgg.id(), "doc_count", "_count", false));
+                    AggPathInput a = new AggPathInput(f, new MetricAggRef(leafAgg.id(), "doc_count", "_count", null));
                     queryC = queryC.with(queryC.aggs().addAgg(leafAgg));
                     return new Tuple<>(queryC, a);
                 }
@@ -678,14 +678,14 @@ class QueryFolder extends RuleExecutor<PhysicalPlan> {
                 aggInput = new AggPathInput(f,
                         new MetricAggRef(cAggPath, ia.innerName(),
                             ia.innerKey() != null ? QueryTranslator.nameOf(ia.innerKey()) : null,
-                            isDateBased(ia.dataType())));
+                            ia.dataType()));
             }
             else {
                 LeafAgg leafAgg = toAgg(functionId, f);
                 if (f instanceof TopHits) {
                     aggInput = new AggPathInput(f, new TopHitsAggRef(leafAgg.id(), f.dataType()));
                 } else {
-                    aggInput = new AggPathInput(f, new MetricAggRef(leafAgg.id(), isDateBased(f.dataType())));
+                    aggInput = new AggPathInput(f, new MetricAggRef(leafAgg.id(), f.dataType()));
                 }
                 queryC = queryC.with(queryC.aggs().addAgg(leafAgg));
             }

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/querydsl/container/MetricAggRef.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/querydsl/container/MetricAggRef.java
@@ -7,6 +7,7 @@
 package org.elasticsearch.xpack.sql.querydsl.container;
 
 import org.elasticsearch.xpack.ql.execution.search.AggRef;
+import org.elasticsearch.xpack.ql.type.DataType;
 import org.elasticsearch.xpack.sql.querydsl.agg.Aggs;
 
 /**
@@ -18,21 +19,21 @@ public class MetricAggRef extends AggRef {
     private final String name;
     private final String property;
     private final String innerKey;
-    private final boolean isDateTimeBased;
+    private final DataType dataType;
 
-    public MetricAggRef(String name, boolean isDateTimeBased) {
-        this(name, "value", isDateTimeBased);
+    public MetricAggRef(String name, DataType dataType) {
+        this(name, "value", dataType);
     }
 
-    public MetricAggRef(String name, String property, boolean isDateTimeBased) {
-        this(name, property, null, isDateTimeBased);
+    public MetricAggRef(String name, String property, DataType dataType) {
+        this(name, property, null, dataType);
     }
 
-    public MetricAggRef(String name, String property, String innerKey, boolean isDateTimeBased) {
+    public MetricAggRef(String name, String property, String innerKey, DataType dataType) {
         this.name = name;
         this.property = property;
         this.innerKey = innerKey;
-        this.isDateTimeBased = isDateTimeBased;
+        this.dataType = dataType;
     }
 
     public String name() {
@@ -47,8 +48,8 @@ public class MetricAggRef extends AggRef {
         return innerKey;
     }
 
-    public boolean isDateTimeBased() {
-        return isDateTimeBased;
+    public DataType dataType() {
+        return dataType;
     }
 
     @Override

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/execution/search/extractor/MetricAggExtractorTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/execution/search/extractor/MetricAggExtractorTests.java
@@ -14,6 +14,7 @@ import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.ql.execution.search.extractor.BucketExtractor;
 import org.elasticsearch.xpack.sql.AbstractSqlWireSerializingTestCase;
 import org.elasticsearch.xpack.sql.SqlIllegalArgumentException;
+import org.elasticsearch.xpack.sql.type.SqlDataTypes;
 import org.elasticsearch.xpack.sql.util.DateUtils;
 
 import java.io.IOException;
@@ -23,16 +24,19 @@ import static java.util.Collections.emptyList;
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.singletonList;
 import static java.util.Collections.singletonMap;
+import static org.elasticsearch.xpack.ql.type.DataTypes.DATETIME;
+import static org.elasticsearch.xpack.sql.type.SqlDataTypes.DATE;
 
 public class MetricAggExtractorTests extends AbstractSqlWireSerializingTestCase<MetricAggExtractor> {
 
     public static MetricAggExtractor randomMetricAggExtractor() {
         return new MetricAggExtractor(randomAlphaOfLength(16), randomAlphaOfLength(16), randomAlphaOfLength(16),
-            randomZone(), randomBoolean());
+            randomZone(), randomFrom(SqlDataTypes.types()));
     }
 
     public static MetricAggExtractor randomMetricAggExtractor(ZoneId zoneId) {
-        return new MetricAggExtractor(randomAlphaOfLength(16), randomAlphaOfLength(16), randomAlphaOfLength(16), zoneId, randomBoolean());
+        return new MetricAggExtractor(randomAlphaOfLength(16), randomAlphaOfLength(16), randomAlphaOfLength(16), zoneId,
+            randomFrom(SqlDataTypes.types()));
     }
 
     @Override
@@ -56,7 +60,7 @@ public class MetricAggExtractorTests extends AbstractSqlWireSerializingTestCase<
             instance.name() + "mutated",
             instance.property() + "mutated",
             instance.innerKey() + "mutated",
-                randomValueOtherThan(instance.zoneId(), ESTestCase::randomZone), randomBoolean());
+                randomValueOtherThan(instance.zoneId(), ESTestCase::randomZone), randomFrom(SqlDataTypes.types()));
     }
 
     public void testNoAggs() {
@@ -67,7 +71,7 @@ public class MetricAggExtractorTests extends AbstractSqlWireSerializingTestCase<
     }
 
     public void testSingleValueProperty() {
-        MetricAggExtractor extractor = new MetricAggExtractor("field", "property", "innerKey", null, false);
+        MetricAggExtractor extractor = new MetricAggExtractor("field", "property", "innerKey", null);
 
         double value = randomDouble();
         Aggregation agg = new TestSingleValueAggregation(extractor.name(), singletonList(extractor.property()), value);
@@ -77,7 +81,7 @@ public class MetricAggExtractorTests extends AbstractSqlWireSerializingTestCase<
 
     public void testSingleValuePropertyDate() {
         ZoneId zoneId = randomZone();
-        MetricAggExtractor extractor = new MetricAggExtractor("my_date_field", "property", "innerKey", zoneId, true);
+        MetricAggExtractor extractor = new MetricAggExtractor("my_date_field", "property", "innerKey", zoneId, DATETIME);
 
         double value = randomDouble();
         Aggregation agg = new TestSingleValueAggregation(extractor.name(), singletonList(extractor.property()), value);
@@ -86,7 +90,7 @@ public class MetricAggExtractorTests extends AbstractSqlWireSerializingTestCase<
     }
 
     public void testSingleValueInnerKey() {
-        MetricAggExtractor extractor = new MetricAggExtractor("field", "property", "innerKey", null, false);
+        MetricAggExtractor extractor = new MetricAggExtractor("field", "property", "innerKey", null);
         double innerValue = randomDouble();
         Aggregation agg = new TestSingleValueAggregation(extractor.name(), singletonList(extractor.property()),
                 singletonMap(extractor.innerKey(), innerValue));
@@ -96,7 +100,7 @@ public class MetricAggExtractorTests extends AbstractSqlWireSerializingTestCase<
 
     public void testSingleValueInnerKeyDate() {
         ZoneId zoneId = randomZone();
-        MetricAggExtractor extractor = new MetricAggExtractor("field", "property", "innerKey", zoneId, true);
+        MetricAggExtractor extractor = new MetricAggExtractor("field", "property", "innerKey", zoneId, DATE);
 
         double innerValue = randomDouble();
         Aggregation agg = new TestSingleValueAggregation(extractor.name(), singletonList(extractor.property()),
@@ -106,7 +110,7 @@ public class MetricAggExtractorTests extends AbstractSqlWireSerializingTestCase<
     }
 
     public void testMultiValueProperty() {
-        MetricAggExtractor extractor = new MetricAggExtractor("field", "property", "innerKey", null, false);
+        MetricAggExtractor extractor = new MetricAggExtractor("field", "property", "innerKey", null);
 
         double value = randomDouble();
         Aggregation agg = new TestMultiValueAggregation(extractor.name(), singletonMap(extractor.property(), value));
@@ -116,7 +120,7 @@ public class MetricAggExtractorTests extends AbstractSqlWireSerializingTestCase<
 
     public void testMultiValuePropertyDate() {
         ZoneId zoneId = randomZone();
-        MetricAggExtractor extractor = new MetricAggExtractor("field", "property", "innerKey", zoneId, true);
+        MetricAggExtractor extractor = new MetricAggExtractor("field", "property", "innerKey", zoneId, DATETIME);
 
         double value = randomDouble();
         Aggregation agg = new TestMultiValueAggregation(extractor.name(), singletonMap(extractor.property(), value));

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/planner/QueryFolderTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/planner/QueryFolderTests.java
@@ -297,9 +297,9 @@ public class QueryFolderTests extends ESTestCase {
         assertEquals(EsQueryExec.class, p.getClass());
         EsQueryExec ee = (EsQueryExec) p;
         assertTrue(ee.queryContainer().aggs().asAggBuilder().toString().replaceAll("\\s+", "").contains(
-                "\"script\":{\"source\":\"InternalQlScriptUtils.nullSafeFilter(InternalQlScriptUtils.gt(params.a0,params.v0))\","
-                        +
-            "\"lang\":\"painless\",\"params\":{\"v0\":10}},"));
+                "\"script\":{\"source\":\"InternalQlScriptUtils.nullSafeFilter(InternalQlScriptUtils.gt(" +
+                    "InternalQlScriptUtils.nullSafeCastNumeric(params.a0,params.v0),params.v1))\"," +
+                    "\"lang\":\"painless\",\"params\":{\"v0\":\"INTEGER\",\"v1\":10}},"));
         assertEquals(2, ee.output().size());
         assertThat(ee.output().get(0).toString(), startsWith("test.keyword{f}#"));
         assertThat(ee.output().get(1).toString(), startsWith("max(int){r}"));


### PR DESCRIPTION
This fixes the way the MIN, MAX and SUM aggs handle the returned data types:
- MIN and MAX must return the same data type as input's.
- SUM must return long/BIGINT for integral types and double otherwise.

The fix concerns both data returned in projections, as well as aggs script
filtering.

Fixes #71390, #65413.

(cherry picked from commit be36c1a)