### PR TITLE
Fix test testGeoShapeBounds (#72878)

### DIFF
--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/search/aggregations/bucket/geogrid/AbstractGeoHashGridTiler.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/search/aggregations/bucket/geogrid/AbstractGeoHashGridTiler.java
@@ -37,10 +37,13 @@ abstract class AbstractGeoHashGridTiler extends GeoGridTiler {
         GeoShapeValues.BoundingBox bounds = geoValue.boundingBox();
         assert bounds.minX() <= bounds.maxX();
 
+        // When the shape represents a point, we compute the hash directly as we do it for GeoPoint
+        if (bounds.minX() == bounds.maxX() && bounds.minY() == bounds.maxY()) {
+            return setValue(values, geoValue, bounds);
+        }
         // TODO: optimize for when a  shape fits in a single tile an
         //  for when brute-force is expected to be faster than rasterization, which
         //  is when the number of tiles expected is less than the precision
-
         return setValuesByRasterization("", values, 0, geoValue);
     }
 

--- a/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/search/aggregations/bucket/geogrid/GeoHashTilerTests.java
+++ b/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/search/aggregations/bucket/geogrid/GeoHashTilerTests.java
@@ -83,6 +83,14 @@ public class GeoHashTilerTests extends GeoGridTilerTestCase {
         if (precision == 0) {
             return 1;
         }
+        GeoShapeValues.BoundingBox bounds = geoValue.boundingBox();
+        if (bounds.minX() == bounds.maxX() && bounds.minY() == bounds.maxY()) {
+            String hash = Geohash.stringEncode(bounds.minX(), bounds.minY(), precision);
+            if (hashIntersectsBounds(hash, bbox) && geoValue.relate(Geohash.toBoundingBox(hash)) != GeoRelation.QUERY_DISJOINT) {
+                return 1;
+            }
+            return 0;
+        }
        return computeBuckets("", bbox, geoValue, precision);
     }
 

--- a/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/search/aggregations/bucket/geogrid/GeoShapeGeoHashGridAggregatorTests.java
+++ b/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/search/aggregations/bucket/geogrid/GeoShapeGeoHashGridAggregatorTests.java
@@ -17,8 +17,6 @@ import org.elasticsearch.search.aggregations.bucket.geogrid.GeoHashGridAggregati
 import org.elasticsearch.search.aggregations.bucket.geogrid.InternalGeoHashGridBucket;
 import org.elasticsearch.xpack.spatial.util.GeoTestUtils;
 
-import java.io.IOException;
-
 import static org.elasticsearch.geometry.utils.Geohash.stringEncode;
 
 public class GeoShapeGeoHashGridAggregatorTests extends GeoShapeGeoGridTestCase<InternalGeoHashGridBucket> {
@@ -51,10 +49,5 @@ public class GeoShapeGeoHashGridAggregatorTests extends GeoShapeGeoGridTestCase<
     @Override
     protected GeoGridAggregationBuilder createBuilder(String name) {
         return new GeoHashGridAggregationBuilder(name);
-    }
-
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/72872")
-    public void testGeoShapeBounds() throws IOException {
-        super.testGeoShapeBounds();
     }
 }


### PR DESCRIPTION
The test GeoShapeGeoHashGridAggregatorTests#testGeoShapeBounds is currently failing because computing the hash of a point directly using Geohash.#stringEncode(lon, lat, precision) might differ from the result when computing the hash using rasterisation.

In #72871 we removed the shortcut for computing hashes directly for points because of that but this makes this test to fail in some cases. Thinking about the behaviour, it should be consistent with geoPoint field and therefore we added back the possibility of computing hashes directly for GeoShape is case of point data.

In order to make test happy, we adapted GeoHashTilerTests to take into account this modification.

backport #72878