### PR TITLE
Enable mixed-version cluster tests for `match_only_text`.

### DIFF
--- a/modules/mapper-extras/src/yamlRestTest/resources/rest-api-spec/test/match_only_text/10_basic.yml
+++ b/modules/mapper-extras/src/yamlRestTest/resources/rest-api-spec/test/match_only_text/10_basic.yml
@@ -1,7 +1,7 @@
 setup:
 
   - skip:
-      version: " - 7.99.99"
+      version: " - 7.13.99"
       reason: "match_only_text was added in 7.14"
 
   - do:


### PR DESCRIPTION
These tests can be enabled now that the new field type has been backported to
7.14.
