### PR TITLE
Add LinkageError to the errors we catch as part of the Painless sandbox

### DIFF
--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/PainlessScriptEngine.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/PainlessScriptEngine.java
@@ -402,7 +402,7 @@ public final class PainlessScriptEngine implements ScriptEngine {
                 }
             }, COMPILATION_CONTEXT);
             // Note that it is safe to catch any of the following errors since Painless is stateless.
-        } catch (OutOfMemoryError | StackOverflowError | VerifyError | Exception e) {
+        } catch (OutOfMemoryError | StackOverflowError | LinkageError | Exception e) {
             throw convertToScriptException(source, e);
         }
     }

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/phase/PainlessUserTreeToIRTreePhase.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/phase/PainlessUserTreeToIRTreePhase.java
@@ -330,7 +330,7 @@ public class PainlessUserTreeToIRTreePhase extends DefaultUserTreeToIRTreePhase 
     //     throw this.convertToScriptException(e, e.getHeaders($DEFINITION))
     // }
     // and
-    // } catch (PainlessError | BootstrapMethodError | OutOfMemoryError | StackOverflowError | Exception e) {
+    // } catch (PainlessError | LinkageError | OutOfMemoryError | StackOverflowError | Exception e) {
     //     throw this.convertToScriptException(e, e.getHeaders())
     // }
     protected void injectSandboxExceptions(FunctionNode irFunctionNode) {
@@ -414,7 +414,7 @@ public class PainlessUserTreeToIRTreePhase extends DefaultUserTreeToIRTreePhase 
             irInvokeCallNode.addArgumentNode(irLoadFieldMemberNode);
 
             for (Class<?> throwable : new Class<?>[] {
-                    PainlessError.class, BootstrapMethodError.class, OutOfMemoryError.class, StackOverflowError.class, Exception.class}) {
+                    PainlessError.class, LinkageError.class, OutOfMemoryError.class, StackOverflowError.class, Exception.class}) {
 
                 String name = throwable.getSimpleName();
                 name = "#" + Character.toLowerCase(name.charAt(0)) + name.substring(1);


### PR DESCRIPTION
This changes the Painless sandbox to be more encompassing of possible compiler bugs including JVM bugs. This prevents any single script from crashing a node under a wider array of circumstances that in theory should be recoverable with possible changes to a user-defined script. 

Note that I tested VerifyError and Bootstrap error manually, but our current infrastructure does not allow for tests easily constructed for bugs that should not happen (in theory).