### PR TITLE
Service Accounts - audit logging for service token name (#72198)

### DIFF
--- a/x-pack/docs/en/security/auditing/event-types.asciidoc
+++ b/x-pack/docs/en/security/auditing/event-types.asciidoc
@@ -343,15 +343,21 @@ that have been previously described:
                             uses the <<run-as-privilege, run as authorization functionality>>.
   `authentication.type`::   Method used to authenticate the user.
                             Possible values are `REALM`, `API_KEY`, `TOKEN`, `ANONYMOUS` or `INTERNAL`.
-  `api_key.id`         ::   API key ID returned by the <<security-api-create-api-key,create API key>> request.
+  `apikey.id`          ::   API key ID returned by the <<security-api-create-api-key,create API key>> request.
                             This attribute is only provided for authentication using an API key.
-  `api_key.name`       ::   API key name provided in the <<security-api-create-api-key,create API key>> request.
+  `apikey.name`        ::   API key name provided in the <<security-api-create-api-key,create API key>> request.
                             This attribute is only provided for authentication using an API key.
+  `authentication.token.name` :: Name of the <<service-accounts,service account>> token.
+                                 This attribute is only provided for authentication using a service account token.
 
 * `authentication_failed`:
   `user.name`          ::    The name of the user that failed authentication.
                              If the request authentication token is invalid or
                              unparsable, this information might be missing.
+  `authentication.token.name` :: Name of the <<service-accounts,service account>> token.
+                                 This attribute is only provided for authentication using a service account token.
+                                 If the request authentication token is invalid or unparsable,
+                                 this information might be missing.
 
 * `realm_authentication_failed`:
   `user.name`          ::    The name of the user that failed authentication.
@@ -360,7 +366,10 @@ that have been previously described:
                              in the chain.**
 
 * `run_as_denied` and `run_as_granted`:
-  `user.roles`         ::    The role names of the user as an array.
+  `user.roles`         ::    The role names as an array of the _authenticated_ user which is being
+                             granted or denied the _impersonation_ action.
+                             If authenticated as a <<service-accounts,service account>>,
+                             this is always an empty array.
   `user.name`          ::    The name of the _authenticated_ user which is being
                              granted or denied the _impersonation_ action.
   `user.realm`         ::    The realm name that the _authenticated_ user belongs to.
@@ -372,6 +381,8 @@ that have been previously described:
   `user.roles`         ::    The role names of the user as an array. If authenticated
                              using an API key, this contains the
                              role names of the API key owner.
+                             If authenticated as a <<service-accounts,service account>>,
+                             this is always an empty array.
   `user.name`          ::    The name of the _effective_ user. This is usually the
                              same as the _authenticated_ user, but if using the
                              <<run-as-privilege, run as authorization functionality>>
@@ -391,7 +402,9 @@ that have been previously described:
                              (_impersonator_) user belongs to.
   `authentication.type`::   Method used to authenticate the user.
                             Possible values are `REALM`, `API_KEY`, `TOKEN`, `ANONYMOUS` or `INTERNAL`.
-  `api_key.id`         ::   API key ID returned by the <<security-api-create-api-key,create API key>> request.
+  `apikey.id`          ::   API key ID returned by the <<security-api-create-api-key,create API key>> request.
                             This attribute is only provided for authentication using an API key.
-  `api_key.name`       ::   API key name provided in the <<security-api-create-api-key,create API key>> request.
+  `apikey.name`        ::   API key name provided in the <<security-api-create-api-key,create API key>> request.
                             This attribute is only provided for authentication using an API key.
+  `authentication.token.name` :: Name of the <<service-accounts,service account>> token.
+                                 This attribute is only provided for authentication using a service account token.

--- a/x-pack/plugin/core/src/main/config/log4j2.properties
+++ b/x-pack/plugin/core/src/main/config/log4j2.properties
@@ -21,6 +21,7 @@ appender.audit_rolling.layout.pattern = {\
                 %varsNotEmpty{, "user.roles":%map{user.roles}}\
                 %varsNotEmpty{, "apikey.id":"%enc{%map{apikey.id}}{JSON}"}\
                 %varsNotEmpty{, "apikey.name":"%enc{%map{apikey.name}}{JSON}"}\
+                %varsNotEmpty{, "authentication.token.name":"%enc{%map{authentication.token.name}}{JSON}"}\
                 %varsNotEmpty{, "origin.type":"%enc{%map{origin.type}}{JSON}"}\
                 %varsNotEmpty{, "origin.address":"%enc{%map{origin.address}}{JSON}"}\
                 %varsNotEmpty{, "realm":"%enc{%map{realm}}{JSON}"}\
@@ -58,6 +59,7 @@ appender.audit_rolling.layout.pattern = {\
 # "user.roles" the roles array of the user; these are the roles that are granting privileges
 # "apikey.id" this field is present if and only if the "authentication.type" is "api_key"
 # "apikey.name" this field is present if and only if the "authentication.type" is "api_key"
+# "authentication.token.name" this field is present if and only if the authenticating credential is a service account token
 # "event.type" informs about what internal system generated the event; possible values are "rest", "transport", "ip_filter" and "security_config_change"
 # "origin.address" the remote address and port of the first network hop, i.e. a REST proxy or another cluster node
 # "realm" name of a realm that has generated an "authentication_failed" or an "authentication_successful"; the subject is not yet authenticated

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/audit/logfile/LoggingAuditTrail.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/audit/logfile/LoggingAuditTrail.java
@@ -78,6 +78,7 @@ import org.elasticsearch.xpack.security.Security;
 import org.elasticsearch.xpack.security.audit.AuditLevel;
 import org.elasticsearch.xpack.security.audit.AuditTrail;
 import org.elasticsearch.xpack.security.authc.ApiKeyService;
+import org.elasticsearch.xpack.security.authc.service.ServiceAccountToken;
 import org.elasticsearch.xpack.security.rest.RemoteHostHeader;
 import org.elasticsearch.xpack.security.transport.filter.IPFilter;
 import org.elasticsearch.xpack.security.transport.filter.SecurityIpFilterRule;
@@ -104,6 +105,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static org.elasticsearch.xpack.core.security.SecurityField.setting;
+import static org.elasticsearch.xpack.core.security.authc.service.ServiceAccountSettings.TOKEN_NAME_FIELD;
 import static org.elasticsearch.xpack.security.audit.AuditLevel.ACCESS_DENIED;
 import static org.elasticsearch.xpack.security.audit.AuditLevel.ACCESS_GRANTED;
 import static org.elasticsearch.xpack.security.audit.AuditLevel.ANONYMOUS_ACCESS_DENIED;
@@ -147,6 +149,7 @@ public class LoggingAuditTrail implements AuditTrail, ClusterStateListener {
     public static final String PRINCIPAL_RUN_AS_REALM_FIELD_NAME = "user.run_as.realm";
     public static final String API_KEY_ID_FIELD_NAME = "apikey.id";
     public static final String API_KEY_NAME_FIELD_NAME = "apikey.name";
+    public static final String SERVICE_TOKEN_NAME_FIELD_NAME = "authentication.token.name";
     public static final String PRINCIPAL_ROLES_FIELD_NAME = "user.roles";
     public static final String AUTHENTICATION_TYPE_FIELD_NAME = "authentication.type";
     public static final String REALM_FIELD_NAME = "realm";
@@ -396,18 +399,21 @@ public class LoggingAuditTrail implements AuditTrail, ClusterStateListener {
             final Optional<String[]> indices = indices(transportRequest);
             if (eventFilterPolicyRegistry.ignorePredicate()
                     .test(new AuditEventMetaInfo(Optional.of(token), Optional.empty(), indices, Optional.of(action))) == false) {
-                new LogEntryBuilder()
-                        .with(EVENT_TYPE_FIELD_NAME, TRANSPORT_ORIGIN_FIELD_VALUE)
-                        .with(EVENT_ACTION_FIELD_NAME, "authentication_failed")
-                        .with(ACTION_FIELD_NAME, action)
-                        .with(PRINCIPAL_FIELD_NAME, token.principal())
-                        .with(REQUEST_NAME_FIELD_NAME, transportRequest.getClass().getSimpleName())
-                        .withRequestId(requestId)
-                        .withRestOrTransportOrigin(transportRequest, threadContext)
-                        .with(INDICES_FIELD_NAME, indices.orElse(null))
-                        .withOpaqueId(threadContext)
-                        .withXForwardedFor(threadContext)
-                        .build();
+                final LogEntryBuilder logEntryBuilder = new LogEntryBuilder()
+                    .with(EVENT_TYPE_FIELD_NAME, TRANSPORT_ORIGIN_FIELD_VALUE)
+                    .with(EVENT_ACTION_FIELD_NAME, "authentication_failed")
+                    .with(ACTION_FIELD_NAME, action)
+                    .with(PRINCIPAL_FIELD_NAME, token.principal())
+                    .with(REQUEST_NAME_FIELD_NAME, transportRequest.getClass().getSimpleName())
+                    .withRequestId(requestId)
+                    .withRestOrTransportOrigin(transportRequest, threadContext)
+                    .with(INDICES_FIELD_NAME, indices.orElse(null))
+                    .withOpaqueId(threadContext)
+                    .withXForwardedFor(threadContext);
+                if (token instanceof ServiceAccountToken) {
+                    logEntryBuilder.with(SERVICE_TOKEN_NAME_FIELD_NAME, ((ServiceAccountToken) token).getTokenName());
+                }
+                logEntryBuilder.build();
             }
         }
     }
@@ -453,17 +459,20 @@ public class LoggingAuditTrail implements AuditTrail, ClusterStateListener {
     public void authenticationFailed(String requestId, AuthenticationToken token, RestRequest request) {
         if (events.contains(AUTHENTICATION_FAILED) && eventFilterPolicyRegistry.ignorePredicate()
                 .test(new AuditEventMetaInfo(Optional.of(token), Optional.empty(), Optional.empty(), Optional.empty())) == false) {
-            new LogEntryBuilder()
-                    .with(EVENT_TYPE_FIELD_NAME, REST_ORIGIN_FIELD_VALUE)
-                    .with(EVENT_ACTION_FIELD_NAME, "authentication_failed")
-                    .with(PRINCIPAL_FIELD_NAME, token.principal())
-                    .withRestUriAndMethod(request)
-                    .withRestOrigin(request)
-                    .withRequestBody(request)
-                    .withRequestId(requestId)
-                    .withOpaqueId(threadContext)
-                    .withXForwardedFor(threadContext)
-                    .build();
+            final LogEntryBuilder logEntryBuilder = new LogEntryBuilder()
+                .with(EVENT_TYPE_FIELD_NAME, REST_ORIGIN_FIELD_VALUE)
+                .with(EVENT_ACTION_FIELD_NAME, "authentication_failed")
+                .with(PRINCIPAL_FIELD_NAME, token.principal())
+                .withRestUriAndMethod(request)
+                .withRestOrigin(request)
+                .withRequestBody(request)
+                .withRequestId(requestId)
+                .withOpaqueId(threadContext)
+                .withXForwardedFor(threadContext);
+            if (token instanceof ServiceAccountToken) {
+                logEntryBuilder.with(SERVICE_TOKEN_NAME_FIELD_NAME, ((ServiceAccountToken) token).getTokenName());
+            }
+            logEntryBuilder.build();
         }
     }
 
@@ -1265,6 +1274,9 @@ public class LoggingAuditTrail implements AuditTrail, ClusterStateListener {
                 } else {
                     logEntry.with(PRINCIPAL_REALM_FIELD_NAME, authentication.getAuthenticatedBy().getName());
                 }
+            }
+            if (authentication.isServiceAccount()) {
+                logEntry.with(SERVICE_TOKEN_NAME_FIELD_NAME, (String) authentication.getMetadata().get(TOKEN_NAME_FIELD));
             }
             return this;
         }


### PR DESCRIPTION
Multiple service tokens can be created for the same service account. Each token
has a name to uniquely identify itself. This PR ensures the token name is
logged for audit events of authentication_success, authentication_failed (when
applicable), access_granted and access_denied.
