### PR TITLE
[7.x] Add basic alias support for data streams

### DIFF
--- a/docs/reference/indices/aliases.asciidoc
+++ b/docs/reference/indices/aliases.asciidoc
@@ -511,3 +511,101 @@ POST /_aliases
 }
 --------------------------------------------------
 // TEST[s/^/PUT test\nPUT test2\n/]
+
+[[aliases-data-streams]]
+===== Data stream aliases
+
+An alias can also point to one or more data streams. To add a data stream to an
+alias, specify the stream's name in the `index` parameter. Wildcards (`*`) are
+supported. If a wildcard pattern matches both data streams and indices, the
+action only uses the matching data streams.
+
+You can only specify data streams in the `add` and `remove` actions. Aliases
+that point to data streams do not support the following parameters:
+
+* `filter`
+* `index_routing`
+* `is_write_index`
+* `routing`
+* `search_routing`
+
+For example, the following request adds two data streams to the `logs` alias.
+
+////
+[source,console]
+----
+PUT _data_stream/logs-my_app-default
+
+PUT _data_stream/logs-nginx.access-prod
+----
+////
+
+[source,console]
+----
+POST _aliases
+{
+  "actions": [
+    { "add": { "index": "logs-my_app-default", "alias": "logs" }},
+    { "add": { "index": "logs-nginx.access-prod", "alias": "logs" }}
+  ]
+}
+----
+// TEST[continued]
+
+To verify the alias points to both data streams, use the
+<<indices-get-alias,get index alias API>>.
+
+[source,console]
+----
+GET logs-*/_alias
+----
+// TEST[continued]
+
+The API returns:
+
+[source,console-result]
+----
+{
+  "logs-my_app-default": {
+    "aliases": {
+      "logs": {}
+    }
+  },
+  "logs-nginx.access-prod": {
+    "aliases": {
+      "logs": {}
+    }
+  }
+}
+----
+
+Use the `remove` action to remove a data stream from an alias.
+
+[source,console]
+----
+POST _aliases
+{
+  "actions": [
+    { "remove": { "index": "logs-my_app-default", "alias": "logs" }}
+  ]
+}
+
+GET logs-*/_alias
+----
+// TEST[continued]
+
+The get index alias API returns:
+
+[source,console-result]
+----
+{
+  "logs-my_app-default": {
+    "aliases": {}
+  },
+  "logs-nginx.access-prod": {
+    "aliases": {
+      "logs": {}
+    }
+  }
+}
+----

--- a/server/src/internalClusterTest/java/org/elasticsearch/indices/template/SimpleIndexTemplateIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/indices/template/SimpleIndexTemplateIT.java
@@ -548,7 +548,7 @@ public class SimpleIndexTemplateIT extends ESIntegTestCase {
 
         InvalidAliasNameException e = expectThrows(InvalidAliasNameException.class,
             () -> createIndex("test"));
-        assertThat(e.getMessage(), equalTo("Invalid alias name [index], an index exists with the same name as the alias"));
+        assertThat(e.getMessage(), equalTo("Invalid alias name [index]: an index or data stream exists with the same name as the alias"));
     }
 
     public void testAliasEmptyName() throws Exception {

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/alias/TransportIndicesAliasesAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/alias/TransportIndicesAliasesAction.java
@@ -88,6 +88,27 @@ public class TransportIndicesAliasesAction extends AcknowledgedTransportMasterNo
         // Resolve all the AliasActions into AliasAction instances and gather all the aliases
         Set<String> aliases = new HashSet<>();
         for (AliasActions action : actions) {
+            List<String> concreteDataStreams =
+                indexNameExpressionResolver.dataStreamNames(state, request.indicesOptions(), action.indices());
+            if (concreteDataStreams.size() != 0) {
+                switch (action.actionType()) {
+                    case ADD:
+                        for (String dataStreamName : concreteDataStreams) {
+                            finalActions.add(new AliasAction.AddDataStreamAlias(action.aliases()[0], dataStreamName));
+                        }
+                        break;
+                    case REMOVE:
+                        for (String dataStreamName : concreteDataStreams) {
+                            finalActions.add(
+                                new AliasAction.RemoveDataStreamAlias(action.aliases()[0], dataStreamName, action.mustExist()));
+                        }
+                        break;
+                    default:
+                        throw new IllegalArgumentException("Unsupported action [" + action.actionType() + "]");
+                }
+                continue;
+            }
+
             final Index[] concreteIndices = indexNameExpressionResolver.concreteIndices(state, request.indicesOptions(), false,
                 action.indices());
             for (Index concreteIndex : concreteIndices) {

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/alias/get/GetAliasesRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/alias/get/GetAliasesRequest.java
@@ -107,4 +107,9 @@ public class GetAliasesRequest extends MasterNodeReadRequest<GetAliasesRequest> 
     public ActionRequestValidationException validate() {
         return null;
     }
+
+    @Override
+    public boolean includeDataStreams() {
+        return true;
+    }
 }

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/alias/get/GetAliasesResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/alias/get/GetAliasesResponse.java
@@ -10,34 +10,48 @@ package org.elasticsearch.action.admin.indices.alias.get;
 
 import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.cluster.metadata.AliasMetadata;
+import org.elasticsearch.cluster.metadata.DataStreamAlias;
+import org.elasticsearch.cluster.metadata.DataStreamMetadata;
 import org.elasticsearch.common.collect.ImmutableOpenMap;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 
 public class GetAliasesResponse extends ActionResponse {
 
     private final ImmutableOpenMap<String, List<AliasMetadata>> aliases;
+    private final Map<String, List<DataStreamAlias>> dataStreamAliases;
 
-    public GetAliasesResponse(ImmutableOpenMap<String, List<AliasMetadata>> aliases) {
+    public GetAliasesResponse(ImmutableOpenMap<String, List<AliasMetadata>> aliases, Map<String, List<DataStreamAlias>> dataStreamAliases) {
         this.aliases = aliases;
+        this.dataStreamAliases = dataStreamAliases;
     }
 
     public GetAliasesResponse(StreamInput in) throws IOException {
         super(in);
         aliases = in.readImmutableMap(StreamInput::readString, i -> i.readList(AliasMetadata::new));
+        dataStreamAliases = in.getVersion().onOrAfter(DataStreamMetadata.DATA_STREAM_ALIAS_VERSION) ?
+            in.readMap(StreamInput::readString, in1 -> in1.readList(DataStreamAlias::new)) : Map.of();
     }
 
     public ImmutableOpenMap<String, List<AliasMetadata>> getAliases() {
         return aliases;
     }
 
+    public Map<String, List<DataStreamAlias>> getDataStreamAliases() {
+        return dataStreamAliases;
+    }
+
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         out.writeMap(aliases, StreamOutput::writeString, StreamOutput::writeList);
+        if (out.getVersion().onOrAfter(DataStreamMetadata.DATA_STREAM_ALIAS_VERSION)) {
+            out.writeMap(dataStreamAliases, StreamOutput::writeString, StreamOutput::writeList);
+        }
     }
 
     @Override
@@ -49,11 +63,12 @@ public class GetAliasesResponse extends ActionResponse {
             return false;
         }
         GetAliasesResponse that = (GetAliasesResponse) o;
-        return Objects.equals(aliases, that.aliases);
+        return Objects.equals(aliases, that.aliases) &&
+            Objects.equals(dataStreamAliases, that.dataStreamAliases);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(aliases);
+        return Objects.hash(aliases, dataStreamAliases);
     }
 }

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/alias/get/GetAliasesResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/alias/get/GetAliasesResponse.java
@@ -17,6 +17,7 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -35,7 +36,7 @@ public class GetAliasesResponse extends ActionResponse {
         super(in);
         aliases = in.readImmutableMap(StreamInput::readString, i -> i.readList(AliasMetadata::new));
         dataStreamAliases = in.getVersion().onOrAfter(DataStreamMetadata.DATA_STREAM_ALIAS_VERSION) ?
-            in.readMap(StreamInput::readString, in1 -> in1.readList(DataStreamAlias::new)) : Map.of();
+            in.readMap(StreamInput::readString, in1 -> in1.readList(DataStreamAlias::new)) : Collections.emptyMap();
     }
 
     public ImmutableOpenMap<String, List<AliasMetadata>> getAliases() {

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/alias/get/TransportGetAliasesAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/alias/get/TransportGetAliasesAction.java
@@ -14,6 +14,8 @@ import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.block.ClusterBlockException;
 import org.elasticsearch.cluster.block.ClusterBlockLevel;
 import org.elasticsearch.cluster.metadata.AliasMetadata;
+import org.elasticsearch.cluster.metadata.DataStreamAlias;
+import org.elasticsearch.cluster.metadata.IndexAbstraction;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.service.ClusterService;
@@ -21,6 +23,7 @@ import org.elasticsearch.common.collect.ImmutableOpenMap;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.logging.DeprecationCategory;
 import org.elasticsearch.common.logging.DeprecationLogger;
+import org.elasticsearch.common.regex.Regex;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.indices.SystemIndices;
 import org.elasticsearch.indices.SystemIndices.SystemIndexAccessLevel;
@@ -30,8 +33,10 @@ import org.elasticsearch.transport.TransportService;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
@@ -67,7 +72,7 @@ public class TransportGetAliasesAction extends TransportMasterNodeReadAction<Get
         final SystemIndexAccessLevel systemIndexAccessLevel = indexNameExpressionResolver.getSystemIndexAccessLevel();
         ImmutableOpenMap<String, List<AliasMetadata>> aliases = state.metadata().findAliases(request, concreteIndices);
         listener.onResponse(new GetAliasesResponse(postProcess(request, concreteIndices, aliases, state,
-            systemIndexAccessLevel, threadPool.getThreadContext(), systemIndices)));
+            systemIndexAccessLevel, threadPool.getThreadContext(), systemIndices), postProcess(request, state)));
     }
 
     /**
@@ -80,6 +85,15 @@ public class TransportGetAliasesAction extends TransportMasterNodeReadAction<Get
         boolean noAliasesSpecified = request.getOriginalAliases() == null || request.getOriginalAliases().length == 0;
         ImmutableOpenMap.Builder<String, List<AliasMetadata>> mapBuilder = ImmutableOpenMap.builder(aliases);
         for (String index : concreteIndices) {
+            IndexAbstraction ia = state.metadata().getIndicesLookup().get(index);
+            assert ia.getType() == IndexAbstraction.Type.CONCRETE_INDEX;
+            if (ia.getParentDataStream() != null) {
+                // Don't include backing indices of data streams,
+                // because it is just noise. Aliases can't refer
+                // to backing indices directly.
+                continue;
+            }
+
             if (aliases.get(index) == null && noAliasesSpecified) {
                 List<AliasMetadata> previous = mapBuilder.put(index, Collections.emptyList());
                 assert previous == null;
@@ -90,6 +104,21 @@ public class TransportGetAliasesAction extends TransportMasterNodeReadAction<Get
             checkSystemIndexAccess(request, systemIndices, state, finalResponse, systemIndexAccessLevel, threadContext);
         }
         return finalResponse;
+    }
+
+    Map<String, List<DataStreamAlias>> postProcess(GetAliasesRequest request, ClusterState state) {
+        Map<String, List<DataStreamAlias>> result = new HashMap<>();
+        boolean noAliasesSpecified = request.getOriginalAliases() == null || request.getOriginalAliases().length == 0;
+        List<String> requestedDataStreams =
+            indexNameExpressionResolver.dataStreamNames(state, request.indicesOptions(), request.indices());
+        for (String requestedDataStream : requestedDataStreams) {
+            List<DataStreamAlias> aliases = state.metadata().dataStreamAliases().values().stream()
+                .filter(alias -> alias.getDataStreams().contains(requestedDataStream))
+                .filter(alias -> noAliasesSpecified || Regex.simpleMatch(request.aliases(), alias.getName()))
+                .collect(Collectors.toList());
+            result.put(requestedDataStream, aliases);
+        }
+        return result;
     }
 
     private static void checkSystemIndexAccess(GetAliasesRequest request, SystemIndices systemIndices, ClusterState state,

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/resolve/ResolveIndexAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/resolve/ResolveIndexAction.java
@@ -560,10 +560,9 @@ public class ResolveIndexAction extends ActionType<ResolveIndexAction.Response> 
                             index.getParentDataStream() == null ? null : index.getParentDataStream().getName()));
                         break;
                     case ALIAS:
-                        IndexAbstraction.Alias alias = (IndexAbstraction.Alias) ia;
-                        String[] indexNames = alias.getIndices().stream().map(i -> i.getIndex().getName()).toArray(String[]::new);
+                        String[] indexNames = ia.getIndices().stream().map(i -> i.getIndex().getName()).toArray(String[]::new);
                         Arrays.sort(indexNames);
-                        aliases.add(new ResolvedAlias(alias.getName(), indexNames));
+                        aliases.add(new ResolvedAlias(ia.getName(), indexNames));
                         break;
                     case DATA_STREAM:
                         IndexAbstraction.DataStream dataStream = (IndexAbstraction.DataStream) ia;

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/AliasAction.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/AliasAction.java
@@ -198,4 +198,60 @@ public abstract class AliasAction {
             throw new UnsupportedOperationException();
         }
     }
+
+    public static class AddDataStreamAlias extends AliasAction {
+
+        private final String aliasName;
+        private final String dataStreamName;
+
+        public AddDataStreamAlias(String aliasName, String dataStreamName) {
+            super(dataStreamName);
+            this.aliasName = aliasName;
+            this.dataStreamName = dataStreamName;
+        }
+
+        public String getAliasName() {
+            return aliasName;
+        }
+
+        public String getDataStreamName() {
+            return dataStreamName;
+        }
+
+        @Override
+        boolean removeIndex() {
+            return false;
+        }
+
+        @Override
+        boolean apply(NewAliasValidator aliasValidator, Metadata.Builder metadata, IndexMetadata index) {
+            aliasValidator.validate(aliasName, null, null, null);
+            return metadata.put(aliasName, dataStreamName);
+        }
+    }
+
+    public static class RemoveDataStreamAlias extends AliasAction {
+
+        private final String aliasName;
+        private final Boolean mustExist;
+        private final String dataStreamName;
+
+        public RemoveDataStreamAlias(String aliasName, String dataStreamName, Boolean mustExist) {
+            super(dataStreamName);
+            this.aliasName = aliasName;
+            this.mustExist = mustExist;
+            this.dataStreamName = dataStreamName;
+        }
+
+        @Override
+        boolean removeIndex() {
+            return false;
+        }
+
+        @Override
+        boolean apply(NewAliasValidator aliasValidator, Metadata.Builder metadata, IndexMetadata index) {
+            boolean mustExist = this.mustExist != null ? this.mustExist : false;
+            return metadata.removeDataStreamAlias(aliasName, dataStreamName, mustExist);
+        }
+    }
 }

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/AliasValidator.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/AliasValidator.java
@@ -24,6 +24,7 @@ import org.elasticsearch.indices.InvalidAliasNameException;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.Optional;
 import java.util.function.Function;
 
 import static org.elasticsearch.index.query.AbstractQueryBuilder.parseInnerQueryBuilder;
@@ -39,7 +40,7 @@ public class AliasValidator {
      * @throws IllegalArgumentException if the alias is not valid
      */
     public void validateAlias(Alias alias, String index, Metadata metadata) {
-        validateAlias(alias.name(), index, alias.indexRouting(), metadata::index);
+        validateAlias(alias.name(), index, alias.indexRouting(), lookup(metadata));
     }
 
     /**
@@ -48,7 +49,7 @@ public class AliasValidator {
      * @throws IllegalArgumentException if the alias is not valid
      */
     public void validateAliasMetadata(AliasMetadata aliasMetadata, String index, Metadata metadata) {
-        validateAlias(aliasMetadata.alias(), index, aliasMetadata.indexRouting(), metadata::index);
+        validateAlias(aliasMetadata.alias(), index, aliasMetadata.indexRouting(), lookup(metadata));
     }
 
     /**
@@ -72,16 +73,16 @@ public class AliasValidator {
     /**
      * Validate a proposed alias.
      */
