### PR TITLE
[7.x][DOCS] Adds missing word in transform checkpoints docs

### DIFF
--- a/docs/reference/transform/checkpoints.asciidoc
+++ b/docs/reference/transform/checkpoints.asciidoc
@@ -40,7 +40,7 @@ The {transform} applies changes related to either new or changed entities or
 time buckets to the destination index. The set of changes can be paginated. The
 {transform} performs a composite aggregation similarly to the batch {transform} 
 operation, however it also injects query filters based on the previous step to 
-reduce the amount work. After all changes have been applied, the checkpoint is 
+reduce the amount of work. After all changes have been applied, the checkpoint is 
 complete.
 --
 


### PR DESCRIPTION
## Overview

This PR backports the following changes to the 7.x branch:  #73005