### PR TITLE
[7.12] [DOCS] Adds max_trees hyperparameter to GET TM API docs (#72298)

### DIFF
--- a/docs/reference/ml/df-analytics/apis/get-trained-models.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/get-trained-models.asciidoc
@@ -230,18 +230,22 @@ List of the available hyperparameters optimized during the
 [%collapsible%open]
 ======
 `absolute_importance`::::
-(Optional, double)
+(double)
 A positive number showing how much the parameter influences the variation of the 
 {ml-docs}/dfa-regression.html#dfa-regression-lossfunction[loss function]. For 
 hyperparameters with values that are not specified by the user but tuned during 
 hyperparameter optimization. 
+
+`max_trees`::::
+(integer)
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=max-trees-trained-models]
 
 `name`::::
 (string)
 Name of the hyperparameter.
 
 `relative_importance`::::
-(Optional, double)
+(double)
 A number between 0 and 1 showing the proportion of influence on the variation of 
 the loss function among all tuned hyperparameters. For hyperparameters with 
 values that are not specified by the user but tuned during hyperparameter 
@@ -285,11 +289,11 @@ A collection of {feat-imp} statistics related to the training data set for this 
 include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=inference-metadata-feature-importance-magnitude]
 
 `max`:::
-(int)
+(integer)
 include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=inference-metadata-feature-importance-max]
 
 `min`:::
-(int)
+(integer)
 include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=inference-metadata-feature-importance-min]
 
 =======

--- a/docs/reference/ml/ml-shared.asciidoc
+++ b/docs/reference/ml/ml-shared.asciidoc
@@ -1101,6 +1101,11 @@ the forest. The maximum value is 2000. By default, this value is calculated
 during hyperparameter optimization.
 end::max-trees[]
 
+tag::max-trees-trained-models[]
+The maximum number of decision trees in the forest. The maximum value is 2000. 
+By default, this value is calculated during hyperparameter optimization.
+end::max-trees-trained-models[]
+
 tag::method[]
 The method that {oldetection} uses. Available methods are `lof`, `ldof`,
 `distance_kth_nn`, `distance_knn`, and `ensemble`. The default value is


### PR DESCRIPTION
Backports the following commits to 7.12:
 - [DOCS] Adds max_trees hyperparameter to GET TM API docs (#72298)