### PR TITLE
[7.12] [DOCS] Update single index APIs reference (#73103)

### DIFF
--- a/docs/reference/api-conventions.asciidoc
+++ b/docs/reference/api-conventions.asciidoc
@@ -47,9 +47,8 @@ string parameter:
 
 include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=ignore_throttled]
 
-NOTE: Single index APIs, such as the <<docs>> and
-<<indices-aliases,single-index `alias` APIs>>, do not support multi-target
-syntax.
+NOTE: APIs with a single target, such as the <<docs-get,get document API>>, do
+not support multi-target syntax.
 
 [[hidden-indices]]
 ==== Hidden data streams and indices

--- a/docs/reference/docs.asciidoc
+++ b/docs/reference/docs.asciidoc
@@ -1,8 +1,9 @@
 [[docs]]
 == Document APIs
 
-This section starts with a short introduction to Elasticsearch's <<docs-replication,data replication model>>, followed by a
-detailed description of the following CRUD APIs:
+This section starts with a short introduction to {es}'s <<docs-replication,data
+replication model>>, followed by a detailed description of the following CRUD
+APIs:
 
 .Single document APIs
 * <<docs-index_>>
@@ -16,9 +17,6 @@ detailed description of the following CRUD APIs:
 * <<docs-delete-by-query>>
 * <<docs-update-by-query>>
 * <<docs-reindex>>
-
-NOTE: All CRUD APIs are single-index APIs. The `index` parameter accepts a single
-index name, or an `alias` which points to a single index.
 
 include::docs/data-replication.asciidoc[]
 


### PR DESCRIPTION
Backports the following commits to 7.12:
 - [DOCS] Update single index APIs reference (#73103)