### PR TITLE
Search analyzer should default to configured index analyzer over default

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/mapper/TextParams.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/TextParams.java
@@ -45,9 +45,11 @@ public final class TextParams {
             this.searchAnalyzer
                 = Parameter.analyzerParam("search_analyzer", true,
                 m -> m.fieldType().getTextSearchInfo().getSearchAnalyzer(), () -> {
-                    NamedAnalyzer defaultAnalyzer = indexAnalyzers.get(AnalysisRegistry.DEFAULT_SEARCH_ANALYZER_NAME);
-                    if (defaultAnalyzer != null) {
-                        return defaultAnalyzer;
+                    if (indexAnalyzer.isConfigured() == false) {
+                        NamedAnalyzer defaultAnalyzer = indexAnalyzers.get(AnalysisRegistry.DEFAULT_SEARCH_ANALYZER_NAME);
+                        if (defaultAnalyzer != null) {
+                            return defaultAnalyzer;
+                        }
                     }
                     return indexAnalyzer.get();
                 })
@@ -56,9 +58,11 @@ public final class TextParams {
             this.searchQuoteAnalyzer
                 = Parameter.analyzerParam("search_quote_analyzer", true,
                 m -> m.fieldType().getTextSearchInfo().getSearchQuoteAnalyzer(), () -> {
-                    NamedAnalyzer defaultAnalyzer = indexAnalyzers.get(AnalysisRegistry.DEFAULT_SEARCH_QUOTED_ANALYZER_NAME);
-                    if (defaultAnalyzer != null) {
-                        return defaultAnalyzer;
+                    if (searchAnalyzer.isConfigured() == false && indexAnalyzer.isConfigured() == false) {
+                        NamedAnalyzer defaultAnalyzer = indexAnalyzers.get(AnalysisRegistry.DEFAULT_SEARCH_QUOTED_ANALYZER_NAME);
+                        if (defaultAnalyzer != null) {
+                            return defaultAnalyzer;
+                        }
                     }
                     return searchAnalyzer.get();
                 })

--- a/server/src/test/java/org/elasticsearch/index/mapper/DefaultAnalyzersTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/DefaultAnalyzersTests.java
@@ -69,6 +69,12 @@ public class DefaultAnalyzersTests extends MapperServiceTestCase {
             MappedFieldType ft = ms.fieldType("field");
             assertEquals("configured", ft.getTextSearchInfo().getSearchAnalyzer().name());
         }
+        {
+            setDefaultSearchAnalyzer = true;
+            MapperService ms = createMapperService(fieldMapping(b -> b.field("type", "text").field("analyzer", "configured")));
+            MappedFieldType ft = ms.fieldType("field");
+            assertEquals("configured", ft.getTextSearchInfo().getSearchAnalyzer().name());
+        }
 
     }
 
@@ -130,6 +136,20 @@ public class DefaultAnalyzersTests extends MapperServiceTestCase {
             setDefaultSearchAnalyzer = true;
             MapperService ms
                 = createMapperService(fieldMapping(b -> b.field("type", "text").field("search_quote_analyzer", "configured")));
+            MappedFieldType ft = ms.fieldType("field");
+            assertEquals("configured", ft.getTextSearchInfo().getSearchQuoteAnalyzer().name());
+        }
+        {
+            setDefaultSearchQuoteAnalyzer = true;
+            setDefaultSearchAnalyzer = false;
+            MapperService ms = createMapperService(fieldMapping(b -> b.field("type", "text").field("analyzer", "configured")));
+            MappedFieldType ft = ms.fieldType("field");
+            assertEquals("configured", ft.getTextSearchInfo().getSearchQuoteAnalyzer().name());
+        }
+        {
+            setDefaultSearchQuoteAnalyzer = true;
+            setDefaultSearchAnalyzer = false;
+            MapperService ms = createMapperService(fieldMapping(b -> b.field("type", "text").field("search_analyzer", "configured")));
             MappedFieldType ft = ms.fieldType("field");
             assertEquals("configured", ft.getTextSearchInfo().getSearchQuoteAnalyzer().name());
         }


### PR DESCRIPTION
When a search or search_quote analyzer on a text mapper is not defined,
we fallback to a configured default search/search_quote analyzer if it
exists.  However, if an index analyzer has been configured on the mapper
then we should first fall back to that.

Fixes #73333