### PR TITLE
[7.x] docs: apm_user deprecation notice (#72279)

### DIFF
--- a/x-pack/docs/en/security/authorization/built-in-roles.asciidoc
+++ b/x-pack/docs/en/security/authorization/built-in-roles.asciidoc
@@ -17,6 +17,7 @@ Grants access necessary for the APM system user to send system-level data
 [[built-in-roles-apm-user]] `apm_user` ::
 Grants the privileges required for APM users (such as `read` and
 `view_index_metadata` privileges on the `apm-*` and `.ml-anomalies*` indices).
+deprecated:[7.13.0,"See {kibana-ref}/apm-app-users.html[APM app users and privileges\] for alternatives."].
 
 [[built-in-roles-beats-admin]] `beats_admin` ::
 Grants access to the `.management-beats` index, which contains configuration


### PR DESCRIPTION
Backports the following commits to 7.x:
 - docs: apm_user deprecation notice (#72279)