### PR TITLE
[7.x] [ML] fix empty body on post issue for datafeed _preview (#73205)

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/PreviewDatafeedAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/PreviewDatafeedAction.java
@@ -13,6 +13,7 @@ import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.action.ActionType;
 import org.elasticsearch.client.ElasticsearchClient;
+import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.bytes.BytesReference;
@@ -56,8 +57,13 @@ public class PreviewDatafeedAction extends ActionType<PreviewDatafeedAction.Resp
             PARSER.declareObject(Builder::setJobBuilder, Job.STRICT_PARSER, JOB_CONFIG);
         }
 
-        public static Request fromXContent(XContentParser parser) {
-            return PARSER.apply(parser, null).build();
+        public static Request fromXContent(XContentParser parser, @Nullable String datafeedId) {
+            Builder builder = PARSER.apply(parser, null);
+            // We don't need to check for "inconsistent ids" as we don't parse an ID from the body
+            if (datafeedId != null) {
+                builder.setDatafeedId(datafeedId);
+            }
+            return builder.build();
         }
 
         private final String datafeedId;

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/rest/datafeeds/RestPreviewDatafeedAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/rest/datafeeds/RestPreviewDatafeedAction.java
@@ -43,7 +43,10 @@ public class RestPreviewDatafeedAction extends BaseRestHandler {
     @Override
     protected RestChannelConsumer prepareRequest(RestRequest restRequest, NodeClient client) throws IOException {
         PreviewDatafeedAction.Request request = restRequest.hasContentOrSourceParam() ?
-            PreviewDatafeedAction.Request.fromXContent(restRequest.contentOrSourceParamParser()) :
+            PreviewDatafeedAction.Request.fromXContent(
+                restRequest.contentOrSourceParamParser(),
+                restRequest.param(DatafeedConfig.ID.getPreferredName(), null)
+            ) :
             new PreviewDatafeedAction.Request(restRequest.param(DatafeedConfig.ID.getPreferredName()));
         return channel -> client.execute(PreviewDatafeedAction.INSTANCE, request, new RestToXContentListener<>(channel));
     }

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/ml/preview_datafeed.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/ml/preview_datafeed.yml
@@ -111,6 +111,25 @@ setup:
 
   - do:
       ml.preview_datafeed:
+        datafeed_id: preview-datafeed-feed
+        body: >
+          {}
+  - length: { $body: 4 }
+  - match: { 0.time: 1487376000000 }
+  - match: { 0.airline: foo }
+  - match: { 0.responsetime: 1.0 }
+  - match: { 1.time: 1487377800000 }
+  - match: { 1.airline: foo }
+  - match: { 1.responsetime: 1.0 }
+  - match: { 2.time: 1487379600000 }
+  - match: { 2.airline: bar }
+  - match: { 2.responsetime: 42.0 }
+  - match: { 3.time: 1487379660000 }
+  - match: { 3.airline: foo }
+  - match: { 3.responsetime: 42.0 }
+
+  - do:
+      ml.preview_datafeed:
         body: >
           {
             "datafeed_config": {


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [ML] fix empty body on post issue for datafeed _preview (#73205)