### PR TITLE
Replace simpleMatchToFullName (#72674)

### DIFF
--- a/benchmarks/src/main/java/org/elasticsearch/benchmark/search/aggregations/AggConstructionContentionBenchmark.java
+++ b/benchmarks/src/main/java/org/elasticsearch/benchmark/search/aggregations/AggConstructionContentionBenchmark.java
@@ -222,7 +222,7 @@ public class AggConstructionContentionBenchmark {
         }
 
         @Override
-        public Collection<MappedFieldType> getFieldTypes() {
+        public Collection<MappedFieldType> getMatchingFieldTypes(String pattern) {
             throw new UnsupportedOperationException();
         }
 

--- a/modules/parent-join/src/main/java/org/elasticsearch/join/mapper/Joiner.java
+++ b/modules/parent-join/src/main/java/org/elasticsearch/join/mapper/Joiner.java
@@ -36,14 +36,14 @@ public final class Joiner {
      * Get the Joiner for this context, or {@code null} if none is configured
      */
     public static Joiner getJoiner(SearchExecutionContext context) {
-        return getJoiner(context.getFieldTypes());
+        return getJoiner(context.getAllFieldTypes());
     }
 
     /**
      * Get the Joiner for this context, or {@code null} if none is configured
      */
     public static Joiner getJoiner(AggregationContext context) {
-        return getJoiner(context.getFieldTypes());
+        return getJoiner(context.getMatchingFieldTypes("*"));
     }
 
     /**

--- a/modules/parent-join/src/main/java/org/elasticsearch/join/mapper/ParentJoinFieldMapper.java
+++ b/modules/parent-join/src/main/java/org/elasticsearch/join/mapper/ParentJoinFieldMapper.java
@@ -292,7 +292,7 @@ public final class ParentJoinFieldMapper extends FieldMapper {
 
     @Override
     protected void doValidate(MappingLookup mappers) {
-        List<String> joinFields = getJoinFieldTypes(mappers.fieldTypes()).stream()
+        List<String> joinFields = getJoinFieldTypes(mappers.getAllFieldTypes()).stream()
             .map(JoinFieldType::name)
             .collect(Collectors.toList());
         if (joinFields.size() > 1) {

--- a/modules/parent-join/src/test/java/org/elasticsearch/join/mapper/ParentJoinFieldMapperTests.java
+++ b/modules/parent-join/src/test/java/org/elasticsearch/join/mapper/ParentJoinFieldMapperTests.java
@@ -47,7 +47,7 @@ public class ParentJoinFieldMapperTests extends MapperServiceTestCase {
         }));
         DocumentMapper docMapper = mapperService.documentMapper();
 
-        Joiner joiner = Joiner.getJoiner(mapperService.mappingLookup().fieldTypes());
+        Joiner joiner = Joiner.getJoiner(mapperService.mappingLookup().getAllFieldTypes());
         assertNotNull(joiner);
         assertEquals("join_field", joiner.getJoinField());
 
@@ -233,7 +233,7 @@ public class ParentJoinFieldMapperTests extends MapperServiceTestCase {
             b.endObject();
         }));
 
-        Joiner joiner = Joiner.getJoiner(mapperService.mappingLookup().fieldTypes());
+        Joiner joiner = Joiner.getJoiner(mapperService.mappingLookup().getAllFieldTypes());
         assertNotNull(joiner);
         assertEquals("join_field", joiner.getJoinField());
         assertTrue(joiner.childTypeExists("child2"));
@@ -259,7 +259,7 @@ public class ParentJoinFieldMapperTests extends MapperServiceTestCase {
             }
             b.endObject();
         }));
-        joiner = Joiner.getJoiner(mapperService.mappingLookup().fieldTypes());
+        joiner = Joiner.getJoiner(mapperService.mappingLookup().getAllFieldTypes());
         assertNotNull(joiner);
         assertEquals("join_field", joiner.getJoinField());
         assertTrue(joiner.childTypeExists("child2"));

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/fields/SearchFieldsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/fields/SearchFieldsIT.java
@@ -26,7 +26,6 @@ import org.elasticsearch.common.xcontent.support.XContentMapValues;
 import org.elasticsearch.index.fielddata.ScriptDocValues;
 import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.plugins.Plugin;
-import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.script.MockScriptPlugin;
 import org.elasticsearch.script.Script;
 import org.elasticsearch.script.ScriptType;
@@ -63,11 +62,9 @@ import static org.elasticsearch.common.util.set.Sets.newHashSet;
 import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
 import static org.elasticsearch.index.query.QueryBuilders.matchAllQuery;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
-import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertFailures;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCount;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailures;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertSearchResponse;
-import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
@@ -650,17 +647,6 @@ public class SearchFieldsIT extends ESIntegTestCase {
         assertThat(searchResponse.getHits().getTotalHits().value, equalTo(1L));
         assertThat(searchResponse.getHits().getAt(0).field("field1"), nullValue());
         assertThat(searchResponse.getHits().getAt(0).field("_routing").getValue().toString(), equalTo("1"));
-    }
-
-    public void testSearchFieldsNonLeafField() throws Exception {
-        client().prepareIndex("my-index", "my-type1", "1")
-                .setSource(jsonBuilder().startObject().startObject("field1").field("field2", "value1").endObject().endObject())
-                .setRefreshPolicy(IMMEDIATE)
-                .get();
-
-        assertFailures(client().prepareSearch("my-index").setTypes("my-type1").addStoredField("field1"),
-                RestStatus.BAD_REQUEST,
-                containsString("field [field1] isn't a leaf field"));
     }
 
     public void testGetFieldsComplexField() throws Exception {

--- a/server/src/main/java/org/elasticsearch/action/fieldcaps/TransportFieldCapabilitiesIndexAction.java
+++ b/server/src/main/java/org/elasticsearch/action/fieldcaps/TransportFieldCapabilitiesIndexAction.java
@@ -109,45 +109,43 @@ public class TransportFieldCapabilitiesIndexAction
 
             Set<String> fieldNames = new HashSet<>();
             for (String pattern : request.fields()) {
-                fieldNames.addAll(searchExecutionContext.simpleMatchToIndexNames(pattern));
+                fieldNames.addAll(searchExecutionContext.getMatchingFieldNames(pattern));
             }
 
             Predicate<String> fieldPredicate = indicesService.getFieldFilter().apply(shardId.getIndexName());
             Map<String, IndexFieldCapabilities> responseMap = new HashMap<>();
             for (String field : fieldNames) {
                 MappedFieldType ft = searchExecutionContext.getFieldType(field);
-                if (ft != null) {
-                    boolean isMetadataField = searchExecutionContext.isMetadataField(field);
-                    if (isMetadataField || fieldPredicate.test(ft.name())) {
-                        IndexFieldCapabilities fieldCap = new IndexFieldCapabilities(field,
-                            ft.familyTypeName(), isMetadataField, ft.isSearchable(), ft.isAggregatable(), ft.meta());
-                        responseMap.put(field, fieldCap);
-                    } else {
-                        continue;
-                    }
+                boolean isMetadataField = searchExecutionContext.isMetadataField(field);
+                if (isMetadataField || fieldPredicate.test(ft.name())) {
+                    IndexFieldCapabilities fieldCap = new IndexFieldCapabilities(field,
+                        ft.familyTypeName(), isMetadataField, ft.isSearchable(), ft.isAggregatable(), ft.meta());
+                    responseMap.put(field, fieldCap);
+                } else {
+                    continue;
+                }
 
-                    // Check the ancestor of the field to find nested and object fields.
-                    // Runtime fields are excluded since they can override any path.
-                    //TODO find a way to do this that does not require an instanceof check
-                    if (ft instanceof RuntimeField == false) {
-                        int dotIndex = ft.name().lastIndexOf('.');
-                        while (dotIndex > -1) {
-                            String parentField = ft.name().substring(0, dotIndex);
-                            if (responseMap.containsKey(parentField)) {
-                                // we added this path on another field already
-                                break;
-                            }
-                            // checks if the parent field contains sub-fields
-                            if (searchExecutionContext.getFieldType(parentField) == null) {
-                                // no field type, it must be an object field
-                                ObjectMapper mapper = searchExecutionContext.getObjectMapper(parentField);
-                                String type = mapper.nested().isNested() ? "nested" : "object";
-                                IndexFieldCapabilities fieldCap = new IndexFieldCapabilities(parentField, type,
-                                    false, false, false, Collections.emptyMap());
-                                responseMap.put(parentField, fieldCap);
-                            }
-                            dotIndex = parentField.lastIndexOf('.');
+                // Check the ancestor of the field to find nested and object fields.
+                // Runtime fields are excluded since they can override any path.
+                //TODO find a way to do this that does not require an instanceof check
+                if (ft instanceof RuntimeField == false) {
+                    int dotIndex = ft.name().lastIndexOf('.');
+                    while (dotIndex > -1) {
+                        String parentField = ft.name().substring(0, dotIndex);
+                        if (responseMap.containsKey(parentField)) {
+                            // we added this path on another field already
+                            break;
                         }
+                        // checks if the parent field contains sub-fields
+                        if (searchExecutionContext.getFieldType(parentField) == null) {
+                            // no field type, it must be an object field
+                            ObjectMapper mapper = searchExecutionContext.getObjectMapper(parentField);
+                            String type = mapper.nested().isNested() ? "nested" : "object";
+                            IndexFieldCapabilities fieldCap = new IndexFieldCapabilities(parentField, type,
+                                false, false, false, Collections.emptyMap());
+                            responseMap.put(parentField, fieldCap);
+                        }
+                        dotIndex = parentField.lastIndexOf('.');
                     }
                 }
             }

--- a/server/src/main/java/org/elasticsearch/index/mapper/FieldTypeLookup.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/FieldTypeLookup.java
@@ -11,10 +11,12 @@ package org.elasticsearch.index.mapper;
 import org.elasticsearch.common.regex.Regex;
 import org.elasticsearch.index.mapper.TypeFieldMapper.TypeFieldType;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
@@ -147,27 +149,50 @@ final class FieldTypeLookup {
     }
 
     /**
-     * Returns all the mapped field types.
+     * Returns all the mapped field types that match a pattern
+     *
+     * Note that if a field is aliased and both its actual name and its alias
+     * match the pattern, the returned collection will contain the field type
+     * twice.
      */
-    Collection<MappedFieldType> get() {
-        return fullNameToFieldType.values();
+    Collection<MappedFieldType> getMatchingFieldTypes(String pattern) {
+        if ("*".equals(pattern)) {
+            return fullNameToFieldType.values();
+        }
+        if (Regex.isSimpleMatchPattern(pattern) == false) {
+            // no wildcards
+            MappedFieldType ft = get(pattern);
+            return ft == null ? Collections.emptySet() : Collections.singleton(ft);
+        }
+        List<MappedFieldType> matchingFields = new ArrayList<>();
+        for (String field : fullNameToFieldType.keySet()) {
+            if (Regex.simpleMatch(pattern, field)) {
+                matchingFields.add(fullNameToFieldType.get(field));
+            }
+        }
+        return matchingFields;
     }
 
     /**
-     * Returns a list of the full names of a simple match regex like pattern against full name and index name.
+     * Returns a set of field names that match a regex-like pattern
+     *
+     * All field names in the returned set are guaranteed to resolve to a field
      */
-    Set<String> simpleMatchToFullName(String pattern) {
+    Set<String> getMatchingFieldNames(String pattern) {
+        if ("*".equals(pattern)) {
+            return fullNameToFieldType.keySet();
+        }
         if (Regex.isSimpleMatchPattern(pattern) == false) {
             // no wildcards
-            return Collections.singleton(pattern);
+            return get(pattern) == null ? Collections.emptySet() : Collections.singleton(pattern);
         }
-        Set<String> fields = new HashSet<>();
+        Set<String> matchingFields = new HashSet<>();
         for (String field : fullNameToFieldType.keySet()) {
             if (Regex.simpleMatch(pattern, field)) {
-                fields.add(field);
+                matchingFields.add(field);
             }
         }
-        return fields;
+        return matchingFields;
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/index/mapper/MapperService.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/MapperService.java
@@ -611,7 +611,9 @@ public class MapperService extends AbstractIndexComponent implements Closeable {
         if (this.mapper == null) {
             return Collections.emptySet();
         }
-        return this.mapper.mappers().fieldTypes().stream().filter(MappedFieldType::eagerGlobalOrdinals).collect(Collectors.toList());
+        return this.mapper.mappers().getAllFieldTypes().stream()
+            .filter(MappedFieldType::eagerGlobalOrdinals)
+            .collect(Collectors.toList());
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/index/mapper/MappingLookup.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/MappingLookup.java
@@ -203,13 +203,6 @@ public final class MappingLookup {
         return fieldMappers.values();
     }
 
-    /**
-     * Returns the registered mapped field types.
-     */
-    public Collection<MappedFieldType> fieldTypes() {
-        return fieldTypeLookup.get();
-    }
-
     void checkLimits(IndexSettings settings) {
         checkFieldLimit(settings.getMappingTotalFieldsLimit());
         checkObjectDepthLimit(settings.getMappingDepthLimit());
@@ -298,8 +291,35 @@ public final class MappingLookup {
         return field.substring(0, lastDot);
     }
 
-    public Set<String> simpleMatchToFullName(String pattern) {
-        return fieldTypesLookup().simpleMatchToFullName(pattern);
+    /**
+     * Returns a set of field names that match a regex-like pattern
+     *
+     * All field names in the returned set are guaranteed to resolve to a field
+     *
+     * @param pattern the pattern to match field names against
+     */
+    public Set<String> getMatchingFieldNames(String pattern) {
+        return fieldTypeLookup.getMatchingFieldNames(pattern);
+    }
+
+    /**
+     * Returns all the mapped field types that match a pattern
+     *
+     * Note that if a field is aliased and both its actual name and its alias
+     * match the pattern, the returned collection will contain the field type
+     * twice.
+     *
+     * @param pattern the pattern to match field names against
+     */
+    public Collection<MappedFieldType> getMatchingFieldTypes(String pattern) {
+        return fieldTypeLookup.getMatchingFieldTypes(pattern);
+    }
+
+    /**
+     * @return all mapped field types
+     */
+    public Collection<MappedFieldType> getAllFieldTypes() {
+        return fieldTypeLookup.getMatchingFieldTypes("*");
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/index/query/ExistsQueryBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/ExistsQueryBuilder.java
@@ -10,7 +10,6 @@ package org.elasticsearch.index.query;
 
 import org.apache.lucene.index.Term;
 import org.apache.lucene.search.BooleanClause;
-import org.apache.lucene.search.BooleanClause.Occur;
 import org.apache.lucene.search.BooleanQuery;
 import org.apache.lucene.search.ConstantScoreQuery;
 import org.apache.lucene.search.MatchNoDocsQuery;
@@ -22,7 +21,6 @@ import org.elasticsearch.common.ParsingException;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
-import org.elasticsearch.common.lucene.search.Queries;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.index.mapper.FieldNamesFieldMapper;
@@ -30,7 +28,6 @@ import org.elasticsearch.index.mapper.MappedFieldType;
 
 import java.io.IOException;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.Objects;
 
 /**
@@ -74,7 +71,7 @@ public class ExistsQueryBuilder extends AbstractQueryBuilder<ExistsQueryBuilder>
     protected QueryBuilder doRewrite(QueryRewriteContext queryRewriteContext) throws IOException {
         SearchExecutionContext context = queryRewriteContext.convertToSearchExecutionContext();
         if (context != null) {
-            Collection<String> fields = getMappedField(context, fieldName);
+            Collection<MappedFieldType> fields = getMappedFields(context, fieldName);
             if (fields.isEmpty()) {
                 return new MatchNoneQueryBuilder();
             }
@@ -134,7 +131,7 @@ public class ExistsQueryBuilder extends AbstractQueryBuilder<ExistsQueryBuilder>
 
     public static Query newFilter(SearchExecutionContext context, String fieldPattern, boolean checkRewrite) {
 
-       Collection<String> fields = getMappedField(context, fieldPattern);
+       Collection<MappedFieldType> fields = getMappedFields(context, fieldPattern);
 
         if (fields.isEmpty()) {
             if (checkRewrite) {
@@ -149,91 +146,37 @@ public class ExistsQueryBuilder extends AbstractQueryBuilder<ExistsQueryBuilder>
         }
 
         if (fields.size() == 1) {
-            String field = fields.iterator().next();
-            return newFieldExistsQuery(context, field);
+            MappedFieldType field = fields.iterator().next();
+            return new ConstantScoreQuery(field.existsQuery(context));
         }
 
         BooleanQuery.Builder boolFilterBuilder = new BooleanQuery.Builder();
-        for (String field : fields) {
-            boolFilterBuilder.add(newFieldExistsQuery(context, field), BooleanClause.Occur.SHOULD);
+        for (MappedFieldType field : fields) {
+            boolFilterBuilder.add(field.existsQuery(context), BooleanClause.Occur.SHOULD);
         }
         return new ConstantScoreQuery(boolFilterBuilder.build());
     }
 
-    private static Query newLegacyExistsQuery(SearchExecutionContext context, Collection<String> fields) {
+    private static Query newLegacyExistsQuery(SearchExecutionContext context, Collection<MappedFieldType> fields) {
         // We create TermsQuery directly here rather than using FieldNamesFieldType.termsQuery()
         // so we don't end up with deprecation warnings
         if (fields.size() == 1) {
-            Query filter = newLegacyExistsQuery(context, fields.iterator().next());
-            return new ConstantScoreQuery(filter);
+            return new ConstantScoreQuery(new TermQuery(new Term(FieldNamesFieldMapper.NAME, fields.iterator().next().name())));
         }
 
         BooleanQuery.Builder boolFilterBuilder = new BooleanQuery.Builder();
-        for (String field : fields) {
-            Query filter = newLegacyExistsQuery(context, field);
+        for (MappedFieldType field : fields) {
+            Query filter = new TermQuery(new Term(FieldNamesFieldMapper.NAME, field.name()));
             boolFilterBuilder.add(filter, BooleanClause.Occur.SHOULD);
         }
         return new ConstantScoreQuery(boolFilterBuilder.build());
     }
 
-    private static Query newLegacyExistsQuery(SearchExecutionContext context, String field) {
-        MappedFieldType fieldType = context.getFieldType(field);
-        String fieldName = fieldType != null ? fieldType.name() : field;
-        return new TermQuery(new Term(FieldNamesFieldMapper.NAME, fieldName));
-    }
-
-    private static Query newFieldExistsQuery(SearchExecutionContext context, String field) {
-        if (context.isFieldMapped(field)) {
-            Query filter = context.getFieldType(field).existsQuery(context);
-            return new ConstantScoreQuery(filter);
-        } else {
-            // The field does not exist as a leaf but could be an object so
-            // check for an object mapper
-            if (context.getObjectMapper(field) != null) {
-                return newObjectFieldExistsQuery(context, field);
-            }
-            return Queries.newMatchNoDocsQuery("User requested \"match_none\" query.");
-        }
-    }
-
-    private static Query newObjectFieldExistsQuery(SearchExecutionContext context, String objField) {
-        BooleanQuery.Builder booleanQuery = new BooleanQuery.Builder();
-        Collection<String> fields = context.simpleMatchToIndexNames(objField + ".*");
-        for (String field : fields) {
-            Query existsQuery = context.getFieldType(field).existsQuery(context);
-            booleanQuery.add(existsQuery, Occur.SHOULD);
-        }
-        return new ConstantScoreQuery(booleanQuery.build());
-    }
-
-    /**
-     * Helper method to get field mapped to this fieldPattern
-     * @return return collection of fields if exists else return empty.
-     */
-    private static Collection<String> getMappedField(SearchExecutionContext context, String fieldPattern) {
-        if (context.isFieldMapped(FieldNamesFieldMapper.NAME) == false) {
-            // can only happen when no types exist, so no docs exist either
-            return Collections.emptySet();
-        }
-
-        final Collection<String> fields;
-        if (context.getObjectMapper(fieldPattern) != null) {
-            // the _field_names field also indexes objects, so we don't have to
-            // do any more work to support exists queries on whole objects
-            fields = Collections.singleton(fieldPattern);
-        } else {
-            fields = context.simpleMatchToIndexNames(fieldPattern);
-        }
-
-        if (fields.size() == 1) {
-            String field = fields.iterator().next();
-            if (context.isFieldMapped(field) == false) {
-                // The field does not exist as a leaf but could be an object so
-                // check for an object mapper
-                if (context.getObjectMapper(field) == null) {
-                    return Collections.emptySet();
-                }
-            }
+    private static Collection<MappedFieldType> getMappedFields(SearchExecutionContext context, String fieldPattern) {
+        Collection<MappedFieldType> fields = context.getMatchingFieldTypes(fieldPattern);
+        if (fields.isEmpty()) {
+            // might be an object field, so try matching it as an object prefix pattern
+            fields = context.getMatchingFieldTypes(fieldPattern + ".*");
         }
 
         return fields;

--- a/server/src/main/java/org/elasticsearch/index/query/SearchExecutionContext.java
+++ b/server/src/main/java/org/elasticsearch/index/query/SearchExecutionContext.java
@@ -62,7 +62,6 @@ import org.elasticsearch.transport.RemoteClusterAware;
 
 import java.io.IOException;
 import java.util.Arrays;
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -318,24 +317,76 @@ public class SearchExecutionContext extends QueryRewriteContext {
     }
 
     /**
-     * Returns all the fields that match a given pattern. If prefixed with a
-     * type then the fields will be returned with a type prefix.
+     * Returns the names of all mapped fields that match a given pattern
+     *
+     * All names returned by this method are guaranteed to resolve to a
+     * MappedFieldType if passed to {@link #getFieldType(String)}
+     *
+     * @param pattern the field name pattern
      */
-    public Set<String> simpleMatchToIndexNames(String pattern) {
+    public Set<String> getMatchingFieldNames(String pattern) {
         if (runtimeMappings.isEmpty()) {
-            return mappingLookup.simpleMatchToFullName(pattern);
+            return mappingLookup.getMatchingFieldNames(pattern);
         }
-        if (Regex.isSimpleMatchPattern(pattern) == false) {
-            // no wildcards
-            return Collections.singleton(pattern);
-        }
-        Set<String> matches = new HashSet<>(mappingLookup.simpleMatchToFullName(pattern));
-        for (String name : runtimeMappings.keySet()) {
-            if (Regex.simpleMatch(pattern, name)) {
-                matches.add(name);
+        Set<String> matches = new HashSet<>(mappingLookup.getMatchingFieldNames(pattern));
+        if ("*".equals(pattern)) {
+            matches.addAll(runtimeMappings.keySet());
+        } else if (Regex.isSimpleMatchPattern(pattern) == false) {
+            // no wildcard
+            if (runtimeMappings.containsKey(pattern)) {
+                matches.add(pattern);
+            }
+        } else {
+            for (String name : runtimeMappings.keySet()) {
+                if (Regex.simpleMatch(pattern, name)) {
+                    matches.add(name);
+                }
             }
         }
         return matches;
+    }
+
+    /**
+     * @return all mapped field types, including runtime fields defined in the request
+     */
+    public Collection<MappedFieldType> getAllFieldTypes() {
+        return getMatchingFieldTypes("*");
+    }
+
+    /**
+     * Returns all mapped field types that match a given pattern
+     *
+     * Includes any runtime fields that have been defined in the request. Note
+     * that a runtime field with the same name as a mapped field will override
+     * the mapped field.
+     *
+     * @param pattern the field name pattern
+     */
+    public Collection<MappedFieldType> getMatchingFieldTypes(String pattern) {
+        Collection<MappedFieldType> mappedFieldTypes = mappingLookup.getMatchingFieldTypes(pattern);
+        if (runtimeMappings.isEmpty()) {
+            return mappedFieldTypes;
+        }
+
+        Map<String, MappedFieldType> mappedByName = new HashMap<>();
+        mappedFieldTypes.forEach(ft -> mappedByName.put(ft.name(), ft));
+
+        if ("*".equals(pattern)) {
+            mappedByName.putAll(runtimeMappings);
+        } else if (Regex.isSimpleMatchPattern(pattern) == false) {
+            // no wildcard
+            if (runtimeMappings.containsKey(pattern) == false) {
+                return mappedFieldTypes;
+            }
+            mappedByName.put(pattern, runtimeMappings.get(pattern));
+        } else {
+            for (String name : runtimeMappings.keySet()) {
+                if (Regex.simpleMatch(pattern, name)) {
+                    mappedByName.put(name, runtimeMappings.get(name));
+                }
+            }
+        }
+        return mappedByName.values();
     }
 
     /**
@@ -349,15 +400,6 @@ public class SearchExecutionContext extends QueryRewriteContext {
      */
     public MappedFieldType getFieldType(String name) {
         return failIfFieldMappingNotFound(name, fieldType(name));
-    }
-
-    /**
-     * Returns the registered mapped field types.
-     */
-    public Collection<MappedFieldType> getFieldTypes() {
-        List<MappedFieldType> fields = new ArrayList<>(mappingLookup.fieldTypes());
-        fields.addAll(runtimeMappings.values());
-        return fields;
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/index/search/QueryParserHelper.java
+++ b/server/src/main/java/org/elasticsearch/index/search/QueryParserHelper.java
@@ -112,16 +112,12 @@ public final class QueryParserHelper {
      */
     static Map<String, Float> resolveMappingField(SearchExecutionContext context, String fieldOrPattern, float weight,
                                                   boolean acceptAllTypes, boolean acceptMetadataField, String fieldSuffix) {
-        Set<String> allFields = context.simpleMatchToIndexNames(fieldOrPattern);
+        Set<String> allFields = context.getMatchingFieldNames(fieldOrPattern);
         Map<String, Float> fields = new HashMap<>();
 
         for (String fieldName : allFields) {
-            if (fieldSuffix != null && context.getFieldType(fieldName + fieldSuffix) != null) {
+            if (fieldSuffix != null && context.isFieldMapped(fieldName + fieldSuffix)) {
                 fieldName = fieldName + fieldSuffix;
-            }
-
-            if (context.isFieldMapped(fieldName) == false) {
-                continue;
             }
 
             MappedFieldType fieldType = context.getFieldType(fieldName);

--- a/server/src/main/java/org/elasticsearch/index/termvectors/TermVectorsService.java
+++ b/server/src/main/java/org/elasticsearch/index/termvectors/TermVectorsService.java
@@ -25,6 +25,7 @@ import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.document.DocumentField;
 import org.elasticsearch.common.lucene.uid.VersionsAndSeqNoResolver.DocIdAndVersion;
+import org.elasticsearch.common.regex.Regex;
 import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.common.xcontent.support.XContentMapValues;
 import org.elasticsearch.index.engine.Engine;
@@ -155,9 +156,18 @@ public class TermVectorsService  {
     }
 
     private static void handleFieldWildcards(IndexShard indexShard, TermVectorsRequest request) {
+        // TODO rewrite this to use a field filter built from field patterns
+        // Using lookups doesn't work for eg dynamic fields
         Set<String> fieldNames = new HashSet<>();
         for (String pattern : request.selectedFields()) {
-            fieldNames.addAll(indexShard.mapperService().mappingLookup().simpleMatchToFullName(pattern));
+            Set<String> expandedFields = indexShard.mapperService().mappingLookup().getMatchingFieldNames(pattern);
+            if (expandedFields.isEmpty()) {
+                if (Regex.isSimpleMatchPattern(pattern) == false) {
+                    fieldNames.add(pattern);
+                }
+            } else {
+                fieldNames.addAll(expandedFields);
+            }
         }
         request.selectedFields(fieldNames.toArray(Strings.EMPTY_ARRAY));
     }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/support/AggregationContext.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/support/AggregationContext.java
@@ -115,7 +115,7 @@ public abstract class AggregationContext implements Releasable {
     /**
      * Returns the registered mapped field types.
      */
-    public abstract Collection<MappedFieldType> getFieldTypes();
+    public abstract Collection<MappedFieldType> getMatchingFieldTypes(String pattern);
 
     /**
      * Returns true if the field identified by the provided name is mapped, false otherwise
@@ -349,8 +349,8 @@ public abstract class AggregationContext implements Releasable {
         }
 
         @Override
-        public Collection<MappedFieldType> getFieldTypes() {
-            return context.getFieldTypes();
+        public Collection<MappedFieldType> getMatchingFieldTypes(String pattern) {
+            return context.getMatchingFieldTypes(pattern);
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/search/fetch/FetchPhase.java
+++ b/server/src/main/java/org/elasticsearch/search/fetch/FetchPhase.java
@@ -214,20 +214,13 @@ public class FetchPhase {
                     continue;
                 }
                 SearchExecutionContext searchExecutionContext = context.getSearchExecutionContext();
-                Collection<String> fieldNames = searchExecutionContext.simpleMatchToIndexNames(fieldNameOrPattern);
+                Collection<String> fieldNames = searchExecutionContext.getMatchingFieldNames(fieldNameOrPattern);
                 for (String fieldName : fieldNames) {
                     MappedFieldType fieldType = searchExecutionContext.getFieldType(fieldName);
-                    if (fieldType == null) {
-                        // Only fail if we know it is a object field, missing paths / fields shouldn't fail.
-                        if (searchExecutionContext.getObjectMapper(fieldName) != null) {
-                            throw new IllegalArgumentException("field [" + fieldName + "] isn't a leaf field");
-                        }
-                    } else {
-                        String storedField = fieldType.name();
-                        Set<String> requestedFields = storedToRequestedFields.computeIfAbsent(
-                            storedField, key -> new HashSet<>());
-                        requestedFields.add(fieldName);
-                    }
+                    String storedField = fieldType.name();
+                    Set<String> requestedFields = storedToRequestedFields.computeIfAbsent(
+                        storedField, key -> new HashSet<>());
+                    requestedFields.add(fieldName);
                 }
             }
             boolean loadSource = sourceRequired(context);

--- a/server/src/main/java/org/elasticsearch/search/fetch/subphase/FetchDocValuesContext.java
+++ b/server/src/main/java/org/elasticsearch/search/fetch/subphase/FetchDocValuesContext.java
@@ -31,11 +31,9 @@ public class FetchDocValuesContext {
      */
     public FetchDocValuesContext(SearchExecutionContext searchExecutionContext, List<FieldAndFormat> fieldPatterns) {
         for (FieldAndFormat field : fieldPatterns) {
-            Collection<String> fieldNames = searchExecutionContext.simpleMatchToIndexNames(field.field);
+            Collection<String> fieldNames = searchExecutionContext.getMatchingFieldNames(field.field);
             for (String fieldName : fieldNames) {
-                if (searchExecutionContext.isFieldMapped(fieldName)) {
-                    fields.add(new FieldAndFormat(fieldName, field.format, field.includeUnmapped));
-                }
+                fields.add(new FieldAndFormat(fieldName, field.format, field.includeUnmapped));
             }
         }
 

--- a/server/src/main/java/org/elasticsearch/search/fetch/subphase/FieldFetcher.java
+++ b/server/src/main/java/org/elasticsearch/search/fetch/subphase/FieldFetcher.java
@@ -70,12 +70,8 @@ public class FieldFetcher {
                 unmappedFetchPattern.add(fieldAndFormat.field);
             }
 
-            Collection<String> concreteFields = context.simpleMatchToIndexNames(fieldPattern);
-            for (String field : concreteFields) {
+            for (String field : context.getMatchingFieldNames(fieldPattern)) {
                 MappedFieldType ft = context.getFieldType(field);
-                if (ft == null) {
-                    continue;
-                }
                 // we want to skip metadata fields if we have a wildcard pattern
                 if (context.isMetadataField(field) && isWildcardPattern) {
                     continue;

--- a/server/src/main/java/org/elasticsearch/search/fetch/subphase/highlight/HighlightPhase.java
+++ b/server/src/main/java/org/elasticsearch/search/fetch/subphase/highlight/HighlightPhase.java
@@ -10,7 +10,6 @@ package org.elasticsearch.search.fetch.subphase.highlight;
 
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.search.Query;
-import org.elasticsearch.common.regex.Regex;
 import org.elasticsearch.index.mapper.KeywordFieldMapper;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.TextFieldMapper;
@@ -20,7 +19,6 @@ import org.elasticsearch.search.fetch.FetchSubPhaseProcessor;
 
 import java.io.IOException;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -94,12 +92,7 @@ public class HighlightPhase implements FetchSubPhase {
         Map<String, Function<HitContext, FieldHighlightContext>> builders = new LinkedHashMap<>();
         for (SearchHighlightContext.Field field : highlightContext.fields()) {
             Highlighter highlighter = getHighlighter(field);
-            Collection<String> fieldNamesToHighlight;
-            if (Regex.isSimpleMatchPattern(field.field())) {
-                fieldNamesToHighlight = context.getSearchExecutionContext().simpleMatchToIndexNames(field.field());
-            } else {
-                fieldNamesToHighlight = Collections.singletonList(field.field());
-            }
+            Collection<String> fieldNamesToHighlight = context.getSearchExecutionContext().getMatchingFieldNames(field.field());
 
             if (highlightContext.forceSource(field)) {
                 if (context.getSearchExecutionContext().isSourceEnabled() == false) {
@@ -111,9 +104,6 @@ public class HighlightPhase implements FetchSubPhase {
             boolean fieldNameContainsWildcards = field.field().contains("*");
             for (String fieldName : fieldNamesToHighlight) {
                 MappedFieldType fieldType = context.getSearchExecutionContext().getFieldType(fieldName);
-                if (fieldType == null) {
-                    continue;
-                }
 
                 // We should prevent highlighting if a field is anything but a text or keyword field.
                 // However, someone might implement a custom field type that has text and still want to

--- a/server/src/test/java/org/elasticsearch/action/termvectors/AbstractTermVectorsTestCase.java
+++ b/server/src/test/java/org/elasticsearch/action/termvectors/AbstractTermVectorsTestCase.java
@@ -335,7 +335,9 @@ public abstract class AbstractTermVectorsTestCase extends ESIntegTestCase {
         for (TestFieldSetting field : testDoc.fieldSettings) {
             Terms esTerms = esTermVectorFields.terms(field.name);
             if (selectedFields != null && selectedFields.contains(field.name) == false) {
-                assertNull(esTerms);
+                if (esTerms != null) {
+                    fail("Expecting only terms for fields " + selectedFields + " but got " + field.name);
+                }
                 continue;
             }
 

--- a/server/src/test/java/org/elasticsearch/index/mapper/DocumentMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/DocumentMapperTests.java
@@ -289,6 +289,6 @@ public class DocumentMapperTests extends MapperServiceTestCase {
         assertNotNull(documentMapper.sourceMapper());
         assertNotNull(documentMapper.IndexFieldMapper());
         assertEquals(10, documentMapper.mappers().getMapping().getMetadataMappersMap().size());
-        assertEquals(10, documentMapper.mappers().fieldTypes().size());
+        assertEquals(10, documentMapper.mappers().getMatchingFieldNames("*").size());
     }
 }

--- a/server/src/test/java/org/elasticsearch/index/mapper/FieldTypeLookupTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/FieldTypeLookupTests.java
@@ -18,20 +18,25 @@ import org.hamcrest.Matchers;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
 
 public class FieldTypeLookupTests extends ESTestCase {
 
     public void testEmpty() {
         FieldTypeLookup lookup = new FieldTypeLookup("_doc", Collections.emptyList(), Collections.emptyList(), Collections.emptyList());
         assertNull(lookup.get("foo"));
-        Collection<String> names = lookup.simpleMatchToFullName("foo");
+        Collection<String> names = lookup.getMatchingFieldNames("foo");
         assertNotNull(names);
-        assertThat(names, equalTo(Set.of("foo")));
+        assertThat(names, hasSize(0));
     }
 
     public void testAddNewField() {
@@ -52,7 +57,7 @@ public class FieldTypeLookupTests extends ESTestCase {
         assertEquals(field.fieldType(), aliasType);
     }
 
-    public void testSimpleMatchToFullName() {
+    public void testMatchingFieldNames() {
         MockFieldMapper field1 = new MockFieldMapper("foo");
         MockFieldMapper field2 = new MockFieldMapper("bar");
 
@@ -61,13 +66,17 @@ public class FieldTypeLookupTests extends ESTestCase {
 
         FieldTypeLookup lookup = new FieldTypeLookup("_doc", List.of(field1, field2), List.of(alias1, alias2), List.of());
 
-        Collection<String> names = lookup.simpleMatchToFullName("b*");
+        Collection<String> names = lookup.getMatchingFieldNames("b*");
 
         assertFalse(names.contains("foo"));
         assertFalse(names.contains("food"));
-
         assertTrue(names.contains("bar"));
         assertTrue(names.contains("barometer"));
+
+        Collection<MappedFieldType> fieldTypes = lookup.getMatchingFieldTypes("b*");
+        assertThat(fieldTypes, hasSize(2));     // both "bar" and "barometer" get returned as field types
+        Collection<String> matchedNames = fieldTypes.stream().map(MappedFieldType::name).collect(Collectors.toSet());
+        assertThat(matchedNames, contains("bar"));  // but they both resolve to "bar" so we only have one name
     }
 
     public void testSourcePathWithMultiFields() {
@@ -131,21 +140,32 @@ public class FieldTypeLookupTests extends ESTestCase {
         assertThat(fieldTypeLookup.get("runtime"), instanceOf(TestRuntimeField.class));
     }
 
-    public void testRuntimeFieldsSimpleMatchToFullName() {
+    public void testRuntimeFieldsGetMatching() {
         MockFieldMapper field1 = new MockFieldMapper("field1");
+        MockFieldMapper shadowed = new MockFieldMapper("field2");
         MockFieldMapper concrete = new MockFieldMapper("concrete");
         TestRuntimeField field2 = new TestRuntimeField("field2", "type");
         TestRuntimeField subfield = new TestRuntimeField("object.subfield", "type");
 
-        FieldTypeLookup fieldTypeLookup = new FieldTypeLookup("_doc", List.of(field1, concrete), emptyList(), List.of(field2, subfield));
+        FieldTypeLookup fieldTypeLookup
+            = new FieldTypeLookup("_doc", List.of(field1, shadowed, concrete), emptyList(), List.of(field2, subfield));
         {
-            java.util.Set<String> matches = fieldTypeLookup.simpleMatchToFullName("fie*");
+            Collection<String> matches = fieldTypeLookup.getMatchingFieldNames("fie*");
             assertEquals(2, matches.size());
             assertTrue(matches.contains("field1"));
             assertTrue(matches.contains("field2"));
         }
         {
-            java.util.Set<String> matches = fieldTypeLookup.simpleMatchToFullName("object.sub*");
+            Collection<MappedFieldType> matches = fieldTypeLookup.getMatchingFieldTypes("fie*");
+            assertThat(matches, hasSize(2));
+            Map<String, MappedFieldType> toName = new HashMap<>();
+            matches.forEach(m -> toName.put(m.name(), m));
+            assertThat(toName.keySet(), hasSize(2));
+            assertThat(toName.get("field2"), instanceOf(TestRuntimeField.class));
+            assertThat(toName.get("field1"), instanceOf(MockFieldMapper.FakeFieldType.class));
+        }
+        {
+            Collection<String> matches = fieldTypeLookup.getMatchingFieldNames("object.sub*");
             assertEquals(1, matches.size());
             assertTrue(matches.contains("object.subfield"));
         }
@@ -192,6 +212,12 @@ public class FieldTypeLookupTests extends ESTestCase {
         assertThat(searchFieldType, Matchers.instanceOf(FlattenedFieldMapper.KeyedFlattenedFieldType.class));
         FlattenedFieldMapper.KeyedFlattenedFieldType keyedFieldType = (FlattenedFieldMapper.KeyedFlattenedFieldType) searchFieldType;
         assertEquals(objectKey, keyedFieldType.key());
+
+        assertThat(lookup.getMatchingFieldNames("object1.*"), contains("object1.object2.field"));
+        // We can directly find dynamic subfields
+        assertThat(lookup.getMatchingFieldNames("object1.object2.field.foo"), contains("object1.object2.field.foo"));
+        // But you can't generate dynamic subfields from a wildcard pattern
+        assertThat(lookup.getMatchingFieldNames("object1.object2.field.foo*"), hasSize(0));
     }
 
     public void testFlattenedLookupWithAlias() {

--- a/server/src/test/java/org/elasticsearch/index/mapper/MappingLookupTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/MappingLookupTests.java
@@ -105,7 +105,7 @@ public class MappingLookupTests extends ESTestCase {
         assertNull(mappingLookup.getMapping().getMeta());
         assertEquals(0, mappingLookup.getMapping().getMetadataMappersMap().size());
         assertFalse(mappingLookup.fieldMappers().iterator().hasNext());
-        assertEquals(0, mappingLookup.fieldTypes().size());
+        assertEquals(0, mappingLookup.getMatchingFieldNames("*").size());
     }
 
     private void assertAnalyzes(Analyzer analyzer, String field, String output) throws IOException {

--- a/server/src/test/java/org/elasticsearch/index/mapper/TextFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/TextFieldMapperTests.java
@@ -843,9 +843,7 @@ public class TextFieldMapperTests extends MapperTestCase {
         when(context.indexVersionCreated()).thenReturn(Version.CURRENT);
         QueryStringQueryParser parser = new QueryStringQueryParser(context, "f");
         Query q = parser.parse("foo:*");
-        assertEquals(new ConstantScoreQuery(new BooleanQuery.Builder()
-            .add(new NormsFieldExistsQuery("foo.bar"), BooleanClause.Occur.SHOULD)
-            .build()), q);
+        assertEquals(new ConstantScoreQuery(new NormsFieldExistsQuery("foo.bar")), q);
     }
 
     private static void assertAnalyzesTo(Analyzer analyzer, String field, String input, String[] output) throws IOException {

--- a/server/src/test/java/org/elasticsearch/index/query/ExistsQueryBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/ExistsQueryBuilderTests.java
@@ -22,6 +22,7 @@ import org.elasticsearch.test.AbstractQueryTestCase;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -49,9 +50,12 @@ public class ExistsQueryBuilderTests extends AbstractQueryTestCase<ExistsQueryBu
     @Override
     protected void doAssertLuceneQuery(ExistsQueryBuilder queryBuilder, Query query, SearchExecutionContext context) throws IOException {
         String fieldPattern = queryBuilder.fieldName();
-        Collection<String> fields = context.simpleMatchToIndexNames(fieldPattern);
+        Collection<String> fields = context.getMatchingFieldNames(fieldPattern);
         Collection<String> mappedFields = fields.stream().filter((field) -> context.getObjectMapper(field) != null
                 || context.isFieldMapped(field)).collect(Collectors.toList());
+        if (mappedFields.size() == 0 && context.getObjectMapper(fieldPattern) != null) {
+            mappedFields = Collections.singleton(fieldPattern);
+        }
         if (mappedFields.size() == 0) {
             assertThat(query, instanceOf(MatchNoDocsQuery.class));
             return;

--- a/server/src/test/java/org/elasticsearch/index/query/SearchExecutionContextTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/SearchExecutionContextTests.java
@@ -75,6 +75,7 @@ import org.elasticsearch.test.ESTestCase;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -86,7 +87,9 @@ import java.util.stream.Collectors;
 
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.singletonMap;
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
@@ -349,14 +352,22 @@ public class SearchExecutionContextTests extends ESTestCase {
             runtimeMappings);
         assertTrue(context.isFieldMapped("cat"));
         assertThat(context.getFieldType("cat"), instanceOf(KeywordScriptFieldType.class));
-        assertThat(context.simpleMatchToIndexNames("cat"), equalTo(Collections.singleton("cat")));
+        assertThat(context.getMatchingFieldNames("cat"), equalTo(Collections.singleton("cat")));
         assertTrue(context.isFieldMapped("dog"));
         assertThat(context.getFieldType("dog"), instanceOf(LongScriptFieldType.class));
-        assertThat(context.simpleMatchToIndexNames("dog"), equalTo(Collections.singleton("dog")));
+        assertThat(context.getMatchingFieldNames("dog"), equalTo(Collections.singleton("dog")));
         assertTrue(context.isFieldMapped("pig"));
         assertThat(context.getFieldType("pig"), instanceOf(MockFieldMapper.FakeFieldType.class));
-        assertThat(context.simpleMatchToIndexNames("pig"), equalTo(org.elasticsearch.common.collect.Set.of("pig")));
-        assertThat(context.simpleMatchToIndexNames("*"), equalTo(org.elasticsearch.common.collect.Set.of("cat", "dog", "pig")));
+        assertThat(context.getMatchingFieldNames("pig"), equalTo(Collections.singleton("pig")));
+        assertThat(context.getMatchingFieldNames("*"), containsInAnyOrder("cat", "dog", "pig"));
+
+        // test that shadowed fields aren't returned by getMatchingFieldTypes
+        Collection<MappedFieldType> matches = context.getMatchingFieldTypes("ca*");
+        assertThat(matches, hasSize(1));
+        assertThat(matches.iterator().next(), instanceOf(KeywordScriptFieldType.class));
+
+        matches = context.getAllFieldTypes();
+        assertThat(matches, hasSize(3));
     }
 
     public void testSearchRequestRuntimeFieldsWrongFormat() {

--- a/test/framework/src/main/java/org/elasticsearch/index/mapper/MapperServiceTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/mapper/MapperServiceTestCase.java
@@ -388,7 +388,7 @@ public abstract class MapperServiceTestCase extends ESTestCase {
             }
 
             @Override
-            public Collection<MappedFieldType> getFieldTypes() {
+            public Collection<MappedFieldType> getMatchingFieldTypes(String pattern) {
                 throw new UnsupportedOperationException();
             }
 
@@ -534,8 +534,11 @@ public abstract class MapperServiceTestCase extends ESTestCase {
         when(searchExecutionContext.getIndexSettings()).thenReturn(mapperService.getIndexSettings());
         when(searchExecutionContext.getObjectMapper(anyString())).thenAnswer(
             inv -> mapperService.mappingLookup().objectMappers().get(inv.getArguments()[0].toString()));
-        when(searchExecutionContext.simpleMatchToIndexNames(anyObject())).thenAnswer(
-            inv -> mapperService.mappingLookup().simpleMatchToFullName(inv.getArguments()[0].toString())
+        when(searchExecutionContext.getMatchingFieldNames(anyObject())).thenAnswer(
+            inv -> mapperService.mappingLookup().getMatchingFieldNames(inv.getArguments()[0].toString())
+        );
+        when(searchExecutionContext.getMatchingFieldTypes(anyObject())).thenAnswer(
+            inv -> mapperService.mappingLookup().getMatchingFieldTypes(inv.getArguments()[0].toString())
         );
         when(searchExecutionContext.allowExpensiveQueries()).thenReturn(true);
         when(searchExecutionContext.lookup()).thenReturn(new SearchLookup(mapperService::fieldType, (ft, s) -> {


### PR DESCRIPTION
MappingLookup has a method simpleMatchToFieldName that attempts
to return all field names that match a given pattern; if no patterns match,
then it returns a single-valued collection containing just the pattern that
was originally passed in. This is a fairly confusing semantic.

This PR replaces simpleMatchToFullName with two new methods:

* getMatchingFieldNames(), which returns a set of all mapped field names
  that match a pattern. Calling getFieldType() with a name returned by
  this method is guaranteed to return a non-null MappedFieldType
* getMatchingFieldTypes, that returns a collection of all MappedFieldTypes
  in a mapping that match the passed-in pattern.

This allows us to clean up several call-sites because we know that
MappedFieldTypes returned from these calls will never be null. It also
simplifies object field exists query construction.