### PR TITLE
Fix test for upgrading shard limit to frozen

### DIFF
--- a/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/upgrade/SearchableSnapshotIndexMetadataUpgraderTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/upgrade/SearchableSnapshotIndexMetadataUpgraderTests.java
@@ -92,10 +92,9 @@ public class SearchableSnapshotIndexMetadataUpgraderTests extends ESTestCase {
     }
 
     private Settings partial_7_13plus() {
-        return shardLimitGroupFrozen(searchableSnapshotSettings(
-            VersionUtils.randomVersionBetween(random(), Version.V_7_13_0, Version.CURRENT),
-            true
-        ));
+        return shardLimitGroupFrozen(
+            searchableSnapshotSettings(VersionUtils.randomVersionBetween(random(), Version.V_7_13_0, Version.CURRENT), true)
+        );
     }
 
     private Settings full() {

--- a/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/upgrade/SearchableSnapshotIndexMetadataUpgraderTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/upgrade/SearchableSnapshotIndexMetadataUpgraderTests.java
@@ -42,7 +42,6 @@ public class SearchableSnapshotIndexMetadataUpgraderTests extends ESTestCase {
         assertThat(needsUpgrade(metadataBuilder), is(true));
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/71973")
     public void testUpgradeIndices() {
         Metadata.Builder metadataBuilder = addIndex(
             partial_7_12(),
@@ -93,15 +92,10 @@ public class SearchableSnapshotIndexMetadataUpgraderTests extends ESTestCase {
     }
 
     private Settings partial_7_13plus() {
-        Settings settings = searchableSnapshotSettings(
+        return shardLimitGroupFrozen(searchableSnapshotSettings(
             VersionUtils.randomVersionBetween(random(), Version.V_7_13_0, Version.CURRENT),
             true
-        );
-        if (randomBoolean()) {
-            return shardLimitGroupFrozen(settings);
-        } else {
-            return settings;
-        }
+        ));
     }
 
     private Settings full() {


### PR DESCRIPTION
Test would assume indices created on 7.13 could have no shard group set,
but this is not true, fixed.

Closes #71973