### PR TITLE
[DOCS] Rename `Bulk index alias` API to `Aliases` API

### DIFF
--- a/docs/reference/indices.asciidoc
+++ b/docs/reference/indices.asciidoc
@@ -34,11 +34,11 @@ index settings, aliases, mappings, and index templates.
 [discrete]
 [[alias-management]]
 === Alias management:
+* <<indices-aliases>>
 * <<indices-add-alias>>
-* <<indices-delete-alias>>
 * <<indices-get-alias>>
 * <<indices-alias-exists>>
-* <<indices-aliases>>
+* <<indices-delete-alias>>
 
 [discrete]
 [[index-settings]]
@@ -90,9 +90,8 @@ For more information, see <<index-templates, Index Templates>>.
 * <<dangling-index-delete>>
 
 
-
-include::indices/analyze.asciidoc[]
 include::indices/aliases.asciidoc[]
+include::indices/analyze.asciidoc[]
 include::indices/clearcache.asciidoc[]
 include::indices/clone-index.asciidoc[]
 include::indices/close.asciidoc[]

--- a/docs/reference/indices/aliases.asciidoc
+++ b/docs/reference/indices/aliases.asciidoc
@@ -1,7 +1,7 @@
 [[indices-aliases]]
-=== Bulk index alias API
+=== Aliases API
 ++++
-<titleabbrev>Bulk index alias</titleabbrev>
+<titleabbrev>Aliases</titleabbrev>
 ++++
 
 Adds and removes multiple index aliases in a single request. Also deletes


### PR DESCRIPTION
In 7.14, the API supports both index and data stream aliases. This also better aligns with resources in the API's endpoint.