### PR TITLE
[DOCS] Consolidate `aliases` parameters

### DIFF
--- a/docs/reference/cat/alias.asciidoc
+++ b/docs/reference/cat/alias.asciidoc
@@ -27,8 +27,9 @@ for any alias you retrieve.
 
 `<alias>`::
 (Optional, string)
-include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=index-alias]
-
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=alias]
++
+To match all aliases, omit this parameter or use `*`.
 
 [[cat-alias-api-query-params]]
 ==== {api-query-parms-title}

--- a/docs/reference/indices/alias-exists.asciidoc
+++ b/docs/reference/indices/alias-exists.asciidoc
@@ -36,7 +36,7 @@ for the index alias. If you specify an index, you must also have
 
 `<alias>`::
 (Required, string)
-include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=index-alias]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=alias]
 
 include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=index]
 

--- a/docs/reference/indices/clone-index.asciidoc
+++ b/docs/reference/indices/clone-index.asciidoc
@@ -170,10 +170,10 @@ include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=wait_for_active_shards
 
 include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=timeoutparms]
 
-
+[role="child_attributes"]
 [[clone-index-api-request-body]]
 ==== {api-request-body-title}
 
-include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=target-index-aliases]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=aliases]
 
 include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=target-index-settings]

--- a/docs/reference/indices/delete-alias.asciidoc
+++ b/docs/reference/indices/delete-alias.asciidoc
@@ -31,6 +31,12 @@ DELETE /my-index-000001/_alias/alias1
 [[delete-alias-api-path-params]]
 ==== {api-path-parms-title}
 
+`<alias>`::
+(Required, string)
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=alias]
++
+To delete all aliases, use `*`.
+
 `<index>`::
 (Required, string)
 Comma-separated list or wildcard expression of index names
@@ -38,14 +44,6 @@ used to limit the request.
 +
 To include all indices in the cluster,
 use a value of `_all` or `*`.
-
-`<alias>`::
-(Required, string)
-include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=index-alias]
-+
-To delete all aliases,
-use a value of `_all` or `*`.
-
 
 [[delete-alias-api-query-params]]
 ==== {api-query-parms-title}

--- a/docs/reference/indices/get-alias.asciidoc
+++ b/docs/reference/indices/get-alias.asciidoc
@@ -39,13 +39,11 @@ for the index alias. If you specify an index, you must also have
 
 `<alias>`::
 (Optional, string)
-include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=index-alias]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=alias]
 +
-To retrieve information for all index aliases,
-use a value of `_all` or `*`.
+To match all aliases, omit this parameter or use `*`.
 
 include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=index]
-
 
 [[get-alias-api-query-params]]
 ==== {api-query-parms-title}

--- a/docs/reference/indices/shrink-index.asciidoc
+++ b/docs/reference/indices/shrink-index.asciidoc
@@ -223,11 +223,11 @@ include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=wait_for_active_shards
 
 include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=timeoutparms]
 
-
+[role="child_attributes"]
 [[shrink-index-api-request-body]]
 ==== {api-request-body-title}
 
-include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=target-index-aliases]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=aliases]
 
 include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=target-index-settings]
 

--- a/docs/reference/indices/simulate-index.asciidoc
+++ b/docs/reference/indices/simulate-index.asciidoc
@@ -89,9 +89,9 @@ The settings, mappings, and aliases that would be applied to the index.
 .Properties of `template`
 [%collapsible%open]
 ====
-include::{es-ref-dir}/rest-api/common-parms.asciidoc[tag=aliases]
-+
-Response includes an empty object if no aliases would be applied. 
+`aliases`::
+(object) Aliases and related options. If no aliases apply, the response includes
+an empty object. 
 
 include::{es-ref-dir}/rest-api/common-parms.asciidoc[tag=mappings]
 +

--- a/docs/reference/indices/simulate-template.asciidoc
+++ b/docs/reference/indices/simulate-template.asciidoc
@@ -94,6 +94,7 @@ Defaults to `false`.
 
 include::{es-ref-dir}/rest-api/common-parms.asciidoc[tag=master-timeout]
 
+[role="child_attributes"]
 [[simulate-template-api-request-body]]
 ==== {api-request-body-title}
 
@@ -163,7 +164,8 @@ The settings, mappings, and aliases that would be applied to matching indices.
 .Properties of `template`
 [%collapsible%open]
 ====
-include::{es-ref-dir}/rest-api/common-parms.asciidoc[tag=aliases]
+`aliases`::
+(object) Aliases and related options.
 
 include::{es-ref-dir}/rest-api/common-parms.asciidoc[tag=mappings]
 

--- a/docs/reference/indices/split-index.asciidoc
+++ b/docs/reference/indices/split-index.asciidoc
@@ -273,10 +273,10 @@ include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=wait_for_active_shards
 
 include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=timeoutparms]
 
-
+[role="child_attributes"]
 [[split-index-api-request-body]]
 ==== {api-request-body-title}
 
-include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=target-index-aliases]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=aliases]
 
 include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=target-index-settings]

--- a/docs/reference/rest-api/common-parms.asciidoc
+++ b/docs/reference/rest-api/common-parms.asciidoc
@@ -18,24 +18,15 @@ the response only includes ongoing shard recoveries.
 Defaults to `false`.
 end::active-only[]
 
-tag::index-alias[]
-Comma-separated list or wildcard expression of index alias names
-used to limit the request.
-end::index-alias[]
+tag::alias[]
+Comma-separated list of aliases. Supports wildcards (`*`).
+end::alias[]
 
 tag::aliases[]
 `aliases`::
-(Optional, <<indices-aliases,alias object>>) <<indices-aliases,Index aliases>>
-which include the index. Index alias names support <<date-math-index-names,date
-math>>.
+(Optional, object) Aliases to add. Index alias names support
+<<date-math-index-names,date math>>.
 end::aliases[]
-
-tag::target-index-aliases[]
-`aliases`::
-(Optional, <<indices-aliases,alias object>>)
-<<indices-aliases,Index aliases>> which include the target index. Index alias
-names support <<date-math-index-names,date math>>.
-end::target-index-aliases[]
 
 tag::allow-no-indices[]
 `allow_no_indices`::


### PR DESCRIPTION
Changes:

* Consolidates duplicate `aliases` parameter definitions
* Separates definitions for the `aliases` request and response parameters.
* Updates the `alias` parameter.