### PR TITLE
Remove race in ensure remote connection test

### DIFF
--- a/server/src/test/java/org/elasticsearch/transport/RemoteClusterConnectionTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/RemoteClusterConnectionTests.java
@@ -1170,7 +1170,7 @@ public class RemoteClusterConnectionTests extends ESTestCase {
                     assertFalse(connectionManager.nodeConnected(seedNode));
                     assertFalse(connectionManager.nodeConnected(discoverableNode));
                     assertTrue(connection.assertNoRunningConnections());
-                    CountDownLatch latch = new CountDownLatch(1);
+                    CountDownLatch firstLatch = new CountDownLatch(1);
                     connection.ensureConnected(new LatchedActionListener<>(new ActionListener<Void>() {
                         @Override
                         public void onResponse(Void aVoid) {
@@ -1180,12 +1180,13 @@ public class RemoteClusterConnectionTests extends ESTestCase {
                         public void onFailure(Exception e) {
                             throw new AssertionError(e);
                         }
-                    }, latch));
-                    latch.await();
+                    }, firstLatch));
+                    firstLatch.await();
                     assertTrue(connectionManager.nodeConnected(seedNode));
                     assertTrue(connectionManager.nodeConnected(discoverableNode));
                     assertTrue(connection.assertNoRunningConnections());
 
+                    CountDownLatch secondLatch = new CountDownLatch(1);
                     // exec again we are already connected
                     connection.ensureConnected(new LatchedActionListener<>(new ActionListener<Void>() {
                         @Override
@@ -1196,8 +1197,8 @@ public class RemoteClusterConnectionTests extends ESTestCase {
                         public void onFailure(Exception e) {
                             throw new AssertionError(e);
                         }
-                    }, latch));
-                    latch.await();
+                    }, secondLatch));
+                    secondLatch.await();
                     assertTrue(connectionManager.nodeConnected(seedNode));
                     assertTrue(connectionManager.nodeConnected(discoverableNode));
                     assertTrue(connection.assertNoRunningConnections());


### PR DESCRIPTION
Currently RemoteClusterConnectionTests#testEnsureConnected uses the same
countdown latch for two ensure connected method calls. This introduces a
race where the test ends before the second ensure connected method
executes. This causes an exception to be thrown and the test to fail.
This commit resolves the issue by adding a second latch.

Fixes #71519.