### PR TITLE
Make NodeEnvironment.availableShardPaths singular

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/allocation/ClusterRerouteIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/allocation/ClusterRerouteIT.java
@@ -48,6 +48,7 @@ import org.elasticsearch.test.ESIntegTestCase.Scope;
 import org.elasticsearch.test.InternalTestCluster;
 import org.elasticsearch.test.MockLogAppender;
 
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.List;
@@ -266,12 +267,12 @@ public class ClusterRerouteIT extends ESIntegTestCase {
         final Index index = resolveIndex("test");
 
         logger.info("--> closing all nodes");
-        Path[] shardLocation = internalCluster().getInstance(NodeEnvironment.class, node_1).availableShardPaths(new ShardId(index, 0));
+        Path shardLocation = internalCluster().getInstance(NodeEnvironment.class, node_1).availableShardPath(new ShardId(index, 0));
         assertThat(FileSystemUtils.exists(shardLocation), equalTo(true)); // make sure the data is there!
         internalCluster().closeNonSharedNodes(false); // don't wipe data directories the index needs to be there!
 
-        logger.info("--> deleting the shard data [{}] ", Arrays.toString(shardLocation));
-        assertThat(FileSystemUtils.exists(shardLocation), equalTo(true)); // verify again after cluster was shut down
+        logger.info("--> deleting the shard data [{}] ", shardLocation);
+        assertThat(Files.exists(shardLocation), equalTo(true)); // verify again after cluster was shut down
         IOUtils.rm(shardLocation);
 
         logger.info("--> starting nodes back, will not allocate the shard since it has no data, but the index will be there");

--- a/server/src/internalClusterTest/java/org/elasticsearch/gateway/RecoveryFromGatewayIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/gateway/RecoveryFromGatewayIT.java
@@ -547,19 +547,17 @@ public class RecoveryFromGatewayIT extends ESIntegTestCase {
         });
 
         if (corrupt) {
-            for (Path path : internalCluster().getInstance(NodeEnvironment.class, nodeName).availableShardPaths(shardId)) {
-                final Path indexPath = path.resolve(ShardPath.INDEX_FOLDER_NAME);
-                if (Files.exists(indexPath)) { // multi data path might only have one path in use
-                    try (DirectoryStream<Path> stream = Files.newDirectoryStream(indexPath)) {
-                        for (Path item : stream) {
-                            if (item.getFileName().toString().startsWith("segments_")) {
-                                logger.debug("--> deleting [{}]", item);
-                                Files.delete(item);
-                            }
+            Path path = internalCluster().getInstance(NodeEnvironment.class, nodeName).availableShardPath(shardId);
+            final Path indexPath = path.resolve(ShardPath.INDEX_FOLDER_NAME);
+            if (Files.exists(indexPath)) { // multi data path might only have one path in use
+                try (DirectoryStream<Path> stream = Files.newDirectoryStream(indexPath)) {
+                    for (Path item : stream) {
+                        if (item.getFileName().toString().startsWith("segments_")) {
+                            logger.debug("--> deleting [{}]", item);
+                            Files.delete(item);
                         }
                     }
                 }
-
             }
         }
 

--- a/server/src/internalClusterTest/java/org/elasticsearch/index/shard/IndexShardIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/index/shard/IndexShardIT.java
@@ -130,11 +130,11 @@ public class IndexShardIT extends ESSingleNodeTestCase {
 
         ClusterService cs = getInstanceFromNode(ClusterService.class);
         final Index index = cs.state().metadata().index("test").getIndex();
-        Path[] shardPaths = env.availableShardPaths(new ShardId(index, 0));
-        logger.info("--> paths: [{}]", (Object)shardPaths);
+        Path shardPath = env.availableShardPath(new ShardId(index, 0));
+        logger.info("--> path: [{}]", shardPath);
         // Should not be able to acquire the lock because it's already open
         try {
-            NodeEnvironment.acquireFSLockForPaths(IndexSettingsModule.newIndexSettings("test", Settings.EMPTY), shardPaths);
+            NodeEnvironment.acquireFSLockForPaths(IndexSettingsModule.newIndexSettings("test", Settings.EMPTY), shardPath);
             fail("should not have been able to acquire the lock");
         } catch (LockObtainFailedException e) {
             assertTrue("msg: " + e.getMessage(), e.getMessage().contains("unable to acquire write.lock"));

--- a/server/src/internalClusterTest/java/org/elasticsearch/index/store/CorruptedFileIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/index/store/CorruptedFileIT.java
@@ -607,14 +607,12 @@ public class CorruptedFileIT extends ESIntegTestCase {
 
     private List<Path> findFilesToCorruptOnNode(final String nodeName, final ShardId shardId) throws IOException {
         List<Path> files = new ArrayList<>();
-        for (Path path : internalCluster().getInstance(NodeEnvironment.class, nodeName).availableShardPaths(shardId)) {
-            path = path.resolve("index");
-            if (Files.exists(path)) { // multi data path might only have one path in use
-                try (DirectoryStream<Path> stream = Files.newDirectoryStream(path)) {
-                    for (Path item : stream) {
-                        if (item.getFileName().toString().startsWith("segments_")) {
-                            files.add(item);
-                        }
+        Path path = internalCluster().getInstance(NodeEnvironment.class, nodeName).availableShardPath(shardId).resolve("index");
+        if (Files.exists(path)) { // multi data path might only have one path in use
+            try (DirectoryStream<Path> stream = Files.newDirectoryStream(path)) {
+                for (Path item : stream) {
+                    if (item.getFileName().toString().startsWith("segments_")) {
+                        files.add(item);
                     }
                 }
             }

--- a/server/src/internalClusterTest/java/org/elasticsearch/indices/store/IndicesStoreIntegrationIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/indices/store/IndicesStoreIntegrationIT.java
@@ -459,9 +459,7 @@ public class IndicesStoreIntegrationIT extends ESIntegTestCase {
 
     private Path shardDirectory(String server, Index index, int shard) {
         NodeEnvironment env = internalCluster().getInstance(NodeEnvironment.class, server);
-        final Path[] paths = env.availableShardPaths(new ShardId(index, shard));
-        assert paths.length == 1;
-        return paths[0];
+        return env.availableShardPath(new ShardId(index, shard));
     }
 
     private void assertShardDeleted(final String server, final Index index, final int shard) throws Exception {

--- a/server/src/internalClusterTest/java/org/elasticsearch/recovery/RelocationIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/recovery/RelocationIT.java
@@ -424,18 +424,17 @@ public class RelocationIT extends ESIntegTestCase {
         logger.info("--> verifying no temporary recoveries are left");
         for (String node : internalCluster().getNodeNames()) {
             NodeEnvironment nodeEnvironment = internalCluster().getInstance(NodeEnvironment.class, node);
-            for (final Path shardLoc : nodeEnvironment.availableShardPaths(new ShardId(indexName, "_na_", 0))) {
-                if (Files.exists(shardLoc)) {
-                    assertBusy(() -> {
-                        try {
-                            forEachFileRecursively(shardLoc,
-                                (file, attrs) -> assertThat("found a temporary recovery file: " + file, file.getFileName().toString(),
-                                    not(startsWith("recovery."))));
-                        } catch (IOException e) {
-                            throw new AssertionError("failed to walk file tree starting at [" + shardLoc + "]", e);
-                        }
-                    });
-                }
+            final Path shardLoc = nodeEnvironment.availableShardPath(new ShardId(indexName, "_na_", 0));
+            if (Files.exists(shardLoc)) {
+                assertBusy(() -> {
+                    try {
+                        forEachFileRecursively(shardLoc,
+                            (file, attrs) -> assertThat("found a temporary recovery file: " + file, file.getFileName().toString(),
+                                not(startsWith("recovery."))));
+                    } catch (IOException e) {
+                        throw new AssertionError("failed to walk file tree starting at [" + shardLoc + "]", e);
+                    }
+                });
             }
         }
     }

--- a/server/src/main/java/org/elasticsearch/env/NodeEnvironment.java
+++ b/server/src/main/java/org/elasticsearch/env/NodeEnvironment.java
@@ -549,8 +549,8 @@ public final class NodeEnvironment  implements Closeable {
         IndexSettings indexSettings,
         Consumer<Path[]> listener
     ) throws IOException, ShardLockObtainFailedException {
-        final Path[] paths = availableShardPaths(shardId);
-        logger.trace("deleting shard {} directory, paths: [{}]", shardId, paths);
+        final Path path = availableShardPath(shardId);
+        logger.trace("deleting shard {} directory, path: [{}]", shardId, path);
         try (ShardLock lock = shardLock(shardId, "shard deletion under lock")) {
             deleteShardDirectoryUnderLock(lock, indexSettings, listener);
         }
@@ -604,11 +604,11 @@ public final class NodeEnvironment  implements Closeable {
     ) throws IOException {
         final ShardId shardId = lock.getShardId();
         assert isShardLocked(shardId) : "shard " + shardId + " is not locked";
-        final Path[] paths = availableShardPaths(shardId);
-        logger.trace("acquiring locks for {}, paths: [{}]", shardId, paths);
-        acquireFSLockForPaths(indexSettings, paths);
-        listener.accept(paths);
-        IOUtils.rm(paths);
+        final Path path = availableShardPath(shardId);
+        logger.trace("acquiring locks for {}, path: [{}]", shardId, path);
+        acquireFSLockForPaths(indexSettings, path);
+        listener.accept(new Path[] { path });
+        IOUtils.rm(path);
         if (indexSettings.hasCustomDataPath()) {
             Path customLocation = resolveCustomLocation(indexSettings.customDataPath(), shardId);
             logger.trace("acquiring lock for {}, custom path: [{}]", shardId, customLocation);
@@ -617,11 +617,11 @@ public final class NodeEnvironment  implements Closeable {
             listener.accept(new Path[]{customLocation});
             IOUtils.rm(customLocation);
         }
-        logger.trace("deleted shard {} directory, paths: [{}]", shardId, paths);
-        assert assertPathsDoNotExist(paths);
+        logger.trace("deleted shard {} directory, path: [{}]", shardId, path);
+        assert assertPathsDoNotExist(path);
     }
 
-    private static boolean assertPathsDoNotExist(final Path[] paths) {
+    private static boolean assertPathsDoNotExist(final Path... paths) {
         Set<Path> existingPaths = Stream.of(paths)
             .filter(FileSystemUtils::exists)
             .filter(leftOver -> {
@@ -954,14 +954,9 @@ public final class NodeEnvironment  implements Closeable {
      * @see #resolveCustomLocation(String, ShardId)
      *
      */
-    public Path[] availableShardPaths(ShardId shardId) {
+    public Path availableShardPath(ShardId shardId) {
         assertEnvIsLocked();
-        final NodePath[] nodePaths = nodePaths();
-        final Path[] shardLocations = new Path[nodePaths.length];
-        for (int i = 0; i < nodePaths.length; i++) {
-            shardLocations[i] = nodePaths[i].resolve(shardId);
-        }
-        return shardLocations;
+        return nodePaths[0].resolve(shardId);
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/gateway/TransportNodesListGatewayStartedShards.java
+++ b/server/src/main/java/org/elasticsearch/gateway/TransportNodesListGatewayStartedShards.java
@@ -98,7 +98,7 @@ public class TransportNodesListGatewayStartedShards extends
             final ShardId shardId = request.getShardId();
             logger.trace("{} loading local shard state info", shardId);
             ShardStateMetadata shardStateMetadata = ShardStateMetadata.FORMAT.loadLatestState(logger, namedXContentRegistry,
-                nodeEnv.availableShardPaths(request.shardId));
+                nodeEnv.availableShardPath(request.shardId));
             if (shardStateMetadata != null) {
                 if (indicesService.getShardOrNull(shardId) == null) {
                     final String customDataPath;

--- a/server/src/main/java/org/elasticsearch/index/shard/ShardPath.java
+++ b/server/src/main/java/org/elasticsearch/index/shard/ShardPath.java
@@ -109,9 +109,9 @@ public final class ShardPath {
      */
     public static ShardPath loadShardPath(Logger logger, NodeEnvironment env,
                                           ShardId shardId, String customDataPath) throws IOException {
-        final Path[] paths = env.availableShardPaths(shardId);
+        final Path shardPath = env.availableShardPath(shardId);
         final Path sharedDataPath = env.sharedDataPath();
-        return loadShardPath(logger, shardId, customDataPath, paths, sharedDataPath);
+        return loadShardPath(logger, shardId, customDataPath, new Path[] { shardPath }, sharedDataPath);
     }
 
     /**
@@ -170,18 +170,16 @@ public final class ShardPath {
         final Consumer<Path[]> listener
     ) throws IOException {
         final String indexUUID = indexSettings.getUUID();
-        final Path[] paths = env.availableShardPaths(lock.getShardId());
-        for (Path path : paths) {
-            // EMPTY is safe here because we never call namedObject
-            ShardStateMetadata load = ShardStateMetadata.FORMAT.loadLatestState(logger, NamedXContentRegistry.EMPTY, path);
-            if (load != null) {
-                if (load.indexUUID.equals(indexUUID) == false && IndexMetadata.INDEX_UUID_NA_VALUE.equals(load.indexUUID) == false) {
-                    logger.warn("{} deleting leftover shard on path: [{}] with a different index UUID", lock.getShardId(), path);
-                    assert Files.isDirectory(path) : path + " is not a directory";
-                    NodeEnvironment.acquireFSLockForPaths(indexSettings, path);
-                    listener.accept(new Path[]{path});
-                    IOUtils.rm(path);
-                }
+        final Path path = env.availableShardPath(lock.getShardId());
+        // EMPTY is safe here because we never call namedObject
+        ShardStateMetadata load = ShardStateMetadata.FORMAT.loadLatestState(logger, NamedXContentRegistry.EMPTY, path);
+        if (load != null) {
+            if (load.indexUUID.equals(indexUUID) == false && IndexMetadata.INDEX_UUID_NA_VALUE.equals(load.indexUUID) == false) {
+                logger.warn("{} deleting leftover shard on path: [{}] with a different index UUID", lock.getShardId(), path);
+                assert Files.isDirectory(path) : path + " is not a directory";
+                NodeEnvironment.acquireFSLockForPaths(indexSettings, path);
+                listener.accept(new Path[]{path});
+                IOUtils.rm(path);
             }
         }
     }

--- a/server/src/main/java/org/elasticsearch/indices/IndicesService.java
+++ b/server/src/main/java/org/elasticsearch/indices/IndicesService.java
@@ -1083,7 +1083,7 @@ public class IndicesService extends AbstractLifecycleComponent
         } else {
             // lets see if it's path is available (return false if the shard doesn't exist)
             // we don't need to delete anything that is not there
-            return FileSystemUtils.exists(nodeEnv.availableShardPaths(shardId)) ?
+            return Files.exists(nodeEnv.availableShardPath(shardId)) ?
                 ShardDeletionCheckResult.FOLDER_FOUND_CAN_DELETE :
                 ShardDeletionCheckResult.NO_FOLDER_FOUND;
         }

--- a/server/src/test/java/org/elasticsearch/env/NodeEnvironmentTests.java
+++ b/server/src/test/java/org/elasticsearch/env/NodeEnvironmentTests.java
@@ -352,23 +352,23 @@ public class NodeEnvironmentTests extends ESTestCase {
         Index index = new Index("myindex", "myindexUUID");
         ShardId sid = new ShardId(index, 0);
 
-        assertThat(env.availableShardPaths(sid), equalTo(env.availableShardPaths(sid)));
+        assertThat(env.availableShardPath(sid), equalTo(env.availableShardPath(sid)));
         assertThat(env.resolveCustomLocation("/tmp/foo", sid).toAbsolutePath(),
             equalTo(PathUtils.get("/tmp/foo/0/" + index.getUUID() + "/0").toAbsolutePath()));
 
         assertThat("shard paths with a custom data_path should contain only regular paths",
-            env.availableShardPaths(sid)[0],
+            env.availableShardPath(sid),
             equalTo(dataPath.resolve("indices/" + index.getUUID() + "/0")));
 
         assertThat("index paths uses the regular template",
             env.indexPaths(index)[0], equalTo(dataPath.resolve("indices/" + index.getUUID())));
 
-        assertThat(env.availableShardPaths(sid), equalTo(env.availableShardPaths(sid)));
+        assertThat(env.availableShardPath(sid), equalTo(env.availableShardPath(sid)));
         assertThat(env.resolveCustomLocation("/tmp/foo", sid).toAbsolutePath(),
             equalTo(PathUtils.get("/tmp/foo/0/" + index.getUUID() + "/0").toAbsolutePath()));
 
         assertThat("shard paths with a custom data_path should contain only regular paths",
-            env.availableShardPaths(sid)[0],
+            env.availableShardPath(sid),
             equalTo(dataPath.resolve("indices/" + index.getUUID() + "/0")));
 
         assertThat("index paths uses the regular template",

--- a/server/src/test/java/org/elasticsearch/index/shard/IndexShardTests.java
+++ b/server/src/test/java/org/elasticsearch/index/shard/IndexShardTests.java
@@ -208,18 +208,18 @@ public class IndexShardTests extends IndexShardTestCase {
             boolean primary = randomBoolean();
             AllocationId allocationId = randomBoolean() ? null : randomAllocationId();
             ShardStateMetadata state1 = new ShardStateMetadata(primary, "fooUUID", allocationId);
-            write(state1, env.availableShardPaths(id));
-            ShardStateMetadata shardStateMetadata = load(logger, env.availableShardPaths(id));
+            write(state1, env.availableShardPath(id));
+            ShardStateMetadata shardStateMetadata = load(logger, env.availableShardPath(id));
             assertEquals(shardStateMetadata, state1);
 
             ShardStateMetadata state2 = new ShardStateMetadata(primary, "fooUUID", allocationId);
-            write(state2, env.availableShardPaths(id));
-            shardStateMetadata = load(logger, env.availableShardPaths(id));
+            write(state2, env.availableShardPath(id));
+            shardStateMetadata = load(logger, env.availableShardPath(id));
             assertEquals(shardStateMetadata, state1);
 
             ShardStateMetadata state3 = new ShardStateMetadata(primary, "fooUUID", allocationId);
-            write(state3, env.availableShardPaths(id));
-            shardStateMetadata = load(logger, env.availableShardPaths(id));
+            write(state3, env.availableShardPath(id));
+            shardStateMetadata = load(logger, env.availableShardPath(id));
             assertEquals(shardStateMetadata, state3);
             assertEquals("fooUUID", state3.indexUUID);
         }

--- a/server/src/test/java/org/elasticsearch/index/shard/ShardPathTests.java
+++ b/server/src/test/java/org/elasticsearch/index/shard/ShardPathTests.java
@@ -24,8 +24,7 @@ public class ShardPathTests extends ESTestCase {
     public void testLoadShardPath() throws IOException {
         try (NodeEnvironment env = newNodeEnvironment(Settings.builder().build())) {
             ShardId shardId = new ShardId("foo", "0xDEADBEEF", 0);
-            Path[] paths = env.availableShardPaths(shardId);
-            Path path = randomFrom(paths);
+            Path path = env.availableShardPath(shardId);
             ShardStateMetadata.FORMAT.writeAndCleanup(
                     new ShardStateMetadata(true, "0xDEADBEEF", AllocationId.newInitializing()), path);
             ShardPath shardPath = ShardPath.loadShardPath(logger, env, shardId, "");
@@ -37,24 +36,10 @@ public class ShardPathTests extends ESTestCase {
         }
     }
 
-    public void testFailLoadShardPathOnMultiState() throws IOException {
-        try (NodeEnvironment env = newNodeEnvironment(Settings.builder().build())) {
-            final String indexUUID = "0xDEADBEEF";
-            ShardId shardId = new ShardId("foo", indexUUID, 0);
-            Path[] paths = env.availableShardPaths(shardId);
-            assumeTrue("This test tests multi data.path but we only got one", paths.length > 1);
-            ShardStateMetadata.FORMAT.writeAndCleanup(
-                    new ShardStateMetadata(true, indexUUID, AllocationId.newInitializing()), paths);
-            Exception e = expectThrows(IllegalStateException.class, () -> ShardPath.loadShardPath(logger, env, shardId, ""));
-            assertThat(e.getMessage(), containsString("more than one shard state found"));
-        }
-    }
-
     public void testFailLoadShardPathIndexUUIDMissmatch() throws IOException {
         try (NodeEnvironment env = newNodeEnvironment(Settings.builder().build())) {
             ShardId shardId = new ShardId("foo", "foobar", 0);
-            Path[] paths = env.availableShardPaths(shardId);
-            Path path = randomFrom(paths);
+            Path path = env.availableShardPath(shardId);
             ShardStateMetadata.FORMAT.writeAndCleanup(
                     new ShardStateMetadata(true, "0xDEADBEEF", AllocationId.newInitializing()), path);
             Exception e = expectThrows(IllegalStateException.class, () -> ShardPath.loadShardPath(logger, env, shardId, ""));
@@ -98,8 +83,7 @@ public class ShardPathTests extends ESTestCase {
         }
         try (NodeEnvironment env = newNodeEnvironment(nodeSettings)) {
             ShardId shardId = new ShardId("foo", indexUUID, 0);
-            Path[] paths = env.availableShardPaths(shardId);
-            Path path = randomFrom(paths);
+            Path path = env.availableShardPath(shardId);
             ShardStateMetadata.FORMAT.writeAndCleanup(
                     new ShardStateMetadata(true, indexUUID, AllocationId.newInitializing()), path);
             ShardPath shardPath = ShardPath.loadShardPath(logger, env, shardId, customDataPath);

--- a/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/AbstractSearchableSnapshotsTestCase.java
+++ b/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/AbstractSearchableSnapshotsTestCase.java
@@ -199,8 +199,8 @@ public abstract class AbstractSearchableSnapshotsTestCase extends ESIndexInputTe
     /**
      * Returns a random shard data path for the specified {@link ShardId}. The returned path can be located on any of the data node paths.
      */
-    protected Path randomShardPath(ShardId shardId) {
-        return randomFrom(nodeEnvironment.availableShardPaths(shardId));
+    protected Path shardPath(ShardId shardId) {
+        return nodeEnvironment.availableShardPath(shardId);
     }
 
     protected static ByteSizeValue randomFrozenCacheSize() {
@@ -287,7 +287,7 @@ public abstract class AbstractSearchableSnapshotsTestCase extends ESIndexInputTe
                     ShardId shardId = new ShardId(indexId.getName(), indexId.getId(), shards);
 
                     final Path cacheDir = Files.createDirectories(
-                        CacheService.resolveSnapshotCache(randomShardPath(shardId)).resolve(snapshotUUID)
+                        CacheService.resolveSnapshotCache(shardPath(shardId)).resolve(snapshotUUID)
                     );
 
                     for (int files = 0; files < between(1, 2); files++) {

--- a/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/cache/full/CacheServiceTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/cache/full/CacheServiceTests.java
@@ -78,7 +78,7 @@ public class CacheServiceTests extends AbstractSearchableSnapshotsTestCase {
         logger.debug("--> creating shard cache directories on disk");
         final Path[] shardsCacheDirs = new Path[numShards];
         for (int i = 0; i < numShards; i++) {
-            final Path shardDataPath = randomShardPath(new ShardId(index, i));
+            final Path shardDataPath = shardPath(new ShardId(index, i));
             assertFalse(Files.exists(shardDataPath));
 
             logger.debug("--> creating directories [{}] for shard [{}]", shardDataPath.toAbsolutePath(), i);
@@ -196,7 +196,7 @@ public class CacheServiceTests extends AbstractSearchableSnapshotsTestCase {
             );
 
             final Path cacheDir = Files.createDirectories(
-                resolveSnapshotCache(randomShardPath(cacheKey.getShardId())).resolve(cacheKey.getSnapshotUUID())
+                resolveSnapshotCache(shardPath(cacheKey.getShardId())).resolve(cacheKey.getSnapshotUUID())
             );
             final String cacheFileUuid = UUIDs.randomBase64UUID(random());
             final SortedSet<ByteRange> cacheFileRanges = randomBoolean() ? randomRanges(fileLength) : emptySortedSet();

--- a/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/store/SearchableSnapshotDirectoryStatsTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/store/SearchableSnapshotDirectoryStatsTests.java
@@ -641,7 +641,7 @@ public class SearchableSnapshotDirectoryStatsTests extends AbstractSearchableSna
         final StoreFileMetadata metadata = new StoreFileMetadata(fileName, fileContent.length, fileChecksum, Version.CURRENT.luceneVersion);
         final List<FileInfo> files = List.of(new FileInfo(blobName, metadata, new ByteSizeValue(fileContent.length)));
         final BlobStoreIndexShardSnapshot snapshot = new BlobStoreIndexShardSnapshot(snapshotId.getName(), 0L, files, 0L, 0L, 0, 0L);
-        final Path shardDir = randomShardPath(shardId);
+        final Path shardDir = shardPath(shardId);
         final ShardPath shardPath = new ShardPath(false, shardDir, shardDir, shardId);
         final Path cacheDir = Files.createDirectories(resolveSnapshotCache(shardDir).resolve(snapshotId.getUUID()));
 

--- a/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/store/SearchableSnapshotDirectoryTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/store/SearchableSnapshotDirectoryTests.java
@@ -629,7 +629,7 @@ public class SearchableSnapshotDirectoryTests extends AbstractSearchableSnapshot
                 final BlobContainer blobContainer = repository.shardContainer(indexId, shardId.id());
                 final BlobStoreIndexShardSnapshot snapshot = repository.loadShardSnapshot(blobContainer, snapshotId);
 
-                final Path shardDir = randomShardPath(shardId);
+                final Path shardDir = shardPath(shardId);
                 final ShardPath shardPath = new ShardPath(false, shardDir, shardDir, shardId);
                 final Path cacheDir = Files.createDirectories(resolveSnapshotCache(shardDir).resolve(snapshotId.getUUID()));
                 final CacheService cacheService = defaultCacheService();
@@ -737,7 +737,7 @@ public class SearchableSnapshotDirectoryTests extends AbstractSearchableSnapshot
             final IndexId indexId = new IndexId("_id", "_uuid");
             final ShardId shardId = new ShardId(new Index("_name", "_id"), 0);
 
-            final Path shardDir = randomShardPath(shardId);
+            final Path shardDir = shardPath(shardId);
             final ShardPath shardPath = new ShardPath(false, shardDir, shardDir, shardId);
             final Path cacheDir = Files.createDirectories(resolveSnapshotCache(shardDir).resolve(snapshotId.getUUID()));
             final FrozenCacheService frozenCacheService = defaultFrozenCacheService();

--- a/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/store/input/CachedBlobContainerIndexInputTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/store/input/CachedBlobContainerIndexInputTests.java
@@ -94,7 +94,7 @@ public class CachedBlobContainerIndexInputTests extends AbstractSearchableSnapsh
                 }
 
                 final boolean recoveryFinalizedDone = randomBoolean();
-                final Path shardDir = randomShardPath(shardId);
+                final Path shardDir = shardPath(shardId);
                 final ShardPath shardPath = new ShardPath(false, shardDir, shardDir, shardId);
                 final Path cacheDir = Files.createDirectories(resolveSnapshotCache(shardDir).resolve(snapshotId.getUUID()));
                 final FrozenCacheService frozenCacheService = defaultFrozenCacheService();
@@ -198,7 +198,7 @@ public class CachedBlobContainerIndexInputTests extends AbstractSearchableSnapsh
             );
 
             final BlobContainer blobContainer = singleBlobContainer(blobName, input);
-            final Path shardDir = randomShardPath(shardId);
+            final Path shardDir = shardPath(shardId);
             final ShardPath shardPath = new ShardPath(false, shardDir, shardDir, shardId);
             final Path cacheDir = Files.createDirectories(resolveSnapshotCache(shardDir).resolve(snapshotId.getUUID()));
             final FrozenCacheService frozenCacheService = defaultFrozenCacheService();

--- a/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/store/input/FrozenIndexInputTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/store/input/FrozenIndexInputTests.java
@@ -90,7 +90,7 @@ public class FrozenIndexInputTests extends AbstractSearchableSnapshotsTestCase {
         final Environment environment = TestEnvironment.newEnvironment(settings);
         Files.createDirectories(environment.dataFile());
         SnapshotId snapshotId = new SnapshotId("_name", "_uuid");
-        final Path shardDir = randomShardPath(SHARD_ID);
+        final Path shardDir = shardPath(SHARD_ID);
         final ShardPath shardPath = new ShardPath(false, shardDir, shardDir, SHARD_ID);
         final Path cacheDir = Files.createDirectories(resolveSnapshotCache(shardDir).resolve(snapshotId.getUUID()));
         try (


### PR DESCRIPTION
This commit renames the availableShardPaths method to be singular and
return a single Path instead of an array.

relates #71205