### PR TITLE
Adjust get alias api with aliases pointing to data streams

### DIFF
--- a/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestGetAliasesAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestGetAliasesAction.java
@@ -77,6 +77,10 @@ public class RestGetAliasesAction extends BaseRestHandler {
                 returnedAliasNames.add(aliasMetadata.alias());
             }
         }
+        dataStreamAliases.entrySet().stream()
+            .flatMap(entry -> entry.getValue().stream())
+            .forEach(dataStreamAlias -> returnedAliasNames.add(dataStreamAlias.getName()));
+
         // compute explicitly requested aliases that have are not returned in the result
         final SortedSet<String> missingAliases = new TreeSet<>();
         // first wildcard index, leading "-" as an alias name after this index means
@@ -133,7 +137,7 @@ public class RestGetAliasesAction extends BaseRestHandler {
             }
 
             for (final var entry : responseAliasMap) {
-                if (aliasesExplicitlyRequested == false || (aliasesExplicitlyRequested && indicesToDisplay.contains(entry.key))) {
+                if (aliasesExplicitlyRequested == false || indicesToDisplay.contains(entry.key)) {
                     builder.startObject(entry.key);
                     {
                         builder.startObject("aliases");
@@ -147,6 +151,8 @@ public class RestGetAliasesAction extends BaseRestHandler {
                     builder.endObject();
                 }
             }
+            // No need to do filtering like is done for aliases pointing to indices (^),
+            // because this already happens in TransportGetAliasesAction.
             for (var entry : dataStreamAliases.entrySet()) {
                 builder.startObject(entry.getKey());
                 {
@@ -182,7 +188,7 @@ public class RestGetAliasesAction extends BaseRestHandler {
 
         //we may want to move this logic to TransportGetAliasesAction but it is based on the original provided aliases, which will
         //not always be available there (they may get replaced so retrieving request.aliases is not quite the same).
-        return channel -> client.admin().indices().getAliases(getAliasesRequest, new RestBuilderListener<GetAliasesResponse>(channel) {
+        return channel -> client.admin().indices().getAliases(getAliasesRequest, new RestBuilderListener<>(channel) {
             @Override
             public RestResponse buildResponse(GetAliasesResponse response, XContentBuilder builder) throws Exception {
                 return buildRestResponse(namesProvided, aliases, response.getAliases(), response.getDataStreamAliases(), builder);

--- a/x-pack/plugin/data-streams/qa/rest/src/javaRestTest/java/org/elasticsearch/xpack/datastreams/DataStreamsRestIT.java
+++ b/x-pack/plugin/data-streams/qa/rest/src/javaRestTest/java/org/elasticsearch/xpack/datastreams/DataStreamsRestIT.java
@@ -195,4 +195,50 @@ public class DataStreamsRestIT extends ESRestTestCase {
         getAliasesRequest = new Request("GET", "/logs-*/_alias");
         assertThat(entityAsMap(client().performRequest(getAliasesRequest)), equalTo(Map.of()));
     }
+
+    public void testGetAliasApiFilterByDataStreamAlias() throws Exception {
+        Request putComposableIndexTemplateRequest = new Request("POST", "/_index_template/1");
+        putComposableIndexTemplateRequest.setJsonEntity("{\"index_patterns\": [\"logs-*\"], \"data_stream\": {}}");
+        assertOK(client().performRequest(putComposableIndexTemplateRequest));
+
+        Request createDocRequest = new Request("POST", "/logs-emea/_doc?refresh=true");
+        createDocRequest.setJsonEntity("{ \"@timestamp\": \"2022-12-12\"}");
+        assertOK(client().performRequest(createDocRequest));
+
+        createDocRequest = new Request("POST", "/logs-nasa/_doc?refresh=true");
+        createDocRequest.setJsonEntity("{ \"@timestamp\": \"2022-12-12\"}");
+        assertOK(client().performRequest(createDocRequest));
+
+        Request updateAliasesRequest = new Request("POST", "/_aliases");
+        updateAliasesRequest.setJsonEntity(
+            "{\"actions\":[{\"add\":{\"index\":\"logs-emea\",\"alias\":\"emea\"}}," +
+                "{\"add\":{\"index\":\"logs-nasa\",\"alias\":\"nasa\"}}]}");
+        assertOK(client().performRequest(updateAliasesRequest));
+
+        Response response = client().performRequest(new Request("GET", "/_alias"));
+        assertOK(response);
+        Map<String, Object> getAliasesResponse = entityAsMap(response);
+        assertThat(getAliasesResponse.size(), equalTo(2));
+        assertEquals(Map.of("emea", Map.of()), XContentMapValues.extractValue("logs-emea.aliases", getAliasesResponse));
+        assertEquals(Map.of("nasa", Map.of()), XContentMapValues.extractValue("logs-nasa.aliases", getAliasesResponse));
+
+        response = client().performRequest(new Request("GET", "/_alias/emea"));
+        assertOK(response);
+        getAliasesResponse = entityAsMap(response);
+        assertThat(getAliasesResponse.size(), equalTo(2)); // Adjust to equalTo(1) when #72953 is merged
+        assertEquals(Map.of("emea", Map.of()), XContentMapValues.extractValue("logs-emea.aliases", getAliasesResponse));
+        assertEquals(Map.of(), XContentMapValues.extractValue("logs-nasa.aliases", getAliasesResponse)); // Remove when #72953 is merged
+
+        ResponseException exception =
+            expectThrows(ResponseException.class, () -> client().performRequest(new Request("GET", "/_alias/wrong_name")));
+        response = exception.getResponse();
+        assertThat(response.getStatusLine().getStatusCode(), equalTo(404));
+        getAliasesResponse = entityAsMap(response);
+        assertThat(getAliasesResponse.size(), equalTo(4)); // Adjust to equalTo(2) when #72953 is merged
+        assertEquals("alias [wrong_name] missing", getAliasesResponse.get("error"));
+        assertEquals(404, getAliasesResponse.get("status"));
+        assertEquals(Map.of(), XContentMapValues.extractValue("logs-emea.aliases", getAliasesResponse)); // Remove when #72953 is merged
+        assertEquals(Map.of(), XContentMapValues.extractValue("logs-nasa.aliases", getAliasesResponse)); // Remove when #72953 is merged
+    }
+
 }


### PR DESCRIPTION
Change the get alias api to not return a 404 when filtering
by alias name that refers to data streams.

Originated from #72953
Relates to #66163