### PR TITLE
Fixes bug when composite aggs when the index is sorted

### DIFF
--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/composite/CompositeAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/composite/CompositeAggregator.java
@@ -406,10 +406,19 @@ final class CompositeAggregator extends BucketsAggregator {
                 // We have an after key and index sort is applicable so we jump directly to the doc
                 // that is after the index sort prefix using the rawAfterKey and we start collecting
                 // document from there.
-                processLeafFromQuery(ctx, indexSortPrefix);
+                try {
+                    processLeafFromQuery(ctx, indexSortPrefix);
+                } catch (CollectionTerminatedException ex) {
+                    return LeafBucketCollector.NO_OP_COLLECTOR;
+                }
                 return LeafBucketCollector.NO_OP_COLLECTOR;
             } else {
-                final LeafBucketCollector inner = queue.getLeafCollector(ctx, getFirstPassCollector(docIdSetBuilder, sortPrefixLen));
+                final LeafBucketCollector inner;
+                try {
+                     inner = queue.getLeafCollector(ctx, getFirstPassCollector(docIdSetBuilder, sortPrefixLen));
+                } catch (CollectionTerminatedException ex) {
+                    return LeafBucketCollector.NO_OP_COLLECTOR;
+                }
                 return new LeafBucketCollector() {
                     @Override
                     public void collect(int doc, long zeroBucket) throws IOException {


### PR DESCRIPTION
Recent work to refactor leaf collection short circuiting caused a bug in composite aggs. 

If the indices are sorted, and an `after` is provided, composite aggs determines if a short circuit is possible when it creates its leaf collector. This check may throw a `CollectionTerminatedException` inside the leaf collector construction, which causes much consternation up the stack.

This bug fix wraps these short circuit checks in a `try..catch` so that the `noop` logic is respected

closes https://github.com/elastic/elasticsearch/issues/72078