### PR TITLE
[TEST] Fix test bug ChainingInputStreamTests.testResetForDoubleMarkAnywhere

### DIFF
--- a/x-pack/plugin/repository-encrypted/src/test/java/org/elasticsearch/repositories/encrypted/ChainingInputStreamTests.java
+++ b/x-pack/plugin/repository-encrypted/src/test/java/org/elasticsearch/repositories/encrypted/ChainingInputStreamTests.java
@@ -961,6 +961,7 @@ public class ChainingInputStreamTests extends ESTestCase {
             verify(lastCurrentIn).close();
         }
         verify(currentIn).reset();
+        final InputStream firstResetStream = currentIn;
         // assert the "nextComponet" arg is the current component
         nextComponentArg.set(currentIn);
         // possibly skips over several components
@@ -991,7 +992,11 @@ public class ChainingInputStreamTests extends ESTestCase {
         if (lastCurrentIn != currentIn) {
             verify(lastCurrentIn).close();
         }
-        verify(currentIn).reset();
+        if (currentIn != firstResetStream) {
+            verify(currentIn).reset();
+        } else {
+            verify(currentIn, times(2)).reset();
+        }
     }
 
     public void testMarkAfterResetNoMock() throws Exception {


### PR DESCRIPTION
This fixes a test bug.
The component stream does not advance, and mockito rightfully intercepts two invocations instead of a single one.

Closes https://github.com/elastic/elasticsearch/issues/71510#issuecomment-818714959