### PR TITLE
Fix small inconsistency in doc_stats search source

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/engine/Engine.java
+++ b/server/src/main/java/org/elasticsearch/index/engine/Engine.java
@@ -98,6 +98,7 @@ public abstract class Engine implements Closeable {
     public static final String MAX_UNSAFE_AUTO_ID_TIMESTAMP_COMMIT_ID = "max_unsafe_auto_id_timestamp";
     public static final String SEARCH_SOURCE = "search"; // TODO: Make source of search enum?
     public static final String CAN_MATCH_SEARCH_SOURCE = "can_match";
+    protected static final String DOC_STATS_SOURCE = "doc_stats";
 
     protected final ShardId shardId;
     protected final Logger logger;
@@ -174,7 +175,7 @@ public abstract class Engine implements Closeable {
         // index.refresh_interval=-1 won't see any doc stats updates at all. This change will give more accurate statistics
         // when indexing but not refreshing in general. Yet, if a refresh happens the internal searcher is refresh as well so we are
         // safe here.
-        try (Searcher searcher = acquireSearcher("docStats", SearcherScope.INTERNAL)) {
+        try (Searcher searcher = acquireSearcher(DOC_STATS_SOURCE, SearcherScope.INTERNAL)) {
             return docsStats(searcher.getIndexReader());
         }
     }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/index/engine/FrozenEngine.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/index/engine/FrozenEngine.java
@@ -216,8 +216,8 @@ public final class FrozenEngine extends ReadOnlyEngine {
             case "load_seq_no":
             case "load_version":
                 assert false : "this is a read-only engine";
-            case "doc_stats":
-                assert false : "doc_stats are overwritten";
+            case DOC_STATS_SOURCE:
+                assert false : "doc stats are eagerly loaded";
             case "refresh_needed":
                 assert false : "refresh_needed is always false";
             case "segments":


### PR DESCRIPTION
This pull request fixes a small inconsistency in the `FrozenEngine` and `Engine` classes when they refer to the source used to open a Searcher for loading doc stats.