### PR TITLE
Revert "Fix ListenableFuture Resolving Listeners under Mutex"

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/StepListener.java
+++ b/server/src/main/java/org/elasticsearch/action/StepListener.java
@@ -9,6 +9,7 @@
 package org.elasticsearch.action;
 
 import org.elasticsearch.common.CheckedConsumer;
+import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.common.util.concurrent.FutureUtils;
 import org.elasticsearch.common.util.concurrent.ListenableFuture;
 
@@ -104,7 +105,7 @@ public final class StepListener<Response> extends NotifyOnceListener<Response> {
      * Registers the given listener to be notified with the result of this step.
      */
     public void addListener(ActionListener<Response> listener) {
-        delegate.addListener(listener);
+        delegate.addListener(listener, EsExecutors.newDirectExecutorService());
     }
 
 }

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/status/TransportSnapshotsStatusAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/status/TransportSnapshotsStatusAction.java
@@ -284,7 +284,7 @@ public class TransportSnapshotsStatusAction extends TransportMasterNodeAction<Sn
                 }
             }
             listener.onResponse(new SnapshotsStatusResponse(Collections.unmodifiableList(builder)));
-        }, listener::onFailure), threadPool.generic(), null);
+        }, listener::onFailure), threadPool.generic());
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/Coordinator.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/Coordinator.java
@@ -45,6 +45,7 @@ import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.transport.TransportAddress;
 import org.elasticsearch.common.unit.TimeValue;
+import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.common.util.concurrent.ListenableFuture;
 import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.common.xcontent.json.JsonXContent;
@@ -1421,7 +1422,7 @@ public class Coordinator extends AbstractLifecycleComponent implements Discovery
                     ackListener.onNodeAck(getLocalNode(), exception); // other nodes have acked, but not the master.
                     publishListener.onFailure(exception);
                 }
