### PR TITLE
Consolidate and clarify MappingLookup semantics

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/mapper/MapperService.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/MapperService.java
@@ -312,7 +312,8 @@ public class MapperService extends AbstractIndexComponent implements Closeable {
     }
 
     /**
-     * Return the document mapper, or {@code null} if no mapping has been put yet.
+     * Return the document mapper, or {@code null} if no mapping has been put yet
+     * or no documents have been indexed in the current index yet (which triggers a dynamic mapping update)
      */
     public DocumentMapper documentMapper() {
         return mapper;
@@ -365,7 +366,10 @@ public class MapperService extends AbstractIndexComponent implements Closeable {
     }
 
     /**
-     * {@code volatile} read a (mostly) immutable snapshot current mapping.
+     * Exposes a snapshot of the mappings for the current index.
+     * If no mappings have been registered for the current index, an empty {@link MappingLookup} instance is returned.
+     * An index does not have mappings only if it was created without providing mappings explicitly,
+     * and no documents have yet been indexed in it.
      */
     public MappingLookup mappingLookup() {
         DocumentMapper mapper = this.mapper;

--- a/server/src/main/java/org/elasticsearch/index/mapper/MappingLookup.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/MappingLookup.java
@@ -18,6 +18,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Stream;
@@ -35,17 +36,10 @@ public final class MappingLookup {
     }
 
     /**
-     * A lookup representing an empty mapping.
+     * A lookup representing an empty mapping. It can be used to look up fields, although it won't hold any, but it does not
+     * hold a valid {@link DocumentParser}, {@link IndexSettings} or {@link IndexAnalyzers}.
      */
-    public static final MappingLookup EMPTY = new MappingLookup(
-        Mapping.EMPTY,
-        List.of(),
-        List.of(),
-        List.of(),
-        null,
-        null,
-        null
-    );
+    public static final MappingLookup EMPTY = fromMappers(Mapping.EMPTY, List.of(), List.of(), List.of());
 
     private final CacheKey cacheKey = new CacheKey();
 
@@ -62,6 +56,15 @@ public final class MappingLookup {
     private final IndexSettings indexSettings;
     private final IndexAnalyzers indexAnalyzers;
 
+    /**
+     * Creates a new {@link MappingLookup} instance by parsing the provided mapping and extracting its field definitions.
+     *
+     * @param mapping the mapping source
+     * @param documentParser the document parser for the current index
+     * @param indexSettings the settings for the current index
+     * @param indexAnalyzers the index analyzers for the current index
+     * @return the newly created lookup instance
+     */
     public static MappingLookup fromMapping(Mapping mapping,
                                             DocumentParser documentParser,
                                             IndexSettings indexSettings,
@@ -82,10 +85,9 @@ public final class MappingLookup {
             newFieldMappers,
             newObjectMappers,
             newFieldAliasMappers,
-            documentParser,
-            indexSettings,
-            indexAnalyzers
-        );
+            Objects.requireNonNull(documentParser),
+            Objects.requireNonNull(indexSettings),
+            Objects.requireNonNull(indexAnalyzers));
     }
 
     private static void collect(Mapper mapper, Collection<ObjectMapper> objectMappers,
@@ -106,7 +108,28 @@ public final class MappingLookup {
         }
     }
 
-    public MappingLookup(Mapping mapping,
+    /**
+     * Creates a new {@link MappingLookup} instance given the provided mappers and mapping.
+     * Note that the provided mappings are not re-parsed but only exposed as-is. No consistency is enforced between
+     * the provided mappings and set of mappers.
+     * This is a commodity method to be used in tests, or whenever no mappings are defined for an index.
+     * When creating a MappingLookup through this method, its exposed functionalities are limited as it does not
+     * hold a valid {@link DocumentParser}, {@link IndexSettings} or {@link IndexAnalyzers}.
+     *
+     * @param mapping the mapping
+     * @param mappers the field mappers
+     * @param objectMappers the object mappers
+     * @param aliasMappers the field alias mappers
+     * @return the newly created lookup instance
+     */
+    public static MappingLookup fromMappers(Mapping mapping,
+                                            Collection<FieldMapper> mappers,
+                                            Collection<ObjectMapper> objectMappers,
+                                            Collection<FieldAliasMapper> aliasMappers) {
+        return new MappingLookup(mapping, mappers, objectMappers, aliasMappers, null, null, null);
+    }
+
+    private MappingLookup(Mapping mapping,
                          Collection<FieldMapper> mappers,
                          Collection<ObjectMapper> objectMappers,
                          Collection<FieldAliasMapper> aliasMappers,
@@ -319,10 +342,22 @@ public final class MappingLookup {
         return fieldTypesLookup().sourcePaths(field);
     }
 
+    /**
+     * Parses the provided document. Note that a {@link DocumentParser} is required which is available only for instances created
+     * by parsing mappings (through {@link MappingLookup#fromMapping(Mapping, DocumentParser, IndexSettings, IndexAnalyzers)}).
+     *
+     * @param source the source to parse
+     * @return the parsed document
+     */
     public ParsedDocument parseDocument(SourceToParse source) {
         return documentParser.parseDocument(source, this);
     }
 
+    /**
+     * Returns true if the index has mappings. An index does not have mappings only if it was created
+     * without providing mappings explicitly, and no documents have yet been indexed in it.
+     * @return true if the current index has mappings, false otherwise
+     */
     public boolean hasMappings() {
         return this != EMPTY;
     }

--- a/server/src/main/java/org/elasticsearch/index/query/IdsQueryBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/IdsQueryBuilder.java
@@ -129,7 +129,7 @@ public class IdsQueryBuilder extends AbstractQueryBuilder<IdsQueryBuilder> {
             return new MatchNoneQueryBuilder();
         }
         SearchExecutionContext context = queryRewriteContext.convertToSearchExecutionContext();
-        if (context != null && context.getFieldType(IdFieldMapper.NAME) == null) {
+        if (context != null && context.hasMappings() == false) {
             // no mappings yet
             return new MatchNoneQueryBuilder();
         }

--- a/server/src/test/java/org/elasticsearch/action/admin/indices/rollover/MetadataRolloverServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/rollover/MetadataRolloverServiceTests.java
@@ -15,13 +15,13 @@ import org.elasticsearch.action.admin.indices.create.CreateIndexRequest;
 import org.elasticsearch.action.support.ActiveShardCount;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.ClusterState;
-import org.elasticsearch.cluster.metadata.DataStreamTestHelper;
 import org.elasticsearch.cluster.metadata.AliasAction;
 import org.elasticsearch.cluster.metadata.AliasMetadata;
 import org.elasticsearch.cluster.metadata.AliasValidator;
 import org.elasticsearch.cluster.metadata.ComponentTemplate;
 import org.elasticsearch.cluster.metadata.ComposableIndexTemplate;
 import org.elasticsearch.cluster.metadata.DataStream;
+import org.elasticsearch.cluster.metadata.DataStreamTestHelper;
 import org.elasticsearch.cluster.metadata.IndexAbstraction;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
@@ -574,14 +574,11 @@ public class MetadataRolloverServiceTests extends ESTestCase {
                     return null;
                 }
             };
-            MappingLookup mappingLookup = new MappingLookup(
+            MappingLookup mappingLookup = MappingLookup.fromMappers(
                 Mapping.EMPTY,
                 List.of(mockedTimestampField, dateFieldMapper),
                 List.of(),
-                List.of(),
-                null,
-                null,
-                null);
+                List.of());
             ClusterService clusterService = ClusterServiceUtils.createClusterService(testThreadPool);
             Environment env = mock(Environment.class);
             when(env.sharedDataFile()).thenReturn(null);
@@ -676,14 +673,11 @@ public class MetadataRolloverServiceTests extends ESTestCase {
                     return null;
                 }
             };
-            MappingLookup mappingLookup = new MappingLookup(
+            MappingLookup mappingLookup = MappingLookup.fromMappers(
                 Mapping.EMPTY,
                 List.of(mockedTimestampField, dateFieldMapper),
                 List.of(),
-                List.of(),
-                null,
-                null,
-                null);
+                List.of());
             ClusterService clusterService = ClusterServiceUtils.createClusterService(testThreadPool);
             Environment env = mock(Environment.class);
             when(env.sharedDataFile()).thenReturn(null);

--- a/server/src/test/java/org/elasticsearch/index/mapper/DocumentMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/DocumentMapperTests.java
@@ -58,7 +58,8 @@ public class DocumentMapperTests extends MapperServiceTestCase {
         // but merged should
         IndexSettings indexSettings = createIndexSettings(Version.CURRENT, Settings.EMPTY);
         IndexAnalyzers indexAnalyzers = createIndexAnalyzers(indexSettings);
-        DocumentMapper mergedMapper = new DocumentMapper(indexSettings, indexAnalyzers, null, merged);
+        DocumentParser documentParser = new DocumentParser(null, null);
+        DocumentMapper mergedMapper = new DocumentMapper(indexSettings, indexAnalyzers, documentParser, merged);
         assertThat(mergedMapper.mappers().getMapper("age"), notNullValue());
         assertThat(mergedMapper.mappers().getMapper("obj1.prop1"), notNullValue());
     }

--- a/server/src/test/java/org/elasticsearch/index/mapper/FieldAliasMapperValidationTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/FieldAliasMapperValidationTests.java
@@ -203,6 +203,6 @@ public class FieldAliasMapperValidationTests extends ESTestCase {
         Map<String, RuntimeField> runtimeFieldTypes = runtimeFields.stream().collect(Collectors.toMap(RuntimeField::name, r -> r));
         builder.setRuntime(runtimeFieldTypes);
         Mapping mapping = new Mapping(builder.build(new ContentPath()), new MetadataFieldMapper[0], Collections.emptyMap());
-        return new MappingLookup(mapping, fieldMappers, objectMappers, fieldAliasMappers, null, null, null);
+        return MappingLookup.fromMappers(mapping, fieldMappers, objectMappers, fieldAliasMappers);
     }
 }

--- a/server/src/test/java/org/elasticsearch/index/mapper/FieldNamesFieldTypeTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/FieldNamesFieldTypeTests.java
@@ -34,7 +34,7 @@ public class FieldNamesFieldTypeTests extends ESTestCase {
         IndexSettings indexSettings = new IndexSettings(
                 new IndexMetadata.Builder("foo").settings(settings).numberOfShards(1).numberOfReplicas(0).build(), settings);
         List<FieldMapper> mappers = Stream.of(fieldNamesFieldType, fieldType).map(MockFieldMapper::new).collect(Collectors.toList());
-        MappingLookup mappingLookup = new MappingLookup(Mapping.EMPTY, mappers, emptyList(), emptyList(), null, null, null);
+        MappingLookup mappingLookup = MappingLookup.fromMappers(Mapping.EMPTY, mappers, emptyList(), emptyList());
         SearchExecutionContext searchExecutionContext = new SearchExecutionContext(0, 0,
                 indexSettings, null, null, null, mappingLookup,
                 null, null, null, null, null, null, () -> 0L, null, null, () -> true, null, emptyMap());

--- a/server/src/test/java/org/elasticsearch/index/mapper/MappingLookupTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/MappingLookupTests.java
@@ -39,7 +39,7 @@ public class MappingLookupTests extends ESTestCase {
         Map<String, RuntimeField> runtimeFieldTypes = runtimeFields.stream().collect(Collectors.toMap(RuntimeField::name, r -> r));
         builder.setRuntime(runtimeFieldTypes);
         Mapping mapping = new Mapping(builder.build(new ContentPath()), new MetadataFieldMapper[0], Collections.emptyMap());
-        return new MappingLookup(mapping, fieldMappers, objectMappers, emptyList(), null, null, null);
+        return MappingLookup.fromMappers(mapping, fieldMappers, objectMappers, emptyList());
     }
 
     public void testOnlyRuntimeField() {

--- a/server/src/test/java/org/elasticsearch/index/mapper/MappingParserTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/MappingParserTests.java
@@ -76,7 +76,10 @@ public class MappingParserTests extends MapperServiceTestCase {
             b.endObject();
         });
         Mapping mapping = createMappingParser(Settings.EMPTY).parse("_doc", new CompressedXContent(BytesReference.bytes(builder)));
-        MappingLookup mappingLookup = MappingLookup.fromMapping(mapping, null, null, null);
+        IndexSettings indexSettings = createIndexSettings(Version.CURRENT, Settings.EMPTY);
+        IndexAnalyzers indexAnalyzers = createIndexAnalyzers(indexSettings);
+        DocumentParser documentParser = new DocumentParser(null, null);
+        MappingLookup mappingLookup = MappingLookup.fromMapping(mapping, documentParser, indexSettings, indexAnalyzers);
         assertNotNull(mappingLookup.getMapper("foo.bar"));
         assertNotNull(mappingLookup.getMapper("foo.baz.deep.field"));
         assertNotNull(mappingLookup.objectMappers().get("foo"));

--- a/server/src/test/java/org/elasticsearch/index/query/SearchExecutionContextTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/SearchExecutionContextTests.java
@@ -328,7 +328,7 @@ public class SearchExecutionContextTests extends ESTestCase {
         Map<String, RuntimeField> runtimeFieldTypes = runtimeFields.stream().collect(Collectors.toMap(RuntimeField::name, r -> r));
         builder.setRuntime(runtimeFieldTypes);
         Mapping mapping = new Mapping(builder.build(new ContentPath()), new MetadataFieldMapper[0], Collections.emptyMap());
-        return new MappingLookup(mapping, mappers, Collections.emptyList(), Collections.emptyList(), null, null, null);
+        return MappingLookup.fromMappers(mapping, mappers, Collections.emptyList(), Collections.emptyList());
     }
 
     public void testSearchRequestRuntimeFields() {

--- a/server/src/test/java/org/elasticsearch/indices/IndicesRequestCacheTests.java
+++ b/server/src/test/java/org/elasticsearch/indices/IndicesRequestCacheTests.java
@@ -203,8 +203,7 @@ public class IndicesRequestCacheTests extends ESTestCase {
     public void testCacheDifferentMapping() throws Exception {
         IndicesRequestCache cache = new IndicesRequestCache(Settings.EMPTY);
         MappingLookup.CacheKey mappingKey1 = MappingLookup.EMPTY.cacheKey();
-        MappingLookup.CacheKey mappingKey2 = new MappingLookup(Mapping.EMPTY, emptyList(), emptyList(), emptyList(),null, null, null)
-            .cacheKey();
+        MappingLookup.CacheKey mappingKey2 = MappingLookup.fromMappers(Mapping.EMPTY, emptyList(), emptyList(), emptyList()).cacheKey();
         AtomicBoolean indexShard =  new AtomicBoolean(true);
         ShardRequestCache requestCacheStats = new ShardRequestCache();
         Directory dir = newDirectory();
@@ -371,7 +370,7 @@ public class IndicesRequestCacheTests extends ESTestCase {
         writer.updateDocument(new Term("id", "0"), newDoc(0, "bar"));
         DirectoryReader secondReader = ElasticsearchDirectoryReader.wrap(DirectoryReader.open(writer),
             new ShardId("foo", "bar", 1));
-        MappingLookup.CacheKey secondMappingKey = new MappingLookup(Mapping.EMPTY, emptyList(), emptyList(), emptyList(), null, null, null)
+        MappingLookup.CacheKey secondMappingKey = MappingLookup.fromMappers(Mapping.EMPTY, emptyList(), emptyList(), emptyList())
             .cacheKey();
         TestEntity secondEntity = new TestEntity(requestCacheStats, indexShard);
         Loader secondLoader = new Loader(secondReader, 0);
@@ -379,8 +378,7 @@ public class IndicesRequestCacheTests extends ESTestCase {
         writer.updateDocument(new Term("id", "0"), newDoc(0, "baz"));
         DirectoryReader thirdReader = ElasticsearchDirectoryReader.wrap(DirectoryReader.open(writer),
             new ShardId("foo", "bar", 1));
-        MappingLookup.CacheKey thirdMappingKey = new MappingLookup(Mapping.EMPTY, emptyList(), emptyList(), emptyList(), null, null, null)
-            .cacheKey();
+        MappingLookup.CacheKey thirdMappingKey = MappingLookup.fromMappers(Mapping.EMPTY, emptyList(), emptyList(), emptyList()).cacheKey();
         AtomicBoolean differentIdentity =  new AtomicBoolean(true);
         TestEntity thirdEntity = new TestEntity(requestCacheStats, differentIdentity);
         Loader thirdLoader = new Loader(thirdReader, 0);
@@ -516,7 +514,7 @@ public class IndicesRequestCacheTests extends ESTestCase {
         AtomicBoolean trueBoolean = new AtomicBoolean(true);
         AtomicBoolean falseBoolean = new AtomicBoolean(false);
         MappingLookup.CacheKey mKey1 = MappingLookup.EMPTY.cacheKey();
-        MappingLookup.CacheKey mKey2 = new MappingLookup(Mapping.EMPTY, emptyList(), emptyList(), emptyList(), null, null, null).cacheKey();
+        MappingLookup.CacheKey mKey2 = MappingLookup.fromMappers(Mapping.EMPTY, emptyList(), emptyList(), emptyList()).cacheKey();
         Directory dir = newDirectory();
         IndexWriterConfig config = newIndexWriterConfig();
         IndexWriter writer = new IndexWriter(dir, config);

--- a/server/src/test/java/org/elasticsearch/search/suggest/AbstractSuggestionBuilderTestCase.java
+++ b/server/src/test/java/org/elasticsearch/search/suggest/AbstractSuggestionBuilderTestCase.java
@@ -172,7 +172,7 @@ public abstract class AbstractSuggestionBuilderTestCase<SB extends SuggestionBui
             when(scriptService.compile(any(Script.class), any())).then(invocation -> new TestTemplateService.MockTemplateScript.Factory(
                     ((Script) invocation.getArguments()[0]).getIdOrCode()));
             List<FieldMapper> mappers = Collections.singletonList(new MockFieldMapper(fieldType));
-            MappingLookup lookup = new MappingLookup(Mapping.EMPTY, mappers, emptyList(), emptyList(), null, null, null);
+            MappingLookup lookup = MappingLookup.fromMappers(Mapping.EMPTY, mappers, emptyList(), emptyList());
             SearchExecutionContext mockContext = new SearchExecutionContext(0, 0, idxSettings, null,
                 null, mapperService, lookup, null, scriptService, xContentRegistry(), namedWriteableRegistry, null, null,
                     System::currentTimeMillis, null, null, () -> true, null, emptyMap());

--- a/test/framework/src/main/java/org/elasticsearch/search/aggregations/AggregatorTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/search/aggregations/AggregatorTestCase.java
@@ -236,18 +236,14 @@ public abstract class AggregatorTestCase extends ESTestCase {
                                                 long bytesToPreallocate,
                                                 int maxBucket,
                                                 MappedFieldType... fieldTypes) throws IOException {
-        MappingLookup mappingLookup = new MappingLookup(
+        MappingLookup mappingLookup = MappingLookup.fromMappers(
             Mapping.EMPTY,
             Arrays.stream(fieldTypes).map(this::buildMockFieldMapper).collect(toList()),
             objectMappers(),
             // Alias all fields to <name>-alias to test aliases
             Arrays.stream(fieldTypes)
                 .map(ft -> new FieldAliasMapper(ft.name() + "-alias", ft.name() + "-alias", ft.name()))
-                .collect(toList()),
-            null,
-            null,
-            null
-        );
+                .collect(toList()));
 
         TriFunction<MappedFieldType, String, Supplier<SearchLookup>, IndexFieldData<?>> fieldDataBuilder = (
             fieldType,
@@ -360,7 +356,7 @@ public abstract class AggregatorTestCase extends ESTestCase {
          * of stuff.
          */
         SearchExecutionContext subContext = spy(searchExecutionContext);
-        MappingLookup disableNestedLookup = new MappingLookup(Mapping.EMPTY, Set.of(), Set.of(), Set.of(), null, null, null);
+        MappingLookup disableNestedLookup = MappingLookup.fromMappers(Mapping.EMPTY, Set.of(), Set.of(), Set.of());
         doReturn(new NestedDocuments(disableNestedLookup, bitsetFilterCache::getBitSetProducer)).when(subContext).getNestedDocuments();
         when(ctx.getSearchExecutionContext()).thenReturn(subContext);
 

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/accesscontrol/DocumentSubsetBitsetCacheTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/accesscontrol/DocumentSubsetBitsetCacheTests.java
@@ -598,7 +598,7 @@ public class DocumentSubsetBitsetCacheTests extends ESTestCase {
             types.add(new MockFieldMapper(new KeywordFieldMapper.KeywordFieldType("dne-" + i)));
         }
 
-        MappingLookup mappingLookup = new MappingLookup(Mapping.EMPTY, types, emptyList(), emptyList(), null, null, null);
+        MappingLookup mappingLookup = MappingLookup.fromMappers(Mapping.EMPTY, types, emptyList(), emptyList());
 
         final Client client = mock(Client.class);
         when(client.settings()).thenReturn(Settings.EMPTY);

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/accesscontrol/SecurityIndexReaderWrapperIntegrationTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/accesscontrol/SecurityIndexReaderWrapperIntegrationTests.java
@@ -290,6 +290,6 @@ public class SecurityIndexReaderWrapperIntegrationTests extends AbstractBuilderT
 
     private static MappingLookup createMappingLookup(List<MappedFieldType> concreteFields) {
         List<FieldMapper> mappers = concreteFields.stream().map(MockFieldMapper::new).collect(Collectors.toList());
-        return new MappingLookup(Mapping.EMPTY, mappers, emptyList(), emptyList(), null, null, null);
+        return MappingLookup.fromMappers(Mapping.EMPTY, mappers, emptyList(), emptyList());
     }
 }


### PR DESCRIPTION
MappingLookup has been introduced to expose a snapshot of the mappings to the search layer. We have been using it more and more over time as it is convenient and always non null.

This commit documents some of its semantics and makes it easier to trace when it is created with limited functionalities (without a document parser, index settings and index analyzers).