### PR TITLE
Improve cleanup of Node Shutdown in tests

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/test/rest/ESRestTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/ESRestTestCase.java
@@ -715,21 +715,21 @@ public abstract class ESRestTestCase extends ESTestCase {
      */
     @SuppressWarnings("unchecked")
     private static void deleteAllNodeShutdownMetadata() throws IOException {
-        final boolean NODE_SHUTDOWN_ENABLED = "true".equals(System.getProperty("es.shutdown_feature_flag_enabled"));
-        if (NODE_SHUTDOWN_ENABLED == false) {
+        Request getShutdownStatus = new Request("GET", "_nodes/shutdown");
+        Map<String, Object> statusResponse = responseAsMap(adminClient().performRequest(getShutdownStatus));
+        if (statusResponse.containsKey("_nodes") && statusResponse.containsKey("cluster_name")) {
+            // If the response contains these two keys, the feature flag isn't enabled on this cluster, so skip out now.
+            // We can't check the system property directly because it only gets set for the cluster under test's JVM, not for the test
+            // runner's JVM.
             return;
         }
-        Request getShutdownStatus = new Request("GET", "_nodes/shutdown");
-        Map<String, Object> statusResponse = responseAsMap(client().performRequest(getShutdownStatus));
-        if (statusResponse.get("nodes") instanceof List) { // for some reason `nodes` is parsed as a Map<> if it's empty
             List<Map<String, Object>> nodesArray = (List<Map<String, Object>>) statusResponse.get("nodes");
             List<String> nodeIds = nodesArray.stream()
                 .map(nodeShutdownMetadata -> (String) nodeShutdownMetadata.get("node_id"))
                 .collect(Collectors.toUnmodifiableList());
             for (String nodeId : nodeIds) {
                 Request deleteRequest = new Request("DELETE", "_nodes/" + nodeId + "/shutdown");
-                assertOK(client().performRequest(deleteRequest));
-            }
+                assertOK(adminClient().performRequest(deleteRequest));
         }
     }
 


### PR DESCRIPTION
Makes the following changes:
 - The node shutdown feature flag isn't set on the test runner, only the
   cluster JVMs, so we can't use it to check here. Instead, the cleanup
   now infers whether it's enabled from the shape of the first
   GET `_nodes/shutdown` response.
 - Now uses `adminClient()` instead of `client()`
 - Removes the unnecessary `instanceof` check, which was *not* due to parsing,
   but the fact that `nodes` is indeed a map if the feature flag isn't enabled.

Follow-up to https://github.com/elastic/elasticsearch/pull/72726
Fixes https://github.com/elastic/elasticsearch/issues/72787