### PR TITLE
[DOCS] Improve shared cache size setting example

### DIFF
--- a/docs/reference/searchable-snapshots/index.asciidoc
+++ b/docs/reference/searchable-snapshots/index.asciidoc
@@ -165,7 +165,7 @@ cache on one or more nodes. Indices mounted with the shared cache mount option
 are only allocated to nodes that have a shared cache.
 
 [[searchable-snapshots-shared-cache]]
-`xpack.searchable.snapshot.shared_cache.size`::
+`xpack.searchable.snapshot.shared_cache.size` {ess-icon}::
 (<<static-cluster-setting,Static>>)
 The size of the space reserved for the shared cache, either specified as a
 percentage of total disk space or an absolute <<byte-units,byte value>>.

--- a/docs/reference/tab-widgets/data-tiers.asciidoc
+++ b/docs/reference/tab-widgets/data-tiers.asciidoc
@@ -28,7 +28,7 @@ snapshots>>.
 +
 [source,yaml]
 ----
-xpack.searchable.snapshot.shared_cache.size: 576GB
+xpack.searchable.snapshot.shared_cache.size: 570GB
 ----
 
 . Click **Save** and **Confirm** to apply your changes.

--- a/docs/reference/tab-widgets/data-tiers.asciidoc
+++ b/docs/reference/tab-widgets/data-tiers.asciidoc
@@ -22,13 +22,13 @@ chosen tier.
 
 . In the `elasticsearch.yml` configuration, set
 <<searchable-snapshots-shared-cache,`xpack.searchable.snapshot.shared_cache.size`>>
-to up to 90% of available disk space. The tier uses this space to
-create a <<shared-cache,shared, fixed-size cache>> for
-<<searchable-snapshots,searchable snapshots>>.
+to up to 90% of the tier's total storage. The tier uses this space to create a
+<<shared-cache,shared, fixed-size cache>> for <<searchable-snapshots,searchable
+snapshots>>.
 +
 [source,yaml]
 ----
-xpack.searchable.snapshot.shared_cache.size: 50GB
+xpack.searchable.snapshot.shared_cache.size: 576GB
 ----
 
 . Click **Save** and **Confirm** to apply your changes.


### PR DESCRIPTION
Changes:

* Adds an ESS icon to `xpack.searchable.snapshot.shared_cache.size`, indicating the setting is supported on the Elasticsearch Service.
* Updates [Use Elasticsearch for time series data][0] to include a more realistic cache setting size. By default, cold tiers have 640GB of total storage. The example now sets `xpack.searchable.snapshot.shared_cache.size` to 570GB (~90% of 640GB).

### Previews
* Settings docs: https://elasticsearch_72391.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/searchable-snapshots.html#searchable-snapshots-shared-cache
* Use ES for time series data: https://elasticsearch_72391.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/use-elasticsearch-for-time-series-data.html#set-up-data-tiers

[0]: https://elasticsearch_72391.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/use-elasticsearch-for-time-series-data.html#set-up-data-tiers