### PR TITLE
[DOCS] Add temporary redirects for service account docs

### DIFF
--- a/docs/reference/redirects.asciidoc
+++ b/docs/reference/redirects.asciidoc
@@ -3,6 +3,36 @@
 
 The following pages have moved or been deleted.
 
+// [START] Service account redirects
+// These redirects are required for the CI builds to pass until the service
+//accounts PR is merged
+[role="exclude",id="security-api-get-service-credentials"]
+=== Get service credentials
+
+See <<security-api,Security APIs>>.
+
+[role="exclude",id="security-api-get-service-accounts"]
+=== Get service accounts
+
+See <<security-api,Security APIs>>.
+
+[role="exclude",id="security-api-delete-service-tokens"]
+=== Delete service account tokens
+
+See <<security-api,Security APIs>>.
+
+[role="exclude",id="security-api-clear-service-token-caches"]
+=== Clear service account token caches
+
+See <<security-api,Security APIs>>.
+
+[role="exclude",id="security-api-create-service-token"]
+=== Create service account tokens
+
+See <<security-api,Security APIs>>.
+
+// [END] Service account redirects
+
 // [START] Security redirects
 
 [role="exclude",id="get-started-users"]


### PR DESCRIPTION
The PR for [service account docs](https://github.com/elastic/elasticsearch/pull/71729) is not yet merged. Because this PR adds new APIs, we're hitting an issue where a broken link in the JSON spec ends up breaking the docs build for the Elasticsearch-JS client and the rest of our docs (see [this issue](https://github.com/elastic/docs/issues/1884)).

These temporary redirects will fix the CI build tests until #71729 is merged.