### PR TITLE
Update docs for `filter` agg

### DIFF
--- a/docs/reference/aggregations/bucket/filter-aggregation.asciidoc
+++ b/docs/reference/aggregations/bucket/filter-aggregation.asciidoc
@@ -4,13 +4,81 @@
 <titleabbrev>Filter</titleabbrev>
 ++++
 
-Defines a single bucket of all the documents in the current document set context that match a specified filter. Often this will be used to narrow down the current aggregation context to a specific set of documents.
+A single bucket aggregation that narrows the set of documents
+to those that match a <<query-dsl,query>>.
 
 Example:
 
 [source,console,id=filter-aggregation-example]
---------------------------------------------------
-POST /sales/_search?size=0
+----
+POST /sales/_search?size=0&filter_path=aggregations
+{
+  "aggs": {
+    "avg_price": { "avg": { "field": "price" } },
+    "t_shirts": {
+      "filter": { "term": { "type": "t-shirt" } },
+      "aggs": {
+        "avg_price": { "avg": { "field": "price" } }
+      }
+    }
+  }
+}
+----
+// TEST[setup:sales]
+
+In the above example, we calculate the average price of all sales as well as
+well as the avergae price of all t-shirts.
+
+Response:
+
+[source,console-result]
+----
+{
+  "aggregations": {
+    "avg_price": { "value": 140.71428571428572 },
+    "t_shirts": {
+      "doc_count": 3,
+      "avg_price": { "value": 128.33333333333334 }
+    }
+  }
+}
+----
+
+==== Prefer top level queries to limit all results
+
+If you have to limit all of results of running all of the aggregations based
+on a query then it is faster if you change the top level `query` rather than
+using a single `filter` aggregation. So do this:
+
+
+[source,console,id=filter-aggregation-top-good]
+----
+POST /sales/_search?size=0&filter_path=aggregations
+{
+  "query": { "term": { "type": "t-shirt" } },
+  "aggs": {
+    "avg_price": { "avg": { "field": "price" } }
+  }
+}
+----
+// TEST[setup:sales]
+
+////
+[source,console-result]
+----
+{
+  "aggregations": {
+    "avg_price": { "value": 128.33333333333334 }
+  }
+}
+----
+////
+
+Instead of this:
+
+[source,console,id=filter-aggregation-top-bad]
+----
+POST /sales/_search?size=0&filter_path=aggregations
 {
   "aggs": {
     "t_shirts": {
@@ -21,17 +89,13 @@ POST /sales/_search?size=0
     }
   }
 }
---------------------------------------------------
+----
 // TEST[setup:sales]
 
-In the above example, we calculate the average price of all the products that are of type t-shirt.
-
-Response:
-
+////
 [source,console-result]
---------------------------------------------------
+----
 {
-  ...
   "aggregations": {
     "t_shirts": {
       "doc_count": 3,
@@ -39,5 +103,96 @@ Response:
     }
   }
 }
---------------------------------------------------
-// TESTRESPONSE[s/\.\.\./"took": $body.took,"timed_out": false,"_shards": $body._shards,"hits": $body.hits,/]
+----
+////
+
+==== Prefer `filters` for multiple filters
+
+If you have to group documents into more than one filter it is faster
+to use the <<search-aggregations-bucket-filters-aggregation,`filters` aggregation>>
+rather than many `filter` aggregations. So do this:
+
+[source,console,id=filter-aggregation-many-good]
+----
+POST /sales/_search?size=0&filter_path=aggregations
+{
+  "aggs": {
+    "f": {
+      "filters": { 
+        "filters": {
+          "hats": { "term": { "type": "hat" } },
+          "t_shirts": { "term": { "type": "t-shirt" } }
+        }
+      },
+      "aggs": {
+        "avg_price": { "avg": { "field": "price" } }
+      }
+    }
+  }
+}
+----
+// TEST[setup:sales]
+
+////
+[source,console-result]
+----
+{
+  "aggregations": {
+    "f": {
+      "buckets": {
+        "hats": {
+          "doc_count": 3,
+          "avg_price": { "value": 150.0 }
+        },
+        "t_shirts": {
+          "doc_count": 3,
+          "avg_price": { "value": 128.33333333333334 }
+        }
+      }
+    }
+  }
+}
+----
+////
+
+Instead of this:
+
+[source,console,id=filter-aggregation-many-bad]
+----
+POST /sales/_search?size=0&filter_path=aggregations
+{
+  "aggs": {
+    "hats": {
+      "filter": { "term": { "type": "hat" } },
+      "aggs": {
+        "avg_price": { "avg": { "field": "price" } }
+      }
+    },
+    "t_shirts": {
+      "filter": { "term": { "type": "t-shirt" } },
+      "aggs": {
+        "avg_price": { "avg": { "field": "price" } }
+      }
+    }
+  }
+}
+----
+// TEST[setup:sales]
+
+////
+[source,console-result]
+----
+{
+  "aggregations": {
+    "hats": {
+      "doc_count": 3,
+      "avg_price": { "value": 150.0 }
+    },
+    "t_shirts": {
+      "doc_count": 3,
+      "avg_price": { "value": 128.33333333333334 }
+    }
+  }
+}
+----
+////

