### PR TITLE
Remove obsolete BWC for max_primary_shard_size

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/admin/indices/rollover/MaxPrimaryShardSizeCondition.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/rollover/MaxPrimaryShardSizeCondition.java
@@ -8,7 +8,6 @@
 
 package org.elasticsearch.action.admin.indices.rollover;
 
-import org.elasticsearch.Version;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.unit.ByteSizeUnit;
@@ -63,10 +62,5 @@ public class MaxPrimaryShardSizeCondition extends Condition<ByteSizeValue> {
         } else {
             throw new IllegalArgumentException("invalid token: " + parser.currentToken());
         }
-    }
-
-    @Override
-    boolean includedInVersion(Version version) {
-        return version.onOrAfter(Version.V_7_12_0);
     }
 }

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/shrink/ResizeRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/shrink/ResizeRequest.java
@@ -7,7 +7,6 @@
  */
 package org.elasticsearch.action.admin.indices.shrink;
 
-import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.IndicesRequest;
 import org.elasticsearch.action.admin.indices.alias.Alias;
@@ -59,10 +58,8 @@ public class ResizeRequest extends AcknowledgedRequest<ResizeRequest> implements
         sourceIndex = in.readString();
         type = in.readEnum(ResizeType.class);
         copySettings = in.readOptionalBoolean();
-        if (in.getVersion().onOrAfter(Version.V_7_12_0)) {
-            if (in.readBoolean()) {
-                maxPrimaryShardSize = new ByteSizeValue(in);
-            }
+        if (in.readBoolean()) {
+            maxPrimaryShardSize = new ByteSizeValue(in);
         }
     }
 
@@ -106,9 +103,7 @@ public class ResizeRequest extends AcknowledgedRequest<ResizeRequest> implements
         out.writeString(sourceIndex);
         out.writeEnum(type);
         out.writeOptionalBoolean(copySettings);
-        if (out.getVersion().onOrAfter(Version.V_7_12_0)) {
-            out.writeOptionalWriteable(maxPrimaryShardSize);
-        }
+        out.writeOptionalWriteable(maxPrimaryShardSize);
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/RolloverAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/RolloverAction.java
@@ -6,7 +6,6 @@
  */
 package org.elasticsearch.xpack.core.ilm;
 
-import org.elasticsearch.Version;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.ParseField;
@@ -84,7 +83,7 @@ public class RolloverAction implements LifecycleAction {
         } else {
             maxSize = null;
         }
