### PR TITLE
Delegate to wrapped map for toString in DynamicMap

### DIFF
--- a/server/src/main/java/org/elasticsearch/script/DynamicMap.java
+++ b/server/src/main/java/org/elasticsearch/script/DynamicMap.java
@@ -94,4 +94,9 @@ public final class DynamicMap implements Map<String, Object> {
     public Set<Entry<String, Object>> entrySet() {
         return delegate.entrySet();
     }
+
+    @Override
+    public String toString() {
+        return delegate.toString();
+    }
 }

--- a/server/src/test/java/org/elasticsearch/script/ScriptTests.java
+++ b/server/src/test/java/org/elasticsearch/script/ScriptTests.java
@@ -199,4 +199,13 @@ public class ScriptTests extends ESTestCase {
         );
         assertEquals("Value must be of type Map: [params]", exc.getMessage());
     }
+
+    public void testDynamicMapToString() {
+        Map<String, Object> map = new HashMap<>();
+        map.put("long", 1L);
+        map.put("string", "value");
+        DynamicMap dm = new DynamicMap(map, Collections.emptyMap());
+        assertTrue(dm.toString().contains("string=value"));
+        assertTrue(dm.toString().contains("long=1"));
+    }
 }


### PR DESCRIPTION
This changes has DynamicMap delegate to its interally wrapped Map for toString to give better debugging information. This is particularly relevant to Debug.explain in Painless.