### PR TITLE
[DOCS] Mark freeze API as deprecated

### DIFF
--- a/docs/reference/indices/apis/freeze.asciidoc
+++ b/docs/reference/indices/apis/freeze.asciidoc
@@ -6,6 +6,8 @@
 <titleabbrev>Freeze index</titleabbrev>
 ++++
 
+deprecated::[8.0, Due to https://www.elastic.co/blog/significantly-decrease-your-elasticsearch-heap-memory-usage[recent improvements in heap memory utilization], frozen indices are no longer beneficial.]
+
 Freezes an index.
 
 [[freeze-index-api-request]]

--- a/docs/reference/indices/apis/freeze.asciidoc
+++ b/docs/reference/indices/apis/freeze.asciidoc
@@ -6,7 +6,7 @@
 <titleabbrev>Freeze index</titleabbrev>
 ++++
 
-deprecated::[8.0, Due to https://www.elastic.co/blog/significantly-decrease-your-elasticsearch-heap-memory-usage[recent improvements in heap memory utilization], frozen indices are no longer beneficial.]
+deprecated::[8.0, Frozen indices are no longer beneficial due to https://www.elastic.co/blog/significantly-decrease-your-elasticsearch-heap-memory-usage[recent improvements in heap memory utilization]]
 
 Freezes an index.
 

--- a/docs/reference/indices/apis/freeze.asciidoc
+++ b/docs/reference/indices/apis/freeze.asciidoc
@@ -6,7 +6,7 @@
 <titleabbrev>Freeze index</titleabbrev>
 ++++
 
-deprecated::[8.0, Frozen indices are no longer useful due to https://www.elastic.co/blog/significantly-decrease-your-elasticsearch-heap-memory-usage[recent improvements in heap memory utilization]]
+deprecated::[8.0, Frozen indices are no longer useful due to https://www.elastic.co/blog/significantly-decrease-your-elasticsearch-heap-memory-usage[recent improvements in heap memory usage].]
 
 Freezes an index.
 

--- a/docs/reference/indices/apis/freeze.asciidoc
+++ b/docs/reference/indices/apis/freeze.asciidoc
@@ -6,7 +6,7 @@
 <titleabbrev>Freeze index</titleabbrev>
 ++++
 
-deprecated::[8.0, Frozen indices are no longer useful due to https://www.elastic.co/blog/significantly-decrease-your-elasticsearch-heap-memory-usage[recent improvements in heap memory usage].]
+deprecated::[7.14, Frozen indices are no longer useful due to https://www.elastic.co/blog/significantly-decrease-your-elasticsearch-heap-memory-usage[recent improvements in heap memory usage].]
 
 Freezes an index.
 

--- a/docs/reference/indices/apis/freeze.asciidoc
+++ b/docs/reference/indices/apis/freeze.asciidoc
@@ -6,7 +6,7 @@
 <titleabbrev>Freeze index</titleabbrev>
 ++++
 
-deprecated::[8.0, Frozen indices are no longer beneficial due to https://www.elastic.co/blog/significantly-decrease-your-elasticsearch-heap-memory-usage[recent improvements in heap memory utilization]]
+deprecated::[8.0, Frozen indices are no longer useful due to https://www.elastic.co/blog/significantly-decrease-your-elasticsearch-heap-memory-usage[recent improvements in heap memory utilization]]
 
 Freezes an index.
 


### PR DESCRIPTION
Relates to #70192

Preview: https://elasticsearch_72946.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/freeze-index-api.html