### PR TITLE
Do not over-allocate when resizing in GeoHashTiler with bounds (#72539)

### DIFF
--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/search/aggregations/bucket/geogrid/BoundedGeoHashGridTiler.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/search/aggregations/bucket/geogrid/BoundedGeoHashGridTiler.java
@@ -17,11 +17,25 @@ import org.elasticsearch.geometry.utils.Geohash;
 public class BoundedGeoHashGridTiler extends AbstractGeoHashGridTiler {
     private final GeoBoundingBox bbox;
     private final boolean crossesDateline;
+    private final long maxHashes;
 
     public BoundedGeoHashGridTiler(int precision, GeoBoundingBox bbox) {
         super(precision);
         this.bbox = bbox;
         this.crossesDateline = bbox.right() < bbox.left();
+        final long hashesY = (long)((bbox.top() - bbox.bottom()) / Geohash.latHeightInDegrees(precision)) + 1;
+        final long hashesX;
+        if (crossesDateline) {
+            hashesX = (long)((360 - bbox.left() + bbox.right()) / Geohash.lonWidthInDegrees(precision)) + 1;
+        } else {
+            hashesX = (long)((bbox.right() - bbox.left()) / Geohash.lonWidthInDegrees(precision)) + 1;
+        }
+        this.maxHashes = hashesX * hashesY;
+    }
+
+    @Override
+    protected long getMaxHashes() {
+        return maxHashes;
     }
 
     @Override

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/search/aggregations/bucket/geogrid/UnboundedGeoHashGridTiler.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/search/aggregations/bucket/geogrid/UnboundedGeoHashGridTiler.java
@@ -13,12 +13,21 @@ package org.elasticsearch.xpack.spatial.search.aggregations.bucket.geogrid;
  */
 public class UnboundedGeoHashGridTiler extends AbstractGeoHashGridTiler {
 
+    private final long maxHashes;
+
+
     public UnboundedGeoHashGridTiler(int precision) {
         super(precision);
+        this.maxHashes = (long) Math.pow(32, precision);
     }
 
     @Override
     protected boolean validHash(String hash) {
        return true;
+    }
+
+    @Override
+    protected long getMaxHashes() {
+        return maxHashes;
     }
 }

--- a/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/search/aggregations/bucket/geogrid/GeoGridTilerTests.java
+++ b/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/search/aggregations/bucket/geogrid/GeoGridTilerTests.java
@@ -106,7 +106,7 @@ public class GeoGridTilerTests extends ESTestCase {
     // tests that bounding boxes of shapes crossing the dateline are correctly wrapped
     public void testGeoTileSetValuesBoundingBoxes_BoundedGeoShapeCellValues() throws Exception {
         for (int i = 0; i < 1; i++) {
-            int precision = randomIntBetween(0, 4);
+            int precision = randomIntBetween(1, 4);
             GeoShapeIndexer indexer = new GeoShapeIndexer(true, "test");
             Geometry geometry = indexer.prepareForIndexing(randomValueOtherThanMany(g -> {
                 try {
@@ -226,7 +226,6 @@ public class GeoGridTilerTests extends ESTestCase {
         }
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/72521")
     public void testGeoHashBoundsExcludeTouchingTiles() throws Exception {
         final int precision = randomIntBetween(1, 5);
         final String hash =
@@ -250,6 +249,7 @@ public class GeoGridTilerTests extends ESTestCase {
             final int numTiles = values.docValueCount();
             final int expected = (int) Math.pow(32, i);
             assertThat(numTiles, equalTo(expected));
+            assertThat((int) bounded.getMaxHashes(), greaterThanOrEqualTo(expected));
         }
     }
 


### PR DESCRIPTION
Currently when declaring bounds with GeoHashTiler, we do not limit the amount of bucket we can create. This change prevents over allocating in such cases.

backport #72539