### PR TITLE
Don't run Node Enrollment Tests on FIPS

### DIFF
--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/action/enrollment/TransportNodeEnrollmentActionTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/action/enrollment/TransportNodeEnrollmentActionTests.java
@@ -65,6 +65,8 @@ public class TransportNodeEnrollmentActionTests extends ESTestCase {
 
     @SuppressWarnings("unchecked")
     public void testDoExecute() throws Exception {
+        assumeFalse("NodeEnrollment is not supported on FIPS because it requires a KeyStore", inFipsJvm());
+
         final Environment env = mock(Environment.class);
         Path tempDir = createTempDir();
         Path httpCaPath = tempDir.resolve("httpCa.p12");


### PR DESCRIPTION
The Node Enrollment API requires the use of a KeyStore, but neither
PKCS#12 nor JKS keystores are supported when running in FIPS mode.

For this reason, the Enrollment APIs are not supported on FIPS mode,
and we therefore shouldn't run the tests under FIPS either.

Resolves: #73012
