### PR TITLE
Separe STATUS from RESULT in async search

### DIFF
--- a/x-pack/plugin/async-search/src/main/java/org/elasticsearch/xpack/search/TransportGetAsyncSearchAction.java
+++ b/x-pack/plugin/async-search/src/main/java/org/elasticsearch/xpack/search/TransportGetAsyncSearchAction.java
@@ -23,12 +23,13 @@ import org.elasticsearch.xpack.core.async.AsyncResultsService;
 import org.elasticsearch.xpack.core.async.AsyncTaskIndexService;
 import org.elasticsearch.xpack.core.async.GetAsyncResultRequest;
 import org.elasticsearch.xpack.core.search.action.AsyncSearchResponse;
+import org.elasticsearch.xpack.core.search.action.AsyncStatusResponse;
 import org.elasticsearch.xpack.core.search.action.GetAsyncSearchAction;
 
 import static org.elasticsearch.xpack.core.ClientHelper.ASYNC_SEARCH_ORIGIN;
 
 public class TransportGetAsyncSearchAction extends HandledTransportAction<GetAsyncResultRequest, AsyncSearchResponse> {
-    private final AsyncResultsService<AsyncSearchTask, AsyncSearchResponse> resultsService;
+    private final AsyncResultsService<AsyncSearchTask, AsyncSearchResponse, AsyncStatusResponse> resultsService;
     private final TransportService transportService;
 
     @Inject
@@ -43,12 +44,11 @@ public class TransportGetAsyncSearchAction extends HandledTransportAction<GetAsy
         this.resultsService = createResultsService(transportService, clusterService, registry, client, threadPool);
     }
 
