### PR TITLE
[DOCS] Update anchor and xrefs for `alias` glossary entry

### DIFF
--- a/docs/reference/glossary.asciidoc
+++ b/docs/reference/glossary.asciidoc
@@ -12,14 +12,11 @@ https://github.com/elastic/stack-docs/tree/master/docs/en/glossary
 
 [glossary]
 [[glossary-alias]] alias::
-[[glossary-index-alias]]
-// tag::index-alias-def[]
 // tag::alias-def[]
 An alias is a secondary name for a group of <<glossary-data-stream,data
 streams>> or <<glossary-index,indices>>. Most {es} APIs accept an alias in place
 of a data stream or index name.
 // end::alias-def[]
-// end::index-alias-def[]
 
 [[glossary-analysis]] analysis::
 // tag::analysis-def[]
@@ -68,7 +65,7 @@ time series data that is accessed occasionally and not normally updated. See
 // tag::component-template-def[]
 Building block for creating <<glossary-index-template,index templates>>. A
 component template can specify <<glossary-mapping,mappings>>,
-{ref}/index-modules.html[index settings], and <<glossary-index-alias,aliases>>. See
+{ref}/index-modules.html[index settings], and <<glossary-alias,aliases>>. See
 {ref}/index-templates.html[index templates].
 // end::component-template-def[]
 
@@ -238,13 +235,13 @@ each phase. See {ref}/ilm-policy-definition.html[Index lifecycle].
 // tag::index-pattern-def[]
 String containing a wildcard (`*`) pattern that can match multiple
 <<glossary-data-stream,data streams>>, <<glossary-index,indices>>, or
-<<glossary-index-alias,aliases>>. See {ref}/multi-index.html[Multi-target syntax].
+<<glossary-alias,aliases>>. See {ref}/multi-index.html[Multi-target syntax].
 // end::index-pattern-def[]
 
 [[glossary-index-template]] index template::
 // tag::index-template-def[]
 Automatically configures the <<glossary-mapping,mappings>>,
-{ref}/index-modules.html[index settings], and <<glossary-index-alias,aliases>>
+{ref}/index-modules.html[index settings], and <<glossary-alias,aliases>>
 of new <<glossary-index,indices>> that match its <<glossary-index-pattern,index
 pattern>>. You can also use index templates to create
 <<glossary-data-stream,data streams>>. See {ref}/index-templates.html[Index
@@ -312,7 +309,7 @@ available for searches. See the {ref}/indices-recovery.html[index recovery API].
 // tag::reindex-def[]
 Copies documents from a source to a destination. The source and destination can
 be a <<glossary-data-stream,data stream>>, <<glossary-index,index>>, or
-<<glossary-index-alias,alias>>. See the {ref}/docs-reindex.html[Reindex API].
+<<glossary-alias,alias>>. See the {ref}/docs-reindex.html[Reindex API].
 // end::reindex-def[]
 
 [[glossary-remote-cluster]] remote cluster::
@@ -339,7 +336,7 @@ Creates a new write index when the current one reaches a certain size, number of
 docs, or age.
 // end::rollover-def-short[]
 A rollover can target a <<glossary-data-stream,data stream>> or an
-<<glossary-index-alias,alias>> with a write index.
+<<glossary-alias,alias>> with a write index.
 // end::rollover-def[]
 
 [[glossary-rollup]] rollup::


### PR DESCRIPTION
Updates anchors and xrefs for the `alias` glossary entry.

Relates to https://github.com/elastic/elasticsearch/pull/73065.