### PR TITLE
[7.12] [DOCS] Revises required privileges info in Transforms API docs (#72803)

### DIFF
--- a/docs/reference/transform/apis/delete-transform.asciidoc
+++ b/docs/reference/transform/apis/delete-transform.asciidoc
@@ -18,17 +18,9 @@ Deletes an existing {transform}.
 [[delete-transform-prereqs]]
 == {api-prereq-title}
 
+* Requires the `manage_transform` cluster privilege. This privilege is included 
+in the `transform_admin` built-in role.
 * Before you can delete the {transform}, you must stop it.
-
-If the {es} {security-features} are enabled, you must have the following 
-privileges:
-
-* `manage_transform` 
-
-The built-in `transform_admin` role has this privilege. 
-
-For more information, see <<security-privileges>> and <<built-in-roles>>.
-
 
 [[delete-transform-path-parms]]
 == {api-path-parms-title}

--- a/docs/reference/transform/apis/get-transform-stats.asciidoc
+++ b/docs/reference/transform/apis/get-transform-stats.asciidoc
@@ -28,14 +28,11 @@ Retrieves usage information for {transforms}.
 [[get-transform-stats-prereqs]]
 == {api-prereq-title}
 
-If the {es} {security-features} are enabled, you must have the following 
-privileges:
+Requires the following privileges:
 
-* `monitor_transform` 
-
-The built-in `transform_user` role has this privilege. 
-
-For more information, see <<security-privileges>> and <<built-in-roles>>.
+* cluster: `monitor_transform` (the `transform_user` built-in role grants this 
+  privilege)
+* destination index: `read`, `view_index_metadata`.
 
 
 [[get-transform-stats-desc]]

--- a/docs/reference/transform/apis/get-transform.asciidoc
+++ b/docs/reference/transform/apis/get-transform.asciidoc
@@ -26,14 +26,8 @@ Retrieves configuration information for {transforms}.
 [[get-transform-prereqs]]
 == {api-prereq-title}
 
-If the {es} {security-features} are enabled, you must have the following
-privileges:
-
-* `monitor_transform`
-
-The built-in `transform_user` role has this privilege.
-
-For more information, see <<security-privileges>> and <<built-in-roles>>.
+Requires the `monitor_transform` cluster privilege. This privilege is included 
+in the `transform_user` built-in role.
 
 [[get-transform-desc]]
 == {api-description-title}

--- a/docs/reference/transform/apis/preview-transform.asciidoc
+++ b/docs/reference/transform/apis/preview-transform.asciidoc
@@ -18,16 +18,11 @@ Previews a {transform}.
 [[preview-transform-prereq]]
 == {api-prereq-title}
 
-If the {es} {security-features} are enabled, you must have the following
-privileges:
+Requires the following privileges:
 
-* `manage_transform`
-* source index: `read`, `view_index_metadata`
-
-The built-in `transform_admin` role has the `manage_transform` privilege.
-
-For more information, see <<security-privileges>> and <<built-in-roles>>.
-
+* cluster: `manage_transform` (the `transform_admin` built-in role grants this 
+  privilege)
+* source indices: `read`, `view_index_metadata`.
 
 [[preview-transform-desc]]
 == {api-description-title}

--- a/docs/reference/transform/apis/put-transform.asciidoc
+++ b/docs/reference/transform/apis/put-transform.asciidoc
@@ -18,16 +18,12 @@ Instantiates a {transform}.
 [[put-transform-prereqs]]
 == {api-prereq-title}
 
-If the {es} {security-features} are enabled, you must have the following
-built-in roles and privileges:
+Requires the following privileges:
 
-* `transform_admin`
-* source index: `read`, `view_index_metadata`
-* destination index: `read`, `create_index`, `manage` and `index`
-
-For more information, see <<built-in-roles>>, <<security-privileges>>, and
-{ml-docs-setup-privileges}.
-
+* cluster: `manage_transform` (the `transform_admin` built-in role grants this 
+  privilege)
+* source indices: `read`, `view_index_metadata`
+* destination index: `read`, `create_index`, index`.
 
 [[put-transform-desc]]
 == {api-description-title}

--- a/docs/reference/transform/apis/start-transform.asciidoc
+++ b/docs/reference/transform/apis/start-transform.asciidoc
@@ -18,14 +18,11 @@ Starts one or more {transforms}.
 [[start-transform-prereqs]]
 == {api-prereq-title}
 
-If the {es} {security-features} are enabled, you must have the following 
-built-in roles and privileges:
+Requires the following privileges:
 
-* `manage_transform`
-* source index: `view_index_metadata`  
-
-For more information, see <<security-privileges>> and <<built-in-roles>>.
-
+* cluster: `manage_transform` (the `transform_admin` built-in role grants this 
+  privilege)
+* source indices: `read`, `view_index_metadata`.
 
 [[start-transform-desc]]
 == {api-description-title}

--- a/docs/reference/transform/apis/stop-transform.asciidoc
+++ b/docs/reference/transform/apis/stop-transform.asciidoc
@@ -24,14 +24,8 @@ Stops one or more {transforms}.
 [[stop-transform-prereq]]
 == {api-prereq-title}
 
-If the {es} {security-features} are enabled, you must have the following 
-built-in roles and privileges:
-
-* `manage_transform` 
-
-The built-in `transform_admin` role has this privilege. 
-
-For more information, see <<security-privileges>> and <<built-in-roles>>.
+Requires the `manage_transform` cluster privilege. This privilege is included 
+in the `transform_admin` built-in role.
 
 
 [[stop-transform-desc]]

--- a/docs/reference/transform/apis/update-transform.asciidoc
+++ b/docs/reference/transform/apis/update-transform.asciidoc
@@ -18,16 +18,12 @@ Updates certain properties of a {transform}.
 [[update-transform-prereqs]]
 == {api-prereq-title}
 
-If the {es} {security-features} are enabled, you must have the following
-built-in roles and privileges:
+Requires the following privileges:
 
-* `transform_admin`
-
-* `manage_transform` (the built-in `transform_admin` role has this privilege)
-* source index: `read`, `view_index_metadata`
-* destination index: `read`, `create_index`, `index`
-
-For more information, see <<security-privileges>> and <<built-in-roles>>.
+* cluster: `manage_transform` (the `transform_admin` built-in role grants this 
+  privilege)
+* source indices: `read`, `view_index_metadata`
+* destination index: `read`, `index`.
 
 
 [[update-transform-desc]]


### PR DESCRIPTION
Backports the following commits to 7.12:
 - [DOCS] Revises required privileges info in Transforms API docs (#72803)