### PR TITLE
[7.x] Fix Spotless failing with InvocationTargetException on JDK 16 (#73246)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,7 +39,7 @@ plugins {
   id 'elasticsearch.fips'
   id 'elasticsearch.testclusters'
   id 'elasticsearch.run'
-  id "com.diffplug.spotless" version "5.12.0" apply false
+  id "com.diffplug.spotless" version "5.12.5" apply false
 }
 
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,7 @@
 org.gradle.warning.mode=none
 org.gradle.parallel=true
-org.gradle.jvmargs=-XX:+HeapDumpOnOutOfMemoryError -Xss2m
+# We need to declare --add-exports to make spotless working seamlessly with jdk16
+org.gradle.jvmargs=-XX:+HeapDumpOnOutOfMemoryError -Xss2m  --add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED --add-exports jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED --add-exports jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED --add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED --add-exports jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED
 
 # Disable duplicate project id detection
 # See https://docs.gradle.org/current/userguide/upgrading_version_6.html#duplicate_project_names_may_cause_publication_to_fail


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Fix Spotless failing with InvocationTargetException on JDK 16 (#73246)