### PR TITLE
[DOCS] Update anchor for alias write index

### DIFF
--- a/docs/reference/ilm/actions/ilm-rollover.asciidoc
+++ b/docs/reference/ilm/actions/ilm-rollover.asciidoc
@@ -21,7 +21,7 @@ must meet the following conditions:
 
 * The index name must match the pattern '^.*-\\d+$', for example (`my-index-000001`).
 * The `index.lifecycle.rollover_alias` must be configured as the alias to roll over.
-* The index must be the <<aliases-write-index,write index>> for the alias.
+* The index must be the <<write-index,write index>> for the alias.
 
 For example, if `my-index-000001` has the alias `my_data`,
 the following settings must be configured.

--- a/docs/reference/indices/aliases.asciidoc
+++ b/docs/reference/indices/aliases.asciidoc
@@ -141,7 +141,7 @@ Defaults to `false`.
 +
 An alias can have one write index at a time.
 +
-See <<aliases-write-index>> for an example.
+See <<write-index>> for an example.
 +
 [IMPORTANT]
 ====
@@ -427,7 +427,7 @@ GET /alias2/_search?q=user.id:kimchy&routing=2,3
 --------------------------------------------------
 // TEST[continued]
 
-[[aliases-write-index]]
+[[write-index]]
 ===== Write index
 
 It is possible to associate the index pointed to by an alias as the write index.

--- a/docs/reference/indices/migrate-to-data-stream.asciidoc
+++ b/docs/reference/indices/migrate-to-data-stream.asciidoc
@@ -88,7 +88,7 @@ See <<set-up-a-data-stream>>.
 Name of the index alias to convert to a data stream. The alias must meet the
 following criteria:
 
-- The alias must have a <<aliases-write-index,write index>>.
+- The alias must have a <<write-index,write index>>.
 - All indices for the alias have a `@timestamp` field mapping of a `date` or `date_nanos` field type.
 - The alias must not have any <<filtered,filters>>.
 - The alias must not use <<aliases-routing,custom routing>>.

--- a/docs/reference/indices/rollover-index.asciidoc
+++ b/docs/reference/indices/rollover-index.asciidoc
@@ -52,7 +52,7 @@ See <<convert-index-alias-to-data-stream>>.
 ====
 
 If an index alias points to multiple indices, one of the indices must be a
-<<aliases-write-index,write index>>. The rollover API creates a new write index
+<<write-index,write index>>. The rollover API creates a new write index
 for the alias with `is_write_index` set to `true`. The API also sets
 `is_write_index` to `false` for the previous write index.
 


### PR DESCRIPTION
Updates the anchor for alias write index content. Changes are no-op but helps
prepare for future work on alias docs.