### PR TITLE
Update skip after backport of #71758

### DIFF
--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.aggregation/10_histogram.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.aggregation/10_histogram.yml
@@ -636,8 +636,8 @@ setup:
 ---
 "Tiny tiny tiny range":
   - skip:
-      version: " - 7.99.99"
-      reason:  fixed in 8.0 and being backported to 7.13.0
+      version: " - 7.12.99"
+      reason:  fixed in 7.13.0
 
   - do:
       bulk:


### PR DESCRIPTION
Now that #71758 has landed in 7.x we don't have to skip its tests when
running backwards compatibility tests.
