### PR TITLE
[7.13] Apply spotless formatting to :x-pack:plugin:voting-only-node

### DIFF
--- a/gradle/formatting.gradle
+++ b/gradle/formatting.gradle
@@ -145,7 +145,6 @@ def projectPathsToExclude = [
   ':x-pack:plugin:sql:sql-proto',
   ':x-pack:plugin:transform',
   ':x-pack:plugin:vectors',
-  ':x-pack:plugin:voting-only-node',
   ':x-pack:plugin:watcher',
   ':x-pack:plugin:wildcard',
   ':x-pack:qa',

--- a/x-pack/plugin/voting-only-node/src/internalClusterTest/java/org/elasticsearch/cluster/coordination/VotingOnlyNodePluginTests.java
+++ b/x-pack/plugin/voting-only-node/src/internalClusterTest/java/org/elasticsearch/cluster/coordination/VotingOnlyNodePluginTests.java
@@ -62,9 +62,10 @@ public class VotingOnlyNodePluginTests extends ESIntegTestCase {
 
     public void testRequireVotingOnlyNodeToBeMasterEligible() {
         internalCluster().setBootstrapMasterNodeIndex(0);
-        IllegalStateException ise = expectThrows(IllegalStateException.class, () -> internalCluster().startNode(Settings.builder()
-            .put(onlyRole(VotingOnlyNodePlugin.VOTING_ONLY_NODE_ROLE))
-            .build()));
+        IllegalStateException ise = expectThrows(
+            IllegalStateException.class,
+            () -> internalCluster().startNode(Settings.builder().put(onlyRole(VotingOnlyNodePlugin.VOTING_ONLY_NODE_ROLE)).build())
+        );
         assertThat(ise.getMessage(), containsString("voting-only node must be master-eligible"));
     }
 
@@ -72,10 +73,24 @@ public class VotingOnlyNodePluginTests extends ESIntegTestCase {
         internalCluster().setBootstrapMasterNodeIndex(0);
         internalCluster().startNodes(2);
         internalCluster().startNode(addRoles(Collections.singleton(VotingOnlyNodePlugin.VOTING_ONLY_NODE_ROLE)));
-        assertBusy(() -> assertThat(client().admin().cluster().prepareState().get().getState().getLastCommittedConfiguration().getNodeIds(),
-            hasSize(3)));
-        assertThat(client().admin().cluster().prepareClusterStats().get().getNodesStats().getCounts().getRoles().get(
-            VotingOnlyNodePlugin.VOTING_ONLY_NODE_ROLE.roleName()).intValue(), equalTo(1));
+        assertBusy(
+            () -> assertThat(
+                client().admin().cluster().prepareState().get().getState().getLastCommittedConfiguration().getNodeIds(),
+                hasSize(3)
+            )
+        );
+        assertThat(
+            client().admin()
+                .cluster()
+                .prepareClusterStats()
+                .get()
+                .getNodesStats()
+                .getCounts()
+                .getRoles()
+                .get(VotingOnlyNodePlugin.VOTING_ONLY_NODE_ROLE.roleName())
+                .intValue(),
+            equalTo(1)
+        );
         assertThat(client().admin().cluster().prepareNodesStats("voting_only:true").get().getNodes(), hasSize(1));
         assertThat(client().admin().cluster().prepareNodesStats("master:true", "voting_only:false").get().getNodes(), hasSize(2));
     }
@@ -85,9 +100,12 @@ public class VotingOnlyNodePluginTests extends ESIntegTestCase {
         internalCluster().startNodes(2);
         internalCluster().startNode(addRoles(Collections.singleton(VotingOnlyNodePlugin.VOTING_ONLY_NODE_ROLE)));
         internalCluster().startDataOnlyNodes(randomInt(2));
-        assertBusy(() -> assertThat(
-            client().admin().cluster().prepareState().get().getState().getLastCommittedConfiguration().getNodeIds().size(),
-            equalTo(3)));
+        assertBusy(
+            () -> assertThat(
+                client().admin().cluster().prepareState().get().getState().getLastCommittedConfiguration().getNodeIds().size(),
+                equalTo(3)
+            )
+        );
         final String originalMaster = internalCluster().getMasterName();
 
         internalCluster().stopCurrentMasterNode();
@@ -95,30 +113,43 @@ public class VotingOnlyNodePluginTests extends ESIntegTestCase {
         assertNotEquals(originalMaster, internalCluster().getMasterName());
         assertThat(
             VotingOnlyNodePlugin.isVotingOnlyNode(client().admin().cluster().prepareState().get().getState().nodes().getMasterNode()),
-            equalTo(false));
+            equalTo(false)
+        );
     }
 
     public void testBootstrapOnlyVotingOnlyNodes() throws Exception {
         internalCluster().setBootstrapMasterNodeIndex(0);
-        internalCluster().startNodes(addRoles(Collections.singleton(VotingOnlyNodePlugin.VOTING_ONLY_NODE_ROLE)),
-            Settings.EMPTY, Settings.EMPTY);
-        assertBusy(() -> assertThat(
-            client().admin().cluster().prepareState().get().getState().getLastCommittedConfiguration().getNodeIds().size(),
-            equalTo(3)));
+        internalCluster().startNodes(
+            addRoles(Collections.singleton(VotingOnlyNodePlugin.VOTING_ONLY_NODE_ROLE)),
+            Settings.EMPTY,
+            Settings.EMPTY
+        );
+        assertBusy(
+            () -> assertThat(
+                client().admin().cluster().prepareState().get().getState().getLastCommittedConfiguration().getNodeIds().size(),
+                equalTo(3)
+            )
+        );
         assertThat(
             VotingOnlyNodePlugin.isVotingOnlyNode(client().admin().cluster().prepareState().get().getState().nodes().getMasterNode()),
-            equalTo(false));
+            equalTo(false)
+        );
     }
 
     public void testBootstrapOnlySingleVotingOnlyNode() throws Exception {
         internalCluster().setBootstrapMasterNodeIndex(0);
-        internalCluster().startNode(Settings.builder().put(addRoles(Collections.singleton(VotingOnlyNodePlugin.VOTING_ONLY_NODE_ROLE)))
-            .put(DiscoverySettings.INITIAL_STATE_TIMEOUT_SETTING.getKey(), "0s").build());
+        internalCluster().startNode(
+            Settings.builder()
+                .put(addRoles(Collections.singleton(VotingOnlyNodePlugin.VOTING_ONLY_NODE_ROLE)))
+                .put(DiscoverySettings.INITIAL_STATE_TIMEOUT_SETTING.getKey(), "0s")
+                .build()
+        );
         internalCluster().startNode();
         assertBusy(() -> assertThat(client().admin().cluster().prepareState().get().getState().getNodes().getSize(), equalTo(2)));
         assertThat(
             VotingOnlyNodePlugin.isVotingOnlyNode(client().admin().cluster().prepareState().get().getState().nodes().getMasterNode()),
-            equalTo(false));
+            equalTo(false)
+        );
     }
 
     public void testVotingOnlyNodesCannotBeMasterWithoutFullMasterNodes() throws Exception {
@@ -126,16 +157,31 @@ public class VotingOnlyNodePluginTests extends ESIntegTestCase {
         internalCluster().startNode();
         internalCluster().startNodes(2, addRoles(Collections.singleton(VotingOnlyNodePlugin.VOTING_ONLY_NODE_ROLE)));
         internalCluster().startDataOnlyNodes(randomInt(2));
-        assertBusy(() -> assertThat(
-            client().admin().cluster().prepareState().get().getState().getLastCommittedConfiguration().getNodeIds().size(),
-            equalTo(3)));
+        assertBusy(
+            () -> assertThat(
+                client().admin().cluster().prepareState().get().getState().getLastCommittedConfiguration().getNodeIds().size(),
+                equalTo(3)
+            )
+        );
         final String oldMasterId = client().admin().cluster().prepareState().get().getState().nodes().getMasterNodeId();
 
         internalCluster().stopCurrentMasterNode();
 
-        expectThrows(MasterNotDiscoveredException.class, () ->
-            assertThat(client().admin().cluster().prepareState().setMasterNodeTimeout("100ms").execute().actionGet()
-                .getState().nodes().getMasterNodeId(), nullValue()));
+        expectThrows(
+            MasterNotDiscoveredException.class,
+            () -> assertThat(
+                client().admin()
+                    .cluster()
+                    .prepareState()
+                    .setMasterNodeTimeout("100ms")
+                    .execute()
+                    .actionGet()
+                    .getState()
+                    .nodes()
+                    .getMasterNodeId(),
+                nullValue()
+            )
+        );
 
         // start a fresh full master node, which will be brought into the cluster as master by the voting-only nodes
         final String newMaster = internalCluster().startNode();
@@ -149,18 +195,25 @@ public class VotingOnlyNodePluginTests extends ESIntegTestCase {
         internalCluster().startNodes(2);
         // dedicated voting-only master node
         final String dedicatedVotingOnlyNode = internalCluster().startNode(
-            onlyRoles(Sets.newHashSet(DiscoveryNodeRole.MASTER_ROLE, VotingOnlyNodePlugin.VOTING_ONLY_NODE_ROLE)));
+            onlyRoles(Sets.newHashSet(DiscoveryNodeRole.MASTER_ROLE, VotingOnlyNodePlugin.VOTING_ONLY_NODE_ROLE))
+        );
         // voting-only master node that also has data
         Settings dataContainingVotingOnlyNodeSettings = addRoles(Sets.newHashSet(VotingOnlyNodePlugin.VOTING_ONLY_NODE_ROLE));
         if (randomBoolean()) {
-            dataContainingVotingOnlyNodeSettings
-                = removeRoles(dataContainingVotingOnlyNodeSettings, Sets.newHashSet(DiscoveryNodeRole.DATA_ROLE));
+            dataContainingVotingOnlyNodeSettings = removeRoles(
+                dataContainingVotingOnlyNodeSettings,
+                Sets.newHashSet(DiscoveryNodeRole.DATA_ROLE)
+            );
         }
         final String nonDedicatedVotingOnlyNode = internalCluster().startNode(dataContainingVotingOnlyNodeSettings);
 
-        assertAcked(client().admin().cluster().preparePutRepository("test-repo")
-            .setType("verifyaccess-fs").setSettings(Settings.builder().put("location", randomRepoPath())
-                .put("compress", randomBoolean())));
+        assertAcked(
+            client().admin()
+                .cluster()
+                .preparePutRepository("test-repo")
+                .setType("verifyaccess-fs")
+                .setSettings(Settings.builder().put("location", randomRepoPath()).put("compress", randomBoolean()))
+        );
         createIndex("test-idx-1");
         createIndex("test-idx-2");
         createIndex("test-idx-3");
@@ -172,18 +225,28 @@ public class VotingOnlyNodePluginTests extends ESIntegTestCase {
         assertTrue(verifyResponse.getNodes().stream().noneMatch(nw -> nw.getName().equals(dedicatedVotingOnlyNode)));
         assertTrue(verifyResponse.getNodes().stream().anyMatch(nw -> nw.getName().equals(nonDedicatedVotingOnlyNode)));
 
-        final String[] indicesToSnapshot = {"test-idx-*", "-test-idx-3"};
+        final String[] indicesToSnapshot = { "test-idx-*", "-test-idx-3" };
 
         logger.info("--> snapshot");
         Client client = client();
-        CreateSnapshotResponse createSnapshotResponse = client.admin().cluster().prepareCreateSnapshot("test-repo", "test-snap")
-            .setWaitForCompletion(true).setIndices(indicesToSnapshot).get();
+        CreateSnapshotResponse createSnapshotResponse = client.admin()
+            .cluster()
+            .prepareCreateSnapshot("test-repo", "test-snap")
+            .setWaitForCompletion(true)
+            .setIndices(indicesToSnapshot)
+            .get();
         assertThat(createSnapshotResponse.getSnapshotInfo().successfulShards(), greaterThan(0));
-        assertThat(createSnapshotResponse.getSnapshotInfo().successfulShards(),
-            Matchers.equalTo(createSnapshotResponse.getSnapshotInfo().totalShards()));
+        assertThat(
+            createSnapshotResponse.getSnapshotInfo().successfulShards(),
+            Matchers.equalTo(createSnapshotResponse.getSnapshotInfo().totalShards())
+        );
 
-        List<SnapshotInfo> snapshotInfos = client.admin().cluster().prepareGetSnapshots("test-repo")
-            .setSnapshots(randomFrom("test-snap", "_all", "*", "*-snap", "test*")).get().getSnapshots();
+        List<SnapshotInfo> snapshotInfos = client.admin()
+            .cluster()
+            .prepareGetSnapshots("test-repo")
+            .setSnapshots(randomFrom("test-snap", "_all", "*", "*-snap", "test*"))
+            .get()
+            .getSnapshots();
         assertThat(snapshotInfos.size(), Matchers.equalTo(1));
         SnapshotInfo snapshotInfo = snapshotInfos.get(0);
         assertThat(snapshotInfo.state(), Matchers.equalTo(SnapshotState.SUCCESS));
@@ -193,8 +256,12 @@ public class VotingOnlyNodePluginTests extends ESIntegTestCase {
         client.admin().indices().prepareClose("test-idx-1", "test-idx-2").get();
 
         logger.info("--> restore all indices from the snapshot");
-        RestoreSnapshotResponse restoreSnapshotResponse = client.admin().cluster().prepareRestoreSnapshot("test-repo", "test-snap")
-            .setWaitForCompletion(true).execute().actionGet();
+        RestoreSnapshotResponse restoreSnapshotResponse = client.admin()
+            .cluster()
+            .prepareRestoreSnapshot("test-repo", "test-snap")
+            .setWaitForCompletion(true)
+            .execute()
+            .actionGet();
         assertThat(restoreSnapshotResponse.getRestoreInfo().totalShards(), greaterThan(0));
 
         ensureGreen();
@@ -203,19 +270,31 @@ public class VotingOnlyNodePluginTests extends ESIntegTestCase {
     public static class RepositoryVerifyAccessPlugin extends org.elasticsearch.plugins.Plugin implements RepositoryPlugin {
 
         @Override
-        public Map<String, Repository.Factory> getRepositories(Environment env, NamedXContentRegistry namedXContentRegistry,
-                                                               ClusterService clusterService, BigArrays bigArrays,
-                                                               RecoverySettings recoverySettings) {
-            return Collections.singletonMap("verifyaccess-fs", (metadata) ->
-                new AccessVerifyingRepo(metadata, env, namedXContentRegistry, clusterService, bigArrays, recoverySettings));
+        public Map<String, Repository.Factory> getRepositories(
+            Environment env,
+            NamedXContentRegistry namedXContentRegistry,
+            ClusterService clusterService,
+            BigArrays bigArrays,
+            RecoverySettings recoverySettings
+        ) {
+            return Collections.singletonMap(
+                "verifyaccess-fs",
+                (metadata) -> new AccessVerifyingRepo(metadata, env, namedXContentRegistry, clusterService, bigArrays, recoverySettings)
+            );
         }
 
         private static class AccessVerifyingRepo extends FsRepository {
 
             private final ClusterService clusterService;
 
-            private AccessVerifyingRepo(RepositoryMetadata metadata, Environment environment, NamedXContentRegistry namedXContentRegistry,
-                                       ClusterService clusterService, BigArrays bigArrays, RecoverySettings recoverySettings) {
+            private AccessVerifyingRepo(
+                RepositoryMetadata metadata,
+                Environment environment,
+                NamedXContentRegistry namedXContentRegistry,
+                ClusterService clusterService,
+                BigArrays bigArrays,
+                RecoverySettings recoverySettings
+            ) {
                 super(metadata, environment, namedXContentRegistry, clusterService, bigArrays, recoverySettings);
                 this.clusterService = clusterService;
             }

--- a/x-pack/plugin/voting-only-node/src/test/java/org/elasticsearch/cluster/coordination/VotingOnlyNodeCoordinationStateTests.java
+++ b/x-pack/plugin/voting-only-node/src/test/java/org/elasticsearch/cluster/coordination/VotingOnlyNodeCoordinationStateTests.java
@@ -19,13 +19,27 @@ import java.util.stream.IntStream;
 public class VotingOnlyNodeCoordinationStateTests extends ESTestCase {
 
     public void testSafety() {
-        new CoordinationStateTestCluster(IntStream.range(0, randomIntBetween(1, 5))
-            .mapToObj(i -> new DiscoveryNode("node_" + i, buildNewFakeTransportAddress(), Collections.emptyMap(),
-                randomBoolean() ? DiscoveryNodeRole.BUILT_IN_ROLES :
-                    Sets.newHashSet(DiscoveryNodeRole.DATA_ROLE, DiscoveryNodeRole.INGEST_ROLE, DiscoveryNodeRole.MASTER_ROLE,
-                    VotingOnlyNodePlugin.VOTING_ONLY_NODE_ROLE), Version.CURRENT))
-            .collect(Collectors.toList()), new VotingOnlyNodePlugin.VotingOnlyNodeElectionStrategy())
-            .runRandomly();
+        new CoordinationStateTestCluster(
+            IntStream.range(0, randomIntBetween(1, 5))
+                .mapToObj(
+                    i -> new DiscoveryNode(
+                        "node_" + i,
+                        buildNewFakeTransportAddress(),
+                        Collections.emptyMap(),
+                        randomBoolean()
+                            ? DiscoveryNodeRole.BUILT_IN_ROLES
+                            : Sets.newHashSet(
+                                DiscoveryNodeRole.DATA_ROLE,
+                                DiscoveryNodeRole.INGEST_ROLE,
+                                DiscoveryNodeRole.MASTER_ROLE,
+                                VotingOnlyNodePlugin.VOTING_ONLY_NODE_ROLE
+                            ),
+                        Version.CURRENT
+                    )
+                )
+                .collect(Collectors.toList()),
+            new VotingOnlyNodePlugin.VotingOnlyNodeElectionStrategy()
+        ).runRandomly();
     }
 
 }

--- a/x-pack/plugin/voting-only-node/src/test/java/org/elasticsearch/cluster/coordination/VotingOnlyNodeCoordinatorTests.java
+++ b/x-pack/plugin/voting-only-node/src/test/java/org/elasticsearch/cluster/coordination/VotingOnlyNodeCoordinatorTests.java
@@ -56,17 +56,28 @@ public class VotingOnlyNodeCoordinatorTests extends AbstractCoordinatorTestCase 
     @Override
     protected DiscoveryNode createDiscoveryNode(int nodeIndex, boolean masterEligible) {
         final TransportAddress address = buildNewFakeTransportAddress();
-        return new DiscoveryNode("", "node" + nodeIndex,
+        return new DiscoveryNode(
+            "",
+            "node" + nodeIndex,
             UUIDs.randomBase64UUID(random()), // generated deterministically for repeatable tests
-            address.address().getHostString(), address.getAddress(), address, Collections.emptyMap(),
-            masterEligible ? DiscoveryNodeRole.BUILT_IN_ROLES :
-                randomBoolean() ? emptySet() : Collections.unmodifiableSet(new HashSet<>(Arrays.asList(
-                    DiscoveryNodeRole.DATA_ROLE,
-                    DiscoveryNodeRole.INGEST_ROLE,
-                    DiscoveryNodeRole.MASTER_ROLE,
-                    VotingOnlyNodePlugin.VOTING_ONLY_NODE_ROLE
-                ))),
-            Version.CURRENT);
+            address.address().getHostString(),
+            address.getAddress(),
+            address,
+            Collections.emptyMap(),
+            masterEligible ? DiscoveryNodeRole.BUILT_IN_ROLES
+                : randomBoolean() ? emptySet()
+                : Collections.unmodifiableSet(
+                    new HashSet<>(
+                        Arrays.asList(
+                            DiscoveryNodeRole.DATA_ROLE,
+                            DiscoveryNodeRole.INGEST_ROLE,
+                            DiscoveryNodeRole.MASTER_ROLE,
+                            VotingOnlyNodePlugin.VOTING_ONLY_NODE_ROLE
+                        )
+                    )
+                ),
+            Version.CURRENT
+        );
     }
 
 }


### PR DESCRIPTION
While there are ongoing discussions (#71560) about how to format the codebase, either suddenly or incrementally, I think some projects are subject to much fewer on-going changes in progress and can therefore be formatted upfront. I gave it a try here with the voting only node module and that will reduce the scope of the whole formatting anyway.

Other projects like :test:fixtures:* and :x-pack:plugin:frozen-indices are good candidates too.

Backport of #72687