### PR TITLE
Fixup test for significant_text

### DIFF
--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.aggregation/90_significant_text.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.aggregation/90_significant_text.yml
@@ -186,6 +186,10 @@ include:
 
 ---
 exclude:
+  - skip:
+      version: " - 7.9.99"
+      reason: 7.9 has trouble with this one, not sure why but not worth tracking down
+
   - do:
       search:
         index: goodbad


### PR DESCRIPTION
The bwc tests were claiming that `exclude` worked in a way that 7.9
doesn't seem to support.
