### PR TITLE
Service Accounts - Add token source to authenticate metadata (#73135)

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authc/Authentication.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authc/Authentication.java
@@ -29,7 +29,6 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 
-import static org.elasticsearch.xpack.core.security.authc.service.ServiceAccountSettings.TOKEN_NAME_FIELD;
 import static org.elasticsearch.xpack.core.security.authz.privilege.ManageOwnApiKeyClusterPrivilege.API_KEY_ID_KEY;
 
 // TODO(hub-cap) Clean this up after moving User over - This class can re-inherit its field AUTHENTICATION_KEY in AuthenticationField.
@@ -233,9 +232,12 @@ public class Authentication implements ToXContentObject {
         builder.field(User.Fields.FULL_NAME.getPreferredName(), user.fullName());
         builder.field(User.Fields.EMAIL.getPreferredName(), user.email());
         if (isServiceAccount()) {
-            final String tokenName = (String) getMetadata().get(TOKEN_NAME_FIELD);
+            final String tokenName = (String) getMetadata().get(ServiceAccountSettings.TOKEN_NAME_FIELD);
             assert tokenName != null : "token name cannot be null";
-            builder.field(User.Fields.TOKEN.getPreferredName(), org.elasticsearch.common.collect.Map.of("name", tokenName));
+            final String tokenSource = (String) getMetadata().get(ServiceAccountSettings.TOKEN_SOURCE_FIELD);
+            assert tokenSource != null : "token source cannot be null";
+            builder.field(User.Fields.TOKEN.getPreferredName(),
+                org.elasticsearch.common.collect.Map.of("name", tokenName, "type", ServiceAccountSettings.REALM_TYPE + "_" + tokenSource));
         }
         builder.field(User.Fields.METADATA.getPreferredName(), user.metadata());
         builder.field(User.Fields.ENABLED.getPreferredName(), user.enabled());

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authc/service/ServiceAccountSettings.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authc/service/ServiceAccountSettings.java
@@ -12,6 +12,7 @@ public final class ServiceAccountSettings {
     public static final String REALM_TYPE = "_service_account";
     public static final String REALM_NAME = "_service_account";
     public static final String TOKEN_NAME_FIELD = "_token_name";
+    public static final String TOKEN_SOURCE_FIELD = "_token_source";
 
     private ServiceAccountSettings() {}
 }

--- a/x-pack/plugin/security/qa/service-account/src/javaRestTest/java/org/elasticsearch/xpack/security/authc/service/ServiceAccountIT.java
+++ b/x-pack/plugin/security/qa/service-account/src/javaRestTest/java/org/elasticsearch/xpack/security/authc/service/ServiceAccountIT.java
@@ -50,7 +50,8 @@ public class ServiceAccountIT extends ESRestTestCase {
         + "  \"full_name\": \"Service account - elastic/fleet-server\",\n"
         + "  \"email\": null,\n"
         + "  \"token\": {\n"
-        + "    \"name\": \"%s\"\n"
+        + "    \"name\": \"%s\",\n"
+        + "    \"type\": \"_service_account_%s\"\n"
         + "  },\n"
         + "  \"metadata\": {\n"
         + "    \"_elastic_service_account\": true\n"
@@ -176,7 +177,7 @@ public class ServiceAccountIT extends ESRestTestCase {
         assertOK(response);
         assertThat(responseAsMap(response),
             equalTo(XContentHelper.convertToMap(
-                new BytesArray(String.format(Locale.ROOT, AUTHENTICATE_RESPONSE, "token1")),
+                new BytesArray(String.format(Locale.ROOT, AUTHENTICATE_RESPONSE, "token1", "file")),
                 false, XContentType.JSON).v2()));
     }
 
@@ -254,7 +255,7 @@ public class ServiceAccountIT extends ESRestTestCase {
         assertOK(response);
         assertThat(responseAsMap(response),
             equalTo(XContentHelper.convertToMap(
-                new BytesArray(String.format(Locale.ROOT, AUTHENTICATE_RESPONSE, "api-token-1")),
+                new BytesArray(String.format(Locale.ROOT, AUTHENTICATE_RESPONSE, "api-token-1", "index")),
                 false, XContentType.JSON).v2()));
     }
 

--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/authc/service/ServiceAccountSingleNodeTests.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/authc/service/ServiceAccountSingleNodeTests.java
@@ -95,7 +95,7 @@ public class ServiceAccountSingleNodeTests extends SecuritySingleNodeTestCase {
             createServiceAccountClient().execute(AuthenticateAction.INSTANCE, authenticateRequest).actionGet();
         final String nodeName = node().settings().get(Node.NODE_NAME_SETTING.getKey());
         assertThat(authenticateResponse.authentication(), equalTo(
-           getExpectedAuthentication("token1")
+           getExpectedAuthentication("token1", "file")
         ));
     }
 
@@ -108,7 +108,7 @@ public class ServiceAccountSingleNodeTests extends SecuritySingleNodeTestCase {
         final AuthenticateRequest authenticateRequest = new AuthenticateRequest("elastic/fleet-server");
         final AuthenticateResponse authenticateResponse = createServiceAccountClient(secretValue1.toString())
             .execute(AuthenticateAction.INSTANCE, authenticateRequest).actionGet();
-        assertThat(authenticateResponse.authentication(), equalTo(getExpectedAuthentication("api-token-1")));
+        assertThat(authenticateResponse.authentication(), equalTo(getExpectedAuthentication("api-token-1", "index")));
         // cache is populated after authenticate
         assertThat(cache.count(), equalTo(1));
 
@@ -168,14 +168,14 @@ public class ServiceAccountSingleNodeTests extends SecuritySingleNodeTestCase {
         return client().filterWithHeader(org.elasticsearch.common.collect.Map.of("Authorization", "Bearer " + bearerString));
     }
 
-    private Authentication getExpectedAuthentication(String tokenName) {
+    private Authentication getExpectedAuthentication(String tokenName, String tokenSource) {
         final String nodeName = node().settings().get(Node.NODE_NAME_SETTING.getKey());
         return new Authentication(
             new User("elastic/fleet-server", Strings.EMPTY_ARRAY, "Service account - elastic/fleet-server", null,
                 org.elasticsearch.common.collect.Map.of("_elastic_service_account", true), true),
             new Authentication.RealmRef("_service_account", "_service_account", nodeName),
             null, Version.CURRENT, Authentication.AuthenticationType.TOKEN,
-            org.elasticsearch.common.collect.Map.of("_token_name", tokenName)
+            org.elasticsearch.common.collect.Map.of("_token_name", tokenName, "_token_source", tokenSource)
         );
     }
 
@@ -194,6 +194,6 @@ public class ServiceAccountSingleNodeTests extends SecuritySingleNodeTestCase {
         final AuthenticateResponse authenticateResponse =
             createServiceAccountClient(secret.toString())
                 .execute(AuthenticateAction.INSTANCE, authenticateRequest).actionGet();
-        assertThat(authenticateResponse.authentication(), equalTo(getExpectedAuthentication(tokenName)));
+        assertThat(authenticateResponse.authentication(), equalTo(getExpectedAuthentication(tokenName, "index")));
     }
 }

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/service/CachingServiceAccountTokenStore.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/service/CachingServiceAccountTokenStore.java
@@ -18,6 +18,7 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.util.concurrent.ListenableFuture;
 import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.xpack.core.security.action.service.TokenInfo.TokenSource;
 import org.elasticsearch.xpack.core.security.authc.support.Hasher;
 import org.elasticsearch.xpack.core.security.support.CacheIteratorHelper;
 import org.elasticsearch.xpack.security.support.CacheInvalidatorRegistry;
@@ -62,7 +63,7 @@ public abstract class CachingServiceAccountTokenStore implements ServiceAccountT
     }
 
     @Override
-    public void authenticate(ServiceAccountToken token, ActionListener<Boolean> listener) {
+    public void authenticate(ServiceAccountToken token, ActionListener<StoreAuthenticationResult> listener) {
         try {
             if (cache == null) {
                 doAuthenticate(token, listener);
@@ -74,7 +75,7 @@ public abstract class CachingServiceAccountTokenStore implements ServiceAccountT
         }
     }
 
-    private void authenticateWithCache(ServiceAccountToken token, ActionListener<Boolean> listener) {
+    private void authenticateWithCache(ServiceAccountToken token, ActionListener<StoreAuthenticationResult> listener) {
         assert cache != null;
         try {
             final AtomicBoolean valueAlreadyInCache = new AtomicBoolean(true);
@@ -85,25 +86,25 @@ public abstract class CachingServiceAccountTokenStore implements ServiceAccountT
             if (valueAlreadyInCache.get()) {
                 listenableCacheEntry.addListener(ActionListener.wrap(result -> {
                     if (result.success) {
-                        listener.onResponse(result.verify(token));
+                        listener.onResponse(new StoreAuthenticationResult(result.verify(token), getTokenSource()));
                     } else if (result.verify(token)) {
                         // same wrong token
-                        listener.onResponse(false);
+                        listener.onResponse(new StoreAuthenticationResult(false, getTokenSource()));
                     } else {
                         cache.invalidate(token.getQualifiedName(), listenableCacheEntry);
                         authenticateWithCache(token, listener);
                     }
                 }, listener::onFailure), threadPool.generic(), threadPool.getThreadContext());
             } else {
-                doAuthenticate(token, ActionListener.wrap(success -> {
-                    if (false == success) {
+                doAuthenticate(token, ActionListener.wrap(storeAuthenticationResult -> {
+                    if (false == storeAuthenticationResult.isSuccess()) {
                         // Do not cache failed attempt
                         cache.invalidate(token.getQualifiedName(), listenableCacheEntry);
                     } else {
                         logger.trace("cache service token [{}] authentication result", token.getQualifiedName());
                     }
-                    listenableCacheEntry.onResponse(new CachedResult(hasher, success, token));
-                    listener.onResponse(success);
+                    listenableCacheEntry.onResponse(new CachedResult(hasher, storeAuthenticationResult.isSuccess(), token));
+                    listener.onResponse(storeAuthenticationResult);
                 }, e -> {
                     // In case of failure, evict the cache entry and notify all listeners
                     cache.invalidate(token.getQualifiedName(), listenableCacheEntry);
@@ -154,7 +155,9 @@ public abstract class CachingServiceAccountTokenStore implements ServiceAccountT
         return threadPool;
     }
 
-    abstract void doAuthenticate(ServiceAccountToken token, ActionListener<Boolean> listener);
+    abstract void doAuthenticate(ServiceAccountToken token, ActionListener<StoreAuthenticationResult> listener);
+
+    abstract TokenSource getTokenSource();
 
     // package private for testing
     Cache<String, ListenableFuture<CachedResult>> getCache() {

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/service/CompositeServiceAccountTokenStore.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/service/CompositeServiceAccountTokenStore.java
@@ -36,15 +36,16 @@ public final class CompositeServiceAccountTokenStore implements ServiceAccountTo
     }
 
     @Override
-    public void authenticate(ServiceAccountToken token, ActionListener<Boolean> listener) {
+    public void authenticate(ServiceAccountToken token, ActionListener<StoreAuthenticationResult> listener) {
         // TODO: optimize store order based on auth result?
-        final IteratingActionListener<Boolean, ServiceAccountTokenStore> authenticatingListener = new IteratingActionListener<>(
-            listener,
-            (store, successListener) -> store.authenticate(token, successListener),
-            stores,
-            threadContext,
-            Function.identity(),
-            success -> Boolean.FALSE == success);
+        final IteratingActionListener<StoreAuthenticationResult, ServiceAccountTokenStore> authenticatingListener =
+            new IteratingActionListener<>(
+                listener,
+                (store, successListener) -> store.authenticate(token, successListener),
+                stores,
+                threadContext,
+                Function.identity(),
+                storeAuthenticationResult -> false == storeAuthenticationResult.isSuccess());
         try {
             authenticatingListener.run();
         } catch (Exception e) {

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/service/IndexServiceAccountTokenStore.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/service/IndexServiceAccountTokenStore.java
@@ -46,6 +46,7 @@ import org.elasticsearch.xpack.core.security.action.service.CreateServiceAccount
 import org.elasticsearch.xpack.core.security.action.service.CreateServiceAccountTokenResponse;
 import org.elasticsearch.xpack.core.security.action.service.DeleteServiceAccountTokenRequest;
 import org.elasticsearch.xpack.core.security.action.service.TokenInfo;
+import org.elasticsearch.xpack.core.security.action.service.TokenInfo.TokenSource;
 import org.elasticsearch.xpack.core.security.authc.Authentication;
 import org.elasticsearch.xpack.core.security.authc.support.Hasher;
 import org.elasticsearch.xpack.security.authc.service.ServiceAccount.ServiceAccountId;
@@ -90,7 +91,7 @@ public class IndexServiceAccountTokenStore extends CachingServiceAccountTokenSto
     }
 
     @Override
-    void doAuthenticate(ServiceAccountToken token, ActionListener<Boolean> listener) {
+    void doAuthenticate(ServiceAccountToken token, ActionListener<StoreAuthenticationResult> listener) {
         final GetRequest getRequest = client
             .prepareGet(SECURITY_MAIN_ALIAS, SINGLE_MAPPING_NAME, docIdForToken(token.getQualifiedName()))
             .setFetchSource(true)
@@ -100,11 +101,17 @@ public class IndexServiceAccountTokenStore extends CachingServiceAccountTokenSto
                 if (response.isExists()) {
                     final String tokenHash = (String) response.getSource().get("password");
                     assert tokenHash != null : "service account token hash cannot be null";
-                    listener.onResponse(Hasher.verifyHash(token.getSecret(), tokenHash.toCharArray()));
+                    listener.onResponse(new StoreAuthenticationResult(
+                        Hasher.verifyHash(token.getSecret(), tokenHash.toCharArray()), getTokenSource()));
                 } else {
                     logger.trace("service account token [{}] not found in index", token.getQualifiedName());
-                    listener.onResponse(false);
+                    listener.onResponse(new StoreAuthenticationResult(false, getTokenSource()));
                 }}, listener::onFailure)));
+    }
+
+    @Override
+    public TokenSource getTokenSource() {
+        return TokenSource.INDEX;
     }
 
     public void createToken(Authentication authentication, CreateServiceAccountTokenRequest request,

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/service/ServiceAccountService.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/service/ServiceAccountService.java
@@ -15,6 +15,7 @@ import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.common.settings.SecureString;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.xpack.core.security.action.service.GetServiceAccountCredentialsResponse;
+import org.elasticsearch.xpack.core.security.action.service.TokenInfo.TokenSource;
 import org.elasticsearch.xpack.core.security.authc.Authentication;
 import org.elasticsearch.xpack.core.security.authc.service.ServiceAccountSettings;
 import org.elasticsearch.xpack.core.security.authz.RoleDescriptor;
@@ -23,9 +24,11 @@ import org.elasticsearch.xpack.security.authc.service.ServiceAccount.ServiceAcco
 import org.elasticsearch.xpack.security.authc.support.HttpTlsRuntimeCheck;
 
 import java.util.Collection;
+import java.util.Locale;
 import java.util.Map;
 
 import static org.elasticsearch.xpack.core.security.authc.service.ServiceAccountSettings.TOKEN_NAME_FIELD;
+import static org.elasticsearch.xpack.core.security.authc.service.ServiceAccountSettings.TOKEN_SOURCE_FIELD;
 import static org.elasticsearch.xpack.security.authc.service.ElasticServiceAccounts.ACCOUNTS;
 
 public class ServiceAccountService {
@@ -113,9 +116,10 @@ public class ServiceAccountService {
                 return;
             }
 
-            serviceAccountTokenStore.authenticate(serviceAccountToken, ActionListener.wrap(success -> {
-                if (success) {
-                    listener.onResponse(createAuthentication(account, serviceAccountToken, nodeName));
+            serviceAccountTokenStore.authenticate(serviceAccountToken, ActionListener.wrap(storeAuthenticationResult -> {
+                if (storeAuthenticationResult.isSuccess()) {
+                    listener.onResponse(
+                        createAuthentication(account, serviceAccountToken, storeAuthenticationResult.getTokenSource() , nodeName));
                 } else {
                     final ElasticsearchSecurityException e = createAuthenticationException(serviceAccountToken);
                     logger.debug(e.getMessage());
@@ -139,12 +143,14 @@ public class ServiceAccountService {
         });
     }
 
-    private Authentication createAuthentication(ServiceAccount account, ServiceAccountToken token, String nodeName) {
+    private Authentication createAuthentication(ServiceAccount account, ServiceAccountToken token, TokenSource tokenSource,
+                                                String nodeName) {
         final User user = account.asUser();
         final Authentication.RealmRef authenticatedBy =
             new Authentication.RealmRef(ServiceAccountSettings.REALM_NAME, ServiceAccountSettings.REALM_TYPE, nodeName);
         return new Authentication(user, authenticatedBy, null, Version.CURRENT, Authentication.AuthenticationType.TOKEN,
-            org.elasticsearch.common.collect.Map.of(TOKEN_NAME_FIELD, token.getTokenName()));
+            org.elasticsearch.common.collect.Map.of(
+                TOKEN_NAME_FIELD, token.getTokenName(), TOKEN_SOURCE_FIELD, tokenSource.name().toLowerCase(Locale.ROOT)));
     }
 
     private ElasticsearchSecurityException createAuthenticationException(ServiceAccountToken serviceAccountToken) {

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/service/ServiceAccountTokenStore.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/service/ServiceAccountTokenStore.java
@@ -9,6 +9,7 @@ package org.elasticsearch.xpack.security.authc.service;
 
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.xpack.core.security.action.service.TokenInfo;
+import org.elasticsearch.xpack.core.security.action.service.TokenInfo.TokenSource;
 import org.elasticsearch.xpack.security.authc.service.ServiceAccount.ServiceAccountId;
 
 import java.util.Collection;
@@ -21,11 +22,28 @@ public interface ServiceAccountTokenStore {
     /**
      * Verify the given token for encapsulated service account and credential
      */
-    void authenticate(ServiceAccountToken token, ActionListener<Boolean> listener);
+    void authenticate(ServiceAccountToken token, ActionListener<StoreAuthenticationResult> listener);
 
     /**
      * Get all tokens belong to the given service account id
      */
     void findTokensFor(ServiceAccountId accountId, ActionListener<Collection<TokenInfo>> listener);
 
+    class StoreAuthenticationResult {
+        private final boolean success;
+        private final TokenSource tokenSource;
+
+        public StoreAuthenticationResult(boolean success, TokenSource tokenSource) {
+            this.success = success;
+            this.tokenSource = tokenSource;
+        }
+
+        public boolean isSuccess() {
+            return success;
+        }
+
+        public TokenSource getTokenSource() {
+            return tokenSource;
+        }
+    }
 }

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/audit/logfile/LoggingAuditTrailTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/audit/logfile/LoggingAuditTrailTests.java
@@ -63,6 +63,7 @@ import org.elasticsearch.xpack.core.security.action.rolemapping.DeleteRoleMappin
 import org.elasticsearch.xpack.core.security.action.rolemapping.DeleteRoleMappingRequest;
 import org.elasticsearch.xpack.core.security.action.rolemapping.PutRoleMappingAction;
 import org.elasticsearch.xpack.core.security.action.rolemapping.PutRoleMappingRequest;
+import org.elasticsearch.xpack.core.security.action.service.TokenInfo;
 import org.elasticsearch.xpack.core.security.action.user.ChangePasswordAction;
 import org.elasticsearch.xpack.core.security.action.user.ChangePasswordRequest;
 import org.elasticsearch.xpack.core.security.action.user.DeleteUserAction;
@@ -2255,7 +2256,9 @@ public class LoggingAuditTrailTests extends ESTestCase {
                 lookedUpBy = null;
                 authBy = new RealmRef("_service_account", "_service_account", randomAlphaOfLengthBetween(3, 8));
                 authenticationType = AuthenticationType.TOKEN;
-                authMetadata = org.elasticsearch.common.collect.Map.of("_token_name", ValidationTests.randomTokenName());
+                final TokenInfo.TokenSource tokenSource = randomFrom(TokenInfo.TokenSource.values());
+                authMetadata = org.elasticsearch.common.collect.Map.of("_token_name", ValidationTests.randomTokenName(),
+                    "_token_source", tokenSource.name().toLowerCase(Locale.ROOT));
         }
         return new Authentication(user, authBy, lookedUpBy, Version.CURRENT, authenticationType, authMetadata);
     }

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/AuthenticationServiceTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/AuthenticationServiceTests.java
@@ -66,6 +66,7 @@ import org.elasticsearch.transport.TransportRequest;
 import org.elasticsearch.xpack.core.XPackField;
 import org.elasticsearch.xpack.core.XPackSettings;
 import org.elasticsearch.xpack.core.security.SecurityContext;
+import org.elasticsearch.xpack.core.security.action.service.TokenInfo;
 import org.elasticsearch.xpack.core.security.authc.Authentication;
 import org.elasticsearch.xpack.core.security.authc.Authentication.AuthenticationType;
 import org.elasticsearch.xpack.core.security.authc.Authentication.RealmRef;
@@ -111,6 +112,7 @@ import java.util.Base64;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
@@ -1912,11 +1914,13 @@ public class AuthenticationServiceTests extends ESTestCase {
 
     public void testCanAuthenticateServiceAccount() throws ExecutionException, InterruptedException {
         Mockito.reset(serviceAccountService);
+        final TokenInfo.TokenSource tokenSource = randomFrom(TokenInfo.TokenSource.values());
         final Authentication authentication = new Authentication(
             new User("elastic/fleet-server"),
             new RealmRef("_service_account", "_service_account", "foo"), null,
             Version.CURRENT, AuthenticationType.TOKEN,
-            org.elasticsearch.common.collect.Map.of("_token_name", ValidationTests.randomTokenName()));
+            org.elasticsearch.common.collect.Map.of("_token_name", ValidationTests.randomTokenName(),
+                "_token_source", tokenSource.name().toLowerCase(Locale.ROOT)));
         try (ThreadContext.StoredContext ignored = threadContext.newStoredContext(false)) {
             boolean requestIdAlreadyPresent = randomBoolean();
             SetOnce<String> reqId = new SetOnce<>();

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/service/CompositeServiceAccountTokenStoreTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/service/CompositeServiceAccountTokenStoreTests.java
@@ -13,7 +13,9 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.core.security.action.service.TokenInfo;
+import org.elasticsearch.xpack.core.security.action.service.TokenInfo.TokenSource;
 import org.elasticsearch.xpack.security.authc.service.ServiceAccount.ServiceAccountId;
+import org.elasticsearch.xpack.security.authc.service.ServiceAccountTokenStore.StoreAuthenticationResult;
 import org.junit.Before;
 import org.mockito.Mockito;
 
@@ -57,32 +59,36 @@ public class CompositeServiceAccountTokenStoreTests extends ESTestCase {
         final boolean store1Success = randomBoolean();
         final boolean store2Success = randomBoolean();
         final boolean store3Success = randomBoolean();
+        final TokenSource tokenSource = randomFrom(TokenSource.values());
 
         doAnswer(invocationOnMock -> {
-            @SuppressWarnings("unchecked")
-            final ActionListener<Boolean> listener = (ActionListener<Boolean>) invocationOnMock.getArguments()[1];
-            listener.onResponse(store1Success);
+            @SuppressWarnings("unchecked") final ActionListener<StoreAuthenticationResult> listener =
+                (ActionListener<StoreAuthenticationResult>) invocationOnMock.getArguments()[1];
+            listener.onResponse(new StoreAuthenticationResult(store1Success, tokenSource));
             return null;
         }).when(store1).authenticate(eq(token), any());
 
         doAnswer(invocationOnMock -> {
             @SuppressWarnings("unchecked")
-            final ActionListener<Boolean> listener = (ActionListener<Boolean>) invocationOnMock.getArguments()[1];
-            listener.onResponse(store2Success);
+            final ActionListener<StoreAuthenticationResult> listener =
+                (ActionListener<StoreAuthenticationResult>) invocationOnMock.getArguments()[1];
+            listener.onResponse(new StoreAuthenticationResult(store2Success, tokenSource));
             return null;
         }).when(store2).authenticate(eq(token), any());
 
         doAnswer(invocationOnMock -> {
             @SuppressWarnings("unchecked")
-            final ActionListener<Boolean> listener = (ActionListener<Boolean>) invocationOnMock.getArguments()[1];
-            listener.onResponse(store3Success);
+            final ActionListener<StoreAuthenticationResult> listener =
+                (ActionListener<StoreAuthenticationResult>) invocationOnMock.getArguments()[1];
+            listener.onResponse(new StoreAuthenticationResult(store3Success, tokenSource));
             return null;
         }).when(store3).authenticate(eq(token), any());
 
-        final PlainActionFuture<Boolean> future = new PlainActionFuture<>();
+        final PlainActionFuture<StoreAuthenticationResult> future = new PlainActionFuture<>();
         compositeStore.authenticate(token, future);
         if (store1Success || store2Success || store3Success) {
-            assertThat(future.get(), is(true));
+            assertThat(future.get().isSuccess(), is(true));
+            assertThat(future.get().getTokenSource(), is(tokenSource));
             if (store1Success) {
                 verify(store1).authenticate(eq(token), any());
                 verifyZeroInteractions(store2);
@@ -97,7 +103,8 @@ public class CompositeServiceAccountTokenStoreTests extends ESTestCase {
                 verify(store3).authenticate(eq(token), any());
             }
         } else {
-            assertThat(future.get(), is(false));
+            assertThat(future.get().isSuccess(), is(false));
+            assertThat(future.get().getTokenSource(), is(tokenSource));
             verify(store1).authenticate(eq(token), any());
             verify(store2).authenticate(eq(token), any());
             verify(store3).authenticate(eq(token), any());

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/service/IndexServiceAccountTokenStoreTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/service/IndexServiceAccountTokenStoreTests.java
@@ -53,11 +53,13 @@ import org.elasticsearch.xpack.core.security.action.service.CreateServiceAccount
 import org.elasticsearch.xpack.core.security.action.service.CreateServiceAccountTokenResponse;
 import org.elasticsearch.xpack.core.security.action.service.DeleteServiceAccountTokenRequest;
 import org.elasticsearch.xpack.core.security.action.service.TokenInfo;
+import org.elasticsearch.xpack.core.security.action.service.TokenInfo.TokenSource;
 import org.elasticsearch.xpack.core.security.authc.Authentication;
 import org.elasticsearch.xpack.core.security.authc.support.Hasher;
 import org.elasticsearch.xpack.core.security.support.ValidationTests;
 import org.elasticsearch.xpack.core.security.user.User;
 import org.elasticsearch.xpack.security.authc.service.ServiceAccount.ServiceAccountId;
+import org.elasticsearch.xpack.security.authc.service.ServiceAccountTokenStore.StoreAuthenticationResult;
 import org.elasticsearch.xpack.security.support.CacheInvalidatorRegistry;
 import org.elasticsearch.xpack.security.support.SecurityIndexManager;
 import org.junit.Before;
@@ -152,25 +154,28 @@ public class IndexServiceAccountTokenStoreTests extends ESTestCase {
 
         // success
         responseProviderHolder.set((r, l) -> l.onResponse(getResponse1));
-        final PlainActionFuture<Boolean> future1 = new PlainActionFuture<>();
+        final PlainActionFuture<StoreAuthenticationResult> future1 = new PlainActionFuture<>();
         store.doAuthenticate(serviceAccountToken, future1);
         final GetRequest getRequest = (GetRequest) requestHolder.get();
         assertThat(getRequest.id(), equalTo("service_account_token-" + serviceAccountToken.getQualifiedName()));
-        assertThat(future1.get(), is(true));
+        assertThat(future1.get().isSuccess(), is(true));
+        assertThat(future1.get().getTokenSource(), is(TokenSource.INDEX));
 
         // token mismatch
         final GetResponse getResponse2 = createGetResponse(ServiceAccountToken.newToken(accountId, randomAlphaOfLengthBetween(3, 8)), true);
         responseProviderHolder.set((r, l) -> l.onResponse(getResponse2));
-        final PlainActionFuture<Boolean> future2 = new PlainActionFuture<>();
+        final PlainActionFuture<StoreAuthenticationResult> future2 = new PlainActionFuture<>();
         store.doAuthenticate(serviceAccountToken, future2);
-        assertThat(future2.get(), is(false));
+        assertThat(future2.get().isSuccess(), is(false));
+        assertThat(future2.get().getTokenSource(), is(TokenSource.INDEX));
 
         // token document not found
         final GetResponse getResponse3 = createGetResponse(serviceAccountToken, false);
         responseProviderHolder.set((r, l) -> l.onResponse(getResponse3));
-        final PlainActionFuture<Boolean> future3 = new PlainActionFuture<>();
+        final PlainActionFuture<StoreAuthenticationResult> future3 = new PlainActionFuture<>();
         store.doAuthenticate(serviceAccountToken, future3);
-        assertThat(future3.get(), is(false));
+        assertThat(future3.get().isSuccess(), is(false));
+        assertThat(future3.get().getTokenSource(), is(TokenSource.INDEX));
     }
 
     public void testCreateToken() throws ExecutionException, InterruptedException {
@@ -263,7 +268,7 @@ public class IndexServiceAccountTokenStoreTests extends ESTestCase {
         final PlainActionFuture<Collection<TokenInfo>> future = new PlainActionFuture<>();
         store.findTokensFor(accountId, future);
         final Collection<TokenInfo> tokenInfos = future.actionGet();
-        assertThat(tokenInfos.stream().map(TokenInfo::getSource).allMatch(TokenInfo.TokenSource.INDEX::equals), is(true));
+        assertThat(tokenInfos.stream().map(TokenInfo::getSource).allMatch(TokenSource.INDEX::equals), is(true));
         assertThat(tokenInfos.stream().map(TokenInfo::getName).collect(Collectors.toSet()),
             equalTo(org.elasticsearch.common.collect.Set.of(tokenNames)));
     }

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/service/ServiceAccountServiceTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/service/ServiceAccountServiceTests.java
@@ -27,6 +27,7 @@ import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.MockLogAppender;
 import org.elasticsearch.transport.Transport;
+import org.elasticsearch.xpack.core.security.action.service.TokenInfo;
 import org.elasticsearch.xpack.core.security.authc.Authentication;
 import org.elasticsearch.xpack.core.security.authc.service.ServiceAccountSettings;
 import org.elasticsearch.xpack.core.security.authz.RoleDescriptor;
@@ -44,6 +45,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Base64;
 import java.util.List;
+import java.util.Locale;
 import java.util.concurrent.ExecutionException;
 
 import static org.hamcrest.Matchers.containsString;
@@ -249,10 +251,13 @@ public class ServiceAccountServiceTests extends ESTestCase {
     public void testTryAuthenticateBearerToken() throws ExecutionException, InterruptedException {
         // Valid token
         final PlainActionFuture<Authentication> future5 = new PlainActionFuture<>();
+        final TokenInfo.TokenSource tokenSource = randomFrom(TokenInfo.TokenSource.values());
+
         doAnswer(invocationOnMock -> {
             @SuppressWarnings("unchecked")
-            final ActionListener<Boolean> listener = (ActionListener<Boolean>) invocationOnMock.getArguments()[1];
-            listener.onResponse(true);
+            final ActionListener<ServiceAccountTokenStore.StoreAuthenticationResult> listener =
+                (ActionListener<ServiceAccountTokenStore.StoreAuthenticationResult>) invocationOnMock.getArguments()[1];
+            listener.onResponse(new ServiceAccountTokenStore.StoreAuthenticationResult(true, tokenSource));
             return null;
         }).when(serviceAccountTokenStore).authenticate(any(), any());
         final String nodeName = randomAlphaOfLengthBetween(3, 8);
@@ -266,7 +271,8 @@ public class ServiceAccountServiceTests extends ESTestCase {
                     org.elasticsearch.common.collect.Map.of("_elastic_service_account", true), true),
                 new Authentication.RealmRef(ServiceAccountSettings.REALM_NAME, ServiceAccountSettings.REALM_TYPE, nodeName),
                 null, Version.CURRENT, Authentication.AuthenticationType.TOKEN,
-                org.elasticsearch.common.collect.Map.of("_token_name", "token1")
+                org.elasticsearch.common.collect.Map.of("_token_name", "token1",
+                    "_token_source", tokenSource.name().toLowerCase(Locale.ROOT))
             )
         ));
     }
@@ -303,7 +309,7 @@ public class ServiceAccountServiceTests extends ESTestCase {
                 ElasticServiceAccounts.NAMESPACE,
                 randomValueOtherThan("fleet-server", () -> randomAlphaOfLengthBetween(3, 8)));
             appender.addExpectation(new MockLogAppender.SeenEventExpectation(
-                "non-elastic service account", ServiceAccountService.class.getName(), Level.DEBUG,
+                "unknown elastic service name", ServiceAccountService.class.getName(), Level.DEBUG,
                 "the [" + accountId2.asPrincipal() + "] service account does not exist"
             ));
             final ServiceAccountToken token2 = new ServiceAccountToken(accountId2, randomAlphaOfLengthBetween(3, 8), secret);
@@ -337,18 +343,21 @@ public class ServiceAccountServiceTests extends ESTestCase {
             final ServiceAccountToken token4 = new ServiceAccountToken(accountId4, randomAlphaOfLengthBetween(3, 8), secret);
             final ServiceAccountToken token5 = new ServiceAccountToken(accountId4, randomAlphaOfLengthBetween(3, 8),
                 new SecureString(randomAlphaOfLength(20).toCharArray()));
+            final TokenInfo.TokenSource tokenSource = randomFrom(TokenInfo.TokenSource.values());
             final String nodeName = randomAlphaOfLengthBetween(3, 8);
             doAnswer(invocationOnMock -> {
                 @SuppressWarnings("unchecked")
-                final ActionListener<Boolean> listener = (ActionListener<Boolean>) invocationOnMock.getArguments()[1];
-                listener.onResponse(true);
+                final ActionListener<ServiceAccountTokenStore.StoreAuthenticationResult> listener =
+                    (ActionListener<ServiceAccountTokenStore.StoreAuthenticationResult>) invocationOnMock.getArguments()[1];
+                listener.onResponse(new ServiceAccountTokenStore.StoreAuthenticationResult(true, tokenSource));
                 return null;
             }).when(serviceAccountTokenStore).authenticate(eq(token4), any());
 
             doAnswer(invocationOnMock -> {
                 @SuppressWarnings("unchecked")
-                final ActionListener<Boolean> listener = (ActionListener<Boolean>) invocationOnMock.getArguments()[1];
-                listener.onResponse(false);
+                final ActionListener<ServiceAccountTokenStore.StoreAuthenticationResult> listener =
+                    (ActionListener<ServiceAccountTokenStore.StoreAuthenticationResult>) invocationOnMock.getArguments()[1];
+                listener.onResponse(new ServiceAccountTokenStore.StoreAuthenticationResult(false, tokenSource));
                 return null;
             }).when(serviceAccountTokenStore).authenticate(eq(token5), any());
 
@@ -362,11 +371,12 @@ public class ServiceAccountServiceTests extends ESTestCase {
                     true),
                 new Authentication.RealmRef(ServiceAccountSettings.REALM_NAME, ServiceAccountSettings.REALM_TYPE, nodeName),
                 null, Version.CURRENT, Authentication.AuthenticationType.TOKEN,
-                org.elasticsearch.common.collect.Map.of("_token_name", token4.getTokenName())
+                org.elasticsearch.common.collect.Map.of("_token_name", token4.getTokenName(),
+                    "_token_source", tokenSource.name().toLowerCase(Locale.ROOT))
             )));
 
             appender.addExpectation(new MockLogAppender.SeenEventExpectation(
-                "non-elastic service account", ServiceAccountService.class.getName(), Level.DEBUG,
+                "invalid credential", ServiceAccountService.class.getName(), Level.DEBUG,
                 "failed to authenticate service account [" + token5.getAccountId().asPrincipal()
                     + "] with token name [" + token5.getTokenName() + "]"
             ));
@@ -385,6 +395,7 @@ public class ServiceAccountServiceTests extends ESTestCase {
     }
 
     public void testGetRoleDescriptor() throws ExecutionException, InterruptedException {
+        final TokenInfo.TokenSource tokenSource = randomFrom(TokenInfo.TokenSource.values());
         final Authentication auth1 = new Authentication(
             new User("elastic/fleet-server",
                 Strings.EMPTY_ARRAY,
@@ -397,7 +408,8 @@ public class ServiceAccountServiceTests extends ESTestCase {
             null,
             Version.CURRENT,
             Authentication.AuthenticationType.TOKEN,
-            org.elasticsearch.common.collect.Map.of("_token_name", randomAlphaOfLengthBetween(3, 8)));
+            org.elasticsearch.common.collect.Map.of("_token_name", randomAlphaOfLengthBetween(3, 8),
+                "_token_source", tokenSource.name().toLowerCase(Locale.ROOT)));
 
         final PlainActionFuture<RoleDescriptor> future1 = new PlainActionFuture<>();
         serviceAccountService.getRoleDescriptor(auth1, future1);
@@ -415,7 +427,8 @@ public class ServiceAccountServiceTests extends ESTestCase {
             null,
             Version.CURRENT,
             Authentication.AuthenticationType.TOKEN,
-            org.elasticsearch.common.collect.Map.of("_token_name", randomAlphaOfLengthBetween(3, 8)));
+            org.elasticsearch.common.collect.Map.of("_token_name", randomAlphaOfLengthBetween(3, 8),
+                "_token_source", tokenSource.name().toLowerCase(Locale.ROOT)));
         final PlainActionFuture<RoleDescriptor> future2 = new PlainActionFuture<>();
         serviceAccountService.getRoleDescriptor(auth2, future2);
         final ElasticsearchSecurityException e = expectThrows(ElasticsearchSecurityException.class, future2::actionGet);
@@ -441,11 +454,16 @@ public class ServiceAccountServiceTests extends ESTestCase {
         assertThat(e1.getMessage(), containsString("[service account authentication] requires TLS for the HTTP interface"));
 
         final PlainActionFuture<RoleDescriptor> future2 = new PlainActionFuture<>();
+        final TokenInfo.TokenSource tokenSource = randomFrom(TokenInfo.TokenSource.values());
         final Authentication authentication = new Authentication(mock(User.class),
             new Authentication.RealmRef(
                 ServiceAccountSettings.REALM_NAME, ServiceAccountSettings.REALM_TYPE,
                 randomAlphaOfLengthBetween(3, 8)),
-            null);
+            null,
+            Version.CURRENT,
+            Authentication.AuthenticationType.TOKEN,
+            org.elasticsearch.common.collect.Map.of("_token_name", randomAlphaOfLengthBetween(3, 8),
+                "_token_source", tokenSource.name().toLowerCase(Locale.ROOT)));
         service.getRoleDescriptor(authentication, future2);
         final ElasticsearchException e2 = expectThrows(ElasticsearchException.class, future2::actionGet);
         assertThat(e2.getMessage(), containsString("[service account role descriptor resolving] requires TLS for the HTTP interface"));

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/ingest/SetSecurityUserProcessorTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/ingest/SetSecurityUserProcessorTests.java
@@ -18,6 +18,7 @@ import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.XContentTestUtils;
 import org.elasticsearch.xpack.core.security.SecurityContext;
 import org.elasticsearch.xpack.core.security.action.ApiKeyTests;
+import org.elasticsearch.xpack.core.security.action.service.TokenInfo;
 import org.elasticsearch.xpack.core.security.authc.Authentication;
 import org.elasticsearch.xpack.core.security.authc.Authentication.AuthenticationType;
 import org.elasticsearch.xpack.core.security.authc.support.AuthenticationContextSerializer;
@@ -32,6 +33,7 @@ import java.util.Collections;
 import java.util.Arrays;
 import java.util.EnumSet;
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
 
 import static org.hamcrest.Matchers.equalTo;
@@ -371,8 +373,10 @@ public class SetSecurityUserProcessorTests extends ESTestCase {
             assert false == user.isRunAs() : "cannot run-as service account";
             final Authentication.RealmRef authBy =
                 new Authentication.RealmRef("_service_account", "_service_account", randomAlphaOfLengthBetween(3, 8));
+            final TokenInfo.TokenSource tokenSource = randomFrom(TokenInfo.TokenSource.values());
             return new Authentication(user, authBy, null, Version.CURRENT, AuthenticationType.TOKEN,
-                org.elasticsearch.common.collect.Map.of("_token_name", ValidationTests.randomTokenName()));
+                org.elasticsearch.common.collect.Map.of("_token_name", ValidationTests.randomTokenName(),
+                    "_token_source", tokenSource.name().toLowerCase(Locale.ROOT)));
         } else {
             final Authentication.RealmRef lookupBy;
             final String nodeName = randomAlphaOfLengthBetween(3, 8);


### PR DESCRIPTION
Service token of the same name can come from either a file or the
security index. Add the token source information to the authentication
metadata to differentiate between them. This information is also
serialised under token.type in the rest response back to users.