### PR TITLE
Use plugin canonical name instead of rest wrapper canonical name

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/ActionModule.java
+++ b/server/src/main/java/org/elasticsearch/action/ActionModule.java
@@ -460,8 +460,8 @@ public class ActionModule extends AbstractModule {
                     throw new IllegalArgumentException("Cannot have more than one plugin implementing a REST wrapper");
                 }
                 restWrapper = newRestWrapper;
-                if (restWrapper.getClass().getCanonicalName() == null ||
-                    restWrapper.getClass().getCanonicalName().startsWith("org.elasticsearch") == false) {
+                if (plugin.getClass().getCanonicalName() == null ||
+                    plugin.getClass().getCanonicalName().startsWith("org.elasticsearch") == false) {
                     deprecationLogger.deprecate(DeprecationCategory.PLUGINS, "3rd_party_rest_deprecation", "The " +
                         plugin.getClass().getName() + "plugin installs a custom REST wrapper. This functionality is deprecated and will " +
                         "not be possible in Elasticsearch 8.0. If this plugin is intended to provide security features for Elasticsearch " +

--- a/server/src/main/java/org/elasticsearch/action/ActionModule.java
+++ b/server/src/main/java/org/elasticsearch/action/ActionModule.java
@@ -463,7 +463,7 @@ public class ActionModule extends AbstractModule {
                 if (plugin.getClass().getCanonicalName() == null ||
                     plugin.getClass().getCanonicalName().startsWith("org.elasticsearch") == false) {
                     deprecationLogger.deprecate(DeprecationCategory.PLUGINS, "3rd_party_rest_deprecation", "The " +
-                        plugin.getClass().getName() + "plugin installs a custom REST wrapper. This functionality is deprecated and will " +
+                        plugin.getClass().getName() + " plugin installs a custom REST wrapper. This functionality is deprecated and will " +
                         "not be possible in Elasticsearch 8.0. If this plugin is intended to provide security features for Elasticsearch " +
                         "then you should switch to using the built-in Elasticsearch features instead.");
                 }

--- a/server/src/main/java/org/elasticsearch/action/ActionModule.java
+++ b/server/src/main/java/org/elasticsearch/action/ActionModule.java
@@ -460,8 +460,7 @@ public class ActionModule extends AbstractModule {
                     throw new IllegalArgumentException("Cannot have more than one plugin implementing a REST wrapper");
                 }
                 restWrapper = newRestWrapper;
-                if (plugin.getClass().getCanonicalName() == null ||
-                    plugin.getClass().getCanonicalName().startsWith("org.elasticsearch") == false) {
+                if ("org.elasticsearch.xpack.security.Security".equals(plugin.getClass().getCanonicalName()) == false) {
                     deprecationLogger.deprecate(DeprecationCategory.PLUGINS, "3rd_party_rest_deprecation", "The " +
                         plugin.getClass().getName() + " plugin installs a custom REST wrapper. This functionality is deprecated and will " +
                         "not be possible in Elasticsearch 8.0. If this plugin is intended to provide security features for Elasticsearch " +


### PR DESCRIPTION
Use plugin canonical name for the 3rd party Security plugin detection instead of rest wrapper canonical name

Resolve: #73227