### PR TITLE
Suppress Exceptions in RecoverySourceHandler Shutdown (#72159)

### DIFF
--- a/server/src/main/java/org/elasticsearch/indices/recovery/RecoverySourceHandler.java
+++ b/server/src/main/java/org/elasticsearch/indices/recovery/RecoverySourceHandler.java
@@ -250,7 +250,7 @@ public class RecoverySourceHandler {
                     sendFileStep.whenComplete(r -> IOUtils.close(safeCommitRef, releaseStore), e -> {
                         try {
                             IOUtils.close(safeCommitRef, releaseStore);
-                        } catch (final IOException ex) {
+                        } catch (Exception ex) {
                             logger.warn("releasing snapshot caused exception", ex);
                         }
                     });


### PR DESCRIPTION
Lets just suppress all exceptions here to stop failing tests when the thread
this executes on is interrupted.
A follow up to this will try to get rid of the interrupt usage for stopping recovery
source handler.

backport of #72159