### PR TITLE
[7.13] [DOCS] Clarify `timeout` and `terminate_after` parameters (#71713)

### DIFF
--- a/docs/reference/rest-api/common-parms.asciidoc
+++ b/docs/reference/rest-api/common-parms.asciidoc
@@ -1091,8 +1091,14 @@ end::term_statistics[]
 
 tag::terminate_after[]
 `terminate_after`::
-(Optional, integer) The maximum number of documents to collect for each shard,
-upon reaching which the query execution will terminate early.
+(Optional, integer) Maximum number of documents to collect for each shard. If a
+query reaches this limit, {es} terminates the query early. {es} collects
+documents before sorting.
++
+IMPORTANT: Use with caution. {es} applies this parameter to each shard handling
+the request. When possible, let {es} perform early termination automatically.
+Avoid specifying this parameter for requests that target data streams with
+backing indices across multiple data tiers.
 end::terminate_after[]
 
 tag::time[]

--- a/docs/reference/search/search-your-data/search-your-data.asciidoc
+++ b/docs/reference/search/search-your-data/search-your-data.asciidoc
@@ -233,12 +233,15 @@ results for a long-running search now and get complete results later.
 === Search timeout
 
 By default, search requests don't time out. The request waits for complete
-results before returning a response.
+results from each shard before returning a response.
 
 While <<async-search-intro,async search>> is designed for long-running
 searches, you can also use the `timeout` parameter to specify a duration you'd
-like to wait for a search to complete. If no response is received before this
-period ends, the request fails and returns an error.
+like to wait on each shard to complete. Each shard collects hits within the
+specified time period. If collection isn't finished when the period ends, {es}
+uses only the hits accumulated up to that point. The overall latency of a search
+request depends on the number of shards needed for the search and the number of
+concurrent shard requests.
 
 [source,console]
 ----

--- a/docs/reference/search/search.asciidoc
+++ b/docs/reference/search/search.asciidoc
@@ -66,7 +66,7 @@ Defaults to `true`.
 [[search-partial-responses]]
 `allow_partial_search_results`::
 (Optional, Boolean)
-If `true`, returns partial results if there are request timeouts or
+If `true`, returns partial results if there are shard request timeouts or
 <<shard-failures,shard failures>>. If `false`, returns an error with
 no partial results. Defaults to `true`.
 +
@@ -287,7 +287,7 @@ Defaults to `0`, which does not terminate query execution early.
 
 `timeout`::
 (Optional, <<time-units, time units>>) Specifies the period of time to wait
-for a response. If no response is received before the timeout expires, the
+for a response from each shard. If no response is received before the timeout expires, the
 request fails and returns an error. Defaults to no timeout.
 
 `track_scores`::
@@ -579,7 +579,7 @@ Defaults to `0`, which does not terminate query execution early.
 
 `timeout`::
 (Optional, <<time-units, time units>>) Specifies the period of time to wait
-for a response. If no response is received before the timeout expires, the
+for a response from each shard. If no response is received before the timeout expires, the
 request fails and returns an error. Defaults to no timeout.
 
 [[request-body-search-version]]


### PR DESCRIPTION
Backports the following commits to 7.13:
 - [DOCS] Clarify `timeout` and `terminate_after` parameters (#71713)