### PR TITLE
Convert index path listeners to single path

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/plugins/IndexFoldersDeletionListenerIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/plugins/IndexFoldersDeletionListenerIT.java
@@ -325,12 +325,12 @@ public class IndexFoldersDeletionListenerIT extends ESIntegTestCase {
         public List<IndexFoldersDeletionListener> getIndexFoldersDeletionListeners() {
             return List.of(new IndexFoldersDeletionListener() {
                 @Override
-                public void beforeIndexFoldersDeleted(Index index, IndexSettings indexSettings, Path[] indexPaths) {
+                public void beforeIndexFoldersDeleted(Index index, IndexSettings indexSettings, Path indexPath) {
                     deletedIndices.add(index);
                 }
 
                 @Override
-                public void beforeShardFoldersDeleted(ShardId shardId, IndexSettings indexSettings, Path[] shardPaths) {
+                public void beforeShardFoldersDeleted(ShardId shardId, IndexSettings indexSettings, Path shardPath) {
                     deletedShards.computeIfAbsent(shardId.getIndex(), i -> new ArrayList<>()).add(shardId);
                 }
             });

--- a/server/src/main/java/org/elasticsearch/index/IndexService.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexService.java
@@ -411,8 +411,8 @@ public class IndexService extends AbstractIndexComponent implements IndicesClust
             } catch (IllegalStateException ex) {
                 logger.warn("{} failed to load shard path, trying to remove leftover", shardId);
                 try {
-                    ShardPath.deleteLeftoverShardDirectory(logger, nodeEnv, lock, this.indexSettings, shardPaths ->
-                        indexFoldersDeletionListener.beforeShardFoldersDeleted(shardId, this.indexSettings, shardPaths));
+                    ShardPath.deleteLeftoverShardDirectory(logger, nodeEnv, lock, this.indexSettings, shardPath ->
+                        indexFoldersDeletionListener.beforeShardFoldersDeleted(shardId, this.indexSettings, shardPath));
                     path = ShardPath.loadShardPath(logger, nodeEnv, shardId, this.indexSettings.customDataPath());
                 } catch (Exception inner) {
                     ex.addSuppressed(inner);

--- a/server/src/main/java/org/elasticsearch/index/shard/ShardPath.java
+++ b/server/src/main/java/org/elasticsearch/index/shard/ShardPath.java
@@ -167,7 +167,7 @@ public final class ShardPath {
         final NodeEnvironment env,
         final ShardLock lock,
         final IndexSettings indexSettings,
-        final Consumer<Path[]> listener
+        final Consumer<Path> listener
     ) throws IOException {
         final String indexUUID = indexSettings.getUUID();
         final Path path = env.availableShardPath(lock.getShardId());
@@ -178,7 +178,7 @@ public final class ShardPath {
                 logger.warn("{} deleting leftover shard on path: [{}] with a different index UUID", lock.getShardId(), path);
                 assert Files.isDirectory(path) : path + " is not a directory";
                 NodeEnvironment.acquireFSLockForPaths(indexSettings, path);
-                listener.accept(new Path[]{path});
+                listener.accept(path);
                 IOUtils.rm(path);
             }
         }

--- a/server/src/main/java/org/elasticsearch/indices/IndicesService.java
+++ b/server/src/main/java/org/elasticsearch/indices/IndicesService.java
@@ -977,7 +977,7 @@ public class IndicesService extends AbstractLifecycleComponent
             throw new IllegalStateException("Can't delete shard " + shardId + " (cause: " + shardDeletionCheckResult + ")");
         }
         nodeEnv.deleteShardDirectorySafe(shardId, indexSettings,
-            paths -> indexFoldersDeletionListeners.beforeShardFoldersDeleted(shardId, indexSettings, paths));
+            path -> indexFoldersDeletionListeners.beforeShardFoldersDeleted(shardId, indexSettings, path));
         logger.debug("{} deleted shard reason [{}]", shardId, reason);
 
         if (canDeleteIndexContents(shardId.getIndex(), indexSettings)) {

--- a/server/src/main/java/org/elasticsearch/indices/IndicesService.java
+++ b/server/src/main/java/org/elasticsearch/indices/IndicesService.java
@@ -40,7 +40,6 @@ import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.component.AbstractLifecycleComponent;
-import org.elasticsearch.common.io.FileSystemUtils;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.io.stream.NamedWriteableAwareStreamInput;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;

--- a/server/src/main/java/org/elasticsearch/indices/store/CompositeIndexFoldersDeletionListener.java
+++ b/server/src/main/java/org/elasticsearch/indices/store/CompositeIndexFoldersDeletionListener.java
@@ -30,10 +30,10 @@ public class CompositeIndexFoldersDeletionListener implements IndexStorePlugin.I
     }
 
     @Override
-    public void beforeIndexFoldersDeleted(Index index, IndexSettings indexSettings, Path[] indexPaths) {
+    public void beforeIndexFoldersDeleted(Index index, IndexSettings indexSettings, Path indexPath) {
         for (IndexStorePlugin.IndexFoldersDeletionListener listener : listeners) {
             try {
-                listener.beforeIndexFoldersDeleted(index, indexSettings, indexPaths);
+                listener.beforeIndexFoldersDeleted(index, indexSettings, indexPath);
             } catch (Exception e) {
                 assert false : new AssertionError(e);
                 throw e;
@@ -42,10 +42,10 @@ public class CompositeIndexFoldersDeletionListener implements IndexStorePlugin.I
     }
 
     @Override
-    public void beforeShardFoldersDeleted(ShardId shardId, IndexSettings indexSettings, Path[] shardPaths) {
+    public void beforeShardFoldersDeleted(ShardId shardId, IndexSettings indexSettings, Path shardPath) {
         for (IndexStorePlugin.IndexFoldersDeletionListener listener : listeners) {
             try {
-                listener.beforeShardFoldersDeleted(shardId, indexSettings, shardPaths);
+                listener.beforeShardFoldersDeleted(shardId, indexSettings, shardPath);
             } catch (Exception e) {
                 assert false : new AssertionError(e);
                 throw e;

--- a/server/src/main/java/org/elasticsearch/plugins/IndexStorePlugin.java
+++ b/server/src/main/java/org/elasticsearch/plugins/IndexStorePlugin.java
@@ -83,24 +83,22 @@ public interface IndexStorePlugin {
      */
     interface IndexFoldersDeletionListener {
         /**
-         * Invoked before the folders of an index are deleted from disk. The list of folders contains {@link Path}s that may or may not
+         * Invoked before the folders of an index are deleted from disk. The folder's {@link Path} may or may not
          * exist on disk. Shard locks are expected to be acquired at the time this method is invoked.
-         *
          * @param index         the {@link Index} of the index whose folders are going to be deleted
          * @param indexSettings settings for the index whose folders are going to be deleted
-         * @param indexPaths    the paths of the folders that are going to be deleted
+         * @param indexPath    the path of the folders that will be deleted
          */
-        void beforeIndexFoldersDeleted(Index index, IndexSettings indexSettings, Path[] indexPaths);
+        void beforeIndexFoldersDeleted(Index index, IndexSettings indexSettings, Path indexPath);
 
         /**
-         * Invoked before the folders of a shard are deleted from disk. The list of folders contains {@link Path}s that may or may not
+         * Invoked before the folders of a shard are deleted from disk. The folder's {@link Path} may or may not
          * exist on disk. Shard locks are expected to be acquired at the time this method is invoked.
-         *
          * @param shardId       the {@link ShardId} of the shard whose folders are going to be deleted
          * @param indexSettings index settings of the shard whose folders are going to be deleted
-         * @param shardPaths    the paths of the folders that are going to be deleted
+         * @param shardPath    the path of the folder that will be deleted
          */
-        void beforeShardFoldersDeleted(ShardId shardId, IndexSettings indexSettings, Path[] shardPaths);
+        void beforeShardFoldersDeleted(ShardId shardId, IndexSettings indexSettings, Path shardPath);
     }
 
     /**

--- a/server/src/test/java/org/elasticsearch/env/NodeEnvironmentTests.java
+++ b/server/src/test/java/org/elasticsearch/env/NodeEnvironmentTests.java
@@ -200,8 +200,8 @@ public class NodeEnvironmentTests extends ESTestCase {
         Files.createDirectories(path.resolve("1"));
 
         expectThrows(ShardLockObtainFailedException.class,
-            () -> env.deleteShardDirectorySafe(new ShardId(index, 0), idxSettings, shardPaths -> {
-                assert false : "should not be called " + shardPaths;
+            () -> env.deleteShardDirectorySafe(new ShardId(index, 0), idxSettings, shardPath -> {
+                assert false : "should not be called " + shardPath;
             }));
 
         path = env.indexPath(index);
@@ -209,12 +209,10 @@ public class NodeEnvironmentTests extends ESTestCase {
         assertTrue(Files.exists(path.resolve("1")));
 
         {
-            SetOnce<Path[]> listener = new SetOnce<>();
+            SetOnce<Path> listener = new SetOnce<>();
             env.deleteShardDirectorySafe(new ShardId(index, 1), idxSettings, listener::set);
-            Path[] deletedPaths = listener.get();
-            for (int i = 0; i < env.nodePaths().length; i++) {
-                assertThat(deletedPaths[i], equalTo(env.nodePaths()[i].resolve(index).resolve("1")));
-            }
+            Path deletedPath = listener.get();
+            assertThat(deletedPath, equalTo(env.nodePaths()[0].resolve(index).resolve("1")));
         }
 
         path = env.indexPath(index);
@@ -263,9 +261,9 @@ public class NodeEnvironmentTests extends ESTestCase {
         start.countDown();
         blockLatch.await();
 
-        final SetOnce<Path[]> listener = new SetOnce<>();
+        final SetOnce<Path> listener = new SetOnce<>();
         env.deleteIndexDirectorySafe(index, 5000, idxSettings, listener::set);
-        assertThat(listener.get()[0], equalTo(env.indexPath(index)));
+        assertThat(listener.get(), equalTo(env.indexPath(index)));
         assertNull(threadException.get());
 
         path = env.indexPath(index);

--- a/server/src/test/java/org/elasticsearch/index/IndexModuleTests.java
+++ b/server/src/test/java/org/elasticsearch/index/IndexModuleTests.java
@@ -122,11 +122,11 @@ public class IndexModuleTests extends ESTestCase {
 
     private IndexStorePlugin.IndexFoldersDeletionListener indexDeletionListener = new IndexStorePlugin.IndexFoldersDeletionListener() {
         @Override
-        public void beforeIndexFoldersDeleted(Index index, IndexSettings indexSettings, Path[] indexPaths) {
+        public void beforeIndexFoldersDeleted(Index index, IndexSettings indexSettings, Path indexPath) {
         }
 
         @Override
-        public void beforeShardFoldersDeleted(ShardId shardId, IndexSettings indexSettings, Path[] shardPaths) {
+        public void beforeShardFoldersDeleted(ShardId shardId, IndexSettings indexSettings, Path shardPath) {
         }
     };
 

--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/allocation/SearchableSnapshotIndexFoldersDeletionListener.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/allocation/SearchableSnapshotIndexFoldersDeletionListener.java
@@ -45,7 +45,7 @@ public class SearchableSnapshotIndexFoldersDeletionListener implements IndexStor
     }
 
     @Override
-    public void beforeIndexFoldersDeleted(Index index, IndexSettings indexSettings, Path[] indexPaths) {
+    public void beforeIndexFoldersDeleted(Index index, IndexSettings indexSettings, Path indexPath) {
         if (SearchableSnapshotsConstants.isSearchableSnapshotStore(indexSettings.getSettings())) {
             for (int shard = 0; shard < indexSettings.getNumberOfShards(); shard++) {
                 markShardAsEvictedInCache(new ShardId(index, shard), indexSettings);
@@ -54,7 +54,7 @@ public class SearchableSnapshotIndexFoldersDeletionListener implements IndexStor
     }
 
     @Override
-    public void beforeShardFoldersDeleted(ShardId shardId, IndexSettings indexSettings, Path[] shardPaths) {
+    public void beforeShardFoldersDeleted(ShardId shardId, IndexSettings indexSettings, Path shardPath) {
         if (SearchableSnapshotsConstants.isSearchableSnapshotStore(indexSettings.getSettings())) {
             markShardAsEvictedInCache(shardId, indexSettings);
         }


### PR DESCRIPTION
The listeners for deletion of index and shard paths previously accepted
an array of paths, since they could exist on several different data
paths. This commit converts the consumer to take a single path.

relates #71205