### PR TITLE
[7.12] [DOCS] Rename `Bulk index alias` API to `Aliases` API (#73077)

### DIFF
--- a/docs/reference/indices.asciidoc
+++ b/docs/reference/indices.asciidoc
@@ -35,11 +35,11 @@ index settings, aliases, mappings, and index templates.
 [discrete]
 [[alias-management]]
 === Alias management:
+* <<indices-aliases>>
 * <<indices-add-alias>>
-* <<indices-delete-alias>>
 * <<indices-get-alias>>
 * <<indices-alias-exists>>
-* <<indices-aliases>>
+* <<indices-delete-alias>>
 
 [discrete]
 [[index-settings]]
@@ -92,9 +92,8 @@ For more information, see <<index-templates, Index Templates>>.
 * <<dangling-index-delete>>
 
 
-
-include::indices/analyze.asciidoc[]
 include::indices/aliases.asciidoc[]
+include::indices/analyze.asciidoc[]
 include::indices/clearcache.asciidoc[]
 include::indices/clone-index.asciidoc[]
 include::indices/close.asciidoc[]

--- a/docs/reference/indices/aliases.asciidoc
+++ b/docs/reference/indices/aliases.asciidoc
@@ -1,7 +1,7 @@
 [[indices-aliases]]
-=== Bulk index alias API
+=== Aliases API
 ++++
-<titleabbrev>Bulk index alias</titleabbrev>
+<titleabbrev>Aliases</titleabbrev>
 ++++
 
 Adds and removes multiple index aliases in a single request. Also deletes


### PR DESCRIPTION
Backports the following commits to 7.12:
 - [DOCS] Rename `Bulk index alias` API to `Aliases` API (#73077)