### PR TITLE
[Transform] fix 2 issues with index sort in integration test

### DIFF
--- a/x-pack/plugin/transform/qa/multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/continuous/TransformContinuousIT.java
+++ b/x-pack/plugin/transform/qa/multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/continuous/TransformContinuousIT.java
@@ -304,6 +304,8 @@ public class TransformContinuousIT extends ESRestTestCase {
      * index sorting, triggers query optimizations.
      */
     private void putIndex(String indexName, String dateType, boolean isDataStream) throws IOException {
+        List<String> sortedFields = Collections.emptyList();
+
         // create mapping and settings
         try (XContentBuilder builder = jsonBuilder()) {
             builder.startObject();
@@ -314,7 +316,7 @@ public class TransformContinuousIT extends ESRestTestCase {
                     builder.field("codec", "best_compression");
                 }
                 if (randomBoolean()) {
-                    List<String> sortedFields = new ArrayList<>(
+                    sortedFields = new ArrayList<>(
                         // note: no index sort for geo_point
                         randomUnique(() -> randomFrom("event", "metric", "run", "timestamp"), randomIntBetween(1, 3))
                     );
@@ -338,11 +340,15 @@ public class TransformContinuousIT extends ESRestTestCase {
                 }
                 builder.endObject();
 
+                final String metricType = sortedFields.contains("metric")
+                    ? randomFrom("integer", "long")
+                    : randomFrom("integer", "long", "unsigned_long");
+
                 builder.startObject("event")
                     .field("type", "keyword")
                     .endObject()
                     .startObject("metric")
-                    .field("type", randomFrom("integer", "long", "unsigned_long"))
+                    .field("type", metricType)
                     .endObject()
                     .startObject("location")
                     .field("type", "geo_point")
@@ -399,8 +405,8 @@ public class TransformContinuousIT extends ESRestTestCase {
                     .endObject()
                     .endObject();
 
-                // random overlay of existing field
-                if (randomBoolean()) {
+                // random overlay of existing field, only if its not part of sorted fields
+                if (sortedFields.contains("metric") == false && randomBoolean()) {
                     if (randomBoolean()) {
                         builder.startObject("metric").field("type", "long").endObject();
                     } else {

--- a/x-pack/plugin/transform/qa/multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/continuous/TransformContinuousIT.java
+++ b/x-pack/plugin/transform/qa/multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/continuous/TransformContinuousIT.java
@@ -339,6 +339,7 @@ public class TransformContinuousIT extends ESRestTestCase {
                 }
                 builder.endObject();
 
+                // gh#72741 : index sort does not support unsigned_long
                 final String metricType = sortedFields.contains("metric")
                     ? randomFrom("integer", "long")
                     : randomFrom("integer", "long", "unsigned_long");

--- a/x-pack/plugin/transform/qa/multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/continuous/TransformContinuousIT.java
+++ b/x-pack/plugin/transform/qa/multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/continuous/TransformContinuousIT.java
@@ -155,7 +155,6 @@ public class TransformContinuousIT extends ESRestTestCase {
         deletePipeline(ContinuousTestCase.INGEST_PIPELINE);
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/72733")
     public void testContinousEvents() throws Exception {
         String sourceIndexName = ContinuousTestCase.CONTINUOUS_EVENTS_SOURCE_INDEX;
         DecimalFormat numberFormat = new DecimalFormat("000", new DecimalFormatSymbols(Locale.ROOT));


### PR DESCRIPTION
fix 2 corner cases in test setup: unsigned_long not support as index sort,do not overlay a runtime field with index sort

fixes #72733
relates #72692

Note: This builds on top of #72692, therefore setting `backport_pending`