### PR TITLE
[DOCS] Remove frozen tier restriction for ESS

### DIFF
--- a/docs/reference/datatiers.asciidoc
+++ b/docs/reference/datatiers.asciidoc
@@ -103,10 +103,6 @@ transitioning into the frozen tier into a shared-cache searchable snapshot.
 Search is typically slower on the frozen tier than the cold tier, because {es}
 must sometimes fetch data from the snapshot repository.
 
-NOTE: The frozen tier is not yet available on {ess-trial}[{ess}]. To
-recreate similar functionality, see
-<<searchable-snapshots-frozen-tier-on-cloud>>.
-
 [discrete]
 [[data-tier-allocation]]
 === Data tier index allocation

--- a/docs/reference/searchable-snapshots/index.asciidoc
+++ b/docs/reference/searchable-snapshots/index.asciidoc
@@ -239,12 +239,3 @@ at rest in the repository.
 The blob storage offered by all major public cloud providers typically offers
 very good protection against data loss or corruption. If you manage your own
 repository storage then you are responsible for its reliability.
-
-[discrete]
-[[searchable-snapshots-frozen-tier-on-cloud]]
-=== Configure a frozen tier on {ess}
-
-The frozen data tier is not yet available on {ess-trial}[{ess}]. However, you
-can configure another tier to use <<shared-cache,shared snapshot caches>>. This
-effectively recreates a frozen tier in your deployment. See
-<<set-up-data-tiers,Set up data tiers>>.

--- a/docs/reference/tab-widgets/data-tiers.asciidoc
+++ b/docs/reference/tab-widgets/data-tiers.asciidoc
@@ -8,31 +8,6 @@ page.
 
 . To enable a data tier, click **Add capacity**.
 
-**Frozen tier**
-
-The frozen tier is not yet available on {ess}. However, you can follow these
-steps to effectively recreate a frozen tier in your deployment:
-
-. Choose an existing tier to use. You'll typically use the cold tier, but the
-hot and warm tiers are also supported. You can use this tier as a shared tier,
-or use it exclusively as a frozen tier.
-
-. On the **Edit deployment** page, click **Edit elasticsearch.yml** for your
-chosen tier.
-
-. In the `elasticsearch.yml` configuration, set
-<<searchable-snapshots-shared-cache,`xpack.searchable.snapshot.shared_cache.size`>>
-to up to 90% of available disk space. The tier uses this space to
-create a <<shared-cache,shared, fixed-size cache>> for
-<<searchable-snapshots,searchable snapshots>>.
-+
-[source,yaml]
-----
-xpack.searchable.snapshot.shared_cache.size: 50GB
-----
-
-. Click **Save** and **Confirm** to apply your changes.
-
 **Enable autoscaling**
 
 {cloud}/ec-autoscaling.html[Autoscaling] automatically adjusts your deployment's


### PR DESCRIPTION
Frozen tiers will be supported on Elasticsearch Service (ESS) beginning on May 4, 2021, on Elasticsearch clusters 7.13 and higher. 

This removes the restriction from [here](https://www.elastic.co/guide/en/elasticsearch/reference/7.12/data-tiers.html#frozen-tier) and [here](https://www.elastic.co/guide/en/elasticsearch/reference/7.12/searchable-snapshots.html#searchable-snapshots-frozen-tier-on-cloud) saying that "the frozen tier is not yet available on ESS" .

@debadair @jrodewig  I'm not used to pushing changes outside of Cloud so please let me know if I'm doing anything wrong. Also, I'd appreciate any assistance with backporting this to 7.13, if you don't mind. :-)