--- a/docs/reference/aggregations/bucket/filter-aggregation.asciidoc
+++ b/docs/reference/aggregations/bucket/filter-aggregation.asciidoc
@@ -26,8 +26,8 @@ POST /sales/_search?size=0&filter_path=aggregations
 ----
 // TEST[setup:sales]
 
-In the above example, we calculate the average price of all sales as well as
-well as the avergae price of all t-shirts.
+The previous example calculates the average price of all sales as well as
+the average price of all T-shirt sales.
 
 Response:
 
@@ -44,11 +44,14 @@ Response:
 }
 ----
 
-==== Prefer top level queries to limit all results
+[[use-top-level-query-to-limit-all-aggs]]
+==== Use a top-level `query` to limit all aggregations
 
-If you have to limit all of results of running all of the aggregations based
-on a query then it is faster if you change the top level `query` rather than
-using a single `filter` aggregation. So do this:
+To limit the documents on which all aggregations in a search run, use a
+top-level `query`. This is faster than a single `filter` aggregation with
+sub-aggregations.
+
+For example, use this:
 
 
 [source,console,id=filter-aggregation-top-good]
@@ -106,11 +109,14 @@ POST /sales/_search?size=0&filter_path=aggregations
 ----
 ////
 
-==== Prefer `filters` for multiple filters
+[[use-filters-agg-for-multiple-filters]]
+==== Use the `filters` aggregation for multiple filters
 
-If you have to group documents into more than one filter it is faster
-to use the <<search-aggregations-bucket-filters-aggregation,`filters` aggregation>>
-rather than many `filter` aggregations. So do this:
+To group documents using multiple filters, use the
+<<search-aggregations-bucket-filters-aggregation,`filters` aggregation>>. This
+is faster than multiple `filter` aggregations.
+
+For example, use this:
 
 [source,console,id=filter-aggregation-many-good]
 ----

--- a/docs/reference/aggregations/bucket/filters-aggregation.asciidoc
+++ b/docs/reference/aggregations/bucket/filters-aggregation.asciidoc
@@ -4,7 +4,7 @@
 <titleabbrev>Filters</titleabbrev>
 ++++
 
-A multi bucket aggregation where each bucket contains the documents
+A multi-bucket aggregation where each bucket contains the documents
 that match a <<query-dsl,query>>.
 
 Example:

--- a/docs/reference/aggregations/bucket/filters-aggregation.asciidoc
+++ b/docs/reference/aggregations/bucket/filters-aggregation.asciidoc
@@ -4,9 +4,8 @@
 <titleabbrev>Filters</titleabbrev>
 ++++
 
-Defines a multi bucket aggregation where each bucket is associated with a
-filter. Each bucket will collect all documents that match its associated
-filter.
+A multi bucket aggregation where each bucket contains the documents
+that match a <<query-dsl,query>>.
 
 Example:
 


### PR DESCRIPTION
The docs for the `filter` agg seemed to suggest that it was the
preferred way to filter results for aggs but its really mostly for when
you need to filter things under another bucketing agg.
