### PR TITLE
Service Accounts - show token name for name validation failures (#73131)

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/service/CreateServiceAccountTokenRequest.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/service/CreateServiceAccountTokenRequest.java
@@ -98,7 +98,7 @@ public class CreateServiceAccountTokenRequest extends ActionRequest {
         }
 
         if (false == Validation.isValidServiceAccountTokenName(tokenName)) {
-            validationException = addValidationError(Validation.INVALID_SERVICE_ACCOUNT_TOKEN_NAME_MESSAGE, validationException);
+            validationException = addValidationError(Validation.formatInvalidServiceTokenNameErrorMessage(tokenName), validationException);
         }
         return validationException;
     }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/service/DeleteServiceAccountTokenRequest.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/service/DeleteServiceAccountTokenRequest.java
@@ -98,7 +98,7 @@ public class DeleteServiceAccountTokenRequest extends ActionRequest {
         }
 
         if (false == Validation.isValidServiceAccountTokenName(tokenName)) {
-            validationException = addValidationError(Validation.INVALID_SERVICE_ACCOUNT_TOKEN_NAME_MESSAGE, validationException);
+            validationException = addValidationError(Validation.formatInvalidServiceTokenNameErrorMessage(tokenName), validationException);
         }
         return validationException;
     }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/support/Validation.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/support/Validation.java
@@ -73,6 +73,10 @@ public final class Validation {
         return name != null && VALID_SERVICE_ACCOUNT_TOKEN_NAME.matcher(name).matches();
     }
 
+    public static String formatInvalidServiceTokenNameErrorMessage(String name) {
+        return "invalid service token name [" + name + "]. " + INVALID_SERVICE_ACCOUNT_TOKEN_NAME_MESSAGE;
+    }
+
     public static final class Users {
 
         private static final int MIN_PASSWD_LENGTH = 6;

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/action/service/CreateServiceAccountTokenRequestTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/action/service/CreateServiceAccountTokenRequestTests.java
@@ -57,6 +57,8 @@ public class CreateServiceAccountTokenRequestTests extends ESTestCase {
             new CreateServiceAccountTokenRequest(namespace, serviceName, ValidationTests.randomInvalidTokenName());
         final ActionRequestValidationException validation3 = request3.validate();
         assertThat(validation3.validationErrors(), contains(containsString(Validation.INVALID_SERVICE_ACCOUNT_TOKEN_NAME_MESSAGE)));
+        assertThat(validation3.validationErrors(),
+            contains(containsString("invalid service token name [" + request3.getTokenName() + "]")));
 
         final CreateServiceAccountTokenRequest request4 = new CreateServiceAccountTokenRequest(namespace, serviceName, tokenName);
         final ActionRequestValidationException validation4 = request4.validate();

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/action/service/DeleteServiceAccountTokenRequestTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/action/service/DeleteServiceAccountTokenRequestTests.java
@@ -73,6 +73,8 @@ public class DeleteServiceAccountTokenRequestTests extends AbstractWireSerializi
             new CreateServiceAccountTokenRequest(namespace, serviceName, ValidationTests.randomInvalidTokenName());
         final ActionRequestValidationException validation3 = request3.validate();
         assertThat(validation3.validationErrors(), contains(containsString(Validation.INVALID_SERVICE_ACCOUNT_TOKEN_NAME_MESSAGE)));
+        assertThat(validation3.validationErrors(),
+            contains(containsString("invalid service token name [" + request3.getTokenName() + "]")));
 
         final CreateServiceAccountTokenRequest request4 = new CreateServiceAccountTokenRequest(namespace, serviceName, tokenName);
         final ActionRequestValidationException validation4 = request4.validate();

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/service/FileTokensTool.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/service/FileTokensTool.java
@@ -169,7 +169,7 @@ public class FileTokensTool extends LoggingAwareMultiCommand {
                 + Strings.collectionToDelimitedString(ServiceAccountService.getServiceAccountPrincipals(), ",") + "]");
         }
         if (false == Validation.isValidServiceAccountTokenName(tokenName)) {
-            throw new UserException(ExitCodes.CODE_ERROR, Validation.INVALID_SERVICE_ACCOUNT_TOKEN_NAME_MESSAGE);
+            throw new UserException(ExitCodes.CODE_ERROR, Validation.formatInvalidServiceTokenNameErrorMessage(tokenName));
         }
         return new ServiceAccountTokenId(ServiceAccountId.fromPrincipal(principal), tokenName);
     }

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/service/ServiceAccountToken.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/service/ServiceAccountToken.java
@@ -166,7 +166,7 @@ public class ServiceAccountToken implements AuthenticationToken, Closeable {
         public ServiceAccountTokenId(ServiceAccountId accountId, String tokenName) {
             this.accountId = Objects.requireNonNull(accountId, "service account ID cannot be null");
             if (false == Validation.isValidServiceAccountTokenName(tokenName)) {
-                throw new IllegalArgumentException(Validation.INVALID_SERVICE_ACCOUNT_TOKEN_NAME_MESSAGE);
+                throw new IllegalArgumentException(Validation.formatInvalidServiceTokenNameErrorMessage(tokenName));
             }
             this.tokenName = Objects.requireNonNull(tokenName, "service account token name cannot be null");
         }

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/rest/action/service/RestClearServiceAccountTokenStoreCacheAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/rest/action/service/RestClearServiceAccountTokenStoreCacheAction.java
@@ -55,7 +55,7 @@ public class RestClearServiceAccountTokenStoreCacheAction extends SecurityBaseRe
             final Set<String> qualifiedTokenNames = new HashSet<>(tokenNames.length);
             for (String name: tokenNames) {
                 if (false == Validation.isValidServiceAccountTokenName(name)) {
-                    throw new IllegalArgumentException(Validation.INVALID_SERVICE_ACCOUNT_TOKEN_NAME_MESSAGE + " got: [" + name + "]");
+                    throw new IllegalArgumentException(Validation.formatInvalidServiceTokenNameErrorMessage(name));
                 }
                 qualifiedTokenNames.add(namespace + "/" + service + "/" + name);
             }

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/service/ServiceAccountTokenTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/service/ServiceAccountTokenTests.java
@@ -24,9 +24,11 @@ public class ServiceAccountTokenTests extends ESTestCase {
         final ServiceAccountId accountId = new ServiceAccountId(randomAlphaOfLengthBetween(3, 8), randomAlphaOfLengthBetween(3, 8));
         ServiceAccountToken.newToken(accountId, ValidationTests.randomTokenName());
 
+        final String invalidTokeName = ValidationTests.randomInvalidTokenName();
         final IllegalArgumentException e1 = expectThrows(IllegalArgumentException.class,
-            () -> ServiceAccountToken.newToken(accountId, ValidationTests.randomInvalidTokenName()));
+            () -> ServiceAccountToken.newToken(accountId, invalidTokeName));
         assertThat(e1.getMessage(), containsString(Validation.INVALID_SERVICE_ACCOUNT_TOKEN_NAME_MESSAGE));
+        assertThat(e1.getMessage(), containsString("invalid service token name [" + invalidTokeName + "]"));
 
         final NullPointerException e2 =
             expectThrows(NullPointerException.class, () -> ServiceAccountToken.newToken(null, ValidationTests.randomTokenName()));
@@ -42,9 +44,11 @@ public class ServiceAccountTokenTests extends ESTestCase {
             expectThrows(NullPointerException.class, () -> new ServiceAccountToken(null, ValidationTests.randomTokenName(), secret));
         assertThat(e1.getMessage(), containsString("service account ID cannot be null"));
 
+        final String invalidTokenName = ValidationTests.randomInvalidTokenName();
         final IllegalArgumentException e2 = expectThrows(IllegalArgumentException.class,
-            () -> new ServiceAccountToken(accountId, ValidationTests.randomInvalidTokenName(), secret));
+            () -> new ServiceAccountToken(accountId, invalidTokenName, secret));
         assertThat(e2.getMessage(), containsString(Validation.INVALID_SERVICE_ACCOUNT_TOKEN_NAME_MESSAGE));
+        assertThat(e2.getMessage(), containsString("invalid service token name [" + invalidTokenName + "]"));
 
         final NullPointerException e3 =
             expectThrows(NullPointerException.class, () -> new ServiceAccountToken(accountId, ValidationTests.randomTokenName(), null));

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/rest/action/service/RestClearServiceAccountTokenStoreCacheActionTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/rest/action/service/RestClearServiceAccountTokenStoreCacheActionTests.java
@@ -105,5 +105,6 @@ public class RestClearServiceAccountTokenStoreCacheActionTests extends RestActio
         final IllegalArgumentException e =
             expectThrows(IllegalArgumentException.class, () -> restAction.innerPrepareRequest(fakeRestRequest, mock(NodeClient.class)));
         assertThat(e.getMessage(), containsString(Validation.INVALID_SERVICE_ACCOUNT_TOKEN_NAME_MESSAGE));
+        assertThat(e.getMessage(), containsString("invalid service token name [" + names[0] + "]"));
     }
 }

