### PR TITLE
Service Accounts - Fix delete token status code (#73021)

### DIFF
--- a/x-pack/plugin/security/qa/service-account/src/javaRestTest/java/org/elasticsearch/xpack/security/authc/service/ServiceAccountIT.java
+++ b/x-pack/plugin/security/qa/service-account/src/javaRestTest/java/org/elasticsearch/xpack/security/authc/service/ServiceAccountIT.java
@@ -7,6 +7,7 @@
 
 package org.elasticsearch.xpack.security.authc.service;
 
+import org.apache.http.util.EntityUtils;
 import org.elasticsearch.client.Request;
 import org.elasticsearch.client.RequestOptions;
 import org.elasticsearch.client.Response;
@@ -337,9 +338,9 @@ public class ServiceAccountIT extends ESRestTestCase {
         )));
 
         final Request deleteTokenRequest2 = new Request("DELETE", "_security/service/elastic/fleet-server/credential/token/non-such-thing");
-        final Response deleteTokenResponse2 = client().performRequest(deleteTokenRequest2);
-        assertOK(deleteTokenResponse2);
-        assertThat(responseAsMap(deleteTokenResponse2).get("found"), is(false));
+        final ResponseException e2 = expectThrows(ResponseException.class, () -> client().performRequest(deleteTokenRequest2));
+        assertThat(e2.getResponse().getStatusLine().getStatusCode(), equalTo(404));
+        assertThat(EntityUtils.toString(e2.getResponse().getEntity()), equalTo("{\"found\":false}"));
     }
 
     public void testClearCache() throws IOException {

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/service/TransportDeleteServiceAccountTokenAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/service/TransportDeleteServiceAccountTokenAction.java
@@ -37,7 +37,7 @@ public class TransportDeleteServiceAccountTokenAction
     @Override
     protected void doExecute(Task task, DeleteServiceAccountTokenRequest request,
                              ActionListener<DeleteServiceAccountTokenResponse> listener) {
-        httpTlsRuntimeCheck.checkTlsThenExecute(listener::onFailure, "create service account token", () -> {
+        httpTlsRuntimeCheck.checkTlsThenExecute(listener::onFailure, "delete service account token", () -> {
             indexServiceAccountTokenStore.deleteToken(request, ActionListener.wrap(found -> {
                 listener.onResponse(new DeleteServiceAccountTokenResponse(found));
             }, listener::onFailure));

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/rest/action/service/RestDeleteServiceAccountTokenAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/rest/action/service/RestDeleteServiceAccountTokenAction.java
@@ -12,9 +12,11 @@ import org.elasticsearch.client.node.NodeClient;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.license.XPackLicenseState;
 import org.elasticsearch.rest.RestRequest;
+import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.rest.action.RestToXContentListener;
 import org.elasticsearch.xpack.core.security.action.service.DeleteServiceAccountTokenAction;
 import org.elasticsearch.xpack.core.security.action.service.DeleteServiceAccountTokenRequest;
+import org.elasticsearch.xpack.core.security.action.service.DeleteServiceAccountTokenResponse;
 import org.elasticsearch.xpack.security.rest.action.SecurityBaseRestHandler;
 
 import java.io.IOException;
@@ -47,9 +49,12 @@ public class RestDeleteServiceAccountTokenAction extends SecurityBaseRestHandler
         if (refreshPolicy != null) {
             deleteServiceAccountTokenRequest.setRefreshPolicy(WriteRequest.RefreshPolicy.parse(refreshPolicy));
         }
-
-        return channel -> client.execute(DeleteServiceAccountTokenAction.INSTANCE,
-            deleteServiceAccountTokenRequest,
-            new RestToXContentListener<>(channel));
+        return channel -> client.execute(DeleteServiceAccountTokenAction.INSTANCE, deleteServiceAccountTokenRequest,
+            new RestToXContentListener<>(channel) {
+                @Override
+                protected RestStatus getStatus(DeleteServiceAccountTokenResponse response) {
+                    return response.found() ? RestStatus.OK : RestStatus.NOT_FOUND;
+                }
+            });
     }
 }

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/rest/action/service/RestDeleteServiceAccountTokenAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/rest/action/service/RestDeleteServiceAccountTokenAction.java
@@ -50,7 +50,7 @@ public class RestDeleteServiceAccountTokenAction extends SecurityBaseRestHandler
             deleteServiceAccountTokenRequest.setRefreshPolicy(WriteRequest.RefreshPolicy.parse(refreshPolicy));
         }
         return channel -> client.execute(DeleteServiceAccountTokenAction.INSTANCE, deleteServiceAccountTokenRequest,
-            new RestToXContentListener<>(channel) {
+            new RestToXContentListener<DeleteServiceAccountTokenResponse>(channel) {
                 @Override
                 protected RestStatus getStatus(DeleteServiceAccountTokenResponse response) {
                     return response.found() ? RestStatus.OK : RestStatus.NOT_FOUND;

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/service_accounts/10_basic.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/service_accounts/10_basic.yml
@@ -11,6 +11,7 @@ teardown:
         namespace: elastic
         service: fleet-server
         name: api-token-1
+        ignore: 404
 
 ---
 "Test get service accounts":


### PR DESCRIPTION
The delete token response now returns status code 404 instead of 200
when the token does not exist.

