### PR TITLE
Use a deterministic seed for repo test kit tests

### DIFF
--- a/x-pack/plugin/snapshot-repo-test-kit/src/test/java/org/elasticsearch/repositories/blobstore/testkit/AbstractSnapshotRepoTestKitRestTestCase.java
+++ b/x-pack/plugin/snapshot-repo-test-kit/src/test/java/org/elasticsearch/repositories/blobstore/testkit/AbstractSnapshotRepoTestKitRestTestCase.java
@@ -31,6 +31,7 @@ public abstract class AbstractSnapshotRepoTestKitRestTestCase extends ESRestTest
         request.addParameter("concurrency", "4");
         request.addParameter("max_blob_size", "1mb");
         request.addParameter("timeout", "120s");
+        request.addParameter("seed", Long.toString(randomLong()));
         assertOK(client().performRequest(request));
     }
 


### PR DESCRIPTION
Today we do not specify the `?seed=` parameter when running the
repository analyzer in REST tests, so we cannot reproduce the set
of operations that led to a failure. This commit introduces a
deterministic value for this parameter.

Relates #72358 which seems to indicate some kind of bug in how certain
checksums are calculated in the test fixtures.