### PR TITLE
Remove Redundant RefCount Checks from InboundHandler (#71783)

### DIFF
--- a/server/src/main/java/org/elasticsearch/transport/InboundHandler.java
+++ b/server/src/main/java/org/elasticsearch/transport/InboundHandler.java
@@ -20,7 +20,6 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.transport.TransportAddress;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.util.concurrent.AbstractRunnable;
-import org.elasticsearch.common.util.concurrent.RefCounted;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.threadpool.ThreadPool;
 
@@ -30,8 +29,7 @@ import java.nio.ByteBuffer;
 
 /**
  * Handles inbound messages by first deserializing a {@link TransportMessage} from an {@link InboundMessage} and then passing
- * it to the appropriate handler. Any deserialized {@code TransportMessage} that is found to implement {@link RefCounted} will have its
- * reference count decremented by one after having been passed to its handler.
+ * it to the appropriate handler.
  */
 public class InboundHandler {
 
@@ -206,9 +204,7 @@ public class InboundHandler {
                             }
                         } else {
                             boolean success = false;
-                            if (request instanceof RefCounted) {
-                                ((RefCounted) request).incRef();
-                            }
+                            request.incRef();
                             try {
                                 threadPool.executor(executor).execute(new AbstractRunnable() {
                                     @Override


### PR DESCRIPTION
We eventually settled on ref counting all messages here
so the type check and comment are redundant now.

backport of #71783