### PR TITLE
Drop support for parsing null mappings

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/mapper/MappingParser.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/MappingParser.java
@@ -17,6 +17,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
+import java.util.Objects;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
@@ -72,26 +73,21 @@ public final class MappingParser {
 
     @SuppressWarnings("unchecked")
     Mapping parse(@Nullable String type, CompressedXContent source) throws MapperParsingException {
-        Map<String, Object> mapping = null;
-        if (source != null) {
-            mapping = XContentHelper.convertToMap(source.compressedReference(), true, XContentType.JSON).v2();
-            if (mapping.isEmpty()) {
-                if (type == null) {
-                    throw new MapperParsingException("malformed mapping, no type name found");
-                }
-            } else {
-                String rootName = mapping.keySet().iterator().next();
-                if (type == null || type.equals(rootName) || documentTypeResolver.apply(type).equals(rootName)) {
-                    type = rootName;
-                    mapping = (Map<String, Object>) mapping.get(rootName);
-                }
+        Objects.requireNonNull(source, "source cannot be null");
+        Map<String, Object> mapping = XContentHelper.convertToMap(source.compressedReference(), true, XContentType.JSON).v2();
+        if (mapping.isEmpty()) {
+            if (type == null) {
+                throw new MapperParsingException("malformed mapping, no type name found");
+            }
+        } else {
+            String rootName = mapping.keySet().iterator().next();
+            if (type == null || type.equals(rootName) || documentTypeResolver.apply(type).equals(rootName)) {
+                type = rootName;
+                mapping = (Map<String, Object>) mapping.get(rootName);
             }
         }
         if (type == null) {
             throw new MapperParsingException("Failed to derive type");
-        }
-        if (mapping == null) {
-            mapping = new HashMap<>();
         }
         return parse(type, mapping);
     }


### PR DESCRIPTION
We used to support parsing null mappings to support the scenario where we need to submit an empty dynamic mapping update when an empty doc is indexed in an index that has no mappings yet. This has recently changed to not go through parsing, as effectively there is nothing to parse. That allows us to enforce that the mapping source is not null when we need to parse it.

Note: this is a master only change. In 7.x we still need to apply the `_default` mappings when creating an empty type, which makes it harder to backport this change.