### PR TITLE
[7.13] [DOCS] Update allowed operations on data stream write index (#72994)

### DIFF
--- a/docs/reference/data-streams/data-streams.asciidoc
+++ b/docs/reference/data-streams/data-streams.asciidoc
@@ -66,7 +66,6 @@ You also cannot perform operations on a write index that may hinder indexing,
 such as:
 
 * <<indices-clone-index,Clone>>
-* <<indices-close,Close>>
 * <<indices-delete-index,Delete>>
 * <<freeze-index-api,Freeze>>
 * <<indices-shrink-index,Shrink>>


### PR DESCRIPTION
Backports the following commits to 7.13:
 - [DOCS] Update allowed operations on data stream write index (#72994)