### PR TITLE
Add id to Translog.Delete#toString()

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/translog/Translog.java
+++ b/server/src/main/java/org/elasticsearch/index/translog/Translog.java
@@ -1394,7 +1394,8 @@ public class Translog extends AbstractIndexShardComponent implements IndexShardC
         @Override
         public String toString() {
             return "Delete{" +
-                "seqNo=" + seqNo +
+                "id='" + id +
+                "', seqNo=" + seqNo +
                 ", primaryTerm=" + primaryTerm +
                 ", version=" + version +
                 '}';


### PR DESCRIPTION
The assertion failure message in #72735 did not indicate why it failed
because `Translog.Delete#toString()` does not expose all the fields of
the problematic operation. This commit adds the missing `id` field.