### PR TITLE
Fixes for packaging upgrade tests

### DIFF
--- a/qa/os/build.gradle
+++ b/qa/os/build.gradle
@@ -11,21 +11,19 @@ plugins {
 }
 
 dependencies {
-  api "junit:junit:${versions.junit}"
-  api "org.hamcrest:hamcrest:${versions.hamcrest}"
-  api "com.carrotsearch.randomizedtesting:randomizedtesting-runner:${versions.randomizedrunner}"
-
-  api "org.apache.httpcomponents:httpcore:${versions.httpcore}"
-  api "org.apache.httpcomponents:httpclient:${versions.httpclient}"
-  api "org.apache.httpcomponents:fluent-hc:${versions.httpclient}"
-  api "org.apache.logging.log4j:log4j-api:${versions.log4j}"
-  api "org.apache.logging.log4j:log4j-core:${versions.log4j}"
-  api "org.apache.logging.log4j:log4j-jcl:${versions.log4j}"
-  api "commons-codec:commons-codec:${versions.commonscodec}"
-  api "commons-logging:commons-logging:${versions.commonslogging}"
-
-  api project(':libs:elasticsearch-core')
-
+  testImplementation project(':server')
+  testImplementation project(':libs:elasticsearch-core')
+  testImplementation "junit:junit:${versions.junit}"
+  testImplementation "org.hamcrest:hamcrest:${versions.hamcrest}"
+  testImplementation "com.carrotsearch.randomizedtesting:randomizedtesting-runner:${versions.randomizedrunner}"
+  testImplementation "org.apache.httpcomponents:httpcore:${versions.httpcore}"
+  testImplementation "org.apache.httpcomponents:httpclient:${versions.httpclient}"
+  testImplementation "org.apache.httpcomponents:fluent-hc:${versions.httpclient}"
+  testImplementation "org.apache.logging.log4j:log4j-api:${versions.log4j}"
+  testImplementation "org.apache.logging.log4j:log4j-core:${versions.log4j}"
+  testImplementation "org.apache.logging.log4j:log4j-jcl:${versions.log4j}"
+  testImplementation "commons-codec:commons-codec:${versions.commonscodec}"
+  testImplementation "commons-logging:commons-logging:${versions.commonslogging}"
   testImplementation "com.fasterxml.jackson.core:jackson-annotations:${versions.jackson}"
   testImplementation "com.fasterxml.jackson.core:jackson-core:${versions.jackson}"
   testImplementation "com.fasterxml.jackson.core:jackson-databind:${versions.jackson}"

--- a/qa/os/src/test/java/org/elasticsearch/packaging/test/PackageUpgradeTests.java
+++ b/qa/os/src/test/java/org/elasticsearch/packaging/test/PackageUpgradeTests.java
@@ -32,7 +32,6 @@ public class PackageUpgradeTests extends PackagingTestCase {
     public void test10InstallBwcVersion() throws Exception {
         installation = installPackage(sh, bwcDistribution);
         assertInstalled(bwcDistribution);
-        verifyPackageInstallation(installation, bwcDistribution, sh);
     }
 
     public void test11ModifyKeystore() throws Exception {

--- a/qa/os/src/test/java/org/elasticsearch/packaging/util/Distribution.java
+++ b/qa/os/src/test/java/org/elasticsearch/packaging/util/Distribution.java
@@ -8,6 +8,8 @@
 
 package org.elasticsearch.packaging.util;
 
+import org.elasticsearch.Version;
+
 import java.nio.file.Path;
 import java.util.Locale;
 
@@ -17,7 +19,8 @@ public class Distribution {
     public final Packaging packaging;
     public final Platform platform;
     public final boolean hasJdk;
-    public final String version;
+    public final String versionString;
+    public final Version version;
 
     public Distribution(Path path) {
         this.path = path;
@@ -39,10 +42,12 @@ public class Distribution {
         this.platform = filename.contains("windows") ? Platform.WINDOWS : Platform.LINUX;
         this.hasJdk = filename.contains("no-jdk") == false;
         String version = filename.split("-", 3)[1];
+        this.version = Version.fromString(version);
         if (filename.contains("-SNAPSHOT")) {
-            version += "-SNAPSHOT";
+            this.versionString = version + "-SNAPSHOT";
+        } else {
+            this.versionString = version;
         }
-        this.version = version;
     }
 
     public boolean isArchive() {

--- a/qa/os/src/test/java/org/elasticsearch/packaging/util/Distribution.java
+++ b/qa/os/src/test/java/org/elasticsearch/packaging/util/Distribution.java
@@ -8,8 +8,6 @@
 
 package org.elasticsearch.packaging.util;
 
-import org.elasticsearch.Version;
-
 import java.nio.file.Path;
 import java.util.Locale;
 
@@ -19,8 +17,8 @@ public class Distribution {
     public final Packaging packaging;
     public final Platform platform;
     public final boolean hasJdk;
-    public final String versionString;
-    public final Version version;
+    public final String baseVersion;
+    public final String version;
 
     public Distribution(Path path) {
         this.path = path;
@@ -42,12 +40,11 @@ public class Distribution {
         this.platform = filename.contains("windows") ? Platform.WINDOWS : Platform.LINUX;
         this.hasJdk = filename.contains("no-jdk") == false;
         String version = filename.split("-", 3)[1];
-        this.version = Version.fromString(version);
+        this.baseVersion = version;
         if (filename.contains("-SNAPSHOT")) {
-            this.versionString = version + "-SNAPSHOT";
-        } else {
-            this.versionString = version;
+            version += "-SNAPSHOT";
         }
+        this.version = version;
     }
 
     public boolean isArchive() {

--- a/qa/os/src/test/java/org/elasticsearch/packaging/util/Packages.java
+++ b/qa/os/src/test/java/org/elasticsearch/packaging/util/Packages.java
@@ -91,7 +91,7 @@ public class Packages {
             Files.write(installation.envFile, List.of("ES_JAVA_HOME=" + systemJavaHome), StandardOpenOption.APPEND);
         }
 
-        if (distribution.version.onOrAfter(Version.V_7_13_0)) {
+        if (Version.fromString(distribution.baseVersion).onOrAfter(Version.V_7_13_0)) {
             ServerUtils.disableGeoIpDownloader(installation);
         }
         return installation;
@@ -233,7 +233,7 @@ public class Packages {
 
         // at this time we only install the current version of archive distributions, but if that changes we'll need to pass
         // the version through here
-        assertThat(es.bin("elasticsearch-sql-cli-" + distribution.versionString + ".jar"), file(File, "root", "root", p755));
+        assertThat(es.bin("elasticsearch-sql-cli-" + distribution.version + ".jar"), file(File, "root", "root", p755));
 
         Stream.of("users", "users_roles", "roles.yml", "role_mapping.yml", "log4j2.properties")
             .forEach(configFile -> assertThat(es.config(configFile), file(File, "root", "elasticsearch", p660)));

--- a/qa/os/src/test/java/org/elasticsearch/packaging/util/Packages.java
+++ b/qa/os/src/test/java/org/elasticsearch/packaging/util/Packages.java
@@ -10,6 +10,7 @@ package org.elasticsearch.packaging.util;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.elasticsearch.Version;
 import org.elasticsearch.packaging.util.Shell.Result;
 
 import java.io.IOException;
@@ -90,7 +91,9 @@ public class Packages {
             Files.write(installation.envFile, List.of("ES_JAVA_HOME=" + systemJavaHome), StandardOpenOption.APPEND);
         }
 
-        ServerUtils.disableGeoIpDownloader(installation);
+        if (distribution.version.onOrAfter(Version.V_7_13_0)) {
+            ServerUtils.disableGeoIpDownloader(installation);
+        }
         return installation;
     }
 
@@ -230,7 +233,7 @@ public class Packages {
 
         // at this time we only install the current version of archive distributions, but if that changes we'll need to pass
         // the version through here
-        assertThat(es.bin("elasticsearch-sql-cli-" + distribution.version + ".jar"), file(File, "root", "root", p755));
+        assertThat(es.bin("elasticsearch-sql-cli-" + distribution.versionString + ".jar"), file(File, "root", "root", p755));
 
         Stream.of("users", "users_roles", "roles.yml", "role_mapping.yml", "log4j2.properties")
             .forEach(configFile -> assertThat(es.config(configFile), file(File, "root", "elasticsearch", p660)));


### PR DESCRIPTION
This PR includes some fixes to our packaging upgrade tests that we incidentally haven't actually been running for some time.

First, we remove the package installation assertions on the BWC distribution. Packaging evolves over time and there's no guarantee the assertions in the main branch will (or should) apply to older versions. Secondly, we conditionally avoid adding the geoip module settings on versions older than 7.13 since those settings don't exist in those versions.