### PR TITLE
Fix privileges for predefined roles

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStore.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStore.java
@@ -358,7 +358,7 @@ public class ReservedRolesStore implements BiConsumer<Set<String>, ActionListene
                     .resources("*")
                     .privileges("read").build(),
                 RoleDescriptor.ApplicationResourcePrivileges.builder()
-                    .application("kibana-.*")
+                    .application("kibana-*")
                     .resources("*")
                     .privileges("reserved_ml_user").build() },
             null,
@@ -389,7 +389,7 @@ public class ReservedRolesStore implements BiConsumer<Set<String>, ActionListene
                     .resources("*")
                     .privileges("all").build(),
                 RoleDescriptor.ApplicationResourcePrivileges.builder()
-                    .application("kibana-.*")
+                    .application("kibana-*")
                     .resources("*")
                     .privileges("reserved_ml_admin").build() },
             null,

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStore.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStore.java
@@ -356,7 +356,11 @@ public class ReservedRolesStore implements BiConsumer<Set<String>, ActionListene
                 RoleDescriptor.ApplicationResourcePrivileges.builder()
                     .application("kibana-.kibana")
                     .resources("*")
-                    .privileges("read").build() },
+                    .privileges("read").build(),
+                RoleDescriptor.ApplicationResourcePrivileges.builder()
+                    .application("kibana-.*")
+                    .resources("*")
+                    .privileges("reserved_ml_user").build() },
             null,
             null,
             MetadataUtils.DEFAULT_RESERVED_METADATA,
@@ -383,7 +387,11 @@ public class ReservedRolesStore implements BiConsumer<Set<String>, ActionListene
                 RoleDescriptor.ApplicationResourcePrivileges.builder()
                     .application("kibana-.kibana")
                     .resources("*")
-                    .privileges("all").build() },
+                    .privileges("all").build(),
+                RoleDescriptor.ApplicationResourcePrivileges.builder()
+                    .application("kibana-.*")
+                    .resources("*")
+                    .privileges("reserved_ml_admin").build() },
             null,
             null,
             MetadataUtils.DEFAULT_RESERVED_METADATA,

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStoreTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStoreTests.java
@@ -1713,6 +1713,11 @@ public class ReservedRolesStoreTests extends ESTestCase {
         // Check application privileges
         assertThat(role.application().grants(new ApplicationPrivilege("kibana-.kibana", "kibana-read", "read"), "*"), is(true));
         assertThat(role.application().grants(new ApplicationPrivilege("kibana-.kibana", "kibana-all", "all"), "*"), is(false));
+        final String kibIndex = "kibana-." + randomAlphaOfLengthBetween(5, 10);
+        assertThat(
+            role.application().grants(new ApplicationPrivilege(kibIndex, "app-reserved_ml_user", "reserved_ml_user"), "*"), is(true));
+        assertThat(
+            role.application().grants(new ApplicationPrivilege(kibIndex, "app-reserved_ml_admin", "reserved_ml_admin"), "*"), is(false));
 
         assertThat(role.runAs().check(randomAlphaOfLengthBetween(1, 20)), is(false));
     }
@@ -1767,6 +1772,9 @@ public class ReservedRolesStoreTests extends ESTestCase {
 
         // Check application privileges
         assertThat(role.application().grants(new ApplicationPrivilege("kibana-.kibana", "kibana-all", "all"), "*"), is(true));
+        assertThat(role.application().grants(
+            new ApplicationPrivilege("kibana-." + randomAlphaOfLengthBetween(6, 10),
+                "app-reserved_ml", "reserved_ml_admin"), "*"), is(true));
 
         assertThat(role.runAs().check(randomAlphaOfLengthBetween(1, 20)), is(false));
     }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStoreTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStoreTests.java
@@ -1713,7 +1713,7 @@ public class ReservedRolesStoreTests extends ESTestCase {
         // Check application privileges
         assertThat(role.application().grants(new ApplicationPrivilege("kibana-.kibana", "kibana-read", "read"), "*"), is(true));
         assertThat(role.application().grants(new ApplicationPrivilege("kibana-.kibana", "kibana-all", "all"), "*"), is(false));
-        final String kibIndex = "kibana-." + randomAlphaOfLengthBetween(5, 10);
+        final String kibIndex = "kibana-" + randomAlphaOfLengthBetween(5, 10);
         assertThat(
             role.application().grants(new ApplicationPrivilege(kibIndex, "app-reserved_ml_user", "reserved_ml_user"), "*"), is(true));
         assertThat(
@@ -1773,7 +1773,7 @@ public class ReservedRolesStoreTests extends ESTestCase {
         // Check application privileges
         assertThat(role.application().grants(new ApplicationPrivilege("kibana-.kibana", "kibana-all", "all"), "*"), is(true));
         assertThat(role.application().grants(
-            new ApplicationPrivilege("kibana-." + randomAlphaOfLengthBetween(6, 10),
+            new ApplicationPrivilege("kibana-" + randomAlphaOfLengthBetween(6, 10),
                 "app-reserved_ml", "reserved_ml_admin"), "*"), is(true));
 
         assertThat(role.runAs().check(randomAlphaOfLengthBetween(1, 20)), is(false));


### PR DESCRIPTION
In #71904 we added two new predefined roles, editor and viewer in
elasticsearch. This change adds a missing application privilege to
these roles. This is only needed in 7.x as the behavior has changed
in Kibana, starting 8.0 and this extra privilege is not necessary.

Marking as non-issue as this is not yet released.
