### PR TITLE
Make sure to return total hits when field collapsing

### DIFF
--- a/server/src/main/java/org/apache/lucene/search/grouping/CollapsingTopDocsCollector.java
+++ b/server/src/main/java/org/apache/lucene/search/grouping/CollapsingTopDocsCollector.java
@@ -69,7 +69,7 @@ public final class CollapsingTopDocsCollector<T> extends FirstPassGroupingCollec
     public CollapseTopFieldDocs getTopDocs() throws IOException {
         Collection<SearchGroup<T>> groups = super.getTopGroups(0);
         if (groups == null) {
-            TotalHits totalHits = new TotalHits(0, TotalHits.Relation.EQUAL_TO);
+            TotalHits totalHits = new TotalHits(totalHitCount, TotalHits.Relation.EQUAL_TO);
             return new CollapseTopFieldDocs(collapseField, totalHits, new ScoreDoc[0], sort.getSort(), new Object[0]);
         }
         FieldDoc[] docs = new FieldDoc[groups.size()];

--- a/server/src/test/java/org/apache/lucene/grouping/CollapsingTopDocsCollectorSearchAfterTests.java
+++ b/server/src/test/java/org/apache/lucene/grouping/CollapsingTopDocsCollectorSearchAfterTests.java
@@ -223,7 +223,7 @@ public class CollapsingTopDocsCollectorSearchAfterTests extends ESTestCase {
             @Override
             public SortField sortField(boolean reversed) {
                 SortField sortField = new SortField("field", SortField.Type.DOUBLE, reversed);
-                sortField.setMissingValue(reversed ? Double.MIN_VALUE : Double.MAX_VALUE);
+                sortField.setMissingValue(reversed ? Double.NEGATIVE_INFINITY : Double.POSITIVE_INFINITY);
                 return sortField;
             }
         };


### PR DESCRIPTION
Previously, we would always return 0 total hits when there were no groups. Now
that collapsing supports search_after, it's possible for total hits to be
greater than 0 but no groups to return.

This PR also fixes a test bug where we set the wrong missing value for sorting
on doubles.

Fixes #73270.