--- a/x-pack/qa/security-tools-tests/src/test/java/org/elasticsearch/xpack/security/authc/service/FileTokensToolTests.java
+++ b/x-pack/qa/security-tools-tests/src/test/java/org/elasticsearch/xpack/security/authc/service/FileTokensToolTests.java
@@ -179,6 +179,7 @@ public class FileTokensToolTests extends CommandTestCase {
         final UserException e = expectThrows(UserException.class, () -> execute(args));
         assertServiceTokenNotExists("elastic/fleet-server/" + tokenName);
         assertThat(e.getMessage(), containsString(Validation.INVALID_SERVICE_ACCOUNT_TOKEN_NAME_MESSAGE));
+        assertThat(e.getMessage(), containsString("invalid service token name [" + tokenName + "]"));
     }
 
     public void testCreateTokenWithInvalidServiceAccount() throws Exception {
@@ -215,6 +216,7 @@ public class FileTokensToolTests extends CommandTestCase {
             new String[] { "delete", pathHomeParameter, "elastic/fleet-server", tokenName2 };
         final UserException e2 = expectThrows(UserException.class, () -> execute(args));
         assertThat(e2.getMessage(), containsString(Validation.INVALID_SERVICE_ACCOUNT_TOKEN_NAME_MESSAGE));
+        assertThat(e2.getMessage(), containsString("invalid service token name [" + tokenName2 + "]"));
 
         // Non-exist token
         final Path serviceTokensFile = confDir.resolve("service_tokens");


### PR DESCRIPTION
The code now shows the exact token name when it fails to validate. So
it is no longer needed to guess the actual failure.

