### PR TITLE
[7.x] Fix monitoring.bulk spec content_type (#71629)

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/monitoring.bulk.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/monitoring.bulk.json
@@ -8,7 +8,7 @@
     "visibility":"public",
     "headers":{
       "accept": [ "application/json"],
-      "content_type": ["application/json"]
+      "content_type": ["application/x-ndjson"]
     },
     "url":{
       "paths":[


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Fix monitoring.bulk spec content_type (#71629)