### PR TITLE
Add Fleet action results system data stream

### DIFF
--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/indices/DataStream.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/indices/DataStream.java
@@ -26,6 +26,7 @@ public final class DataStream {
     private final List<String> indices;
     private final long generation;
     private final boolean hidden;
+    private final boolean system;
     ClusterHealthStatus dataStreamStatus;
     @Nullable
     String indexTemplate;
@@ -36,7 +37,7 @@ public final class DataStream {
 
     public DataStream(String name, String timeStampField, List<String> indices, long generation, ClusterHealthStatus dataStreamStatus,
                       @Nullable String indexTemplate, @Nullable String ilmPolicyName, @Nullable  Map<String, Object> metadata,
-                      boolean hidden) {
+                      boolean hidden, boolean system) {
         this.name = name;
         this.timeStampField = timeStampField;
         this.indices = indices;
@@ -46,6 +47,7 @@ public final class DataStream {
         this.ilmPolicyName = ilmPolicyName;
         this.metadata = metadata;
         this.hidden = hidden;
+        this.system = system;
     }
 
     public String getName() {
@@ -84,6 +86,10 @@ public final class DataStream {
         return hidden;
     }
 
+    public boolean isSystem() {
+        return system;
+    }
+
     public static final ParseField NAME_FIELD = new ParseField("name");
     public static final ParseField TIMESTAMP_FIELD_FIELD = new ParseField("timestamp_field");
     public static final ParseField INDICES_FIELD = new ParseField("indices");
@@ -93,6 +99,7 @@ public final class DataStream {
     public static final ParseField ILM_POLICY_FIELD = new ParseField("ilm_policy");
     public static final ParseField METADATA_FIELD = new ParseField("_meta");
     public static final ParseField HIDDEN_FIELD = new ParseField("hidden");
+    public static final ParseField SYSTEM_FIELD = new ParseField("system");
 
     @SuppressWarnings("unchecked")
     private static final ConstructingObjectParser<DataStream, Void> PARSER = new ConstructingObjectParser<>("data_stream",
@@ -107,9 +114,10 @@ public final class DataStream {
             String indexTemplate = (String) args[5];
             String ilmPolicy = (String) args[6];
             Map<String, Object> metadata = (Map<String, Object>) args[7];
-            Boolean hidden = (Boolean) args[8];
-            hidden = hidden != null && hidden;
-            return new DataStream(dataStreamName, timeStampField, indices, generation, status, indexTemplate, ilmPolicy, metadata, hidden);
+            boolean hidden = args[8] != null && (boolean) args[8];
+            boolean system = args[9] != null && (boolean) args[9];
+            return new DataStream(dataStreamName, timeStampField, indices, generation, status, indexTemplate, ilmPolicy, metadata, hidden,
+                system);
         });
 
     static {
@@ -122,6 +130,7 @@ public final class DataStream {
         PARSER.declareString(ConstructingObjectParser.optionalConstructorArg(), ILM_POLICY_FIELD);
         PARSER.declareObject(ConstructingObjectParser.optionalConstructorArg(), (p, c) -> p.map(), METADATA_FIELD);
         PARSER.declareBoolean(ConstructingObjectParser.optionalConstructorArg(), HIDDEN_FIELD);
+        PARSER.declareBoolean(ConstructingObjectParser.optionalConstructorArg(), SYSTEM_FIELD);
     }
 
     public static DataStream fromXContent(XContentParser parser) throws IOException {
@@ -138,6 +147,8 @@ public final class DataStream {
             timeStampField.equals(that.timeStampField) &&
             indices.equals(that.indices) &&
             dataStreamStatus == that.dataStreamStatus &&
+            hidden == that.hidden &&
+            system == that.system &&
             Objects.equals(indexTemplate, that.indexTemplate) &&
             Objects.equals(ilmPolicyName, that.ilmPolicyName) &&
             Objects.equals(metadata, that.metadata);
@@ -145,6 +156,7 @@ public final class DataStream {
 
     @Override
     public int hashCode() {
-        return Objects.hash(name, timeStampField, indices, generation, dataStreamStatus, indexTemplate, ilmPolicyName, metadata);
+        return Objects.hash(name, timeStampField, indices, generation, dataStreamStatus, indexTemplate, ilmPolicyName, metadata, hidden,
+            system);
     }
 }

--- a/docs/reference/data-streams/change-mappings-and-settings.asciidoc
+++ b/docs/reference/data-streams/change-mappings-and-settings.asciidoc
@@ -572,7 +572,8 @@ stream's oldest backing index.
       "generation": 2,
       "status": "GREEN",
       "template": "my-data-stream-template",
-      "hidden": false
+      "hidden": false,
+      "system": false
     }
   ]
 }

--- a/docs/reference/indices/get-data-stream.asciidoc
+++ b/docs/reference/indices/get-data-stream.asciidoc
@@ -203,6 +203,11 @@ use the <<indices-get-settings,get index settings API>>.
 `hidden`::
 (Boolean)
 If `true`, the data stream is <<hidden-indices,hidden>>.
+
+`system`::
+(Boolean)
+If `true`, the data stream is created and managed by an Elastic stack component
+and cannot be modified through normal user interaction.
 ====
 
 [[get-data-stream-api-example]]
@@ -241,7 +246,8 @@ The API returns the following response:
       "status": "GREEN",
       "template": "my-index-template",
       "ilm_policy": "my-lifecycle-policy",
-      "hidden": false
+      "hidden": false,
+      "system": false
     },
     {
       "name": "my-data-stream-two",
@@ -261,7 +267,8 @@ The API returns the following response:
       "status": "YELLOW",
       "template": "my-index-template",
       "ilm_policy": "my-lifecycle-policy",
-      "hidden": false
+      "hidden": false,
+      "system": false
     }
   ]
 }

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/alias/get/TransportGetAliasesAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/alias/get/TransportGetAliasesAction.java
@@ -16,7 +16,6 @@ import org.elasticsearch.cluster.block.ClusterBlockLevel;
 import org.elasticsearch.cluster.metadata.AliasMetadata;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
-import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver.SystemIndexAccessLevel;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.collect.ImmutableOpenMap;
 import org.elasticsearch.common.inject.Inject;
@@ -24,6 +23,7 @@ import org.elasticsearch.common.logging.DeprecationCategory;
 import org.elasticsearch.common.logging.DeprecationLogger;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.indices.SystemIndices;
+import org.elasticsearch.indices.SystemIndices.SystemIndexAccessLevel;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 
@@ -65,11 +65,9 @@ public class TransportGetAliasesAction extends TransportMasterNodeReadAction<Get
             concreteIndices = indexNameExpressionResolver.concreteIndexNames(state, request);
         }
         final SystemIndexAccessLevel systemIndexAccessLevel = indexNameExpressionResolver.getSystemIndexAccessLevel();
-        final String elasticProduct =
-            threadPool.getThreadContext().getHeader(IndexNameExpressionResolver.EXTERNAL_SYSTEM_INDEX_ACCESS_CONTROL_HEADER_KEY);
         ImmutableOpenMap<String, List<AliasMetadata>> aliases = state.metadata().findAliases(request, concreteIndices);
         listener.onResponse(new GetAliasesResponse(postProcess(request, concreteIndices, aliases, state,
-            systemIndexAccessLevel, elasticProduct, systemIndices)));
+            systemIndexAccessLevel, threadPool.getThreadContext(), systemIndices)));
     }
 
     /**
@@ -78,7 +76,7 @@ public class TransportGetAliasesAction extends TransportMasterNodeReadAction<Get
     static ImmutableOpenMap<String, List<AliasMetadata>> postProcess(GetAliasesRequest request, String[] concreteIndices,
                                                                      ImmutableOpenMap<String, List<AliasMetadata>> aliases,
                                                                      ClusterState state, SystemIndexAccessLevel systemIndexAccessLevel,
-                                                                     String elasticProduct, SystemIndices systemIndices) {
+                                                                     ThreadContext threadContext, SystemIndices systemIndices) {
         boolean noAliasesSpecified = request.getOriginalAliases() == null || request.getOriginalAliases().length == 0;
         ImmutableOpenMap.Builder<String, List<AliasMetadata>> mapBuilder = ImmutableOpenMap.builder(aliases);
         for (String index : concreteIndices) {
@@ -89,19 +87,19 @@ public class TransportGetAliasesAction extends TransportMasterNodeReadAction<Get
         }
         final ImmutableOpenMap<String, List<AliasMetadata>> finalResponse = mapBuilder.build();
         if (systemIndexAccessLevel != SystemIndexAccessLevel.ALL) {
-            checkSystemIndexAccess(request, systemIndices, state, finalResponse, systemIndexAccessLevel, elasticProduct);
+            checkSystemIndexAccess(request, systemIndices, state, finalResponse, systemIndexAccessLevel, threadContext);
         }
         return finalResponse;
     }
 
     private static void checkSystemIndexAccess(GetAliasesRequest request, SystemIndices systemIndices, ClusterState state,
                                                ImmutableOpenMap<String, List<AliasMetadata>> aliasesMap,
-                                               SystemIndexAccessLevel systemIndexAccessLevel, String elasticProduct) {
+                                               SystemIndexAccessLevel systemIndexAccessLevel, ThreadContext threadContext) {
         final Predicate<IndexMetadata> systemIndexAccessAllowPredicate;
         if (systemIndexAccessLevel == SystemIndexAccessLevel.NONE) {
             systemIndexAccessAllowPredicate = indexMetadata -> false;
         } else if (systemIndexAccessLevel == SystemIndexAccessLevel.RESTRICTED) {
-            systemIndexAccessAllowPredicate = systemIndices.getProductSystemIndexMetadataPredicate(elasticProduct);
+            systemIndexAccessAllowPredicate = systemIndices.getProductSystemIndexMetadataPredicate(threadContext);
         } else {
             throw new IllegalArgumentException("Unexpected system index access level: " + systemIndexAccessLevel);
         }
@@ -121,23 +119,23 @@ public class TransportGetAliasesAction extends TransportMasterNodeReadAction<Get
                 "this request accesses system indices: {}, but in a future major version, direct access to system " +
                     "indices will be prevented by default", systemIndicesNames);
         } else {
-            checkSystemAliasAccess(request, systemIndices, systemIndexAccessLevel, elasticProduct);
+            checkSystemAliasAccess(request, systemIndices, systemIndexAccessLevel, threadContext);
         }
     }
 
     private static void checkSystemAliasAccess(GetAliasesRequest request, SystemIndices systemIndices,
-                                               SystemIndexAccessLevel systemIndexAccessLevel, String elasticProduct) {
+                                               SystemIndexAccessLevel systemIndexAccessLevel, ThreadContext threadContext) {
         final Predicate<String> systemIndexAccessAllowPredicate;
         if (systemIndexAccessLevel == SystemIndexAccessLevel.NONE) {
             systemIndexAccessAllowPredicate = name -> true;
         } else if (systemIndexAccessLevel == SystemIndexAccessLevel.RESTRICTED) {
-            systemIndexAccessAllowPredicate = systemIndices.getProductSystemIndexNamePredicate(elasticProduct).negate();
+            systemIndexAccessAllowPredicate = systemIndices.getProductSystemIndexNamePredicate(threadContext).negate();
         } else {
             throw new IllegalArgumentException("Unexpected system index access level: " + systemIndexAccessLevel);
         }
 
         final List<String> systemAliases = Arrays.stream(request.aliases())
-            .filter(systemIndices::isSystemIndex)
+            .filter(systemIndices::isSystemName)
             .filter(systemIndexAccessAllowPredicate)
             .collect(Collectors.toList());
         if (systemAliases.isEmpty() == false) {

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/create/AutoCreateAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/create/AutoCreateAction.java
@@ -34,6 +34,7 @@ import org.elasticsearch.common.Priority;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.IndexNotFoundException;
+import org.elasticsearch.indices.SystemDataStreamDescriptor;
 import org.elasticsearch.indices.SystemIndexDescriptor;
 import org.elasticsearch.indices.SystemIndices;
 import org.elasticsearch.threadpool.ThreadPool;
@@ -109,11 +110,17 @@ public final class AutoCreateAction extends ActionType<CreateIndexResponse> {
 
                 @Override
                 public ClusterState execute(ClusterState currentState) throws Exception {
+                    final SystemDataStreamDescriptor dataStreamDescriptor =
+                        systemIndices.validateDataStreamAccess(request.index(), threadPool.getThreadContext());
+                    final boolean isSystemDataStream = dataStreamDescriptor != null;
+                    final boolean isSystemIndex = isSystemDataStream == false && systemIndices.isSystemIndex(request.index());
                     final ComposableIndexTemplate template = resolveTemplate(request, currentState.metadata());
+                    final boolean isDataStream = isSystemIndex == false &&
+                        (isSystemDataStream || (template != null && template.getDataStreamTemplate() != null));
 
-                    if (template != null && template.getDataStreamTemplate() != null) {
+                    if (isDataStream) {
                         // This expression only evaluates to true when the argument is non-null and false
-                        if (Boolean.FALSE.equals(template.getAllowAutoCreate())) {
+                        if (isSystemDataStream == false && Boolean.FALSE.equals(template.getAllowAutoCreate())) {
                             throw new IndexNotFoundException(
                                 "composable template " + template.indexPatterns() + " forbids index auto creation"
                             );
@@ -121,6 +128,7 @@ public final class AutoCreateAction extends ActionType<CreateIndexResponse> {
 
                         CreateDataStreamClusterStateUpdateRequest createRequest = new CreateDataStreamClusterStateUpdateRequest(
                             request.index(),
+                            dataStreamDescriptor,
                             request.masterNodeTimeout(),
                             request.timeout()
                         );
@@ -130,21 +138,27 @@ public final class AutoCreateAction extends ActionType<CreateIndexResponse> {
                     } else {
                         String indexName = indexNameExpressionResolver.resolveDateMathExpression(request.index());
                         indexNameRef.set(indexName);
+                        if (isSystemIndex) {
+                            if (indexName.equals(request.index()) == false) {
+                                throw new IllegalStateException("system indices do not support date math expressions");
+                            }
+                        } else {
+                            // This will throw an exception if the index does not exist and creating it is prohibited
+                            final boolean shouldAutoCreate = autoCreateIndex.shouldAutoCreate(indexName, currentState);
 
-                        // This will throw an exception if the index does not exist and creating it is prohibited
-                        final boolean shouldAutoCreate = autoCreateIndex.shouldAutoCreate(indexName, currentState);
-
-                        if (shouldAutoCreate == false) {
-                            // The index already exists.
-                            return currentState;
+                            if (shouldAutoCreate == false) {
+                                // The index already exists.
+                                return currentState;
+                            }
                         }
 
-                        final SystemIndexDescriptor mainDescriptor = systemIndices.findMatchingDescriptor(indexName);
-                        final boolean isSystemIndex = mainDescriptor != null && mainDescriptor.isAutomaticallyManaged();
+                        final SystemIndexDescriptor mainDescriptor =
+                            isSystemIndex ? systemIndices.findMatchingDescriptor(indexName) : null;
+                        final boolean isManagedSystemIndex = mainDescriptor != null && mainDescriptor.isAutomaticallyManaged();
 
                         final CreateIndexClusterStateUpdateRequest updateRequest;
 
-                        if (isSystemIndex) {
+                        if (isManagedSystemIndex) {
                             final SystemIndexDescriptor descriptor =
                                 mainDescriptor.getDescriptorCompatibleWith(state.nodes().getSmallestNonClientNodeVersion());
                             if (descriptor == null) {

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/create/CreateIndexClusterStateUpdateRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/create/CreateIndexClusterStateUpdateRequest.java
@@ -16,6 +16,7 @@ import org.elasticsearch.cluster.block.ClusterBlock;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.Index;
+import org.elasticsearch.indices.SystemDataStreamDescriptor;
 
 import java.util.HashMap;
 import java.util.HashSet;
@@ -35,6 +36,7 @@ public class CreateIndexClusterStateUpdateRequest extends ClusterStateUpdateRequ
     private Index recoverFrom;
     private ResizeType resizeType;
     private boolean copySettings;
+    private SystemDataStreamDescriptor systemDataStreamDescriptor;
 
     private Settings settings = Settings.Builder.EMPTY_SETTINGS;
 
@@ -95,6 +97,11 @@ public class CreateIndexClusterStateUpdateRequest extends ClusterStateUpdateRequ
         return this;
     }
 
+    public CreateIndexClusterStateUpdateRequest systemDataStreamDescriptor(SystemDataStreamDescriptor systemDataStreamDescriptor) {
+        this.systemDataStreamDescriptor = systemDataStreamDescriptor;
+        return this;
+    }
+
     public String cause() {
         return cause;
     }
@@ -121,6 +128,10 @@ public class CreateIndexClusterStateUpdateRequest extends ClusterStateUpdateRequ
 
     public Index recoverFrom() {
         return recoverFrom;
+    }
+
+    public SystemDataStreamDescriptor systemDataStreamDescriptor() {
+        return systemDataStreamDescriptor;
     }
 
     /**
@@ -178,6 +189,7 @@ public class CreateIndexClusterStateUpdateRequest extends ClusterStateUpdateRequ
             ", aliases=" + aliases +
             ", blocks=" + blocks +
             ", waitForActiveShards=" + waitForActiveShards +
+            ", systemDataStreamDescriptor=" + systemDataStreamDescriptor +
             '}';
     }
 }

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/rollover/MetadataRolloverService.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/rollover/MetadataRolloverService.java
@@ -28,6 +28,8 @@ import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.indices.SystemDataStreamDescriptor;
+import org.elasticsearch.indices.SystemIndices;
 import org.elasticsearch.snapshots.SnapshotInProgressException;
 import org.elasticsearch.snapshots.SnapshotsService;
 import org.elasticsearch.threadpool.ThreadPool;
@@ -57,14 +59,17 @@ public class MetadataRolloverService {
     private final MetadataCreateIndexService createIndexService;
     private final MetadataIndexAliasesService indexAliasesService;
     private final IndexNameExpressionResolver indexNameExpressionResolver;
+    private final SystemIndices systemIndices;
+
     @Inject
     public MetadataRolloverService(ThreadPool threadPool,
                                    MetadataCreateIndexService createIndexService, MetadataIndexAliasesService indexAliasesService,
-                                   IndexNameExpressionResolver indexNameExpressionResolver) {
+                                   IndexNameExpressionResolver indexNameExpressionResolver, SystemIndices systemIndices) {
         this.threadPool = threadPool;
         this.createIndexService = createIndexService;
         this.indexAliasesService = indexAliasesService;
         this.indexNameExpressionResolver = indexNameExpressionResolver;
+        this.systemIndices = systemIndices;
     }
 
     public static class RolloverResult {
@@ -212,7 +217,16 @@ public class MetadataRolloverService {
             );
         }
 
-        lookupTemplateForDataStream(dataStreamName, currentState.metadata());
+        final SystemDataStreamDescriptor systemDataStreamDescriptor;
+        if (dataStream.isSystem() == false) {
+            systemDataStreamDescriptor = null;
+            lookupTemplateForDataStream(dataStreamName, currentState.metadata());
+        } else {
+            systemDataStreamDescriptor = systemIndices.findMatchingDataStreamDescriptor(dataStreamName);
+            if (systemDataStreamDescriptor == null) {
+                throw new IllegalArgumentException("no system data stream descriptor found for data stream [" + dataStreamName + "]");
+            }
+        }
 
         final Version minNodeVersion = currentState.nodes().getMinNodeVersion();
         final DataStream ds = dataStream.getDataStream();
@@ -223,8 +237,12 @@ public class MetadataRolloverService {
             return new RolloverResult(rolledDataStream.getWriteIndex().getName(), originalWriteIndex.getIndex().getName(), currentState);
         }
 
-        CreateIndexClusterStateUpdateRequest createIndexClusterStateRequest =
-            prepareDataStreamCreateIndexRequest(dataStreamName, rolledDataStream.getWriteIndex().getName(), createIndexRequest);
+        CreateIndexClusterStateUpdateRequest createIndexClusterStateRequest = prepareDataStreamCreateIndexRequest(
+            dataStreamName,
+            rolledDataStream.getWriteIndex().getName(),
+            createIndexRequest,
+            systemDataStreamDescriptor
+        );
         ClusterState newState = createIndexService.applyCreateIndexRequest(currentState, createIndexClusterStateRequest, silent,
             (builder, indexMetadata) -> builder.put(ds.rollover(currentState.metadata(), indexMetadata.getIndexUUID(), minNodeVersion)));
 
@@ -256,10 +274,12 @@ public class MetadataRolloverService {
 
     static CreateIndexClusterStateUpdateRequest prepareDataStreamCreateIndexRequest(final String dataStreamName,
                                                                                     final String targetIndexName,
-                                                                                    CreateIndexRequest createIndexRequest) {
-        Settings settings = Settings.builder().put("index.hidden", true).build();
+                                                                                    CreateIndexRequest createIndexRequest,
+                                                                                    final SystemDataStreamDescriptor descriptor) {
+        Settings settings = descriptor != null ? Settings.EMPTY : Settings.builder().put("index.hidden", true).build();
         return prepareCreateIndexRequest(targetIndexName, targetIndexName, "rollover_data_stream", createIndexRequest, settings)
-            .dataStreamName(dataStreamName);
+            .dataStreamName(dataStreamName)
+            .systemDataStreamDescriptor(descriptor);
     }
 
     static CreateIndexClusterStateUpdateRequest prepareCreateIndexRequest(

--- a/server/src/main/java/org/elasticsearch/action/support/AutoCreateIndex.java
+++ b/server/src/main/java/org/elasticsearch/action/support/AutoCreateIndex.java
@@ -62,7 +62,7 @@ public final class AutoCreateIndex {
         }
 
         // Always auto-create system indexes
-        if (systemIndices.isSystemIndex(index)) {
+        if (systemIndices.isSystemName(index)) {
             return true;
         }
 

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/DataStream.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/DataStream.java
@@ -51,19 +51,25 @@ public final class DataStream extends AbstractDiffable<DataStream> implements To
     private final Map<String, Object> metadata;
     private final boolean hidden;
     private final boolean replicated;
+    private final boolean system;
 
     public DataStream(String name, TimestampField timeStampField, List<Index> indices, long generation, Map<String, Object> metadata) {
-        this(name, timeStampField, indices, generation, metadata, false, false);
+        this(name, timeStampField, indices, generation, metadata, false, false, false);
     }
 
     public DataStream(String name, TimestampField timeStampField, List<Index> indices, long generation, Map<String, Object> metadata,
                       boolean hidden, boolean replicated) {
-        this(name, timeStampField, indices, generation, metadata, hidden, replicated, System::currentTimeMillis);
+        this(name, timeStampField, indices, generation, metadata, hidden, replicated, false, System::currentTimeMillis);
+    }
+
+    public DataStream(String name, TimestampField timeStampField, List<Index> indices, long generation, Map<String, Object> metadata,
+                      boolean hidden, boolean replicated, boolean system) {
+        this(name, timeStampField, indices, generation, metadata, hidden, replicated, system, System::currentTimeMillis);
     }
 
     // visible for testing
     DataStream(String name, TimestampField timeStampField, List<Index> indices, long generation, Map<String, Object> metadata,
-        boolean hidden, boolean replicated, LongSupplier timeProvider) {
+        boolean hidden, boolean replicated, boolean system, LongSupplier timeProvider) {
         this.name = name;
         this.timeStampField = timeStampField;
         this.indices = Collections.unmodifiableList(indices);
@@ -72,6 +78,7 @@ public final class DataStream extends AbstractDiffable<DataStream> implements To
         this.hidden = hidden;
         this.replicated = replicated;
         this.timeProvider = timeProvider;
+        this.system = system;
         assert indices.size() > 0;
     }
 
@@ -118,6 +125,10 @@ public final class DataStream extends AbstractDiffable<DataStream> implements To
         return replicated;
     }
 
+    public boolean isSystem() {
+        return system;
+    }
+
     /**
      * Performs a rollover on a {@code DataStream} instance and returns a new instance containing
      * the updated list of backing indices and incremented generation.
@@ -142,7 +153,7 @@ public final class DataStream extends AbstractDiffable<DataStream> implements To
             newWriteIndexName = DataStream.getDefaultBackingIndexName(getName(), ++generation, currentTimeMillis, minNodeVersion);
         } while (clusterMetadata.getIndicesLookup().containsKey(newWriteIndexName));
         backingIndices.add(new Index(newWriteIndexName, writeIndexUuid));
-        return new DataStream(name, timeStampField, backingIndices, generation, metadata, hidden, replicated);
+        return new DataStream(name, timeStampField, backingIndices, generation, metadata, hidden, replicated, system);
     }
 
     /**
@@ -156,7 +167,7 @@ public final class DataStream extends AbstractDiffable<DataStream> implements To
         List<Index> backingIndices = new ArrayList<>(indices);
         backingIndices.remove(index);
         assert backingIndices.size() == indices.size() - 1;
-        return new DataStream(name, timeStampField, backingIndices, generation, metadata, hidden, replicated);
+        return new DataStream(name, timeStampField, backingIndices, generation, metadata, hidden, replicated, system);
     }
 
     /**
@@ -181,11 +192,11 @@ public final class DataStream extends AbstractDiffable<DataStream> implements To
                 "it is the write index", existingBackingIndex.getName(), name));
         }
         backingIndices.set(backingIndexPosition, newBackingIndex);
-        return new DataStream(name, timeStampField, backingIndices, generation, metadata, hidden, replicated);
+        return new DataStream(name, timeStampField, backingIndices, generation, metadata, hidden, replicated, system);
     }
 
     public DataStream promoteDataStream() {
-        return new DataStream(name, timeStampField, indices, getGeneration(), metadata, hidden, false, timeProvider);
+        return new DataStream(name, timeStampField, indices, getGeneration(), metadata, hidden, false, system, timeProvider);
     }
 
     /**
@@ -215,7 +226,8 @@ public final class DataStream extends AbstractDiffable<DataStream> implements To
             generation,
             metadata == null ? null : new HashMap<>(metadata),
             hidden,
-            replicated
+            replicated,
+            system
         );
     }
 
@@ -269,7 +281,9 @@ public final class DataStream extends AbstractDiffable<DataStream> implements To
         this(in.readString(), new TimestampField(in), in.readList(Index::new), in.readVLong(),
             in.getVersion().onOrAfter(NEW_FEATURES_VERSION) ? in.readMap(): null,
             in.getVersion().onOrAfter(NEW_FEATURES_VERSION) && in.readBoolean(),
-            in.getVersion().onOrAfter(NEW_FEATURES_VERSION) && in.readBoolean());
+            in.getVersion().onOrAfter(NEW_FEATURES_VERSION) && in.readBoolean(),
+            in.getVersion().onOrAfter(Version.V_7_13_0) && in.readBoolean()
+        );
     }
 
     public static Diff<DataStream> readDiffFrom(StreamInput in) throws IOException {
@@ -286,6 +300,9 @@ public final class DataStream extends AbstractDiffable<DataStream> implements To
             out.writeMap(metadata);
             out.writeBoolean(hidden);
             out.writeBoolean(replicated);
+            if (out.getVersion().onOrAfter(Version.V_7_13_0)) {
+                out.writeBoolean(system);
+            }
         }
     }
 
@@ -296,11 +313,13 @@ public final class DataStream extends AbstractDiffable<DataStream> implements To
     public static final ParseField METADATA_FIELD = new ParseField("_meta");
     public static final ParseField HIDDEN_FIELD = new ParseField("hidden");
     public static final ParseField REPLICATED_FIELD = new ParseField("replicated");
+    public static final ParseField SYSTEM_FIELD = new ParseField("system");
 
     @SuppressWarnings("unchecked")
     private static final ConstructingObjectParser<DataStream, Void> PARSER = new ConstructingObjectParser<>("data_stream",
         args -> new DataStream((String) args[0], (TimestampField) args[1], (List<Index>) args[2], (Long) args[3],
-            (Map<String, Object>) args[4], args[5] != null && (boolean) args[5], args[6] != null && (boolean) args[6]));
+            (Map<String, Object>) args[4], args[5] != null && (boolean) args[5], args[6] != null && (boolean) args[6],
+            args[7] != null && (boolean) args[7]));
 
     static {
         PARSER.declareString(ConstructingObjectParser.constructorArg(), NAME_FIELD);
@@ -310,6 +329,7 @@ public final class DataStream extends AbstractDiffable<DataStream> implements To
         PARSER.declareObject(ConstructingObjectParser.optionalConstructorArg(), (p, c) -> p.map(), METADATA_FIELD);
         PARSER.declareBoolean(ConstructingObjectParser.optionalConstructorArg(), HIDDEN_FIELD);
         PARSER.declareBoolean(ConstructingObjectParser.optionalConstructorArg(), REPLICATED_FIELD);
+        PARSER.declareBoolean(ConstructingObjectParser.optionalConstructorArg(), SYSTEM_FIELD);
     }
 
     public static DataStream fromXContent(XContentParser parser) throws IOException {
@@ -328,6 +348,7 @@ public final class DataStream extends AbstractDiffable<DataStream> implements To
         }
         builder.field(HIDDEN_FIELD.getPreferredName(), hidden);
         builder.field(REPLICATED_FIELD.getPreferredName(), replicated);
+        builder.field(SYSTEM_FIELD.getPreferredName(), system);
         builder.endObject();
         return builder;
     }

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/IndexAbstraction.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/IndexAbstraction.java
@@ -296,8 +296,7 @@ public interface IndexAbstraction {
 
         @Override
         public boolean isSystem() {
-            // No such thing as system data streams (yet)
-            return false;
+            return dataStream.isSystem();
         }
 
         public org.elasticsearch.cluster.metadata.DataStream getDataStream() {

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/IndexNameExpressionResolver.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/IndexNameExpressionResolver.java
@@ -13,7 +13,7 @@ import org.elasticsearch.Version;
 import org.elasticsearch.action.IndicesRequest;
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.cluster.ClusterState;
-import org.elasticsearch.common.Booleans;
+import org.elasticsearch.cluster.metadata.IndexAbstraction.Type;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.collect.ImmutableOpenMap;
@@ -31,6 +31,7 @@ import org.elasticsearch.index.IndexNotFoundException;
 import org.elasticsearch.indices.IndexClosedException;
 import org.elasticsearch.indices.InvalidIndexNameException;
 import org.elasticsearch.indices.SystemIndices;
+import org.elasticsearch.indices.SystemIndices.SystemIndexAccessLevel;
 
 import java.time.Instant;
 import java.time.ZoneId;
@@ -57,8 +58,6 @@ public class IndexNameExpressionResolver {
     private static final DeprecationLogger deprecationLogger = DeprecationLogger.getLogger(IndexNameExpressionResolver.class);
 
     public static final String EXCLUDED_DATA_STREAMS_KEY = "es.excluded_ds";
-    public static final String SYSTEM_INDEX_ACCESS_CONTROL_HEADER_KEY = "_system_index_access_allowed";
-    public static final String EXTERNAL_SYSTEM_INDEX_ACCESS_CONTROL_HEADER_KEY = "_external_system_index_access_origin";
     public static final Version SYSTEM_INDEX_ENFORCEMENT_VERSION = Version.V_7_10_0;
 
     private final DateMathExpressionResolver dateMathExpressionResolver = new DateMathExpressionResolver();
@@ -80,7 +79,7 @@ public class IndexNameExpressionResolver {
      */
     public String[] concreteIndexNames(ClusterState state, IndicesRequest request) {
         Context context = new Context(state, request.indicesOptions(), false, false, request.includeDataStreams(),
-            getSystemIndexAccessLevel());
+            getSystemIndexAccessPredicate());
         return concreteIndexNames(context, request.indices());
     }
 
