### PR TITLE
[DOCS] Update Docker instructions for quick start

### DIFF
--- a/docs/reference/tab-widgets/quick-start-cleanup.asciidoc
+++ b/docs/reference/tab-widgets/quick-start-cleanup.asciidoc
@@ -13,10 +13,11 @@ docker stop es01-test
 docker stop kib01-test
 ----
 
-To remove the containers, run:
+To remove your containers and their network, run:
 
 [source,sh]
 ----
+docker network rm elastic
 docker rm es01-test
 docker rm kib01-test
 ----

--- a/docs/reference/tab-widgets/quick-start-cleanup.asciidoc
+++ b/docs/reference/tab-widgets/quick-start-cleanup.asciidoc
@@ -13,7 +13,7 @@ docker stop es01-test
 docker stop kib01-test
 ----
 
-To remove your containers and their network, run:
+To remove the containers and their network, run:
 
 [source,sh]
 ----

--- a/docs/reference/tab-widgets/quick-start-install.asciidoc
+++ b/docs/reference/tab-widgets/quick-start-install.asciidoc
@@ -19,8 +19,9 @@ Desktop].
 +
 [source,sh,subs="attributes"]
 ----
+docker network create elastic
 docker pull {docker-repo}:{version}
-docker run --name es01-test -p 9200:9200 -p 9300:9300 -e "discovery.type=single-node" {docker-image}
+docker run --name es01-test --net elastic -p 9200:9200 -p 9300:9300 -e "discovery.type=single-node" {docker-image}
 ----
 endif::[]
 
@@ -39,7 +40,7 @@ ifeval::["{release-state}"!="unreleased"]
 ["source","txt",subs="attributes"]
 ----
 docker pull docker.elastic.co/kibana/kibana:{version}
-docker run --name kib01-test  --link es01-test:elasticsearch -p 5601:5601 docker.elastic.co/kibana/kibana:{version}
+docker run --name kib01-test --net elastic -p 5601:5601 -e "ELASTICSEARCH_HOSTS=http://es01-test:9200" docker.elastic.co/kibana/kibana:{version}
 ----
 
 . To access {kib}, go to http://localhost:5601[http://localhost:5601]


### PR DESCRIPTION
Docker has deprecated the [`--link` flag][0]. This PR updates the quick start guide's Docker instructions to use a container network and an environment flag to connect ES and Kibana instead.

[0]: https://docs.docker.com/network/links/