### PR TITLE
[7.x] Fix typo in validation for destination port (#70883)

### DIFF
--- a/modules/ingest-common/src/main/java/org/elasticsearch/ingest/common/CommunityIdProcessor.java
+++ b/modules/ingest-common/src/main/java/org/elasticsearch/ingest/common/CommunityIdProcessor.java
@@ -178,7 +178,7 @@ public final class CommunityIdProcessor extends AbstractProcessor {
 
                 Object destinationPortValue = d.getFieldValue(destinationPortField, Object.class, ignoreMissing);
                 flow.destinationPort = parseIntFromObjectOrString(destinationPortValue, "destination port");
-                if (flow.destinationPort < 1 || flow.sourcePort > 65535) {
+                if (flow.destinationPort < 1 || flow.destinationPort > 65535) {
                     throw new IllegalArgumentException("invalid destination port [" + destinationPortValue + "]");
                 }
                 break;

--- a/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/CommunityIdProcessorTests.java
+++ b/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/CommunityIdProcessorTests.java
@@ -300,6 +300,20 @@ public class CommunityIdProcessorTests extends ESTestCase {
         source2.put("port", 65536);
         e = expectThrows(IllegalArgumentException.class, () -> testCommunityIdProcessor(event, null));
         assertThat(e.getMessage(), containsString("invalid source port [65536]"));
+
+        event = buildEvent();
+        @SuppressWarnings("unchecked")
+        var source3 = (Map<String, Object>) event.get("destination");
+        source3.put("port", 0);
+        e = expectThrows(IllegalArgumentException.class, () -> testCommunityIdProcessor(event, null));
+        assertThat(e.getMessage(), containsString("invalid destination port [0]"));
+
+        event = buildEvent();
+        @SuppressWarnings("unchecked")
+        var source4 = (Map<String, Object>) event.get("destination");
+        source4.put("port", 65536);
+        e = expectThrows(IllegalArgumentException.class, () -> testCommunityIdProcessor(event, null));
+        assertThat(e.getMessage(), containsString("invalid destination port [65536]"));
     }
 
     public void testIgnoreMissing() throws Exception {

--- a/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/CommunityIdProcessorTests.java
+++ b/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/CommunityIdProcessorTests.java
@@ -303,14 +303,14 @@ public class CommunityIdProcessorTests extends ESTestCase {
 
         event = buildEvent();
         @SuppressWarnings("unchecked")
-        var source3 = (Map<String, Object>) event.get("destination");
+        Map<String, Object> source3 = (Map<String, Object>) event.get("destination");
         source3.put("port", 0);
         e = expectThrows(IllegalArgumentException.class, () -> testCommunityIdProcessor(event, null));
         assertThat(e.getMessage(), containsString("invalid destination port [0]"));
 
         event = buildEvent();
         @SuppressWarnings("unchecked")
-        var source4 = (Map<String, Object>) event.get("destination");
+        Map<String, Object> source4 = (Map<String, Object>) event.get("destination");
         source4.put("port", 65536);
         e = expectThrows(IllegalArgumentException.class, () -> testCommunityIdProcessor(event, null));
         assertThat(e.getMessage(), containsString("invalid destination port [65536]"));


### PR DESCRIPTION
Backport of #70883
