### PR TITLE
[7.x] [DOCS] Fix data stream ref in index template docs (#73292)

### DIFF
--- a/docs/reference/indices/put-index-template.asciidoc
+++ b/docs/reference/indices/put-index-template.asciidoc
@@ -95,7 +95,7 @@ specified, meaning that the last component template specified has the highest pr
 `data_stream`::
 (Optional, object)
 If this object is included, the template is used to create data streams and
-their backing indices. Supports an empty object: `data_stream: { }`
+their backing indices. Supports an empty object.
 +
 Data streams require a matching index template with a `data_stream` object.
 See <<create-index-template,create an index template>>.
@@ -293,10 +293,8 @@ To check the `_meta`, you can use the <<indices-get-template, get index template
 [[data-stream-definition]]
 ===== Data stream definition
 
-To use an index template for a data stream, the template must include an empty `data_stream` object. 
-Data stream templates are only used for a stream's backing indices, 
-they are not applied to regular indices.
-See <<create-index-template,create an index template>>.
+To use an index template for data streams, the template must include a
+`data_stream` object. See <<create-index-template,create an index template>>.
 
 [source,console]
 --------------------------------------------------


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [DOCS] Fix data stream ref in index template docs (#73292)