### PR TITLE
Feature reset integration test should tolerate failed resets

### DIFF
--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/FeaturesIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/FeaturesIT.java
@@ -20,7 +20,6 @@ import java.util.Collections;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.notNullValue;
 
@@ -37,6 +36,12 @@ public class FeaturesIT extends ESRestHighLevelClientTestCase {
         assertTrue(response.getFeatures().stream().anyMatch(feature -> "tasks".equals(feature.getFeatureName())));
     }
 
+    /**
+     * This test assumes that at least one of our defined features should reset successfully.
+     * Since plugins should be testing their own reset operations if they use something
+     * other than the default, this test tolerates failures in the response from the
+     * feature reset API.
+     */
     public void testResetFeatures() throws IOException {
         ResetFeaturesRequest request = new ResetFeaturesRequest();
 
@@ -59,6 +64,6 @@ public class FeaturesIT extends ESRestHighLevelClientTestCase {
             .map(ResetFeaturesResponse.ResetFeatureStateStatus::getStatus)
             .collect(Collectors.toSet());
 
-        assertThat(statuses, contains("SUCCESS"));
+        assertTrue("At least one feature should have been successfully reset", statuses.contains("SUCCESS"));
     }
 }

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/FeaturesIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/FeaturesIT.java
@@ -59,11 +59,5 @@ public class FeaturesIT extends ESRestHighLevelClientTestCase {
         assertThat(response.getFeatureResetStatuses().size(), greaterThan(1));
         assertTrue(response.getFeatureResetStatuses().stream().anyMatch(
             feature -> "tasks".equals(feature.getFeatureName()) && "SUCCESS".equals(feature.getStatus())));
-
-        Set<String> statuses = response.getFeatureResetStatuses().stream()
-            .map(ResetFeaturesResponse.ResetFeatureStateStatus::getStatus)
-            .collect(Collectors.toSet());
-
-        assertTrue("At least one feature should have been successfully reset", statuses.contains("SUCCESS"));
     }
 }

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/FeaturesIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/FeaturesIT.java
@@ -38,7 +38,7 @@ public class FeaturesIT extends ESRestHighLevelClientTestCase {
      * This test assumes that at least one of our defined features should reset successfully.
      * Since plugins should be testing their own reset operations if they use something
      * other than the default, this test tolerates failures in the response from the
-     * feature reset API.
+     * feature reset API. We just need to check that we can reset the "tasks" system index.
      */
     public void testResetFeatures() throws IOException {
         ResetFeaturesRequest request = new ResetFeaturesRequest();

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/FeaturesIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/FeaturesIT.java
@@ -17,8 +17,6 @@ import org.elasticsearch.search.SearchModule;
 
 import java.io.IOException;
 import java.util.Collections;
-import java.util.Set;
-import java.util.stream.Collectors;
 
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.notNullValue;


### PR DESCRIPTION
This didn't cause a problem in the branch builds, but it did on the intake build. Basically, in this test we should just be looking for at least one success, but the `contains` matcher required the result to just be "SUCCESS". This was wrong. In fact, it was redundant with a check a few lines above, so it's probably best to just remove it and add a comment about what the test is looking for.