### PR TITLE
Delete redundant index path permissions operation

### DIFF
--- a/server/src/main/java/org/elasticsearch/env/NodeEnvironment.java
+++ b/server/src/main/java/org/elasticsearch/env/NodeEnvironment.java
@@ -1331,20 +1331,6 @@ public final class NodeEnvironment  implements Closeable {
                 Path indexStatePath = indexPath.resolve(MetadataStateFormat.STATE_DIR_NAME);
                 tryWriteTempFile(indexStatePath);
                 tryWriteTempFile(indexPath);
-                try (DirectoryStream<Path> stream = Files.newDirectoryStream(indexPath)) {
-                    for (Path shardPath : stream) {
-                        String fileName = shardPath.getFileName().toString();
-                        if (Files.isDirectory(shardPath) && fileName.chars().allMatch(Character::isDigit)) {
-                            Path indexDir = shardPath.resolve(ShardPath.INDEX_FOLDER_NAME);
-                            Path statePath = shardPath.resolve(MetadataStateFormat.STATE_DIR_NAME);
-                            Path translogDir = shardPath.resolve(ShardPath.TRANSLOG_FOLDER_NAME);
-                            tryWriteTempFile(indexDir);
-                            tryWriteTempFile(translogDir);
-                            tryWriteTempFile(statePath);
-                            tryWriteTempFile(shardPath);
-                        }
-                    }
-                }
             }
         }
     }


### PR DESCRIPTION
Each restart will check the write permissions of all shard directories. This will take a long time. Can it only check the configured data directory? When deploying the es service, the permissions will be set.