### PR TITLE
[7.13] [DOCS] Remove internal versioning for concurrency control (#71570)

### DIFF
--- a/docs/reference/docs/index_.asciidoc
+++ b/docs/reference/docs/index_.asciidoc
@@ -519,9 +519,6 @@ In addition to the `external` version type, Elasticsearch
 also supports other types for specific use cases:
 
 [[_version_types]]
-`internal`:: Only index the document if the given version is identical to the version
-of the stored document.
-
 `external` or `external_gt`:: Only index the document if the given version is strictly higher
 than the version of the stored document *or* if there is no existing document. The given
 version will be used as the new version and will be stored with the new document. The supplied

--- a/docs/reference/rest-api/common-parms.asciidoc
+++ b/docs/reference/rest-api/common-parms.asciidoc
@@ -1168,7 +1168,7 @@ end::segment-version[]
 
 tag::version_type[]
 `version_type`::
-(Optional, enum) Specific version type: `internal`, `external`,
+(Optional, enum) Specific version type: `external`,
 `external_gte`.
 end::version_type[]
 


### PR DESCRIPTION
Backports the following commits to 7.13:
 - [DOCS] Remove internal versioning for concurrency control (#71570)