### PR TITLE
Increase implicit suite timeout to 40 mins

### DIFF
--- a/buildSrc/src/main/java/org/elasticsearch/gradle/internal/ElasticsearchTestBasePlugin.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/internal/ElasticsearchTestBasePlugin.java
@@ -176,7 +176,7 @@ public class ElasticsearchTestBasePlugin implements Plugin<Project> {
 
             if (OS.current().equals(OS.WINDOWS) && System.getProperty("tests.timeoutSuite") == null) {
                 // override the suite timeout to 30 mins for windows, because it has the most inefficient filesystem known to man
-                test.systemProperty("tests.timeoutSuite", "1800000!");
+                test.systemProperty("tests.timeoutSuite", "2400000!");
             }
 
             /*


### PR DESCRIPTION
The `MixedClusterClientYamlTestSuiteIT` test suite has been ordained with a [40 mins timeout ](https://github.com/elastic/elasticsearch/blob/0074ba6d5afb9975f63b6ff905f8dae5b90ab021/qa/mixed-cluster/src/test/java/org/elasticsearch/backwards/MixedClusterClientYamlTestSuiteIT.java#L17).

But the `ElasticsearchTestBasePlugin` [overrides the suite annotation, using a system prop, to 30 mins](https://github.com/elastic/elasticsearch/blob/0074ba6d5afb9975f63b6ff905f8dae5b90ab021/buildSrc/src/main/java/org/elasticsearch/gradle/internal/ElasticsearchTestBasePlugin.java#L179); see also SysGlobals#SYSPROP_TIMEOUT_SUITE .

This has recently caused a timeout fest on windows machines:
https://gradle-enterprise.elastic.co/s/3tftym4uu3s66
https://gradle-enterprise.elastic.co/s/ufgbyhkw3hgsi
https://gradle-enterprise.elastic.co/s/uiox4z3ft7qcm
https://gradle-enterprise.elastic.co/s/3ac6u6iojr67m

This PR increases the value for the system prop override to 40 mins (to match the above suites declarations) 

Closes https://github.com/elastic/elasticsearch/issues/72393