### PR TITLE
[7.x] [DOCS] Fix typo (#72930)

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/breaker/ChildMemoryCircuitBreaker.java
+++ b/server/src/main/java/org/elasticsearch/common/breaker/ChildMemoryCircuitBreaker.java
@@ -69,7 +69,7 @@ public class ChildMemoryCircuitBreaker implements CircuitBreaker {
      * Add a number of bytes, tripping the circuit breaker if the aggregated
      * estimates are above the limit. Automatically trips the breaker if the
      * memory limit is set to 0. Will never trip the breaker if the limit is
-     * set &lt; 0, but can still be used to aggregate estimations.
+     * set to -1, but can still be used to aggregate estimations.
      * @param bytes number of bytes to add to the breaker
      */
     @Override


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [DOCS] Fix typo (#72930)