### PR TITLE
Move the MDP error check into Environment

### DIFF
--- a/server/src/main/java/org/elasticsearch/env/Environment.java
+++ b/server/src/main/java/org/elasticsearch/env/Environment.java
@@ -101,7 +101,11 @@ public class Environment {
         pluginsFile = homeFile.resolve("plugins");
 
         if (PATH_DATA_SETTING.exists(settings)) {
-            dataFile = PathUtils.get(PATH_DATA_SETTING.get(settings)).toAbsolutePath().normalize();
+            String rawDataPath = PATH_DATA_SETTING.get(settings);
+            if (rawDataPath.startsWith("[")) {
+                throw new IllegalArgumentException("[path.data] is a list. Specify as a string value.");
+            }
+            dataFile = PathUtils.get(rawDataPath).toAbsolutePath().normalize();
         } else {
             dataFile = homeFile.resolve("data");
         }
@@ -290,15 +294,6 @@ public class Environment {
         if (Files.isDirectory(tmpFile) == false) {
             throw new IOException("Configured temporary file directory [" + tmpFile + "] is not a directory");
         }
-    }
-
-    /** Returns true if the data path is a list, false otherwise */
-    public static boolean dataPathUsesList(Settings settings) {
-        if (settings.hasValue(PATH_DATA_SETTING.getKey()) == false) {
-            return false;
-        }
-        String rawDataPath = settings.get(PATH_DATA_SETTING.getKey());
-        return rawDataPath.startsWith("[");
     }
 
     public static FileStore getFileStore(final Path path) throws IOException {

--- a/server/src/main/java/org/elasticsearch/node/Node.java
+++ b/server/src/main/java/org/elasticsearch/node/Node.java
@@ -306,10 +306,6 @@ public class Node implements Closeable {
                     Build.CURRENT.getQualifiedVersion());
             }
 
-            if (Environment.dataPathUsesList(tmpSettings)) {
-                throw new IllegalArgumentException("[path.data] is a list. Specify as a string value.");
-            }
-
             if (logger.isDebugEnabled()) {
                 logger.debug("using config [{}], data [{}], logs [{}], plugins [{}]",
                     initialEnvironment.configFile(), initialEnvironment.dataFile(),

--- a/server/src/test/java/org/elasticsearch/env/EnvironmentTests.java
+++ b/server/src/test/java/org/elasticsearch/env/EnvironmentTests.java
@@ -158,19 +158,37 @@ public class EnvironmentTests extends ESTestCase {
     }
 
     public void testSingleDataPathListCheck() {
+        Path homeDir = createTempDir();
         {
-            final Settings settings = Settings.builder().build();
-            assertThat(Environment.dataPathUsesList(settings), is(false));
+            final Settings settings = Settings.builder()
+                .put(Environment.PATH_HOME_SETTING.getKey(), homeDir).build();
+            Environment env = new Environment(settings, null, createTempDir());
+            assertThat(env.dataFile(), equalTo(homeDir.resolve("data")));
         }
         {
             final Settings settings = Settings.builder()
+                .put(Environment.PATH_HOME_SETTING.getKey(), homeDir)
                 .putList(Environment.PATH_DATA_SETTING.getKey(), createTempDir().toString(), createTempDir().toString()).build();
-            assertThat(Environment.dataPathUsesList(settings), is(true));
+            IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () ->
+                new Environment(settings, null, createTempDir()));
+            assertThat(e.getMessage(), startsWith("[path.data] is a list"));
         }
         {
             final Settings settings = Settings.builder()
+                .put(Environment.PATH_HOME_SETTING.getKey(), homeDir)
                 .putList(Environment.PATH_DATA_SETTING.getKey(), createTempDir().toString()).build();
-            assertThat(Environment.dataPathUsesList(settings), is(true));
+            IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () ->
+                new Environment(settings, null, createTempDir()));
+            assertThat(e.getMessage(), startsWith("[path.data] is a list"));
+        }
+        {
+            // also check as if the data was munged into a string already in settings
+            final Settings settings = Settings.builder()
+                .put(Environment.PATH_HOME_SETTING.getKey(), homeDir)
+                .put(Environment.PATH_DATA_SETTING.getKey(), "[" + createTempDir().toString() + "]").build();
+            IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () ->
+                new Environment(settings, null, createTempDir()));
+            assertThat(e.getMessage(), startsWith("[path.data] is a list"));
         }
     }
 

--- a/server/src/test/java/org/elasticsearch/env/EnvironmentTests.java
+++ b/server/src/test/java/org/elasticsearch/env/EnvironmentTests.java
@@ -23,7 +23,6 @@ import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.CoreMatchers.startsWith;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
-import static org.hamcrest.Matchers.is;
 
 /**
  * Simple unit-tests for Environment.java


### PR DESCRIPTION
The path.data setting could previously be configured as either a yaml
string, or a list. When a list, it appears internally to Settings as a
List object. However, now that path.data is a String setting, it gets
munged into a string representation of a list, beginning with `[`. That
works if checking the original version of the setting, but there are
several Settings and Environment objects creating during node
initialization, and the error check would not occur until after the path
was made absolute. This would make the string beginning with bracket
relative to the current directory, so the check for a list string would
just not work.

This commit moves the check into Environment, so that the first reading
of settings can error if a list is found.

relates #71205
