### PR TITLE
TermsEnum api - allow null search strings (#73144)

### DIFF
--- a/docs/reference/search/terms-enum.asciidoc
+++ b/docs/reference/search/terms-enum.asciidoc
@@ -72,8 +72,9 @@ Which field to match
 
 [[terms-enum-string-param]]
 `string`::
-(Mandatory, string)
-The string to match at the start of indexed terms
+(Optional, string)
+The string to match at the start of indexed terms. If not provided, all terms in the field
+are considered.
 
 [[terms-enum-size-param]]
 `size`::

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/termsenum/action/TermsEnumRequest.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/termsenum/action/TermsEnumRequest.java
@@ -182,7 +182,9 @@ public class TermsEnumRequest extends BroadcastRequest<TermsEnumRequest> impleme
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startObject();
         builder.field("field", field);
-        builder.field("string", string);
+        if (string != null) {
+            builder.field("string", string);
+        }
         if (searchAfter != null) {
             builder.field("search_after", searchAfter);            
         }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/termsenum/action/TransportTermsEnumAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/termsenum/action/TransportTermsEnumAction.java
@@ -301,7 +301,7 @@ public class TransportTermsEnumAction extends HandledTransportAction<TermsEnumRe
                 if (mappedFieldType != null) {
                     TermsEnum terms = mappedFieldType.getTerms(
                         request.caseInsensitive(),
-                        request.string(),
+                        request.string() == null ? "" : request.string(),
                         queryShardContext,
                         request.searchAfter()                        
                     );

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/terms_enum/10_basic.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/terms_enum/10_basic.yml
@@ -279,6 +279,17 @@ teardown:
   - length: {terms: 0}
 
 ---
+"Test null search string allowed":
+  - skip:
+      version: " - 7.99.99"
+      reason:  TODO remove this skip after PR 73144 is backported to 7.x
+
+  - do:
+      terms_enum:
+        index:  test_k
+        body:  {"field": "foo"}
+  - length: {terms: 1}
+---
 "Test search after keyword field":
   - do:
       terms_enum:

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/terms_enum/10_basic.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/terms_enum/10_basic.yml
@@ -280,10 +280,6 @@ teardown:
 
 ---
 "Test null search string allowed":
-  - skip:
-      version: " - 7.99.99"
-      reason:  TODO remove this skip after PR 73144 is backported to 7.x
-
   - do:
       terms_enum:
         index:  test_k


### PR DESCRIPTION
Allow null search strings (matches all) 

Closes #73141