### PR TITLE
[DOCS] Setup passwords utility should be run once per cluster

### DIFF
--- a/x-pack/docs/en/security/securing-communications/security-minimal-setup.asciidoc
+++ b/x-pack/docs/en/security/securing-communications/security-minimal-setup.asciidoc
@@ -71,7 +71,13 @@ when enabling minimal or basic security.
 ----
 
 . In another terminal window, set the passwords for the built-in users by
-running the `elasticsearch-setup-passwords` utility. Using the `auto` parameter
+running the <<setup-passwords,`elasticsearch-setup-passwords`>> utility.
++
+IMPORTANT: You can run the `elasticsearch-setup-passwords` utility
+against any node in your cluster. However, you should only run this utility *one
+time* for the entire cluster.
++
+Using the `auto` parameter
 outputs randomly-generated passwords to the console that you can change later
 if necessary:
 +


### PR DESCRIPTION
This PR adds clarifying language that you can run the `elasticsearch-setup-passwords` utility against any node in your cluster, but should only run this utility *one time* for the entire cluster.

Preview link: https://elasticsearch_72507.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/security-minimal-setup.html#security-create-builtin-users

Closes #72357