### PR TITLE
[7.12] [DOCS] Use query parameters in search API example (#73158)

### DIFF
--- a/docs/reference/search/search.asciidoc
+++ b/docs/reference/search/search.asciidoc
@@ -755,7 +755,7 @@ Key is the field name. Value is the value for the field.
 
 [source,console]
 ----
-GET /my-index-000001/_search
+GET /my-index-000001/_search?from=40&size=20
 {
   "query": {
     "term": {
@@ -765,6 +765,7 @@ GET /my-index-000001/_search
 }
 ----
 // TEST[setup:my_index]
+// TEST[s/\?from=40&size=20//]
 
 The API returns the following response:
 
@@ -781,7 +782,7 @@ The API returns the following response:
   },
   "hits": {
     "total": {
-      "value": 1,
+      "value": 20,
       "relation": "eq"
     },
     "max_score": 1.3862942,
@@ -811,9 +812,12 @@ The API returns the following response:
             "id": "kimchy"
           }
         }
-      }
+      },
+      ...
     ]
   }
 }
 ----
 // TESTRESPONSE[s/"took": 5/"took": $body.took/]
+// TESTRESPONSE[s/"value": 20,/"value": 1,/]
+// TESTRESPONSE[s/,\n      \.\.\.//]


### PR DESCRIPTION
Backports the following commits to 7.12:
 - [DOCS] Use query parameters in search API example (#73158)