### PR TITLE
Validate max docs limit with lucene value for ilm rollover policy

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/RolloverAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/RolloverAction.java
@@ -21,6 +21,7 @@ import org.elasticsearch.common.xcontent.ObjectParser.ValueType;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.xpack.core.ilm.Step.StepKey;
+import org.apache.lucene.index.IndexWriter;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -71,6 +72,11 @@ public class RolloverAction implements LifecycleAction {
         if (maxSize == null && maxPrimaryShardSize == null && maxAge == null && maxDocs == null) {
             throw new IllegalArgumentException("At least one rollover condition must be set.");
         }
+
+        if (maxDocs != null && maxDocs > IndexWriter.MAX_DOCS) {
+            throw new IllegalArgumentException("max_docs cannot exceed Lucene limit.");
+        }
+
         this.maxSize = maxSize;
         this.maxPrimaryShardSize = maxPrimaryShardSize;
         this.maxAge = maxAge;

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/RolloverActionTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/RolloverActionTests.java
@@ -6,6 +6,7 @@
  */
 package org.elasticsearch.xpack.core.ilm;
 
+import org.apache.lucene.index.IndexWriter;
 import org.elasticsearch.common.io.stream.Writeable.Reader;
 import org.elasticsearch.common.unit.ByteSizeUnit;
 import org.elasticsearch.common.unit.ByteSizeValue;
@@ -83,6 +84,13 @@ public class RolloverActionTests extends AbstractActionTestCase<RolloverAction> 
         IllegalArgumentException exception = expectThrows(IllegalArgumentException.class,
                 () -> new RolloverAction(null, null, null, null));
         assertEquals("At least one rollover condition must be set.", exception.getMessage());
+    }
+
+    public void testMaxDocsLimit() {
+        Long maxDocsLimit =  Long.valueOf(IndexWriter.MAX_DOCS);
+        IllegalArgumentException exception = expectThrows(IllegalArgumentException.class,
+            () -> new RolloverAction(null, null, null,  maxDocsLimit + 1));
+        assertEquals("max_docs cannot exceed Lucene limit.", exception.getMessage());
     }
 
     public void testToSteps() {


### PR DESCRIPTION
This PR addresses the issue mentioned here https://github.com/elastic/elasticsearch/issues/72786 by preventing a rollover action creation when `max_docs` value is set to a value greater than what Lucene allows.

