### PR TITLE
speed up geotile aggregation over geo_shape field (#72984)

### DIFF
--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/search/aggregations/bucket/geogrid/AbstractGeoTileGridTiler.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/search/aggregations/bucket/geogrid/AbstractGeoTileGridTiler.java
@@ -157,21 +157,5 @@ abstract class AbstractGeoTileGridTiler extends GeoGridTiler {
         return (int) numTilesAtPrecision;
     }
 
-    protected int setValuesForFullyContainedTile(int xTile, int yTile, int zTile, GeoShapeCellValues values, int valuesIndex) {
-        zTile++;
-        for (int i = 0; i < 2; i++) {
-            for (int j = 0; j < 2; j++) {
-                int nextX = 2 * xTile + i;
-                int nextY = 2 * yTile + j;
-                if (validTile(nextX, nextY, zTile)) {
-                    if (zTile == precision) {
-                        values.add(valuesIndex++, GeoTileUtils.longEncodeTiles(zTile, nextX, nextY));
-                    } else {
-                        valuesIndex = setValuesForFullyContainedTile(nextX, nextY, zTile, values, valuesIndex);
-                    }
-                }
-            }
-        }
-        return valuesIndex;
-    }
+    protected abstract int setValuesForFullyContainedTile(int xTile, int yTile, int zTile, GeoShapeCellValues values, int valuesIndex);
 }

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/search/aggregations/bucket/geogrid/BoundedGeoTileGridTiler.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/search/aggregations/bucket/geogrid/BoundedGeoTileGridTiler.java
@@ -11,13 +11,13 @@ import org.elasticsearch.common.geo.GeoBoundingBox;
 import org.elasticsearch.geometry.Rectangle;
 import org.elasticsearch.search.aggregations.bucket.geogrid.GeoTileUtils;
 
