### PR TITLE
[7.x] [DOCS] Update 'shared_cache' references for searchable snapshots (#72775)

### DIFF
--- a/docs/reference/ilm/actions/ilm-searchable-snapshot.asciidoc
+++ b/docs/reference/ilm/actions/ilm-searchable-snapshot.asciidoc
@@ -4,16 +4,16 @@
 
 Phases allowed: hot, cold, frozen.
 
-Takes a snapshot of the managed index in the configured repository
-and mounts it as a searchable snapshot.
-If the managed index is part of a <<data-streams, data stream>>,
-the mounted index replaces the original index in the data stream.
+Takes a snapshot of the managed index in the configured repository and mounts it
+as a <<searchable-snapshots,{search-snap}>>.
 
-To use the `searchable_snapshot` action in the `hot` phase, the `rollover`
-action *must* be present. If no rollover action is configured, {ilm-init}
-will reject the policy.
+In the frozen phase, the action mounts a <<partially-mounted,partially mounted
+index>>. In other phases, the action mounts a <<fully-mounted,fully mounted
+index>>. If the original index is part of a
+<<data-streams, data stream>>, the mounted index replaces the original index in
+the data stream.
 
-IMPORTANT: If the `searchable_snapshot` action is used in the `hot` phase the
+IMPORTANT: If the `searchable_snapshot` action is used in the hot phase the
 subsequent phases cannot define any of the `shrink`, `forcemerge`, `freeze` or
 `searchable_snapshot` (also available in the cold and frozen phases) actions.
 
@@ -35,9 +35,7 @@ To keep the snapshot, set `delete_searchable_snapshot` to `false` in the delete 
 
 `snapshot_repository`::
 (Required, string)
-Specifies where to store the snapshot. 
-See <<snapshots-register-repository>> for more information. In non-frozen phases the snapshot will
-be mounted as a `full_copy`, and in frozen phases mounted with the `shared_cache` storage type.
+<<snapshots-register-repository,Repository>> used to store the snapshot.
 
 `force_merge_index`::
 (Optional, Boolean)

--- a/docs/reference/index-modules/allocation/data_tier_allocation.asciidoc
+++ b/docs/reference/index-modules/allocation/data_tier_allocation.asciidoc
@@ -16,8 +16,8 @@ These tier attributes are set using the data node roles:
 * <<data-frozen-node, data_frozen>>
 
 NOTE: The <<data-node, data>> role is not a valid data tier and cannot be used
-for data tier filtering. The <<data-frozen-node, data_frozen>> role can only be
-used for searchable snapshots mounted with the `shared_cache` option.
+for data tier filtering. The frozen tier stores <<partially-mounted,partially
+mounted indices>> exclusively.
 
 [discrete]
 [[data-tier-allocation-filters]]

--- a/docs/reference/modules/node.asciidoc
+++ b/docs/reference/modules/node.asciidoc
@@ -275,10 +275,11 @@ node.roles: [ data_cold ]
 [[data-frozen-node]]
 ==== [x-pack]#Frozen data node#
 
-Frozen data nodes store searchable snapshots mounted with the `shared_cache`
-option exclusively.
+The frozen tier stores <<partially-mounted,partially mounted indices>>
+exclusively. We recommend you use dedicated nodes in the frozen tier.
 
 To create a dedicated frozen node, set:
+
 [source,yaml]
 ----
 node.roles: [ data_frozen ]


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [DOCS] Update 'shared_cache' references for searchable snapshots (#72775)