### PR TITLE
[Test] Synchronize when iterate through SynchronizedCollection (#73080)

### DIFF
--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/authc/TokenAuthIntegTests.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/authc/TokenAuthIntegTests.java
@@ -550,7 +550,6 @@ public class TokenAuthIntegTests extends SecurityIntegTestCase {
         assertEquals("token has already been refreshed more than 30 seconds in the past", e.getHeader("error_description").get(0));
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/68664")
     public void testRefreshingMultipleTimesWithinWindowSucceeds() throws Exception {
         final Clock clock = Clock.systemUTC();
         Client client = client().filterWithHeader(Collections.singletonMap("Authorization",

--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/authc/TokenAuthIntegTests.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/authc/TokenAuthIntegTests.java
@@ -621,11 +621,15 @@ public class TokenAuthIntegTests extends SecurityIntegTestCase {
         completedLatch.await();
         assertThat(failed.get(), equalTo(false));
         // Assert that we only ever got one token/refresh_token pair
-        assertThat((int) tokens.stream().distinct().count(), equalTo(1));
+        synchronized (tokens) {
+            assertThat((int) tokens.stream().distinct().count(), equalTo(1));
+        }
         // Assert that all requests from all threads could authenticate at the time they received the access token
         // see: https://github.com/elastic/elasticsearch/issues/54289
-        assertThat((int) authStatuses.stream().distinct().count(), equalTo(1));
-        assertThat(authStatuses, hasItem(RestStatus.OK));
+        synchronized (authStatuses) {
+            assertThat((int) authStatuses.stream().distinct().count(), equalTo(1));
+            assertThat(authStatuses, hasItem(RestStatus.OK));
+        }
     }
 
     public void testRefreshAsDifferentUser() {


### PR DESCRIPTION
A SychronizedCollection needs to be manually synchronized when iterating
through it, including stream. This is explicitly called out in its
source code
https://github.com/openjdk/jdk15u/blob/master/src/java.base/share/classes/java/util/Collections.java#L2105

NOTE: Though this issue exists for both master and 7.x, the test was
muted for a different reason in master. Hence this PR does not remove
the mute on master. It will remove the mute on 7.x when backporting.

Resolves: #68664
