### PR TITLE
Dry up Wrapping Releasable in AbstractRefCounted

### DIFF
--- a/libs/core/src/main/java/org/elasticsearch/common/util/concurrent/RefCountedReleasable.java
+++ b/libs/core/src/main/java/org/elasticsearch/common/util/concurrent/RefCountedReleasable.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.common.util.concurrent;
+
+import org.elasticsearch.common.lease.Releasable;
+import org.elasticsearch.common.lease.Releasables;
+
+public final class RefCountedReleasable extends AbstractRefCounted {
+
+    private final Releasable releasable;
+
+    public RefCountedReleasable(String name, Releasable releasable) {
+        super(name);
+        this.releasable = releasable;
+    }
+
+    @Override
+    protected void closeInternal() {
+        Releasables.closeExpectNoException(releasable);
+    }
+}

--- a/server/src/main/java/org/elasticsearch/common/bytes/ReleasableBytesReference.java
+++ b/server/src/main/java/org/elasticsearch/common/bytes/ReleasableBytesReference.java
@@ -12,9 +12,9 @@ import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.BytesRefIterator;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.lease.Releasable;
-import org.elasticsearch.common.lease.Releasables;
 import org.elasticsearch.common.util.concurrent.AbstractRefCounted;
 import org.elasticsearch.common.util.concurrent.RefCounted;
+import org.elasticsearch.common.util.concurrent.RefCountedReleasable;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 
 import java.io.IOException;
@@ -39,7 +39,7 @@ public final class ReleasableBytesReference implements RefCounted, Releasable, B
     }
 
     public ReleasableBytesReference(BytesReference delegate, Releasable releasable) {
-        this(delegate, new RefCountedReleasable(releasable));
+        this(delegate, new RefCountedReleasable("bytes-reference", releasable));
     }
 
     public ReleasableBytesReference(BytesReference delegate, AbstractRefCounted refCounted) {
@@ -211,18 +211,4 @@ public final class ReleasableBytesReference implements RefCounted, Releasable, B
         return delegate.arrayOffset();
     }
 
-    private static final class RefCountedReleasable extends AbstractRefCounted {
-
-        private final Releasable releasable;
-
-        RefCountedReleasable(Releasable releasable) {
-            super("bytes-reference");
-            this.releasable = releasable;
-        }
-
-        @Override
-        protected void closeInternal() {
-            Releasables.closeExpectNoException(releasable);
-        }
-    }
 }

--- a/server/src/main/java/org/elasticsearch/index/store/Store.java
+++ b/server/src/main/java/org/elasticsearch/index/store/Store.java
@@ -55,6 +55,7 @@ import org.elasticsearch.common.settings.Setting.Property;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.util.concurrent.AbstractRefCounted;
 import org.elasticsearch.common.util.concurrent.RefCounted;
+import org.elasticsearch.common.util.concurrent.RefCountedReleasable;
 import org.elasticsearch.common.util.iterable.Iterables;
 import org.elasticsearch.core.internal.io.IOUtils;
 import org.elasticsearch.env.NodeEnvironment;
@@ -136,13 +137,7 @@ public class Store extends AbstractIndexShardComponent implements Closeable, Ref
     private final ShardLock shardLock;
     private final OnClose onClose;
 
-    private final AbstractRefCounted refCounter = new AbstractRefCounted("store") {
-        @Override
-        protected void closeInternal() {
-            // close us once we are done
-            Store.this.closeInternal();
-        }
-    };
+    private final AbstractRefCounted refCounter = new RefCountedReleasable("store", this::closeInternal);
 
     public Store(ShardId shardId, IndexSettings indexSettings, Directory directory, ShardLock shardLock) {
         this(shardId, indexSettings, directory, shardLock, OnClose.EMPTY);


### PR DESCRIPTION
We do this in a number of spots and can dry things up, aligning
`Page` and `ReleasableBytesReference` some more in the process
which both are essentially doing the same thing anyway and allow
for some follow-up drying up.
