### PR TITLE
Update skip after backport

### DIFF
--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.aggregation/10_histogram.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.aggregation/10_histogram.yml
@@ -664,8 +664,8 @@ setup:
 ---
 "Tiny tiny tiny date_range":
   - skip:
-      version: " - 7.99.99"
-      reason:  fixed in 8.0 and being backported to 7.13.0
+      version: " - 7.13.99"
+      reason:  fixed in 7.14.0
 
   - do:
       bulk:


### PR DESCRIPTION
Now that #72081 has landed in the 7.x branch we can run its test in the
backwards compatibility test suite.
