### PR TITLE
[7.x] [Transform] Make transform _stats work again, even if there are no transform nodes (#72221)

### DIFF
--- a/x-pack/plugin/transform/src/internalClusterTest/java/org/elasticsearch/xpack/transform/integration/TransformNoTransformNodeIT.java
+++ b/x-pack/plugin/transform/src/internalClusterTest/java/org/elasticsearch/xpack/transform/integration/TransformNoTransformNodeIT.java
@@ -23,6 +23,7 @@ import org.elasticsearch.xpack.core.transform.transforms.TransformConfigUpdate;
 import org.elasticsearch.xpack.core.transform.transforms.pivot.PivotConfigTests;
 import org.elasticsearch.xpack.transform.TransformSingleNodeTestCase;
 
+import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 
@@ -34,13 +35,8 @@ public class TransformNoTransformNodeIT extends TransformSingleNodeTestCase {
 
     public void testGetTransformStats() {
         GetTransformStatsAction.Request request = new GetTransformStatsAction.Request("_all");
-        ElasticsearchStatusException e =
-            expectThrows(
-                ElasticsearchStatusException.class,
-                () -> client().execute(GetTransformStatsAction.INSTANCE, request).actionGet());
-        assertThat(
-            e.getMessage(),
-            is(equalTo("Transform requires the transform node role for at least 1 node, found no transform nodes")));
+        GetTransformStatsAction.Response response = client().execute(GetTransformStatsAction.INSTANCE, request).actionGet();
+        assertThat(response.getTransformsStats(), is(empty()));
 
         assertWarnings("Transform requires the transform node role for at least 1 node, found no transform nodes");
     }
@@ -48,7 +44,7 @@ public class TransformNoTransformNodeIT extends TransformSingleNodeTestCase {
     public void testGetTransform() {
         GetTransformAction.Request request = new GetTransformAction.Request("_all");
         GetTransformAction.Response response = client().execute(GetTransformAction.INSTANCE, request).actionGet();
-        assertEquals(0, response.getTransformConfigurations().size());
+        assertThat(response.getTransformConfigurations(), is(empty()));
 
         assertWarnings("Transform requires the transform node role for at least 1 node, found no transform nodes");
     }

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportGetTransformStatsAction.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportGetTransformStatsAction.java
@@ -147,9 +147,9 @@ public class TransportGetTransformStatsAction extends TransportTasksAction<Trans
             request.getPageParams(),
             request.isAllowNoMatch(),
             ActionListener.wrap(hitsAndIds -> {
-                TransformNodes.throwIfNoTransformNodes(clusterState);
+                boolean hasAnyTransformNode = TransformNodes.hasAnyTransformNode(clusterState.getNodes());
                 boolean requiresRemote = hitsAndIds.v2().v2().stream().anyMatch(config -> config.getSource().requiresRemoteCluster());
-                if (TransformNodes.redirectToAnotherNodeIfNeeded(
+                if (hasAnyTransformNode && TransformNodes.redirectToAnotherNodeIfNeeded(
                         clusterState, nodeSettings, requiresRemote, transportService, actionName, request, Response::new, finalListener)) {
                     return;
                 }

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/TransformNodes.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/TransformNodes.java
@@ -141,13 +141,12 @@ public final class TransformNodes {
     /**
      * Get the number of transform nodes in the cluster
      *
-     * @param clusterState state
+     * @param nodes nodes to examine
      * @return number of transform nodes
      */
-    public static long getNumberOfTransformNodes(ClusterState clusterState) {
-        return StreamSupport.stream(clusterState.getNodes().spliterator(), false)
-            .filter(node -> node.getRoles().contains(Transform.TRANSFORM_ROLE))
-            .count();
+    public static boolean hasAnyTransformNode(DiscoveryNodes nodes) {
+        return StreamSupport.stream(nodes.spliterator(), false)
+            .anyMatch(node -> node.getRoles().contains(Transform.TRANSFORM_ROLE));
     }
 
     /**
@@ -160,8 +159,7 @@ public final class TransformNodes {
      */
     public static void warnIfNoTransformNodes(ClusterState clusterState) {
         if (TransformMetadata.getTransformMetadata(clusterState).isResetMode() == false) {
-            long transformNodes = getNumberOfTransformNodes(clusterState);
-            if (transformNodes == 0) {
+            if (hasAnyTransformNode(clusterState.getNodes()) == false) {
                 HeaderWarning.addWarning(TransformMessages.REST_WARN_NO_TRANSFORM_NODES);
             }
         }
@@ -174,8 +172,7 @@ public final class TransformNodes {
      * @param clusterState state
      */
     public static void throwIfNoTransformNodes(ClusterState clusterState) {
-        long transformNodes = getNumberOfTransformNodes(clusterState);
-        if (transformNodes == 0) {
+        if (hasAnyTransformNode(clusterState.getNodes()) == false) {
             throw ExceptionsHelper.badRequestException(TransformMessages.REST_WARN_NO_TRANSFORM_NODES);
         }
     }


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [Transform] Make transform _stats work again, even if there are no transform nodes  (#72221)