### PR TITLE
[Test] Add match for new error message from zulu jdk (#72223)

### DIFF
--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/transport/nio/SSLDriverTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/transport/nio/SSLDriverTests.java
@@ -166,7 +166,8 @@ public class SSLDriverTests extends ESTestCase {
 
         final String[] serverProtocols;
         final String[] clientProtocols;
-        final Matcher expectedMessageMatcher;
+        final Matcher<String> expectedMessageMatcher;
+        final boolean inZuluJvm = System.getProperty("java.vendor", "").contains("Azul");
         if (inFipsJvm()) {
             // fips JSSE does not support TLSv1.3 yet
             serverProtocols = new String[]{"TLSv1.2"};
@@ -182,8 +183,13 @@ public class SSLDriverTests extends ESTestCase {
         } else {
             serverProtocols = new String[]{"TLSv1.2"};
             clientProtocols = new String[]{"TLSv1.1"};
-            expectedMessageMatcher = anyOf(is("The client supported protocol versions [TLSv1.1] are not accepted by server preferences " +
-                    "[TLS12]"), is("Client requested protocol TLSv1.1 not enabled or not supported"));
+            if (inZuluJvm) {
+                expectedMessageMatcher = is("No appropriate protocol (protocol is disabled or cipher suites are inappropriate)");
+            } else {
+                expectedMessageMatcher = anyOf(
+                    is("The client supported protocol versions [TLSv1.1] are not accepted by server preferences [TLS12]"),
+                    is("Client requested protocol TLSv1.1 not enabled or not supported"));
+            }
         }
 
         serverEngine.setEnabledProtocols(serverProtocols);
@@ -196,8 +202,17 @@ public class SSLDriverTests extends ESTestCase {
 
         // Prior to JDK11 we still need to send a close alert
         if (serverDriver.isClosed() == false) {
-            failedCloseAlert(serverDriver, clientDriver, Arrays.asList("Received fatal alert: protocol_version",
-                "Received fatal alert: handshake_failure"));
+            if (false == inFipsJvm() && inZuluJvm && false == serverDriver.getOutboundBuffer().hasEncryptedBytesToFlush()) {
+                serverDriver.getSSLEngine().closeInbound();
+                serverDriver.getSSLEngine().closeOutbound();
+                serverDriver.close();;
+                assertTrue(serverDriver.isClosed());
+                clientDriver.close();
+                assertTrue(clientDriver.isClosed());
+            } else {
+                failedCloseAlert(serverDriver, clientDriver, Arrays.asList("Received fatal alert: protocol_version",
+                    "Received fatal alert: handshake_failure"));
+            }
         }
     }
 


### PR DESCRIPTION
Azul backported JDK-8196584 to Zulu JDK 8+. This changed the error message for TLSv1.1.
This PR adds a new match for the new error message specifically for Zulu JDK.
