### PR TITLE
Fix up-to-date check for build tool IT tests

### DIFF
--- a/buildSrc/src/integTest/java/org/elasticsearch/gradle/ReaperPluginIT.java
+++ b/buildSrc/src/integTest/java/org/elasticsearch/gradle/ReaperPluginIT.java
@@ -9,20 +9,17 @@ package org.elasticsearch.gradle;
 
 import org.elasticsearch.gradle.internal.test.GradleIntegrationTestCase;
 import org.gradle.testkit.runner.BuildResult;
-import org.gradle.testkit.runner.GradleRunner;
-import org.junit.Before;
 
 public class ReaperPluginIT extends GradleIntegrationTestCase {
-    private GradleRunner runner;
-
-    @Before
-    public void setup() {
-        runner = getGradleRunner("reaper");
+    @Override
+    public String projectName() {
+        return "reaper";
     }
 
     public void testCanLaunchReaper() {
-        BuildResult result = runner.withArguments(":launchReaper", "-S", "--info").build();
+        BuildResult result = getGradleRunner().withArguments(":launchReaper", "-S", "--info").build();
         assertTaskSuccessful(result, ":launchReaper");
         assertOutputContains(result.getOutput(), "Copying reaper.jar...");
     }
+
 }

--- a/buildSrc/src/integTest/java/org/elasticsearch/gradle/internal/BuildPluginIT.java
+++ b/buildSrc/src/integTest/java/org/elasticsearch/gradle/internal/BuildPluginIT.java
@@ -7,11 +7,9 @@
  */
 package org.elasticsearch.gradle.internal;
 
-import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.elasticsearch.gradle.internal.test.GradleIntegrationTestCase;
 import org.gradle.testkit.runner.BuildResult;
-import org.gradle.testkit.runner.GradleRunner;
 import org.junit.Rule;
 import org.junit.rules.TemporaryFolder;
 
@@ -19,9 +17,6 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.util.List;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
 
@@ -32,54 +27,31 @@ public class BuildPluginIT extends GradleIntegrationTestCase {
     @Rule
     public TemporaryFolder tmpDir = new TemporaryFolder();
 
+    @Override
+    public String projectName() {
+        return "elasticsearch.build";
+    }
+
     public void testPluginCanBeApplied() {
-        BuildResult result = getGradleRunner("elasticsearch.build").withArguments("hello", "-s").build();
+        BuildResult result = getGradleRunner().withArguments("hello", "-s").build();
         assertTaskSuccessful(result, ":hello");
         assertOutputContains("build plugin can be applied");
     }
 
     public void testCheckTask() {
-        setupJarJdkClasspath(getProjectDir("elasticsearch.build"));
-        BuildResult result = getGradleRunner("elasticsearch.build").withArguments("check", "assemble", "-s").build();
+        setupJarJdkClasspath(getProjectDir());
+        BuildResult result = getGradleRunner().withArguments("check", "assemble", "-s").build();
         assertTaskSuccessful(result, ":check");
     }
 
-    private void runInsecureArtifactRepositoryTest(final String name, final String url, final List<String> lines) throws IOException {
-        final File projectDir = getProjectDir("elasticsearch.build");
-        final Path projectDirPath = projectDir.toPath();
-        FileUtils.copyDirectory(projectDir, tmpDir.getRoot(), file -> {
-            final Path relativePath = projectDirPath.relativize(file.toPath());
-            for (Path segment : relativePath) {
-                if (segment.toString().equals("build")) {
-                    return false;
-                }
-            }
-            return true;
-        });
-        final List<String> buildGradleLines = Files.readAllLines(tmpDir.getRoot().toPath().resolve("build.gradle"), StandardCharsets.UTF_8);
-        buildGradleLines.addAll(lines);
-        Files.write(tmpDir.getRoot().toPath().resolve("build.gradle"), buildGradleLines, StandardCharsets.UTF_8);
-        final BuildResult result = GradleRunner.create()
-            .withProjectDir(tmpDir.getRoot())
-            .withArguments("clean", "hello", "-s", "-i", "--warning-mode=all", "--scan")
-            .withPluginClasspath()
-            .forwardOutput()
-            .buildAndFail();
-
-        assertOutputContains(
-            result.getOutput(),
-            "repository [" + name + "] on project with path [:] is not using a secure protocol for artifacts on [" + url + "]"
-        );
-    }
-
     public void testLicenseAndNotice() throws IOException {
-        BuildResult result = getGradleRunner("elasticsearch.build").withArguments("clean", "assemble").build();
+        BuildResult result = getGradleRunner().withArguments("clean", "assemble").build();
 
         assertTaskSuccessful(result, ":assemble");
 
-        assertBuildFileExists(result, "elasticsearch.build", "distributions/elasticsearch.build.jar");
+        assertBuildFileExists(result, projectName(), "distributions/elasticsearch.build.jar");
 
-        try (ZipFile zipFile = new ZipFile(new File(getBuildDir("elasticsearch.build"), "distributions/elasticsearch.build.jar"))) {
+        try (ZipFile zipFile = new ZipFile(new File(getBuildDir(projectName()), "distributions/elasticsearch.build.jar"))) {
             ZipEntry licenseEntry = zipFile.getEntry("META-INF/LICENSE.txt");
             ZipEntry noticeEntry = zipFile.getEntry("META-INF/NOTICE.txt");
             assertNotNull("Jar does not have META-INF/LICENSE.txt", licenseEntry);
@@ -90,5 +62,4 @@ public class BuildPluginIT extends GradleIntegrationTestCase {
             }
         }
     }
-
 }

--- a/buildSrc/src/integTest/java/org/elasticsearch/gradle/internal/ExportElasticsearchBuildResourcesTaskIT.java
+++ b/buildSrc/src/integTest/java/org/elasticsearch/gradle/internal/ExportElasticsearchBuildResourcesTaskIT.java
@@ -15,22 +15,27 @@ public class ExportElasticsearchBuildResourcesTaskIT extends GradleIntegrationTe
 
     public static final String PROJECT_NAME = "elasticsearch-build-resources";
 
-    public void testUpToDateWithSourcesConfigured() {
-        getGradleRunner(PROJECT_NAME).withArguments("clean", "-s").build();
+    @Override
+    public String projectName() {
+        return PROJECT_NAME;
+    }
 
-        BuildResult result = getGradleRunner(PROJECT_NAME).withArguments("buildResources", "-s", "-i").build();
+    public void testUpToDateWithSourcesConfigured() {
+        getGradleRunner().withArguments("clean", "-s").build();
+
+        BuildResult result = getGradleRunner().withArguments("buildResources", "-s", "-i").build();
         assertTaskSuccessful(result, ":buildResources");
         assertBuildFileExists(result, PROJECT_NAME, "build-tools-exported/checkstyle.xml");
         assertBuildFileExists(result, PROJECT_NAME, "build-tools-exported/checkstyle_suppressions.xml");
 
-        result = getGradleRunner(PROJECT_NAME).withArguments("buildResources", "-s", "-i").build();
+        result = getGradleRunner().withArguments("buildResources", "-s", "-i").build();
         assertTaskUpToDate(result, ":buildResources");
         assertBuildFileExists(result, PROJECT_NAME, "build-tools-exported/checkstyle.xml");
         assertBuildFileExists(result, PROJECT_NAME, "build-tools-exported/checkstyle_suppressions.xml");
     }
 
     public void testOutputAsInput() {
-        BuildResult result = getGradleRunner(PROJECT_NAME).withArguments("clean", "sampleCopy", "-s", "-i").build();
+        BuildResult result = getGradleRunner().withArguments("clean", "sampleCopy", "-s", "-i").build();
 
         assertTaskSuccessful(result, ":sampleCopy");
         assertBuildFileExists(result, PROJECT_NAME, "sampleCopy/checkstyle.xml");
@@ -39,8 +44,9 @@ public class ExportElasticsearchBuildResourcesTaskIT extends GradleIntegrationTe
 
     public void testIncorrectUsage() {
         assertOutputContains(
-            getGradleRunner(PROJECT_NAME).withArguments("noConfigAfterExecution", "-s", "-i").buildAndFail().getOutput(),
+            getGradleRunner().withArguments("noConfigAfterExecution", "-s", "-i").buildAndFail().getOutput(),
             "buildResources can't be configured after the task ran"
         );
     }
+
 }

--- a/buildSrc/src/integTest/java/org/elasticsearch/gradle/internal/SymbolicLinkPreservingTarIT.java
+++ b/buildSrc/src/integTest/java/org/elasticsearch/gradle/internal/SymbolicLinkPreservingTarIT.java
@@ -31,6 +31,11 @@ import static org.hamcrest.CoreMatchers.equalTo;
 
 public class SymbolicLinkPreservingTarIT extends GradleIntegrationTestCase {
 
+    @Override
+    public String projectName() {
+        return "symbolic-link-preserving-tar";
+    }
+
     @Rule
     public final TemporaryFolder temporaryFolder = new TemporaryFolder();
 
@@ -133,17 +138,13 @@ public class SymbolicLinkPreservingTarIT extends GradleIntegrationTestCase {
     }
 
     private void runBuild(final String task, final boolean preserveFileTimestamps) {
-        final GradleRunner runner = getGradleRunner("symbolic-link-preserving-tar").withArguments(
+        final GradleRunner runner = getGradleRunner().withArguments(
             task,
             "-Dtests.symbolic_link_preserving_tar_source=" + temporaryFolder.getRoot().toString(),
             "-Dtests.symbolic_link_preserving_tar_preserve_file_timestamps=" + preserveFileTimestamps,
             "-i"
         );
         runner.build();
-    }
-
-    private File getProjectDir() {
-        return getProjectDir("symbolic-link-preserving-tar");
     }
 
     private File getOutputFile(final String extension) {

--- a/buildSrc/src/integTest/java/org/elasticsearch/gradle/precommit/TestingConventionsTasksIT.java
+++ b/buildSrc/src/integTest/java/org/elasticsearch/gradle/precommit/TestingConventionsTasksIT.java
@@ -10,20 +10,16 @@ package org.elasticsearch.gradle.precommit;
 import org.elasticsearch.gradle.internal.test.GradleIntegrationTestCase;
 import org.gradle.testkit.runner.BuildResult;
 import org.gradle.testkit.runner.GradleRunner;
-import org.junit.Before;
 
 public class TestingConventionsTasksIT extends GradleIntegrationTestCase {
 
-    @Before
-    public void setUp() {}
+    @Override
+    public String projectName() {
+        return "testingConventions";
+    }
 
     public void testInnerClasses() {
-        GradleRunner runner = getGradleRunner("testingConventions").withArguments(
-            "clean",
-            ":no_tests_in_inner_classes:testingConventions",
-            "-i",
-            "-s"
-        );
+        GradleRunner runner = getGradleRunner().withArguments("clean", ":no_tests_in_inner_classes:testingConventions", "-i", "-s");
         BuildResult result = runner.buildAndFail();
         assertOutputContains(
             result.getOutput(),
@@ -37,12 +33,7 @@ public class TestingConventionsTasksIT extends GradleIntegrationTestCase {
     }
 
     public void testNamingConvention() {
-        GradleRunner runner = getGradleRunner("testingConventions").withArguments(
-            "clean",
-            ":incorrect_naming_conventions:testingConventions",
-            "-i",
-            "-s"
-        );
+        GradleRunner runner = getGradleRunner().withArguments("clean", ":incorrect_naming_conventions:testingConventions", "-i", "-s");
         BuildResult result = runner.buildAndFail();
         assertOutputContains(
             result.getOutput(),
@@ -55,12 +46,7 @@ public class TestingConventionsTasksIT extends GradleIntegrationTestCase {
     }
 
     public void testNoEmptyTasks() {
-        GradleRunner runner = getGradleRunner("testingConventions").withArguments(
-            "clean",
-            ":empty_test_task:testingConventions",
-            "-i",
-            "-s"
-        );
+        GradleRunner runner = getGradleRunner().withArguments("clean", ":empty_test_task:testingConventions", "-i", "-s");
         BuildResult result = runner.buildAndFail();
         assertOutputContains(
             result.getOutput(),
@@ -70,12 +56,7 @@ public class TestingConventionsTasksIT extends GradleIntegrationTestCase {
     }
 
     public void testAllTestTasksIncluded() {
-        GradleRunner runner = getGradleRunner("testingConventions").withArguments(
-            "clean",
-            ":all_classes_in_tasks:testingConventions",
-            "-i",
-            "-s"
-        );
+        GradleRunner runner = getGradleRunner().withArguments("clean", ":all_classes_in_tasks:testingConventions", "-i", "-s");
         BuildResult result = runner.buildAndFail();
         assertOutputContains(
             result.getOutput(),
@@ -85,12 +66,7 @@ public class TestingConventionsTasksIT extends GradleIntegrationTestCase {
     }
 
     public void testTaskNotImplementBaseClass() {
-        GradleRunner runner = getGradleRunner("testingConventions").withArguments(
-            "clean",
-            ":not_implementing_base:testingConventions",
-            "-i",
-            "-s"
-        );
+        GradleRunner runner = getGradleRunner().withArguments("clean", ":not_implementing_base:testingConventions", "-i", "-s");
         BuildResult result = runner.buildAndFail();
         assertOutputContains(
             result.getOutput(),
@@ -104,29 +80,19 @@ public class TestingConventionsTasksIT extends GradleIntegrationTestCase {
     }
 
     public void testValidSetupWithoutBaseClass() {
-        GradleRunner runner = getGradleRunner("testingConventions").withArguments(
-            "clean",
-            ":valid_setup_no_base:testingConventions",
-            "-i",
-            "-s"
-        );
+        GradleRunner runner = getGradleRunner().withArguments("clean", ":valid_setup_no_base:testingConventions", "-i", "-s");
         BuildResult result = runner.build();
         assertTaskSuccessful(result, ":valid_setup_no_base:testingConventions");
     }
 
     public void testValidSetupWithBaseClass() {
-        GradleRunner runner = getGradleRunner("testingConventions").withArguments(
-            "clean",
-            ":valid_setup_with_base:testingConventions",
-            "-i",
-            "-s"
-        );
+        GradleRunner runner = getGradleRunner().withArguments("clean", ":valid_setup_with_base:testingConventions", "-i", "-s");
         BuildResult result = runner.build();
         assertTaskSuccessful(result, ":valid_setup_with_base:testingConventions");
     }
 
     public void testTestsInMain() {
-        GradleRunner runner = getGradleRunner("testingConventions").withArguments("clean", ":tests_in_main:testingConventions", "-i", "-s");
+        GradleRunner runner = getGradleRunner().withArguments("clean", ":tests_in_main:testingConventions", "-i", "-s");
         BuildResult result = runner.buildAndFail();
         assertOutputContains(
             result.getOutput(),

--- a/buildSrc/src/integTest/java/org/elasticsearch/gradle/precommit/ThirdPartyAuditTaskIT.java
+++ b/buildSrc/src/integTest/java/org/elasticsearch/gradle/precommit/ThirdPartyAuditTaskIT.java
@@ -16,16 +16,21 @@ import static org.elasticsearch.gradle.internal.test.TestClasspathUtils.setupJar
 
 public class ThirdPartyAuditTaskIT extends GradleIntegrationTestCase {
 
+    @Override
+    public String projectName() {
+        return "thirdPartyAudit";
+    }
+
     @Before
     public void setUp() throws Exception {
         // Build the sample jars
-        getGradleRunner("thirdPartyAudit").withArguments(":sample_jars:build", "-s").build();
+        getGradleRunner().withArguments(":sample_jars:build", "-s").build();
         // propagate jdkjarhell jar
-        setupJarJdkClasspath(getProjectDir("thirdPartyAudit"));
+        setupJarJdkClasspath(getProjectDir());
     }
 
     public void testElasticsearchIgnored() {
-        BuildResult result = getGradleRunner("thirdPartyAudit").withArguments(
+        BuildResult result = getGradleRunner().withArguments(
             ":clean",
             ":empty",
             "-s",
@@ -39,7 +44,7 @@ public class ThirdPartyAuditTaskIT extends GradleIntegrationTestCase {
     }
 
     public void testViolationFoundAndCompileOnlyIgnored() {
-        BuildResult result = getGradleRunner("thirdPartyAudit").withArguments(
+        BuildResult result = getGradleRunner().withArguments(
             ":clean",
             ":absurd",
             "-s",
@@ -56,7 +61,7 @@ public class ThirdPartyAuditTaskIT extends GradleIntegrationTestCase {
     }
 
     public void testClassNotFoundAndCompileOnlyIgnored() {
-        BuildResult result = getGradleRunner("thirdPartyAudit").withArguments(
+        BuildResult result = getGradleRunner().withArguments(
             ":clean",
             ":absurd",
             "-s",
@@ -78,7 +83,7 @@ public class ThirdPartyAuditTaskIT extends GradleIntegrationTestCase {
     }
 
     public void testJarHellWithJDK() {
-        BuildResult result = getGradleRunner("thirdPartyAudit").withArguments(
+        BuildResult result = getGradleRunner().withArguments(
             ":clean",
             ":absurd",
             "-s",
@@ -100,7 +105,7 @@ public class ThirdPartyAuditTaskIT extends GradleIntegrationTestCase {
     }
 
     public void testElasticsearchIgnoredWithViolations() {
-        BuildResult result = getGradleRunner("thirdPartyAudit").withArguments(
+        BuildResult result = getGradleRunner().withArguments(
             ":clean",
             ":absurd",
             "-s",

--- a/buildSrc/src/test/java/org/elasticsearch/gradle/internal/docker/DockerSupportServiceTests.java
+++ b/buildSrc/src/test/java/org/elasticsearch/gradle/internal/docker/DockerSupportServiceTests.java
@@ -7,7 +7,7 @@
  */
 package org.elasticsearch.gradle.internal.docker;
 
-import org.elasticsearch.gradle.internal.test.GradleIntegrationTestCase;
+import org.elasticsearch.gradle.internal.test.GradleUnitTestCase;
 
 import java.util.HashMap;
 import java.util.List;
@@ -17,7 +17,7 @@ import static org.elasticsearch.gradle.internal.docker.DockerSupportService.deri
 import static org.elasticsearch.gradle.internal.docker.DockerSupportService.parseOsRelease;
 import static org.hamcrest.CoreMatchers.equalTo;
 
-public class DockerSupportServiceTests extends GradleIntegrationTestCase {
+public class DockerSupportServiceTests extends GradleUnitTestCase {
 
     public void testParseOsReleaseOnOracle() {
         final List<String> lines = List.of(


### PR DESCRIPTION
the `build-tools:integTest` task is never up to date on local environments. 

Running the IT test builds directly in src/testkit causes up-to-date
check to constantly fail as gradle internal files change on every
invocation.

The problem can be seen in this build scan: 
https://gradle-enterprise.elastic.co/s/szyqfhonp3ivq/timeline?details=orjfcz7hu5lqo

Furthermore did some cleanup and simplification on IT tests too 