### PR TITLE
Extract parsing util class into QL module

### DIFF
--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/parser/AbstractBuilder.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/parser/AbstractBuilder.java
@@ -7,17 +7,14 @@
 package org.elasticsearch.xpack.eql.parser;
 
 import org.antlr.v4.runtime.ParserRuleContext;
-import org.antlr.v4.runtime.Token;
-import org.antlr.v4.runtime.misc.Interval;
 import org.antlr.v4.runtime.tree.ParseTree;
-import org.antlr.v4.runtime.tree.TerminalNode;
+import org.elasticsearch.xpack.ql.parser.ParserUtils;
 import org.elasticsearch.xpack.ql.plan.logical.LogicalPlan;
-import org.elasticsearch.xpack.ql.tree.Location;
 import org.elasticsearch.xpack.ql.tree.Source;
-import org.elasticsearch.xpack.ql.util.Check;
 
-import java.util.ArrayList;
 import java.util.List;
+
+import static org.elasticsearch.xpack.ql.parser.ParserUtils.visitList;
 
 /**
  * Base parsing visitor class offering utility methods.
@@ -26,21 +23,11 @@ abstract class AbstractBuilder extends EqlBaseBaseVisitor<Object> {
 
     @Override
     public Object visit(ParseTree tree) {
-        Object result = super.visit(tree);
-        Check.notNull(result, "Don't know how to handle context [{}] with value [{}]", tree.getClass(), tree.getText());
-        return result;
+        return ParserUtils.visit(super::visit, tree);
     }
 
-    @SuppressWarnings("unchecked")
     protected <T> T typedParsing(ParseTree ctx, Class<T> type) {
-        Object result = ctx.accept(this);
-        if (type.isInstance(result)) {
-            return (T) result;
-        }
-
-        throw new ParsingException(source(ctx), "Invalid query '{}'[{}] given; expected {} but found {}",
-                        ctx.getText(), ctx.getClass().getSimpleName(),
-                        type.getSimpleName(), (result != null ? result.getClass().getSimpleName() : "null"));
+        return ParserUtils.typedParsing(this, ctx, type);
     }
 
     protected LogicalPlan plan(ParseTree ctx) {
@@ -48,68 +35,7 @@ abstract class AbstractBuilder extends EqlBaseBaseVisitor<Object> {
     }
 
     protected List<LogicalPlan> plans(List<? extends ParserRuleContext> ctxs) {
-        return visitList(ctxs, LogicalPlan.class);
-    }
-
-    protected <T> List<T> visitList(List<? extends ParserRuleContext> contexts, Class<T> clazz) {
-        List<T> results = new ArrayList<>(contexts.size());
-        for (ParserRuleContext context : contexts) {
-            results.add(clazz.cast(visit(context)));
-        }
-        return results;
-    }
-
-    static Source source(ParseTree ctx) {
-        if (ctx instanceof ParserRuleContext) {
-            return source((ParserRuleContext) ctx);
-        }
-        return Source.EMPTY;
-    }
-
-    static Source source(TerminalNode terminalNode) {
-        Check.notNull(terminalNode, "terminalNode is null");
-        return source(terminalNode.getSymbol());
-    }
-
-    static Source source(ParserRuleContext parserRuleContext) {
-        Check.notNull(parserRuleContext, "parserRuleContext is null");
-        Token start = parserRuleContext.start;
-        Token stop = parserRuleContext.stop != null ? parserRuleContext.stop : start;
-        Interval interval = new Interval(start.getStartIndex(), stop.getStopIndex());
-        String text = start.getInputStream().getText(interval);
-        return new Source(new Location(start.getLine(), start.getCharPositionInLine()), text);
-    }
-
-    static Source source(Token token) {
-        Check.notNull(token, "token is null");
-        String text = token.getInputStream().getText(new Interval(token.getStartIndex(), token.getStopIndex()));
-        return new Source(new Location(token.getLine(), token.getCharPositionInLine()), text);
-    }
-
-    Source source(ParserRuleContext begin, ParserRuleContext end) {
-        Check.notNull(begin, "begin is null");
-        Check.notNull(end, "end is null");
-        Token start = begin.start;
-        Token stop = end.stop != null ? end.stop : begin.stop;
-        Interval interval = new Interval(start.getStartIndex(), stop.getStopIndex());
-        String text = start.getInputStream().getText(interval);
-        return new Source(new Location(start.getLine(), start.getCharPositionInLine()), text);
-    }
-
-    static Source source(TerminalNode begin, ParserRuleContext end) {
-        Check.notNull(begin, "begin is null");
-        Check.notNull(end, "end is null");
-        Token start = begin.getSymbol();
-        Token stop = end.stop != null ? end.stop : start;
-        String text = start.getInputStream().getText(new Interval(start.getStartIndex(), stop.getStopIndex()));
-        return new Source(new Location(start.getLine(), start.getCharPositionInLine()), text);
-    }
-
-    /**
-     * Retrieves the raw text of the node (without interpreting it as a string literal).
-     */
-    static String text(ParseTree node) {
-        return node == null ? null : node.getText();
+        return visitList(this, ctxs, LogicalPlan.class);
     }
 
     public static String unquoteString(Source source) {
@@ -212,11 +138,4 @@ abstract class AbstractBuilder extends EqlBaseBaseVisitor<Object> {
                     "Use double quotes [\"] to define string literals, not single quotes [']");
         }
     }
