### PR TITLE
Service Accounts - fix privilege for get credentials

### DIFF
--- a/x-pack/plugin/security/qa/service-account/build.gradle
+++ b/x-pack/plugin/security/qa/service-account/build.gradle
@@ -12,6 +12,7 @@ testClusters.javaRestTest {
   testDistribution = 'DEFAULT'
   numberOfNodes = 2
 
+  extraConfigFile 'roles.yml', file('src/javaRestTest/resources/roles.yml')
   extraConfigFile 'node.key', file('src/javaRestTest/resources/ssl/node.key')
   extraConfigFile 'node.crt', file('src/javaRestTest/resources/ssl/node.crt')
   extraConfigFile 'ca.crt', file('src/javaRestTest/resources/ssl/ca.crt')
@@ -41,4 +42,5 @@ testClusters.javaRestTest {
 
   user username: "test_admin", password: 'x-pack-test-password', role: "superuser"
   user username: "elastic/fleet-server", password: 'x-pack-test-password', role: "superuser"
+  user username: "service_account_manager", password: 'x-pack-test-password', role: "service_account_manager"
 }

--- a/x-pack/plugin/security/qa/service-account/src/javaRestTest/resources/roles.yml
+++ b/x-pack/plugin/security/qa/service-account/src/javaRestTest/resources/roles.yml
@@ -1,0 +1,3 @@
+service_account_manager:
+  cluster:
+    - "manage_service_account"


### PR DESCRIPTION
The action of "get service account credentials" should be covered by the `manage_service_account` privilege. But a bug makes it require read access for the security index. This PR addresses it by executing the request with the security origin.

This PR is tagged as `>non-issue` because the original changes are not released yet.