### PR TITLE
[7.x] [DOCS] Add missing comma in sample payload for the watcher's pagerduty action

### DIFF
--- a/x-pack/docs/en/watcher/actions/pagerduty.asciidoc
+++ b/x-pack/docs/en/watcher/actions/pagerduty.asciidoc
@@ -46,7 +46,7 @@ payload as well as an array of contexts to the action.
     "throttle_period" : "5m",
     "pagerduty" : {
       "account" : "team1",
-      "description" : "Main system down, please check! Happened at {{ctx.execution_time}}"
+      "description" : "Main system down, please check! Happened at {{ctx.execution_time}}",
       "attach_payload" : true,
       "client" : "/foo/bar/{{ctx.watch_id}}",
       "client_url" : "http://www.example.org/",


### PR DESCRIPTION
Added missing comma in sample payload for the watcher's pagerduty action

Backport of #65785