-
-    @Override
-    public Object visitTerminal(TerminalNode node) {
-        Source source = source(node);
-        throw new ParsingException(source, "Does not know how to handle {}", source.text());
-    }
-
 }

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/parser/ExpressionBuilder.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/parser/ExpressionBuilder.java
@@ -58,6 +58,8 @@ import java.util.List;
 
 import static java.util.Collections.emptyList;
 import static java.util.stream.Collectors.toList;
+import static org.elasticsearch.xpack.ql.parser.ParserUtils.source;
+import static org.elasticsearch.xpack.ql.parser.ParserUtils.visitList;
 
 
 public class ExpressionBuilder extends IdentifierBuilder {
@@ -73,7 +75,7 @@ public class ExpressionBuilder extends IdentifierBuilder {
     }
 
     protected List<Expression> expressions(List<? extends ParserRuleContext> contexts) {
-        return visitList(contexts, Expression.class);
+        return visitList(this, contexts, Expression.class);
     }
 
     @Override
@@ -84,7 +86,7 @@ public class ExpressionBuilder extends IdentifierBuilder {
     @Override
     public List<Attribute> visitJoinKeys(JoinKeysContext ctx) {
         try {
-            return ctx != null ? visitList(ctx.expression(), Attribute.class) : emptyList();
+            return ctx != null ? visitList(this, ctx.expression(), Attribute.class) : emptyList();
         } catch (ClassCastException ex) {
             Source source = source(ctx);
             throw new ParsingException(source, "Unsupported join key ", source.text());
@@ -203,7 +205,7 @@ public class ExpressionBuilder extends IdentifierBuilder {
         List<? extends ParserRuleContext> expressions,
         java.util.function.Function<Expression, Expression> mapper
     ) {
-        return Predicates.combineOr(expressions(expressions).stream().map(mapper::apply).collect(toList()));
+        return Predicates.combineOr(expressions(expressions).stream().map(mapper).collect(toList()));
     }
 
     @Override

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/parser/IdentifierBuilder.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/parser/IdentifierBuilder.java
@@ -10,6 +10,8 @@ import org.elasticsearch.common.Strings;
 import org.elasticsearch.xpack.eql.parser.EqlBaseParser.IdentifierContext;
 import org.elasticsearch.xpack.eql.parser.EqlBaseParser.QualifiedNameContext;
 
+import static org.elasticsearch.xpack.ql.parser.ParserUtils.visitList;
+
 abstract class IdentifierBuilder extends AbstractBuilder {
 
     @Override
@@ -24,7 +26,7 @@ abstract class IdentifierBuilder extends AbstractBuilder {
         }
 
         // this is fine, because we've already checked for array indexes [...]
-        return Strings.collectionToDelimitedString(visitList(ctx.identifier(), String.class), ".");
+        return Strings.collectionToDelimitedString(visitList(this, ctx.identifier(), String.class), ".");
     }
 
     private static String unquoteIdentifier(String identifier) {

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/parser/LogicalPlanBuilder.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/parser/LogicalPlanBuilder.java
@@ -56,6 +56,8 @@ import java.util.concurrent.TimeUnit;
 
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
+import static org.elasticsearch.xpack.ql.parser.ParserUtils.source;
+import static org.elasticsearch.xpack.ql.parser.ParserUtils.text;
 import static org.elasticsearch.xpack.ql.tree.Source.synthetic;
 
 public abstract class LogicalPlanBuilder extends ExpressionBuilder {

--- a/x-pack/plugin/ql/build.gradle
+++ b/x-pack/plugin/ql/build.gradle
@@ -8,10 +8,16 @@ esplugin {
   extendedPlugins = ['x-pack-core']
 }
 
+ext {
+  // EQL dependency versions
+  antlrVersion = "4.5.3"
+}
+
 archivesBaseName = 'x-pack-ql'
 
 dependencies {
   compileOnly project(path: xpackModule('core'))
+  compileOnly "org.antlr:antlr4-runtime:${antlrVersion}"
   testImplementation project(':test:framework')
   testImplementation(testArtifact(project(xpackModule('core'))))
   testImplementation(project(xpackModule('ql:test-fixtures'))) {

--- a/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/parser/CaseInsensitiveStream.java
+++ b/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/parser/CaseInsensitiveStream.java
@@ -4,7 +4,7 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-package org.elasticsearch.xpack.sql.parser;
+package org.elasticsearch.xpack.ql.parser;
 
 import org.antlr.v4.runtime.ANTLRInputStream;
 import org.antlr.v4.runtime.IntStream;
@@ -17,10 +17,10 @@ import java.util.Locale;
 // This approach is the official solution from the ANTLR authors
 // in that it's both faster and easier than having a dedicated lexer
 // see https://github.com/antlr/antlr4/issues/1002
-class CaseInsensitiveStream extends ANTLRInputStream {
+public class CaseInsensitiveStream extends ANTLRInputStream {
     protected char[] uppedChars;
 
-    CaseInsensitiveStream(String input) {
+    public CaseInsensitiveStream(String input) {
         super(input);
         this.uppedChars = input.toUpperCase(Locale.ROOT).toCharArray();
     }

--- a/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/parser/ParserUtils.java
+++ b/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/parser/ParserUtils.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.ql.parser;
+
+import org.antlr.v4.runtime.ParserRuleContext;
+import org.antlr.v4.runtime.Token;
+import org.antlr.v4.runtime.misc.Interval;
+import org.antlr.v4.runtime.tree.ParseTree;
+import org.antlr.v4.runtime.tree.ParseTreeVisitor;
+import org.antlr.v4.runtime.tree.TerminalNode;
+import org.elasticsearch.xpack.ql.ParsingException;
+import org.elasticsearch.xpack.ql.tree.Location;
+import org.elasticsearch.xpack.ql.tree.Source;
+import org.elasticsearch.xpack.ql.util.Check;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Function;
+
+public final class ParserUtils {
+
+    private ParserUtils() {}
+
+    public static Object visit(Function<ParseTree, Object> visitor, ParseTree tree) {
+        Object result = visitor.apply(tree);
+        Check.notNull(result, "Don't know how to handle context [{}] with value [{}]", tree.getClass(), tree.getText());
+        return result;
+    }
+
+    public static <T> List<T> visitList(ParseTreeVisitor<?> visitor, List<? extends ParserRuleContext> contexts, Class<T> clazz) {
+        List<T> results = new ArrayList<>(contexts.size());
+        for (ParserRuleContext context : contexts) {
+            results.add(clazz.cast(visitor.visit(context)));
+        }
+        return results;
+    }
+
+    @SuppressWarnings("unchecked")
+    public static <T> T typedParsing(ParseTreeVisitor<?> visitor, ParseTree ctx, Class<T> type) {
+        Object result = ctx.accept(visitor);
+        if (type.isInstance(result)) {
+            return (T) result;
+        }
+
+        throw new ParsingException(
+            source(ctx),
+            "Invalid query '{}'[{}] given; expected {} but found {}",
+            ctx.getText(),
+            ctx.getClass().getSimpleName(),
+            type.getSimpleName(),
+            (result != null ? result.getClass().getSimpleName() : "null")
+        );
+    }
+
+    public static Source source(ParseTree ctx) {
+        if (ctx instanceof ParserRuleContext) {
+            return source((ParserRuleContext) ctx);
+        }
+        return Source.EMPTY;
+    }
+
+    public static Source source(TerminalNode terminalNode) {
+        Check.notNull(terminalNode, "terminalNode is null");
+        return source(terminalNode.getSymbol());
+    }
+
+    public static Source source(ParserRuleContext parserRuleContext) {
+        Check.notNull(parserRuleContext, "parserRuleContext is null");
+        Token start = parserRuleContext.start;
+        Token stop = parserRuleContext.stop != null ? parserRuleContext.stop : start;
+        Interval interval = new Interval(start.getStartIndex(), stop.getStopIndex());
+        String text = start.getInputStream().getText(interval);
+        return new Source(new Location(start.getLine(), start.getCharPositionInLine()), text);
+    }
+
+    public static Source source(Token token) {
+        Check.notNull(token, "token is null");
+        String text = token.getInputStream().getText(new Interval(token.getStartIndex(), token.getStopIndex()));
+        return new Source(new Location(token.getLine(), token.getCharPositionInLine()), text);
+    }
+
+    public static Source source(ParserRuleContext begin, ParserRuleContext end) {
+        Check.notNull(begin, "begin is null");
+        Check.notNull(end, "end is null");
+        Token start = begin.start;
+        Token stop = end.stop != null ? end.stop : begin.stop;
+        Interval interval = new Interval(start.getStartIndex(), stop.getStopIndex());
+        String text = start.getInputStream().getText(interval);
+        return new Source(new Location(start.getLine(), start.getCharPositionInLine()), text);
+    }
+
+    public static Source source(TerminalNode begin, ParserRuleContext end) {
+        Check.notNull(begin, "begin is null");
+        Check.notNull(end, "end is null");
+        Token start = begin.getSymbol();
+        Token stop = end.stop != null ? end.stop : start;
+        String text = start.getInputStream().getText(new Interval(start.getStartIndex(), stop.getStopIndex()));
+        return new Source(new Location(start.getLine(), start.getCharPositionInLine()), text);
+    }
+
+    /**
+     * Retrieves the raw text of the node (without interpreting it as a string literal).
+     */
+    public static String text(ParseTree node) {
+        return node == null ? null : node.getText();
+    }
+}

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/parser/AbstractBuilder.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/parser/AbstractBuilder.java
@@ -7,17 +7,15 @@
 package org.elasticsearch.xpack.sql.parser;
 
 import org.antlr.v4.runtime.ParserRuleContext;
-import org.antlr.v4.runtime.Token;
-import org.antlr.v4.runtime.misc.Interval;
 import org.antlr.v4.runtime.tree.ParseTree;
 import org.antlr.v4.runtime.tree.TerminalNode;
+import org.elasticsearch.xpack.ql.parser.ParserUtils;
 import org.elasticsearch.xpack.ql.plan.logical.LogicalPlan;
-import org.elasticsearch.xpack.ql.tree.Location;
-import org.elasticsearch.xpack.ql.tree.Source;
-import org.elasticsearch.xpack.sql.util.Check;
 
-import java.util.ArrayList;
 import java.util.List;
+
+import static org.elasticsearch.xpack.ql.parser.ParserUtils.source;
+import static org.elasticsearch.xpack.ql.parser.ParserUtils.visitList;
 
 /**
  * Base parsing visitor class offering utility methods.
@@ -33,21 +31,11 @@ abstract class AbstractBuilder extends SqlBaseBaseVisitor<Object> {
 
     @Override
     public Object visit(ParseTree tree) {
-        Object result = super.visit(tree);
-        Check.notNull(result, "Don't know how to handle context [{}] with value [{}]", tree.getClass(), tree.getText());
-        return result;
+        return ParserUtils.visit(super::visit, tree);
     }
 
-    @SuppressWarnings("unchecked")
     protected <T> T typedParsing(ParseTree ctx, Class<T> type) {
-        Object result = ctx.accept(this);
-        if (type.isInstance(result)) {
-            return (T) result;
-        }
-
-        throw new ParsingException(source(ctx), "Invalid query '{}'[{}] given; expected {} but found {}",
-                        ctx.getText(), ctx.getClass().getSimpleName(),
-                        type.getSimpleName(), (result != null ? result.getClass().getSimpleName() : "null"));
+        return ParserUtils.typedParsing(this, ctx, type);
     }
 
     protected LogicalPlan plan(ParseTree ctx) {
@@ -55,68 +43,7 @@ abstract class AbstractBuilder extends SqlBaseBaseVisitor<Object> {
     }
 
     protected List<LogicalPlan> plans(List<? extends ParserRuleContext> ctxs) {
-        return visitList(ctxs, LogicalPlan.class);
-    }
-
-    protected <T> List<T> visitList(List<? extends ParserRuleContext> contexts, Class<T> clazz) {
-        List<T> results = new ArrayList<>(contexts.size());
-        for (ParserRuleContext context : contexts) {
-            results.add(clazz.cast(visit(context)));
-        }
-        return results;
-    }
-
-    static Source source(ParseTree ctx) {
-        if (ctx instanceof ParserRuleContext) {
-            return source((ParserRuleContext) ctx);
-        }
-        return Source.EMPTY;
-    }
-
-    static Source source(TerminalNode terminalNode) {
-        Check.notNull(terminalNode, "terminalNode is null");
-        return source(terminalNode.getSymbol());
-    }
-
-    static Source source(ParserRuleContext parserRuleContext) {
-        Check.notNull(parserRuleContext, "parserRuleContext is null");
-        Token start = parserRuleContext.start;
-        Token stop = parserRuleContext.stop != null ? parserRuleContext.stop : start;
-        Interval interval = new Interval(start.getStartIndex(), stop.getStopIndex());
-        String text = start.getInputStream().getText(interval);
-        return new Source(new Location(start.getLine(), start.getCharPositionInLine()), text);
-    }
-
-    static Source source(Token token) {
-        Check.notNull(token, "token is null");
-        String text = token.getInputStream().getText(new Interval(token.getStartIndex(), token.getStopIndex()));
-        return new Source(new Location(token.getLine(), token.getCharPositionInLine()), text);
-    }
-
-    Source source(ParserRuleContext begin, ParserRuleContext end) {
-        Check.notNull(begin, "begin is null");
-        Check.notNull(end, "end is null");
-        Token start = begin.start;
-        Token stop = end.stop != null ? end.stop : begin.stop;
-        Interval interval = new Interval(start.getStartIndex(), stop.getStopIndex());
-        String text = start.getInputStream().getText(interval);
-        return new Source(new Location(start.getLine(), start.getCharPositionInLine()), text);
-    }
-
-    static Source source(TerminalNode begin, ParserRuleContext end) {
-        Check.notNull(begin, "begin is null");
-        Check.notNull(end, "end is null");
-        Token start = begin.getSymbol();
-        Token stop = end.stop != null ? end.stop : start;
-        String text = start.getInputStream().getText(new Interval(start.getStartIndex(), stop.getStopIndex()));
-        return new Source(new Location(start.getLine(), start.getCharPositionInLine()), text);
-    }
-
-    /**
-     * Retrieves the raw text of the node (without interpreting it as a string literal).
-     */
-    static String text(ParseTree node) {
-        return node == null ? null : node.getText();
+        return visitList(this, ctxs, LogicalPlan.class);
     }
 
     /**
@@ -133,7 +60,6 @@ abstract class AbstractBuilder extends SqlBaseBaseVisitor<Object> {
 
     @Override
     public Object visitTerminal(TerminalNode node) {
-        Source source = source(node);
-        throw new ParsingException(source, "Does not know how to handle {}", source.text());
+        return source(node);
     }
 }

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/parser/CommandBuilder.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/parser/CommandBuilder.java
@@ -44,6 +44,8 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 
+import static org.elasticsearch.xpack.ql.parser.ParserUtils.source;
+
 abstract class CommandBuilder extends LogicalPlanBuilder {
 
     protected CommandBuilder(Map<Token, SqlTypedParamValue> params, ZoneId zoneId) {
@@ -115,7 +117,7 @@ abstract class CommandBuilder extends LogicalPlanBuilder {
         }
         boolean graphViz = ctx.format != null && ctx.format.getType() == SqlBaseLexer.GRAPHVIZ;
         Explain.Format format = graphViz ? Explain.Format.GRAPHVIZ : Explain.Format.TEXT;
-        boolean verify = (ctx.verify != null ? Booleans.parseBoolean(ctx.verify.getText().toLowerCase(Locale.ROOT), true) : true);
+        boolean verify = (ctx.verify == null || Booleans.parseBoolean(ctx.verify.getText().toLowerCase(Locale.ROOT), true));
 
         return new Explain(source, plan(ctx.statement()), type, format, verify);
     }

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/parser/ExpressionBuilder.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/parser/ExpressionBuilder.java
@@ -134,6 +134,9 @@ import java.util.StringJoiner;
 
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
+import static org.elasticsearch.xpack.ql.parser.ParserUtils.source;
+import static org.elasticsearch.xpack.ql.parser.ParserUtils.text;
+import static org.elasticsearch.xpack.ql.parser.ParserUtils.visitList;
 import static org.elasticsearch.xpack.sql.type.SqlDataTypeConverter.canConvert;
 import static org.elasticsearch.xpack.sql.type.SqlDataTypeConverter.converterFor;
 import static org.elasticsearch.xpack.sql.util.DateUtils.asDateOnly;
@@ -155,7 +158,7 @@ abstract class ExpressionBuilder extends IdentifierBuilder {
     }
 
     protected List<Expression> expressions(List<? extends ParserRuleContext> contexts) {
-        return visitList(contexts, Expression.class);
+        return visitList(this, contexts, Expression.class);
     }
 
     @Override

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/parser/IdentifierBuilder.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/parser/IdentifierBuilder.java
@@ -14,6 +14,9 @@ import org.elasticsearch.xpack.sql.parser.SqlBaseParser.IdentifierContext;
 import org.elasticsearch.xpack.sql.parser.SqlBaseParser.QualifiedNameContext;
 import org.elasticsearch.xpack.sql.parser.SqlBaseParser.TableIdentifierContext;
 
+import static org.elasticsearch.xpack.ql.parser.ParserUtils.source;
+import static org.elasticsearch.xpack.ql.parser.ParserUtils.visitList;
+
 abstract class IdentifierBuilder extends AbstractBuilder {
 
     @Override
@@ -40,7 +43,7 @@ abstract class IdentifierBuilder extends AbstractBuilder {
             return null;
         }
 
-        return Strings.collectionToDelimitedString(visitList(ctx.identifier(), String.class), ".");
+        return Strings.collectionToDelimitedString(visitList(this, ctx.identifier(), String.class), ".");
     }
 
     private static String unquoteIdentifier(String identifier) {

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/parser/SqlParser.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/parser/SqlParser.java
@@ -26,6 +26,7 @@ import org.antlr.v4.runtime.tree.TerminalNode;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.xpack.ql.expression.Expression;
+import org.elasticsearch.xpack.ql.parser.CaseInsensitiveStream;
 import org.elasticsearch.xpack.ql.plan.logical.LogicalPlan;
 import org.elasticsearch.xpack.sql.proto.SqlTypedParamValue;
 


### PR DESCRIPTION
Remove code duplication inside the EQL and SQL parser by moving it into
QL project. ANTLR is declared as a compile-time only dependency so that
submodules are still in charge of the final ANTLR version.