### PR TITLE
Adjust SourceOnlySnapshotIT with DocumentMapper changes

### DIFF
--- a/x-pack/plugin/core/src/internalClusterTest/java/org/elasticsearch/snapshots/SourceOnlySnapshotIT.java
+++ b/x-pack/plugin/core/src/internalClusterTest/java/org/elasticsearch/snapshots/SourceOnlySnapshotIT.java
@@ -198,7 +198,7 @@ public class SourceOnlySnapshotIT extends AbstractSnapshotIntegTestCase {
                 "}}}}}", mapping.source().string());
         } else {
             assertEquals("{\"_doc\":{\"enabled\":false," +
-                "\"_meta\":{\"_doc\":{\"properties\":{\"field1\":{\"type\":\"text\"," +
+                "\"_meta\":{\"_doc\":{\"_meta\":{},\"properties\":{\"field1\":{\"type\":\"text\"," +
                 "\"fields\":{\"keyword\":{\"type\":\"keyword\",\"ignore_above\":256}}}" + nested + "}}}}}",
                 mapping.source().string());
         }


### PR DESCRIPTION
This test started to fail after #72616 got merged. In this last
change we made sure that indices with at least 1 empty doc also
has mappings.

Since source only repository stores the mappings in `_meta` at
restore time we need to adapt the test to not fail.

Build scan:
https://gradle-enterprise.elastic.co/s/2iuq7aznq3wea

Reproduce with:
```
./gradlew ':x-pack:plugin:core:internalClusterTest' --tests "org.elasticsearch.snapshots.SourceOnlySnapshotIT.testSnapshotAndRestore" -Dtests.seed=215FC999B123ED33 -Dtests.locale=is-IS -Dtests.timezone=Pacific/Rarotonga
```
