### PR TITLE
Service Accounts - rename service account realm

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authc/service/ServiceAccountSettings.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authc/service/ServiceAccountSettings.java
@@ -9,8 +9,8 @@ package org.elasticsearch.xpack.core.security.authc.service;
 
 public final class ServiceAccountSettings {
 
-    public static final String REALM_TYPE = "service_account";
-    public static final String REALM_NAME = "service_account";
+    public static final String REALM_TYPE = "_service_account";
+    public static final String REALM_NAME = "_service_account";
     public static final String TOKEN_NAME_FIELD = "_token_name";
 
     private ServiceAccountSettings() {}

--- a/x-pack/plugin/security/qa/service-account/src/javaRestTest/java/org/elasticsearch/xpack/security/authc/service/ServiceAccountIT.java
+++ b/x-pack/plugin/security/qa/service-account/src/javaRestTest/java/org/elasticsearch/xpack/security/authc/service/ServiceAccountIT.java
@@ -56,12 +56,12 @@ public class ServiceAccountIT extends ESRestTestCase {
         + "  },\n"
         + "  \"enabled\": true,\n"
         + "  \"authentication_realm\": {\n"
-        + "    \"name\": \"service_account\",\n"
-        + "    \"type\": \"service_account\"\n"
+        + "    \"name\": \"_service_account\",\n"
+        + "    \"type\": \"_service_account\"\n"
         + "  },\n"
         + "  \"lookup_realm\": {\n"
-        + "    \"name\": \"service_account\",\n"
-        + "    \"type\": \"service_account\"\n"
+        + "    \"name\": \"_service_account\",\n"
+        + "    \"type\": \"_service_account\"\n"
         + "  },\n"
         + "  \"authentication_type\": \"token\"\n"
         + "}\n";
@@ -406,7 +406,7 @@ public class ServiceAccountIT extends ESRestTestCase {
         assertThat(apiKey.get("id"), equalTo(apiKeyId));
         assertThat(apiKey.get("name"), equalTo(name));
         assertThat(apiKey.get("username"), equalTo("elastic/fleet-server"));
-        assertThat(apiKey.get("realm"), equalTo("service_account"));
+        assertThat(apiKey.get("realm"), equalTo("_service_account"));
         assertThat(apiKey.get("invalidated"), is(invalidated));
     }
 

--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/authc/service/ServiceAccountSingleNodeTests.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/authc/service/ServiceAccountSingleNodeTests.java
@@ -175,7 +175,7 @@ public class ServiceAccountSingleNodeTests extends SecuritySingleNodeTestCase {
         return new Authentication(
             new User("elastic/fleet-server", Strings.EMPTY_ARRAY, "Service account - elastic/fleet-server", null,
                 Map.of("_elastic_service_account", true), true),
-            new Authentication.RealmRef("service_account", "service_account", nodeName),
+            new Authentication.RealmRef("_service_account", "_service_account", nodeName),
             null, Version.CURRENT, Authentication.AuthenticationType.TOKEN, Map.of("_token_name", tokenName)
         );
     }

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/action/token/TransportCreateTokenActionTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/action/token/TransportCreateTokenActionTests.java
@@ -304,7 +304,7 @@ public class TransportCreateTokenActionTests extends ESTestCase {
             securityIndex, securityIndex, clusterService);
         Authentication authentication = new Authentication(
             new User(randomAlphaOfLengthBetween(3, 8) + "/" + randomAlphaOfLengthBetween(3, 8)),
-            new Authentication.RealmRef("_service_account_" + randomFrom("file", "index"), "service_account", "node"), null);
+            new Authentication.RealmRef("_service_account", "_service_account", "node"), null);
         authentication.writeToContext(threadPool.getThreadContext());
 
         final TransportCreateTokenAction action = new TransportCreateTokenAction(threadPool,

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/audit/logfile/LoggingAuditTrailTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/audit/logfile/LoggingAuditTrailTests.java
@@ -2229,7 +2229,7 @@ public class LoggingAuditTrailTests extends ESTestCase {
                 user = new User(principal, Strings.EMPTY_ARRAY, "Service account - " + principal, null,
                     Map.of("_elastic_service_account", true), true);
                 lookedUpBy = null;
-                authBy = new RealmRef("service_account", "service_account", randomAlphaOfLengthBetween(3, 8));
+                authBy = new RealmRef("_service_account", "_service_account", randomAlphaOfLengthBetween(3, 8));
                 authenticationType = AuthenticationType.TOKEN;
                 authMetadata = Map.of("_token_name", ValidationTests.randomTokenName());
         }

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/AuthenticationServiceTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/AuthenticationServiceTests.java
@@ -1918,7 +1918,7 @@ public class AuthenticationServiceTests extends ESTestCase {
         Mockito.reset(serviceAccountService);
         final Authentication authentication = new Authentication(
             new User("elastic/fleet-server"),
-            new RealmRef("service_account", "service_account", "foo"), null,
+            new RealmRef("_service_account", "_service_account", "foo"), null,
             Version.CURRENT, AuthenticationType.TOKEN, Map.of("_token_name", ValidationTests.randomTokenName()));
         try (ThreadContext.StoredContext ignored = threadContext.newStoredContext(false)) {
             boolean requestIdAlreadyPresent = randomBoolean();

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/AuthorizationServiceTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/AuthorizationServiceTests.java
@@ -701,7 +701,7 @@ public class AuthorizationServiceTests extends ESTestCase {
 
         final User serviceUser = new User(randomAlphaOfLengthBetween(3, 8) + "/" + randomAlphaOfLengthBetween(3, 8));
         final Authentication authentication = new Authentication(serviceUser,
-            new RealmRef("service_account", "service_account", randomAlphaOfLengthBetween(3, 8)),
+            new RealmRef("_service_account", "_service_account", randomAlphaOfLengthBetween(3, 8)),
             null,
             Version.CURRENT,
             Authentication.AuthenticationType.TOKEN,

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/ingest/SetSecurityUserProcessorTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/ingest/SetSecurityUserProcessorTests.java
@@ -366,7 +366,7 @@ public class SetSecurityUserProcessorTests extends ESTestCase {
         if (user.fullName().startsWith("Service account - ")) {
             assert false == user.isRunAs() : "cannot run-as service account";
             final Authentication.RealmRef authBy =
-                new Authentication.RealmRef("service_account", "service_account", randomAlphaOfLengthBetween(3, 8));
+                new Authentication.RealmRef("_service_account", "_service_account", randomAlphaOfLengthBetween(3, 8));
             return new Authentication(user, authBy, null, Version.CURRENT, AuthenticationType.TOKEN,
                 Map.of("_token_name", ValidationTests.randomTokenName()));
         } else {


### PR DESCRIPTION
Add a leading underscore for both realm type and nane since they are
synthetic.
