### PR TITLE
Make S3 Fixture Code Easier to Read and Less Resource Hungry

### DIFF
--- a/plugins/repository-s3/src/internalClusterTest/java/org/elasticsearch/repositories/s3/S3BlobStoreRepositoryTests.java
+++ b/plugins/repository-s3/src/internalClusterTest/java/org/elasticsearch/repositories/s3/S3BlobStoreRepositoryTests.java
@@ -121,8 +121,7 @@ public class S3BlobStoreRepositoryTests extends ESMockAPIBasedRepositoryIntegTes
         final Settings.Builder builder = Settings.builder()
             .put(ThreadPool.ESTIMATED_TIME_INTERVAL_SETTING.getKey(), 0) // We have tests that verify an exact wait time
             .put(S3ClientSettings.ENDPOINT_SETTING.getConcreteSettingForNamespace("test").getKey(), httpServerUrl())
-            // Disable chunked encoding as it simplifies a lot the request parsing on the httpServer side
-            .put(S3ClientSettings.DISABLE_CHUNKED_ENCODING.getConcreteSettingForNamespace("test").getKey(), true)
+            .put(S3ClientSettings.DISABLE_CHUNKED_ENCODING.getConcreteSettingForNamespace("test").getKey(), randomBoolean())
             // Disable request throttling because some random values in tests might generate too many failures for the S3 client
             .put(S3ClientSettings.USE_THROTTLE_RETRIES_SETTING.getConcreteSettingForNamespace("test").getKey(), false)
             .put(super.nodeSettings(nodeOrdinal, otherSettings))


### PR DESCRIPTION
This removes a number of spots from the request body handling for chunked encoding that aren't obviously safe (like reading to a `byte[]` without checking the return or using `toString(UTF_8)` which quietly suppresses non-utf8 bytes), removes a bunch of copying and looping over of blob bytes (makes test run quicker and allows for testing larger blobs) and hopefully generally makes the code clearer.

Also, we should run our repo ITs using chunked encoding randomly as we run the repo test kit (and I believe other ITs) against this
fixture using chunked encoding and have chunked encoding implemented.

