### PR TITLE
Test: Use hamcrest for MatchAssertion (#72928)

### DIFF
--- a/test/framework/build.gradle
+++ b/test/framework/build.gradle
@@ -26,6 +26,7 @@ dependencies {
   api "commons-codec:commons-codec:${versions.commonscodec}"
   api "org.elasticsearch:securemock:${versions.securemock}"
   api "org.elasticsearch:mocksocket:${versions.mocksocket}"
+  api "io.github.nik9000:mapmatcher:0.0.2"
 
   // json schema validation dependencies
   api "com.fasterxml.jackson.core:jackson-core:${versions.jackson}"

--- a/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/section/MatchAssertion.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/section/MatchAssertion.java
@@ -7,16 +7,21 @@
  */
 package org.elasticsearch.test.rest.yaml.section;
 
+
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.common.collect.Tuple;
 import org.elasticsearch.common.xcontent.XContentLocation;
 import org.elasticsearch.common.xcontent.XContentParser;
-import org.elasticsearch.test.NotEqualMessageBuilder;
 
 import java.io.IOException;
+import java.util.List;
+import java.util.Map;
 import java.util.regex.Pattern;
 
+import static io.github.nik9000.mapmatcher.ListMatcher.matchesList;
+import static io.github.nik9000.mapmatcher.MapMatcher.assertMap;
+import static io.github.nik9000.mapmatcher.MapMatcher.matchesMap;
 import static org.elasticsearch.test.hamcrest.RegexMatcher.matches;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
@@ -76,10 +81,13 @@ public class MatchAssertion extends Assertion {
             }
         }
 
-        if (expectedValue.equals(actualValue) == false) {
-            NotEqualMessageBuilder message = new NotEqualMessageBuilder();
-            message.compare(getField(), true, actualValue, expectedValue);
-            throw new AssertionError(getField() + " didn't match expected value:\n" + message);
+        if (expectedValue instanceof Map) {
+            assertThat(actualValue, instanceOf(Map.class));
+            assertMap((Map<?, ?>) actualValue, matchesMap((Map<?, ?>) expectedValue));
+        } else if (expectedValue instanceof List) {
+            assertThat(actualValue, instanceOf(List.class));
+            assertMap((List<?>) actualValue, matchesList((List<?>) expectedValue));
         }
+        assertThat(expectedValue, equalTo(actualValue));
     }
 }

--- a/test/framework/src/test/java/org/elasticsearch/test/rest/yaml/section/MatchAssertionTests.java
+++ b/test/framework/src/test/java/org/elasticsearch/test/rest/yaml/section/MatchAssertionTests.java
@@ -39,6 +39,6 @@ public class MatchAssertionTests extends ESTestCase  {
         matchAssertion.doAssert(singletonMap("a", null), matchAssertion.getExpectedValue());
         AssertionError e = expectThrows(AssertionError.class, () ->
             matchAssertion.doAssert(emptyMap(), matchAssertion.getExpectedValue()));
-        assertThat(e.getMessage(), containsString("expected [null] but not found"));
+        assertThat(e.getMessage(), containsString("Expected a map containing\na: expected null but was <missing>"));
     }
 }


### PR DESCRIPTION
Ever since I wrote `NotEqualsMessageBuilder` I've thought to myself
"if this were a hamcrest matcher we could use it everywhere and get
nicer error messages." A few weeks ago I finally built a work-alike
hamcrest matcher that I think produces better error messages. This plugs
that matcher into the `MatchAssertion` used by our yaml and docs tests.
