### PR TITLE
Correctly resolve type for delete operations

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/shard/IndexShard.java
+++ b/server/src/main/java/org/elasticsearch/index/shard/IndexShard.java
@@ -980,8 +980,9 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
                     mapperService.mappingLookup().getType() + "]");
         }
         final Term uid = new Term(IdFieldMapper.NAME, Uid.encodeId(id));
-        final Engine.Delete delete = prepareDelete(type, id, uid, seqNo, opPrimaryTerm, version,
+        final Engine.Delete delete = prepareDelete(resolvedType, id, uid, seqNo, opPrimaryTerm, version,
             versionType, origin, ifSeqNo, ifPrimaryTerm);
+        assert Objects.equals(resolvedType, delete.type());
         return delete(engine, delete);
     }
 


### PR DESCRIPTION
#62616 refactored how we deal with building mapping updates for 
delete operations against an empty index.  In 7x, delete operations
include a type as part of the operation UID, and this type needs to
be resolved against mappings.  In particular, the type `_doc` can
mean either a type called `_doc` (the general case), or it can mean
`whatever type this index actually has`.  There are two code paths
in `IndexShard.applyDeleteOperation`, one for empty mappings 
and one for the standard case; #62616 was resolving the type for
the first code path, but not the second, which meant that some 
delete operations could be written to the translog with an incorrect
type.

This commit adds type resolution to the second code path as well.

Fixes #72735