### PR TITLE
[DOCS] Expand and reuse `aliases` parameters

### DIFF
--- a/docs/reference/indices/clone-index.asciidoc
+++ b/docs/reference/indices/clone-index.asciidoc
@@ -170,10 +170,10 @@ include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=wait_for_active_shards
 
 include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=timeoutparms]
 
-
+[role="child_attributes"]
 [[clone-index-api-request-body]]
 ==== {api-request-body-title}
 
-include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=target-index-aliases]
+include::{es-repo-dir}/indices/create-index.asciidoc[tag=aliases]
 
 include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=target-index-settings]

--- a/docs/reference/indices/create-index.asciidoc
+++ b/docs/reference/indices/create-index.asciidoc
@@ -88,7 +88,7 @@ alias can access.
 
 `index_routing`::
 (Optional, string) Value used to route indexing operations to a specific shard.
-If specified, this overrides the `routing` value for indexing operations.
+If specified, this overwrites the `routing` value for indexing operations.
 
 `is_hidden`::
 (Optional, Boolean) If `true`, the index is <<hidden,hidden>>. Defaults to
@@ -104,7 +104,7 @@ specific shard.
 
 `search_routing`::
 (Optional, string) Value used to route search operations to a specific shard. If
-specified, this overrides the `routing` value for search operations.
+specified, this overwrites the `routing` value for search operations.
 =====
 ====
 // end::aliases[]

--- a/docs/reference/indices/create-index.asciidoc
+++ b/docs/reference/indices/create-index.asciidoc
@@ -62,13 +62,52 @@ include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=wait_for_active_shards
 
 include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=timeoutparms]
 
-
+[role="child_attributes"]
 [[indices-create-api-request-body]]
 ==== {api-request-body-title}
 
+// tag::aliases[]
 `aliases`::
-(Optional, <<indices-aliases,alias object>>) Index aliases which include the
-index. Index alias names support <<date-math-index-names,date math>>.
+(Optional, object) Aliases for the index.
++
+.Properties of `aliases` objects
+[%collapsible%open]
+====
+`<alias>`::
+(Required, object) The key is the alias name. Supports
+<<date-math-index-names,date math>>.
++
+The object body contains options for the alias. Supports an empty object.
++
+.Properties of `<alias>`
+[%collapsible%open]
+=====
+`filter`::
+(Optional, <<query-dsl,Query DSL object>>) Query used to limit the documents an
+alias can access.
+
+`index_routing`::
+(Optional, string) Value used to route indexing operations to a specific shard.
+If specified, this overrides the `routing` value for indexing operations.
+
+`is_hidden`::
+(Optional, Boolean) If `true`, the index is <<hidden,hidden>>. Defaults to
+`false`.
+
+`is_write_index`::
+(Optional, Boolean) If `true`, the index is the <<write-index,write index>> for
+the alias. Defaults to `false`.
+
+`routing`::
+(Optional, string) Value used to route indexing and search operations to a
+specific shard.
+
+`search_routing`::
+(Optional, string) Value used to route search operations to a specific shard. If
+specified, this overrides the `routing` value for search operations.
+=====
+====
+// end::aliases[]
 
 include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=mappings]
 

--- a/docs/reference/indices/shrink-index.asciidoc
+++ b/docs/reference/indices/shrink-index.asciidoc
@@ -223,11 +223,11 @@ include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=wait_for_active_shards
 
 include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=timeoutparms]
 
-
+[role="child_attributes"]
 [[shrink-index-api-request-body]]
 ==== {api-request-body-title}
 
-include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=target-index-aliases]
+include::{es-repo-dir}/indices/create-index.asciidoc[tag=aliases]
 
 include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=target-index-settings]
 

--- a/docs/reference/indices/split-index.asciidoc
+++ b/docs/reference/indices/split-index.asciidoc
@@ -273,10 +273,10 @@ include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=wait_for_active_shards
 
 include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=timeoutparms]
 
-
+[role="child_attributes"]
 [[split-index-api-request-body]]
 ==== {api-request-body-title}
 
-include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=target-index-aliases]
+include::{es-repo-dir}/indices/create-index.asciidoc[tag=aliases]
 
 include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=target-index-settings]

--- a/docs/reference/rest-api/common-parms.asciidoc
+++ b/docs/reference/rest-api/common-parms.asciidoc
@@ -30,13 +30,6 @@ which include the index. Index alias names support <<date-math-index-names,date
 math>>.
 end::aliases[]
 
-tag::target-index-aliases[]
-`aliases`::
-(Optional, <<indices-aliases,alias object>>)
-<<indices-aliases,Index aliases>> which include the target index. Index alias
-names support <<date-math-index-names,date math>>.
-end::target-index-aliases[]
-
 tag::allow-no-indices[]
 `allow_no_indices`::
 (Optional, Boolean)


### PR DESCRIPTION
Changes:

* Expands the `aliases` parameter for the create index API to better document
  supported properties.

* Reuses `aliases` parameter in the following API docs:
  * Clone index API
  * Shrink index API
  * Split index API

* Removes `target-index-aliases` from`common-parms.asciidoc`.

### Previews
* Create index API: https://elasticsearch_73296.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/indices-create-index.html#indices-create-api-request-body
* Clone index API: https://elasticsearch_73296.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/indices-clone-index.html#clone-index-api-request-body
* Shrink index API: https://elasticsearch_73296.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/indices-shrink-index.html#shrink-index-api-request-body
* Split index API: https://elasticsearch_73296.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/indices-split-index.html#split-index-api-request-body