### PR TITLE
Replace some documentMapper(type) usages

### DIFF
--- a/modules/percolator/src/test/java/org/elasticsearch/percolator/CandidateQueryTests.java
+++ b/modules/percolator/src/test/java/org/elasticsearch/percolator/CandidateQueryTests.java
@@ -136,7 +136,7 @@ public class CandidateQueryTests extends ESSingleNodeTestCase {
         indexService = createIndex(indexName, Settings.EMPTY);
         mapperService = indexService.mapperService();
 
-        String mapper = Strings.toString(XContentFactory.jsonBuilder().startObject().startObject("type")
+        String mapper = Strings.toString(XContentFactory.jsonBuilder().startObject().startObject("_doc")
                 .startObject("properties")
                 .startObject("int_field").field("type", "integer").endObject()
                 .startObject("long_field").field("type", "long").endObject()
@@ -146,14 +146,14 @@ public class CandidateQueryTests extends ESSingleNodeTestCase {
                 .startObject("ip_field").field("type", "ip").endObject()
                 .startObject("field").field("type", "keyword").endObject()
                 .endObject().endObject().endObject());
-        documentMapper = mapperService.merge("type", new CompressedXContent(mapper), MapperService.MergeReason.MAPPING_UPDATE);
+        documentMapper = mapperService.merge("_doc", new CompressedXContent(mapper), MapperService.MergeReason.MAPPING_UPDATE);
 
         String queryField = "query_field";
-        String percolatorMapper = Strings.toString(XContentFactory.jsonBuilder().startObject().startObject("type")
+        String percolatorMapper = Strings.toString(XContentFactory.jsonBuilder().startObject().startObject("_doc")
                 .startObject("properties").startObject(queryField).field("type", "percolator").endObject().endObject()
                 .endObject().endObject());
-        mapperService.merge("type", new CompressedXContent(percolatorMapper), MapperService.MergeReason.MAPPING_UPDATE);
-        fieldMapper = (PercolatorFieldMapper) mapperService.documentMapper("type").mappers().getMapper(queryField);
+        mapperService.merge("_doc", new CompressedXContent(percolatorMapper), MapperService.MergeReason.MAPPING_UPDATE);
+        fieldMapper = (PercolatorFieldMapper) mapperService.documentMapper().mappers().getMapper(queryField);
         fieldType = (PercolatorFieldMapper.PercolatorFieldType) fieldMapper.fieldType();
 
         queries = new ArrayList<>();

--- a/modules/percolator/src/test/java/org/elasticsearch/percolator/PercolatorFieldMapperTests.java
+++ b/modules/percolator/src/test/java/org/elasticsearch/percolator/PercolatorFieldMapperTests.java
@@ -132,7 +132,7 @@ public class PercolatorFieldMapperTests extends ESSingleNodeTestCase {
         indexService = createIndex("test");
         mapperService = indexService.mapperService();
 
-        String mapper = Strings.toString(XContentFactory.jsonBuilder().startObject().startObject("doc")
+        String mapper = Strings.toString(XContentFactory.jsonBuilder().startObject().startObject("_doc")
             .startObject("properties")
                 .startObject("field").field("type", "text").endObject()
                 .startObject("field1").field("type", "text").endObject()
@@ -148,15 +148,15 @@ public class PercolatorFieldMapperTests extends ESSingleNodeTestCase {
                 .startObject("number_field7").field("type", "ip").endObject()
                 .startObject("date_field").field("type", "date").endObject()
             .endObject().endObject().endObject());
-        mapperService.merge("doc", new CompressedXContent(mapper), MapperService.MergeReason.MAPPING_UPDATE);
+        mapperService.merge("_doc", new CompressedXContent(mapper), MapperService.MergeReason.MAPPING_UPDATE);
     }
 
     private void addQueryFieldMappings() throws Exception {
         fieldName = randomAlphaOfLength(4);
-        String percolatorMapper = Strings.toString(XContentFactory.jsonBuilder().startObject().startObject("doc")
+        String percolatorMapper = Strings.toString(XContentFactory.jsonBuilder().startObject().startObject("_doc")
                 .startObject("properties").startObject(fieldName).field("type", "percolator").endObject().endObject()
                 .endObject().endObject());
-        mapperService.merge("doc", new CompressedXContent(percolatorMapper), MapperService.MergeReason.MAPPING_UPDATE);
+        mapperService.merge("_doc", new CompressedXContent(percolatorMapper), MapperService.MergeReason.MAPPING_UPDATE);
         fieldType = (PercolatorFieldMapper.PercolatorFieldType) mapperService.fieldType(fieldName);
     }
 
@@ -168,7 +168,7 @@ public class PercolatorFieldMapperTests extends ESSingleNodeTestCase {
         TermQuery termQuery2 = new TermQuery(new Term("field", "term2"));
         bq.add(termQuery2, Occur.SHOULD);
 
-        DocumentMapper documentMapper = mapperService.documentMapper("doc");
+        DocumentMapper documentMapper = mapperService.documentMapper();
         PercolatorFieldMapper fieldMapper = (PercolatorFieldMapper) documentMapper.mappers().getMapper(fieldName);
         ParseContext.InternalParseContext parseContext = new ParseContext.InternalParseContext(documentMapper.mappers(), null, null, null);
         fieldMapper.processQuery(bq.build(), parseContext);
@@ -218,7 +218,7 @@ public class PercolatorFieldMapperTests extends ESSingleNodeTestCase {
             .rangeQuery(15, 20, true, true, null, null, null, context);
         bq.add(rangeQuery2, Occur.MUST);
 
-        DocumentMapper documentMapper = mapperService.documentMapper("doc");
+        DocumentMapper documentMapper = mapperService.documentMapper();
         PercolatorFieldMapper fieldMapper = (PercolatorFieldMapper) documentMapper.mappers().getMapper(fieldName);
         ParseContext.InternalParseContext parseContext = new ParseContext.InternalParseContext(documentMapper.mappers(), null, null, null);
         fieldMapper.processQuery(bq.build(), parseContext);
@@ -266,7 +266,7 @@ public class PercolatorFieldMapperTests extends ESSingleNodeTestCase {
     public void testExtractTermsAndRanges_failed() throws Exception {
         addQueryFieldMappings();
         TermRangeQuery query = new TermRangeQuery("field1", new BytesRef("a"), new BytesRef("z"), true, true);
-        DocumentMapper documentMapper = mapperService.documentMapper("doc");
+        DocumentMapper documentMapper = mapperService.documentMapper();
         PercolatorFieldMapper fieldMapper = (PercolatorFieldMapper) documentMapper.mappers().getMapper(fieldName);
         ParseContext.InternalParseContext parseContext = new ParseContext.InternalParseContext(documentMapper.mappers(), null, null, null);
         fieldMapper.processQuery(query, parseContext);
@@ -280,7 +280,7 @@ public class PercolatorFieldMapperTests extends ESSingleNodeTestCase {
     public void testExtractTermsAndRanges_partial() throws Exception {
         addQueryFieldMappings();
         PhraseQuery phraseQuery = new PhraseQuery("field", "term");
-        DocumentMapper documentMapper = mapperService.documentMapper("doc");
+        DocumentMapper documentMapper = mapperService.documentMapper();
         PercolatorFieldMapper fieldMapper = (PercolatorFieldMapper) documentMapper.mappers().getMapper(fieldName);
         ParseContext.InternalParseContext parseContext = new ParseContext.InternalParseContext(documentMapper.mappers(), null, null, null);
         fieldMapper.processQuery(phraseQuery, parseContext);
@@ -444,7 +444,7 @@ public class PercolatorFieldMapperTests extends ESSingleNodeTestCase {
     public void testPercolatorFieldMapper() throws Exception {
         addQueryFieldMappings();
         QueryBuilder queryBuilder = termQuery("field", "value");
-        ParsedDocument doc = mapperService.documentMapper("doc").parse(new SourceToParse("test", "doc", "1",
+        ParsedDocument doc = mapperService.documentMapper().parse(new SourceToParse("test", "_doc", "1",
                         BytesReference.bytes(XContentFactory
                                 .jsonBuilder()
                                 .startObject()
@@ -463,7 +463,7 @@ public class PercolatorFieldMapperTests extends ESSingleNodeTestCase {
 
         // add an query for which we don't extract terms from
         queryBuilder = rangeQuery("field").from("a").to("z");
-        doc = mapperService.documentMapper("doc").parse(new SourceToParse("test", "doc", "1", BytesReference.bytes(XContentFactory
+        doc = mapperService.documentMapper().parse(new SourceToParse("test", "_doc", "1", BytesReference.bytes(XContentFactory
                 .jsonBuilder()
                 .startObject()
                 .field(fieldName, queryBuilder)
@@ -478,7 +478,7 @@ public class PercolatorFieldMapperTests extends ESSingleNodeTestCase {
         assertQueryBuilder(qbSource, queryBuilder);
 
         queryBuilder = rangeQuery("date_field").from("now");
-        doc = mapperService.documentMapper().parse(new SourceToParse("test", "doc", "1", BytesReference.bytes(XContentFactory
+        doc = mapperService.documentMapper().parse(new SourceToParse("test", "_doc", "1", BytesReference.bytes(XContentFactory
             .jsonBuilder()
             .startObject()
             .field(fieldName, queryBuilder)
@@ -500,7 +500,7 @@ public class PercolatorFieldMapperTests extends ESSingleNodeTestCase {
         // (it can't use shard data for rewriting purposes, because percolator queries run on MemoryIndex)
 
         for (QueryBuilder query : queries) {
-            ParsedDocument doc = mapperService.documentMapper("doc").parse(new SourceToParse("test", "doc", "1",
+            ParsedDocument doc = mapperService.documentMapper().parse(new SourceToParse("test", "_doc", "1",
                     BytesReference.bytes(XContentFactory.jsonBuilder().startObject()
                     .field(fieldName, query)
                     .endObject()),
@@ -512,9 +512,9 @@ public class PercolatorFieldMapperTests extends ESSingleNodeTestCase {
 
     public void testQueryWithRewrite() throws Exception {
         addQueryFieldMappings();
-        client().prepareIndex("remote", "doc", "1").setSource("field", "value").get();
+        client().prepareIndex("remote", "_doc", "1").setSource("field", "value").get();
         QueryBuilder queryBuilder = termsLookupQuery("field", new TermsLookup("remote", "1", "field"));
-        ParsedDocument doc = mapperService.documentMapper("doc").parse(new SourceToParse("test", "doc", "1",
+        ParsedDocument doc = mapperService.documentMapper().parse(new SourceToParse("test", "_doc", "1",
                         BytesReference.bytes(XContentFactory
                                 .jsonBuilder()
                                 .startObject()
@@ -535,7 +535,7 @@ public class PercolatorFieldMapperTests extends ESSingleNodeTestCase {
     public void testPercolatorFieldMapperUnMappedField() throws Exception {
         addQueryFieldMappings();
         MapperParsingException exception = expectThrows(MapperParsingException.class, () -> {
-            mapperService.documentMapper("doc").parse(new SourceToParse("test", "doc", "1", BytesReference.bytes(XContentFactory
+            mapperService.documentMapper().parse(new SourceToParse("test", "_doc", "1", BytesReference.bytes(XContentFactory
                     .jsonBuilder()
                     .startObject()
                     .field(fieldName, termQuery("unmapped_field", "value"))
@@ -549,7 +549,7 @@ public class PercolatorFieldMapperTests extends ESSingleNodeTestCase {
 
     public void testPercolatorFieldMapper_noQuery() throws Exception {
         addQueryFieldMappings();
-        ParsedDocument doc = mapperService.documentMapper("doc").parse(new SourceToParse("test", "doc", "1", BytesReference
+        ParsedDocument doc = mapperService.documentMapper().parse(new SourceToParse("test", "_doc", "1", BytesReference
                 .bytes(XContentFactory
                         .jsonBuilder()
                         .startObject()
@@ -558,7 +558,7 @@ public class PercolatorFieldMapperTests extends ESSingleNodeTestCase {
         assertThat(doc.rootDoc().getFields(fieldType.queryBuilderField.name()).length, equalTo(0));
 
         try {
-            mapperService.documentMapper("doc").parse(new SourceToParse("test", "doc", "1", BytesReference.bytes(XContentFactory
+            mapperService.documentMapper().parse(new SourceToParse("test", "_doc", "1", BytesReference.bytes(XContentFactory
                     .jsonBuilder()
                     .startObject()
                     .nullField(fieldName)
@@ -574,27 +574,26 @@ public class PercolatorFieldMapperTests extends ESSingleNodeTestCase {
         IndexService indexService = createIndex("test1", Settings.EMPTY);
         MapperService mapperService = indexService.mapperService();
 
-        String percolatorMapper = Strings.toString(XContentFactory.jsonBuilder().startObject().startObject("doc")
+        String percolatorMapper = Strings.toString(XContentFactory.jsonBuilder().startObject().startObject("_doc")
             .startObject("properties").startObject(fieldName).field("type", "percolator").field("index", "no").endObject().endObject()
             .endObject().endObject());
         MapperParsingException e = expectThrows(MapperParsingException.class, () ->
-            mapperService.merge("doc", new CompressedXContent(percolatorMapper), MapperService.MergeReason.MAPPING_UPDATE));
+            mapperService.merge("_doc", new CompressedXContent(percolatorMapper), MapperService.MergeReason.MAPPING_UPDATE));
         assertThat(e.getMessage(), containsString("Mapping definition for [" + fieldName + "] has unsupported parameters:  [index : no]"));
     }
 
     // multiple percolator fields are allowed in the mapping, but only one field can be used at index time.
     public void testMultiplePercolatorFields() throws Exception {
-        String typeName = "doc";
-        String percolatorMapper = Strings.toString(XContentFactory.jsonBuilder().startObject().startObject(typeName)
+        String percolatorMapper = Strings.toString(XContentFactory.jsonBuilder().startObject().startObject("_doc")
                 .startObject("properties")
                     .startObject("query_field1").field("type", "percolator").endObject()
                     .startObject("query_field2").field("type", "percolator").endObject()
                 .endObject()
                 .endObject().endObject());
-        mapperService.merge(typeName, new CompressedXContent(percolatorMapper), MapperService.MergeReason.MAPPING_UPDATE);
+        mapperService.merge("_doc", new CompressedXContent(percolatorMapper), MapperService.MergeReason.MAPPING_UPDATE);
 
         QueryBuilder queryBuilder = matchQuery("field", "value");
-        ParsedDocument doc = mapperService.documentMapper(typeName).parse(new SourceToParse("test", typeName, "1",
+        ParsedDocument doc = mapperService.documentMapper().parse(new SourceToParse("test", "_doc", "1",
                 BytesReference.bytes(jsonBuilder().startObject()
                         .field("query_field1", queryBuilder)
                         .field("query_field2", queryBuilder)
@@ -610,8 +609,7 @@ public class PercolatorFieldMapperTests extends ESSingleNodeTestCase {
 
     // percolator field can be nested under an object field, but only one query can be specified per document
     public void testNestedPercolatorField() throws Exception {
-        String typeName = "doc";
-        String percolatorMapper = Strings.toString(XContentFactory.jsonBuilder().startObject().startObject(typeName)
+        String percolatorMapper = Strings.toString(XContentFactory.jsonBuilder().startObject().startObject("_doc")
                 .startObject("properties")
                 .startObject("object_field")
                     .field("type", "object")
@@ -621,10 +619,10 @@ public class PercolatorFieldMapperTests extends ESSingleNodeTestCase {
                 .endObject()
                 .endObject()
                 .endObject().endObject());
-        mapperService.merge(typeName, new CompressedXContent(percolatorMapper), MapperService.MergeReason.MAPPING_UPDATE);
+        mapperService.merge("_doc", new CompressedXContent(percolatorMapper), MapperService.MergeReason.MAPPING_UPDATE);
 
         QueryBuilder queryBuilder = matchQuery("field", "value");
-        ParsedDocument doc = mapperService.documentMapper(typeName).parse(new SourceToParse("test", typeName, "1",
+        ParsedDocument doc = mapperService.documentMapper().parse(new SourceToParse("test", "_doc", "1",
                 BytesReference.bytes(jsonBuilder().startObject().startObject("object_field")
                             .field("query_field", queryBuilder)
                         .endObject().endObject()),
@@ -637,7 +635,7 @@ public class PercolatorFieldMapperTests extends ESSingleNodeTestCase {
         BytesRef queryBuilderAsBytes = queryBuilderField.binaryValue();
         assertQueryBuilder(queryBuilderAsBytes, queryBuilder);
 
-        doc = mapperService.documentMapper(typeName).parse(new SourceToParse("test", typeName, "1",
+        doc = mapperService.documentMapper().parse(new SourceToParse("test", "_doc", "1",
                 BytesReference.bytes(jsonBuilder().startObject()
                             .startArray("object_field")
                                 .startObject().field("query_field", queryBuilder).endObject()
@@ -649,7 +647,7 @@ public class PercolatorFieldMapperTests extends ESSingleNodeTestCase {
         assertQueryBuilder(queryBuilderAsBytes, queryBuilder);
 
         MapperParsingException e = expectThrows(MapperParsingException.class, () -> {
-                    mapperService.documentMapper(typeName).parse(new SourceToParse("test", typeName, "1",
+                    mapperService.documentMapper().parse(new SourceToParse("test", "_doc", "1",
                             BytesReference.bytes(jsonBuilder().startObject()
                                     .startArray("object_field")
                                         .startObject().field("query_field", queryBuilder).endObject()
@@ -732,7 +730,7 @@ public class PercolatorFieldMapperTests extends ESSingleNodeTestCase {
         query.endObject();
         query.endObject();
 
-        ParsedDocument doc = mapperService.documentMapper("doc").parse(new SourceToParse("test", "doc", "1",
+        ParsedDocument doc = mapperService.documentMapper().parse(new SourceToParse("test", "_doc", "1",
                 BytesReference.bytes(XContentFactory.jsonBuilder().startObject()
                         .rawField(fieldName, new BytesArray(Strings.toString(query)).streamInput(), query.contentType())
                         .endObject()),
@@ -770,7 +768,7 @@ public class PercolatorFieldMapperTests extends ESSingleNodeTestCase {
         query.endObject();
         query.endObject();
 
-        doc = mapperService.documentMapper("doc").parse(new SourceToParse("test", "doc", "1",
+        doc = mapperService.documentMapper().parse(new SourceToParse("test", "_doc", "1",
                 BytesReference.bytes(XContentFactory.jsonBuilder().startObject()
                         .rawField(fieldName, new BytesArray(Strings.toString(query)).streamInput(), query.contentType())
                         .endObject()),
@@ -856,7 +854,7 @@ public class PercolatorFieldMapperTests extends ESSingleNodeTestCase {
         QueryBuilder qb = boolQuery()
                 .must(boolQuery().must(termQuery("field", "value1")).must(termQuery("field", "value2")))
                 .must(boolQuery().must(termQuery("field", "value2")).must(termQuery("field", "value3")));
-        ParsedDocument doc = mapperService.documentMapper("doc").parse(new SourceToParse("test", "doc", "1",
+        ParsedDocument doc = mapperService.documentMapper().parse(new SourceToParse("test", "_doc", "1",
                 BytesReference.bytes(XContentFactory.jsonBuilder().startObject()
                         .field(fieldName, qb)
                         .endObject()),
@@ -878,7 +876,7 @@ public class PercolatorFieldMapperTests extends ESSingleNodeTestCase {
                 .must(boolQuery().must(termQuery("field", "value2")).must(termQuery("field", "value3")))
                 .must(boolQuery().must(termQuery("field", "value3")).must(termQuery("field", "value4")))
                 .must(boolQuery().should(termQuery("field", "value4")).should(termQuery("field", "value5")));
-        doc = mapperService.documentMapper("doc").parse(new SourceToParse("test", "doc", "1",
+        doc = mapperService.documentMapper().parse(new SourceToParse("test", "_doc", "1",
                 BytesReference.bytes(XContentFactory.jsonBuilder().startObject()
                         .field(fieldName, qb)
                         .endObject()),
@@ -903,7 +901,7 @@ public class PercolatorFieldMapperTests extends ESSingleNodeTestCase {
                 .should(boolQuery().should(termQuery("field", "value2")).should(termQuery("field", "value3")))
                 .should(boolQuery().should(termQuery("field", "value3")).should(termQuery("field", "value4")))
                 .should(boolQuery().should(termQuery("field", "value4")).should(termQuery("field", "value5")));
-        doc = mapperService.documentMapper("doc").parse(new SourceToParse("test", "doc", "1",
+        doc = mapperService.documentMapper().parse(new SourceToParse("test", "_doc", "1",
                 BytesReference.bytes(XContentFactory.jsonBuilder().startObject()
                         .field(fieldName, qb)
                         .endObject()),

--- a/server/src/test/java/org/elasticsearch/index/mapper/AllFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/AllFieldMapperTests.java
@@ -84,7 +84,7 @@ public class AllFieldMapperTests extends ESSingleNodeTestCase {
 
             String mapping = Strings.toString(XContentFactory.jsonBuilder().startObject().endObject());
             indexService.mapperService().merge("_doc", new CompressedXContent(mapping), MergeReason.MAPPING_UPDATE);
-            assertEquals("{\"_doc\":{}}", indexService.mapperService().documentMapper("_doc").mapping().toString());
+            assertEquals("{\"_doc\":{}}", indexService.mapperService().documentMapper().mapping().toString());
         }
     }
 
@@ -94,7 +94,7 @@ public class AllFieldMapperTests extends ESSingleNodeTestCase {
                 .put("index.analysis.analyzer.default_search.tokenizer", "standard").build());
         String mapping = Strings.toString(XContentFactory.jsonBuilder().startObject().startObject("_doc").endObject().endObject());
         indexService.mapperService().merge("_doc", new CompressedXContent(mapping), MergeReason.MAPPING_UPDATE);
-        assertEquals(mapping, indexService.mapperService().documentMapper("_doc").mapping().toString());
+        assertEquals(mapping, indexService.mapperService().documentMapper().mapping().toString());
     }
 
 }

--- a/x-pack/plugin/ccr/src/internalClusterTest/java/org/elasticsearch/xpack/ccr/FollowerFailOverIT.java
+++ b/x-pack/plugin/ccr/src/internalClusterTest/java/org/elasticsearch/xpack/ccr/FollowerFailOverIT.java
@@ -283,17 +283,17 @@ public class FollowerFailOverIT extends CcrIntegTestCase {
                 }
             }
         });
-        leaderCluster.client().admin().indices().preparePutMapping().setType("doc")
+        leaderCluster.client().admin().indices().preparePutMapping().setType("_doc")
             .setSource("balance", "type=long").setTimeout(TimeValue.ZERO).get();
         try {
             // Make sure the mapping is ready on the shard before we execute the index request; otherwise the index request
             // will perform a dynamic mapping update which however will be blocked because the latch is remained closed.
             assertBusy(() -> {
-                DocumentMapper mapper = indexShard.mapperService().documentMapper("doc");
+                DocumentMapper mapper = indexShard.mapperService().documentMapper();
                 assertNotNull(mapper);
                 assertNotNull(mapper.mappers().getMapper("balance"));
             });
-            IndexResponse indexResp = leaderCluster.client().prepareIndex("leader-index", "doc", "1")
+            IndexResponse indexResp = leaderCluster.client().prepareIndex("leader-index", "_doc", "1")
                 .setSource("{\"balance\": 100}", XContentType.JSON).setTimeout(TimeValue.ZERO).get();
             assertThat(indexResp.getResult(), equalTo(DocWriteResponse.Result.CREATED));
             assertThat(indexShard.getLastKnownGlobalCheckpoint(), equalTo(0L));

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/snapshots/SourceOnlySnapshotShardTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/snapshots/SourceOnlySnapshotShardTests.java
@@ -296,7 +296,7 @@ public class SourceOnlySnapshotShardTests extends IndexShardTestCase {
             }
             expectThrows(UnsupportedOperationException.class, () -> searcher.search(new TermQuery(new Term("boom", "boom")), 1));
             targetShard = reindex(searcher.getDirectoryReader(), new MappingMetadata("_doc",
-                restoredShard.mapperService().documentMapper("_doc").mapping().getMeta()));
+                restoredShard.mapperService().documentMapper().mapping().getMeta()));
         }
 
         for (int i = 0; i < numInitialDocs; i++) {


### PR DESCRIPTION
MapperService in 7.x exposes two ways to retrieve the DocumentMapper: one method takes the type as a string argument, while the other does not take any argument. The one that takes a type is still needed while it has been removed in master, but in many cases the other one should be used.

This commit replaces some of the usages of documentMapper(type) with using documentMapper() without arguments in some tests.