### PR TITLE
[7.x] [DOCS] Fix typo (#72936)

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/shard/IndexShard.java
+++ b/server/src/main/java/org/elasticsearch/index/shard/IndexShard.java
@@ -3558,7 +3558,7 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
         if (readAllowed) {
             refreshListeners.addOrNotify(location, listener);
         } else {
-            // we're not yet ready fo ready for reads, just ignore refresh cycles
+            // we're not yet ready for reads, just ignore refresh cycles
             listener.accept(false);
         }
     }


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [DOCS] Fix typo (#72936)