### PR TITLE
Fix `minimum_should_match` for `combined_fields` query

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/query/CombinedFieldsQueryBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/CombinedFieldsQueryBuilder.java
@@ -29,6 +29,7 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.lucene.search.Queries;
 import org.elasticsearch.common.xcontent.ConstructingObjectParser;
+import org.elasticsearch.common.xcontent.ObjectParser.ValueType;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.index.mapper.MappedFieldType;
@@ -75,7 +76,13 @@ public class CombinedFieldsQueryBuilder extends AbstractQueryBuilder<CombinedFie
         }, FIELDS_FIELD);
 
         PARSER.declareString(CombinedFieldsQueryBuilder::operator, Operator::fromString, OPERATOR_FIELD);
-        PARSER.declareString(CombinedFieldsQueryBuilder::minimumShouldMatch, MINIMUM_SHOULD_MATCH_FIELD);
+        PARSER.declareField(
+            CombinedFieldsQueryBuilder::minimumShouldMatch,
+            XContentParser::textOrNull,
+            MINIMUM_SHOULD_MATCH_FIELD,
+            // using INT_OR_NULL (which includes VALUE_NUMBER, VALUE_STRING, VALUE_NULL) to also allow for numeric values and null
+            ValueType.INT_OR_NULL
+        );
         PARSER.declareBoolean(CombinedFieldsQueryBuilder::autoGenerateSynonymsPhraseQuery, GENERATE_SYNONYMS_PHRASE_QUERY);
         PARSER.declareString(CombinedFieldsQueryBuilder::zeroTermsQuery, value -> {
             if ("none".equalsIgnoreCase(value)) {

--- a/server/src/test/java/org/elasticsearch/index/query/CombinedFieldsQueryBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/CombinedFieldsQueryBuilderTests.java
@@ -88,4 +88,27 @@ public class CombinedFieldsQueryBuilderTests extends AbstractQueryTestCase<Combi
         assertEquals(json, Operator.OR, parsed.operator());
         assertEquals(json, 2.0, parsed.boost, 1e-6);
     }
+
+    /**
+     * We parse `minimum_should_match` to a String but other queries supporting this parameter also accept integer values and null
+     */
+    public void testMinumumShouldMatchFromXContent() throws IOException {
+        Object[] testValues = new Object[] { 2, "\"2\"", "\"2%\"", null };
+        Object[] expectedValues = new Object[] { "2", "2", "2%", null };
+        int i = 0;
+        for (Object value : testValues) {
+            String json = "{\n"
+                + "  \"combined_fields\" : {\n"
+                + "    \"query\" : \"quick brown fox\",\n"
+                + "    \"minimum_should_match\" : " + value + "\n"
+                + "  }\n"
+                + "}";
+
+            CombinedFieldsQueryBuilder parsed = (CombinedFieldsQueryBuilder) parseQuery(json);
+
+            assertEquals(json, "quick brown fox", parsed.value());
+            assertEquals(json, expectedValues[i], parsed.minimumShouldMatch());
+            i++;
+        }
+    }
 }


### PR DESCRIPTION
The `minimum_should_match` parameter for queries like `match` or `query_string"
accepts either string values like "2" or "25%", numeric values and in most older
cases also `null` as a no-op parameter. We also use examples for these different
values in our documentation, so we should also support these value types for the
new `combined_fields` query. This changes the ConstructingObjectParser used in
CombinedFieldsQueryBuilder so it also accepts integer value types and adds a
parsing test for the different cases.

Closes #72148