### PR TITLE
[ML] Fixes empty overall_buckets response

### DIFF
--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetOverallBucketsAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetOverallBucketsAction.java
@@ -84,7 +84,7 @@ public class TransportGetOverallBucketsAction extends HandledTransportAction<Get
                 jobPage -> {
                     if (jobPage.count() == 0) {
                         listener.onResponse(new GetOverallBucketsAction.Response(
-                            new QueryPage<>(Collections.emptyList(), 0, Job.RESULTS_FIELD)));
+                            new QueryPage<>(Collections.emptyList(), 0, OverallBucket.RESULTS_FIELD)));
                         return;
                     }
 
@@ -113,7 +113,8 @@ public class TransportGetOverallBucketsAction extends HandledTransportAction<Get
 
         ActionListener<ChunkedBucketSearcher> chunkedBucketSearcherListener = ActionListener.wrap(searcher -> {
             if (searcher == null) {
-                listener.onResponse(new GetOverallBucketsAction.Response(new QueryPage<>(Collections.emptyList(), 0, Job.RESULTS_FIELD)));
+                listener.onResponse(new GetOverallBucketsAction.Response(
+                    new QueryPage<>(Collections.emptyList(), 0, OverallBucket.RESULTS_FIELD)));
                 return;
             }
             searcher.searchAndComputeOverallBuckets(overallBucketsListener);

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/ml/jobs_get_result_overall_buckets.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/ml/jobs_get_result_overall_buckets.yml
@@ -621,6 +621,18 @@ setup:
   - match: { overall_buckets.0.result_type: overall_bucket }
 
 ---
+"Test overall buckets given no matching jobs":
+  - do:
+      ml.get_overall_buckets:
+        job_id: "jobs-that-do-not-exist-*"
+        bucket_span: "2h"
+        overall_score: "41.0"
+        allow_no_match: true
+
+  - match: { count: 0 }
+  - length: { overall_buckets: 0 }
+
+---
 "Test overall buckets given bucket_span is smaller than max job bucket_span":
   - do:
       catch: /.*Param \[bucket_span\] must be greater or equal to the max bucket_span \[60m\]*/


### PR DESCRIPTION
When the response was empty we were incorrectly returning an
empty array called "jobs" rather than "overall_buckets".
This PR corrects this edge case.

Fixes #72478