### PR TITLE
[DOCS] Update allowed operations on data stream write index

### DIFF
--- a/docs/reference/data-streams/data-streams.asciidoc
+++ b/docs/reference/data-streams/data-streams.asciidoc
@@ -66,7 +66,6 @@ You also cannot perform operations on a write index that may hinder indexing,
 such as:
 
 * <<indices-clone-index,Clone>>
-* <<indices-close,Close>>
 * <<indices-delete-index,Delete>>
 * <<freeze-index-api,Freeze>>
 * <<indices-shrink-index,Shrink>>


### PR DESCRIPTION
With #70908, you can close a write index in 7.12.1 and later versions. This removes an outdated reference from the data stream overview docs.