### PR TITLE
[DOCS] Clarify remote_cluster_client on master nodes for transforms

### DIFF
--- a/docs/reference/modules/node.asciidoc
+++ b/docs/reference/modules/node.asciidoc
@@ -379,6 +379,9 @@ node.roles: [ transform, remote_cluster_client ] <1>
 <1> The `remote_cluster_client` role is optional but strongly recommended.
 Otherwise, {ccs} fails when used in {transforms}. See <<remote-node>>.
 
+NOTE: If you use {ccs} in your {transforms}, the `remote_cluster_client` role
+is also required on all master-eligible nodes.
+
 [[change-node-role]]
 ==== Changing the role of a node
 


### PR DESCRIPTION
Related to https://github.com/elastic/elasticsearch/pull/72569

This PR clarifies that the remote_cluster_client role is required on master-eligible nodes when you use cross-cluster search (CCS) in transforms.

### Preview

https://elasticsearch_72634.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/7.12/modules-node.html#transform-node