### PR TITLE
[7.x] [DOCS] EQL: Note CCS is not supported (#72975)

### DIFF
--- a/docs/reference/eql/syntax.asciidoc
+++ b/docs/reference/eql/syntax.asciidoc
@@ -827,6 +827,13 @@ sub-fields of a `nested` field. However, data streams and indices containing
 `nested` field mappings are otherwise supported.
 
 [discrete]
+[[eql-ccs-support]]
+==== {ccs-cap} is not supported
+
+EQL search APIs do not support <<modules-cross-cluster-search,{ccs}
+({ccs-init})>>.
+
+[discrete]
 [[eql-unsupported-syntax]]
 ==== Differences from Endgame EQL syntax
 


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [DOCS] EQL: Note CCS is not supported (#72975)