### PR TITLE
Add warnings if timer thread is late to wake up

### DIFF
--- a/server/src/main/java/org/elasticsearch/threadpool/ThreadPool.java
+++ b/server/src/main/java/org/elasticsearch/threadpool/ThreadPool.java
@@ -143,6 +143,9 @@ public class ThreadPool implements ReportingService<ThreadPoolInfo>, Scheduler {
     public static Setting<TimeValue> ESTIMATED_TIME_INTERVAL_SETTING =
         Setting.timeSetting("thread_pool.estimated_time_interval",
             TimeValue.timeValueMillis(200), TimeValue.ZERO, Setting.Property.NodeScope);
+    public static Setting<TimeValue> LATE_TIME_INTERVAL_WARN_THRESHOLD_SETTING =
+        Setting.timeSetting("thread_pool.estimated_time_interval.warn_threshold",
+            TimeValue.timeValueSeconds(5), TimeValue.ZERO, Setting.Property.NodeScope);
 
     @SuppressWarnings({"rawtypes", "unchecked"})
     public ThreadPool(final Settings settings, final ExecutorBuilder<?>... customBuilders) {
@@ -206,8 +209,10 @@ public class ThreadPool implements ReportingService<ThreadPoolInfo>, Scheduler {
                         .collect(Collectors.toList());
         this.threadPoolInfo = new ThreadPoolInfo(infos);
         this.scheduler = Scheduler.initScheduler(settings, "scheduler");
-        TimeValue estimatedTimeInterval = ESTIMATED_TIME_INTERVAL_SETTING.get(settings);
-        this.cachedTimeThread = new CachedTimeThread(EsExecutors.threadName(settings, "[timer]"), estimatedTimeInterval.millis());
+        this.cachedTimeThread = new CachedTimeThread(
+                EsExecutors.threadName(settings, "[timer]"),
+                ESTIMATED_TIME_INTERVAL_SETTING.get(settings).millis(),
+                LATE_TIME_INTERVAL_WARN_THRESHOLD_SETTING.get(settings).millis());
         this.cachedTimeThread.start();
     }
 
@@ -485,15 +490,20 @@ public class ThreadPool implements ReportingService<ThreadPoolInfo>, Scheduler {
     static class CachedTimeThread extends Thread {
 
         final long interval;
+        private final TimeChangeChecker timeChangeChecker;
+        private final long thresholdMillis;
+
         volatile boolean running = true;
         volatile long relativeNanos;
         volatile long absoluteMillis;
 
-        CachedTimeThread(String name, long interval) {
+        CachedTimeThread(String name, long intervalMillis, long thresholdMillis) {
             super(name);
-            this.interval = interval;
+            this.interval = intervalMillis;
+            this.thresholdMillis = thresholdMillis;
             this.relativeNanos = System.nanoTime();
             this.absoluteMillis = System.currentTimeMillis();
+            this.timeChangeChecker = new TimeChangeChecker(thresholdMillis, absoluteMillis, relativeNanos);
             setDaemon(true);
         }
 
@@ -531,12 +541,69 @@ public class ThreadPool implements ReportingService<ThreadPoolInfo>, Scheduler {
             while (running && 0 < interval) {
                 relativeNanos = System.nanoTime();
                 absoluteMillis = System.currentTimeMillis();
+                timeChangeChecker.check(absoluteMillis, relativeNanos);
                 try {
+                    // busy-waiting is the whole point!
+                    // noinspection BusyWait
                     Thread.sleep(interval);
                 } catch (InterruptedException e) {
                     running = false;
                     return;
                 }
+            }
+        }
+    }
+
+    static class TimeChangeChecker {
+
+        private final long thresholdMillis;
+        private final long thresholdNanos;
+        private long absoluteMillis;
+        private long relativeNanos;
+
+        TimeChangeChecker(long thresholdMillis, long absoluteMillis, long relativeNanos) {
+            this.thresholdMillis = thresholdMillis;
+            this.thresholdNanos = TimeValue.timeValueMillis(thresholdMillis).nanos();
+            this.absoluteMillis = absoluteMillis;
+            this.relativeNanos = relativeNanos;
+        }
+
+        void check(long newAbsoluteMillis, long newRelativeNanos) {
+            if (thresholdMillis <= 0) {
+                return;
+            }
+
+            try {
+                final long deltaMillis = newAbsoluteMillis - absoluteMillis;
+                if (deltaMillis > thresholdMillis) {
+                    final TimeValue delta = TimeValue.timeValueMillis(deltaMillis);
+                    logger.warn("timer thread slept for [{}/{}ms] on absolute clock which is above the warn threshold of [{}ms]",
+                            delta,
+                            deltaMillis,
+                            thresholdMillis);
+                } else if (deltaMillis < 0) {
+                    final TimeValue delta = TimeValue.timeValueMillis(-deltaMillis);
+                    logger.warn("absolute clock went backwards by [{}/{}ms] while timer thread was sleeping",
+                            delta,
+                            -deltaMillis);
+                }
+
+                final long deltaNanos = newRelativeNanos - relativeNanos;
+                if (deltaNanos > thresholdNanos) {
+                    final TimeValue delta = TimeValue.timeValueNanos(deltaNanos);
+                    logger.warn("timer thread slept for [{}/{}ns] on relative clock which is above the warn threshold of [{}ms]",
+                            delta,
+                            deltaNanos,
+                            thresholdMillis);
+                } else if (deltaNanos < 0) {
+                    final TimeValue delta = TimeValue.timeValueNanos(-deltaNanos);
+                    logger.warn("relative clock went backwards by [{}/{}ns] while timer thread was sleeping",
+                            delta,
+                            -deltaNanos);
+                }
+            } finally {
+                absoluteMillis = newAbsoluteMillis;
+                relativeNanos = newRelativeNanos;
             }
         }
     }

--- a/server/src/main/java/org/elasticsearch/threadpool/ThreadPool.java
+++ b/server/src/main/java/org/elasticsearch/threadpool/ThreadPool.java
@@ -597,9 +597,10 @@ public class ThreadPool implements ReportingService<ThreadPoolInfo>, Scheduler {
                             thresholdMillis);
                 } else if (deltaNanos < 0) {
                     final TimeValue delta = TimeValue.timeValueNanos(-deltaNanos);
-                    logger.warn("relative clock went backwards by [{}/{}ns] while timer thread was sleeping",
+                    logger.error("relative clock went backwards by [{}/{}ns] while timer thread was sleeping",
                             delta,
                             -deltaNanos);
+                    assert false : "System::nanoTime time should be monotonic";
                 }
             } finally {
                 absoluteMillis = newAbsoluteMillis;

--- a/server/src/test/java/org/elasticsearch/threadpool/ThreadPoolTests.java
+++ b/server/src/test/java/org/elasticsearch/threadpool/ThreadPoolTests.java
@@ -8,18 +8,25 @@
 
 package org.elasticsearch.threadpool;
 
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.elasticsearch.common.logging.Loggers;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.common.util.concurrent.FutureUtils;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.MockLogAppender;
 
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 
 import static org.elasticsearch.threadpool.ThreadPool.ESTIMATED_TIME_INTERVAL_SETTING;
+import static org.elasticsearch.threadpool.ThreadPool.LATE_TIME_INTERVAL_WARN_THRESHOLD_SETTING;
 import static org.elasticsearch.threadpool.ThreadPool.assertCurrentMethodIsNotCalledRecursively;
 import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.Matchers.greaterThan;
 
 public class ThreadPoolTests extends ESTestCase {
 
@@ -58,9 +65,112 @@ public class ThreadPoolTests extends ESTestCase {
     }
 
     public void testEstimatedTimeIntervalSettingAcceptsOnlyZeroAndPositiveTime() {
-        Settings settings = Settings.builder().put("thread_pool.estimated_time_interval", -1).build();
-        Exception e = expectThrows(IllegalArgumentException.class, () -> ESTIMATED_TIME_INTERVAL_SETTING.get(settings));
-        assertEquals("failed to parse value [-1] for setting [thread_pool.estimated_time_interval], must be >= [0ms]", e.getMessage());
+        final Settings settings = Settings.builder().put("thread_pool.estimated_time_interval", -1).build();
+        assertThat(expectThrows(IllegalArgumentException.class, () -> ESTIMATED_TIME_INTERVAL_SETTING.get(settings)).getMessage(),
+                equalTo("failed to parse value [-1] for setting [thread_pool.estimated_time_interval], must be >= [0ms]"));
+    }
+
+    public void testLateTimeIntervalWarningSettingAcceptsOnlyZeroAndPositiveTime() {
+        final Settings settings = Settings.builder().put("thread_pool.estimated_time_interval.warn_threshold", -1).build();
+        assertThat(expectThrows(IllegalArgumentException.class, () -> LATE_TIME_INTERVAL_WARN_THRESHOLD_SETTING.get(settings)).getMessage(),
+                equalTo("failed to parse value [-1] for setting [thread_pool.estimated_time_interval.warn_threshold], must be >= [0ms]"));
+    }
+
+    public void testLateTimeIntervalWarningMuchLongerThanEstimatedTimeIntervalByDefault() {
+        assertThat(LATE_TIME_INTERVAL_WARN_THRESHOLD_SETTING.get(Settings.EMPTY).getMillis(),
+                greaterThan(ESTIMATED_TIME_INTERVAL_SETTING.get(Settings.EMPTY).getMillis() + 4000));
+    }
+
+    public void testTimerThreadWarningLogging() throws Exception {
+        final Logger threadPoolLogger = LogManager.getLogger(ThreadPool.class);
+        final MockLogAppender appender = new MockLogAppender();
+        appender.start();
+        try {
+            Loggers.addAppender(threadPoolLogger, appender);
+            appender.addExpectation(new MockLogAppender.SeenEventExpectation(
+                    "expected warning for absolute clock",
+                    ThreadPool.class.getName(),
+                    Level.WARN,
+                    "timer thread slept for [*] on absolute clock which is above the warn threshold of [100ms]"));
+            appender.addExpectation(new MockLogAppender.SeenEventExpectation(
+                    "expected warning for relative clock",
+                    ThreadPool.class.getName(),
+                    Level.WARN,
+                    "timer thread slept for [*] on relative clock which is above the warn threshold of [100ms]"));
+
+            final ThreadPool.CachedTimeThread thread = new ThreadPool.CachedTimeThread("[timer]", 200, 100);
+            thread.start();
+
+            assertBusy(appender::assertAllExpectationsMatched);
+
+            thread.interrupt();
+            thread.join();
+        } finally {
+            Loggers.removeAppender(threadPoolLogger, appender);
+            appender.stop();
+        }
+    }
+
+    public void testTimeChangeChecker() throws Exception {
+        final Logger threadPoolLogger = LogManager.getLogger(ThreadPool.class);
+        final MockLogAppender appender = new MockLogAppender();
+        appender.start();
+        try {
+            Loggers.addAppender(threadPoolLogger, appender);
+
+            long absoluteMillis = randomLongBetween(Long.MIN_VALUE, Long.MAX_VALUE - TimeValue.timeValueSeconds(10).millis());
+            long relativeNanos  = randomLongBetween(Long.MIN_VALUE, Long.MAX_VALUE - TimeValue.timeValueSeconds(10).nanos());
+
+            final ThreadPool.TimeChangeChecker timeChangeChecker = new ThreadPool.TimeChangeChecker(100, absoluteMillis, relativeNanos);
+
+
+            appender.addExpectation(new MockLogAppender.SeenEventExpectation(
+                    "expected warning for absolute clock",
+                    ThreadPool.class.getName(),
+                    Level.WARN,
+                    "timer thread slept for [2s/2000ms] on absolute clock which is above the warn threshold of [100ms]"));
+
+            absoluteMillis += TimeValue.timeValueSeconds(2).millis();
+            timeChangeChecker.check(absoluteMillis, relativeNanos);
+            appender.assertAllExpectationsMatched();
+
+
+            appender.addExpectation(new MockLogAppender.SeenEventExpectation(
+                    "expected warning for relative clock",
+                    ThreadPool.class.getName(),
+                    Level.WARN,
+                    "timer thread slept for [3s/3000000000ns] on relative clock which is above the warn threshold of [100ms]"));
+
+            relativeNanos += TimeValue.timeValueSeconds(3).nanos();
+            timeChangeChecker.check(absoluteMillis, relativeNanos);
+            appender.assertAllExpectationsMatched();
+
+
+            appender.addExpectation(new MockLogAppender.SeenEventExpectation(
+                    "expected warning for absolute clock",
+                    ThreadPool.class.getName(),
+                    Level.WARN,
+                    "absolute clock went backwards by [1ms/1ms] while timer thread was sleeping"));
+
+            absoluteMillis -= 1;
+            timeChangeChecker.check(absoluteMillis, relativeNanos);
+            appender.assertAllExpectationsMatched();
+
+
+            appender.addExpectation(new MockLogAppender.SeenEventExpectation(
+                    "expected warning for absolute clock",
+                    ThreadPool.class.getName(),
+                    Level.WARN,
+                    "relative clock went backwards by [1nanos/1ns] while timer thread was sleeping"));
+
+            relativeNanos -= 1;
+            timeChangeChecker.check(absoluteMillis, relativeNanos);
+            appender.assertAllExpectationsMatched();
+
+        } finally {
+            Loggers.removeAppender(threadPoolLogger, appender);
+            appender.stop();
+        }
     }
 
     int factorial(int n) {


### PR DESCRIPTION
Sometimes we encounter a node that appears simply to have frozen for a
while - maybe something sent it a `SIGSTOP` or maybe the underlying VM
just paused. The effects of this can be pretty weird and in particular
they're hard to distinguish from other problems.

The `[timer]` thread is supposed to wake up every 200ms or so just to
update the cached time. With this commit we also look at how the clocks
changed while the thread was asleep, and log a warning if it's too far
away from our expectations.