### PR TITLE
[DOCS] EQL: Note CCS is not supported

### DIFF
--- a/docs/reference/eql/syntax.asciidoc
+++ b/docs/reference/eql/syntax.asciidoc
@@ -827,6 +827,13 @@ sub-fields of a `nested` field. However, data streams and indices containing
 `nested` field mappings are otherwise supported.
 
 [discrete]
+[[eql-ccs-support]]
+==== {ccs-cap} is not supported
+
+EQL search APIs do not support <<modules-cross-cluster-search,{ccs}
+({ccs-init})>>.
+
+[discrete]
 [[eql-unsupported-syntax]]
 ==== Differences from Endgame EQL syntax
 


### PR DESCRIPTION
Adds a note related to CCS support to the EQL limitations docs.

Closes #72958

### Preview
https://elasticsearch_72975.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/eql-syntax.html#eql-syntax-limitations