### PR TITLE
[7.x] [DOCS] EQL: Use ECS example in EQL syntax docs (#72414)

### DIFF
--- a/docs/reference/eql/syntax.asciidoc
+++ b/docs/reference/eql/syntax.asciidoc
@@ -567,13 +567,13 @@ to:
 
 * Events with the same `user.name` value
 * `file` events with a `file.path` value equal to the following `process`
-   event's `process.path` value.
+   event's `process.executable` value.
 
 [source,eql]
 ----
 sequence
   [ file where file.extension == "exe" ] by user.name, file.path
-  [ process where true ] by user.name, process.path
+  [ process where true ] by user.name, process.executable
 ----
 
 Because the `user.name` field is shared across all events in the sequence, it
@@ -584,7 +584,7 @@ prior one.
 ----
 sequence by user.name
   [ file where file.extension == "exe" ] by file.path
-  [ process where true ] by process.path
+  [ process where true ] by process.executable
 ----
 
 You can combine the `sequence by` and `with maxspan` keywords to constrain a
@@ -609,7 +609,7 @@ keywords to match only a sequence of events that:
 ----
 sequence by user.name with maxspan=15m
   [ file where file.extension == "exe" ] by file.path
-  [ process where true ] by process.path
+  [ process where true ] by process.executable
 ----
 
 [discrete]


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [DOCS] EQL: Use ECS example in EQL syntax docs (#72414)