### PR TITLE
Ensure that ExecuteEnrichPolicyStatus is properly registered.

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/enrich/action/ExecuteEnrichPolicyStatus.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/enrich/action/ExecuteEnrichPolicyStatus.java
@@ -7,6 +7,7 @@
 package org.elasticsearch.xpack.core.enrich.action;
 
 import java.io.IOException;
+import java.util.Objects;
 
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -64,5 +65,18 @@ public class ExecuteEnrichPolicyStatus implements Task.Status {
         }
         builder.endObject();
         return builder;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        ExecuteEnrichPolicyStatus that = (ExecuteEnrichPolicyStatus) o;
+        return Objects.equals(phase, that.phase);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(phase);
     }
 }

--- a/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/EnrichPlugin.java
+++ b/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/EnrichPlugin.java
@@ -35,6 +35,7 @@ import org.elasticsearch.repositories.RepositoriesService;
 import org.elasticsearch.rest.RestController;
 import org.elasticsearch.rest.RestHandler;
 import org.elasticsearch.script.ScriptService;
+import org.elasticsearch.tasks.Task;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.watcher.ResourceWatcherService;
 import org.elasticsearch.xpack.core.XPackPlugin;
@@ -43,6 +44,7 @@ import org.elasticsearch.xpack.core.action.XPackUsageFeatureAction;
 import org.elasticsearch.xpack.core.enrich.action.DeleteEnrichPolicyAction;
 import org.elasticsearch.xpack.core.enrich.action.EnrichStatsAction;
 import org.elasticsearch.xpack.core.enrich.action.ExecuteEnrichPolicyAction;
+import org.elasticsearch.xpack.core.enrich.action.ExecuteEnrichPolicyStatus;
 import org.elasticsearch.xpack.core.enrich.action.GetEnrichPolicyAction;
 import org.elasticsearch.xpack.core.enrich.action.PutEnrichPolicyAction;
 import org.elasticsearch.xpack.enrich.action.EnrichCoordinatorProxyAction;
@@ -211,7 +213,8 @@ public class EnrichPlugin extends Plugin implements SystemIndexPlugin, IngestPlu
                 NamedDiff.class,
                 EnrichMetadata.TYPE,
                 in -> EnrichMetadata.readDiffFrom(Metadata.Custom.class, EnrichMetadata.TYPE, in)
-            )
+            ),
+            new NamedWriteableRegistry.Entry(Task.Status.class, ExecuteEnrichPolicyStatus.NAME, ExecuteEnrichPolicyStatus::new)
         );
     }
 

--- a/x-pack/plugin/enrich/src/test/java/org/elasticsearch/xpack/enrich/action/EnrichStatsResponseTests.java
+++ b/x-pack/plugin/enrich/src/test/java/org/elasticsearch/xpack/enrich/action/EnrichStatsResponseTests.java
@@ -7,6 +7,7 @@
 package org.elasticsearch.xpack.enrich.action;
 
 import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.tasks.Task;
 import org.elasticsearch.tasks.TaskId;
 import org.elasticsearch.tasks.TaskInfo;
 import org.elasticsearch.test.AbstractWireSerializingTestCase;
@@ -50,6 +51,10 @@ public class EnrichStatsResponseTests extends AbstractWireSerializingTestCase<En
     }
 
     public static TaskInfo randomTaskInfo() {
+        return randomTaskInfo(null);
+    }
+
+    public static TaskInfo randomTaskInfo(Task.Status status) {
         TaskId taskId = new TaskId(randomAlphaOfLength(5), randomLong());
         String type = randomAlphaOfLength(5);
         String action = randomAlphaOfLength(5);
@@ -61,6 +66,6 @@ public class EnrichStatsResponseTests extends AbstractWireSerializingTestCase<En
         Map<String, String> headers = randomBoolean()
             ? Collections.emptyMap()
             : Collections.singletonMap(randomAlphaOfLength(5), randomAlphaOfLength(5));
-        return new TaskInfo(taskId, type, action, description, null, startTime, runningTimeNanos, cancellable, parentTaskId, headers);
+        return new TaskInfo(taskId, type, action, description, status, startTime, runningTimeNanos, cancellable, parentTaskId, headers);
     }
 }

--- a/x-pack/plugin/enrich/src/test/java/org/elasticsearch/xpack/enrich/action/ExecuteEnrichPolicyStatusTests.java
+++ b/x-pack/plugin/enrich/src/test/java/org/elasticsearch/xpack/enrich/action/ExecuteEnrichPolicyStatusTests.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+package org.elasticsearch.xpack.enrich.action;
+
+import org.elasticsearch.Version;
+import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
+import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.tasks.TaskInfo;
+import org.elasticsearch.test.AbstractWireSerializingTestCase;
+import org.elasticsearch.xpack.core.enrich.action.ExecuteEnrichPolicyStatus;
+import org.elasticsearch.xpack.enrich.EnrichPlugin;
+
+import static org.elasticsearch.xpack.enrich.action.EnrichStatsResponseTests.randomTaskInfo;
+import static org.hamcrest.Matchers.equalTo;
+
+public class ExecuteEnrichPolicyStatusTests extends AbstractWireSerializingTestCase<ExecuteEnrichPolicyStatus> {
+
+    @Override
+    protected Writeable.Reader<ExecuteEnrichPolicyStatus> instanceReader() {
+        return ExecuteEnrichPolicyStatus::new;
+    }
+
+    @Override
+    protected ExecuteEnrichPolicyStatus createTestInstance() {
+        return new ExecuteEnrichPolicyStatus(randomAlphaOfLengthBetween(2, 8));
+    }
+
+    @Override
+    protected NamedWriteableRegistry getNamedWriteableRegistry() {
+        EnrichPlugin enrichPlugin = new EnrichPlugin(Settings.EMPTY);
+        return new NamedWriteableRegistry(enrichPlugin.getNamedWriteables());
+    }
+
+    public void testEnsureExecuteEnrichPolicyStatusIsRegistered() throws Exception {
+        TaskInfo testInstance = randomTaskInfo(createTestInstance());
+        TaskInfo instance = copyWriteable(testInstance, getNamedWriteableRegistry(), TaskInfo::new, Version.CURRENT);
+        assertThat(testInstance, equalTo(instance));
+    }
+}


### PR DESCRIPTION
When executing the enrich execute policy api and not waiting for completion,
then querying for task via task list api can result into a serialization error.

Relates to #70554