### PR TITLE
Add snakyaml forbidden apis

### DIFF
--- a/buildSrc/src/main/java/org/elasticsearch/gradle/internal/precommit/ForbiddenApisPrecommitPlugin.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/internal/precommit/ForbiddenApisPrecommitPlugin.java
@@ -44,6 +44,7 @@ public class ForbiddenApisPrecommitPlugin extends PrecommitPlugin implements Int
             t.copy("forbidden/es-test-signatures.txt");
             t.copy("forbidden/http-signatures.txt");
             t.copy("forbidden/es-server-signatures.txt");
+            t.copy("forbidden/snakeyaml-signatures.txt");
         });
         project.getTasks().withType(CheckForbiddenApis.class).configureEach(t -> {
             t.dependsOn(resourcesTask);

--- a/buildSrc/src/main/resources/forbidden/snakeyaml-signatures.txt
+++ b/buildSrc/src/main/resources/forbidden/snakeyaml-signatures.txt
@@ -1,0 +1,6 @@
+@defaultMessage Pass SafeConstructor to Yaml
+org.yaml.snakeyaml.Yaml#<init>()
+org.yaml.snakeyaml.Yaml#<init>(org.yaml.snakeyaml.DumperOptions)
+org.yaml.snakeyaml.Yaml#<init>(org.yaml.snakeyaml.LoaderOptions)
+org.yaml.snakeyaml.Yaml#<init>(org.yaml.snakeyaml.representer.Representer)
+org.yaml.snakeyaml.Yaml#<init>(org.yaml.snakeyaml.representer.Representer, org.yaml.snakeyaml.DumperOptions)

--- a/distribution/tools/launchers/build.gradle
+++ b/distribution/tools/launchers/build.gradle
@@ -20,7 +20,7 @@ dependencies {
 archivesBaseName = 'elasticsearch-launchers'
 
 tasks.withType(CheckForbiddenApis).configureEach {
-  replaceSignatureFiles 'jdk-signatures'
+  replaceSignatureFiles 'jdk-signatures', 'snakeyaml-signatures'
 }
 
 tasks.named("testingConventions").configure {


### PR DESCRIPTION
This commit adds a new signature file for snakeyaml, to avoid certain
constructors. It is not added as part of server signatures so that it
can be used in launchers where there is also a use of snakeyaml.
