### PR TITLE
Remove unused method (backport of #71969)

### DIFF
--- a/server/src/main/java/org/elasticsearch/search/aggregations/LeafBucketCollector.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/LeafBucketCollector.java
@@ -13,8 +13,6 @@ import org.apache.lucene.search.Scorable;
 import org.elasticsearch.search.aggregations.bucket.terms.LongKeyedBucketOrds;
 
 import java.io.IOException;
-import java.util.stream.Stream;
-import java.util.stream.StreamSupport;
 
 /**
  * Collects results for a particular segment. See the docs for
@@ -43,36 +41,6 @@ public abstract class LeafBucketCollector implements LeafCollector {
             return true;
         }
     };
-
-    public static LeafBucketCollector wrap(Iterable<LeafBucketCollector> collectors) {
-        final Stream<LeafBucketCollector> actualCollectors = StreamSupport.stream(collectors.spliterator(), false)
-            .filter(c -> c != NO_OP_COLLECTOR);
-        final LeafBucketCollector[] colls = actualCollectors.toArray(size -> new LeafBucketCollector[size]);
-        switch (colls.length) {
-        case 0:
-            return NO_OP_COLLECTOR;
-        case 1:
-            return colls[0];
-        default:
-            return new LeafBucketCollector() {
-
-                @Override
-                public void setScorer(Scorable s) throws IOException {
-                    for (LeafBucketCollector c : colls) {
-                        c.setScorer(s);
-                    }
-                }
-
-                @Override
-                public void collect(int doc, long bucket) throws IOException {
-                    for (LeafBucketCollector c : colls) {
-                        c.collect(doc, bucket);
-                    }
-                }
-
-            };
-        }
-    }
 
     /**
      * Collect the given {@code doc} in the bucket owned by


### PR DESCRIPTION
Removes the unused `LeafBucketCollector#wrap` method. Its been entirely
replaced by `MultiBucketCollector#wrap`.
