### PR TITLE
[DOCS] Add get user privileges API

### DIFF
--- a/docs/java-rest/high-level/security/get-builtin-privileges.asciidoc
+++ b/docs/java-rest/high-level/security/get-builtin-privileges.asciidoc
@@ -7,6 +7,9 @@
 [id="{upid}-{api}"]
 === Get Builtin Privileges API
 
+Retrieves the list of cluster privileges and index privileges that are 
+available in this version of {es}.
+
 include::../execution-no-req.asciidoc[]
 
 [id="{upid}-{api}-response"]

--- a/docs/java-rest/high-level/security/get-privileges.asciidoc
+++ b/docs/java-rest/high-level/security/get-privileges.asciidoc
@@ -6,12 +6,14 @@
 --
 [role="xpack"]
 [id="{upid}-{api}"]
-=== Get Privileges API
+=== Get Application Privileges API
+
+Retrieves application privileges.
 
 [id="{upid}-{api}-request"]
 ==== Get Privileges Request
 
-The +{request}+ supports getting privilege(s) for all or for specific applications.
+The +{request}+ supports getting privileges for all or for specific applications.
 
 ===== Specific privilege of a specific application
 

--- a/docs/java-rest/high-level/security/get-user-privileges.asciidoc
+++ b/docs/java-rest/high-level/security/get-user-privileges.asciidoc
@@ -7,6 +7,8 @@
 [id="{upid}-{api}"]
 === Get User Privileges API
 
+Retrieves security privileges for the logged in user.
+
 include::../execution-no-req.asciidoc[]
 
 [id="{upid}-{api}-response"]

--- a/docs/java-rest/high-level/security/has-privileges.asciidoc
+++ b/docs/java-rest/high-level/security/has-privileges.asciidoc
@@ -7,6 +7,8 @@
 [id="{upid}-{api}"]
 === Has Privileges API
 
+Determines whether the logged in user has a specified list of privileges.
+
 [id="{upid}-{api}-request"]
 ==== Has Privileges Request
 The +{request}+ supports checking for any or all of the following privilege types:

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/security.get_user_privileges.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/security.get_user_privileges.json
@@ -1,8 +1,8 @@
 {
   "security.get_user_privileges":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-get-privileges.html",
-      "description":"Retrieves application privileges."
+      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-get-user-privileges.html",
+      "description":"Retrieves security privileges for the logged in user."
     },
     "stability":"stable",
     "visibility":"public",

--- a/x-pack/docs/en/rest-api/security.asciidoc
+++ b/x-pack/docs/en/rest-api/security.asciidoc
@@ -10,6 +10,7 @@ You can use the following APIs to perform security activities.
 * <<security-api-has-privileges>>
 * <<security-api-ssl>>
 * <<security-api-get-builtin-privileges>>
+* <<security-api-get-user-privileges>>
 
 [discrete]
 [[security-api-app-privileges]]
@@ -130,6 +131,7 @@ include::security/get-builtin-privileges.asciidoc[]
 include::security/get-role-mappings.asciidoc[]
 include::security/get-roles.asciidoc[]
 include::security/get-tokens.asciidoc[]
+include::security/get-user-privileges.asciidoc[]
 include::security/get-users.asciidoc[]
 include::security/grant-api-keys.asciidoc[]
 include::security/has-privileges.asciidoc[]

--- a/x-pack/docs/en/rest-api/security/get-user-privileges.asciidoc
+++ b/x-pack/docs/en/rest-api/security/get-user-privileges.asciidoc
@@ -1,0 +1,72 @@
+[role="xpack"]
+[[security-api-get-user-privileges]]
+=== Get user privileges API
+++++
+<titleabbrev>Get user privileges</titleabbrev>
+++++
+
+Retrieves the <<security-privileges,security privileges>> for the logged in 
+user.
+
+[[security-api-get-user-privileges-request]]
+==== {api-request-title}
+
+`GET /_security/user/_privileges`
+
+[[security-api-get-user-privileges-prereqs]]
+==== {api-prereq-title}
+
+* All users can use this API, but only to determine their own privileges. To 
+check the privileges of other users, you must use the run as feature. For
+more information, see <<run-as-privilege>>.
+
+[[security-api-get-user-privileges-desc]]
+==== {api-description-title}
+
+To check whether a user has a specific list of privileges, use the
+<<security-api-has-privileges,has privileges API>>.
+
+
+[[security-api-get-user-privileges-example]]
+==== {api-examples-title}
+
+[source,console]
+--------------------------------------------------
+GET /_security/user/_privileges
+--------------------------------------------------
+
+[source,console-result]
+--------------------------------------------------
+{
+  "cluster" : [
+    "all"
+  ],
+  "global" : [ ],
+  "indices" : [
+    {
+      "names" : [
+        "*"
+      ],
+      "privileges" : [
+        "all"
+      ],
+      "allow_restricted_indices" : true
+    }
+  ],
+  "applications" : [
+    {
+      "application" : "*",
+      "privileges" : [
+        "*"
+      ],
+      "resources" : [
+        "*"
+      ]
+    }
+  ],
+  "run_as" : [
+    "*"
+  ]
+}
+--------------------------------------------------
+// TESTRESPONSE[s/: false/: true/]

--- a/x-pack/docs/en/rest-api/security/has-privileges.asciidoc
+++ b/x-pack/docs/en/rest-api/security/has-privileges.asciidoc
@@ -6,8 +6,7 @@
 ++++
 [[security-api-has-privilege]]
 
-The `has_privileges` API allows you to determine whether the logged in user has
-a specified list of privileges.
+Determines whether the logged in user has a specified list of privileges.
 
 [[security-api-has-privileges-request]]
 ==== {api-request-title}


### PR DESCRIPTION
Related to https://github.com/elastic/elasticsearch/issues/39491

This PR adds the missing "get user privileges API" documentation for Elasticsearch, updates the URL in the API spec (https://github.com/elastic/elasticsearch/blob/master/rest-api-spec/src/main/resources/rest-api-spec/api/security.get_user_privileges.json), and adds missing introductory text to the related APIs in the Java high level REST client docs.

### Preview
* https://elasticsearch_73016.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/security-api-get-user-privileges.html