### PR TITLE
Temporarilly use shadowplugin 6.2 snapshot version

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -78,7 +78,14 @@ tasks.withType(JavaCompile).configureEach {
 
 repositories {
   mavenCentral()
+  // for resolving the gradle 7.0 compatible shadow plugin 6.2-SNAPSHOT
   gradlePluginPortal()
+  maven {
+    url 'https://jitpack.io'
+    metadataSources {
+      artifact()
+    }
+  }
 }
 
 dependencies {
@@ -92,7 +99,8 @@ dependencies {
   api 'com.netflix.nebula:gradle-info-plugin:9.2.0'
   api 'org.apache.rat:apache-rat:0.11'
   api "org.elasticsearch:jna:5.7.0-1"
-  api 'com.github.jengelman.gradle.plugins:shadow:6.1.0'
+  api 'com.github.johnrengelman:shadow:486da28'
+//  api 'com.github.jengelman.gradle.plugins:shadow:6.2.0-SNAPSHOT'
   // When upgrading forbidden apis, ensure dependency version is bumped in ThirdPartyPrecommitPlugin as well
   api 'de.thetaphi:forbiddenapis:3.1'
   api 'com.avast.gradle:gradle-docker-compose-plugin:0.14.0'


### PR DESCRIPTION
This fixes a gradle 7.0 incompatibility with the shadow plugin 6.1
see https://github.com/johnrengelman/shadow/pull/655 for details