### PR TITLE
[DOCS] Add missing anchor for script contexts

### DIFF
--- a/docs/painless/painless-guide/painless-execute-script.asciidoc
+++ b/docs/painless/painless-guide/painless-execute-script.asciidoc
@@ -30,6 +30,7 @@ The Painless script to execute.
 include::../painless-contexts/painless-runtime-fields-context.asciidoc[tag=runtime-field-emit]
 --
 
+[[_contexts]]
 `context`:: (Optional, string)
 The context that the script should run in. Defaults to `painless_test` if no
 context is specified.


### PR DESCRIPTION
#72131 changed the structure of the Painless execute API docs. This re-adds an anchor that caused a broken link in Kibana.