### PR TITLE
Frozen default cache size (#71844)

### DIFF
--- a/docs/reference/searchable-snapshots/index.asciidoc
+++ b/docs/reference/searchable-snapshots/index.asciidoc
@@ -153,18 +153,42 @@ for search. Many searches will need to retrieve only a small subset of the
 total shard data before returning results.
 
 To mount a searchable snapshot index with the shared cache mount option, you
-must configure the `xpack.searchable.snapshot.shared_cache.size` setting to
-reserve space for the cache on one or more nodes. Indices mounted with the
-shared cache mount option are only allocated to nodes that have this setting
-configured.
+must have one or more nodes with a shared cache available. By default,
+dedicated frozen data tier nodes (nodes with the `data_frozen` role and no other
+data roles) have a shared cache configured using the greater of 90% of total
+disk space and total disk space subtracted a headroom of 100GB.
+
+Using a dedicated frozen tier is highly recommended for production use. If you
+do not have a dedicated frozen tier, you must configure the
+`xpack.searchable.snapshot.shared_cache.size` setting to reserve space for the
+cache on one or more nodes. Indices mounted with the shared cache mount option
+are only allocated to nodes that have a shared cache.
 
 [[searchable-snapshots-shared-cache]]
 `xpack.searchable.snapshot.shared_cache.size`::
-(<<static-cluster-setting,Static>>, <<byte-units,byte value>>)
-The size of the space reserved for the shared cache. Defaults to `0b`, meaning
-that the node has no shared cache.
+(<<static-cluster-setting,Static>>)
+The size of the space reserved for the shared cache, either specified as a
+percentage of total disk space or an absolute <<byte-units,byte value>>.
+Defaults to 90% of total disk space on dedicated frozen data tier nodes,
+otherwise `0b`.
 
-You can configure the setting in `elasticsearch.yml`:
+`xpack.searchable.snapshot.shared_cache.size.max_headroom`::
+(<<static-cluster-setting,Static>>, <<byte-units,byte value>>)
+For dedicated frozen tier nodes, the max headroom to maintain. Defaults to 100GB
+on dedicated frozen tier nodes when
+`xpack.searchable.snapshot.shared_cache.size` is not explicitly set, otherwise
+-1 (not set). Can only be set when `xpack.searchable.snapshot.shared_cache.size`
+is set as a percentage.
+
+To illustrate how these settings work in concert let us look at two examples
+when using the default values of the settings on a dedicated frozen node:
+
+* A 4000 GB disk will result in a shared cache sized at 3900 GB. 90% of 4000 GB
+is 3600 GB, leaving 400 GB headroom. The default `max_headroom` of 100 GB
+takes effect, and the result is therefore 3900 GB.
+* A 400 GB disk will result in a shard cache sized at 360 GB.
+
+You can configure the settings in `elasticsearch.yml`:
 
 [source,yaml]
 ----
@@ -174,7 +198,8 @@ xpack.searchable.snapshot.shared_cache.size: 4TB
 IMPORTANT: Currently, you can configure
 `xpack.searchable.snapshot.shared_cache.size` on any node. However, if the cache size is set on any
 node that does not have the <<data-frozen-node,`data_frozen`>> role, it will be treated as though it
-is set to `0b`.
+is set to `0b`. Additionally, nodes with a shared  cache can only have a single
+<<path-settings,data path>>.
 
 You can set `xpack.searchable.snapshot.shared_cache.size` to any size between a
 couple of gigabytes up to 90% of available disk space. We only recommend larger

--- a/server/src/main/java/org/elasticsearch/cluster/node/DiscoveryNode.java
+++ b/server/src/main/java/org/elasticsearch/cluster/node/DiscoveryNode.java
@@ -104,6 +104,19 @@ public class DiscoveryNode implements Writeable, ToXContentFragment {
         return hasRole(settings, DiscoveryNodeRole.REMOTE_CLUSTER_CLIENT_ROLE);
     }
 
+    private static boolean isDedicatedFrozenRoles(Set<DiscoveryNodeRole> roles) {
+        return roles.contains(DiscoveryNodeRole.DATA_FROZEN_NODE_ROLE) &&
+            roles.stream().filter(DiscoveryNodeRole::canContainData)
+                .anyMatch(r -> r != DiscoveryNodeRole.DATA_FROZEN_NODE_ROLE) == false;
+    }
+
+    /**
+     * Check if the settings are for a dedicated frozen node, i.e. has frozen role and no other data roles.
+     */
+    public static boolean isDedicatedFrozenNode(final Settings settings) {
+        return isDedicatedFrozenRoles(getRolesFromSettings(settings));
+    }
+
     private final String nodeName;
     private final String nodeId;
     private final String ephemeralId;
@@ -424,6 +437,14 @@ public class DiscoveryNode implements Writeable, ToXContentFragment {
      */
     public boolean isRemoteClusterClient() {
         return roles.contains(DiscoveryNodeRole.REMOTE_CLUSTER_CLIENT_ROLE);
+    }
+
+    /**
+     * Returns whether or not the node is a frozen only node, i.e., has data frozen role and no other data roles.
+     * @return
+     */
+    public boolean isDedicatedFrozenNode() {
+        return isDedicatedFrozenRoles(getRoles());
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/DiskThresholdMonitor.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/DiskThresholdMonitor.java
@@ -23,7 +23,6 @@ import org.elasticsearch.cluster.DiskUsage;
 import org.elasticsearch.cluster.block.ClusterBlockLevel;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.node.DiscoveryNode;
-import org.elasticsearch.cluster.node.DiscoveryNodeRole;
 import org.elasticsearch.cluster.routing.RerouteService;
 import org.elasticsearch.cluster.routing.RoutingNode;
 import org.elasticsearch.cluster.routing.RoutingNodes;
@@ -150,7 +149,7 @@ public class DiskThresholdMonitor {
             final DiskUsage usage = entry.value;
             final RoutingNode routingNode = routingNodes.node(node);
 
-            if (isFrozenOnlyNode(routingNode)) {
+            if (isDedicatedFrozenNode(routingNode)) {
                 ByteSizeValue total = ByteSizeValue.ofBytes(usage.getTotalBytes());
                 long frozenFloodStageThreshold = diskThresholdSettings.getFreeBytesThresholdFrozenFloodStage(total).getBytes();
                 if (usage.getFreeBytes() < frozenFloodStageThreshold) {
@@ -395,13 +394,11 @@ public class DiskThresholdMonitor {
         }
     }
 
-    private boolean isFrozenOnlyNode(RoutingNode routingNode) {
+    private boolean isDedicatedFrozenNode(RoutingNode routingNode) {
         if (routingNode == null) {
             return false;
         }
         DiscoveryNode node = routingNode.node();
-        return node.getRoles().contains(DiscoveryNodeRole.DATA_FROZEN_NODE_ROLE) &&
-            node.getRoles().stream().filter(DiscoveryNodeRole::canContainData)
-                .anyMatch(r -> r != DiscoveryNodeRole.DATA_FROZEN_NODE_ROLE) == false;
+        return node.isDedicatedFrozenNode();
     }
 }

--- a/server/src/main/java/org/elasticsearch/common/unit/RelativeByteSizeValue.java
+++ b/server/src/main/java/org/elasticsearch/common/unit/RelativeByteSizeValue.java
@@ -18,7 +18,7 @@ import org.elasticsearch.ElasticsearchParseException;
  */
 public class RelativeByteSizeValue {
 
-    public static final String MAX_HEADROOM_PREFIX = "max_headroom=";
+    public static final RelativeByteSizeValue ZERO = new RelativeByteSizeValue(ByteSizeValue.ZERO);
     private final ByteSizeValue absolute;
     private final RatioValue ratio;
 

--- a/server/src/main/java/org/elasticsearch/monitor/fs/FsProbe.java
+++ b/server/src/main/java/org/elasticsearch/monitor/fs/FsProbe.java
@@ -19,6 +19,7 @@ import org.elasticsearch.env.NodeEnvironment;
 import org.elasticsearch.env.NodeEnvironment.NodePath;
 
 import java.io.IOException;
+import java.nio.file.FileStore;
 import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -133,12 +134,16 @@ public class FsProbe {
         // NOTE: we use already cached (on node startup) FileStore and spins
         // since recomputing these once per second (default) could be costly,
         // and they should not change:
-        fsPath.total = adjustForHugeFilesystems(nodePath.fileStore.getTotalSpace());
+        fsPath.total = getTotal(nodePath.fileStore);
         fsPath.free = adjustForHugeFilesystems(nodePath.fileStore.getUnallocatedSpace());
         fsPath.available = adjustForHugeFilesystems(nodePath.fileStore.getUsableSpace());
         fsPath.type = nodePath.fileStore.type();
         fsPath.mount = nodePath.fileStore.toString();
         return fsPath;
+    }
+
+    public static long getTotal(FileStore fileStore) throws IOException {
+        return adjustForHugeFilesystems(fileStore.getTotalSpace());
     }
 
 }

--- a/server/src/test/java/org/elasticsearch/cluster/node/DiscoveryNodeRoleSettingTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/node/DiscoveryNodeRoleSettingTests.java
@@ -71,7 +71,8 @@ public class DiscoveryNodeRoleSettingTests extends ESTestCase {
     }
 
     public void testIsDedicatedFrozenNode() {
-        runRoleTest(DiscoveryNode::isDedicatedFrozenNode, DiscoveryNodeRole.DATA_FROZEN_NODE_ROLE);
+        assertTrue(DiscoveryNode.isDedicatedFrozenNode(onlyRole(DiscoveryNodeRole.DATA_FROZEN_NODE_ROLE)));
+        assertFalse(DiscoveryNode.isDedicatedFrozenNode(removeRoles(Collections.singleton(DiscoveryNodeRole.DATA_FROZEN_NODE_ROLE))));
         assertTrue(DiscoveryNode.isDedicatedFrozenNode(addRoles(nonDataNode(),
             org.elasticsearch.common.collect.Set.of(DiscoveryNodeRole.DATA_FROZEN_NODE_ROLE))));
         assertFalse(DiscoveryNode.isDedicatedFrozenNode(

--- a/server/src/test/java/org/elasticsearch/cluster/node/DiscoveryNodeRoleSettingTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/node/DiscoveryNodeRoleSettingTests.java
@@ -15,6 +15,8 @@ import org.elasticsearch.test.ESTestCase;
 import java.util.Collections;
 import java.util.function.Predicate;
 
+import static org.elasticsearch.test.NodeRoles.addRoles;
+import static org.elasticsearch.test.NodeRoles.nonDataNode;
 import static org.elasticsearch.test.NodeRoles.onlyRole;
 import static org.elasticsearch.test.NodeRoles.removeRoles;
 import static org.hamcrest.Matchers.hasItem;
@@ -68,4 +70,12 @@ public class DiscoveryNodeRoleSettingTests extends ESTestCase {
         assertSettingDeprecationsAndWarnings(new Setting<?>[]{role.legacySetting()});
     }
 
+    public void testIsDedicatedFrozenNode() {
+        runRoleTest(DiscoveryNode::isDedicatedFrozenNode, DiscoveryNodeRole.DATA_FROZEN_NODE_ROLE);
+        assertTrue(DiscoveryNode.isDedicatedFrozenNode(addRoles(nonDataNode(),
+            org.elasticsearch.common.collect.Set.of(DiscoveryNodeRole.DATA_FROZEN_NODE_ROLE))));
+        assertFalse(DiscoveryNode.isDedicatedFrozenNode(
+            addRoles(org.elasticsearch.common.collect.Set.of(DiscoveryNodeRole.DATA_FROZEN_NODE_ROLE,
+                DiscoveryNodeRole.DATA_HOT_NODE_ROLE))));
+    }
 }

--- a/server/src/test/java/org/elasticsearch/common/unit/RelativeByteSizeValueTests.java
+++ b/server/src/test/java/org/elasticsearch/common/unit/RelativeByteSizeValueTests.java
@@ -27,8 +27,7 @@ public class RelativeByteSizeValueTests extends ESTestCase {
     public void testRatio() {
         double value = (double) randomIntBetween(1, 100) / 100;
         RelativeByteSizeValue parsed = RelativeByteSizeValue.parseRelativeByteSizeValue(Double.toString(value), "test");
-        assertThat(parsed.getRatio().getAsRatio(),
-            equalTo(value));
+        assertThat(parsed.getRatio().getAsRatio(), equalTo(value));
         assertThat(parsed.isAbsolute(), is(false));
         assertThat(parsed.isNonZeroSize(), is(true));
     }

--- a/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/BaseFrozenSearchableSnapshotsIntegTestCase.java
+++ b/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/BaseFrozenSearchableSnapshotsIntegTestCase.java
@@ -11,6 +11,7 @@ import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.ByteSizeUnit;
 import org.elasticsearch.common.unit.ByteSizeValue;
+import org.elasticsearch.common.unit.RatioValue;
 import org.elasticsearch.xpack.searchablesnapshots.cache.shared.FrozenCacheService;
 
 public class BaseFrozenSearchableSnapshotsIntegTestCase extends BaseSearchableSnapshotsIntegTestCase {
@@ -27,9 +28,10 @@ public class BaseFrozenSearchableSnapshotsIntegTestCase extends BaseSearchableSn
                 FrozenCacheService.SNAPSHOT_CACHE_SIZE_SETTING.getKey(),
                 rarely()
                     ? randomBoolean()
-                        ? new ByteSizeValue(randomIntBetween(1, 10), ByteSizeUnit.KB)
-                        : new ByteSizeValue(randomIntBetween(1, 1000), ByteSizeUnit.BYTES)
-                    : new ByteSizeValue(randomIntBetween(1, 10), ByteSizeUnit.MB)
+                        ? new ByteSizeValue(randomIntBetween(1, 10), ByteSizeUnit.KB).getStringRep()
+                        : new ByteSizeValue(randomIntBetween(1, 1000), ByteSizeUnit.BYTES).getStringRep()
+                    : randomBoolean() ? new ByteSizeValue(randomIntBetween(1, 10), ByteSizeUnit.MB).getStringRep()
+                    : new RatioValue(randomDoubleBetween(0.0d, 0.1d, false)).toString() // only use up to 0.1% disk to be friendly.
             );
         }
 

--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/SearchableSnapshots.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/SearchableSnapshots.java
@@ -307,6 +307,7 @@ public class SearchableSnapshots extends Plugin implements IndexStorePlugin, Eng
             CacheService.SNAPSHOT_CACHE_SYNC_SHUTDOWN_TIMEOUT,
             SearchableSnapshotEnableAllocationDecider.SEARCHABLE_SNAPSHOTS_ALLOCATE_ON_ROLLING_RESTART,
             FrozenCacheService.SNAPSHOT_CACHE_SIZE_SETTING,
+            FrozenCacheService.SNAPSHOT_CACHE_SIZE_MAX_HEADROOM_SETTING,
             FrozenCacheService.SNAPSHOT_CACHE_REGION_SIZE_SETTING,
             FrozenCacheService.SHARED_CACHE_RANGE_SIZE_SETTING,
             FrozenCacheService.FROZEN_CACHE_RECOVERY_RANGE_SIZE_SETTING,

--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/action/cache/FrozenCacheInfoNodeAction.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/action/cache/FrozenCacheInfoNodeAction.java
@@ -53,7 +53,7 @@ public class FrozenCacheInfoNodeAction extends ActionType<FrozenCacheInfoRespons
         @Inject
         public TransportAction(Settings settings, TransportService transportService, ActionFilters actionFilters) {
             super(NAME, transportService, actionFilters, Request::new);
-            response = new FrozenCacheInfoResponse(SNAPSHOT_CACHE_SIZE_SETTING.get(settings).getBytes() > 0);
+            response = new FrozenCacheInfoResponse(SNAPSHOT_CACHE_SIZE_SETTING.get(settings).isNonZeroSize());
         }
 
         @Override

--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/cache/shared/FrozenCacheService.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/cache/shared/FrozenCacheService.java
@@ -13,6 +13,7 @@ import org.apache.lucene.store.AlreadyClosedException;
 import org.elasticsearch.Assertions;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.StepListener;
+import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodeRole;
 import org.elasticsearch.common.lease.Releasable;
 import org.elasticsearch.common.lease.Releasables;
@@ -23,6 +24,7 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.settings.SettingsException;
 import org.elasticsearch.common.unit.ByteSizeUnit;
 import org.elasticsearch.common.unit.ByteSizeValue;
+import org.elasticsearch.common.unit.RelativeByteSizeValue;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.util.concurrent.AbstractAsyncTask;
 import org.elasticsearch.common.util.concurrent.AbstractRefCounted;
@@ -31,18 +33,21 @@ import org.elasticsearch.common.util.concurrent.KeyedLock;
 import org.elasticsearch.env.Environment;
 import org.elasticsearch.env.NodeEnvironment;
 import org.elasticsearch.index.shard.ShardId;
+import org.elasticsearch.monitor.fs.FsProbe;
+import org.elasticsearch.xpack.searchablesnapshots.cache.common.CacheKey;
+import org.elasticsearch.xpack.searchablesnapshots.cache.common.SparseFileTracker;
 import org.elasticsearch.node.NodeRoleSettings;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.xpack.core.DataTier;
 import org.elasticsearch.xpack.searchablesnapshots.cache.common.ByteRange;
-import org.elasticsearch.xpack.searchablesnapshots.cache.common.CacheKey;
-import org.elasticsearch.xpack.searchablesnapshots.cache.common.SparseFileTracker;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashSet;
+import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -95,23 +100,29 @@ public class FrozenCacheService implements Releasable {
         };
     }
 
-    public static final Setting<ByteSizeValue> SNAPSHOT_CACHE_SIZE_SETTING = new Setting<ByteSizeValue>(
-        SHARED_CACHE_SETTINGS_PREFIX + "size",
-        ByteSizeValue.ZERO.getStringRep(),
-        s -> ByteSizeValue.parseBytesSizeValue(s, SHARED_CACHE_SETTINGS_PREFIX + "size"),
-        new Setting.Validator<ByteSizeValue>() {
+    public static final Setting<RelativeByteSizeValue> SNAPSHOT_CACHE_SIZE_SETTING = new Setting<RelativeByteSizeValue>(
+        new Setting.SimpleKey(SHARED_CACHE_SETTINGS_PREFIX + "size"),
+        (settings) -> {
+            if (DiscoveryNode.isDedicatedFrozenNode(settings)) {
+                return "90%";
+            } else {
+                return ByteSizeValue.ZERO.getStringRep();
+            }
+        },
+        s -> RelativeByteSizeValue.parseRelativeByteSizeValue(s, SHARED_CACHE_SETTINGS_PREFIX + "size"),
+        new Setting.Validator<RelativeByteSizeValue>() {
 
             @Override
-            public void validate(final ByteSizeValue value) {
+            public void validate(final RelativeByteSizeValue value) {
 
             }
 
             @Override
-            public void validate(final ByteSizeValue value, final Map<Setting<?>, Object> settings) {
-                if (value.getBytes() == -1) {
+            public void validate(final RelativeByteSizeValue value, final Map<Setting<?>, Object> settings) {
+                if (value.isAbsolute() && value.getAbsolute().getBytes() == -1) {
                     throw new SettingsException("setting [{}] must be non-negative", SHARED_CACHE_SETTINGS_PREFIX + "size");
                 }
-                if (value.getBytes() > 0) {
+                if (value.isNonZeroSize()) {
                     @SuppressWarnings("unchecked")
                     final List<DiscoveryNodeRole> roles = (List<DiscoveryNodeRole>) settings.get(NodeRoleSettings.NODE_ROLES_SETTING);
                     if (DataTier.isFrozenNode(new HashSet<>(roles)) == false) {
@@ -148,17 +159,58 @@ public class FrozenCacheService implements Releasable {
         Setting.Property.NodeScope
     ) {
         @Override
-        public ByteSizeValue get(final Settings settings) {
-            final ByteSizeValue value = super.get(settings);
+        public RelativeByteSizeValue get(final Settings settings) {
+            final RelativeByteSizeValue value = super.get(settings);
             final List<DiscoveryNodeRole> roles = NodeRoleSettings.NODE_ROLES_SETTING.get(settings);
             final Set<DiscoveryNodeRole> roleSet = new HashSet<>(roles);
             if (DataTier.isFrozenNode(roleSet)) {
                 return value;
             } else {
-                return ByteSizeValue.ZERO;
+                return RelativeByteSizeValue.ZERO;
             }
         }
     };
+
+    public static final Setting<ByteSizeValue> SNAPSHOT_CACHE_SIZE_MAX_HEADROOM_SETTING = new Setting<>(
+        new Setting.SimpleKey(SHARED_CACHE_SETTINGS_PREFIX + "size.max_headroom"),
+        (settings) -> {
+            if (SNAPSHOT_CACHE_SIZE_SETTING.exists(settings) == false && DiscoveryNode.isDedicatedFrozenNode(settings)) {
+                return "100GB";
+            }
+
+            return "-1";
+        },
+        (s) -> ByteSizeValue.parseBytesSizeValue(s, SHARED_CACHE_SETTINGS_PREFIX + "size.max_headroom"),
+        new Setting.Validator<ByteSizeValue>() {
+            private final Collection<Setting<?>> dependencies = Collections.singletonList(SNAPSHOT_CACHE_SIZE_SETTING);
+
+            @Override
+            public Iterator<Setting<?>> settings() {
+                return dependencies.iterator();
+            }
+
+            @Override
+            public void validate(ByteSizeValue value) {
+                // ignore
+            }
+
+            @Override
+            public void validate(ByteSizeValue value, Map<Setting<?>, Object> settings, boolean isPresent) {
+                if (isPresent && value.getBytes() != -1) {
+                    RelativeByteSizeValue sizeValue = (RelativeByteSizeValue) settings.get(SNAPSHOT_CACHE_SIZE_SETTING);
+                    if (sizeValue.isAbsolute()) {
+                        throw new SettingsException(
+                            "setting [{}] cannot be specified for absolute [{}={}]",
+                            SNAPSHOT_CACHE_SIZE_MAX_HEADROOM_SETTING.getKey(),
+                            SNAPSHOT_CACHE_SIZE_SETTING.getKey(),
+                            sizeValue.getStringRep()
+                        );
+                    }
+                }
+            }
+        },
+        Setting.Property.NodeScope
+    );
 
     public static final Setting<ByteSizeValue> FROZEN_CACHE_RECOVERY_RANGE_SIZE_SETTING = Setting.byteSizeSetting(
         SHARED_CACHE_SETTINGS_PREFIX + "recovery_range_size",
@@ -227,11 +279,13 @@ public class FrozenCacheService implements Releasable {
     @SuppressWarnings({ "unchecked", "rawtypes" })
     public FrozenCacheService(NodeEnvironment environment, Settings settings, ThreadPool threadPool) {
         this.currentTimeSupplier = threadPool::relativeTimeInMillis;
-        long cacheSize = SNAPSHOT_CACHE_SIZE_SETTING.get(settings).getBytes();
-        if (cacheSize == Long.MAX_VALUE) {
-            cacheSize = 0L;
+        long totalFsSize;
+        try {
+            totalFsSize = FsProbe.getTotal(Environment.getFileStore(environment.nodeDataPaths()[0]));
+        } catch (IOException e) {
+            throw new IllegalStateException("unable to probe size of filesystem [" + environment.nodeDataPaths()[0] + "]");
         }
-        this.cacheSize = cacheSize;
+        this.cacheSize = calculateCacheSize(settings, totalFsSize);
         final long regionSize = SNAPSHOT_CACHE_REGION_SIZE_SETTING.get(settings).getBytes();
         this.numRegions = Math.toIntExact(cacheSize / regionSize);
         keyMapping = new ConcurrentHashMap<>();
@@ -260,6 +314,12 @@ public class FrozenCacheService implements Releasable {
         decayTask.rescheduleIfNecessary();
         this.rangeSize = SHARED_CACHE_RANGE_SIZE_SETTING.get(settings);
         this.recoveryRangeSize = FROZEN_CACHE_RECOVERY_RANGE_SIZE_SETTING.get(settings);
+    }
+
+    static long calculateCacheSize(Settings settings, long totalFsSize) {
+        return SNAPSHOT_CACHE_SIZE_SETTING.get(settings)
+            .calculateValue(ByteSizeValue.ofBytes(totalFsSize), SNAPSHOT_CACHE_SIZE_MAX_HEADROOM_SETTING.get(settings))
+            .getBytes();
     }
 
     public int getRangeSize() {

--- a/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/cache/shared/FrozenCacheServiceTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/cache/shared/FrozenCacheServiceTests.java
@@ -13,6 +13,9 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.settings.SettingsException;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.env.Environment;
+import org.elasticsearch.common.unit.RatioValue;
+import org.elasticsearch.common.unit.RelativeByteSizeValue;
+import org.elasticsearch.common.util.set.Sets;
 import org.elasticsearch.env.NodeEnvironment;
 import org.elasticsearch.env.TestEnvironment;
 import org.elasticsearch.index.shard.ShardId;
@@ -24,6 +27,8 @@ import org.elasticsearch.xpack.searchablesnapshots.cache.common.CacheKey;
 import org.elasticsearch.xpack.searchablesnapshots.cache.shared.FrozenCacheService.CacheFileRegion;
 
 import java.io.IOException;
+import java.util.HashSet;
+import java.util.stream.Collectors;
 
 import static org.elasticsearch.node.Node.NODE_NAME_SETTING;
 import static org.hamcrest.Matchers.equalTo;
@@ -201,8 +206,9 @@ public class FrozenCacheServiceTests extends ESTestCase {
     }
 
     public void testCacheSizeDeprecatedOnNonFrozenNodes() {
+        String cacheSize = randomBoolean() ? new ByteSizeValue(size(500)).getStringRep() : new RatioValue(between(1, 100)).toString();
         final Settings settings = Settings.builder()
-            .put(FrozenCacheService.SNAPSHOT_CACHE_SIZE_SETTING.getKey(), new ByteSizeValue(size(500)).getStringRep())
+            .put(FrozenCacheService.SNAPSHOT_CACHE_SIZE_SETTING.getKey(), cacheSize)
             .put(FrozenCacheService.SNAPSHOT_CACHE_REGION_SIZE_SETTING.getKey(), new ByteSizeValue(size(100)).getStringRep())
             .putList(NodeRoleSettings.NODE_ROLES_SETTING.getKey(), DiscoveryNodeRole.DATA_HOT_NODE_ROLE.roleName())
             .build();
@@ -211,7 +217,7 @@ public class FrozenCacheServiceTests extends ESTestCase {
             "setting ["
                 + FrozenCacheService.SNAPSHOT_CACHE_SIZE_SETTING.getKey()
                 + "] to be positive ["
-                + new ByteSizeValue(size(500)).getStringRep()
+                + cacheSize
                 + "] on node without the data_frozen role is deprecated, roles are [data_hot]"
         );
     }
@@ -222,8 +228,8 @@ public class FrozenCacheServiceTests extends ESTestCase {
             .put(FrozenCacheService.SNAPSHOT_CACHE_REGION_SIZE_SETTING.getKey(), new ByteSizeValue(size(100)).getStringRep())
             .putList(NodeRoleSettings.NODE_ROLES_SETTING.getKey(), DiscoveryNodeRole.DATA_HOT_NODE_ROLE.roleName())
             .build();
-        final ByteSizeValue value = FrozenCacheService.SNAPSHOT_CACHE_SIZE_SETTING.get(settings);
-        assertThat(value, equalTo(ByteSizeValue.ZERO));
+        final RelativeByteSizeValue value = FrozenCacheService.SNAPSHOT_CACHE_SIZE_SETTING.get(settings);
+        assertThat(value.isNonZeroSize(), is(false));
         assertWarnings(
             "setting ["
                 + FrozenCacheService.SNAPSHOT_CACHE_SIZE_SETTING.getKey()
@@ -255,6 +261,88 @@ public class FrozenCacheServiceTests extends ESTestCase {
                     + "] is not permitted on nodes with multiple data paths [a,b]"
             )
         );
+    }
+
+    public void testDedicateFrozenCacheSizeDefaults() {
+        final Settings settings = Settings.builder()
+            .putList(NodeRoleSettings.NODE_ROLES_SETTING.getKey(), DiscoveryNodeRole.DATA_FROZEN_NODE_ROLE.roleName())
+            .build();
+
+        RelativeByteSizeValue relativeCacheSize = FrozenCacheService.SNAPSHOT_CACHE_SIZE_SETTING.get(settings);
+        assertThat(relativeCacheSize.isAbsolute(), is(false));
+        assertThat(relativeCacheSize.isNonZeroSize(), is(true));
+        assertThat(relativeCacheSize.calculateValue(ByteSizeValue.ofBytes(10000), null), equalTo(ByteSizeValue.ofBytes(9000)));
+        assertThat(FrozenCacheService.SNAPSHOT_CACHE_SIZE_MAX_HEADROOM_SETTING.get(settings), equalTo(ByteSizeValue.ofGb(100)));
+    }
+
+    public void testNotDedicatedFrozenCacheSizeDefaults() {
+        final Settings settings = Settings.builder()
+            .putList(
+                NodeRoleSettings.NODE_ROLES_SETTING.getKey(),
+                Sets.union(
+                    org.elasticsearch.common.collect.Set.of(
+                        randomFrom(
+                            DiscoveryNodeRole.DATA_HOT_NODE_ROLE,
+                            DiscoveryNodeRole.DATA_COLD_NODE_ROLE,
+                            DiscoveryNodeRole.DATA_WARM_NODE_ROLE,
+                            DiscoveryNodeRole.DATA_CONTENT_NODE_ROLE
+                        )
+                    ),
+                    new HashSet<>(
+                        randomSubsetOf(
+                            between(0, 3),
+                            DiscoveryNodeRole.DATA_FROZEN_NODE_ROLE,
+                            DiscoveryNodeRole.INGEST_ROLE,
+                            DiscoveryNodeRole.MASTER_ROLE
+                        )
+                    )
+                ).stream().map(DiscoveryNodeRole::roleName).collect(Collectors.toList())
+            )
+            .build();
+
+        RelativeByteSizeValue relativeCacheSize = FrozenCacheService.SNAPSHOT_CACHE_SIZE_SETTING.get(settings);
+        assertThat(relativeCacheSize.isNonZeroSize(), is(false));
+        assertThat(relativeCacheSize.isAbsolute(), is(true));
+        assertThat(relativeCacheSize.getAbsolute(), equalTo(ByteSizeValue.ZERO));
+        assertThat(FrozenCacheService.SNAPSHOT_CACHE_SIZE_MAX_HEADROOM_SETTING.get(settings), equalTo(ByteSizeValue.ofBytes(-1)));
+    }
+
+    public void testMaxHeadroomRejectedForAbsoluteCacheSize() {
+        String cacheSize = new ByteSizeValue(size(500)).getStringRep();
+        final Settings settings = Settings.builder()
+            .put(FrozenCacheService.SNAPSHOT_CACHE_SIZE_SETTING.getKey(), cacheSize)
+            .put(FrozenCacheService.SNAPSHOT_CACHE_SIZE_MAX_HEADROOM_SETTING.getKey(), new ByteSizeValue(size(100)).getStringRep())
+            .putList(NodeRoleSettings.NODE_ROLES_SETTING.getKey(), DiscoveryNodeRole.DATA_FROZEN_NODE_ROLE.roleName())
+            .build();
+        final IllegalArgumentException e = expectThrows(
+            IllegalArgumentException.class,
+            () -> FrozenCacheService.SNAPSHOT_CACHE_SIZE_MAX_HEADROOM_SETTING.get(settings)
+        );
+        assertThat(e.getCause(), notNullValue());
+        assertThat(e.getCause(), instanceOf(SettingsException.class));
+        assertThat(
+            e.getCause().getMessage(),
+            is(
+                "setting ["
+                    + FrozenCacheService.SNAPSHOT_CACHE_SIZE_MAX_HEADROOM_SETTING.getKey()
+                    + "] cannot be specified for absolute ["
+                    + FrozenCacheService.SNAPSHOT_CACHE_SIZE_SETTING.getKey()
+                    + "="
+                    + cacheSize
+                    + "]"
+            )
+        );
+    }
+
+    public void testCalculateCacheSize() {
+        long smallSize = 10000;
+        long largeSize = ByteSizeValue.ofTb(10).getBytes();
+        assertThat(FrozenCacheService.calculateCacheSize(Settings.EMPTY, smallSize), equalTo(0L));
+        final Settings settings = Settings.builder()
+            .putList(NodeRoleSettings.NODE_ROLES_SETTING.getKey(), DiscoveryNodeRole.DATA_FROZEN_NODE_ROLE.roleName())
+            .build();
+        assertThat(FrozenCacheService.calculateCacheSize(settings, smallSize), equalTo(9000L));
+        assertThat(FrozenCacheService.calculateCacheSize(settings, largeSize), equalTo(largeSize - ByteSizeValue.ofGb(100).getBytes()));
     }
 
     private static CacheKey generateCacheKey() {


### PR DESCRIPTION
This commit adds a default cache size to frozen tier of the greater of
90% and total disk size minus 100 GB.
