### PR TITLE
Clean up Node Shutdown metadata in test cleanup

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/test/rest/ESRestTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/ESRestTestCase.java
@@ -715,6 +715,10 @@ public abstract class ESRestTestCase extends ESTestCase {
      */
     @SuppressWarnings("unchecked")
     private static void deleteAllNodeShutdownMetadata() throws IOException {
+        final boolean NODE_SHUTDOWN_ENABLED = "true".equals(System.getProperty("es.shutdown_feature_flag_enabled"));
+        if (NODE_SHUTDOWN_ENABLED == false) {
+            return;
+        }
         Request getShutdownStatus = new Request("GET", "_nodes/shutdown");
         Map<String, Object> statusResponse = responseAsMap(client().performRequest(getShutdownStatus));
         if (statusResponse.get("nodes") instanceof List) { // for some reason `nodes` is parsed as a Map<> if it's empty

--- a/x-pack/plugin/shutdown/qa/multi-node/src/javaRestTest/java/org/elasticsearch/xpack/shutdown/NodeShutdownIT.java
+++ b/x-pack/plugin/shutdown/qa/multi-node/src/javaRestTest/java/org/elasticsearch/xpack/shutdown/NodeShutdownIT.java
@@ -65,7 +65,6 @@ public class NodeShutdownIT extends ESRestTestCase {
     /**
      * A very basic smoke test to make sure the allocation decider is working.
      */
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/72589")
     @SuppressWarnings("unchecked")
     public void testAllocationPreventedForRemoval() throws Exception {
         Request nodesRequest = new Request("GET", "_nodes");


### PR DESCRIPTION
This commit ensures that node shutdown metadata is cleaned up between
tests, as it causes unrelated tests to fail if a test leaves node
shutdown metadata in place.

Fixes https://github.com/elastic/elasticsearch/issues/72589