### PR TITLE
[ML] Check the out stream exists before consuming it

### DIFF
--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/process/AbstractNativeProcess.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/process/AbstractNativeProcess.java
@@ -319,6 +319,10 @@ public abstract class AbstractNativeProcess implements NativeProcess {
     }
 
     public void consumeAndCloseOutputStream() {
+        if (processOutStream.get() == null) {
+            return;
+        }
+
         try (InputStream outStream = processOutStream()) {
             byte[] buff = new byte[512];
             while (outStream.read(buff) >= 0) {

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/process/AbstractNativeProcessTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/process/AbstractNativeProcessTests.java
@@ -195,6 +195,15 @@ public class AbstractNativeProcessTests extends ESTestCase {
         }
     }
 
+    public void testConsumeAndCloseOutputStream_GivenNoOutputStream() throws Exception {
+        when(processPipes.getProcessOutStream()).thenReturn(Optional.empty());
+        try (AbstractNativeProcess process = new TestNativeProcess()) {
+            process.consumeAndCloseOutputStream();
+        } finally {
+            mockNativeProcessLoggingStreamEnds.countDown();
+        }
+    }
+
     /**
      * Mock-based implementation of {@link AbstractNativeProcess}.
      */


### PR DESCRIPTION
If something goes wrong when starting the process and
the connection to the out stream fails, we will get a
NPE when we close the process as we're missing a null
check when we try to consume the out stream. This pollutes
the log with a misleading error.

This commit adds a null check before we go on and consume
the out stream.
