### PR TITLE
[DOCS] Fix query parameters for restore API

### DIFF
--- a/docs/reference/snapshot-restore/apis/restore-snapshot-api.asciidoc
+++ b/docs/reference/snapshot-restore/apis/restore-snapshot-api.asciidoc
@@ -99,6 +99,17 @@ Name of the repository to restore a snapshot from.
 (Required, string)
 Name of the snapshot to restore.
 
+[[restore-snapshot-api-query-params]]
+==== {api-query-parms-title}
+
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=master-timeout]
+
+`wait_for_completion`::
+(Optional, Boolean)
+If `true`, the request returns a response when the restore operation completes.
+If `false`, the request returns a response when the restore operation
+initializes. Defaults to `false`.
+
 [role="child_attributes"]
 [[restore-snapshot-api-request-body]]
 ==== {api-request-body-title}
@@ -198,14 +209,6 @@ include::{es-ref-dir}/snapshot-restore/restore-snapshot.asciidoc[tag=rename-rest
 `rename_replacement`::
 (Optional, string)
 Defines the rename replacement string. See <<restore-snapshot-api-rename-pattern,`rename_pattern`>> for more information.
-
-`wait_for_completion`::
-(Optional, Boolean)
-If `false`, the request returns a response when the restore operation initializes.
-Defaults to `false`.
-+
-If `true`, the request returns a response when the restore operation
-completes.
 
 [[restore-snapshot-api-example]]
 ==== {api-examples-title}

--- a/docs/reference/snapshot-restore/apis/restore-snapshot-api.asciidoc
+++ b/docs/reference/snapshot-restore/apis/restore-snapshot-api.asciidoc
@@ -105,10 +105,9 @@ Name of the snapshot to restore.
 include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=master-timeout]
 
 `wait_for_completion`::
-(Optional, Boolean)
-If `true`, the request returns a response when the restore operation completes.
-If `false`, the request returns a response when the restore operation
-initializes. Defaults to `false`.
+(Optional, Boolean) If `true`, the request returns a response when the restore
+operation completes. If `false`, the request returns a response when the restore
+operation initializes. Defaults to `false`.
 
 [role="child_attributes"]
 [[restore-snapshot-api-request-body]]


### PR DESCRIPTION
Changes:

* Documents the `master_timeout` query param
* Moves `wait_for_completion` to the query param section

### Preview
https://elasticsearch_73015.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/restore-snapshot-api.html