### PR TITLE
[7.x][Transform] Fix rolling upgrade regression introduced in #72533

### DIFF
--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/persistence/TransformInternalIndex.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/persistence/TransformInternalIndex.java
@@ -414,7 +414,8 @@ public final class TransformInternalIndex {
 
     private static void waitForLatestVersionedIndexShardsActive(Client client, ActionListener<Void> listener) {
         ClusterHealthRequest request = new ClusterHealthRequest(TransformInternalIndexConstants.LATEST_INDEX_VERSIONED_NAME)
-            .waitForActiveShards(ActiveShardCount.ALL);
+            // cluster health does not wait for active shards per default
+            .waitForActiveShards(ActiveShardCount.ONE);
         ActionListener<ClusterHealthResponse> innerListener = ActionListener.wrap(r -> listener.onResponse(null), listener::onFailure);
         executeAsyncWithOrigin(
             client.threadPool().getThreadContext(),
@@ -450,7 +451,8 @@ public final class TransformInternalIndex {
                 // BWC: for mixed clusters with nodes < 7.5, we need the alias to make new docs visible for them
                 .alias(new Alias(".data-frame-internal-3"))
                 .origin(TRANSFORM_ORIGIN)
-                .waitForActiveShards(ActiveShardCount.ALL);
+                // explicitly wait for the primary shard (although this might be default)
+                .waitForActiveShards(ActiveShardCount.ONE);
             ActionListener<CreateIndexResponse> innerListener = ActionListener.wrap(
                 r -> listener.onResponse(null),
                 e -> {

--- a/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/mixed_cluster/80_transform_jobs_crud.yml
+++ b/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/mixed_cluster/80_transform_jobs_crud.yml
@@ -226,8 +226,6 @@
 ---
 "Test GET, start, and stop old cluster batch transforms":
   - skip:
-      version: all
-      reason: https://github.com/elastic/elasticsearch/issues/72617
       features: allowed_warnings
 
   - do:
@@ -343,8 +341,6 @@
 ---
 "Test GET, stop, start, old continuous transforms":
   - skip:
-      version: all
-      reason: https://github.com/elastic/elasticsearch/issues/72617
       features: allowed_warnings
 
   - do:


### PR DESCRIPTION
#72533 introduced a regression, causing transforms to timeout/fail.
With this change transform only waits for 1 active shard(primary) as waiting for all can block during
rolling upgrade

fixes #72617
relates #72533
backport #72666

non-issue as #72533 is unreleased, however blocker for 7.13/7.12.2