### PR TITLE
[DOCS] EQL: Update tiebreaker docs for implicit tiebreaker

### DIFF
--- a/docs/reference/eql/eql.asciidoc
+++ b/docs/reference/eql/eql.asciidoc
@@ -551,7 +551,7 @@ tiebreaker value after events with a value.
 
 If you don't specify a tiebreaker field or the events also share the same
 tiebreaker value, {es} considers the events concurrent and may
-not return the events in a consistent sort order.
+not return them in a consistent sort order.
 
 To specify a tiebreaker field, use the `tiebreaker_field` parameter. If you use
 the {ecs-ref}[ECS], we recommend using `event.sequence` as the tiebreaker field.

--- a/docs/reference/eql/eql.asciidoc
+++ b/docs/reference/eql/eql.asciidoc
@@ -550,8 +550,8 @@ the events in ascending order. {es} orders events with no
 tiebreaker value after events with a value.
 
 If you don't specify a tiebreaker field or the events also share the same
-tiebreaker value, {es} considers the events concurrent. Concurrent events cannot
-be part of the same sequence and may not be returned in a consistent sort order.
+tiebreaker value, {es} considers the events concurrent. {es} may
+not return concurrent events in a consistent sort order.
 
 To specify a tiebreaker field, use the `tiebreaker_field` parameter. If you use
 the {ecs-ref}[ECS], we recommend using `event.sequence` as the tiebreaker field.

--- a/docs/reference/eql/eql.asciidoc
+++ b/docs/reference/eql/eql.asciidoc
@@ -550,8 +550,8 @@ the events in ascending order. {es} orders events with no
 tiebreaker value after events with a value.
 
 If you don't specify a tiebreaker field or the events also share the same
-tiebreaker value, {es} considers the events concurrent. {es} may
-not return concurrent events in a consistent sort order.
+tiebreaker value, {es} considers the events concurrent and may
+not return the events in a consistent sort order.
 
 To specify a tiebreaker field, use the `tiebreaker_field` parameter. If you use
 the {ecs-ref}[ECS], we recommend using `event.sequence` as the tiebreaker field.


### PR DESCRIPTION
#72089 adds an implicit tiebreaker value for EQL searches.

This PR updates the related EQL tiebreaker docs and cleans up some contradictory language.

### Preview
https://elasticsearch_72808.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/eql.html#eql-search-specify-a-sort-tiebreaker