### PR TITLE
Add warning for path.data as a list to deprecation api

### DIFF
--- a/server/src/main/java/org/elasticsearch/env/Environment.java
+++ b/server/src/main/java/org/elasticsearch/env/Environment.java
@@ -158,7 +158,12 @@ public class Environment {
 
         final Settings.Builder finalSettings = Settings.builder().put(settings);
         if (PATH_DATA_SETTING.exists(settings)) {
-            finalSettings.putList(PATH_DATA_SETTING.getKey(), Arrays.stream(dataFiles).map(Path::toString).collect(Collectors.toList()));
+            if (dataFiles.length == 1) {
+                finalSettings.put(PATH_DATA_SETTING.getKey(), dataFiles[0]);
+            } else {
+                finalSettings.putList(PATH_DATA_SETTING.getKey(),
+                    Arrays.stream(dataFiles).map(Path::toString).collect(Collectors.toList()));
+            }
         }
         finalSettings.put(PATH_HOME_SETTING.getKey(), homeFile);
         finalSettings.put(PATH_LOGS_SETTING.getKey(), logsFile.toString());

--- a/server/src/main/java/org/elasticsearch/env/Environment.java
+++ b/server/src/main/java/org/elasticsearch/env/Environment.java
@@ -10,7 +10,6 @@ package org.elasticsearch.env;
 
 import org.elasticsearch.common.SuppressForbidden;
 import org.elasticsearch.common.io.PathUtils;
-import org.elasticsearch.common.logging.DeprecationLogger;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Setting.Property;
 import org.elasticsearch.common.settings.Settings;

--- a/server/src/main/java/org/elasticsearch/env/Environment.java
+++ b/server/src/main/java/org/elasticsearch/env/Environment.java
@@ -10,6 +10,7 @@ package org.elasticsearch.env;
 
 import org.elasticsearch.common.SuppressForbidden;
 import org.elasticsearch.common.io.PathUtils;
+import org.elasticsearch.common.logging.DeprecationLogger;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Setting.Property;
 import org.elasticsearch.common.settings.Settings;

--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/DeprecationChecks.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/DeprecationChecks.java
@@ -83,7 +83,8 @@ public class DeprecationChecks {
                         XPackSettings.TRANSFORM_ENABLED),
                     (settings, pluginsAndModules) -> NodeDeprecationChecks.checkNodeBasicLicenseFeatureEnabledSetting(settings,
                         XPackSettings.VECTORS_ENABLED),
-                    NodeDeprecationChecks::checkMultipleDataPaths
+                    NodeDeprecationChecks::checkMultipleDataPaths,
+                    NodeDeprecationChecks::checkDataPathsList
                 )
             ).collect(Collectors.toList());
         }

--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/NodeDeprecationChecks.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/NodeDeprecationChecks.java
@@ -390,4 +390,14 @@ class NodeDeprecationChecks {
         return null;
     }
 
+    static DeprecationIssue checkDataPathsList(Settings nodeSettings, PluginsAndModules plugins) {
+        if (Environment.dataPathUsesList(nodeSettings)) {
+            return new DeprecationIssue(DeprecationIssue.Level.CRITICAL,
+                "[path.data] in a list is deprecated, use a string value",
+                "https://www.elastic.co/guide/en/elasticsearch/reference/master/breaking-changes-8.0.html#breaking_80_packaging_changes",
+                "Configuring [path.data] with a list is deprecated. Instead specify as a string value.");
+        }
+        return null;
+    }
+
 }

--- a/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/NodeDeprecationChecksTests.java
+++ b/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/NodeDeprecationChecksTests.java
@@ -534,4 +534,26 @@ public class NodeDeprecationChecksTests extends ESTestCase {
         final DeprecationIssue issue = NodeDeprecationChecks.checkMultipleDataPaths(settings, null);
         assertThat(issue, nullValue());
     }
+
+    public void testDataPathsList() {
+        final Settings settings = Settings.builder().putList("path.data", "d1").build();
+        final DeprecationIssue issue = NodeDeprecationChecks.checkDataPathsList(settings, null);
+        assertThat(issue, not(nullValue()));
+        assertThat(issue.getLevel(), equalTo(DeprecationIssue.Level.CRITICAL));
+        assertThat(
+            issue.getMessage(),
+            equalTo("[path.data] in a list is deprecated, use a string value"));
+        assertThat(
+            issue.getDetails(),
+            equalTo("Configuring [path.data] with a list is deprecated. Instead specify as a string value."));
+        String url =
+            "https://www.elastic.co/guide/en/elasticsearch/reference/master/breaking-changes-8.0.html#breaking_80_packaging_changes";
+        assertThat(issue.getUrl(), equalTo(url));
+    }
+
+    public void testNoDataPathsListDefault() {
+        final Settings settings = Settings.builder().build();
+        final DeprecationIssue issue = NodeDeprecationChecks.checkDataPathsList(settings, null);
+        assertThat(issue, nullValue());
+    }
 }


### PR DESCRIPTION
This commit adds a deprecation warning when a single data path is used
with a yaml list. See #72180