### PR TITLE
[DOCS] Disable shard allocation - data nodes only

### DIFF
--- a/docs/reference/setup/restart-cluster.asciidoc
+++ b/docs/reference/setup/restart-cluster.asciidoc
@@ -173,6 +173,8 @@ the datafeeds from {kib} or with the <<ml-open-job,open jobs>> and
 
 include::{es-repo-dir}/setup/restart-cluster.asciidoc[tag=disable_shard_alloc]
 
+This step is only necessary for <<data-node,data nodes>>.
+
 include::{es-repo-dir}/setup/restart-cluster.asciidoc[tag=stop_indexing]
 
 include::{es-repo-dir}/setup/restart-cluster.asciidoc[tag=stop_ml]

--- a/docs/reference/setup/restart-cluster.asciidoc
+++ b/docs/reference/setup/restart-cluster.asciidoc
@@ -13,11 +13,13 @@ time, so the service remains uninterrupted.
 [[restart-cluster-full]]
 === Full-cluster restart
 
+// tag::disable_shard_alloc[]
 . *Disable shard allocation.*
 +
 --
 include::{es-repo-dir}/upgrade/disable-shard-alloc.asciidoc[]
 --
+// end::disable_shard_alloc[]
 // tag::stop_indexing[]
 . *Stop indexing and perform a flush.*
 +
@@ -168,12 +170,8 @@ the datafeeds from {kib} or with the <<ml-open-job,open jobs>> and
 [[restart-cluster-rolling]]
 === Rolling restart
 
-. *Disable shard allocation.*
-+
---
-include::{es-repo-dir}/upgrade/disable-shard-alloc.asciidoc[]
-This step is only necessary for <<data-node,data nodes>>.
---
+
+include::{es-repo-dir}/setup/restart-cluster.asciidoc[tag=disable_shard_alloc]
 
 include::{es-repo-dir}/setup/restart-cluster.asciidoc[tag=stop_indexing]
 
@@ -211,7 +209,7 @@ GET _cat/nodes
 . *Reenable shard allocation.*
 +
 --
-Once the node has joined the cluster, remove the
+For data nodes, once the node has joined the cluster, remove the
 `cluster.routing.allocation.enable` setting to enable shard allocation and start
 using the node:
 

--- a/docs/reference/setup/restart-cluster.asciidoc
+++ b/docs/reference/setup/restart-cluster.asciidoc
@@ -13,13 +13,11 @@ time, so the service remains uninterrupted.
 [[restart-cluster-full]]
 === Full-cluster restart
 
-// tag::disable_shard_alloc[]
 . *Disable shard allocation.*
 +
 --
 include::{es-repo-dir}/upgrade/disable-shard-alloc.asciidoc[]
 --
-// end::disable_shard_alloc[]
 // tag::stop_indexing[]
 . *Stop indexing and perform a flush.*
 +
@@ -170,10 +168,12 @@ the datafeeds from {kib} or with the <<ml-open-job,open jobs>> and
 [[restart-cluster-rolling]]
 === Rolling restart
 
-
-include::{es-repo-dir}/setup/restart-cluster.asciidoc[tag=disable_shard_alloc]
-
+. *Disable shard allocation.*
++
+--
+include::{es-repo-dir}/upgrade/disable-shard-alloc.asciidoc[]
 This step is only necessary for <<data-node,data nodes>>.
+--
 
 include::{es-repo-dir}/setup/restart-cluster.asciidoc[tag=stop_indexing]
 

--- a/docs/reference/upgrade/disable-shard-alloc.asciidoc
+++ b/docs/reference/upgrade/disable-shard-alloc.asciidoc
@@ -1,9 +1,9 @@
 
-When you shut down a node, the allocation process waits for
+When you shut down a data node, the allocation process waits for
 `index.unassigned.node_left.delayed_timeout` (by default, one minute) before
 starting to replicate the shards on that node to other nodes in the cluster,
 which can involve a lot of I/O. Since the node is shortly going to be
-restarted, this I/O is unnecessary. You can avoid racing the clock by 
+restarted, this I/O is unnecessary. You can avoid racing the clock by
 <<cluster-routing-allocation-enable,disabling allocation>> of replicas before
 shutting down the node:
 

--- a/docs/reference/upgrade/disable-shard-alloc.asciidoc
+++ b/docs/reference/upgrade/disable-shard-alloc.asciidoc
@@ -5,7 +5,7 @@ starting to replicate the shards on that node to other nodes in the cluster,
 which can involve a lot of I/O. Since the node is shortly going to be
 restarted, this I/O is unnecessary. You can avoid racing the clock by
 <<cluster-routing-allocation-enable,disabling allocation>> of replicas before
-shutting down the node:
+shutting down <<data-node,data nodes>>:
 
 [source,console]
 --------------------------------------------------

--- a/docs/reference/upgrade/rolling_upgrade.asciidoc
+++ b/docs/reference/upgrade/rolling_upgrade.asciidoc
@@ -122,8 +122,9 @@ GET _cat/nodes
 +
 --
 
-Once the node has joined the cluster, remove the `cluster.routing.allocation.enable`
-setting to enable shard allocation and start using the node:
+For data nodes, once the node has joined the cluster, remove the
+`cluster.routing.allocation.enable` setting to enable shard allocation and start
+using the node:
 
 [source,console]
 --------------------------------------------------

--- a/docs/reference/upgrade/rolling_upgrade.asciidoc
+++ b/docs/reference/upgrade/rolling_upgrade.asciidoc
@@ -53,6 +53,7 @@ To perform a rolling upgrade to {version}:
 +
 --
 include::disable-shard-alloc.asciidoc[]
+This step is only necessary for <<data-node,data nodes>>.
 --
 
 . *Stop non-essential indexing and perform a flush.* (Optional)
@@ -103,7 +104,7 @@ a node.
 . If you use {es} {security-features} to define realms, verify that your realm
 settings are up-to-date. The format of realm settings changed in version 7.0, in
 particular, the placement of the realm type changed. See
-<<realm-settings,Realm settings>>. 
+<<realm-settings,Realm settings>>.
 
 . *Start the upgraded node.*
 +

--- a/docs/reference/upgrade/rolling_upgrade.asciidoc
+++ b/docs/reference/upgrade/rolling_upgrade.asciidoc
@@ -53,7 +53,6 @@ To perform a rolling upgrade to {version}:
 +
 --
 include::disable-shard-alloc.asciidoc[]
-This step is only necessary for <<data-node,data nodes>>.
 --
 
 . *Stop non-essential indexing and perform a flush.* (Optional)


### PR DESCRIPTION
When doing a rolling restart we recommend disabling shard allocation to
avoid unnecessary recoveries. However, this advise is unnecessary or
even harmful when restarting nodes that do not carry any data like a
pure ML node.
