### PR TITLE
Service Accounts - enforcing token secret min length at authc time (#72519)

### DIFF
--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/service/ServiceAccountService.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/service/ServiceAccountService.java
@@ -31,6 +31,7 @@ import static org.elasticsearch.xpack.security.authc.service.ElasticServiceAccou
 public class ServiceAccountService {
 
     private static final Logger logger = LogManager.getLogger(ServiceAccountService.class);
+    private static final int MIN_TOKEN_SECRET_LENGTH = 10;
 
     private final ServiceAccountTokenStore serviceAccountTokenStore;
     private final HttpTlsRuntimeCheck httpTlsRuntimeCheck;
@@ -97,6 +98,17 @@ public class ServiceAccountService {
             final ServiceAccount account = ACCOUNTS.get(serviceAccountToken.getAccountId().asPrincipal());
             if (account == null) {
                 logger.debug("the [{}] service account does not exist", serviceAccountToken.getAccountId().asPrincipal());
+                listener.onFailure(createAuthenticationException(serviceAccountToken));
+                return;
+            }
+
+            if (serviceAccountToken.getSecret().length() < MIN_TOKEN_SECRET_LENGTH) {
+                logger.debug("failing authentication for service account token [{}],"
+                        + " the provided credential has length [{}]"
+                        + " but a token's secret value must be at least [{}] characters",
+                    serviceAccountToken.getQualifiedName(),
+                    serviceAccountToken.getSecret().length(),
+                    MIN_TOKEN_SECRET_LENGTH);
                 listener.onFailure(createAuthenticationException(serviceAccountToken));
                 return;
             }


### PR DESCRIPTION
The secret value of a service account token generated using either the CLI or
API is a time-based UUID of length 22 which provides sufficient entropy. But
file-based service account tokens can be created with external tools. It is
therefore possible that a token is created with too short secret value. Since
there is no way to detect it at the token creation or load (from the file)
time, this PR adds a check at authentication time to reject such tokens, i.e.
it returns an error if the service token (decoded from the bearer string) has a
secret value with length less than 10.

