### PR TITLE
Service Accounts - Disallow oauth2 creation (#72553)

### DIFF
--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/token/TransportCreateTokenAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/token/TransportCreateTokenAction.java
@@ -6,6 +6,7 @@
  */
 package org.elasticsearch.xpack.security.action.token;
 
+import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.HandledTransportAction;
@@ -69,6 +70,10 @@ public final class TransportCreateTokenAction extends HandledTransportAction<Cre
                 break;
             case CLIENT_CREDENTIALS:
                 Authentication authentication = securityContext.getAuthentication();
+                if (authentication.isServiceAccount()) {
+                    listener.onFailure(new ElasticsearchException("OAuth2 token creation is not supported for service accounts"));
+                    return;
+                }
                 createToken(type, request, authentication, authentication, false, listener);
                 break;
             default:

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/action/token/TransportCreateTokenActionTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/action/token/TransportCreateTokenActionTests.java
@@ -7,6 +7,7 @@
 
 package org.elasticsearch.xpack.security.action.token;
 
+import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.ElasticsearchSecurityException;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.get.GetAction;
@@ -297,6 +298,26 @@ public class TransportCreateTokenActionTests extends ESTestCase {
         assertThat(e.getMessage(), containsString("could not decode base64 kerberos ticket"));
         // The code flow should stop after above failure and never reach authenticationService
         Mockito.verifyZeroInteractions(authenticationService);
+    }
+
+    public void testServiceAccountCannotCreateOAuthToken() throws Exception {
+        final TokenService tokenService = new TokenService(SETTINGS, Clock.systemUTC(), client, license, securityContext,
+            securityIndex, securityIndex, clusterService);
+        Authentication authentication = new Authentication(
+            new User(randomAlphaOfLengthBetween(3, 8) + "/" + randomAlphaOfLengthBetween(3, 8)),
+            new Authentication.RealmRef("_service_account_" + randomFrom("file", "index"), "service_account", "node"), null);
+        authentication.writeToContext(threadPool.getThreadContext());
+
+        final TransportCreateTokenAction action = new TransportCreateTokenAction(threadPool,
+            mock(TransportService.class), new ActionFilters(Collections.emptySet()), tokenService,
+            authenticationService, securityContext);
+        final CreateTokenRequest createTokenRequest = new CreateTokenRequest();
+        createTokenRequest.setGrantType("client_credentials");
+
+        PlainActionFuture<CreateTokenResponse> future = new PlainActionFuture<>();
+        action.doExecute(null, createTokenRequest, future);
+        final ElasticsearchException e = expectThrows(ElasticsearchException.class, future::actionGet);
+        assertThat(e.getMessage(), containsString("OAuth2 token creation is not supported for service accounts"));
     }
 
     private static <T> ActionListener<T> assertListenerIsOnlyCalledOnce(ActionListener<T> delegate) {


### PR DESCRIPTION
Service accounts must be authenticate with their service tokens. We
intentionally do not support other authentication schemes (other than
API keys). Hence we should not allow service account to create oauth2
tokens.

Note this is not an issue now because the only elastic/fleet-server
service account does not have permission to create oauth2 token anyway.