### PR TITLE
Dissect parsing: An `%` occurring in the delimiter causes incorrect capture of the `${key}` that follows

### DIFF
--- a/libs/dissect/src/main/java/org/elasticsearch/dissect/DissectParser.java
+++ b/libs/dissect/src/main/java/org/elasticsearch/dissect/DissectParser.java
@@ -83,8 +83,8 @@ import java.util.stream.Collectors;
  * Inspired by the Logstash Dissect Filter by Guy Boertje
  */
 public final class DissectParser {
-    private static final Pattern LEADING_DELIMITER_PATTERN = Pattern.compile("^(.*?)%");
-    private static final Pattern KEY_DELIMITER_FIELD_PATTERN = Pattern.compile("%\\{([^}]*?)}([^%]*)", Pattern.DOTALL);
+    private static final Pattern LEADING_DELIMITER_PATTERN = Pattern.compile("^(.*?)%\\{");
+    private static final Pattern KEY_DELIMITER_FIELD_PATTERN = Pattern.compile("%\\{([^}]*?)}(.+?(?=%\\{)|.*$)", Pattern.DOTALL);
     private static final EnumSet<DissectKey.Modifier> ASSOCIATE_MODIFIERS = EnumSet.of(
         DissectKey.Modifier.FIELD_NAME,
         DissectKey.Modifier.FIELD_VALUE);

--- a/libs/dissect/src/test/java/org/elasticsearch/dissect/DissectParserTests.java
+++ b/libs/dissect/src/test/java/org/elasticsearch/dissect/DissectParserTests.java
@@ -179,6 +179,13 @@ public class DissectParserTests extends ESTestCase {
         assertMiss("%{*a} %{&a} {a} %{*b} %{&b}", "foo bar x baz lol");
     }
 
+    public void testPartialKeyDefinition() {
+        assertMatch("%{a} %%{b},%{c}", "foo %bar,baz", Arrays.asList("a", "b", "c"), Arrays.asList("foo", "bar", "baz"));
+        assertMatch("%{a} %{b},%%{c}", "foo bar,%baz", Arrays.asList("a", "b", "c"), Arrays.asList("foo", "bar", "baz"));
+        assertMatch("%%{a} %{b},%{c}", "%foo bar,baz", Arrays.asList("a", "b", "c"), Arrays.asList("foo", "bar", "baz"));
+        assertMatch("%foo %{bar}", "%foo test", Arrays.asList("bar"),  Arrays.asList("test"));
+    }
+
     public void testAppendAndAssociate() {
         assertMatch("%{a} %{+a} %{*b} %{&b}", "foo bar baz lol", Arrays.asList("a", "baz"), Arrays.asList("foobar", "lol"));
         assertMatch("%{a->} %{+a/2} %{+a/1} %{*b} %{&b}", "foo      bar baz lol x",


### PR DESCRIPTION
Backport #72876 to 7.x branch.

* Extending parser Regex Patterns to take into account % appearing in the input.
* Adding example failure from the ER to the tests