### PR TITLE
[DOCS] Expand information on using a runtime field without a script

### DIFF
--- a/docs/reference/mapping/runtime.asciidoc
+++ b/docs/reference/mapping/runtime.asciidoc
@@ -177,13 +177,7 @@ data is loaded from Lucene.
 However, there are cases where retrieving fields from `_source` is necessary.
 For example, `text` fields do not have `doc_values` available by default, so you
 have to retrieve values from `_source`. In other instances, you might choose to
-not index specific fields or choose to disable `doc_values` on an index.
-
-With `doc_values` disabled, you could have a field in your index mapping where
-`index` is `true` and `doc_values` is `false`. This combination can be
-confusing because although the field isn't indexed, it is _searchable_. In this
-case, define a runtime field without a script to retrieve values directly
-from `_source`.
+disable `doc_values` on a specific field.
 
 NOTE: You can alternatively prefix the field you want to retrieve values for
 with `params._source` (such as `params._source.day_of_week`). For simplicity,

--- a/docs/reference/mapping/runtime.asciidoc
+++ b/docs/reference/mapping/runtime.asciidoc
@@ -145,34 +145,10 @@ PUT my-index
 
 [[runtime-fields-scriptless]]
 ==== Define runtime fields without a script
-Defining a runtime field to access <<doc-values,`doc_values`>> is faster than
-retrieving values from `_source`. The `doc_values` are loaded directly from
-Lucene `doc_values`, whereas accessing `_source` requires loading values from a
-Lucene stored field. This means that accessing values from `_source` takes about
-twice as long as using a runtime field that extracts from `doc_values`.
-
-However, there are cases such as `text` fields where `doc_values` are not
-available by default, or where you choose to not index specific fields or set
-`doc_values` to `false`. In these instances, you have two options to retrieve
-values directly from `_source` using runtime fields:
-
-* Define a runtime field in the mapping without a script (*recommended*)
-* Prefix the field you want to retrieve values for with `params._source` (such
-as `params._source.day_of_week`)
-
-Defining a runtime field in the mapping definition without a script is the
-recommended option. At query time, {es} implicitly looks in `_source` for a
-field with the same name as the runtime field and returns a value if one exists.
-If a field with the same name doesn’t exist, the response doesn't include any
-values for that runtime field.
-
-Additionally, a runtime field without a script ignores errors as if <<ignore-malformed,`ignore_malformed`>> is `true`. Your runtime field will
-return values for the specified field, regardless of how the data is formatted.
-This behavior is really useful for exploring your data and determining how you
-might want to <<runtime-mapping-fields,map a runtime field>>.
-
-The following request adds a `day_of_week` runtime field to `my-index` without
-a script. 
+Runtime fields typically include a Painless script that manipulates data in some
+way. However, there are instances where you might define a runtime field
+_without_ a script. For example, if you want to retrieve a single value from `_source` without making changes, you don't need a script. You can just create
+a runtime field without a script, such as `day_of_week`:
 
 [source,console]
 ----
@@ -187,6 +163,26 @@ PUT my-index/
   }
 }
 ----
+
+When no script is provided, {es} implicitly looks in `_source` at query time
+for a field with the same name as the runtime field, and returns a value if one
+exists. If a field with the same name doesn’t exist, the response doesn't
+include any values for that runtime field.
+
+In most cases, you should retrieve field values through
+<<doc-values,`doc_values`>> whenever possible. Accessing `doc_values` with a
+runtime field is faster than retrieving values from `_source` because of how
+data is loaded from Lucene.
+
+However, there are cases such as `text` fields where `doc_values` are not
+available by default, or where you choose to not index specific fields or set
+`doc_values` to `false`. In these instances, define a runtime field without a
+script to retrieve values directly from `_source`.
+
+NOTE: You can alternatively prefix the field you want to retrieve values for
+with `params._source` (such as `params._source.day_of_week`). For simplicity,
+defining a runtime field in the mapping definition without a script is the
+recommended option.
 
 [[runtime-updating-scripts]]
 ==== Updating and removing runtime fields

--- a/docs/reference/mapping/runtime.asciidoc
+++ b/docs/reference/mapping/runtime.asciidoc
@@ -145,10 +145,34 @@ PUT my-index
 
 [[runtime-fields-scriptless]]
 ==== Define runtime fields without a script
