### PR TITLE
Rework RerunTestResultProcessor to handle aborted tests better (7.x backport)

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -87,6 +87,9 @@ repositories {
   gradlePluginPortal()
 }
 
+configurations {
+  integTestRuntimeOnly.extendsFrom(testRuntimeOnly)
+}
 dependencies {
 
   api localGroovy()
@@ -124,7 +127,7 @@ dependencies {
   integTestImplementation("org.junit.jupiter:junit-jupiter") {
     because 'allows to write and run Jupiter tests'
   }
-  integTestRuntimeOnly("org.junit.vintage:junit-vintage-engine") {
+  testRuntimeOnly("org.junit.vintage:junit-vintage-engine") {
     because 'allows JUnit 3 and JUnit 4 tests to run'
   }
 
@@ -132,11 +135,16 @@ dependencies {
     because 'allows tests to run from IDEs that bundle older version of launcher'
   }
 
+  testImplementation platform("org.spockframework:spock-bom:2.0-M5-groovy-3.0")
+  testImplementation("org.spockframework:spock-core") {
+    exclude module: "groovy"
+  }
   integTestImplementation platform("org.spockframework:spock-bom:2.0-M5-groovy-3.0")
   integTestImplementation("org.spockframework:spock-core") {
     exclude module: "groovy"
   }
-  integTestImplementation "org.spockframework:spock-junit4"  // you can remove this if your code does not rely on old JUnit 4 rules
+  // required as we rely on junit4 rules
+  integTestImplementation "org.spockframework:spock-junit4"
   integTestImplementation "org.xmlunit:xmlunit-core:2.8.2"
 }
 
@@ -212,9 +220,14 @@ if (project != rootProject) {
     }
   }
 
-  // Track reaper jar as a test input using runtime classpath normalization strategy
   tasks.withType(Test).configureEach {
+    // Track reaper jar as a test input using runtime classpath normalization strategy
     inputs.files(configurations.reaper).withNormalizer(ClasspathNormalizer)
+    useJUnitPlatform()
+  }
+
+  tasks.named("test").configure {
+    include("**/*TestSpec.class")
   }
 
   normalization {
@@ -240,8 +253,8 @@ if (project != rootProject) {
       Tests {
         baseClass 'org.elasticsearch.gradle.internal.test.GradleUnitTestCase'
       }
-      IT {
-        baseClass 'org.elasticsearch.gradle.internal.test.GradleIntegrationTestCase'
+      TestSpec {
+        baseClass 'spock.lang.Specification'
       }
     }
   }

--- a/buildSrc/src/integTest/groovy/org/elasticsearch/gradle/internal/test/rerun/InternalTestRerunPluginFuncTest.groovy
+++ b/buildSrc/src/integTest/groovy/org/elasticsearch/gradle/internal/test/rerun/InternalTestRerunPluginFuncTest.groovy
@@ -95,7 +95,6 @@ Test jvm system exit trace:""") == false
         
         """
         createTest("AnotherTest")
-        createFailedTest("AnotherTest1")
         createTest("AnotherTest2")
         createTest("AnotherTest3")
         createTest("AnotherTest4")
@@ -103,7 +102,6 @@ Test jvm system exit trace:""") == false
         createSystemExitTest("AnotherTest6")
         createTest("AnotherTest7")
         createTest("AnotherTest8")
-        createFailedTest("AnotherTest9")
         createTest("AnotherTest10")
         createTest("SimpleTest")
         createTest("SimpleTest2")
@@ -124,6 +122,47 @@ Test jvm exited unexpectedly.
 Test jvm system exit trace (run: 1)
 Gradle Test Executor 1 > AnotherTest6 > someTest
 ================""")
+    }
+
+    def "rerun build fails due to any test failure"() {
+        when:
+        buildFile.text = """
+        plugins {
+          id 'java'
+          id 'elasticsearch.internal-test-rerun'
+        }
+
+        repositories {
+            mavenCentral()
+        }
+        
+        dependencies {
+            testImplementation 'junit:junit:4.13.1'
+        }
+        
+        tasks.named("test").configure {
+            maxParallelForks = 5
+            testLogging {
+                events "started", "passed", "standard_out", "failed"
+                exceptionFormat "short"
+            }
+        }
+        
+        """
+        createSystemExitTest("AnotherTest6")
+        createFailedTest("SimpleTest1")
+        createFailedTest("SimpleTest2")
+        createFailedTest("SimpleTest3")
+        createFailedTest("SimpleTest4")
+        createFailedTest("SimpleTest5")
+        createFailedTest("SimpleTest6")
+        createFailedTest("SimpleTest7")
+        createFailedTest("SimpleTest8")
+        createFailedTest("SimpleTest9")
+        then:
+        def result = gradleRunner("test").buildAndFail()
+        result.output.contains("AnotherTest6 total executions: 2")
+        result.output.contains("> There were failing tests. See the report at:")
     }
 
     def "reruns tests till max rerun count is reached"() {
@@ -179,6 +218,9 @@ Gradle Test Executor 1 > AnotherTest6 > someTest
 
             ${fail ? """
                     if(count <= ${timesFailing}) {
+                        try {
+                            Thread.sleep(2000);
+                        } catch(Exception e) {}
                         Assert.fail();
                     }
                     """ : ''

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/internal/test/rerun/executer/RerunTestResultProcessor.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/internal/test/rerun/executer/RerunTestResultProcessor.java
@@ -38,13 +38,15 @@ final class RerunTestResultProcessor implements TestResultProcessor {
 
     @Override
     public void started(TestDescriptorInternal descriptor, TestStartEvent testStartEvent) {
+        activeDescriptorsById.put(descriptor.getId(), descriptor);
         if (rootTestDescriptorId == null) {
             rootTestDescriptorId = descriptor.getId();
-            activeDescriptorsById.put(descriptor.getId(), descriptor);
             delegate.started(descriptor, testStartEvent);
         } else if (descriptor.getId().equals(rootTestDescriptorId) == false) {
-            activeDescriptorsById.put(descriptor.getId(), descriptor);
-            delegate.started(descriptor, testStartEvent);
+            boolean active = activeDescriptorsById.containsKey(testStartEvent.getParentId());
+            if (active) {
+                delegate.started(descriptor, testStartEvent);
+            }
         }
     }
 
@@ -73,6 +75,7 @@ final class RerunTestResultProcessor implements TestResultProcessor {
     @Override
     public void failure(Object testId, Throwable throwable) {
         if (activeDescriptorsById.containsKey(testId)) {
+            activeDescriptorsById.remove(testId);
             delegate.failure(testId, throwable);
         }
     }

--- a/buildSrc/src/test/groovy/org/elasticsearch/gradle/internal/test/rerun/executer/RerunTestResultProcessorTestSpec.groovy
+++ b/buildSrc/src/test/groovy/org/elasticsearch/gradle/internal/test/rerun/executer/RerunTestResultProcessorTestSpec.groovy
@@ -1,0 +1,141 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.gradle.internal.test.rerun.executer
+
+import org.gradle.api.internal.tasks.testing.TestCompleteEvent
+import org.gradle.api.internal.tasks.testing.TestDescriptorInternal
+import org.gradle.api.internal.tasks.testing.TestResultProcessor
+import org.gradle.api.internal.tasks.testing.TestStartEvent
+import org.gradle.api.tasks.testing.TestOutputEvent
+import spock.lang.Specification
+
+class RerunTestResultProcessorTestSpec extends Specification {
+
+    def "delegates test events"() {
+        given:
+        def delegate = Mock(TestResultProcessor)
+        def processor = new RerunTestResultProcessor(delegate);
+        def testDesciptorInternal = Mock(TestDescriptorInternal);
+        def testId = "TestId"
+        _ * testDesciptorInternal.getId() >> testId
+
+        def testStartEvent = Mock(TestStartEvent)
+        def testOutputEvent = Mock(TestOutputEvent)
+        def testCompleteEvent = Mock(TestCompleteEvent)
+
+        when:
+        processor.started(testDesciptorInternal, testStartEvent)
+        then:
+        1 * delegate.started(testDesciptorInternal, testStartEvent)
+
+        when:
+        processor.output(testId, testOutputEvent)
+        then:
+        1 * delegate.output(testId, testOutputEvent)
+
+        when:
+        processor.completed(testId, testCompleteEvent)
+        then:
+        1 * delegate.completed(testId, testCompleteEvent)
+    }
+
+    def "ignores retriggered root test events"() {
+        given:
+        def delegate = Mock(TestResultProcessor)
+        def processor = new RerunTestResultProcessor(delegate);
+        def rootDescriptor = descriptor("rootId")
+        def testStartEvent = Mock(TestStartEvent)
+
+        when:
+        processor.started(rootDescriptor, testStartEvent)
+        processor.started(rootDescriptor, testStartEvent)
+        then:
+        1 * delegate.started(rootDescriptor, testStartEvent)
+        _ * delegate.started(_, _)
+    }
+
+    def "ignores root complete event when tests not finished"() {
+        given:
+        def delegate = Mock(TestResultProcessor)
+        def processor = new RerunTestResultProcessor(delegate);
+
+        def rootDescriptor = descriptor("rootId")
+        def rootTestStartEvent = startEvent("rootId")
+        def rootCompleteEvent = Mock(TestCompleteEvent)
+
+        def testDescriptor1 = descriptor("testId1")
+        def testStartEvent1 = startEvent("testId1")
+        def testCompleteEvent1 = Mock(TestCompleteEvent)
+
+        def testDescriptor2 = descriptor("testId2")
+        def testStartEvent2 = startEvent("testId2")
+        def testError2 = Mock(Throwable)
+
+        when:
+        processor.started(rootDescriptor, rootTestStartEvent)
+        processor.started(testDescriptor1, testStartEvent1)
+        processor.started(testDescriptor2, testStartEvent2)
+        processor.failure("testId2", testError2)
+        processor.completed("rootId", rootCompleteEvent)
+
+        then:
+        1 * delegate.started(rootDescriptor, rootTestStartEvent)
+        1 * delegate.started(testDescriptor1, testStartEvent1)
+        1 * delegate.started(testDescriptor2, testStartEvent2)
+        1 * delegate.failure("testId2", testError2)
+        0 * delegate.completed("rootId", rootCompleteEvent)
+
+        when:
+        processor.completed("testId1", testCompleteEvent1)
+        processor.completed("rootId", rootCompleteEvent)
+
+        then:
+        1 * delegate.completed("testId1", testCompleteEvent1)
+        1 * delegate.completed("rootId", rootCompleteEvent)
+    }
+
+    def "events for aborted tests are ignored"() {
+        given:
+        def delegate = Mock(TestResultProcessor)
+        def processor = new RerunTestResultProcessor(delegate);
+        def rootDescriptor = descriptor("rootId")
+        def rootTestStartEvent = startEvent("rootId")
+
+        def testDescriptor = descriptor("testId")
+        def testStartEvent = startEvent("testId")
+        def testCompleteEvent = Mock(TestCompleteEvent)
+
+        processor.started(rootDescriptor, rootTestStartEvent)
+        processor.started(testDescriptor, testStartEvent)
+
+        when:
+        processor.reset()
+        processor.completed("testId", testCompleteEvent)
+        then:
+        0 * delegate.completed("testId", testCompleteEvent)
+    }
+
+    TestDescriptorInternal descriptor(String id) {
+        def desc = Mock(TestDescriptorInternal)
+        _ * desc.getId() >> id
+        desc
+    }
+
+    TestStartEvent startEvent(String parentId) {
+        def event = Mock(TestStartEvent)
+        _ * event.getParentId() >> parentId
+        event
+    }
+
+//    TestFinishEvent finishEvent(String parentId) {
+//        def event = Mock(TestFinishEvent)
+//        _ * event.getParentId() >> parentId
+//        event
+//    }
+}


### PR DESCRIPTION
backports #72710 to 7.x branch