### PR TITLE
Add permissions for apm_user for datastreams

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStore.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStore.java
@@ -209,9 +209,15 @@ public class ReservedRolesStore implements BiConsumer<Set<String>, ActionListene
                             // APM Server under fleet (data streams)
                             RoleDescriptor.IndicesPrivileges.builder().indices("logs-apm.*")
                             .privileges("read", "view_index_metadata").build(),
+                            RoleDescriptor.IndicesPrivileges.builder().indices("logs-apm-*")
+                            .privileges("read", "view_index_metadata").build(),
                             RoleDescriptor.IndicesPrivileges.builder().indices("metrics-apm.*")
                             .privileges("read", "view_index_metadata").build(),
+                            RoleDescriptor.IndicesPrivileges.builder().indices("metrics-apm-*")
+                            .privileges("read", "view_index_metadata").build(),
                             RoleDescriptor.IndicesPrivileges.builder().indices("traces-apm.*")
+                            .privileges("read", "view_index_metadata").build(),
+                            RoleDescriptor.IndicesPrivileges.builder().indices("traces-apm-*")
                             .privileges("read", "view_index_metadata").build(),
 
                             // Machine Learning indices. Only needed for legacy reasons

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStoreTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStoreTests.java
@@ -1261,12 +1261,18 @@ public class ReservedRolesStoreTests extends ESTestCase {
         assertNoAccessAllowed(role, "foo");
         assertNoAccessAllowed(role, "foo-apm");
         assertNoAccessAllowed(role, "foo-logs-apm.bar");
+        assertNoAccessAllowed(role, "foo-logs-apm-bar");
         assertNoAccessAllowed(role, "foo-traces-apm.bar");
+        assertNoAccessAllowed(role, "foo-traces-apm-bar");
         assertNoAccessAllowed(role, "foo-metrics-apm.bar");
+        assertNoAccessAllowed(role, "foo-metrics-apm-bar");
 
         assertOnlyReadAllowed(role, "logs-apm." + randomIntBetween(0, 5));
+        assertOnlyReadAllowed(role, "logs-apm-" + randomIntBetween(0, 5));
         assertOnlyReadAllowed(role, "traces-apm." + randomIntBetween(0, 5));
+        assertOnlyReadAllowed(role, "traces-apm-" + randomIntBetween(0, 5));
         assertOnlyReadAllowed(role, "metrics-apm." + randomIntBetween(0, 5));
+        assertOnlyReadAllowed(role, "metrics-apm-" + randomIntBetween(0, 5));
         assertOnlyReadAllowed(role, "apm-" + randomIntBetween(0, 5));
         assertOnlyReadAllowed(role, AnomalyDetectorsIndexFields.RESULTS_INDEX_PREFIX + AnomalyDetectorsIndexFields.RESULTS_INDEX_DEFAULT);
 


### PR DESCRIPTION
As described in #72737 we would like to get this fix into `7.13`. @henningandersen could you please take a look if that's feasible? 

cc @elastic/apm-server @kobelb 