### PR TITLE
EQL: Use the implicit tiebreaker sort value in the search queries (#72089)

### DIFF
--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/execution/assembler/ExecutionManager.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/execution/assembler/ExecutionManager.java
@@ -15,6 +15,7 @@ import org.elasticsearch.xpack.eql.execution.search.PITAwareQueryClient;
 import org.elasticsearch.xpack.eql.execution.search.QueryRequest;
 import org.elasticsearch.xpack.eql.execution.search.RuntimeUtils;
 import org.elasticsearch.xpack.eql.execution.search.extractor.FieldHitExtractor;
+import org.elasticsearch.xpack.eql.execution.search.extractor.ImplicitTiebreakerHitExtractor;
 import org.elasticsearch.xpack.eql.execution.search.extractor.TimestampFieldHitExtractor;
 import org.elasticsearch.xpack.eql.execution.sequence.SequenceMatcher;
 import org.elasticsearch.xpack.eql.execution.sequence.TumblingWindow;
@@ -59,6 +60,8 @@ public class ExecutionManager {
         // fields
         HitExtractor tsExtractor = timestampExtractor(hitExtractor(timestamp, extractorRegistry));
         HitExtractor tbExtractor = Expressions.isPresent(tiebreaker) ? hitExtractor(tiebreaker, extractorRegistry) : null;
+        // implicit tiebreake, present only in the response and which doesn't have a corresponding field
+        HitExtractor itbExtractor = ImplicitTiebreakerHitExtractor.INSTANCE;
         // NB: since there's no aliasing inside EQL, the attribute name is the same as the underlying field name
         String timestampName = Expressions.name(timestamp);
 
@@ -93,7 +96,7 @@ public class ExecutionManager {
                 QueryRequest original = () -> source;
                 BoxedQueryRequest boxedRequest = new BoxedQueryRequest(original, timestampName, keyFields);
                 Criterion<BoxedQueryRequest> criterion =
-                        new Criterion<>(i, boxedRequest, keyExtractors, tsExtractor, tbExtractor, i == 0 && descending);
+                        new Criterion<>(i, boxedRequest, keyExtractors, tsExtractor, tbExtractor, itbExtractor, i == 0 && descending);
                 criteria.add(criterion);
             } else {
                 // until

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/execution/search/Ordinal.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/execution/search/Ordinal.java
@@ -13,10 +13,12 @@ public class Ordinal implements Comparable<Ordinal> {
 
     private final long timestamp;
     private final Comparable<Object> tiebreaker;
+    private final long implicitTiebreaker; // _shard_doc tiebreaker automatically added by ES PIT
 
-    public Ordinal(long timestamp, Comparable<Object> tiebreaker) {
+    public Ordinal(long timestamp, Comparable<Object> tiebreaker, long implicitTiebreaker) {
         this.timestamp = timestamp;
         this.tiebreaker = tiebreaker;
+        this.implicitTiebreaker = implicitTiebreaker;
     }
 
     public long timestamp() {
@@ -27,9 +29,13 @@ public class Ordinal implements Comparable<Ordinal> {
         return tiebreaker;
     }
 
+    public long implicitTiebreaker() {
+        return implicitTiebreaker;
+    }
+
     @Override
     public int hashCode() {
-        return Objects.hash(timestamp, tiebreaker);
+        return Objects.hash(timestamp, tiebreaker, implicitTiebreaker);
     }
 
     @Override
@@ -44,12 +50,13 @@ public class Ordinal implements Comparable<Ordinal> {
 
         Ordinal other = (Ordinal) obj;
         return Objects.equals(timestamp, other.timestamp)
-                && Objects.equals(tiebreaker, other.tiebreaker);
+                && Objects.equals(tiebreaker, other.tiebreaker)
+                && Objects.equals(implicitTiebreaker, other.implicitTiebreaker);
     }
 
     @Override
     public String toString() {
-        return "[" + timestamp + "][" + (tiebreaker != null ? tiebreaker.toString() : "") + "]";
+        return "[" + timestamp + "][" + (tiebreaker != null ? tiebreaker.toString() : "") + "][" + implicitTiebreaker + "]";
     }
 
     @Override
@@ -59,8 +66,14 @@ public class Ordinal implements Comparable<Ordinal> {
         }
         if (timestamp == o.timestamp) {
             if (tiebreaker != null) {
-                // if the other tiebreaker is null, it is higher (nulls are last)
-                return o.tiebreaker != null ? tiebreaker.compareTo(o.tiebreaker) : -1;
+                if (o.tiebreaker != null) {
+                    if (tiebreaker.compareTo(o.tiebreaker) == 0) {
+                        return Long.compare(implicitTiebreaker, o.implicitTiebreaker);
+                    }
+                    return tiebreaker.compareTo(o.tiebreaker);
+                } else {
+                    return -1;
+                }
             }
             // this tiebreaker is null
             else {
@@ -68,7 +81,7 @@ public class Ordinal implements Comparable<Ordinal> {
                 // this ordinal is greater (after) then the other tiebreaker
                 // so fall through to 1
                 if (o.tiebreaker == null) {
-                    return 0;
+                    return Long.compare(implicitTiebreaker, o.implicitTiebreaker);
                 }
             }
         }
@@ -97,6 +110,8 @@ public class Ordinal implements Comparable<Ordinal> {
     }
 
     public Object[] toArray() {
-        return tiebreaker != null ? new Object[] { timestamp, tiebreaker } : new Object[] { timestamp };
+        return tiebreaker != null ?
+            new Object[] { timestamp, tiebreaker, implicitTiebreaker } 
+            : new Object[] { timestamp, implicitTiebreaker };
     }
 }

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/execution/search/extractor/ImplicitTiebreakerHitExtractor.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/execution/search/extractor/ImplicitTiebreakerHitExtractor.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+package org.elasticsearch.xpack.eql.execution.search.extractor;
+
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.search.SearchHit;
+import org.elasticsearch.xpack.eql.EqlIllegalArgumentException;
+import org.elasticsearch.xpack.ql.execution.search.extractor.HitExtractor;
+
+import java.io.IOException;
+
+/**
+ * Returns the implicit Elasticsearch tiebreaker value associated with a PIT request for every search hit against which it is run.
+ */
+public class ImplicitTiebreakerHitExtractor implements HitExtractor {
+
+    public static final HitExtractor INSTANCE = new ImplicitTiebreakerHitExtractor();
+    static final String NAME = "tb";
+
+    private ImplicitTiebreakerHitExtractor() {}
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException { }
+
+    @Override
+    public String getWriteableName() {
+        return NAME;
+    }
+
+    @Override
+    public Object extract(SearchHit hit) {
+        Object[] sortValues = hit.getRawSortValues();
+        if (sortValues.length == 0) {
+            throw new EqlIllegalArgumentException("Expected at least one sorting value in the search hit, but got none");
+        }
+        return sortValues[sortValues.length - 1];
+    }
+
+    @Override
+    public String hitName() {
+        return null;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == null || obj.getClass() != getClass()) {
+            return false;
+        }
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        return ImplicitTiebreakerHitExtractor.class.hashCode();
+    }
+
+    @Override
+    public String toString() {
+        return "_shard_doc";
+    }
+}

--- a/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/EqlTestUtils.java
+++ b/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/EqlTestUtils.java
@@ -10,6 +10,8 @@ package org.elasticsearch.xpack.eql;
 import org.elasticsearch.Version;
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.common.unit.TimeValue;
+import org.elasticsearch.search.DocValueFormat;
+import org.elasticsearch.search.SearchSortValues;
 import org.elasticsearch.tasks.TaskId;
 import org.elasticsearch.xpack.core.async.AsyncExecutionId;
 import org.elasticsearch.xpack.eql.action.EqlSearchAction;
@@ -73,5 +75,24 @@ public final class EqlTestUtils {
     public static IndicesOptions randomIndicesOptions() {
         return IndicesOptions.fromOptions(randomBoolean(), randomBoolean(), randomBoolean(), randomBoolean(), randomBoolean(),
             randomBoolean(), randomBoolean(), randomBoolean(), randomBoolean());
+    }
+
+    public static SearchSortValues randomSearchSortValues(Object[] values) {
+        DocValueFormat[] sortValueFormats = new DocValueFormat[values.length];
+        for (int i = 0; i < values.length; i++) {
+            sortValueFormats[i] = DocValueFormat.RAW;
+        }
+        return new SearchSortValues(values, sortValueFormats);
+    }
+
+    public static SearchSortValues randomSearchLongSortValues() {
+        int size = randomIntBetween(1, 20);
+        Object[] values = new Object[size];
+        DocValueFormat[] sortValueFormats = new DocValueFormat[size];
+        for (int i = 0; i < size; i++) {
+            values[i] = randomLong();
+            sortValueFormats[i] = DocValueFormat.RAW;
+        }
+        return new SearchSortValues(values, sortValueFormats);
     }
 }

--- a/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/execution/assembler/ImplicitTiebreakerTests.java
+++ b/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/execution/assembler/ImplicitTiebreakerTests.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.eql.execution.assembler;
+
+import org.apache.lucene.search.TotalHits;
+import org.apache.lucene.search.TotalHits.Relation;
+import org.elasticsearch.ExceptionsHelper;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.action.search.SearchResponse.Clusters;
+import org.elasticsearch.action.search.SearchResponseSections;
+import org.elasticsearch.common.text.Text;
+import org.elasticsearch.common.unit.TimeValue;
+import org.elasticsearch.search.DocValueFormat;
+import org.elasticsearch.search.SearchHit;
+import org.elasticsearch.search.SearchHits;
+import org.elasticsearch.search.SearchSortValues;
+import org.elasticsearch.search.builder.SearchSourceBuilder;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.eql.execution.assembler.SequenceSpecTests.TimestampExtractor;
+import org.elasticsearch.xpack.eql.execution.search.HitReference;
+import org.elasticsearch.xpack.eql.execution.search.QueryClient;
+import org.elasticsearch.xpack.eql.execution.search.QueryRequest;
+import org.elasticsearch.xpack.eql.execution.search.extractor.ImplicitTiebreakerHitExtractor;
+import org.elasticsearch.xpack.eql.execution.sequence.SequenceMatcher;
+import org.elasticsearch.xpack.eql.execution.sequence.TumblingWindow;
+import org.elasticsearch.xpack.ql.execution.search.extractor.HitExtractor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static java.util.Collections.emptyList;
+import static org.elasticsearch.action.ActionListener.wrap;
+import static org.elasticsearch.index.query.QueryBuilders.matchAllQuery;
+
+public class ImplicitTiebreakerTests extends ESTestCase {
+
+    private final List<HitExtractor> keyExtractors = emptyList();
+    private final HitExtractor tsExtractor = TimestampExtractor.INSTANCE;
+    private final HitExtractor tbExtractor = null;
+    private final HitExtractor implicitTbExtractor = ImplicitTiebreakerHitExtractor.INSTANCE;
+    private final List<Long> implicitTiebreakerValues;
+    private final int stages = randomIntBetween(3, 10);
+
+    public ImplicitTiebreakerTests() {
+        this.implicitTiebreakerValues = new ArrayList<>(stages);
+        for (int i = 0; i < stages; i++) {
+            implicitTiebreakerValues.add(randomLong());
+        }
+    }
+
+    class TestQueryClient implements QueryClient {
+
+        @Override
+        public void query(QueryRequest r, ActionListener<SearchResponse> l) {
+            int ordinal = r.searchSource().terminateAfter();
+            if (ordinal > 0) {
+                int previous = ordinal - 1;
+                // except the first request, the rest should have the previous response's search_after _shard_doc value
+                assertArrayEquals("Elements at stage " + ordinal + " do not match",
+                    r.searchSource().searchAfter(), new Object[] { (long) previous, implicitTiebreakerValues.get(previous) });
+            }
+
+            long sortValue = implicitTiebreakerValues.get(ordinal);
+            SearchHit searchHit = new SearchHit(ordinal, String.valueOf(ordinal), new Text("_doc"), null, null);
+            searchHit.sortValues(new SearchSortValues(
+                new Long[] { (long) ordinal, sortValue },
+                new DocValueFormat[] { DocValueFormat.RAW, DocValueFormat.RAW }));
+            SearchHits searchHits = new SearchHits(new SearchHit[] { searchHit }, new TotalHits(1, Relation.EQUAL_TO), 0.0f);
+            SearchResponseSections internal = new SearchResponseSections(searchHits, null, null, false, false, null, 0);
+            SearchResponse s = new SearchResponse(internal, null, 0, 1, 0, 0, null, Clusters.EMPTY);
+            l.onResponse(s);
+        }
+
+        @Override
+        public void fetchHits(Iterable<List<HitReference>> refs, ActionListener<List<List<SearchHit>>> listener) {
+            List<List<SearchHit>> searchHits = new ArrayList<>();
+            for (List<HitReference> ref : refs) {
+                List<SearchHit> hits = new ArrayList<>(ref.size());
+                for (HitReference hitRef : ref) {
+                    hits.add(new SearchHit(-1, hitRef.id(), new Text("_doc"), null, null));
+                }
+                searchHits.add(hits);
+            }
+            listener.onResponse(searchHits);
+        }
+    }
+
+    public void testImplicitTiebreakerBeingSet() {
+        QueryClient client = new TestQueryClient();
+        List<Criterion<BoxedQueryRequest>> criteria = new ArrayList<>(stages);
+        boolean descending = randomBoolean();
+        boolean criteriaDescending = descending;
+
+        for (int i = 0; i < stages; i++) {
+            final int j = i;
+            criteria.add(new Criterion<BoxedQueryRequest>(i,
+                new BoxedQueryRequest(() -> SearchSourceBuilder.searchSource()
+                    .size(10)
+                    .query(matchAllQuery())
+                    .terminateAfter(j), "@timestamp", emptyList()),
+                keyExtractors,
+                tsExtractor,
+                tbExtractor,
+                implicitTbExtractor,
+                criteriaDescending));
+            // for DESC (TAIL) sequences only the first criterion is descending the rest are ASC, so flip it after the first query
+            if (criteriaDescending && i == 0) {
+                criteriaDescending = false;
+            }
+        }
+
+        SequenceMatcher matcher = new SequenceMatcher(stages, descending, TimeValue.MINUS_ONE, null);
+        TumblingWindow window = new TumblingWindow(client, criteria, null, matcher);
+        window.execute(wrap(p -> {}, ex -> {
+            throw ExceptionsHelper.convertToRuntime(ex);
+        }));
+    }
+}

--- a/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/execution/assembler/SequenceSpecTests.java
+++ b/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/execution/assembler/SequenceSpecTests.java
@@ -60,6 +60,7 @@ public class SequenceSpecTests extends ESTestCase {
     private final List<HitExtractor> keyExtractors;
     private final HitExtractor tsExtractor;
     private final HitExtractor tbExtractor;
+    private final HitExtractor implicitTbExtractor;
 
     abstract static class EmptyHitExtractor implements HitExtractor {
         @Override
@@ -93,6 +94,15 @@ public class SequenceSpecTests extends ESTestCase {
         }
     }
 
+    static class ImplicitTbExtractor extends EmptyHitExtractor {
+        static final ImplicitTbExtractor INSTANCE = new ImplicitTbExtractor();
+        
+        @Override
+        public Long extract(SearchHit hit) {
+            return (long) hit.docId();
+        }
+    }
+
     class TestCriterion extends Criterion<BoxedQueryRequest> {
         private final int ordinal;
         private boolean unused = true;
@@ -106,7 +116,7 @@ public class SequenceSpecTests extends ESTestCase {
                       // pass the ordinal through terminate after
                       .terminateAfter(ordinal), "timestamp", emptyList()),
                   keyExtractors,
-                  tsExtractor, tbExtractor, false);
+                  tsExtractor, tbExtractor, implicitTbExtractor, false);
             this.ordinal = ordinal;
         }
 
@@ -212,6 +222,7 @@ public class SequenceSpecTests extends ESTestCase {
         this.keyExtractors = hasKeys ? singletonList(new KeyExtractor()) : emptyList();
         this.tsExtractor = TimestampExtractor.INSTANCE;
         this.tbExtractor = null;
+        this.implicitTbExtractor = ImplicitTbExtractor.INSTANCE;
     }
 
     @ParametersFactory(shuffle = false, argumentFormatting = PARAM_FORMATTING)

--- a/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/execution/search/CriterionOrdinalExtractionTests.java
+++ b/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/execution/search/CriterionOrdinalExtractionTests.java
@@ -11,21 +11,26 @@ import org.elasticsearch.common.document.DocumentField;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.text.Text;
 import org.elasticsearch.search.SearchHit;
+import org.elasticsearch.search.SearchSortValues;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.eql.EqlIllegalArgumentException;
 import org.elasticsearch.xpack.eql.execution.assembler.BoxedQueryRequest;
 import org.elasticsearch.xpack.eql.execution.assembler.Criterion;
 import org.elasticsearch.xpack.eql.execution.search.extractor.FieldHitExtractor;
+import org.elasticsearch.xpack.eql.execution.search.extractor.ImplicitTiebreakerHitExtractor;
 import org.elasticsearch.xpack.ql.execution.search.extractor.HitExtractor;
 import org.elasticsearch.xpack.ql.type.DataTypes;
 
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.function.Supplier;
 
 import static java.util.Collections.emptyList;
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.singletonList;
+import static org.elasticsearch.xpack.eql.EqlTestUtils.randomSearchLongSortValues;
+import static org.elasticsearch.xpack.eql.EqlTestUtils.randomSearchSortValues;
 
 public class CriterionOrdinalExtractionTests extends ESTestCase {
     private String tsField = "timestamp";
@@ -33,20 +38,25 @@ public class CriterionOrdinalExtractionTests extends ESTestCase {
 
     private HitExtractor tsExtractor = new FieldHitExtractor(tsField, DataTypes.LONG, null, null, false);
     private HitExtractor tbExtractor = new FieldHitExtractor(tbField, DataTypes.LONG, null, null, false);
+    private HitExtractor implicitTbExtractor = ImplicitTiebreakerHitExtractor.INSTANCE;
 
     public void testTimeOnly() throws Exception {
         long time = randomLong();
-        Ordinal ordinal = ordinal(searchHit(time, null), false);
+        long implicitTbValue = randomLong();
+        Ordinal ordinal = ordinal(searchHit(time, null, new Object[] { implicitTbValue }), false);
         assertEquals(time, ordinal.timestamp());
         assertNull(ordinal.tiebreaker());
+        assertEquals(implicitTbValue, ordinal.implicitTiebreaker());
     }
 
     public void testTimeAndTiebreaker() throws Exception {
         long time = randomLong();
         long tb = randomLong();
-        Ordinal ordinal = ordinal(searchHit(time, tb), true);
+        long implicitTbValue = randomLong();
+        Ordinal ordinal = ordinal(searchHit(time, tb, new Object[] { implicitTbValue }), true);
         assertEquals(time, ordinal.timestamp());
         assertEquals(tb, ordinal.tiebreaker());
+        assertEquals(implicitTbValue, ordinal.implicitTiebreaker());
     }
 
     public void testTimeAndTiebreakerNull() throws Exception {
@@ -59,9 +69,25 @@ public class CriterionOrdinalExtractionTests extends ESTestCase {
     public void testTimeNotComparable() throws Exception {
         HitExtractor badExtractor = new FieldHitExtractor(tsField, DataTypes.BINARY, null, null, false);
         SearchHit hit = searchHit(randomAlphaOfLength(10), null);
-        Criterion<BoxedQueryRequest> criterion = new Criterion<BoxedQueryRequest>(0, null, emptyList(), badExtractor, null, false);
+        Criterion<BoxedQueryRequest> criterion = new Criterion<BoxedQueryRequest>(0, null, emptyList(), badExtractor, null, null, false);
         EqlIllegalArgumentException exception = expectThrows(EqlIllegalArgumentException.class, () -> criterion.ordinal(hit));
         assertTrue(exception.getMessage().startsWith("Expected timestamp"));
+    }
+
+    public void testImplicitTiebreakerMissing() throws Exception {
+        SearchHit hit = searchHit(randomLong(), null, new Object[0]);
+        Criterion<BoxedQueryRequest> criterion = new Criterion<BoxedQueryRequest>(0, null, emptyList(), tsExtractor, null,
+            implicitTbExtractor, randomBoolean());
+        EqlIllegalArgumentException exception = expectThrows(EqlIllegalArgumentException.class, () -> criterion.ordinal(hit));
+        assertTrue(exception.getMessage().startsWith("Expected at least one sorting value in the search hit, but got none"));
+    }
+
+    public void testImplicitTiebreakerNotANumber() throws Exception {
+        SearchHit hit = searchHit(randomLong(), null, new Object[] { "test string" });
+        Criterion<BoxedQueryRequest> criterion = new Criterion<BoxedQueryRequest>(0, null, emptyList(), tsExtractor, null,
+            implicitTbExtractor, randomBoolean());
+        EqlIllegalArgumentException exception = expectThrows(EqlIllegalArgumentException.class, () -> criterion.ordinal(hit));
+        assertTrue(exception.getMessage().startsWith("Expected _shard_doc/implicit tiebreaker as long but got [test string]"));
     }
 
     public void testTiebreakerNotComparable() throws Exception {
@@ -87,20 +113,32 @@ public class CriterionOrdinalExtractionTests extends ESTestCase {
             }
         };
         SearchHit hit = searchHit(randomLong(), o);
-        Criterion<BoxedQueryRequest> criterion = new Criterion<BoxedQueryRequest>(0, null, emptyList(), tsExtractor, badExtractor, false);
+        Criterion<BoxedQueryRequest> criterion = new Criterion<BoxedQueryRequest>(0, null, emptyList(), tsExtractor, badExtractor,
+            implicitTbExtractor, false);
         EqlIllegalArgumentException exception = expectThrows(EqlIllegalArgumentException.class, () -> criterion.ordinal(hit));
         assertTrue(exception.getMessage().startsWith("Expected tiebreaker"));
     }
 
     private SearchHit searchHit(Object timeValue, Object tiebreakerValue) {
+        return searchHit(timeValue, tiebreakerValue, () -> randomSearchLongSortValues());
+    }
+
+    private SearchHit searchHit(Object timeValue, Object tiebreakerValue, Object[] implicitTiebreakerValues) {
+        return searchHit(timeValue, tiebreakerValue, () -> randomSearchSortValues(implicitTiebreakerValues));
+    }
+
+    private SearchHit searchHit(Object timeValue, Object tiebreakerValue, Supplier<SearchSortValues> searchSortValues) {
         Map<String, DocumentField> fields = new HashMap<>();
         fields.put(tsField, new DocumentField(tsField, singletonList(timeValue)));
         fields.put(tbField, new DocumentField(tsField, singletonList(tiebreakerValue)));
+        SearchHit searchHit = new SearchHit(randomInt(), randomAlphaOfLength(10), new Text("_doc"), fields, emptyMap());
+        searchHit.sortValues(searchSortValues.get());
 
-        return new SearchHit(randomInt(), randomAlphaOfLength(10), new Text("_doc"), fields, emptyMap());
+        return searchHit;
     }
 
     private Ordinal ordinal(SearchHit hit, boolean withTiebreaker) {
-        return new Criterion<BoxedQueryRequest>(0, null, emptyList(), tsExtractor, withTiebreaker ? tbExtractor : null, false).ordinal(hit);
+        return new Criterion<BoxedQueryRequest>(0, null, emptyList(), tsExtractor, withTiebreaker ? tbExtractor : null,
+            implicitTbExtractor, false).ordinal(hit);
     }
 }

--- a/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/execution/search/OrdinalTests.java
+++ b/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/execution/search/OrdinalTests.java
@@ -13,65 +13,91 @@ import org.elasticsearch.test.ESTestCase;
 public class OrdinalTests extends ESTestCase {
 
     public void testCompareToDifferentTs() {
-        Ordinal one = new Ordinal(randomLong(), (Comparable) randomLong());
-        Ordinal two = new Ordinal(randomLong(), (Comparable) randomLong());
+        long ts1 = randomLong();
+        long ts2 = randomValueOtherThan(ts1, () -> randomLong());
+        Ordinal one = new Ordinal(ts1, (Comparable) randomLong(), randomLong());
+        Ordinal two = new Ordinal(ts2, (Comparable) randomLong(), randomLong());
 
         assertEquals(Long.valueOf(one.timestamp()).compareTo(two.timestamp()), one.compareTo(two));
     }
 
     public void testCompareToSameTsDifferentTie() {
         long ts = randomLong();
-        Ordinal one = new Ordinal(ts, (Comparable) randomLong());
-        Ordinal two = new Ordinal(ts, (Comparable) randomLong());
+        Comparable tie1 = (Comparable) randomLong();
+        Comparable tie2 = randomValueOtherThan(tie1, () -> (Comparable) randomLong());
+        Ordinal one = new Ordinal(ts, tie1, randomLong());
+        Ordinal two = new Ordinal(ts, tie2, randomLong());
 
         assertEquals(one.tiebreaker().compareTo(two.tiebreaker()), one.compareTo(two));
     }
 
     public void testCompareToSameTsOneTieNull() {
         long ts = randomLong();
-        Ordinal one = new Ordinal(ts, (Comparable) randomLong());
-        Ordinal two = new Ordinal(ts, null);
+        Ordinal one = new Ordinal(ts, (Comparable) randomLong(), randomLong());
+        Ordinal two = new Ordinal(ts, null, randomLong());
 
         assertEquals(-1, one.compareTo(two));
     }
 
-    public void testCompareToSameTsSameTie() {
+    public void testCompareToSameTsSameTieSameImplicitTb() {
         long ts = randomLong();
         Comparable c = randomLong();
-        Ordinal one = new Ordinal(ts, c);
-        Ordinal two = new Ordinal(ts, c);
+        long implicitTb = randomLong();
+        Ordinal one = new Ordinal(ts, c, implicitTb);
+        Ordinal two = new Ordinal(ts, c, implicitTb);
 
         assertEquals(0, one.compareTo(two));
         assertEquals(0, one.compareTo(one));
         assertEquals(0, two.compareTo(two));
     }
 
-    public void testCompareToSameTsSameTieNull() {
+    public void testCompareToSameTsSameTieDifferentImplicitTb() {
         long ts = randomLong();
-        Ordinal one = new Ordinal(ts, null);
-        Ordinal two = new Ordinal(ts, null);
+        Comparable c = randomLong();
+        long implicitTb = randomLong();
+        Ordinal one = new Ordinal(ts, c, implicitTb);
+        Ordinal two = new Ordinal(ts, c, randomValueOtherThan(implicitTb, () -> randomLong()));
+
+        assertEquals(Long.valueOf(one.implicitTiebreaker()).compareTo(two.implicitTiebreaker()), one.compareTo(two));
+    }
+
+    public void testCompareToSameTsSameTieNullSameImplicitTb() {
+        long ts = randomLong();
+        long implicitTb = randomLong();
+        Ordinal one = new Ordinal(ts, null, implicitTb);
+        Ordinal two = new Ordinal(ts, null, implicitTb);
 
         assertEquals(0, one.compareTo(two));
         assertEquals(0, one.compareTo(one));
         assertEquals(0, two.compareTo(two));
+    }
+
+    public void testCompareToSameTsSameTieNullDifferentImplicitTb() {
+        long ts = randomLong();
+        long implicitTb1 = randomLong();
+        long implicitTb2 = randomValueOtherThan(implicitTb1, () -> randomLong());
+        Ordinal one = new Ordinal(ts, null, implicitTb1);
+        Ordinal two = new Ordinal(ts, null, implicitTb2);
+
+        assertEquals(Long.valueOf(one.implicitTiebreaker()).compareTo(two.implicitTiebreaker()), one.compareTo(two));
     }
 
     public void testTestBetween() {
-        Ordinal before = new Ordinal(randomLongBetween(1000, 2000), (Comparable) randomLong());
-        Ordinal between = new Ordinal(randomLongBetween(3000, 4000), (Comparable) randomLong());
-        Ordinal after = new Ordinal(randomLongBetween(5000, 6000), (Comparable) randomLong());
+        Ordinal before = new Ordinal(randomLongBetween(1000, 2000), (Comparable) randomLong(), randomLong());
+        Ordinal between = new Ordinal(randomLongBetween(3000, 4000), (Comparable) randomLong(), randomLong());
+        Ordinal after = new Ordinal(randomLongBetween(5000, 6000), (Comparable) randomLong(), randomLong());
 
         assertTrue(before.between(before, after));
         assertTrue(after.between(before, after));
         assertTrue(between.between(before, after));
 
-        assertFalse(new Ordinal(randomLongBetween(0, 999), null).between(before, after));
-        assertFalse(new Ordinal(randomLongBetween(7000, 8000), null).between(before, after));
+        assertFalse(new Ordinal(randomLongBetween(0, 999), null, randomLong()).between(before, after));
+        assertFalse(new Ordinal(randomLongBetween(7000, 8000), null, randomLong()).between(before, after));
     }
 
     public void testTestBefore() {
-        Ordinal before = new Ordinal(randomLongBetween(1000, 2000), (Comparable) randomLong());
-        Ordinal after = new Ordinal(randomLongBetween(5000, 6000), (Comparable) randomLong());
+        Ordinal before = new Ordinal(randomLongBetween(1000, 2000), (Comparable) randomLong(), randomLong());
+        Ordinal after = new Ordinal(randomLongBetween(5000, 6000), (Comparable) randomLong(), randomLong());
 
         assertTrue(before.before(after));
         assertFalse(before.before(before));
@@ -79,8 +105,8 @@ public class OrdinalTests extends ESTestCase {
     }
 
     public void testBeforeOrAt() {
-        Ordinal before = new Ordinal(randomLongBetween(1000, 2000), (Comparable) randomLong());
-        Ordinal after = new Ordinal(randomLongBetween(5000, 6000), (Comparable) randomLong());
+        Ordinal before = new Ordinal(randomLongBetween(1000, 2000), (Comparable) randomLong(), randomLong());
+        Ordinal after = new Ordinal(randomLongBetween(5000, 6000), (Comparable) randomLong(), randomLong());
 
         assertTrue(before.beforeOrAt(after));
         assertTrue(before.beforeOrAt(before));
@@ -88,8 +114,8 @@ public class OrdinalTests extends ESTestCase {
     }
 
     public void testTestAfter() {
-        Ordinal before = new Ordinal(randomLongBetween(1000, 2000), (Comparable) randomLong());
-        Ordinal after = new Ordinal(randomLongBetween(5000, 6000), (Comparable) randomLong());
+        Ordinal before = new Ordinal(randomLongBetween(1000, 2000), (Comparable) randomLong(), randomLong());
+        Ordinal after = new Ordinal(randomLongBetween(5000, 6000), (Comparable) randomLong(), randomLong());
 
         assertTrue(after.after(before));
         assertFalse(after.after(after));
@@ -97,8 +123,8 @@ public class OrdinalTests extends ESTestCase {
     }
 
     public void testAfterOrAt() {
-        Ordinal before = new Ordinal(randomLongBetween(1000, 2000), (Comparable) randomLong());
-        Ordinal after = new Ordinal(randomLongBetween(5000, 6000), (Comparable) randomLong());
+        Ordinal before = new Ordinal(randomLongBetween(1000, 2000), (Comparable) randomLong(), randomLong());
+        Ordinal after = new Ordinal(randomLongBetween(5000, 6000), (Comparable) randomLong(), randomLong());
 
         assertTrue(after.afterOrAt(before));
         assertTrue(after.afterOrAt(after));


### PR DESCRIPTION
(cherry picked from commit fa92fc43eac4d8c6a33877a41e6541de33488820)