### PR TITLE
[DOCS] Fix search template API path params

### DIFF
--- a/docs/reference/search/search-template.asciidoc
+++ b/docs/reference/search/search-template.asciidoc
@@ -7,8 +7,8 @@
 Allows you to use the mustache language to pre render search requests.
 
 [source,console]
-------------------------------------------
-GET my-index-000001/_search/template
+----
+GET my-index/_search/template
 {
   "source" : {
     "query": { "match" : { "{{my_field}}" : "{{my_value}}" } },
@@ -20,8 +20,8 @@ GET my-index-000001/_search/template
     "my_size" : 5
   }
 }
-------------------------------------------
-// TEST[setup:my_index]
+----
+// TEST[s/^/PUT my-index\n/]
 
 [[search-template-api-request]]
 ==== {api-request-title}

--- a/docs/reference/search/search-template.asciidoc
+++ b/docs/reference/search/search-template.asciidoc
@@ -8,7 +8,7 @@ Allows you to use the mustache language to pre render search requests.
 
 [source,console]
 ------------------------------------------
-GET _search/template
+GET my-index-000001/_search/template
 {
   "source" : {
     "query": { "match" : { "{{my_field}}" : "{{my_value}}" } },
@@ -27,6 +27,12 @@ GET _search/template
 ==== {api-request-title}
 
 `GET _search/template`
+
+`GET <target>/_search/template`
+
+`POST _search/template`
+
+`POST <target>/_search/template`
 
 [[search-template-api-prereqs]]
 ==== {api-prereq-title}
@@ -55,8 +61,13 @@ per type and context as described in the
 [[search-template-api-path-params]]
 ==== {api-path-parms-title}
 
-include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=index]
-
+`<target>`::
+(Optional, string)
+Comma-separated list of data streams, indices, and index aliases to search.
+Supports wildcards (`*`).
++
+To search all data streams and indices in a cluster, omit this parameter or use
+`_all` or `*`.
 
 [[search-template-api-query-params]]
 ==== {api-query-parms-title}

--- a/docs/reference/search/search-template.asciidoc
+++ b/docs/reference/search/search-template.asciidoc
@@ -8,7 +8,7 @@ Allows you to use the mustache language to pre render search requests.
 
 [source,console]
 ------------------------------------------
-GET my-index-000001/_search/template
+GET _search/template
 {
   "source" : {
     "query": { "match" : { "{{my_field}}" : "{{my_value}}" } },

--- a/docs/reference/search/search-template.asciidoc
+++ b/docs/reference/search/search-template.asciidoc
@@ -7,8 +7,8 @@
 Allows you to use the mustache language to pre render search requests.
 
 [source,console]
-----
-GET my-index/_search/template
+------------------------------------------
+GET my-index-000001/_search/template
 {
   "source" : {
     "query": { "match" : { "{{my_field}}" : "{{my_value}}" } },
@@ -20,8 +20,8 @@ GET my-index/_search/template
     "my_size" : 5
   }
 }
-----
-// TEST[s/^/PUT my-index\n/]
+------------------------------------------
+// TEST[setup:my_index]
 
 [[search-template-api-request]]
 ==== {api-request-title}


### PR DESCRIPTION
Changes:

* Includes all supported request paths
* Updates the `<index>` path parameter to `<target>` to indicate data stream and index support