### PR TITLE
[7.x] [DOCS] Fix JSON spec link for terms enum API (#72996)

### DIFF
--- a/docs/reference/redirects.asciidoc
+++ b/docs/reference/redirects.asciidoc
@@ -1537,6 +1537,11 @@ See <<getting-started>>.
 
 See <<set-jvm-options>>.
 
+[role="exclude",id="terms-enum"]
+=== Terms enum API
+
+See <<search-terms-enum>>.
+
 [role="exclude",id="frozen-indices"]
 === Frozen indices
 

--- a/docs/reference/search/terms-enum.asciidoc
+++ b/docs/reference/search/terms-enum.asciidoc
@@ -1,5 +1,8 @@
 [[search-terms-enum]]
-=== Terms enum
+=== Terms enum API
+++++
+<titleabbrev>Terms enum</titleabbrev>
+++++
 
 The terms enum API can be used to discover terms in the index that match
 a partial string. This is used for auto-complete:

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/termsenum.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/termsenum.json
@@ -1,7 +1,7 @@
 {
   "termsenum":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/terms-enum.html",
+      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/search-terms-enum.html",
       "description": "The terms enum API  can be used to discover terms in the index that begin with the provided string. It is designed for low-latency look-ups used in auto-complete scenarios."
     },
     "stability":"beta",


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [DOCS] Fix JSON spec link for terms enum API (#72996)