### PR TITLE
[test] Avoid numerical error for sub-atomic values

### DIFF
--- a/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/search/aggregations/bucket/geogrid/GeoShapeGeoTileGridAggregatorTests.java
+++ b/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/search/aggregations/bucket/geogrid/GeoShapeGeoTileGridAggregatorTests.java
@@ -37,9 +37,17 @@ public class GeoShapeGeoTileGridAggregatorTests extends GeoShapeGeoGridTestCase<
 
     @Override
     protected GeoBoundingBox randomBBox() {
-         return randomValueOtherThanMany(
+        GeoBoundingBox bbox =  randomValueOtherThanMany(
             (b) -> b.top() > GeoTileUtils.LATITUDE_MASK || b.bottom() < -GeoTileUtils.LATITUDE_MASK,
             GeoTestUtils::randomBBox);
+        // Avoid numerical errors for sub-atomic values
+        double left = GeoTestUtils.encodeDecodeLon(bbox.left());
+        double right = GeoTestUtils.encodeDecodeLon(bbox.right());
+        double top = GeoTestUtils.encodeDecodeLat(bbox.top());
+        double bottom = GeoTestUtils.encodeDecodeLat(bbox.bottom());
+        bbox.topLeft().reset(top, left);
+        bbox.bottomRight().reset(bottom, right);
+        return bbox;
     }
 
     @Override


### PR DESCRIPTION
With the introduction of #72295, we make some GeoTileGrider test more sensitive to sub-atomic values on Geogrid bounds. This change avoid creating sub-atomic values for those bounds.

fixes #72390 