### PR TITLE
[7.13] [DOCS] Remove 7.12.1 coming tag (#71846)

### DIFF
--- a/docs/reference/release-notes/7.12.asciidoc
+++ b/docs/reference/release-notes/7.12.asciidoc
@@ -1,8 +1,6 @@
 [[release-notes-7.12.1]]
 == {es} version 7.12.1
 
-coming[7.12.1]
-
 Also see <<breaking-changes-7.12,Breaking changes in 7.12>>.
 
 [[enhancement-7.12.1]]


### PR DESCRIPTION
Backports the following commits to 7.13:
 - [DOCS] Remove 7.12.1 coming tag (#71846)