### PR TITLE
npe of sourceAsBytes may be thrown when extract GetResult in UpdateHelper

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/update/UpdateHelper.java
+++ b/server/src/main/java/org/elasticsearch/action/update/UpdateHelper.java
@@ -282,7 +282,7 @@ public class UpdateHelper {
             sourceLookup.setSource(source);
             Object value = sourceLookup.filter(request.fetchSource());
             try {
-                final int initialCapacity = Math.min(1024, sourceAsBytes.length());
+                final int initialCapacity = sourceAsBytes != null ? Math.min(1024, sourceAsBytes.length()) : 1024;
                 BytesStreamOutput streamOutput = new BytesStreamOutput(initialCapacity);
                 try (XContentBuilder builder = new XContentBuilder(sourceContentType.xContent(), streamOutput)) {
                     builder.value(value);


### PR DESCRIPTION
UpdateHelper.extractGetResult do not check null value of sourceAsBytes parameter, which may cause throw of npe.