@@ -89,7 +88,7 @@ public class IndexNameExpressionResolver {
      */
     public String[] concreteIndexNamesWithSystemIndexAccess(ClusterState state, IndicesRequest request) {
         Context context = new Context(state, request.indicesOptions(), false, false, request.includeDataStreams(),
-            SystemIndexAccessLevel.ALL);
+            name -> true);
         return concreteIndexNames(context, request.indices());
     }
 
@@ -99,7 +98,7 @@ public class IndexNameExpressionResolver {
      */
     public Index[] concreteIndices(ClusterState state, IndicesRequest request) {
         Context context = new Context(state, request.indicesOptions(), false, false, request.includeDataStreams(),
-            getSystemIndexAccessLevel());
+            getSystemIndexAccessPredicate());
         return concreteIndices(context, request.indices());
     }
 
@@ -117,28 +116,27 @@ public class IndexNameExpressionResolver {
      * indices options in the context don't allow such a case.
      */
     public String[] concreteIndexNames(ClusterState state, IndicesOptions options, String... indexExpressions) {
-        Context context = new Context(state, options, getSystemIndexAccessLevel());
+        Context context = new Context(state, options, getSystemIndexAccessPredicate());
         return concreteIndexNames(context, indexExpressions);
     }
 
     public String[] concreteIndexNames(ClusterState state, IndicesOptions options, boolean includeDataStreams, String... indexExpressions) {
-        Context context = new Context(state, options, false, false, includeDataStreams, getSystemIndexAccessLevel());
+        Context context = new Context(state, options, false, false, includeDataStreams, getSystemIndexAccessPredicate());
         return concreteIndexNames(context, indexExpressions);
     }
 
     public String[] concreteIndexNames(ClusterState state, IndicesOptions options, IndicesRequest request) {
-        Context context = new Context(state, options, false, false, request.includeDataStreams(), getSystemIndexAccessLevel());
+        Context context = new Context(state, options, false, false, request.includeDataStreams(), getSystemIndexAccessPredicate());
         return concreteIndexNames(context, request.indices());
     }
 
     public String[] concreteIndexNamesWithSystemIndexAccess(ClusterState state, IndicesOptions options, String... indexExpressions) {
-        Context context = new Context(state, options, SystemIndexAccessLevel.ALL);
+        Context context = new Context(state, options, name -> true);
         return concreteIndexNames(context, indexExpressions);
     }
 
     public List<String> dataStreamNames(ClusterState state, IndicesOptions options, String... indexExpressions) {
-        // Allow system index access - they'll be filtered out below as there's no such thing (yet) as system data streams
-        Context context = new Context(state, options, false, false, true, true, SystemIndexAccessLevel.ALL);
+        Context context = new Context(state, options, false, false, true, true, getSystemIndexAccessPredicate());
         if (indexExpressions == null || indexExpressions.length == 0) {
             indexExpressions = new String[]{"*"};
         }
@@ -171,7 +169,7 @@ public class IndexNameExpressionResolver {
 
     public Index[] concreteIndices(ClusterState state, IndicesOptions options, boolean includeDataStreams, String... indexExpressions) {
         Context context = new Context(state, options, false, false, includeDataStreams,
-            getSystemIndexAccessLevel());
+            getSystemIndexAccessPredicate());
         return concreteIndices(context, indexExpressions);
     }
 
@@ -189,7 +187,7 @@ public class IndexNameExpressionResolver {
      */
     public Index[] concreteIndices(ClusterState state, IndicesRequest request, long startTime) {
         Context context = new Context(state, request.indicesOptions(), startTime, false, false, request.includeDataStreams(), false,
-            getSystemIndexAccessLevel());
+            getSystemIndexAccessPredicate());
         return concreteIndices(context, request.indices());
     }
 
@@ -316,30 +314,37 @@ public class IndexNameExpressionResolver {
     }
 
     private void checkSystemIndexAccess(Context context, Metadata metadata, Set<Index> concreteIndices, String[] originalPatterns) {
-        final SystemIndexAccessLevel systemIndexAccessLevel = context.getSystemIndexAccessLevel();
-        if (systemIndexAccessLevel != SystemIndexAccessLevel.ALL) {
-            final Predicate<IndexMetadata> systemIndexAccessLevelPredicate;
-            if (systemIndexAccessLevel == SystemIndexAccessLevel.NONE) {
-                // everything should be included in the deprecation message
-                systemIndexAccessLevelPredicate = indexMetadata -> true;
+        final Predicate<String> systemIndexAccessPredicate = context.getSystemIndexAccessPredicate().negate();
+        final List<IndexMetadata> matchedSystemIndexMetadata = concreteIndices.stream()
+            .map(metadata::index)
+            .filter(IndexMetadata::isSystem)
+            .filter(idxMetadata -> systemIndexAccessPredicate.test(idxMetadata.getIndex().getName()))
+            .collect(Collectors.toList());
+
+        if (matchedSystemIndexMetadata.isEmpty()) {
+            return;
+        }
+
+        final List<String> resolvedSystemIndices = new ArrayList<>();
+        final Set<String> resolvedSystemDataStreams = new HashSet<>();
+        final SortedMap<String, IndexAbstraction> indicesLookup = metadata.getIndicesLookup();
+        for (IndexMetadata idxMetadata : matchedSystemIndexMetadata) {
+            IndexAbstraction abstraction = indicesLookup.get(idxMetadata.getIndex().getName());
+            if (abstraction.getParentDataStream() != null) {
+                resolvedSystemDataStreams.add(abstraction.getParentDataStream().getName());
             } else {
-                // everything other than allowed should be included in the deprecation message
-                systemIndexAccessLevelPredicate = systemIndices
-                    .getProductSystemIndexMetadataPredicate(threadContext.getHeader(EXTERNAL_SYSTEM_INDEX_ACCESS_CONTROL_HEADER_KEY))
-                    .negate();
+                resolvedSystemIndices.add(idxMetadata.getIndex().getName());
             }
-            final List<String> resolvedSystemIndices = concreteIndices.stream()
-                .map(metadata::index)
-                .filter(IndexMetadata::isSystem)
-                .filter(systemIndexAccessLevelPredicate)
-                .map(i -> i.getIndex().getName())
-                .sorted() // reliable order for testing
-                .collect(Collectors.toList());
-            if (resolvedSystemIndices.isEmpty() == false) {
-                deprecationLogger.deprecate(DeprecationCategory.API, "open_system_index_access",
-                    "this request accesses system indices: {}, but in a future major version, direct access to system " +
-                        "indices will be prevented by default", resolvedSystemIndices);
-            }
+        }
+
+        if (resolvedSystemIndices.isEmpty() == false) {
+            Collections.sort(resolvedSystemIndices);
+            deprecationLogger.deprecate(DeprecationCategory.API, "open_system_index_access",
+                "this request accesses system indices: {}, but in a future major version, direct access to system " +
+                    "indices will be prevented by default", resolvedSystemIndices);
+        }
+        if (resolvedSystemDataStreams.isEmpty() == false) {
+            throw systemIndices.dataStreamAccessException(threadContext, resolvedSystemDataStreams);
         }
     }
 
@@ -427,7 +432,7 @@ public class IndexNameExpressionResolver {
             options.allowAliasesToMultipleIndices(), options.forbidClosedIndices(), options.ignoreAliases(),
             options.ignoreThrottled());
 
-        Context context = new Context(state, combinedOptions, false, true, includeDataStreams, getSystemIndexAccessLevel());
+        Context context = new Context(state, combinedOptions, false, true, includeDataStreams, getSystemIndexAccessPredicate());
         Index[] indices = concreteIndices(context, index);
         if (allowNoIndices && indices.length == 0) {
             return null;
@@ -444,7 +449,7 @@ public class IndexNameExpressionResolver {
      *         If the data stream, index or alias contains date math then that is resolved too.
      */
     public boolean hasIndexAbstraction(String indexAbstraction, ClusterState state) {
-        Context context = new Context(state, IndicesOptions.lenientExpandOpen(), false, false, true, getSystemIndexAccessLevel());
+        Context context = new Context(state, IndicesOptions.lenientExpandOpen(), false, false, true, getSystemIndexAccessPredicate());
         String resolvedAliasOrIndex = dateMathExpressionResolver.resolveExpression(indexAbstraction, context);
         return state.metadata().getIndicesLookup().containsKey(resolvedAliasOrIndex);
     }
@@ -455,7 +460,7 @@ public class IndexNameExpressionResolver {
     public String resolveDateMathExpression(String dateExpression) {
         // The data math expression resolver doesn't rely on cluster state or indices options, because
         // it just resolves the date math to an actual date.
-        return dateMathExpressionResolver.resolveExpression(dateExpression, new Context(null, null, getSystemIndexAccessLevel()));
+        return dateMathExpressionResolver.resolveExpression(dateExpression, new Context(null, null, getSystemIndexAccessPredicate()));
     }
 
     /**
@@ -463,14 +468,14 @@ public class IndexNameExpressionResolver {
      * @return If the specified string is data math expression then this method returns the resolved expression.
      */
     public String resolveDateMathExpression(String dateExpression, long time) {
-        return dateMathExpressionResolver.resolveExpression(dateExpression, new Context(null, null, time, getSystemIndexAccessLevel()));
+        return dateMathExpressionResolver.resolveExpression(dateExpression, new Context(null, null, time, getSystemIndexAccessPredicate()));
     }
 
     /**
      * Resolve an array of expressions to the set of indices and aliases that these expressions match.
      */
     public Set<String> resolveExpressions(ClusterState state, String... expressions) {
-        Context context = new Context(state, IndicesOptions.lenientExpandOpen(), true, false, true, getSystemIndexAccessLevel());
+        Context context = new Context(state, IndicesOptions.lenientExpandOpen(), true, false, true, getSystemIndexAccessPredicate());
         List<String> resolvedExpressions = Arrays.asList(expressions);
         for (ExpressionResolver expressionResolver : expressionResolvers) {
             resolvedExpressions = expressionResolver.resolve(context, resolvedExpressions);
@@ -564,7 +569,7 @@ public class IndexNameExpressionResolver {
      */
     public Map<String, Set<String>> resolveSearchRouting(ClusterState state, @Nullable String routing, String... expressions) {
         List<String> resolvedExpressions = expressions != null ? Arrays.asList(expressions) : Collections.emptyList();
-        Context context = new Context(state, IndicesOptions.lenientExpandOpen(), false, false, true, getSystemIndexAccessLevel());
+        Context context = new Context(state, IndicesOptions.lenientExpandOpen(), false, false, true, getSystemIndexAccessPredicate());
         for (ExpressionResolver expressionResolver : expressionResolvers) {
             resolvedExpressions = expressionResolver.resolve(context, resolvedExpressions);
         }
@@ -715,33 +720,22 @@ public class IndexNameExpressionResolver {
         return false;
     }
 
-    /**
-     * Determines what level of system index access should be allowed in the current context.
-     *
-     * @return {@link SystemIndexAccessLevel#ALL} if unrestricted system index access should be allowed,
-     * {@link SystemIndexAccessLevel#RESTRICTED} if a subset of system index access should be allowed, or
-     * {@link SystemIndexAccessLevel#NONE} if no system index access should be allowed.
-     */
     public SystemIndexAccessLevel getSystemIndexAccessLevel() {
-        final String headerValue = threadContext.getHeader(SYSTEM_INDEX_ACCESS_CONTROL_HEADER_KEY);
-        final String productHeaderValue = threadContext.getHeader(EXTERNAL_SYSTEM_INDEX_ACCESS_CONTROL_HEADER_KEY);
-
-        final boolean allowed = Booleans.parseBoolean(headerValue, true);
-        if (allowed) {
-            if (productHeaderValue != null) {
-                return SystemIndexAccessLevel.RESTRICTED;
-            } else {
-                return SystemIndexAccessLevel.ALL;
-            }
-        } else {
-            return SystemIndexAccessLevel.NONE;
-        }
+        return systemIndices.getSystemIndexAccessLevel(threadContext);
     }
 
-    public enum SystemIndexAccessLevel {
-        ALL,
-        NONE,
-        RESTRICTED
+    public Predicate<String> getSystemIndexAccessPredicate() {
+        final SystemIndexAccessLevel systemIndexAccessLevel = getSystemIndexAccessLevel();
+        final Predicate<String> systemIndexAccessLevelPredicate;
+        if (systemIndexAccessLevel == SystemIndexAccessLevel.NONE) {
+            systemIndexAccessLevelPredicate = s -> false;
+        } else if (systemIndexAccessLevel == SystemIndexAccessLevel.ALL) {
+            systemIndexAccessLevelPredicate = s -> true;
+        } else {
+            // everything other than allowed should be included in the deprecation message
+            systemIndexAccessLevelPredicate = systemIndices.getProductSystemIndexNamePredicate(threadContext);
+        }
+        return systemIndexAccessLevelPredicate;
     }
 
     public static class Context {
@@ -753,30 +747,30 @@ public class IndexNameExpressionResolver {
         private final boolean resolveToWriteIndex;
         private final boolean includeDataStreams;
         private final boolean preserveDataStreams;
-        private final SystemIndexAccessLevel systemIndexAccessLevel;
+        private final Predicate<String> systemIndexAccessPredicate;
 
-        Context(ClusterState state, IndicesOptions options, SystemIndexAccessLevel systemIndexAccessLevel) {
-            this(state, options, System.currentTimeMillis(), systemIndexAccessLevel);
+        Context(ClusterState state, IndicesOptions options, Predicate<String> systemIndexAccessPredicate) {
+            this(state, options, System.currentTimeMillis(), systemIndexAccessPredicate);
         }
 
         Context(ClusterState state, IndicesOptions options, boolean preserveAliases, boolean resolveToWriteIndex,
-                boolean includeDataStreams, SystemIndexAccessLevel systemIndexAccessLevel) {
+                boolean includeDataStreams, Predicate<String> systemIndexAccessPredicate) {
             this(state, options, System.currentTimeMillis(), preserveAliases, resolveToWriteIndex, includeDataStreams, false,
-                systemIndexAccessLevel);
+                systemIndexAccessPredicate);
         }
 
         Context(ClusterState state, IndicesOptions options, boolean preserveAliases, boolean resolveToWriteIndex,
-                boolean includeDataStreams, boolean preserveDataStreams, SystemIndexAccessLevel systemIndexAccessLevel) {
+                boolean includeDataStreams, boolean preserveDataStreams, Predicate<String> systemIndexAccessPredicate) {
             this(state, options, System.currentTimeMillis(), preserveAliases, resolveToWriteIndex, includeDataStreams, preserveDataStreams,
-                systemIndexAccessLevel);
+                systemIndexAccessPredicate);
         }
 
-        Context(ClusterState state, IndicesOptions options, long startTime, SystemIndexAccessLevel systemIndexAccessLevel) {
-           this(state, options, startTime, false, false, false, false, systemIndexAccessLevel);
+        Context(ClusterState state, IndicesOptions options, long startTime, Predicate<String> systemIndexAccessPredicate) {
+           this(state, options, startTime, false, false, false, false, systemIndexAccessPredicate);
         }
 
         protected Context(ClusterState state, IndicesOptions options, long startTime, boolean preserveAliases, boolean resolveToWriteIndex,
-                          boolean includeDataStreams, boolean preserveDataStreams, SystemIndexAccessLevel systemIndexAccessLevel) {
+                          boolean includeDataStreams, boolean preserveDataStreams, Predicate<String> systemIndexAccessPredicate) {
             this.state = state;
             this.options = options;
             this.startTime = startTime;
@@ -784,7 +778,7 @@ public class IndexNameExpressionResolver {
             this.resolveToWriteIndex = resolveToWriteIndex;
             this.includeDataStreams = includeDataStreams;
             this.preserveDataStreams = preserveDataStreams;
-            this.systemIndexAccessLevel = systemIndexAccessLevel;
+            this.systemIndexAccessPredicate = systemIndexAccessPredicate;
         }
 
         public ClusterState getState() {
@@ -827,8 +821,8 @@ public class IndexNameExpressionResolver {
         /**
          * Used to determine system index access is allowed in this context (e.g. for this request).
          */
-        public SystemIndexAccessLevel getSystemIndexAccessLevel() {
-            return systemIndexAccessLevel;
+        public Predicate<String> getSystemIndexAccessPredicate() {
+            return systemIndexAccessPredicate;
         }
     }
 
@@ -860,7 +854,20 @@ public class IndexNameExpressionResolver {
             }
 
             if (isEmptyOrTrivialWildcard(expressions)) {
-                List<String> resolvedExpressions = resolveEmptyOrTrivialWildcard(options, metadata);
+                List<String> resolvedExpressions = resolveEmptyOrTrivialWildcard(options, metadata).stream()
+                    .filter(expression -> {
+                        IndexAbstraction abstraction = metadata.getIndicesLookup().get(expression);
+                        if (abstraction != null && abstraction.isSystem()) {
+                            if (abstraction.getType() == Type.DATA_STREAM || abstraction.getParentDataStream() != null) {
+                                return context.systemIndexAccessPredicate.test(abstraction.getName());
+                            } else {
+                                return true;
+                            }
+                        } else {
+                            return true;
+                        }
+                    })
+                    .collect(Collectors.toList());
                 if (context.includeDataStreams()) {
                     final IndexMetadata.State excludeState = excludeState(options);
                     final Map<String, IndexAbstraction> dataStreamsAbstractions = metadata.getIndicesLookup().entrySet()
@@ -1059,6 +1066,13 @@ public class IndexNameExpressionResolver {
             for (Map.Entry<String, IndexAbstraction> entry : matches.entrySet()) {
                 String aliasOrIndexName = entry.getKey();
                 IndexAbstraction indexAbstraction = entry.getValue();
+
+                if (indexAbstraction.isSystem() &&
+                    (indexAbstraction.getType() == Type.DATA_STREAM || indexAbstraction.getParentDataStream() != null)) {
+                    if (context.systemIndexAccessPredicate.test(indexAbstraction.getName()) == false) {
+                        continue;
+                    }
+                }
 
                 if (indexAbstraction.isHidden() == false || includeHidden || implicitHiddenMatch(aliasOrIndexName, expression)) {
                     if (context.isPreserveAliases() && indexAbstraction.getType() == IndexAbstraction.Type.ALIAS) {

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/IndexNameExpressionResolver.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/IndexNameExpressionResolver.java
@@ -315,20 +315,20 @@ public class IndexNameExpressionResolver {
 
     private void checkSystemIndexAccess(Context context, Metadata metadata, Set<Index> concreteIndices, String[] originalPatterns) {
         final Predicate<String> systemIndexAccessPredicate = context.getSystemIndexAccessPredicate().negate();
-        final List<IndexMetadata> matchedSystemIndexMetadata = concreteIndices.stream()
+        final List<IndexMetadata> systemIndicesThatShouldNotBeAccessed = concreteIndices.stream()
             .map(metadata::index)
             .filter(IndexMetadata::isSystem)
             .filter(idxMetadata -> systemIndexAccessPredicate.test(idxMetadata.getIndex().getName()))
             .collect(Collectors.toList());
 
-        if (matchedSystemIndexMetadata.isEmpty()) {
+        if (systemIndicesThatShouldNotBeAccessed.isEmpty()) {
             return;
         }
 
         final List<String> resolvedSystemIndices = new ArrayList<>();
         final Set<String> resolvedSystemDataStreams = new HashSet<>();
         final SortedMap<String, IndexAbstraction> indicesLookup = metadata.getIndicesLookup();
-        for (IndexMetadata idxMetadata : matchedSystemIndexMetadata) {
+        for (IndexMetadata idxMetadata : systemIndicesThatShouldNotBeAccessed) {
             IndexAbstraction abstraction = indicesLookup.get(idxMetadata.getIndex().getName());
             if (abstraction.getParentDataStream() != null) {
                 resolvedSystemDataStreams.add(abstraction.getParentDataStream().getName());

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataIndexTemplateService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataIndexTemplateService.java
@@ -416,7 +416,7 @@ public class MetadataIndexTemplateService {
 
     public static void validateV2TemplateRequest(Metadata metadata, String name, ComposableIndexTemplate template) {
         if (template.indexPatterns().stream().anyMatch(Regex::isMatchAllPattern)) {
-            Settings mergedSettings = resolveSettings(metadata, template);
+            Settings mergedSettings = resolveSettings(template, metadata.componentTemplates());
             if (IndexMetadata.INDEX_HIDDEN_SETTING.exists(mergedSettings)) {
                 throw new InvalidIndexTemplateException(name, "global composable templates may not specify the setting "
                     + IndexMetadata.INDEX_HIDDEN_SETTING.getKey());
@@ -968,6 +968,16 @@ public class MetadataIndexTemplateService {
         }
 
         final Map<String, ComponentTemplate> componentTemplates = state.metadata().componentTemplates();
+        return collectMappings(template, componentTemplates, indexName);
+    }
+
+    /**
+     * Collect the given v2 template into an ordered list of mappings.
+     */
+    public static List<CompressedXContent> collectMappings(final ComposableIndexTemplate template,
+                                                           final Map<String, ComponentTemplate> componentTemplates,
+                                                           final String indexName) throws Exception {
+        Objects.requireNonNull(template, "Composable index template must be provided");
         List<CompressedXContent> mappings = template.composedOf().stream()
             .map(componentTemplates::get)
             .filter(Objects::nonNull)
@@ -1027,11 +1037,15 @@ public class MetadataIndexTemplateService {
         if (template == null) {
             return Settings.EMPTY;
         }
-        return resolveSettings(metadata, template);
+        return resolveSettings(template, metadata.componentTemplates());
     }
 
-    private static Settings resolveSettings(Metadata metadata, ComposableIndexTemplate template) {
-        final Map<String, ComponentTemplate> componentTemplates = metadata.componentTemplates();
+    /**
+     * Resolve the provided v2 template and component templates into a collected {@link Settings} object
+     */
+    public static Settings resolveSettings(ComposableIndexTemplate template, Map<String, ComponentTemplate> componentTemplates) {
+        Objects.requireNonNull(template, "attempted to resolve settings for a null template");
+        Objects.requireNonNull(componentTemplates, "attempted to resolve settings with null component templates");
         List<Settings> componentSettings = template.composedOf().stream()
             .map(componentTemplates::get)
             .filter(Objects::nonNull)
@@ -1089,6 +1103,18 @@ public class MetadataIndexTemplateService {
             return Collections.emptyList();
         }
         final Map<String, ComponentTemplate> componentTemplates = metadata.componentTemplates();
+        return resolveAliases(template, componentTemplates, failIfTemplateHasDataStream, templateName);
+    }
+
+    /**
+     * Resolve the given v2 template and component templates into an ordered list of aliases
+     */
+    static List<Map<String, AliasMetadata>> resolveAliases(final ComposableIndexTemplate template,
+                                                           final Map<String, ComponentTemplate> componentTemplates,
+                                                           final boolean failIfTemplateHasDataStream,
+                                                           @Nullable String templateName) {
+        Objects.requireNonNull(template, "attempted to resolve aliases for a null template");
+        Objects.requireNonNull(componentTemplates, "attempted to resolve aliases with null component templates");
         List<Map<String, AliasMetadata>> aliases = template.composedOf().stream()
             .map(componentTemplates::get)
             .filter(Objects::nonNull)

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/SystemIndexMetadataUpgradeService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/SystemIndexMetadataUpgradeService.java
@@ -54,7 +54,9 @@ public class SystemIndexMetadataUpgradeService implements ClusterStateListener {
             if (lastIndexMetadataMap != indexMetadataMap) {
                 for (ObjectObjectCursor<String, IndexMetadata> cursor : indexMetadataMap) {
                     if (cursor.value != lastIndexMetadataMap.get(cursor.key)) {
-                        if (systemIndices.isSystemIndex(cursor.value.getIndex()) != cursor.value.isSystem()) {
+                        final boolean isSystem = systemIndices.isSystemIndex(cursor.value.getIndex()) ||
+                            systemIndices.isSystemIndexBackingDataStream(cursor.value.getIndex().getName());
+                        if (isSystem != cursor.value.isSystem()) {
                             updateTaskPending = true;
                             clusterService.submitStateUpdateTask("system_index_metadata_upgrade_service {system metadata change}",
                                 new SystemIndexMetadataUpdateTask());
@@ -74,7 +76,9 @@ public class SystemIndexMetadataUpgradeService implements ClusterStateListener {
             final List<IndexMetadata> updatedMetadata = new ArrayList<>();
             for (ObjectObjectCursor<String, IndexMetadata> cursor : indexMetadataMap) {
                 if (cursor.value != lastIndexMetadataMap.get(cursor.key)) {
-                    if (systemIndices.isSystemIndex(cursor.value.getIndex()) != cursor.value.isSystem()) {
+                    final boolean isSystem = systemIndices.isSystemIndex(cursor.value.getIndex()) ||
+                        systemIndices.isSystemIndexBackingDataStream(cursor.value.getIndex().getName());
+                    if (isSystem != cursor.value.isSystem()) {
                         updatedMetadata.add(IndexMetadata.builder(cursor.value).system(cursor.value.isSystem() == false).build());
                     }
                 }

--- a/server/src/main/java/org/elasticsearch/indices/SystemDataStreamDescriptor.java
+++ b/server/src/main/java/org/elasticsearch/indices/SystemDataStreamDescriptor.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.indices;
+
+import org.elasticsearch.cluster.metadata.ComponentTemplate;
+import org.elasticsearch.cluster.metadata.ComposableIndexTemplate;
+import org.elasticsearch.cluster.metadata.DataStream;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Describes a {@link DataStream} that is reserved for use by a system component. The data stream will be managed by the system and also
+ * protected by the system against user modification so that system features are not broken by inadvertent user operations.
+ */
+public class SystemDataStreamDescriptor {
+
+    private final String dataStreamName;
+    private final String description;
+    private final Type type;
+    private final ComposableIndexTemplate composableIndexTemplate;
+    private final Map<String, ComponentTemplate> componentTemplates;
+    private final List<String> allowedElasticProductOrigins;
+
+    /**
+     * Creates a new descriptor for a system data descriptor
+     * @param dataStreamName the name of the data stream. Must not be {@code null}
+     * @param description a brief description of what the data stream is used for. Must not be {@code null}
+     * @param type the {@link Type} of the data stream which determines how the data stream can be accessed. Must not be {@code null}
+     * @param composableIndexTemplate the {@link ComposableIndexTemplate} that contains the mappings and settings for the data stream.
+     *                                Must not be {@code null}
+     * @param componentTemplates a map that contains {@link ComponentTemplate} instances corresponding to those references in the
+     *                           {@link ComposableIndexTemplate}
+     * @param allowedElasticProductOrigins a list of product origin values that are allowed to access this data stream if the
+     *                                     type is {@link Type#EXTERNAL}. Must not be {@code null}
+     */
+    public SystemDataStreamDescriptor(String dataStreamName, String description, Type type,
+                                      ComposableIndexTemplate composableIndexTemplate, Map<String, ComponentTemplate> componentTemplates,
+                                      List<String> allowedElasticProductOrigins) {
+        this.dataStreamName = Objects.requireNonNull(dataStreamName, "dataStreamName must be specified");
+        this.description = Objects.requireNonNull(description, "description must be specified");
+        this.type = Objects.requireNonNull(type, "type must be specified");
+        this.composableIndexTemplate = Objects.requireNonNull(composableIndexTemplate, "composableIndexTemplate must be provided");
+        this.componentTemplates =
+            componentTemplates == null ? Collections.emptyMap() : Collections.unmodifiableMap(new HashMap<>((componentTemplates)));
+        this.allowedElasticProductOrigins =
+            Objects.requireNonNull(allowedElasticProductOrigins, "allowedElasticProductOrigins must not be null");
+        if (type == Type.EXTERNAL && allowedElasticProductOrigins.isEmpty()) {
+            throw new IllegalArgumentException("External system data stream without allowed products is not a valid combination");
+        }
+    }
+
+    public String getDataStreamName() {
+        return dataStreamName;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public ComposableIndexTemplate getComposableIndexTemplate() {
+        return composableIndexTemplate;
+    }
+
+    public boolean isExternal() {
+        return type == Type.EXTERNAL;
+    }
+
+    public String getBackingIndexPattern() {
+        return DataStream.BACKING_INDEX_PREFIX + getDataStreamName() + "-*";
+    }
+
+    public List<String> getAllowedElasticProductOrigins() {
+        return allowedElasticProductOrigins;
+    }
+
+    public Map<String, ComponentTemplate> getComponentTemplates() {
+        return componentTemplates;
+    }
+
+    public enum Type {
+        INTERNAL,
+        EXTERNAL
+    }
+}

--- a/server/src/main/java/org/elasticsearch/indices/SystemIndexDescriptor.java
+++ b/server/src/main/java/org/elasticsearch/indices/SystemIndexDescriptor.java
@@ -261,14 +261,17 @@ public class SystemIndexDescriptor implements Comparable<SystemIndexDescriptor> 
 
         this.indexPattern = indexPattern;
         this.primaryIndex = primaryIndex;
+        this.aliasName = aliasName;
 
         final Automaton automaton = buildAutomaton(indexPattern, aliasName);
         this.indexPatternAutomaton = new CharacterRunAutomaton(automaton);
+        if (primaryIndex != null && indexPatternAutomaton.run(primaryIndex) == false) {
+            throw new IllegalArgumentException("primary index does not match the index pattern!");
+        }
 
         this.description = description;
         this.mappings = mappings;
         this.settings = settings;
-        this.aliasName = aliasName;
         this.indexFormat = indexFormat;
         this.versionMetaKey = versionMetaKey;
         this.origin = origin;
@@ -403,7 +406,7 @@ public class SystemIndexDescriptor implements Comparable<SystemIndexDescriptor> 
 
     public Version getMappingVersion() {
         if (type.isManaged() == false) {
-            throw new IllegalStateException(toString() + " is not managed so there are no mappings or version");
+            throw new IllegalStateException(this + " is not managed so there are no mappings or version");
         }
         return mappingVersion;
     }

--- a/server/src/main/java/org/elasticsearch/indices/SystemIndices.java
+++ b/server/src/main/java/org/elasticsearch/indices/SystemIndices.java
@@ -21,13 +21,18 @@ import org.elasticsearch.action.support.master.AcknowledgedResponse;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.Booleans;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.TriConsumer;
 import org.elasticsearch.common.collect.Tuple;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.index.Index;
+import org.elasticsearch.plugins.SystemIndexPlugin;
 import org.elasticsearch.snapshots.SnapshotsService;
 
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
@@ -36,6 +41,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
+import java.util.Set;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -52,11 +58,18 @@ import static org.elasticsearch.tasks.TaskResultsService.TASKS_FEATURE_NAME;
  * to reduce the locations within the code that need to deal with {@link SystemIndexDescriptor}s.
  */
 public class SystemIndices {
+    public static final String SYSTEM_INDEX_ACCESS_CONTROL_HEADER_KEY = "_system_index_access_allowed";
+    public static final String EXTERNAL_SYSTEM_INDEX_ACCESS_CONTROL_HEADER_KEY = "_external_system_index_access_origin";
+
+    private static final Automaton EMPTY = Automata.makeEmpty();
+
     private static final Map<String, Feature> SERVER_SYSTEM_INDEX_DESCRIPTORS = singletonMap(
         TASKS_FEATURE_NAME, new Feature(TASKS_FEATURE_NAME, "Manages task results", singletonList(TASKS_DESCRIPTOR))
     );
 
-    private final CharacterRunAutomaton runAutomaton;
+    private final CharacterRunAutomaton systemIndexAutomaton;
+    private final CharacterRunAutomaton systemDataStreamIndicesAutomaton;
+    private final Predicate<String> systemDataStreamAutomaton;
     private final Map<String, Feature> featureDescriptors;
     private final Map<String, CharacterRunAutomaton> productToSystemIndicesMatcher;
 
@@ -69,11 +82,13 @@ public class SystemIndices {
         featureDescriptors = buildSystemIndexDescriptorMap(pluginAndModulesDescriptors);
         checkForOverlappingPatterns(featureDescriptors);
         checkForDuplicateAliases(this.getSystemIndexDescriptors());
-        this.runAutomaton = buildCharacterRunAutomaton(featureDescriptors);
-        this.productToSystemIndicesMatcher = getProductToSystemIndicesMap(this.getSystemIndexDescriptors());
+        this.systemIndexAutomaton = buildIndexCharacterRunAutomaton(featureDescriptors);
+        this.systemDataStreamIndicesAutomaton = buildDataStreamBackingIndicesAutomaton(featureDescriptors);
+        this.systemDataStreamAutomaton = buildDataStreamNamePredicate(featureDescriptors);
+        this.productToSystemIndicesMatcher = getProductToSystemIndicesMap(featureDescriptors);
     }
 
-    private void checkForDuplicateAliases(Collection<SystemIndexDescriptor> descriptors) {
+    private static void checkForDuplicateAliases(Collection<SystemIndexDescriptor> descriptors) {
         final Map<String, Integer> aliasCounts = new HashMap<>();
 
         for (SystemIndexDescriptor descriptor : descriptors) {
@@ -95,18 +110,44 @@ public class SystemIndices {
         }
     }
 
-    private static Map<String, CharacterRunAutomaton> getProductToSystemIndicesMap(Collection<SystemIndexDescriptor> descriptors) {
-        Map<String, Automaton> map = descriptors.stream()
-            .filter(SystemIndexDescriptor::isExternal)
-            .flatMap(descriptor -> descriptor.getAllowedElasticProductOrigins().stream().map(product -> new Tuple<>(product, descriptor)))
-            .collect(Collectors.toMap(Tuple::v1, tuple -> {
-                SystemIndexDescriptor descriptor = tuple.v2();
-                return SystemIndexDescriptor.buildAutomaton(descriptor.getIndexPattern(), descriptor.getAliasName());
-            }, Operations::union));
+    private static Map<String, CharacterRunAutomaton> getProductToSystemIndicesMap(Map<String, Feature> descriptors) {
+        Map<String, Automaton> productToSystemIndicesMap = new HashMap<>();
+        for (Feature feature : descriptors.values()) {
+            feature.getIndexDescriptors().forEach(systemIndexDescriptor -> {
+                if (systemIndexDescriptor.isExternal()) {
+                    systemIndexDescriptor.getAllowedElasticProductOrigins().forEach(origin ->
+                        productToSystemIndicesMap.compute(origin, (key, value) -> {
+                            Automaton automaton = SystemIndexDescriptor.buildAutomaton(
+                                systemIndexDescriptor.getIndexPattern(), systemIndexDescriptor.getAliasName());
+                            return value == null ? automaton : Operations.union(value, automaton);
+                        })
+                    );
+                }
+            });
+            feature.getDataStreamDescriptors().forEach(dataStreamDescriptor -> {
+                if (dataStreamDescriptor.isExternal()) {
+                    dataStreamDescriptor.getAllowedElasticProductOrigins().forEach(origin ->
+                        productToSystemIndicesMap.compute(origin, (key, value) -> {
+                            Automaton automaton = SystemIndexDescriptor.buildAutomaton(
+                                dataStreamDescriptor.getBackingIndexPattern(), dataStreamDescriptor.getDataStreamName());
+                            return value == null ? automaton : Operations.union(value, automaton);
+                        })
+                    );
+                }
+            });
+        }
 
-        return Collections.unmodifiableMap(map.entrySet().stream()
+        return unmodifiableMap(productToSystemIndicesMap.entrySet().stream()
             .collect(Collectors.toMap(Entry::getKey, entry ->
                 new CharacterRunAutomaton(MinimizationOperations.minimize(entry.getValue(), Integer.MAX_VALUE)))));
+    }
+
+    /**
+     * Checks whether the given name matches a reserved name or pattern that is intended for use by a system component. The name
+     * is checked against index names, aliases, data stream names, and the names of indices that back a system data stream.
+     */
+    public boolean isSystemName(String name) {
+        return isSystemIndex(name) || isSystemDataStream(name) || isSystemIndexBackingDataStream(name);
     }
 
     /**
@@ -119,12 +160,28 @@ public class SystemIndices {
     }
 
     /**
-     * Determines whether a given index is a system index by comparing its name to the collection of loaded {@link SystemIndexDescriptor}s
+     * Determines whether a given index is a system index by comparing its name to the collection of loaded {@link SystemIndexDescriptor}s.
+     * This will also match alias names that belong to system indices.
      * @param indexName the index name to check against loaded {@link SystemIndexDescriptor}s
      * @return true if the index name matches a pattern from a {@link SystemIndexDescriptor}
      */
     public boolean isSystemIndex(String indexName) {
-        return runAutomaton.run(indexName);
+        return systemIndexAutomaton.run(indexName);
+    }
+
+    /**
+     * Determines whether the provided name matches that of a system data stream that has been defined by a
+     * {@link SystemDataStreamDescriptor}
+     */
+    public boolean isSystemDataStream(String name) {
+        return systemDataStreamAutomaton.test(name);
+    }
+
+    /**
+     * Determines whether the provided name matches that of an index that backs a system data stream.
+     */
+    public boolean isSystemIndexBackingDataStream(String name) {
+        return systemDataStreamIndicesAutomaton.run(name);
     }
 
     /**
@@ -159,11 +216,47 @@ public class SystemIndices {
     }
 
     /**
+     * Finds a single matching {@link SystemDataStreamDescriptor}, if any, for the given DataStream name.
+     * @param name the name of the DataStream
+     * @return The matching {@link SystemDataStreamDescriptor} or {@code null} if no descriptor is found
+     * @throws IllegalStateException if multiple descriptors match the name
+     */
+    public @Nullable SystemDataStreamDescriptor findMatchingDataStreamDescriptor(String name) {
+        final List<SystemDataStreamDescriptor> matchingDescriptors = featureDescriptors.values().stream()
+            .flatMap(feature -> feature.getDataStreamDescriptors().stream())
+            .filter(descriptor -> descriptor.getDataStreamName().equals(name))
+            .collect(Collectors.toList());
+
+        if (matchingDescriptors.isEmpty()) {
+            return null;
+        } else if (matchingDescriptors.size() == 1) {
+            return matchingDescriptors.get(0);
+        } else {
+            // This should be prevented by failing on overlapping patterns at startup time, but is here just in case.
+            StringBuilder errorMessage = new StringBuilder()
+                .append("DataStream name [")
+                .append(name)
+                .append("] is claimed as a system data stream by multiple descriptors: [")
+                .append(matchingDescriptors.stream()
+                    .map(descriptor -> "name: [" + descriptor.getDataStreamName() +
+                        "], description: [" + descriptor.getDescription() + "]").collect(Collectors.joining("; ")));
+            // Throw AssertionError if assertions are enabled, or a regular exception otherwise:
+            assert false : errorMessage.toString();
+            throw new IllegalStateException(errorMessage.toString());
+        }
+    }
+
+    /**
      * Builds a predicate that tests if a system index should be accessible based on the provided product name
-     * @param product the name of the product that is attempting to access an external system index
+     * contained in headers.
+     * @param threadContext the threadContext containing headers used for system index access
      * @return Predicate to check external system index metadata with
      */
-    public Predicate<IndexMetadata> getProductSystemIndexMetadataPredicate(String product) {
+    public Predicate<IndexMetadata> getProductSystemIndexMetadataPredicate(ThreadContext threadContext) {
+        final String product = threadContext.getHeader(EXTERNAL_SYSTEM_INDEX_ACCESS_CONTROL_HEADER_KEY);
+        if (product == null) {
+            return indexMetadata -> false;
+        }
         final CharacterRunAutomaton automaton = productToSystemIndicesMatcher.get(product);
         if (automaton == null) {
             return indexMetadata -> false;
@@ -173,10 +266,15 @@ public class SystemIndices {
 
     /**
      * Builds a predicate that tests if a system index name should be accessible based on the provided product name
-     * @param product the name of the product that is attempting to access an external system index
+     * contained in headers.
+     * @param threadContext the threadContext containing headers used for system index access
      * @return Predicate to check external system index names with
      */
-    public Predicate<String> getProductSystemIndexNamePredicate(String product) {
+    public Predicate<String> getProductSystemIndexNamePredicate(ThreadContext threadContext) {
+        final String product = threadContext.getHeader(EXTERNAL_SYSTEM_INDEX_ACCESS_CONTROL_HEADER_KEY);
+        if (product == null) {
+            return name -> false;
+        }
         final CharacterRunAutomaton automaton = productToSystemIndicesMatcher.get(product);
         if (automaton == null) {
             return name -> false;
@@ -188,25 +286,141 @@ public class SystemIndices {
         return featureDescriptors;
     }
 
-    private static CharacterRunAutomaton buildCharacterRunAutomaton(Map<String, Feature> descriptors) {
+    private static CharacterRunAutomaton buildIndexCharacterRunAutomaton(Map<String, Feature> descriptors) {
         Optional<Automaton> automaton = descriptors.values().stream()
-            .flatMap(feature -> feature.getIndexDescriptors().stream())
+            .map(SystemIndices::featureToIndexAutomaton)
+            .reduce(Operations::union);
+        return new CharacterRunAutomaton(MinimizationOperations.minimize(automaton.orElse(EMPTY), Integer.MAX_VALUE));
+    }
+
+    private static Automaton featureToIndexAutomaton(Feature feature) {
+        Optional<Automaton> systemIndexAutomaton = feature.getIndexDescriptors().stream()
             .map(descriptor -> SystemIndexDescriptor.buildAutomaton(descriptor.getIndexPattern(), descriptor.getAliasName()))
             .reduce(Operations::union);
-        return new CharacterRunAutomaton(MinimizationOperations.minimize(automaton.orElse(Automata.makeEmpty()), Integer.MAX_VALUE));
+
+        return systemIndexAutomaton.orElse(EMPTY);
+    }
+
+    private static Predicate<String> buildDataStreamNamePredicate(Map<String, Feature> descriptors) {
+        Set<String> systemDataStreamNames = descriptors.values().stream()
+            .flatMap(feature -> feature.getDataStreamDescriptors().stream())
+            .map(SystemDataStreamDescriptor::getDataStreamName)
+            .collect(Collectors.toSet());
+        return systemDataStreamNames::contains;
+    }
+
+    private static CharacterRunAutomaton buildDataStreamBackingIndicesAutomaton(Map<String, Feature> descriptors) {
+        Optional<Automaton> automaton = descriptors.values().stream()
+            .map(SystemIndices::featureToDataStreamBackingIndicesAutomaton)
+            .reduce(Operations::union);
+        return new CharacterRunAutomaton(automaton.orElse(EMPTY));
+    }
+
+    private static Automaton featureToDataStreamBackingIndicesAutomaton(Feature feature) {
+        Optional<Automaton> systemDataStreamAutomaton = feature.getDataStreamDescriptors().stream()
+            .map(descriptor -> SystemIndexDescriptor.buildAutomaton(
+                descriptor.getBackingIndexPattern(),
+                null
+            ))
+            .reduce(Operations::union);
+        return systemDataStreamAutomaton.orElse(EMPTY);
+    }
+
+    public SystemDataStreamDescriptor validateDataStreamAccess(String dataStreamName, ThreadContext threadContext) {
+        if (systemDataStreamAutomaton.test(dataStreamName)) {
+            SystemDataStreamDescriptor dataStreamDescriptor = featureDescriptors.values().stream()
+                .flatMap(feature -> feature.getDataStreamDescriptors().stream())
+                .filter(descriptor -> descriptor.getDataStreamName().equals(dataStreamName))
+                .findFirst()
+                .orElseThrow(() -> new IllegalStateException("system data stream descriptor not found for [" + dataStreamName + "]"));
+            if (dataStreamDescriptor.isExternal()) {
+                final SystemIndexAccessLevel accessLevel = getSystemIndexAccessLevel(threadContext);
+                if (accessLevel == SystemIndexAccessLevel.NONE) {
+                    throw dataStreamAccessException(null, dataStreamName);
+                } else if (accessLevel == SystemIndexAccessLevel.RESTRICTED) {
+                    if (getProductSystemIndexNamePredicate(threadContext).test(dataStreamName) == false) {
+                        throw dataStreamAccessException(
+                            threadContext.getHeader(EXTERNAL_SYSTEM_INDEX_ACCESS_CONTROL_HEADER_KEY),
+                            dataStreamName);
+                    } else {
+                        return dataStreamDescriptor;
+                    }
+                } else {
+                    assert accessLevel == SystemIndexAccessLevel.ALL;
+                    return dataStreamDescriptor;
+                }
+            } else {
+                return dataStreamDescriptor;
+            }
+        } else {
+            return null;
+        }
+    }
+
+    public IllegalArgumentException dataStreamAccessException(ThreadContext threadContext, Collection<String> names) {
+        return dataStreamAccessException(
+            threadContext.getHeader(EXTERNAL_SYSTEM_INDEX_ACCESS_CONTROL_HEADER_KEY),
+            names.toArray(Strings.EMPTY_ARRAY)
+        );
+    }
+
+    IllegalArgumentException dataStreamAccessException(@Nullable String product, String... dataStreamNames) {
+        if (product == null) {
+            return new IllegalArgumentException("Data stream(s) " + Arrays.toString(dataStreamNames) +
+                " use and access is reserved for system operations");
+        } else {
+            return new IllegalArgumentException("Data stream(s) " + Arrays.toString(dataStreamNames) + " may not be accessed by product ["
+                + product + "]");
+        }
+    }
+
+    /**
+     * Determines what level of system index access should be allowed in the current context.
+     *
+     * @return {@link SystemIndexAccessLevel#ALL} if unrestricted system index access should be allowed,
+     * {@link SystemIndexAccessLevel#RESTRICTED} if a subset of system index access should be allowed, or
+     * {@link SystemIndexAccessLevel#NONE} if no system index access should be allowed.
+     */
+    public SystemIndexAccessLevel getSystemIndexAccessLevel(ThreadContext threadContext) {
+        final String headerValue = threadContext.getHeader(SYSTEM_INDEX_ACCESS_CONTROL_HEADER_KEY);
+        final String productHeaderValue = threadContext.getHeader(EXTERNAL_SYSTEM_INDEX_ACCESS_CONTROL_HEADER_KEY);
+
+        final boolean allowed = Booleans.parseBoolean(headerValue, true);
+        if (allowed) {
+            if (productHeaderValue != null) {
+                return SystemIndexAccessLevel.RESTRICTED;
+            } else {
+                return SystemIndexAccessLevel.ALL;
+            }
+        } else {
+            return SystemIndexAccessLevel.NONE;
+        }
+    }
+
+    public enum SystemIndexAccessLevel {
+        ALL,
+        NONE,
+        RESTRICTED
     }
 
     /**
      * Given a collection of {@link SystemIndexDescriptor}s and their sources, checks to see if the index patterns of the listed
      * descriptors overlap with any of the other patterns. If any do, throws an exception.
      *
-     * @param sourceToDescriptors A map of source (plugin) names to the SystemIndexDescriptors they provide.
+     * @param sourceToFeature A map of source (plugin) names to the SystemIndexDescriptors they provide.
      * @throws IllegalStateException Thrown if any of the index patterns overlaps with another.
      */
-    static void checkForOverlappingPatterns(Map<String, Feature> sourceToDescriptors) {
-        List<Tuple<String, SystemIndexDescriptor>> sourceDescriptorPair = sourceToDescriptors.entrySet().stream()
+    static void checkForOverlappingPatterns(Map<String, Feature> sourceToFeature) {
+        List<Tuple<String, SystemIndexDescriptor>> sourceDescriptorPair = sourceToFeature.entrySet().stream()
             .flatMap(entry -> entry.getValue().getIndexDescriptors().stream().map(descriptor -> new Tuple<>(entry.getKey(), descriptor)))
             .sorted(Comparator.comparing(d -> d.v1() + ":" + d.v2().getIndexPattern())) // Consistent ordering -> consistent error message
+            .collect(Collectors.toList());
+        List<Tuple<String, SystemDataStreamDescriptor>> sourceDataStreamDescriptorPair = sourceToFeature.entrySet().stream()
+            .filter(entry -> entry.getValue().getDataStreamDescriptors().isEmpty() == false)
+            .flatMap(entry ->
+                entry.getValue().getDataStreamDescriptors().stream().map(descriptor -> new Tuple<>(entry.getKey(), descriptor)))
+            .sorted(
+                Comparator.comparing(d -> d.v1() + ":" + d.v2().getDataStreamName())) // Consistent ordering -> consistent error message
             .collect(Collectors.toList());
 
         // This is O(n^2) with the number of system index descriptors, and each check is quadratic with the number of states in the
@@ -214,9 +428,9 @@ public class SystemIndices {
         // per pattern should be low as well. If these assumptions change, this might need to be reworked.
         sourceDescriptorPair.forEach(descriptorToCheck -> {
             List<Tuple<String, SystemIndexDescriptor>> descriptorsMatchingThisPattern = sourceDescriptorPair.stream()
-
                 .filter(d -> descriptorToCheck.v2() != d.v2()) // Exclude the pattern currently being checked
-                .filter(d -> overlaps(descriptorToCheck.v2(), d.v2()))
+                .filter(d -> overlaps(descriptorToCheck.v2(), d.v2()) ||
+                    (d.v2().getAliasName() != null && descriptorToCheck.v2().matchesIndexPattern(d.v2().getAliasName())))
                 .collect(Collectors.toList());
             if (descriptorsMatchingThisPattern.isEmpty() == false) {
                 throw new IllegalStateException("a system index descriptor [" + descriptorToCheck.v2() + "] from [" +
@@ -225,12 +439,28 @@ public class SystemIndices {
                         .map(descriptor -> descriptor.v2() + " from [" + descriptor.v1() + "]")
                         .collect(Collectors.joining(", ")));
             }
+
+            List<Tuple<String, SystemDataStreamDescriptor>> dataStreamsMatching = sourceDataStreamDescriptorPair.stream()
+                .filter(dsTuple -> descriptorToCheck.v2().matchesIndexPattern(dsTuple.v2().getDataStreamName()) ||
+                    overlaps(descriptorToCheck.v2().getIndexPattern(), dsTuple.v2().getBackingIndexPattern()))
+                .collect(Collectors.toList());
+            if (dataStreamsMatching.isEmpty() == false) {
+                throw new IllegalStateException("a system index descriptor [" + descriptorToCheck.v2() + "] from [" +
+                    descriptorToCheck.v1() + "] overlaps with one or more data stream descriptors: [" +
+                    dataStreamsMatching.stream()
+                        .map(descriptor -> descriptor.v2() + " from [" + descriptor.v1() + "]")
+                        .collect(Collectors.joining(", ")));
+            }
         });
     }
 
     private static boolean overlaps(SystemIndexDescriptor a1, SystemIndexDescriptor a2) {
-        Automaton a1Automaton = SystemIndexDescriptor.buildAutomaton(a1.getIndexPattern(), null);
-        Automaton a2Automaton = SystemIndexDescriptor.buildAutomaton(a2.getIndexPattern(), null);
+        return overlaps(a1.getIndexPattern(), a2.getIndexPattern());
+    }
+
+    private static boolean overlaps(String pattern1, String pattern2) {
+        Automaton a1Automaton = SystemIndexDescriptor.buildAutomaton(pattern1, null);
+        Automaton a2Automaton = SystemIndexDescriptor.buildAutomaton(pattern2, null);
         return Operations.isEmpty(Operations.intersection(a1Automaton, a2Automaton)) == false;
     }
 
@@ -271,23 +501,27 @@ public class SystemIndices {
     public static class Feature {
         private final String description;
         private final Collection<SystemIndexDescriptor> indexDescriptors;
+        private final Collection<SystemDataStreamDescriptor> dataStreamDescriptors;
         private final Collection<String> associatedIndexPatterns;
         private final TriConsumer<ClusterService, Client, ActionListener<ResetFeatureStateStatus>> cleanUpFunction;
 
         /**
          * Construct a Feature with a custom cleanup function
          * @param description Description of the feature
-         * @param indexDescriptors Patterns describing system indices for this feature
+         * @param indexDescriptors Collection of objects describing system indices for this feature
+         * @param dataStreamDescriptors Collection of objects describing system data streams for this feature
          * @param associatedIndexPatterns Patterns describing associated indices
          * @param cleanUpFunction A function that will clean up the feature's state
          */
         public Feature(
             String description,
             Collection<SystemIndexDescriptor> indexDescriptors,
+            Collection<SystemDataStreamDescriptor> dataStreamDescriptors,
             Collection<String> associatedIndexPatterns,
             TriConsumer<ClusterService, Client, ActionListener<ResetFeatureStateStatus>> cleanUpFunction) {
             this.description = description;
             this.indexDescriptors = indexDescriptors;
+            this.dataStreamDescriptors = dataStreamDescriptors;
             this.associatedIndexPatterns = associatedIndexPatterns;
             this.cleanUpFunction = cleanUpFunction;
         }
@@ -299,7 +533,21 @@ public class SystemIndices {
          * @param indexDescriptors Patterns describing system indices for this feature
          */
         public Feature(String name, String description, Collection<SystemIndexDescriptor> indexDescriptors) {
-            this(description, indexDescriptors, Collections.emptyList(),
+            this(description, indexDescriptors, Collections.emptyList(), Collections.emptyList(),
+                (clusterService, client, listener) ->
+                    cleanUpFeature(indexDescriptors, Collections.emptyList(), name, clusterService, client, listener)
+            );
+        }
+        /**
+         * Construct a Feature using the default clean-up function
+         * @param name Name of the feature, used in logging
+         * @param description Description of the feature
+         * @param indexDescriptors Patterns describing system indices for this feature
+         * @param dataStreamDescriptors Collection of objects describing system data streams for this feature
+         */
+        public Feature(String name, String description, Collection<SystemIndexDescriptor> indexDescriptors,
+                       Collection<SystemDataStreamDescriptor> dataStreamDescriptors) {
+            this(description, indexDescriptors, dataStreamDescriptors, Collections.emptyList(),
                 (clusterService, client, listener) ->
                     cleanUpFeature(indexDescriptors, Collections.emptyList(), name, clusterService, client, listener)
             );
@@ -311,6 +559,10 @@ public class SystemIndices {
 
         public Collection<SystemIndexDescriptor> getIndexDescriptors() {
             return indexDescriptors;
+        }
+
+        public Collection<SystemDataStreamDescriptor> getDataStreamDescriptors() {
+            return dataStreamDescriptors;
         }
 
         public Collection<String> getAssociatedIndexPatterns() {
@@ -364,5 +616,13 @@ public class SystemIndices {
                 }
             });
         }
+    }
+
+    public static Feature pluginToFeature(SystemIndexPlugin plugin, Settings settings) {
+        return new Feature(plugin.getFeatureDescription(),
+            plugin.getSystemIndexDescriptors(settings),
+            plugin.getSystemDataStreamDescriptors(),
+            plugin.getAssociatedIndexPatterns(),
+            plugin::cleanUpFeature);
     }
 }

--- a/server/src/main/java/org/elasticsearch/node/Node.java
+++ b/server/src/main/java/org/elasticsearch/node/Node.java
@@ -447,20 +447,33 @@ public class Node implements Closeable {
             final ClusterInfoService clusterInfoService = newClusterInfoService(settings, clusterService, threadPool, client);
             final UsageService usageService = new UsageService();
 
-            final Map<String, SystemIndices.Feature> featuresMap = Collections.unmodifiableMap(pluginsService
+            SearchModule searchModule = new SearchModule(settings, false, pluginsService.filterPlugins(SearchPlugin.class));
+            IndicesModule indicesModule = new IndicesModule(pluginsService.filterPlugins(MapperPlugin.class));
+            List<NamedWriteableRegistry.Entry> namedWriteables = Stream.of(
+                NetworkModule.getNamedWriteables().stream(),
+                indicesModule.getNamedWriteables().stream(),
+                searchModule.getNamedWriteables().stream(),
+                pluginsService.filterPlugins(Plugin.class).stream()
+                    .flatMap(p -> p.getNamedWriteables().stream()),
+                ClusterModule.getNamedWriteables().stream())
+                .flatMap(Function.identity()).collect(Collectors.toList());
+            final NamedWriteableRegistry namedWriteableRegistry = new NamedWriteableRegistry(namedWriteables);
+            NamedXContentRegistry xContentRegistry = new NamedXContentRegistry(Stream.of(
+                NetworkModule.getNamedXContents().stream(),
+                IndicesModule.getNamedXContents().stream(),
+                searchModule.getNamedXContents().stream(),
+                pluginsService.filterPlugins(Plugin.class).stream()
+                    .flatMap(p -> p.getNamedXContent().stream()),
+                ClusterModule.getNamedXWriteables().stream())
+                .flatMap(Function.identity()).collect(toList()));
+            final Map<String, SystemIndices.Feature> featuresMap = pluginsService
                 .filterPlugins(SystemIndexPlugin.class)
                 .stream()
                 .peek(plugin -> SystemIndices.validateFeatureName(plugin.getFeatureName(), plugin.getClass().getCanonicalName()))
                 .collect(Collectors.toMap(
-                    plugin -> plugin.getFeatureName(),
-                    plugin -> new SystemIndices.Feature(
-                        plugin.getFeatureDescription(),
-                        plugin.getSystemIndexDescriptors(settings),
-                        plugin.getAssociatedIndexPatterns(),
-                        plugin::cleanUpFeature
-                    ))
-                )
-            );
+                    SystemIndexPlugin::getFeatureName,
+                    plugin -> SystemIndices.pluginToFeature(plugin, settings)
+                ));
             final SystemIndices systemIndices = new SystemIndices(featuresMap);
 
             ModulesBuilder modules = new ModulesBuilder();
@@ -477,10 +490,8 @@ public class Node implements Closeable {
             final ClusterModule clusterModule = new ClusterModule(settings, clusterService, clusterPlugins, clusterInfoService,
                 snapshotsInfoService, threadPool.getThreadContext(), systemIndices);
             modules.add(clusterModule);
-            IndicesModule indicesModule = new IndicesModule(pluginsService.filterPlugins(MapperPlugin.class));
             modules.add(indicesModule);
 
-            SearchModule searchModule = new SearchModule(settings, false, pluginsService.filterPlugins(SearchPlugin.class));
             List<BreakerSettings> pluginCircuitBreakers = pluginsService.filterPlugins(CircuitBreakerPlugin.class)
                 .stream()
                 .map(plugin -> plugin.getCircuitBreaker(settings))
@@ -500,23 +511,7 @@ public class Node implements Closeable {
             PageCacheRecycler pageCacheRecycler = createPageCacheRecycler(settings);
             BigArrays bigArrays = createBigArrays(pageCacheRecycler, circuitBreakerService);
             modules.add(settingsModule);
-            List<NamedWriteableRegistry.Entry> namedWriteables = Stream.of(
-                NetworkModule.getNamedWriteables().stream(),
-                indicesModule.getNamedWriteables().stream(),
-                searchModule.getNamedWriteables().stream(),
-                pluginsService.filterPlugins(Plugin.class).stream()
-                    .flatMap(p -> p.getNamedWriteables().stream()),
-                ClusterModule.getNamedWriteables().stream())
-                .flatMap(Function.identity()).collect(Collectors.toList());
-            final NamedWriteableRegistry namedWriteableRegistry = new NamedWriteableRegistry(namedWriteables);
-            NamedXContentRegistry xContentRegistry = new NamedXContentRegistry(Stream.of(
-                NetworkModule.getNamedXContents().stream(),
-                IndicesModule.getNamedXContents().stream(),
-                searchModule.getNamedXContents().stream(),
-                pluginsService.filterPlugins(Plugin.class).stream()
-                    .flatMap(p -> p.getNamedXContent().stream()),
-                ClusterModule.getNamedXWriteables().stream())
-                .flatMap(Function.identity()).collect(toList()));
+
             final MetaStateService metaStateService = new MetaStateService(nodeEnvironment, xContentRegistry);
             final PersistedClusterStateService lucenePersistedStateFactory
                 = new PersistedClusterStateService(nodeEnvironment, xContentRegistry, bigArrays, clusterService.getClusterSettings(),

--- a/server/src/main/java/org/elasticsearch/plugins/SystemIndexPlugin.java
+++ b/server/src/main/java/org/elasticsearch/plugins/SystemIndexPlugin.java
@@ -13,6 +13,7 @@ import org.elasticsearch.action.admin.cluster.snapshots.features.ResetFeatureSta
 import org.elasticsearch.client.Client;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.indices.SystemDataStreamDescriptor;
 import org.elasticsearch.indices.SystemIndexDescriptor;
 import org.elasticsearch.indices.SystemIndices;
 
@@ -32,6 +33,10 @@ public interface SystemIndexPlugin extends ActionPlugin {
      * @return Descriptions of the system indices managed by this plugin.
      */
     default Collection<SystemIndexDescriptor> getSystemIndexDescriptors(Settings settings) {
+        return Collections.emptyList();
+    }
+
+    default Collection<SystemDataStreamDescriptor> getSystemDataStreamDescriptors() {
         return Collections.emptyList();
     }
 

--- a/server/src/main/java/org/elasticsearch/rest/RestController.java
+++ b/server/src/main/java/org/elasticsearch/rest/RestController.java
@@ -44,8 +44,8 @@ import java.util.function.Supplier;
 import java.util.function.UnaryOperator;
 import java.util.stream.Collectors;
 
-import static org.elasticsearch.cluster.metadata.IndexNameExpressionResolver.EXTERNAL_SYSTEM_INDEX_ACCESS_CONTROL_HEADER_KEY;
-import static org.elasticsearch.cluster.metadata.IndexNameExpressionResolver.SYSTEM_INDEX_ACCESS_CONTROL_HEADER_KEY;
+import static org.elasticsearch.indices.SystemIndices.EXTERNAL_SYSTEM_INDEX_ACCESS_CONTROL_HEADER_KEY;
+import static org.elasticsearch.indices.SystemIndices.SYSTEM_INDEX_ACCESS_CONTROL_HEADER_KEY;
 import static org.elasticsearch.rest.BytesRestResponse.TEXT_CONTENT_TYPE;
 import static org.elasticsearch.rest.RestStatus.BAD_REQUEST;
 import static org.elasticsearch.rest.RestStatus.INTERNAL_SERVER_ERROR;

--- a/server/src/main/java/org/elasticsearch/snapshots/RestoreService.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/RestoreService.java
@@ -769,7 +769,7 @@ public class RestoreService implements ClusterStateApplier {
     }
 
     private boolean isSystemIndex(IndexMetadata indexMetadata) {
-        return indexMetadata.isSystem() || systemIndices.isSystemIndex(indexMetadata.getIndex());
+        return indexMetadata.isSystem() || systemIndices.isSystemName(indexMetadata.getIndex().getName());
     }
 
     private Map<String, DataStream> getDataStreamsToRestore(Repository repository, SnapshotId snapshotId, SnapshotInfo snapshotInfo,

--- a/server/src/test/java/org/elasticsearch/action/admin/indices/alias/get/TransportGetAliasesActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/alias/get/TransportGetAliasesActionTests.java
@@ -11,12 +11,14 @@ import org.elasticsearch.Version;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.AliasMetadata;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
-import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver.SystemIndexAccessLevel;
 import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.common.collect.ImmutableOpenMap;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.indices.EmptySystemIndices;
 import org.elasticsearch.indices.SystemIndexDescriptor;
 import org.elasticsearch.indices.SystemIndices;
+import org.elasticsearch.indices.SystemIndices.SystemIndexAccessLevel;
 import org.elasticsearch.test.ESTestCase;
 
 import java.util.Collections;
@@ -130,7 +132,7 @@ public class TransportGetAliasesActionTests extends ESTestCase {
         assertEquals(state.metadata().findAliases(request, concreteIndices), aliases);
         ImmutableOpenMap<String, List<AliasMetadata>> result =
             TransportGetAliasesAction.postProcess(request, concreteIndices, aliases, state,
-                SystemIndexAccessLevel.ALL, "", EmptySystemIndices.INSTANCE);
+                SystemIndexAccessLevel.ALL, new ThreadContext(Settings.EMPTY), EmptySystemIndices.INSTANCE);
         assertThat(result.size(), equalTo(1));
         assertThat(result.get(".b").size(), equalTo(1));
     }
@@ -150,7 +152,7 @@ public class TransportGetAliasesActionTests extends ESTestCase {
         assertEquals(state.metadata().findAliases(request, concreteIndices), aliases);
         ImmutableOpenMap<String, List<AliasMetadata>> result =
             TransportGetAliasesAction.postProcess(request, concreteIndices, aliases, state,
-                SystemIndexAccessLevel.NONE, "", EmptySystemIndices.INSTANCE);
+                SystemIndexAccessLevel.NONE, new ThreadContext(Settings.EMPTY), EmptySystemIndices.INSTANCE);
         assertThat(result.size(), equalTo(1));
         assertThat(result.get("c").size(), equalTo(1));
     }

--- a/server/src/test/java/org/elasticsearch/action/admin/indices/rollover/MetadataRolloverServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/rollover/MetadataRolloverServiceTests.java
@@ -336,7 +336,7 @@ public class MetadataRolloverServiceTests extends ESTestCase {
             .build();
         rolloverRequest.getCreateIndexRequest().settings(settings);
         final CreateIndexClusterStateUpdateRequest createIndexRequest = MetadataRolloverService.prepareDataStreamCreateIndexRequest(
-            dataStream.getName(), newWriteIndexName, rolloverRequest.getCreateIndexRequest());
+            dataStream.getName(), newWriteIndexName, rolloverRequest.getCreateIndexRequest(), null);
         for (String settingKey : settings.keySet()) {
             assertThat(settings.get(settingKey), equalTo(createIndexRequest.settings().get(settingKey)));
         }
@@ -504,7 +504,7 @@ public class MetadataRolloverServiceTests extends ESTestCase {
             MetadataIndexAliasesService indexAliasesService = new MetadataIndexAliasesService(clusterService, indicesService,
                 new AliasValidator(), null, xContentRegistry());
             MetadataRolloverService rolloverService = new MetadataRolloverService(testThreadPool, createIndexService, indexAliasesService,
-                mockIndexNameExpressionResolver);
+                mockIndexNameExpressionResolver, EmptySystemIndices.INSTANCE);
 
             MaxDocsCondition condition = new MaxDocsCondition(randomNonNegativeLong());
             List<Condition<?>> metConditions = Collections.singletonList(condition);
@@ -609,7 +609,7 @@ public class MetadataRolloverServiceTests extends ESTestCase {
             MetadataIndexAliasesService indexAliasesService = new MetadataIndexAliasesService(clusterService, indicesService,
                 new AliasValidator(), null, xContentRegistry());
             MetadataRolloverService rolloverService = new MetadataRolloverService(testThreadPool, createIndexService, indexAliasesService,
-                mockIndexNameExpressionResolver);
+                mockIndexNameExpressionResolver, EmptySystemIndices.INSTANCE);
 
             MaxDocsCondition condition = new MaxDocsCondition(randomNonNegativeLong());
             List<Condition<?>> metConditions = Collections.singletonList(condition);
@@ -718,7 +718,7 @@ public class MetadataRolloverServiceTests extends ESTestCase {
             MetadataIndexAliasesService indexAliasesService = new MetadataIndexAliasesService(clusterService, indicesService,
                 new AliasValidator(), null, xContentRegistry());
             MetadataRolloverService rolloverService = new MetadataRolloverService(testThreadPool, createIndexService, indexAliasesService,
-                mockIndexNameExpressionResolver);
+                mockIndexNameExpressionResolver, EmptySystemIndices.INSTANCE);
 
             MaxDocsCondition condition = new MaxDocsCondition(randomNonNegativeLong());
             List<Condition<?>> metConditions = Collections.singletonList(condition);
@@ -781,7 +781,7 @@ public class MetadataRolloverServiceTests extends ESTestCase {
         IndexNameExpressionResolver mockIndexNameExpressionResolver = mock(IndexNameExpressionResolver.class);
         when(mockIndexNameExpressionResolver.resolveDateMathExpression(any())).then(returnsFirstArg());
         MetadataRolloverService rolloverService = new MetadataRolloverService(null, createIndexService, metadataIndexAliasesService,
-            mockIndexNameExpressionResolver);
+            mockIndexNameExpressionResolver, EmptySystemIndices.INSTANCE);
 
         String newIndexName = useDataStream == false && randomBoolean() ? "logs-index-9" : null;
 
@@ -831,7 +831,7 @@ public class MetadataRolloverServiceTests extends ESTestCase {
         MetadataIndexAliasesService indexAliasesService = new MetadataIndexAliasesService(clusterService, indicesService,
             new AliasValidator(), null, xContentRegistry());
         MetadataRolloverService rolloverService = new MetadataRolloverService(testThreadPool, createIndexService, indexAliasesService,
-            mockIndexNameExpressionResolver);
+            mockIndexNameExpressionResolver, EmptySystemIndices.INSTANCE);
 
         MaxDocsCondition condition = new MaxDocsCondition(randomNonNegativeLong());
         List<Condition<?>> metConditions = Collections.singletonList(condition);

--- a/server/src/test/java/org/elasticsearch/action/admin/indices/rollover/TransportRolloverActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/rollover/TransportRolloverActionTests.java
@@ -52,6 +52,7 @@ import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.index.shard.ShardPath;
 import org.elasticsearch.index.store.StoreStats;
 import org.elasticsearch.index.warmer.WarmerStats;
+import org.elasticsearch.indices.EmptySystemIndices;
 import org.elasticsearch.search.suggest.completion.CompletionStats;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.test.ESTestCase;
@@ -252,7 +253,7 @@ public class TransportRolloverActionTests extends ESTestCase {
         when(mockCreateIndexService.applyCreateIndexRequest(any(), any(), anyBoolean())).thenReturn(stateBefore);
         when(mdIndexAliasesService.applyAliasActions(any(), any())).thenReturn(stateBefore);
         MetadataRolloverService rolloverService = new MetadataRolloverService(mockThreadPool, mockCreateIndexService,
-            mdIndexAliasesService, mockIndexNameExpressionResolver);
+            mdIndexAliasesService, mockIndexNameExpressionResolver, EmptySystemIndices.INSTANCE);
         final TransportRolloverAction transportRolloverAction = new TransportRolloverAction(mockTransportService, mockClusterService,
             mockThreadPool, mockActionFilters, mockIndexNameExpressionResolver, rolloverService, mockClient);
 

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/DateMathExpressionResolverTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/DateMathExpressionResolverTests.java
@@ -14,7 +14,6 @@ import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver.Context;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver.DateMathExpressionResolver;
-import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver.SystemIndexAccessLevel;
 import org.elasticsearch.test.ESTestCase;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
@@ -25,7 +24,6 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
-import static org.elasticsearch.cluster.metadata.IndexNameExpressionResolver.SystemIndexAccessLevel.NONE;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.joda.time.DateTimeZone.UTC;
@@ -35,7 +33,7 @@ public class DateMathExpressionResolverTests extends ESTestCase {
     private final DateMathExpressionResolver expressionResolver = new DateMathExpressionResolver();
     private final Context context = new Context(
         ClusterState.builder(new ClusterName("_name")).build(), IndicesOptions.strictExpand(),
-        SystemIndexAccessLevel.NONE
+        name -> false
     );
 
     public void testNormal() throws Exception {
@@ -138,7 +136,7 @@ public class DateMathExpressionResolverTests extends ESTestCase {
             // rounding to today 00:00
             now = DateTime.now(UTC).withHourOfDay(0).withMinuteOfHour(0).withSecondOfMinute(0);
         }
-        Context context = new Context(this.context.getState(), this.context.getOptions(), now.getMillis(), NONE);
+        Context context = new Context(this.context.getState(), this.context.getOptions(), now.getMillis(), name -> false);
         List<String> results = expressionResolver.resolve(context, Arrays.asList("<.marvel-{now/d{yyyy.MM.dd|" + timeZone.getID() + "}}>"));
         assertThat(results.size(), equalTo(1));
         logger.info("timezone: [{}], now [{}], name: [{}]", timeZone, now, results.get(0));

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/IndexNameExpressionResolverTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/IndexNameExpressionResolverTests.java
@@ -36,7 +36,6 @@ import org.elasticsearch.indices.SystemIndices.Feature;
 import org.elasticsearch.indices.TestIndexNameExpressionResolver;
 import org.elasticsearch.test.ESTestCase;
 
-
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.ZoneOffset;
@@ -48,15 +47,15 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.function.Function;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 import static org.elasticsearch.cluster.metadata.DataStreamTestHelper.createBackingIndex;
 import static org.elasticsearch.cluster.metadata.DataStreamTestHelper.createTimestampField;
 import static org.elasticsearch.cluster.metadata.IndexMetadata.INDEX_HIDDEN_SETTING;
-import static org.elasticsearch.cluster.metadata.IndexNameExpressionResolver.EXTERNAL_SYSTEM_INDEX_ACCESS_CONTROL_HEADER_KEY;
-import static org.elasticsearch.cluster.metadata.IndexNameExpressionResolver.SYSTEM_INDEX_ACCESS_CONTROL_HEADER_KEY;
-import static org.elasticsearch.cluster.metadata.IndexNameExpressionResolver.SystemIndexAccessLevel.NONE;
 import static org.elasticsearch.common.util.set.Sets.newHashSet;
+import static org.elasticsearch.indices.SystemIndices.EXTERNAL_SYSTEM_INDEX_ACCESS_CONTROL_HEADER_KEY;
+import static org.elasticsearch.indices.SystemIndices.SYSTEM_INDEX_ACCESS_CONTROL_HEADER_KEY;
 import static org.hamcrest.Matchers.arrayContaining;
 import static org.hamcrest.Matchers.arrayContainingInAnyOrder;
 import static org.hamcrest.Matchers.arrayWithSize;
@@ -71,6 +70,9 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 
 public class IndexNameExpressionResolverTests extends ESTestCase {
+
+    private static final Predicate<String> NONE = name -> false;
+
     private IndexNameExpressionResolver indexNameExpressionResolver;
     private ThreadContext threadContext;
     private long epochMillis;

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataCreateDataStreamServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataCreateDataStreamServiceTests.java
@@ -12,19 +12,27 @@ import org.elasticsearch.Version;
 import org.elasticsearch.action.admin.indices.create.CreateIndexClusterStateUpdateRequest;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.metadata.ComposableIndexTemplate.DataStreamTemplate;
 import org.elasticsearch.cluster.metadata.MetadataCreateDataStreamService.CreateDataStreamClusterStateUpdateRequest;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.TimeValue;
+import org.elasticsearch.indices.SystemDataStreamDescriptor;
+import org.elasticsearch.indices.SystemDataStreamDescriptor.Type;
+import org.elasticsearch.indices.SystemIndices;
+import org.elasticsearch.indices.SystemIndices.Feature;
 import org.elasticsearch.test.ESTestCase;
 
 import java.util.Collections;
+import java.util.Map;
 
 import static org.elasticsearch.cluster.metadata.DataStreamTestHelper.createFirstBackingIndex;
 import static org.elasticsearch.cluster.metadata.DataStreamTestHelper.createTimestampField;
 import static org.elasticsearch.cluster.metadata.DataStreamTestHelper.generateMapping;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyBoolean;
 import static org.mockito.Mockito.mock;
@@ -44,12 +52,38 @@ public class MetadataCreateDataStreamServiceTests extends ESTestCase {
             .build();
         CreateDataStreamClusterStateUpdateRequest req =
             new CreateDataStreamClusterStateUpdateRequest(dataStreamName, TimeValue.ZERO, TimeValue.ZERO);
-        ClusterState newState = MetadataCreateDataStreamService.createDataStream(metadataCreateIndexService, cs, req);
+        ClusterState newState =
+            MetadataCreateDataStreamService.createDataStream(metadataCreateIndexService, cs, req);
         assertThat(newState.metadata().dataStreams().size(), equalTo(1));
         assertThat(newState.metadata().dataStreams().get(dataStreamName).getName(), equalTo(dataStreamName));
+        assertThat(newState.metadata().dataStreams().get(dataStreamName).isSystem(), is(false));
+        assertThat(newState.metadata().dataStreams().get(dataStreamName).isHidden(), is(false));
+        assertThat(newState.metadata().dataStreams().get(dataStreamName).isReplicated(), is(false));
         assertThat(newState.metadata().index(DataStream.getDefaultBackingIndexName(dataStreamName, 1)), notNullValue());
         assertThat(newState.metadata().index(DataStream.getDefaultBackingIndexName(dataStreamName, 1)).getSettings().get("index.hidden"),
             equalTo("true"));
+        assertThat(newState.metadata().index(DataStream.getDefaultBackingIndexName(dataStreamName, 1)).isSystem(), is(false));
+    }
+
+    public void testCreateSystemDataStream() throws Exception {
+        final MetadataCreateIndexService metadataCreateIndexService = getMetadataCreateIndexService();
+        final String dataStreamName = ".system-data-stream";
+        ClusterState cs = ClusterState.builder(new ClusterName("_name"))
+            .metadata(Metadata.builder().build())
+            .build();
+        CreateDataStreamClusterStateUpdateRequest req = new CreateDataStreamClusterStateUpdateRequest(
+            dataStreamName, systemDataStreamDescriptor(), TimeValue.ZERO, TimeValue.ZERO);
+        ClusterState newState =
+            MetadataCreateDataStreamService.createDataStream(metadataCreateIndexService, cs, req);
+        assertThat(newState.metadata().dataStreams().size(), equalTo(1));
+        assertThat(newState.metadata().dataStreams().get(dataStreamName).getName(), equalTo(dataStreamName));
+        assertThat(newState.metadata().dataStreams().get(dataStreamName).isSystem(), is(true));
+        assertThat(newState.metadata().dataStreams().get(dataStreamName).isHidden(), is(false));
+        assertThat(newState.metadata().dataStreams().get(dataStreamName).isReplicated(), is(false));
+        assertThat(newState.metadata().index(DataStream.getDefaultBackingIndexName(dataStreamName, 1)), notNullValue());
+        assertThat(newState.metadata().index(DataStream.getDefaultBackingIndexName(dataStreamName, 1)).getSettings().get("index.hidden"),
+            nullValue());
+        assertThat(newState.metadata().index(DataStream.getDefaultBackingIndexName(dataStreamName, 1)).isSystem(), is(true));
     }
 
     public void testCreateDuplicateDataStream() throws Exception {
@@ -146,6 +180,7 @@ public class MetadataCreateDataStreamServiceTests extends ESTestCase {
 
     private static MetadataCreateIndexService getMetadataCreateIndexService() throws Exception {
         MetadataCreateIndexService s = mock(MetadataCreateIndexService.class);
+        when(s.getSystemIndices()).thenReturn(getSystemIndices());
         when(s.applyCreateIndexRequest(any(ClusterState.class), any(CreateIndexClusterStateUpdateRequest.class), anyBoolean()))
             .thenAnswer(mockInvocation -> {
                 ClusterState currentState = (ClusterState) mockInvocation.getArguments()[0];
@@ -158,6 +193,7 @@ public class MetadataCreateDataStreamServiceTests extends ESTestCase {
                             .put(request.settings())
                             .build())
                         .putMapping("_doc", generateMapping("@timestamp"))
+                        .system(getSystemIndices().isSystemName(request.index()))
                         .numberOfShards(1)
                         .numberOfReplicas(1)
                         .build(), false);
@@ -165,5 +201,28 @@ public class MetadataCreateDataStreamServiceTests extends ESTestCase {
             });
 
         return s;
+    }
+
+    private static SystemIndices getSystemIndices() {
+        Map<String, Feature> map = Collections.singletonMap("system", new Feature(
+            "systemFeature",
+            "system feature description",
+            Collections.emptyList(),
+            Collections.singletonList(systemDataStreamDescriptor())
+        ));
+
+        return new SystemIndices(map);
+    }
+
+    private static SystemDataStreamDescriptor systemDataStreamDescriptor() {
+        return new SystemDataStreamDescriptor(
+            ".system-data-stream",
+            "test system datastream",
+            Type.EXTERNAL,
+            new ComposableIndexTemplate(
+                Collections.singletonList(".system-data-stream"), null, null, null, null, null, new DataStreamTemplate()),
+            Collections.emptyMap(),
+            Collections.singletonList("stack")
+        );
     }
 }

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/WildcardExpressionResolverTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/WildcardExpressionResolverTests.java
@@ -20,15 +20,18 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
+import java.util.function.Predicate;
 
 import static org.elasticsearch.cluster.metadata.DataStreamTestHelper.createBackingIndex;
 import static org.elasticsearch.cluster.metadata.DataStreamTestHelper.createTimestampField;
-import static org.elasticsearch.cluster.metadata.IndexNameExpressionResolver.SystemIndexAccessLevel.NONE;
 import static org.elasticsearch.common.util.set.Sets.newHashSet;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.equalTo;
 
 public class WildcardExpressionResolverTests extends ESTestCase {
+
+    private static final Predicate<String> NONE = name -> false;
+
     public void testConvertWildcardsJustIndicesTests() {
         Metadata.Builder mdBuilder = Metadata.builder()
                 .put(indexBuilder("testXXX"))

--- a/test/framework/src/main/java/org/elasticsearch/cluster/metadata/DataStreamTestHelper.java
+++ b/test/framework/src/main/java/org/elasticsearch/cluster/metadata/DataStreamTestHelper.java
@@ -11,9 +11,6 @@ import org.apache.lucene.util.LuceneTestCase;
 import org.elasticsearch.Version;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.ClusterState;
-import org.elasticsearch.cluster.metadata.DataStream;
-import org.elasticsearch.cluster.metadata.IndexMetadata;
-import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.common.UUIDs;
 import org.elasticsearch.common.collect.Tuple;
 import org.elasticsearch.common.settings.Settings;
@@ -116,7 +113,7 @@ public final class DataStreamTestHelper {
             metadata.put("key", "value");
         }
         return new DataStream(dataStreamName, createTimestampField("@timestamp"), indices, generation, metadata,
-            randomBoolean(), randomBoolean(), timeProvider);
+            randomBoolean(), randomBoolean(), false, timeProvider);
     }
 
     /**

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/action/GetDataStreamAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/action/GetDataStreamAction.java
@@ -123,6 +123,7 @@ public class GetDataStreamAction extends ActionType<GetDataStreamAction.Response
             public static final ParseField INDEX_TEMPLATE_FIELD = new ParseField("template");
             public static final ParseField ILM_POLICY_FIELD = new ParseField("ilm_policy");
             public static final ParseField HIDDEN_FIELD = new ParseField("hidden");
+            public static final ParseField SYSTEM_FIELD = new ParseField("system");
 
             DataStream dataStream;
             ClusterHealthStatus dataStreamStatus;
@@ -185,6 +186,7 @@ public class GetDataStreamAction extends ActionType<GetDataStreamAction.Response
                     builder.field(ILM_POLICY_FIELD.getPreferredName(), ilmPolicyName);
                 }
                 builder.field(HIDDEN_FIELD.getPreferredName(), dataStream.isHidden());
+                builder.field(SYSTEM_FIELD.getPreferredName(), dataStream.isSystem());
                 builder.endObject();
                 return builder;
             }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/GenerateSnapshotNameStep.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/GenerateSnapshotNameStep.java
@@ -13,7 +13,6 @@ import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
-import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver.SystemIndexAccessLevel;
 import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.Strings;
@@ -140,7 +139,7 @@ public class GenerateSnapshotNameStep extends ClusterStateActionStep {
         }
 
         public ResolverContext(long startTime) {
-            super(null, null, startTime, false, false, false, false, SystemIndexAccessLevel.NONE);
+            super(null, null, startTime, false, false, false, false, name -> false);
         }
 
         @Override

--- a/x-pack/plugin/core/src/main/resources/fleet-actions-results-ilm-policy.json
+++ b/x-pack/plugin/core/src/main/resources/fleet-actions-results-ilm-policy.json
@@ -1,0 +1,21 @@
+{
+  "phases": {
+    "hot": {
+      "min_age": "0ms",
+      "actions": {
+        "rollover": {
+          "max_size": "300gb",
+          "max_age": "30d"
+        }
+      }
+    },
+    "delete": {
+      "min_age": "90d",
+      "actions": {
+        "delete": {
+          "delete_searchable_snapshot": true
+        }
+      }
+    }
+  }
+}

--- a/x-pack/plugin/core/src/main/resources/fleet-actions-results.json
+++ b/x-pack/plugin/core/src/main/resources/fleet-actions-results.json
@@ -1,0 +1,54 @@
+{
+  "index_patterns": [
+    ".fleet-actions-results"
+  ],
+  "data_stream": {},
+  "template": {
+    "settings": {
+      "index.lifecycle.name": ".fleet-actions-results-ilm-policy"
+    },
+    "mappings": {
+      "_meta": {
+        "version": "${fleet.version}"
+      },
+      "dynamic": false,
+      "properties": {
+        "action_id": {
+          "type": "keyword"
+        },
+        "agent_id": {
+          "type": "keyword"
+        },
+        "action_data": {
+          "enabled": false,
+          "type": "object"
+        },
+        "data": {
+          "enabled": false,
+          "type": "object"
+        },
+        "error": {
+          "type": "text",
+          "fields": {
+            "keyword": {
+              "type": "keyword",
+              "ignore_above": 1024
+            }
+          }
+        },
+        "@timestamp": {
+          "type": "date"
+        },
+        "started_at": {
+          "type": "date"
+        },
+        "completed_at": {
+          "type": "date"
+        }
+      }
+    }
+  },
+  "composed_of": [],
+  "priority": 200,
+  "version": 1
+}

--- a/x-pack/plugin/data-streams/build.gradle
+++ b/x-pack/plugin/data-streams/build.gradle
@@ -11,6 +11,16 @@ archivesBaseName = 'x-pack-data-streams'
 dependencies {
   compileOnly project(path: xpackModule('core'))
   testImplementation(testArtifact(project(xpackModule('core'))))
+  testImplementation project(path: ':modules:transport-netty4') // for http in SystemDataStreamIT
+  testImplementation project(path: ':plugins:transport-nio') // for http in SystemDataStreamIT
 }
 
 addQaCheckDependencies()
+
+tasks.named("internalClusterTest").configure {
+  /*
+   * We have to disable setting the number of available processors as tests in the same JVM randomize processors and will step on each
+   * other if we allow them to set the number of available processors as it's set-once in Netty.
+   */
+  systemProperty 'es.set.netty.runtime.available.processors', 'false'
+}

--- a/x-pack/plugin/data-streams/src/internalClusterTest/java/org/elasticsearch/datastreams/SystemDataStreamIT.java
+++ b/x-pack/plugin/data-streams/src/internalClusterTest/java/org/elasticsearch/datastreams/SystemDataStreamIT.java
@@ -38,6 +38,7 @@ import org.elasticsearch.plugins.SystemIndexPlugin;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.elasticsearch.transport.Netty4Plugin;
 import org.elasticsearch.transport.nio.NioTransportPlugin;
+import org.elasticsearch.xpack.core.XPackClientPlugin;
 import org.elasticsearch.xpack.core.action.DeleteDataStreamAction;
 import org.elasticsearch.xpack.datastreams.DataStreamsPlugin;
 import org.junit.After;
@@ -83,7 +84,8 @@ public class SystemDataStreamIT extends ESIntegTestCase {
 
     @Override
     protected Collection<Class<? extends Plugin>> transportClientPlugins() {
-        List<Class<? extends Plugin>> plugins = new ArrayList<>(super.nodePlugins());
+        List<Class<? extends Plugin>> plugins = new ArrayList<>(super.transportClientPlugins());
+        plugins.add(XPackClientPlugin.class);
         plugins.add(DataStreamsPlugin.class);
         return plugins;
     }

--- a/x-pack/plugin/data-streams/src/internalClusterTest/java/org/elasticsearch/datastreams/SystemDataStreamIT.java
+++ b/x-pack/plugin/data-streams/src/internalClusterTest/java/org/elasticsearch/datastreams/SystemDataStreamIT.java
@@ -73,10 +73,18 @@ public class SystemDataStreamIT extends ESIntegTestCase {
     @Override
     protected Collection<Class<? extends Plugin>> nodePlugins() {
         List<Class<? extends Plugin>> plugins = new ArrayList<>(super.nodePlugins());
+        plugins.add(getTestTransportPlugin());
         plugins.add(NioTransportPlugin.class);
         plugins.add(DataStreamsPlugin.class);
         plugins.add(TestSystemDataStreamPlugin.class);
         plugins.add(Netty4Plugin.class);
+        return plugins;
+    }
+
+    @Override
+    protected Collection<Class<? extends Plugin>> transportClientPlugins() {
+        List<Class<? extends Plugin>> plugins = new ArrayList<>(super.nodePlugins());
+        plugins.add(DataStreamsPlugin.class);
         return plugins;
     }
 

--- a/x-pack/plugin/data-streams/src/internalClusterTest/java/org/elasticsearch/datastreams/SystemDataStreamIT.java
+++ b/x-pack/plugin/data-streams/src/internalClusterTest/java/org/elasticsearch/datastreams/SystemDataStreamIT.java
@@ -1,0 +1,374 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.datastreams;
+
+import org.apache.http.util.EntityUtils;
+import org.elasticsearch.ResourceNotFoundException;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.admin.cluster.snapshots.features.ResetFeatureStateResponse.ResetFeatureStateStatus;
+import org.elasticsearch.action.support.IndicesOptions;
+import org.elasticsearch.action.support.IndicesOptions.Option;
+import org.elasticsearch.action.support.PlainActionFuture;
+import org.elasticsearch.client.Client;
+import org.elasticsearch.client.Request;
+import org.elasticsearch.client.RequestOptions;
+import org.elasticsearch.client.Response;
+import org.elasticsearch.client.ResponseException;
+import org.elasticsearch.client.RestClient;
+import org.elasticsearch.cluster.metadata.ComposableIndexTemplate;
+import org.elasticsearch.cluster.metadata.ComposableIndexTemplate.DataStreamTemplate;
+import org.elasticsearch.cluster.metadata.Template;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.compress.CompressedXContent;
+import org.elasticsearch.common.network.NetworkModule;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.xcontent.XContentHelper;
+import org.elasticsearch.common.xcontent.XContentType;
+import org.elasticsearch.indices.SystemDataStreamDescriptor;
+import org.elasticsearch.indices.SystemDataStreamDescriptor.Type;
+import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.plugins.SystemIndexPlugin;
+import org.elasticsearch.test.ESIntegTestCase;
+import org.elasticsearch.transport.Netty4Plugin;
+import org.elasticsearch.transport.nio.NioTransportPlugin;
+import org.elasticsearch.xpack.core.action.DeleteDataStreamAction;
+import org.elasticsearch.xpack.datastreams.DataStreamsPlugin;
+import org.junit.After;
+import org.junit.BeforeClass;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+
+public class SystemDataStreamIT extends ESIntegTestCase {
+
+    private static String nodeHttpTypeKey;
+
+    @BeforeClass
+    public static void setUpTransport() {
+        if (randomBoolean()) {
+            nodeHttpTypeKey = NioTransportPlugin.NIO_HTTP_TRANSPORT_NAME;
+        } else {
+            nodeHttpTypeKey = Netty4Plugin.NETTY_HTTP_TRANSPORT_NAME;
+        }
+    }
+
+    @Override
+    protected Collection<Class<? extends Plugin>> nodePlugins() {
+        List<Class<? extends Plugin>> plugins = new ArrayList<>(super.nodePlugins());
+        plugins.add(NioTransportPlugin.class);
+        plugins.add(DataStreamsPlugin.class);
+        plugins.add(TestSystemDataStreamPlugin.class);
+        plugins.add(Netty4Plugin.class);
+        return plugins;
+    }
+
+    @Override
+    protected Settings nodeSettings(int nodeOrdinal, Settings otherSettings) {
+        return Settings.builder()
+            .put(super.nodeSettings(nodeOrdinal, otherSettings))
+            .put(NetworkModule.HTTP_TYPE_KEY, nodeHttpTypeKey)
+            .build();
+    }
+
+    @Override
+    protected boolean addMockHttpTransport() {
+        return false;
+    }
+
+    @SuppressWarnings("unchecked")
+    public void testSystemDataStreamCRUD() throws Exception {
+        try (RestClient restClient = createRestClient()) {
+            Request putRequest = new Request("PUT", "/_data_stream/.test-data-stream");
+
+            // no product header
+            ResponseException re = expectThrows(ResponseException.class, () -> restClient.performRequest(putRequest));
+            assertThat(re.getMessage(), containsString("reserved for system"));
+
+            // wrong header
+            putRequest.setOptions(RequestOptions.DEFAULT.toBuilder().addHeader("X-elastic-product-origin", "wrong").build());
+            re = expectThrows(ResponseException.class, () -> restClient.performRequest(putRequest));
+            assertThat(re.getMessage(), containsString("accessed by product"));
+
+            // correct
+            putRequest.setOptions(RequestOptions.DEFAULT.toBuilder().addHeader("X-elastic-product-origin", "product").build());
+            Response putResponse = restClient.performRequest(putRequest);
+            assertThat(putResponse.getStatusLine().getStatusCode(), is(200));
+
+            // list - no header needed
+            Request listAllRequest = new Request("GET", "/_data_stream");
+            Response listAllResponse = restClient.performRequest(listAllRequest);
+            assertThat(listAllResponse.getStatusLine().getStatusCode(), is(200));
+            Map<String, Object> responseMap = XContentHelper.convertToMap(
+                XContentType.JSON.xContent(),
+                EntityUtils.toString(listAllResponse.getEntity()),
+                false
+            );
+            List<Object> dataStreams = (List<Object>) responseMap.get("data_streams");
+            assertThat(dataStreams.size(), is(1));
+
+            Request listRequest = new Request("GET", "/_data_stream/.test-data-stream");
+            Response listResponse = restClient.performRequest(listRequest);
+            assertThat(listResponse.getStatusLine().getStatusCode(), is(200));
+            responseMap = XContentHelper.convertToMap(XContentType.JSON.xContent(), EntityUtils.toString(listResponse.getEntity()), false);
+            dataStreams = (List<Object>) responseMap.get("data_streams");
+            assertThat(dataStreams.size(), is(1));
+
+            // delete
+            Request deleteRequest = new Request("DELETE", "/_data_stream/.test-data-stream");
+
+            // no header
+            re = expectThrows(ResponseException.class, () -> restClient.performRequest(deleteRequest));
+            assertThat(re.getMessage(), containsString("reserved for system"));
+
+            // incorrect header
+            deleteRequest.setOptions(RequestOptions.DEFAULT.toBuilder().addHeader("X-elastic-product-origin", "wrong").build());
+            re = expectThrows(ResponseException.class, () -> restClient.performRequest(deleteRequest));
+            assertThat(re.getMessage(), containsString("accessed by product"));
+
+            // correct
+            deleteRequest.setOptions(putRequest.getOptions());
+            Response deleteResponse = restClient.performRequest(deleteRequest);
+            assertThat(deleteResponse.getStatusLine().getStatusCode(), is(200));
+        }
+    }
+
+    public void testDataStreamStats() throws Exception {
+        try (RestClient restClient = createRestClient()) {
+            Request putRequest = new Request("PUT", "/_data_stream/.test-data-stream");
+            putRequest.setOptions(RequestOptions.DEFAULT.toBuilder().addHeader("X-elastic-product-origin", "product").build());
+            Response putResponse = restClient.performRequest(putRequest);
+            assertThat(putResponse.getStatusLine().getStatusCode(), is(200));
+
+            Request statsRequest = new Request("GET", "/_data_stream/_stats");
+            Response response = restClient.performRequest(statsRequest);
+            assertThat(response.getStatusLine().getStatusCode(), is(200));
+
+            Map<String, Object> map = XContentHelper.convertToMap(
+                XContentType.JSON.xContent(),
+                EntityUtils.toString(response.getEntity()),
+                false
+            );
+            assertThat(map.get("data_stream_count"), equalTo(1));
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    public void testSystemDataStreamReadWrite() throws Exception {
+        try (RestClient restClient = createRestClient()) {
+            Request putRequest = new Request("PUT", "/_data_stream/.test-data-stream");
+            putRequest.setOptions(RequestOptions.DEFAULT.toBuilder().addHeader("X-elastic-product-origin", "product").build());
+            Response putResponse = restClient.performRequest(putRequest);
+            assertThat(putResponse.getStatusLine().getStatusCode(), is(200));
+
+            // write
+            Request index = new Request("POST", "/.test-data-stream/_doc");
+            index.setJsonEntity("{ \"@timestamp\": \"2099-03-08T11:06:07.000Z\", \"name\": \"my-name\" }");
+            index.addParameter("refresh", "true");
+
+            // no product specified
+            ResponseException re = expectThrows(ResponseException.class, () -> restClient.performRequest(index));
+            assertThat(re.getMessage(), containsString("reserved for system"));
+
+            // wrong header
+            index.setOptions(RequestOptions.DEFAULT.toBuilder().addHeader("X-elastic-product-origin", "wrong").build());
+            re = expectThrows(ResponseException.class, () -> restClient.performRequest(index));
+            assertThat(re.getMessage(), containsString("accessed by product"));
+
+            // correct
+            index.setOptions(putRequest.getOptions());
+            Response response = restClient.performRequest(index);
+            assertEquals(201, response.getStatusLine().getStatusCode());
+
+            Map<String, Object> responseMap = XContentHelper.convertToMap(
+                XContentType.JSON.xContent(),
+                EntityUtils.toString(response.getEntity()),
+                false
+            );
+            String indexName = (String) responseMap.get("_index");
+            String id = (String) responseMap.get("_id");
+
+            // get
+            Request get = new Request("GET", "/" + indexName + "/_doc/" + id);
+
+            // no product specified
+            re = expectThrows(ResponseException.class, () -> restClient.performRequest(get));
+            assertThat(re.getMessage(), containsString("reserved for system"));
+
+            // wrong product
+            get.setOptions(RequestOptions.DEFAULT.toBuilder().addHeader("X-elastic-product-origin", "wrong").build());
+            re = expectThrows(ResponseException.class, () -> restClient.performRequest(get));
+            assertThat(re.getMessage(), containsString("accessed by product"));
+
+            // correct
+            get.setOptions(putRequest.getOptions());
+            Response getResponse = restClient.performRequest(get);
+            assertThat(getResponse.getStatusLine().getStatusCode(), is(200));
+
+            // search all
+            Request search = new Request("GET", "/_search");
+            search.setJsonEntity("{ \"query\": { \"match_all\": {} } }");
+
+            // no header
+            Response searchResponse = restClient.performRequest(search);
+            assertThat(searchResponse.getStatusLine().getStatusCode(), is(200));
+            responseMap = XContentHelper.convertToMap(
+                XContentType.JSON.xContent(),
+                EntityUtils.toString(searchResponse.getEntity()),
+                false
+            );
+            Map<String, Object> hits = (Map<String, Object>) responseMap.get("hits");
+            List<Object> hitsHits = (List<Object>) hits.get("hits");
+            assertThat(hitsHits.size(), is(0));
+
+            // wrong header
+            search.setOptions(RequestOptions.DEFAULT.toBuilder().addHeader("X-elastic-product-origin", "wrong").build());
+            searchResponse = restClient.performRequest(search);
+            assertThat(searchResponse.getStatusLine().getStatusCode(), is(200));
+            responseMap = XContentHelper.convertToMap(
+                XContentType.JSON.xContent(),
+                EntityUtils.toString(searchResponse.getEntity()),
+                false
+            );
+            hits = (Map<String, Object>) responseMap.get("hits");
+            hitsHits = (List<Object>) hits.get("hits");
+            assertThat(hitsHits.size(), is(0));
+
+            // correct
+            search.setOptions(putRequest.getOptions());
+            searchResponse = restClient.performRequest(search);
+            assertThat(searchResponse.getStatusLine().getStatusCode(), is(200));
+            responseMap = XContentHelper.convertToMap(
+                XContentType.JSON.xContent(),
+                EntityUtils.toString(searchResponse.getEntity()),
+                false
+            );
+            hits = (Map<String, Object>) responseMap.get("hits");
+            hitsHits = (List<Object>) hits.get("hits");
+            assertThat(hitsHits.size(), is(1));
+
+            // search the datastream
+            Request searchIdx = new Request("GET", "/.test-data-stream/_search");
+            searchIdx.setJsonEntity("{ \"query\": { \"match_all\": {} } }");
+
+            // no header
+            re = expectThrows(ResponseException.class, () -> restClient.performRequest(searchIdx));
+            assertThat(re.getMessage(), containsString("reserved for system"));
+
+            // incorrect header
+            searchIdx.setOptions(RequestOptions.DEFAULT.toBuilder().addHeader("X-elastic-product-origin", "wrong").build());
+            re = expectThrows(ResponseException.class, () -> restClient.performRequest(searchIdx));
+            assertThat(re.getMessage(), containsString("accessed by product"));
+
+            // correct
+            searchIdx.setOptions(putRequest.getOptions());
+            searchResponse = restClient.performRequest(searchIdx);
+            assertThat(searchResponse.getStatusLine().getStatusCode(), is(200));
+            responseMap = XContentHelper.convertToMap(
+                XContentType.JSON.xContent(),
+                EntityUtils.toString(searchResponse.getEntity()),
+                false
+            );
+            hits = (Map<String, Object>) responseMap.get("hits");
+            hitsHits = (List<Object>) hits.get("hits");
+            assertThat(hitsHits.size(), is(1));
+        }
+    }
+
+    @After
+    public void cleanup() {
+        try {
+            PlainActionFuture<ResetFeatureStateStatus> stateStatusPlainActionFuture = new PlainActionFuture<>();
+            new TestSystemDataStreamPlugin().cleanUpFeature(
+                internalCluster().clusterService(),
+                internalCluster().client(),
+                stateStatusPlainActionFuture
+            );
+            stateStatusPlainActionFuture.actionGet();
+        } catch (ResourceNotFoundException e) {
+            // ignore
+        }
+    }
+
+    public static final class TestSystemDataStreamPlugin extends Plugin implements SystemIndexPlugin {
+
+        @Override
+        public Collection<SystemDataStreamDescriptor> getSystemDataStreamDescriptors() {
+            try {
+                CompressedXContent mappings = new CompressedXContent("{\"properties\":{\"name\":{\"type\":\"keyword\"}}}");
+                return Collections.singletonList(
+                    new SystemDataStreamDescriptor(
+                        ".test-data-stream",
+                        "system data stream test",
+                        Type.EXTERNAL,
+                        new ComposableIndexTemplate(
+                            Collections.singletonList(".test-data-stream"),
+                            new Template(Settings.EMPTY, mappings, null),
+                            null,
+                            null,
+                            null,
+                            null,
+                            new DataStreamTemplate()
+                        ),
+                        Collections.emptyMap(),
+                        Collections.singletonList("product")
+                    )
+                );
+            } catch (IOException e) {
+                throw new UncheckedIOException(e);
+            }
+        }
+
+        @Override
+        public String getFeatureName() {
+            return SystemDataStreamIT.class.getSimpleName();
+        }
+
+        @Override
+        public String getFeatureDescription() {
+            return "Integration testing of system data streams";
+        }
+
+        @Override
+        public void cleanUpFeature(ClusterService clusterService, Client client, ActionListener<ResetFeatureStateStatus> listener) {
+            Collection<SystemDataStreamDescriptor> dataStreamDescriptors = getSystemDataStreamDescriptors();
+            final DeleteDataStreamAction.Request request = new DeleteDataStreamAction.Request(
+                dataStreamDescriptors.stream()
+                    .map(SystemDataStreamDescriptor::getDataStreamName)
+                    .collect(Collectors.toList())
+                    .toArray(Strings.EMPTY_ARRAY)
+            );
+            EnumSet<Option> options = request.indicesOptions().getOptions();
+            options.add(Option.IGNORE_UNAVAILABLE);
+            options.add(Option.ALLOW_NO_INDICES);
+            request.indicesOptions(new IndicesOptions(options, request.indicesOptions().getExpandWildcards()));
+            client.execute(
+                DeleteDataStreamAction.INSTANCE,
+                request,
+                ActionListener.wrap(response -> SystemIndexPlugin.super.cleanUpFeature(clusterService, client, listener), e -> {
+                    if (e instanceof ResourceNotFoundException) {
+                        SystemIndexPlugin.super.cleanUpFeature(clusterService, client, listener);
+                    } else {
+                        listener.onFailure(e);
+                    }
+                })
+            );
+        }
+    }
+}

--- a/x-pack/plugin/data-streams/src/internalClusterTest/java/org/elasticsearch/datastreams/SystemDataStreamIT.java
+++ b/x-pack/plugin/data-streams/src/internalClusterTest/java/org/elasticsearch/datastreams/SystemDataStreamIT.java
@@ -38,7 +38,6 @@ import org.elasticsearch.plugins.SystemIndexPlugin;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.elasticsearch.transport.Netty4Plugin;
 import org.elasticsearch.transport.nio.NioTransportPlugin;
-import org.elasticsearch.xpack.core.XPackClientPlugin;
 import org.elasticsearch.xpack.core.action.DeleteDataStreamAction;
 import org.elasticsearch.xpack.datastreams.DataStreamsPlugin;
 import org.junit.After;
@@ -58,6 +57,7 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 
+@ESIntegTestCase.ClusterScope(transportClientRatio = 0)
 public class SystemDataStreamIT extends ESIntegTestCase {
 
     private static String nodeHttpTypeKey;
@@ -79,14 +79,6 @@ public class SystemDataStreamIT extends ESIntegTestCase {
         plugins.add(DataStreamsPlugin.class);
         plugins.add(TestSystemDataStreamPlugin.class);
         plugins.add(Netty4Plugin.class);
-        return plugins;
-    }
-
-    @Override
-    protected Collection<Class<? extends Plugin>> transportClientPlugins() {
-        List<Class<? extends Plugin>> plugins = new ArrayList<>(super.transportClientPlugins());
-        plugins.add(XPackClientPlugin.class);
-        plugins.add(DataStreamsPlugin.class);
         return plugins;
     }
 

--- a/x-pack/plugin/data-streams/src/main/java/org/elasticsearch/xpack/datastreams/action/CreateDataStreamTransportAction.java
+++ b/x-pack/plugin/data-streams/src/main/java/org/elasticsearch/xpack/datastreams/action/CreateDataStreamTransportAction.java
@@ -17,6 +17,8 @@ import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.metadata.MetadataCreateDataStreamService;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.indices.SystemDataStreamDescriptor;
+import org.elasticsearch.indices.SystemIndices;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.xpack.core.action.CreateDataStreamAction;
@@ -24,6 +26,7 @@ import org.elasticsearch.xpack.core.action.CreateDataStreamAction;
 public class CreateDataStreamTransportAction extends AcknowledgedTransportMasterNodeAction<CreateDataStreamAction.Request> {
 
     private final MetadataCreateDataStreamService metadataCreateDataStreamService;
+    private final SystemIndices systemIndices;
 
     @Inject
     public CreateDataStreamTransportAction(
@@ -32,7 +35,8 @@ public class CreateDataStreamTransportAction extends AcknowledgedTransportMaster
         ThreadPool threadPool,
         ActionFilters actionFilters,
         IndexNameExpressionResolver indexNameExpressionResolver,
-        MetadataCreateDataStreamService metadataCreateDataStreamService
+        MetadataCreateDataStreamService metadataCreateDataStreamService,
+        SystemIndices systemIndices
     ) {
         super(
             CreateDataStreamAction.NAME,
@@ -45,6 +49,7 @@ public class CreateDataStreamTransportAction extends AcknowledgedTransportMaster
             ThreadPool.Names.SAME
         );
         this.metadataCreateDataStreamService = metadataCreateDataStreamService;
+        this.systemIndices = systemIndices;
     }
 
     @Override
@@ -53,9 +58,14 @@ public class CreateDataStreamTransportAction extends AcknowledgedTransportMaster
         ClusterState state,
         ActionListener<AcknowledgedResponse> listener
     ) throws Exception {
+        final SystemDataStreamDescriptor systemDataStreamDescriptor = systemIndices.validateDataStreamAccess(
+            request.getName(),
+            threadPool.getThreadContext()
+        );
         MetadataCreateDataStreamService.CreateDataStreamClusterStateUpdateRequest updateRequest =
             new MetadataCreateDataStreamService.CreateDataStreamClusterStateUpdateRequest(
                 request.getName(),
+                systemDataStreamDescriptor,
                 request.masterNodeTimeout(),
                 request.timeout()
             );

--- a/x-pack/plugin/data-streams/src/main/java/org/elasticsearch/xpack/datastreams/action/DeleteDataStreamTransportAction.java
+++ b/x-pack/plugin/data-streams/src/main/java/org/elasticsearch/xpack/datastreams/action/DeleteDataStreamTransportAction.java
@@ -27,6 +27,7 @@ import org.elasticsearch.common.Priority;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.index.Index;
+import org.elasticsearch.indices.SystemIndices;
 import org.elasticsearch.snapshots.SnapshotInProgressException;
 import org.elasticsearch.snapshots.SnapshotsService;
 import org.elasticsearch.threadpool.ThreadPool;
@@ -37,6 +38,7 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.function.Consumer;
 
 import static org.elasticsearch.xpack.datastreams.action.DataStreamsActionUtil.getDataStreamNames;
 
@@ -45,6 +47,7 @@ public class DeleteDataStreamTransportAction extends AcknowledgedTransportMaster
     private static final Logger LOGGER = LogManager.getLogger(DeleteDataStreamTransportAction.class);
 
     private final MetadataDeleteIndexService deleteIndexService;
+    private final SystemIndices systemIndices;
 
     @Inject
     public DeleteDataStreamTransportAction(
@@ -53,7 +56,8 @@ public class DeleteDataStreamTransportAction extends AcknowledgedTransportMaster
         ThreadPool threadPool,
         ActionFilters actionFilters,
         IndexNameExpressionResolver indexNameExpressionResolver,
-        MetadataDeleteIndexService deleteIndexService
+        MetadataDeleteIndexService deleteIndexService,
+        SystemIndices systemIndices
     ) {
         super(
             DeleteDataStreamAction.NAME,
@@ -66,6 +70,7 @@ public class DeleteDataStreamTransportAction extends AcknowledgedTransportMaster
             ThreadPool.Names.SAME
         );
         this.deleteIndexService = deleteIndexService;
+        this.systemIndices = systemIndices;
     }
 
     @Override
@@ -74,6 +79,13 @@ public class DeleteDataStreamTransportAction extends AcknowledgedTransportMaster
         ClusterState state,
         ActionListener<AcknowledgedResponse> listener
     ) throws Exception {
+        // resolve the names in the request early
+        List<String> names = getDataStreamNames(indexNameExpressionResolver, state, request.getNames(), request.indicesOptions());
+        for (String name : names) {
+            systemIndices.validateDataStreamAccess(name, threadPool.getThreadContext());
+        }
+        request.indices(names.toArray(Strings.EMPTY_ARRAY));
+
         clusterService.submitStateUpdateTask(
             "remove-data-stream [" + Strings.arrayToCommaDelimitedString(request.getNames()) + "]",
             new ClusterStateUpdateTask(Priority.HIGH, request.masterNodeTimeout()) {
@@ -85,7 +97,13 @@ public class DeleteDataStreamTransportAction extends AcknowledgedTransportMaster
 
                 @Override
                 public ClusterState execute(ClusterState currentState) {
-                    return removeDataStream(deleteIndexService, indexNameExpressionResolver, currentState, request);
+                    return removeDataStream(
+                        deleteIndexService,
+                        indexNameExpressionResolver,
+                        currentState,
+                        request,
+                        ds -> systemIndices.validateDataStreamAccess(ds, threadPool.getThreadContext())
+                    );
                 }
 
                 @Override
@@ -100,10 +118,15 @@ public class DeleteDataStreamTransportAction extends AcknowledgedTransportMaster
         MetadataDeleteIndexService deleteIndexService,
         IndexNameExpressionResolver indexNameExpressionResolver,
         ClusterState currentState,
-        DeleteDataStreamAction.Request request
+        DeleteDataStreamAction.Request request,
+        Consumer<String> systemDataStreamAccessValidator
     ) {
+        // resolve the names in the request early
         List<String> names = getDataStreamNames(indexNameExpressionResolver, currentState, request.getNames(), request.indicesOptions());
         Set<String> dataStreams = new HashSet<>(names);
+        for (String name : names) {
+            systemDataStreamAccessValidator.accept(name);
+        }
         Set<String> snapshottingDataStreams = SnapshotsService.snapshottingDataStreams(currentState, dataStreams);
 
         if (dataStreams.isEmpty()) {

--- a/x-pack/plugin/data-streams/src/main/java/org/elasticsearch/xpack/datastreams/action/GetDataStreamsTransportAction.java
+++ b/x-pack/plugin/data-streams/src/main/java/org/elasticsearch/xpack/datastreams/action/GetDataStreamsTransportAction.java
@@ -23,6 +23,8 @@ import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.Index;
+import org.elasticsearch.indices.SystemDataStreamDescriptor;
+import org.elasticsearch.indices.SystemIndices;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.xpack.core.action.GetDataStreamAction;
@@ -38,6 +40,7 @@ public class GetDataStreamsTransportAction extends TransportMasterNodeReadAction
     GetDataStreamAction.Response> {
 
     private static final Logger LOGGER = LogManager.getLogger(GetDataStreamsTransportAction.class);
+    private final SystemIndices systemIndices;
 
     @Inject
     public GetDataStreamsTransportAction(
@@ -45,7 +48,8 @@ public class GetDataStreamsTransportAction extends TransportMasterNodeReadAction
         ClusterService clusterService,
         ThreadPool threadPool,
         ActionFilters actionFilters,
-        IndexNameExpressionResolver indexNameExpressionResolver
+        IndexNameExpressionResolver indexNameExpressionResolver,
+        SystemIndices systemIndices
     ) {
         super(
             GetDataStreamAction.NAME,
@@ -58,6 +62,7 @@ public class GetDataStreamsTransportAction extends TransportMasterNodeReadAction
             GetDataStreamAction.Response::new,
             ThreadPool.Names.SAME
         );
+        this.systemIndices = systemIndices;
     }
 
     @Override
@@ -69,18 +74,32 @@ public class GetDataStreamsTransportAction extends TransportMasterNodeReadAction
         List<DataStream> dataStreams = getDataStreams(state, indexNameExpressionResolver, request);
         List<GetDataStreamAction.Response.DataStreamInfo> dataStreamInfos = new ArrayList<>(dataStreams.size());
         for (DataStream dataStream : dataStreams) {
-            String indexTemplate = MetadataIndexTemplateService.findV2Template(state.metadata(), dataStream.getName(), false);
+            final String indexTemplate;
             String ilmPolicyName = null;
-            if (indexTemplate != null) {
-                Settings settings = MetadataIndexTemplateService.resolveSettings(state.metadata(), indexTemplate);
-                ilmPolicyName = settings.get("index.lifecycle.name");
+            if (dataStream.isSystem()) {
+                SystemDataStreamDescriptor dataStreamDescriptor = systemIndices.findMatchingDataStreamDescriptor(dataStream.getName());
+                indexTemplate = dataStreamDescriptor != null ? dataStreamDescriptor.getDataStreamName() : null;
+                if (dataStreamDescriptor != null) {
+                    Settings settings = MetadataIndexTemplateService.resolveSettings(
+                        dataStreamDescriptor.getComposableIndexTemplate(),
+                        dataStreamDescriptor.getComponentTemplates()
+                    );
+                    ilmPolicyName = settings.get("index.lifecycle.name");
+                }
             } else {
-                LOGGER.warn(
-                    "couldn't find any matching template for data stream [{}]. has it been restored (and possibly renamed)"
-                        + "from a snapshot?",
-                    dataStream.getName()
-                );
+                indexTemplate = MetadataIndexTemplateService.findV2Template(state.metadata(), dataStream.getName(), false);
+                if (indexTemplate != null) {
+                    Settings settings = MetadataIndexTemplateService.resolveSettings(state.metadata(), indexTemplate);
+                    ilmPolicyName = settings.get("index.lifecycle.name");
+                } else {
+                    LOGGER.warn(
+                        "couldn't find any matching template for data stream [{}]. has it been restored (and possibly renamed)"
+                            + "from a snapshot?",
+                        dataStream.getName()
+                    );
+                }
             }
+
             ClusterStateHealth streamHealth = new ClusterStateHealth(
                 state,
                 dataStream.getIndices().stream().map(Index::getName).toArray(String[]::new)

--- a/x-pack/plugin/data-streams/src/main/java/org/elasticsearch/xpack/datastreams/action/MigrateToDataStreamTransportAction.java
+++ b/x-pack/plugin/data-streams/src/main/java/org/elasticsearch/xpack/datastreams/action/MigrateToDataStreamTransportAction.java
@@ -15,9 +15,11 @@ import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.block.ClusterBlockException;
 import org.elasticsearch.cluster.block.ClusterBlockLevel;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
+import org.elasticsearch.cluster.metadata.MetadataCreateIndexService;
 import org.elasticsearch.cluster.metadata.MetadataMigrateToDataStreamService;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.indices.IndicesService;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.xpack.core.MigrateToDataStreamAction;
@@ -33,7 +35,8 @@ public class MigrateToDataStreamTransportAction extends AcknowledgedTransportMas
         ThreadPool threadPool,
         ActionFilters actionFilters,
         IndexNameExpressionResolver indexNameExpressionResolver,
-        MetadataMigrateToDataStreamService metadataMigrateToDataStreamService
+        IndicesService indicesService,
+        MetadataCreateIndexService metadataCreateIndexService
     ) {
         super(
             MigrateToDataStreamAction.NAME,
@@ -45,7 +48,12 @@ public class MigrateToDataStreamTransportAction extends AcknowledgedTransportMas
             indexNameExpressionResolver,
             ThreadPool.Names.SAME
         );
-        this.metadataMigrateToDataStreamService = metadataMigrateToDataStreamService;
+        this.metadataMigrateToDataStreamService = new MetadataMigrateToDataStreamService(
+            threadPool,
+            clusterService,
+            indicesService,
+            metadataCreateIndexService
+        );
     }
 
     @Override

--- a/x-pack/plugin/data-streams/src/main/java/org/elasticsearch/xpack/datastreams/rest/RestDataStreamsStatsAction.java
+++ b/x-pack/plugin/data-streams/src/main/java/org/elasticsearch/xpack/datastreams/rest/RestDataStreamsStatsAction.java
@@ -38,4 +38,9 @@ public class RestDataStreamsStatsAction extends BaseRestHandler {
         dataStreamsStatsRequest.indicesOptions(IndicesOptions.fromRequest(request, dataStreamsStatsRequest.indicesOptions()));
         return channel -> client.execute(DataStreamsStatsAction.INSTANCE, dataStreamsStatsRequest, new RestToXContentListener<>(channel));
     }
+
+    @Override
+    public boolean allowSystemIndexAccessByDefault() {
+        return true;
+    }
 }

--- a/x-pack/plugin/data-streams/src/main/java/org/elasticsearch/xpack/datastreams/rest/RestGetDataStreamsAction.java
+++ b/x-pack/plugin/data-streams/src/main/java/org/elasticsearch/xpack/datastreams/rest/RestGetDataStreamsAction.java
@@ -39,4 +39,9 @@ public class RestGetDataStreamsAction extends BaseRestHandler {
         getDataStreamsRequest.indicesOptions(IndicesOptions.fromRequest(request, getDataStreamsRequest.indicesOptions()));
         return channel -> client.execute(GetDataStreamAction.INSTANCE, getDataStreamsRequest, new RestToXContentListener<>(channel));
     }
+
+    @Override
+    public boolean allowSystemIndexAccessByDefault() {
+        return true;
+    }
 }

--- a/x-pack/plugin/fleet/src/javaRestTest/java/org/elasticsearch/xpack/fleet/FleetSystemIndicesIT.java
+++ b/x-pack/plugin/fleet/src/javaRestTest/java/org/elasticsearch/xpack/fleet/FleetSystemIndicesIT.java
@@ -31,11 +31,15 @@ import org.elasticsearch.client.Request;
 import org.elasticsearch.client.Response;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
+import org.elasticsearch.common.xcontent.XContentHelper;
+import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.test.SecuritySettingsSourceField;
 import org.elasticsearch.test.rest.ESRestTestCase;
 
-import static org.elasticsearch.xpack.core.security.authc.support.UsernamePasswordToken.basicAuthHeaderValue;
+import java.util.Map;
+
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
 
 public class FleetSystemIndicesIT extends ESRestTestCase {
 
@@ -170,5 +174,27 @@ public class FleetSystemIndicesIT extends ESRestTestCase {
         response = client().performRequest(request);
         responseBody = EntityUtils.toString(response.getEntity());
         assertThat(responseBody, containsString("architecture"));
+    }
+
+    public void testCreationOfFleetActionsResults() throws Exception {
+        Request request = new Request("POST", "/.fleet-actions-results/_doc");
+        request.setJsonEntity("{ \"@timestamp\": \"2099-03-08T11:06:07.000Z\", \"agent_id\": \"my-agent\" }");
+        Response response = client().performRequest(request);
+        assertEquals(201, response.getStatusLine().getStatusCode());
+    }
+
+    @SuppressWarnings("unchecked")
+    public void verifyILMPolicyExists() throws Exception {
+        assertBusy(() -> {
+            Request request = new Request("GET", "_ilm/policy/.fleet-actions-results-ilm-policy");
+            Response response = client().performRequest(request);
+            assertEquals(200, response.getStatusLine().getStatusCode());
+            final String responseJson = EntityUtils.toString(response.getEntity());
+            Map<String, Object> responseMap = XContentHelper.convertToMap(XContentType.JSON.xContent(), responseJson, false);
+            assertNotNull(responseMap.get(".fleet-actions-results-ilm-policy"));
+            Map<String, Object> policyMap = (Map<String, Object>) responseMap.get(".fleet-actions-results-ilm-policy");
+            assertNotNull(policyMap);
+            assertThat(policyMap.size(), equalTo(2));
+        });
     }
 }

--- a/x-pack/plugin/fleet/src/main/java/org/elasticsearch/xpack/fleet/Fleet.java
+++ b/x-pack/plugin/fleet/src/main/java/org/elasticsearch/xpack/fleet/Fleet.java
@@ -7,33 +7,56 @@
 
 package org.elasticsearch.xpack.fleet;
 
+import org.elasticsearch.ResourceNotFoundException;
 import org.elasticsearch.Version;
+import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionResponse;
+import org.elasticsearch.action.admin.cluster.snapshots.features.ResetFeatureStateResponse.ResetFeatureStateStatus;
 import org.elasticsearch.action.admin.indices.template.put.PutIndexTemplateRequest;
+import org.elasticsearch.client.Client;
+import org.elasticsearch.cluster.metadata.ComposableIndexTemplate;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.settings.ClusterSettings;
 import org.elasticsearch.common.settings.IndexScopedSettings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.settings.SettingsFilter;
+import org.elasticsearch.common.xcontent.DeprecationHandler;
+import org.elasticsearch.common.xcontent.NamedXContentRegistry;
+import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.XContentType;
+import org.elasticsearch.env.Environment;
+import org.elasticsearch.env.NodeEnvironment;
+import org.elasticsearch.indices.SystemDataStreamDescriptor;
 import org.elasticsearch.indices.SystemIndexDescriptor;
 import org.elasticsearch.indices.SystemIndexDescriptor.Type;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.plugins.SystemIndexPlugin;
+import org.elasticsearch.repositories.RepositoriesService;
 import org.elasticsearch.rest.RestController;
 import org.elasticsearch.rest.RestHandler;
+import org.elasticsearch.script.ScriptService;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.watcher.ResourceWatcherService;
+import org.elasticsearch.xpack.core.action.DeleteDataStreamAction;
+import org.elasticsearch.xpack.core.action.DeleteDataStreamAction.Request;
 import org.elasticsearch.xpack.core.template.TemplateUtils;
 import org.elasticsearch.xpack.fleet.action.GetGlobalCheckpointsAction;
 import org.elasticsearch.xpack.fleet.action.GetGlobalCheckpointsShardAction;
 import org.elasticsearch.xpack.fleet.rest.RestGetGlobalCheckpointsAction;
 
+import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.function.Supplier;
+import java.util.stream.Collectors;
 
 import static org.elasticsearch.xpack.core.ClientHelper.FLEET_ORIGIN;
 
@@ -50,6 +73,31 @@ public class Fleet extends Plugin implements SystemIndexPlugin {
     private static final List<String> ALLOWED_PRODUCTS = Collections.unmodifiableList(Arrays.asList("kibana", "fleet"));
 
     @Override
+    public Collection<Object> createComponents(
+        Client client,
+        ClusterService clusterService,
+        ThreadPool threadPool,
+        ResourceWatcherService resourceWatcherService,
+        ScriptService scriptService,
+        NamedXContentRegistry xContentRegistry,
+        Environment environment,
+        NodeEnvironment nodeEnvironment,
+        NamedWriteableRegistry namedWriteableRegistry,
+        IndexNameExpressionResolver expressionResolver,
+        Supplier<RepositoriesService> repositoriesServiceSupplier
+    ) {
+        FleetTemplateRegistry registry = new FleetTemplateRegistry(
+            environment.settings(),
+            clusterService,
+            threadPool,
+            client,
+            xContentRegistry
+        );
+        registry.initialize();
+        return Collections.emptyList();
+    }
+
+    @Override
     public Collection<SystemIndexDescriptor> getSystemIndexDescriptors(Settings settings) {
         return Collections.unmodifiableList(
             Arrays.asList(
@@ -62,6 +110,11 @@ public class Fleet extends Plugin implements SystemIndexPlugin {
                 fleetArtifactsSystemIndexDescriptors()
             )
         );
+    }
+
+    @Override
+    public Collection<SystemDataStreamDescriptor> getSystemDataStreamDescriptors() {
+        return Collections.singletonList(fleetActionsResultsDescriptor());
     }
 
     @Override
@@ -86,7 +139,7 @@ public class Fleet extends Plugin implements SystemIndexPlugin {
             .setMappings(request.mappings().get("_doc"))
             .setSettings(request.settings())
             .setPrimaryIndex(".fleet-actions-" + CURRENT_INDEX_VERSION)
-            .setIndexPattern(".fleet-actions*")
+            .setIndexPattern(".fleet-actions~(-results*)")
             .setAliasName(".fleet-actions")
             .setDescription("Fleet agents")
             .build();
@@ -200,6 +253,51 @@ public class Fleet extends Plugin implements SystemIndexPlugin {
             .build();
     }
 
+    private SystemDataStreamDescriptor fleetActionsResultsDescriptor() {
+        final String source = loadTemplateSource("/fleet-actions-results.json");
+        try (
+            XContentParser parser = XContentType.JSON.xContent()
+                .createParser(NamedXContentRegistry.EMPTY, DeprecationHandler.THROW_UNSUPPORTED_OPERATION, source)
+        ) {
+            ComposableIndexTemplate composableIndexTemplate = ComposableIndexTemplate.parse(parser);
+            return new SystemDataStreamDescriptor(
+                ".fleet-actions-results",
+                "Result history of fleet actions",
+                SystemDataStreamDescriptor.Type.EXTERNAL,
+                composableIndexTemplate,
+                Collections.emptyMap(),
+                ALLOWED_PRODUCTS
+            );
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    @Override
+    public void cleanUpFeature(ClusterService clusterService, Client client, ActionListener<ResetFeatureStateStatus> listener) {
+        Collection<SystemDataStreamDescriptor> dataStreamDescriptors = getSystemDataStreamDescriptors();
+        if (dataStreamDescriptors.isEmpty() == false) {
+            client.execute(
+                DeleteDataStreamAction.INSTANCE,
+                new Request(
+                    dataStreamDescriptors.stream()
+                        .map(SystemDataStreamDescriptor::getDataStreamName)
+                        .collect(Collectors.toList())
+                        .toArray(Strings.EMPTY_ARRAY)
+                ),
+                ActionListener.wrap(response -> SystemIndexPlugin.super.cleanUpFeature(clusterService, client, listener), e -> {
+                    if (e instanceof ResourceNotFoundException) {
+                        SystemIndexPlugin.super.cleanUpFeature(clusterService, client, listener);
+                    } else {
+                        listener.onFailure(e);
+                    }
+                })
+            );
+        } else {
+            SystemIndexPlugin.super.cleanUpFeature(clusterService, client, listener);
+        }
+    }
+
     private String loadTemplateSource(String resource) {
         return TemplateUtils.loadTemplate(resource, Version.CURRENT.toString(), MAPPING_VERSION_VARIABLE);
     }
@@ -222,6 +320,6 @@ public class Fleet extends Plugin implements SystemIndexPlugin {
         IndexNameExpressionResolver indexNameExpressionResolver,
         Supplier<DiscoveryNodes> nodesInCluster
     ) {
-        return Arrays.asList(new RestGetGlobalCheckpointsAction());
+        return Collections.singletonList(new RestGetGlobalCheckpointsAction());
     }
 }

--- a/x-pack/plugin/fleet/src/main/java/org/elasticsearch/xpack/fleet/FleetTemplateRegistry.java
+++ b/x-pack/plugin/fleet/src/main/java/org/elasticsearch/xpack/fleet/FleetTemplateRegistry.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.xpack.fleet;
+
+import org.elasticsearch.client.Client;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.xcontent.NamedXContentRegistry;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.xpack.core.ClientHelper;
+import org.elasticsearch.xpack.core.template.IndexTemplateRegistry;
+import org.elasticsearch.xpack.core.template.LifecyclePolicyConfig;
+
+import java.util.List;
+
+import static java.util.Collections.singletonList;
+
+public class FleetTemplateRegistry extends IndexTemplateRegistry {
+
+    public static final LifecyclePolicyConfig FLEET_ACTIONS_RESULTS_POLICY = new LifecyclePolicyConfig(
+        ".fleet-actions-results-ilm-policy",
+        "/fleet-actions-results-ilm-policy.json"
+    );
+
+    public FleetTemplateRegistry(
+        Settings nodeSettings,
+        ClusterService clusterService,
+        ThreadPool threadPool,
+        Client client,
+        NamedXContentRegistry xContentRegistry
+    ) {
+        super(nodeSettings, clusterService, threadPool, client, xContentRegistry);
+    }
+
+    @Override
+    protected String getOrigin() {
+        return ClientHelper.FLEET_ORIGIN;
+    }
+
+    @Override
+    protected List<LifecyclePolicyConfig> getPolicyConfigs() {
+        return singletonList(FLEET_ACTIONS_RESULTS_POLICY);
+    }
+}

--- a/x-pack/plugin/fleet/src/test/java/org/elasticsearch/xpack/fleet/FleetTests.java
+++ b/x-pack/plugin/fleet/src/test/java/org/elasticsearch/xpack/fleet/FleetTests.java
@@ -9,9 +9,12 @@ package org.elasticsearch.xpack.fleet;
 
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.indices.SystemIndexDescriptor;
+import org.elasticsearch.indices.SystemIndices;
+import org.elasticsearch.indices.SystemIndices.Feature;
 import org.elasticsearch.test.ESTestCase;
 
 import java.util.Collection;
+import java.util.Collections;
 import java.util.stream.Collectors;
 
 import static org.hamcrest.Matchers.containsInAnyOrder;
@@ -29,7 +32,7 @@ public class FleetTests extends ESTestCase {
                 ".fleet-servers*",
                 ".fleet-policies-[0-9]+*",
                 ".fleet-agents*",
-                ".fleet-actions*",
+                ".fleet-actions~(-results*)",
                 ".fleet-policies-leader*",
                 ".fleet-enrollment-api-keys*",
                 ".fleet-artifacts*"
@@ -44,7 +47,13 @@ public class FleetTests extends ESTestCase {
         assertTrue(fleetDescriptors.stream().anyMatch(d -> d.matchesIndexPattern(".fleet-agents")));
 
         assertTrue(fleetDescriptors.stream().anyMatch(d -> d.matchesIndexPattern(".fleet-actions")));
-        assertTrue(fleetDescriptors.stream().anyMatch(d -> d.matchesIndexPattern(".fleet-actions-results")));
+        assertFalse(fleetDescriptors.stream().anyMatch(d -> d.matchesIndexPattern(".fleet-actions-results")));
+    }
 
+    public void testFleetFeature() {
+        Fleet module = new Fleet();
+        Feature fleet = SystemIndices.pluginToFeature(module, Settings.EMPTY);
+        SystemIndices systemIndices = new SystemIndices(Collections.singletonMap(module.getFeatureName(), fleet));
+        assertNotNull(systemIndices);
     }
 }


### PR DESCRIPTION
This commit adds support for system data streams and also the first use
of a system data stream with the fleet action results data stream. A
system data stream is one that is used to store system data that users
should not interact with directly. Elasticsearch will manage these data
streams. REST API access is available for external system data streams
so that other stack components can store system data within a system
datastream. System data streams will not use the system index read and
write threadpools.

Backport of #71667