### PR TITLE
Emit from source to be the default for runtime fields scripts

### DIFF
--- a/server/src/main/java/org/elasticsearch/script/AbstractFieldScript.java
+++ b/server/src/main/java/org/elasticsearch/script/AbstractFieldScript.java
@@ -132,5 +132,7 @@ public abstract class AbstractFieldScript {
         }
     }
 
-    public abstract void execute();
+    public void execute() {
+        emitFromSource();
+    }
 }

--- a/server/src/main/java/org/elasticsearch/script/BooleanFieldScript.java
+++ b/server/src/main/java/org/elasticsearch/script/BooleanFieldScript.java
@@ -15,23 +15,12 @@ import org.elasticsearch.search.lookup.SearchLookup;
 import java.util.Map;
 import java.util.function.Consumer;
 
-public abstract class BooleanFieldScript extends AbstractFieldScript {
+public class BooleanFieldScript extends AbstractFieldScript {
 
     public static final ScriptContext<Factory> CONTEXT = newContext("boolean_field", Factory.class);
 
     public static final BooleanFieldScript.Factory PARSE_FROM_SOURCE
-        = (field, params, lookup) -> (BooleanFieldScript.LeafFactory) ctx -> new BooleanFieldScript
-        (
-            field,
-            params,
-            lookup,
-            ctx
-        ) {
-        @Override
-        public void execute() {
-            emitFromSource();
-        }
-    };
+        = (field, params, lookup) -> (BooleanFieldScript.LeafFactory) ctx -> new BooleanFieldScript(field, params, lookup, ctx);
 
     @SuppressWarnings("unused")
     public static final String[] PARAMETERS = {};

--- a/server/src/main/java/org/elasticsearch/script/DateFieldScript.java
+++ b/server/src/main/java/org/elasticsearch/script/DateFieldScript.java
@@ -15,23 +15,11 @@ import org.elasticsearch.search.lookup.SearchLookup;
 import java.util.Map;
 import java.util.Objects;
 
-public abstract class DateFieldScript extends AbstractLongFieldScript {
+public class DateFieldScript extends AbstractLongFieldScript {
     public static final ScriptContext<Factory> CONTEXT = newContext("date_field", Factory.class);
 
-    public static final DateFieldScript.Factory PARSE_FROM_SOURCE
-        = (field, params, lookup, formatter) -> (DateFieldScript.LeafFactory) ctx -> new DateFieldScript
-        (
-            field,
-            params,
-            lookup,
-            formatter,
-            ctx
-        ) {
-        @Override
-        public void execute() {
-            emitFromSource();
-        }
-    };
+    public static final DateFieldScript.Factory PARSE_FROM_SOURCE = (field, params, lookup, formatter) ->
+        (DateFieldScript.LeafFactory) ctx -> new DateFieldScript(field, params, lookup, formatter, ctx);
 
     @SuppressWarnings("unused")
     public static final String[] PARAMETERS = {};

--- a/server/src/main/java/org/elasticsearch/script/DoubleFieldScript.java
+++ b/server/src/main/java/org/elasticsearch/script/DoubleFieldScript.java
@@ -15,22 +15,11 @@ import org.elasticsearch.search.lookup.SearchLookup;
 import java.util.Map;
 import java.util.function.DoubleConsumer;
 
-public abstract class DoubleFieldScript extends AbstractFieldScript {
+public class DoubleFieldScript extends AbstractFieldScript {
     public static final ScriptContext<Factory> CONTEXT = newContext("double_field", Factory.class);
 
     public static final DoubleFieldScript.Factory PARSE_FROM_SOURCE
-        = (field, params, lookup) -> (DoubleFieldScript.LeafFactory) ctx -> new DoubleFieldScript
-        (
-            field,
-            params,
-            lookup,
-            ctx
-        ) {
-        @Override
-        public void execute() {
-            emitFromSource();
-        }
-    };
+        = (field, params, lookup) -> (DoubleFieldScript.LeafFactory) ctx -> new DoubleFieldScript(field, params, lookup, ctx);
 
     @SuppressWarnings("unused")
     public static final String[] PARAMETERS = {};

--- a/server/src/main/java/org/elasticsearch/script/GeoPointFieldScript.java
+++ b/server/src/main/java/org/elasticsearch/script/GeoPointFieldScript.java
@@ -28,23 +28,11 @@ import static org.apache.lucene.geo.GeoEncodingUtils.encodeLongitude;
  * Script producing geo points. Similarly to what {@link LatLonDocValuesField} does,
  * it encodes the points as a long value.
  */
-public abstract class GeoPointFieldScript extends AbstractLongFieldScript {
+public class GeoPointFieldScript extends AbstractLongFieldScript {
     public static final ScriptContext<Factory> CONTEXT = newContext("geo_point_field", Factory.class);
 
     public static final GeoPointFieldScript.Factory PARSE_FROM_SOURCE
-        = (field, params, lookup) -> (GeoPointFieldScript.LeafFactory) ctx -> new GeoPointFieldScript
-        (
-            field,
-            params,
-            lookup,
-            ctx
-        ) {
-
-        @Override
-        public void execute() {
-            emitFromSource();
-        }
-    };
+        = (field, params, lookup) -> (GeoPointFieldScript.LeafFactory) ctx -> new GeoPointFieldScript(field, params, lookup, ctx);
 
     @SuppressWarnings("unused")
     public static final String[] PARAMETERS = {};

--- a/server/src/main/java/org/elasticsearch/script/IpFieldScript.java
+++ b/server/src/main/java/org/elasticsearch/script/IpFieldScript.java
@@ -36,22 +36,11 @@ import java.util.function.Consumer;
  * so it saves us a lot of trouble to use the same representation.
  * </ul>
  */
-public abstract class IpFieldScript extends AbstractFieldScript {
+public class IpFieldScript extends AbstractFieldScript {
     public static final ScriptContext<Factory> CONTEXT = newContext("ip_field", Factory.class);
 
     public static final IpFieldScript.Factory PARSE_FROM_SOURCE
-        = (field, params, lookup) -> (IpFieldScript.LeafFactory) ctx -> new IpFieldScript
-        (
-            field,
-            params,
-            lookup,
-            ctx
-        ) {
-        @Override
-        public void execute() {
-            emitFromSource();
-        }
-    };
+        = (field, params, lookup) -> (IpFieldScript.LeafFactory) ctx -> new IpFieldScript(field, params, lookup, ctx);
 
     @SuppressWarnings("unused")
     public static final String[] PARAMETERS = {};

--- a/server/src/main/java/org/elasticsearch/script/LongFieldScript.java
+++ b/server/src/main/java/org/elasticsearch/script/LongFieldScript.java
@@ -14,22 +14,11 @@ import org.elasticsearch.search.lookup.SearchLookup;
 
 import java.util.Map;
 
-public abstract class LongFieldScript extends AbstractLongFieldScript {
+public class LongFieldScript extends AbstractLongFieldScript {
     public static final ScriptContext<Factory> CONTEXT = newContext("long_field", Factory.class);
 
     public static final LongFieldScript.Factory PARSE_FROM_SOURCE
-        = (field, params, lookup) -> (LongFieldScript.LeafFactory) ctx -> new LongFieldScript
-        (
-            field,
-            params,
-            lookup,
-            ctx
-        ) {
-        @Override
-        public void execute() {
-            emitFromSource();
-        }
-    };
+        = (field, params, lookup) -> (LongFieldScript.LeafFactory) ctx -> new LongFieldScript(field, params, lookup, ctx);
 
     @SuppressWarnings("unused")
     public static final String[] PARAMETERS = {};

--- a/server/src/main/java/org/elasticsearch/script/StringFieldScript.java
+++ b/server/src/main/java/org/elasticsearch/script/StringFieldScript.java
@@ -17,7 +17,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.function.Consumer;
 
-public abstract class StringFieldScript extends AbstractFieldScript {
+public class StringFieldScript extends AbstractFieldScript {
     /**
      * The maximum number of chars a script should be allowed to emit.
      */
@@ -26,18 +26,7 @@ public abstract class StringFieldScript extends AbstractFieldScript {
     public static final ScriptContext<Factory> CONTEXT = newContext("keyword_field", Factory.class);
 
     public static final StringFieldScript.Factory PARSE_FROM_SOURCE
-        = (field, params, lookup) -> (StringFieldScript.LeafFactory) ctx -> new StringFieldScript
-        (
-            field,
-            params,
-            lookup,
-            ctx
-        ) {
-        @Override
-        public void execute() {
-            emitFromSource();
-        }
-    };
+        = (field, params, lookup) -> (StringFieldScript.LeafFactory) ctx -> new StringFieldScript(field, params, lookup, ctx);
 
     @SuppressWarnings("unused")
     public static final String[] PARAMETERS = {};


### PR DESCRIPTION
Currently each runtime field scripts declares a constant factory that returns the script itself with its execute overridden so that it emits the field from _source. With this commit we save a bit of code by making this the default behaviour. The base execute method does not need to be abstract and each leaf script class no longer need to be abstract either.