### PR TITLE
Validate IP filter settings

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/settings/Setting.java
+++ b/server/src/main/java/org/elasticsearch/common/settings/Setting.java
@@ -1283,13 +1283,23 @@ public class Setting<T> implements ToXContentObject {
             final Function<String, T> singleValueParser,
             final Function<Settings, List<String>> defaultStringValue,
             final Property... properties) {
+        return listSetting(key, fallbackSetting, singleValueParser, defaultStringValue, v -> {}, properties);
+    }
+
+    public static <T> Setting<List<T>> listSetting(
+            final String key,
+            final @Nullable Setting<List<T>> fallbackSetting,
+            final Function<String, T> singleValueParser,
+            final Function<Settings, List<String>> defaultStringValue,
+            final Validator<List<T>> validator,
+            final Property... properties) {
         if (defaultStringValue.apply(Settings.EMPTY) == null) {
             throw new IllegalArgumentException("default value function must not return null");
         }
         Function<String, List<T>> parser = (s) ->
                 parseableStringToList(s).stream().map(singleValueParser).collect(Collectors.toList());
 
-        return new ListSetting<>(key, fallbackSetting, defaultStringValue, parser, properties);
+        return new ListSetting<>(key, fallbackSetting, defaultStringValue, parser, validator, properties);
     }
 
     private static List<String> parseableStringToList(String parsableString) {
@@ -1336,13 +1346,14 @@ public class Setting<T> implements ToXContentObject {
                 final @Nullable Setting<List<T>> fallbackSetting,
                 final Function<Settings, List<String>> defaultStringValue,
                 final Function<String, List<T>> parser,
+                final Validator<List<T>> validator,
                 final Property... properties) {
             super(
                     new ListKey(key),
                     fallbackSetting,
                     s -> Setting.arrayToParsableString(defaultStringValue.apply(s)),
                     parser,
-                    v -> {},
+                    validator,
                     properties);
             this.defaultStringValue = defaultStringValue;
         }

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/transport/filter/IPFilter.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/transport/filter/IPFilter.java
@@ -53,30 +53,80 @@ public class IPFilter {
     public static final Setting<Boolean> IP_FILTER_ENABLED_SETTING = Setting.boolSetting(setting("transport.filter.enabled"),
             true, Property.Dynamic, Property.NodeScope);
 
-    public static final Setting<List<String>> TRANSPORT_FILTER_ALLOW_SETTING = Setting.listSetting(setting("transport.filter.allow"),
-            Collections.emptyList(), Function.identity(), Property.Dynamic, Property.NodeScope);
+    private static final IPFilterValidator ALLOW_VALIDATOR = new IPFilterValidator(true);
+    private static final IPFilterValidator DENY_VALIDATOR = new IPFilterValidator(false);
 
-    public static final Setting<List<String>> TRANSPORT_FILTER_DENY_SETTING = Setting.listSetting(setting("transport.filter.deny"),
-            Collections.emptyList(), Function.identity(), Property.Dynamic, Property.NodeScope);
+    public static final Setting<List<String>> TRANSPORT_FILTER_ALLOW_SETTING = Setting.listSetting(
+            setting("transport.filter.allow"),
+            null,
+            Function.identity(),
+            s -> Collections.emptyList(),
+            ALLOW_VALIDATOR,
+            Property.Dynamic,
+            Property.NodeScope);
+    public static final Setting<List<String>> TRANSPORT_FILTER_DENY_SETTING = Setting.listSetting(
+            setting("transport.filter.deny"),
+            null,
+            Function.identity(),
+            s -> Collections.emptyList(),
+            DENY_VALIDATOR,
+            Property.Dynamic,
+            Property.NodeScope);
 
-    public static final Setting.AffixSetting<List<String>> PROFILE_FILTER_DENY_SETTING = Setting.affixKeySetting("transport.profiles.",
-            "xpack.security.filter.deny", key -> Setting.listSetting(key, Collections.emptyList(), Function.identity(),
-            Property.Dynamic, Property.NodeScope));
-    public static final Setting.AffixSetting<List<String>> PROFILE_FILTER_ALLOW_SETTING = Setting.affixKeySetting("transport.profiles.",
-            "xpack.security.filter.allow", key -> Setting.listSetting(key, Collections.emptyList(), Function.identity(),
-            Property.Dynamic, Property.NodeScope));
+    public static final Setting.AffixSetting<List<String>> PROFILE_FILTER_DENY_SETTING = Setting.affixKeySetting(
+            "transport.profiles.",
+            "xpack.security.filter.deny",
+            key -> Setting.listSetting(
+                    key,
+                    null,
+                    Function.identity(),
+                    s -> Collections.emptyList(),
+                    DENY_VALIDATOR,
+                    Property.Dynamic,
+                    Property.NodeScope));
+    public static final Setting.AffixSetting<List<String>> PROFILE_FILTER_ALLOW_SETTING = Setting.affixKeySetting(
+            "transport.profiles.",
+            "xpack.security.filter.allow",
+            key -> Setting.listSetting(
+                    key,
+                    null,
+                    Function.identity(),
+                    s -> Collections.emptyList(),
+                    ALLOW_VALIDATOR,
+                    Property.Dynamic,
+                    Property.NodeScope));
 
-    private static final Setting<List<String>> HTTP_FILTER_ALLOW_FALLBACK =
-            Setting.listSetting("transport.profiles.default.xpack.security.filter.allow", TRANSPORT_FILTER_ALLOW_SETTING, s -> s,
-                    Property.NodeScope);
-    public static final Setting<List<String>> HTTP_FILTER_ALLOW_SETTING = Setting.listSetting(setting("http.filter.allow"),
-            HTTP_FILTER_ALLOW_FALLBACK, Function.identity(), Property.Dynamic, Property.NodeScope);
+    private static final Setting<List<String>> HTTP_FILTER_ALLOW_FALLBACK = Setting.listSetting(
+            "transport.profiles.default.xpack.security.filter.allow",
+            TRANSPORT_FILTER_ALLOW_SETTING,
+            Function.identity(),
+            TRANSPORT_FILTER_ALLOW_SETTING::get,
+            ALLOW_VALIDATOR,
+            Property.NodeScope);
+    public static final Setting<List<String>> HTTP_FILTER_ALLOW_SETTING = Setting.listSetting(
+            setting("http.filter.allow"),
+            HTTP_FILTER_ALLOW_FALLBACK,
+            Function.identity(),
+            HTTP_FILTER_ALLOW_FALLBACK::get,
+            ALLOW_VALIDATOR,
+            Property.Dynamic,
+            Property.NodeScope);
 
-    private static final Setting<List<String>> HTTP_FILTER_DENY_FALLBACK =
-            Setting.listSetting("transport.profiles.default.xpack.security.filter.deny", TRANSPORT_FILTER_DENY_SETTING, s -> s,
-                    Property.NodeScope);
-    public static final Setting<List<String>> HTTP_FILTER_DENY_SETTING = Setting.listSetting(setting("http.filter.deny"),
-            HTTP_FILTER_DENY_FALLBACK, Function.identity(), Property.Dynamic, Property.NodeScope);
+    private static final Setting<List<String>> HTTP_FILTER_DENY_FALLBACK = Setting.listSetting(
+            "transport.profiles.default.xpack.security.filter.deny",
+            TRANSPORT_FILTER_DENY_SETTING,
+            Function.identity(),
+            TRANSPORT_FILTER_DENY_SETTING::get,
+            DENY_VALIDATOR,
+            Property.NodeScope);
+    public static final Setting<List<String>> HTTP_FILTER_DENY_SETTING = Setting.listSetting(
+            setting("http.filter.deny"),
+            HTTP_FILTER_DENY_FALLBACK,
+            Function.identity(),
+            HTTP_FILTER_DENY_FALLBACK::get,
+            DENY_VALIDATOR,
+            Property.Dynamic,
+            Property.NodeScope);
 
     public static final Map<String, Object> DISABLED_USAGE_STATS = new MapBuilder<String, Object>()
             .put("http", false)
@@ -301,4 +351,26 @@ public class IPFilter {
         settings.add(PROFILE_FILTER_ALLOW_SETTING);
         settings.add(PROFILE_FILTER_DENY_SETTING);
     }
+
+    private static class IPFilterValidator implements Setting.Validator<List<String>> {
+
+        private final boolean isAllowRule;
+
+        IPFilterValidator(boolean isAllowRule) {
+            this.isAllowRule = isAllowRule;
+        }
+
+        @Override
+        public void validate(List<String> filterSpecs) {
+            for (String filterSpec : filterSpecs) {
+                try {
+                    // It's enough just to create the specified rule:
+                    new SecurityIpFilterRule(isAllowRule, filterSpec);
+                } catch (Exception e) {
+                    throw new IllegalArgumentException("invalid IP filter [" + filterSpec + "]", e);
+                }
+            }
+        }
+    }
+
 }

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/transport/filter/IpFilteringUpdateTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/transport/filter/IpFilteringUpdateTests.java
@@ -20,6 +20,8 @@ import java.util.Locale;
 
 import static org.elasticsearch.test.ESIntegTestCase.Scope.TEST;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
 
 @ClusterScope(scope = TEST, supportsDedicatedMasters = false, numDataNodes = 1)
@@ -115,6 +117,41 @@ public class IpFilteringUpdateTests extends SecurityIntegTestCase {
             assertAcked(client().admin().cluster().prepareUpdateSettings().setPersistentSettings(settings));
             assertAcked(client().admin().cluster().prepareUpdateSettings().setTransientSettings(settings));
             assertConnectionAccepted(".http", "127.0.0.8");
+        }
+    }
+
+    public void testThatInvalidDynamicIpFilterConfigurationIsRejected() {
+        final Settings.Builder initialSettingsBuilder = Settings.builder();
+        if (randomBoolean()) {
+            initialSettingsBuilder.put(IPFilter.IP_FILTER_ENABLED_SETTING.getKey(), randomBoolean());
+        }
+        if (randomBoolean()) {
+            initialSettingsBuilder.put(IPFilter.IP_FILTER_ENABLED_HTTP_SETTING.getKey(), randomBoolean());
+        }
+        final Settings initialSettings = initialSettingsBuilder.build();
+        if (initialSettings.isEmpty() == false) {
+            updateSettings(initialSettings);
+        }
+
+        final String invalidValue = "http://";
+
+        for (final String settingPrefix : new String[] {
+                "xpack.security.transport.filter",
+                "xpack.security.http.filter",
+                "transport.profiles.default.xpack.security.filter",
+                "transport.profiles.anotherprofile.xpack.security.filter"
+        }) {
+            for (final String settingSuffix : new String[]{"allow", "deny"}) {
+                final String settingName = settingPrefix + "." + settingSuffix;
+                final Settings settings = Settings.builder().put(settingName, invalidValue).build();
+                assertThat(
+                        settingName,
+                        expectThrows(
+                                IllegalArgumentException.class,
+                                settingName,
+                                () -> updateSettings(settings)).getMessage(),
+                        allOf(containsString("invalid IP filter"), containsString(invalidValue)));
+            }
         }
     }
 


### PR DESCRIPTION
Today it is possible to set up an IP filter which throws an exception on
creation, which is fatal to the cluster. This commit adds validation to
the IP filtering settings to prevent this.

Closes #72192
Backport of #72195 to 6.8