### PR TITLE
Provide Facility to Read a Paged BytesReference From StreamInput

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/io/stream/DelayableWriteable.java
+++ b/server/src/main/java/org/elasticsearch/common/io/stream/DelayableWriteable.java
@@ -46,7 +46,9 @@ public abstract class DelayableWriteable<T extends Writeable> implements Writeab
      * when {@link #expand()} is called.
      */
     public static <T extends Writeable> DelayableWriteable<T> delayed(Writeable.Reader<T> reader, StreamInput in) throws IOException {
-        return new Serialized<>(reader, in.getVersion(), in.namedWriteableRegistry(), in.readBytesReference());
+        // TODO: the BytesReference read here can be very large => we should move to not copying the bytes by using
+        //       in.readReleasableBytesReference instead
+        return new Serialized<>(reader, in.getVersion(), in.namedWriteableRegistry(), in.readLargeBytesReference());
     }
 
     private DelayableWriteable() {}


### PR DESCRIPTION
In case of large allocations the bytes reference read in the adjusted spot
in `DelayableWritable` could grow to `O(100M)` which isn't a `byte[]` we should
allocate contiguously.
This provides the facility to read into a compound bytes reference.

This commit specifically does not adjust the normal path to reading `BytesReference`
even though it may seem desirable to generally start paging above a certain size.
This is because the existing `readBytesReference` method is used for reading indexing
requests which implicitly rely on the fact that a `ByteArray` is read here for
performance (see `SourceToParse` which currently 0-copies these references but
wouldn't do so for a compound reference).
