### PR TITLE
Prevent histogram from allocating tons of buckets (backport of #71758)

### DIFF
--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.aggregation/10_histogram.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.aggregation/10_histogram.yml
@@ -704,3 +704,31 @@ setup:
   - match: { aggregations.foo.histo.buckets.2.doc_count: 0 }
   - match: { aggregations.foo.histo.buckets.3.key_as_string: "2016-01-04T01:00:00.000Z" }
   - match: { aggregations.foo.histo.buckets.3.doc_count: 0 }
+
+---
+"Tiny tiny tiny range":
+  - skip:
+      version: " - 7.12.99"
+      reason:  fixed in 7.13.0
+
+  - do:
+      bulk:
+        index: test_1
+        refresh: true
+        body:
+            - '{"index": {}}'
+            - '{"number": 1}'
+            - '{"index": {}}'
+            - '{"number": 2}'
+
+  - do:
+      catch: '/Trying to create too many buckets. Must be less than or equal to: \[65536\]/'
+      search:
+        index: test_1
+        body:
+          size: 0
+          aggs:
+            histo:
+              histogram:
+                field: number
+                interval: 5e-10

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/InternalHistogram.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/InternalHistogram.java
@@ -30,6 +30,7 @@ import java.util.List;
 import java.util.ListIterator;
 import java.util.Map;
 import java.util.Objects;
+import java.util.function.DoubleConsumer;
 
 /**
  * Implementation of {@link Histogram}.
@@ -279,7 +280,7 @@ public final class InternalHistogram extends InternalMultiBucketAggregation<Inte
         for (InternalAggregation aggregation : aggregations) {
             InternalHistogram histogram = (InternalHistogram) aggregation;
             if (histogram.buckets.isEmpty() == false) {
-                pq.add(new IteratorAndCurrent(histogram.buckets.iterator()));
+                pq.add(new IteratorAndCurrent<Bucket>(histogram.buckets.iterator()));
             }
         }
 
@@ -347,56 +348,95 @@ public final class InternalHistogram extends InternalMultiBucketAggregation<Inte
     }
 
     private void addEmptyBuckets(List<Bucket> list, ReduceContext reduceContext) {
-        ListIterator<Bucket> iter = list.listIterator();
+        /*
+         * Make sure we have space for the empty buckets we're going to add by
+         * counting all of the empties we plan to add and firing them into
+         * consumeBucketsAndMaybeBreak.
+         *
+         * We don't count all of the buckets we plan to allocate and then report
+         * them all at once because we you can configure the histogram to create
+         * more buckets than there are hydrogen atoms in the universe. It'd take
+         * a while to count that high only to abort. So we report every couple
+         * thousand buckets. It's be simpler to report every single bucket we plan
+         * to allocate one at a time but that'd cause needless overhead on the
+         * circuit breakers. Counting a couple thousand buckets is plenty fast
+         * to fail this quickly in pathological cases and plenty large to keep
+         * the overhead minimal.
+         */
+        int reportEmptyEvery = 10000;
+        class Counter implements DoubleConsumer {
+            private int size = list.size();
 
-        // first adding all the empty buckets *before* the actual data (based on th extended_bounds.min the user requested)
+            @Override
+            public void accept(double key) {
+                size++;
+                if (size >= reportEmptyEvery) {
+                    reduceContext.consumeBucketsAndMaybeBreak(size);
+                    size = 0;
+                }
+            }
+        }
+        Counter counter = new Counter();
+        iterateEmptyBuckets(list, list.listIterator(), counter);
+        reduceContext.consumeBucketsAndMaybeBreak(counter.size);
+
+        /*
+         * Now that we're sure we have space we allocate all the buckets.
+         */
         InternalAggregations reducedEmptySubAggs = InternalAggregations.reduce(
-                Collections.singletonList(emptyBucketInfo.subAggregations),
-                reduceContext);
+            Collections.singletonList(emptyBucketInfo.subAggregations),
+            reduceContext
+        );
+        ListIterator<Bucket> iter = list.listIterator();
+        iterateEmptyBuckets(list, iter, key -> iter.add(new Bucket(key, 0, keyed, format, reducedEmptySubAggs)));
+    }
 
