### PR TITLE
[7.x] URI parts processor handles URLs containing spaces (#71559)

### DIFF
--- a/modules/ingest-common/src/main/java/org/elasticsearch/ingest/common/UriPartsProcessor.java
+++ b/modules/ingest-common/src/main/java/org/elasticsearch/ingest/common/UriPartsProcessor.java
@@ -8,13 +8,16 @@
 
 package org.elasticsearch.ingest.common;
 
+import org.elasticsearch.common.SuppressForbidden;
 import org.elasticsearch.ingest.AbstractProcessor;
 import org.elasticsearch.ingest.ConfigurationUtils;
 import org.elasticsearch.ingest.IngestDocument;
 import org.elasticsearch.ingest.Processor;
 
+import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.net.URL;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -55,21 +58,65 @@ public class UriPartsProcessor extends AbstractProcessor {
     public IngestDocument execute(IngestDocument ingestDocument) throws Exception {
         String value = ingestDocument.getFieldValue(field, String.class);
 
-        URI uri;
+        URI uri = null;
+        URL url = null;
         try {
             uri = new URI(value);
         } catch (URISyntaxException e) {
-            throw new IllegalArgumentException("unable to parse URI [" + value + "]");
+            try {
+                url = new URL(value);
+            } catch (MalformedURLException e2) {
+                throw new IllegalArgumentException("unable to parse URI [" + value + "]");
+            }
         }
-        Map<String, Object> uriParts = new HashMap<String, Object>();
-        uriParts.put("domain", uri.getHost());
-        if (uri.getFragment() != null) {
-            uriParts.put("fragment", uri.getFragment());
-        }
+        Map<String, Object> uriParts = getUriParts(uri, url);
         if (keepOriginal) {
             uriParts.put("original", value);
         }
-        final String path = uri.getPath();
+
+        if (removeIfSuccessful && targetField.equals(field) == false) {
+            ingestDocument.removeField(field);
+        }
+        ingestDocument.setFieldValue(targetField, uriParts);
+        return ingestDocument;
+    }
+
+    @SuppressForbidden(reason = "URL.getPath is used only if URI.getPath is unavailable")
+    private static Map<String, Object> getUriParts(URI uri, URL fallbackUrl) {
+        Map<String, Object> uriParts = new HashMap<>();
+        String domain;
+        String fragment;
+        String path;
+        int port;
+        String query;
+        String scheme;
+        String userInfo;
+
+        if (uri != null) {
+            domain = uri.getHost();
+            fragment = uri.getFragment();
+            path = uri.getPath();
+            port = uri.getPort();
+            query = uri.getQuery();
+            scheme = uri.getScheme();
+            userInfo = uri.getUserInfo();
+        } else if (fallbackUrl != null) {
+            domain = fallbackUrl.getHost();
+            fragment = fallbackUrl.getRef();
+            path = fallbackUrl.getPath();
+            port = fallbackUrl.getPort();
+            query = fallbackUrl.getQuery();
+            scheme = fallbackUrl.getProtocol();
+            userInfo = fallbackUrl.getUserInfo();
+        } else {
+            // should never occur during processor execution
+            throw new IllegalArgumentException("at least one argument must be non-null");
+        }
+
+        uriParts.put("domain", domain);
+        if (fragment != null) {
+            uriParts.put("fragment", fragment);
+        }
         if (path != null) {
             uriParts.put("path", path);
             if (path.contains(".")) {
@@ -77,14 +124,13 @@ public class UriPartsProcessor extends AbstractProcessor {
                 uriParts.put("extension", periodIndex < path.length() ? path.substring(periodIndex + 1) : "");
             }
         }
-        if (uri.getPort() != -1) {
-            uriParts.put("port", uri.getPort());
+        if (port != -1) {
+            uriParts.put("port", port);
         }
-        if (uri.getQuery() != null) {
-            uriParts.put("query", uri.getQuery());
+        if (query != null) {
+            uriParts.put("query", query);
         }
-        uriParts.put("scheme", uri.getScheme());
-        final String userInfo = uri.getUserInfo();
+        uriParts.put("scheme", scheme);
         if (userInfo != null) {
             uriParts.put("user_info", userInfo);
             if (userInfo.contains(":")) {
@@ -94,11 +140,7 @@ public class UriPartsProcessor extends AbstractProcessor {
             }
         }
 
-        if (removeIfSuccessful && targetField.equals(field) == false) {
-            ingestDocument.removeField(field);
-        }
-        ingestDocument.setFieldValue(targetField, uriParts);
-        return ingestDocument;
+        return uriParts;
     }
 
     @Override

--- a/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/UriPartsProcessorTests.java
+++ b/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/UriPartsProcessorTests.java
@@ -148,6 +148,37 @@ public class UriPartsProcessorTests extends ESTestCase {
         );
     }
 
+    public void testUrlWithCharactersNotToleratedByUri()  throws Exception {
+        testUriParsing(
+            "http://www.google.com/path with spaces",
+            Map.of("scheme", "http", "domain", "www.google.com", "path", "/path with spaces")
+        );
+
+        testUriParsing(
+            "https://user:pw@testing.google.com:8080/foo with space/bar?foo1=bar1&foo2=bar2#anchorVal",
+            Map.of(
+                "scheme",
+                "https",
+                "domain",
+                "testing.google.com",
+                "fragment",
+                "anchorVal",
+                "path",
+                "/foo with space/bar",
+                "port",
+                8080,
+                "username",
+                "user",
+                "password",
+                "pw",
+                "user_info",
+                "user:pw",
+                "query",
+                "foo1=bar1&foo2=bar2"
+            )
+        );
+    }
+
     public void testRemoveIfSuccessfulDoesNotRemoveTargetField() throws Exception {
         String field = "field";
         UriPartsProcessor processor = new UriPartsProcessor(null, null, field, field, true, false);


### PR DESCRIPTION
The URI parts processor uses the `java.net.URI` class to parse the input string which is fairly strict in its interpretation of the URI spec and it rejects such characters as non-URI-encoded spaces. In the interest of handling as broad a range of input data as possible, this change attempts to parse the input string using the `java.net.URL` class which is more lenient if the first attempt to parse with `java.net.URI` fails.

This fixes the issue raised in #70947.

Backport of #71559