### PR TITLE
Service Accounts - no roles in denial error message

### DIFF
--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/AuthorizationService.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/AuthorizationService.java
@@ -631,8 +631,9 @@ public class AuthorizationService {
             final String apiKeyId = (String) authentication.getMetadata().get(ApiKeyService.API_KEY_ID_KEY);
             assert apiKeyId != null : "api key id must be present in the metadata";
             userText = "API key id [" + apiKeyId + "] of " + userText;
-        } else {
+        } else if (false == authentication.isServiceAccount()) {
             // Don't print roles for API keys because they're not meaningful
+            // Also not printing roles for service accounts since they have no roles
             userText = userText + " with roles [" + Strings.arrayToCommaDelimitedString(authentication.getUser().roles()) + "]";
         }
 

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/service_accounts/10_basic.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/service_accounts/10_basic.yml
@@ -57,6 +57,17 @@ teardown:
   - match: { "token.name": "api-token-1" }
 
   - do:
+      catch: forbidden
+      headers:
+        Authorization: Bearer ${service_token}
+      security.delete_user:
+        username: foo
+
+  - match: { "error.type": "security_exception" }
+  - match:
+      error.reason: "action [cluster:admin/xpack/security/user/delete] is unauthorized for user [elastic/fleet-server], this action is granted by the cluster privileges [manage_security,all]"
+
+  - do:
       security.get_service_credentials:
         namespace: elastic
         service: fleet-server


### PR DESCRIPTION
Service Accounts have no roles, i.e. it is always an empty list. Hence
it is better to not show it in the denial error message to reduce
clutter.