### PR TITLE
Catch and Log IOExceptions in CacheFile Ref Counting (#71901)

### DIFF
--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/cache/common/CacheFile.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/cache/common/CacheFile.java
@@ -6,6 +6,9 @@
  */
 package org.elasticsearch.xpack.searchablesnapshots.cache.common;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.apache.lucene.store.AlreadyClosedException;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.PlainActionFuture;
@@ -17,7 +20,6 @@ import org.elasticsearch.common.util.concurrent.AbstractRunnable;
 import org.elasticsearch.core.internal.io.IOUtils;
 
 import java.io.IOException;
-import java.io.UncheckedIOException;
 import java.nio.channels.FileChannel;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -34,6 +36,8 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
 
 public class CacheFile {
+
+    private static final Logger logger = LogManager.getLogger(CacheFile.class);
 
     @FunctionalInterface
     public interface EvictionListener {
@@ -68,7 +72,8 @@ public class CacheFile {
             try {
                 Files.deleteIfExists(file);
             } catch (IOException e) {
-                throw new UncheckedIOException(e);
+                // nothing to do but log failures here since closeInternal could be called from anywhere and must not throw
+                logger.warn(() -> new ParameterizedMessage("Failed to delete [{}]", file), e);
             } finally {
                 listener.onCacheFileDelete(CacheFile.this);
             }
@@ -120,7 +125,8 @@ public class CacheFile {
             try {
                 fileChannel.close();
             } catch (IOException e) {
-                throw new UncheckedIOException(e);
+                // nothing to do but log failures here since closeInternal could be called from anywhere and must not throw
+                logger.warn(() -> new ParameterizedMessage("Failed to close [{}]", file), e);
             } finally {
                 decrementRefCount();
             }


### PR DESCRIPTION
We ultimately handle these exceptions via `IOUtils.closeWhileHandlingException`
invoking the refcount decrement for these spots. Now that we don't allow
throwing in `closeInternal` any longer we're seeing broken tests on Windows CI
(probably due to BitDefender or so).
As we can't do anything about these failures, we should log them where they
happen at least and not rethrow them to where they're ignored anyway.

closes #71887
closes #71824

backport of #71901