### PR TITLE
Document signature for runtime fields (#72630)

### DIFF
--- a/docs/painless/painless-contexts/painless-runtime-fields-context.asciidoc
+++ b/docs/painless/painless-contexts/painless-runtime-fields-context.asciidoc
@@ -8,13 +8,30 @@ about how to use runtime fields.
 
 *Methods*
 
+--
 `emit` (Required)::
         Accepts the values from the script valuation. Scripts can call the
         `emit` method multiple times to emit multiple values.
 +
---
-IMPORTANT: This method cannot accept `null` values. Do not call this method if
+IMPORTANT: The `emit` method cannot accept `null` values. Do not call this method if
 the referenced fields do not have any values.
++
+.Signatures of `emit`
+[%collapsible%open]
+====
+The signature for `emit` depends on the `type` of the field.
+
+[horizontal]
+[[emit-boolean]]   `boolean`::   `emit(boolean)`
+[[emit-date]]      `date`::      `emit(long)`
+[[emit-double]]    `double`::    `emit(double)`
+[[emit-geo-point]] `geo_point`:: `emit(double lat, double long)`
+[[emit-ip]]        `ip`::        `emit(String)`
+[[emit-long]]      `long`::      `emit(long)`
+[[emit-keyword]]   `keyword`::   `emit(String)`
+
+====
+
 --
 
 --


### PR DESCRIPTION
This documents the different signatures of the `emit` method for runtime
fields. For fields like `long` the signature is fairly obvious -
`emit(long)`. But for `date`, `ip`, and `geo_point` its not obvious from
the name what the signature of the method will be.


Co-authored-by: Adam Locke <adam.locke@elastic.co>
