### PR TITLE
[ML] Add new ml_standard tokenizer for ML categorization

### DIFF
--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MachineLearning.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MachineLearning.java
@@ -267,6 +267,8 @@ import org.elasticsearch.xpack.ml.job.JobManagerHolder;
 import org.elasticsearch.xpack.ml.job.UpdateJobProcessNotifier;
 import org.elasticsearch.xpack.ml.job.categorization.MlClassicTokenizer;
 import org.elasticsearch.xpack.ml.job.categorization.MlClassicTokenizerFactory;
+import org.elasticsearch.xpack.ml.job.categorization.MlStandardTokenizer;
+import org.elasticsearch.xpack.ml.job.categorization.MlStandardTokenizerFactory;
 import org.elasticsearch.xpack.ml.job.persistence.JobConfigProvider;
 import org.elasticsearch.xpack.ml.job.persistence.JobDataCountsPersister;
 import org.elasticsearch.xpack.ml.job.persistence.JobResultsPersister;
@@ -1078,7 +1080,8 @@ public class MachineLearning extends Plugin implements SystemIndexPlugin,
 
     @Override
     public Map<String, AnalysisProvider<TokenizerFactory>> getTokenizers() {
-        return Collections.singletonMap(MlClassicTokenizer.NAME, MlClassicTokenizerFactory::new);
+        return Map.of(MlClassicTokenizer.NAME, MlClassicTokenizerFactory::new,
+            MlStandardTokenizer.NAME, MlStandardTokenizerFactory::new);
     }
 
     @Override

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/categorization/AbstractMlTokenizer.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/categorization/AbstractMlTokenizer.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.ml.job.categorization;
+
+import org.apache.lucene.analysis.Tokenizer;
+import org.apache.lucene.analysis.tokenattributes.CharTermAttribute;
+import org.apache.lucene.analysis.tokenattributes.OffsetAttribute;
+import org.apache.lucene.analysis.tokenattributes.PositionIncrementAttribute;
+
+import java.io.IOException;
+
+public abstract class AbstractMlTokenizer extends Tokenizer {
+
+    protected final CharTermAttribute termAtt = addAttribute(CharTermAttribute.class);
+    protected final OffsetAttribute offsetAtt = addAttribute(OffsetAttribute.class);
+    protected final PositionIncrementAttribute posIncrAtt = addAttribute(PositionIncrementAttribute.class);
+
+    protected int nextOffset;
+    protected int skippedPositions;
+
+    AbstractMlTokenizer() {
+    }
+
+    @Override
+    public final void end() throws IOException {
+        super.end();
+        // Set final offset
+        int finalOffset = nextOffset + (int) input.skip(Integer.MAX_VALUE);
+        offsetAtt.setOffset(finalOffset, finalOffset);
+        // Adjust any skipped tokens
+        posIncrAtt.setPositionIncrement(posIncrAtt.getPositionIncrement() + skippedPositions);
+    }
+
+    @Override
+    public void reset() throws IOException {
+        super.reset();
+        nextOffset = 0;
+        skippedPositions = 0;
+    }
+}

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/categorization/MlClassicTokenizer.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/categorization/MlClassicTokenizer.java
@@ -6,11 +6,6 @@
  */
 package org.elasticsearch.xpack.ml.job.categorization;
 
-import org.apache.lucene.analysis.Tokenizer;
-import org.apache.lucene.analysis.tokenattributes.CharTermAttribute;
-import org.apache.lucene.analysis.tokenattributes.OffsetAttribute;
-import org.apache.lucene.analysis.tokenattributes.PositionIncrementAttribute;
-
 import java.io.IOException;
 
 
@@ -19,22 +14,15 @@ import java.io.IOException;
  *
  * In common with the original ML C++ code, there are no configuration options.
  */
