### PR TITLE
[master]adding a case of localDateFromWeekBasedDate

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/time/DateFormatters.java
+++ b/server/src/main/java/org/elasticsearch/common/time/DateFormatters.java
@@ -1905,6 +1905,8 @@ public class DateFormatters {
                             .with(weekFields.weekBasedYear(), accessor.get(weekFields.weekBasedYear()))
                             .with(weekFields.weekOfWeekBasedYear(), accessor.get(weekFields.weekOfWeekBasedYear()))
                             .with(TemporalAdjusters.previousOrSame(weekFields.getFirstDayOfWeek()));
+        } else if (accessor.isSupported(MONTH_OF_YEAR) && accessor.isSupported(DAY_OF_MONTH)) {
+            return LocalDate.of(accessor.get(weekFields.weekBasedYear()), accessor.get(MONTH_OF_YEAR), accessor.get(DAY_OF_MONTH));
         } else {
             return LocalDate.ofEpochDay(0)
                             .with(weekFields.weekBasedYear(), accessor.get(weekFields.weekBasedYear()))

--- a/server/src/test/java/org/elasticsearch/common/time/DateFormattersTests.java
+++ b/server/src/test/java/org/elasticsearch/common/time/DateFormattersTests.java
@@ -16,6 +16,9 @@ import java.time.Instant;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
+import java.time.format.ResolverStyle;
 import java.time.temporal.ChronoField;
 import java.time.temporal.TemporalAccessor;
 import java.util.Locale;
@@ -386,5 +389,14 @@ public class DateFormattersTests extends ESTestCase {
             Instant instant = Instant.from(formatter.parse("2019-05-06T14:52:37.123456789Z"));
             assertThat(instant.getNano(), is(123_456_789));
         }
+    }
+
+    public void testWeekBasedCalendarYear() {
+        DateTimeFormatter formatter = new DateTimeFormatterBuilder().appendPattern("YYYY-MM-dd").toFormatter(Locale.ROOT)
+            .withResolverStyle(ResolverStyle.STRICT);
+        assertThat(DateFormatters.from(formatter.parse("2019-12-31")) ,
+            equalTo(ZonedDateTime.of(2019,12,31, 0,0,0,0,ZoneOffset.UTC)));
+        assertThat(DateFormatters.from(formatter.parse("2021-04-27")) ,
+            equalTo(ZonedDateTime.of(2021,4,27, 0,0,0,0,ZoneOffset.UTC)));
     }
 }


### PR DESCRIPTION
adding a case of localDateFromWeekBasedDate function to use YYYY-MM-dd format. 
Close [issues/72556](https://github.com/elastic/elasticsearch/issues/72556)