### PR TITLE
[7.12] [DOCS] Fix typos (#72227)

### DIFF
--- a/docs/reference/aggregations/metrics/top-metrics-aggregation.asciidoc
+++ b/docs/reference/aggregations/metrics/top-metrics-aggregation.asciidoc
@@ -334,8 +334,8 @@ Which returns:
 ===== Mixed sort types
 
 Sorting `top_metrics` by a field that has different types across different
-indices producs somewhat suprising results: floating point fields are
-always sorted independantly of whole numbered fields.
+indices producs somewhat surprising results: floating point fields are
+always sorted independently of whole numbered fields.
 
 [source,console,id=search-aggregations-metrics-top-metrics-mixed-sort]
 ----
@@ -374,7 +374,7 @@ Which returns:
 // TESTRESPONSE
 
 While this is better than an error it *probably* isn't what you were going for.
-While it does lose some precision, you can explictly cast the whole number
+While it does lose some precision, you can explicitly cast the whole number
 fields to floating points with something like:
 
 [source,console]

--- a/docs/reference/docs/reindex.asciidoc
+++ b/docs/reference/docs/reindex.asciidoc
@@ -336,7 +336,7 @@ section above, creating sub-requests which means it has some quirks:
 sub-requests are "child" tasks of the task for the request with `slices`.
 * Fetching the status of the task for the request with `slices` only contains
 the status of completed slices.
-* These sub-requests are individually addressable for things like cancelation
+* These sub-requests are individually addressable for things like cancellation
 and rethrottling.
 * Rethrottling the request with `slices` will rethrottle the unfinished
 sub-request proportionally.

--- a/docs/reference/indices/aliases.asciidoc
+++ b/docs/reference/indices/aliases.asciidoc
@@ -126,7 +126,7 @@ See <<filtered>> for an example.
 `is_hidden`::
 (Optional, Boolean)
 If `true`, the alias will be excluded from wildcard expressions by default,
-unless overriden in the request using the `expand_wildcards` parameter,
+unless overridden in the request using the `expand_wildcards` parameter,
 similar to <<index-hidden,hidden indices>>. This property must be set to the
 same value on all indices that share an alias. Defaults to `false`.
 

--- a/docs/reference/indices/put-component-template.asciidoc
+++ b/docs/reference/indices/put-component-template.asciidoc
@@ -222,7 +222,7 @@ To check the `version`, you can use the <<getting-component-templates,get compon
 
 You can use the `_meta` parameter to add arbitrary metadata to a component template.
 This user-defined object is stored in the cluster state,
-so keeping it short is preferrable.
+so keeping it short is preferable.
 
 The `_meta` parameter is optional and not automatically generated or used by {es}.
 

--- a/docs/reference/indices/put-index-template.asciidoc
+++ b/docs/reference/indices/put-index-template.asciidoc
@@ -260,7 +260,7 @@ To check the `version`, you can use the <<indices-get-template, get index templa
 
 You can use the `_meta` parameter to add arbitrary metadata to an index template. 
 This user-defined object is stored in the cluster state,
-so keeping it short is preferrable.
+so keeping it short is preferable.
 
 The `_meta` parameter is optional and not automatically generated or used by {es}.
 

--- a/docs/reference/ml/ml-shared.asciidoc
+++ b/docs/reference/ml/ml-shared.asciidoc
@@ -560,7 +560,7 @@ end::dfas-downsample-factor[]
 tag::dfas-early-stopping-enabled[]
 Advanced configuration option.
 Specifies whether the training process should finish if it is not finding any
-better perfoming models. If disabled, the training process can take significantly
+better performing models. If disabled, the training process can take significantly
 longer and the chance of finding a better performing model is unremarkable.
 By default, early stoppping is enabled.
 end::dfas-early-stopping-enabled[]

--- a/docs/reference/rest-api/common-parms.asciidoc
+++ b/docs/reference/rest-api/common-parms.asciidoc
@@ -1028,7 +1028,7 @@ Defines optional {transform} settings.
 end::transform-settings[]
 
 tag::transform-settings-dates-as-epoch-milli[]
-Defines if dates in the ouput should be written as ISO formatted string (default)
+Defines if dates in the output should be written as ISO formatted string (default)
 or as millis since epoch. `epoch_millis` has been the default for transforms created
 before version `7.11`. For compatible output set this to `true`.
 The default value is `false`.

--- a/docs/reference/slm/apis/slm-get.asciidoc
+++ b/docs/reference/slm/apis/slm-get.asciidoc
@@ -109,7 +109,7 @@ This request returns the following response:
 }
 --------------------------------------------------
 // TESTRESPONSE[s/"modified_date": "2019-04-23T01:30:00.000Z"/"modified_date": $body.daily-snapshots.modified_date/ s/"modified_date_millis": 1556048137314/"modified_date_millis": $body.daily-snapshots.modified_date_millis/ s/"next_execution": "2019-04-24T01:30:00.000Z"/"next_execution": $body.daily-snapshots.next_execution/ s/"next_execution_millis": 1556048160000/"next_execution_millis": $body.daily-snapshots.next_execution_millis/]
-<1> The version of the snapshot policy, only the latest verison is stored and incremented when the policy is updated
+<1> The version of the snapshot policy, only the latest version is stored and incremented when the policy is updated
 <2> The last time this policy was modified.
 <3> The next time this policy will be executed.
 


### PR DESCRIPTION
Backports the following commits to 7.12:
 - [DOCS] Fix typos (#72227)