### PR TITLE
[7.x] [DOCS] EQL: Update tiebreaker docs for implicit tiebreaker (#72808)

### DIFF
--- a/docs/reference/eql/eql.asciidoc
+++ b/docs/reference/eql/eql.asciidoc
@@ -550,8 +550,8 @@ the events in ascending order. {es} orders events with no
 tiebreaker value after events with a value.
 
 If you don't specify a tiebreaker field or the events also share the same
-tiebreaker value, {es} considers the events concurrent. Concurrent events cannot
-be part of the same sequence and may not be returned in a consistent sort order.
+tiebreaker value, {es} considers the events concurrent and may
+not return them in a consistent sort order.
 
 To specify a tiebreaker field, use the `tiebreaker_field` parameter. If you use
 the {ecs-ref}[ECS], we recommend using `event.sequence` as the tiebreaker field.


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [DOCS] EQL: Update tiebreaker docs for implicit tiebreaker (#72808)