### PR TITLE
Muting search/110_field_collapsing/field collapsing and search_after

### DIFF
--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search/110_field_collapsing.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search/110_field_collapsing.yml
@@ -258,8 +258,10 @@ setup:
 ---
 "field collapsing and search_after":
   - skip:
-      version: " - 7.13.99"
-      reason: "support for collapsing with search_after was added in 7.14"
+      version: all
+      reason: "AwaitsFix https://github.com/elastic/elasticsearch/issues/73316"
+      #version: " - 7.13.99"
+      #reason: "support for collapsing with search_after was added in 7.14"
   - do:
       search:
         index: test


### PR DESCRIPTION
Due to https://github.com/elastic/elasticsearch/issues/73316