### PR TITLE
[DOCS] Update id for service account redirect

### DIFF
--- a/docs/reference/redirects.asciidoc
+++ b/docs/reference/redirects.asciidoc
@@ -16,13 +16,18 @@ See <<security-api,Security APIs>>.
 
 See <<security-api,Security APIs>>.
 
-[role="exclude",id="security-api-delete-service-tokens"]
+[role="exclude",id="security-api-delete-service-token"]
 === Delete service account tokens
 
 See <<security-api,Security APIs>>.
 
 [role="exclude",id="security-api-clear-service-token-caches"]
 === Clear service account token caches
+
+See <<security-api,Security APIs>>.
+
+[role="exclude",id="security-api-create-service-token"]
+=== Create service account tokens
 
 See <<security-api,Security APIs>>.
 

--- a/docs/reference/redirects.asciidoc
+++ b/docs/reference/redirects.asciidoc
@@ -31,11 +31,6 @@ See <<security-api,Security APIs>>.
 
 See <<security-api,Security APIs>>.
 
-[role="exclude",id="security-api-create-service-token"]
-=== Create service account tokens
-
-See <<security-api,Security APIs>>.
-
 // [END] Service account redirects
 
 // [START] Security redirects


### PR DESCRIPTION
Fixes `id` for service account redirect causing failures in the CI build: https://elasticsearch-ci.elastic.co/job/elastic+docs+master+build/3869/console