### PR TITLE
[7.x][Transform] avoid transform failure during rolling upgrade (#72533)

### DIFF
--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/persistence/TransformInternalIndex.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/persistence/TransformInternalIndex.java
@@ -11,15 +11,19 @@ import org.elasticsearch.ResourceAlreadyExistsException;
 import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.admin.indices.alias.Alias;
+import org.elasticsearch.action.admin.cluster.health.ClusterHealthRequest;
+import org.elasticsearch.action.admin.cluster.health.ClusterHealthResponse;
 import org.elasticsearch.action.admin.indices.create.CreateIndexRequest;
 import org.elasticsearch.action.admin.indices.create.CreateIndexResponse;
 import org.elasticsearch.action.admin.indices.template.put.PutIndexTemplateRequest;
+import org.elasticsearch.action.support.ActiveShardCount;
 import org.elasticsearch.action.support.master.AcknowledgedResponse;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.AliasMetadata;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.IndexTemplateMetadata;
+import org.elasticsearch.cluster.routing.IndexRoutingTable;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.bytes.BytesReference;
@@ -394,12 +398,31 @@ public final class TransformInternalIndex {
         );
     }
 
-    protected static boolean haveLatestVersionedIndex(ClusterState state) {
+    protected static boolean hasLatestVersionedIndex(ClusterState state) {
         return state.getMetadata().getIndicesLookup().containsKey(TransformInternalIndexConstants.LATEST_INDEX_VERSIONED_NAME);
     }
 
-    protected static boolean haveLatestAuditIndexTemplate(ClusterState state) {
+    protected static boolean allPrimaryShardsActiveForLatestVersionedIndex(ClusterState state) {
+        IndexRoutingTable indexRouting = state.routingTable().index(TransformInternalIndexConstants.LATEST_INDEX_VERSIONED_NAME);
+
+        return indexRouting != null && indexRouting.allPrimaryShardsActive();
+    }
+
+    protected static boolean hasLatestAuditIndexTemplate(ClusterState state) {
         return state.getMetadata().getTemplates().containsKey(TransformInternalIndexConstants.AUDIT_INDEX);
+    }
+
+    private static void waitForLatestVersionedIndexShardsActive(Client client, ActionListener<Void> listener) {
+        ClusterHealthRequest request = new ClusterHealthRequest(TransformInternalIndexConstants.LATEST_INDEX_VERSIONED_NAME)
+            .waitForActiveShards(ActiveShardCount.ALL);
+        ActionListener<ClusterHealthResponse> innerListener = ActionListener.wrap(r -> listener.onResponse(null), listener::onFailure);
+        executeAsyncWithOrigin(
+            client.threadPool().getThreadContext(),
+            TRANSFORM_ORIGIN,
+            request,
+            innerListener,
+            client.admin().cluster()::health
+        );
     }
 
     protected static void createLatestVersionedIndexIfRequired(
@@ -407,10 +430,15 @@ public final class TransformInternalIndex {
         Client client,
         ActionListener<Void> listener
     ) {
-
-        // The check for existence of the template is against local cluster state, so very cheap
-        if (haveLatestVersionedIndex(clusterService.state())) {
-            listener.onResponse(null);
+        ClusterState state = clusterService.state();
+        // The check for existence is against local cluster state, so very cheap
+        if (hasLatestVersionedIndex(state)) {
+            if (allPrimaryShardsActiveForLatestVersionedIndex(state)) {
+                listener.onResponse(null);
+                return;
+            }
+            // the index exists but is not ready yet
+            waitForLatestVersionedIndexShardsActive(client, listener);
             return;
         }
 
@@ -421,14 +449,21 @@ public final class TransformInternalIndex {
                 .mapping(MapperService.SINGLE_MAPPING_NAME, mappings())
                 // BWC: for mixed clusters with nodes < 7.5, we need the alias to make new docs visible for them
                 .alias(new Alias(".data-frame-internal-3"))
-                .origin(TRANSFORM_ORIGIN);
+                .origin(TRANSFORM_ORIGIN)
+                .waitForActiveShards(ActiveShardCount.ALL);
             ActionListener<CreateIndexResponse> innerListener = ActionListener.wrap(
                 r -> listener.onResponse(null),
                 e -> {
                     // It's not a problem if the index already exists - another node could be running
                     // this method at the same time as this one, and also have created the index
+                    // check if shards are active
                     if (ExceptionsHelper.unwrapCause(e) instanceof ResourceAlreadyExistsException) {
-                        listener.onResponse(null);
+                        if (allPrimaryShardsActiveForLatestVersionedIndex(clusterService.state())) {
+                            listener.onResponse(null);
+                            return;
+                        }
+                        // the index exists but is not ready yet
+                        waitForLatestVersionedIndexShardsActive(client, listener);
                     } else {
                         listener.onFailure(e);
                     }
@@ -453,7 +488,7 @@ public final class TransformInternalIndex {
     ) {
 
         // The check for existence of the template is against local cluster state, so very cheap
-        if (haveLatestAuditIndexTemplate(clusterService.state())) {
+        if (hasLatestAuditIndexTemplate(clusterService.state())) {
             listener.onResponse(null);
             return;
         }

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/persistence/TransformInternalIndexTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/persistence/TransformInternalIndexTests.java
@@ -7,26 +7,36 @@
 
 package org.elasticsearch.xpack.transform.persistence;
 
+import org.elasticsearch.ResourceAlreadyExistsException;
 import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.admin.cluster.health.ClusterHealthResponse;
 import org.elasticsearch.action.admin.indices.create.CreateIndexResponse;
 import org.elasticsearch.action.support.master.AcknowledgedResponse;
 import org.elasticsearch.client.AdminClient;
 import org.elasticsearch.client.Client;
+import org.elasticsearch.client.ClusterAdminClient;
 import org.elasticsearch.client.IndicesAdminClient;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.IndexTemplateMetadata;
 import org.elasticsearch.cluster.metadata.Metadata;
+import org.elasticsearch.cluster.routing.IndexRoutingTable;
+import org.elasticsearch.cluster.routing.RoutingTable;
+import org.elasticsearch.cluster.routing.ShardRoutingState;
+import org.elasticsearch.cluster.routing.TestShardRouting;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.UUIDs;
 import org.elasticsearch.common.collect.ImmutableOpenMap;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
+import org.elasticsearch.index.Index;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.xpack.core.transform.transforms.persistence.TransformInternalIndexConstants;
+import org.junit.Before;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
@@ -43,20 +53,22 @@ import static org.mockito.Mockito.when;
 
 public class TransformInternalIndexTests extends ESTestCase {
 
-    public static ClusterState STATE_WITH_LATEST_VERSIONED_INDEX;
-    public static ClusterState STATE_WITH_LATEST_AUDIT_INDEX_TEMPLATE;
+    private ClusterState stateWithLatestVersionedIndex;
+    private ClusterState stateWithLatestAuditIndexTemplate;
 
-    static {
+    public static ClusterState randomTransformClusterState() {
+        return randomTransformClusterState(true);
+    }
+
+    public static ClusterState randomTransformClusterState(boolean shardsReady) {
         ImmutableOpenMap.Builder<String, IndexMetadata> indexMapBuilder = ImmutableOpenMap.builder();
         try {
-            IndexMetadata.Builder builder = new IndexMetadata.Builder(TransformInternalIndexConstants.LATEST_INDEX_VERSIONED_NAME)
-                .settings(Settings.builder()
+            IndexMetadata.Builder builder = new IndexMetadata.Builder(TransformInternalIndexConstants.LATEST_INDEX_VERSIONED_NAME).settings(
+                Settings.builder()
                     .put(TransformInternalIndex.settings())
                     .put(IndexMetadata.SETTING_INDEX_VERSION_CREATED.getKey(), Version.CURRENT)
-                    .build())
-                .numberOfReplicas(0)
-                .numberOfShards(1)
-                .putMapping(SINGLE_MAPPING_NAME, Strings.toString(TransformInternalIndex.mappings()));
+                    .build()
+            ).numberOfReplicas(0).numberOfShards(1).putMapping(SINGLE_MAPPING_NAME, Strings.toString(TransformInternalIndex.mappings()));
             indexMapBuilder.put(TransformInternalIndexConstants.LATEST_INDEX_VERSIONED_NAME, builder.build());
         } catch (IOException e) {
             throw new UncheckedIOException(e);
@@ -65,8 +77,32 @@ public class TransformInternalIndexTests extends ESTestCase {
         metaBuilder.indices(indexMapBuilder.build());
         ClusterState.Builder csBuilder = ClusterState.builder(ClusterName.DEFAULT);
         csBuilder.metadata(metaBuilder.build());
-        STATE_WITH_LATEST_VERSIONED_INDEX = csBuilder.build();
 
+        csBuilder.routingTable(
+            RoutingTable.builder()
+                .add(
+                    IndexRoutingTable.builder(
+                        new Index(TransformInternalIndexConstants.LATEST_INDEX_VERSIONED_NAME, UUIDs.randomBase64UUID())
+                    )
+                        .addShard(
+                            TestShardRouting.newShardRouting(
+                                TransformInternalIndexConstants.LATEST_INDEX_VERSIONED_NAME,
+                                0,
+                                "node_a",
+                                null,
+                                true,
+                                shardsReady ? ShardRoutingState.STARTED : ShardRoutingState.INITIALIZING
+                            )
+                        )
+                        .build()
+                )
+                .build()
+        );
+
+        return csBuilder.build();
+    }
+
+    public static ClusterState randomTransformAuditClusterState() {
         ImmutableOpenMap.Builder<String, IndexTemplateMetadata> templateMapBuilder = ImmutableOpenMap.builder();
         try {
             templateMapBuilder.put(TransformInternalIndexConstants.AUDIT_INDEX,
@@ -74,23 +110,31 @@ public class TransformInternalIndexTests extends ESTestCase {
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }
-        metaBuilder = Metadata.builder();
+        Metadata.Builder metaBuilder = Metadata.builder();
         metaBuilder.templates(templateMapBuilder.build());
-        csBuilder = ClusterState.builder(ClusterName.DEFAULT);
+        ClusterState.Builder csBuilder = ClusterState.builder(ClusterName.DEFAULT);
         csBuilder.metadata(metaBuilder.build());
-        STATE_WITH_LATEST_AUDIT_INDEX_TEMPLATE = csBuilder.build();
+        return csBuilder.build();
+    }
+
+    @Before
+    public void setupClusterStates() {
+        stateWithLatestVersionedIndex = randomTransformClusterState();
+        stateWithLatestAuditIndexTemplate = randomTransformAuditClusterState();
     }
 
     public void testHaveLatestVersionedIndexTemplate() {
-
-        assertTrue(TransformInternalIndex.haveLatestVersionedIndex(STATE_WITH_LATEST_VERSIONED_INDEX));
-        assertFalse(TransformInternalIndex.haveLatestVersionedIndex(ClusterState.EMPTY_STATE));
+        assertTrue(TransformInternalIndex.hasLatestVersionedIndex(stateWithLatestVersionedIndex));
+        assertTrue(TransformInternalIndex.allPrimaryShardsActiveForLatestVersionedIndex(stateWithLatestVersionedIndex));
+        assertFalse(TransformInternalIndex.hasLatestVersionedIndex(ClusterState.EMPTY_STATE));
+        assertFalse(TransformInternalIndex.allPrimaryShardsActiveForLatestVersionedIndex(ClusterState.EMPTY_STATE));
+        assertFalse(TransformInternalIndex.allPrimaryShardsActiveForLatestVersionedIndex(randomTransformClusterState(false)));
     }
 
     public void testCreateLatestVersionedIndexIfRequired_GivenNotRequired() {
 
         ClusterService clusterService = mock(ClusterService.class);
-        when(clusterService.state()).thenReturn(TransformInternalIndexTests.STATE_WITH_LATEST_VERSIONED_INDEX);
+        when(clusterService.state()).thenReturn(stateWithLatestVersionedIndex);
 
         Client client = mock(Client.class);
 
@@ -140,16 +184,141 @@ public class TransformInternalIndexTests extends ESTestCase {
         verifyNoMoreInteractions(indicesClient);
     }
 
+    public void testCreateLatestVersionedIndexIfRequired_GivenShardInitializationPending() {
+
+        ClusterService clusterService = mock(ClusterService.class);
+        when(clusterService.state()).thenReturn(randomTransformClusterState(false));
+
+        ClusterAdminClient clusterClient = mock(ClusterAdminClient.class);
+        doAnswer(invocationOnMock -> {
+            @SuppressWarnings("unchecked")
+            ActionListener<ClusterHealthResponse> listener = (ActionListener<ClusterHealthResponse>) invocationOnMock.getArguments()[1];
+            listener.onResponse(new ClusterHealthResponse());
+            return null;
+        }).when(clusterClient).health(any(), any());
+
+        AdminClient adminClient = mock(AdminClient.class);
+        when(adminClient.cluster()).thenReturn(clusterClient);
+        Client client = mock(Client.class);
+        when(client.admin()).thenReturn(adminClient);
+
+        ThreadPool threadPool = mock(ThreadPool.class);
+        when(threadPool.getThreadContext()).thenReturn(new ThreadContext(Settings.EMPTY));
+        when(client.threadPool()).thenReturn(threadPool);
+
+        AtomicBoolean gotResponse = new AtomicBoolean(false);
+        ActionListener<Void> testListener = ActionListener.wrap(aVoid -> gotResponse.set(true), e -> fail(e.getMessage()));
+
+        TransformInternalIndex.createLatestVersionedIndexIfRequired(clusterService, client, testListener);
+
+        assertTrue(gotResponse.get());
+        verify(client, times(1)).threadPool();
+        verify(client, times(1)).admin();
+        verifyNoMoreInteractions(client);
+        verify(adminClient, times(1)).cluster();
+        verifyNoMoreInteractions(adminClient);
+        verify(clusterClient, times(1)).health(any(), any());
+        verifyNoMoreInteractions(clusterClient);
+    }
+
+    public void testCreateLatestVersionedIndexIfRequired_GivenConcurrentCreation() {
+
+        // simulate the case that 1st the index does not exist, but got created and allocated meanwhile
+        ClusterService clusterService = mock(ClusterService.class);
+        when(clusterService.state()).thenReturn(ClusterState.EMPTY_STATE).thenReturn(stateWithLatestVersionedIndex);
+
+        IndicesAdminClient indicesClient = mock(IndicesAdminClient.class);
+        doAnswer(invocationOnMock -> {
+            @SuppressWarnings("unchecked")
+            ActionListener<CreateIndexResponse> listener = (ActionListener<CreateIndexResponse>) invocationOnMock.getArguments()[1];
+            listener.onFailure(new ResourceAlreadyExistsException(TransformInternalIndexConstants.LATEST_INDEX_VERSIONED_NAME));
+            return null;
+        }).when(indicesClient).create(any(), any());
+
+        AdminClient adminClient = mock(AdminClient.class);
+        when(adminClient.indices()).thenReturn(indicesClient);
+        Client client = mock(Client.class);
+        when(client.admin()).thenReturn(adminClient);
+
+        ThreadPool threadPool = mock(ThreadPool.class);
+        when(threadPool.getThreadContext()).thenReturn(new ThreadContext(Settings.EMPTY));
+        when(client.threadPool()).thenReturn(threadPool);
+
+        AtomicBoolean gotResponse = new AtomicBoolean(false);
+        ActionListener<Void> testListener = ActionListener.wrap(aVoid -> gotResponse.set(true), e -> fail(e.getMessage()));
+
+        TransformInternalIndex.createLatestVersionedIndexIfRequired(clusterService, client, testListener);
+
+        assertTrue(gotResponse.get());
+        verify(client, times(1)).threadPool();
+        verify(client, times(1)).admin();
+        verifyNoMoreInteractions(client);
+        verify(adminClient, times(1)).indices();
+        verifyNoMoreInteractions(adminClient);
+        verify(indicesClient, times(1)).create(any(), any());
+        verifyNoMoreInteractions(indicesClient);
+    }
+
+    public void testCreateLatestVersionedIndexIfRequired_GivenConcurrentCreationShardInitializationPending() {
+
+        // simulate the case that 1st the index does not exist, but got created, however allocation is pending
+        ClusterService clusterService = mock(ClusterService.class);
+        when(clusterService.state()).thenReturn(ClusterState.EMPTY_STATE).thenReturn(randomTransformClusterState(false));
+
+        IndicesAdminClient indicesClient = mock(IndicesAdminClient.class);
+        doAnswer(invocationOnMock -> {
+            @SuppressWarnings("unchecked")
+            ActionListener<CreateIndexResponse> listener = (ActionListener<CreateIndexResponse>) invocationOnMock.getArguments()[1];
+            listener.onFailure(new ResourceAlreadyExistsException(TransformInternalIndexConstants.LATEST_INDEX_VERSIONED_NAME));
+            return null;
+        }).when(indicesClient).create(any(), any());
+
+        ClusterAdminClient clusterClient = mock(ClusterAdminClient.class);
+        doAnswer(invocationOnMock -> {
+            @SuppressWarnings("unchecked")
+            ActionListener<ClusterHealthResponse> listener = (ActionListener<ClusterHealthResponse>) invocationOnMock.getArguments()[1];
+            listener.onResponse(new ClusterHealthResponse());
+            return null;
+        }).when(clusterClient).health(any(), any());
+
+        AdminClient adminClient = mock(AdminClient.class);
+        when(adminClient.indices()).thenReturn(indicesClient);
+        when(adminClient.cluster()).thenReturn(clusterClient);
+        Client client = mock(Client.class);
+        when(client.admin()).thenReturn(adminClient);
+
+        ThreadPool threadPool = mock(ThreadPool.class);
+        when(threadPool.getThreadContext()).thenReturn(new ThreadContext(Settings.EMPTY));
+        when(client.threadPool()).thenReturn(threadPool);
+
+        AtomicBoolean gotResponse = new AtomicBoolean(false);
+        ActionListener<Void> testListener = ActionListener.wrap(aVoid -> gotResponse.set(true), e -> fail(e.getMessage()));
+
+        TransformInternalIndex.createLatestVersionedIndexIfRequired(clusterService, client, testListener);
+
+        assertTrue(gotResponse.get());
+        verify(client, times(2)).threadPool();
+        verify(client, times(2)).admin();
+        verifyNoMoreInteractions(client);
+        verify(adminClient, times(1)).indices();
+        verify(adminClient, times(1)).cluster();
+        verifyNoMoreInteractions(adminClient);
+        verify(indicesClient, times(1)).create(any(), any());
+        verifyNoMoreInteractions(indicesClient);
+        verify(clusterClient, times(1)).health(any(), any());
+        verifyNoMoreInteractions(clusterClient);
+    }
+
     public void testHaveLatestAuditIndexTemplate() {
 
-        assertTrue(TransformInternalIndex.haveLatestAuditIndexTemplate(STATE_WITH_LATEST_AUDIT_INDEX_TEMPLATE));
-        assertFalse(TransformInternalIndex.haveLatestAuditIndexTemplate(ClusterState.EMPTY_STATE));
+        assertTrue(TransformInternalIndex.hasLatestAuditIndexTemplate(stateWithLatestAuditIndexTemplate));
+        assertFalse(TransformInternalIndex.hasLatestAuditIndexTemplate(ClusterState.EMPTY_STATE));
     }
 
     public void testInstallLatestAuditIndexTemplateIfRequired_GivenNotRequired() {
 
         ClusterService clusterService = mock(ClusterService.class);
-        when(clusterService.state()).thenReturn(TransformInternalIndexTests.STATE_WITH_LATEST_AUDIT_INDEX_TEMPLATE);
+        when(clusterService.state()).thenReturn(stateWithLatestAuditIndexTemplate);
 
         Client client = mock(Client.class);
 

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/TransformPersistentTasksExecutorTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/TransformPersistentTasksExecutorTests.java
@@ -254,7 +254,7 @@ public class TransformPersistentTasksExecutorTests extends ESTestCase {
         ClusterSettings cSettings = new ClusterSettings(Settings.EMPTY, Collections.singleton(Transform.NUM_FAILURE_RETRIES_SETTING));
         ClusterService clusterService = mock(ClusterService.class);
         when(clusterService.getClusterSettings()).thenReturn(cSettings);
-        when(clusterService.state()).thenReturn(TransformInternalIndexTests.STATE_WITH_LATEST_VERSIONED_INDEX);
+        when(clusterService.state()).thenReturn(TransformInternalIndexTests.randomTransformClusterState());
         TransformPersistentTasksExecutor executor = new TransformPersistentTasksExecutor(
             client,
             transformServices,
@@ -531,7 +531,7 @@ public class TransformPersistentTasksExecutorTests extends ESTestCase {
         ClusterSettings cSettings = new ClusterSettings(Settings.EMPTY, Collections.singleton(Transform.NUM_FAILURE_RETRIES_SETTING));
         ClusterService clusterService = mock(ClusterService.class);
         when(clusterService.getClusterSettings()).thenReturn(cSettings);
-        when(clusterService.state()).thenReturn(TransformInternalIndexTests.STATE_WITH_LATEST_VERSIONED_INDEX);
+        when(clusterService.state()).thenReturn(TransformInternalIndexTests.randomTransformClusterState());
 
         return new TransformPersistentTasksExecutor(
             client,


### PR DESCRIPTION
ensure shards are searchable after creation of a new internal index version

fixes #72525
backport #72533