### PR TITLE
[Transform] Ensure no duplicate names among aggs and groups

### DIFF
--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/transform/transforms/pivot/AggregationConfigTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/transform/transforms/pivot/AggregationConfigTests.java
@@ -20,8 +20,6 @@ import org.elasticsearch.common.xcontent.json.JsonXContent;
 import org.elasticsearch.search.aggregations.AggregationBuilder;
 import org.elasticsearch.search.aggregations.AggregationBuilders;
 import org.elasticsearch.search.aggregations.AggregatorFactories;
-import org.elasticsearch.search.aggregations.PipelineAggregationBuilder;
-import org.elasticsearch.search.aggregations.PipelineAggregatorBuilders;
 import org.elasticsearch.xpack.core.transform.AbstractSerializingTransformTestCase;
 import org.elasticsearch.xpack.core.transform.MockDeprecatedAggregationBuilder;
 import org.junit.Before;
@@ -47,12 +45,6 @@ public class AggregationConfigTests extends AbstractSerializingTransformTestCase
             AggregationBuilder aggBuilder = getRandomSupportedAggregation();
             if (names.add(aggBuilder.getName())) {
                 builder.addAggregator(aggBuilder);
-            }
-        }
-        for (int i = 0; i < randomIntBetween(1, 20); ++i) {
-            PipelineAggregationBuilder aggBuilder = getRandomSupportedPipelineAggregation();
-            if (names.add(aggBuilder.getName())) {
-                builder.addPipelineAggregator(aggBuilder);
             }
         }
 
@@ -151,21 +143,6 @@ public class AggregationConfigTests extends AbstractSerializingTransformTestCase
                 return AggregationBuilders.max("max_" + randomAlphaOfLengthBetween(1, 10)).field(randomAlphaOfLengthBetween(1, 10));
             case 4:
                 return AggregationBuilders.sum("sum_" + randomAlphaOfLengthBetween(1, 10)).field(randomAlphaOfLengthBetween(1, 10));
-        }
-        return null;
-    }
-
-    private static PipelineAggregationBuilder getRandomSupportedPipelineAggregation() {
-        final int numberOfSupportedAggs = 4;
-        switch (randomIntBetween(1, numberOfSupportedAggs)) {
-            case 1:
-                return PipelineAggregatorBuilders.avgBucket("avgbucket_" + randomAlphaOfLengthBetween(1, 10), randomAlphaOfLength(5));
-            case 2:
-                return PipelineAggregatorBuilders.minBucket("minbucket_" + randomAlphaOfLengthBetween(1, 10), randomAlphaOfLength(5));
-            case 3:
-                return PipelineAggregatorBuilders.maxBucket("maxbucket_" + randomAlphaOfLengthBetween(1, 10), randomAlphaOfLength(5));
-            case 4:
-                return PipelineAggregatorBuilders.sumBucket("sumbucket_" + randomAlphaOfLengthBetween(1, 10), randomAlphaOfLength(5));
         }
         return null;
     }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/transform/transforms/pivot/AggregationConfigTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/transform/transforms/pivot/AggregationConfigTests.java
@@ -20,6 +20,8 @@ import org.elasticsearch.common.xcontent.json.JsonXContent;
 import org.elasticsearch.search.aggregations.AggregationBuilder;
 import org.elasticsearch.search.aggregations.AggregationBuilders;
 import org.elasticsearch.search.aggregations.AggregatorFactories;
+import org.elasticsearch.search.aggregations.PipelineAggregationBuilder;
+import org.elasticsearch.search.aggregations.PipelineAggregatorBuilders;
 import org.elasticsearch.xpack.core.transform.AbstractSerializingTransformTestCase;
 import org.elasticsearch.xpack.core.transform.MockDeprecatedAggregationBuilder;
 import org.junit.Before;
@@ -47,9 +49,14 @@ public class AggregationConfigTests extends AbstractSerializingTransformTestCase
                 builder.addAggregator(aggBuilder);
             }
         }
