### PR TITLE
Adjust get alias api with aliases pointing to data streams

### DIFF
--- a/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestGetAliasesAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestGetAliasesAction.java
@@ -79,6 +79,10 @@ public class RestGetAliasesAction extends BaseRestHandler {
                 returnedAliasNames.add(aliasMetadata.alias());
             }
         }
+        dataStreamAliases.entrySet().stream()
+            .flatMap(entry -> entry.getValue().stream())
+            .forEach(dataStreamAlias -> returnedAliasNames.add(dataStreamAlias.getName()));
+
         // compute explicitly requested aliases that have are not returned in the result
         final SortedSet<String> missingAliases = new TreeSet<>();
         // first wildcard index, leading "-" as an alias name after this index means
@@ -135,7 +139,7 @@ public class RestGetAliasesAction extends BaseRestHandler {
             }
 
             for (final ObjectObjectCursor<String, List<AliasMetadata>> entry : responseAliasMap) {
-                if (aliasesExplicitlyRequested == false || (aliasesExplicitlyRequested && indicesToDisplay.contains(entry.key))) {
+                if (aliasesExplicitlyRequested == false || indicesToDisplay.contains(entry.key)) {
                     builder.startObject(entry.key);
                     {
                         builder.startObject("aliases");
@@ -149,6 +153,8 @@ public class RestGetAliasesAction extends BaseRestHandler {
                     builder.endObject();
                 }
             }
+            // No need to do filtering like is done for aliases pointing to indices (^),
+            // because this already happens in TransportGetAliasesAction.
             for (Map.Entry<String, List<DataStreamAlias>> entry : dataStreamAliases.entrySet()) {
                 builder.startObject(entry.getKey());
                 {

--- a/x-pack/plugin/data-streams/qa/rest/src/javaRestTest/java/org/elasticsearch/xpack/datastreams/DataStreamsRestIT.java
+++ b/x-pack/plugin/data-streams/qa/rest/src/javaRestTest/java/org/elasticsearch/xpack/datastreams/DataStreamsRestIT.java
@@ -197,4 +197,50 @@ public class DataStreamsRestIT extends ESRestTestCase {
         getAliasesRequest = new Request("GET", "/logs-*/_alias");
         assertThat(entityAsMap(client().performRequest(getAliasesRequest)), equalTo(emptyMap()));
     }
+
+    public void testGetAliasApiFilterByDataStreamAlias() throws Exception {
+        Request putComposableIndexTemplateRequest = new Request("POST", "/_index_template/1");
+        putComposableIndexTemplateRequest.setJsonEntity("{\"index_patterns\": [\"logs-*\"], \"data_stream\": {}}");
+        assertOK(client().performRequest(putComposableIndexTemplateRequest));
+
+        Request createDocRequest = new Request("POST", "/logs-emea/_doc?refresh=true");
+        createDocRequest.setJsonEntity("{ \"@timestamp\": \"2022-12-12\"}");
+        assertOK(client().performRequest(createDocRequest));
+
+        createDocRequest = new Request("POST", "/logs-nasa/_doc?refresh=true");
+        createDocRequest.setJsonEntity("{ \"@timestamp\": \"2022-12-12\"}");
+        assertOK(client().performRequest(createDocRequest));
+
+        Request updateAliasesRequest = new Request("POST", "/_aliases");
+        updateAliasesRequest.setJsonEntity(
+            "{\"actions\":[{\"add\":{\"index\":\"logs-emea\",\"alias\":\"emea\"}}," +
+                "{\"add\":{\"index\":\"logs-nasa\",\"alias\":\"nasa\"}}]}");
+        assertOK(client().performRequest(updateAliasesRequest));
+
+        Response response = client().performRequest(new Request("GET", "/_alias"));
+        assertOK(response);
+        Map<String, Object> getAliasesResponse = entityAsMap(response);
+        assertThat(getAliasesResponse.size(), equalTo(2));
+        assertEquals(Map.of("emea", Map.of()), XContentMapValues.extractValue("logs-emea.aliases", getAliasesResponse));
+        assertEquals(Map.of("nasa", Map.of()), XContentMapValues.extractValue("logs-nasa.aliases", getAliasesResponse));
+
+        response = client().performRequest(new Request("GET", "/_alias/emea"));
+        assertOK(response);
+        getAliasesResponse = entityAsMap(response);
+        assertThat(getAliasesResponse.size(), equalTo(2)); // Adjust to equalTo(1) when #72953 is merged
+        assertEquals(Map.of("emea", Map.of()), XContentMapValues.extractValue("logs-emea.aliases", getAliasesResponse));
+        assertEquals(Map.of(), XContentMapValues.extractValue("logs-nasa.aliases", getAliasesResponse)); // Remove when #72953 is merged
+
+        ResponseException exception =
+            expectThrows(ResponseException.class, () -> client().performRequest(new Request("GET", "/_alias/wrong_name")));
+        response = exception.getResponse();
+        assertThat(response.getStatusLine().getStatusCode(), equalTo(404));
+        getAliasesResponse = entityAsMap(response);
+        assertThat(getAliasesResponse.size(), equalTo(4)); // Adjust to equalTo(2) when #72953 is merged
+        assertEquals("alias [wrong_name] missing", getAliasesResponse.get("error"));
+        assertEquals(404, getAliasesResponse.get("status"));
+        assertEquals(Map.of(), XContentMapValues.extractValue("logs-emea.aliases", getAliasesResponse)); // Remove when #72953 is merged
+        assertEquals(Map.of(), XContentMapValues.extractValue("logs-nasa.aliases", getAliasesResponse)); // Remove when #72953 is merged
+    }
+
 }

--- a/x-pack/plugin/data-streams/qa/rest/src/javaRestTest/java/org/elasticsearch/xpack/datastreams/DataStreamsRestIT.java
+++ b/x-pack/plugin/data-streams/qa/rest/src/javaRestTest/java/org/elasticsearch/xpack/datastreams/DataStreamsRestIT.java
@@ -221,15 +221,15 @@ public class DataStreamsRestIT extends ESRestTestCase {
         assertOK(response);
         Map<String, Object> getAliasesResponse = entityAsMap(response);
         assertThat(getAliasesResponse.size(), equalTo(2));
-        assertEquals(Map.of("emea", Map.of()), XContentMapValues.extractValue("logs-emea.aliases", getAliasesResponse));
-        assertEquals(Map.of("nasa", Map.of()), XContentMapValues.extractValue("logs-nasa.aliases", getAliasesResponse));
+        assertEquals(singletonMap("emea", emptyMap()), XContentMapValues.extractValue("logs-emea.aliases", getAliasesResponse));
+        assertEquals(singletonMap("nasa", emptyMap()), XContentMapValues.extractValue("logs-nasa.aliases", getAliasesResponse));
 
         response = client().performRequest(new Request("GET", "/_alias/emea"));
         assertOK(response);
         getAliasesResponse = entityAsMap(response);
         assertThat(getAliasesResponse.size(), equalTo(2)); // Adjust to equalTo(1) when #72953 is merged
-        assertEquals(Map.of("emea", Map.of()), XContentMapValues.extractValue("logs-emea.aliases", getAliasesResponse));
-        assertEquals(Map.of(), XContentMapValues.extractValue("logs-nasa.aliases", getAliasesResponse)); // Remove when #72953 is merged
+        assertEquals(singletonMap("emea", emptyMap()), XContentMapValues.extractValue("logs-emea.aliases", getAliasesResponse));
+        assertEquals(emptyMap(), XContentMapValues.extractValue("logs-nasa.aliases", getAliasesResponse)); // Remove when #72953 is merged
 
         ResponseException exception =
             expectThrows(ResponseException.class, () -> client().performRequest(new Request("GET", "/_alias/wrong_name")));
@@ -239,8 +239,8 @@ public class DataStreamsRestIT extends ESRestTestCase {
         assertThat(getAliasesResponse.size(), equalTo(4)); // Adjust to equalTo(2) when #72953 is merged
         assertEquals("alias [wrong_name] missing", getAliasesResponse.get("error"));
         assertEquals(404, getAliasesResponse.get("status"));
-        assertEquals(Map.of(), XContentMapValues.extractValue("logs-emea.aliases", getAliasesResponse)); // Remove when #72953 is merged
-        assertEquals(Map.of(), XContentMapValues.extractValue("logs-nasa.aliases", getAliasesResponse)); // Remove when #72953 is merged
+        assertEquals(emptyMap(), XContentMapValues.extractValue("logs-emea.aliases", getAliasesResponse)); // Remove when #72953 is merged
+        assertEquals(emptyMap(), XContentMapValues.extractValue("logs-nasa.aliases", getAliasesResponse)); // Remove when #72953 is merged
     }
 
 }


### PR DESCRIPTION
Backport #73140 to 7.x branch.

Change the get alias api to not return a 404 when filtering
by alias name that refers to data streams.

Originated from #72953
Relates to #66163