### PR TITLE
[7.x] [DOCS] Clarify that at least one met condition triggers rollover (#73224)

### DIFF
--- a/docs/reference/ilm/actions/ilm-rollover.asciidoc
+++ b/docs/reference/ilm/actions/ilm-rollover.asciidoc
@@ -4,7 +4,7 @@
 
 Phases allowed: hot.
 
-Rolls over a target to a new index when the existing index meets one of the rollover conditions.
+Rolls over a target to a new index when the existing index meets one or more of the rollover conditions.
 
 IMPORTANT: If the rollover action is used on a <<ccr-put-follow,follower index>>,
 policy execution waits until the leader index rolls over (or is


### PR DESCRIPTION
(cherry picked from commit 6a38aff777eed7c04ab0923b4edf8e54ce1431ba)
Signed-off-by: Andrei Dan <andrei.dan@elastic.co>

Backport of #73224