### PR TITLE
Bump bundled JDK to 16.0.1

### DIFF
--- a/buildSrc/version.properties
+++ b/buildSrc/version.properties
@@ -2,7 +2,7 @@ elasticsearch     = 8.0.0
 lucene            = 8.8.2
 
 bundled_jdk_vendor = adoptopenjdk
-bundled_jdk = 16+36
+bundled_jdk = 16.0.1+9
 
 checkstyle = 8.39
 


### PR DESCRIPTION
New JDK patch release is out. We want to stay on the latest so bump our bundled JDK version.