### PR TITLE
Cleanup BlobPath Class (#72860)

### DIFF
--- a/modules/repository-url/src/main/java/org/elasticsearch/common/blobstore/url/URLBlobStore.java
+++ b/modules/repository-url/src/main/java/org/elasticsearch/common/blobstore/url/URLBlobStore.java
@@ -23,6 +23,7 @@ import org.elasticsearch.common.unit.ByteSizeValue;
 
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.util.List;
 
 /**
  * Read-only URL-based blob store
@@ -112,15 +113,13 @@ public class URLBlobStore implements BlobStore {
      * @return Base URL + path
      */
     private URL buildPath(BlobPath path) throws MalformedURLException {
-        String[] paths = path.toArray();
-        if (paths.length == 0) {
+        List<String> paths = path.parts();
+        if (paths.isEmpty()) {
             return path();
         }
-        URL blobPath = new URL(this.path, paths[0] + "/");
-        if (paths.length > 1) {
-            for (int i = 1; i < paths.length; i++) {
-                blobPath = new URL(blobPath, paths[i] + "/");
-            }
+        URL blobPath = new URL(this.path, paths.get(0) + "/");
+        for (int i = 1; i < paths.size(); i++) {
+            blobPath = new URL(blobPath, paths.get(i) + "/");
         }
         return blobPath;
     }

--- a/modules/repository-url/src/main/java/org/elasticsearch/repositories/url/URLRepository.java
+++ b/modules/repository-url/src/main/java/org/elasticsearch/repositories/url/URLRepository.java
@@ -96,7 +96,7 @@ public class URLRepository extends BlobStoreRepository {
         this.environment = environment;
         supportedProtocols = SUPPORTED_PROTOCOLS_SETTING.get(environment.settings());
         urlWhiteList = ALLOWED_URLS_SETTING.get(environment.settings()).toArray(new URIPattern[]{});
-        basePath = BlobPath.cleanPath();
+        basePath = BlobPath.EMPTY;
         url = URL_SETTING.exists(metadata.settings())
             ? URL_SETTING.get(metadata.settings()) : REPOSITORIES_URL_SETTING.get(environment.settings());
 

--- a/modules/repository-url/src/test/java/org/elasticsearch/common/blobstore/url/FileURLBlobStoreTests.java
+++ b/modules/repository-url/src/test/java/org/elasticsearch/common/blobstore/url/FileURLBlobStoreTests.java
@@ -54,7 +54,7 @@ public class FileURLBlobStoreTests extends AbstractURLBlobStoreTests {
 
     @Override
     BlobContainer getBlobContainer() {
-        return blobStore.blobContainer(new BlobPath());
+        return blobStore.blobContainer(BlobPath.EMPTY);
     }
 
     @Override

--- a/modules/repository-url/src/test/java/org/elasticsearch/common/blobstore/url/HttpURLBlobStoreTests.java
+++ b/modules/repository-url/src/test/java/org/elasticsearch/common/blobstore/url/HttpURLBlobStoreTests.java
@@ -119,7 +119,7 @@ public class HttpURLBlobStoreTests extends AbstractURLBlobStoreTests {
 
     @Override
     BlobContainer getBlobContainer() {
-        return urlBlobStore.blobContainer(new BlobPath().add("indices"));
+        return urlBlobStore.blobContainer(BlobPath.EMPTY.add("indices"));
     }
 
     @Override

--- a/modules/repository-url/src/test/java/org/elasticsearch/common/blobstore/url/URLBlobContainerRetriesTests.java
+++ b/modules/repository-url/src/test/java/org/elasticsearch/common/blobstore/url/URLBlobContainerRetriesTests.java
@@ -91,7 +91,7 @@ public class URLBlobContainerRetriesTests extends AbstractBlobContainerRetriesTe
             final URLHttpClientSettings httpClientSettings = URLHttpClientSettings.fromSettings(settings);
             URLBlobStore urlBlobStore =
                 new URLBlobStore(settings, new URL(getEndpointForServer()), factory.create(httpClientSettings), httpClientSettings);
-            return urlBlobStore.blobContainer(new BlobPath());
+            return urlBlobStore.blobContainer(BlobPath.EMPTY);
         } catch (MalformedURLException e) {
             throw new RuntimeException("Unable to create URLBlobStore", e);
         }

--- a/plugins/repository-azure/src/internalClusterTest/java/org/elasticsearch/repositories/azure/AzureBlobStoreRepositoryTests.java
+++ b/plugins/repository-azure/src/internalClusterTest/java/org/elasticsearch/repositories/azure/AzureBlobStoreRepositoryTests.java
@@ -209,7 +209,7 @@ public class AzureBlobStoreRepositoryTests extends ESMockAPIBasedRepositoryInteg
     public void testLargeBlobCountDeletion() throws Exception {
         int numberOfBlobs = randomIntBetween(257, 2000);
         try (BlobStore store = newBlobStore()) {
-            final BlobContainer container = store.blobContainer(new BlobPath());
+            final BlobContainer container = store.blobContainer(BlobPath.EMPTY);
             for (int i = 0; i < numberOfBlobs; i++) {
                 byte[] bytes = randomBytes(randomInt(100));
                 String blobName = randomAlphaOfLength(10);
@@ -223,7 +223,7 @@ public class AzureBlobStoreRepositoryTests extends ESMockAPIBasedRepositoryInteg
 
     public void testDeleteBlobsIgnoringIfNotExists() throws Exception {
         try (BlobStore store = newBlobStore()) {
-            final BlobContainer container = store.blobContainer(new BlobPath());
+            final BlobContainer container = store.blobContainer(BlobPath.EMPTY);
             List<String> blobsToDelete = new ArrayList<>();
             for (int i = 0; i < 10; i++) {
                 byte[] bytes = randomBytes(randomInt(100));

--- a/plugins/repository-azure/src/main/java/org/elasticsearch/repositories/azure/AzureBlobStore.java
+++ b/plugins/repository-azure/src/main/java/org/elasticsearch/repositories/azure/AzureBlobStore.java
@@ -366,7 +366,7 @@ public class AzureBlobStore implements BlobStore {
                         // Remove trailing slash
                         directoryName = directoryName.substring(0, directoryName.length() - 1);
                         childrenBuilder.put(directoryName,
-                            new AzureBlobContainer(BlobPath.cleanPath().add(blobItem.getName()), this));
+                            new AzureBlobContainer(BlobPath.EMPTY.add(blobItem.getName()), this));
                     }
                 }
             });

--- a/plugins/repository-azure/src/main/java/org/elasticsearch/repositories/azure/AzureRepository.java
+++ b/plugins/repository-azure/src/main/java/org/elasticsearch/repositories/azure/AzureRepository.java
@@ -88,13 +88,13 @@ public class AzureRepository extends MeteredBlobStoreRepository {
         final String basePath = Strings.trimLeadingCharacter(Repository.BASE_PATH_SETTING.get(metadata.settings()), '/');
         if (Strings.hasLength(basePath)) {
             // Remove starting / if any
-            BlobPath path = new BlobPath();
+            BlobPath path = BlobPath.EMPTY;
             for(final String elem : basePath.split("/")) {
                 path = path.add(elem);
             }
             this.basePath = path;
         } else {
-            this.basePath = BlobPath.cleanPath();
+            this.basePath = BlobPath.EMPTY;
         }
 
         // If the user explicitly did not define a readonly value, we set it by ourselves depending on the location mode setting.

--- a/plugins/repository-azure/src/test/java/org/elasticsearch/repositories/azure/AzureBlobContainerRetriesTests.java
+++ b/plugins/repository-azure/src/test/java/org/elasticsearch/repositories/azure/AzureBlobContainerRetriesTests.java
@@ -172,7 +172,7 @@ public class AzureBlobContainerRetriesTests extends ESTestCase {
                 .put(MAX_SINGLE_PART_UPLOAD_SIZE_SETTING.getKey(), new ByteSizeValue(1, ByteSizeUnit.MB))
                 .build());
 
-        return new AzureBlobContainer(BlobPath.cleanPath(), new AzureBlobStore(repositoryMetadata, service));
+        return new AzureBlobContainer(BlobPath.EMPTY, new AzureBlobStore(repositoryMetadata, service));
     }
 
     public void testReadNonexistentBlobThrowsNoSuchFileException() {

--- a/plugins/repository-gcs/src/internalClusterTest/java/org/elasticsearch/repositories/gcs/GoogleCloudStorageBlobStoreRepositoryTests.java
+++ b/plugins/repository-gcs/src/internalClusterTest/java/org/elasticsearch/repositories/gcs/GoogleCloudStorageBlobStoreRepositoryTests.java
@@ -176,7 +176,7 @@ public class GoogleCloudStorageBlobStoreRepositoryTests extends ESMockAPIBasedRe
 
     public void testWriteReadLarge() throws IOException {
         try (BlobStore store = newBlobStore()) {
-            final BlobContainer container = store.blobContainer(new BlobPath());
+            final BlobContainer container = store.blobContainer(BlobPath.EMPTY);
             byte[] data = randomBytes(GoogleCloudStorageBlobStore.LARGE_BLOB_THRESHOLD_BYTE_SIZE + 1);
             writeBlob(container, "foobar", new BytesArray(data), randomBoolean());
             if (randomBoolean()) {

--- a/plugins/repository-gcs/src/main/java/org/elasticsearch/repositories/gcs/GoogleCloudStorageRepository.java
+++ b/plugins/repository-gcs/src/main/java/org/elasticsearch/repositories/gcs/GoogleCloudStorageRepository.java
@@ -74,13 +74,13 @@ class GoogleCloudStorageRepository extends MeteredBlobStoreRepository {
 
         String basePath = BASE_PATH.get(metadata.settings());
         if (Strings.hasLength(basePath)) {
-            BlobPath path = new BlobPath();
+            BlobPath path = BlobPath.EMPTY;
             for (String elem : basePath.split("/")) {
                 path = path.add(elem);
             }
             this.basePath = path;
         } else {
-            this.basePath = BlobPath.cleanPath();
+            this.basePath = BlobPath.EMPTY;
         }
 
         this.chunkSize = getSetting(CHUNK_SIZE, metadata);

--- a/plugins/repository-gcs/src/test/java/org/elasticsearch/repositories/gcs/GoogleCloudStorageBlobContainerRetriesTests.java
+++ b/plugins/repository-gcs/src/test/java/org/elasticsearch/repositories/gcs/GoogleCloudStorageBlobContainerRetriesTests.java
@@ -156,7 +156,7 @@ public class GoogleCloudStorageBlobContainerRetriesTests extends AbstractBlobCon
         final GoogleCloudStorageBlobStore blobStore = new GoogleCloudStorageBlobStore("bucket", client, "repo", service,
             randomIntBetween(1, 8) * 1024);
 
-        return new GoogleCloudStorageBlobContainer(BlobPath.cleanPath(), blobStore);
+        return new GoogleCloudStorageBlobContainer(BlobPath.EMPTY, blobStore);
     }
 
     public void testReadLargeBlobWithRetries() throws Exception {

--- a/plugins/repository-gcs/src/test/java/org/elasticsearch/repositories/gcs/GoogleCloudStorageBlobStoreContainerTests.java
+++ b/plugins/repository-gcs/src/test/java/org/elasticsearch/repositories/gcs/GoogleCloudStorageBlobStoreContainerTests.java
@@ -78,7 +78,7 @@ public class GoogleCloudStorageBlobStoreContainerTests extends ESTestCase {
 
         try (BlobStore store = new GoogleCloudStorageBlobStore("bucket", "test", "repo", storageService,
             randomIntBetween(1, 8) * 1024)) {
-            final BlobContainer container = store.blobContainer(new BlobPath());
+            final BlobContainer container = store.blobContainer(BlobPath.EMPTY);
 
             IOException e = expectThrows(IOException.class, () -> container.deleteBlobsIgnoringIfNotExists(blobs));
             assertThat(e.getCause(), instanceOf(StorageException.class));

--- a/plugins/repository-hdfs/src/main/java/org/elasticsearch/repositories/hdfs/HdfsBlobStore.java
+++ b/plugins/repository-hdfs/src/main/java/org/elasticsearch/repositories/hdfs/HdfsBlobStore.java
@@ -81,7 +81,7 @@ final class HdfsBlobStore implements BlobStore {
 
     private Path translateToHdfsPath(BlobPath blobPath) {
         Path path = root;
-        for (String p : blobPath) {
+        for (String p : blobPath.parts()) {
             path = new Path(path, p);
         }
         return path;

--- a/plugins/repository-hdfs/src/main/java/org/elasticsearch/repositories/hdfs/HdfsRepository.java
+++ b/plugins/repository-hdfs/src/main/java/org/elasticsearch/repositories/hdfs/HdfsRepository.java
@@ -49,7 +49,7 @@ public final class HdfsRepository extends BlobStoreRepository {
 
     private final Environment environment;
     private final ByteSizeValue chunkSize;
-    private final BlobPath basePath = BlobPath.cleanPath();
+    private final BlobPath basePath = BlobPath.EMPTY;
     private final URI uri;
     private final String pathSetting;
 

--- a/plugins/repository-hdfs/src/test/java/org/elasticsearch/repositories/hdfs/HdfsBlobStoreContainerTests.java
+++ b/plugins/repository-hdfs/src/test/java/org/elasticsearch/repositories/hdfs/HdfsBlobStoreContainerTests.java
@@ -106,12 +106,12 @@ public class HdfsBlobStoreContainerTests extends ESTestCase {
         FileContext.Util util = fileContext.util();
         Path root = fileContext.makeQualified(new Path("dir"));
         assertFalse(util.exists(root));
-        BlobPath blobPath = BlobPath.cleanPath().add("path");
+        BlobPath blobPath = BlobPath.EMPTY.add("path");
 
         // blobContainer() will not create path if read only
         hdfsBlobStore.blobContainer(blobPath);
         Path hdfsPath = root;
-        for (String p : blobPath) {
+        for (String p : blobPath.parts()) {
             hdfsPath = new Path(hdfsPath, p);
         }
         assertFalse(util.exists(hdfsPath));
@@ -135,12 +135,12 @@ public class HdfsBlobStoreContainerTests extends ESTestCase {
         FileContext.Util util = fileContext.util();
         Path root = fileContext.makeQualified(new Path("dir"));
         assertFalse(util.exists(root));
-        BlobPath blobPath = BlobPath.cleanPath().add("path");
+        BlobPath blobPath = BlobPath.EMPTY.add("path");
 
         // blobContainer() will not create path if read only
         hdfsBlobStore.blobContainer(blobPath);
         Path hdfsPath = root;
-        for (String p : blobPath) {
+        for (String p : blobPath.parts()) {
             hdfsPath = new Path(hdfsPath, p);
         }
         assertFalse(util.exists(hdfsPath));

--- a/plugins/repository-s3/src/main/java/org/elasticsearch/repositories/s3/S3Repository.java
+++ b/plugins/repository-s3/src/main/java/org/elasticsearch/repositories/s3/S3Repository.java
@@ -235,9 +235,9 @@ class S3Repository extends MeteredBlobStoreRepository {
 
         final String basePath = BASE_PATH_SETTING.get(metadata.settings());
         if (Strings.hasLength(basePath)) {
-            this.basePath = new BlobPath().add(basePath);
+            this.basePath = BlobPath.EMPTY.add(basePath);
         } else {
-            this.basePath = BlobPath.cleanPath();
+            this.basePath = BlobPath.EMPTY;
         }
 
         this.serverSideEncryption = SERVER_SIDE_ENCRYPTION_SETTING.get(metadata.settings());

--- a/plugins/repository-s3/src/test/java/org/elasticsearch/repositories/s3/S3BlobContainerRetriesTests.java
+++ b/plugins/repository-s3/src/test/java/org/elasticsearch/repositories/s3/S3BlobContainerRetriesTests.java
@@ -121,7 +121,7 @@ public class S3BlobContainerRetriesTests extends AbstractBlobContainerRetriesTes
         final RepositoryMetadata repositoryMetadata = new RepositoryMetadata("repository", S3Repository.TYPE,
             Settings.builder().put(S3Repository.CLIENT_NAME.getKey(), clientName).build());
 
-        return new S3BlobContainer(BlobPath.cleanPath(), new S3BlobStore(service, "bucket",
+        return new S3BlobContainer(BlobPath.EMPTY, new S3BlobStore(service, "bucket",
             S3Repository.SERVER_SIDE_ENCRYPTION_SETTING.getDefault(Settings.EMPTY),
             bufferSize == null ? S3Repository.BUFFER_SIZE_SETTING.getDefault(Settings.EMPTY) : bufferSize,
             S3Repository.CANNED_ACL_SETTING.getDefault(Settings.EMPTY),

--- a/plugins/repository-s3/src/test/java/org/elasticsearch/repositories/s3/S3BlobStoreContainerTests.java
+++ b/plugins/repository-s3/src/test/java/org/elasticsearch/repositories/s3/S3BlobStoreContainerTests.java
@@ -76,7 +76,7 @@ public class S3BlobStoreContainerTests extends ESTestCase {
         final String bucketName = randomAlphaOfLengthBetween(1, 10);
         final String blobName = randomAlphaOfLengthBetween(1, 10);
 
-        final BlobPath blobPath = new BlobPath();
+        final BlobPath blobPath = BlobPath.EMPTY;
         if (randomBoolean()) {
             IntStream.of(randomIntBetween(1, 5)).forEach(value -> blobPath.add("path_" + value));
         }
@@ -149,7 +149,7 @@ public class S3BlobStoreContainerTests extends ESTestCase {
         final String bucketName = randomAlphaOfLengthBetween(1, 10);
         final String blobName = randomAlphaOfLengthBetween(1, 10);
 
-        final BlobPath blobPath = new BlobPath();
+        final BlobPath blobPath = BlobPath.EMPTY;
         if (randomBoolean()) {
             IntStream.of(randomIntBetween(1, 5)).forEach(value -> blobPath.add("path_" + value));
         }
@@ -250,7 +250,7 @@ public class S3BlobStoreContainerTests extends ESTestCase {
     public void testExecuteMultipartUploadAborted() {
         final String bucketName = randomAlphaOfLengthBetween(1, 10);
         final String blobName = randomAlphaOfLengthBetween(1, 10);
-        final BlobPath blobPath = new BlobPath();
+        final BlobPath blobPath = BlobPath.EMPTY;
 
         final long blobSize = ByteSizeUnit.MB.toBytes(765);
         final long bufferSize =  ByteSizeUnit.MB.toBytes(150);

--- a/server/src/main/java/org/elasticsearch/common/blobstore/BlobPath.java
+++ b/server/src/main/java/org/elasticsearch/common/blobstore/BlobPath.java
@@ -13,38 +13,26 @@ import org.elasticsearch.common.util.CollectionUtils;
 
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Objects;
 
 /**
  * The list of paths where a blob can reside.  The contents of the paths are dependent upon the implementation of {@link BlobContainer}.
  */
-public class BlobPath implements Iterable<String> {
+public class BlobPath {
+
+    public static final BlobPath EMPTY = new BlobPath(Collections.emptyList());
 
     private static final String SEPARATOR = "/";
 
     private final List<String> paths;
 
-    public BlobPath() {
-        this.paths = Collections.emptyList();
-    }
-
-    public static BlobPath cleanPath() {
-        return new BlobPath();
-    }
-
     private BlobPath(List<String> paths) {
         this.paths = paths;
     }
 
-    @Override
-    public Iterator<String> iterator() {
-        return paths.iterator();
-    }
-
-    public String[] toArray() {
-        return paths.toArray(new String[paths.size()]);
+    public List<String> parts() {
+        return paths;
     }
 
     public BlobPath add(String path) {
@@ -66,10 +54,15 @@ public class BlobPath implements Iterable<String> {
      */
     @Nullable
     public BlobPath parent() {
-        if (paths.isEmpty()) {
-            return null;
-        } else {
-            return new BlobPath(new ArrayList<>(paths.subList(0, paths.size() - 1)));
+
+        int size = paths.size();
+        switch (size) {
+            case 0:
+                return null;
+            case 1:
+                return EMPTY;
+            default:
+                return new BlobPath(Collections.unmodifiableList(new ArrayList<>(paths.subList(0, size - 1))));
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/common/blobstore/fs/FsBlobStore.java
+++ b/server/src/main/java/org/elasticsearch/common/blobstore/fs/FsBlobStore.java
@@ -16,6 +16,7 @@ import org.elasticsearch.common.blobstore.BlobStore;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.List;
 
 public class FsBlobStore implements BlobStore {
 
@@ -70,15 +71,13 @@ public class FsBlobStore implements BlobStore {
     }
 
     private Path buildPath(BlobPath path) {
-        String[] paths = path.toArray();
-        if (paths.length == 0) {
+        List<String> paths = path.parts();
+        if (paths.isEmpty()) {
             return path();
         }
-        Path blobPath = this.path.resolve(paths[0]);
-        if (paths.length > 1) {
-            for (int i = 1; i < paths.length; i++) {
-                blobPath = blobPath.resolve(paths[i]);
-            }
+        Path blobPath = this.path.resolve(paths.get(0));
+        for (int i = 1; i < paths.size(); i++) {
+            blobPath = blobPath.resolve(paths.get(i));
         }
         return blobPath;
     }

--- a/server/src/main/java/org/elasticsearch/common/util/CollectionUtils.java
+++ b/server/src/main/java/org/elasticsearch/common/util/CollectionUtils.java
@@ -325,7 +325,7 @@ public class CollectionUtils {
         final int size = collection.size() + 1;
         final E[] array = collection.toArray((E[]) new Object[size]);
         array[size - 1] = element;
-        return Arrays.asList(array);
+        return Collections.unmodifiableList(Arrays.asList(array));
     }
 
     public static <E> ArrayList<E> newSingletonArrayList(E element) {

--- a/server/src/main/java/org/elasticsearch/repositories/fs/FsRepository.java
+++ b/server/src/main/java/org/elasticsearch/repositories/fs/FsRepository.java
@@ -95,7 +95,7 @@ public class FsRepository extends BlobStoreRepository {
         } else {
             this.chunkSize = REPOSITORIES_CHUNK_SIZE_SETTING.get(environment.settings());
         }
-        this.basePath = BlobPath.cleanPath();
+        this.basePath = BlobPath.EMPTY;
     }
 
     private static boolean calculateCompress(RepositoryMetadata metadata, Environment environment) {

--- a/server/src/test/java/org/elasticsearch/common/blobstore/BlobPathTests.java
+++ b/server/src/test/java/org/elasticsearch/common/blobstore/BlobPathTests.java
@@ -15,7 +15,7 @@ import static org.hamcrest.Matchers.is;
 public class BlobPathTests extends ESTestCase {
 
     public void testBuildAsString() {
-        BlobPath path = new BlobPath();
+        BlobPath path = BlobPath.EMPTY;
         assertThat(path.buildAsString(), is(""));
 
         path = path.add("a");

--- a/server/src/test/java/org/elasticsearch/common/blobstore/fs/FsBlobContainerTests.java
+++ b/server/src/test/java/org/elasticsearch/common/blobstore/fs/FsBlobContainerTests.java
@@ -66,7 +66,7 @@ public class FsBlobContainerTests extends ESTestCase {
         Files.write(path.resolve(blobName), blobData);
 
         final FsBlobContainer container =
-            new FsBlobContainer(new FsBlobStore(randomIntBetween(1, 8) * 1024, path, false), BlobPath.cleanPath(), path);
+            new FsBlobContainer(new FsBlobStore(randomIntBetween(1, 8) * 1024, path, false), BlobPath.EMPTY, path);
         assertThat(totalBytesRead.get(), equalTo(0L));
 
         final long start = randomLongBetween(0L, Math.max(0L, blobData.length - 1));

--- a/server/src/test/java/org/elasticsearch/repositories/RepositoriesServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/repositories/RepositoriesServiceTests.java
@@ -341,7 +341,7 @@ public class RepositoriesServiceTests extends ESTestCase {
 
         @Override
         public BlobPath basePath() {
-            return BlobPath.cleanPath();
+            return BlobPath.EMPTY;
         }
     }
 
@@ -371,7 +371,7 @@ public class RepositoriesServiceTests extends ESTestCase {
 
         @Override
         public BlobPath basePath() {
-            return BlobPath.cleanPath();
+            return BlobPath.EMPTY;
         }
     }
 }

--- a/server/src/test/java/org/elasticsearch/snapshots/BlobStoreFormatTests.java
+++ b/server/src/test/java/org/elasticsearch/snapshots/BlobStoreFormatTests.java
@@ -89,7 +89,7 @@ public class BlobStoreFormatTests extends ESTestCase {
 
     public void testBlobStoreOperations() throws IOException {
         BlobStore blobStore = createTestBlobStore();
-        BlobContainer blobContainer = blobStore.blobContainer(BlobPath.cleanPath());
+        BlobContainer blobContainer = blobStore.blobContainer(BlobPath.EMPTY);
         ChecksumBlobStoreFormat<BlobObj> checksumSMILE = new ChecksumBlobStoreFormat<>(BLOB_CODEC, "%s", BlobObj::fromXContent);
 
         // Write blobs in different formats
@@ -106,7 +106,7 @@ public class BlobStoreFormatTests extends ESTestCase {
 
     public void testCompressionIsApplied() throws IOException {
         BlobStore blobStore = createTestBlobStore();
-        BlobContainer blobContainer = blobStore.blobContainer(BlobPath.cleanPath());
+        BlobContainer blobContainer = blobStore.blobContainer(BlobPath.EMPTY);
         StringBuilder veryRedundantText = new StringBuilder();
         for (int i = 0; i < randomIntBetween(100, 300); i++) {
             veryRedundantText.append("Blah ");
@@ -122,7 +122,7 @@ public class BlobStoreFormatTests extends ESTestCase {
 
     public void testBlobCorruption() throws IOException {
         BlobStore blobStore = createTestBlobStore();
-        BlobContainer blobContainer = blobStore.blobContainer(BlobPath.cleanPath());
+        BlobContainer blobContainer = blobStore.blobContainer(BlobPath.EMPTY);
         String testString = randomAlphaOfLength(randomInt(10000));
         BlobObj blobObj = new BlobObj(testString);
         ChecksumBlobStoreFormat<BlobObj> checksumFormat = new ChecksumBlobStoreFormat<>(BLOB_CODEC, "%s", BlobObj::fromXContent);

--- a/server/src/test/java/org/elasticsearch/snapshots/mockstore/MockEventuallyConsistentRepository.java
+++ b/server/src/test/java/org/elasticsearch/snapshots/mockstore/MockEventuallyConsistentRepository.java
@@ -99,7 +99,7 @@ public class MockEventuallyConsistentRepository extends BlobStoreRepository {
 
     @Override
     public BlobPath basePath() {
-        return BlobPath.cleanPath();
+        return BlobPath.EMPTY;
     }
 
     /**

--- a/test/framework/src/main/java/org/elasticsearch/repositories/AbstractThirdPartyRepositoryTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/repositories/AbstractThirdPartyRepositoryTestCase.java
@@ -77,7 +77,7 @@ public abstract class AbstractThirdPartyRepositoryTestCase extends ESSingleNodeT
         if (parent == null) {
             assertChildren(path, Collections.emptyList());
         } else {
-            assertDeleted(parent, path.toArray()[path.toArray().length - 1]);
+            assertDeleted(parent, path.parts().get(path.parts().size() - 1));
         }
     }
 

--- a/test/framework/src/main/java/org/elasticsearch/repositories/blobstore/ESBlobStoreRepositoryIntegTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/repositories/blobstore/ESBlobStoreRepositoryIntegTestCase.java
@@ -110,7 +110,7 @@ public abstract class ESBlobStoreRepositoryIntegTestCase extends ESIntegTestCase
 
     public void testReadNonExistingPath() throws IOException {
         try (BlobStore store = newBlobStore()) {
-            final BlobContainer container = store.blobContainer(new BlobPath());
+            final BlobContainer container = store.blobContainer(BlobPath.EMPTY);
             expectThrows(NoSuchFileException.class, () -> {
                 try (InputStream is = container.readBlob("non-existing")) {
                     is.read();
@@ -121,7 +121,7 @@ public abstract class ESBlobStoreRepositoryIntegTestCase extends ESIntegTestCase
 
     public void testWriteRead() throws IOException {
         try (BlobStore store = newBlobStore()) {
-            final BlobContainer container = store.blobContainer(new BlobPath());
+            final BlobContainer container = store.blobContainer(BlobPath.EMPTY);
             byte[] data = randomBytes(randomIntBetween(10, scaledRandomIntBetween(1024, 1 << 16)));
             writeBlob(container, "foobar", new BytesArray(data), randomBoolean());
             if (randomBoolean()) {
@@ -150,7 +150,7 @@ public abstract class ESBlobStoreRepositoryIntegTestCase extends ESIntegTestCase
 
     public void testList() throws IOException {
         try (BlobStore store = newBlobStore()) {
-            final BlobContainer container = store.blobContainer(new BlobPath());
+            final BlobContainer container = store.blobContainer(BlobPath.EMPTY);
             assertThat(container.listBlobs().size(), CoreMatchers.equalTo(0));
             int numberOfFooBlobs = randomIntBetween(0, 10);
             int numberOfBarBlobs = randomIntBetween(3, 20);
@@ -191,7 +191,7 @@ public abstract class ESBlobStoreRepositoryIntegTestCase extends ESIntegTestCase
     public void testDeleteBlobs() throws IOException {
         try (BlobStore store = newBlobStore()) {
             final List<String> blobNames = Arrays.asList("foobar", "barfoo");
-            final BlobContainer container = store.blobContainer(new BlobPath());
+            final BlobContainer container = store.blobContainer(BlobPath.EMPTY);
             container.deleteBlobsIgnoringIfNotExists(blobNames); // does not raise when blobs don't exist
             byte[] data = randomBytes(randomIntBetween(10, scaledRandomIntBetween(1024, 1 << 16)));
             final BytesArray bytesArray = new BytesArray(data);
@@ -216,8 +216,8 @@ public abstract class ESBlobStoreRepositoryIntegTestCase extends ESIntegTestCase
 
     public void testContainerCreationAndDeletion() throws IOException {
         try (BlobStore store = newBlobStore()) {
-            final BlobContainer containerFoo = store.blobContainer(new BlobPath().add("foo"));
-            final BlobContainer containerBar = store.blobContainer(new BlobPath().add("bar"));
+            final BlobContainer containerFoo = store.blobContainer(BlobPath.EMPTY.add("foo"));
+            final BlobContainer containerBar = store.blobContainer(BlobPath.EMPTY.add("bar"));
             byte[] data1 = randomBytes(randomIntBetween(10, scaledRandomIntBetween(1024, 1 << 16)));
             byte[] data2 = randomBytes(randomIntBetween(10, scaledRandomIntBetween(1024, 1 << 16)));
             writeBlob(containerFoo, "test", new BytesArray(data1));

--- a/test/framework/src/main/java/org/elasticsearch/repositories/blobstore/ESFsBasedRepositoryIntegTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/repositories/blobstore/ESFsBasedRepositoryIntegTestCase.java
@@ -88,10 +88,10 @@ public abstract class ESFsBasedRepositoryIntegTestCase extends ESBlobStoreReposi
 
         try (BlobStore store = newBlobStore(repoName)) {
             assertFalse(Files.exists(repoPath));
-            BlobPath blobPath = BlobPath.cleanPath().add("foo");
+            BlobPath blobPath = BlobPath.EMPTY.add("foo");
             store.blobContainer(blobPath);
             Path storePath = repoPath;
-            for (String d : blobPath) {
+            for (String d : blobPath.parts()) {
                 storePath = storePath.resolve(d);
             }
             assertFalse(Files.exists(storePath));
@@ -101,10 +101,10 @@ public abstract class ESFsBasedRepositoryIntegTestCase extends ESBlobStoreReposi
 
         try (BlobStore store = newBlobStore(repoName)) {
             assertTrue(Files.exists(repoPath));
-            BlobPath blobPath = BlobPath.cleanPath().add("foo");
+            BlobPath blobPath = BlobPath.EMPTY.add("foo");
             BlobContainer container = store.blobContainer(blobPath);
             Path storePath = repoPath;
-            for (String d : blobPath) {
+            for (String d : blobPath.parts()) {
                 storePath = storePath.resolve(d);
             }
             assertTrue(Files.exists(storePath));

--- a/test/framework/src/main/java/org/elasticsearch/snapshots/mockstore/MockRepository.java
+++ b/test/framework/src/main/java/org/elasticsearch/snapshots/mockstore/MockRepository.java
@@ -433,7 +433,7 @@ public class MockRepository extends FsRepository {
                     deleteByteCount += blobs.get(blob).length();
                 }
                 blobStore().blobContainer(path().parent()).deleteBlobsIgnoringIfNotExists(
-                    Collections.singletonList(path().toArray()[path().toArray().length - 1]));
+                    Collections.singletonList(path().parts().get(path().parts().size() - 1)));
                 return deleteResult.add(deleteBlobCount, deleteByteCount);
             }
 

--- a/x-pack/plugin/repository-encrypted/src/main/java/org/elasticsearch/repositories/encrypted/EncryptedRepository.java
+++ b/x-pack/plugin/repository-encrypted/src/main/java/org/elasticsearch/repositories/encrypted/EncryptedRepository.java
@@ -56,7 +56,6 @@ import java.nio.file.NoSuchFileException;
 import java.security.GeneralSecurityException;
 import java.security.SecureRandom;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
@@ -272,7 +271,7 @@ public class EncryptedRepository extends BlobStoreRepository {
     public BlobPath basePath() {
         // the encrypted repository uses a hardcoded empty base blob path,
         // but the base path setting is honored for the delegated repository
-        return BlobPath.cleanPath();
+        return BlobPath.EMPTY;
     }
 
     @Override
@@ -488,10 +487,9 @@ public class EncryptedRepository extends BlobStoreRepository {
 
         @Override
         public BlobContainer blobContainer(BlobPath path) {
-            final Iterator<String> pathIterator = path.iterator();
             BlobPath delegatedBlobContainerPath = delegatedBasePath;
-            while (pathIterator.hasNext()) {
-                delegatedBlobContainerPath = delegatedBlobContainerPath.add(pathIterator.next());
+            for (String s : path.parts()) {
+                delegatedBlobContainerPath = delegatedBlobContainerPath.add(s);
             }
             final BlobContainer delegatedBlobContainer = delegatedBlobStore.blobContainer(delegatedBlobContainerPath);
             return new EncryptedBlobContainer(path, repositoryName, delegatedBlobContainer, singleUseDEKSupplier, this::getDEKById);
@@ -520,7 +518,7 @@ public class EncryptedRepository extends BlobStoreRepository {
         ) {
             super(path);
             this.repositoryName = repositoryName;
-            final String rootPathElement = path.iterator().hasNext() ? path.iterator().next() : null;
+            final String rootPathElement = path.parts().isEmpty() ? null : path.parts().get(0);
             if (DEK_ROOT_CONTAINER.equals(rootPathElement)) {
                 throw new RepositoryException(repositoryName, "Cannot descend into the DEK blob container " + path);
             }
@@ -687,7 +685,7 @@ public class EncryptedRepository extends BlobStoreRepository {
             final Map<String, BlobContainer> childEncryptedBlobContainers = delegatedBlobContainer.children();
             final Map<String, BlobContainer> resultBuilder = new HashMap<>(childEncryptedBlobContainers.size());
             for (Map.Entry<String, BlobContainer> childBlobContainer : childEncryptedBlobContainers.entrySet()) {
-                if (childBlobContainer.getKey().equals(DEK_ROOT_CONTAINER) && false == path().iterator().hasNext()) {
+                if (childBlobContainer.getKey().equals(DEK_ROOT_CONTAINER) && path().parts().isEmpty()) {
                     // do not descend into the DEK blob container
                     continue;
                 }

--- a/x-pack/plugin/repository-encrypted/src/test/java/org/elasticsearch/repositories/encrypted/EncryptedRepositoryTests.java
+++ b/x-pack/plugin/repository-encrypted/src/test/java/org/elasticsearch/repositories/encrypted/EncryptedRepositoryTests.java
@@ -60,9 +60,9 @@ public class EncryptedRepositoryTests extends ESTestCase {
     public void setUpMocks() throws Exception {
         this.repoPassword = new SecureString(randomAlphaOfLength(20).toCharArray());
         this.delegatedPath = randomFrom(
-            BlobPath.cleanPath(),
-            BlobPath.cleanPath().add(randomAlphaOfLength(8)),
-            BlobPath.cleanPath().add(randomAlphaOfLength(4)).add(randomAlphaOfLength(4))
+            BlobPath.EMPTY,
+            BlobPath.EMPTY.add(randomAlphaOfLength(8)),
+            BlobPath.EMPTY.add(randomAlphaOfLength(4)).add(randomAlphaOfLength(4))
         );
         this.delegatedBlobStore = mock(BlobStore.class);
         this.delegatedRepository = mock(BlobStoreRepository.class);

--- a/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/store/SearchableSnapshotDirectoryTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/store/SearchableSnapshotDirectoryTests.java
@@ -730,7 +730,7 @@ public class SearchableSnapshotDirectoryTests extends AbstractSearchableSnapshot
             final BlobStoreIndexShardSnapshot snapshot = new BlobStoreIndexShardSnapshot("_snapshot", 0L, randomFiles, 0L, 0L, 0, 0L);
             final BlobContainer blobContainer = new FsBlobContainer(
                 new FsBlobStore(randomIntBetween(1, 8) * 1024, shardSnapshotDir, true),
-                BlobPath.cleanPath(),
+                BlobPath.EMPTY,
                 shardSnapshotDir
             );
 

--- a/x-pack/plugin/snapshot-repo-test-kit/src/internalClusterTest/java/org/elasticsearch/repositories/blobstore/testkit/RepositoryAnalysisFailureIT.java
+++ b/x-pack/plugin/snapshot-repo-test-kit/src/internalClusterTest/java/org/elasticsearch/repositories/blobstore/testkit/RepositoryAnalysisFailureIT.java
@@ -319,7 +319,7 @@ public class RepositoryAnalysisFailureIT extends AbstractSnapshotIntegTestCase {
                     clusterService,
                     bigArrays,
                     recoverySettings,
-                    new BlobPath()
+                    BlobPath.EMPTY
                 )
             );
         }

--- a/x-pack/plugin/snapshot-repo-test-kit/src/internalClusterTest/java/org/elasticsearch/repositories/blobstore/testkit/RepositoryAnalysisSuccessIT.java
+++ b/x-pack/plugin/snapshot-repo-test-kit/src/internalClusterTest/java/org/elasticsearch/repositories/blobstore/testkit/RepositoryAnalysisSuccessIT.java
@@ -160,9 +160,9 @@ public class RepositoryAnalysisSuccessIT extends AbstractSnapshotIntegTestCase {
     private static BlobPath buildBlobPath(Settings settings) {
         final String basePath = settings.get(BASE_PATH_SETTING_KEY);
         if (basePath == null) {
-            return BlobPath.cleanPath();
+            return BlobPath.EMPTY;
         } else {
-            return BlobPath.cleanPath().add(basePath);
+            return BlobPath.EMPTY.add(basePath);
         }
     }
 


### PR DESCRIPTION
There should be a singleton for the empty version of this.
All the copying to `String[]` or use as an iterator make
no sense either when we can just use the list outright.

backport of #72860