### PR TITLE
[DOCS] Change field alias anchor

### DIFF
--- a/docs/reference/indices/put-mapping.asciidoc
+++ b/docs/reference/indices/put-mapping.asciidoc
@@ -392,7 +392,7 @@ POST /_reindex
 
 // tag::rename-field[]
 Renaming a field would invalidate data already indexed under the old field name.
-Instead, add an <<alias, `alias`>> field to create an alternate field name.
+Instead, add an <<field-alias, `alias`>> field to create an alternate field name.
 // end::rename-field[]
 
 For example,

--- a/docs/reference/mapping/types.asciidoc
+++ b/docs/reference/mapping/types.asciidoc
@@ -29,7 +29,7 @@ type: `boolean`.
                         express amounts.
 Dates::                 Date types, including <<date,`date`>> and
                         <<date_nanos,`date_nanos`>>.
-<<alias,`alias`>>::     Defines an alias for an existing field.
+<<field-alias,`alias`>>::     Defines an alias for an existing field.
 
 
 [discrete]

--- a/docs/reference/mapping/types/alias.asciidoc
+++ b/docs/reference/mapping/types/alias.asciidoc
@@ -1,4 +1,4 @@
-[[alias]]
+[[field-alias]]
 === Alias field type
 ++++
 <titleabbrev>Alias</titleabbrev>

--- a/docs/reference/mapping/types/percolator.asciidoc
+++ b/docs/reference/mapping/types/percolator.asciidoc
@@ -732,7 +732,7 @@ aren't available.
 [discrete]
 ===== Field aliases
 
-Percolator queries that contain <<alias, field aliases>> may not always behave as expected. In particular, if a
+Percolator queries that contain <<field-alias, field aliases>> may not always behave as expected. In particular, if a
 percolator query is registered that contains a field alias, and then that alias is updated in the mappings to refer
 to a different field, the stored query will still refer to the original target field. To pick up the change to
 the field alias, the percolator query must be explicitly reindexed.

--- a/docs/reference/search/search-your-data/retrieve-selected-fields.asciidoc
+++ b/docs/reference/search/search-your-data/retrieve-selected-fields.asciidoc
@@ -28,7 +28,7 @@ advantages over referencing the `_source` directly. Specifically, the `fields`
 parameter:
 
 * Returns each value in a standardized way that matches its mapping type
-* Accepts <<multi-fields,multi-fields>> and <<alias,field aliases>>
+* Accepts <<multi-fields,multi-fields>> and <<field-alias,field aliases>>
 * Formats dates and spatial data types
 * Retrieves <<runtime-retrieving-fields,runtime field values>>
 * Returns fields calculated by a script at index time

--- a/x-pack/docs/en/security/authorization/field-level-security.asciidoc
+++ b/x-pack/docs/en/security/authorization/field-level-security.asciidoc
@@ -217,7 +217,7 @@ The resulting permission is equal to:
 --------------------------------------------------
 // NOTCONSOLE
 
-NOTE: Field-level security should not be set on <<alias,`alias`>> fields.
+NOTE: Field-level security should not be set on <<field-alias,`alias`>> fields.
 To secure a
 concrete field, its field name must be used directly.
 


### PR DESCRIPTION
Changes the anchor for the field alias page to `field-alias`. I plan to use the `alias` anchor in an upcoming refactor of the data stream and index alias docs.