### PR TITLE
[7.x] The get aliases api should not return entries for data streams with no aliases

### DIFF
--- a/docs/reference/indices/aliases.asciidoc
+++ b/docs/reference/indices/aliases.asciidoc
@@ -599,9 +599,6 @@ The get index alias API returns:
 [source,console-result]
 ----
 {
-  "logs-my_app-default": {
-    "aliases": {}
-  },
   "logs-nginx.access-prod": {
     "aliases": {
       "logs": {}

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/alias/get/TransportGetAliasesAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/alias/get/TransportGetAliasesAction.java
@@ -72,7 +72,8 @@ public class TransportGetAliasesAction extends TransportMasterNodeReadAction<Get
         final SystemIndexAccessLevel systemIndexAccessLevel = indexNameExpressionResolver.getSystemIndexAccessLevel();
         ImmutableOpenMap<String, List<AliasMetadata>> aliases = state.metadata().findAliases(request, concreteIndices);
         listener.onResponse(new GetAliasesResponse(postProcess(request, concreteIndices, aliases, state,
-            systemIndexAccessLevel, threadPool.getThreadContext(), systemIndices), postProcess(request, state)));
+            systemIndexAccessLevel, threadPool.getThreadContext(), systemIndices),
+            postProcess(indexNameExpressionResolver, request, state)));
     }
 
     /**
@@ -106,17 +107,19 @@ public class TransportGetAliasesAction extends TransportMasterNodeReadAction<Get
         return finalResponse;
     }
 
-    Map<String, List<DataStreamAlias>> postProcess(GetAliasesRequest request, ClusterState state) {
+    static Map<String, List<DataStreamAlias>> postProcess(IndexNameExpressionResolver resolver, GetAliasesRequest request,
+                                                          ClusterState state) {
         Map<String, List<DataStreamAlias>> result = new HashMap<>();
         boolean noAliasesSpecified = request.getOriginalAliases() == null || request.getOriginalAliases().length == 0;
-        List<String> requestedDataStreams =
-            indexNameExpressionResolver.dataStreamNames(state, request.indicesOptions(), request.indices());
+        List<String> requestedDataStreams = resolver.dataStreamNames(state, request.indicesOptions(), request.indices());
         for (String requestedDataStream : requestedDataStreams) {
             List<DataStreamAlias> aliases = state.metadata().dataStreamAliases().values().stream()
                 .filter(alias -> alias.getDataStreams().contains(requestedDataStream))
                 .filter(alias -> noAliasesSpecified || Regex.simpleMatch(request.aliases(), alias.getName()))
                 .collect(Collectors.toList());
-            result.put(requestedDataStream, aliases);
+            if (aliases.isEmpty() == false) {
+                result.put(requestedDataStream, aliases);
+            }
         }
         return result;
     }

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/Metadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/Metadata.java
@@ -1300,7 +1300,7 @@ public class Metadata implements Iterable<IndexMetadata>, Diffable<Metadata>, To
             return this;
         }
 
-        public boolean put(String name, String dataStream) {
+        public boolean put(String aliasName, String dataStream) {
             Map<String, DataStream> existingDataStream =
                 Optional.ofNullable((DataStreamMetadata) this.customs.get(DataStreamMetadata.TYPE))
                     .map(dsmd -> new HashMap<>(dsmd.dataStreams()))
@@ -1311,21 +1311,21 @@ public class Metadata implements Iterable<IndexMetadata>, Diffable<Metadata>, To
                     .orElse(new HashMap<>());
 
             if (existingDataStream.containsKey(dataStream) == false) {
-                throw new IllegalArgumentException("alias [" + name + "] refers to a non existing data stream [" + dataStream + "]");
+                throw new IllegalArgumentException("alias [" + aliasName + "] refers to a non existing data stream [" + dataStream + "]");
             }
 
-            DataStreamAlias alias = dataStreamAliases.get(name);
+            DataStreamAlias alias = dataStreamAliases.get(aliasName);
             if (alias == null) {
-                alias = new DataStreamAlias(name, Collections.singletonList(dataStream));
+                alias = new DataStreamAlias(aliasName, Collections.singletonList(dataStream));
             } else {
                 Set<String> dataStreams = new HashSet<>(alias.getDataStreams());
                 boolean added = dataStreams.add(dataStream);
                 if (added == false) {
                     return false;
                 }
-                alias = new DataStreamAlias(name, dataStreams);
+                alias = new DataStreamAlias(aliasName, dataStreams);
             }
-            dataStreamAliases.put(name, alias);
+            dataStreamAliases.put(aliasName, alias);
 
             this.customs.put(DataStreamMetadata.TYPE, new DataStreamMetadata(existingDataStream, dataStreamAliases));
             return true;

--- a/x-pack/plugin/data-streams/qa/rest/src/javaRestTest/java/org/elasticsearch/xpack/datastreams/DataStreamsRestIT.java
+++ b/x-pack/plugin/data-streams/qa/rest/src/javaRestTest/java/org/elasticsearch/xpack/datastreams/DataStreamsRestIT.java
@@ -132,8 +132,7 @@ public class DataStreamsRestIT extends ESRestTestCase {
 
         getAliasesRequest = new Request("GET", "/_aliases");
         getAliasesResponse = entityAsMap(client().performRequest(getAliasesRequest));
-        assertEquals(emptyMap(), XContentMapValues.extractValue("logs-myapp1.aliases", getAliasesResponse));
-        assertEquals(emptyMap(), XContentMapValues.extractValue("logs-myapp2.aliases", getAliasesResponse));
+        assertEquals(emptyMap(), getAliasesResponse);
         expectThrows(ResponseException.class, () -> client().performRequest(new Request("GET", "/logs/_search")));
 
         // Add logs-* -> logs
@@ -157,8 +156,7 @@ public class DataStreamsRestIT extends ESRestTestCase {
 
         getAliasesRequest = new Request("GET", "/_aliases");
         getAliasesResponse = entityAsMap(client().performRequest(getAliasesRequest));
-        assertEquals(emptyMap(), XContentMapValues.extractValue("logs-myapp1.aliases", getAliasesResponse));
-        assertEquals(emptyMap(), XContentMapValues.extractValue("logs-myapp2.aliases", getAliasesResponse));
+        assertEquals(emptyMap(), getAliasesResponse);
         expectThrows(ResponseException.class, () -> client().performRequest(new Request("GET", "/logs/_search")));
     }
 
@@ -227,20 +225,17 @@ public class DataStreamsRestIT extends ESRestTestCase {
         response = client().performRequest(new Request("GET", "/_alias/emea"));
         assertOK(response);
         getAliasesResponse = entityAsMap(response);
-        assertThat(getAliasesResponse.size(), equalTo(2)); // Adjust to equalTo(1) when #72953 is merged
+        assertThat(getAliasesResponse.size(), equalTo(1));
         assertEquals(singletonMap("emea", emptyMap()), XContentMapValues.extractValue("logs-emea.aliases", getAliasesResponse));
-        assertEquals(emptyMap(), XContentMapValues.extractValue("logs-nasa.aliases", getAliasesResponse)); // Remove when #72953 is merged
 
         ResponseException exception =
             expectThrows(ResponseException.class, () -> client().performRequest(new Request("GET", "/_alias/wrong_name")));
         response = exception.getResponse();
         assertThat(response.getStatusLine().getStatusCode(), equalTo(404));
         getAliasesResponse = entityAsMap(response);
-        assertThat(getAliasesResponse.size(), equalTo(4)); // Adjust to equalTo(2) when #72953 is merged
+        assertThat(getAliasesResponse.size(), equalTo(2));
         assertEquals("alias [wrong_name] missing", getAliasesResponse.get("error"));
         assertEquals(404, getAliasesResponse.get("status"));
-        assertEquals(emptyMap(), XContentMapValues.extractValue("logs-emea.aliases", getAliasesResponse)); // Remove when #72953 is merged
-        assertEquals(emptyMap(), XContentMapValues.extractValue("logs-nasa.aliases", getAliasesResponse)); // Remove when #72953 is merged
     }
 
 }


### PR DESCRIPTION
Backport #72953 to 7.x branch.

The get alias api should take into account the aliases parameter when
returning aliases that refer to data streams and don't return entries
for data streams that don't have any aliases pointing to it.

Relates to #66163