### PR TITLE
Fixing Test get builtin privileges

### DIFF
--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/privileges/11_builtin.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/privileges/11_builtin.yml
@@ -9,6 +9,25 @@ setup:
 
 ---
 "Test get builtin privileges":
+  - skip:
+        version: " - 7.99.99"
+        reason: "new privileges in 8.0 only"
+
+  - do:
+      security.get_builtin_privileges: {}
+
+  # This is fragile - it needs to be updated every time we add a new cluster/index privilege
+  # I would much prefer we could just check that specific entries are in the array, but we don't have
+  # an assertion for that
+  - length: { "cluster" : 43 }
+  - length: { "index" : 19 }
+
+---
+"Test get builtin privileges":
+  - skip:
+        version: "7.99.99 - "
+        reason: "new privileges in 8.0 only"
+
   - do:
       security.get_builtin_privileges: {}
 

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/privileges/11_builtin.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/privileges/11_builtin.yml
@@ -8,7 +8,7 @@ setup:
         wait_for_status: yellow
 
 ---
-"Test get builtin privileges":
+"Test get builtin privileges 8.x":
   - skip:
         version: " - 7.99.99"
         reason: "new privileges in 8.0 only"
@@ -23,7 +23,7 @@ setup:
   - length: { "index" : 19 }
 
 ---
-"Test get builtin privileges":
+"Test get builtin privileges 7.x":
   - skip:
         version: "7.99.99 - "
         reason: "new privileges in 8.0 only"


### PR DESCRIPTION
Fixing Test get builtin privileges to reflect the difference in # of privileges in 8.0

RElated: #72129