### PR TITLE
[7.13] Fix IndexShardTests.testIndexCheckOnStartup

### DIFF
--- a/server/src/test/java/org/elasticsearch/index/shard/IndexShardTests.java
+++ b/server/src/test/java/org/elasticsearch/index/shard/IndexShardTests.java
@@ -10,6 +10,8 @@ package org.elasticsearch.index.shard;
 import org.apache.logging.log4j.Logger;
 import org.apache.lucene.index.CorruptIndexException;
 import org.apache.lucene.index.DirectoryReader;
+import org.apache.lucene.index.IndexFormatTooNewException;
+import org.apache.lucene.index.IndexFormatTooOldException;
 import org.apache.lucene.index.IndexableField;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.search.TermQuery;
@@ -3143,7 +3145,7 @@ public class IndexShardTests extends IndexShardTestCase {
         // Close the directory under the shard first because it's probably a MockDirectoryWrapper which throws exceptions when corrupt
         try {
             ((FilterDirectory) corruptedShard.store().directory()).getDelegate().close();
-        } catch (CorruptIndexException | RuntimeException e) {
+        } catch (CorruptIndexException | IndexFormatTooNewException | IndexFormatTooOldException | RuntimeException e) {
             // ignored
         }
 


### PR DESCRIPTION
In #70373 the test was adapted to close any MockDirectoryWrapper
before closing the shard, forcing exceptions to be thrown in case
of corruption.

But the test only catches CorruptIndexException and RuntimeException,
and in some cases the corruption of the shard can also trigger some
IndexFormatTooOldException or IndexFormatTooNewException.

Closes #71827

Backport of #72225