### PR TITLE
[ML] Further increase memory estimates for categorization

### DIFF
--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportEstimateModelMemoryAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportEstimateModelMemoryAction.java
@@ -200,11 +200,12 @@ public class TransportEstimateModelMemoryAction
             return 0;
         }
 
-        // 10MB is a pretty conservative estimate of the memory requirement for categorization,
+        // 20MB is a pretty conservative estimate of the memory requirement for categorization,
         // providing categorization is working well and not creating large numbers of inappropriate
         // categories.  Often it is considerably less, but it's very hard to predict from simple
-        // statistics.
-        long memoryPerPartitionMb = 10;
+        // statistics, and we have seen some data sets that legitimately create hundreds of
+        // categories, so it's best to allow for this.
+        long memoryPerPartitionMb = 20;
 
         long relevantPartitionFieldCardinalityEstimate = 1;
         if (analysisConfig.getPerPartitionCategorizationConfig().isEnabled()) {
@@ -224,6 +225,10 @@ public class TransportEstimateModelMemoryAction
             if (analysisConfig.getPerPartitionCategorizationConfig().isStopOnWarn() == false) {
                 memoryPerPartitionMb *= 2;
             }
+        } else {
+            // Stop-on-warn is not an option for unpartitioned categorization, so bump up the
+            // estimate like we do when stop-on-warn is disabled with per-partition categorization.
+            memoryPerPartitionMb *= 2;
         }
 
         return ByteSizeValue.ofMb(memoryPerPartitionMb * relevantPartitionFieldCardinalityEstimate).getBytes();

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/action/TransportEstimateModelMemoryActionTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/action/TransportEstimateModelMemoryActionTests.java
@@ -95,7 +95,7 @@ public class TransportEstimateModelMemoryActionTests extends ESTestCase {
         AnalysisConfig analysisConfig =
             createCountAnalysisConfig(randomAlphaOfLength(10), randomBoolean() ? "part" : null);
         assertThat(TransportEstimateModelMemoryAction.calculateCategorizationRequirementBytes(analysisConfig, overallCardinality),
-            is(10L * 1024 * 1024));
+            is(40L * 1024 * 1024));
     }
 
     public void testCalculateCategorizationRequirementBytesPerPartitionCategorization() {
@@ -108,7 +108,7 @@ public class TransportEstimateModelMemoryActionTests extends ESTestCase {
         AnalysisConfig analysisConfig = createCountAnalysisConfigBuilder(randomAlphaOfLength(10), "part")
             .setPerPartitionCategorizationConfig(new PerPartitionCategorizationConfig(true, isStopOnWarn)).build();
         assertThat(TransportEstimateModelMemoryAction.calculateCategorizationRequirementBytes(analysisConfig, overallCardinality),
-            is(partitionCardinality * 10L * (isStopOnWarn ? 1 : 2) * 1024 * 1024));
+            is(partitionCardinality * 20L * (isStopOnWarn ? 1 : 2) * 1024 * 1024));
     }
 
     public void testRoundUpToNextMb() {


### PR DESCRIPTION
Memory estimates for categorization were increased in #68859,
but testing has shown some data sets where categorization
legitimately creates far more categories that usual.

This change doubles the categorization memory estimate to
20MB per partition, and also applies the multiplier when
stop-on-warn is disabled to single partition categorization
(where it is not possible to enable stop-on-warn).