### PR TITLE
SQL: Fix issue with aliased subqueries and GROUP BY (#73233)

### DIFF
--- a/x-pack/plugin/sql/qa/server/src/main/resources/select.sql-spec
+++ b/x-pack/plugin/sql/qa/server/src/main/resources/select.sql-spec
@@ -155,3 +155,5 @@ selectGroupByOrderByOrderByLimit
 SELECT * FROM (SELECT max(salary) AS max, languages FROM test_emp GROUP BY languages ORDER BY max ASC) ORDER BY max DESC NULLS FIRST LIMIT 4;
 selectGroupByOrderByOrderByLimitNulls
 SELECT * FROM (SELECT max(salary) AS max, languages FROM test_emp GROUP BY languages ORDER BY max ASC NULLS LAST) ORDER BY max DESC NULLS FIRST LIMIT 4;
+selectGroupByWithAliasedSubQuery
+SELECT max, languages FROM (SELECT max(salary) AS max, languages FROM test_emp GROUP BY languages ORDER BY max ASC NULLS LAST) AS subquery;

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/planner/QueryTranslatorSpecTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/planner/QueryTranslatorSpecTests.java
@@ -28,7 +28,6 @@ import org.elasticsearch.xpack.sql.util.DateUtils;
 import org.hamcrest.Matcher;
 import org.junit.BeforeClass;
 
-import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -54,12 +53,8 @@ public class QueryTranslatorSpecTests extends ESTestCase {
             planner = new Planner();
         }
 
-        LogicalPlan plan(String sql, ZoneId zoneId) {
-            return analyzer.analyze(parser.createStatement(sql, zoneId), true);
-        }
-
         LogicalPlan plan(String sql) {
-            return plan(sql, DateUtils.UTC);
+            return analyzer.analyze(parser.createStatement(sql, DateUtils.UTC), true);
         }
 
         PhysicalPlan optimizeAndPlan(String sql) {

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/planner/QueryTranslatorTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/planner/QueryTranslatorTests.java
@@ -66,6 +66,7 @@ import org.elasticsearch.xpack.sql.expression.function.scalar.string.UnaryString
 import org.elasticsearch.xpack.sql.optimizer.Optimizer;
 import org.elasticsearch.xpack.sql.parser.SqlParser;
 import org.elasticsearch.xpack.sql.plan.physical.EsQueryExec;
+import org.elasticsearch.xpack.sql.plan.physical.LocalExec;
 import org.elasticsearch.xpack.sql.plan.physical.PhysicalPlan;
 import org.elasticsearch.xpack.sql.planner.QueryFolder.FoldAggregate.GroupingContext;
 import org.elasticsearch.xpack.sql.planner.QueryTranslator.QueryTranslation;
@@ -73,6 +74,7 @@ import org.elasticsearch.xpack.sql.proto.SqlTypedParamValue;
 import org.elasticsearch.xpack.sql.querydsl.agg.AggFilter;
 import org.elasticsearch.xpack.sql.querydsl.agg.GroupByDateHistogram;
 import org.elasticsearch.xpack.sql.querydsl.container.MetricAggRef;
+import org.elasticsearch.xpack.sql.session.SingletonExecutable;
 import org.elasticsearch.xpack.sql.stats.Metrics;
 import org.elasticsearch.xpack.sql.types.SqlTypesTests;
 import org.elasticsearch.xpack.sql.util.DateUtils;
@@ -1287,5 +1289,42 @@ public class QueryTranslatorTests extends ESTestCase {
             .transformDown(FieldAttribute.class, x -> x.name().equals("int") ? (FieldAttribute) expectedInts.toArray()[0] : x);
 
         assertEquals(expectedCondition, condition);
+    }
+
+    // Subqueries
+    /////////////////////
+    public void testMultiLevelSubqueryWithoutRelation1() {
+        PhysicalPlan p = optimizeAndPlan(
+                "SELECT int FROM (" +
+                "  SELECT int FROM (" +
+                "    SELECT 1 AS int" +
+                "  ) AS subq1" +
+                ") AS subq2");
+        assertThat(p, instanceOf(LocalExec.class));
+        LocalExec le = (LocalExec) p;
+        assertThat(le.executable(), instanceOf(SingletonExecutable.class));
+        assertEquals(1, le.executable().output().size());
+        assertEquals("int", le.executable().output().get(0).name());
+    }
+
+    public void testMultiLevelSubqueryWithoutRelation2() {
+        PhysicalPlan p = optimizeAndPlan(
+                "SELECT i, string FROM (" +
+                "  SELECT * FROM (" +
+                "    SELECT int as i, str AS string FROM (" +
+                "      SELECT * FROM (" +
+                "        SELECT int, s AS str FROM (" +
+                "          SELECT 1 AS int, 'foo' AS s" +
+                "        ) AS subq1" +
+                "      )" +
+                "    ) AS subq2" +
+                "  ) AS subq3" +
+                ")");
+        assertThat(p, instanceOf(LocalExec.class));
+        LocalExec le = (LocalExec) p;
+        assertThat(le.executable(), instanceOf(SingletonExecutable.class));
+        assertEquals(2, le.executable().output().size());
+        assertEquals("i", le.executable().output().get(0).name());
+        assertEquals("string", le.executable().output().get(1).name());
     }
 }

--- a/x-pack/plugin/sql/src/test/resources/org/elasticsearch/xpack/sql/planner/querytranslator_subqueries_tests.txt
+++ b/x-pack/plugin/sql/src/test/resources/org/elasticsearch/xpack/sql/planner/querytranslator_subqueries_tests.txt
@@ -178,6 +178,52 @@ SELECT j AS k FROM (
 ) GROUP BY k;
 ;
 
+MultiLevelAliasedSubqueryGroupBy1
+SELECT int FROM (
+    SELECT int FROM (
+        SELECT int FROM test GROUP BY int
+    ) AS subq1
+) AS subq2;
+;
+
+MultiLevelAliasedSubqueryGroupBy2
+SELECT int FROM (
+    SELECT int FROM (
+        SELECT int FROM test
+    GROUP BY int) AS subq1
+) AS subq2;
+;
+
+MultiLevelAliasedSubqueryGroupBy3
+SELECT * FROM (
+    SELECT int FROM (
+        SELECT * FROM (
+            SELECT int FROM test
+        GROUP BY int) AS subq1
+    ) AS subq2
+)AS subq3;
+;
+
+MultiLevelAliasedSubqueryGroupBy4
+SELECT subq3.int FROM (
+    SELECT int FROM (
+        SELECT subq1.int FROM (
+            SELECT int FROM test
+        GROUP BY int) AS subq1
+    ) AS subq2
+)AS subq3;
+;
+
+MultiLevelAliasedSubqueryGroupBy5
+SELECT subq3.int FROM (
+    SELECT subq2.i AS int FROM (
+        SELECT subq1.int AS i FROM (
+            SELECT int FROM test
+        GROUP BY int) AS subq1
+    ) AS subq2
+)AS subq3;
+;
+
 SubqueryGroupByFilterAndOrderByByRealiased
 SELECT g as h FROM (
     SELECT date AS f, int AS g FROM test


### PR DESCRIPTION
Previously, when a subquery was used with an alias in combination with
a nested GROUP BY, the collapsing of the nested queries into a flattened
`Aggregate` query, lead to wrong attribute qualifier on the external
projection, which was still referencing the removed subquery. e.g.:

For the following query:
```
SELECT languages FROM (
    SELECT languages FROM test_emp GROUP BY languages
) AS subquery
```
The `languages` of the top level SELECT, was qualified with `subquery`
which was removed during the flattening optimisation leading to
Exception of not being able to resolve the refenced group:
`test_emp.languages`.

Fix this behaviour by introducing a new rule which precedes the
`PruneSubqueryAliases` rules and updates the `qualifier` for the
`FieldAttributes`.

Fixes: #69263
(cherry picked from commit 1a2a3df78bdb4551367fa229564d3a489f6a3946)
