### PR TITLE
[7.12] [ML] fix autoscaling bug where many jobs take a long time to open (#72423)

### DIFF
--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/autoscaling/MlAutoscalingDeciderService.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/autoscaling/MlAutoscalingDeciderService.java
@@ -15,9 +15,11 @@ import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodeRole;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.Nullable;
+import org.elasticsearch.common.collect.Tuple;
 import org.elasticsearch.common.component.LifecycleListener;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.xcontent.XContentElasticsearchExtension;
 import org.elasticsearch.persistent.PersistentTasksCustomMetadata;
@@ -28,6 +30,7 @@ import org.elasticsearch.xpack.autoscaling.capacity.AutoscalingDeciderResult;
 import org.elasticsearch.xpack.autoscaling.capacity.AutoscalingDeciderService;
 import org.elasticsearch.xpack.core.ml.MlTasks;
 import org.elasticsearch.xpack.core.ml.action.StartDatafeedAction.DatafeedParams;
+import org.elasticsearch.xpack.core.ml.job.config.AnalysisLimits;
 import org.elasticsearch.xpack.ml.MachineLearning;
 import org.elasticsearch.xpack.ml.job.NodeLoad;
 import org.elasticsearch.xpack.ml.job.NodeLoadDetector;
@@ -43,10 +46,12 @@ import java.util.Comparator;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.OptionalLong;
+import java.util.PriorityQueue;
 import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
@@ -54,6 +59,8 @@ import java.util.stream.Stream;
 
 import static org.elasticsearch.xpack.core.ml.MlTasks.getDataFrameAnalyticsState;
 import static org.elasticsearch.xpack.core.ml.MlTasks.getJobStateModifiedForReassignments;
+import static org.elasticsearch.xpack.ml.MachineLearning.MAX_OPEN_JOBS_PER_NODE;
+import static org.elasticsearch.xpack.ml.MachineLearning.NATIVE_EXECUTABLE_CODE_OVERHEAD;
 import static org.elasticsearch.xpack.ml.job.JobNodeSelector.AWAITING_LAZY_ASSIGNMENT;
 import static org.elasticsearch.xpack.ml.job.NodeLoad.taskStateFilter;
 
@@ -93,13 +100,13 @@ public class MlAutoscalingDeciderService implements AutoscalingDeciderService,
         this.nodeLoadDetector = nodeLoadDetector;
         this.mlMemoryTracker = nodeLoadDetector.getMlMemoryTracker();
         this.maxMachineMemoryPercent = MachineLearning.MAX_MACHINE_MEMORY_PERCENT.get(settings);
-        this.maxOpenJobs = MachineLearning.MAX_OPEN_JOBS_PER_NODE.get(settings);
+        this.maxOpenJobs = MAX_OPEN_JOBS_PER_NODE.get(settings);
         this.useAuto = MachineLearning.USE_AUTO_MACHINE_MEMORY_PERCENT.get(settings);
         this.timeSupplier = timeSupplier;
         this.scaleDownDetected = NO_SCALE_DOWN_POSSIBLE;
         clusterService.getClusterSettings().addSettingsUpdateConsumer(MachineLearning.MAX_MACHINE_MEMORY_PERCENT,
             this::setMaxMachineMemoryPercent);
-        clusterService.getClusterSettings().addSettingsUpdateConsumer(MachineLearning.MAX_OPEN_JOBS_PER_NODE, this::setMaxOpenJobs);
+        clusterService.getClusterSettings().addSettingsUpdateConsumer(MAX_OPEN_JOBS_PER_NODE, this::setMaxOpenJobs);
         clusterService.getClusterSettings().addSettingsUpdateConsumer(MachineLearning.USE_AUTO_MACHINE_MEMORY_PERCENT, this::setUseAuto);
         clusterService.addLocalNodeMasterListener(this);
         clusterService.addLifecycleListener(new LifecycleListener() {
@@ -168,6 +175,70 @@ public class MlAutoscalingDeciderService implements AutoscalingDeciderService,
             iter.remove();
         }
         return Optional.of(new NativeMemoryCapacity(tierMemory, nodeMemory));
+    }
+
+    static Optional<Tuple<NativeMemoryCapacity, List<NodeLoad>>> determineUnassignableJobs(List<String> unassignedJobs,
+                                                                                           Function<String, Long> sizeFunction,
+                                                                                           int maxNumInQueue,
+                                                                                           List<NodeLoad> nodeLoads) {
+        if (unassignedJobs.isEmpty()) {
+            return Optional.empty();
+        }
+        if (unassignedJobs.size() < maxNumInQueue) {
+            return Optional.empty();
+        }
+        PriorityQueue<NodeLoad.Builder> mostFreeMemoryFirst = new PriorityQueue<>(
+            nodeLoads.size(),
+            // If we have no more remaining jobs, its the same as having no more free memory
+            Comparator.<NodeLoad.Builder>comparingLong(v -> v.remainingJobs() == 0 ? 0L : v.getFreeMemory()).reversed()
+        );
+        for (NodeLoad load : nodeLoads) {
+            mostFreeMemoryFirst.add(NodeLoad.builder(load));
+        }
+        List<Long> jobSizes = unassignedJobs
+            .stream()
+            .map(sizeFunction)
+            .map(l -> l == null ? 0L : l)
+            .sorted(Comparator.comparingLong(Long::longValue).reversed())
+            .collect(Collectors.toList());
+
+        Iterator<Long> assignmentIter = jobSizes.iterator();
+        while (jobSizes.size() > maxNumInQueue && assignmentIter.hasNext()) {
+            long requiredMemory = assignmentIter.next();
+            NodeLoad.Builder nodeLoad = mostFreeMemoryFirst.peek();
+            assert nodeLoad != null : "unexpected null value while calculating assignable memory";
+            // We can assign it given our current size
+            if (nodeLoad.getNumAssignedJobs() == 0) {
+                requiredMemory += NATIVE_EXECUTABLE_CODE_OVERHEAD.getBytes();
+            }
+            // Since we have the least loaded node (by memory) first, if it can't fit here, it can't fit anywhere
+            if (nodeLoad.getFreeMemory() >= requiredMemory) {
+                assignmentIter.remove();
+                // Remove and add to the priority queue to make sure the biggest node with availability is first
+                mostFreeMemoryFirst.add(mostFreeMemoryFirst.poll().incNumAssignedJobs().incAssignedJobMemory(requiredMemory));
+            }
+        }
+        List<NodeLoad> adjustedLoads = mostFreeMemoryFirst.stream().map(NodeLoad.Builder::build).collect(Collectors.toList());
+
+        List<Long> unassignableMemory = new ArrayList<>();
+        Iterator<Long> unassignableIter = jobSizes.iterator();
+        // If we cannot assign enough jobs given the current cluster size
+        while (jobSizes.size() > maxNumInQueue && unassignableIter.hasNext()) {
+            unassignableMemory.add(unassignableIter.next());
+            unassignableIter.remove();
+        }
+        if (unassignableMemory.isEmpty()) {
+            // We don't need to scale but we have adjusted node load given what we could assign
+            return Optional.of(Tuple.tuple(NativeMemoryCapacity.ZERO, adjustedLoads));
+        }
+        return Optional.of(Tuple.tuple(
+            new NativeMemoryCapacity(
+                unassignableMemory.stream().mapToLong(Long::longValue).sum(),
+                // Node memory needs to be AT LEAST the size of the largest job + the required overhead.
+                unassignableMemory.get(0) + NATIVE_EXECUTABLE_CODE_OVERHEAD.getBytes()
+            ),
+            adjustedLoads
+        ));
     }
 
     private static Collection<PersistentTask<?>> anomalyDetectionTasks(PersistentTasksCustomMetadata tasksCustomMetadata) {
@@ -281,14 +352,6 @@ public class MlAutoscalingDeciderService implements AutoscalingDeciderService,
         PersistentTasksCustomMetadata tasks = clusterState.getMetadata().custom(PersistentTasksCustomMetadata.TYPE);
         Collection<PersistentTask<?>> anomalyDetectionTasks = anomalyDetectionTasks(tasks);
         Collection<PersistentTask<?>> dataframeAnalyticsTasks = dataframeAnalyticsTasks(tasks);
-        final List<DiscoveryNode> nodes = getNodes(clusterState);
-        Optional<NativeMemoryCapacity> futureFreedCapacity = calculateFutureAvailableCapacity(
-            tasks,
-            memoryTrackingStale,
-            nodes,
-            clusterState
-        );
-
         final List<String> waitingAnomalyJobs = anomalyDetectionTasks.stream()
             .filter(t -> AWAITING_LAZY_ASSIGNMENT.equals(t.getAssignment()))
             .map(t -> MlTasks.jobId(t.getId()))
@@ -298,6 +361,10 @@ public class MlAutoscalingDeciderService implements AutoscalingDeciderService,
             .map(t -> MlTasks.dataFrameAnalyticsId(t.getId()))
             .collect(Collectors.toList());
 
+        final int numAnalyticsJobsInQueue = NUM_ANALYTICS_JOBS_IN_QUEUE.get(configuration);
+        final int numAnomalyJobsInQueue = NUM_ANOMALY_JOBS_IN_QUEUE.get(configuration);
+
+        final List<DiscoveryNode> nodes = getNodes(clusterState);
         final NativeMemoryCapacity currentScale = currentScale(nodes);
         final MlScalingReason.Builder reasonBuilder = MlScalingReason.builder()
             .setWaitingAnomalyJobs(waitingAnomalyJobs)
@@ -305,9 +372,68 @@ public class MlAutoscalingDeciderService implements AutoscalingDeciderService,
             .setCurrentMlCapacity(currentScale.autoscalingCapacity(maxMachineMemoryPercent, useAuto))
             .setPassedConfiguration(configuration);
 
+        // There are no ML nodes, scale up as quick as possible, no matter if memory is stale or not
+        if (nodes.isEmpty()
+            && (waitingAnomalyJobs.isEmpty() == false
+            || waitingAnalyticsJobs.isEmpty() == false)) {
+            return scaleUpFromZero(waitingAnomalyJobs, waitingAnalyticsJobs, reasonBuilder);
+        }
+
+        if (mlMemoryTracker.isRecentlyRefreshed(memoryTrackingStale) == false) {
+            logger.debug(() -> new ParameterizedMessage(
+                "view of job memory is stale given duration [{}]. Not attempting to make scaling decision",
+                memoryTrackingStale));
+            return buildDecisionAndRequestRefresh(reasonBuilder);
+        }
+        // We need the current node loads to determine if we need to scale up or down
+        List<NodeLoad> nodeLoads = new ArrayList<>(nodes.size());
+        boolean nodeIsMemoryAccurate = true;
+        for (DiscoveryNode node : nodes) {
+            NodeLoad nodeLoad = nodeLoadDetector.detectNodeLoad(clusterState,
+                true,
+                node,
+                maxOpenJobs,
+                maxMachineMemoryPercent,
+                true,
+                useAuto);
+            if (nodeLoad.getError() != null) {
+                logger.warn("[{}] failed to gather node load limits, failure [{}]. Returning no scale",
+                    node.getId(),
+                    nodeLoad.getError());
+                return noScaleResultOrRefresh(reasonBuilder, true, new AutoscalingDeciderResult(context.currentCapacity(),
+                    reasonBuilder
+                        .setSimpleReason(
+                            "Passing currently perceived capacity as there was a failure gathering node limits ["
+                                + nodeLoad.getError()
+                                + "]"
+                        )
+                        .build()));
+            }
+            nodeLoads.add(nodeLoad);
+            nodeIsMemoryAccurate = nodeIsMemoryAccurate && nodeLoad.isUseMemory();
+        }
+        // This is an exceptional case, the memory tracking became stale between us checking previously and calculating the loads
+        // We should return a no scale in this case
+        if (nodeIsMemoryAccurate == false) {
+            return noScaleResultOrRefresh(reasonBuilder, true, new AutoscalingDeciderResult(context.currentCapacity(),
+                reasonBuilder
+                    .setSimpleReason(
+                        "Passing currently perceived capacity as nodes were unable to provide an accurate view of their memory usage"
+                    )
+                    .build()));
+        }
+
+        Optional<NativeMemoryCapacity> futureFreedCapacity = calculateFutureAvailableCapacity(
+            tasks,
+            memoryTrackingStale,
+            nodes,
+            clusterState
+        );
+
         final Optional<AutoscalingDeciderResult> scaleUpDecision = checkForScaleUp(
-            NUM_ANOMALY_JOBS_IN_QUEUE.get(configuration),
-            NUM_ANALYTICS_JOBS_IN_QUEUE.get(configuration),
+            numAnomalyJobsInQueue,
+            numAnalyticsJobsInQueue,
+            nodeLoads,
             waitingAnomalyJobs,
             waitingAnalyticsJobs,
             futureFreedCapacity.orElse(null),
@@ -322,18 +448,22 @@ public class MlAutoscalingDeciderService implements AutoscalingDeciderService,
         if (waitingAnalyticsJobs.isEmpty() == false || waitingAnomalyJobs.isEmpty() == false) {
             // We don't want to continue to consider a scale down if there are now waiting jobs
             resetScaleDownCoolDown();
-            return noScaleResultOrRefresh(reasonBuilder, memoryTrackingStale, new AutoscalingDeciderResult(
-                context.currentCapacity(),
-                reasonBuilder
-                    .setSimpleReason("Passing currently perceived capacity as there are analytics and anomaly jobs in the queue, " +
-                        "but the number in the queue is less than the configured maximum allowed.")
+            return noScaleResultOrRefresh(reasonBuilder,
+                mlMemoryTracker.isRecentlyRefreshed(memoryTrackingStale) == false,
+                new AutoscalingDeciderResult(
+                    context.currentCapacity(),
+                    reasonBuilder
+                        .setSimpleReason(
+                            String.format(
+                                Locale.ROOT,
+                                "Passing currently perceived capacity as there are [%d] analytics and [%d] anomaly jobs in the queue, "
+                                    + "but the number in the queue is less than the configured maximum allowed "
+                                    + " or the queued jobs will eventually be assignable at the current size. ",
+                                waitingAnalyticsJobs.size(),
+                                waitingAnomalyJobs.size()
+                        )
+                    )
                     .build()));
-        }
-        if (mlMemoryTracker.isRecentlyRefreshed(memoryTrackingStale) == false) {
-            logger.debug(() -> new ParameterizedMessage(
-                "view of job memory is stale given duration [{}]. Not attempting to scale down",
-                memoryTrackingStale));
-            return buildDecisionAndRequestRefresh(reasonBuilder);
         }
 
         long largestJob = Math.max(
@@ -367,7 +497,7 @@ public class MlAutoscalingDeciderService implements AutoscalingDeciderService,
                 anomalyDetectionTasks.size(),
                 dataframeAnalyticsTasks.size()
             );
-            return noScaleResultOrRefresh(reasonBuilder, memoryTrackingStale, new AutoscalingDeciderResult(
+            return noScaleResultOrRefresh(reasonBuilder, true, new AutoscalingDeciderResult(
                 context.currentCapacity(),
                 reasonBuilder
                     .setSimpleReason("Passing currently perceived capacity as there are running analytics and anomaly jobs, " +
@@ -375,10 +505,31 @@ public class MlAutoscalingDeciderService implements AutoscalingDeciderService,
                     .build()));
         }
 
-        final Optional<AutoscalingDeciderResult> scaleDownDecision =
-            checkForScaleDown(nodes, clusterState, largestJob, currentScale, reasonBuilder);
+        final Optional<AutoscalingDeciderResult> scaleDownDecision = checkForScaleDown(nodeLoads, largestJob, currentScale, reasonBuilder);
 
         if (scaleDownDecision.isPresent()) {
+            // Given maxOpenJobs, could we scale down to just one node?
+            // We have no way of saying "we need X nodes"
+            if (nodeLoads.size() > 1) {
+                long totalAssignedJobs = nodeLoads.stream().mapToLong(NodeLoad::getNumAssignedJobs).sum();
+                // one volatile read
+                long maxOpenJobs = this.maxOpenJobs;
+                if (totalAssignedJobs > maxOpenJobs) {
+                    String msg = String.format(Locale.ROOT,
+                        "not scaling down as the total number of jobs [%d] exceeds the setting [%s (%d)]. "
+                            + " To allow a scale down [%s] must be increased.",
+                        totalAssignedJobs,
+                        MAX_OPEN_JOBS_PER_NODE.getKey(),
+                        maxOpenJobs,
+                        MAX_OPEN_JOBS_PER_NODE.getKey());
+                    logger.info(() -> new ParameterizedMessage("{} Calculated potential scaled down capacity [{}] ",
+                        msg,
+                        scaleDownDecision.get().requiredCapacity()));
+                    return new AutoscalingDeciderResult(context.currentCapacity(), reasonBuilder.setSimpleReason(msg).build());
+                }
+            }
+
+            final long now = timeSupplier.get();
             if (newScaleDownCheck()) {
                 scaleDownDetected = timeSupplier.get();
             }
@@ -404,27 +555,65 @@ public class MlAutoscalingDeciderService implements AutoscalingDeciderService,
                     .build());
         }
 
-        return noScaleResultOrRefresh(reasonBuilder, memoryTrackingStale, new AutoscalingDeciderResult(context.currentCapacity(),
-            reasonBuilder
-                .setSimpleReason("Passing currently perceived capacity as no scaling changes were detected to be possible")
-                .build()));
+        return noScaleResultOrRefresh(reasonBuilder,
+            mlMemoryTracker.isRecentlyRefreshed(memoryTrackingStale) == false,
+            new AutoscalingDeciderResult(context.currentCapacity(),
+                reasonBuilder
+                    .setSimpleReason("Passing currently perceived capacity as no scaling changes were detected to be possible")
+                    .build()));
     }
 
     AutoscalingDeciderResult noScaleResultOrRefresh(MlScalingReason.Builder reasonBuilder,
-                                                    Duration memoryTrackingStale,
+                                                    boolean memoryTrackingStale,
                                                     AutoscalingDeciderResult potentialResult) {
-        if (mlMemoryTracker.isRecentlyRefreshed(memoryTrackingStale) == false) {
-            logger.debug(() -> new ParameterizedMessage(
-                "current view of job memory is stale given the duration [{}]. Returning a no scale event",
-                memoryTrackingStale.toString()));
+        if (memoryTrackingStale) {
+            logger.debug("current view of job memory is stale given. Returning a no scale event");
             return buildDecisionAndRequestRefresh(reasonBuilder);
         } else {
             return potentialResult;
         }
     }
 
+    // This doesn't allow any jobs to wait in the queue, this is because in a "normal" scaling event, we also verify if a job
+    // can eventually start, and given the current cluster, no job can eventually start.
+    AutoscalingDeciderResult scaleUpFromZero(List<String> waitingAnomalyJobs,
+                                             List<String> waitingAnalyticsJobs,
+                                             MlScalingReason.Builder reasonBuilder) {
+        final Optional<NativeMemoryCapacity> analyticsCapacity = requiredCapacityForUnassignedJobs(waitingAnalyticsJobs,
+            this::getAnalyticsMemoryRequirement,
+            0);
+        final Optional<NativeMemoryCapacity> anomalyCapacity = requiredCapacityForUnassignedJobs(waitingAnomalyJobs,
+            this::getAnomalyMemoryRequirement,
+            0);
+        NativeMemoryCapacity updatedCapacity = NativeMemoryCapacity.ZERO
+            .merge(anomalyCapacity.orElse(NativeMemoryCapacity.ZERO))
+            .merge(analyticsCapacity.orElse(NativeMemoryCapacity.ZERO));
+        // If we still have calculated zero, this means the ml memory tracker does not have the required info.
+        // So, request a scale for the default. This is only for the 0 -> N scaling case.
+        if (updatedCapacity.getNode() == 0L) {
+            updatedCapacity.merge(new NativeMemoryCapacity(
+                ByteSizeValue.ofMb(AnalysisLimits.DEFAULT_MODEL_MEMORY_LIMIT_MB).getBytes(),
+                ByteSizeValue.ofMb(AnalysisLimits.DEFAULT_MODEL_MEMORY_LIMIT_MB).getBytes()
+            ));
+        }
+        updatedCapacity.merge(new NativeMemoryCapacity(
+            MachineLearning.NATIVE_EXECUTABLE_CODE_OVERHEAD.getBytes(), MachineLearning.NATIVE_EXECUTABLE_CODE_OVERHEAD.getBytes()
+        ));
+        AutoscalingCapacity requiredCapacity = updatedCapacity.autoscalingCapacity(maxMachineMemoryPercent, useAuto);
+        return new AutoscalingDeciderResult(
+            requiredCapacity,
+            reasonBuilder
+                .setRequiredCapacity(requiredCapacity)
+                .setSimpleReason(
+                    "requesting scale up as number of jobs in queues exceeded configured limit and there are no machine learning nodes"
+                )
+                .build()
+        );
+    }
+
     Optional<AutoscalingDeciderResult> checkForScaleUp(int numAnomalyJobsInQueue,
                                                        int numAnalyticsJobsInQueue,
+                                                       List<NodeLoad> nodeLoads,
                                                        List<String> waitingAnomalyJobs,
                                                        List<String> waitingAnalyticsJobs,
                                                        @Nullable NativeMemoryCapacity futureFreedCapacity,
@@ -434,17 +623,28 @@ public class MlAutoscalingDeciderService implements AutoscalingDeciderService,
         // Are we in breach of maximum waiting jobs?
         if (waitingAnalyticsJobs.size() > numAnalyticsJobsInQueue
             || waitingAnomalyJobs.size() > numAnomalyJobsInQueue) {
-            NativeMemoryCapacity updatedCapacity = NativeMemoryCapacity.from(currentScale);
-            // We check both analytics and anomaly capacity as we want to be able to support the largest job in either queue
-            Optional<NativeMemoryCapacity> analyticsCapacity = requiredCapacityForUnassignedJobs(waitingAnalyticsJobs,
-                this::getAnalyticsMemoryRequirement,
-                numAnalyticsJobsInQueue);
-            Optional<NativeMemoryCapacity> anomalyCapacity = requiredCapacityForUnassignedJobs(waitingAnomalyJobs,
-                this::getAnomalyMemoryRequirement,
-                numAnomalyJobsInQueue);
 
-            updatedCapacity.merge(anomalyCapacity.orElse(NativeMemoryCapacity.ZERO))
-                .merge(analyticsCapacity.orElse(NativeMemoryCapacity.ZERO))
+            Tuple<NativeMemoryCapacity, List<NodeLoad>> anomalyCapacityAndNewLoad = determineUnassignableJobs(
+                waitingAnomalyJobs,
+                this::getAnomalyMemoryRequirement,
+                numAnomalyJobsInQueue,
+                nodeLoads).orElse(Tuple.tuple(NativeMemoryCapacity.ZERO, nodeLoads));
+
+            Tuple<NativeMemoryCapacity, List<NodeLoad>> analyticsCapacityAndNewLoad = determineUnassignableJobs(
+                waitingAnalyticsJobs,
+                this::getAnalyticsMemoryRequirement,
+                numAnalyticsJobsInQueue,
+                anomalyCapacityAndNewLoad.v2()).orElse(Tuple.tuple(NativeMemoryCapacity.ZERO, anomalyCapacityAndNewLoad.v2()));
+
+            if (analyticsCapacityAndNewLoad.v1().equals(NativeMemoryCapacity.ZERO)
+                && anomalyCapacityAndNewLoad.v1().equals(NativeMemoryCapacity.ZERO)) {
+                logger.debug("no_scale event as current capacity, even though there are waiting jobs, is adequate to run the queued jobs");
+                return Optional.empty();
+            }
+
+            NativeMemoryCapacity updatedCapacity = NativeMemoryCapacity.from(currentScale)
+                .merge(analyticsCapacityAndNewLoad.v1())
+                .merge(anomalyCapacityAndNewLoad.v1())
                 // Since we require new capacity, it COULD be we require a brand new node
                 // We should account for overhead in the tier capacity just in case.
                 .merge(new NativeMemoryCapacity(MachineLearning.NATIVE_EXECUTABLE_CODE_OVERHEAD.getBytes(), 0));
@@ -453,7 +653,10 @@ public class MlAutoscalingDeciderService implements AutoscalingDeciderService,
                 requiredCapacity,
                 reasonBuilder
                     .setRequiredCapacity(requiredCapacity)
-                    .setSimpleReason("requesting scale up as number of jobs in queues exceeded configured limit")
+                    .setSimpleReason(
+                        "requesting scale up as number of jobs in queues exceeded configured limit "
+                            + "and current capacity is not large enough for waiting jobs"
+                    )
                     .build()
             ));
         }
@@ -606,36 +809,10 @@ public class MlAutoscalingDeciderService implements AutoscalingDeciderService,
         return getAnomalyMemoryRequirement(MlTasks.jobId(task.getId()));
     }
 
-    Optional<AutoscalingDeciderResult> checkForScaleDown(List<DiscoveryNode> nodes,
-                                                         ClusterState clusterState,
+    Optional<AutoscalingDeciderResult> checkForScaleDown(List<NodeLoad> nodeLoads,
                                                          long largestJob,
                                                          NativeMemoryCapacity currentCapacity,
                                                          MlScalingReason.Builder reasonBuilder) {
-        List<NodeLoad> nodeLoads = new ArrayList<>();
-        boolean isMemoryAccurateFlag = true;
-        for (DiscoveryNode node : nodes) {
-            NodeLoad nodeLoad = nodeLoadDetector.detectNodeLoad(clusterState,
-                true,
-                node,
-                maxOpenJobs,
-                maxMachineMemoryPercent,
-                true,
-                useAuto);
-            if (nodeLoad.getError() != null) {
-                logger.warn("[{}] failed to gather node load limits, failure [{}]. Returning no scale",
-                    node.getId(),
-                    nodeLoad.getError());
-                return Optional.empty();
-            }
-            nodeLoads.add(nodeLoad);
-            isMemoryAccurateFlag = isMemoryAccurateFlag && nodeLoad.isUseMemory();
-        }
-        // Even if we verify that memory usage is up to date before checking node capacity, we could still run into stale information.
-        // We should not make a decision if the memory usage is stale/inaccurate.
-        if (isMemoryAccurateFlag == false) {
-            assert isMemoryAccurateFlag : "view of memory is inaccurate after recent check";
-            return Optional.empty();
-        }
         long currentlyNecessaryTier = nodeLoads.stream().mapToLong(NodeLoad::getAssignedJobMemory).sum();
         // The required NATIVE node memory is the largest job and our static overhead.
         long currentlyNecessaryNode = largestJob == 0 ? 0 : largestJob + MachineLearning.NATIVE_EXECUTABLE_CODE_OVERHEAD.getBytes();
@@ -677,4 +854,3 @@ public class MlAutoscalingDeciderService implements AutoscalingDeciderService,
         return org.elasticsearch.common.collect.List.of(MachineLearning.ML_ROLE);
     }
 }
-

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/NodeLoad.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/NodeLoad.java
@@ -156,6 +156,10 @@ public class NodeLoad {
         return new Builder(nodeId);
     }
 
+    public static Builder builder(NodeLoad nodeLoad) {
+        return new Builder(nodeLoad);
+    }
+
     public static class Builder {
         private long maxMemory;
         private int maxJobs;
@@ -166,8 +170,27 @@ public class NodeLoad {
         private long assignedJobMemory;
         private long numAllocatingJobs;
 
+        public Builder(NodeLoad nodeLoad) {
+            this.maxMemory = nodeLoad.maxMemory;
+            this.maxJobs = nodeLoad.maxJobs;
+            this.nodeId = nodeLoad.nodeId;
+            this.useMemory = nodeLoad.useMemory;
+            this.error = nodeLoad.error;
+            this.numAssignedJobs = nodeLoad.numAssignedJobs;
+            this.assignedJobMemory = nodeLoad.assignedJobMemory;
+            this.numAllocatingJobs = nodeLoad.numAllocatingJobs;
+        }
+
         public Builder(String nodeId) {
             this.nodeId = nodeId;
+        }
+
+        public long getFreeMemory() {
+            return Math.max(maxMemory - assignedJobMemory, 0L);
+        }
+
+        public int remainingJobs() {
+            return Math.max(maxJobs - (int)numAssignedJobs, 0);
         }
 
         public String getNodeId() {

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/autoscaling/MlAutoscalingDeciderServiceTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/autoscaling/MlAutoscalingDeciderServiceTests.java
@@ -63,7 +63,6 @@ import static org.hamcrest.Matchers.lessThanOrEqualTo;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyBoolean;
 import static org.mockito.Matchers.anyInt;
-import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -88,6 +87,11 @@ public class MlAutoscalingDeciderServiceTests extends ESTestCase {
         when(mlMemoryTracker.getDataFrameAnalyticsJobMemoryRequirement(any())).thenReturn(DEFAULT_JOB_SIZE);
         nodeLoadDetector = mock(NodeLoadDetector.class);
         when(nodeLoadDetector.getMlMemoryTracker()).thenReturn(mlMemoryTracker);
+        when(nodeLoadDetector.detectNodeLoad(any(), anyBoolean(), any(), anyInt(), anyInt(), anyBoolean(), anyBoolean()))
+            .thenReturn(NodeLoad.builder("any")
+                .setUseMemory(true)
+                .incAssignedJobMemory(ByteSizeValue.ofGb(1).getBytes())
+                .build());
         clusterService = mock(ClusterService.class);
         settings = Settings.EMPTY;
         timeSupplier = System::currentTimeMillis;
@@ -112,7 +116,10 @@ public class MlAutoscalingDeciderServiceTests extends ESTestCase {
         MlAutoscalingDeciderService service = buildService();
         service.onMaster();
 
-        assertThat(service.checkForScaleUp(0, 0,
+        assertThat(service.checkForScaleUp(
+            0,
+            0,
+            Collections.emptyList(),
             Collections.emptyList(),
             Collections.emptyList(),
             null,
@@ -121,18 +128,25 @@ public class MlAutoscalingDeciderServiceTests extends ESTestCase {
             equalTo(Optional.empty()));
     }
 
-    public void testScaleUp_withWaitingJobsAndAutoMemory() {
+    public void testScaleUp_withWaitingJobsAndAutoMemoryAndNoRoomInNodes() {
         when(mlMemoryTracker.getAnomalyDetectorJobMemoryRequirement(any())).thenReturn(ByteSizeValue.ofGb(2).getBytes());
         when(mlMemoryTracker.getDataFrameAnalyticsJobMemoryRequirement(any())).thenReturn(ByteSizeValue.ofGb(2).getBytes());
         List<String> jobTasks = Arrays.asList("waiting_job", "waiting_job_2");
         List<String> analytics = Arrays.asList("analytics_waiting");
+        List<NodeLoad> fullyLoadedNode = Arrays.asList(NodeLoad.builder("any")
+            .setMaxMemory(ByteSizeValue.ofGb(1).getBytes())
+            .setUseMemory(true)
+            .incAssignedJobMemory(ByteSizeValue.ofGb(1).getBytes()).build());
         MlScalingReason.Builder reasonBuilder = new MlScalingReason.Builder()
             .setPassedConfiguration(Settings.EMPTY)
             .setCurrentMlCapacity(AutoscalingCapacity.ZERO);
         MlAutoscalingDeciderService service = buildService();
         service.setUseAuto(true);
         { // No time in queue
-            Optional<AutoscalingDeciderResult> decision = service.checkForScaleUp(0, 0,
+            Optional<AutoscalingDeciderResult> decision = service.checkForScaleUp(
+                0,
+                0,
+                fullyLoadedNode,
                 jobTasks,
                 analytics,
                 null,
@@ -144,6 +158,7 @@ public class MlAutoscalingDeciderServiceTests extends ESTestCase {
         }
         { // we allow one job in the analytics queue
             Optional<AutoscalingDeciderResult> decision = service.checkForScaleUp(0, 1,
+                fullyLoadedNode,
                 jobTasks,
                 analytics,
                 null,
@@ -155,6 +170,7 @@ public class MlAutoscalingDeciderServiceTests extends ESTestCase {
         }
         { // we allow one job in the anomaly queue and analytics queue
             Optional<AutoscalingDeciderResult> decision = service.checkForScaleUp(1, 1,
+                fullyLoadedNode,
                 jobTasks,
                 analytics,
                 null,
@@ -166,16 +182,74 @@ public class MlAutoscalingDeciderServiceTests extends ESTestCase {
         }
     }
 
-    public void testScaleUp_withWaitingJobs() {
+    public void testScaleUp_withWaitingJobsAndRoomInNodes() {
         List<String> jobTasks = Arrays.asList("waiting_job", "waiting_job_2");
         List<String> analytics = Arrays.asList("analytics_waiting");
         MlScalingReason.Builder reasonBuilder = new MlScalingReason.Builder()
             .setPassedConfiguration(Settings.EMPTY)
             .setCurrentMlCapacity(AutoscalingCapacity.ZERO);
+        List<NodeLoad> nodesWithRoom = Arrays.asList(NodeLoad.builder("partially_filled")
+            .setMaxMemory(ByteSizeValue.ofMb(430).getBytes())
+            .setUseMemory(true)
+            .setMaxJobs(10)
+            .incNumAssignedJobs()
+            .incAssignedJobMemory(ByteSizeValue.ofMb(230).getBytes()).build(),
+            NodeLoad.builder("not_filled")
+                .setMaxMemory(ByteSizeValue.ofMb(230).getBytes())
+                .setMaxJobs(10)
+                .setUseMemory(true).build());
+        MlAutoscalingDeciderService service = buildService();
+        service.setMaxMachineMemoryPercent(25);
+        { // No time in queue, should be able to assign all but one job given the current node load
+            Optional<AutoscalingDeciderResult> decision = service.checkForScaleUp(0, 0,
+                nodesWithRoom,
+                jobTasks,
+                analytics,
+                null,
+                NativeMemoryCapacity.ZERO,
+                reasonBuilder);
+            assertTrue(decision.isPresent());
+            assertThat(decision.get().requiredCapacity().node().memory().getBytes(), equalTo((DEFAULT_JOB_SIZE + OVERHEAD) * 4));
+            assertThat(decision.get().requiredCapacity().total().memory().getBytes(),
+                equalTo(4 * (DEFAULT_JOB_SIZE + OVERHEAD)));
+        }
+        { // we allow one job in the analytics queue
+            Optional<AutoscalingDeciderResult> decision = service.checkForScaleUp(0, 1,
+                nodesWithRoom,
+                jobTasks,
+                analytics,
+                null,
+                NativeMemoryCapacity.ZERO,
+                reasonBuilder);
+            assertFalse(decision.isPresent());
+        }
+        { // we allow one job in the anomaly queue
+            Optional<AutoscalingDeciderResult> decision = service.checkForScaleUp(1, 0,
+                nodesWithRoom,
+                jobTasks,
+                analytics,
+                null,
+                NativeMemoryCapacity.ZERO,
+                reasonBuilder);
+            assertFalse(decision.isPresent());
+        }
+    }
+
+    public void testScaleUp_withWaitingJobsAndNoRoomInNodes() {
+        List<String> jobTasks = Arrays.asList("waiting_job", "waiting_job_2");
+        List<String> analytics = Arrays.asList("analytics_waiting");
+        MlScalingReason.Builder reasonBuilder = new MlScalingReason.Builder()
+            .setPassedConfiguration(Settings.EMPTY)
+            .setCurrentMlCapacity(AutoscalingCapacity.ZERO);
+        List<NodeLoad> fullyLoadedNode = Arrays.asList(NodeLoad.builder("any")
+            .setMaxMemory(ByteSizeValue.ofGb(1).getBytes())
+            .setUseMemory(true)
+            .incAssignedJobMemory(ByteSizeValue.ofGb(1).getBytes()).build());
         MlAutoscalingDeciderService service = buildService();
         service.setMaxMachineMemoryPercent(25);
         { // No time in queue
             Optional<AutoscalingDeciderResult> decision = service.checkForScaleUp(0, 0,
+                fullyLoadedNode,
                 jobTasks,
                 analytics,
                 null,
@@ -188,6 +262,7 @@ public class MlAutoscalingDeciderServiceTests extends ESTestCase {
         }
         { // we allow one job in the analytics queue
             Optional<AutoscalingDeciderResult> decision = service.checkForScaleUp(0, 1,
+                fullyLoadedNode,
                 jobTasks,
                 analytics,
                 null,
@@ -200,6 +275,7 @@ public class MlAutoscalingDeciderServiceTests extends ESTestCase {
         }
         { // we allow one job in the anomaly queue and analytics queue
             Optional<AutoscalingDeciderResult> decision = service.checkForScaleUp(1, 1,
+                fullyLoadedNode,
                 jobTasks,
                 analytics,
                 null,
@@ -217,10 +293,15 @@ public class MlAutoscalingDeciderServiceTests extends ESTestCase {
         MlScalingReason.Builder reasonBuilder = new MlScalingReason.Builder()
             .setPassedConfiguration(Settings.EMPTY)
             .setCurrentMlCapacity(AutoscalingCapacity.ZERO);
+        List<NodeLoad> fullyLoadedNode = Arrays.asList(NodeLoad.builder("any")
+            .setMaxMemory(ByteSizeValue.ofGb(1).getBytes())
+            .setUseMemory(true)
+            .incAssignedJobMemory(ByteSizeValue.ofGb(1).getBytes()).build());
         MlAutoscalingDeciderService service = buildService();
         service.setMaxMachineMemoryPercent(25);
         { // with null future capacity and current capacity has a small node
             Optional<AutoscalingDeciderResult> decision = service.checkForScaleUp(2, 1,
+                fullyLoadedNode,
                 jobTasks,
                 analytics,
                 null,
@@ -232,6 +313,7 @@ public class MlAutoscalingDeciderServiceTests extends ESTestCase {
         }
         {
             Optional<AutoscalingDeciderResult> decision = service.checkForScaleUp(2, 1,
+                fullyLoadedNode,
                 jobTasks,
                 analytics,
                 new NativeMemoryCapacity(ByteSizeValue.ofGb(3).getBytes(), ByteSizeValue.ofGb(1).getBytes()),
@@ -241,6 +323,7 @@ public class MlAutoscalingDeciderServiceTests extends ESTestCase {
         }
         {
             Optional<AutoscalingDeciderResult> decision = service.checkForScaleUp(2, 1,
+                fullyLoadedNode,
                 jobTasks,
                 analytics,
                 new NativeMemoryCapacity(ByteSizeValue.ofMb(1).getBytes(), ByteSizeValue.ofMb(1).getBytes()),
@@ -252,57 +335,20 @@ public class MlAutoscalingDeciderServiceTests extends ESTestCase {
         }
     }
 
-    public void testScaleDown_WithDetectionError() {
-        List<DiscoveryNode> nodes = withMlNodes("foo", "bar", "baz");
-        DiscoveryNode badNode = randomFrom(nodes);
-        NodeLoad badLoad = NodeLoad.builder(badNode.getId()).setError("bad node").build();
-        when(nodeLoadDetector.detectNodeLoad(any(), anyBoolean(), any(), anyInt(), anyInt(), anyBoolean(), anyBoolean()))
-            .thenReturn(NodeLoad.builder(badNode.getId()).setUseMemory(true).build());
-        when(nodeLoadDetector.detectNodeLoad(any(), anyBoolean(), eq(badNode), anyInt(), anyInt(), anyBoolean(), anyBoolean()))
-            .thenReturn(badLoad);
-
-        MlAutoscalingDeciderService service = buildService();
-        MlScalingReason.Builder reasonBuilder = new MlScalingReason.Builder();
-        assertThat(service.checkForScaleDown(nodes,
-            ClusterState.EMPTY_STATE,
-            Long.MAX_VALUE,
-            new NativeMemoryCapacity(ByteSizeValue.ofGb(3).getBytes(), ByteSizeValue.ofGb(1).getBytes()),
-            reasonBuilder).isPresent(), is(false));
-    }
-
-    public void testScaleDown_WhenMemoryIsInaccurate() {
-        List<DiscoveryNode> nodes = withMlNodes("foo", "bar", "baz");
-        DiscoveryNode badNode = randomFrom(nodes);
-        NodeLoad badLoad = NodeLoad.builder(badNode.getId()).setUseMemory(false).build();
-        when(nodeLoadDetector.detectNodeLoad(any(), anyBoolean(), any(), anyInt(), anyInt(), anyBoolean(), anyBoolean()))
-            .thenReturn(NodeLoad.builder(badNode.getId()).setUseMemory(true).build());
-        when(nodeLoadDetector.detectNodeLoad(any(), anyBoolean(), eq(badNode), anyInt(), anyInt(), anyBoolean(), anyBoolean()))
-            .thenReturn(badLoad);
-
-        MlAutoscalingDeciderService service = buildService();
-        MlScalingReason.Builder reasonBuilder = new MlScalingReason.Builder();
-        expectThrows(AssertionError.class, () -> service.checkForScaleDown(nodes,
-            ClusterState.EMPTY_STATE,
-            Long.MAX_VALUE,
-            new NativeMemoryCapacity(ByteSizeValue.ofGb(3).getBytes(), ByteSizeValue.ofGb(1).getBytes()),
-            reasonBuilder));
-    }
-
     public void testScaleDown() {
-        List<DiscoveryNode> nodes = withMlNodes("foo", "bar", "baz");
-        when(nodeLoadDetector.detectNodeLoad(any(), anyBoolean(), any(), anyInt(), anyInt(), anyBoolean(), anyBoolean()))
-            .thenReturn(NodeLoad.builder("any")
-                .setUseMemory(true)
-                .incAssignedJobMemory(ByteSizeValue.ofGb(1).getBytes())
-                .build());
+        List<NodeLoad> nodeLoads = Arrays.asList(
+            NodeLoad.builder("foo").setMaxMemory(DEFAULT_NODE_SIZE).incAssignedJobMemory(ByteSizeValue.ofGb(1).getBytes()).build(),
+            NodeLoad.builder("bar").setMaxMemory(DEFAULT_NODE_SIZE).incAssignedJobMemory(ByteSizeValue.ofGb(1).getBytes()).build(),
+            NodeLoad.builder("baz").setMaxMemory(DEFAULT_NODE_SIZE).incAssignedJobMemory(ByteSizeValue.ofGb(1).getBytes()).build()
+        );
+
         MlAutoscalingDeciderService service = buildService();
         service.setMaxMachineMemoryPercent(25);
         MlScalingReason.Builder reasonBuilder = new MlScalingReason.Builder()
             .setPassedConfiguration(Settings.EMPTY)
             .setCurrentMlCapacity(AutoscalingCapacity.ZERO);
         {//Current capacity allows for smaller node
-            Optional<AutoscalingDeciderResult> result = service.checkForScaleDown(nodes,
-                ClusterState.EMPTY_STATE,
+            Optional<AutoscalingDeciderResult> result = service.checkForScaleDown(nodeLoads,
                 ByteSizeValue.ofMb(100).getBytes(),
                 new NativeMemoryCapacity(ByteSizeValue.ofGb(3).getBytes(), ByteSizeValue.ofGb(1).getBytes()),
                 reasonBuilder);
@@ -314,8 +360,7 @@ public class MlAutoscalingDeciderServiceTests extends ESTestCase {
                 equalTo(ByteSizeValue.ofGb(12).getBytes()));
         }
         {// Current capacity allows for smaller tier
-            Optional<AutoscalingDeciderResult> result = service.checkForScaleDown(nodes,
-                ClusterState.EMPTY_STATE,
+            Optional<AutoscalingDeciderResult> result = service.checkForScaleDown(nodeLoads,
                 ByteSizeValue.ofMb(100).getBytes(),
                 new NativeMemoryCapacity(ByteSizeValue.ofGb(4).getBytes(), ByteSizeValue.ofMb(100).getBytes()),
                 reasonBuilder);
@@ -327,8 +372,7 @@ public class MlAutoscalingDeciderServiceTests extends ESTestCase {
                 equalTo(ByteSizeValue.ofGb(12).getBytes()));
         }
         {// Scale down is not really possible
-            Optional<AutoscalingDeciderResult> result = service.checkForScaleDown(nodes,
-                ClusterState.EMPTY_STATE,
+            Optional<AutoscalingDeciderResult> result = service.checkForScaleDown(nodeLoads,
                 ByteSizeValue.ofMb(100).getBytes(),
                 new NativeMemoryCapacity(ByteSizeValue.ofGb(3).getBytes(), ByteSizeValue.ofMb(100).getBytes()),
                 reasonBuilder);
@@ -401,8 +445,10 @@ public class MlAutoscalingDeciderServiceTests extends ESTestCase {
         DeciderContext deciderContext = new DeciderContext(clusterState, autoscalingCapacity);
 
         AutoscalingDeciderResult result = service.scale(settings, deciderContext);
-        assertThat(result.reason().summary(),
-            containsString("Passing currently perceived capacity as there are analytics and anomaly jobs in the queue"));
+        assertThat(
+            result.reason().summary(),
+            containsString("but the number in the queue is less than the configured maximum allowed")
+        );
         assertThat(result.requiredCapacity(), equalTo(autoscalingCapacity));
     }
 


### PR DESCRIPTION
This commit fixes two bugs:

First: it causes autoscaling to respect the max_open_jobs setting. This setting should probably be set to its maximum value of 512 if autoscaling is turned on to minimize its impact in decision making

Second: it fixes the following scenario:

 - Many jobs are sitting in the `opening` state. There is plenty of room in the cluster, but they are still waiting assignment. This could be caused by very view, but large machine learning nodes in conjunction with a low `xpack.ml.node_concurrent_job_allocations` (default is 2).
 - If autoscaling requests a size decision, the machine learning service sees that jobs are not assigned (even though they could be) and assumes there is not enough room in the cluster
 - ML requests a scale up
 - Rense/repeat

^ This can occur until at last all jobs are assigned, at that point, a massive scale_down will occur. This will potentially cause the same pattern again as in certain architectures (ESS), scaling down means adding a new node to the cluster and removing the old one (So jobs must be re-assigned, starting the cycle all over again).
