### PR TITLE
[DOCS] Use kibana_system when setting up Kibana security

### DIFF
--- a/x-pack/docs/en/security/securing-communications/security-minimal-setup.asciidoc
+++ b/x-pack/docs/en/security/securing-communications/security-minimal-setup.asciidoc
@@ -104,17 +104,17 @@ When the {es} security features are enabled, users must log in to {kib} with a
 valid username and password.
 
 {kib} also performs some background tasks that require use of the built-in
-`elastic` user.
+`kibana_system` user.
 
-You'll configure {kib} to use the built-in `elastic` user and the
+You'll configure {kib} to use the built-in `kibana_system` user and the
 password that you created earlier.
 
 . Add the `elasticsearch.username` setting to the `KIB_PATH_CONF/kibana.yml`
-file and set the value to the `elastic` user:
+file and set the value to the `kibana_system` user:
 +
 [source,yaml]
 ----
-elasticsearch.username: "elastic"
+elasticsearch.username: "kibana_system"
 ----
 +
 NOTE: The `KIB_PATH_CONF` variable is the path for the {kib}
@@ -132,14 +132,14 @@ to create the {kib} keystore and add the secure settings:
 ./bin/kibana-keystore create
 ----
 
-   b. Add the password for the `elastic` user to the {kib} keystore:
+   b. Add the password for the `kibana_system` user to the {kib} keystore:
 +
 [source,shell]
 ----
 ./bin/kibana-keystore add elasticsearch.password
 ----
 +
-When prompted, enter the password for the `elastic` user.
+When prompted, enter the password for the `kibana_system` user.
 
 . Restart {kib}. For example, if you installed {kib} with a `.tar.gz` package, run the following command from the {kib} directory:
 +


### PR DESCRIPTION
The `kibana_system` user is specifically intended for use within
Kibana, and has access to all the privileges that are needed or useful
to Kibana. We should advise admins to use that user (rather than
`elastic`) when they set up Kibana for the first time.

The kibana setup docs recommend using `kibana_system` (as they
should because that it is recommended production setup),and though
it may appear convenient to reduce the number of passwords that need
to be tracked during the minimal setup, it creates confusion when
admins try to reconcile conflicting docs.

Preview: https://elasticsearch_72433.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/security-minimal-setup.html

Closes #72454