### PR TITLE
[7.x] [DOCS] Fix typo (#73137)

### DIFF
--- a/x-pack/docs/en/rest-api/watcher/get-watch.asciidoc
+++ b/x-pack/docs/en/rest-api/watcher/get-watch.asciidoc
@@ -43,7 +43,7 @@ this API. For more information, see
 [[watcher-api-get-watch-example]]
 ==== {api-examples-title}
 
-The following example gets a watch with `my-watch` id:
+The following example gets a watch with `my_watch` id:
 
 [source,console]
 --------------------------------------------------


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [DOCS] Fix typo (#73137)