### PR TITLE
Fixes for package upgrade tests for versions prior to 7.7

### DIFF
--- a/qa/os/src/test/java/org/elasticsearch/packaging/test/PackageUpgradeTests.java
+++ b/qa/os/src/test/java/org/elasticsearch/packaging/test/PackageUpgradeTests.java
@@ -75,9 +75,9 @@ public class PackageUpgradeTests extends PackagingTestCase {
     public void test20InstallUpgradedVersion() throws Exception {
         if (bwcDistribution.path.equals(distribution.path)) {
             // the old and new distributions are the same, so we are testing force upgrading
-            Packages.forceUpgradePackage(sh, distribution);
+            installation = Packages.forceUpgradePackage(sh, distribution);
         } else {
-            Packages.upgradePackage(sh, distribution);
+            installation = Packages.upgradePackage(sh, distribution);
         }
         assertInstalled(distribution);
         verifyPackageInstallation(installation, distribution, sh);

--- a/qa/os/src/test/java/org/elasticsearch/packaging/test/PackagingTestCase.java
+++ b/qa/os/src/test/java/org/elasticsearch/packaging/test/PackagingTestCase.java
@@ -16,6 +16,7 @@ import com.carrotsearch.randomizedtesting.annotations.TestMethodProviders;
 import com.carrotsearch.randomizedtesting.annotations.Timeout;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.elasticsearch.Version;
 import org.elasticsearch.common.CheckedConsumer;
 import org.elasticsearch.common.CheckedRunnable;
 import org.elasticsearch.core.internal.io.IOUtils;
@@ -167,7 +168,10 @@ public abstract class PackagingTestCase extends Assert {
             Platforms.onLinux(() -> sh.getEnv().put("ES_JAVA_HOME", systemJavaHome));
             Platforms.onWindows(() -> sh.getEnv().put("ES_JAVA_HOME", systemJavaHome));
         }
-        if (installation != null && distribution.isDocker() == false) {
+        if (installation != null
+            && installation.distribution.isDocker() == false
+            && Version.fromString(installation.distribution.baseVersion).onOrAfter(Version.V_7_11_0)) {
+            // Explicitly set heap for versions 7.11 and later otherwise auto heap sizing will cause OOM issues
             setHeap("1g");
         }
     }

--- a/qa/os/src/test/java/org/elasticsearch/packaging/util/Packages.java
+++ b/qa/os/src/test/java/org/elasticsearch/packaging/util/Packages.java
@@ -175,9 +175,12 @@ public class Packages {
         assertThat(es.config, file(Directory, "root", "elasticsearch", p750));
         assertThat(sh.run("find \"" + es.config + "\" -maxdepth 0 -printf \"%m\"").stdout, containsString("2750"));
 
-        final Path jvmOptionsDirectory = es.config.resolve("jvm.options.d");
-        assertThat(jvmOptionsDirectory, file(Directory, "root", "elasticsearch", p750));
-        assertThat(sh.run("find \"" + jvmOptionsDirectory + "\" -maxdepth 0 -printf \"%m\"").stdout, containsString("2750"));
+        // We introduced the jvm.options.d folder in 7.7
+        if (Version.fromString(distribution.baseVersion).onOrAfter(Version.V_7_7_0)) {
+            final Path jvmOptionsDirectory = es.config.resolve("jvm.options.d");
+            assertThat(jvmOptionsDirectory, file(Directory, "root", "elasticsearch", p750));
+            assertThat(sh.run("find \"" + jvmOptionsDirectory + "\" -maxdepth 0 -printf \"%m\"").stdout, containsString("2750"));
+        }
 
         Stream.of("elasticsearch.keystore", "elasticsearch.yml", "jvm.options", "log4j2.properties")
             .forEach(configFile -> assertThat(es.config(configFile), file(File, "root", "elasticsearch", p660)));


### PR DESCRIPTION
Follow up to #72420 with more packaging upgrade test fixes. This pull request fixes these tests when upgrading from versions prior to 7.7. In Elasticsearch 7.7 we added the `jvm.options.d` folder for customizing JVM options. In this PR we conditionally avoid verifying the existence of this folder for version prior to 7.7. We also leverage this in our tests to set JVM heap size. This is actually only necessary when testing versions 7.11 and later (we introduced auto heap in 7.11) so we wrap that in a conditional as well.