### PR TITLE
[7.x] [Transform] Ensure no duplicate names among aggs and groups (#71993)

### DIFF
--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/transform/transforms/pivot/AggregationConfigTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/transform/transforms/pivot/AggregationConfigTests.java
@@ -49,7 +49,6 @@ public class AggregationConfigTests extends AbstractSerializingTransformTestCase
         }
 
         try (XContentBuilder xContentBuilder = XContentFactory.jsonBuilder()) {
-
             XContentBuilder content = builder.toXContent(xContentBuilder, ToXContent.EMPTY_PARAMS);
             source = XContentHelper.convertToMap(BytesReference.bytes(content), true, XContentType.JSON).v2();
         } catch (IOException e) {
@@ -137,15 +136,14 @@ public class AggregationConfigTests extends AbstractSerializingTransformTestCase
         final int numberOfSupportedAggs = 4;
         switch (randomIntBetween(1, numberOfSupportedAggs)) {
             case 1:
-                return AggregationBuilders.avg(randomAlphaOfLengthBetween(1, 10)).field(randomAlphaOfLengthBetween(1, 10));
+                return AggregationBuilders.avg("avg_" + randomAlphaOfLengthBetween(1, 10)).field(randomAlphaOfLengthBetween(1, 10));
             case 2:
-                return AggregationBuilders.min(randomAlphaOfLengthBetween(1, 10)).field(randomAlphaOfLengthBetween(1, 10));
+                return AggregationBuilders.min("min_" + randomAlphaOfLengthBetween(1, 10)).field(randomAlphaOfLengthBetween(1, 10));
             case 3:
-                return AggregationBuilders.max(randomAlphaOfLengthBetween(1, 10)).field(randomAlphaOfLengthBetween(1, 10));
+                return AggregationBuilders.max("max_" + randomAlphaOfLengthBetween(1, 10)).field(randomAlphaOfLengthBetween(1, 10));
             case 4:
-                return AggregationBuilders.sum(randomAlphaOfLengthBetween(1, 10)).field(randomAlphaOfLengthBetween(1, 10));
+                return AggregationBuilders.sum("sum_" + randomAlphaOfLengthBetween(1, 10)).field(randomAlphaOfLengthBetween(1, 10));
         }
-
         return null;
     }
 }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/transform/transforms/pivot/GroupConfigTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/transform/transforms/pivot/GroupConfigTests.java
@@ -49,7 +49,7 @@ public class GroupConfigTests extends AbstractSerializingTestCase<GroupConfig> {
         // ensure that the unlikely does not happen: 2 group_by's share the same name
         Set<String> names = new HashSet<>();
         for (int i = 0; i < randomIntBetween(1, 20); ++i) {
-            String targetFieldName = randomAlphaOfLengthBetween(1, 20);
+            String targetFieldName = "group_" + randomAlphaOfLengthBetween(1, 20);
             if (names.add(targetFieldName)) {
                 SingleGroupSource groupBy = singleGroupSourceSupplier.get();
                 source.put(targetFieldName, Collections.singletonMap(groupBy.getType().value(), getSource(groupBy)));


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [Transform] Ensure no duplicate names among aggs and groups  (#71993)