### PR TITLE
[7.13][DOCS] Clarify remote_cluster_client is required to run ML (#72569)

### DIFF
--- a/docs/reference/modules/node.asciidoc
+++ b/docs/reference/modules/node.asciidoc
@@ -364,6 +364,10 @@ xpack.ml.enabled: true <2>
 Otherwise, {ccs} fails when used in {ml} jobs or {dfeeds}. See <<remote-node>>.
 <2> The `xpack.ml.enabled` setting is enabled by default.
 
+NOTE: If you use {ccs} in your {anomaly-jobs}, the `remote_cluster_client` role 
+is also required on all master-eligible nodes. Otherwise, the {dfeed} cannot 
+start.
+
 [[transform-node]]
 ==== [xpack]#{transform-cap} node#
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/messages/Messages.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/messages/Messages.java
@@ -61,7 +61,7 @@ public final class Messages {
     public static final String DATAFEED_ID_ALREADY_TAKEN = "A datafeed with id [{0}] already exists";
     public static final String DATAFEED_NEEDS_REMOTE_CLUSTER_SEARCH = "Datafeed [{0}] is configured with a remote index pattern(s) {1}" +
         " but the current node [{2}] is not allowed to connect to remote clusters." +
-        " Please enable node.remote_cluster_client for all machine learning nodes.";
+        " Please enable node.remote_cluster_client for all machine learning nodes and master-eligible nodes.";
 
     public static final String DATA_FRAME_ANALYTICS_BAD_QUERY_FORMAT = "Data Frame Analytics config query is not parsable";
     public static final String DATA_FRAME_ANALYTICS_BAD_FIELD_FILTER = "No field [{0}] could be detected";


### PR DESCRIPTION
Backports https://github.com/elastic/elasticsearch/pull/72569