+    private void iterateEmptyBuckets(List<Bucket> list, ListIterator<Bucket> iter, DoubleConsumer onBucket) {
         if (iter.hasNext() == false) {
             // fill with empty buckets
             for (double key = round(emptyBucketInfo.minBound); key <= emptyBucketInfo.maxBound; key = nextKey(key)) {
-                iter.add(new Bucket(key, 0, keyed, format, reducedEmptySubAggs));
+                onBucket.accept(key);
             }
-        } else {
-            Bucket first = list.get(iter.nextIndex());
-            if (Double.isFinite(emptyBucketInfo.minBound)) {
-                // fill with empty buckets until the first key
-                for (double key = round(emptyBucketInfo.minBound); key < first.key; key = nextKey(key)) {
-                    iter.add(new Bucket(key, 0, keyed, format, reducedEmptySubAggs));
-                }
+            return;
+        }
+        Bucket first = list.get(iter.nextIndex());
+        if (Double.isFinite(emptyBucketInfo.minBound)) {
+            // fill with empty buckets until the first key
+            for (double key = round(emptyBucketInfo.minBound); key < first.key; key = nextKey(key)) {
+                onBucket.accept(key);
             }
+        }
 
-            // now adding the empty buckets within the actual data,
-            // e.g. if the data series is [1,2,3,7] there're 3 empty buckets that will be created for 4,5,6
-            Bucket lastBucket = null;
-            do {
-                Bucket nextBucket = list.get(iter.nextIndex());
-                if (lastBucket != null) {
-                    double key = nextKey(lastBucket.key);
-                    while (key < nextBucket.key) {
-                        iter.add(new Bucket(key, 0, keyed, format, reducedEmptySubAggs));
-                        key = nextKey(key);
-                    }
-                    assert key == nextBucket.key || Double.isNaN(nextBucket.key) : "key: " + key + ", nextBucket.key: " + nextBucket.key;
+        // now adding the empty buckets within the actual data,
+        // e.g. if the data series is [1,2,3,7] there're 3 empty buckets that will be created for 4,5,6
+        Bucket lastBucket = null;
+        do {
+            Bucket nextBucket = list.get(iter.nextIndex());
+            if (lastBucket != null) {
+                double key = nextKey(lastBucket.key);
+                while (key < nextBucket.key) {
+                    onBucket.accept(key);
+                    key = nextKey(key);
                 }
-                lastBucket = iter.next();
-            } while (iter.hasNext());
-
-            // finally, adding the empty buckets *after* the actual data (based on the extended_bounds.max requested by the user)
-            for (double key = nextKey(lastBucket.key); key <= emptyBucketInfo.maxBound; key = nextKey(key)) {
-                iter.add(new Bucket(key, 0, keyed, format, reducedEmptySubAggs));
+                assert key == nextBucket.key || Double.isNaN(nextBucket.key) : "key: " + key + ", nextBucket.key: " + nextBucket.key;
             }
+            lastBucket = iter.next();
+        } while (iter.hasNext());
+
+        // finally, adding the empty buckets *after* the actual data (based on the extended_bounds.max requested by the user)
+        for (double key = nextKey(lastBucket.key); key <= emptyBucketInfo.maxBound; key = nextKey(key)) {
+            onBucket.accept(key);
         }
     }
 
     @Override
     public InternalAggregation reduce(List<InternalAggregation> aggregations, ReduceContext reduceContext) {
         List<Bucket> reducedBuckets = reduceBuckets(aggregations, reduceContext);
+        boolean alreadyAccountedForBuckets = false;
         if (reduceContext.isFinalReduce()) {
             if (minDocCount == 0) {
                 addEmptyBuckets(reducedBuckets, reduceContext);
+                alreadyAccountedForBuckets = true;
             }
             if (InternalOrder.isKeyDesc(order)) {
                 // we just need to reverse here...
@@ -410,7 +450,9 @@ public final class InternalHistogram extends InternalMultiBucketAggregation<Inte
                 CollectionUtil.introSort(reducedBuckets, order.comparator());
             }
         }
-        reduceContext.consumeBucketsAndMaybeBreak(reducedBuckets.size());
+        if (false == alreadyAccountedForBuckets) {
+            reduceContext.consumeBucketsAndMaybeBreak(reducedBuckets.size());
+        }
         return new InternalHistogram(getName(), reducedBuckets, order, minDocCount, emptyBucketInfo, format, keyed, getMetadata());
     }
 

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/histogram/InternalHistogramTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/histogram/InternalHistogramTests.java
@@ -9,9 +9,12 @@
 package org.elasticsearch.search.aggregations.bucket.histogram;
 
 import org.apache.lucene.util.TestUtil;
+import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.aggregations.BucketOrder;
+import org.elasticsearch.search.aggregations.InternalAggregation;
 import org.elasticsearch.search.aggregations.InternalAggregations;
+import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator.PipelineTree;
 import org.elasticsearch.test.InternalAggregationTestCase;
 import org.elasticsearch.test.InternalMultiBucketAggregationTestCase;
 
@@ -21,6 +24,9 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
+import java.util.function.IntConsumer;
+
+import static org.hamcrest.Matchers.equalTo;
 
 public class InternalHistogramTests extends InternalMultiBucketAggregationTestCase<InternalHistogram> {
 
@@ -94,6 +100,40 @@ public class InternalHistogramTests extends InternalMultiBucketAggregationTestCa
         InternalHistogram newHistogram = histogram.create(newBuckets);
         newHistogram.reduce(Arrays.asList(newHistogram, histogram2),
                 InternalAggregationTestCase.emptyReduceContextBuilder().forPartialReduction());
+    }
+
+    public void testLargeReduce() {
+        InternalHistogram histo = new InternalHistogram(
+            "h",
+            org.elasticsearch.common.collect.List.of(),
+            BucketOrder.key(true),
+            0,
+            new InternalHistogram.EmptyBucketInfo(5e-10, 0, 0, 100, InternalAggregations.EMPTY),
+            DocValueFormat.RAW,
+            false,
+            null
+        );
+        InternalAggregation.ReduceContext reduceContext = InternalAggregation.ReduceContext.forFinalReduction(
+            BigArrays.NON_RECYCLING_INSTANCE,
+            null,
+            new IntConsumer() {
+                int buckets;
+
+                @Override
+                public void accept(int value) {
+                    buckets += value;
+                    if (buckets > 100000) {
+                        throw new IllegalArgumentException("too big!");
+                    }
+                }
+            },
+            PipelineTree.EMPTY
+        );
+        Exception e = expectThrows(
+            IllegalArgumentException.class,
+            () -> histo.reduce(org.elasticsearch.common.collect.List.of(histo), reduceContext)
+        );
+        assertThat(e.getMessage(), equalTo("too big!"));
     }
 
     @Override


### PR DESCRIPTION
This prevents the `histogram` aggregation from allocating tons of empty
buckets when you set the `interval` to something tiny. Instead, we
reject the request. We're not in a place where we can aggregate over
huge ranges with tiny intervals, but we should fail gracefully when you
ask us to do so rather than OOM.

Closes #71744
