### PR TITLE
[7.x] [DOCS] Revises required privileges info in Anomaly Detection API docs (#72483)

### DIFF
--- a/docs/reference/ml/anomaly-detection/apis/close-job.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/close-job.asciidoc
@@ -24,9 +24,8 @@ operations, but you can still explore and navigate results.
 [[ml-close-job-prereqs]]
 == {api-prereq-title}
 
-* If the {es} {security-features} are enabled, you must have `manage_ml` or
-`manage` cluster privileges to use this API. See
-<<security-privileges>> and {ml-docs-setup-privileges}.
+* Requires the `manage_ml` cluster privilege. This privilege is included in the 
+`machine_learning_admin` built-in role.
 * Before you can close an {anomaly-job}, you must stop its {dfeed}. See
 <<ml-stop-datafeed>>.
 

--- a/docs/reference/ml/anomaly-detection/apis/delete-calendar-event.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/delete-calendar-event.asciidoc
@@ -16,9 +16,8 @@ Deletes scheduled events from a calendar.
 [[ml-delete-calendar-event-prereqs]]
 == {api-prereq-title}
 
-* If the {es} {security-features} are enabled, you must have `manage_ml` or
-`manage` cluster privileges to use this API. See
-<<security-privileges>> and {ml-docs-setup-privileges}.
+Requires the `manage_ml` cluster privilege. This privilege is included in the 
+`machine_learning_admin` built-in role.
 
 [[ml-delete-calendar-event-desc]]
 == {api-description-title}

--- a/docs/reference/ml/anomaly-detection/apis/delete-calendar-job.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/delete-calendar-job.asciidoc
@@ -16,9 +16,8 @@ Deletes {anomaly-jobs} from a calendar.
 [[ml-delete-calendar-job-prereqs]]
 == {api-prereq-title}
 
-* If the {es} {security-features} are enabled, you must have `manage_ml` or
-`manage` cluster privileges to use this API. See
-<<security-privileges>> and {ml-docs-setup-privileges}.
+Requires the `manage_ml` cluster privilege. This privilege is included in the 
+`machine_learning_admin` built-in role.
 
 [[ml-delete-calendar-job-path-parms]]
 == {api-path-parms-title}

--- a/docs/reference/ml/anomaly-detection/apis/delete-calendar.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/delete-calendar.asciidoc
@@ -16,9 +16,8 @@ Deletes a calendar.
 [[ml-delete-calendar-prereqs]]
 == {api-prereq-title}
 
-* If the {es} {security-features} are enabled, you must have `manage_ml` or
-`manage` cluster privileges to use this API. See
-<<security-privileges>> and {ml-docs-setup-privileges}.
+Requires the `manage_ml` cluster privilege. This privilege is included in the 
+`machine_learning_admin` built-in role.
 
 [[ml-delete-calendar-desc]]
 == {api-description-title}

--- a/docs/reference/ml/anomaly-detection/apis/delete-datafeed.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/delete-datafeed.asciidoc
@@ -18,11 +18,10 @@ Deletes an existing {dfeed}.
 [[ml-delete-datafeed-prereqs]]
 == {api-prereq-title}
 
+* Requires the `manage_ml` cluster privilege. This privilege is included in the 
+`machine_learning_admin` built-in role.
 * Unless you use the `force` parameter, you must stop the {dfeed} before you
 can delete it.
-* If the {es} {security-features} are enabled, you must have `manage_ml` or
-`manage` cluster privileges to use this API. See
-<<security-privileges>> and {ml-docs-setup-privileges}.
 
 [[ml-delete-datafeed-path-parms]]
 == {api-path-parms-title}

--- a/docs/reference/ml/anomaly-detection/apis/delete-expired-data.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/delete-expired-data.asciidoc
@@ -18,9 +18,8 @@ Deletes expired and unused machine learning data.
 [[ml-delete-expired-data-prereqs]]
 == {api-prereq-title}
 
-* If the {es} {security-features} are enabled, you must have `manage_ml` or
-`manage` cluster privileges to use this API. See
-<<security-privileges>> and {ml-docs-setup-privileges}.
+Requires the `manage_ml` cluster privilege. This privilege is included in the 
+`machine_learning_admin` built-in role.
 
 [[ml-delete-expired-data-desc]]
 == {api-description-title}
@@ -29,10 +28,10 @@ Deletes all job results, model snapshots and forecast data that have exceeded
 their `retention days` period. Machine learning state documents that are not
 associated with any job are also deleted.
 
-You can limit the request to a single or set of {anomaly-jobs} by using a job identifier,
-a group name, a comma-separated list of jobs, or a wildcard expression.
-You can delete expired data for all {anomaly-jobs} by using `_all`, by specifying
-`*` as the `<job_id>`, or by omitting the `<job_id>`.
+You can limit the request to a single or set of {anomaly-jobs} by using a job 
+identifier, a group name, a comma-separated list of jobs, or a wildcard 
+expression. You can delete expired data for all {anomaly-jobs} by using `_all`, 
+by specifying `*` as the `<job_id>`, or by omitting the `<job_id>`.
 
 [[ml-delete-expired-data-path-parms]]
 == {api-path-parms-title}

--- a/docs/reference/ml/anomaly-detection/apis/delete-filter.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/delete-filter.asciidoc
@@ -16,9 +16,8 @@ Deletes a filter.
 [[ml-delete-filter-prereqs]]
 == {api-prereq-title}
 
-* If the {es} {security-features} are enabled, you must have `manage_ml` or
-`manage` cluster privileges to use this API. See
-<<security-privileges>> and {ml-docs-setup-privileges}.
+Requires the `manage_ml` cluster privilege. This privilege is included in the 
+`machine_learning_admin` built-in role.
 
 [[ml-delete-filter-desc]]
 == {api-description-title}

--- a/docs/reference/ml/anomaly-detection/apis/delete-forecast.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/delete-forecast.asciidoc
@@ -20,9 +20,8 @@ Deletes forecasts from a {ml} job.
 [[ml-delete-forecast-prereqs]]
 == {api-prereq-title}
 
-* If the {es} {security-features} are enabled, you must have `manage_ml` or
-`manage` cluster privileges to use this API. See
-<<security-privileges>> and {ml-docs-setup-privileges}.
+Requires the `manage_ml` cluster privilege. This privilege is included in the 
+`machine_learning_admin` built-in role.
 
 [[ml-delete-forecast-desc]]
 == {api-description-title}

--- a/docs/reference/ml/anomaly-detection/apis/delete-job.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/delete-job.asciidoc
@@ -16,12 +16,12 @@ Deletes an existing {anomaly-job}.
 [[ml-delete-job-prereqs]]
 == {api-prereq-title}
 
-* If {es} {security-features} are enabled, you must have `manage_ml` or `manage`
-cluster privileges to use this API. See <<security-privileges>> and
-{ml-docs-setup-privileges}.
+* Requires the `manage_ml` cluster privilege. This privilege is included in the 
+`machine_learning_admin` built-in role.
 * Before you can delete a job, you must delete the {dfeeds} that are associated
 with it. See <<ml-delete-datafeed>>.
-* Before you can delete a job, you must close it (unless you specify the `force` parameter). See <<ml-close-job>>.
+* Before you can delete a job, you must close it (unless you specify the `force` 
+parameter). See <<ml-close-job>>.
 
 [[ml-delete-job-desc]]
 == {api-description-title}

--- a/docs/reference/ml/anomaly-detection/apis/delete-snapshot.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/delete-snapshot.asciidoc
@@ -16,9 +16,8 @@ Deletes an existing model snapshot.
 [[ml-delete-snapshot-prereqs]]
 == {api-prereq-title}
 
-* If the {es} {security-features} are enabled, you must have `manage_ml` or
-`manage` cluster privileges to use this API. See <<security-privileges>> and
-{ml-docs-setup-privileges}.
+Requires the `manage_ml` cluster privilege. This privilege is included in the 
+`machine_learning_admin` built-in role.
 
 [[ml-delete-snapshot-desc]]
 == {api-description-title}

--- a/docs/reference/ml/anomaly-detection/apis/estimate-model-memory.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/estimate-model-memory.asciidoc
@@ -6,8 +6,8 @@
 <titleabbrev>Estimate model memory</titleabbrev>
 ++++
 
-Makes an estimation of the memory usage for an {anomaly-job} model. It 
-is based on analysis configuration details for the job and cardinality estimates for the 
+Makes an estimation of the memory usage for an {anomaly-job} model. It is based 
+on analysis configuration details for the job and cardinality estimates for the 
 fields it references.
 
 
@@ -19,13 +19,8 @@ fields it references.
 [[ml-estimate-model-memory-prereqs]]
 == {api-prereq-title}
 
-If the {es} {security-features} are enabled, you must have the following privileges:
-
-* `manage_ml` or cluster: `manage`
-
-For more information, see <<security-privileges>> and
-{ml-docs-setup-privileges}.
-
+Requires the `manage_ml` cluster privilege. This privilege is included in the 
+`machine_learning_admin` built-in role.
 
 [[ml-estimate-model-memory-request-body]]
 == {api-request-body-title}

--- a/docs/reference/ml/anomaly-detection/apis/flush-job.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/flush-job.asciidoc
@@ -16,9 +16,8 @@ Forces any buffered data to be processed by the job.
 [[ml-flush-job-prereqs]]
 == {api-prereq-title}
 
-* If the {es} {security-features} are enabled, you must have `manage_ml` or
-`manage` cluster privileges to use this API. See
-<<security-privileges>> and {ml-docs-setup-privileges}.
+Requires the `manage_ml` cluster privilege. This privilege is included in the 
+`machine_learning_admin` built-in role.
 
 [[ml-flush-job-desc]]
 == {api-description-title}

--- a/docs/reference/ml/anomaly-detection/apis/forecast.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/forecast.asciidoc
@@ -16,9 +16,8 @@ Predicts the future behavior of a time series by using its historical behavior.
 [[ml-forecast-prereqs]]
 == {api-prereq-title}
 
-* If the {es} {security-features} are enabled, you must have `manage_ml` or
-`manage` cluster privileges to use this API. See
-<<security-privileges>> and {ml-docs-setup-privileges}.
+Requires the `manage_ml` cluster privilege. This privilege is included in the 
+`machine_learning_admin` built-in role.
 
 [[ml-forecast-desc]]
 == {api-description-title}

--- a/docs/reference/ml/anomaly-detection/apis/get-bucket.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/get-bucket.asciidoc
@@ -18,12 +18,9 @@ Retrieves {anomaly-job} results for one or more buckets.
 [[ml-get-bucket-prereqs]]
 == {api-prereq-title}
 
-* If the {es} {security-features} are enabled, you must have `monitor_ml`,
-`monitor`, `manage_ml`, or `manage` cluster privileges to use this API. You also
-need `read` index privilege on the index that stores the results. The
-`machine_learning_admin` and `machine_learning_user` roles provide these
-privileges. For more information, see <<security-privileges>>,
-<<built-in-roles>>, and {ml-docs-setup-privileges}.
+
+Requires the `monitor_ml` cluster privilege. This privilege is included in the 
+`machine_learning_user` built-in role.
 
 [[ml-get-bucket-desc]]
 == {api-description-title}

--- a/docs/reference/ml/anomaly-detection/apis/get-calendar-event.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/get-calendar-event.asciidoc
@@ -18,9 +18,8 @@ Retrieves information about the scheduled events in calendars.
 [[ml-get-calendar-event-prereqs]]
 == {api-prereq-title}
 
-* If the {es} {security-features} are enabled, you must have `monitor_ml`,
-`monitor`, `manage_ml`, or `manage` cluster privileges to use this API. See
-<<security-privileges>> and {ml-docs-setup-privileges}.
+Requires the `monitor_ml` cluster privilege. This privilege is included in the 
+`machine_learning_user` built-in role.
 
 [[ml-get-calendar-event-desc]]
 == {api-description-title}

--- a/docs/reference/ml/anomaly-detection/apis/get-calendar.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/get-calendar.asciidoc
@@ -18,9 +18,8 @@ Retrieves configuration information for calendars.
 [[ml-get-calendar-prereqs]]
 == {api-prereq-title}
 
-* If the {es} {security-features} are enabled, you must have `monitor_ml`,
-`monitor`, `manage_ml`, or `manage` cluster privileges to use this API. See
-<<security-privileges>> and {ml-docs-setup-privileges}.
+Requires the `monitor_ml` cluster privilege. This privilege is included in the 
+`machine_learning_user` built-in role.
 
 [[ml-get-calendar-desc]]
 == {api-description-title}

--- a/docs/reference/ml/anomaly-detection/apis/get-category.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/get-category.asciidoc
@@ -18,12 +18,8 @@ Retrieves {anomaly-job} results for one or more categories.
 [[ml-get-category-prereqs]]
 == {api-prereq-title}
 
-* If the {es} {security-features} are enabled, you must have `monitor_ml`,
-`monitor`, `manage_ml`, or `manage` cluster privileges to use this API. You also
-need `read` index privilege on the index that stores the results. The
-`machine_learning_admin` and `machine_learning_user` roles provide these
-privileges. See <<security-privileges>>, <<built-in-roles>>, and
-{ml-docs-setup-privileges}.
+Requires the `monitor_ml` cluster privilege. This privilege is included in the 
+`machine_learning_user` built-in role.
 
 [[ml-get-category-desc]]
 == {api-description-title}

--- a/docs/reference/ml/anomaly-detection/apis/get-datafeed-stats.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/get-datafeed-stats.asciidoc
@@ -24,9 +24,8 @@ Retrieves usage information for {dfeeds}.
 [[ml-get-datafeed-stats-prereqs]]
 == {api-prereq-title}
 
-* If the {es} {security-features} are enabled, you must have `monitor_ml`,
-`monitor`, `manage_ml`, or `manage` cluster privileges to use this API. See
-<<security-privileges>> and {ml-docs-setup-privileges}.
+Requires the `monitor_ml` cluster privilege. This privilege is included in the 
+`machine_learning_user` built-in role.
 
 [[ml-get-datafeed-stats-desc]]
 == {api-description-title}

--- a/docs/reference/ml/anomaly-detection/apis/get-datafeed.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/get-datafeed.asciidoc
@@ -24,9 +24,8 @@ Retrieves configuration information for {dfeeds}.
 [[ml-get-datafeed-prereqs]]
 == {api-prereq-title}
 
-* If the {es} {security-features} are enabled, you must have `monitor_ml`,
-`monitor`, `manage_ml`, or `manage` cluster privileges to use this API. See
-<<security-privileges>> and {ml-docs-setup-privileges}.
+Requires the `monitor_ml` cluster privilege. This privilege is included in the 
+`machine_learning_user` built-in role.
 
 [[ml-get-datafeed-desc]]
 == {api-description-title}

--- a/docs/reference/ml/anomaly-detection/apis/get-filter.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/get-filter.asciidoc
@@ -18,9 +18,8 @@ Retrieves filters.
 [[ml-get-filter-prereqs]]
 == {api-prereq-title}
 
-* If the {es} {security-features} are enabled, you must have `monitor_ml`,
-`monitor`, `manage_ml`, or `manage` cluster privileges to use this API. See
-<<security-privileges>> and {ml-docs-setup-privileges}.
+Requires the `manage_ml` cluster privilege. This privilege is included in the 
+`machine_learning_admin` built-in role.
 
 [[ml-get-filter-desc]]
 == {api-description-title}

--- a/docs/reference/ml/anomaly-detection/apis/get-influencer.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/get-influencer.asciidoc
@@ -16,12 +16,8 @@ Retrieves {anomaly-job} results for one or more influencers.
 [[ml-get-influencer-prereqs]]
 == {api-prereq-title}
 
-* If the {es} {security-features} are enabled, you must have `monitor_ml`,
-`monitor`, `manage_ml`, or `manage` cluster privileges to use this API. You also
-need `read` index privilege on the index that stores the results. The
-`machine_learning_admin` and `machine_learning_user` roles provide these
-privileges. See <<security-privileges>>, <<built-in-roles>>, and
-{ml-docs-setup-privileges}.
+Requires the `monitor_ml` cluster privilege. This privilege is included in the 
+`machine_learning_user` built-in role.`
 
 [[ml-get-influencer-desc]]
 == {api-description-title}

--- a/docs/reference/ml/anomaly-detection/apis/get-job-stats.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/get-job-stats.asciidoc
@@ -22,9 +22,8 @@ Retrieves usage information for {anomaly-jobs}.
 [[ml-get-job-stats-prereqs]]
 == {api-prereq-title}
 
-* If the {es} {security-features} are enabled, you must have `monitor_ml`,
-`monitor`, `manage_ml`, or `manage` cluster privileges to use this API. See
-<<security-privileges>> and {ml-docs-setup-privileges}.
+Requires the `monitor_ml` cluster privilege. This privilege is included in the 
+`machine_learning_user` built-in role.
 
 [[ml-get-job-stats-desc]]
 == {api-description-title}

--- a/docs/reference/ml/anomaly-detection/apis/get-job.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/get-job.asciidoc
@@ -22,9 +22,8 @@ Retrieves configuration information for {anomaly-jobs}.
 [[ml-get-job-prereqs]]
 == {api-prereq-title}
 
-* If the {es} {security-features} are enabled, you must have `monitor_ml`,
-`monitor`, `manage_ml`, or `manage` cluster privileges to use this API. See
-<<security-privileges>> and {ml-docs-setup-privileges}.
+Requires the `monitor_ml` cluster privilege. This privilege is included in the 
+`machine_learning_user` built-in role.
 
 [[ml-get-job-desc]]
 == {api-description-title}

--- a/docs/reference/ml/anomaly-detection/apis/get-ml-info.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/get-ml-info.asciidoc
@@ -18,11 +18,8 @@ Returns defaults and limits used by machine learning.
 [[get-ml-info-prereqs]]
 == {api-prereq-title}
 
-* If the {es} {security-features} are enabled, you must have `monitor_ml`,
-`monitor`, `manage_ml`, or `manage` cluster privileges to use this API. The
-`machine_learning_admin` and `machine_learning_user` roles provide these
-privileges. See <<security-privileges>>, <<built-in-roles>> and
-{ml-docs-setup-privileges}.
+Requires the `monitor_ml` cluster privilege. This privilege is included in the 
+`machine_learning_user` built-in role.
 
 [[get-ml-info-desc]]
 == {api-description-title}

--- a/docs/reference/ml/anomaly-detection/apis/get-overall-buckets.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/get-overall-buckets.asciidoc
@@ -21,12 +21,8 @@ Retrieves overall bucket results that summarize the bucket results of multiple
 [[ml-get-overall-buckets-prereqs]]
 == {api-prereq-title}
 
-* If the {es} {security-features} are enabled, you must have `monitor_ml`,
-`monitor`, `manage_ml`, or `manage` cluster privileges to use this API. You also
-need `read` index privilege on the index that stores the results. The
-`machine_learning_admin` and `machine_learning_user` roles provide these
-privileges. See <<security-privileges>>, <<built-in-roles>>, and
-{ml-docs-setup-privileges}.
+Requires the `monitor_ml` cluster privilege. This privilege is included in the 
+`machine_learning_user` built-in role.
 
 [[ml-get-overall-buckets-desc]]
 == {api-description-title}

--- a/docs/reference/ml/anomaly-detection/apis/get-record.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/get-record.asciidoc
@@ -16,12 +16,8 @@ Retrieves anomaly records for an {anomaly-job}.
 [[ml-get-record-prereqs]]
 == {api-prereq-title}
 
-* If the {es} {security-features} are enabled, you must have `monitor_ml`,
-`monitor`, `manage_ml`, or `manage` cluster privileges to use this API. You also
-need `read` index privilege on the index that stores the results. The
-`machine_learning_admin` and `machine_learning_user` roles provide these
-privileges. See <<security-privileges>>, <<built-in-roles>>, and
-{ml-docs-setup-privileges}.
+Requires the `monitor_ml` cluster privilege. This privilege is included in the 
+`machine_learning_user` built-in role.
 
 [[ml-get-record-desc]]
 == {api-description-title}

--- a/docs/reference/ml/anomaly-detection/apis/get-snapshot.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/get-snapshot.asciidoc
@@ -19,10 +19,8 @@ Retrieves information about model snapshots.
 [[ml-get-snapshot-prereqs]]
 == {api-prereq-title}
 
-* If the {es} {security-features} are enabled, you must have `monitor_ml`,
-`monitor`, `manage_ml`, or `manage` cluster privileges to use this API. See
-<<security-privileges>> and {ml-docs-setup-privileges}.
-
+Requires the `monitor_ml` cluster privilege. This privilege is included in the 
+`machine_learning_user` built-in role.
 
 [[ml-get-snapshot-path-parms]]
 == {api-path-parms-title}

--- a/docs/reference/ml/anomaly-detection/apis/open-job.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/open-job.asciidoc
@@ -16,9 +16,8 @@ Opens one or more {anomaly-jobs}.
 [[ml-open-job-prereqs]]
 == {api-prereq-title}
 
-* If the {es} {security-features} are enabled, you must have `manage_ml` or
-`manage` cluster privileges to use this API. See
-<<security-privileges>> and {ml-docs-setup-privileges}.
+Requires the `manage_ml` cluster privilege. This privilege is included in the 
+`machine_learning_admin` built-in role.
 
 [[ml-open-job-desc]]
 == {api-description-title}

--- a/docs/reference/ml/anomaly-detection/apis/post-calendar-event.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/post-calendar-event.asciidoc
@@ -16,9 +16,8 @@ Posts scheduled events in a calendar.
 [[ml-post-calendar-event-prereqs]]
 == {api-prereq-title}
 
-* If the {es} {security-features} are enabled, you must have `manage_ml` or
-`manage` cluster privileges to use this API. See
-<<security-privileges>> and {ml-docs-setup-privileges}.
+Requires the `manage_ml` cluster privilege. This privilege is included in the 
+`machine_learning_admin` built-in role.
 
 [[ml-post-calendar-event-desc]]
 == {api-description-title}

--- a/docs/reference/ml/anomaly-detection/apis/post-data.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/post-data.asciidoc
@@ -18,9 +18,8 @@ Sends data to an anomaly detection job for analysis.
 [[ml-post-data-prereqs]]
 == {api-prereq-title}
 
-* If the {es} {security-features} are enabled, you must have `manage_ml` or
-`manage` cluster privileges to use this API. See
-<<security-privileges>> and {ml-docs-setup-privileges}.
+Requires the `manage_ml` cluster privilege. This privilege is included in the 
+`machine_learning_admin` built-in role.
 
 [[ml-post-data-desc]]
 == {api-description-title}

--- a/docs/reference/ml/anomaly-detection/apis/preview-datafeed.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/preview-datafeed.asciidoc
@@ -24,9 +24,10 @@ Previews a {dfeed}.
 [[ml-preview-datafeed-prereqs]]
 == {api-prereq-title}
 
-* If {es} {security-features} are enabled, you must have `monitor_ml`, `monitor`,
-`manage_ml`, or `manage` cluster privileges to use this API. See
-<<security-privileges>> and {ml-docs-setup-privileges}.
+Requires the following privileges:
+* cluster: `manage_ml` (the `machine_learning_admin` built-in role grants this 
+   privilege)
+* source index configured in the {dfeed}: `read`.
 
 [[ml-preview-datafeed-desc]]
 == {api-description-title}

--- a/docs/reference/ml/anomaly-detection/apis/put-calendar-job.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/put-calendar-job.asciidoc
@@ -16,9 +16,8 @@ Adds an {anomaly-job} to a calendar.
 [[ml-put-calendar-job-prereqs]]
 == {api-prereq-title}
 
-* If the {es} {security-features} are enabled, you must have `manage_ml` or
-`manage` cluster privileges to use this API. See
-<<security-privileges>> and {ml-docs-setup-privileges}.
+Requires the `manage_ml` cluster privilege. This privilege is included in the 
+`machine_learning_admin` built-in role.
 
 [[ml-put-calendar-job-path-parms]]
 == {api-path-parms-title}

--- a/docs/reference/ml/anomaly-detection/apis/put-calendar.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/put-calendar.asciidoc
@@ -16,9 +16,8 @@ Instantiates a calendar.
 [[ml-put-calendar-prereqs]]
 == {api-prereq-title}
 
-* If the {es} {security-features} are enabled, you must have `manage_ml` or
-`manage` cluster privileges to use this API. See
-<<security-privileges>> and {ml-docs-setup-privileges}.
+Requires the `manage_ml` cluster privilege. This privilege is included in the 
+`machine_learning_admin` built-in role.
 
 [[ml-put-calendar-desc]]
 == {api-description-title}

--- a/docs/reference/ml/anomaly-detection/apis/put-datafeed.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/put-datafeed.asciidoc
@@ -19,9 +19,10 @@ Instantiates a {dfeed}.
 == {api-prereq-title}
 
 * You must create an {anomaly-job} before you create a {dfeed}.
-* If {es} {security-features} are enabled, you must have `manage_ml` or `manage`
-cluster privileges to use this API. See <<security-privileges>> and
-{ml-docs-setup-privileges}.
+* Requires the following privileges:
+** cluster: `manage_ml` (the `machine_learning_admin` built-in role grants this 
+  privilege)
+** source index configured in the {dfeed}: `read`
 
 [[ml-put-datafeed-desc]]
 == {api-description-title}

--- a/docs/reference/ml/anomaly-detection/apis/put-filter.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/put-filter.asciidoc
@@ -16,9 +16,8 @@ Instantiates a filter.
 [[ml-put-filter-prereqs]]
 == {api-prereq-title}
 
-* If the {es} {security-features} are enabled, you must have `manage_ml` or
-`manage` cluster privileges to use this API. See
-<<security-privileges>> and {ml-docs-setup-privileges}.
+Requires the `manage_ml` cluster privilege. This privilege is included in the 
+`machine_learning_admin` built-in role.
 
 [[ml-put-filter-desc]]
 == {api-description-title}

--- a/docs/reference/ml/anomaly-detection/apis/put-job.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/put-job.asciidoc
@@ -16,9 +16,8 @@ Instantiates an {anomaly-job}.
 [[ml-put-job-prereqs]]
 == {api-prereq-title}
 
-* If the {es} {security-features} are enabled, you must have `manage_ml` or
-`manage` cluster privileges to use this API. See
-<<security-privileges>> and {ml-docs-setup-privileges}.
+Requires the `manage_ml` cluster privilege. This privilege is included in the 
+`machine_learning_admin` built-in role.
 
 [[ml-put-job-desc]]
 == {api-description-title}

--- a/docs/reference/ml/anomaly-detection/apis/revert-snapshot.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/revert-snapshot.asciidoc
@@ -17,10 +17,8 @@ Reverts to a specific snapshot.
 == {api-prereq-title}
 
 * Before you revert to a saved snapshot, you must close the job.
-* If the {es} {security-features} are enabled, you must have `manage_ml` or
-`manage` cluster privileges to use this API. See
-<<security-privileges>> and {ml-docs-setup-privileges}.
-
+* Requires the `manage_ml` cluster privilege. This privilege is included in the 
+`machine_learning_admin` built-in role.
 
 [[ml-revert-snapshot-desc]]
 == {api-description-title}

--- a/docs/reference/ml/anomaly-detection/apis/set-upgrade-mode.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/set-upgrade-mode.asciidoc
@@ -27,9 +27,8 @@ POST /_ml/set_upgrade_mode?enabled=false&timeout=10m
 [[ml-set-upgrade-mode-prereqs]]
 == {api-prereq-title}
 
-* If the {es} {security-features} are enabled, you must have `manage_ml` or
-`manage` cluster privileges to use this API. See
-<<security-privileges>> and {ml-docs-setup-privileges}.
+Requires the `manage_ml` cluster privilege. This privilege is included in the 
+`machine_learning_admin` built-in role.
 
 [[ml-set-upgrade-mode-desc]]
 == {api-description-title}

--- a/docs/reference/ml/anomaly-detection/apis/start-datafeed.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/start-datafeed.asciidoc
@@ -20,9 +20,8 @@ Starts one or more {dfeeds}.
 
 * Before you can start a {dfeed}, the {anomaly-job} must be open. Otherwise, an
 error occurs.
-* If {es} {security-features} are enabled, you must have `manage_ml` or `manage`
-cluster privileges to use this API. See
-<<security-privileges>> and {ml-docs-setup-privileges}.
+* Requires the `manage_ml` cluster privilege. This privilege is included in the 
+`machine_learning_admin` built-in role.
 
 [[ml-start-datafeed-desc]]
 == {api-description-title}

--- a/docs/reference/ml/anomaly-detection/apis/stop-datafeed.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/stop-datafeed.asciidoc
@@ -22,9 +22,8 @@ Stops one or more {dfeeds}.
 [[ml-stop-datafeed-prereqs]]
 == {api-prereq-title}
 
-* If the {es} {security-features} are enabled, you must have `manage_ml` or
-`manage` cluster privileges to use this API. See
-<<security-privileges>> and {ml-docs-setup-privileges}.
+Requires the `manage_ml` cluster privilege. This privilege is included in the 
+`machine_learning_admin` built-in role.
 
 [[ml-stop-datafeed-desc]]
 == {api-description-title}

--- a/docs/reference/ml/anomaly-detection/apis/update-datafeed.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/update-datafeed.asciidoc
@@ -20,10 +20,8 @@ Updates certain properties of a {dfeed}.
 [[ml-update-datafeed-prereqs]]
 == {api-prereq-title}
 
-* If {es} {security-features} are enabled, you must have `manage_ml`, or `manage`
-cluster privileges to use this API. See
-<<security-privileges>> and {ml-docs-setup-privileges}.
-
+Requires the `manage_ml` cluster privilege. This privilege is included in the 
+`machine_learning_admin` built-in role.
 
 [[ml-update-datafeed-desc]]
 == {api-description-title}

--- a/docs/reference/ml/anomaly-detection/apis/update-filter.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/update-filter.asciidoc
@@ -16,9 +16,8 @@ Updates the description of a filter, adds items, or removes items.
 [[ml-update-filter-prereqs]]
 == {api-prereq-title}
 
-* If the {es} {security-features} are enabled, you must have `manage_ml` or
-`manage` cluster privileges to use this API. See
-<<security-privileges>> and {ml-docs-setup-privileges}.
+Requires the `manage_ml` cluster privilege. This privilege is included in the 
+`machine_learning_admin` built-in role.
 
 [[ml-update-filter-path-parms]]
 == {api-path-parms-title}

--- a/docs/reference/ml/anomaly-detection/apis/update-job.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/update-job.asciidoc
@@ -16,10 +16,8 @@ Updates certain properties of an {anomaly-job}.
 [[ml-update-job-prereqs]]
 == {api-prereq-title}
 
-* If the {es} {security-features} are enabled, you must have `manage_ml` or
-`manage` cluster privileges to use this API. See
-<<security-privileges>> and {ml-docs-setup-privileges}.
-
+Requires the `manage_ml` cluster privilege. This privilege is included in the 
+`machine_learning_admin` built-in role.
 
 [[ml-update-job-path-parms]]
 == {api-path-parms-title}

--- a/docs/reference/ml/anomaly-detection/apis/update-snapshot.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/update-snapshot.asciidoc
@@ -16,10 +16,8 @@ Updates certain properties of a snapshot.
 [[ml-update-snapshot-prereqs]]
 == {api-prereq-title}
 
-* If the {es} {security-features} are enabled, you must have `manage_ml` or
-`manage` cluster privileges to use this API. See
-<<security-privileges>> and {ml-docs-setup-privileges}.
-
+Requires the `manage_ml` cluster privilege. This privilege is included in the 
+`machine_learning_admin` built-in role.
 
 [[ml-update-snapshot-path-parms]]
 == {api-path-parms-title}

--- a/docs/reference/ml/anomaly-detection/apis/upgrade-job-model-snapshot.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/upgrade-job-model-snapshot.asciidoc
@@ -16,9 +16,8 @@ Upgrades an {anomaly-detect} model snapshot to the latest major version.
 [[ml-upgrade-job-model-snapshot-prereqs]]
 == {api-prereq-title}
 
-* If the {es} {security-features} are enabled, you must have `manage_ml` or
-`manage` cluster privileges to use this API. See
-<<security-privileges>> and {ml-docs-setup-privileges}.
+* Requires the `manage_ml` cluster privilege. This privilege is included in the 
+`machine_learning_admin` built-in role.
 * The upgraded snapshot must have a version matching the previous major version.
 * The upgraded snapshot must NOT be the current {anomaly-job} snapshot.
 

--- a/docs/reference/ml/anomaly-detection/apis/validate-detector.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/validate-detector.asciidoc
@@ -16,9 +16,8 @@ Validates detector configuration information.
 [[ml-valid-detector-prereqs]]
 == {api-prereq-title}
 
-* If the {es} {security-features} are enabled, you must have `manage_ml` or
-`manage` cluster privileges to use this API. See
-<<security-privileges>> and {ml-docs-setup-privileges}.
+Requires the `manage_ml` cluster privilege. This privilege is included in the 
+`machine_learning_admin` built-in role.
 
 [[ml-valid-detector-desc]]
 == {api-description-title}

--- a/docs/reference/ml/anomaly-detection/apis/validate-job.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/validate-job.asciidoc
@@ -16,9 +16,8 @@ Validates {anomaly-job} configuration information.
 [[ml-valid-job-prereqs]]
 == {api-prereq-title}
 
-* If the {es} {security-features} are enabled, you must have `manage_ml` or
-`manage` cluster privileges to use this API. See
-<<security-privileges>> and {ml-docs-setup-privileges}.
+Requires the `manage_ml` cluster privilege. This privilege is included in the 
+`machine_learning_admin` built-in role.
 
 [[ml-valid-job-desc]]
 == {api-description-title}


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [DOCS] Revises required privileges info in Anomaly Detection API docs (#72483)