### PR TITLE
Refactor uri_parts processor so it can be exposed in Painless

### DIFF
--- a/modules/ingest-common/src/main/java/org/elasticsearch/ingest/common/UriPartsProcessor.java
+++ b/modules/ingest-common/src/main/java/org/elasticsearch/ingest/common/UriPartsProcessor.java
@@ -19,7 +19,6 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.HashMap;
-import java.util.Locale;
 import java.util.Map;
 
 public class UriPartsProcessor extends AbstractProcessor {

--- a/modules/ingest-common/src/main/java/org/elasticsearch/ingest/common/UriPartsProcessor.java
+++ b/modules/ingest-common/src/main/java/org/elasticsearch/ingest/common/UriPartsProcessor.java
@@ -19,6 +19,7 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
 
 public class UriPartsProcessor extends AbstractProcessor {
@@ -58,18 +59,7 @@ public class UriPartsProcessor extends AbstractProcessor {
     public IngestDocument execute(IngestDocument ingestDocument) throws Exception {
         String value = ingestDocument.getFieldValue(field, String.class);
 
-        URI uri = null;
-        URL url = null;
-        try {
-            uri = new URI(value);
-        } catch (URISyntaxException e) {
-            try {
-                url = new URL(value);
-            } catch (MalformedURLException e2) {
-                throw new IllegalArgumentException("unable to parse URI [" + value + "]");
-            }
-        }
-        var uriParts = getUriParts(uri, url);
+        var uriParts = apply(value);
         if (keepOriginal) {
             uriParts.put("original", value);
         }
@@ -79,6 +69,21 @@ public class UriPartsProcessor extends AbstractProcessor {
         }
         ingestDocument.setFieldValue(targetField, uriParts);
         return ingestDocument;
+    }
+
+    public static Map<String, Object> apply(String urlString) {
+        URI uri = null;
+        URL url = null;
+        try {
+            uri = new URI(urlString);
+        } catch (URISyntaxException e) {
+            try {
+                url = new URL(urlString);
+            } catch (MalformedURLException e2) {
+                throw new IllegalArgumentException("unable to parse URI [" + urlString + "]");
+            }
+        }
+        return getUriParts(uri, url);
     }
 
     @SuppressForbidden(reason = "URL.getPath is used only if URI.getPath is unavailable")


### PR DESCRIPTION
Adds a `static apply(String param)` method similar to the one in the [lowercase processor](https://github.com/elastic/elasticsearch/blob/master/modules/ingest-common/src/main/java/org/elasticsearch/ingest/common/LowercaseProcessor.java#L27) so that the URI parts processor functionality can be exposed in Painless.

Relates to #73346