### PR TITLE
Use latest Oracle JDK for build

### DIFF
--- a/.ci/java-versions.properties
+++ b/.ci/java-versions.properties
@@ -4,6 +4,6 @@
 # build and test Elasticsearch for this branch. Valid Java versions
 # are 'java' or 'openjdk' followed by the major release number.
 
-ES_BUILD_JAVA=openjdk11
+ES_BUILD_JAVA=java11
 ES_RUNTIME_JAVA=java8
 


### PR DESCRIPTION
Java.net stopped publishing binaries for Java11 so let's switch to using the Oracle builds which are kept up to date.