+        for (int i = 0; i < randomIntBetween(1, 20); ++i) {
+            PipelineAggregationBuilder aggBuilder = getRandomSupportedPipelineAggregation();
+            if (names.add(aggBuilder.getName())) {
+                builder.addPipelineAggregator(aggBuilder);
+            }
+        }
 
         try (XContentBuilder xContentBuilder = XContentFactory.jsonBuilder()) {
-
             XContentBuilder content = builder.toXContent(xContentBuilder, ToXContent.EMPTY_PARAMS);
             source = XContentHelper.convertToMap(BytesReference.bytes(content), true, XContentType.JSON).v2();
         } catch (IOException e) {
@@ -137,15 +144,29 @@ public class AggregationConfigTests extends AbstractSerializingTransformTestCase
         final int numberOfSupportedAggs = 4;
         switch (randomIntBetween(1, numberOfSupportedAggs)) {
             case 1:
-                return AggregationBuilders.avg(randomAlphaOfLengthBetween(1, 10)).field(randomAlphaOfLengthBetween(1, 10));
+                return AggregationBuilders.avg("avg_" + randomAlphaOfLengthBetween(1, 10)).field(randomAlphaOfLengthBetween(1, 10));
             case 2:
-                return AggregationBuilders.min(randomAlphaOfLengthBetween(1, 10)).field(randomAlphaOfLengthBetween(1, 10));
+                return AggregationBuilders.min("min_" + randomAlphaOfLengthBetween(1, 10)).field(randomAlphaOfLengthBetween(1, 10));
             case 3:
-                return AggregationBuilders.max(randomAlphaOfLengthBetween(1, 10)).field(randomAlphaOfLengthBetween(1, 10));
+                return AggregationBuilders.max("max_" + randomAlphaOfLengthBetween(1, 10)).field(randomAlphaOfLengthBetween(1, 10));
             case 4:
-                return AggregationBuilders.sum(randomAlphaOfLengthBetween(1, 10)).field(randomAlphaOfLengthBetween(1, 10));
+                return AggregationBuilders.sum("sum_" + randomAlphaOfLengthBetween(1, 10)).field(randomAlphaOfLengthBetween(1, 10));
         }
+        return null;
+    }
 
+    private static PipelineAggregationBuilder getRandomSupportedPipelineAggregation() {
+        final int numberOfSupportedAggs = 4;
+        switch (randomIntBetween(1, numberOfSupportedAggs)) {
+            case 1:
+                return PipelineAggregatorBuilders.avgBucket("avgbucket_" + randomAlphaOfLengthBetween(1, 10), randomAlphaOfLength(5));
+            case 2:
+                return PipelineAggregatorBuilders.minBucket("minbucket_" + randomAlphaOfLengthBetween(1, 10), randomAlphaOfLength(5));
+            case 3:
+                return PipelineAggregatorBuilders.maxBucket("maxbucket_" + randomAlphaOfLengthBetween(1, 10), randomAlphaOfLength(5));
+            case 4:
+                return PipelineAggregatorBuilders.sumBucket("sumbucket_" + randomAlphaOfLengthBetween(1, 10), randomAlphaOfLength(5));
+        }
         return null;
     }
 }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/transform/transforms/pivot/GroupConfigTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/transform/transforms/pivot/GroupConfigTests.java
@@ -49,7 +49,7 @@ public class GroupConfigTests extends AbstractSerializingTestCase<GroupConfig> {
         // ensure that the unlikely does not happen: 2 group_by's share the same name
         Set<String> names = new HashSet<>();
         for (int i = 0; i < randomIntBetween(1, 20); ++i) {
-            String targetFieldName = randomAlphaOfLengthBetween(1, 20);
+            String targetFieldName = "group_" + randomAlphaOfLengthBetween(1, 20);
             if (names.add(targetFieldName)) {
                 SingleGroupSource groupBy = singleGroupSourceSupplier.get();
                 source.put(targetFieldName, Collections.singletonMap(groupBy.getType().value(), getSource(groupBy)));


### PR DESCRIPTION
This PR makes sure the generated names of groups and aggs are never the same.

Closes https://github.com/elastic/elasticsearch/issues/71950