-
 /**
  * Bounded geotile aggregation. It accepts tiles that intersects the provided bounds.
  */
 public class BoundedGeoTileGridTiler extends AbstractGeoTileGridTiler {
     private final boolean crossesDateline;
     private final long maxTiles;
+    // min values are included, max values are excluded
     private final int minX, maxX, minY, maxY;
 
     public BoundedGeoTileGridTiler(int precision, GeoBoundingBox bbox) {
@@ -40,12 +40,12 @@ public class BoundedGeoTileGridTiler extends AbstractGeoTileGridTiler {
             final int maxY = GeoTileUtils.getYTile(bbox.bottom(), this.tiles);
             final Rectangle maxTile = GeoTileUtils.toBoundingBox(maxX, maxY, precision);
             // touching tiles are excluded, they need to share at least one interior point
-            this.maxX = maxTile.getMinX() == bbox.right() ? maxX - 1 : maxX;
-            this.maxY = maxTile.getMaxY() == bbox.bottom() ? maxY - 1 : maxY;
+            this.maxX = maxTile.getMinX() == bbox.right() ? maxX : maxX + 1;
+            this.maxY = maxTile.getMaxY() == bbox.bottom() ? maxY : maxY + 1;
             if (crossesDateline) {
-                this.maxTiles = (tiles + this.maxX - this.minX + 1) * (this.maxY - this.minY + 1);
+                this.maxTiles = (tiles + this.maxX - this.minX) * (this.maxY - this.minY);
             } else {
-                this.maxTiles = (long) (this.maxX - this.minX + 1) * (this.maxY - this.minY + 1);
+                this.maxTiles = (long) (this.maxX - this.minX) * (this.maxY - this.minY);
             }
         }
     }
@@ -55,12 +55,12 @@ public class BoundedGeoTileGridTiler extends AbstractGeoTileGridTiler {
         // compute number of splits at precision
         final int splits = 1 << precision - z;
         final int yMin = y * splits;
-        if (maxY >= yMin && minY < yMin + splits) {
+        if (maxY > yMin && minY < yMin + splits) {
             final int xMin = x * splits;
             if (crossesDateline) {
-                return maxX >= xMin || minX < xMin + splits;
+                return maxX > xMin || minX < xMin + splits;
             } else {
-                return maxX >= xMin && minX < xMin + splits;
+                return maxX > xMin && minX < xMin + splits;
             }
         }
         return false;
@@ -69,5 +69,46 @@ public class BoundedGeoTileGridTiler extends AbstractGeoTileGridTiler {
     @Override
     protected long getMaxCells() {
         return maxTiles;
+    }
+
+    @Override
+    protected int setValuesForFullyContainedTile(int xTile, int yTile, int zTile, GeoShapeCellValues values, int valuesIndex) {
+        // For every level we go down, we half each dimension. The total number of splits is equal to 1 << (levelEnd - levelStart)
+        final int splits = 1 << precision - zTile;
+        // The start value of a dimension is calculated by multiplying the  value of that dimension at the start level
+        // by the number of splits. Choose the max value with respect to the bounding box.
+        final int minY = Math.max(this.minY, yTile * splits);
+        // The end value of a dimension is calculated by adding to the start value the number of splits.
+        // Choose the min value with respect to the bounding box.
+        final int maxY = Math.min(this.maxY, yTile * splits + splits);
+        // Do the same for the X dimension taking into account that the bounding box might cross the dateline.
+        if (crossesDateline) {
+            final int eastMinX = xTile * splits;
+            final int eastMaxX = Math.min(this.maxX, xTile * splits + splits);
+            final int westMinX = Math.max(this.minX, xTile * splits);
+            final int westMaxX = xTile * splits + splits;
+            for (int i = eastMinX; i < eastMaxX; i++) {
+                for (int j = minY; j < maxY; j++) {
+                    assert validTile(i, j, precision);
+                    values.add(valuesIndex++, GeoTileUtils.longEncodeTiles(precision, i, j));
+                }
+            }
+            for (int i = westMinX; i < westMaxX; i++) {
+                for (int j = minY; j < maxY; j++) {
+                    assert validTile(i, j, precision);
+                    values.add(valuesIndex++, GeoTileUtils.longEncodeTiles(precision, i, j));
+                }
+            }
+        } else {
+            final int minX = Math.max(this.minX, xTile * splits);
+            final int maxX = Math.min(this.maxX, xTile * splits + splits);
+            for (int i = minX; i < maxX; i++) {
+                for (int j = minY; j < maxY; j++) {
+                    assert validTile(i, j, precision);
+                    values.add(valuesIndex++, GeoTileUtils.longEncodeTiles(precision, i, j));
+                }
+            }
+        }
+        return valuesIndex;
     }
 }

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/search/aggregations/bucket/geogrid/UnboundedGeoTileGridTiler.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/search/aggregations/bucket/geogrid/UnboundedGeoTileGridTiler.java
@@ -8,6 +8,8 @@
 package org.elasticsearch.xpack.spatial.search.aggregations.bucket.geogrid;
 
 
+import org.elasticsearch.search.aggregations.bucket.geogrid.GeoTileUtils;
+
 /**
  * Unbounded geotile aggregation. It accepts any tile.
  */
@@ -27,5 +29,25 @@ public class UnboundedGeoTileGridTiler extends AbstractGeoTileGridTiler {
     @Override
     protected long getMaxCells() {
         return maxTiles;
+    }
+
+    @Override
+    protected int setValuesForFullyContainedTile(int xTile, int yTile, int zTile, GeoShapeCellValues values, int valuesIndex) {
+        // For every level we go down, we half each dimension. The total number of splits is equal to 1 << (levelEnd - levelStart)
+        final int splits = 1 << precision - zTile;
+        // The start value of a dimension is calculated by multiplying the  value of that dimension at the start level
+        // by the number of splits
+        final int minX = xTile * splits;
+        final int minY = yTile * splits;
+        // The end value of a dimension is calculated by adding to the start value the number of splits
+        final int maxX = minX + splits;
+        final int maxY = minY + splits;
+        for (int i = minX; i < maxX; i++) {
+            for (int j = minY; j < maxY; j++) {
+                assert validTile(i, j, precision);
+                values.add(valuesIndex++, GeoTileUtils.longEncodeTiles(precision, i, j));
+            }
+        }
+        return valuesIndex;
     }
 }

--- a/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/search/aggregations/bucket/geogrid/GeoGridTilerTestCase.java
+++ b/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/search/aggregations/bucket/geogrid/GeoGridTilerTestCase.java
@@ -112,7 +112,7 @@ public abstract class GeoGridTilerTestCase extends ESTestCase {
                 }
             }, () -> boxToGeo(randomBBox())));
 
-            GeoBoundingBox geoBoundingBox = randomBBox();
+            GeoBoundingBox geoBoundingBox = randomValueOtherThanMany(b -> b.right() == -180 && b.left() == 180,() -> randomBBox());
             GeoShapeValues.GeoShapeValue value = geoShapeValue(geometry);
             GeoShapeCellValues cellValues =
                 new GeoShapeCellValues(makeGeoShapeValues(value), getBoundedGridTiler(geoBoundingBox, precision), NOOP_BREAKER);


### PR DESCRIPTION
When a tile is inside a geometry, we use recursion to add all the tiles at the aggregation precision. For GeoTile aggregation we can do better by computing the range of tiles that needs to be added. Then we just need to do a simple iteration to add the corresponding tiles. Some rough measurement shows speed ups of around ~15%.

backport #72984