### PR TITLE
Fix spurious error in test

### DIFF
--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/filter/FiltersAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/filter/FiltersAggregatorTests.java
@@ -885,20 +885,16 @@ public class FiltersAggregatorTests extends AggregatorTestCase {
         IntFunction<List<? extends IndexableField>> buildDocWithField
     ) throws IOException {
         AggregationBuilder builder = new FiltersAggregationBuilder("test", new KeyedFilter("q1", exists));
-        CheckedConsumer<RandomIndexWriter, IOException> buildIndex = iw -> {
-            for (int i = 0; i < 10; i++) {
-                iw.addDocument(buildDocWithField.apply(i));
-            }
-            for (int i = 0; i < 10; i++) {
-                iw.addDocument(List.of());
-            }
-        };
         // Exists queries convert to MatchNone if this isn't defined
         FieldNamesFieldMapper.FieldNamesFieldType fnft = new FieldNamesFieldMapper.FieldNamesFieldType(true);
         debugTestCase(
             builder,
             new MatchAllDocsQuery(),
-            buildIndex,
+            iw -> {
+                for (int i = 0; i < 10; i++) {
+                    iw.addDocument(buildDocWithField.apply(i));
+                }
+            },
             (InternalFilters result, Class<? extends Aggregator> impl, Map<String, Map<String, Object>> debug) -> {
                 assertThat(result.getBuckets(), hasSize(1));
                 assertThat(result.getBucketByKey("q1").getDocCount(), equalTo(10L));
@@ -913,7 +909,14 @@ public class FiltersAggregatorTests extends AggregatorTestCase {
             fieldType,
             fnft
         );
-        withAggregator(builder, new MatchAllDocsQuery(), buildIndex, (searcher, aggregator) -> {
+        withAggregator(builder, new MatchAllDocsQuery(), iw -> {
+            for (int i = 0; i < 10; i++) {
+                iw.addDocument(buildDocWithField.apply(i));
+            }
+            for (int i = 0; i < 10; i++) {
+                iw.addDocument(List.of());
+            }
+        }, (searcher, aggregator) -> {
             long estimatedCost = ((FiltersAggregator.FilterByFilter) aggregator).estimateCost(Long.MAX_VALUE);
             Map<String, Object> debug = new HashMap<>();
             aggregator.collectDebugInfo(debug::put);


### PR DESCRIPTION
Fix a test that was failing to correctly identify that we can't optimize
the `exist` filter on keyword fields. We can't optimize it most of the
time, but it thought we could *sometimes* because we can optimize it
*sometimes*. Specifically, when there are no values for that field in
the segment at all. The test bumped into segments like that and,
correctly, optimized the filter. This changes the test to make sure we
never bump into segments like that when we're asserting that we *can't*
optimize the agg.

Closes #73185
