### PR TITLE
[7.x][Transform] unmute mixed continuous transform test

### DIFF
--- a/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/upgraded_cluster/80_transform_jobs_crud.yml
+++ b/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/upgraded_cluster/80_transform_jobs_crud.yml
@@ -213,9 +213,6 @@ setup:
         transform_id: "old-simple-continuous-transform"
 ---
 "Test GET, mixed continuous transforms":
-  - skip:
-      version: "all"
-      reason: "AwaitsFix https://github.com/elastic/elasticsearch/issues/56196"
   - do:
       transform.get_transform:
         transform_id: "mixed-simple-continuous-transform"


### PR DESCRIPTION
unmute mixed continuous transform test which is only muted on 7.x, but not on master. The master test
hasn't created any issues in the last months.