### PR TITLE
[7.x] Fix comment about number of roles (#73163)

### DIFF
--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/SecurityDocumentationIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/SecurityDocumentationIT.java
@@ -688,7 +688,7 @@ public class SecurityDocumentationIT extends ESRestHighLevelClientTestCase {
 
             List<Role> roles = response.getRoles();
             assertNotNull(response);
-            // 29 system roles plus the three we created
+            // 31 system roles plus the three we created
             assertThat(roles.size(), equalTo(31 + 3));
         }
 


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Fix comment about number of roles (#73163)