### PR TITLE
[Backport 7.x] Designate reporting_user as a deprecated role (#72057)

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStore.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStore.java
@@ -103,8 +103,15 @@ public class ReservedRolesStore implements BiConsumer<Set<String>, ActionListene
                 .put("ingest_admin", new RoleDescriptor("ingest_admin", new String[] { "manage_index_templates", "manage_pipeline" },
                         null, null, MetadataUtils.DEFAULT_RESERVED_METADATA))
                 // reporting_user doesn't have any privileges in Elasticsearch, and Kibana authorizes privileges based on this role
-                .put("reporting_user", new RoleDescriptor("reporting_user", null, null,
-                        null, MetadataUtils.DEFAULT_RESERVED_METADATA))
+                .put("reporting_user", new RoleDescriptor(
+                    "reporting_user",
+                    null,
+                    null,
+                    null,
+                    null,
+                    null,
+                    MetadataUtils.getDeprecatedReservedMetadata("Please use Kibana feature privileges instead"),
+                    null))
                 .put("kibana_dashboard_only_user", new RoleDescriptor(
                         "kibana_dashboard_only_user",
                         null,

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStoreTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStoreTests.java
@@ -952,6 +952,7 @@ public class ReservedRolesStoreTests extends ESTestCase {
         RoleDescriptor roleDescriptor = new ReservedRolesStore().roleDescriptor("reporting_user");
         assertNotNull(roleDescriptor);
         assertThat(roleDescriptor.getMetadata(), hasEntry("_reserved", true));
+        assertThat(roleDescriptor.getMetadata(), hasEntry("_deprecated", true));
 
         Role reportingUserRole = Role.builder(roleDescriptor, null).build();
         assertThat(reportingUserRole.cluster().check(ClusterHealthAction.NAME, request, authentication), is(false));


### PR DESCRIPTION
Backport of https://github.com/elastic/elasticsearch/pull/72057 to 7.x to be released in 7.14

This change deprecates the `reporting_user` built-in reserved role.