### PR TITLE
Add a cluster deprecation check for index templates containing multiple types

### DIFF
--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/DeprecationChecks.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/DeprecationChecks.java
@@ -38,7 +38,8 @@ public class DeprecationChecks {
             ClusterDeprecationChecks::checkUserAgentPipelines,
             ClusterDeprecationChecks::checkTemplatesWithTooManyFields,
             ClusterDeprecationChecks::checkPollIntervalTooLow,
-            ClusterDeprecationChecks::checkTemplatesWithFieldNamesDisabled
+            ClusterDeprecationChecks::checkTemplatesWithFieldNamesDisabled,
+            ClusterDeprecationChecks::checkTemplatesWithMultipleTypes
         ));
 
 


### PR DESCRIPTION
Using an index template that creates multiple mapping types will already
throw an error in 7.x.  This upgrade check should help filter out any unused
templates with multiple types that are still lurking in the cluster state.