### PR TITLE
[7.x] Mute NodeShutdownIT.testAllocationPreventedForRemoval

### DIFF
--- a/x-pack/plugin/shutdown/qa/multi-node/src/javaRestTest/java/org/elasticsearch/xpack/shutdown/NodeShutdownIT.java
+++ b/x-pack/plugin/shutdown/qa/multi-node/src/javaRestTest/java/org/elasticsearch/xpack/shutdown/NodeShutdownIT.java
@@ -65,6 +65,7 @@ public class NodeShutdownIT extends ESRestTestCase {
     /**
      * A very basic smoke test to make sure the allocation decider is working.
      */
+    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/72589")
     @SuppressWarnings("unchecked")
     public void testAllocationPreventedForRemoval() throws Exception {
         Request nodesRequest = new Request("GET", "_nodes");


### PR DESCRIPTION
Backport of https://github.com/elastic/elasticsearch/pull/72590

See https://github.com/elastic/elasticsearch/issues/72589