-            }, null, transportService.getThreadPool().getThreadContext());
+            }, EsExecutors.newDirectExecutorService(), transportService.getThreadPool().getThreadContext());
         }
 
         private void cancelTimeoutHandlers() {

--- a/server/src/main/java/org/elasticsearch/common/util/concurrent/ListenableFuture.java
+++ b/server/src/main/java/org/elasticsearch/common/util/concurrent/ListenableFuture.java
@@ -9,8 +9,8 @@
 package org.elasticsearch.common.util.concurrent;
 
 import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.ActionRunnable;
 import org.elasticsearch.action.support.ContextPreservingActionListener;
-import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.collect.Tuple;
 
 import java.util.ArrayList;
@@ -30,33 +30,31 @@ import java.util.concurrent.TimeUnit;
 public final class ListenableFuture<V> extends BaseFuture<V> implements ActionListener<V> {
 
     private volatile boolean done = false;
-    private List<Tuple<ActionListener<V>, ExecutorService>> listeners;
+    private final List<Tuple<ActionListener<V>, ExecutorService>> listeners = new ArrayList<>();
+
 
     /**
      * Adds a listener to this future. If the future has not yet completed, the listener will be
-     * notified of a response or exception on the thread completing this future.
+     * notified of a response or exception in a runnable submitted to the ExecutorService provided.
      * If the future has completed, the listener will be notified immediately without forking to
      * a different thread.
      */
-    public void addListener(ActionListener<V> listener) {
-        addListener(listener, null, null);
+    public void addListener(ActionListener<V> listener, ExecutorService executor) {
+        addListener(listener, executor, null);
     }
 
     /**
      * Adds a listener to this future. If the future has not yet completed, the listener will be
-     * notified of a response or exception in a runnable submitted to the ExecutorService provided
-     * if one is provided. If a null executor is provided the listener will be executed directly
-     * on the thread completing the future.
+     * notified of a response or exception in a runnable submitted to the ExecutorService provided.
      * If the future has completed, the listener will be notified immediately without forking to
      * a different thread.
      *
      * It will apply the provided ThreadContext (if not null) when executing the listening.
      */
-    public void addListener(ActionListener<V> listener, @Nullable ExecutorService executor, ThreadContext threadContext) {
-        assert executor != EsExecutors.newDirectExecutorService() : "using direct executor here instead of null is needless overhead";
+    public void addListener(ActionListener<V> listener, ExecutorService executor, ThreadContext threadContext) {
         if (done) {
             // run the callback directly, we don't hold the lock and don't need to fork!
-            notifyListenerDirectly(listener);
+            notifyListener(listener, EsExecutors.newDirectExecutorService());
         } else {
             final boolean run;
             // check done under lock since it could have been modified and protect modifications
@@ -71,9 +69,6 @@ public final class ListenableFuture<V> extends BaseFuture<V> implements ActionLi
                     } else {
                         wrappedListener = ContextPreservingActionListener.wrapPreservingContext(listener, threadContext);
                     }
-                    if (listeners == null) {
-                        listeners = new ArrayList<>();
-                    }
                     listeners.add(new Tuple<>(wrappedListener, executor));
                     run = false;
                 }
@@ -81,50 +76,29 @@ public final class ListenableFuture<V> extends BaseFuture<V> implements ActionLi
 
             if (run) {
                 // run the callback directly, we don't hold the lock and don't need to fork!
-                notifyListenerDirectly(listener);
+                notifyListener(listener, EsExecutors.newDirectExecutorService());
             }
         }
     }
 
     @Override
-    protected void done(boolean ignored) {
-        final List<Tuple<ActionListener<V>, ExecutorService>> existingListeners;
-        synchronized (this) {
-            done = true;
-            existingListeners = listeners;
-            if (existingListeners == null) {
-                return;
-            }
-            listeners = null;
-        }
-        for (Tuple<ActionListener<V>, ExecutorService> t : existingListeners) {
-            final ExecutorService executorService = t.v2();
-            final ActionListener<V> listener = t.v1();
-            if (executorService == null) {
-                notifyListenerDirectly(listener);
-            } else {
-                notifyListener(listener, executorService);
-            }
-        }
-    }
-
-    private void notifyListenerDirectly(ActionListener<V> listener) {
-        try {
-            // call get in a non-blocking fashion as we could be on a network thread
-            // or another thread like the scheduler, which we should never block!
-            V value = FutureUtils.get(ListenableFuture.this, 0L, TimeUnit.NANOSECONDS);
-            listener.onResponse(value);
-        } catch (Exception e) {
-            listener.onFailure(e);
-        }
+    protected synchronized void done(boolean ignored) {
+        done = true;
+        listeners.forEach(t -> notifyListener(t.v1(), t.v2()));
+        // release references to any listeners as we no longer need them and will live
+        // much longer than the listeners in most cases
+        listeners.clear();
     }
 
     private void notifyListener(ActionListener<V> listener, ExecutorService executorService) {
         try {
-            executorService.execute(new Runnable() {
+            executorService.execute(new ActionRunnable<>(listener) {
                 @Override
-                public void run() {
-                    notifyListenerDirectly(listener);
+                protected void doRun() {
+                    // call get in a non-blocking fashion as we could be on a network thread
+                    // or another thread like the scheduler, which we should never block!
+                    V value = FutureUtils.get(ListenableFuture.this, 0L, TimeUnit.NANOSECONDS);
+                    listener.onResponse(value);
                 }
 
                 @Override

--- a/server/src/main/java/org/elasticsearch/indices/recovery/RecoveryRequestTracker.java
+++ b/server/src/main/java/org/elasticsearch/indices/recovery/RecoveryRequestTracker.java
@@ -10,6 +10,7 @@ package org.elasticsearch.indices.recovery;
 
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.common.Nullable;
+import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.common.util.concurrent.ListenableFuture;
 import org.elasticsearch.index.seqno.LocalCheckpointTracker;
 
@@ -40,7 +41,7 @@ public class RecoveryRequestTracker {
         if (checkpointTracker.hasProcessed(requestSeqNo)) {
             final ListenableFuture<Void> existingFuture = ongoingRequests.get(requestSeqNo);
             if (existingFuture != null) {
-                existingFuture.addListener(listener);
+                existingFuture.addListener(listener, EsExecutors.newDirectExecutorService());
             } else {
                 listener.onResponse(null);
             }
@@ -52,7 +53,7 @@ public class RecoveryRequestTracker {
             future.addListener(listener.delegateFailure((l, v) -> {
                 ongoingRequests.remove(requestSeqNo);
                 l.onResponse(v);
-            }));
+            }), EsExecutors.newDirectExecutorService());
             return future;
         }
     }

--- a/server/src/main/java/org/elasticsearch/indices/recovery/RecoverySourceHandler.java
+++ b/server/src/main/java/org/elasticsearch/indices/recovery/RecoverySourceHandler.java
@@ -41,6 +41,7 @@ import org.elasticsearch.common.lucene.store.InputStreamIndexInput;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.util.CancellableThreads;
+import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.common.util.concurrent.FutureUtils;
 import org.elasticsearch.common.util.concurrent.ListenableFuture;
 import org.elasticsearch.core.internal.io.IOUtils;
@@ -129,7 +130,7 @@ public class RecoverySourceHandler {
     }
 
     public void addListener(ActionListener<RecoveryResponse> listener) {
-        future.addListener(listener);
+        future.addListener(listener, EsExecutors.newDirectExecutorService());
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/transport/ClusterConnectionManager.java
+++ b/server/src/main/java/org/elasticsearch/transport/ClusterConnectionManager.java
@@ -14,6 +14,7 @@ import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.AbstractRefCounted;
 import org.elasticsearch.common.util.concurrent.ConcurrentCollections;
+import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.common.util.concurrent.ListenableFuture;
 import org.elasticsearch.common.util.concurrent.RunOnce;
 import org.elasticsearch.core.internal.io.IOUtils;
@@ -114,14 +115,14 @@ public class ClusterConnectionManager implements ConnectionManager {
         if (existingListener != null) {
             try {
                 // wait on previous entry to complete connection attempt
-                existingListener.addListener(listener);
+                existingListener.addListener(listener, EsExecutors.newDirectExecutorService());
             } finally {
                 connectingRefCounter.decRef();
             }
             return;
         }
 
-        currentListener.addListener(listener);
+        currentListener.addListener(listener, EsExecutors.newDirectExecutorService());
 
         final RunOnce releaseOnce = new RunOnce(connectingRefCounter::decRef);
         internalOpenConnection(node, resolvedProfile, ActionListener.wrap(conn -> {

--- a/server/src/test/java/org/elasticsearch/common/util/concurrent/ListenableFutureTests.java
+++ b/server/src/test/java/org/elasticsearch/common/util/concurrent/ListenableFutureTests.java
@@ -39,7 +39,7 @@ public class ListenableFutureTests extends ESTestCase {
         AtomicInteger notifications = new AtomicInteger(0);
         final int numberOfListeners = scaledRandomIntBetween(1, 12);
         for (int i = 0; i < numberOfListeners; i++) {
-            future.addListener(ActionListener.wrap(notifications::incrementAndGet), null, threadContext);
+            future.addListener(ActionListener.wrap(notifications::incrementAndGet), EsExecutors.newDirectExecutorService(), threadContext);
         }
 
         future.onResponse("");
@@ -56,7 +56,7 @@ public class ListenableFutureTests extends ESTestCase {
             future.addListener(ActionListener.wrap(s -> fail("this should never be called"), e -> {
                 assertEquals(exception, e);
                 notifications.incrementAndGet();
-            }), null, threadContext);
+            }), EsExecutors.newDirectExecutorService(), threadContext);
         }
 
         future.onFailure(exception);

--- a/x-pack/plugin/data-streams/src/internalClusterTest/java/org/elasticsearch/datastreams/SystemDataStreamIT.java
+++ b/x-pack/plugin/data-streams/src/internalClusterTest/java/org/elasticsearch/datastreams/SystemDataStreamIT.java
@@ -8,7 +8,6 @@
 package org.elasticsearch.datastreams;
 
 import org.apache.http.util.EntityUtils;
-import org.apache.lucene.util.LuceneTestCase.AwaitsFix;
 import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.ResourceNotFoundException;
 import org.elasticsearch.action.ActionListener;
@@ -57,7 +56,6 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 
-@AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/72031")
 public class SystemDataStreamIT extends ESIntegTestCase {
 
     private static String nodeHttpTypeKey;

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/oidc/OpenIdConnectAuthenticator.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/oidc/OpenIdConnectAuthenticator.java
@@ -79,6 +79,7 @@ import org.elasticsearch.common.CheckedRunnable;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.collect.Tuple;
+import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.common.util.concurrent.ListenableFuture;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.watcher.FileChangesListener;
@@ -808,7 +809,7 @@ public class OpenIdConnectAuthenticator {
                     future = reloadFutureRef.get();
                 }
             }
-            future.addListener(toNotify);
+            future.addListener(toNotify, EsExecutors.newDirectExecutorService(), null);
         }
 
         void reloadAsync(final ListenableFuture<Void> future) {


### PR DESCRIPTION
We think that this PR, along with #70373, has exposed some legitimate bugs
that we need to address. They're currently causing test failures that are hard
to scope and mute. For now we'll revert this commit, with the plan to
reintroduce it along with the bug fixes.

Relates to #72033, #72031.