### PR TITLE
Fix path.data list deprecation to work in all cases

### DIFF
--- a/.idea/runConfigurations/Debug_Elasticsearch.xml
+++ b/.idea/runConfigurations/Debug_Elasticsearch.xml
@@ -6,7 +6,10 @@
     <option name="HOST" value="localhost" />
     <option name="PORT" value="5005" />
     <option name="AUTO_RESTART" value="true" />
+    <RunnerSettings RunnerId="Debug">
+      <option name="DEBUG_PORT" value="5005" />
+      <option name="LOCAL" value="false" />
+    </RunnerSettings>
     <method v="2" />
   </configuration>
 </component>
-

--- a/server/src/main/java/org/elasticsearch/env/Environment.java
+++ b/server/src/main/java/org/elasticsearch/env/Environment.java
@@ -157,11 +157,11 @@ public class Environment {
 
         final Settings.Builder finalSettings = Settings.builder().put(settings);
         if (PATH_DATA_SETTING.exists(settings)) {
-            if (dataFiles.length == 1) {
-                finalSettings.put(PATH_DATA_SETTING.getKey(), dataFiles[0]);
-            } else {
+            if (dataPathUsesList(settings)) {
                 finalSettings.putList(PATH_DATA_SETTING.getKey(),
                     Arrays.stream(dataFiles).map(Path::toString).collect(Collectors.toList()));
+            } else {
+                finalSettings.put(PATH_DATA_SETTING.getKey(), dataFiles[0]);
             }
         }
         finalSettings.put(PATH_HOME_SETTING.getKey(), homeFile);

--- a/server/src/test/java/org/elasticsearch/env/EnvironmentTests.java
+++ b/server/src/test/java/org/elasticsearch/env/EnvironmentTests.java
@@ -216,6 +216,37 @@ public class EnvironmentTests extends ESTestCase {
         }
     }
 
+    public void testLegacyDataPathListPropagation() {
+        {
+            final Settings settings = Settings.builder()
+                .put(Environment.PATH_HOME_SETTING.getKey(), createTempDir())
+                .build();
+            Environment env = new Environment(settings, null);
+            assertThat(Environment.dataPathUsesList(env.settings()), is(false));
+        }
+        {
+            final Settings settings = Settings.builder()
+                .put(Environment.PATH_HOME_SETTING.getKey(), createTempDir())
+                .putList(Environment.PATH_DATA_SETTING.getKey(), createTempDir().toString(), createTempDir().toString()).build();
+            Environment env = new Environment(settings, null);
+            assertThat(Environment.dataPathUsesList(env.settings()), is(true));
+        }
+        {
+            final Settings settings = Settings.builder()
+                .put(Environment.PATH_HOME_SETTING.getKey(), createTempDir())
+                .putList(Environment.PATH_DATA_SETTING.getKey(), createTempDir().toString()).build();
+            Environment env = new Environment(settings, null);
+            assertThat(Environment.dataPathUsesList(env.settings()), is(true));
+        }
+        {
+            final Settings settings = Settings.builder()
+                .put(Environment.PATH_HOME_SETTING.getKey(), createTempDir())
+                .put(Environment.PATH_DATA_SETTING.getKey(), createTempDir().toString()).build();
+            Environment env = new Environment(settings, null);
+            assertThat(Environment.dataPathUsesList(env.settings()), is(false));
+        }
+    }
+
     private void assertPath(final String actual, final Path expected) {
         assertIsAbsolute(actual);
         assertIsNormalized(actual);


### PR DESCRIPTION
path.data can appear as a list, or a string. On node startup, several
Environment and Setting objects are created. The Environment propagates
the path.data setting, but needs to choose whether it is propagated as a
list or a string. This commit adjusts how it is propagated so that if
the path.data is originally a string, it will stay a string, so that the
deprecation message for path.data as a list can properly detect a list
case.

relates #71205
