### PR TITLE
[7.13] [DOCS] EQL: Deprecate `wildcard` function (#72119)

### DIFF
--- a/docs/reference/eql/functions.asciidoc
+++ b/docs/reference/eql/functions.asciidoc
@@ -1027,6 +1027,8 @@ If using a field as the argument, this parameter supports only
 [[eql-fn-wildcard]]
 === `wildcard`
 
+deprecated::[7.13.0,"The `wildcard` function is deprecated. Use the <<eql-syntax-pattern-comparison-keywords,`like`>> or <<eql-syntax-pattern-comparison-keywords,`regex`>> keyword instead."]
+
 Returns `true` if a source string matches one or more provided wildcard
 expressions. Matching is case-sensitive by default.
 

--- a/docs/reference/migration/migrate_7_13.asciidoc
+++ b/docs/reference/migration/migrate_7_13.asciidoc
@@ -76,6 +76,19 @@ To find out if you are using any deprecated functionality,
 enable <<deprecation-logging, deprecation logging>>.
 
 [discrete]
+[[breaking_713_eql_deprecations]]
+==== EQL deprecations
+
+[[wildcard-function-deprecated]]
+.The `wildcard` function is deprecated.
+[%collapsible]
+====
+*Impact* +
+Use the <<eql-syntax-pattern-comparison-keywords,`like`>> or
+<<eql-syntax-pattern-comparison-keywords,`regex`>> keyword instead.
+====
+
+[discrete]
 [[breaking_713_security_changes]]
 ==== Security deprecations
 


### PR DESCRIPTION
Backports the following commits to 7.13:
 - [DOCS] EQL: Deprecate `wildcard` function (#72119)