### PR TITLE
Restore global state does not merge

### DIFF
--- a/docs/reference/snapshot-restore/apis/restore-snapshot-api.asciidoc
+++ b/docs/reference/snapshot-restore/apis/restore-snapshot-api.asciidoc
@@ -138,9 +138,14 @@ The global state includes:
 * Ingest pipelines
 * {ilm-init} lifecycle policies
 * For snapshots taken after 7.12.0, data stored in system indices, such as Watches and task records, replacing any existing configuration (configurable via `feature_states`)
+
+If `include_global_state` is `true` then the restore operation merges the
+legacy index templates in your cluster with the templates contained in the
+snapshot, replacing any existing ones whose name matches one in the snapshot.
+It completely removes all persistent settings, non-legacy index templates,
+ingest pipelines and {ilm-init} lifecycle policies that exist in your cluster
+and replaces them with the corresponding items from the snapshot.
 --
-+
-IMPORTANT: By default, the entire restore operation will fail if one or more indices included in the snapshot do not have all primary shards available. You can change this behavior by setting <<restore-snapshot-api-partial,`partial`>> to `true`.
 
 [[restore-snapshot-api-feature-states]]
 `feature_states`::

--- a/docs/reference/snapshot-restore/restore-snapshot.asciidoc
+++ b/docs/reference/snapshot-restore/restore-snapshot.asciidoc
@@ -93,10 +93,12 @@ POST /_snapshot/my_backup/snapshot_1/_restore
 <1> By default, `include_global_state` is `false`, meaning the snapshot's
 cluster state and feature states are not restored.
 +
-If `true`, the snapshot's persistent settings, index templates, ingest
-pipelines, and {ilm-init} policies are restored into the current cluster. This
-overwrites any existing cluster settings, templates, pipelines and {ilm-init}
-policies whose names match those in the snapshot.
+If `true` then the restore operation merges the legacy index templates in your
+cluster with the templates contained in the snapshot, replacing any existing
+ones whose name matches one in the snapshot. It completely removes all
+persistent settings, non-legacy index templates, ingest pipelines and
+{ilm-init} lifecycle policies that exist in your cluster and replaces them with
+the corresponding items from the snapshot.
 
 The restore operation must be performed on a functioning cluster. However, an
 existing index can be only restored if it's <<indices-close,closed>> and


### PR DESCRIPTION
Today the docs indicate that restoring a snapshot with
`include_global_state` set will merge the ingest pipelines, ILM
policies, settings etc in the snapshot with those already in the
cluster. This isn't the case, we simply replace all the things. This
commit corrects the docs.