### PR TITLE
Tests mute impacted by JDK8 racy bug JDK-8266279

### DIFF
--- a/x-pack/plugin/security/cli/src/test/java/org/elasticsearch/xpack/security/cli/CertificateToolTests.java
+++ b/x-pack/plugin/security/cli/src/test/java/org/elasticsearch/xpack/security/cli/CertificateToolTests.java
@@ -26,6 +26,7 @@ import org.bouncycastle.openssl.PEMDecryptorProvider;
 import org.bouncycastle.openssl.PEMEncryptedKeyPair;
 import org.bouncycastle.openssl.PEMParser;
 import org.bouncycastle.pkcs.PKCS10CertificationRequest;
+import org.elasticsearch.bootstrap.JavaVersion;
 import org.elasticsearch.cli.MockTerminal;
 import org.elasticsearch.cli.Terminal;
 import org.elasticsearch.cli.UserException;
@@ -558,6 +559,8 @@ public class CertificateToolTests extends ESTestCase {
      * - Checks that all 3 certificates have the right values based on the command line options provided during generation
      */
     public void testCreateCaAndMultipleInstances() throws Exception {
+        assumeFalse("JDK bug JDK-8266279, https://github.com/elastic/elasticsearch/issues/72359",
+                JavaVersion.current().compareTo(JavaVersion.parse("8")) == 0);
         final Path tempDir = initTempDir();
 
         final Terminal terminal = new MockTerminal();
@@ -707,6 +710,8 @@ public class CertificateToolTests extends ESTestCase {
      * - Checks that the PKCS12 certificate and the PEM certificate trust one another
      */
     public void testTrustBetweenPEMandPKCS12() throws Exception {
+        assumeFalse("JDK bug JDK-8266279, https://github.com/elastic/elasticsearch/issues/72359",
+                JavaVersion.current().compareTo(JavaVersion.parse("8")) == 0);
         final Path tempDir = initTempDir();
 
         final MockTerminal terminal = new MockTerminal();

--- a/x-pack/plugin/security/cli/src/test/java/org/elasticsearch/xpack/security/cli/HttpCertificateCommandTests.java
+++ b/x-pack/plugin/security/cli/src/test/java/org/elasticsearch/xpack/security/cli/HttpCertificateCommandTests.java
@@ -23,6 +23,7 @@ import org.bouncycastle.pkcs.PKCS10CertificationRequest;
 import org.bouncycastle.pkcs.jcajce.JcaPKCS10CertificationRequest;
 import org.bouncycastle.util.io.pem.PemObject;
 import org.bouncycastle.util.io.pem.PemReader;
+import org.elasticsearch.bootstrap.JavaVersion;
 import org.elasticsearch.cli.MockTerminal;
 import org.elasticsearch.common.CheckedBiFunction;
 import org.elasticsearch.common.CheckedFunction;
@@ -116,6 +117,9 @@ public class HttpCertificateCommandTests extends ESTestCase {
     }
 
     public void testGenerateSingleCertificateSigningRequest() throws Exception {
+        assumeFalse("JDK bug JDK-8266279, https://github.com/elastic/elasticsearch/issues/72359",
+                JavaVersion.current().compareTo(JavaVersion.parse("8")) == 0);
+
         final Path outFile = testRoot.resolve("csr.zip").toAbsolutePath();
 
         final List<String> hostNames = randomHostNames();
@@ -216,6 +220,8 @@ public class HttpCertificateCommandTests extends ESTestCase {
     }
 
     public void testGenerateSingleCertificateWithExistingCA() throws Exception {
+        assumeFalse("JDK bug JDK-8266279, https://github.com/elastic/elasticsearch/issues/72359",
+                JavaVersion.current().compareTo(JavaVersion.parse("8")) == 0);
         final Path outFile = testRoot.resolve("certs.zip").toAbsolutePath();
 
         final List<String> hostNames = randomHostNames();
@@ -329,6 +335,8 @@ public class HttpCertificateCommandTests extends ESTestCase {
     }
 
     public void testGenerateMultipleCertificateWithNewCA() throws Exception {
+        assumeFalse("JDK bug JDK-8266279, https://github.com/elastic/elasticsearch/issues/72359",
+                JavaVersion.current().compareTo(JavaVersion.parse("8")) == 0);
         final Path outFile = testRoot.resolve("certs.zip").toAbsolutePath();
 
         final int numberCerts = randomIntBetween(3, 6);
@@ -470,6 +478,8 @@ public class HttpCertificateCommandTests extends ESTestCase {
     }
 
     public void testParsingValidityPeriod() throws Exception {
+        assumeFalse("JDK bug JDK-8266279, https://github.com/elastic/elasticsearch/issues/72359",
+                JavaVersion.current().compareTo(JavaVersion.parse("8")) == 0);
         final HttpCertificateCommand command = new HttpCertificateCommand();
         final MockTerminal terminal = new MockTerminal();
 
@@ -523,6 +533,8 @@ public class HttpCertificateCommandTests extends ESTestCase {
     }
 
     public void testValidityPeriodToString() throws Exception {
+        assumeFalse("JDK bug JDK-8266279, https://github.com/elastic/elasticsearch/issues/72359",
+                JavaVersion.current().compareTo(JavaVersion.parse("8")) == 0);
         assertThat(HttpCertificateCommand.toString(Period.ofYears(2)), is("2y"));
         assertThat(HttpCertificateCommand.toString(Period.ofMonths(5)), is("5m"));
         assertThat(HttpCertificateCommand.toString(Period.ofDays(60)), is("60d"));
@@ -536,6 +548,8 @@ public class HttpCertificateCommandTests extends ESTestCase {
     }
 
     public void testGuessFileType() throws Exception {
+        assumeFalse("JDK bug JDK-8266279, https://github.com/elastic/elasticsearch/issues/72359",
+                JavaVersion.current().compareTo(JavaVersion.parse("8")) == 0);
         MockTerminal terminal = new MockTerminal();
 
         final Path caCert = getDataPath("ca.crt");
@@ -563,6 +577,8 @@ public class HttpCertificateCommandTests extends ESTestCase {
     }
 
     public void testTextFileSubstitutions() throws Exception {
+        assumeFalse("JDK bug JDK-8266279, https://github.com/elastic/elasticsearch/issues/72359",
+                JavaVersion.current().compareTo(JavaVersion.parse("8")) == 0);
         CheckedBiFunction<String, Map<String, String>, String, Exception> copy = (source, subs) -> {
             try (InputStream in = new ByteArrayInputStream(source.getBytes(StandardCharsets.UTF_8));
                  StringWriter out = new StringWriter();


### PR DESCRIPTION
Relates https://github.com/elastic/elasticsearch/issues/72359