-        if (in.getVersion().onOrAfter(Version.V_7_13_0) && in.readBoolean()) {
+        if (in.readBoolean()) {
             maxPrimaryShardSize = new ByteSizeValue(in);
         } else {
             maxPrimaryShardSize = null;
@@ -96,26 +95,14 @@ public class RolloverAction implements LifecycleAction {
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         boolean hasMaxSize = maxSize != null;
-        boolean hasMaxPrimaryShardSize = maxPrimaryShardSize != null;
+        out.writeBoolean(hasMaxSize);
         if (hasMaxSize) {
-            out.writeBoolean(true);
             maxSize.writeTo(out);
-        } else if (hasMaxPrimaryShardSize && out.getVersion().before(Version.V_7_13_0)) {
-            // In the case that the outgoing node is on a version that doesn't support maxPrimaryShardSize then
-            // serialize it as maxSize. When the outgoing node receives that node-to-node response there is no validation
-            // taking place (see constructors_ and otherwise we could end up with a rollover action instance without any conditions.
-            // If the node is rebooted then it would be unable to read the cluster state and fail starting up.
-            // (ilm policies are part of cluster state)
-            out.writeBoolean(true);
-            maxPrimaryShardSize.writeTo(out);
-        } else {
-            out.writeBoolean(false);
         }
-        if (out.getVersion().onOrAfter(Version.V_7_13_0)) {
-            out.writeBoolean(hasMaxPrimaryShardSize);
-            if (hasMaxPrimaryShardSize) {
-                maxPrimaryShardSize.writeTo(out);
-            }
+        boolean hasMaxPrimaryShardSize = maxPrimaryShardSize != null;
+        out.writeBoolean(hasMaxPrimaryShardSize);
+        if (hasMaxPrimaryShardSize) {
+            maxPrimaryShardSize.writeTo(out);
         }
         out.writeOptionalTimeValue(maxAge);
         out.writeOptionalVLong(maxDocs);

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/ShrinkAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/ShrinkAction.java
@@ -8,7 +8,6 @@ package org.elasticsearch.xpack.core.ilm;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.elasticsearch.Version;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.cluster.metadata.IndexAbstraction;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
@@ -81,17 +80,12 @@ public class ShrinkAction implements LifecycleAction {
     }
 
     public ShrinkAction(StreamInput in) throws IOException {
-        if (in.getVersion().onOrAfter(Version.V_7_12_0)) {
-            if (in.readBoolean()) {
-                this.numberOfShards = in.readVInt();
-                this.maxPrimaryShardSize = null;
-            } else {
-                this.numberOfShards = null;
-                this.maxPrimaryShardSize = new ByteSizeValue(in);
-            }
-        } else {
+        if (in.readBoolean()) {
             this.numberOfShards = in.readVInt();
             this.maxPrimaryShardSize = null;
+        } else {
+            this.numberOfShards = null;
+            this.maxPrimaryShardSize = new ByteSizeValue(in);
         }
     }
 
@@ -105,16 +99,12 @@ public class ShrinkAction implements LifecycleAction {
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        if (out.getVersion().onOrAfter(Version.V_7_12_0)) {
-            boolean hasNumberOfShards = numberOfShards != null;
-            out.writeBoolean(hasNumberOfShards);
-            if (hasNumberOfShards) {
-                out.writeVInt(numberOfShards);
-            } else {
-                maxPrimaryShardSize.writeTo(out);
-            }
-        } else {
+        boolean hasNumberOfShards = numberOfShards != null;
+        out.writeBoolean(hasNumberOfShards);
+        if (hasNumberOfShards) {
             out.writeVInt(numberOfShards);
+        } else {
+            maxPrimaryShardSize.writeTo(out);
         }
     }
 

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/RolloverActionTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/RolloverActionTests.java
@@ -6,7 +6,6 @@
  */
 package org.elasticsearch.xpack.core.ilm;
 
-import org.elasticsearch.Version;
 import org.elasticsearch.common.io.stream.Writeable.Reader;
 import org.elasticsearch.common.unit.ByteSizeUnit;
 import org.elasticsearch.common.unit.ByteSizeValue;
@@ -16,9 +15,6 @@ import org.elasticsearch.xpack.core.ilm.Step.StepKey;
 
 import java.io.IOException;
 import java.util.List;
-
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.nullValue;
 
 public class RolloverActionTests extends AbstractActionTestCase<RolloverAction> {
 
@@ -121,19 +117,5 @@ public class RolloverActionTests extends AbstractActionTestCase<RolloverAction> 
         assertEquals(action.getMaxAge(), firstStep.getMaxAge());
         assertEquals(action.getMaxDocs(), firstStep.getMaxDocs());
         assertEquals(nextStepKey, fifthStep.getNextStepKey());
-    }
-
-    public void testBwcSerializationWithMaxPrimaryShardSize() throws Exception {
-        // In case of serializing to node with older version, replace maxPrimaryShardSize with maxSize.
-        RolloverAction instance = new RolloverAction(null, new ByteSizeValue(1L), null, null);
-        RolloverAction deserializedInstance = copyInstance(instance, Version.V_7_11_2);
-        assertThat(deserializedInstance.getMaxPrimaryShardSize(), nullValue());
-        assertThat(deserializedInstance.getMaxSize(), equalTo(instance.getMaxPrimaryShardSize()));
-
-        // But not if maxSize is also specified:
-        instance = new RolloverAction(new ByteSizeValue(1L), new ByteSizeValue(2L), null, null);
-        deserializedInstance = copyInstance(instance, Version.V_7_11_2);
-        assertThat(deserializedInstance.getMaxPrimaryShardSize(), nullValue());
-        assertThat(deserializedInstance.getMaxSize(), equalTo(instance.getMaxSize()));
     }
 }


### PR DESCRIPTION
These checks aren't necessary on `master` anymore, but be careful, because we ran into an issue here with this before (see #70076).