### PR TITLE
[7.x] [DOCS] Remove 7.13.0 coming tag (#73330)

### DIFF
--- a/docs/reference/release-notes/highlights.asciidoc
+++ b/docs/reference/release-notes/highlights.asciidoc
@@ -1,8 +1,6 @@
 [[release-highlights]]
 == What's new in {minor-version}
 
-coming[{minor-version}]
-
 Here are the highlights of what's new and improved in {es} {minor-version}!
 
 For detailed information about this release, see the <<es-release-notes>> and


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [DOCS] Remove 7.13.0 coming tag (#73330)