-    static AsyncResultsService<AsyncSearchTask, AsyncSearchResponse> createResultsService(TransportService transportService,
-                                                                                          ClusterService clusterService,
-                                                                                          NamedWriteableRegistry registry,
-                                                                                          Client client,
-                                                                                          ThreadPool threadPool) {
-        AsyncTaskIndexService<AsyncSearchResponse> store = new AsyncTaskIndexService<>(XPackPlugin.ASYNC_RESULTS_INDEX, clusterService,
+    static AsyncResultsService<AsyncSearchTask, AsyncSearchResponse, AsyncStatusResponse> createResultsService(
+            TransportService transportService, ClusterService clusterService, NamedWriteableRegistry registry,
+            Client client, ThreadPool threadPool) {
+        AsyncTaskIndexService<AsyncSearchResponse, AsyncStatusResponse> store = new AsyncTaskIndexService<>(
+                XPackPlugin.ASYNC_RESULTS_INDEX, clusterService,
             threadPool.getThreadContext(), client, ASYNC_SEARCH_ORIGIN, AsyncSearchResponse::new, registry);
         return new AsyncResultsService<>(store, true, AsyncSearchTask.class, AsyncSearchTask::addCompletionListener,
             transportService.getTaskManager(), clusterService);

--- a/x-pack/plugin/async-search/src/main/java/org/elasticsearch/xpack/search/TransportGetAsyncStatusAction.java
+++ b/x-pack/plugin/async-search/src/main/java/org/elasticsearch/xpack/search/TransportGetAsyncStatusAction.java
@@ -33,7 +33,7 @@ import static org.elasticsearch.xpack.core.ClientHelper.ASYNC_SEARCH_ORIGIN;
 public class TransportGetAsyncStatusAction extends HandledTransportAction<GetAsyncStatusRequest, AsyncStatusResponse> {
     private final TransportService transportService;
     private final ClusterService clusterService;
-    private final AsyncTaskIndexService<AsyncSearchResponse> store;
+    private final AsyncTaskIndexService<AsyncSearchResponse, AsyncStatusResponse> store;
 
     @Inject
     public TransportGetAsyncStatusAction(TransportService transportService,
@@ -60,7 +60,8 @@ public class TransportGetAsyncStatusAction extends HandledTransportAction<GetAsy
                 taskManager,
                 AsyncSearchTask.class,
                 AsyncSearchTask::getStatusResponse,
-                AsyncStatusResponse::getStatusFromStoredSearch,
+                AsyncStatusResponse::getStatusFromSearchResponse,
+                AsyncStatusResponse::new,
                 listener
             );
         } else {

--- a/x-pack/plugin/async-search/src/test/java/org/elasticsearch/xpack/search/AsyncSearchTaskTests.java
+++ b/x-pack/plugin/async-search/src/test/java/org/elasticsearch/xpack/search/AsyncSearchTaskTests.java
@@ -8,6 +8,7 @@ package org.elasticsearch.xpack.search;
 
 import org.apache.lucene.search.TotalHits;
 import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.OriginalIndices;
 import org.elasticsearch.action.search.SearchPhaseExecutionException;
@@ -73,7 +74,7 @@ public class AsyncSearchTaskTests extends ESTestCase {
 
     private AsyncSearchTask createAsyncSearchTask() {
         return new AsyncSearchTask(0L, "", "", new TaskId("node1", 0), () -> null, TimeValue.timeValueHours(1),
-            Collections.emptyMap(), Collections.emptyMap(), new AsyncExecutionId("0", new TaskId("node1", 1)),
+            Collections.emptyMap(), Collections.emptyMap(), new AsyncExecutionId("0", new TaskId("node1", 1), Version.CURRENT),
             new NoOpClient(threadPool), threadPool, null);
     }
 
@@ -81,7 +82,8 @@ public class AsyncSearchTaskTests extends ESTestCase {
         SearchRequest searchRequest = new SearchRequest("index1", "index2").source(
             new SearchSourceBuilder().query(QueryBuilders.termQuery("field", "value")));
         AsyncSearchTask asyncSearchTask = new AsyncSearchTask(0L, "", "", new TaskId("node1", 0), searchRequest::buildDescription,
-            TimeValue.timeValueHours(1), Collections.emptyMap(), Collections.emptyMap(), new AsyncExecutionId("0", new TaskId("node1", 1)),
+            TimeValue.timeValueHours(1), Collections.emptyMap(), Collections.emptyMap(),
+            new AsyncExecutionId("0", new TaskId("node1", 1), Version.CURRENT),
             new NoOpClient(threadPool), threadPool, null);
         assertEquals("async_search{indices[index1,index2], search_type[QUERY_THEN_FETCH], " +
             "source[{\"query\":{\"term\":{\"field\":{\"value\":\"value\",\"boost\":1.0}}}}]}", asyncSearchTask.getDescription());
@@ -89,7 +91,7 @@ public class AsyncSearchTaskTests extends ESTestCase {
 
     public void testWaitForInit() throws InterruptedException {
         AsyncSearchTask task = new AsyncSearchTask(0L, "", "", new TaskId("node1", 0), () -> null, TimeValue.timeValueHours(1),
-            Collections.emptyMap(), Collections.emptyMap(), new AsyncExecutionId("0", new TaskId("node1", 1)),
+            Collections.emptyMap(), Collections.emptyMap(), new AsyncExecutionId("0", new TaskId("node1", 1), Version.CURRENT),
             new NoOpClient(threadPool), threadPool, null);
         int numShards = randomIntBetween(0, 10);
         List<SearchShard> shards = new ArrayList<>();

--- a/x-pack/plugin/async-search/src/test/java/org/elasticsearch/xpack/search/RestSubmitAsyncSearchActionTests.java
+++ b/x-pack/plugin/async-search/src/test/java/org/elasticsearch/xpack/search/RestSubmitAsyncSearchActionTests.java
@@ -18,7 +18,6 @@ import org.elasticsearch.xpack.core.search.action.AsyncSearchResponse;
 import org.elasticsearch.xpack.core.search.action.SubmitAsyncSearchRequest;
 import org.junit.Before;
 
-import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Function;
@@ -41,7 +40,7 @@ public class RestSubmitAsyncSearchActionTests extends RestActionTestCase {
      * no parameters are specified on the rest request itself.
      */
     @SuppressWarnings("unchecked")
-    public void testRequestParameterDefaults() throws IOException {
+    public void testRequestParameterDefaults() {
         SetOnce<Boolean> executeCalled = new SetOnce<>();
         verifyingClient.setExecuteLocallyVerifier((actionType, request) -> {
                 assertThat(request, instanceOf(SubmitAsyncSearchRequest.class));

--- a/x-pack/plugin/async/src/main/java/org/elasticsearch/xpack/async/AsyncResultsIndexPlugin.java
+++ b/x-pack/plugin/async/src/main/java/org/elasticsearch/xpack/async/AsyncResultsIndexPlugin.java
@@ -27,6 +27,7 @@ import org.elasticsearch.xpack.core.XPackPlugin;
 import org.elasticsearch.xpack.core.async.AsyncTaskIndexService;
 import org.elasticsearch.xpack.core.async.AsyncTaskMaintenanceService;
 import org.elasticsearch.xpack.core.search.action.AsyncSearchResponse;
+import org.elasticsearch.xpack.core.search.action.AsyncStatusResponse;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -75,7 +76,7 @@ public class AsyncResultsIndexPlugin extends Plugin implements SystemIndexPlugin
         List<Object> components = new ArrayList<>();
         if (DiscoveryNode.canContainData(environment.settings())) {
             // only data nodes should be eligible to run the maintenance service.
-            AsyncTaskIndexService<AsyncSearchResponse> indexService = new AsyncTaskIndexService<>(
+            AsyncTaskIndexService<AsyncSearchResponse, AsyncStatusResponse> indexService = new AsyncTaskIndexService<>(
                 XPackPlugin.ASYNC_RESULTS_INDEX,
                 clusterService,
                 threadPool.getThreadContext(),

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/async/AsyncResultsService.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/async/AsyncResultsService.java
@@ -19,6 +19,7 @@ import org.elasticsearch.common.TriConsumer;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.tasks.TaskManager;
+import org.elasticsearch.xpack.core.search.action.SearchStatusResponse;
 
 import java.util.Objects;
 
@@ -26,12 +27,13 @@ import java.util.Objects;
  * Service that is capable of retrieving and cleaning up AsyncTasks regardless of their state. It works with the TaskManager, if a task
  * is still running and AsyncTaskIndexService if task results already stored there.
  */
-public class AsyncResultsService<Task extends AsyncTask, Response extends AsyncResponse<Response>> {
+public class AsyncResultsService<Task extends AsyncTask, Response extends AsyncResponse<Response>,
+        StatusResponse extends SearchStatusResponse> {
     private final Logger logger = LogManager.getLogger(AsyncResultsService.class);
     private final Class<? extends Task> asyncTaskClass;
     private final TaskManager taskManager;
     private final ClusterService clusterService;
-    private final AsyncTaskIndexService<Response> store;
+    private final AsyncTaskIndexService<Response, StatusResponse> store;
     private final boolean updateInitialResultsInStore;
     private final TriConsumer<Task, ActionListener<Response>, TimeValue> addCompletionListener;
 
@@ -45,7 +47,7 @@ public class AsyncResultsService<Task extends AsyncTask, Response extends AsyncR
      * @param taskManager                 task manager
      * @param clusterService              cluster service
      */
-    public AsyncResultsService(AsyncTaskIndexService<Response> store,
+    public AsyncResultsService(AsyncTaskIndexService<Response, StatusResponse> store,
                                boolean updateInitialResultsInStore,
                                Class<? extends Task> asyncTaskClass,
                                TriConsumer<Task, ActionListener<Response>, TimeValue> addCompletionListener,

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/async/DeleteAsyncResultsService.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/async/DeleteAsyncResultsService.java
@@ -16,6 +16,7 @@ import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.master.AcknowledgedResponse;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.tasks.TaskManager;
+import org.elasticsearch.xpack.core.search.action.SearchStatusResponse;
 import org.elasticsearch.xpack.core.security.action.user.HasPrivilegesAction;
 import org.elasticsearch.xpack.core.security.action.user.HasPrivilegesRequest;
 import org.elasticsearch.xpack.core.security.authc.Authentication;
@@ -31,7 +32,7 @@ import java.util.function.Consumer;
 public class DeleteAsyncResultsService {
     private final Logger logger = LogManager.getLogger(DeleteAsyncResultsService.class);
     private final TaskManager taskManager;
-    private final AsyncTaskIndexService<? extends AsyncResponse<?>> store;
+    private final AsyncTaskIndexService<? extends AsyncResponse<?>, ? extends SearchStatusResponse> store;
 
     /**
      * Creates async results service
@@ -39,7 +40,7 @@ public class DeleteAsyncResultsService {
      * @param store          AsyncTaskIndexService for the response we are working with
      * @param taskManager    task manager
      */
-    public DeleteAsyncResultsService(AsyncTaskIndexService<? extends AsyncResponse<?>> store,
+    public DeleteAsyncResultsService(AsyncTaskIndexService<? extends AsyncResponse<?>, ? extends SearchStatusResponse> store,
                                      TaskManager taskManager) {
         this.taskManager = taskManager;
         this.store = store;

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/async/TransportDeleteAsyncResultAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/async/TransportDeleteAsyncResultAction.java
@@ -38,7 +38,7 @@ public class TransportDeleteAsyncResultAction extends HandledTransportAction<Del
         super(DeleteAsyncResultAction.NAME, transportService, actionFilters, DeleteAsyncResultRequest::new);
         this.transportService = transportService;
         this.clusterService = clusterService;
-        AsyncTaskIndexService<?> store = new AsyncTaskIndexService<>(XPackPlugin.ASYNC_RESULTS_INDEX, clusterService,
+        AsyncTaskIndexService<?, ?> store = new AsyncTaskIndexService<>(XPackPlugin.ASYNC_RESULTS_INDEX, clusterService,
             threadPool.getThreadContext(), client, ASYNC_SEARCH_ORIGIN,
             (in) -> {throw new UnsupportedOperationException("Reading is not supported during deletion");}, registry);
         this.deleteResultsService = new DeleteAsyncResultsService(store, transportService.getTaskManager());

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/search/action/AsyncStatusResponse.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/search/action/AsyncStatusResponse.java
@@ -29,7 +29,7 @@ public class AsyncStatusResponse extends ActionResponse implements SearchStatusR
     private final boolean isRunning;
     private final boolean isPartial;
     private final long startTimeMillis;
-    private final long expirationTimeMillis;
+    private long expirationTimeMillis;
     private final int totalShards;
     private final int successfulShards;
     private final int skippedShards;
@@ -65,7 +65,7 @@ public class AsyncStatusResponse extends ActionResponse implements SearchStatusR
      * @param id – encoded async search id
      * @return status response
      */
-    public static AsyncStatusResponse getStatusFromStoredSearch(AsyncSearchResponse asyncSearchResponse,
+    public static AsyncStatusResponse getStatusFromSearchResponse(AsyncSearchResponse asyncSearchResponse,
             long expirationTimeMillis, String id) {
         int totalShards = 0;
         int successfulShards = 0;
@@ -213,6 +213,14 @@ public class AsyncStatusResponse extends ActionResponse implements SearchStatusR
     @Override
     public long getExpirationTime() {
         return expirationTimeMillis;
+    }
+
+    /**
+     * Sets a new timestamp when the search will be expired, in milliseconds since epoch.
+     */
+    @Override
+    public void setExpirationTime(long expirationTime) {
+        this.expirationTimeMillis = expirationTime;
     }
 
     /**

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/search/action/SearchStatusResponse.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/search/action/SearchStatusResponse.java
@@ -7,13 +7,20 @@
 
 package org.elasticsearch.xpack.core.search.action;
 
+import org.elasticsearch.common.io.stream.Writeable;
+
 /**
  * An interface for status response of the stored or running async search
  */
-public interface SearchStatusResponse {
+public interface SearchStatusResponse extends Writeable {
 
     /**
      * Returns a timestamp when the search will be expired, in milliseconds since epoch.
      */
     long getExpirationTime();
+
+    /**
+     * Sets the new expiration time, in milliseconds since epoch.
+     */
+    void setExpirationTime(long expirationTime);
 }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/async/AsyncSearchIndexServiceTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/async/AsyncSearchIndexServiceTests.java
@@ -11,6 +11,7 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.test.ESSingleNodeTestCase;
 import org.elasticsearch.transport.TransportService;
+import org.elasticsearch.xpack.core.search.action.SearchStatusResponse;
 import org.junit.Before;
 
 import java.io.IOException;
@@ -21,7 +22,7 @@ import static org.hamcrest.Matchers.equalTo;
 
 // TODO: test CRUD operations
 public class AsyncSearchIndexServiceTests extends ESSingleNodeTestCase {
-    private AsyncTaskIndexService<TestAsyncResponse> indexService;
+    private AsyncTaskIndexService<TestAsyncResponse, TestStatusResponse> indexService;
 
     public static class TestAsyncResponse implements AsyncResponse<TestAsyncResponse> {
         public final String test;
@@ -65,6 +66,41 @@ public class AsyncSearchIndexServiceTests extends ESSingleNodeTestCase {
         @Override
         public int hashCode() {
             return Objects.hash(test, expirationTimeMillis);
+        }
+
+        public static TestStatusResponse getStatusResponse(TestAsyncResponse asyncResponse, long expirationTimeMillis, String id) {
+            return new TestStatusResponse(asyncResponse.test, expirationTimeMillis);
+        }
+    }
+
+    public static class TestStatusResponse implements SearchStatusResponse {
+        public final String test;
+        public long expirationTimeMillis;
+
+        public TestStatusResponse(String test, long expirationTimeMillis) {
+            this.test = test;
+            this.expirationTimeMillis = expirationTimeMillis;
+        }
+
+        public TestStatusResponse(StreamInput in) throws IOException {
+            this.test = in.readOptionalString();
+            this.expirationTimeMillis = in.readLong();
+        }
+
+        @Override
+        public long getExpirationTime() {
+            return expirationTimeMillis;
+        }
+
+        @Override
+        public void setExpirationTime(long expirationTime) {
+            this.expirationTimeMillis = expirationTime;
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            out.writeOptionalString(test);
+            out.writeLong(expirationTimeMillis);
         }
     }
 

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/action/EqlStatusResponse.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/action/EqlStatusResponse.java
@@ -29,7 +29,7 @@ public class EqlStatusResponse extends ActionResponse implements SearchStatusRes
     private final boolean isRunning;
     private final boolean isPartial;
     private final Long startTimeMillis;
-    private final long expirationTimeMillis;
+    private long expirationTimeMillis;
     private final RestStatus completionStatus;
 
     public EqlStatusResponse(String id,
@@ -53,7 +53,7 @@ public class EqlStatusResponse extends ActionResponse implements SearchStatusRes
      * @param id – encoded async search id
      * @return a status response
      */
-    public static EqlStatusResponse getStatusFromStoredSearch(StoredAsyncResponse<EqlSearchResponse> storedResponse,
+    public static EqlStatusResponse getStatusFromSearchResponse(StoredAsyncResponse<EqlSearchResponse> storedResponse,
             long expirationTimeMillis, String id) {
         EqlSearchResponse searchResponse = storedResponse.getResponse();
         if (searchResponse != null) {
@@ -179,6 +179,14 @@ public class EqlStatusResponse extends ActionResponse implements SearchStatusRes
     @Override
     public long getExpirationTime() {
         return expirationTimeMillis;
+    }
+
+    /**
+     * Sets a new timestamp when the eql search will be expired, in milliseconds since epoch.
+     */
+    @Override
+    public void setExpirationTime(long expirationTime) {
+        this.expirationTimeMillis = expirationTime;
     }
 
     /**

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/plugin/TransportEqlAsyncGetStatusAction.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/plugin/TransportEqlAsyncGetStatusAction.java
@@ -36,7 +36,7 @@ import static org.elasticsearch.xpack.core.ClientHelper.ASYNC_SEARCH_ORIGIN;
 public class TransportEqlAsyncGetStatusAction extends HandledTransportAction<GetAsyncStatusRequest, EqlStatusResponse> {
     private final TransportService transportService;
     private final ClusterService clusterService;
-    private final AsyncTaskIndexService<StoredAsyncResponse<EqlSearchResponse>> store;
+    private final AsyncTaskIndexService<StoredAsyncResponse<EqlSearchResponse>, EqlStatusResponse> store;
 
     @Inject
     public TransportEqlAsyncGetStatusAction(TransportService transportService,
@@ -64,7 +64,8 @@ public class TransportEqlAsyncGetStatusAction extends HandledTransportAction<Get
                 taskManager,
                 EqlSearchTask.class,
                 EqlSearchTask::getStatusResponse,
-                EqlStatusResponse::getStatusFromStoredSearch,
+                EqlStatusResponse::getStatusFromSearchResponse,
+                EqlStatusResponse::new,
                 listener
             );
         } else {

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/plugin/TransportEqlSearchAction.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/plugin/TransportEqlSearchAction.java
@@ -34,6 +34,7 @@ import org.elasticsearch.xpack.eql.action.EqlSearchAction;
 import org.elasticsearch.xpack.eql.action.EqlSearchRequest;
 import org.elasticsearch.xpack.eql.action.EqlSearchResponse;
 import org.elasticsearch.xpack.eql.action.EqlSearchTask;
+import org.elasticsearch.xpack.eql.action.EqlStatusResponse;
 import org.elasticsearch.xpack.eql.async.AsyncTaskManagementService;
 import org.elasticsearch.xpack.eql.execution.PlanExecutor;
 import org.elasticsearch.xpack.eql.parser.ParserParams;
@@ -59,7 +60,8 @@ public class TransportEqlSearchAction extends HandledTransportAction<EqlSearchRe
     private final PlanExecutor planExecutor;
     private final ThreadPool threadPool;
     private final TransportService transportService;
-    private final AsyncTaskManagementService<EqlSearchRequest, EqlSearchResponse, EqlSearchTask> asyncTaskManagementService;
+    private final AsyncTaskManagementService
+        <EqlSearchRequest, EqlSearchResponse, EqlSearchTask, EqlStatusResponse> asyncTaskManagementService;
 
     @Inject
     public TransportEqlSearchAction(Settings settings, ClusterService clusterService, TransportService transportService,
@@ -75,7 +77,8 @@ public class TransportEqlSearchAction extends HandledTransportAction<EqlSearchRe
         this.transportService = transportService;
 
         this.asyncTaskManagementService = new AsyncTaskManagementService<>(XPackPlugin.ASYNC_RESULTS_INDEX, client, ASYNC_SEARCH_ORIGIN,
-            registry, taskManager, EqlSearchAction.INSTANCE.name(), this, EqlSearchTask.class, clusterService, threadPool);
+            registry, taskManager, EqlSearchAction.INSTANCE.name(), this, EqlSearchTask.class, clusterService, threadPool,
+            EqlStatusResponse::getStatusFromSearchResponse);
     }
 
     @Override

--- a/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/EqlTestUtils.java
+++ b/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/EqlTestUtils.java
@@ -59,7 +59,7 @@ public final class EqlTestUtils {
 
     public static EqlSearchTask randomTask() {
         return new EqlSearchTask(randomLong(), "transport", EqlSearchAction.NAME, "", null, emptyMap(), emptyMap(),
-            new AsyncExecutionId("", new TaskId(randomAlphaOfLength(10), 1)), TimeValue.timeValueDays(5));
+            new AsyncExecutionId("", new TaskId(randomAlphaOfLength(10), 1), Version.CURRENT), TimeValue.timeValueDays(5));
     }
 
     public static InsensitiveEquals seq(Expression left, Expression right) {


### PR DESCRIPTION
Separate metadata from the actual response in async search

Getting the status of an async search could be costly if the response is
already stored. In this case, we need to read the whole document's source,
parse from the source async search response, and build from it a status
response. This could take not trivial amount of time if the initial
stored async search response is big.

This PR:
- separate STATUS into a separate stored binary field
- make EXPIRATION_TIME also stored field (as we can update
  keep_alive without updating STATUS or RESULT), as we want
  status to reflect the most recent expiration time.
- change retrieving status from GET request with _source to
  GET request with stored_fields=[STATUS, EXPIRATION_TIME] without
  _source. This allows faster retrieval of status.

Relates to #62947
Closes #71223