### PR TITLE
[7.x] [DOCS] Fix indent in get snapshot API response (#72219)

### DIFF
--- a/docs/reference/snapshot-restore/apis/get-snapshot-api.asciidoc
+++ b/docs/reference/snapshot-restore/apis/get-snapshot-api.asciidoc
@@ -259,7 +259,7 @@ The API returns the following response:
       "indices": [],
       "data_streams": [],
       "feature_states": [],
-          "include_global_state": true,
+      "include_global_state": true,
       "state": "SUCCESS",
       "start_time": "2020-07-06T21:55:18.129Z",
       "start_time_in_millis": 1593093628850,


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [DOCS] Fix indent in get snapshot API response (#72219)