### PR TITLE
Add test for correct ProfileResult node time

### DIFF
--- a/server/src/test/java/org/elasticsearch/search/profile/query/QueryProfilerTests.java
+++ b/server/src/test/java/org/elasticsearch/search/profile/query/QueryProfilerTests.java
@@ -118,6 +118,23 @@ public class QueryProfilerTests extends ESTestCase {
         assertThat(rewriteTime, greaterThan(0L));
     }
 
+    public void testNodeTime() throws IOException {
+        QueryProfiler profiler = new QueryProfiler();
+        searcher.setProfiler(profiler);
+        Query query = new TermQuery(new Term("foo", "bar"));
+        searcher.search(query, 1);
+        List<ProfileResult> results = profiler.getTree();
+        assertEquals(1, results.size());
+        Map<String, Long> breakdown = results.get(0).getTimeBreakdown();
+
+        // test that nodeTime is sum of values excluding the _count values
+        long sum = 0;
+        for (QueryTimingType type : QueryTimingType.values()) {
+            sum += breakdown.get(type.toString());
+        }
+        assertEquals(results.get(0).getTime(), sum);
+    }
+
     public void testNoScoring() throws IOException {
         QueryProfiler profiler = new QueryProfiler();
         searcher.setProfiler(profiler);


### PR DESCRIPTION
In #45972 we saw that in earlier versions we didn't calculate the profile node
time correctly, instead the `time_in_nanos` calculation wrongly included the
method "_count" values. This is fixed in 7.x by #56208 but we don't seem to have
a test for this anywhere which this commit add.

Relates to #45972