### PR TITLE
Document that sum(nothing) is 0

### DIFF
--- a/docs/reference/aggregations/metrics/sum-aggregation.asciidoc
+++ b/docs/reference/aggregations/metrics/sum-aggregation.asciidoc
@@ -45,6 +45,10 @@ Resulting in:
 
 The name of the aggregation (`hat_prices` above) also serves as the key by which the aggregation result can be retrieved from the returned response.
 
+[[sum-aggregation-0-not-null]]
+[NOTE]
+When `sum` runs on an unmapped field or when the query filters out all matches, the `sum`'s value will be `0`. Not `null` as you might expect if you are used to relatoinal databases.
+
 ==== Script
 
 If you need to get the `sum` for something more complex than a single

--- a/docs/reference/aggregations/metrics/sum-aggregation.asciidoc
+++ b/docs/reference/aggregations/metrics/sum-aggregation.asciidoc
@@ -47,7 +47,9 @@ The name of the aggregation (`hat_prices` above) also serves as the key by which
 
 [[sum-aggregation-0-not-null]]
 [NOTE]
-When `sum` runs on an unmapped field or when the query filters out all matches, the `sum`'s value will be `0`. Not `null` as you might expect if you are used to relatoinal databases.
+When `sum` runs on an unmapped field, when the query filters out all matches,
+or when all matches are misssing values for the field, the `sum`'s value will
+be `0.0`. Not `null` as you might expect if you are used to relational databases.
 
 ==== Script
 
@@ -124,13 +126,17 @@ POST /sales/_search?size=0
     "hat_prices": {
       "sum": {
         "field": "price",
-        "missing": 100 <1>
+        "missing": 100
       }
     }
   }
 }
 --------------------------------------------------
 // TEST[setup:sales]
+
+If all values are missing are you don't define a `missing` value then the
+result is `0.0`. See also the <<sum-aggregation-0-not-null,note>> about empty
+sums for more.
 
 [[search-aggregations-metrics-sum-aggregation-histogram-fields]]
 ==== Histogram fields


### PR DESCRIPTION
It'd be super reasonable if the `sum` aggregation returned `null` when
run on an unmapped field. Or if the query filtered out all results. But
it doesn't. It returns `0`. Which is also reasonable! Its just different
from what other reasonable systems like Postgresql do.

This adds a note to with an anchor we can link to. Folks ask about this
a fair bit.

Closes #71582
