### PR TITLE
[DOCS] Fix cat test snippets

### DIFF
--- a/docs/reference/cat.asciidoc
+++ b/docs/reference/cat.asciidoc
@@ -33,17 +33,17 @@ Each of the commands accepts a query string parameter `v` to turn on
 verbose output. For example:
 
 [source,console]
---------------------------------------------------
-GET /_cat/master?v=true
---------------------------------------------------
+----
+GET _cat/master?v=true
+----
 
 Might respond with:
 
 [source,txt]
---------------------------------------------------
+----
 id                     host      ip        node
 u_n93zwxThWHi1PDBJAGAg 127.0.0.1 127.0.0.1 u_n93zw
---------------------------------------------------
+----
 // TESTRESPONSE[s/u_n93zw(xThWHi1PDBJAGAg)?/.+/ non_json]
 
 [discrete]
@@ -54,19 +54,19 @@ Each of the commands accepts a query string parameter `help` which will
 output its available columns. For example:
 
 [source,console]
---------------------------------------------------
-GET /_cat/master?help
---------------------------------------------------
+----
+GET _cat/master?help
+----
 
 Might respond with:
 
 [source,txt]
---------------------------------------------------
+----
 id   |   | node id
 host | h | host name
 ip   |   | ip address
 node | n | node name
---------------------------------------------------
+----
 // TESTRESPONSE[s/[|]/[|]/ non_json]
 
 NOTE: `help` is not supported if any optional url parameter is used.
@@ -82,16 +82,16 @@ Each of the commands accepts a query string parameter `h` which forces
 only those columns to appear. For example:
 
 [source,console]
---------------------------------------------------
+----
 GET /_cat/nodes?h=ip,port,heapPercent,name
---------------------------------------------------
+----
 
 Responds with:
 
 [source,txt]
---------------------------------------------------
+----
 127.0.0.1 9300 27 sLBaIGK
---------------------------------------------------
+----
 // TESTRESPONSE[s/9300 27 sLBaIGK/\\d+ \\d+ .+/ non_json]
 
 You can also request multiple columns using simple wildcards like
@@ -118,20 +118,21 @@ by shard storage descending order and then index name in ascending order.
 . The `v` (verbose) parameter to include column headings in the response.
 
 [source,console]
---------------------------------------------------
+----
 GET /_cat/indices?bytes=b&s=store.size:desc,index:asc&v=true
---------------------------------------------------
+----
 // TEST[setup:my_index_huge]
 // TEST[s/^/PUT my-index-000002\n{"settings": {"number_of_replicas": 0}}\n/]
+// TEST[s/s=store\.size\:desc,index\:asc/s=index:asc/]
 
 The API returns the following response:
 
 [source,txt]
---------------------------------------------------
+----
 health status index            uuid                   pri rep docs.count docs.deleted store.size pri.store.size
 yellow open   my-index-000001  u8FNjxh8Rfy_awN11oDKYQ   1   1       1200            0      72171         72171
 green  open   my-index-000002  nYFWZEO7TUiOjLQXBaYJpA   1   0          0            0        230          230
---------------------------------------------------
+----
 // TESTRESPONSE[s/72171|230/\\d+/]
 // TESTRESPONSE[s/u8FNjxh8Rfy_awN11oDKYQ|nYFWZEO7TUiOjLQXBaYJpA/.+/ non_json]
 
@@ -145,7 +146,7 @@ If you want to change the <<byte-units,byte units>>, use `bytes` parameter.
 ==== Response as text, json, smile, yaml or cbor
 
 [source,sh]
---------------------------------------------------
+----
 % curl 'localhost:9200/_cat/indices?format=json&pretty'
 [
   {
@@ -160,7 +161,7 @@ If you want to change the <<byte-units,byte units>>, use `bytes` parameter.
     "store.size": "650b"
   }
 ]
---------------------------------------------------
+----
 // NOTCONSOLE
 
 Currently supported formats (for the `?format=` parameter):
@@ -175,7 +176,7 @@ All formats above are supported, the GET parameter takes precedence over the hea
 For example:
 
 [source,sh]
---------------------------------------------------
+----
 % curl '192.168.56.10:9200/_cat/indices?pretty' -H "Accept: application/json"
 [
   {
@@ -190,7 +191,7 @@ For example:
     "store.size": "650b"
   }
 ]
---------------------------------------------------
+----
 // NOTCONSOLE
 
 [discrete]
@@ -207,21 +208,20 @@ For example, with a sort string `s=column1,column2:desc,column3`, the table will
 sorted in ascending order by column1, in descending order by column2, and in ascending
 order by column3.
 
-[source,sh]
---------------------------------------------------
+[source,console]
+----
 GET _cat/templates?v=true&s=order:desc,index_patterns
---------------------------------------------------
-//CONSOLE
+----
 
 returns:
 
 [source,txt]
---------------------------------------------------
+----
 name                  index_patterns order version
 pizza_pepperoni       [*pepperoni*]  2
 sushi_california_roll [*avocado*]    1     1
 pizza_hawaiian        [*pineapples*] 1
---------------------------------------------------
+----
 
 include::cat/alias.asciidoc[]
 

--- a/docs/reference/cat.asciidoc
+++ b/docs/reference/cat.asciidoc
@@ -83,7 +83,7 @@ only those columns to appear. For example:
 
 [source,console]
 ----
-GET /_cat/nodes?h=ip,port,heapPercent,name
+GET _cat/nodes?h=ip,port,heapPercent,name
 ----
 
 Responds with:
@@ -119,7 +119,7 @@ by shard storage descending order and then index name in ascending order.
 
 [source,console]
 ----
-GET /_cat/indices?bytes=b&s=store.size:desc,index:asc&v=true
+GET _cat/indices?bytes=b&s=store.size:desc,index:asc&v=true
 ----
 // TEST[setup:my_index_huge]
 // TEST[s/^/PUT my-index-000002\n{"settings": {"number_of_replicas": 0}}\n/]


### PR DESCRIPTION
* Updates a cat test snippet to always return by index name in asc order
* Removes several leading slashes
* Reduces length of several snippet delimiters

Closes https://github.com/elastic/elasticsearch/issues/71683