### PR TITLE
Log elapsed time for host resolution timeouts

### DIFF
--- a/server/src/test/java/org/elasticsearch/discovery/SeedHostsResolverTests.java
+++ b/server/src/test/java/org/elasticsearch/discovery/SeedHostsResolverTests.java
@@ -301,7 +301,8 @@ public class SeedHostsResolverTests extends ESTestCase {
                 getTestName(),
                 logger.getName(),
                 Level.WARN,
-                "timed out after [" + SeedHostsResolver.getResolveTimeout(Settings.EMPTY) + "] resolving host [hostname2]"));
+                "timed out after [*] ([discovery.seed_resolver.timeout]=[" + SeedHostsResolver.getResolveTimeout(Settings.EMPTY)
+                        + "]) resolving host [hostname2]"));
 
         try {
             Loggers.addAppender(logger, appender);


### PR DESCRIPTION
Today we log the following message if resolving a host times out:

    timed out after [5s] resolving host [node-name:9300]

The `[5s]` is the timeout, not the elapsed time, and indeed there's no
indication how long the resolution actually took. It could be much
longer than 5 seconds if something else is very broken. This commit adds
the elapsed time to this message.