### PR TITLE
Add index details to HLRC get-snapshots parser (#72079)

### DIFF
--- a/server/src/main/java/org/elasticsearch/snapshots/SnapshotInfo.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/SnapshotInfo.java
@@ -19,6 +19,7 @@ import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.time.DateFormatter;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.unit.TimeValue;
+import org.elasticsearch.common.xcontent.ConstructingObjectParser;
 import org.elasticsearch.common.xcontent.ObjectParser;
 import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.ToXContentObject;
@@ -96,6 +97,7 @@ public final class SnapshotInfo implements Comparable<SnapshotInfo>, ToXContent,
         private List<String> indices = null;
         private List<String> dataStreams = null;
         private List<SnapshotFeatureInfo> featureStates = null;
+        private Map<String, IndexSnapshotDetails> indexSnapshotDetails = null;
         private long startTime = 0L;
         private long endTime = 0L;
         private ShardStatsBuilder shardStatsBuilder = null;
@@ -130,6 +132,10 @@ public final class SnapshotInfo implements Comparable<SnapshotInfo>, ToXContent,
 
         private void setFeatureStates(List<SnapshotFeatureInfo> featureStates) {
             this.featureStates = featureStates;
+        }
+
+        private void setIndexSnapshotDetails(Map<String, IndexSnapshotDetails> indexSnapshotDetails) {
+            this.indexSnapshotDetails = indexSnapshotDetails;
         }
 
         private void setStartTime(long startTime) {
@@ -175,6 +181,10 @@ public final class SnapshotInfo implements Comparable<SnapshotInfo>, ToXContent,
                 featureStates = Collections.emptyList();
             }
 
+            if (indexSnapshotDetails == null) {
+                indexSnapshotDetails = Collections.emptyMap();
+            }
+
             SnapshotState snapshotState = state == null ? null : SnapshotState.valueOf(state);
             Version version = this.version == -1 ? Version.CURRENT : Version.fromId(this.version);
 
@@ -185,8 +195,22 @@ public final class SnapshotInfo implements Comparable<SnapshotInfo>, ToXContent,
                 shardFailures = new ArrayList<>();
             }
 
-            return new SnapshotInfo(snapshotId, indices, dataStreams, featureStates, reason, version, startTime, endTime, totalShards,
-                successfulShards, shardFailures, includeGlobalState, userMetadata, snapshotState, Collections.emptyMap()
+            return new SnapshotInfo(
+                    snapshotId,
+                    indices,
+                    dataStreams,
+                    featureStates,
+                    reason,
+                    version,
+                    startTime,
+                    endTime,
+                    totalShards,
+                    successfulShards,
+                    shardFailures,
+                    includeGlobalState,
+                    userMetadata,
+                    snapshotState,
+                    indexSnapshotDetails
             );
         }
     }
@@ -227,6 +251,10 @@ public final class SnapshotInfo implements Comparable<SnapshotInfo>, ToXContent,
         SNAPSHOT_INFO_PARSER.declareStringArray(SnapshotInfoBuilder::setDataStreams, new ParseField(DATA_STREAMS));
         SNAPSHOT_INFO_PARSER.declareObjectArray(SnapshotInfoBuilder::setFeatureStates, SnapshotFeatureInfo.SNAPSHOT_FEATURE_INFO_PARSER,
             new ParseField(FEATURE_STATES));
+        SNAPSHOT_INFO_PARSER.declareObject(
+                SnapshotInfoBuilder::setIndexSnapshotDetails,
+                (p, c) -> p.map(HashMap::new, p2 -> IndexSnapshotDetails.PARSER.parse(p2, c)),
+                new ParseField(INDEX_DETAILS));
         SNAPSHOT_INFO_PARSER.declareLong(SnapshotInfoBuilder::setStartTime, new ParseField(START_TIME_IN_MILLIS));
         SNAPSHOT_INFO_PARSER.declareLong(SnapshotInfoBuilder::setEndTime, new ParseField(END_TIME_IN_MILLIS));
         SNAPSHOT_INFO_PARSER.declareObject(SnapshotInfoBuilder::setShardStatsBuilder, SHARD_STATS_PARSER, new ParseField(SHARDS));
