### PR TITLE
[7.x] Rename 'termsenum' API to 'terms_enum' for better readability

### DIFF
--- a/docs/reference/search/terms-enum.asciidoc
+++ b/docs/reference/search/terms-enum.asciidoc
@@ -47,7 +47,7 @@ set of terms examined was not the full set of available values.
 [[search-terms-enum-api-desc]]
 ==== {api-description-title}
 
-The termsenum API  can be used to discover terms in the index that begin with the provided
+The terms_enum API  can be used to discover terms in the index that begin with the provided
 string. It is designed for low-latency look-ups used in auto-complete scenarios.
 
 

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/terms_enum.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/terms_enum.json
@@ -1,5 +1,5 @@
 {
-  "termsenum":{
+  "terms_enum":{
     "documentation":{
       "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/search-terms-enum.html",
       "description": "The terms enum API  can be used to discover terms in the index that begin with the provided string. It is designed for low-latency look-ups used in auto-complete scenarios."

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/terms_enum/10_basic.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/terms_enum/10_basic.yml
@@ -234,14 +234,14 @@ teardown:
 ---
 "Test basic term enumeration":
   - do:
-      termsenum:
+      terms_enum:
         index:  test_*
         body:  {"field": "foo", "string":"b"}
   - length: {terms: 3}
 
 
   - do:
-      termsenum:
+      terms_enum:
         index:  test_*
         body:  {"field": "foo.bar", "string":"b"}
   - length: {terms: 1}
@@ -249,31 +249,31 @@ teardown:
 ---
 "Test case insensitivity":
   - do:
-      termsenum:
+      terms_enum:
         index:  test_k
         body:  {"field": "foo", "string":"B"}
   - length: {terms: 0}
 
   - do:
-      termsenum:
+      terms_enum:
         index:  test_k
         body:  {"field": "foo", "string":"B", "case_insensitive": true}
   - length: {terms: 1}
 
   - do:
-      termsenum:
+      terms_enum:
         index:  test_f
         body:  {"field": "foo.bar", "string":"B"}
   - length: {terms: 0}
 
   - do:
-      termsenum:
+      terms_enum:
         index:  test_f
         body:  {"field": "foo.bar", "string":"B", "case_insensitive": true}
   - length: {terms: 1}
 
   - do:
-      termsenum:
+      terms_enum:
         index:  test_f
         body:  {"field": "foo.Bar", "string":"B", "case_insensitive": true}
   - length: {terms: 0}
@@ -281,25 +281,25 @@ teardown:
 ---
 "Test search after keyword field":
   - do:
-      termsenum:
+      terms_enum:
         index:  test_k
         body:  {"field": "foo", "string":"b", "search_after":"baz"}
   - length: {terms: 0}
 
   - do:
-      termsenum:
+      terms_enum:
         index:  test_k
         body:  {"field": "foo", "string":"b", "search_after":"bar_k"}
   - length: {terms: 0}
 
   - do:
-      termsenum:
+      terms_enum:
         index:  test_k
         body:  {"field": "foo", "string":"b", "search_after":"baa"}
   - length: {terms: 1}
 
   - do:
-      termsenum:
+      terms_enum:
         index:  test_k
         body:  {"field": "foo", "string":"", "search_after":"baa"}
   - length: {terms: 1}
@@ -308,25 +308,25 @@ teardown:
 ---
 "Test search after flattened field":
   - do:
-      termsenum:
+      terms_enum:
         index:  test_f
         body:  {"field": "foo.bar", "string":"b", "search_after":"baz"}
   - length: {terms: 0}
 
   - do:
-      termsenum:
+      terms_enum:
         index:  test_f
         body:  {"field": "foo.bar", "string":"b", "search_after":"bar_f"}
   - length: {terms: 0}
 
   - do:
-      termsenum:
+      terms_enum:
         index:  test_f
         body:  {"field": "foo.bar", "string":"b", "search_after":"baa"}
   - length: {terms: 1}
 
   - do:
-      termsenum:
+      terms_enum:
         index:  test_f
         body:  {"field": "foo.bar", "string":"", "search_after":"baa"}
   - length: {terms: 1}
@@ -334,25 +334,25 @@ teardown:
 ---
 "Test search after constant keyword field":
   - do:
-      termsenum:
+      terms_enum:
         index:  test_ck
         body:  {"field": "foo", "string":"b", "search_after":"baz"}
   - length: {terms: 0}
 
   - do:
-      termsenum:
+      terms_enum:
         index:  test_ck
         body:  {"field": "foo", "string":"b", "search_after":"bar_ck"}
   - length: {terms: 0}
 
   - do:
-      termsenum:
+      terms_enum:
         index:  test_ck
         body:  {"field": "foo", "string":"b", "search_after":"baa"}
   - length: {terms: 1}
 
   - do:
-      termsenum:
+      terms_enum:
         index:  test_ck
         body:  {"field": "foo", "string":"", "search_after":"baa"}
   - length: {terms: 1}
@@ -360,14 +360,14 @@ teardown:
 ---
 "Test index filtering":
   - do:
-      termsenum:
+      terms_enum:
         index:  test_*
         body:  {"field": "foo", "string":"b", "index_filter":{"range":{"timestamp":{"gte":"2021-01-01T01:01:01.000Z"}}}}
   - length: {terms: 1}
 ---
 "Test legal timeout":
   - do:
-      termsenum:
+      terms_enum:
         index:  test_*
         body:  {"field": "foo", "string":"b", "timeout": "1s"}
   - length: {terms: 3}
@@ -375,7 +375,7 @@ teardown:
 "Test illegal timeout":
   - do:
       catch: /Timeout cannot be > 1 minute/
-      termsenum:
+      terms_enum:
         index:  test_*
         body:  {"field": "foo", "string":"b", "timeout": "2m"}
 ---
@@ -383,28 +383,28 @@ teardown:
 
   - do:
       headers: { Authorization: "Basic dGVzdF9hZG1pbjp4LXBhY2stdGVzdC1wYXNzd29yZA==" } # admin_user sees all docs
-      termsenum:
+      terms_enum:
         index:  test_security
         body:  {"field": "foo", "string":"b"}
   - length: {terms: 1}
 
   - do:
       headers: { Authorization: "Basic ZGxzX2FsbF91c2VyOngtcGFjay10ZXN0LXBhc3N3b3Jk" } # dls_all_user sees all docs
-      termsenum:
+      terms_enum:
         index:  test_security
         body:  {"field": "foo", "string":"b"}
   - length: {terms: 1}
 
   - do:
       headers: { Authorization: "Basic ZGxzX3NvbWVfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA==" } # dls_some_user sees selected docs
-      termsenum:
+      terms_enum:
         index:  test_security
         body:  {"field": "foo", "string":"b"}
   - length: {terms: 0}
 
   - do:
       headers: { Authorization: "Basic ZmxzX3VzZXI6eC1wYWNrLXRlc3QtcGFzc3dvcmQ=" } # fls_user can't see field
-      termsenum:
+      terms_enum:
         index:  test_security
         body:  {"field": "foo", "string":"b"}
   - length: {terms: 0}


### PR DESCRIPTION
Backport of #73119