### PR TITLE
[ML] slight refactor of the bucket_correlation aggregation

### DIFF
--- a/server/src/main/java/org/elasticsearch/search/aggregations/pipeline/BucketMetricsPipelineAggregationBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/pipeline/BucketMetricsPipelineAggregationBuilder.java
@@ -23,11 +23,17 @@ import java.util.Optional;
 public abstract class BucketMetricsPipelineAggregationBuilder<AF extends BucketMetricsPipelineAggregationBuilder<AF>>
         extends AbstractPipelineAggregationBuilder<AF> {
 
-    private String format = null;
-    private GapPolicy gapPolicy = GapPolicy.SKIP;
+    private String format;
+    private GapPolicy gapPolicy;
 
     protected BucketMetricsPipelineAggregationBuilder(String name, String type, String[] bucketsPaths) {
+        this(name, type, bucketsPaths, null, GapPolicy.SKIP);
+    }
+
+    protected BucketMetricsPipelineAggregationBuilder(String name, String type, String[] bucketsPaths, String format, GapPolicy gapPolicy) {
         super(name, type, bucketsPaths);
+        this.format = format;
+        this.gapPolicy = gapPolicy;
     }
 
     /**

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/aggs/correlation/BucketCorrelationAggregationBuilderTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/aggs/correlation/BucketCorrelationAggregationBuilderTests.java
@@ -22,8 +22,6 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import static org.hamcrest.Matchers.containsString;
 
@@ -48,10 +46,6 @@ public class BucketCorrelationAggregationBuilderTests extends BasePipelineAggreg
 
     @Override
     protected BucketCorrelationAggregationBuilder createTestAggregatorFactory() {
-        List<String> bucketPaths = Stream.generate(() -> randomAlphaOfLength(8))
-            .limit(2)
-            .collect(Collectors.toList());
-
         CorrelationFunction function = new CountCorrelationFunction(CountCorrelationIndicatorTests.randomInstance());
         return new BucketCorrelationAggregationBuilder(
             NAME,


### PR DESCRIPTION
This PR moves the bucket_correlation aggregation to inherit from pipeline bucket metrics. 

This allows the validation code to be reused from the parent object.