### PR TITLE
[DOCS] Clarify CCR auto-follow requirements for data streams

### DIFF
--- a/docs/reference/ccr/apis/auto-follow/put-auto-follow-pattern.asciidoc
+++ b/docs/reference/ccr/apis/auto-follow/put-auto-follow-pattern.asciidoc
@@ -75,7 +75,9 @@ indices.
 `follow_index_pattern`::
   (Optional, string) The name of follower index. The template `{{leader_index}}`
   can be used to derive the name of the follower index from the name of the
-  leader index.
+  leader index. When following a data stream, `{{leader_index}}` should be used
+  as changing the names of a follower data stream's backing indices is not
+  supported.
 
 include::../follow-request-body.asciidoc[]
 

--- a/docs/reference/ccr/apis/auto-follow/put-auto-follow-pattern.asciidoc
+++ b/docs/reference/ccr/apis/auto-follow/put-auto-follow-pattern.asciidoc
@@ -75,9 +75,9 @@ indices.
 `follow_index_pattern`::
   (Optional, string) The name of follower index. The template `{{leader_index}}`
   can be used to derive the name of the follower index from the name of the
-  leader index. When following a data stream, `{{leader_index}}` should be used
-  as changing the names of a follower data stream's backing indices is not
-  supported.
+  leader index. When following a data stream, use `{{leader_index}}`; {ccr-init}
+  does not support changes to the names of a follower data stream's backing
+  indices.
 
 include::../follow-request-body.asciidoc[]
 


### PR DESCRIPTION
When configuring an auto-follow pattern that includes data streams, the `follow_index_pattern` option must not change the index name as differing backing index names on leader and follower data streams are not supported.
