### PR TITLE
Designate reporting_user as a deprecated role

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStore.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStore.java
@@ -104,12 +104,14 @@ public class ReservedRolesStore implements BiConsumer<Set<String>, ActionListene
                         null, null, MetadataUtils.DEFAULT_RESERVED_METADATA))
                 // reporting_user doesn't have any privileges in Elasticsearch, and Kibana authorizes privileges based on this role
                 .put("reporting_user", new RoleDescriptor(
-                        "reporting_user",
-                        null,
-                        null,
-                        null, null,
-                        MetadataUtils.getDeprecatedReservedMetadata("Please use Kibana feature privileges instead"),
-                        null)
+                    "reporting_user",
+                    null,
+                    null,
+                    null,
+                    null,
+                    null,
+                    MetadataUtils.getDeprecatedReservedMetadata("Please use Kibana feature privileges instead"),
+                    null))
                 .put("kibana_dashboard_only_user", new RoleDescriptor(
                         "kibana_dashboard_only_user",
                         null,

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStore.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStore.java
@@ -103,8 +103,13 @@ public class ReservedRolesStore implements BiConsumer<Set<String>, ActionListene
                 .put("ingest_admin", new RoleDescriptor("ingest_admin", new String[] { "manage_index_templates", "manage_pipeline" },
                         null, null, MetadataUtils.DEFAULT_RESERVED_METADATA))
                 // reporting_user doesn't have any privileges in Elasticsearch, and Kibana authorizes privileges based on this role
-                .put("reporting_user", new RoleDescriptor("reporting_user", null, null,
-                        null, MetadataUtils.DEFAULT_RESERVED_METADATA))
+                .put("reporting_user", new RoleDescriptor(
+                        "reporting_user",
+                        null,
+                        null,
+                        null, null,
+                        MetadataUtils.getDeprecatedReservedMetadata("Please use Kibana feature privileges instead"),
+                        null)
                 .put("kibana_dashboard_only_user", new RoleDescriptor(
                         "kibana_dashboard_only_user",
                         null,

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStoreTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStoreTests.java
@@ -945,6 +945,7 @@ public class ReservedRolesStoreTests extends ESTestCase {
         RoleDescriptor roleDescriptor = new ReservedRolesStore().roleDescriptor("reporting_user");
         assertNotNull(roleDescriptor);
         assertThat(roleDescriptor.getMetadata(), hasEntry("_reserved", true));
+        assertThat(roleDescriptor.getMetadata(), hasEntry("_deprecated", true));
 
         Role reportingUserRole = Role.builder(roleDescriptor, null).build();
         assertThat(reportingUserRole.cluster().check(ClusterHealthAction.NAME, request, authentication), is(false));


### PR DESCRIPTION
The built-in `reporting_user` role is used by Kibana to grant report-generation privileges to a user that has that role assigned. That is deprecated in Kibana, as the [Kibana admin can now migrate to using the Kibana application privileges APIs for Reporting](https://github.com/elastic/kibana/pull/94966).

This PR follows the path of deprecating built-in roles that https://github.com/elastic/elasticsearch/pull/46456 introduced. It updates the built-in `reporting_user` role to be marked as "deprecated" in the metadata. This change will allow Kibana to show notices to the admin user in the UI that migrating to Kibana application privileges is the preferred option.