### PR TITLE
Ban Path.of

### DIFF
--- a/buildSrc/src/main/resources/forbidden/es-all-signatures.txt
+++ b/buildSrc/src/main/resources/forbidden/es-all-signatures.txt
@@ -5,6 +5,8 @@
 # Side Public License, v 1.
 
 java.nio.file.Paths @ Use org.elasticsearch.common.io.PathUtils.get() instead.
+java.nio.file.Path#of(java.net.URI) @ Use org.elasticsearch.common.io.PathUtils.get() instead.
+java.nio.file.Path#of(java.lang.String, java.lang.String[]) @ Use org.elasticsearch.common.io.PathUtils.get() instead.
 java.nio.file.FileSystems#getDefault() @ use org.elasticsearch.common.io.PathUtils.getDefaultFileSystem() instead.
 
 java.nio.file.Files#getFileStore(java.nio.file.Path) @ Use org.elasticsearch.env.Environment.getFileStore() instead, impacted by JDK-8034057

--- a/x-pack/plugin/sql/qa/server/single-node/src/test/java/org/elasticsearch/xpack/sql/qa/single_node/ConsistentFunctionArgHandlingIT.java
+++ b/x-pack/plugin/sql/qa/server/single-node/src/test/java/org/elasticsearch/xpack/sql/qa/single_node/ConsistentFunctionArgHandlingIT.java
@@ -8,14 +8,15 @@
 package org.elasticsearch.xpack.sql.qa.single_node;
 
 import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
+
 import org.elasticsearch.common.CheckedConsumer;
 import org.elasticsearch.common.UUIDs;
 import org.elasticsearch.common.collect.Tuple;
+import org.elasticsearch.common.io.PathUtils;
 import org.elasticsearch.xpack.sql.qa.jdbc.JdbcIntegrationTestCase;
 
 import java.io.IOException;
 import java.nio.file.Files;
-import java.nio.file.Path;
 import java.sql.ResultSet;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
@@ -78,7 +79,9 @@ public class ConsistentFunctionArgHandlingIT extends JdbcIntegrationTestCase {
     static {
         try {
             Class<?> c = ConsistentFunctionArgHandlingIT.class;
-            NON_TESTED_FUNCTIONS = Files.readAllLines(Path.of(c.getResource(c.getSimpleName() + "-non-tested-functions.txt").toURI()));
+            NON_TESTED_FUNCTIONS = Files.readAllLines(
+                PathUtils.get(c.getResource(c.getSimpleName() + "-non-tested-functions.txt").toURI())
+            );
         } catch (Exception ex) {
             throw new RuntimeException(ex);
         }

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/DateTimeToCharProcessorTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/DateTimeToCharProcessorTests.java
@@ -9,11 +9,11 @@ package org.elasticsearch.xpack.sql.expression.function.scalar.datetime;
 
 import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
 
+import org.elasticsearch.common.io.PathUtils;
 import org.elasticsearch.test.ESTestCase;
 
 import java.math.BigDecimal;
 import java.nio.file.Files;
-import java.nio.file.Path;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
@@ -59,7 +59,7 @@ public class DateTimeToCharProcessorTests extends ESTestCase {
         List<Object[]> params = new ArrayList<>();
         String testFile = "tochar-generated.csv";
         int lineNumber = 0;
-        for (String line : Files.readAllLines(Path.of(DateTimeToCharProcessorTests.class.getResource(testFile).toURI()))) {
+        for (String line : Files.readAllLines(PathUtils.get(DateTimeToCharProcessorTests.class.getResource(testFile).toURI()))) {
             lineNumber += 1;
             if (line.startsWith("#")) {
                 continue;

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/ToCharTestScript.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/ToCharTestScript.java
@@ -10,6 +10,7 @@ package org.elasticsearch.xpack.sql.expression.function.scalar.datetime;
 import com.carrotsearch.randomizedtesting.generators.RandomNumbers;
 
 import org.elasticsearch.common.SuppressForbidden;
+import org.elasticsearch.common.io.PathUtils;
 import org.elasticsearch.common.util.set.Sets;
 
 import java.math.BigDecimal;
@@ -17,7 +18,6 @@ import java.net.URI;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
-import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -190,7 +190,7 @@ public class ToCharTestScript {
     static List<String> readAllLinesWithoutComment(URL url) {
         try {
             URI uri = url.toURI();
-            return Files.readAllLines(Path.of(uri))
+            return Files.readAllLines(PathUtils.get(uri))
                 .stream()
                 .filter(s -> s.startsWith("#") == false)
                 .filter(s -> s.isBlank() == false)
@@ -237,6 +237,6 @@ public class ToCharTestScript {
 
     public static void main(String[] args) throws Exception {
         String scriptFilename = args.length < 1 ? "postgresql-tochar-test.sql" : args[0];
-        Files.writeString(Path.of(scriptFilename), new ToCharTestScript(rnd()).unitTestExporterScript(), StandardCharsets.UTF_8);
+        Files.writeString(PathUtils.get(scriptFilename), new ToCharTestScript(rnd()).unitTestExporterScript(), StandardCharsets.UTF_8);
     }
 }


### PR DESCRIPTION
We use `PathUtils.get` to look up paths with our custom testing
infrastructure rather than `Paths.get`. In the past few years java has
grown a `Path.of` which is very similar to `Paths.get`. Just like
`Paths.get`, we should always be using `PathUtils.get` so that we get
our fancy testing infrastructure. This uses forbiddenapis to ban
`Path.of` and fixed the build errors.

Closes #72392
