### PR TITLE
[7.x] Revive documentation for experimental Searchable Snapshots APIs 

### DIFF
--- a/docs/reference/redirects.asciidoc
+++ b/docs/reference/redirects.asciidoc
@@ -1356,24 +1356,6 @@ See <<constant-keyword-field-type>>.
 
 See <<wildcard-field-type>>.
 
-[role="exclude",id="searchable-snapshots-api-clear-cache"]
-=== Clear cache API
-
-We have removed documentation for this API. This a low-level API used to clear
-the searchable snapshot cache. We plan to remove or drastically change this API
-as part of a future release.
-
-For other searchable snapshot APIs, see <<searchable-snapshots-apis>>.
-
-[role="exclude",id="searchable-snapshots-api-stats"]
-=== Searchable snapshot statistics API
-
-We have removed documentation for this API. This a low-level API used to get
-information about searchable snapshot indices. We plan to remove or drastically
-change this API as part of a future release.
-
-For other searchable snapshot APIs, see <<searchable-snapshots-apis>>.
-
 [role="exclude",id="searchable-snapshots-repository-stats"]
 === Searchable snapshot repository statistics API
 

--- a/docs/reference/searchable-snapshots/apis/clear-cache.asciidoc
+++ b/docs/reference/searchable-snapshots/apis/clear-cache.asciidoc
@@ -1,0 +1,74 @@
+[role="xpack"]
+[testenv="enterprise"]
+[[searchable-snapshots-api-clear-cache]]
+=== Clear cache API
+++++
+<titleabbrev>Clear cache</titleabbrev>
+++++
+
+experimental::[]
+
+Clears indices and data streams from the <<shared-cache,shared searchable
+snapshot cache>>.
+
+[[searchable-snapshots-api-clear-cache-request]]
+==== {api-request-title}
+
+`POST /_searchable_snapshots/cache/clear`
+
+`POST /<target>/_searchable_snapshots/cache/clear`
+
+[[searchable-snapshots-api-clear-cache-prereqs]]
+==== {api-prereq-title}
+
+If the {es} {security-features} are enabled, you must have the `manage`
+<<privileges-list-cluster,cluster privilege>> to use this API. You must also
+have the `manage` <<privileges-list-indices,index privileges>> for the target
+data stream, index, or index alias.
+
+[[searchable-snapshots-api-clear-cache-path-params]]
+==== {api-path-parms-title}
+
+`<target>`::
+(Optional, string)
+Comma-separated list of data streams, indices, and index aliases to clear from the cache.
+To clear the entire cache, omit this parameter. Supports wildcards (`*`).
+
+
+[[searchable-snapshots-api-clear-cache-example]]
+==== {api-examples-title}
+////
+[source,console]
+-----------------------------------
+PUT /docs
+{
+  "settings" : {
+    "index.number_of_shards" : 1,
+    "index.number_of_replicas" : 0
+  }
+}
+
+PUT /_snapshot/my_repository/my_snapshot?wait_for_completion=true
+{
+  "include_global_state": false,
+  "indices": "docs"
+}
+
+DELETE /docs
+
+POST /_snapshot/my_repository/my_snapshot/_mount?wait_for_completion=true
+{
+  "index": "docs",
+  "renamed_index": "my-index"
+}
+-----------------------------------
+// TEST[setup:setup-repository]
+////
+
+Clears the cache of the index `my-index`:
+
+[source,console]
+--------------------------------------------------
+POST /my-index/_searchable_snapshots/cache/clear
+--------------------------------------------------
+// TEST[continued]

--- a/docs/reference/searchable-snapshots/apis/searchable-snapshots-apis.asciidoc
+++ b/docs/reference/searchable-snapshots/apis/searchable-snapshots-apis.asciidoc
@@ -7,6 +7,10 @@ You can use the following APIs to perform searchable snapshots operations.
 
 * <<searchable-snapshots-api-mount-snapshot,Mount snapshot>>
 * <<searchable-snapshots-api-cache-stats,Cache statistics>>
+* <<searchable-snapshots-api-stats,Shard statistics>>
+* <<searchable-snapshots-api-clear-cache,Clear cache>>
 
 include::mount-snapshot.asciidoc[]
 include::node-cache-stats.asciidoc[]
+include::shard-stats.asciidoc[]
+include::clear-cache.asciidoc[]

--- a/docs/reference/searchable-snapshots/apis/shard-stats.asciidoc
+++ b/docs/reference/searchable-snapshots/apis/shard-stats.asciidoc
@@ -1,0 +1,77 @@
+[role="xpack"]
+[testenv="enterprise"]
+[[searchable-snapshots-api-stats]]
+=== Searchable snapshot statistics API
+++++
+<titleabbrev>Searchable snapshot statistics</titleabbrev>
+++++
+
+experimental::[]
+
+Retrieves statistics about searchable snapshots.
+
+[[searchable-snapshots-api-stats-request]]
+==== {api-request-title}
+
+`GET /_searchable_snapshots/stats`
+
+`GET /<target>/_searchable_snapshots/stats`
+
+[[searchable-snapshots-api-stats-prereqs]]
+==== {api-prereq-title}
+
+If the {es} {security-features} are enabled, you must have the `manage`
+<<privileges-list-cluster,cluster privilege>> to use this API. You must also
+have the `manage` <<privileges-list-indices,index privileges>> for the target
+data stream or index.
+
+[[searchable-snapshots-api-stats-desc]]
+==== {api-description-title}
+
+
+[[searchable-snapshots-api-stats-path-params]]
+==== {api-path-parms-title}
+
+`<target>`::
+(Optional, string)
+Comma-separated list of data streams and indices to retrieve statistics for. To
+retrieve statistics for all data streams and indices, omit this parameter.
+
+
+[[searchable-snapshots-api-stats-example]]
+==== {api-examples-title}
+////
+[source,console]
+-----------------------------------
+PUT /docs
+{
+  "settings" : {
+    "index.number_of_shards" : 1,
+    "index.number_of_replicas" : 0
+  }
+}
+
+PUT /_snapshot/my_repository/my_snapshot?wait_for_completion=true
+{
+  "include_global_state": false,
+  "indices": "docs"
+}
+
+DELETE /docs
+
+POST /_snapshot/my_repository/my_snapshot/_mount?wait_for_completion=true
+{
+  "index": "docs",
+  "renamed_index": "my-index"
+}
+-----------------------------------
+// TEST[setup:setup-repository]
+////
+
+Retrieves the statistics of the index `my-index`:
+
+[source,console]
+--------------------------------------------------
+GET /my-index/_searchable_snapshots/stats
+--------------------------------------------------
+// TEST[continued]

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/searchable_snapshots.stats.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/searchable_snapshots.stats.json
@@ -2,7 +2,7 @@
   "searchable_snapshots.stats": {
     "documentation": {
       "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/searchable-snapshots-apis.html",
-      "description": "Retrieve various statistics about searchable snapshots."
+      "description": "Retrieve shard-level statistics about searchable snapshots."
     },
     "stability": "experimental",
     "visibility":"public",


### PR DESCRIPTION
This commit revives the documentation of the "Clear Cache" and
"Shard Stats" APIs of Searchable Snapshots that was removed
in #62217. This is a partial revert of the commit b545c55 with
some light wording changes.

Co-authored-by: James Rodewig <40268737+jrodewig@users.noreply.github.com>

Backport of #71927