### PR TITLE
Links new TermsEnum api into docs. 

### DIFF
--- a/docs/reference/search.asciidoc
+++ b/docs/reference/search.asciidoc
@@ -18,6 +18,7 @@ exception of the <<search-explain,explain API>>.
 * <<scroll-api>>
 * <<clear-scroll-api>>
 * <<search-suggesters>>
+* <<search-terms-enum>>
 
 [discrete]
 [[search-testing-apis]]
@@ -78,6 +79,8 @@ include::eql/delete-async-eql-search-api.asciidoc[]
 include::search/count.asciidoc[]
 
 include::search/validate.asciidoc[]
+
+include::search/terms-enum.asciidoc[]
 
 include::search/explain.asciidoc[]
 

--- a/docs/reference/search/terms-enum.asciidoc
+++ b/docs/reference/search/terms-enum.asciidoc
@@ -1,5 +1,5 @@
 [[search-terms-enum]]
-=== Terms enum API
+=== Terms enum
 
 The terms enum API can be used to discover terms in the index that match
 a partial string. This is used for auto-complete:


### PR DESCRIPTION
Also remove superfluous “API” from page title. 

Closes #72982