### PR TITLE
Document signature for runtime fields

### DIFF
--- a/docs/painless/painless-contexts/painless-runtime-fields-context.asciidoc
+++ b/docs/painless/painless-contexts/painless-runtime-fields-context.asciidoc
@@ -12,10 +12,22 @@ about how to use runtime fields.
         Accepts the values from the script valuation. Scripts can call the
         `emit` method multiple times to emit multiple values.
 +
---
+.Signatures of `emit`
+[%collapsible%open]
+====
+`emit`'s signature depends on the `type` of the field.
+
+[[emit-boolean]]   `boolean`::   `emit(boolean)`
+[[emit-date]]      `date`::      `emit(long)`
+[[emit-double]]    `double`::    `emit(double)`
+[[emit-geo-point]] `geo_point`:: `emit(double lat, double lon)`
+[[emit-ip]]        `ip`::        `emit(String)`
+[[emit-long]]      `long`::      `emit(long)`
+[[emit-keyword]]   `keyword`::   `emit(String)`
+
 IMPORTANT: This method cannot accept `null` values. Do not call this method if
 the referenced fields do not have any values.
---
+====
 
 --
 `grok`::

--- a/docs/painless/painless-contexts/painless-runtime-fields-context.asciidoc
+++ b/docs/painless/painless-contexts/painless-runtime-fields-context.asciidoc
@@ -8,26 +8,31 @@ about how to use runtime fields.
 
 *Methods*
 
+--
 `emit` (Required)::
         Accepts the values from the script valuation. Scripts can call the
         `emit` method multiple times to emit multiple values.
 +
+IMPORTANT: The `emit` method cannot accept `null` values. Do not call this method if
+the referenced fields do not have any values.
++
 .Signatures of `emit`
 [%collapsible%open]
 ====
-`emit`'s signature depends on the `type` of the field.
+The signature for `emit` depends on the `type` of the field.
 
+[horizontal]
 [[emit-boolean]]   `boolean`::   `emit(boolean)`
 [[emit-date]]      `date`::      `emit(long)`
 [[emit-double]]    `double`::    `emit(double)`
-[[emit-geo-point]] `geo_point`:: `emit(double lat, double lon)`
+[[emit-geo-point]] `geo_point`:: `emit(double lat, double long)`
 [[emit-ip]]        `ip`::        `emit(String)`
 [[emit-long]]      `long`::      `emit(long)`
 [[emit-keyword]]   `keyword`::   `emit(String)`
 
-IMPORTANT: This method cannot accept `null` values. Do not call this method if
-the referenced fields do not have any values.
 ====
+
+--
 
 --
 `grok`::


### PR DESCRIPTION
This documents the different signatures of the `emit` method for runtime
fields. For fields like `long` the signature is fairly obvious -
`emit(long)`. But for `date`, `ip`, and `geo_point` its not obvious from
the name what the signature of the method will be.
