### PR TITLE
Fix Edge Case Datastream Snapshot Create Bug

### DIFF
--- a/server/src/main/java/org/elasticsearch/snapshots/SnapshotsService.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/SnapshotsService.java
@@ -744,8 +744,6 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
                 for (Index index : dataStream.getIndices()) {
                     final String indexName = index.getName();
                     if (builder.get(indexName) == null || indicesInSnapshot.contains(indexName) == false) {
-                        assert snapshot.partial() : "Data stream [" + dataStreamName +
-                                "] is missing index [" + index + "] but snapshot was not partial.";
                         missingIndex = true;
                         break;
                     }
@@ -1300,9 +1298,8 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
                         final SnapshotInfo snapshotInfo = new SnapshotInfo(
                                 snapshot.getSnapshotId(),
                                 finalIndices,
-                                entry.partial() ? entry.dataStreams().stream()
-                                        .filter(metaForSnapshot.dataStreams()::containsKey)
-                                        .collect(Collectors.toList()) : entry.dataStreams(),
+                                entry.dataStreams().stream().filter(metaForSnapshot.dataStreams()::containsKey)
+                                    .collect(Collectors.toList()),
                                 entry.partial() ? onlySuccessfulFeatureStates(entry, finalIndices) : entry.featureStates(),
                                 failure,
                                 threadPool.absoluteTimeInMillis(),


### PR DESCRIPTION
We always clean up the list of datastreams depending on the indices actually
in the snapshot. Even for non-partial snapshots datastream indices could be
excluded from the snapshot by index exclusions that remove all the datastream's
indices from the snapshot.

