### PR TITLE
Fix Spotless failing with InvocationTargetException on JDK 16

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,7 +42,7 @@ plugins {
   id 'elasticsearch.fips'
   id 'elasticsearch.internal-testclusters'
   id 'elasticsearch.run'
-  id "com.diffplug.spotless" version "5.12.0" apply false
+  id "com.diffplug.spotless" version "5.12.5" apply false
 }
 
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,7 @@
 org.gradle.warning.mode=none
 org.gradle.parallel=true
-org.gradle.jvmargs=-XX:+HeapDumpOnOutOfMemoryError -Xss2m
+# We need to declare --add-exports to make spotless working seamlessly with jdk16
+org.gradle.jvmargs=-XX:+HeapDumpOnOutOfMemoryError -Xss2m  --add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED --add-exports jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED --add-exports jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED --add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED --add-exports jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED
 
 # Disable duplicate project id detection
 # See https://docs.gradle.org/current/userguide/upgrading_version_6.html#duplicate_project_names_may_cause_publication_to_fail


### PR DESCRIPTION
This fixes our spotless check tasks in the build when running with java 16. 
Unfortunately the spotless plugin runs within the main gradle java process so we have to make these jvm args changes on the global gradle process. 
Ideally spotless plugin would use a dedicated java process using the gradle worker api. 
We might consider contributing this to the spotless plugin at one point.   