### PR TITLE
Check if HTTP Connection is Open in RestActionListener (#72688)

### DIFF
--- a/server/src/main/java/org/elasticsearch/rest/action/DispatchingRestToXContentListener.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/DispatchingRestToXContentListener.java
@@ -16,7 +16,6 @@ import org.elasticsearch.rest.BytesRestResponse;
 import org.elasticsearch.rest.RestChannel;
 import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.rest.RestResponse;
-import org.elasticsearch.tasks.TaskCancelledException;
 
 import java.util.concurrent.ExecutorService;
 
@@ -35,19 +34,12 @@ public class DispatchingRestToXContentListener<Response extends StatusToXContent
         this.restRequest = restRequest;
     }
 
-    private void ensureOpen() {
-        if (restRequest.getHttpChannel().isOpen() == false) {
-            throw new TaskCancelledException("response channel [" + restRequest.getHttpChannel() + "] closed");
-        }
-    }
-
     protected ToXContent.Params getParams() {
         return restRequest;
     }
 
     @Override
     protected void processResponse(Response response) {
-        ensureOpen();
         executor.execute(ActionRunnable.wrap(this, l -> new RestBuilderListener<Response>(channel) {
             @Override
             public RestResponse buildResponse(final Response response, final XContentBuilder builder) throws Exception {

--- a/server/src/main/java/org/elasticsearch/rest/action/RestActionListener.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/RestActionListener.java
@@ -13,6 +13,7 @@ import org.apache.logging.log4j.Logger;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.rest.BytesRestResponse;
 import org.elasticsearch.rest.RestChannel;
+import org.elasticsearch.tasks.TaskCancelledException;
 
 /**
  * An action listener that requires {@link #processResponse(Object)} to be implemented
@@ -22,7 +23,7 @@ public abstract class RestActionListener<Response> implements ActionListener<Res
 
     // we use static here so we won't have to pass the actual logger each time for a very rare case of logging
     // where the settings don't matter that much
-    private static Logger logger = LogManager.getLogger(RestResponseListener.class);
+    private static final Logger logger = LogManager.getLogger(RestResponseListener.class);
 
     protected final RestChannel channel;
 
@@ -33,6 +34,7 @@ public abstract class RestActionListener<Response> implements ActionListener<Res
     @Override
     public final void onResponse(Response response) {
         try {
+            ensureOpen();
             processResponse(response);
         } catch (Exception e) {
             onFailure(e);
@@ -40,6 +42,12 @@ public abstract class RestActionListener<Response> implements ActionListener<Res
     }
 
     protected abstract void processResponse(Response response) throws Exception;
+
+    protected void ensureOpen() {
+        if (channel.request().getHttpChannel().isOpen() == false) {
+            throw new TaskCancelledException("response channel [" + channel.request().getHttpChannel() + "] closed");
+        }
+    }
 
     @Override
     public final void onFailure(Exception e) {


### PR DESCRIPTION
Moving up the check from `DispatchingRestToXContentListener` as it never actually
makes sense to serialize a response once the channel has been closed already.


backport of #72688