### PR TITLE
[DOCS] Add redirects for Cloud pages to SAML and OIDC docs

### DIFF
--- a/docs/reference/redirects.asciidoc
+++ b/docs/reference/redirects.asciidoc
@@ -30,10 +30,33 @@ See <<security-basic-setup,Set up basic security for the Elastic Stack>>.
 
 See <<secure-cluster,Secure the Elastic Stack>>.
 
+// [START] OpenID Connect authentication
+[role="exclude",id="oidc-guide-authentication"]
+=== Configure {es} for OpenID Connect authentication
+
+See <<oidc-elasticsearch-authentication,Configure {es} for OpenID Connect authentication>>.
+
+[role="exclude",id="oidc-kibana"]
+=== Configuring {kib}
+
+See <<oidc-configure-kibana,Configuring {kib} for OpenID Connect>>.
+
+[role="exclude",id="oidc-role-mapping"]
+=== Configuring role mappings
+
+See <<oidc-role-mappings,Configuring OpenID Connect role mappings>>.
+// [END] OpenID Connect authentication
+
+// [START] SAML authentication
 [role="exclude",id="saml-guide"]
 === Configure SAML single-sign on
 
 See <<saml-guide-stack,Configuring SAML single-sign-on on the {stack}>>.
+
+[role="exclude",id="saml-kibana"]
+=== Configuring {kib}
+
+See <<saml-configure-kibana,Configuring {kib} for SAML>>.
 
 [role="exclude",id="saml-guide-authentication"]
 === Configure {es} for SAML authentication
@@ -44,6 +67,12 @@ See <<saml-elasticsearch-authentication,Configure {es} for SAML authentication>>
 ==== Attribute mapping
 
 See <<saml-attributes-mapping,SAML attribute mapping>>.
+
+[role="exclude",id="saml-user-properties"]
+===== User properties
+
+See <<saml-es-user-properties,{es} user properties>>.
+// [END] SAML authentication
 
 [role="exclude",id="active-directory-ssl"]
 === Setting up SSL between {es} and Active Directory

--- a/x-pack/docs/en/security/authentication/oidc-guide.asciidoc
+++ b/x-pack/docs/en/security/authentication/oidc-guide.asciidoc
@@ -44,7 +44,7 @@ called `Callback URI`.
 At the end of the registration process, the OP will assign a Client Identifier and a Client Secret for the RP ({stack}) to use.
 Note these two values as they will be used in the {es} configuration.
 
-[[oidc-guide-authentication]]
+[[oidc-elasticsearch-authentication]]
 === Configure {es} for OpenID Connect authentication
 
 The following is a summary of the configuration steps required in order to enable authentication
@@ -53,7 +53,7 @@ using OpenID Connect in {es}:
 . <<oidc-enable-http,Enable SSL/TLS for HTTP>>
 . <<oidc-enable-token,Enable the Token Service>>
 . <<oidc-create-realm,Create one or more OpenID Connect realms>>
-. <<oidc-role-mapping,Configure role mappings>>
+. <<oidc-role-mappings,Configure role mappings>>
 
 [[oidc-enable-http]]
 ==== Enable TLS for HTTP
@@ -233,7 +233,7 @@ largely supported.
 The goal of claims mapping is to configure {es} in such a way as to be able to map the values of
 specified returned claims to one of the <<oidc-user-properties, user properties>> that are supported
 by {es}. These user properties are then utilized to identify the user in the {kib} UI or the audit
-logs, and can also be used to create <<oidc-role-mapping, role mapping>> rules.
+logs, and can also be used to create <<oidc-role-mappings, role mapping>> rules.
 
 The recommended steps for configuring OpenID Claims mapping are as follows:
 
@@ -297,7 +297,7 @@ NOTE: If the principal property fails to be mapped from a claim, the authenticat
 groups:: _(Recommended)_
     If you wish to use your OP's concept of groups or roles as the basis for a
     user's {es} privileges, you should map them with this property.
-    The `groups` are passed directly to your <<oidc-role-mapping, role mapping rules>>.
+    The `groups` are passed directly to your <<oidc-role-mappings, role mapping rules>>.
 
 name:: _(Optional)_ The user's full name.
 mail:: _(Optional)_ The user's email address.
@@ -407,7 +407,7 @@ xpack.security.authc.realms.oidc.oidc1:
   ssl.certificate_authorities: ["/oidc/company-ca.pem"]
 -------------------------------------------------------------------------------------
 
-[[oidc-role-mapping]]
+[[oidc-role-mappings]]
 === Configuring role mappings
 
 When a user authenticates using OpenID Connect, they are identified to the Elastic Stack,
@@ -504,7 +504,7 @@ that pertain to the authentication event, rather than the user themselves.
 This behaviour can be disabled by adding `populate_user_metadata: false` as
 a setting in the oidc realm.
 
-[[oidc-kibana]]
+[[oidc-configure-kibana]]
 === Configuring {kib}
 
 OpenID Connect authentication in {kib} requires a small number of additional settings

--- a/x-pack/docs/en/security/authentication/saml-guide.asciidoc
+++ b/x-pack/docs/en/security/authentication/saml-guide.asciidoc
@@ -295,7 +295,7 @@ xpack.security.authc.realms.saml.saml1:
   attributes.groups: "roles"
 ------------------------------------------------------------
 
-[[saml-user-properties]]
+[[saml-es-user-properties]]
 ===== {es} user properties
 
 The {es} SAML realm can be configured to map SAML `attributes` to the
@@ -731,7 +731,7 @@ fields.
 This behaviour can be disabled by adding `populate_user_metadata: false` to as
 a setting in the saml realm.
 
-[[saml-kibana]]
+[[saml-configure-kibana]]
 === Configuring {kib}
 
 SAML authentication in {kib} requires a small number of additional settings


### PR DESCRIPTION
Adds necessary redirects to fix broken links from Cloud pages to SAML and OIDC pages in the Elasticsearch Guide. 