### PR TITLE
Fixup skip in test

### DIFF
--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.aggregation/235_composite_sorted.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.aggregation/235_composite_sorted.yml
@@ -1,6 +1,5 @@
 ---
 setup:
-
   - do:
       indices.create:
         index: sorted
@@ -75,8 +74,8 @@ setup:
 ---
 one source - first page:
   - skip:
-      version: "all"
-      reason: "Awaits fix: https://github.com/elastic/elasticsearch/issues/72362"
+      version: " - 7.1.99"
+      reason: calendar_interval added in 7.2.0
   - do:
       search:
         index: sorted
@@ -101,8 +100,8 @@ one source - first page:
 ---
 one source - second page:
   - skip:
-      version: "all"
-      reason: "Awaits fix: https://github.com/elastic/elasticsearch/issues/72362"
+      version: " - 7.1.99"
+      reason: calendar_interval added in 7.2.0
   - do:
       search:
         index: sorted
@@ -129,8 +128,8 @@ one source - second page:
 ---
 two sources - first page:
   - skip:
-      version: "all"
-      reason: "Awaits fix: https://github.com/elastic/elasticsearch/issues/72362"
+      version: " - 7.1.99"
+      reason: calendar_interval added in 7.2.0
   - do:
       search:
         index: sorted
@@ -160,8 +159,8 @@ two sources - first page:
 ---
 two sources - second page:
   - skip:
-      version: "all"
-      reason: "Awaits fix: https://github.com/elastic/elasticsearch/issues/72362"
+      version: " - 7.1.99"
+      reason: calendar_interval added in 7.2.0
   - do:
       search:
         index: sorted


### PR DESCRIPTION
A new test I added #72101 was failing randomly. It turns out that I was
using `calendar_interval` which was added in 7.2.0 but running backwards
compatibility tests against 7.0.0. This skips the test before 7.2.0.

Closes #72362