### PR TITLE
Update skip after backport

### DIFF
--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.aggregation/90_significant_text.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.aggregation/90_significant_text.yml
@@ -120,8 +120,8 @@ simple:
 ---
 profile:
   - skip:
-      version: " - 7.99.99"
-      reason: extra profiling added in 8.0.0 to be backported to 7.14.0
+      version: " - 7.13.99"
+      reason: extra profiling added in 7.14.0
 
   - do:
       search:


### PR DESCRIPTION
Now that #72727 has landed in 7.x we can run the bwc tests against its
changes.
