### PR TITLE
Fix off-by-one in testDoesNotSubmitRerouteTaskTooFrequently

### DIFF
--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/DiskThresholdMonitorTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/DiskThresholdMonitorTests.java
@@ -154,7 +154,6 @@ public class DiskThresholdMonitorTests extends ESAllocationTestCase {
         assertEquals(Collections.singleton("test_1"), indices.get());
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/71424")
     public void testDoesNotSubmitRerouteTaskTooFrequently() {
         final ClusterState clusterState = ClusterState.builder(ClusterName.CLUSTER_NAME_SETTING.getDefault(Settings.EMPTY))
             .nodes(DiscoveryNodes.builder().add(newNormalNode("node1")).add(newNormalNode("node2"))).build();
@@ -198,7 +197,7 @@ public class DiskThresholdMonitorTests extends ESAllocationTestCase {
         if (randomBoolean()) {
             // should not re-route again within the reroute interval
             currentTime.addAndGet(randomLongBetween(0,
-                DiskThresholdSettings.CLUSTER_ROUTING_ALLOCATION_REROUTE_INTERVAL_SETTING.get(Settings.EMPTY).millis()));
+                DiskThresholdSettings.CLUSTER_ROUTING_ALLOCATION_REROUTE_INTERVAL_SETTING.get(Settings.EMPTY).millis() - 1));
             monitor.onNewInfo(clusterInfo(allDisksOk));
             assertNull(listenerReference.get());
         }


### PR DESCRIPTION
We reroute when the elapsed time is >= 60000ms, but the test assumes
that no reroute happens exactly at 60000ms. This commit fixes this
off-by-one-ms error.

Relates #60869 which introduced this test issue
Relates #68316 which mostly fixed this test issue except this one spot
Closes #71424