### PR TITLE
Allow container restarts with file logging

### DIFF
--- a/distribution/docker/src/docker/bin/docker-entrypoint.sh
+++ b/distribution/docker/src/docker/bin/docker-entrypoint.sh
@@ -63,8 +63,9 @@ if [[ -n "$ES_LOG_STYLE" ]]; then
       # This is the default. Nothing to do.
       ;;
     file)
-      # Overwrite the default config with the stack config
-      mv /usr/share/elasticsearch/config/log4j2.file.properties /usr/share/elasticsearch/config/log4j2.properties
+      # Overwrite the default config with the stack config. Do this as a
+      # copy, not a move, in case the container is restarted.
+      cp -f /usr/share/elasticsearch/config/log4j2.file.properties /usr/share/elasticsearch/config/log4j2.properties
       ;;
     *)
       echo "ERROR: ES_LOG_STYLE set to [$ES_LOG_STYLE]. Expected [console] or [file]" >&2

--- a/qa/os/src/test/java/org/elasticsearch/packaging/test/DockerTests.java
+++ b/qa/os/src/test/java/org/elasticsearch/packaging/test/DockerTests.java
@@ -45,6 +45,7 @@ import static org.elasticsearch.packaging.util.Docker.getImageLabels;
 import static org.elasticsearch.packaging.util.Docker.getJson;
 import static org.elasticsearch.packaging.util.Docker.mkDirWithPrivilegeEscalation;
 import static org.elasticsearch.packaging.util.Docker.removeContainer;
+import static org.elasticsearch.packaging.util.Docker.restartContainer;
 import static org.elasticsearch.packaging.util.Docker.rmDirWithPrivilegeEscalation;
 import static org.elasticsearch.packaging.util.Docker.runContainer;
 import static org.elasticsearch.packaging.util.Docker.runContainerExpectingFailure;
@@ -674,6 +675,20 @@ public class DockerTests extends PackagingTestCase {
         final Result result = runContainerExpectingFailure(distribution(), builder().envVars(Map.of("ES_LOG_STYLE", "unknown")));
 
         assertThat(result.stderr, containsString("ERROR: ES_LOG_STYLE set to [unknown]. Expected [console] or [file]"));
+    }
+
+    /**
+     * Check that it when configuring logging to write to disk, the container can be restarted.
+     */
+    public void test124CanRestartContainerWithStackLoggingConfig() throws Exception {
+        runContainer(distribution(), builder().envVars(Map.of("ES_LOG_STYLE", "file")));
+
+        waitForElasticsearch(installation);
+
+        restartContainer();
+
+        // If something went wrong running Elasticsearch the second time, this will fail.
+        waitForElasticsearch(installation);
     }
 
     /**

--- a/qa/os/src/test/java/org/elasticsearch/packaging/util/Docker.java
+++ b/qa/os/src/test/java/org/elasticsearch/packaging/util/Docker.java
@@ -612,4 +612,11 @@ public class Docker {
     public static Shell.Result getContainerLogs() {
         return sh.run("docker logs " + containerId);
     }
+
+    /**
+     * Restarts the current docker container.
+     */
+    public static void restartContainer() {
+        sh.run("docker restart " + containerId);
+    }
 }


### PR DESCRIPTION
Closes #72702. It wasn't possible to restart an Elasticsearch Docker
container when using `ES_LOG_STYLE=file`, and now it is.
