### PR TITLE
[7.x] [DOCS] Include link to ES_TMPDIR with docs on jna.tmpdir (#72845)

### DIFF
--- a/docs/reference/setup/sysconfig/executable-jna-tmpdir.asciidoc
+++ b/docs/reference/setup/sysconfig/executable-jna-tmpdir.asciidoc
@@ -6,9 +6,10 @@ This is only relevant for Linux.
 
 Elasticsearch uses the Java Native Access (JNA) library for executing some
 platform-dependent native code. On Linux, the native code backing this library
-is extracted at runtime from the JNA archive. By default, this code is extracted
+is extracted at runtime from the JNA archive. This code is extracted
 to the Elasticsearch temporary directory which defaults to a sub-directory of
-`/tmp`. Alternatively, this location can be controlled with the JVM flag
+`/tmp` and can be configured with the <<es-tmpdir,ES_TMPDIR>> variable.
+Alternatively, this location can be controlled with the JVM flag
 `-Djna.tmpdir=<path>`. As the native library is mapped into the JVM virtual
 address space as executable, the underlying mount point of the location that
 this code is extracted to must *not* be mounted with `noexec` as this prevents


### PR DESCRIPTION
Added link to the ES_TMPDIR configuration.

Backport of #72845
