### PR TITLE
[7.12] [DOCS] Update `hidden` anchor (#73287)

### DIFF
--- a/docs/reference/api-conventions.asciidoc
+++ b/docs/reference/api-conventions.asciidoc
@@ -50,7 +50,7 @@ include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=ignore_throttled]
 NOTE: APIs with a single target, such as the <<docs-get,get document API>>, do
 not support multi-target syntax.
 
-[[hidden-indices]]
+[[hidden]]
 ==== Hidden data streams and indices
 
 For most APIs, wildcard expressions do not match hidden data streams and indices

--- a/docs/reference/glossary.asciidoc
+++ b/docs/reference/glossary.asciidoc
@@ -190,7 +190,7 @@ hold time series data that is accessed rarely and not normally updated. See
 // tag::hidden-index-def[]
 <<glossary-data-stream,Data stream>> or <<glossary-index,index>> excluded from
 most <<glossary-index-pattern,index patterns>> by default. See
-{ref}/multi-index.html#hidden-indices[Hidden data streams and indices].
+{ref}/multi-index.html#hidden[Hidden data streams and indices].
 // end::hidden-index-def[]
 
 [[glossary-hot-phase]] hot phase::

--- a/docs/reference/indices/get-data-stream.asciidoc
+++ b/docs/reference/indices/get-data-stream.asciidoc
@@ -201,8 +201,7 @@ policies. To retrieve the lifecycle policy for individual backing indices,
 use the <<indices-get-settings,get index settings API>>.
 
 `hidden`::
-(Boolean)
-If `true`, the data stream is <<hidden-indices,hidden>>.
+(Boolean) If `true`, the data stream is <<hidden,hidden>>.
 ====
 
 [[get-data-stream-api-example]]

--- a/docs/reference/indices/put-index-template.asciidoc
+++ b/docs/reference/indices/put-index-template.asciidoc
@@ -104,8 +104,8 @@ See <<create-index-template,create an index template>>.
 [%collapsible%open]
 ====
 `hidden`::
-(Optional, Boolean)
-If `true`, the data stream is <<hidden-indices,hidden>>. Defaults to `false`.
+(Optional, Boolean) If `true`, the data stream is <<hidden,hidden>>. Defaults to
+`false`.
 ====
 
 `index_patterns`::

--- a/docs/reference/rest-api/common-parms.asciidoc
+++ b/docs/reference/rest-api/common-parms.asciidoc
@@ -225,7 +225,7 @@ Type of data stream that wildcard expressions can match. Supports
 comma-separated values, such as `open,hidden`. Valid values are:
 
 `all`, `hidden`::
-Match any data stream, including <<hidden-indices,hidden>> ones.
+Match any data stream, including <<hidden,hidden>> ones.
 
 `open`, `closed`::
 Matches any non-hidden data stream. Data streams cannot be closed.
@@ -246,7 +246,7 @@ hidden data streams. Supports comma-separated values, such as `open,hidden`.
 Valid values are:
 
 `all`::
-Match any data stream or index, including <<hidden-indices,hidden>> ones.
+Match any data stream or index, including <<hidden,hidden>> ones.
 
 `open`::
 Match open, non-hidden indices. Also matches any non-hidden data stream.


### PR DESCRIPTION
Backports the following commits to 7.12:
 - [DOCS] Update `hidden` anchor (#73287)