### PR TITLE
[7.x] Change data tier preference of snapshot blob cache index to data_content,data_hot

### DIFF
--- a/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/cache/blob/SearchableSnapshotsBlobStoreCacheIntegTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/cache/blob/SearchableSnapshotsBlobStoreCacheIntegTests.java
@@ -60,7 +60,6 @@ import static org.elasticsearch.index.IndexSettings.INDEX_SOFT_DELETES_SETTING;
 import static org.elasticsearch.index.mapper.MapperService.SINGLE_MAPPING_NAME;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCount;
-import static org.elasticsearch.xpack.searchablesnapshots.SearchableSnapshots.DATA_TIERS_CACHE_INDEX_PREFERENCE;
 import static org.elasticsearch.xpack.searchablesnapshots.SearchableSnapshotsConstants.SNAPSHOT_BLOB_CACHE_INDEX;
 import static org.elasticsearch.xpack.searchablesnapshots.cache.shared.SharedBytes.pageAligned;
 import static org.hamcrest.Matchers.equalTo;
@@ -211,7 +210,7 @@ public class SearchableSnapshotsBlobStoreCacheIntegTests extends BaseFrozenSearc
                     .prepareGetSettings(SNAPSHOT_BLOB_CACHE_INDEX)
                     .get()
                     .getSetting(SNAPSHOT_BLOB_CACHE_INDEX, DataTierAllocationDecider.INDEX_ROUTING_PREFER),
-                equalTo(DATA_TIERS_CACHE_INDEX_PREFERENCE)
+                equalTo("data_content,data_hot")
             );
         }
 

--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/SearchableSnapshots.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/SearchableSnapshots.java
@@ -227,15 +227,10 @@ public class SearchableSnapshots extends Plugin implements IndexStorePlugin, Eng
     );
 
     /**
-     * Prefer to allocate to the cold tier, then the warm tier, then the hot tier
+     * Prefer to allocate to the data content tier and then the hot tier.
      * This affects the system searchable snapshot cache index (not the searchable snapshot index itself)
      */
-    public static final String DATA_TIERS_CACHE_INDEX_PREFERENCE = String.join(
-        ",",
-        DataTier.DATA_COLD,
-        DataTier.DATA_WARM,
-        DataTier.DATA_HOT
-    );
+    public static final String DATA_TIERS_CACHE_INDEX_PREFERENCE = String.join(",", DataTier.DATA_CONTENT, DataTier.DATA_HOT);
 
     /**
      * Returns the preference for new searchable snapshot indices. When

--- a/x-pack/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/SearchableSnapshotsRollingUpgradeIT.java
+++ b/x-pack/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/SearchableSnapshotsRollingUpgradeIT.java
@@ -226,7 +226,7 @@ public class SearchableSnapshotsRollingUpgradeIT extends AbstractUpgradeTestCase
             assertHitCount(index, equalTo(numberOfDocs * 2L));
             deleteIndex(index);
 
-            if (UPGRADE_FROM_VERSION.onOrAfter(Version.V_8_0_0)) { // TODO Adjust to 7.13.0
+            if (UPGRADE_FROM_VERSION.onOrAfter(Version.V_7_13_0)) {
                 final Request request = new Request("GET",
                     "/.snapshot-blob-cache/_settings/index.routing.allocation.include._tier_preference");
                 request.setOptions(expectWarnings("this request accesses system indices: [.snapshot-blob-cache], but in a future major " +


### PR DESCRIPTION
snapshot-blob-cache index is created today with a data tier 
preference set to data_cold,data_warm,data_hot. This does 
not works well with autoscaling and clusters that only have 
a hot and a frozen tier: in such cases autoscaling adds a 
cold tier just to host this system index.

This commit changes the tier preference to data_content,data_hot.

Backport of #72817