### PR TITLE
BACKPORT 7.12 [TEST] Updated smoke test JDK's trusted certs (#72594)

### DIFF
--- a/libs/ssl-config/src/test/java/org/elasticsearch/common/ssl/DefaultJdkTrustConfigTests.java
+++ b/libs/ssl-config/src/test/java/org/elasticsearch/common/ssl/DefaultJdkTrustConfigTests.java
@@ -26,7 +26,6 @@ public class DefaultJdkTrustConfigTests extends ESTestCase {
 
     private static final BiFunction<String, String, String> EMPTY_SYSTEM_PROPERTIES = (key, defaultValue) -> defaultValue;
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/71717")
     public void testGetSystemTrustStoreWithNoSystemProperties() throws Exception {
         final DefaultJdkTrustConfig trustConfig = new DefaultJdkTrustConfig((key, defaultValue) -> defaultValue);
         assertThat(trustConfig.getDependentFiles(), emptyIterable());
@@ -34,7 +33,6 @@ public class DefaultJdkTrustConfigTests extends ESTestCase {
         assertStandardIssuers(trustManager);
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/71717")
     public void testGetNonPKCS11TrustStoreWithPasswordSet() throws Exception {
         final DefaultJdkTrustConfig trustConfig = new DefaultJdkTrustConfig(EMPTY_SYSTEM_PROPERTIES, "fakepassword".toCharArray());
         assertThat(trustConfig.getDependentFiles(), emptyIterable());
@@ -46,11 +44,12 @@ public class DefaultJdkTrustConfigTests extends ESTestCase {
         assertThat(trustManager.getAcceptedIssuers(), not(emptyArray()));
         // This is a sample of the CAs that we expect on every JRE.
         // We can safely change this list if the JRE's issuer list changes, but we want to assert something useful.
-        assertHasTrustedIssuer(trustManager, "VeriSign");
-        assertHasTrustedIssuer(trustManager, "GeoTrust");
         assertHasTrustedIssuer(trustManager, "DigiCert");
-        assertHasTrustedIssuer(trustManager, "thawte");
         assertHasTrustedIssuer(trustManager, "COMODO");
+        assertHasTrustedIssuer(trustManager, "GlobalSign");
+        assertHasTrustedIssuer(trustManager, "GoDaddy");
+        assertHasTrustedIssuer(trustManager, "QuoVadis");
+        assertHasTrustedIssuer(trustManager, "Internet Security Research Group");
     }
 
     private void assertHasTrustedIssuer(X509ExtendedTrustManager trustManager, String name) {


### PR DESCRIPTION
Backport of #72594

The list of trusted CAs in the latest OpenJDK builds has changed:
https://bugs.java.com/bugdatabase/view_bug.do?bug_id=JDK-8243559
This PR updates the default jdk trust config smoke test.

Closes #71717