### PR TITLE
[7.x] [ML] [Transform] use feature reset API for transform test cleanup (#72044)

### DIFF
--- a/x-pack/plugin/transform/qa/multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/TestFeatureResetIT.java
+++ b/x-pack/plugin/transform/qa/multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/TestFeatureResetIT.java
@@ -21,7 +21,9 @@ import org.elasticsearch.search.aggregations.AggregatorFactories;
 import org.elasticsearch.search.aggregations.bucket.histogram.DateHistogramInterval;
 import org.elasticsearch.test.rest.ESRestTestCase;
 import org.junit.After;
+import org.junit.Before;
 
+import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -32,6 +34,17 @@ import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
 
 public class TestFeatureResetIT extends TransformIntegTestCase {
+
+    @Before
+    public void setLogging() throws IOException {
+        Request settingsRequest = new Request("PUT", "/_cluster/settings");
+        settingsRequest.setJsonEntity(
+            "{\"transient\": {"
+                + "\"logger.org.elasticsearch.xpack.core.indexing.AsyncTwoPhaseIndexer\": \"debug\","
+                + "\"logger.org.elasticsearch.xpack.transform\": \"trace\"}}"
+        );
+        client().performRequest(settingsRequest);
+    }
 
     @After
     public void cleanup() throws Exception {

--- a/x-pack/plugin/transform/qa/single-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/TransformAuditorIT.java
+++ b/x-pack/plugin/transform/qa/single-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/TransformAuditorIT.java
@@ -44,6 +44,8 @@ public class TransformAuditorIT extends TransformRestTestCase {
 
     @Before
     public void createIndexes() throws IOException {
+        setupDataAccessRole(DATA_ACCESS_ROLE, REVIEWS_INDEX_NAME);
+        setupUser(TEST_USER_NAME, Arrays.asList("transform_admin", DATA_ACCESS_ROLE));
 
         // it's not possible to run it as @BeforeClass as clients aren't initialized then, so we need this little hack
         if (indicesCreated) {
@@ -52,8 +54,6 @@ public class TransformAuditorIT extends TransformRestTestCase {
 
         createReviewsIndex();
         indicesCreated = true;
-        setupDataAccessRole(DATA_ACCESS_ROLE, REVIEWS_INDEX_NAME);
-        setupUser(TEST_USER_NAME, Arrays.asList("transform_admin", DATA_ACCESS_ROLE));
     }
 
     @SuppressWarnings("unchecked")

--- a/x-pack/plugin/transform/qa/single-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/TransformGetAndGetStatsIT.java
+++ b/x-pack/plugin/transform/qa/single-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/TransformGetAndGetStatsIT.java
@@ -71,15 +71,6 @@ public class TransformGetAndGetStatsIT extends TransformRestTestCase {
 
     @Before
     public void createIndexes() throws IOException {
-
-        // it's not possible to run it as @BeforeClass as clients aren't initialized then, so we need this little hack
-        if (indicesCreated) {
-            return;
-        }
-
-        createReviewsIndex();
-        indicesCreated = true;
-
         // at random test the old deprecated roles, to be removed in 9.0.0
         if (useDeprecatedEndpoints() && randomBoolean()) {
             setupUser(TEST_USER_NAME, Collections.singletonList("data_frame_transforms_user"));
@@ -88,11 +79,19 @@ public class TransformGetAndGetStatsIT extends TransformRestTestCase {
             setupUser(TEST_USER_NAME, Collections.singletonList("transform_user"));
             setupUser(TEST_ADMIN_USER_NAME, Collections.singletonList("transform_admin"));
         }
+        // it's not possible to run it as @BeforeClass as clients aren't initialized then, so we need this little hack
+        if (indicesCreated) {
+            return;
+        }
+
+        createReviewsIndex();
+        indicesCreated = true;
+
     }
 
     @After
     public void clearOutTransforms() throws Exception {
-        wipeTransforms();
+        adminClient().performRequest(new Request("POST", "/_features/_reset"));
     }
 
     @SuppressWarnings("unchecked")

--- a/x-pack/plugin/transform/qa/single-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/TransformPivotRestIT.java
+++ b/x-pack/plugin/transform/qa/single-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/TransformPivotRestIT.java
@@ -56,6 +56,12 @@ public class TransformPivotRestIT extends TransformRestTestCase {
 
     @Before
     public void createIndexes() throws IOException {
+        setupDataAccessRole(DATA_ACCESS_ROLE, REVIEWS_INDEX_NAME);
+        if (useDeprecatedEndpoints() && randomBoolean()) {
+            setupUser(TEST_USER_NAME, Arrays.asList("data_frame_transforms_admin", DATA_ACCESS_ROLE));
+        } else {
+            setupUser(TEST_USER_NAME, Arrays.asList("transform_admin", DATA_ACCESS_ROLE));
+        }
 
         // it's not possible to run it as @BeforeClass as clients aren't initialized then, so we need this little hack
         if (indicesCreated) {
@@ -65,14 +71,6 @@ public class TransformPivotRestIT extends TransformRestTestCase {
         createReviewsIndex();
         createReviewsIndexNano();
         indicesCreated = true;
-        setupDataAccessRole(DATA_ACCESS_ROLE, REVIEWS_INDEX_NAME);
-
-        // at random test the old deprecated roles, to be removed in 9.0.0
-        if (useDeprecatedEndpoints() && randomBoolean()) {
-            setupUser(TEST_USER_NAME, Arrays.asList("data_frame_transforms_admin", DATA_ACCESS_ROLE));
-        } else {
-            setupUser(TEST_USER_NAME, Arrays.asList("transform_admin", DATA_ACCESS_ROLE));
-        }
     }
 
     public void testSimplePivot() throws Exception {

--- a/x-pack/plugin/transform/qa/single-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/TransformRestTestCase.java
+++ b/x-pack/plugin/transform/qa/single-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/TransformRestTestCase.java
@@ -465,8 +465,7 @@ public abstract class TransformRestTestCase extends ESRestTestCase {
         ensureNoInitializingShards();
         logAudits();
         if (preserveClusterUponCompletion() == false) {
-            wipeTransforms();
-            waitForPendingTransformTasks();
+            adminClient().performRequest(new Request("POST", "/_features/_reset"));
         }
     }
 
@@ -475,58 +474,6 @@ public abstract class TransformRestTestCase extends ESRestTestCase {
         // we might have disabled wiping indices, but now its time to get rid of them
         // note: can not use super.cleanUpCluster() as this method must be static
         wipeAllIndices();
-    }
-
-    public void wipeTransforms() throws IOException {
-        List<Map<String, Object>> transformConfigs = getTransforms();
-        for (Map<String, Object> transformConfig : transformConfigs) {
-            String transformId = (String) transformConfig.get("id");
-            Request request = new Request("POST", getTransformEndpoint() + transformId + "/_stop");
-            request.addParameter("wait_for_completion", "true");
-            request.addParameter("timeout", "10s");
-            request.addParameter("ignore", "404");
-            adminClient().performRequest(request);
-        }
-
-        for (Map<String, Object> transformConfig : transformConfigs) {
-            String transformId = (String) transformConfig.get("id");
-            String state = getTransformState(transformId);
-            assertEquals("Transform [" + transformId + "] is not in the stopped state", "stopped", state);
-        }
-
-        for (Map<String, Object> transformConfig : transformConfigs) {
-            String transformId = (String) transformConfig.get("id");
-            deleteTransform(transformId);
-        }
-
-        // transforms should be all gone
-        transformConfigs = getTransforms();
-        assertTrue(transformConfigs.isEmpty());
-
-        // the configuration index should be empty
-        Request request = new Request("GET", TransformInternalIndexConstants.LATEST_INDEX_NAME + "/_search");
-        request.setOptions(
-            expectWarnings(
-                "this request accesses system indices: ["
-                    + TransformInternalIndexConstants.LATEST_INDEX_NAME
-                    + "], but in a future major version, direct access to system indices will be prevented by default"
-            )
-        );
-        try {
-            Response searchResponse = adminClient().performRequest(request);
-            Map<String, Object> searchResult = entityAsMap(searchResponse);
-
-            assertEquals(0, XContentMapValues.extractValue("hits.total.value", searchResult));
-        } catch (ResponseException e) {
-            // 404 here just means we had no transforms, true for some tests
-            if (e.getResponse().getStatusLine().getStatusCode() != 404) {
-                throw e;
-            }
-        }
-    }
-
-    protected static void waitForPendingTransformTasks() throws Exception {
-        waitForPendingTasks(adminClient(), taskName -> taskName.startsWith(TransformField.TASK_NAME) == false);
     }
 
     static int getTransformCheckpoint(String transformId) throws IOException {

--- a/x-pack/plugin/transform/qa/single-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/TransformTaskFailedStateIT.java
+++ b/x-pack/plugin/transform/qa/single-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/TransformTaskFailedStateIT.java
@@ -20,8 +20,6 @@ import org.junit.After;
 import org.junit.Before;
 
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
@@ -32,8 +30,6 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.matchesRegex;
 
 public class TransformTaskFailedStateIT extends TransformRestTestCase {
-
-    private final List<String> failureTransforms = new ArrayList<>();
 
     @Before
     public void setClusterSettings() throws IOException {
@@ -55,12 +51,7 @@ public class TransformTaskFailedStateIT extends TransformRestTestCase {
 
     @After
     public void cleanUpPotentiallyFailedTransform() throws Exception {
-        // If the tests failed in the middle, we should force stop it. This prevents other transform tests from failing due
-        // to this left over transform
-        for (String transformId : failureTransforms) {
-            stopTransform(transformId, true);
-            deleteTransform(transformId);
-        }
+        adminClient().performRequest(new Request("POST", "/_features/_reset"));
     }
 
     public void testForceStopFailedTransform() throws Exception {
@@ -69,7 +60,6 @@ public class TransformTaskFailedStateIT extends TransformRestTestCase {
         String transformIndex = "failure_pivot_reviews";
         createDestinationIndexWithBadMapping(transformIndex);
         createContinuousPivotReviewsTransform(transformId, transformIndex, null);
-        failureTransforms.add(transformId);
         startTransform(transformId);
         awaitState(transformId, TransformStats.State.FAILED);
         Map<?, ?> fullState = getTransformStateAndStats(transformId);
@@ -107,7 +97,6 @@ public class TransformTaskFailedStateIT extends TransformRestTestCase {
         String transformIndex = "failure_pivot_reviews";
         createDestinationIndexWithBadMapping(transformIndex);
         createContinuousPivotReviewsTransform(transformId, transformIndex, null);
-        failureTransforms.add(transformId);
         startTransform(transformId);
         awaitState(transformId, TransformStats.State.FAILED);
         Map<?, ?> fullState = getTransformStateAndStats(transformId);

--- a/x-pack/plugin/transform/qa/single-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/TransformUpdateIT.java
+++ b/x-pack/plugin/transform/qa/single-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/TransformUpdateIT.java
@@ -65,6 +65,12 @@ public class TransformUpdateIT extends TransformRestTestCase {
 
     @Before
     public void createIndexes() throws IOException {
+        setupDataAccessRole(DATA_ACCESS_ROLE, REVIEWS_INDEX_NAME);
+        setupDataAccessRole(DATA_ACCESS_ROLE_2, REVIEWS_INDEX_NAME);
+
+        setupUser(TEST_USER_NAME, Arrays.asList("transform_user", DATA_ACCESS_ROLE));
+        setupUser(TEST_ADMIN_USER_NAME_1, Arrays.asList("transform_admin", DATA_ACCESS_ROLE));
+        setupUser(TEST_ADMIN_USER_NAME_2, Arrays.asList("transform_admin", DATA_ACCESS_ROLE_2));
 
         // it's not possible to run it as @BeforeClass as clients aren't initialized then, so we need this little hack
         if (indicesCreated) {
@@ -73,13 +79,6 @@ public class TransformUpdateIT extends TransformRestTestCase {
 
         createReviewsIndex();
         indicesCreated = true;
-
-        setupDataAccessRole(DATA_ACCESS_ROLE, REVIEWS_INDEX_NAME);
-        setupDataAccessRole(DATA_ACCESS_ROLE_2, REVIEWS_INDEX_NAME);
-
-        setupUser(TEST_USER_NAME, Arrays.asList("transform_user", DATA_ACCESS_ROLE));
-        setupUser(TEST_ADMIN_USER_NAME_1, Arrays.asList("transform_admin", DATA_ACCESS_ROLE));
-        setupUser(TEST_ADMIN_USER_NAME_2, Arrays.asList("transform_admin", DATA_ACCESS_ROLE_2));
     }
 
     @SuppressWarnings("unchecked")

--- a/x-pack/plugin/transform/src/internalClusterTest/java/org/elasticsearch/xpack/transform/TransformSingleNodeTestCase.java
+++ b/x-pack/plugin/transform/src/internalClusterTest/java/org/elasticsearch/xpack/transform/TransformSingleNodeTestCase.java
@@ -9,16 +9,15 @@ package org.elasticsearch.xpack.transform;
 
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.LatchedActionListener;
-import org.elasticsearch.action.admin.cluster.node.tasks.list.ListTasksAction;
-import org.elasticsearch.action.admin.cluster.node.tasks.list.ListTasksRequest;
-import org.elasticsearch.action.admin.cluster.node.tasks.list.ListTasksResponse;
+import org.elasticsearch.action.admin.cluster.snapshots.features.ResetFeatureStateAction;
+import org.elasticsearch.action.admin.cluster.snapshots.features.ResetFeatureStateRequest;
 import org.elasticsearch.common.CheckedConsumer;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.reindex.ReindexPlugin;
 import org.elasticsearch.node.NodeRoleSettings;
 import org.elasticsearch.plugins.Plugin;
-import org.elasticsearch.tasks.TaskInfo;
 import org.elasticsearch.test.ESSingleNodeTestCase;
+import org.junit.After;
 
 import java.util.Collection;
 import java.util.concurrent.CountDownLatch;
@@ -37,6 +36,11 @@ public abstract class TransformSingleNodeTestCase extends ESSingleNodeTestCase {
     @Override
     protected Settings nodeSettings() {
         return Settings.builder().put(NodeRoleSettings.NODE_ROLES_SETTING.getKey(), "master, data, ingest, transform").build();
+    }
+
+    @After
+    public void cleanup() {
+        client().execute(ResetFeatureStateAction.INSTANCE, new ResetFeatureStateRequest()).actionGet();
     }
 
     protected <T> void assertAsync(Consumer<ActionListener<T>> function, T expected, CheckedConsumer<T, ? extends Exception> onAnswer,
@@ -66,27 +70,4 @@ public abstract class TransformSingleNodeTestCase extends ESSingleNodeTestCase {
         assertTrue("timed out after 20s", latch.await(20, TimeUnit.SECONDS));
     }
 
-    protected void waitForPendingTasks() throws Exception {
-        assertBusy(() -> {
-            try {
-                final ListTasksRequest request = new ListTasksRequest().setDetailed(true);
-                final ListTasksResponse response = client().execute(ListTasksAction.INSTANCE, request).actionGet();
-
-                // Check to see if there are outstanding tasks; we exclude the list task itself.
-                StringBuilder tasksListString = new StringBuilder();
-                int activeTasks = 0;
-                for (TaskInfo task : response.getTasks()) {
-                    if (task.getAction().startsWith(ListTasksAction.NAME)) {
-                        continue;
-                    }
-                    ++activeTasks;
-                    tasksListString.append(task.toString());
-                    tasksListString.append('\n');
-                }
-                assertEquals(activeTasks + " active tasks found:\n" + tasksListString, 0, activeTasks);
-            } catch (final Exception e) {
-                throw new AssertionError("error getting active tasks list", e);
-            }
-        }, 30L, TimeUnit.SECONDS);
-    }
 }

--- a/x-pack/plugin/transform/src/internalClusterTest/java/org/elasticsearch/xpack/transform/integration/TransformInternalIndexIT.java
+++ b/x-pack/plugin/transform/src/internalClusterTest/java/org/elasticsearch/xpack/transform/integration/TransformInternalIndexIT.java
@@ -26,7 +26,6 @@ import org.elasticsearch.xpack.core.transform.transforms.TransformConfigUpdate;
 import org.elasticsearch.xpack.core.transform.transforms.persistence.TransformInternalIndexConstants;
 import org.elasticsearch.xpack.transform.TransformSingleNodeTestCase;
 import org.elasticsearch.xpack.transform.persistence.TransformInternalIndex;
-import org.junit.After;
 
 import static org.elasticsearch.index.mapper.MapperService.SINGLE_MAPPING_NAME;
 import static org.hamcrest.Matchers.equalTo;
@@ -37,14 +36,6 @@ public class TransformInternalIndexIT extends TransformSingleNodeTestCase {
 
     private static final String CURRENT_INDEX = TransformInternalIndexConstants.LATEST_INDEX_NAME;
     private static final String OLD_INDEX = TransformInternalIndexConstants.INDEX_PATTERN + "001";
-
-    @After
-    public void preCleanup() throws Exception {
-        // Updating a transform will leave indexing an audit message in-flight, so
-        // we need to wait for that to complete or it could interfere with deleting
-        // all the indices
-        waitForPendingTasks();
-    }
 
     public void testUpdateDeletesOldTransformConfig() throws Exception {
 

--- a/x-pack/plugin/transform/src/internalClusterTest/java/org/elasticsearch/xpack/transform/integration/TransformNoRemoteClusterClientNodeIT.java
+++ b/x-pack/plugin/transform/src/internalClusterTest/java/org/elasticsearch/xpack/transform/integration/TransformNoRemoteClusterClientNodeIT.java
@@ -20,7 +20,6 @@ import org.elasticsearch.xpack.core.transform.transforms.TransformConfig;
 import org.elasticsearch.xpack.core.transform.transforms.TransformConfigUpdate;
 import org.elasticsearch.xpack.core.transform.transforms.pivot.PivotConfigTests;
 import org.elasticsearch.xpack.transform.TransformSingleNodeTestCase;
-import org.junit.After;
 
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.containsString;
@@ -30,14 +29,6 @@ public class TransformNoRemoteClusterClientNodeIT extends TransformSingleNodeTes
     @Override
     protected Settings nodeSettings() {
         return Settings.builder().put(NodeRoleSettings.NODE_ROLES_SETTING.getKey(), "master, data, ingest, transform").build();
-    }
-
-    @After
-    public void preCleanup() throws Exception {
-        // Updating a transform will leave indexing an audit message in-flight, so
-        // we need to wait for that to complete or it could interfere with deleting
-        // all the indices
-        waitForPendingTasks();
     }
 
     public void testPreviewTransformWithRemoteIndex() {

--- a/x-pack/plugin/transform/src/internalClusterTest/java/org/elasticsearch/xpack/transform/integration/TransformNoTransformNodeIT.java
+++ b/x-pack/plugin/transform/src/internalClusterTest/java/org/elasticsearch/xpack/transform/integration/TransformNoTransformNodeIT.java
@@ -22,7 +22,6 @@ import org.elasticsearch.xpack.core.transform.transforms.TransformConfig;
 import org.elasticsearch.xpack.core.transform.transforms.TransformConfigUpdate;
 import org.elasticsearch.xpack.core.transform.transforms.pivot.PivotConfigTests;
 import org.elasticsearch.xpack.transform.TransformSingleNodeTestCase;
-import org.junit.After;
 
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
@@ -31,14 +30,6 @@ public class TransformNoTransformNodeIT extends TransformSingleNodeTestCase {
     @Override
     protected Settings nodeSettings() {
         return Settings.builder().put(NodeRoleSettings.NODE_ROLES_SETTING.getKey(), "master, data, ingest").build();
-    }
-
-    @After
-    public void preCleanup() throws Exception {
-        // Updating a transform will leave indexing an audit message in-flight, so
-        // we need to wait for that to complete or it could interfere with deleting
-        // all the indices
-        waitForPendingTasks();
     }
 
     public void testGetTransformStats() {

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/notifications/TransformAuditor.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/notifications/TransformAuditor.java
@@ -14,6 +14,7 @@ import org.elasticsearch.client.OriginSettingClient;
 import org.elasticsearch.cluster.metadata.AliasMetadata;
 import org.elasticsearch.cluster.metadata.IndexTemplateMetadata;
 import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.xpack.core.common.notifications.AbstractAuditor;
 import org.elasticsearch.xpack.core.transform.TransformMetadata;
@@ -72,6 +73,13 @@ public class TransformAuditor extends AbstractAuditor<TransformAuditMessage> {
                 isResetMode = TransformMetadata.getTransformMetadata(event.state()).isResetMode();
             }
         });
+    }
+
+    @Override
+    protected void indexDoc(ToXContent toXContent) {
+        if (isResetMode == false) {
+            super.indexDoc(toXContent);
+        }
     }
 
     @Override


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [ML] [Transform] use feature reset API for transform test cleanup (#72044)