### PR TITLE
[7.12] [DOCS] Clarify when SLM deletes expired snapshots (#73155)

### DIFF
--- a/docs/reference/slm/apis/slm-put.asciidoc
+++ b/docs/reference/slm/apis/slm-put.asciidoc
@@ -94,7 +94,8 @@ Retention rules used to retain and delete snapshots created by the policy.
 `expire_after`::
 (Optional, <<time-units, time units>>)
 Time period after which a snapshot is considered expired and eligible for
-deletion.
+deletion. {slm-init} deletes expired snapshots based on the
+<<slm-retention-schedule,`slm.retention_schedule`>>.
 
 `max_count`::
 (Optional, integer)
@@ -113,8 +114,8 @@ Minimum number of snapshots to retain, even if the snapshots have expired.
 
 `schedule`::
 (Required, <<cron-expressions,Cron syntax>>)
-Periodic or absolute schedule at which the policy creates snapshots and deletes 
-expired snapshots. Schedule changes to existing policies are applied immediately.
+Periodic or absolute schedule at which the policy creates snapshots. {slm-init}
+applies `schedule` changes immediately.
 
 [[slm-api-put-example]]
 ==== {api-examples-title}


### PR DESCRIPTION
Backports the following commits to 7.12:
 - [DOCS] Clarify when SLM deletes expired snapshots (#73155)