-    public void validateAlias(String alias, String index, @Nullable String indexRouting, Function<String, IndexMetadata> indexLookup) {
+    public void validateAlias(String alias, String index, @Nullable String indexRouting, Function<String, String> lookup) {
         validateAliasStandalone(alias, indexRouting);
 
         if (Strings.hasText(index) == false) {
             throw new IllegalArgumentException("index name is required");
         }
 
-        IndexMetadata indexNamedSameAsAlias = indexLookup.apply(alias);
-        if (indexNamedSameAsAlias != null) {
-            throw new InvalidAliasNameException(indexNamedSameAsAlias.getIndex(), alias, "an index exists with the same name as the alias");
+        String sameNameAsAlias = lookup.apply(alias);
+        if (sameNameAsAlias != null) {
+            throw new InvalidAliasNameException(alias, "an index or data stream exists with the same name as the alias");
         }
     }
 
@@ -133,5 +134,11 @@ public class AliasValidator {
         QueryBuilder parseInnerQueryBuilder = parseInnerQueryBuilder(parser);
         QueryBuilder queryBuilder = Rewriteable.rewrite(parseInnerQueryBuilder, searchExecutionContext, true);
         queryBuilder.toQuery(searchExecutionContext);
+    }
+
+    private static Function<String, String> lookup(Metadata metadata) {
+        return name -> Optional.ofNullable(metadata.getIndicesLookup().get(name))
+            .filter(indexAbstraction -> indexAbstraction.getType() != IndexAbstraction.Type.ALIAS)
+            .map(IndexAbstraction::getName).orElse(null);
     }
 }

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/DataStreamAlias.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/DataStreamAlias.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+package org.elasticsearch.cluster.metadata;
+
+import org.elasticsearch.cluster.AbstractDiffable;
+import org.elasticsearch.cluster.Diff;
+import org.elasticsearch.common.ParseField;
+import org.elasticsearch.common.ParsingException;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.xcontent.ConstructingObjectParser;
+import org.elasticsearch.common.xcontent.ToXContentObject;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentParser;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Objects;
+
+public class DataStreamAlias extends AbstractDiffable<DataStreamAlias> implements ToXContentObject {
+
+    public static final ParseField DATA_STREAMS_FIELD = new ParseField("data_streams");
+
+    @SuppressWarnings("unchecked")
+    private static final ConstructingObjectParser<DataStreamAlias, String> PARSER = new ConstructingObjectParser<>(
+        "data_stream_alias",
+        false,
+        (args, name) -> new DataStreamAlias(name, (List<String>) args[0])
+    );
+
+    static {
+        PARSER.declareStringArray(ConstructingObjectParser.constructorArg(), DATA_STREAMS_FIELD);
+    }
+
+    private final String name;
+    private final List<String> dataStreams;
+
+    public DataStreamAlias(String name, List<String> dataStreams) {
+        this.name = Objects.requireNonNull(name);
+        this.dataStreams = List.copyOf(dataStreams);
+    }
+
+    public DataStreamAlias(StreamInput in) throws IOException {
+        this.name = in.readString();
+        this.dataStreams = in.readStringList();
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public List<String> getDataStreams() {
+        return dataStreams;
+    }
+
+    public static Diff<DataStreamAlias> readDiffFrom(StreamInput in) throws IOException {
+        return readDiffFrom(DataStreamAlias::new, in);
+    }
+
+    public static DataStreamAlias fromXContent(XContentParser parser) throws IOException {
+        XContentParser.Token token = parser.currentToken();
+        if (token != XContentParser.Token.FIELD_NAME) {
+            throw new ParsingException(parser.getTokenLocation(), "unexpected token");
+        }
+        String name = parser.currentName();
+        DataStreamAlias alias = PARSER.parse(parser, name);
+        return alias;
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.startObject(name);
+        builder.field(DATA_STREAMS_FIELD.getPreferredName(), dataStreams);
+        builder.endObject();
+        return builder;
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeString(name);
+        out.writeStringCollection(dataStreams);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        DataStreamAlias that = (DataStreamAlias) o;
+        return Objects.equals(name, that.name) &&
+            Objects.equals(dataStreams, that.dataStreams);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name, dataStreams);
+    }
+}

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/DataStreamAlias.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/DataStreamAlias.java
@@ -19,6 +19,9 @@ import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 
@@ -40,9 +43,9 @@ public class DataStreamAlias extends AbstractDiffable<DataStreamAlias> implement
     private final String name;
     private final List<String> dataStreams;
 
-    public DataStreamAlias(String name, List<String> dataStreams) {
+    public DataStreamAlias(String name, Collection<String> dataStreams) {
         this.name = Objects.requireNonNull(name);
-        this.dataStreams = List.copyOf(dataStreams);
+        this.dataStreams = Collections.unmodifiableList(new ArrayList<>(dataStreams));
     }
 
     public DataStreamAlias(StreamInput in) throws IOException {

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/DataStreamMetadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/DataStreamMetadata.java
@@ -34,9 +34,17 @@ public class DataStreamMetadata implements Metadata.Custom {
 
     public static final String TYPE = "data_stream";
     private static final ParseField DATA_STREAM = new ParseField("data_stream");
+    private static final ParseField DATA_STREAM_ALIASES = new ParseField("data_stream_aliases");
     @SuppressWarnings("unchecked")
     private static final ConstructingObjectParser<DataStreamMetadata, Void> PARSER = new ConstructingObjectParser<>(TYPE, false,
-        a -> new DataStreamMetadata((Map<String, DataStream>) a[0]));
+        args -> {
+            Map<String, DataStream> dataStreams = (Map<String, DataStream>) args[0];
+            Map<String, DataStreamAlias> dataStreamAliases = (Map<String, DataStreamAlias>) args[1];
+            if (dataStreamAliases == null) {
+                dataStreamAliases = Map.of();
+            }
+            return new DataStreamMetadata(dataStreams, dataStreamAliases);
+    });
 
     static {
         PARSER.declareObject(ConstructingObjectParser.constructorArg(), (p, c) -> {
@@ -47,20 +55,38 @@ public class DataStreamMetadata implements Metadata.Custom {
             }
             return dataStreams;
         }, DATA_STREAM);
+        PARSER.declareObject(ConstructingObjectParser.optionalConstructorArg(), (p, c) -> {
+            Map<String, DataStreamAlias> dataStreams = new HashMap<>();
+            while (p.nextToken() != XContentParser.Token.END_OBJECT) {
+                DataStreamAlias alias = DataStreamAlias.fromXContent(p);
+                dataStreams.put(alias.getName(), alias);
+            }
+            return dataStreams;
+        }, DATA_STREAM_ALIASES);
     }
 
-    private final Map<String, DataStream> dataStreams;
+    public static final Version DATA_STREAM_ALIAS_VERSION = Version.V_8_0_0;
 
-    public DataStreamMetadata(Map<String, DataStream> dataStreams) {
+    private final Map<String, DataStream> dataStreams;
+    private final Map<String, DataStreamAlias> dataStreamAliases;
+
+    public DataStreamMetadata(Map<String, DataStream> dataStreams,
+                              Map<String, DataStreamAlias> dataStreamAliases) {
         this.dataStreams = Collections.unmodifiableMap(new HashMap<>(dataStreams));
+        this.dataStreamAliases = Map.copyOf(dataStreamAliases);
     }
 
     public DataStreamMetadata(StreamInput in) throws IOException {
-        this(in.readMap(StreamInput::readString, DataStream::new));
+        this(in.readMap(StreamInput::readString, DataStream::new), in.getVersion().onOrAfter(DATA_STREAM_ALIAS_VERSION) ?
+            in.readMap(StreamInput::readString, DataStreamAlias::new) : Map.of());
     }
 
     public Map<String, DataStream> dataStreams() {
         return this.dataStreams;
+    }
+
+    public Map<String, DataStreamAlias> getDataStreamAliases() {
+        return dataStreamAliases;
     }
 
     @Override
@@ -90,6 +116,9 @@ public class DataStreamMetadata implements Metadata.Custom {
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         out.writeMap(this.dataStreams, StreamOutput::writeString, (stream, val) -> val.writeTo(stream));
+        if (out.getVersion().onOrAfter(DATA_STREAM_ALIAS_VERSION)) {
+            out.writeMap(this.dataStreamAliases, StreamOutput::writeString, (stream, val) -> val.writeTo(stream));
+        }
     }
 
     public static DataStreamMetadata fromXContent(XContentParser parser) throws IOException {
@@ -103,12 +132,17 @@ public class DataStreamMetadata implements Metadata.Custom {
             builder.field(dataStream.getKey(), dataStream.getValue());
         }
         builder.endObject();
+        builder.startObject(DATA_STREAM_ALIASES.getPreferredName());
+        for (Map.Entry<String, DataStreamAlias> dataStream : dataStreamAliases.entrySet()) {
+            dataStream.getValue().toXContent(builder, params);
+        }
+        builder.endObject();
         return builder;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(this.dataStreams);
+        return Objects.hash(this.dataStreams, dataStreamAliases);
     }
 
     @Override
@@ -120,7 +154,8 @@ public class DataStreamMetadata implements Metadata.Custom {
             return false;
         }
         DataStreamMetadata other = (DataStreamMetadata) obj;
-        return Objects.equals(this.dataStreams, other.dataStreams);
+        return Objects.equals(this.dataStreams, other.dataStreams) &&
+            Objects.equals(this.dataStreamAliases, other.dataStreamAliases);
     }
 
     @Override
@@ -131,25 +166,40 @@ public class DataStreamMetadata implements Metadata.Custom {
     static class DataStreamMetadataDiff implements NamedDiff<Metadata.Custom> {
 
         final Diff<Map<String, DataStream>> dataStreamDiff;
+        final Diff<Map<String, DataStreamAlias>> dataStreamAliasDiff;
 
         DataStreamMetadataDiff(DataStreamMetadata before, DataStreamMetadata after) {
             this.dataStreamDiff = DiffableUtils.diff(before.dataStreams, after.dataStreams,
+                DiffableUtils.getStringKeySerializer());
+            this.dataStreamAliasDiff = DiffableUtils.diff(before.dataStreamAliases, after.dataStreamAliases,
                 DiffableUtils.getStringKeySerializer());
         }
 
         DataStreamMetadataDiff(StreamInput in) throws IOException {
             this.dataStreamDiff = DiffableUtils.readJdkMapDiff(in, DiffableUtils.getStringKeySerializer(),
                 DataStream::new, DataStream::readDiffFrom);
+            if (in.getVersion().onOrAfter(DATA_STREAM_ALIAS_VERSION)) {
+                this.dataStreamAliasDiff = DiffableUtils.readJdkMapDiff(in, DiffableUtils.getStringKeySerializer(),
+                    DataStreamAlias::new, DataStreamAlias::readDiffFrom);
+            } else {
+                this.dataStreamAliasDiff = null;
+            }
         }
 
         @Override
         public Metadata.Custom apply(Metadata.Custom part) {
-            return new DataStreamMetadata(dataStreamDiff.apply(((DataStreamMetadata) part).dataStreams));
+            return new DataStreamMetadata(
+                dataStreamDiff.apply(((DataStreamMetadata) part).dataStreams),
+                dataStreamAliasDiff != null ? dataStreamAliasDiff.apply(((DataStreamMetadata) part).dataStreamAliases) : Map.of()
+            );
         }
 
         @Override
         public void writeTo(StreamOutput out) throws IOException {
             dataStreamDiff.writeTo(out);
+            if (out.getVersion().onOrAfter(DATA_STREAM_ALIAS_VERSION)) {
+                dataStreamAliasDiff.writeTo(out);
+            }
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/DataStreamMetadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/DataStreamMetadata.java
@@ -41,7 +41,7 @@ public class DataStreamMetadata implements Metadata.Custom {
             Map<String, DataStream> dataStreams = (Map<String, DataStream>) args[0];
             Map<String, DataStreamAlias> dataStreamAliases = (Map<String, DataStreamAlias>) args[1];
             if (dataStreamAliases == null) {
-                dataStreamAliases = Map.of();
+                dataStreamAliases = Collections.emptyMap();
             }
             return new DataStreamMetadata(dataStreams, dataStreamAliases);
     });
@@ -65,7 +65,7 @@ public class DataStreamMetadata implements Metadata.Custom {
         }, DATA_STREAM_ALIASES);
     }
 
-    public static final Version DATA_STREAM_ALIAS_VERSION = Version.V_8_0_0;
+    public static final Version DATA_STREAM_ALIAS_VERSION = Version.V_7_14_0;
 
     private final Map<String, DataStream> dataStreams;
     private final Map<String, DataStreamAlias> dataStreamAliases;
@@ -73,12 +73,12 @@ public class DataStreamMetadata implements Metadata.Custom {
     public DataStreamMetadata(Map<String, DataStream> dataStreams,
                               Map<String, DataStreamAlias> dataStreamAliases) {
         this.dataStreams = Collections.unmodifiableMap(new HashMap<>(dataStreams));
-        this.dataStreamAliases = Map.copyOf(dataStreamAliases);
+        this.dataStreamAliases = Collections.unmodifiableMap(new HashMap<>(dataStreamAliases));
     }
 
     public DataStreamMetadata(StreamInput in) throws IOException {
         this(in.readMap(StreamInput::readString, DataStream::new), in.getVersion().onOrAfter(DATA_STREAM_ALIAS_VERSION) ?
-            in.readMap(StreamInput::readString, DataStreamAlias::new) : Map.of());
+            in.readMap(StreamInput::readString, DataStreamAlias::new) : Collections.emptyMap());
     }
 
     public Map<String, DataStream> dataStreams() {
@@ -190,7 +190,8 @@ public class DataStreamMetadata implements Metadata.Custom {
         public Metadata.Custom apply(Metadata.Custom part) {
             return new DataStreamMetadata(
                 dataStreamDiff.apply(((DataStreamMetadata) part).dataStreams),
-                dataStreamAliasDiff != null ? dataStreamAliasDiff.apply(((DataStreamMetadata) part).dataStreamAliases) : Map.of()
+                dataStreamAliasDiff != null ? dataStreamAliasDiff.apply(((DataStreamMetadata) part).dataStreamAliases) :
+                    Collections.emptyMap()
             );
         }
 

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/IndexAbstraction.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/IndexAbstraction.java
@@ -303,4 +303,55 @@ public interface IndexAbstraction {
             return dataStream;
         }
     }
+
+    class DataStreamAlias implements IndexAbstraction {
+
+        private final org.elasticsearch.cluster.metadata.DataStreamAlias dataStreamAlias;
+        private final List<IndexMetadata> indicesOfAllDataStreams;
+
+        public DataStreamAlias(org.elasticsearch.cluster.metadata.DataStreamAlias dataStreamAlias,
+                               List<IndexMetadata> indicesOfAllDataStreams) {
+            this.dataStreamAlias = dataStreamAlias;
+            this.indicesOfAllDataStreams = indicesOfAllDataStreams;
+        }
+
+        @Override
+        public Type getType() {
+            return Type.ALIAS;
+        }
+
+        @Override
+        public String getName() {
+            return dataStreamAlias.getName();
+        }
+
+        @Override
+        public List<IndexMetadata> getIndices() {
+            return indicesOfAllDataStreams;
+        }
+
+        @Override
+        public IndexMetadata getWriteIndex() {
+            return null;
+        }
+
+        @Override
+        public DataStream getParentDataStream() {
+            return null;
+        }
+
+        @Override
+        public boolean isHidden() {
+            return false;
+        }
+
+        @Override
+        public boolean isSystem() {
+            return false;
+        }
+
+        public org.elasticsearch.cluster.metadata.DataStreamAlias getDataStreamAlias() {
+            return dataStreamAlias;
+        }
+    }
 }

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/Metadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/Metadata.java
@@ -15,6 +15,7 @@ import com.carrotsearch.hppc.cursors.ObjectObjectCursor;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.LogManager;
 import org.apache.lucene.util.CollectionUtil;
+import org.elasticsearch.ResourceNotFoundException;
 import org.elasticsearch.Version;
 import org.elasticsearch.action.AliasesRequest;
 import org.elasticsearch.cluster.ClusterState;
@@ -273,6 +274,19 @@ public class Metadata implements Iterable<IndexMetadata>, Diffable<Metadata>, To
                 return false;
             }
             if (otherIndex.getAliases().equals(thisIndex.getAliases()) == false) {
+                return false;
+            }
+        }
+
+        if (other.dataStreamAliases().size() != dataStreamAliases().size()) {
+            return false;
+        }
+        for (DataStreamAlias otherAlias : other.dataStreamAliases().values()) {
+            DataStreamAlias thisAlias = dataStreamAliases().get(otherAlias.getName());
+            if (thisAlias == null) {
+                return false;
+            }
+            if (thisAlias.equals(otherAlias) == false) {
                 return false;
             }
         }
@@ -611,22 +625,12 @@ public class Metadata implements Iterable<IndexMetadata>, Diffable<Metadata>, To
         if (writeIndex == null) {
             throw new IllegalArgumentException("alias [" + aliasOrIndex + "] does not have a write index");
         }
-        AliasMetadata aliasMd = writeIndex.getAliases().get(result.getName());
-        if (aliasMd.indexRouting() != null) {
-            if (aliasMd.indexRouting().indexOf(',') != -1) {
-                throw new IllegalArgumentException("index/alias [" + aliasOrIndex + "] provided with routing value ["
-                    + aliasMd.getIndexRouting() + "] that resolved to several routing values, rejecting operation");
-            }
-            if (routing != null) {
-                if (routing.equals(aliasMd.indexRouting()) == false) {
-                    throw new IllegalArgumentException("Alias [" + aliasOrIndex + "] has index routing associated with it ["
-                        + aliasMd.indexRouting() + "], and was provided with routing value [" + routing + "], rejecting operation");
-                }
-            }
-            // Alias routing overrides the parent routing (if any).
-            return aliasMd.indexRouting();
+        AliasMetadata writeIndexAliasMetadata = writeIndex.getAliases().get(result.getName());
+        if (writeIndexAliasMetadata != null) {
+            return resolveRouting(routing, aliasOrIndex, writeIndexAliasMetadata);
+        } else {
+            return routing;
         }
-        return routing;
     }
 
     /**
@@ -752,6 +756,12 @@ public class Metadata implements Iterable<IndexMetadata>, Diffable<Metadata>, To
     public Map<String, DataStream> dataStreams() {
         return Optional.ofNullable((DataStreamMetadata) this.custom(DataStreamMetadata.TYPE))
             .map(DataStreamMetadata::dataStreams)
+            .orElse(Collections.emptyMap());
+    }
+
+    public Map<String, DataStreamAlias> dataStreamAliases() {
+        return Optional.ofNullable((DataStreamMetadata) this.custom(DataStreamMetadata.TYPE))
+            .map(DataStreamMetadata::getDataStreamAliases)
             .orElse(Collections.emptyMap());
     }
 
@@ -1251,11 +1261,18 @@ public class Metadata implements Iterable<IndexMetadata>, Diffable<Metadata>, To
         }
 
         public DataStream dataStream(String dataStreamName) {
-            return ((DataStreamMetadata) customs.get(DataStreamMetadata.TYPE)).dataStreams().get(dataStreamName);
+            DataStreamMetadata dataStreamMetadata = (DataStreamMetadata) customs.get(DataStreamMetadata.TYPE);
+            if (dataStreamMetadata != null) {
+                return dataStreamMetadata.dataStreams().get(dataStreamName);
+            } else {
+                return null;
+            }
         }
 
         public Builder dataStreams(Map<String, DataStream> dataStreams) {
-            this.customs.put(DataStreamMetadata.TYPE, new DataStreamMetadata(dataStreams));
+            // TODO: take into account aliases...
+            // (this is only used from snapshot / restore)
+            this.customs.put(DataStreamMetadata.TYPE, new DataStreamMetadata(dataStreams, new HashMap<>()));
             return this;
         }
 
@@ -1266,8 +1283,44 @@ public class Metadata implements Iterable<IndexMetadata>, Diffable<Metadata>, To
                     .map(dsmd -> new HashMap<>(dsmd.dataStreams()))
                     .orElse(new HashMap<>());
             existingDataStreams.put(dataStream.getName(), dataStream);
-            this.customs.put(DataStreamMetadata.TYPE, new DataStreamMetadata(existingDataStreams));
+            Map<String, DataStreamAlias> existingDataStreamAliases =
+                Optional.ofNullable((DataStreamMetadata) this.customs.get(DataStreamMetadata.TYPE))
+                .map(dsmd -> new HashMap<>(dsmd.getDataStreamAliases()))
+                .orElse(new HashMap<>());
+
+            this.customs.put(DataStreamMetadata.TYPE, new DataStreamMetadata(existingDataStreams, existingDataStreamAliases));
             return this;
+        }
+
+        public boolean put(String name, String dataStream) {
+            Map<String, DataStream> existingDataStream =
+                Optional.ofNullable((DataStreamMetadata) this.customs.get(DataStreamMetadata.TYPE))
+                    .map(dsmd -> new HashMap<>(dsmd.dataStreams()))
+                    .orElse(new HashMap<>());
+            Map<String, DataStreamAlias> dataStreamAliases =
+                Optional.ofNullable((DataStreamMetadata) this.customs.get(DataStreamMetadata.TYPE))
+                    .map(dsmd -> new HashMap<>(dsmd.getDataStreamAliases()))
+                    .orElse(new HashMap<>());
+
+            if (existingDataStream.containsKey(dataStream) == false) {
+                throw new IllegalArgumentException("alias [" + name + "] refers to a non existing data stream [" + dataStream + "]");
+            }
+
+            DataStreamAlias alias = dataStreamAliases.get(name);
+            if (alias == null) {
+                alias = new DataStreamAlias(name, List.of(dataStream));
+            } else {
+                Set<String> dataStreams = new HashSet<>(alias.getDataStreams());
+                boolean added = dataStreams.add(dataStream);
+                if (added == false) {
+                    return false;
+                }
+                alias = new DataStreamAlias(name, List.copyOf(dataStreams));
+            }
+            dataStreamAliases.put(name, alias);
+
+            this.customs.put(DataStreamMetadata.TYPE, new DataStreamMetadata(existingDataStream, dataStreamAliases));
+            return true;
         }
 
         public Builder removeDataStream(String name) {
@@ -1276,8 +1329,63 @@ public class Metadata implements Iterable<IndexMetadata>, Diffable<Metadata>, To
                     .map(dsmd -> new HashMap<>(dsmd.dataStreams()))
                     .orElse(new HashMap<>());
             existingDataStreams.remove(name);
-            this.customs.put(DataStreamMetadata.TYPE, new DataStreamMetadata(existingDataStreams));
+
+            Map<String, DataStreamAlias> existingDataStreamAliases =
+                Optional.ofNullable((DataStreamMetadata) this.customs.get(DataStreamMetadata.TYPE))
+                    .map(dsmd -> new HashMap<>(dsmd.getDataStreamAliases()))
+                    .orElse(new HashMap<>());
+
+            Set<String> aliasesToDelete = new HashSet<>();
+            List<DataStreamAlias> aliasesToUpdate = new ArrayList<>();
+            for (var alias : existingDataStreamAliases.values()) {
+                Set<String> dataStreams = new HashSet<>(alias.getDataStreams());
+                if (dataStreams.contains(name)) {
+                    dataStreams.remove(name);
+                    if (dataStreams.isEmpty()) {
+                        aliasesToDelete.add(alias.getName());
+                    } else {
+                        aliasesToUpdate.add(new DataStreamAlias(alias.getName(), List.copyOf(dataStreams)));
+                    }
+                }
+            }
+            for (DataStreamAlias alias : aliasesToUpdate) {
+                existingDataStreamAliases.put(alias.getName(), alias);
+            }
+            for (String aliasToDelete : aliasesToDelete) {
+                existingDataStreamAliases.remove(aliasToDelete);
+            }
+
+            this.customs.put(DataStreamMetadata.TYPE, new DataStreamMetadata(existingDataStreams, existingDataStreamAliases));
             return this;
+        }
+
+        public boolean removeDataStreamAlias(String aliasName, String dataStreamName, boolean mustExist) {
+            Map<String, DataStreamAlias> dataStreamAliases =
+                Optional.ofNullable((DataStreamMetadata) this.customs.get(DataStreamMetadata.TYPE))
+                    .map(dsmd -> new HashMap<>(dsmd.getDataStreamAliases()))
+                    .orElse(new HashMap<>());
+
+            DataStreamAlias existing = dataStreamAliases.get(aliasName);
+            if (mustExist && existing == null) {
+                throw new ResourceNotFoundException("alias [" + aliasName + "] doesn't exist");
+            } else if (existing == null) {
+                return false;
+            }
+            Set<String> dataStreams = new HashSet<>(existing.getDataStreams());
+            dataStreams.remove(dataStreamName);
+            if (dataStreams.isEmpty()) {
+                dataStreamAliases.remove(aliasName);
+            } else {
+                dataStreamAliases.put(aliasName,
+                    new DataStreamAlias(existing.getName(), List.copyOf(dataStreams)));
+            }
+
+            Map<String, DataStream> existingDataStream =
+                Optional.ofNullable((DataStreamMetadata) this.customs.get(DataStreamMetadata.TYPE))
+                    .map(dsmd -> new HashMap<>(dsmd.dataStreams()))
+                    .orElse(new HashMap<>());
+            this.customs.put(DataStreamMetadata.TYPE, new DataStreamMetadata(existingDataStream, dataStreamAliases));
+            return true;
         }
 
         public Custom getCustom(String type) {
@@ -1527,6 +1635,16 @@ public class Metadata implements Iterable<IndexMetadata>, Diffable<Metadata>, To
                         indexToDataStreamLookup.put(i.getName(), dataStream);
                     }
                 }
+                for (DataStreamAlias alias : dataStreamMetadata.getDataStreamAliases().values()) {
+                    List<IndexMetadata> allIndicesOfAllDataStreams = alias.getDataStreams().stream()
+                        .map(name -> dataStreamMetadata.dataStreams().get(name))
+                        .flatMap(ds -> ds.getIndices().stream())
+                        .map(index -> indices.get(index.getName()))
+                        .collect(Collectors.toList());
+                    IndexAbstraction existing = indicesLookup.put(alias.getName(),
+                        new IndexAbstraction.DataStreamAlias(alias, allIndicesOfAllDataStreams));
+                    assert existing == null : "duplicate data stream alias for " + alias.getName();
+                }
             }
 
             Map<String, List<IndexMetadata>> aliasToIndices = new HashMap<>();
@@ -1575,6 +1693,7 @@ public class Metadata implements Iterable<IndexMetadata>, Diffable<Metadata>, To
                 // Sanity check, because elsewhere a more user friendly error should have occurred:
                 List<String> conflictingAliases = indicesLookup.values().stream()
                     .filter(ia -> ia.getType() == IndexAbstraction.Type.ALIAS)
+                    .filter(ia -> ia instanceof IndexAbstraction.Alias) // TODO: a nicer to only select index aliases?
                     .filter(ia -> {
                         for (IndexMetadata index : ia.getIndices()) {
                             if (indicesLookup.get(index.getIndex().getName()).getParentDataStream() != null) {

--- a/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestGetAliasesAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestGetAliasesAction.java
@@ -134,7 +134,7 @@ public class RestGetAliasesAction extends BaseRestHandler {
                 builder.field("status", status.getStatus());
             }
 
-            for (final var entry : responseAliasMap) {
+            for (final ObjectObjectCursor<String, List<AliasMetadata>> entry : responseAliasMap) {
                 if (aliasesExplicitlyRequested == false || (aliasesExplicitlyRequested && indicesToDisplay.contains(entry.key))) {
                     builder.startObject(entry.key);
                     {
@@ -149,7 +149,7 @@ public class RestGetAliasesAction extends BaseRestHandler {
                     builder.endObject();
                 }
             }
-            for (var entry : dataStreamAliases.entrySet()) {
+            for (Map.Entry<String, List<DataStreamAlias>> entry : dataStreamAliases.entrySet()) {
                 builder.startObject(entry.getKey());
                 {
                     builder.startObject("aliases");

--- a/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestGetAliasesAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestGetAliasesAction.java
@@ -14,6 +14,7 @@ import org.elasticsearch.action.admin.indices.alias.get.GetAliasesResponse;
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.client.node.NodeClient;
 import org.elasticsearch.cluster.metadata.AliasMetadata;
+import org.elasticsearch.cluster.metadata.DataStreamAlias;
 import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.collect.ImmutableOpenMap;
@@ -31,6 +32,7 @@ import java.io.IOException;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import java.util.Set;
 import java.util.SortedSet;
 import java.util.TreeSet;
@@ -65,7 +67,7 @@ public class RestGetAliasesAction extends BaseRestHandler {
 
     static RestResponse buildRestResponse(boolean aliasesExplicitlyRequested, String[] requestedAliases,
                                           ImmutableOpenMap<String, List<AliasMetadata>> responseAliasMap,
-                                          XContentBuilder builder) throws Exception {
+                                          Map<String, List<DataStreamAlias>> dataStreamAliases, XContentBuilder builder) throws Exception {
         final Set<String> indicesToDisplay = new HashSet<>();
         final Set<String> returnedAliasNames = new HashSet<>();
         for (final ObjectObjectCursor<String, List<AliasMetadata>> cursor : responseAliasMap) {
@@ -132,7 +134,7 @@ public class RestGetAliasesAction extends BaseRestHandler {
                 builder.field("status", status.getStatus());
             }
 
-            for (final ObjectObjectCursor<String, List<AliasMetadata>> entry : responseAliasMap) {
+            for (final var entry : responseAliasMap) {
                 if (aliasesExplicitlyRequested == false || (aliasesExplicitlyRequested && indicesToDisplay.contains(entry.key))) {
                     builder.startObject(entry.key);
                     {
@@ -146,6 +148,20 @@ public class RestGetAliasesAction extends BaseRestHandler {
                     }
                     builder.endObject();
                 }
+            }
+            for (var entry : dataStreamAliases.entrySet()) {
+                builder.startObject(entry.getKey());
+                {
+                    builder.startObject("aliases");
+                    {
+                        for (DataStreamAlias alias : entry.getValue()) {
+                            builder.startObject(alias.getName());
+                            builder.endObject();
+                        }
+                    }
+                    builder.endObject();
+                }
+                builder.endObject();
             }
         }
         builder.endObject();
@@ -171,7 +187,7 @@ public class RestGetAliasesAction extends BaseRestHandler {
         return channel -> client.admin().indices().getAliases(getAliasesRequest, new RestBuilderListener<GetAliasesResponse>(channel) {
             @Override
             public RestResponse buildResponse(GetAliasesResponse response, XContentBuilder builder) throws Exception {
-                return buildRestResponse(namesProvided, aliases, response.getAliases(), builder);
+                return buildRestResponse(namesProvided, aliases, response.getAliases(), response.getDataStreamAliases(), builder);
             }
         });
     }

--- a/server/src/test/java/org/elasticsearch/action/admin/indices/alias/AliasActionsTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/alias/AliasActionsTests.java
@@ -19,6 +19,7 @@ import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.common.xcontent.XContentParseException;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.XContentType;
+import org.elasticsearch.index.alias.RandomAliasActionsGenerator;
 import org.elasticsearch.test.ESTestCase;
 
 import java.io.IOException;
@@ -26,7 +27,6 @@ import java.util.Map;
 import java.util.Objects;
 
 import static org.elasticsearch.index.alias.RandomAliasActionsGenerator.randomAliasAction;
-import static org.elasticsearch.index.alias.RandomAliasActionsGenerator.randomMap;
 import static org.elasticsearch.index.alias.RandomAliasActionsGenerator.randomRouting;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.Matchers.arrayContaining;
@@ -111,7 +111,7 @@ public class AliasActionsTests extends ESTestCase {
     public void testParseAdd() throws IOException {
         String[] indices = generateRandomStringArray(10, 5, false, false);
         String[] aliases = generateRandomStringArray(10, 5, false, false);
-        Map<String, Object> filter = randomBoolean() ? randomMap(5) : null;
+        Map<String, Object> filter = randomBoolean() ? RandomAliasActionsGenerator.randomMap(5) : null;
         Object searchRouting = randomBoolean() ? randomRouting() : null;
         Object indexRouting = randomBoolean() ? randomBoolean() ? searchRouting : randomRouting() : null;
         boolean writeIndex = randomBoolean();

--- a/server/src/test/java/org/elasticsearch/action/admin/indices/alias/get/GetAliasesResponseTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/alias/get/GetAliasesResponseTests.java
@@ -8,9 +8,11 @@
 
 package org.elasticsearch.action.admin.indices.alias.get;
 
+import org.elasticsearch.cluster.metadata.DataStreamTestHelper;
 import org.elasticsearch.cluster.metadata.AliasMetadata;
 import org.elasticsearch.cluster.metadata.AliasMetadata.Builder;
 import org.elasticsearch.common.collect.ImmutableOpenMap;
+import org.elasticsearch.common.collect.Tuple;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.test.AbstractWireSerializingTestCase;
 
@@ -34,7 +36,8 @@ public class GetAliasesResponseTests extends AbstractWireSerializingTestCase<Get
 
     @Override
     protected GetAliasesResponse mutateInstance(GetAliasesResponse response) {
-        return new GetAliasesResponse(mutateAliases(response.getAliases()));
+        return new GetAliasesResponse(mutateAliases(response.getAliases()),
+            randomMap(5, 5, () -> new Tuple<>(randomAlphaOfLength(4), randomList(5, DataStreamTestHelper::randomAliasInstance))));
     }
 
     private static ImmutableOpenMap<String, List<AliasMetadata>> mutateAliases(ImmutableOpenMap<String, List<AliasMetadata>> aliases) {
@@ -75,7 +78,8 @@ public class GetAliasesResponseTests extends AbstractWireSerializingTestCase<Get
     }
 
     private static GetAliasesResponse createTestItem() {
-        return new GetAliasesResponse(createIndicesAliasesMap(0, 5).build());
+        return new GetAliasesResponse(mutateAliases(createIndicesAliasesMap(0, 5).build()
+        ), randomMap(5, 5, () -> new Tuple<>(randomAlphaOfLength(4), randomList(5, DataStreamTestHelper::randomAliasInstance))));
     }
 
     private static ImmutableOpenMap.Builder<String, List<AliasMetadata>> createIndicesAliasesMap(int min, int max) {

--- a/server/src/test/java/org/elasticsearch/action/admin/indices/alias/get/TransportGetAliasesActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/alias/get/TransportGetAliasesActionTests.java
@@ -29,12 +29,19 @@ import static org.hamcrest.Matchers.equalTo;
 public class TransportGetAliasesActionTests extends ESTestCase {
 
     public void testPostProcess() {
+        Metadata.Builder metadata = Metadata.builder();
+        metadata.put(IndexMetadata.builder("a").settings(ESTestCase.settings(Version.CURRENT)).numberOfShards(1).numberOfReplicas(0));
+        metadata.put(IndexMetadata.builder("b").settings(ESTestCase.settings(Version.CURRENT)).numberOfShards(1).numberOfReplicas(0));
+        metadata.put(IndexMetadata.builder("c").settings(ESTestCase.settings(Version.CURRENT)).numberOfShards(1).numberOfReplicas(0));
+        ClusterState clusterState = ClusterState.builder(ClusterState.EMPTY_STATE)
+            .metadata(metadata).build();
+
         GetAliasesRequest request = new GetAliasesRequest();
         ImmutableOpenMap<String, List<AliasMetadata>> aliases = ImmutableOpenMap.<String, List<AliasMetadata>>builder()
             .fPut("b", Collections.singletonList(new AliasMetadata.Builder("y").build()))
             .build();
         ImmutableOpenMap<String, List<AliasMetadata>> result =
-            TransportGetAliasesAction.postProcess(request, new String[]{"a", "b", "c"}, aliases, ClusterState.EMPTY_STATE,
+            TransportGetAliasesAction.postProcess(request, new String[]{"a", "b", "c"}, aliases, clusterState,
                 SystemIndexAccessLevel.NONE, null, EmptySystemIndices.INSTANCE);
         assertThat(result.size(), equalTo(3));
         assertThat(result.get("a").size(), equalTo(0));
@@ -46,7 +53,7 @@ public class TransportGetAliasesActionTests extends ESTestCase {
         aliases = ImmutableOpenMap.<String, List<AliasMetadata>>builder()
             .fPut("b", Collections.singletonList(new AliasMetadata.Builder("y").build()))
             .build();
-        result = TransportGetAliasesAction.postProcess(request, new String[]{"a", "b", "c"}, aliases, ClusterState.EMPTY_STATE,
+        result = TransportGetAliasesAction.postProcess(request, new String[]{"a", "b", "c"}, aliases, clusterState,
             SystemIndexAccessLevel.NONE, null, EmptySystemIndices.INSTANCE);
         assertThat(result.size(), equalTo(3));
         assertThat(result.get("a").size(), equalTo(0));
@@ -57,7 +64,7 @@ public class TransportGetAliasesActionTests extends ESTestCase {
         aliases = ImmutableOpenMap.<String, List<AliasMetadata>>builder()
             .fPut("b", Collections.singletonList(new AliasMetadata.Builder("y").build()))
             .build();
-        result = TransportGetAliasesAction.postProcess(request, new String[]{"a", "b", "c"}, aliases, ClusterState.EMPTY_STATE,
+        result = TransportGetAliasesAction.postProcess(request, new String[]{"a", "b", "c"}, aliases, clusterState,
             SystemIndexAccessLevel.NONE, null, EmptySystemIndices.INSTANCE);
         assertThat(result.size(), equalTo(1));
         assertThat(result.get("b").size(), equalTo(1));

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/ComposableIndexTemplateTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/ComposableIndexTemplateTests.java
@@ -139,7 +139,7 @@ public class ComposableIndexTemplateTests extends AbstractDiffableSerializationT
         if (randomBoolean()) {
             return null;
         } else {
-            return new ComposableIndexTemplate.DataStreamTemplate();
+           return DataStreamTemplateTests.randomInstance();
         }
     }
 

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/DataStreamMetadataTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/DataStreamMetadataTests.java
@@ -9,6 +9,7 @@
 package org.elasticsearch.cluster.metadata;
 
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
+import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.test.AbstractNamedWriteableTestCase;
 
 import java.io.IOException;
@@ -16,18 +17,34 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
+import static org.elasticsearch.test.AbstractXContentTestCase.xContentTester;
+
 public class DataStreamMetadataTests extends AbstractNamedWriteableTestCase<DataStreamMetadata> {
+
+    public void testFromXContent() throws IOException {
+        xContentTester(this::createParser, this::createTestInstance, ToXContent.EMPTY_PARAMS, DataStreamMetadata::fromXContent)
+            .assertEqualsConsumer(this::assertEqualInstances)
+            .test();
+    }
 
     @Override
     protected DataStreamMetadata createTestInstance() {
         if (randomBoolean()) {
-            return new DataStreamMetadata(Collections.emptyMap());
+            return new DataStreamMetadata(Map.of(), Map.of());
         }
         Map<String, DataStream> dataStreams = new HashMap<>();
         for (int i = 0; i < randomIntBetween(1, 5); i++) {
             dataStreams.put(randomAlphaOfLength(5), DataStreamTestHelper.randomInstance());
         }
-        return new DataStreamMetadata(dataStreams);
+
+        Map<String, DataStreamAlias> dataStreamsAliases = new HashMap<>();
+        if (randomBoolean()) {
+            for (int i = 0; i < randomIntBetween(1, 5); i++) {
+                DataStreamAlias alias = DataStreamTestHelper.randomAliasInstance();
+                dataStreamsAliases.put(alias.getName(), alias);
+            }
+        }
+        return new DataStreamMetadata(dataStreams, dataStreamsAliases);
     }
 
     @Override

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/DataStreamMetadataTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/DataStreamMetadataTests.java
@@ -30,7 +30,7 @@ public class DataStreamMetadataTests extends AbstractNamedWriteableTestCase<Data
     @Override
     protected DataStreamMetadata createTestInstance() {
         if (randomBoolean()) {
-            return new DataStreamMetadata(Map.of(), Map.of());
+            return new DataStreamMetadata(Collections.emptyMap(), Collections.emptyMap());
         }
         Map<String, DataStream> dataStreams = new HashMap<>();
         for (int i = 0; i < randomIntBetween(1, 5); i++) {

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/DataStreamTemplateTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/DataStreamTemplateTests.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+package org.elasticsearch.cluster.metadata;
+
+import java.io.IOException;
+
+import org.elasticsearch.cluster.metadata.ComposableIndexTemplate.DataStreamTemplate;
+import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.test.AbstractSerializingTestCase;
+
+public class DataStreamTemplateTests extends AbstractSerializingTestCase<DataStreamTemplate> {
+
+    @Override
+    protected DataStreamTemplate doParseInstance(XContentParser parser) throws IOException {
+        return DataStreamTemplate.PARSER.parse(parser, null);
+    }
+
+    @Override
+    protected Writeable.Reader<DataStreamTemplate> instanceReader() {
+        return DataStreamTemplate::new;
+    }
+
+    @Override
+    protected DataStreamTemplate createTestInstance() {
+        return randomInstance();
+    }
+
+    public static DataStreamTemplate randomInstance() {
+        return new ComposableIndexTemplate.DataStreamTemplate(randomBoolean());
+    }
+
+}

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataIndexAliasesServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataIndexAliasesServiceTests.java
@@ -504,10 +504,10 @@ public class MetadataIndexAliasesServiceTests extends ESTestCase {
     }
 
     public void testDataStreamAliases() {
-        ClusterState state = DataStreamTestHelper.getClusterStateWithDataStreams(List.of(
-            new Tuple<>("logs-foobar", 1), new Tuple<>("metrics-foobar", 1)), List.of());
+        ClusterState state = DataStreamTestHelper.getClusterStateWithDataStreams(Arrays.asList(
+            new Tuple<>("logs-foobar", 1), new Tuple<>("metrics-foobar", 1)), Collections.emptyList());
 
-        ClusterState result = service.applyAliasActions(state, List.of(
+        ClusterState result = service.applyAliasActions(state, org.elasticsearch.common.collect.List.of(
             new AliasAction.AddDataStreamAlias("foobar", "logs-foobar"),
             new AliasAction.AddDataStreamAlias("foobar", "metrics-foobar")
         ));
@@ -515,13 +515,13 @@ public class MetadataIndexAliasesServiceTests extends ESTestCase {
         assertThat(result.metadata().dataStreamAliases().get("foobar").getDataStreams(),
             containsInAnyOrder("logs-foobar", "metrics-foobar"));
 
-        result = service.applyAliasActions(result, List.of(
+        result = service.applyAliasActions(result, Collections.singletonList(
             new AliasAction.RemoveDataStreamAlias("foobar", "logs-foobar", null)
         ));
         assertThat(result.metadata().dataStreamAliases().get("foobar"), notNullValue());
         assertThat(result.metadata().dataStreamAliases().get("foobar").getDataStreams(), containsInAnyOrder("metrics-foobar"));
 
-        result = service.applyAliasActions(result, List.of(
+        result = service.applyAliasActions(result, Collections.singletonList(
             new AliasAction.RemoveDataStreamAlias("foobar", "metrics-foobar", null)
         ));
         assertThat(result.metadata().dataStreamAliases().get("foobar"), nullValue());

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataIndexAliasesServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataIndexAliasesServiceTests.java
@@ -12,6 +12,7 @@ import org.elasticsearch.ResourceNotFoundException;
 import org.elasticsearch.Version;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.common.collect.Tuple;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.set.Sets;
 import org.elasticsearch.index.Index;
@@ -30,9 +31,12 @@ import java.util.Set;
 import static java.util.Collections.singletonList;
 import static org.elasticsearch.cluster.metadata.DataStreamTestHelper.createTimestampField;
 import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.Matchers.startsWith;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anySetOf;
@@ -497,6 +501,30 @@ public class MetadataIndexAliasesServiceTests extends ESTestCase {
             singletonList(new AliasAction.Add(backingIndexName, "test", null, null, null, null, null))));
         assertThat(exception.getMessage(), is("The provided index [" + backingIndexName + "] is a backing index belonging to data " +
             "stream [foo-stream]. Data streams and their backing indices don't support alias operations."));
+    }
+
+    public void testDataStreamAliases() {
+        ClusterState state = DataStreamTestHelper.getClusterStateWithDataStreams(List.of(
+            new Tuple<>("logs-foobar", 1), new Tuple<>("metrics-foobar", 1)), List.of());
+
+        ClusterState result = service.applyAliasActions(state, List.of(
+            new AliasAction.AddDataStreamAlias("foobar", "logs-foobar"),
+            new AliasAction.AddDataStreamAlias("foobar", "metrics-foobar")
+        ));
+        assertThat(result.metadata().dataStreamAliases().get("foobar"), notNullValue());
+        assertThat(result.metadata().dataStreamAliases().get("foobar").getDataStreams(),
+            containsInAnyOrder("logs-foobar", "metrics-foobar"));
+
+        result = service.applyAliasActions(result, List.of(
+            new AliasAction.RemoveDataStreamAlias("foobar", "logs-foobar", null)
+        ));
+        assertThat(result.metadata().dataStreamAliases().get("foobar"), notNullValue());
+        assertThat(result.metadata().dataStreamAliases().get("foobar").getDataStreams(), containsInAnyOrder("metrics-foobar"));
+
+        result = service.applyAliasActions(result, List.of(
+            new AliasAction.RemoveDataStreamAlias("foobar", "metrics-foobar", null)
+        ));
+        assertThat(result.metadata().dataStreamAliases().get("foobar"), nullValue());
     }
 
     private ClusterState applyHiddenAliasMix(ClusterState before, Boolean isHidden1, Boolean isHidden2) {

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataTests.java
@@ -1231,7 +1231,8 @@ public class MetadataTests extends ESTestCase {
                 indicesLookup.put(indexMeta.getIndex().getName(), new IndexAbstraction.Index(indexMeta, dataStreamAbstraction));
             }
         }
-        DataStreamMetadata dataStreamMetadata = new DataStreamMetadata(org.elasticsearch.common.collect.Map.of(dataStreamName, dataStream), Map.of());
+        DataStreamMetadata dataStreamMetadata =
+            new DataStreamMetadata(org.elasticsearch.common.collect.Map.of(dataStreamName, dataStream), Collections.emptyMap());
 
         // prefixed indices with a lower generation than the data stream's generation are allowed even if the non-prefixed, matching the
         // data stream backing indices naming pattern, indices are already in the system

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataTests.java
@@ -8,6 +8,7 @@
 
 package org.elasticsearch.cluster.metadata;
 
+import org.elasticsearch.ResourceNotFoundException;
 import org.elasticsearch.Version;
 import org.elasticsearch.action.admin.indices.alias.get.GetAliasesRequest;
 import org.elasticsearch.cluster.ClusterModule;
@@ -50,11 +51,13 @@ import static org.elasticsearch.cluster.metadata.DataStreamTestHelper.createBack
 import static org.elasticsearch.cluster.metadata.DataStreamTestHelper.createFirstBackingIndex;
 import static org.elasticsearch.cluster.metadata.DataStreamTestHelper.createTimestampField;
 import static org.elasticsearch.cluster.metadata.Metadata.Builder.validateDataStreams;
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.Matchers.startsWith;
 
 public class MetadataTests extends ESTestCase {
@@ -1228,7 +1231,7 @@ public class MetadataTests extends ESTestCase {
                 indicesLookup.put(indexMeta.getIndex().getName(), new IndexAbstraction.Index(indexMeta, dataStreamAbstraction));
             }
         }
-        DataStreamMetadata dataStreamMetadata = new DataStreamMetadata(org.elasticsearch.common.collect.Map.of(dataStreamName, dataStream));
+        DataStreamMetadata dataStreamMetadata = new DataStreamMetadata(org.elasticsearch.common.collect.Map.of(dataStreamName, dataStream), Map.of());
 
         // prefixed indices with a lower generation than the data stream's generation are allowed even if the non-prefixed, matching the
         // data stream backing indices naming pattern, indices are already in the system
@@ -1295,6 +1298,118 @@ public class MetadataTests extends ESTestCase {
             () -> Metadata.snapshot(postSnapshotMetadata, dataStreamsToSnapshot, indicesInSnapshot)
         );
         assertThat(e.getMessage(), containsString("unable to find data stream [" + missingDataStream + "]"));
+    }
+
+    public void testDataStreamAliases() {
+        Metadata.Builder mdBuilder = Metadata.builder();
+
+        mdBuilder.put(DataStreamTestHelper.randomInstance("logs-postgres-eu"));
+        assertThat(mdBuilder.put("logs-postgres", "logs-postgres-eu"), is(true));
+        mdBuilder.put(DataStreamTestHelper.randomInstance("logs-postgres-us"));
+        assertThat(mdBuilder.put("logs-postgres", "logs-postgres-us"), is(true));
+        mdBuilder.put(DataStreamTestHelper.randomInstance("logs-postgres-au"));
+        assertThat(mdBuilder.put("logs-postgres", "logs-postgres-au"), is(true));
+        assertThat(mdBuilder.put("logs-postgres", "logs-postgres-au"), is(false));
+
+        Metadata metadata = mdBuilder.build();
+        assertThat(metadata.dataStreamAliases().get("logs-postgres"), notNullValue());
+        assertThat(metadata.dataStreamAliases().get("logs-postgres").getDataStreams(),
+            containsInAnyOrder("logs-postgres-eu", "logs-postgres-us", "logs-postgres-au"));
+    }
+
+    public void testDataStreamReferToNonExistingDataStream() {
+        Metadata.Builder mdBuilder = Metadata.builder();
+
+        Exception e = expectThrows(IllegalArgumentException.class, () -> mdBuilder.put("logs-postgres", "logs-postgres-eu"));
+        assertThat(e.getMessage(), equalTo("alias [logs-postgres] refers to a non existing data stream [logs-postgres-eu]"));
+
+        mdBuilder.put(DataStreamTestHelper.randomInstance("logs-postgres-eu"));
+        mdBuilder.put("logs-postgres", "logs-postgres-eu");
+        Metadata metadata = mdBuilder.build();
+        assertThat(metadata.dataStreamAliases().get("logs-postgres"), notNullValue());
+        assertThat(metadata.dataStreamAliases().get("logs-postgres").getDataStreams(), containsInAnyOrder("logs-postgres-eu"));
+    }
+
+    public void testDeleteDataStreamShouldUpdateAlias() {
+        Metadata.Builder mdBuilder = Metadata.builder();
+        mdBuilder.put(DataStreamTestHelper.randomInstance("logs-postgres-eu"));
+        mdBuilder.put("logs-postgres", "logs-postgres-eu");
+        mdBuilder.put(DataStreamTestHelper.randomInstance("logs-postgres-us"));
+        mdBuilder.put("logs-postgres", "logs-postgres-us");
+        mdBuilder.put(DataStreamTestHelper.randomInstance("logs-postgres-au"));
+        mdBuilder.put("logs-postgres", "logs-postgres-au");
+        Metadata metadata = mdBuilder.build();
+        assertThat(metadata.dataStreamAliases().get("logs-postgres"), notNullValue());
+        assertThat(metadata.dataStreamAliases().get("logs-postgres").getDataStreams(),
+            containsInAnyOrder("logs-postgres-eu", "logs-postgres-us", "logs-postgres-au"));
+
+        mdBuilder = Metadata.builder(metadata);
+        mdBuilder.removeDataStream("logs-postgres-us");
+        metadata = mdBuilder.build();
+        assertThat(metadata.dataStreamAliases().get("logs-postgres"), notNullValue());
+        assertThat(metadata.dataStreamAliases().get("logs-postgres").getDataStreams(),
+            containsInAnyOrder("logs-postgres-eu", "logs-postgres-au"));
+
+        mdBuilder = Metadata.builder(metadata);
+        mdBuilder.removeDataStream("logs-postgres-au");
+        metadata = mdBuilder.build();
+        assertThat(metadata.dataStreamAliases().get("logs-postgres"), notNullValue());
+        assertThat(metadata.dataStreamAliases().get("logs-postgres").getDataStreams(), containsInAnyOrder("logs-postgres-eu"));
+
+        mdBuilder = Metadata.builder(metadata);
+        mdBuilder.removeDataStream("logs-postgres-eu");
+        metadata = mdBuilder.build();
+        assertThat(metadata.dataStreamAliases().get("logs-postgres"), nullValue());
+    }
+
+    public void testDeleteDataStreamAlias() {
+        Metadata.Builder mdBuilder = Metadata.builder();
+        mdBuilder.put(DataStreamTestHelper.randomInstance("logs-postgres-eu"));
+        mdBuilder.put("logs-postgres", "logs-postgres-eu");
+        mdBuilder.put(DataStreamTestHelper.randomInstance("logs-postgres-us"));
+        mdBuilder.put("logs-postgres", "logs-postgres-us");
+        mdBuilder.put(DataStreamTestHelper.randomInstance("logs-postgres-au"));
+        mdBuilder.put("logs-postgres", "logs-postgres-au");
+        Metadata metadata = mdBuilder.build();
+        assertThat(metadata.dataStreamAliases().get("logs-postgres"), notNullValue());
+        assertThat(metadata.dataStreamAliases().get("logs-postgres").getDataStreams(),
+            containsInAnyOrder("logs-postgres-eu", "logs-postgres-us", "logs-postgres-au"));
+
+        mdBuilder = Metadata.builder(metadata);
+        assertThat(mdBuilder.removeDataStreamAlias("logs-postgres", "logs-postgres-us", true), is(true));
+        metadata = mdBuilder.build();
+        assertThat(metadata.dataStreamAliases().get("logs-postgres"), notNullValue());
+        assertThat(metadata.dataStreamAliases().get("logs-postgres").getDataStreams(),
+            containsInAnyOrder("logs-postgres-eu", "logs-postgres-au"));
+
+        mdBuilder = Metadata.builder(metadata);
+        assertThat(mdBuilder.removeDataStreamAlias("logs-postgres", "logs-postgres-au", true), is(true));
+        metadata = mdBuilder.build();
+        assertThat(metadata.dataStreamAliases().get("logs-postgres"), notNullValue());
+        assertThat(metadata.dataStreamAliases().get("logs-postgres").getDataStreams(), containsInAnyOrder("logs-postgres-eu"));
+
+        mdBuilder = Metadata.builder(metadata);
+        assertThat(mdBuilder.removeDataStreamAlias("logs-postgres", "logs-postgres-eu", true), is(true));
+        metadata = mdBuilder.build();
+        assertThat(metadata.dataStreamAliases().get("logs-postgres"), nullValue());
+    }
+
+    public void testDeleteDataStreamAliasMustExists() {
+        Metadata.Builder mdBuilder = Metadata.builder();
+        mdBuilder.put(DataStreamTestHelper.randomInstance("logs-postgres-eu"));
+        mdBuilder.put("logs-postgres", "logs-postgres-eu");
+        mdBuilder.put(DataStreamTestHelper.randomInstance("logs-postgres-us"));
+        mdBuilder.put("logs-postgres", "logs-postgres-us");
+        mdBuilder.put(DataStreamTestHelper.randomInstance("logs-postgres-au"));
+        mdBuilder.put("logs-postgres", "logs-postgres-au");
+        Metadata metadata = mdBuilder.build();
+        assertThat(metadata.dataStreamAliases().get("logs-postgres"), notNullValue());
+        assertThat(metadata.dataStreamAliases().get("logs-postgres").getDataStreams(),
+            containsInAnyOrder("logs-postgres-eu", "logs-postgres-us", "logs-postgres-au"));
+
+        Metadata.Builder mdBuilder2 = Metadata.builder(metadata);
+        expectThrows(ResourceNotFoundException.class, () -> mdBuilder2.removeDataStreamAlias("logs-mysql", "logs-postgres-us", true));
+        assertThat(mdBuilder2.removeDataStreamAlias("logs-mysql", "logs-postgres-us", false), is(false));
     }
 
     public static Metadata randomMetadata() {

--- a/server/src/test/java/org/elasticsearch/rest/action/admin/indices/RestGetAliasesActionTests.java
+++ b/server/src/test/java/org/elasticsearch/rest/action/admin/indices/RestGetAliasesActionTests.java
@@ -18,6 +18,7 @@ import org.elasticsearch.test.ESTestCase;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 
 import static org.elasticsearch.rest.RestStatus.OK;
 import static org.elasticsearch.rest.RestStatus.NOT_FOUND;
@@ -41,7 +42,7 @@ public class RestGetAliasesActionTests extends ESTestCase {
         final AliasMetadata fooAliasMetadata = AliasMetadata.builder("foo").build();
         openMapBuilder.put("index", Arrays.asList(fooAliasMetadata, foobarAliasMetadata));
         final RestResponse restResponse = RestGetAliasesAction.buildRestResponse(false, new String[0], openMapBuilder.build(),
-                xContentBuilder);
+            Map.of(), xContentBuilder);
         assertThat(restResponse.status(), equalTo(OK));
         assertThat(restResponse.contentType(), equalTo("application/json; charset=UTF-8"));
         assertThat(restResponse.content().utf8ToString(), equalTo("{\"index\":{\"aliases\":{\"foo\":{},\"foobar\":{}}}}"));
@@ -51,7 +52,7 @@ public class RestGetAliasesActionTests extends ESTestCase {
         final XContentBuilder xContentBuilder = XContentFactory.contentBuilder(XContentType.JSON);
         final ImmutableOpenMap.Builder<String, List<AliasMetadata>> openMapBuilder = ImmutableOpenMap.builder();
         final RestResponse restResponse = RestGetAliasesAction.buildRestResponse(true, new String[] { "baz*" }, openMapBuilder.build(),
-                xContentBuilder);
+            Map.of(), xContentBuilder);
         assertThat(restResponse.status(), equalTo(OK));
         assertThat(restResponse.contentType(), equalTo("application/json; charset=UTF-8"));
         assertThat(restResponse.content().utf8ToString(), equalTo("{}"));
@@ -63,7 +64,7 @@ public class RestGetAliasesActionTests extends ESTestCase {
         final AliasMetadata aliasMetadata = AliasMetadata.builder("foobar").build();
         openMapBuilder.put("index", Arrays.asList(aliasMetadata));
         final RestResponse restResponse = RestGetAliasesAction.buildRestResponse(true, new String[] { "baz*", "foobar*" },
-                openMapBuilder.build(), xContentBuilder);
+                openMapBuilder.build(), Map.of(), xContentBuilder);
         assertThat(restResponse.status(), equalTo(OK));
         assertThat(restResponse.contentType(), equalTo("application/json; charset=UTF-8"));
         assertThat(restResponse.content().utf8ToString(), equalTo("{\"index\":{\"aliases\":{\"foobar\":{}}}}"));
@@ -73,7 +74,7 @@ public class RestGetAliasesActionTests extends ESTestCase {
         final XContentBuilder xContentBuilder = XContentFactory.contentBuilder(XContentType.JSON);
         final ImmutableOpenMap.Builder<String, List<AliasMetadata>> openMapBuilder = ImmutableOpenMap.builder();
         final RestResponse restResponse = RestGetAliasesAction.buildRestResponse(true, new String[] { "foob*", "-foo*" },
-                openMapBuilder.build(), xContentBuilder);
+                openMapBuilder.build(), Map.of(), xContentBuilder);
         assertThat(restResponse.status(), equalTo(OK));
         assertThat(restResponse.contentType(), equalTo("application/json; charset=UTF-8"));
         assertThat(restResponse.content().utf8ToString(), equalTo("{}"));
@@ -85,7 +86,7 @@ public class RestGetAliasesActionTests extends ESTestCase {
         final AliasMetadata aliasMetadata = AliasMetadata.builder("foo").build();
         openMapBuilder.put("index", Arrays.asList(aliasMetadata));
         final RestResponse restResponse = RestGetAliasesAction.buildRestResponse(true, new String[] { "foo*", "-foob*" },
-                openMapBuilder.build(), xContentBuilder);
+                openMapBuilder.build(), Map.of(), xContentBuilder);
         assertThat(restResponse.status(), equalTo(OK));
         assertThat(restResponse.contentType(), equalTo("application/json; charset=UTF-8"));
         assertThat(restResponse.content().utf8ToString(), equalTo("{\"index\":{\"aliases\":{\"foo\":{}}}}"));
@@ -104,7 +105,7 @@ public class RestGetAliasesActionTests extends ESTestCase {
         }
 
         final RestResponse restResponse = RestGetAliasesAction.buildRestResponse(true, aliasPattern, openMapBuilder.build(),
-                xContentBuilder);
+            Map.of(), xContentBuilder);
         assertThat(restResponse.status(), equalTo(NOT_FOUND));
         assertThat(restResponse.contentType(), equalTo("application/json; charset=UTF-8"));
         assertThat(restResponse.content().utf8ToString(),
@@ -115,7 +116,7 @@ public class RestGetAliasesActionTests extends ESTestCase {
         final XContentBuilder xContentBuilder = XContentFactory.contentBuilder(XContentType.JSON);
         final ImmutableOpenMap.Builder<String, List<AliasMetadata>> openMapBuilder = ImmutableOpenMap.builder();
         final RestResponse restResponse = RestGetAliasesAction.buildRestResponse(true, new String[] { "foo", "foofoo", "-foo*" },
-                openMapBuilder.build(), xContentBuilder);
+                openMapBuilder.build(), Map.of(), xContentBuilder);
         assertThat(restResponse.status(), equalTo(OK));
         assertThat(restResponse.contentType(), equalTo("application/json; charset=UTF-8"));
         assertThat(restResponse.content().utf8ToString(), equalTo("{}"));

--- a/server/src/test/java/org/elasticsearch/rest/action/admin/indices/RestGetAliasesActionTests.java
+++ b/server/src/test/java/org/elasticsearch/rest/action/admin/indices/RestGetAliasesActionTests.java
@@ -17,8 +17,8 @@ import org.elasticsearch.rest.RestResponse;
 import org.elasticsearch.test.ESTestCase;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 
 import static org.elasticsearch.rest.RestStatus.OK;
 import static org.elasticsearch.rest.RestStatus.NOT_FOUND;
@@ -42,7 +42,7 @@ public class RestGetAliasesActionTests extends ESTestCase {
         final AliasMetadata fooAliasMetadata = AliasMetadata.builder("foo").build();
         openMapBuilder.put("index", Arrays.asList(fooAliasMetadata, foobarAliasMetadata));
         final RestResponse restResponse = RestGetAliasesAction.buildRestResponse(false, new String[0], openMapBuilder.build(),
-            Map.of(), xContentBuilder);
+            Collections.emptyMap(), xContentBuilder);
         assertThat(restResponse.status(), equalTo(OK));
         assertThat(restResponse.contentType(), equalTo("application/json; charset=UTF-8"));
         assertThat(restResponse.content().utf8ToString(), equalTo("{\"index\":{\"aliases\":{\"foo\":{},\"foobar\":{}}}}"));
@@ -52,7 +52,7 @@ public class RestGetAliasesActionTests extends ESTestCase {
         final XContentBuilder xContentBuilder = XContentFactory.contentBuilder(XContentType.JSON);
         final ImmutableOpenMap.Builder<String, List<AliasMetadata>> openMapBuilder = ImmutableOpenMap.builder();
         final RestResponse restResponse = RestGetAliasesAction.buildRestResponse(true, new String[] { "baz*" }, openMapBuilder.build(),
-            Map.of(), xContentBuilder);
+            Collections.emptyMap(), xContentBuilder);
         assertThat(restResponse.status(), equalTo(OK));
         assertThat(restResponse.contentType(), equalTo("application/json; charset=UTF-8"));
         assertThat(restResponse.content().utf8ToString(), equalTo("{}"));
@@ -64,7 +64,7 @@ public class RestGetAliasesActionTests extends ESTestCase {
         final AliasMetadata aliasMetadata = AliasMetadata.builder("foobar").build();
         openMapBuilder.put("index", Arrays.asList(aliasMetadata));
         final RestResponse restResponse = RestGetAliasesAction.buildRestResponse(true, new String[] { "baz*", "foobar*" },
-                openMapBuilder.build(), Map.of(), xContentBuilder);
+                openMapBuilder.build(), Collections.emptyMap(), xContentBuilder);
         assertThat(restResponse.status(), equalTo(OK));
         assertThat(restResponse.contentType(), equalTo("application/json; charset=UTF-8"));
         assertThat(restResponse.content().utf8ToString(), equalTo("{\"index\":{\"aliases\":{\"foobar\":{}}}}"));
@@ -74,7 +74,7 @@ public class RestGetAliasesActionTests extends ESTestCase {
         final XContentBuilder xContentBuilder = XContentFactory.contentBuilder(XContentType.JSON);
         final ImmutableOpenMap.Builder<String, List<AliasMetadata>> openMapBuilder = ImmutableOpenMap.builder();
         final RestResponse restResponse = RestGetAliasesAction.buildRestResponse(true, new String[] { "foob*", "-foo*" },
-                openMapBuilder.build(), Map.of(), xContentBuilder);
+                openMapBuilder.build(), Collections.emptyMap(), xContentBuilder);
         assertThat(restResponse.status(), equalTo(OK));
         assertThat(restResponse.contentType(), equalTo("application/json; charset=UTF-8"));
         assertThat(restResponse.content().utf8ToString(), equalTo("{}"));
@@ -86,7 +86,7 @@ public class RestGetAliasesActionTests extends ESTestCase {
         final AliasMetadata aliasMetadata = AliasMetadata.builder("foo").build();
         openMapBuilder.put("index", Arrays.asList(aliasMetadata));
         final RestResponse restResponse = RestGetAliasesAction.buildRestResponse(true, new String[] { "foo*", "-foob*" },
-                openMapBuilder.build(), Map.of(), xContentBuilder);
+                openMapBuilder.build(), Collections.emptyMap(), xContentBuilder);
         assertThat(restResponse.status(), equalTo(OK));
         assertThat(restResponse.contentType(), equalTo("application/json; charset=UTF-8"));
         assertThat(restResponse.content().utf8ToString(), equalTo("{\"index\":{\"aliases\":{\"foo\":{}}}}"));
@@ -105,7 +105,7 @@ public class RestGetAliasesActionTests extends ESTestCase {
         }
 
         final RestResponse restResponse = RestGetAliasesAction.buildRestResponse(true, aliasPattern, openMapBuilder.build(),
-            Map.of(), xContentBuilder);
+            Collections.emptyMap(), xContentBuilder);
         assertThat(restResponse.status(), equalTo(NOT_FOUND));
         assertThat(restResponse.contentType(), equalTo("application/json; charset=UTF-8"));
         assertThat(restResponse.content().utf8ToString(),
@@ -116,7 +116,7 @@ public class RestGetAliasesActionTests extends ESTestCase {
         final XContentBuilder xContentBuilder = XContentFactory.contentBuilder(XContentType.JSON);
         final ImmutableOpenMap.Builder<String, List<AliasMetadata>> openMapBuilder = ImmutableOpenMap.builder();
         final RestResponse restResponse = RestGetAliasesAction.buildRestResponse(true, new String[] { "foo", "foofoo", "-foo*" },
-                openMapBuilder.build(), Map.of(), xContentBuilder);
+                openMapBuilder.build(), Collections.emptyMap(), xContentBuilder);
         assertThat(restResponse.status(), equalTo(OK));
         assertThat(restResponse.contentType(), equalTo("application/json; charset=UTF-8"));
         assertThat(restResponse.content().utf8ToString(), equalTo("{}"));

--- a/test/framework/src/main/java/org/elasticsearch/cluster/metadata/DataStreamTestHelper.java
+++ b/test/framework/src/main/java/org/elasticsearch/cluster/metadata/DataStreamTestHelper.java
@@ -27,6 +27,7 @@ import java.util.stream.Collectors;
 
 import static org.elasticsearch.cluster.metadata.DataStream.getDefaultBackingIndexName;
 import static org.elasticsearch.cluster.metadata.IndexMetadata.SETTING_INDEX_UUID;
+import static org.elasticsearch.test.ESTestCase.generateRandomStringArray;
 import static org.elasticsearch.test.ESTestCase.randomAlphaOfLength;
 import static org.elasticsearch.test.ESTestCase.randomBoolean;
 
@@ -102,10 +103,18 @@ public final class DataStreamTestHelper {
         return randomInstance(System::currentTimeMillis);
     }
 
+    public static DataStream randomInstance(String name) {
+        return randomInstance(name, System::currentTimeMillis);
+    }
+
     public static DataStream randomInstance(LongSupplier timeProvider) {
+        String dataStreamName = randomAlphaOfLength(10).toLowerCase(Locale.ROOT);
+        return randomInstance(dataStreamName, timeProvider);
+    }
+
+    public static DataStream randomInstance(String dataStreamName, LongSupplier timeProvider) {
         List<Index> indices = randomIndexInstances();
         long generation = indices.size() + ESTestCase.randomLongBetween(1, 128);
-        String dataStreamName = randomAlphaOfLength(10).toLowerCase(Locale.ROOT);
         indices.add(new Index(getDefaultBackingIndexName(dataStreamName, generation), UUIDs.randomBase64UUID(LuceneTestCase.random())));
         Map<String, Object> metadata = null;
         if (randomBoolean()) {
@@ -114,6 +123,13 @@ public final class DataStreamTestHelper {
         }
         return new DataStream(dataStreamName, createTimestampField("@timestamp"), indices, generation, metadata,
             randomBoolean(), randomBoolean(), false, timeProvider);
+    }
+
+    public static DataStreamAlias randomAliasInstance() {
+        return new DataStreamAlias(
+            randomAlphaOfLength(5),
+            List.of(generateRandomStringArray(5, 5, false))
+        );
     }
 
     /**

--- a/test/framework/src/main/java/org/elasticsearch/cluster/metadata/DataStreamTestHelper.java
+++ b/test/framework/src/main/java/org/elasticsearch/cluster/metadata/DataStreamTestHelper.java
@@ -18,6 +18,7 @@ import org.elasticsearch.index.Index;
 import org.elasticsearch.test.ESTestCase;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
@@ -128,7 +129,7 @@ public final class DataStreamTestHelper {
     public static DataStreamAlias randomAliasInstance() {
         return new DataStreamAlias(
             randomAlphaOfLength(5),
-            List.of(generateRandomStringArray(5, 5, false))
+            Arrays.asList(generateRandomStringArray(5, 5, false))
         );
     }
 

--- a/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
@@ -46,6 +46,7 @@ import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.common.CheckedRunnable;
 import org.elasticsearch.common.SuppressForbidden;
 import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.collect.Tuple;
 import org.elasticsearch.common.io.PathUtils;
 import org.elasticsearch.common.io.PathUtilsForTesting;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
@@ -123,6 +124,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.EnumSet;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -876,6 +878,15 @@ public abstract class ESTestCase extends LuceneTestCase {
         return list;
     }
 
+    public static <K, V> Map<K, V> randomMap(int minListSize, int maxListSize, Supplier<Tuple<K, V>> valueConstructor) {
+        final int size = randomIntBetween(minListSize, maxListSize);
+        Map<K, V> list = new HashMap<>(size);
+        for (int i = 0; i < size; i++) {
+            Tuple<K, V> entry = valueConstructor.get();
+            list.put(entry.v1(), entry.v2());
+        }
+        return list;
+    }
 
     private static final String[] TIME_SUFFIXES = new String[]{"d", "h", "ms", "s", "m", "micros", "nanos"};
 

--- a/x-pack/plugin/data-streams/qa/rest/src/javaRestTest/java/org/elasticsearch/xpack/datastreams/DataStreamsRestIT.java
+++ b/x-pack/plugin/data-streams/qa/rest/src/javaRestTest/java/org/elasticsearch/xpack/datastreams/DataStreamsRestIT.java
@@ -18,7 +18,9 @@ import java.io.IOException;
 import java.util.Collections;
 import java.util.Map;
 
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
 
 public class DataStreamsRestIT extends ESRestTestCase {
 
@@ -88,5 +90,109 @@ public class DataStreamsRestIT extends ESRestTestCase {
         putComposableIndexTemplateRequest.setJsonEntity(body);
         Exception e = expectThrows(ResponseException.class, () -> client().performRequest(putComposableIndexTemplateRequest));
         assertThat(e.getMessage(), containsString("template [my-template] has alias and data stream definitions"));
+    }
+
+    public void testDataStreamAliases() throws Exception {
+        // Create a template
+        Request putComposableIndexTemplateRequest = new Request("POST", "/_index_template/1");
+        putComposableIndexTemplateRequest.setJsonEntity("{\"index_patterns\": [\"logs-*\"], \"data_stream\": {}}");
+        assertOK(client().performRequest(putComposableIndexTemplateRequest));
+
+        Request createDocRequest = new Request("POST", "/logs-myapp1/_doc?refresh=true");
+        createDocRequest.setJsonEntity("{ \"@timestamp\": \"2022-12-12\"}");
+        assertOK(client().performRequest(createDocRequest));
+
+        createDocRequest = new Request("POST", "/logs-myapp2/_doc?refresh=true");
+        createDocRequest.setJsonEntity("{ \"@timestamp\": \"2022-12-12\"}");
+        assertOK(client().performRequest(createDocRequest));
+
+        // Add logs-myapp1 -> logs & logs-myapp2 -> logs
+        Request updateAliasesRequest = new Request("POST", "/_aliases");
+        updateAliasesRequest.setJsonEntity("{\"actions\":[{\"add\":{\"index\":\"logs-myapp1\",\"alias\":\"logs\"}}," +
+            "{\"add\":{\"index\":\"logs-myapp2\",\"alias\":\"logs\"}}]}");
+        assertOK(client().performRequest(updateAliasesRequest));
+
+        Request getAliasesRequest = new Request("GET", "/_aliases");
+        Map<String, Object> getAliasesResponse = entityAsMap(client().performRequest(getAliasesRequest));
+        assertThat(getAliasesResponse.keySet(), containsInAnyOrder("logs-myapp1", "logs-myapp2"));
+        assertEquals(Map.of("logs", Map.of()), XContentMapValues.extractValue("logs-myapp1.aliases", getAliasesResponse));
+        assertEquals(Map.of("logs", Map.of()), XContentMapValues.extractValue("logs-myapp2.aliases", getAliasesResponse));
+
+        Request searchRequest = new Request("GET", "/logs/_search");
+        Map<String, Object> searchResponse = entityAsMap(client().performRequest(searchRequest));
+        assertEquals(2, XContentMapValues.extractValue("hits.total.value", searchResponse));
+
+        // Remove logs-myapp1 -> logs & logs-myapp2 -> logs
+        updateAliasesRequest = new Request("POST", "/_aliases");
+        updateAliasesRequest.setJsonEntity("{\"actions\":[{\"remove\":{\"index\":\"logs-myapp1\",\"alias\":\"logs\"}}," +
+            "{\"remove\":{\"index\":\"logs-myapp2\",\"alias\":\"logs\"}}]}");
+        assertOK(client().performRequest(updateAliasesRequest));
+
+        getAliasesRequest = new Request("GET", "/_aliases");
+        getAliasesResponse = entityAsMap(client().performRequest(getAliasesRequest));
+        assertEquals(Map.of(), XContentMapValues.extractValue("logs-myapp1.aliases", getAliasesResponse));
+        assertEquals(Map.of(), XContentMapValues.extractValue("logs-myapp2.aliases", getAliasesResponse));
+        expectThrows(ResponseException.class, () -> client().performRequest(new Request("GET", "/logs/_search")));
+
+        // Add logs-* -> logs
+        updateAliasesRequest = new Request("POST", "/_aliases");
+        updateAliasesRequest.setJsonEntity("{\"actions\":[{\"add\":{\"index\":\"logs-*\",\"alias\":\"logs\"}}]}");
+        assertOK(client().performRequest(updateAliasesRequest));
+
+        getAliasesRequest = new Request("GET", "/_aliases");
+        getAliasesResponse = entityAsMap(client().performRequest(getAliasesRequest));
+        assertEquals(Map.of("logs", Map.of()), XContentMapValues.extractValue("logs-myapp1.aliases", getAliasesResponse));
+        assertEquals(Map.of("logs", Map.of()), XContentMapValues.extractValue("logs-myapp2.aliases", getAliasesResponse));
+
+        searchRequest = new Request("GET", "/logs/_search");
+        searchResponse = entityAsMap(client().performRequest(searchRequest));
+        assertEquals(2, XContentMapValues.extractValue("hits.total.value", searchResponse));
+
+        // Remove logs-* -> logs
+        updateAliasesRequest = new Request("POST", "/_aliases");
+        updateAliasesRequest.setJsonEntity("{\"actions\":[{\"remove\":{\"index\":\"logs-*\",\"alias\":\"logs\"}}]}");
+        assertOK(client().performRequest(updateAliasesRequest));
+
+        getAliasesRequest = new Request("GET", "/_aliases");
+        getAliasesResponse = entityAsMap(client().performRequest(getAliasesRequest));
+        assertEquals(Map.of(), XContentMapValues.extractValue("logs-myapp1.aliases", getAliasesResponse));
+        assertEquals(Map.of(), XContentMapValues.extractValue("logs-myapp2.aliases", getAliasesResponse));
+        expectThrows(ResponseException.class, () -> client().performRequest(new Request("GET", "/logs/_search")));
+    }
+
+    public void testDeleteDataStreamApiWithAliasFails() throws IOException {
+        // Create a template
+        Request putComposableIndexTemplateRequest = new Request("POST", "/_index_template/1");
+        putComposableIndexTemplateRequest.setJsonEntity("{\"index_patterns\": [\"logs-*\"], \"data_stream\": {}}");
+        assertOK(client().performRequest(putComposableIndexTemplateRequest));
+
+        Request createDocRequest = new Request("POST", "/logs-emea/_doc?refresh=true");
+        createDocRequest.setJsonEntity("{ \"@timestamp\": \"2022-12-12\"}");
+        assertOK(client().performRequest(createDocRequest));
+
+        createDocRequest = new Request("POST", "/logs-nasa/_doc?refresh=true");
+        createDocRequest.setJsonEntity("{ \"@timestamp\": \"2022-12-12\"}");
+        assertOK(client().performRequest(createDocRequest));
+
+        Request updateAliasesRequest = new Request("POST", "/_aliases");
+        updateAliasesRequest.setJsonEntity(
+            "{\"actions\":[{\"add\":{\"index\":\"logs-emea\",\"alias\":\"logs\"}}," +
+                "{\"add\":{\"index\":\"logs-nasa\",\"alias\":\"logs\"}}]}");
+        assertOK(client().performRequest(updateAliasesRequest));
+
+        Request getAliasesRequest = new Request("GET", "/logs-*/_alias");
+        Map<String, Object> getAliasesResponse = entityAsMap(client().performRequest(getAliasesRequest));
+        assertEquals(Map.of("logs", Map.of()), XContentMapValues.extractValue("logs-emea.aliases", getAliasesResponse));
+        assertEquals(Map.of("logs", Map.of()), XContentMapValues.extractValue("logs-nasa.aliases", getAliasesResponse));
+
+        Exception e = expectThrows(ResponseException.class, () -> client().performRequest(new Request("DELETE", "/_data_stream/logs")));
+        assertThat(e.getMessage(), containsString("The provided expression [logs] matches an alias, " +
+            "specify the corresponding concrete indices instead"));
+
+        assertOK(client().performRequest(new Request("DELETE", "/_data_stream/logs-emea")));
+        assertOK(client().performRequest(new Request("DELETE", "/_data_stream/logs-nasa")));
+
+        getAliasesRequest = new Request("GET", "/logs-*/_alias");
+        assertThat(entityAsMap(client().performRequest(getAliasesRequest)), equalTo(Map.of()));
     }
 }

