### PR TITLE
Empty mapping to hold null meta (#72709)

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/mapper/Mapping.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/Mapping.java
@@ -23,7 +23,6 @@ import org.elasticsearch.index.mapper.MapperService.MergeReason;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.Map;
@@ -37,9 +36,7 @@ import static java.util.Collections.unmodifiableMap;
 public final class Mapping implements ToXContentFragment {
 
     public static final Mapping EMPTY = new Mapping(
-        new RootObjectMapper.Builder("_doc", Version.CURRENT).build(new ContentPath()),
-        new MetadataFieldMapper[0],
-        Collections.emptyMap());
+        new RootObjectMapper.Builder("_doc", Version.CURRENT).build(new ContentPath()), new MetadataFieldMapper[0], null);
 
     private final RootObjectMapper root;
     private final Map<String, Object> meta;

--- a/server/src/test/java/org/elasticsearch/index/mapper/DocumentMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/DocumentMapperTests.java
@@ -13,6 +13,7 @@ import org.apache.lucene.analysis.core.KeywordAnalyzer;
 import org.apache.lucene.analysis.core.WhitespaceAnalyzer;
 import org.apache.lucene.analysis.standard.StandardAnalyzer;
 import org.elasticsearch.Version;
+import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.compress.CompressedXContent;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.IndexSettings;
@@ -278,5 +279,18 @@ public class DocumentMapperTests extends MapperServiceTestCase {
             "field", "value",
             "object", org.elasticsearch.common.collect.Map.of("field1", "value1", "field2", "new_value", "field3", "value3"));
         assertThat(merged.getMeta(), equalTo(expected));
+    }
+
+    public void testEmptyDocumentMapper() {
+        MapperService mapperService = createMapperService(Version.CURRENT, Settings.EMPTY, () -> false);
+        String type = randomAlphaOfLengthBetween(3, 6);
+        DocumentMapper documentMapper = DocumentMapper.createEmpty(type, mapperService);
+        assertEquals("{\"" + type + "\":{}}", Strings.toString(documentMapper.mapping()));
+        assertTrue(documentMapper.mappers().hasMappings());
+        assertNotNull(documentMapper.idFieldMapper());
+        assertNotNull(documentMapper.sourceMapper());
+        assertNotNull(documentMapper.IndexFieldMapper());
+        assertEquals(10, documentMapper.mappers().getMapping().getMetadataMappersMap().size());
+        assertEquals(10, documentMapper.mappers().fieldTypes().size());
     }
 }

--- a/server/src/test/java/org/elasticsearch/index/mapper/MappingLookupTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/MappingLookupTests.java
@@ -14,6 +14,7 @@ import org.apache.lucene.analysis.Tokenizer;
 import org.apache.lucene.analysis.tokenattributes.CharTermAttribute;
 import org.elasticsearch.Version;
 import org.elasticsearch.common.Explicit;
+import org.elasticsearch.common.Strings;
 import org.elasticsearch.index.analysis.AnalyzerScope;
 import org.elasticsearch.index.analysis.NamedAnalyzer;
 import org.elasticsearch.index.query.SearchExecutionContext;
@@ -95,6 +96,16 @@ public class MappingLookupTests extends ESTestCase {
             () -> mappingLookup.indexAnalyzer("field3", f -> {
                 throw new IllegalArgumentException();
             }).tokenStream("field3", "blah"));
+    }
+
+    public void testEmptyMappingLookup() {
+        MappingLookup mappingLookup = MappingLookup.EMPTY;
+        assertEquals("{\"_doc\":{}}", Strings.toString(mappingLookup.getMapping()));
+        assertFalse(mappingLookup.hasMappings());
+        assertNull(mappingLookup.getMapping().getMeta());
+        assertEquals(0, mappingLookup.getMapping().getMetadataMappersMap().size());
+        assertFalse(mappingLookup.fieldMappers().iterator().hasNext());
+        assertEquals(0, mappingLookup.fieldTypes().size());
     }
 
     private void assertAnalyzes(Analyzer analyzer, String field, String output) throws IOException {

--- a/x-pack/plugin/core/src/internalClusterTest/java/org/elasticsearch/snapshots/SourceOnlySnapshotIT.java
+++ b/x-pack/plugin/core/src/internalClusterTest/java/org/elasticsearch/snapshots/SourceOnlySnapshotIT.java
@@ -99,7 +99,6 @@ public class SourceOnlySnapshotIT extends AbstractSnapshotIntegTestCase {
         }
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/pull/72695")
     public void testSnapshotAndRestore() throws Exception {
         final String sourceIdx = "test-idx";
         boolean requireRouting = randomBoolean();
@@ -130,7 +129,6 @@ public class SourceOnlySnapshotIT extends AbstractSnapshotIntegTestCase {
         assertHits(sourceIdx, builders.length, sourceHadDeletions);
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/pull/72695")
     public void testSnapshotAndRestoreWithNested() throws Exception {
         final String sourceIdx = "test-idx";
         boolean requireRouting = randomBoolean();
@@ -188,7 +186,7 @@ public class SourceOnlySnapshotIT extends AbstractSnapshotIntegTestCase {
         assertSuccessful(startFullSnapshot(repo, "snapshot-3"));
     }
 
-    private void assertMappings(String sourceIdx, boolean requireRouting, boolean useNested) {
+    private static void assertMappings(String sourceIdx, boolean requireRouting, boolean useNested) {
         GetMappingsResponse getMappingsResponse = client().admin().indices().prepareGetMappings(sourceIdx).get();
         ImmutableOpenMap<String, MappingMetadata> mapping = getMappingsResponse
             .getMappings().get(sourceIdx);


### PR DESCRIPTION
With #72616 we have changed the way that empty mappings are created for an index. Accidentally such mappings have been created with an empty meta map instead of null, which causes test failures in tests that compare mappings and are now finding an unexpected empty meta object which was not there before.

This commit fixes the empty mapping to not hold any meta, replacing the empty map with a null argument.