### PR TITLE
Fix Tripped Assertion on Throw in RestActionListener

### DIFF
--- a/server/src/main/java/org/elasticsearch/rest/AbstractRestChannel.java
+++ b/server/src/main/java/org/elasticsearch/rest/AbstractRestChannel.java
@@ -68,6 +68,8 @@ public abstract class AbstractRestChannel implements RestChannel {
 
     @Override
     public XContentBuilder newErrorBuilder() throws IOException {
+        // release whatever output we already buffered and write error response to fresh buffer
+        releaseOutputBuffer();
         // Disable filtering when building error responses
         return newBuilder(request.getXContentType(), false);
     }


### PR DESCRIPTION
Follow up to #72274. If we throw inside the response handler,
we move from a normal (already instantiated builder+buffer) to a new
error builder so we have to release the buffer first to not trip the assertion.

non issue as this hasn't reached a realease yet.