### PR TITLE
[DOCS] Update self-managed frozen tier instructions

### DIFF
--- a/docs/reference/tab-widgets/data-tiers.asciidoc
+++ b/docs/reference/tab-widgets/data-tiers.asciidoc
@@ -61,19 +61,8 @@ node.roles: [ data_cold ]
 node.roles: [ data_frozen ]
 ----
 
-For nodes in the frozen tier, set
-<<searchable-snapshots-shared-cache,`xpack.searchable.snapshot.shared_cache.size`>>
-to up to 90% of the node's available disk space. The frozen tier uses this space
-to create a <<shared-cache,shared, fixed-size cache>> for
-<<searchable-snapshots,searchable snapshots>>.
-
-[source,yaml]
-----
-node.roles: [ data_frozen ]
-xpack.searchable.snapshot.shared_cache.size: 50GB
-----
-
-If needed, you can assign a node to more than one tier.
+We recommend using dedicated nodes for the frozen tier. However, if needed, you
+can assign other nodes to more than one tier.
 
 [source,yaml]
 ----


### PR DESCRIPTION
With #71844, we now have a default shared cache size for the frozen tier. We also recommend using dedicated nodes for the frozen tier.

This updates the self-managed instructions for the frozen tier in [Use ES for time series data](https://www.elastic.co/guide/en/elasticsearch/reference/master/use-elasticsearch-for-time-series-data.html#set-up-data-tiers).

#72624 updates the ESS instructions.

### Preview
https://elasticsearch_72626.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/use-elasticsearch-for-time-series-data.html#set-up-data-tiers