### PR TITLE
[DRAFT] Replace simpleMatchToFieldName with getMatchingFieldTypes()

### DIFF
--- a/benchmarks/src/main/java/org/elasticsearch/benchmark/search/aggregations/AggConstructionContentionBenchmark.java
+++ b/benchmarks/src/main/java/org/elasticsearch/benchmark/search/aggregations/AggConstructionContentionBenchmark.java
@@ -213,7 +213,7 @@ public class AggConstructionContentionBenchmark {
         }
 
         @Override
-        public Collection<MappedFieldType> getFieldTypes() {
+        public Collection<MappedFieldType> getMatchingFieldTypes(String pattern) {
             throw new UnsupportedOperationException();
         }
 

--- a/modules/parent-join/src/main/java/org/elasticsearch/join/mapper/Joiner.java
+++ b/modules/parent-join/src/main/java/org/elasticsearch/join/mapper/Joiner.java
@@ -36,14 +36,14 @@ public final class Joiner {
      * Get the Joiner for this context, or {@code null} if none is configured
      */
     public static Joiner getJoiner(SearchExecutionContext context) {
-        return getJoiner(context.getFieldTypes());
+        return getJoiner(context.getMatchingFieldTypes("*"));
     }
 
     /**
      * Get the Joiner for this context, or {@code null} if none is configured
      */
     public static Joiner getJoiner(AggregationContext context) {
-        return getJoiner(context.getFieldTypes());
+        return getJoiner(context.getMatchingFieldTypes("*"));
     }
 
     /**

--- a/modules/parent-join/src/main/java/org/elasticsearch/join/mapper/ParentJoinFieldMapper.java
+++ b/modules/parent-join/src/main/java/org/elasticsearch/join/mapper/ParentJoinFieldMapper.java
@@ -292,7 +292,7 @@ public final class ParentJoinFieldMapper extends FieldMapper {
 
     @Override
     protected void doValidate(MappingLookup mappers) {
-        List<String> joinFields = getJoinFieldTypes(mappers.fieldTypes()).stream()
+        List<String> joinFields = getJoinFieldTypes(mappers.getMatchingFieldTypes("*")).stream()
             .map(JoinFieldType::name)
             .collect(Collectors.toList());
         if (joinFields.size() > 1) {

--- a/modules/parent-join/src/test/java/org/elasticsearch/join/mapper/ParentJoinFieldMapperTests.java
+++ b/modules/parent-join/src/test/java/org/elasticsearch/join/mapper/ParentJoinFieldMapperTests.java
@@ -47,7 +47,7 @@ public class ParentJoinFieldMapperTests extends MapperServiceTestCase {
         }));
         DocumentMapper docMapper = mapperService.documentMapper();
 
-        Joiner joiner = Joiner.getJoiner(mapperService.mappingLookup().fieldTypes());
+        Joiner joiner = Joiner.getJoiner(mapperService.mappingLookup().getMatchingFieldTypes("*"));
         assertNotNull(joiner);
         assertEquals("join_field", joiner.getJoinField());
 
@@ -233,7 +233,7 @@ public class ParentJoinFieldMapperTests extends MapperServiceTestCase {
             b.endObject();
         }));
 
-        Joiner joiner = Joiner.getJoiner(mapperService.mappingLookup().fieldTypes());
+        Joiner joiner = Joiner.getJoiner(mapperService.mappingLookup().getMatchingFieldTypes("*"));
         assertNotNull(joiner);
         assertEquals("join_field", joiner.getJoinField());
         assertTrue(joiner.childTypeExists("child2"));
@@ -259,7 +259,7 @@ public class ParentJoinFieldMapperTests extends MapperServiceTestCase {
             }
             b.endObject();
         }));
-        joiner = Joiner.getJoiner(mapperService.mappingLookup().fieldTypes());
+        joiner = Joiner.getJoiner(mapperService.mappingLookup().getMatchingFieldTypes("*"));
         assertNotNull(joiner);
         assertEquals("join_field", joiner.getJoinField());
         assertTrue(joiner.childTypeExists("child2"));

--- a/server/src/main/java/org/elasticsearch/index/mapper/MapperService.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/MapperService.java
@@ -379,7 +379,9 @@ public class MapperService extends AbstractIndexComponent implements Closeable {
         if (this.mapper == null) {
             return Collections.emptySet();
         }
-        return this.mapper.mappers().fieldTypes().stream().filter(MappedFieldType::eagerGlobalOrdinals).collect(Collectors.toList());
+        return this.mapper.mappers().getMatchingFieldTypes("*").stream()
+            .filter(MappedFieldType::eagerGlobalOrdinals)
+            .collect(Collectors.toList());
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/index/mapper/MappingLookup.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/MappingLookup.java
@@ -197,13 +197,6 @@ public final class MappingLookup {
         return fieldMappers.values();
     }
 
-    /**
-     * Returns the registered mapped field types.
-     */
-    public Collection<MappedFieldType> fieldTypes() {
-        return fieldTypeLookup.get();
-    }
-
     void checkLimits(IndexSettings settings) {
         checkFieldLimit(settings.getMappingTotalFieldsLimit());
         checkObjectDepthLimit(settings.getMappingDepthLimit());
@@ -292,8 +285,8 @@ public final class MappingLookup {
         return field.substring(0, lastDot);
     }
 
-    public Set<String> simpleMatchToFullName(String pattern) {
-        return fieldTypesLookup().simpleMatchToFullName(pattern);
+    public Collection<MappedFieldType> getMatchingFieldTypes(String pattern) {
+        return fieldTypesLookup().getMatching(pattern);
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/index/query/ExistsQueryBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/ExistsQueryBuilder.java
@@ -9,7 +9,6 @@
 package org.elasticsearch.index.query;
 
 import org.apache.lucene.search.BooleanClause;
-import org.apache.lucene.search.BooleanClause.Occur;
 import org.apache.lucene.search.BooleanQuery;
 import org.apache.lucene.search.ConstantScoreQuery;
 import org.apache.lucene.search.MatchNoDocsQuery;
@@ -19,14 +18,12 @@ import org.elasticsearch.common.ParsingException;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
-import org.elasticsearch.common.lucene.search.Queries;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
-import org.elasticsearch.index.mapper.FieldNamesFieldMapper;
+import org.elasticsearch.index.mapper.MappedFieldType;
 
 import java.io.IOException;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.Objects;
 
 /**
@@ -70,7 +67,7 @@ public class ExistsQueryBuilder extends AbstractQueryBuilder<ExistsQueryBuilder>
     protected QueryBuilder doRewrite(QueryRewriteContext queryRewriteContext) throws IOException {
         SearchExecutionContext context = queryRewriteContext.convertToSearchExecutionContext();
         if (context != null) {
-            Collection<String> fields = getMappedField(context, fieldName);
+            Collection<MappedFieldType> fields = getMappedFields(context, fieldName);
             if (fields.isEmpty()) {
                 return new MatchNoneQueryBuilder();
             }
@@ -130,7 +127,7 @@ public class ExistsQueryBuilder extends AbstractQueryBuilder<ExistsQueryBuilder>
 
     public static Query newFilter(SearchExecutionContext context, String fieldPattern, boolean checkRewrite) {
 
-       Collection<String> fields = getMappedField(context, fieldPattern);
+       Collection<MappedFieldType> fields = getMappedFields(context, fieldPattern);
 
         if (fields.isEmpty()) {
             if (checkRewrite) {
@@ -141,71 +138,26 @@ public class ExistsQueryBuilder extends AbstractQueryBuilder<ExistsQueryBuilder>
         }
 
         if (fields.size() == 1) {
-            String field = fields.iterator().next();
-            return newFieldExistsQuery(context, field);
+            return new ConstantScoreQuery(fields.iterator().next().existsQuery(context));
         }
 
         BooleanQuery.Builder boolFilterBuilder = new BooleanQuery.Builder();
-        for (String field : fields) {
-            boolFilterBuilder.add(newFieldExistsQuery(context, field), BooleanClause.Occur.SHOULD);
+        for (MappedFieldType field : fields) {
+            boolFilterBuilder.add(field.existsQuery(context), BooleanClause.Occur.SHOULD);
         }
         return new ConstantScoreQuery(boolFilterBuilder.build());
-    }
-
-    private static Query newFieldExistsQuery(SearchExecutionContext context, String field) {
-        if (context.isFieldMapped(field)) {
-            Query filter = context.getFieldType(field).existsQuery(context);
-            return new ConstantScoreQuery(filter);
-        } else {
-            // The field does not exist as a leaf but could be an object so
-            // check for an object mapper
-            if (context.getObjectMapper(field) != null) {
-                return newObjectFieldExistsQuery(context, field);
-            }
-            return Queries.newMatchNoDocsQuery("User requested \"match_none\" query.");
-        }
-    }
-
-    private static Query newObjectFieldExistsQuery(SearchExecutionContext context, String objField) {
-        BooleanQuery.Builder booleanQuery = new BooleanQuery.Builder();
-        Collection<String> fields = context.simpleMatchToIndexNames(objField + ".*");
-        for (String field : fields) {
-            Query existsQuery = context.getFieldType(field).existsQuery(context);
-            booleanQuery.add(existsQuery, Occur.SHOULD);
-        }
-        return new ConstantScoreQuery(booleanQuery.build());
     }
 
     /**
      * Helper method to get field mapped to this fieldPattern
      * @return return collection of fields if exists else return empty.
      */
-    private static Collection<String> getMappedField(SearchExecutionContext context, String fieldPattern) {
-        if (context.isFieldMapped(FieldNamesFieldMapper.NAME) == false) {
-            // can only happen when no types exist, so no docs exist either
-            return Collections.emptySet();
+    private static Collection<MappedFieldType> getMappedFields(SearchExecutionContext context, String fieldPattern) {
+        Collection<MappedFieldType> fields = context.getMatchingFieldTypes(fieldPattern);
+        if (fields.isEmpty()) {
+            // might be an object field, so try matching it as an object prefix pattern
+            fields = context.getMatchingFieldTypes(fieldPattern + ".*");
         }
-
-        final Collection<String> fields;
-        if (context.getObjectMapper(fieldPattern) != null) {
-            // the _field_names field also indexes objects, so we don't have to
-            // do any more work to support exists queries on whole objects
-            fields = Collections.singleton(fieldPattern);
-        } else {
-            fields = context.simpleMatchToIndexNames(fieldPattern);
-        }
-
-        if (fields.size() == 1) {
-            String field = fields.iterator().next();
-            if (context.isFieldMapped(field) == false) {
-                // The field does not exist as a leaf but could be an object so
-                // check for an object mapper
-                if (context.getObjectMapper(field) == null) {
-                    return Collections.emptySet();
-                }
-            }
-        }
-
         return fields;
     }
 

--- a/server/src/main/java/org/elasticsearch/index/termvectors/TermVectorsService.java
+++ b/server/src/main/java/org/elasticsearch/index/termvectors/TermVectorsService.java
@@ -152,7 +152,7 @@ public class TermVectorsService  {
     private static void handleFieldWildcards(IndexShard indexShard, TermVectorsRequest request) {
         Set<String> fieldNames = new HashSet<>();
         for (String pattern : request.selectedFields()) {
-            fieldNames.addAll(indexShard.mapperService().mappingLookup().simpleMatchToFullName(pattern));
+            indexShard.mapperService().mappingLookup().getMatchingFieldTypes(pattern).forEach(ft -> fieldNames.add(ft.name()));
         }
         request.selectedFields(fieldNames.toArray(Strings.EMPTY_ARRAY));
     }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/support/AggregationContext.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/support/AggregationContext.java
@@ -114,7 +114,7 @@ public abstract class AggregationContext implements Releasable {
     /**
      * Returns the registered mapped field types.
      */
-    public abstract Collection<MappedFieldType> getFieldTypes();
+    public abstract Collection<MappedFieldType> getMatchingFieldTypes(String pattern);
 
     /**
      * Returns true if the field identified by the provided name is mapped, false otherwise
@@ -346,8 +346,8 @@ public abstract class AggregationContext implements Releasable {
         }
 
         @Override
-        public Collection<MappedFieldType> getFieldTypes() {
-            return context.getFieldTypes();
+        public Collection<MappedFieldType> getMatchingFieldTypes(String pattern) {
+            return context.getMatchingFieldTypes(pattern);
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/search/fetch/FetchPhase.java
+++ b/server/src/main/java/org/elasticsearch/search/fetch/FetchPhase.java
@@ -211,20 +211,12 @@ public class FetchPhase {
                     continue;
                 }
                 SearchExecutionContext searchExecutionContext = context.getSearchExecutionContext();
-                Collection<String> fieldNames = searchExecutionContext.simpleMatchToIndexNames(fieldNameOrPattern);
-                for (String fieldName : fieldNames) {
-                    MappedFieldType fieldType = searchExecutionContext.getFieldType(fieldName);
-                    if (fieldType == null) {
-                        // Only fail if we know it is a object field, missing paths / fields shouldn't fail.
-                        if (searchExecutionContext.getObjectMapper(fieldName) != null) {
-                            throw new IllegalArgumentException("field [" + fieldName + "] isn't a leaf field");
-                        }
-                    } else {
-                        String storedField = fieldType.name();
-                        Set<String> requestedFields = storedToRequestedFields.computeIfAbsent(
-                            storedField, key -> new HashSet<>());
-                        requestedFields.add(fieldName);
-                    }
+                Collection<MappedFieldType> fields = searchExecutionContext.getMatchingFieldTypes(fieldNameOrPattern);
+                for (MappedFieldType fieldType : fields) {
+                    String storedField = fieldType.name();
+                    Set<String> requestedFields = storedToRequestedFields.computeIfAbsent(
+                        storedField, key -> new HashSet<>());
+                    requestedFields.add(storedField);
                 }
             }
             boolean loadSource = sourceRequired(context);

--- a/server/src/main/java/org/elasticsearch/search/fetch/subphase/FetchDocValuesContext.java
+++ b/server/src/main/java/org/elasticsearch/search/fetch/subphase/FetchDocValuesContext.java
@@ -8,6 +8,7 @@
 package org.elasticsearch.search.fetch.subphase;
 
 import org.elasticsearch.index.IndexSettings;
+import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.query.SearchExecutionContext;
 
 import java.util.ArrayList;
@@ -31,11 +32,9 @@ public class FetchDocValuesContext {
      */
     public FetchDocValuesContext(SearchExecutionContext searchExecutionContext, List<FieldAndFormat> fieldPatterns) {
         for (FieldAndFormat field : fieldPatterns) {
-            Collection<String> fieldNames = searchExecutionContext.simpleMatchToIndexNames(field.field);
-            for (String fieldName : fieldNames) {
-                if (searchExecutionContext.isFieldMapped(fieldName)) {
-                    fields.add(new FieldAndFormat(fieldName, field.format, field.includeUnmapped));
-                }
+            Collection<MappedFieldType> fieldTypes = searchExecutionContext.getMatchingFieldTypes(field.field);
+            for (MappedFieldType fieldType : fieldTypes) {
+                fields.add(new FieldAndFormat(fieldType.name(), field.format, field.includeUnmapped));
             }
         }
 

--- a/server/src/test/java/org/elasticsearch/index/mapper/TextFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/TextFieldMapperTests.java
@@ -831,9 +831,7 @@ public class TextFieldMapperTests extends MapperTestCase {
         SearchExecutionContext context = createSearchExecutionContext(ms);
         QueryStringQueryParser parser = new QueryStringQueryParser(context, "f");
         Query q = parser.parse("foo:*");
-        assertEquals(new ConstantScoreQuery(new BooleanQuery.Builder()
-            .add(new NormsFieldExistsQuery("foo.bar"), BooleanClause.Occur.SHOULD)
-            .build()), q);
+        assertEquals(new ConstantScoreQuery(new NormsFieldExistsQuery("foo.bar")), q);
     }
 
     private static void assertAnalyzesTo(Analyzer analyzer, String field, String input, String[] output) throws IOException {

--- a/server/src/test/java/org/elasticsearch/index/query/MultiMatchQueryBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/MultiMatchQueryBuilderTests.java
@@ -219,12 +219,10 @@ public class MultiMatchQueryBuilderTests extends AbstractQueryTestCase<MultiMatc
 
     public void testToQueryFieldsWildcard() throws Exception {
         Query query = multiMatchQuery("test").field("mapped_str*").tieBreaker(1.0f).toQuery(createSearchExecutionContext());
-        assertThat(query, instanceOf(DisjunctionMaxQuery.class));
-        DisjunctionMaxQuery dQuery = (DisjunctionMaxQuery) query;
-        assertThat(dQuery.getTieBreakerMultiplier(), equalTo(1.0f));
-        assertThat(dQuery.getDisjuncts().size(), equalTo(2));
-        assertThat(assertDisjunctionSubQuery(query, TermQuery.class, 0).getTerm(), equalTo(new Term(TEXT_FIELD_NAME, "test")));
-        assertThat(assertDisjunctionSubQuery(query, TermQuery.class, 1).getTerm(), equalTo(new Term(KEYWORD_FIELD_NAME, "test")));
+        Query expected = new DisjunctionMaxQuery(List.of(
+            new TermQuery(new Term(KEYWORD_FIELD_NAME, "test")),
+            new TermQuery(new Term(TEXT_FIELD_NAME, "test"))), 1.0f);
+        assertThat(query, equalTo(expected));
     }
 
     public void testToQueryFieldMissing() throws Exception {

--- a/server/src/test/java/org/elasticsearch/index/query/SearchExecutionContextTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/SearchExecutionContextTests.java
@@ -79,7 +79,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -87,7 +86,10 @@ import java.util.stream.Collectors;
 
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.singletonMap;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
@@ -348,14 +350,23 @@ public class SearchExecutionContextTests extends ESTestCase {
             runtimeMappings);
         assertTrue(context.isFieldMapped("cat"));
         assertThat(context.getFieldType("cat"), instanceOf(KeywordScriptFieldType.class));
-        assertThat(context.simpleMatchToIndexNames("cat"), equalTo(Set.of("cat")));
+        assertThat(context.getMatchingFieldTypes("cat"), hasSize(1));
+        assertThat(context.getMatchingFieldTypes("cat"), contains(context.getFieldType("cat")));
         assertTrue(context.isFieldMapped("dog"));
         assertThat(context.getFieldType("dog"), instanceOf(LongScriptFieldType.class));
-        assertThat(context.simpleMatchToIndexNames("dog"), equalTo(Set.of("dog")));
+        assertThat(context.getMatchingFieldTypes("dog"), hasSize(1));
+        assertThat(context.getMatchingFieldTypes("dog"), contains(context.getFieldType("dog")));
         assertTrue(context.isFieldMapped("pig"));
         assertThat(context.getFieldType("pig"), instanceOf(MockFieldMapper.FakeFieldType.class));
-        assertThat(context.simpleMatchToIndexNames("pig"), equalTo(Set.of("pig")));
-        assertThat(context.simpleMatchToIndexNames("*"), equalTo(Set.of("cat", "dog", "pig")));
+        assertThat(context.getMatchingFieldTypes("pig"), hasSize(1));
+        assertThat(context.getMatchingFieldTypes("pig"), contains(context.getFieldType("pig")));
+
+        assertThat(context.getMatchingFieldTypes("*"), hasSize(3));
+        assertThat(context.getMatchingFieldTypes("*"), containsInAnyOrder(
+            context.getFieldType("cat"),
+            context.getFieldType("dog"),
+            context.getFieldType("pig")
+        ));
     }
 
     public void testSearchRequestRuntimeFieldsWrongFormat() {

--- a/test/framework/src/main/java/org/elasticsearch/index/mapper/MapperServiceTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/mapper/MapperServiceTestCase.java
@@ -377,8 +377,8 @@ public abstract class MapperServiceTestCase extends ESTestCase {
             }
 
             @Override
-            public Collection<MappedFieldType> getFieldTypes() {
-                throw new UnsupportedOperationException();
+            public Collection<MappedFieldType> getMatchingFieldTypes(String pattern) {
+                return mapperService.mappingLookup().getMatchingFieldTypes(pattern);
             }
 
             @Override
@@ -518,8 +518,8 @@ public abstract class MapperServiceTestCase extends ESTestCase {
         when(searchExecutionContext.getIndexSettings()).thenReturn(mapperService.getIndexSettings());
         when(searchExecutionContext.getObjectMapper(anyString())).thenAnswer(
             inv -> mapperService.mappingLookup().objectMappers().get(inv.getArguments()[0].toString()));
-        when(searchExecutionContext.simpleMatchToIndexNames(anyObject())).thenAnswer(
-            inv -> mapperService.mappingLookup().simpleMatchToFullName(inv.getArguments()[0].toString())
+        when(searchExecutionContext.getMatchingFieldTypes(anyObject())).thenAnswer(
+            inv -> mapperService.mappingLookup().getMatchingFieldTypes(inv.getArguments()[0].toString())
         );
         when(searchExecutionContext.allowExpensiveQueries()).thenReturn(true);
         when(searchExecutionContext.lookup()).thenReturn(new SearchLookup(mapperService::fieldType, (ft, s) -> {


### PR DESCRIPTION
MappingLookup has a method `simpleMatchToFieldName` that attempts
to return all field names that match a given pattern; if no patterns match,
then it returns a single-valued collection containing just the pattern that
was originally passed in.  This is a fairly confusing semantic.

This PR replaces `simpleMatchToFieldName` with a new method,
`getMatchingFieldTypes`, that returns a collection of all MappedFieldTypes
in a mapping that match the passed-in pattern.  It simplifies several
call sites because we know that field types returned by the method will
not be null.

Marked as [DRAFT] because there are still some open questions and failing
tests:
* FieldFetcher will returned aliased fields under the name of the fields that
  they point to
* QueryStringQuery and friends are broken with flattened fields, because
  the name() returned by a flattened key field type doesn't match the name
  they are registered under (ie you can't call `lookup.getFieldType(flattened.name())`
  and get the same MappedFieldType back.

Both of these are fixable but might require some further formalisation of the
MappedFieldType API - one fix would be to add a new `fieldName()` method 
which flattened fields would return and alias fields could work by wrapping their
target MFT and overriding fieldName().