### PR TITLE
[7.x][ML] Avoid direct action on system index in evaluate REST tests …

### DIFF
--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/ml/evaluate_data_frame.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/ml/evaluate_data_frame.yml
@@ -187,7 +187,8 @@ setup:
           }
 
   - do:
-      indices.refresh: {}
+      indices.refresh:
+        index: utopia
 
 ---
 "Test outlier_detection auc_roc":


### PR DESCRIPTION
…(#72069)

Refreshing all indices seems to potentially touch on the `.ml-config`
index which is a system index. That can cause a depracation warning
for directly accessing system indices. This commit changes the
refresh request to just be on the data index the test uses.

Closes #72046

Backport of #72069
