### PR TITLE
Close IndexInput before Store

### DIFF
--- a/server/src/main/java/org/elasticsearch/indices/recovery/RecoverySourceHandler.java
+++ b/server/src/main/java/org/elasticsearch/indices/recovery/RecoverySourceHandler.java
@@ -946,7 +946,7 @@ public class RecoverySourceHandler {
                     IOUtils.close(currentInput, () -> currentInput = null);
                 }
             };
-        resources.add(multiFileSender);
+        resources.add(0, multiFileSender);
         multiFileSender.start();
     }
 

--- a/server/src/main/java/org/elasticsearch/indices/recovery/RecoverySourceHandler.java
+++ b/server/src/main/java/org/elasticsearch/indices/recovery/RecoverySourceHandler.java
@@ -412,7 +412,13 @@ public class RecoverySourceHandler {
         //       While practically unlikely at a min pool size of 128 we could technically block the whole pool by waiting on futures
         //       below and thus make it impossible for the store release to execute which in turn would block the futures forever
         threadPool.generic().execute(ActionRunnable.run(future, task));
-        FutureUtils.get(future);
+        try {
+            FutureUtils.get(future);
+        } catch (IllegalStateException e) {
+            if (threadPool.generic().isShutdown() == false) {
+                throw e;
+            }
+        }
     }
 
     static final class SendFileResult {


### PR DESCRIPTION
Currently the IndexInput that is opened from a Store is closed after
the Store has been closed, which can cause issues if the Store throws
when a File is still open when the Store is closed.