### PR TITLE
GeoBoundingBoxQueryGeoShapeIT should take into account the version

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/search/geo/AbstractGeoBoundingBoxQueryIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/geo/AbstractGeoBoundingBoxQueryIT.java
@@ -38,12 +38,12 @@ abstract class AbstractGeoBoundingBoxQueryIT extends ESIntegTestCase {
         return false;
     }
 
-    public abstract XContentBuilder getMapping() throws IOException;
+    public abstract XContentBuilder getMapping(Version version) throws IOException;
 
     public void testSimpleBoundingBoxTest() throws Exception {
         Version version = VersionUtils.randomIndexCompatibleVersion(random());
         Settings settings = Settings.builder().put(IndexMetadata.SETTING_VERSION_CREATED, version).build();
-        XContentBuilder xContentBuilder = getMapping();
+        XContentBuilder xContentBuilder = getMapping(version);
         assertAcked(prepareCreate("test").setSettings(settings).setMapping(xContentBuilder));
         ensureGreen();
 
@@ -121,7 +121,7 @@ abstract class AbstractGeoBoundingBoxQueryIT extends ESIntegTestCase {
     public void testLimit2BoundingBox() throws Exception {
         Version version = VersionUtils.randomIndexCompatibleVersion(random());
         Settings settings = Settings.builder().put(IndexMetadata.SETTING_VERSION_CREATED, version).build();
-        XContentBuilder xContentBuilder = getMapping();
+        XContentBuilder xContentBuilder = getMapping(version);
         assertAcked(prepareCreate("test").setSettings(settings).setMapping(xContentBuilder));
         ensureGreen();
 
@@ -188,7 +188,7 @@ abstract class AbstractGeoBoundingBoxQueryIT extends ESIntegTestCase {
     public void testCompleteLonRange() throws Exception {
         Version version = VersionUtils.randomIndexCompatibleVersion(random());
         Settings settings = Settings.builder().put(IndexMetadata.SETTING_VERSION_CREATED, version).build();
-        XContentBuilder xContentBuilder = getMapping();
+        XContentBuilder xContentBuilder = getMapping(version);
         assertAcked(prepareCreate("test").setSettings(settings).setMapping(xContentBuilder));
         ensureGreen();
 

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/geo/GeoBoundingBoxQueryGeoPointIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/geo/GeoBoundingBoxQueryGeoPointIT.java
@@ -8,6 +8,7 @@
 
 package org.elasticsearch.search.geo;
 
+import org.elasticsearch.Version;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentFactory;
 
@@ -16,7 +17,7 @@ import java.io.IOException;
 public class GeoBoundingBoxQueryGeoPointIT extends AbstractGeoBoundingBoxQueryIT {
 
     @Override
-    public XContentBuilder getMapping() throws IOException {
+    public XContentBuilder getMapping(Version version) throws IOException {
         XContentBuilder xContentBuilder = XContentFactory.jsonBuilder().startObject().startObject("_doc")
             .startObject("properties").startObject("location").field("type", "geo_point");
         xContentBuilder.endObject().endObject().endObject().endObject();

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/geo/GeoBoundingBoxQueryGeoShapeIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/geo/GeoBoundingBoxQueryGeoShapeIT.java
@@ -8,20 +8,19 @@
 
 package org.elasticsearch.search.geo;
 
-import org.apache.lucene.util.LuceneTestCase;
+import org.elasticsearch.Version;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentFactory;
 
 import java.io.IOException;
 
-@LuceneTestCase.AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/72602")
 public class GeoBoundingBoxQueryGeoShapeIT extends AbstractGeoBoundingBoxQueryIT {
 
     @Override
-    public XContentBuilder getMapping() throws IOException {
+    public XContentBuilder getMapping(Version version) throws IOException {
         XContentBuilder xContentBuilder = XContentFactory.jsonBuilder().startObject().startObject("_doc")
             .startObject("properties").startObject("location").field("type", "geo_shape");
-        if (randomBoolean()) {
+        if (version.before(Version.V_8_0_0) && randomBoolean()) {
             xContentBuilder.field("strategy", "recursive");
         }
         xContentBuilder.endObject().endObject().endObject().endObject();


### PR DESCRIPTION
GeoShape legacy parameters should only be used when version is lower than 8.0.

fixes https://github.com/elastic/elasticsearch/issues/72602