### PR TITLE
Log Slow Executions on Scheduler Thread (#72606)

### DIFF
--- a/server/src/main/java/org/elasticsearch/threadpool/ThreadPool.java
+++ b/server/src/main/java/org/elasticsearch/threadpool/ThreadPool.java
@@ -146,16 +146,33 @@ public class ThreadPool implements ReportingService<ThreadPoolInfo>, Scheduler {
 
     private final ScheduledThreadPoolExecutor scheduler;
 
+    private final long slowSchedulerWarnThresholdNanos;
+
+    @SuppressWarnings("rawtypes")
     public Collection<ExecutorBuilder> builders() {
         return Collections.unmodifiableCollection(builders.values());
     }
 
-    public static Setting<TimeValue> ESTIMATED_TIME_INTERVAL_SETTING =
-        Setting.timeSetting("thread_pool.estimated_time_interval",
-            TimeValue.timeValueMillis(200), TimeValue.ZERO, Setting.Property.NodeScope);
-    public static Setting<TimeValue> LATE_TIME_INTERVAL_WARN_THRESHOLD_SETTING =
-        Setting.timeSetting("thread_pool.estimated_time_interval.warn_threshold",
-            TimeValue.timeValueSeconds(5), TimeValue.ZERO, Setting.Property.NodeScope);
+    public static final Setting<TimeValue> ESTIMATED_TIME_INTERVAL_SETTING = Setting.timeSetting(
+            "thread_pool.estimated_time_interval",
+            TimeValue.timeValueMillis(200),
+            TimeValue.ZERO,
+            Setting.Property.NodeScope
+    );
+
+    public static final Setting<TimeValue> LATE_TIME_INTERVAL_WARN_THRESHOLD_SETTING = Setting.timeSetting(
+            "thread_pool.estimated_time_interval.warn_threshold",
+            TimeValue.timeValueSeconds(5),
+            TimeValue.ZERO,
+            Setting.Property.NodeScope
+    );
+
+    public static final Setting<TimeValue> SLOW_SCHEDULER_TASK_WARN_THRESHOLD_SETTING = Setting.timeSetting(
+            "thread_pool.scheduler.warn_threshold",
+            TimeValue.timeValueSeconds(5),
+            TimeValue.ZERO,
+            Setting.Property.NodeScope
+    );
 
     public ThreadPool(final Settings settings, final ExecutorBuilder<?>... customBuilders) {
         assert Node.NODE_NAME_SETTING.exists(settings);
@@ -223,6 +240,7 @@ public class ThreadPool implements ReportingService<ThreadPoolInfo>, Scheduler {
                         .collect(Collectors.toList());
         this.threadPoolInfo = new ThreadPoolInfo(infos);
         this.scheduler = Scheduler.initScheduler(settings, "scheduler");
+        this.slowSchedulerWarnThresholdNanos = SLOW_SCHEDULER_TASK_WARN_THRESHOLD_SETTING.get(settings).nanos();
         this.cachedTimeThread = new CachedTimeThread(
                 EsExecutors.threadName(settings, "[timer]"),
                 ESTIMATED_TIME_INTERVAL_SETTING.get(settings).millis(),
@@ -351,11 +369,39 @@ public class ThreadPool implements ReportingService<ThreadPoolInfo>, Scheduler {
      */
     @Override
     public ScheduledCancellable schedule(Runnable command, TimeValue delay, String executor) {
-        command = threadContext.preserveContext(command);
+        final Runnable contextPreservingRunnable = threadContext.preserveContext(command);
+        final Runnable toSchedule;
         if (Names.SAME.equals(executor) == false) {
-            command = new ThreadedRunnable(command, executor(executor));
+            toSchedule = new ThreadedRunnable(contextPreservingRunnable, executor(executor));
+        } else if (slowSchedulerWarnThresholdNanos > 0) {
+            toSchedule = new Runnable() {
+                @Override
+                public void run() {
+                    final long startTime = ThreadPool.this.relativeTimeInNanos();
+                    try {
+                        contextPreservingRunnable.run();
+                    } finally {
+                        final long took = ThreadPool.this.relativeTimeInNanos() - startTime;
+                        if (took > slowSchedulerWarnThresholdNanos) {
+                            logger.warn(
+                                    "execution of [{}] took [{}ms] which is above the warn threshold of [{}ms]",
+                                    contextPreservingRunnable,
+                                    TimeUnit.NANOSECONDS.toMillis(took),
+                                    TimeUnit.NANOSECONDS.toMillis(slowSchedulerWarnThresholdNanos)
+                            );
+                        }
+                    }
+                }
+
+                @Override
+                public String toString() {
+                    return contextPreservingRunnable.toString();
+                }
+            };
+        } else {
+            toSchedule = contextPreservingRunnable;
         }
-        return new ScheduledCancellableAdapter(scheduler.schedule(command, delay.millis(), TimeUnit.MILLISECONDS));
+        return new ScheduledCancellableAdapter(scheduler.schedule(toSchedule, delay.millis(), TimeUnit.MILLISECONDS));
     }
 
     public void scheduleUnlessShuttingDown(TimeValue delay, String executor, Runnable command) {
@@ -539,7 +585,6 @@ public class ThreadPool implements ReportingService<ThreadPoolInfo>, Scheduler {
 
         final long interval;
         private final TimeChangeChecker timeChangeChecker;
-        private final long thresholdMillis;
 
         volatile boolean running = true;
         volatile long relativeNanos;
@@ -548,7 +593,6 @@ public class ThreadPool implements ReportingService<ThreadPoolInfo>, Scheduler {
         CachedTimeThread(String name, long intervalMillis, long thresholdMillis) {
             super(name);
             this.interval = intervalMillis;
-            this.thresholdMillis = thresholdMillis;
             this.relativeNanos = System.nanoTime();
             this.absoluteMillis = System.currentTimeMillis();
             this.timeChangeChecker = new TimeChangeChecker(thresholdMillis, absoluteMillis, relativeNanos);

--- a/server/src/test/java/org/elasticsearch/threadpool/ThreadPoolTests.java
+++ b/server/src/test/java/org/elasticsearch/threadpool/ThreadPoolTests.java
@@ -238,4 +238,42 @@ public class ThreadPoolTests extends ESTestCase {
             terminate(threadPool);
         }
     }
+
+    public void testSchedulerWarnLogging() throws Exception {
+        final ThreadPool threadPool = new TestThreadPool("test",
+                Settings.builder().put(ThreadPool.SLOW_SCHEDULER_TASK_WARN_THRESHOLD_SETTING.getKey(), "10ms").build());
+        final Logger logger = LogManager.getLogger(ThreadPool.class);
+        final MockLogAppender appender = new MockLogAppender();
+        appender.start();
+        try {
+            Loggers.addAppender(logger, appender);
+            appender.addExpectation(new MockLogAppender.SeenEventExpectation(
+                    "expected warning for slow task",
+                    ThreadPool.class.getName(),
+                    Level.WARN,
+                    "execution of [slow-test-task] took [*ms] which is above the warn threshold of [10ms]"));
+            final Runnable runnable = new Runnable() {
+                @Override
+                public void run() {
+                    final long start = threadPool.relativeTimeInMillis();
+                    try {
+                        assertBusy(() -> assertThat(threadPool.relativeTimeInMillis() - start, greaterThan(10L)));
+                    } catch (Exception e) {
+                        throw new AssertionError(e);
+                    }
+                }
+
+                @Override
+                public String toString() {
+                    return "slow-test-task";
+                }
+            };
+            threadPool.schedule(runnable, TimeValue.timeValueMillis(randomLongBetween(0, 300)), ThreadPool.Names.SAME);
+            assertBusy(appender::assertAllExpectationsMatched);
+        } finally {
+            Loggers.removeAppender(logger, appender);
+            appender.stop();
+            assertTrue(terminate(threadPool));
+        }
+    }
 }


### PR DESCRIPTION
Same as we did for transport and the cached time thread but for the
scheduler thread that shouldn't be blocked for any non-trivial
period of time either.

backport of #72606