--- a/x-pack/plugin/data-streams/qa/rest/src/javaRestTest/java/org/elasticsearch/xpack/datastreams/DataStreamsRestIT.java
+++ b/x-pack/plugin/data-streams/qa/rest/src/javaRestTest/java/org/elasticsearch/xpack/datastreams/DataStreamsRestIT.java
@@ -15,9 +15,11 @@ import org.elasticsearch.test.rest.ESRestTestCase;
 import org.junit.After;
 
 import java.io.IOException;
-import java.util.Collections;
 import java.util.Map;
 
+import static java.util.Collections.singletonMap;
+import static java.util.Collections.singletonList;
+import static java.util.Collections.emptyMap;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
@@ -43,10 +45,10 @@ public class DataStreamsRestIT extends ESRestTestCase {
         Request getDataStreamsRequest = new Request("GET", "/_data_stream?expand_wildcards=hidden");
         Response response = client().performRequest(getDataStreamsRequest);
         Map<String, Object> dataStreams = entityAsMap(response);
-        assertEquals(Collections.singletonList("hidden"), XContentMapValues.extractValue("data_streams.name", dataStreams));
-        assertEquals(Collections.singletonList("hidden"), XContentMapValues.extractValue("data_streams.template", dataStreams));
-        assertEquals(Collections.singletonList(1), XContentMapValues.extractValue("data_streams.generation", dataStreams));
-        assertEquals(Collections.singletonList(true), XContentMapValues.extractValue("data_streams.hidden", dataStreams));
+        assertEquals(singletonList("hidden"), XContentMapValues.extractValue("data_streams.name", dataStreams));
+        assertEquals(singletonList("hidden"), XContentMapValues.extractValue("data_streams.template", dataStreams));
+        assertEquals(singletonList(1), XContentMapValues.extractValue("data_streams.generation", dataStreams));
+        assertEquals(singletonList(true), XContentMapValues.extractValue("data_streams.hidden", dataStreams));
 
         Request searchRequest = new Request("GET", "/hidd*/_search");
         response = client().performRequest(searchRequest);
@@ -73,10 +75,10 @@ public class DataStreamsRestIT extends ESRestTestCase {
         Request getDataStreamsRequest = new Request("GET", "/_data_stream?expand_wildcards=hidden");
         Response response = client().performRequest(getDataStreamsRequest);
         Map<String, Object> dataStreams = entityAsMap(response);
-        assertEquals(Collections.singletonList(".hidden"), XContentMapValues.extractValue("data_streams.name", dataStreams));
-        assertEquals(Collections.singletonList("hidden"), XContentMapValues.extractValue("data_streams.template", dataStreams));
-        assertEquals(Collections.singletonList(1), XContentMapValues.extractValue("data_streams.generation", dataStreams));
-        assertEquals(Collections.singletonList(true), XContentMapValues.extractValue("data_streams.hidden", dataStreams));
+        assertEquals(singletonList(".hidden"), XContentMapValues.extractValue("data_streams.name", dataStreams));
+        assertEquals(singletonList("hidden"), XContentMapValues.extractValue("data_streams.template", dataStreams));
+        assertEquals(singletonList(1), XContentMapValues.extractValue("data_streams.generation", dataStreams));
+        assertEquals(singletonList(true), XContentMapValues.extractValue("data_streams.hidden", dataStreams));
 
         Request searchRequest = new Request("GET", "/.hidd*/_search");
         response = client().performRequest(searchRequest);
@@ -115,8 +117,8 @@ public class DataStreamsRestIT extends ESRestTestCase {
         Request getAliasesRequest = new Request("GET", "/_aliases");
         Map<String, Object> getAliasesResponse = entityAsMap(client().performRequest(getAliasesRequest));
         assertThat(getAliasesResponse.keySet(), containsInAnyOrder("logs-myapp1", "logs-myapp2"));
-        assertEquals(Map.of("logs", Map.of()), XContentMapValues.extractValue("logs-myapp1.aliases", getAliasesResponse));
-        assertEquals(Map.of("logs", Map.of()), XContentMapValues.extractValue("logs-myapp2.aliases", getAliasesResponse));
+        assertEquals(singletonMap("logs", emptyMap()), XContentMapValues.extractValue("logs-myapp1.aliases", getAliasesResponse));
+        assertEquals(singletonMap("logs", emptyMap()), XContentMapValues.extractValue("logs-myapp2.aliases", getAliasesResponse));
 
         Request searchRequest = new Request("GET", "/logs/_search");
         Map<String, Object> searchResponse = entityAsMap(client().performRequest(searchRequest));
@@ -130,8 +132,8 @@ public class DataStreamsRestIT extends ESRestTestCase {
 
         getAliasesRequest = new Request("GET", "/_aliases");
         getAliasesResponse = entityAsMap(client().performRequest(getAliasesRequest));
-        assertEquals(Map.of(), XContentMapValues.extractValue("logs-myapp1.aliases", getAliasesResponse));
-        assertEquals(Map.of(), XContentMapValues.extractValue("logs-myapp2.aliases", getAliasesResponse));
+        assertEquals(emptyMap(), XContentMapValues.extractValue("logs-myapp1.aliases", getAliasesResponse));
+        assertEquals(emptyMap(), XContentMapValues.extractValue("logs-myapp2.aliases", getAliasesResponse));
         expectThrows(ResponseException.class, () -> client().performRequest(new Request("GET", "/logs/_search")));
 
         // Add logs-* -> logs
@@ -141,8 +143,8 @@ public class DataStreamsRestIT extends ESRestTestCase {
 
         getAliasesRequest = new Request("GET", "/_aliases");
         getAliasesResponse = entityAsMap(client().performRequest(getAliasesRequest));
-        assertEquals(Map.of("logs", Map.of()), XContentMapValues.extractValue("logs-myapp1.aliases", getAliasesResponse));
-        assertEquals(Map.of("logs", Map.of()), XContentMapValues.extractValue("logs-myapp2.aliases", getAliasesResponse));
+        assertEquals(singletonMap("logs", emptyMap()), XContentMapValues.extractValue("logs-myapp1.aliases", getAliasesResponse));
+        assertEquals(singletonMap("logs", emptyMap()), XContentMapValues.extractValue("logs-myapp2.aliases", getAliasesResponse));
 
         searchRequest = new Request("GET", "/logs/_search");
         searchResponse = entityAsMap(client().performRequest(searchRequest));
@@ -155,8 +157,8 @@ public class DataStreamsRestIT extends ESRestTestCase {
 
         getAliasesRequest = new Request("GET", "/_aliases");
         getAliasesResponse = entityAsMap(client().performRequest(getAliasesRequest));
-        assertEquals(Map.of(), XContentMapValues.extractValue("logs-myapp1.aliases", getAliasesResponse));
-        assertEquals(Map.of(), XContentMapValues.extractValue("logs-myapp2.aliases", getAliasesResponse));
+        assertEquals(emptyMap(), XContentMapValues.extractValue("logs-myapp1.aliases", getAliasesResponse));
+        assertEquals(emptyMap(), XContentMapValues.extractValue("logs-myapp2.aliases", getAliasesResponse));
         expectThrows(ResponseException.class, () -> client().performRequest(new Request("GET", "/logs/_search")));
     }
 
@@ -182,8 +184,8 @@ public class DataStreamsRestIT extends ESRestTestCase {
 
         Request getAliasesRequest = new Request("GET", "/logs-*/_alias");
         Map<String, Object> getAliasesResponse = entityAsMap(client().performRequest(getAliasesRequest));
-        assertEquals(Map.of("logs", Map.of()), XContentMapValues.extractValue("logs-emea.aliases", getAliasesResponse));
-        assertEquals(Map.of("logs", Map.of()), XContentMapValues.extractValue("logs-nasa.aliases", getAliasesResponse));
+        assertEquals(singletonMap("logs", emptyMap()), XContentMapValues.extractValue("logs-emea.aliases", getAliasesResponse));
+        assertEquals(singletonMap("logs", emptyMap()), XContentMapValues.extractValue("logs-nasa.aliases", getAliasesResponse));
 
         Exception e = expectThrows(ResponseException.class, () -> client().performRequest(new Request("DELETE", "/_data_stream/logs")));
         assertThat(e.getMessage(), containsString("The provided expression [logs] matches an alias, " +
@@ -193,6 +195,6 @@ public class DataStreamsRestIT extends ESRestTestCase {
         assertOK(client().performRequest(new Request("DELETE", "/_data_stream/logs-nasa")));
 
         getAliasesRequest = new Request("GET", "/logs-*/_alias");
-        assertThat(entityAsMap(client().performRequest(getAliasesRequest)), equalTo(Map.of()));
+        assertThat(entityAsMap(client().performRequest(getAliasesRequest)), equalTo(emptyMap()));
     }
 }

--- a/x-pack/plugin/data-streams/src/internalClusterTest/java/org/elasticsearch/datastreams/DataStreamIT.java
+++ b/x-pack/plugin/data-streams/src/internalClusterTest/java/org/elasticsearch/datastreams/DataStreamIT.java
@@ -14,6 +14,8 @@ import org.elasticsearch.action.ActionRequestBuilder;
 import org.elasticsearch.action.DocWriteRequest;
 import org.elasticsearch.action.admin.cluster.state.ClusterStateRequest;
 import org.elasticsearch.action.admin.indices.alias.IndicesAliasesRequest;
+import org.elasticsearch.action.admin.indices.alias.get.GetAliasesRequest;
+import org.elasticsearch.action.admin.indices.alias.get.GetAliasesResponse;
 import org.elasticsearch.action.admin.indices.get.GetIndexRequest;
 import org.elasticsearch.action.admin.indices.get.GetIndexResponse;
 import org.elasticsearch.action.admin.indices.mapping.get.GetMappingsResponse;
@@ -42,6 +44,7 @@ import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.health.ClusterHealthStatus;
 import org.elasticsearch.cluster.metadata.ComposableIndexTemplate;
 import org.elasticsearch.cluster.metadata.DataStream;
+import org.elasticsearch.cluster.metadata.DataStreamAlias;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.Template;
 import org.elasticsearch.common.Nullable;
@@ -566,7 +569,7 @@ public class DataStreamIT extends ESIntegTestCase {
         verifyResolvability(dataStreamName, client().admin().indices().prepareUpgrade(dataStreamName), false);
         verifyResolvability(dataStreamName, client().admin().indices().prepareRecoveries(dataStreamName), false);
         verifyResolvability(dataStreamName, client().admin().indices().prepareUpgradeStatus(dataStreamName), false);
-        verifyResolvability(dataStreamName, client().admin().indices().prepareGetAliases("dummy").addIndices(dataStreamName), true);
+        verifyResolvability(dataStreamName, client().admin().indices().prepareGetAliases("dummy").addIndices(dataStreamName), false);
         verifyResolvability(dataStreamName, client().admin().indices().prepareGetFieldMappings(dataStreamName), false);
         verifyResolvability(
             dataStreamName,
@@ -685,7 +688,7 @@ public class DataStreamIT extends ESIntegTestCase {
         assertTrue(maybeE.isPresent());
     }
 
-    public void testAliasActionsFailOnDataStreams() throws Exception {
+    public void testAliasActionsOnDataStreams() throws Exception {
         putComposableIndexTemplate("id1", List.of("metrics-foo*"));
         String dataStreamName = "metrics-foo";
         CreateDataStreamAction.Request createDataStreamRequest = new CreateDataStreamAction.Request(dataStreamName);
@@ -696,8 +699,12 @@ public class DataStreamIT extends ESIntegTestCase {
             .aliases("foo");
         IndicesAliasesRequest aliasesAddRequest = new IndicesAliasesRequest();
         aliasesAddRequest.addAliasAction(addAction);
-        Exception e = expectThrows(IndexNotFoundException.class, () -> client().admin().indices().aliases(aliasesAddRequest).actionGet());
-        assertThat(e.getMessage(), equalTo("no such index [" + dataStreamName + "]"));
+        assertAcked(client().admin().indices().aliases(aliasesAddRequest).actionGet());
+        GetAliasesResponse response = client().admin().indices().getAliases(new GetAliasesRequest()).actionGet();
+        assertThat(
+            response.getDataStreamAliases(),
+            equalTo(Map.of("metrics-foo", List.of(new DataStreamAlias("foo", List.of("metrics-foo")))))
+        );
     }
 
     public void testAliasActionsFailOnDataStreamBackingIndices() throws Exception {

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/IndicesAndAliasesResolverTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/IndicesAndAliasesResolverTests.java
@@ -1648,18 +1648,18 @@ public class IndicesAndAliasesResolverTests extends ESTestCase {
         final User user = new User("data-stream-tester2", "data_stream_test2");
         GetAliasesRequest request = new GetAliasesRequest("*");
         assertThat(request, instanceOf(IndicesRequest.Replaceable.class));
-        assertThat(request.includeDataStreams(), is(false));
+        assertThat(request.includeDataStreams(), is(true));
 
         // data streams and their backing indices should _not_ be in the authorized list since the backing indices
         // do not match the requested pattern
         List<String> dataStreams = org.elasticsearch.common.collect.List.of("logs-foo", "logs-foobar");
         final List<String> authorizedIndices = buildAuthorizedIndices(user, GetAliasesAction.NAME, request);
         for (String dsName : dataStreams) {
-            assertThat(authorizedIndices, not(hasItem(dsName)));
+            assertThat(authorizedIndices, hasItem(dsName));
             DataStream dataStream = metadata.dataStreams().get(dsName);
-            assertThat(authorizedIndices, not(hasItem(dsName)));
+            assertThat(authorizedIndices, hasItem(dsName));
             for (Index i : dataStream.getIndices()) {
-                assertThat(authorizedIndices, not(hasItem(i.getName())));
+                assertThat(authorizedIndices, hasItem(i.getName()));
             }
         }
 
@@ -1667,11 +1667,11 @@ public class IndicesAndAliasesResolverTests extends ESTestCase {
         // pattern
         ResolvedIndices resolvedIndices = defaultIndicesResolver.resolveIndicesAndAliases(request, metadata, authorizedIndices);
         for (String dsName : dataStreams) {
-            assertThat(resolvedIndices.getLocal(), not(hasItem(dsName)));
+            assertThat(resolvedIndices.getLocal(), hasItem(dsName));
             DataStream dataStream = metadata.dataStreams().get(dsName);
-            assertThat(resolvedIndices.getLocal(), not(hasItem(dsName)));
+            assertThat(resolvedIndices.getLocal(), hasItem(dsName));
             for (Index i : dataStream.getIndices()) {
-                assertThat(resolvedIndices.getLocal(), not(hasItem(i.getName())));
+                assertThat(resolvedIndices.getLocal(), hasItem(i.getName()));
             }
         }
     }
@@ -1681,24 +1681,24 @@ public class IndicesAndAliasesResolverTests extends ESTestCase {
         String dataStreamName = "logs-foobar";
         GetAliasesRequest request = new GetAliasesRequest(dataStreamName);
         assertThat(request, instanceOf(IndicesRequest.Replaceable.class));
-        assertThat(request.includeDataStreams(), is(false));
+        assertThat(request.includeDataStreams(), is(true));
 
         // data streams and their backing indices should _not_ be in the authorized list since the backing indices
         // do not match the requested name
         final List<String> authorizedIndices = buildAuthorizedIndices(user, GetAliasesAction.NAME, request);
-        assertThat(authorizedIndices, not(hasItem(dataStreamName)));
+        assertThat(authorizedIndices, hasItem(dataStreamName));
         DataStream dataStream = metadata.dataStreams().get(dataStreamName);
-        assertThat(authorizedIndices, not(hasItem(dataStreamName)));
+        assertThat(authorizedIndices, hasItem(dataStreamName));
         for (Index i : dataStream.getIndices()) {
-            assertThat(authorizedIndices, not(hasItem(i.getName())));
+            assertThat(authorizedIndices, hasItem(i.getName()));
         }
 
         // neither data streams nor their backing indices will be in the resolved list since the backing indices do not match the
         // requested name(s)
         ResolvedIndices resolvedIndices = defaultIndicesResolver.resolveIndicesAndAliases(request, metadata, authorizedIndices);
-        assertThat(resolvedIndices.getLocal(), not(hasItem(dataStreamName)));
+        assertThat(resolvedIndices.getLocal(), hasItem(dataStreamName));
         for (Index i : dataStream.getIndices()) {
-            assertThat(resolvedIndices.getLocal(), not(hasItem(i.getName())));
+            assertThat(resolvedIndices.getLocal(), hasItem(i.getName()));
         }
     }
 
@@ -1795,24 +1795,24 @@ public class IndicesAndAliasesResolverTests extends ESTestCase {
         String dataStreamName = "logs-foobar";
         GetAliasesRequest request = new GetAliasesRequest(dataStreamName);
         assertThat(request, instanceOf(IndicesRequest.Replaceable.class));
-        assertThat(request.includeDataStreams(), is(false));
+        assertThat(request.includeDataStreams(), is(true));
 
         // data streams and their backing indices should _not_ be in the authorized list since the backing indices
         // did not match the requested pattern and the request does not support data streams
         final List<String> authorizedIndices = buildAuthorizedIndices(user, GetAliasesAction.NAME, request);
-        assertThat(authorizedIndices, not(hasItem(dataStreamName)));
+        assertThat(authorizedIndices, hasItem(dataStreamName));
         DataStream dataStream = metadata.dataStreams().get(dataStreamName);
-        assertThat(authorizedIndices, not(hasItem(dataStreamName)));
+        assertThat(authorizedIndices, hasItem(dataStreamName));
         for (Index i : dataStream.getIndices()) {
-            assertThat(authorizedIndices, not(hasItem(i.getName())));
+            assertThat(authorizedIndices, hasItem(i.getName()));
         }
 
         // neither data streams nor their backing indices will be in the resolved list since the request does not support data streams
         // and the backing indices do not match the requested name
         ResolvedIndices resolvedIndices = defaultIndicesResolver.resolveIndicesAndAliases(request, metadata, authorizedIndices);
-        assertThat(resolvedIndices.getLocal(), not(hasItem(dataStreamName)));
+        assertThat(resolvedIndices.getLocal(), hasItem(dataStreamName));
         for (Index i : dataStream.getIndices()) {
-            assertThat(resolvedIndices.getLocal(), not(hasItem(i.getName())));
+            assertThat(resolvedIndices.getLocal(), hasItem(i.getName()));
         }
     }
 
@@ -1867,7 +1867,7 @@ public class IndicesAndAliasesResolverTests extends ESTestCase {
         String indexName = ".ds-logs-foobar-*";
         GetAliasesRequest request = new GetAliasesRequest(indexName);
         assertThat(request, instanceOf(IndicesRequest.Replaceable.class));
-        assertThat(request.includeDataStreams(), is(false));
+        assertThat(request.includeDataStreams(), is(true));
 
         // data streams should _not_ be in the authorized list but their backing indices that matched both the requested pattern
         // and the authorized pattern should be in the list
@@ -1893,7 +1893,7 @@ public class IndicesAndAliasesResolverTests extends ESTestCase {
         String indexName = ".ds-logs-foobar-*";
         GetAliasesRequest request = new GetAliasesRequest(indexName);
         assertThat(request, instanceOf(IndicesRequest.Replaceable.class));
-        assertThat(request.includeDataStreams(), is(false));
+        assertThat(request.includeDataStreams(), is(true));
 
         // data streams should _not_ be in the authorized list but a single backing index that matched the requested pattern
         // and the authorized name should be in the list

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/data_stream/140_data_stream_aliases.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/data_stream/140_data_stream_aliases.yml
@@ -1,0 +1,73 @@
+---
+"Create data stream alias":
+  - skip:
+      version: " - 7.99.99"
+      reason: "data streams alias not yet backported to the 7.x branch"
+      features: allowed_warnings
+
+  - do:
+      allowed_warnings:
+        - "index template [my-template] has index patterns [events-*] matching patterns from existing older templates [global] with patterns (global => [*]); this template [my-template] will take precedence during new index creation"
+      indices.put_index_template:
+        name: my-template
+        body:
+          index_patterns: [events-*]
+          template:
+            settings:
+              index.number_of_replicas: 0
+          data_stream: {}
+
+  - do:
+      indices.create_data_stream:
+        name: events-app1
+  - is_true: acknowledged
+
+  - do:
+      index:
+        index:  events-app1
+        refresh: true
+        body:
+          '@timestamp': '2022-12-12'
+          foo: bar
+
+  - do:
+      indices.create_data_stream:
+        name: events-app2
+  - is_true: acknowledged
+
+  - do:
+      index:
+        index:  events-app2
+        refresh: true
+        body:
+          '@timestamp': '2022-12-12'
+          foo: bar
+
+  - do:
+      indices.update_aliases:
+        body:
+          actions:
+            - add:
+                index: events-app1
+                alias: events
+            - add:
+                index: events-app2
+                alias: events
+
+  - do:
+      indices.get_data_stream:
+        name: "*"
+  - match: { data_streams.0.name: events-app1 }
+  - match: { data_streams.1.name: events-app2 }
+
+  - do:
+      indices.get_alias: {}
+
+  - match: {events-app1.aliases.events: {}}
+  - match: {events-app2.aliases.events: {}}
+
+  - do:
+      search:
+        index: events
+        body: { query: { match_all: {} } }
+  - length:   { hits.hits: 2  }

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/security/authz/50_data_streams.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/security/authz/50_data_streams.yml
@@ -192,8 +192,8 @@ teardown:
 
   - do:
       headers: { Authorization: "Basic dGVzdF91c2VyOngtcGFjay10ZXN0LXBhc3N3b3Jk" } # test_user
-      indices.get_alias:
-        name: easy*
+      indices.get:
+        index: easy*
 
   - match: {easy-index.aliases.easy-alias: {}}
   - is_false: easy-data-stream1

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/security/authz/51_data_stream_aliases.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/security/authz/51_data_stream_aliases.yml
@@ -1,0 +1,286 @@
+---
+setup:
+  - skip:
+      features: ["headers", "allowed_warnings"]
+      version: " - 7.99.99"
+      reason: "data stream aliases not yet backported to 7.x branch"
+
+  - do:
+      cluster.health:
+        wait_for_status: yellow
+
+  - do:
+      security.put_role:
+        name: "ingest_events_role"
+        body:  >
+          {
+            "indices": [
+              { "names": ["events*"], "privileges": ["create_doc", "create_index"] }
+            ]
+          }
+
+  - do:
+      security.put_role:
+        name: "query_events_role"
+        body:  >
+          {
+            "indices": [
+              { "names": ["app1", "events*"], "privileges": ["read", "view_index_metadata", "monitor"] }
+            ]
+          }
+
+  - do:
+      security.put_role:
+        name: "admin_events_role"
+        body:  >
+          {
+            "indices": [
+              { "names": ["events*"], "privileges": ["read", "write", "manage"] }
+            ]
+          }
+
+  - do:
+      security.put_role:
+        name: "ingest_logs_role"
+        body:  >
+          {
+            "indices": [
+              { "names": ["logs*"], "privileges": ["create_doc", "create_index"] }
+            ]
+          }
+
+  - do:
+      security.put_role:
+        name: "query_logs_role"
+        body:  >
+          {
+            "indices": [
+              { "names": ["app1", "logs*"], "privileges": ["read", "view_index_metadata", "monitor"] }
+            ]
+          }
+
+  - do:
+      security.put_role:
+        name: "admin_logs_role"
+        body:  >
+          {
+            "indices": [
+              { "names": ["logs*"], "privileges": ["read", "write", "manage"] }
+            ]
+          }
+
+  - do:
+      security.put_user:
+        username: "test_user"
+        body:  >
+          {
+            "password" : "x-pack-test-password",
+            "roles" : [ "ingest_events_role", "query_events_role" ],
+            "full_name" : "user with privileges on event data streams"
+          }
+
+  - do:
+      security.put_user:
+        username: "no_authz_user"
+        body:  >
+          {
+            "password" : "x-pack-test-password",
+            "roles" : [ "ingest_logs_role", "query_logs_role" ],
+            "full_name" : "user with privileges on logs data streams"
+          }
+
+  - do:
+      allowed_warnings:
+        - "index template [my-template1] has index patterns [events-*] matching patterns from existing older templates [global] with patterns (global => [*]); this template [my-template1] will take precedence during new index creation"
+      indices.put_index_template:
+        name: my-template1
+        body:
+          index_patterns: [events-*]
+          template:
+            mappings:
+              properties:
+                '@timestamp':
+                  type: date
+                'foo':
+                  type: keyword
+          data_stream: {}
+
+  - do:
+      allowed_warnings:
+        - "index template [my-template2] has index patterns [logs-*] matching patterns from existing older templates [global] with patterns (global => [*]); this template [my-template2] will take precedence during new index creation"
+      indices.put_index_template:
+        name: my-template2
+        body:
+          index_patterns: [logs-*]
+          template:
+            mappings:
+              properties:
+                '@timestamp':
+                  type: date
+                'foo':
+                  type: keyword
+          data_stream: {}
+
+---
+teardown:
+  - do:
+      security.delete_user:
+        username: "test_user"
+        ignore: 404
+
+  - do:
+      security.delete_user:
+        username: "test_user2"
+        ignore: 404
+
+  - do:
+      security.delete_role:
+        name: "ingest_events_role"
+        ignore: 404
+
+  - do:
+      security.delete_role:
+        name: "query_events_role"
+        ignore: 404
+
+  - do:
+      security.delete_role:
+        name: "admin_events_role"
+        ignore: 404
+
+  - do:
+      security.delete_role:
+        name: "ingest_logs_role"
+        ignore: 404
+
+  - do:
+      security.delete_role:
+        name: "query_logs_role"
+        ignore: 404
+
+  - do:
+      security.delete_role:
+        name: "admin_logs_role"
+        ignore: 404
+
+---
+"Basic read authorization test":
+  - skip:
+      features: ["headers", "allowed_warnings"]
+      version: " - 7.99.99"
+      reason: "data stream aliases not yet backported to 7.x branch"
+
+  - do:
+      index:
+        index:  events-app1
+        refresh: true
+        body:
+          '@timestamp': '2022-12-12'
+          foo: bar
+
+  - do:
+      index:
+        index:  logs-app1
+        refresh: true
+        body:
+          '@timestamp': '2022-12-12'
+          bar: baz
+
+  - do:
+      indices.update_aliases:
+        body:
+          actions:
+            - add:
+                index: events-app1
+                alias: app1
+            - add:
+                index: logs-app1
+                alias: app1
+
+  # app1 allows access to both data streams for this user irregardless whether privileges have been granted on data streams
+  - do:
+      headers: { Authorization: "Basic dGVzdF91c2VyOngtcGFjay10ZXN0LXBhc3N3b3Jk" } # test_user
+      search:
+        rest_total_hits_as_int: true
+        index: app1
+  - match: { hits.total: 2 }
+  - match: { hits.hits.0._source.foo: bar }
+  - match: { hits.hits.1._source.bar: baz }
+
+  # this user is authorized to use events-app1 data stream directly
+  - do:
+      headers: { Authorization: "Basic dGVzdF91c2VyOngtcGFjay10ZXN0LXBhc3N3b3Jk" } # test_user
+      search:
+        rest_total_hits_as_int: true
+        index: events-app1
+  - match: { hits.total: 1 }
+  - match: { hits.hits.0._source.foo: bar }
+
+  # this user is authorized to use a backing index of events-app1 data stream directly
+  - do:
+      headers: { Authorization: "Basic dGVzdF91c2VyOngtcGFjay10ZXN0LXBhc3N3b3Jk" } # test_user
+      search:
+        rest_total_hits_as_int: true
+        index: .ds-events-app1*
+  - match: { hits.total: 1 }
+  - match: { hits.hits.0._source.foo: bar }
+
+  # this user isn't authorized to use logs-app1 data stream directly
+  - do:
+      headers: { Authorization: "Basic dGVzdF91c2VyOngtcGFjay10ZXN0LXBhc3N3b3Jk" } # test_user
+      catch: forbidden
+      search:
+        rest_total_hits_as_int: true
+        index: logs-app1
+
+  # this user isn't authorized to use a backing index of logs-app1 data stream directly
+  - do:
+      headers: { Authorization: "Basic dGVzdF91c2VyOngtcGFjay10ZXN0LXBhc3N3b3Jk" } # test_user
+      search:
+        rest_total_hits_as_int: true
+        index: .ds-logs-app1*
+  - match: { hits.total: 0 }
+
+  # app1 allows access to both data streams for this user irregardless whether privileges have been granted on data streams
+  - do:
+      headers: { Authorization: "Basic bm9fYXV0aHpfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA==" } # no_authz_user
+      search:
+        rest_total_hits_as_int: true
+        index: app1
+  - match: { hits.total: 2 }
+  - match: { hits.hits.0._source.foo: bar }
+  - match: { hits.hits.1._source.bar: baz }
+
+  # this user isn't authorized to use events-app1 data stream directly
+  - do:
+      headers: { Authorization: "Basic bm9fYXV0aHpfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA==" } # no_authz_user
+      catch: forbidden
+      search:
+        rest_total_hits_as_int: true
+        index: events-app1
+
+  # this user isn't authorized to use a backing index of events-app1 data stream directly
+  - do:
+      headers: { Authorization: "Basic bm9fYXV0aHpfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA==" } # no_authz_user
+      search:
+        rest_total_hits_as_int: true
+        index: .ds-events-app1*
+  - match: { hits.total: 0 }
+
+  # this user is authorized to use logs-app1 data stream directly
+  - do:
+      headers: { Authorization: "Basic bm9fYXV0aHpfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA==" } # no_authz_user
+      search:
+        rest_total_hits_as_int: true
+        index: logs-app1
+  - match: { hits.total: 1 }
+  - match: { hits.hits.0._source.bar: baz }
+
+  # this user is authorized to use a backing index of logs-app1 data stream directly
+  - do:
+      headers: { Authorization: "Basic bm9fYXV0aHpfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA==" } # no_authz_user
+      search:
+        rest_total_hits_as_int: true
+        index: .ds-logs-app1*
+  - match: { hits.total: 1 }
+  - match: { hits.hits.0._source.bar: baz }


### PR DESCRIPTION
Backporting #72613 to 7.x.

Aliases to data streams can be defined via the existing update aliases api.
Aliases can either only refer to data streams or to indices (not both).
Also the existing get aliases api has been modified to support returning
aliases that refer to data streams.

Aliases for data streams are stored separately from data streams and
and refer to data streams by name and not to the backing indices of
a data stream. This means that when backing indices are added or removed
from a data stream that then the data stream alias doesn't need to be
updated.

The authorization model for aliases that refer to data streams is the
same as for aliases the refer to indices. In security privileges can
be defined on aliases, indices and data streams. When a privilege is
granted on an alias then access is also granted on the indices that
an alias refers to (irregardless whether privileges are granted or denied
on the actual indices). The same will apply for aliases that refer
to data streams. See for more details:
#66163 (comment)

Relates to #66163