### PR TITLE
Remove Redundant ClusterService#submitStateUpdateTask Overload

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/service/ClusterApplierService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/service/ClusterApplierService.java
@@ -323,7 +323,7 @@ public class ClusterApplierService extends AbstractLifecycleComponent implements
         try (ThreadContext.StoredContext ignore = threadContext.stashContext()) {
             threadContext.markAsSystemContext();
             final UpdateTask updateTask = new UpdateTask(config.priority(), source,
-                new SafeClusterApplyListener(listener, supplier, logger), executor);
+                new SafeClusterApplyListener(listener, supplier), executor);
             if (config.timeout() != null) {
                 threadPoolExecutor.execute(updateTask, config.timeout(),
                     () -> threadPool.generic().execute(
@@ -517,12 +517,10 @@ public class ClusterApplierService extends AbstractLifecycleComponent implements
     private static class SafeClusterApplyListener implements ClusterApplyListener {
         private final ClusterApplyListener listener;
         protected final Supplier<ThreadContext.StoredContext> context;
-        private final Logger logger;
 
-        SafeClusterApplyListener(ClusterApplyListener listener, Supplier<ThreadContext.StoredContext> context, Logger logger) {
+        SafeClusterApplyListener(ClusterApplyListener listener, Supplier<ThreadContext.StoredContext> context) {
             this.listener = listener;
             this.context = context;
-            this.logger = logger;
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/cluster/service/ClusterService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/service/ClusterService.java
@@ -29,7 +29,6 @@ import org.elasticsearch.node.Node;
 import org.elasticsearch.threadpool.ThreadPool;
 
 import java.util.Collections;
-import java.util.Map;
 
 public class ClusterService extends AbstractLifecycleComponent {
     private final MasterService masterService;
@@ -249,25 +248,6 @@ public class ClusterService extends AbstractLifecycleComponent {
                                           ClusterStateTaskConfig config,
                                           ClusterStateTaskExecutor<T> executor,
                                           ClusterStateTaskListener listener) {
-        submitStateUpdateTasks(source, Collections.singletonMap(task, listener), config, executor);
-    }
-
-    /**
-     * Submits a batch of cluster state update tasks; submitted updates are guaranteed to be processed together,
-     * potentially with more tasks of the same executor.
-     *
-     * @param source   the source of the cluster state update task
-     * @param tasks    a map of update tasks and their corresponding listeners
-     * @param config   the cluster state update task configuration
-     * @param executor the cluster state update task executor; tasks
-     *                 that share the same executor will be executed
-     *                 batches on this executor
-     * @param <T>      the type of the cluster state update task state
-     *
-     */
-    public <T> void submitStateUpdateTasks(final String source,
-                                           final Map<T, ClusterStateTaskListener> tasks, final ClusterStateTaskConfig config,
-                                           final ClusterStateTaskExecutor<T> executor) {
-        masterService.submitStateUpdateTasks(source, tasks, config, executor);
+        masterService.submitStateUpdateTasks(source, Collections.singletonMap(task, listener), config, executor);
     }
 }

--- a/server/src/main/java/org/elasticsearch/cluster/service/PendingClusterTask.java
+++ b/server/src/main/java/org/elasticsearch/cluster/service/PendingClusterTask.java
@@ -19,11 +19,11 @@ import java.io.IOException;
 
 public class PendingClusterTask implements Writeable {
 
-    private long insertOrder;
-    private Priority priority;
-    private Text source;
-    private long timeInQueue;
-    private boolean executing;
+    private final long insertOrder;
+    private final Priority priority;
+    private final Text source;
+    private final long timeInQueue;
+    private final boolean executing;
 
     public PendingClusterTask(StreamInput in) throws IOException {
         insertOrder = in.readVLong();


### PR DESCRIPTION
Two versions of `#submitStateUpdateTask` are enough to confuse people, no need
for a third unused one. (+ some other minor cleanup)
