### PR TITLE
Expose API Key metadata to SetSecurityUser ingest processor (#72137)

### DIFF
--- a/docs/reference/ingest/processors/set-security-user.asciidoc
+++ b/docs/reference/ingest/processors/set-security-user.asciidoc
@@ -8,7 +8,8 @@ Sets user-related details (such as `username`,  `roles`, `email`, `full_name`,
 `metadata`, `api_key`, `realm` and `authentication_type`) from the current
 authenticated user to the current document by pre-processing the ingest.
 The `api_key` property exists only if the user authenticates with an
-API key. It is an object containing the `id` and `name` fields of the API key.
+API key. It is an object containing the `id`, `name` and `metadata`
+(if it exists and is non-empty) fields of the API key.
 The `realm` property is also an object with two fields, `name` and `type`.
 When using API key authentication, the `realm` property refers to the realm
 from which the API key is created.

--- a/x-pack/docs/en/security/authorization/set-security-user.asciidoc
+++ b/x-pack/docs/en/security/authorization/set-security-user.asciidoc
@@ -3,7 +3,7 @@
 
 // If an index is shared by many small users it makes sense to put all these users
 // into the same index. Having a dedicated index or shard per user is wasteful.
-// TBD: It's unclear why we're putting users in an index here. 
+// TBD: It's unclear why we're putting users in an index here.
 
 To guarantee that a user reads only their own documents, it makes sense to set up
 document level security. In this scenario, each document must have the username
@@ -20,7 +20,8 @@ The {ref}/ingest-node-set-security-user-processor.html[set security user process
 `username`,  `roles`, `email`, `full_name` and `metadata` ) from the current
 authenticated user to the current document by pre-processing the ingest. When
 you index data with an ingest pipeline, user details are automatically attached
-to the document.
+to the document. If the authenticating credential is an API key, the API key
+`id`, `name` and `metadata` (if it exists and is non-empty) are also attached to
+the document.
 
 For more information see {ref}/ingest.html[Ingest node] and {ref}/ingest-node-set-security-user-processor.html[Set security user processor].
-

--- a/x-pack/plugin/security/qa/security-disabled/build.gradle
+++ b/x-pack/plugin/security/qa/security-disabled/build.gradle
@@ -1,5 +1,5 @@
 /*
- * This QA project tests the security plugin when security is explicitlt disabled.
+ * This QA project tests the security plugin when security is explicitly disabled.
  * It is intended to cover security functionality which is supposed to
  * function in a specific way even if security is disabled on the cluster
  * For example: If a cluster has a pipeline with the set_security_user processor

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/ApiKeyService.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/ApiKeyService.java
@@ -1145,6 +1145,27 @@ public class ApiKeyService {
         }
     }
 
+    /**
+     * If the authentication has type of api_key, returns the metadata associated to the
+     * API key.
+     * @param authentication {@link Authentication}
+     * @return A map for the metadata or an empty map if no metadata is found.
+     */
+    public static Map<String, Object> getApiKeyMetadata(Authentication authentication) {
+        if (AuthenticationType.API_KEY != authentication.getAuthenticationType()) {
+            throw new IllegalArgumentException("authentication type must be [api_key], got ["
+                + authentication.getAuthenticationType().name().toLowerCase(Locale.ROOT) + "]");
+        }
+        final Object apiKeyMetadata = authentication.getMetadata().get(ApiKeyService.API_KEY_METADATA_KEY);
+        if (apiKeyMetadata != null) {
+            final Tuple<XContentType, Map<String, Object>> tuple =
+                XContentHelper.convertToMap((BytesReference) apiKeyMetadata, false, XContentType.JSON);
+            return tuple.v2();
+        } else {
+            return org.elasticsearch.common.collect.Map.of();
+        }
+    }
+
     final class CachedApiKeyHashResult {
         final boolean success;
         final char[] hash;

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/ingest/SetSecurityUserProcessor.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/ingest/SetSecurityUserProcessor.java
@@ -118,21 +118,27 @@ public final class SetSecurityUserProcessor extends AbstractProcessor {
                     }
                     break;
                 case API_KEY:
-                    final String apiKey = "api_key";
-                    final Object existingApiKeyField = userObject.get(apiKey);
-                    @SuppressWarnings("unchecked")
-                    final Map<String, Object> apiKeyField =
-                        existingApiKeyField instanceof Map ? (Map<String, Object>) existingApiKeyField : new HashMap<>();
-                    Object apiKeyName = authentication.getMetadata().get(ApiKeyService.API_KEY_NAME_KEY);
-                    if (apiKeyName != null) {
-                        apiKeyField.put("name", apiKeyName);
-                    }
-                    Object apiKeyId = authentication.getMetadata().get(ApiKeyService.API_KEY_ID_KEY);
-                    if (apiKeyId != null) {
-                        apiKeyField.put("id", apiKeyId);
-                    }
-                    if (false == apiKeyField.isEmpty()) {
-                        userObject.put(apiKey, apiKeyField);
+                    if (Authentication.AuthenticationType.API_KEY == authentication.getAuthenticationType()) {
+                        final String apiKey = "api_key";
+                        final Object existingApiKeyField = userObject.get(apiKey);
+                        @SuppressWarnings("unchecked")
+                        final Map<String, Object> apiKeyField =
+                            existingApiKeyField instanceof Map ? (Map<String, Object>) existingApiKeyField : new HashMap<>();
+                        Object apiKeyName = authentication.getMetadata().get(ApiKeyService.API_KEY_NAME_KEY);
+                        if (apiKeyName != null) {
+                            apiKeyField.put("name", apiKeyName);
+                        }
+                        Object apiKeyId = authentication.getMetadata().get(ApiKeyService.API_KEY_ID_KEY);
+                        if (apiKeyId != null) {
+                            apiKeyField.put("id", apiKeyId);
+                        }
+                        final Map<String,Object> apiKeyMetadata = ApiKeyService.getApiKeyMetadata(authentication);
+                        if (false == apiKeyMetadata.isEmpty()) {
+                            apiKeyField.put("metadata", apiKeyMetadata);
+                        }
+                        if (false == apiKeyField.isEmpty()) {
+                            userObject.put(apiKey, apiKeyField);
+                        }
                     }
                     break;
                 case REALM:

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/ApiKeyServiceTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/ApiKeyServiceTests.java
@@ -95,6 +95,8 @@ import static org.elasticsearch.xpack.core.security.authc.AuthenticationField.AP
 import static org.elasticsearch.xpack.core.security.authc.AuthenticationField.API_KEY_ROLE_DESCRIPTORS_KEY;
 import static org.elasticsearch.xpack.core.security.authz.store.ReservedRolesStore.SUPERUSER_ROLE_DESCRIPTOR;
 import static org.elasticsearch.xpack.security.Security.SECURITY_CRYPTO_THREAD_POOL_NAME;
+import static org.elasticsearch.xpack.security.authc.ApiKeyService.API_KEY_METADATA_KEY;
+import static org.hamcrest.Matchers.anEmptyMap;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.emptyArray;
@@ -1024,6 +1026,32 @@ public class ApiKeyServiceTests extends ESTestCase {
         verify(client).execute(eq(BulkAction.INSTANCE), any(BulkRequest.class), any());
     }
 
+    public void testGetApiKeyMetadata() throws IOException {
+        final Authentication apiKeyAuthentication = mock(Authentication.class);
+        when(apiKeyAuthentication.getAuthenticationType()).thenReturn(AuthenticationType.API_KEY);
+        final Map<String, Object> apiKeyMetadata = ApiKeyTests.randomMetadata();
+        if (apiKeyMetadata == null) {
+            when(apiKeyAuthentication.getMetadata()).thenReturn(org.elasticsearch.common.collect.Map.of());
+        } else {
+            final BytesReference metadataBytes = XContentTestUtils.convertToXContent(apiKeyMetadata, XContentType.JSON);
+            when(apiKeyAuthentication.getMetadata()).thenReturn(org.elasticsearch.common.collect.Map.of(API_KEY_METADATA_KEY, metadataBytes));
+        }
+
+        final Map<String, Object> restoredApiKeyMetadata = ApiKeyService.getApiKeyMetadata(apiKeyAuthentication);
+        if (apiKeyMetadata == null) {
+            assertThat(restoredApiKeyMetadata, anEmptyMap());
+        } else {
+            assertThat(restoredApiKeyMetadata, equalTo(apiKeyMetadata));
+        }
+
+        final Authentication authentication = mock(Authentication.class);
+        when(authentication.getAuthenticationType()).thenReturn(
+            randomValueOtherThan(AuthenticationType.API_KEY, () -> randomFrom(AuthenticationType.values())));
+        final IllegalArgumentException e =
+            expectThrows(IllegalArgumentException.class, () -> ApiKeyService.getApiKeyMetadata(authentication));
+        assertThat(e.getMessage(), containsString("authentication type must be [api_key]"));
+    }
+
     public static class Utils {
 
         private static final AuthenticationContextSerializer authenticationContextSerializer = new AuthenticationContextSerializer();
@@ -1169,7 +1197,7 @@ public class ApiKeyServiceTests extends ESTestCase {
         } else {
             //noinspection unchecked
             assertThat(
-                authResult1.getMetadata().get(ApiKeyService.API_KEY_METADATA_KEY),
+                authResult1.getMetadata().get(API_KEY_METADATA_KEY),
                 equalTo(XContentTestUtils.convertToXContent((Map<String, Object>) metadata, XContentType.JSON)));
         }
     }

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/ApiKeyServiceTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/ApiKeyServiceTests.java
@@ -1034,7 +1034,8 @@ public class ApiKeyServiceTests extends ESTestCase {
             when(apiKeyAuthentication.getMetadata()).thenReturn(org.elasticsearch.common.collect.Map.of());
         } else {
             final BytesReference metadataBytes = XContentTestUtils.convertToXContent(apiKeyMetadata, XContentType.JSON);
-            when(apiKeyAuthentication.getMetadata()).thenReturn(org.elasticsearch.common.collect.Map.of(API_KEY_METADATA_KEY, metadataBytes));
+            when(apiKeyAuthentication.getMetadata()).thenReturn(
+                org.elasticsearch.common.collect.Map.of(API_KEY_METADATA_KEY, metadataBytes));
         }
 
         final Map<String, Object> restoredApiKeyMetadata = ApiKeyService.getApiKeyMetadata(apiKeyAuthentication);

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/set_security_user/20_api_key.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/set_security_user/20_api_key.yml
@@ -1,0 +1,127 @@
+---
+setup:
+  - skip:
+      features: headers
+
+  - do:
+      cluster.health:
+        wait_for_status: yellow
+  - do:
+      ingest.put_pipeline:
+        id: "my_pipeline"
+        body:  >
+          {
+            "processors": [
+              {
+                "set_security_user" : {
+                  "field" : "user"
+                }
+              }
+            ]
+          }
+
+---
+teardown:
+  - do:
+      ingest.delete_pipeline:
+        id: "my_pipeline"
+        ignore: 404
+
+---
+"Test set security user ingest processor works for API keys":
+  - do:
+      security.create_api_key:
+        body:  >
+          {
+            "name": "with-metadata",
+            "metadata": {
+              "string": "hello",
+              "number": 42,
+              "complex": { "foo": "bar", "values": [1, 3, 5] }
+            }
+          }
+  - set: { id: id_with_metadata }
+  - transform_and_set: { login_creds: "#base64EncodeCredentials(id,api_key)" }
+
+  - do:
+      headers:
+        Authorization: ApiKey ${login_creds}
+      index:
+        index: index
+        id: 1
+        pipeline: "my_pipeline"
+        body: >
+          {
+            "message": "should have api key metadata"
+          }
+
+  - do:
+      security.create_api_key:
+        body:  >
+          {
+            "name": "no-metadata"
+          }
+  - set: { id: id_no_metadata }
+  - transform_and_set: { login_creds: "#base64EncodeCredentials(id,api_key)" }
+
+  - do:
+      headers:
+        Authorization: ApiKey ${login_creds}
+      index:
+        index: index
+        id: 2
+        pipeline: "my_pipeline"
+        body: >
+          {
+            "message": "should not have api key metadata"
+          }
+
+  - do:
+      security.create_api_key:
+        body:  >
+          {
+            "name": "empty-metadata",
+            "metadata": { }
+          }
+  - set: { id: id_empty_metadata }
+  - transform_and_set: { login_creds: "#base64EncodeCredentials(id,api_key)" }
+
+  - do:
+      headers:
+        Authorization: ApiKey ${login_creds}
+      index:
+        index: index
+        id: 3
+        pipeline: "my_pipeline"
+        body: >
+          {
+            "message": "should not have api key metadata either"
+          }
+
+  - do:
+      indices.refresh:
+        index: index
+
+  - do:
+      get:
+        index: index
+        id: 1
+  - match: { _source.user.api_key.name: "with-metadata" }
+  - match: { _source.user.api_key.id: $id_with_metadata }
+  - match: { _source.user.api_key.metadata: { "string": "hello", "number": 42, "complex": {"foo": "bar", "values": [1, 3, 5]} } }
+
+  - do:
+      get:
+        index: index
+        id: 2
+  - match: { _source.user.api_key.name: "no-metadata" }
+  - match: { _source.user.api_key.id: $id_no_metadata }
+  - is_false: _source.user.api_key.metadata
+
+  - do:
+      get:
+        index: index
+        id: 3
+  - match: { _source.user.api_key.name: "empty-metadata" }
+  - match: { _source.user.api_key.id: $id_empty_metadata }
+  - is_false: _source.user.api_key.metadata


### PR DESCRIPTION
This PR ensures SetSecurityUserProcessor adds the API key metadata
inside the existing api_key object if the metadata is not null or empty.
