### PR TITLE
Service Accounts - Ensure valid random service token name (#73098)

### DIFF
--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/rest/action/service/RestCreateServiceAccountTokenAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/rest/action/service/RestCreateServiceAccountTokenAction.java
@@ -48,7 +48,7 @@ public class RestCreateServiceAccountTokenAction extends SecurityBaseRestHandler
     protected RestChannelConsumer innerPrepareRequest(RestRequest request, NodeClient client) throws IOException {
         String tokenName = request.param("name");
         if (Strings.isNullOrEmpty(tokenName)) {
-            tokenName = UUIDs.base64UUID();
+            tokenName = "token_" + UUIDs.base64UUID();
         }
         final CreateServiceAccountTokenRequest createServiceAccountTokenRequest = new CreateServiceAccountTokenRequest(
                 request.param("namespace"), request.param("service"), tokenName);


### PR DESCRIPTION
The random token name is a base64 UUID. It can sometimes vilolate the
validation rules. The base64 UUID is now prefixed with a string token_
to ensure the name is always valid.
