### PR TITLE
In expand phase, call onPhaseFailure when multi-search fails.

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/search/AbstractSearchAsyncAction.java
+++ b/server/src/main/java/org/elasticsearch/action/search/AbstractSearchAsyncAction.java
@@ -717,11 +717,6 @@ abstract class AbstractSearchAsyncAction<Result extends SearchPhaseResult> exten
     }
 
     @Override
-    public final void onFailure(Exception e) {
-        listener.onFailure(e);
-    }
-
-    @Override
     public final ShardSearchRequest buildShardSearchRequest(SearchShardIterator shardIt, int shardIndex) {
         AliasFilter filter = aliasFilter.get(shardIt.shardId().getIndex().getUUID());
         assert filter != null;

--- a/server/src/main/java/org/elasticsearch/action/search/ExpandSearchPhase.java
+++ b/server/src/main/java/org/elasticsearch/action/search/ExpandSearchPhase.java
@@ -103,7 +103,7 @@ final class ExpandSearchPhase extends SearchPhase {
                         }
                     }
                     context.sendSearchResponse(searchResponse, queryResults);
-                }, context::onFailure)
+                }, e -> context.onPhaseFailure(this, "failed to expand hits", e))
             );
         } else {
             context.sendSearchResponse(searchResponse, queryResults);

--- a/server/src/main/java/org/elasticsearch/action/search/SearchPhaseContext.java
+++ b/server/src/main/java/org/elasticsearch/action/search/SearchPhaseContext.java
@@ -62,11 +62,6 @@ interface SearchPhaseContext extends Executor {
     void sendSearchResponse(InternalSearchResponse internalSearchResponse, AtomicArray<SearchPhaseResult> queryResults);
 
     /**
-     * Notifies the top-level listener of the provided exception
-     */
-    void onFailure(Exception e);
-
-    /**
      * This method will communicate a fatal phase failure back to the user. In contrast to a shard failure
      * will this method immediately fail the search request and return the failure to the issuer of the request
      * @param phase the phase that failed

--- a/server/src/test/java/org/elasticsearch/action/search/MockSearchPhaseContext.java
+++ b/server/src/test/java/org/elasticsearch/action/search/MockSearchPhaseContext.java
@@ -131,11 +131,6 @@ public final class MockSearchPhaseContext implements SearchPhaseContext {
     }
 
     @Override
-    public void onFailure(Exception e) {
-        Assert.fail("should not be called");
-    }
-
-    @Override
     public void sendReleaseSearchContext(ShardSearchContextId contextId, Transport.Connection connection, OriginalIndices originalIndices) {
         releasedSearchContexts.add(contextId);
     }


### PR DESCRIPTION
Before we called SearchPhaseContext#onFailure, which doesn't release contexts.
This also lets us remove the onFailure method, since there are no other callers.

This is just a small clean-up, I didn't see evidence that this actually caused
problems with unreleased contexts.