-You can define a runtime field in the mapping definition without a
-script. At query time, {es} looks in `_source` for a field with the same name
-and returns a value if one exists. If a field with the same name doesn’t
-exist, the response doesn't include any values for that runtime field.
+Defining a runtime field to access <<doc-values,`doc_values`>> is faster than
+retrieving values from `_source`. The `doc_values` are loaded directly from
+Lucene `doc_values`, whereas accessing `_source` requires loading values from a
+Lucene stored field. This means that accessing values from `_source` takes about
+twice as long as using a runtime field that extracts from `doc_values`.
+
+However, there are cases such as `text` fields where `doc_values` are not
+available by default, or where you choose to not index specific fields or set
+`doc_values` to `false`. In these instances, you have two options to retrieve
+values directly from `_source` using runtime fields:
+
+* Define a runtime field in the mapping without a script (*recommended*)
+* Prefix the field you want to retrieve values for with `params._source` (such
+as `params._source.day_of_week`)
+
+Defining a runtime field in the mapping definition without a script is the
+recommended option. At query time, {es} implicitly looks in `_source` for a
+field with the same name as the runtime field and returns a value if one exists.
+If a field with the same name doesn’t exist, the response doesn't include any
+values for that runtime field.
+
+Additionally, a runtime field without a script ignores errors as if <<ignore-malformed,`ignore_malformed`>> is `true`. Your runtime field will
+return values for the specified field, regardless of how the data is formatted.
+This behavior is really useful for exploring your data and determining how you
+might want to <<runtime-mapping-fields,map a runtime field>>.
+
+The following request adds a `day_of_week` runtime field to `my-index` without
+a script. 
 
 [source,console]
 ----

--- a/docs/reference/mapping/runtime.asciidoc
+++ b/docs/reference/mapping/runtime.asciidoc
@@ -147,7 +147,7 @@ PUT my-index
 ==== Define runtime fields without a script
 Runtime fields typically include a Painless script that manipulates data in some
 way. However, there are instances where you might define a runtime field
-_without_ a script. For example, if you want to retrieve a single value from `_source` without making changes, you don't need a script. You can just create
+_without_ a script. For example, if you want to retrieve a single field from `_source` without making changes, you don't need a script. You can just create
 a runtime field without a script, such as `day_of_week`:
 
 [source,console]
@@ -169,20 +169,26 @@ for a field with the same name as the runtime field, and returns a value if one
 exists. If a field with the same name doesn’t exist, the response doesn't
 include any values for that runtime field.
 
-In most cases, you should retrieve field values through
+In most cases, retrieve field values through
 <<doc-values,`doc_values`>> whenever possible. Accessing `doc_values` with a
 runtime field is faster than retrieving values from `_source` because of how
 data is loaded from Lucene.
 
-However, there are cases such as `text` fields where `doc_values` are not
-available by default, or where you choose to not index specific fields or set
-`doc_values` to `false`. In these instances, define a runtime field without a
-script to retrieve values directly from `_source`.
+However, there are cases where retrieving fields from `_source` is necessary.
+For example, `text` fields do not have `doc_values` available by default, so you
+have to retrieve values from `_source`. In other instances, you might choose to
+not index specific fields or choose to disable `doc_values` on an index.
+
+With `doc_values` disabled, you could have a field in your index mapping where
+`index` is `true` and `doc_values` is `false`. This combination can be
+confusing because although the field isn't indexed, it is _searchable_. In this
+case, define a runtime field without a script to retrieve values directly
+from `_source`.
 
 NOTE: You can alternatively prefix the field you want to retrieve values for
 with `params._source` (such as `params._source.day_of_week`). For simplicity,
 defining a runtime field in the mapping definition without a script is the
-recommended option.
+recommended option, whenever possible.
 
 [[runtime-updating-scripts]]
 ==== Updating and removing runtime fields


### PR DESCRIPTION
To retrieve field values from `_source` with a runtime field, you can define a runtime field without a script, or prefix a field with `params._source`. This change expands on the existing section for defining a runtime field without a script to provide additional guidance, and also advocate for using `doc_values` when available. 

Preview link: https://elasticsearch_73219.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/runtime-mapping-fields.html#runtime-fields-scriptless