### PR TITLE
Granting kibana_system reserved role access to "all" privileges to .alerts* and .siem-signals* index

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStore.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStore.java
@@ -38,9 +38,7 @@ import java.util.stream.Collectors;
 
 public class ReservedRolesStore implements BiConsumer<Set<String>, ActionListener<RoleRetrievalResult>> {
     public static final String LEGACY_ALERTS_INDEX = ".siem-signals*";
-    public static final String LEGACY_ALERTS_INDEX_CCS = "*:.siem-signals*";
     public static final String ALERTS_INDEX = ".alerts*";
-    public static final String ALERTS_INDEX_CCS = "*:.alerts*";
 
     public static final RoleDescriptor SUPERUSER_ROLE_DESCRIPTOR = new RoleDescriptor("superuser",
             new String[] { "all" },
@@ -185,15 +183,7 @@ public class ReservedRolesStore implements BiConsumer<Set<String>, ActionListene
                                 // Kibana user will read / write to these indices
                                 RoleDescriptor.IndicesPrivileges.builder()
                                     .indices(ReservedRolesStore.ALERTS_INDEX)
-                                    .privileges("all").build(),
-                                // Legacy "Alerts as data" CCS
-                                RoleDescriptor.IndicesPrivileges.builder()
-                                    .indices(ReservedRolesStore.LEGACY_ALERTS_INDEX_CCS)
-                                    .privileges("all").build(),
-                                // Legacy "Alerts as data" CCS
-                                RoleDescriptor.IndicesPrivileges.builder()
-                                    .indices(ReservedRolesStore.ALERTS_INDEX_CCS)
-                                    .privileges("all").build(),
+                                    .privileges("all").build()
                         },
                         null,
                         new ConfigurableClusterPrivilege[] { new ManageApplicationPrivileges(Collections.singleton("kibana-*")) },

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStore.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStore.java
@@ -38,7 +38,9 @@ import java.util.stream.Collectors;
 
 public class ReservedRolesStore implements BiConsumer<Set<String>, ActionListener<RoleRetrievalResult>> {
     public static final String LEGACY_ALERTS_INDEX = ".siem-signals*";
+    public static final String LEGACY_ALERTS_INDEX_CCS = "*:.siem-signals*";
     public static final String ALERTS_INDEX = ".alerts*";
+    public static final String ALERTS_INDEX_CCS = "*:.alerts*";
 
     public static final RoleDescriptor SUPERUSER_ROLE_DESCRIPTOR = new RoleDescriptor("superuser",
             new String[] { "all" },
@@ -183,6 +185,14 @@ public class ReservedRolesStore implements BiConsumer<Set<String>, ActionListene
                                 // Kibana user will read / write to these indices
                                 RoleDescriptor.IndicesPrivileges.builder()
                                     .indices(ReservedRolesStore.ALERTS_INDEX)
+                                    .privileges("all").build(),
+                                // Legacy "Alerts as data" CCS
+                                RoleDescriptor.IndicesPrivileges.builder()
+                                    .indices(ReservedRolesStore.LEGACY_ALERTS_INDEX_CCS)
+                                    .privileges("all").build(),
+                                // Legacy "Alerts as data" CCS
+                                RoleDescriptor.IndicesPrivileges.builder()
+                                    .indices(ReservedRolesStore.ALERTS_INDEX_CCS)
                                     .privileges("all").build(),
                         },
                         null,

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStore.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStore.java
@@ -37,6 +37,8 @@ import java.util.function.BiConsumer;
 import java.util.stream.Collectors;
 
 public class ReservedRolesStore implements BiConsumer<Set<String>, ActionListener<RoleRetrievalResult>> {
+    public static final String LEGACY_ALERTS_INDEX = ".siem-signals*";
+    public static final String ALERTS_INDEX = ".alerts*";
 
     public static final RoleDescriptor SUPERUSER_ROLE_DESCRIPTOR = new RoleDescriptor("superuser",
             new String[] { "all" },
@@ -171,6 +173,16 @@ public class ReservedRolesStore implements BiConsumer<Set<String>, ActionListene
                                 // Fleet Server indices. Kibana read and write to this indice to manage Elastic Agents
                                 RoleDescriptor.IndicesPrivileges.builder()
                                     .indices(".fleet*")
+                                    .privileges("all").build(),
+                                // Legacy "Alerts as data" index. Kibana user will create this index.
+                                // Kibana user will read / write to these indices
+                                RoleDescriptor.IndicesPrivileges.builder()
+                                    .indices(ReservedRolesStore.LEGACY_ALERTS_INDEX)
+                                    .privileges("all").build(),
+                                // "Alerts as data" index. Kibana user will create this index.
+                                // Kibana user will read / write to these indices
+                                RoleDescriptor.IndicesPrivileges.builder()
+                                    .indices(ReservedRolesStore.ALERTS_INDEX)
                                     .privileges("all").build(),
                         },
                         null,

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStoreTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStoreTests.java
@@ -402,7 +402,9 @@ public class ReservedRolesStoreTests extends ESTestCase {
             ".apm-agent-configuration",
             ".apm-custom-link",
             ReservedRolesStore.LEGACY_ALERTS_INDEX,
-            ReservedRolesStore.ALERTS_INDEX
+            ReservedRolesStore.ALERTS_INDEX,
+            ReservedRolesStore.LEGACY_ALERTS_INDEX_CCS,
+            ReservedRolesStore.ALERTS_INDEX_CCS
         ).forEach((index) -> {
             logger.info("index name [{}]", index);
             assertThat(kibanaRole.indices().allowedIndicesMatcher("indices:foo").test(mockIndexAbstraction(index)), is(true));

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStoreTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStoreTests.java
@@ -401,10 +401,8 @@ public class ReservedRolesStoreTests extends ESTestCase {
             ".reporting-" + randomAlphaOfLength(randomIntBetween(0, 13)),
             ".apm-agent-configuration",
             ".apm-custom-link",
-            ReservedRolesStore.LEGACY_ALERTS_INDEX,
-            ReservedRolesStore.ALERTS_INDEX,
-            ReservedRolesStore.LEGACY_ALERTS_INDEX_CCS,
-            ReservedRolesStore.ALERTS_INDEX_CCS
+            ReservedRolesStore.LEGACY_ALERTS_INDEX + randomAlphaOfLength(randomIntBetween(0, 13)),
+            ReservedRolesStore.ALERTS_INDEX + randomAlphaOfLength(randomIntBetween(0, 13))
         ).forEach((index) -> {
             logger.info("index name [{}]", index);
             assertThat(kibanaRole.indices().allowedIndicesMatcher("indices:foo").test(mockIndexAbstraction(index)), is(true));

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStoreTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStoreTests.java
@@ -400,7 +400,9 @@ public class ReservedRolesStoreTests extends ESTestCase {
             ".kibana-devnull",
             ".reporting-" + randomAlphaOfLength(randomIntBetween(0, 13)),
             ".apm-agent-configuration",
-            ".apm-custom-link"
+            ".apm-custom-link",
+            ReservedRolesStore.LEGACY_ALERTS_INDEX,
+            ReservedRolesStore.ALERTS_INDEX
         ).forEach((index) -> {
             logger.info("index name [{}]", index);
             assertThat(kibanaRole.indices().allowedIndicesMatcher("indices:foo").test(mockIndexAbstraction(index)), is(true));


### PR DESCRIPTION
The RAC team is storing alerts as data in the `.alerts*` and `.siem-signals*` (legacy) indices, which the Kibana user needs access to in order to CRUD alerts.

Ref: https://github.com/elastic/kibana/issues/95721

drake: https://github.com/elastic/kibana/issues/94502