### PR TITLE
Service Accounts - add token source to realm name

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authc/service/ServiceAccountSettings.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authc/service/ServiceAccountSettings.java
@@ -9,8 +9,8 @@ package org.elasticsearch.xpack.core.security.authc.service;
 
 public final class ServiceAccountSettings {
 
-    public static final String REALM_TYPE = "service_account";
-    public static final String REALM_NAME = "service_account";
+    public static final String REALM_NAME_PREFIX = "_service_account_";
+    public static final String REALM_TYPE = "_service_account";
     public static final String TOKEN_NAME_FIELD = "_token_name";
 
     private ServiceAccountSettings() {}

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authc/AuthenticationTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authc/AuthenticationTests.java
@@ -10,6 +10,7 @@ package org.elasticsearch.xpack.core.security.authc;
 import org.elasticsearch.Version;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.VersionUtils;
+import org.elasticsearch.xpack.core.security.action.service.TokenInfo.TokenSource;
 import org.elasticsearch.xpack.core.security.authc.Authentication.AuthenticationType;
 import org.elasticsearch.xpack.core.security.authc.Authentication.RealmRef;
 import org.elasticsearch.xpack.core.security.authc.esnative.NativeRealmSettings;
@@ -19,6 +20,7 @@ import org.elasticsearch.xpack.core.security.user.User;
 
 import java.util.Arrays;
 import java.util.EnumSet;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -101,7 +103,7 @@ public class AuthenticationTests extends ESTestCase {
         final boolean authRealmIsForServiceAccount = randomBoolean();
         if (authRealmIsForServiceAccount) {
             authRealm = new Authentication.RealmRef(
-                ServiceAccountSettings.REALM_NAME,
+                randomFrom(TokenSource.values()).name().toLowerCase(Locale.ROOT),
                 ServiceAccountSettings.REALM_TYPE,
                 randomAlphaOfLengthBetween(3, 8));
         } else {

--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/authc/service/ServiceAccountSingleNodeTests.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/authc/service/ServiceAccountSingleNodeTests.java
@@ -95,9 +95,8 @@ public class ServiceAccountSingleNodeTests extends SecuritySingleNodeTestCase {
         final AuthenticateRequest authenticateRequest = new AuthenticateRequest("elastic/fleet-server");
         final AuthenticateResponse authenticateResponse =
             createServiceAccountClient().execute(AuthenticateAction.INSTANCE, authenticateRequest).actionGet();
-        final String nodeName = node().settings().get(Node.NODE_NAME_SETTING.getKey());
         assertThat(authenticateResponse.authentication(), equalTo(
-           getExpectedAuthentication("token1")
+           getExpectedAuthentication("token1", "_service_account_file")
         ));
     }
 
@@ -110,7 +109,7 @@ public class ServiceAccountSingleNodeTests extends SecuritySingleNodeTestCase {
         final AuthenticateRequest authenticateRequest = new AuthenticateRequest("elastic/fleet-server");
         final AuthenticateResponse authenticateResponse = createServiceAccountClient(secretValue1.toString())
             .execute(AuthenticateAction.INSTANCE, authenticateRequest).actionGet();
-        assertThat(authenticateResponse.authentication(), equalTo(getExpectedAuthentication("api-token-1")));
+        assertThat(authenticateResponse.authentication(), equalTo(getExpectedAuthentication("api-token-1", "_service_account_index")));
         // cache is populated after authenticate
         assertThat(cache.count(), equalTo(1));
 
@@ -170,12 +169,12 @@ public class ServiceAccountSingleNodeTests extends SecuritySingleNodeTestCase {
         return client().filterWithHeader(Map.of("Authorization", "Bearer " + bearerString));
     }
 
-    private Authentication getExpectedAuthentication(String tokenName) {
+    private Authentication getExpectedAuthentication(String tokenName, String realmName) {
         final String nodeName = node().settings().get(Node.NODE_NAME_SETTING.getKey());
         return new Authentication(
             new User("elastic/fleet-server", Strings.EMPTY_ARRAY, "Service account - elastic/fleet-server", null,
                 Map.of("_elastic_service_account", true), true),
-            new Authentication.RealmRef("service_account", "service_account", nodeName),
+            new Authentication.RealmRef(realmName, "_service_account", nodeName),
             null, Version.CURRENT, Authentication.AuthenticationType.TOKEN, Map.of("_token_name", tokenName)
         );
     }
@@ -195,6 +194,6 @@ public class ServiceAccountSingleNodeTests extends SecuritySingleNodeTestCase {
         final AuthenticateResponse authenticateResponse =
             createServiceAccountClient(secret.toString())
                 .execute(AuthenticateAction.INSTANCE, authenticateRequest).actionGet();
-        assertThat(authenticateResponse.authentication(), equalTo(getExpectedAuthentication(tokenName)));
+        assertThat(authenticateResponse.authentication(), equalTo(getExpectedAuthentication(tokenName, "_service_account_index")));
     }
 }

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/service/CachingServiceAccountTokenStore.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/service/CachingServiceAccountTokenStore.java
@@ -18,6 +18,7 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.util.concurrent.ListenableFuture;
 import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.xpack.core.security.action.service.TokenInfo.TokenSource;
 import org.elasticsearch.xpack.core.security.authc.support.Hasher;
 import org.elasticsearch.xpack.core.security.support.CacheIteratorHelper;
 import org.elasticsearch.xpack.security.support.CacheInvalidatorRegistry;
@@ -62,7 +63,7 @@ public abstract class CachingServiceAccountTokenStore implements ServiceAccountT
     }
 
     @Override
-    public void authenticate(ServiceAccountToken token, ActionListener<Boolean> listener) {
+    public void authenticate(ServiceAccountToken token, ActionListener<StoreAuthenticationResult> listener) {
         try {
             if (cache == null) {
                 doAuthenticate(token, listener);
@@ -74,7 +75,7 @@ public abstract class CachingServiceAccountTokenStore implements ServiceAccountT
         }
     }
 
-    private void authenticateWithCache(ServiceAccountToken token, ActionListener<Boolean> listener) {
+    private void authenticateWithCache(ServiceAccountToken token, ActionListener<StoreAuthenticationResult> listener) {
         assert cache != null;
         try {
             final AtomicBoolean valueAlreadyInCache = new AtomicBoolean(true);
@@ -85,25 +86,25 @@ public abstract class CachingServiceAccountTokenStore implements ServiceAccountT
             if (valueAlreadyInCache.get()) {
                 listenableCacheEntry.addListener(ActionListener.wrap(result -> {
                     if (result.success) {
-                        listener.onResponse(result.verify(token));
+                        listener.onResponse(new StoreAuthenticationResult(result.verify(token), getTokenSource()));
                     } else if (result.verify(token)) {
                         // same wrong token
-                        listener.onResponse(false);
+                        listener.onResponse(new StoreAuthenticationResult(false, getTokenSource()));
                     } else {
                         cache.invalidate(token.getQualifiedName(), listenableCacheEntry);
                         authenticateWithCache(token, listener);
                     }
                 }, listener::onFailure), threadPool.generic(), threadPool.getThreadContext());
             } else {
-                doAuthenticate(token, ActionListener.wrap(success -> {
-                    if (false == success) {
+                doAuthenticate(token, ActionListener.wrap(storeAuthenticationResult -> {
+                    if (false == storeAuthenticationResult.isSuccess()) {
                         // Do not cache failed attempt
                         cache.invalidate(token.getQualifiedName(), listenableCacheEntry);
                     } else {
                         logger.trace("cache service token [{}] authentication result", token.getQualifiedName());
                     }
-                    listenableCacheEntry.onResponse(new CachedResult(hasher, success, token));
-                    listener.onResponse(success);
+                    listenableCacheEntry.onResponse(new CachedResult(hasher, storeAuthenticationResult.isSuccess(), token));
+                    listener.onResponse(storeAuthenticationResult);
                 }, e -> {
                     // In case of failure, evict the cache entry and notify all listeners
                     cache.invalidate(token.getQualifiedName(), listenableCacheEntry);
@@ -154,7 +155,9 @@ public abstract class CachingServiceAccountTokenStore implements ServiceAccountT
         return threadPool;
     }
 
-    abstract void doAuthenticate(ServiceAccountToken token, ActionListener<Boolean> listener);
+    abstract void doAuthenticate(ServiceAccountToken token, ActionListener<StoreAuthenticationResult> listener);
+
+    abstract TokenSource getTokenSource();
 
     // package private for testing
     Cache<String, ListenableFuture<CachedResult>> getCache() {

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/service/CompositeServiceAccountTokenStore.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/service/CompositeServiceAccountTokenStore.java
@@ -36,15 +36,16 @@ public final class CompositeServiceAccountTokenStore implements ServiceAccountTo
     }
 
     @Override
-    public void authenticate(ServiceAccountToken token, ActionListener<Boolean> listener) {
+    public void authenticate(ServiceAccountToken token, ActionListener<StoreAuthenticationResult> listener) {
         // TODO: optimize store order based on auth result?
-        final IteratingActionListener<Boolean, ServiceAccountTokenStore> authenticatingListener = new IteratingActionListener<>(
-            listener,
-            (store, successListener) -> store.authenticate(token, successListener),
-            stores,
-            threadContext,
-            Function.identity(),
-            success -> Boolean.FALSE == success);
+        final IteratingActionListener<StoreAuthenticationResult, ServiceAccountTokenStore> authenticatingListener =
+            new IteratingActionListener<>(
+                listener,
+                (store, successListener) -> store.authenticate(token, successListener),
+                stores,
+                threadContext,
+                Function.identity(),
+                storeAuthenticationResult -> false == storeAuthenticationResult.isSuccess());
         try {
             authenticatingListener.run();
         } catch (Exception e) {

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/service/IndexServiceAccountTokenStore.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/service/IndexServiceAccountTokenStore.java
@@ -46,6 +46,7 @@ import org.elasticsearch.xpack.core.security.action.service.CreateServiceAccount
 import org.elasticsearch.xpack.core.security.action.service.CreateServiceAccountTokenResponse;
 import org.elasticsearch.xpack.core.security.action.service.DeleteServiceAccountTokenRequest;
 import org.elasticsearch.xpack.core.security.action.service.TokenInfo;
+import org.elasticsearch.xpack.core.security.action.service.TokenInfo.TokenSource;
 import org.elasticsearch.xpack.core.security.authc.Authentication;
 import org.elasticsearch.xpack.core.security.authc.support.Hasher;
 import org.elasticsearch.xpack.security.authc.service.ServiceAccount.ServiceAccountId;
@@ -90,7 +91,7 @@ public class IndexServiceAccountTokenStore extends CachingServiceAccountTokenSto
     }
 
     @Override
-    void doAuthenticate(ServiceAccountToken token, ActionListener<Boolean> listener) {
+    void doAuthenticate(ServiceAccountToken token, ActionListener<StoreAuthenticationResult> listener) {
         final GetRequest getRequest = client
             .prepareGet(SECURITY_MAIN_ALIAS, docIdForToken(token.getQualifiedName()))
             .setFetchSource(true)
@@ -100,11 +101,17 @@ public class IndexServiceAccountTokenStore extends CachingServiceAccountTokenSto
                 if (response.isExists()) {
                     final String tokenHash = (String) response.getSource().get("password");
                     assert tokenHash != null : "service account token hash cannot be null";
-                    listener.onResponse(Hasher.verifyHash(token.getSecret(), tokenHash.toCharArray()));
+                    listener.onResponse(new StoreAuthenticationResult(
+                        Hasher.verifyHash(token.getSecret(), tokenHash.toCharArray()), getTokenSource()));
                 } else {
                     logger.trace("service account token [{}] not found in index", token.getQualifiedName());
-                    listener.onResponse(false);
+                    listener.onResponse(new StoreAuthenticationResult(false, getTokenSource()));
                 }}, listener::onFailure)));
+    }
+
+    @Override
+    public TokenSource getTokenSource() {
+        return TokenSource.INDEX;
     }
 
     public void createToken(Authentication authentication, CreateServiceAccountTokenRequest request,

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/service/ServiceAccountService.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/service/ServiceAccountService.java
@@ -15,6 +15,7 @@ import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.common.settings.SecureString;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.xpack.core.security.action.service.GetServiceAccountCredentialsResponse;
+import org.elasticsearch.xpack.core.security.action.service.TokenInfo.TokenSource;
 import org.elasticsearch.xpack.core.security.authc.Authentication;
 import org.elasticsearch.xpack.core.security.authc.service.ServiceAccountSettings;
 import org.elasticsearch.xpack.core.security.authz.RoleDescriptor;
@@ -23,6 +24,7 @@ import org.elasticsearch.xpack.security.authc.service.ServiceAccount.ServiceAcco
 import org.elasticsearch.xpack.security.authc.support.HttpTlsRuntimeCheck;
 
 import java.util.Collection;
+import java.util.Locale;
 import java.util.Map;
 
 import static org.elasticsearch.xpack.core.security.authc.service.ServiceAccountSettings.TOKEN_NAME_FIELD;
@@ -101,9 +103,10 @@ public class ServiceAccountService {
                 return;
             }
 
-            serviceAccountTokenStore.authenticate(serviceAccountToken, ActionListener.wrap(success -> {
-                if (success) {
-                    listener.onResponse(createAuthentication(account, serviceAccountToken, nodeName));
+            serviceAccountTokenStore.authenticate(serviceAccountToken, ActionListener.wrap(storeAuthenticationResult -> {
+                if (storeAuthenticationResult.isSuccess()) {
+                    listener.onResponse(
+                        createAuthentication(account, serviceAccountToken, storeAuthenticationResult.getTokenSource() , nodeName));
                 } else {
                     final ElasticsearchSecurityException e = createAuthenticationException(serviceAccountToken);
                     logger.debug(e.getMessage());
@@ -127,10 +130,12 @@ public class ServiceAccountService {
         });
     }
 
-    private Authentication createAuthentication(ServiceAccount account, ServiceAccountToken token, String nodeName) {
+    private Authentication createAuthentication(ServiceAccount account, ServiceAccountToken token, TokenSource tokenSource,
+                                                String nodeName) {
         final User user = account.asUser();
-        final Authentication.RealmRef authenticatedBy =
-            new Authentication.RealmRef(ServiceAccountSettings.REALM_NAME, ServiceAccountSettings.REALM_TYPE, nodeName);
+        final Authentication.RealmRef authenticatedBy = new Authentication.RealmRef(
+            ServiceAccountSettings.REALM_NAME_PREFIX + tokenSource.name().toLowerCase(Locale.ROOT),
+            ServiceAccountSettings.REALM_TYPE, nodeName);
         return new Authentication(user, authenticatedBy, null, Version.CURRENT, Authentication.AuthenticationType.TOKEN,
             Map.of(TOKEN_NAME_FIELD, token.getTokenName()));
     }

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/service/ServiceAccountTokenStore.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/service/ServiceAccountTokenStore.java
@@ -9,6 +9,7 @@ package org.elasticsearch.xpack.security.authc.service;
 
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.xpack.core.security.action.service.TokenInfo;
+import org.elasticsearch.xpack.core.security.action.service.TokenInfo.TokenSource;
 import org.elasticsearch.xpack.security.authc.service.ServiceAccount.ServiceAccountId;
 
 import java.util.Collection;
@@ -21,11 +22,28 @@ public interface ServiceAccountTokenStore {
     /**
      * Verify the given token for encapsulated service account and credential
      */
-    void authenticate(ServiceAccountToken token, ActionListener<Boolean> listener);
+    void authenticate(ServiceAccountToken token, ActionListener<StoreAuthenticationResult> listener);
 
     /**
      * Get all tokens belong to the given service account id
      */
     void findTokensFor(ServiceAccountId accountId, ActionListener<Collection<TokenInfo>> listener);
 
+    class StoreAuthenticationResult {
+        private final boolean success;
+        private final TokenSource tokenSource;
+
+        public StoreAuthenticationResult(boolean success, TokenSource tokenSource) {
+            this.success = success;
+            this.tokenSource = tokenSource;
+        }
+
+        public boolean isSuccess() {
+            return success;
+        }
+
+        public TokenSource getTokenSource() {
+            return tokenSource;
+        }
+    }
 }

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/AuthenticationServiceTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/AuthenticationServiceTests.java
@@ -66,6 +66,7 @@ import org.elasticsearch.transport.TransportRequest;
 import org.elasticsearch.xpack.core.XPackField;
 import org.elasticsearch.xpack.core.XPackSettings;
 import org.elasticsearch.xpack.core.security.SecurityContext;
+import org.elasticsearch.xpack.core.security.action.service.TokenInfo;
 import org.elasticsearch.xpack.core.security.authc.Authentication;
 import org.elasticsearch.xpack.core.security.authc.Authentication.AuthenticationType;
 import org.elasticsearch.xpack.core.security.authc.Authentication.RealmRef;
@@ -115,6 +116,7 @@ import java.util.Base64;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
@@ -1916,9 +1918,10 @@ public class AuthenticationServiceTests extends ESTestCase {
 
     public void testCanAuthenticateServiceAccount() throws ExecutionException, InterruptedException {
         Mockito.reset(serviceAccountService);
+        final TokenInfo.TokenSource tokenSource = randomFrom(TokenInfo.TokenSource.values());
         final Authentication authentication = new Authentication(
             new User("elastic/fleet-server"),
-            new RealmRef("service_account", "service_account", "foo"), null,
+            new RealmRef(tokenSource.name().toLowerCase(Locale.ROOT), "service_account", "foo"), null,
             Version.CURRENT, AuthenticationType.TOKEN, Map.of("_token_name", ValidationTests.randomTokenName()));
         try (ThreadContext.StoredContext ignored = threadContext.newStoredContext(false)) {
             boolean requestIdAlreadyPresent = randomBoolean();

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/ingest/SetSecurityUserProcessorTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/ingest/SetSecurityUserProcessorTests.java
@@ -17,6 +17,7 @@ import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.XContentTestUtils;
 import org.elasticsearch.xpack.core.security.SecurityContext;
 import org.elasticsearch.xpack.core.security.action.ApiKeyTests;
+import org.elasticsearch.xpack.core.security.action.service.TokenInfo;
 import org.elasticsearch.xpack.core.security.authc.Authentication;
 import org.elasticsearch.xpack.core.security.authc.Authentication.AuthenticationType;
 import org.elasticsearch.xpack.core.security.authc.support.AuthenticationContextSerializer;
@@ -31,6 +32,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
 
 import static org.hamcrest.Matchers.equalTo;
@@ -363,10 +365,12 @@ public class SetSecurityUserProcessorTests extends ESTestCase {
 
     private Authentication randomAuthentication() {
         final User user = randomUser();
+        final TokenInfo.TokenSource tokenSource = randomFrom(TokenInfo.TokenSource.values());
         if (user.fullName().startsWith("Service account - ")) {
             assert false == user.isRunAs() : "cannot run-as service account";
             final Authentication.RealmRef authBy =
-                new Authentication.RealmRef("service_account", "service_account", randomAlphaOfLengthBetween(3, 8));
+                new Authentication.RealmRef(
+                    tokenSource.name().toLowerCase(Locale.ROOT), "service_account", randomAlphaOfLengthBetween(3, 8));
             return new Authentication(user, authBy, null, Version.CURRENT, AuthenticationType.TOKEN,
                 Map.of("_token_name", ValidationTests.randomTokenName()));
         } else {


### PR DESCRIPTION
A service account token can come from either file or the security index.
It is also possible to have two tokens with the same fully qualified
name with one from the file and the other from the index. As a result,
they are not differentiable in the authenticate response or in audit
log.

This PR updates the realm name to include the token source so it is
automatically included in the auth response and audit log.
It also prefix both realm type and name with a leading underscore to
follow the general convention of reserved names.

