### PR TITLE
[7.x] Fix typo in Rectangle() error message (#73124)

### DIFF
--- a/libs/geo/src/main/java/org/elasticsearch/geometry/Rectangle.java
+++ b/libs/geo/src/main/java/org/elasticsearch/geometry/Rectangle.java
@@ -70,7 +70,7 @@ public class Rectangle implements Geometry {
         this.maxZ = maxZ;
         empty = false;
         if (maxY < minY) {
-            throw new IllegalArgumentException("max y cannot be less than min x");
+            throw new IllegalArgumentException("max y cannot be less than min y");
         }
         if (Double.isNaN(minZ) != Double.isNaN(maxZ)) {
             throw new IllegalArgumentException("only one z value is specified");

--- a/libs/geo/src/test/java/org/elasticsearch/geometry/RectangleTests.java
+++ b/libs/geo/src/test/java/org/elasticsearch/geometry/RectangleTests.java
@@ -45,7 +45,7 @@ public class RectangleTests extends BaseGeometryTestCase<Rectangle> {
 
         ex = expectThrows(IllegalArgumentException.class,
             () -> validator.validate(new Rectangle(2, 3, 1, 2)));
-        assertEquals("max y cannot be less than min x", ex.getMessage());
+        assertEquals("max y cannot be less than min y", ex.getMessage());
 
         ex = expectThrows(IllegalArgumentException.class,
             () -> validator.validate(new Rectangle(2, 3, 2, 1, 5, Double.NaN)));


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Fix typo in Rectangle() error message (#73124)