### PR TITLE
docs amendment match-only-text has limited support for aggs

### DIFF
--- a/docs/reference/mapping/types/match-only-text.asciidoc
+++ b/docs/reference/mapping/types/match-only-text.asciidoc
@@ -20,7 +20,7 @@ Analysis is not configurable: text is always analyzed with the
 <<text-field-type,`text`>> field type if you absolutely need span queries.
 
 Other than that, `match_only_text` supports the same queries as `text`. And
-like `text`, it doesn't support sorting or aggregating.
+like `text`, it has limited support for sorting and aggregating.
 
 [source,console]
 --------------------------------

--- a/docs/reference/mapping/types/match-only-text.asciidoc
+++ b/docs/reference/mapping/types/match-only-text.asciidoc
@@ -20,7 +20,7 @@ Analysis is not configurable: text is always analyzed with the
 <<text-field-type,`text`>> field type if you absolutely need span queries.
 
 Other than that, `match_only_text` supports the same queries as `text`. And
-like `text`, it has limited support for sorting and aggregating.
+like `text`, it does not support sorting and has only limited support for aggretations.
 
 [source,console]
 --------------------------------


### PR DESCRIPTION
Small correction to Docs for [`match_only_text`](https://www.elastic.co/guide/en/elasticsearch/reference/master/text.html#match-only-text-field-type) states this field does not support `aggs`, however, you can still run an aggregations in some shape or form see [this gist](https://gist.github.com/djptek/c2018b0dc2a9f7a2d360161fe90850ec)

If the intention is to reject `aggs` in the same way as `sort` e.g. by raising `illegal_argument_exception` then please reject this PR