@@ -864,7 +892,7 @@ public final class SnapshotInfo implements Comparable<SnapshotInfo>, ToXContent,
                         if (USER_METADATA.equals(currentFieldName)) {
                             userMetadata = parser.map();
                         } else if (INDEX_DETAILS.equals(currentFieldName)) {
-                            indexSnapshotDetails = parser.map(HashMap::new, IndexSnapshotDetails::fromXContent);
+                            indexSnapshotDetails = parser.map(HashMap::new, p -> IndexSnapshotDetails.PARSER.parse(p, null));
                         } else {
                             // It was probably created by newer version - ignoring
                             parser.skipChildren();
@@ -982,6 +1010,17 @@ public final class SnapshotInfo implements Comparable<SnapshotInfo>, ToXContent,
 
         public static final IndexSnapshotDetails SKIPPED = new IndexSnapshotDetails(0, ByteSizeValue.ZERO, 0);
 
+        public static final ConstructingObjectParser<IndexSnapshotDetails, Void> PARSER = new ConstructingObjectParser<>(
+                IndexSnapshotDetails.class.getName(),
+                true,
+                a -> new IndexSnapshotDetails((int)a[0], ByteSizeValue.ofBytes((long) a[1]), (int)a[2]));
+
+        static {
+            PARSER.declareInt(ConstructingObjectParser.constructorArg(), new ParseField(SHARD_COUNT));
+            PARSER.declareLong(ConstructingObjectParser.constructorArg(), new ParseField(SIZE));
+            PARSER.declareInt(ConstructingObjectParser.constructorArg(), new ParseField(MAX_SEGMENTS_PER_SHARD));
+        }
+
         private final int shardCount;
         private final ByteSizeValue size;
         private final int maxSegmentsPerShard;
@@ -1047,42 +1086,6 @@ public final class SnapshotInfo implements Comparable<SnapshotInfo>, ToXContent,
             builder.field(MAX_SEGMENTS_PER_SHARD, maxSegmentsPerShard);
             builder.endObject();
             return builder;
-        }
-
-        public static IndexSnapshotDetails fromXContent(XContentParser parser) throws IOException {
-            XContentParserUtils.ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.currentToken(), parser);
-            int shardCount = -1;
-            ByteSizeValue size = null;
-            int maxSegmentsPerShard = -1;
-            String currentFieldName;
-            while (parser.nextToken() != XContentParser.Token.END_OBJECT) {
-                XContentParserUtils.ensureExpectedToken(XContentParser.Token.FIELD_NAME, parser.currentToken(), parser);
-                currentFieldName = parser.currentName();
-                XContentParserUtils.ensureExpectedToken(XContentParser.Token.VALUE_NUMBER, parser.nextToken(), parser);
-                switch (currentFieldName) {
-                    case SHARD_COUNT:
-                        shardCount = parser.intValue();
-                        break;
-                    case SIZE:
-                        size = new ByteSizeValue(parser.longValue());
-                        break;
-                    case MAX_SEGMENTS_PER_SHARD:
-                        maxSegmentsPerShard = parser.intValue();
-                        break;
-                }
-            }
-
-            if (shardCount < 1) {
-                throw new IllegalArgumentException("field [" + SHARD_COUNT + "] missing or invalid: " + shardCount);
-            }
-            if (size == null) {
-                throw new IllegalArgumentException("field [" + SIZE + "] missing");
-            }
-            if (maxSegmentsPerShard < 0) {
-                throw new IllegalArgumentException("field [" + MAX_SEGMENTS_PER_SHARD + "] missing or invalid: " + maxSegmentsPerShard);
-            }
-
-            return new IndexSnapshotDetails(shardCount, size, maxSegmentsPerShard);
         }
     }
 

--- a/server/src/test/java/org/elasticsearch/snapshots/SnapshotInfoTestUtils.java
+++ b/server/src/test/java/org/elasticsearch/snapshots/SnapshotInfoTestUtils.java
@@ -73,7 +73,7 @@ public class SnapshotInfoTestUtils {
         );
     }
 
-    private static Map<String, SnapshotInfo.IndexSnapshotDetails> randomIndexSnapshotDetails() {
+    public static Map<String, SnapshotInfo.IndexSnapshotDetails> randomIndexSnapshotDetails() {
         final Map<String, SnapshotInfo.IndexSnapshotDetails> result = new HashMap<>();
         final int size = between(0, 10);
         while (result.size() < size) {


### PR DESCRIPTION
In #71754 we added some per-index details to the `SnapshotInfo` blobs
stored in the repository. This class is also used as part of the
response to a get-snapshots request by the HLRC, but the HLRC uses a
different parser from the one which reads the blobs held in the
repository and this other parser was not extended to deal with the new
details. This commit addresses that.