### PR TITLE
[7.13] Adjust geoip downloader

### DIFF
--- a/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/GeoIpDownloader.java
+++ b/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/GeoIpDownloader.java
@@ -11,9 +11,10 @@ package org.elasticsearch.ingest.geoip;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.action.ActionListener;
-import org.elasticsearch.action.support.ActiveShardCount;
+import org.elasticsearch.action.admin.indices.flush.FlushRequest;
+import org.elasticsearch.action.admin.indices.refresh.RefreshRequest;
+import org.elasticsearch.action.index.IndexRequest;
 import org.elasticsearch.action.support.PlainActionFuture;
-import org.elasticsearch.action.support.WriteRequest;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.client.OriginSettingClient;
 import org.elasticsearch.cluster.service.ClusterService;
@@ -181,14 +182,22 @@ public class GeoIpDownloader extends AllocatedPersistentTask {
         MessageDigest md = MessageDigests.md5();
         for (byte[] buf = getChunk(is); buf.length != 0; buf = getChunk(is)) {
             md.update(buf);
-            client.prepareIndex(DATABASES_INDEX, "_doc").setId(name + "_" + chunk + "_" + timestamp)
-                .setCreate(true)
-                .setSource(XContentType.SMILE, "name", name, "chunk", chunk, "data", buf)
-                .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE)
-                .setWaitForActiveShards(ActiveShardCount.ALL)
-                .get();
+            IndexRequest indexRequest = new IndexRequest(DATABASES_INDEX, "_doc")
+                .id(name + "_" + chunk + "_" + timestamp)
+                .create(true)
+                .source(XContentType.SMILE, "name", name, "chunk", chunk, "data", buf);
+            client.index(indexRequest).actionGet();
             chunk++;
         }
+
+        // May take some time before automatic flush kicks in:
+        // (otherwise the translog will contain large documents for some time without good reason)
+        FlushRequest flushRequest = new FlushRequest(DATABASES_INDEX);
+        client.admin().indices().flush(flushRequest).actionGet();
+        // Ensure that the chunk documents are visible:
+        RefreshRequest refreshRequest = new RefreshRequest(DATABASES_INDEX);
+        client.admin().indices().refresh(refreshRequest).actionGet();
+
         String actualMd5 = MessageDigests.toHexString(md.digest());
         if (Objects.equals(expectedMd5, actualMd5) == false) {
             throw new IOException("md5 checksum mismatch, expected [" + expectedMd5 + "], actual [" + actualMd5 + "]");

--- a/modules/ingest-geoip/src/test/java/org/elasticsearch/ingest/geoip/GeoIpDownloaderTests.java
+++ b/modules/ingest-geoip/src/test/java/org/elasticsearch/ingest/geoip/GeoIpDownloaderTests.java
@@ -13,6 +13,12 @@ import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.action.ActionType;
 import org.elasticsearch.action.DocWriteRequest.OpType;
+import org.elasticsearch.action.admin.indices.flush.FlushAction;
+import org.elasticsearch.action.admin.indices.flush.FlushRequest;
+import org.elasticsearch.action.admin.indices.flush.FlushResponse;
+import org.elasticsearch.action.admin.indices.refresh.RefreshAction;
+import org.elasticsearch.action.admin.indices.refresh.RefreshRequest;
+import org.elasticsearch.action.admin.indices.refresh.RefreshResponse;
 import org.elasticsearch.action.index.IndexAction;
 import org.elasticsearch.action.index.IndexRequest;
 import org.elasticsearch.action.index.IndexResponse;
@@ -141,11 +147,29 @@ public class GeoIpDownloaderTests extends ESTestCase {
     }
 
     public void testIndexChunksNoData() throws IOException {
+        client.addHandler(FlushAction.INSTANCE, (FlushRequest request, ActionListener<FlushResponse> flushResponseActionListener) -> {
+            assertArrayEquals(new String[] {GeoIpDownloader.DATABASES_INDEX}, request.indices());
+            flushResponseActionListener.onResponse(mock(FlushResponse.class));
+        });
+        client.addHandler(RefreshAction.INSTANCE, (RefreshRequest request, ActionListener<RefreshResponse> flushResponseActionListener) -> {
+            assertArrayEquals(new String[] {GeoIpDownloader.DATABASES_INDEX}, request.indices());
+            flushResponseActionListener.onResponse(mock(RefreshResponse.class));
+        });
+
         InputStream empty = new ByteArrayInputStream(new byte[0]);
         assertEquals(0, geoIpDownloader.indexChunks("test", empty, 0, "d41d8cd98f00b204e9800998ecf8427e", 0));
     }
 
     public void testIndexChunksMd5Mismatch() {
+        client.addHandler(FlushAction.INSTANCE, (FlushRequest request, ActionListener<FlushResponse> flushResponseActionListener) -> {
+            assertArrayEquals(new String[] {GeoIpDownloader.DATABASES_INDEX}, request.indices());
+            flushResponseActionListener.onResponse(mock(FlushResponse.class));
+        });
+        client.addHandler(RefreshAction.INSTANCE, (RefreshRequest request, ActionListener<RefreshResponse> flushResponseActionListener) -> {
+            assertArrayEquals(new String[] {GeoIpDownloader.DATABASES_INDEX}, request.indices());
+            flushResponseActionListener.onResponse(mock(RefreshResponse.class));
+        });
+
         IOException exception = expectThrows(IOException.class, () -> geoIpDownloader.indexChunks("test",
             new ByteArrayInputStream(new byte[0]), 0, "123123", 0));
         assertEquals("md5 checksum mismatch, expected [123123], actual [d41d8cd98f00b204e9800998ecf8427e]", exception.getMessage());
@@ -174,6 +198,14 @@ public class GeoIpDownloaderTests extends ESTestCase {
             assertArrayEquals(chunksData[chunk], (byte[]) source.get("data"));
             assertEquals(chunk + 15, source.get("chunk"));
             listener.onResponse(mock(IndexResponse.class));
+        });
+        client.addHandler(FlushAction.INSTANCE, (FlushRequest request, ActionListener<FlushResponse> flushResponseActionListener) -> {
+            assertArrayEquals(new String[] {GeoIpDownloader.DATABASES_INDEX}, request.indices());
+            flushResponseActionListener.onResponse(mock(FlushResponse.class));
+        });
+        client.addHandler(RefreshAction.INSTANCE, (RefreshRequest request, ActionListener<RefreshResponse> flushResponseActionListener) -> {
+            assertArrayEquals(new String[] {GeoIpDownloader.DATABASES_INDEX}, request.indices());
+            flushResponseActionListener.onResponse(mock(RefreshResponse.class));
         });
 
         InputStream big = new ByteArrayInputStream(bigArray);


### PR DESCRIPTION
Backporting #72094 to 7.13 branch.

Instead of doing a refresh as part of each index request, perform
this separately after all chunks have been indexed.

Also perform a flush, so that the translog is trimmed and
doesn't contain all these large write operations (1mb) until
an automatic refresh happens (which may take a while since
no other indexing will take place for a while).