### PR TITLE
Prevent Encrypted Repository from Closing IndexInput (#71636)

### DIFF
--- a/x-pack/plugin/repository-encrypted/src/main/java/org/elasticsearch/repositories/encrypted/EncryptedRepository.java
+++ b/x-pack/plugin/repository-encrypted/src/main/java/org/elasticsearch/repositories/encrypted/EncryptedRepository.java
@@ -634,7 +634,8 @@ public class EncryptedRepository extends BlobStoreRepository {
             final SingleUseKey singleUseNonceAndDEK = singleUseDEKSupplier.get();
             final BytesReference dekIdBytes = getDEKBytes(singleUseNonceAndDEK);
             final long encryptedBlobSize = getEncryptedBlobByteLength(blobSize);
-            try (InputStream encryptedInputStream = encryptedInput(inputStream, singleUseNonceAndDEK, dekIdBytes)) {
+            // make sure we do not close this stream here, it is closed by the caller
+            try (InputStream encryptedInputStream = encryptedInput(Streams.noCloseStream(inputStream), singleUseNonceAndDEK, dekIdBytes)) {
                 delegatedBlobContainer.writeBlob(blobName, encryptedInputStream, encryptedBlobSize, failIfAlreadyExists);
             }
         }


### PR DESCRIPTION
We shouldn't allow the repo to close the original input stream ever. This is handled
further up-stream and not the responsibility of this code.

closes #71326 (apparently some combination of resetting can trigger a
close on the original stream which this change ensure will not happen any longer)

backport of #71636