### PR TITLE
WIP: Trying to fix the generate-license build

### DIFF
--- a/x-pack/license-tools/build.gradle
+++ b/x-pack/license-tools/build.gradle
@@ -14,7 +14,7 @@ tasks.named("dependencyLicenses").configure { enabled = false }
 
 tasks.register("buildZip", Zip) {
   dependsOn "jar"
-  String parentDir = "license-tools-${archiveVersion}"
+  String parentDir = "license-tools-${project.version}"
   into(parentDir + '/lib') {
     from jar
     from configurations.runtimeClasspath


### PR DESCRIPTION
Trying to fix the generate-license build because it packages the content into a zip with a weird name (seems that the property `archiveVersion` isn't initialized for this gradle task).