-public class MlClassicTokenizer extends Tokenizer {
+public class MlClassicTokenizer extends AbstractMlTokenizer {
 
     public static String NAME = "ml_classic";
-
-    private final CharTermAttribute termAtt = addAttribute(CharTermAttribute.class);
-    private final OffsetAttribute offsetAtt = addAttribute(OffsetAttribute.class);
-    private final PositionIncrementAttribute posIncrAtt = addAttribute(PositionIncrementAttribute.class);
-
-    private int nextOffset;
-    private int skippedPositions;
 
     MlClassicTokenizer() {
     }
 
     /**
-     * Basically tokenise into [a-zA-Z0-9]+ strings, but also allowing underscores, dots and dashes in the middle.
+     * Basically tokenize into [a-zA-Z0-9]+ strings, but also allowing underscores, dots and dashes in the middle.
      * Then discard tokens that are hex numbers or begin with a digit.
      */
     @Override
@@ -100,22 +88,5 @@ public class MlClassicTokenizer extends Tokenizer {
         posIncrAtt.setPositionIncrement(skippedPositions + 1);
 
         return true;
-    }
-
-    @Override
-    public final void end() throws IOException {
-        super.end();
-        // Set final offset
-        int finalOffset = nextOffset + (int) input.skip(Integer.MAX_VALUE);
-        offsetAtt.setOffset(finalOffset, finalOffset);
-        // Adjust any skipped tokens
-        posIncrAtt.setPositionIncrement(posIncrAtt.getPositionIncrement() + skippedPositions);
-    }
-
-    @Override
-    public void reset() throws IOException {
-        super.reset();
-        nextOffset = 0;
-        skippedPositions = 0;
     }
 }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/categorization/MlStandardTokenizer.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/categorization/MlStandardTokenizer.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.ml.job.categorization;
+
+import java.io.IOException;
+import java.io.Reader;
+
+/**
+ * The new standard ML categorization tokenizer. This differs from the "classic"
+ * ML tokenizer in that it treats URLs and paths as a single token.
+ *
+ * In common with the original ML C++ code, there are no configuration options.
+ */
+public class MlStandardTokenizer extends AbstractMlTokenizer {
+
+    public static String NAME = "ml_standard";
+
+    private int putBackChar = -1;
+
+    MlStandardTokenizer() {
+    }
+
+    /**
+     * Basically tokenize into [a-zA-Z0-9]+ strings, but also allowing forward slashes, and underscores, dots and dashes in the middle.
+     * Additionally, one colon is allowed, providing only characters come before it and it's followed by a slash, and forward slashes
+     * are allowed if we've previously seen a colon.  These rules are designed to keep URLs plus Unix and Windows paths as single tokens.
+     * Windows paths may use a drive letter, e.g. C:\whatever, or may be UNC, e.g. \\myserver\folder.
+     * We discard tokens that are hex numbers or begin with a digit.
+     */
+    @Override
+    public final boolean incrementToken() throws IOException {
+        clearAttributes();
+        skippedPositions = 0;
+
+        int start = -1;
+        int length = 0;
+
+        boolean haveNonHex = false;
+        int lettersBeforeColon = 0;
+        boolean haveColon = false;
+        int firstBackslashPos = -1;
+        int firstForwardSlashPos = -1;
+        int slashCount = 0;
+        int curChar;
+        while ((curChar = getNextChar()) >= 0) {
+            ++nextOffset;
+            if (Character.isLetterOrDigit(curChar)
+                || (length > 0 && (curChar == '_' || curChar == '.' || curChar == '-' || (curChar == ':' && lettersBeforeColon == length)))
+                || curChar == '/'
+                || (curChar == '\\' && (length == 0 || (haveColon && lettersBeforeColon == 1) || firstBackslashPos == 0))) {
+                if (length == 0) {
+                    // We're at the first character of a candidate token, so record the offset
+                    start = nextOffset - 1;
+                }
+                termAtt.append((char) curChar);
+                ++length;
+
+                // Tracking related to colons and slashes
+                if (curChar == ':') {
+                    haveColon = true;
+                } else if (curChar == '/') {
+                    ++slashCount;
+                    if (firstForwardSlashPos == -1) {
+                        firstForwardSlashPos = length - 1;
+                    }
+                } else if (curChar == '\\') {
+                    ++slashCount;
+                    if (firstBackslashPos == -1) {
+                        firstBackslashPos = length - 1;
+                    }
+                } else {
+                    if (haveColon) {
+                        if (firstBackslashPos != lettersBeforeColon + 1 && firstForwardSlashPos != lettersBeforeColon + 1) {
+                            // If our token contains a colon but not followed by a slash, drop the colon and everything after it
+                            assert length - lettersBeforeColon == 2;
+                            length -= 2;
+                            putBackChar = curChar;
+                            --nextOffset;
+                            break;
+                        }
+                    } else if (Character.isLetter(curChar)) {
+                        ++lettersBeforeColon;
+                    }
+                }
+
+                // We don't return tokens that are hex numbers, and it's most efficient to keep a running note of this
+                haveNonHex = haveNonHex ||
+                    // Count dots, dashes and colons as numeric
+                    (Character.digit(curChar, 16) == -1 && curChar != '.' && curChar != '-' && curChar != ':');
+            } else if (length > 0) {
+                // If we get here, we've found a separator character having built up a candidate token
+
+                if (haveNonHex && Character.isDigit(termAtt.charAt(0)) == false && length > slashCount) {
+                    // The candidate token is valid to return
+                    break;
+                }
+
+                // The candidate token is not valid to return, i.e. it's hex, begins with a digit or all slashes,
+                // so wipe it and carry on searching
+                ++skippedPositions;
+                start = -1;
+                length = 0;
+                termAtt.setEmpty();
+
+                haveNonHex = false;
+                lettersBeforeColon = 0;
+                haveColon = false;
+                firstBackslashPos = -1;
+                firstForwardSlashPos = -1;
+                slashCount = 0;
+            }
+        }
+
+        // We need to recheck whether we've got a valid token after the loop because
+        // the loop can also be exited on reaching the end of the stream
+        if (length == 0) {
+            return false;
+        }
+
+        if (haveNonHex == false || Character.isDigit(termAtt.charAt(0)) || length == slashCount) {
+            ++skippedPositions;
+            return false;
+        }
+
+        // Strip dots, dashes, underscores and colons at the end of the token
+        char toCheck;
+        while ((toCheck = termAtt.charAt(length - 1)) == '_' || toCheck == '.' || toCheck == '-' || toCheck == ':') {
+            --length;
+        }
+
+        // Characters that may exist in the term attribute beyond its defined length are ignored
+        termAtt.setLength(length);
+        offsetAtt.setOffset(start, start + length);
+        posIncrAtt.setPositionIncrement(skippedPositions + 1);
+
+        return true;
+    }
+
+    /**
+     * Augments a {@link Reader} with a single character putback facility.
+     * This means that the putback facility is available regardless of
+     * whether {@link Reader#mark} is implemented.
+     */
+    private int getNextChar() throws IOException {
+        int nextChar;
+        if (putBackChar >= 0) {
+            nextChar = putBackChar;
+            putBackChar = -1;
+        } else {
+            nextChar = input.read();
+        }
+        return nextChar;
+    }
+}

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/categorization/MlStandardTokenizerFactory.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/categorization/MlStandardTokenizerFactory.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.ml.job.categorization;
+
+import org.apache.lucene.analysis.Tokenizer;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.env.Environment;
+import org.elasticsearch.index.IndexSettings;
+import org.elasticsearch.index.analysis.AbstractTokenizerFactory;
+
+/**
+ * Factory for the standard ML categorization tokenizer.
+ *
+ * This differs from the "classic" ML tokenizer in that it treats URLs and paths as a single token.
+ *
+ * In common with the original ML C++ code, there are no configuration options.
+ */
+public class MlStandardTokenizerFactory extends AbstractTokenizerFactory {
+
+    public MlStandardTokenizerFactory(IndexSettings indexSettings, Environment environment, String name, Settings settings) {
+        super(indexSettings, settings, name);
+    }
+
+    @Override
+    public Tokenizer create() {
+        return new MlStandardTokenizer();
+    }
+}

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/categorization/MlStandardTokenizerTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/categorization/MlStandardTokenizerTests.java
@@ -1,0 +1,200 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.ml.job.categorization;
+
+import org.apache.lucene.analysis.Tokenizer;
+import org.apache.lucene.analysis.tokenattributes.CharTermAttribute;
+import org.apache.lucene.analysis.tokenattributes.OffsetAttribute;
+import org.elasticsearch.test.ESTestCase;
+
+import java.io.IOException;
+import java.io.StringReader;
+
+public class MlStandardTokenizerTests extends ESTestCase {
+
+    public void testTokenizeNoPaths() throws IOException {
+        String testData = "one .-_two **stars**in**their**eyes** three.-_ sand.-_wich 4four five5 a1b2c3 42 www.elastic.co";
+        try (Tokenizer tokenizer = new MlStandardTokenizer()) {
+            tokenizer.setReader(new StringReader(testData));
+            tokenizer.reset();
+            CharTermAttribute term = tokenizer.addAttribute(CharTermAttribute.class);
+            OffsetAttribute offset = tokenizer.addAttribute(OffsetAttribute.class);
+            assertTrue(tokenizer.incrementToken());
+            assertEquals("one", term.toString());
+            assertEquals(0, offset.startOffset());
+            assertTrue(tokenizer.incrementToken());
+            assertEquals("two", term.toString());
+            assertEquals(7, offset.startOffset());
+            assertTrue(tokenizer.incrementToken());
+            assertEquals("stars", term.toString());
+            assertEquals(13, offset.startOffset());
+            assertTrue(tokenizer.incrementToken());
+            assertEquals("in", term.toString());
+            assertEquals(20, offset.startOffset());
+            assertTrue(tokenizer.incrementToken());
+            assertEquals("their", term.toString());
+            assertEquals(24, offset.startOffset());
+            assertTrue(tokenizer.incrementToken());
+            assertEquals("eyes", term.toString());
+            assertEquals(31, offset.startOffset());
+            assertTrue(tokenizer.incrementToken());
+            assertEquals("three", term.toString());
+            assertEquals(38, offset.startOffset());
+            assertTrue(tokenizer.incrementToken());
+            assertEquals("sand.-_wich", term.toString());
+            assertEquals(47, offset.startOffset());
+            assertTrue(tokenizer.incrementToken());
+            assertEquals("five5", term.toString());
+            assertEquals(65, offset.startOffset());
+            assertTrue(tokenizer.incrementToken());
+            assertEquals("www.elastic.co", term.toString());
+            assertEquals(81, offset.startOffset());
+            assertFalse(tokenizer.incrementToken());
+            tokenizer.end();
+            assertEquals(testData.length(), offset.endOffset());
+        }
+    }
+
+    public void testTokenizeWithUnixPath() throws IOException {
+        String testData = "Apr 27 21:04:05 Davids-MacBook-Pro com.apple.xpc.launchd[1] (com.apple.xpc.launchd.domain.pid.mdmclient.320): "
+            + "Failed to bootstrap path: path = /usr/libexec/mdmclient, error = 108: Invalid path\n";
+        try (Tokenizer tokenizer = new MlStandardTokenizer()) {
+            tokenizer.setReader(new StringReader(testData));
+            tokenizer.reset();
+            CharTermAttribute term = tokenizer.addAttribute(CharTermAttribute.class);
+            OffsetAttribute offset = tokenizer.addAttribute(OffsetAttribute.class);
+            assertTrue(tokenizer.incrementToken());
+            assertEquals("Apr", term.toString());
+            assertEquals(0, offset.startOffset());
+            assertTrue(tokenizer.incrementToken());
+            assertEquals("Davids-MacBook-Pro", term.toString());
+            assertEquals(16, offset.startOffset());
+            assertTrue(tokenizer.incrementToken());
+            assertEquals("com.apple.xpc.launchd", term.toString());
+            assertEquals(35, offset.startOffset());
+            assertTrue(tokenizer.incrementToken());
+            assertEquals("com.apple.xpc.launchd.domain.pid.mdmclient.320", term.toString());
+            assertEquals(61, offset.startOffset());
+            assertTrue(tokenizer.incrementToken());
+            assertEquals("Failed", term.toString());
+            assertEquals(110, offset.startOffset());
+            assertTrue(tokenizer.incrementToken());
+            assertEquals("to", term.toString());
+            assertEquals(117, offset.startOffset());
+            assertTrue(tokenizer.incrementToken());
+            assertEquals("bootstrap", term.toString());
+            assertEquals(120, offset.startOffset());
+            assertTrue(tokenizer.incrementToken());
+            assertEquals("path", term.toString());
+            assertEquals(130, offset.startOffset());
+            assertTrue(tokenizer.incrementToken());
+            assertEquals("path", term.toString());
+            assertEquals(136, offset.startOffset());
+            assertTrue(tokenizer.incrementToken());
+            assertEquals("/usr/libexec/mdmclient", term.toString());
+            assertEquals(143, offset.startOffset());
+            assertTrue(tokenizer.incrementToken());
+            assertEquals("error", term.toString());
+            assertEquals(167, offset.startOffset());
+            assertTrue(tokenizer.incrementToken());
+            assertEquals("Invalid", term.toString());
+            assertEquals(180, offset.startOffset());
+            assertTrue(tokenizer.incrementToken());
+            assertEquals("path", term.toString());
+            assertEquals(188, offset.startOffset());
+            assertFalse(tokenizer.incrementToken());
+            tokenizer.end();
+            assertEquals(testData.length(), offset.endOffset());
+        }
+    }
+
+    public void testTokenizeWithWindowsPaths() throws IOException {
+        String testData = "05/05/2021 C:\\Windows\\System something:else \\\\myserver\\share\\folder \\ at_end\\ \\no\\drive\\specified "
+            + "at_end_with_colon:\\";
+        try (Tokenizer tokenizer = new MlStandardTokenizer()) {
+            tokenizer.setReader(new StringReader(testData));
+            tokenizer.reset();
+            CharTermAttribute term = tokenizer.addAttribute(CharTermAttribute.class);
+            OffsetAttribute offset = tokenizer.addAttribute(OffsetAttribute.class);
+            assertTrue(tokenizer.incrementToken());
+            assertEquals("C:\\Windows\\System", term.toString());
+            assertEquals(11, offset.startOffset());
+            assertTrue(tokenizer.incrementToken());
+            assertEquals("something", term.toString());
+            assertEquals(29, offset.startOffset());
+            assertTrue(tokenizer.incrementToken());
+            assertEquals("else", term.toString());
+            assertEquals(39, offset.startOffset());
+            assertTrue(tokenizer.incrementToken());
+            assertEquals("\\\\myserver\\share\\folder", term.toString());
+            assertEquals(44, offset.startOffset());
+            assertTrue(tokenizer.incrementToken());
+            assertEquals("at_end", term.toString());
+            assertEquals(70, offset.startOffset());
+            assertTrue(tokenizer.incrementToken());
+            assertEquals("\\no\\drive\\specified", term.toString());
+            assertEquals(78, offset.startOffset());
+            assertTrue(tokenizer.incrementToken());
+            assertEquals("at_end_with_colon", term.toString());
+            assertEquals(98, offset.startOffset());
+            assertFalse(tokenizer.incrementToken());
+            tokenizer.end();
+            assertEquals(testData.length(), offset.endOffset());
+        }
+    }
+
+    public void testTokenizeWithUrl() throws IOException {
+        String testData = "10.8.0.12 - - [29/Nov/2020:21:34:55 +0000] \"POST /intake/v2/events HTTP/1.1\" 202 0 \"-\" "
+            + "\"elasticapm-dotnet/1.5.1 System.Net.Http/4.6.28208.02 .NET_Core/2.2.8\" 27821 0.002 [default-apm-apm-server-8200] "
+            + "[] 10.8.1.19:8200 0 0.001 202 f961c776ff732f5c8337530aa22c7216\n";
+        try (Tokenizer tokenizer = new MlStandardTokenizer()) {
+            tokenizer.setReader(new StringReader(testData));
+            tokenizer.reset();
+            CharTermAttribute term = tokenizer.addAttribute(CharTermAttribute.class);
+            OffsetAttribute offset = tokenizer.addAttribute(OffsetAttribute.class);
+            assertTrue(tokenizer.incrementToken());
+            assertEquals("POST", term.toString());
+            assertEquals(44, offset.startOffset());
+            assertTrue(tokenizer.incrementToken());
+            assertEquals("/intake/v2/events", term.toString());
+            assertEquals(49, offset.startOffset());
+            assertTrue(tokenizer.incrementToken());
+            assertEquals("HTTP/1.1", term.toString());
+            assertEquals(67, offset.startOffset());
+            assertTrue(tokenizer.incrementToken());
+            assertEquals("elasticapm-dotnet/1.5.1", term.toString());
+            assertEquals(88, offset.startOffset());
+            assertTrue(tokenizer.incrementToken());
+            assertEquals("System.Net.Http/4.6.28208.02", term.toString());
+            assertEquals(112, offset.startOffset());
+            assertTrue(tokenizer.incrementToken());
+            assertEquals("NET_Core/2.2.8", term.toString());
+            assertEquals(142, offset.startOffset());
+            assertTrue(tokenizer.incrementToken());
+            assertEquals("default-apm-apm-server-8200", term.toString());
+            assertEquals(171, offset.startOffset());
+            assertFalse(tokenizer.incrementToken());
+            tokenizer.end();
+            assertEquals(testData.length(), offset.endOffset());
+        }
+    }
+
+    public void testTokenize_emptyString() throws IOException {
+        String testData = "";
+        try (Tokenizer tokenizer = new MlStandardTokenizer()) {
+            tokenizer.setReader(new StringReader(testData));
+            tokenizer.reset();
+            CharTermAttribute term = tokenizer.addAttribute(CharTermAttribute.class);
+            OffsetAttribute offset = tokenizer.addAttribute(OffsetAttribute.class);
+            assertFalse(tokenizer.incrementToken());
+            assertEquals("", term.toString());
+            tokenizer.end();
+            assertEquals(testData.length(), offset.endOffset());
+        }
+    }
+}


### PR DESCRIPTION
This new tokenizer, ml_standard, is very similar to the original
ml_classic tokenizer.

The difference is that ml_standard aims to parse URLs and
filesystem paths as single tokens instead of splitting them at
the slashes.