### PR TITLE
Tweak constructor for yaml parser

### DIFF
--- a/distribution/tools/launchers/src/main/java/org/elasticsearch/tools/launchers/MachineDependentHeap.java
+++ b/distribution/tools/launchers/src/main/java/org/elasticsearch/tools/launchers/MachineDependentHeap.java
@@ -9,6 +9,7 @@
 package org.elasticsearch.tools.launchers;
 
 import org.yaml.snakeyaml.Yaml;
+import org.yaml.snakeyaml.constructor.SafeConstructor;
 import org.yaml.snakeyaml.error.YAMLException;
 
 import java.io.IOException;
@@ -101,7 +102,7 @@ public final class MachineDependentHeap {
 
         @SuppressWarnings("unchecked")
         public static MachineNodeRole parse(InputStream config) {
-            Yaml yaml = new Yaml();
+            Yaml yaml = new Yaml(new SafeConstructor());
             Map<String, Object> root;
             try {
                 root = yaml.load(config);


### PR DESCRIPTION
This commit switches to using a better constructor
when parsing yaml in the machine dependent sizing code.