### PR TITLE
[DOCS] Use partially mounted in autoscaling docs

### DIFF
--- a/docs/reference/autoscaling/autoscaling-deciders.asciidoc
+++ b/docs/reference/autoscaling/autoscaling-deciders.asciidoc
@@ -12,11 +12,12 @@ Estimates required storage capacity based on current ingestion into hot nodes.
 Available for policies governing hot data nodes.
 
 <<autoscaling-frozen-shards-decider,Frozen shards decider>>::
-Estimates required memory capacity based on number of frozen shards.
+Estimates required memory capacity based on number of partially mounted shards.
 Available for policies governing frozen data nodes.
 
 <<autoscaling-frozen-storage-decider,Frozen storage decider>>::
-Estimates required storage capacity as a percentage of total frozen data set.
+Estimates required storage capacity as a percentage of the total data set of
+partially mounted indices.
 Available for policies governing frozen data nodes.
 
 <<autoscaling-machine-learning-decider,Machine learning decider>>::

--- a/docs/reference/autoscaling/autoscaling-deciders.asciidoc
+++ b/docs/reference/autoscaling/autoscaling-deciders.asciidoc
@@ -12,7 +12,7 @@ Estimates required storage capacity based on current ingestion into hot nodes.
 Available for policies governing hot data nodes.
 
 <<autoscaling-frozen-shards-decider,Frozen shards decider>>::
-Estimates required memory capacity based on number of partially mounted shards.
+Estimates required memory capacity based on the number of partially mounted shards.
 Available for policies governing frozen data nodes.
 
 <<autoscaling-frozen-storage-decider,Frozen storage decider>>::

--- a/docs/reference/autoscaling/deciders/frozen-shards-decider.asciidoc
+++ b/docs/reference/autoscaling/deciders/frozen-shards-decider.asciidoc
@@ -3,8 +3,8 @@
 === Frozen shards decider
 
 The frozen shards decider (`frozen_shards`) calculates the memory required to search
-the current frozen tier data set. Based on a required memory amount per shard, it
-calculates the necessary memory in the frozen tier.
+the current set of partially mounted indices in the frozen tier. Based on a
+required memory amount per shard, it calculates the necessary memory in the frozen tier.
 
 [[autoscaling-frozen-shards-decider-settings]]
 ==== Configuration settings

--- a/docs/reference/autoscaling/deciders/frozen-storage-decider.asciidoc
+++ b/docs/reference/autoscaling/deciders/frozen-storage-decider.asciidoc
@@ -3,10 +3,10 @@
 === Frozen storage decider
 
 The frozen storage decider (`frozen_storage`) calculates the local storage
-required to search the current set of frozen indices based on a percentage of
-the total data set size. It signals that additional storage capacity is
-necessary when existing capacity is less than the percentage multiplied by
-total data set size.
+required to search the current set of partially mounted indices based on a
+percentage of the total data set size of such indices. It signals that
+additional storage capacity is necessary when existing capacity is less than the
+percentage multiplied by total data set size.
 
 The frozen storage decider is enabled for all policies governing frozen data
 nodes and has no configuration options.


### PR DESCRIPTION
Fixed autoscaling docs to not longer call partially mounted indices or
shards for frozen indices/shards, now uses partially mounted indices or
shards.

Closes #73132