### PR TITLE
[GeoShape] Grid aggregations with bounds should exclude touching tiles

### DIFF
--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/search/aggregations/bucket/geogrid/AbstractGeoTileGridTiler.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/search/aggregations/bucket/geogrid/AbstractGeoTileGridTiler.java
@@ -173,18 +173,4 @@ abstract class AbstractGeoTileGridTiler extends GeoGridTiler {
         }
         return valuesIndex;
     }
-
-    /**
-     * Return the number of tiles contained in the provided bounding box at the given zoom level
-     */
-    protected static long numTilesFromPrecision(int zoom, double minX, double maxX, double minY, double maxY) {
-        final long tiles = 1L << zoom;
-        final double xDeltaPrecision = 360.0 / (10 * tiles);
-        final double yHalfPrecision = 180.0 / (10 * tiles);
-        final int minXTile = GeoTileUtils.getXTile(Math.max(-180, minX - xDeltaPrecision), tiles);
-        final int minYTile = GeoTileUtils.getYTile(maxY + yHalfPrecision, tiles);
-        final int maxXTile = GeoTileUtils.getXTile(Math.min(180, maxX + xDeltaPrecision), tiles);
-        final int maxYTile = GeoTileUtils.getYTile(minY - yHalfPrecision, tiles);
-        return (long) (maxXTile - minXTile + 1) * (maxYTile - minYTile + 1);
-    }
 }

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/search/aggregations/bucket/geogrid/BoundedGeoHashGridTiler.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/search/aggregations/bucket/geogrid/BoundedGeoHashGridTiler.java
@@ -26,12 +26,13 @@ public class BoundedGeoHashGridTiler extends AbstractGeoHashGridTiler {
 
     @Override
     protected boolean validHash(String hash) {
-        Rectangle rectangle = Geohash.toBoundingBox(hash);
-        if (bbox.top() >= rectangle.getMinY() && bbox.bottom() <= rectangle.getMaxY()) {
+        final Rectangle rectangle = Geohash.toBoundingBox(hash);
+        // touching hashes are excluded
+        if (bbox.top() > rectangle.getMinY() && bbox.bottom() < rectangle.getMaxY()) {
             if (crossesDateline) {
-                return bbox.left() <= rectangle.getMaxX() || bbox.right() >= rectangle.getMinX();
+                return bbox.left() < rectangle.getMaxX() || bbox.right() > rectangle.getMinX();
             } else {
-                return bbox.left() <= rectangle.getMaxX() && bbox.right() >= rectangle.getMinX();
+                return bbox.left() < rectangle.getMaxX() && bbox.right() > rectangle.getMinX();
             }
         }
         return false;

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/search/aggregations/bucket/geogrid/BoundedGeoTileGridTiler.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/search/aggregations/bucket/geogrid/BoundedGeoTileGridTiler.java
@@ -16,31 +16,45 @@ import org.elasticsearch.search.aggregations.bucket.geogrid.GeoTileUtils;
  * Bounded geotile aggregation. It accepts tiles that intersects the provided bounds.
  */
 public class BoundedGeoTileGridTiler extends AbstractGeoTileGridTiler {
-    private final GeoBoundingBox bbox;
     private final boolean crossesDateline;
     private final long maxTiles;
+    private final int minX, maxX, minY, maxY;
 
     public BoundedGeoTileGridTiler(int precision, GeoBoundingBox bbox) {
         super(precision);
-        this.bbox = bbox;
         this.crossesDateline = bbox.right() < bbox.left();
+        // compute minX, minY
+        final int minX = GeoTileUtils.getXTile(bbox.left(), this.tiles);
+        final int minY = GeoTileUtils.getYTile(bbox.top(), this.tiles);
+        final Rectangle minTile = GeoTileUtils.toBoundingBox(minX, minY, precision);
+        // touching tiles are excluded, they need to share at least one interior point
+        this.minX = minTile.getMaxX() == bbox.left() ? minX + 1: minX;
+        this.minY = minTile.getMinY() == bbox.top() ? minY + 1 : minY;
+        // compute maxX, maxY
+        final int maxX = GeoTileUtils.getXTile(bbox.right(), this.tiles);
+        final int maxY = GeoTileUtils.getYTile(bbox.bottom(), this.tiles);
+        final Rectangle maxTile = GeoTileUtils.toBoundingBox(maxX, maxY, precision);
+        // touching tiles are excluded, they need to share at least one interior point
+        this.maxX = maxTile.getMinX() == bbox.right() ? maxX - 1 : maxX;
+        this.maxY = maxTile.getMaxY() == bbox.bottom() ? maxY - 1 : maxY;
         if (crossesDateline) {
-            maxTiles =  numTilesFromPrecision(precision, bbox.left(), 180, bbox.bottom(), bbox.top())
-                + numTilesFromPrecision(precision, -180, bbox.right(), bbox.bottom(), bbox.top());
-
+            this.maxTiles = (tiles + this.maxX - this.minX + 1) * (this.maxY - this.minY + 1);
         } else {
-            maxTiles = numTilesFromPrecision(precision, bbox.left(), bbox.right(), bbox.bottom(), bbox.top());
+            this.maxTiles = (long) (this.maxX - this.minX + 1) * (this.maxY - this.minY + 1);
         }
     }
 
     @Override
     protected boolean validTile(int x, int y, int z) {
-        Rectangle rectangle = GeoTileUtils.toBoundingBox(x, y, z);
-        if (bbox.top() >= rectangle.getMinY() && bbox.bottom() <= rectangle.getMaxY()) {
+        // compute number of splits at precision
+        final int splits = 1 << precision - z;
+        final int yMin = y * splits;
+        if (maxY >= yMin && minY < yMin + splits) {
+            final int xMin = x * splits;
             if (crossesDateline) {
-                return bbox.left() <= rectangle.getMaxX() || bbox.right() >= rectangle.getMinX();
+                return maxX >= xMin || minX < xMin + splits;
             } else {
-                return bbox.left() <= rectangle.getMaxX() && bbox.right() >= rectangle.getMinX();
+                return maxX >= xMin && minX < xMin + splits;
             }
         }
         return false;

--- a/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/search/aggregations/bucket/geogrid/GeoShapeGeoGridTestCase.java
+++ b/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/search/aggregations/bucket/geogrid/GeoShapeGeoGridTestCase.java
@@ -191,9 +191,9 @@ public abstract class GeoShapeGeoGridTestCase<T extends InternalGeoGridBucket<T>
 
             GeoShapeValues.GeoShapeValue value = geoShapeValue(p);
             GeoRelation tileRelation =  value.relate(pointTile);
-            boolean intersectsBounds = boundsTop >= pointTile.getMinY() && boundsBottom <= pointTile.getMaxY()
-                && (boundsEastLeft <= pointTile.getMaxX() && boundsEastRight >= pointTile.getMinX()
-                || (crossesDateline && boundsWestLeft <= pointTile.getMaxX() && boundsWestRight >= pointTile.getMinX()));
+            boolean intersectsBounds = boundsTop > pointTile.getMinY() && boundsBottom < pointTile.getMaxY()
+                && (boundsEastLeft < pointTile.getMaxX() && boundsEastRight > pointTile.getMinX()
+                || (crossesDateline && boundsWestLeft < pointTile.getMaxX() && boundsWestRight > pointTile.getMinX()));
             if (tileRelation != GeoRelation.QUERY_DISJOINT && intersectsBounds) {
                 numDocsWithin += 1;
             }


### PR DESCRIPTION
When using grid aggregations, users can add bounds to it to limit the number of buckets the aggregation can generate.  For example:

```
{
  "aggregations": {
    "tiles-in-bounds": {
      "geotile_grid": {
        "field": "location",
        "precision": 12,
        "bounds": {
          "top_left": "72.60712040027555, 42.1875,
          "bottom_right": "72.3957057065326, 42.890625"
        }
      }
    }
  }
}

```

The example above the bonus correspond to the bounds for tile 9/316/103. Therefore what I would expect is that the aggregation above can generate up to 64 buckets as the difference between the bounds zoom (9) and the aggregation precision(12) is 3. 

At the moment the aggregation might generate more buckets as it will include touching tiles. I think this behaviour is not correct and bounds should only include tiles that has at least one interior point in common.  Therefore I set this PR as a bug fix.
