### PR TITLE
Validate IP filter settings

### DIFF
--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/transport/filter/IPFilter.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/transport/filter/IPFilter.java
@@ -98,14 +98,14 @@ public class IPFilter {
             "transport.profiles.default.xpack.security.filter.allow",
             TRANSPORT_FILTER_ALLOW_SETTING,
             Function.identity(),
-            s -> Collections.emptyList(),
+            TRANSPORT_FILTER_ALLOW_SETTING::get,
             ALLOW_VALIDATOR,
             Property.NodeScope);
     public static final Setting<List<String>> HTTP_FILTER_ALLOW_SETTING = Setting.listSetting(
             setting("http.filter.allow"),
             HTTP_FILTER_ALLOW_FALLBACK,
             Function.identity(),
-            s -> Collections.emptyList(),
+            HTTP_FILTER_ALLOW_FALLBACK::get,
             ALLOW_VALIDATOR,
             Property.OperatorDynamic,
             Property.NodeScope);
@@ -114,14 +114,14 @@ public class IPFilter {
             "transport.profiles.default.xpack.security.filter.deny",
             TRANSPORT_FILTER_DENY_SETTING,
             Function.identity(),
-            s -> Collections.emptyList(),
+            TRANSPORT_FILTER_DENY_SETTING::get,
             DENY_VALIDATOR,
             Property.NodeScope);
     public static final Setting<List<String>> HTTP_FILTER_DENY_SETTING = Setting.listSetting(
             setting("http.filter.deny"),
             HTTP_FILTER_DENY_FALLBACK,
             Function.identity(),
-            s -> Collections.emptyList(),
+            HTTP_FILTER_DENY_FALLBACK::get,
             DENY_VALIDATOR,
             Property.OperatorDynamic,
             Property.NodeScope);

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/transport/filter/IPFilter.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/transport/filter/IPFilter.java
@@ -55,30 +55,76 @@ public class IPFilter {
     public static final Setting<Boolean> IP_FILTER_ENABLED_SETTING = Setting.boolSetting(setting("transport.filter.enabled"),
             true, Property.OperatorDynamic, Property.NodeScope);
 
-    public static final Setting<List<String>> TRANSPORT_FILTER_ALLOW_SETTING = Setting.listSetting(setting("transport.filter.allow"),
-            Collections.emptyList(), Function.identity(), Property.OperatorDynamic, Property.NodeScope);
+    private static final IPFilterValidator ALLOW_VALIDATOR = new IPFilterValidator(true);
+    private static final IPFilterValidator DENY_VALIDATOR = new IPFilterValidator(false);
 
-    public static final Setting<List<String>> TRANSPORT_FILTER_DENY_SETTING = Setting.listSetting(setting("transport.filter.deny"),
-            Collections.emptyList(), Function.identity(), Property.OperatorDynamic, Property.NodeScope);
+    public static final Setting<List<String>> TRANSPORT_FILTER_ALLOW_SETTING = Setting.listSetting(
+            setting("transport.filter.allow"),
+            Collections.emptyList(),
+            Function.identity(),
+            ALLOW_VALIDATOR,
+            Property.OperatorDynamic,
+            Property.NodeScope);
+    public static final Setting<List<String>> TRANSPORT_FILTER_DENY_SETTING = Setting.listSetting(
+            setting("transport.filter.deny"),
+            Collections.emptyList(),
+            Function.identity(),
+            DENY_VALIDATOR,
+            Property.OperatorDynamic,
+            Property.NodeScope);
 
-    public static final Setting.AffixSetting<List<String>> PROFILE_FILTER_DENY_SETTING = Setting.affixKeySetting("transport.profiles.",
-            "xpack.security.filter.deny", key -> Setting.listSetting(key, Collections.emptyList(), Function.identity(),
-            Property.OperatorDynamic, Property.NodeScope));
-    public static final Setting.AffixSetting<List<String>> PROFILE_FILTER_ALLOW_SETTING = Setting.affixKeySetting("transport.profiles.",
-            "xpack.security.filter.allow", key -> Setting.listSetting(key, Collections.emptyList(), Function.identity(),
-            Property.OperatorDynamic, Property.NodeScope));
+    public static final Setting.AffixSetting<List<String>> PROFILE_FILTER_DENY_SETTING = Setting.affixKeySetting(
+            "transport.profiles.",
+            "xpack.security.filter.deny",
+            key -> Setting.listSetting(
+                    key,
+                    Collections.emptyList(),
+                    Function.identity(),
+                    DENY_VALIDATOR,
+                    Property.OperatorDynamic,
+                    Property.NodeScope));
+    public static final Setting.AffixSetting<List<String>> PROFILE_FILTER_ALLOW_SETTING = Setting.affixKeySetting(
+            "transport.profiles.",
+            "xpack.security.filter.allow",
+            key -> Setting.listSetting(
+                    key,
+                    Collections.emptyList(),
+                    Function.identity(),
+                    ALLOW_VALIDATOR,
+                    Property.OperatorDynamic,
+                    Property.NodeScope));
 
-    private static final Setting<List<String>> HTTP_FILTER_ALLOW_FALLBACK =
-            Setting.listSetting("transport.profiles.default.xpack.security.filter.allow", TRANSPORT_FILTER_ALLOW_SETTING, s -> s,
-                    Property.NodeScope);
-    public static final Setting<List<String>> HTTP_FILTER_ALLOW_SETTING = Setting.listSetting(setting("http.filter.allow"),
-            HTTP_FILTER_ALLOW_FALLBACK, Function.identity(), Property.OperatorDynamic, Property.NodeScope);
+    private static final Setting<List<String>> HTTP_FILTER_ALLOW_FALLBACK = Setting.listSetting(
+            "transport.profiles.default.xpack.security.filter.allow",
+            TRANSPORT_FILTER_ALLOW_SETTING,
+            Function.identity(),
+            s -> Collections.emptyList(),
+            ALLOW_VALIDATOR,
+            Property.NodeScope);
+    public static final Setting<List<String>> HTTP_FILTER_ALLOW_SETTING = Setting.listSetting(
+            setting("http.filter.allow"),
+            HTTP_FILTER_ALLOW_FALLBACK,
+            Function.identity(),
+            s -> Collections.emptyList(),
+            ALLOW_VALIDATOR,
+            Property.OperatorDynamic,
+            Property.NodeScope);
 
-    private static final Setting<List<String>> HTTP_FILTER_DENY_FALLBACK =
-            Setting.listSetting("transport.profiles.default.xpack.security.filter.deny", TRANSPORT_FILTER_DENY_SETTING, s -> s,
-                    Property.NodeScope);
-    public static final Setting<List<String>> HTTP_FILTER_DENY_SETTING = Setting.listSetting(setting("http.filter.deny"),
-            HTTP_FILTER_DENY_FALLBACK, Function.identity(), Property.OperatorDynamic, Property.NodeScope);
+    private static final Setting<List<String>> HTTP_FILTER_DENY_FALLBACK = Setting.listSetting(
+            "transport.profiles.default.xpack.security.filter.deny",
+            TRANSPORT_FILTER_DENY_SETTING,
+            Function.identity(),
+            s -> Collections.emptyList(),
+            DENY_VALIDATOR,
+            Property.NodeScope);
+    public static final Setting<List<String>> HTTP_FILTER_DENY_SETTING = Setting.listSetting(
+            setting("http.filter.deny"),
+            HTTP_FILTER_DENY_FALLBACK,
+            Function.identity(),
+            s -> Collections.emptyList(),
+            DENY_VALIDATOR,
+            Property.OperatorDynamic,
+            Property.NodeScope);
 
     public static final Map<String, Object> DISABLED_USAGE_STATS = Map.of(
             "http", false,
@@ -304,4 +350,26 @@ public class IPFilter {
         settings.add(PROFILE_FILTER_ALLOW_SETTING);
         settings.add(PROFILE_FILTER_DENY_SETTING);
     }
+
+    private static class IPFilterValidator implements Setting.Validator<List<String>> {
+
+        private final boolean isAllowRule;
+
+        IPFilterValidator(boolean isAllowRule) {
+            this.isAllowRule = isAllowRule;
+        }
+
+        @Override
+        public void validate(List<String> filterSpecs) {
+            for (String filterSpec : filterSpecs) {
+                try {
+                    // It's enough just to create the specified rule:
+                    new SecurityIpFilterRule(isAllowRule, filterSpec);
+                } catch (Exception e) {
+                    throw new IllegalArgumentException("invalid IP filter [" + filterSpec + "]", e);
+                }
+            }
+        }
+    }
+
 }


### PR DESCRIPTION
Today it is possible to set up an IP filter which throws an exception on
creation, which is fatal to the cluster. This commit adds validation to
the IP filtering settings to prevent this.

Closes #72192