### PR TITLE
[DOCS] Clarify update transform API

### DIFF
--- a/docs/reference/transform/apis/update-transform.asciidoc
+++ b/docs/reference/transform/apis/update-transform.asciidoc
@@ -172,6 +172,13 @@ include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=source-query-transform
 (Optional, object)
 include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=sync]
 +
+--
+NOTE: You can update these properties only if it is a continuous {transform}. You
+cannot change a batch {transform} into a continuous {transform} or vice versa.
+Instead, clone the {transform} in {kib} and add or remove the `sync` property.
+
+--
++
 .Properties of `sync`
 [%collapsible%open]
 ====


### PR DESCRIPTION
This PR amends the [update transform API](https://www.elastic.co/guide/en/elasticsearch/reference/master/update-transform.html) so that it's clear that you cannot add the sync property for batch transforms nor set it to null for continuous transforms.

### Preview

https://elasticsearch_72427.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/update-transform.html