### PR TITLE
[Transform] Fix rolling upgrade regression introduced in #72533

### DIFF
--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/persistence/TransformInternalIndex.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/persistence/TransformInternalIndex.java
@@ -408,7 +408,8 @@ public final class TransformInternalIndex {
 
     private static void waitForLatestVersionedIndexShardsActive(Client client, ActionListener<Void> listener) {
         ClusterHealthRequest request = new ClusterHealthRequest(TransformInternalIndexConstants.LATEST_INDEX_VERSIONED_NAME)
-            .waitForActiveShards(ActiveShardCount.ALL);
+            // cluster health does not wait for active shards per default
+            .waitForActiveShards(ActiveShardCount.ONE);
         ActionListener<ClusterHealthResponse> innerListener = ActionListener.wrap(r -> listener.onResponse(null), listener::onFailure);
         executeAsyncWithOrigin(
             client.threadPool().getThreadContext(),
@@ -442,7 +443,8 @@ public final class TransformInternalIndex {
                 .settings(settings())
                 .mapping(mappings())
                 .origin(TRANSFORM_ORIGIN)
-                .waitForActiveShards(ActiveShardCount.ALL);
+                // explicitly wait for the primary shard (although this might be default)
+                .waitForActiveShards(ActiveShardCount.ONE);
             ActionListener<CreateIndexResponse> innerListener = ActionListener.wrap(
                 r -> listener.onResponse(null),
                 e -> {


### PR DESCRIPTION
#72533 introduced a regression, causing transforms to timeout/fail.
With this change transform only waits for 1 active shard(primary) as waiting for all can block during
rolling upgrade

fixes #72617
relates #72533

non-issue as #72533 is unreleased, however blocker for 7.13/7.12.2