### PR TITLE
[7.x] Bump bundled JDK to 16.0.1 (#73057)

### DIFF
--- a/buildSrc/version.properties
+++ b/buildSrc/version.properties
@@ -2,7 +2,7 @@ elasticsearch     = 7.14.0
 lucene            = 8.8.2
 
 bundled_jdk_vendor = adoptopenjdk
-bundled_jdk = 16+36
+bundled_jdk = 16.0.1+9
 
 checkstyle = 8.39
 


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Bump bundled JDK to 16.0.1 (#73057)