### PR TITLE
[7.13] Do not remove write block when unfreezing cold/frozen indices

### DIFF
--- a/x-pack/plugin/frozen-indices/src/internalClusterTest/java/org/elasticsearch/index/engine/FrozenIndexTests.java
+++ b/x-pack/plugin/frozen-indices/src/internalClusterTest/java/org/elasticsearch/index/engine/FrozenIndexTests.java
@@ -219,6 +219,8 @@ public class FrozenIndexTests extends ESSingleNodeTestCase {
             Index index = resolveIndex("index");
             IndexService indexService = indexServices.indexServiceSafe(index);
             assertTrue(indexService.getIndexSettings().isSearchThrottled());
+            assertTrue(FrozenEngine.INDEX_FROZEN.get(indexService.getIndexSettings().getSettings()));
+            assertTrue(FrozenEngine.INDEX_FROZEN.exists(indexService.getIndexSettings().getSettings()));
             IndexShard shard = indexService.getShard(0);
             assertEquals(0, shard.refreshStats().getTotal());
             assertThat(indexService.getMetadata().getTimestampRange(), sameInstance(IndexLongFieldRange.UNKNOWN));
@@ -229,6 +231,8 @@ public class FrozenIndexTests extends ESSingleNodeTestCase {
             Index index = resolveIndex("index");
             IndexService indexService = indexServices.indexServiceSafe(index);
             assertFalse(indexService.getIndexSettings().isSearchThrottled());
+            assertFalse(FrozenEngine.INDEX_FROZEN.get(indexService.getIndexSettings().getSettings()));
+            assertFalse(FrozenEngine.INDEX_FROZEN.exists(indexService.getIndexSettings().getSettings()));
             IndexShard shard = indexService.getShard(0);
             Engine engine = IndexShardTestCase.getEngine(shard);
             assertThat(engine, Matchers.instanceOf(InternalEngine.class));

--- a/x-pack/plugin/frozen-indices/src/main/java/org/elasticsearch/xpack/frozen/action/TransportFreezeIndexAction.java
+++ b/x-pack/plugin/frozen-indices/src/main/java/org/elasticsearch/xpack/frozen/action/TransportFreezeIndexAction.java
@@ -41,6 +41,7 @@ import org.elasticsearch.tasks.Task;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.xpack.core.frozen.action.FreezeIndexAction;
+import org.elasticsearch.xpack.searchablesnapshots.SearchableSnapshotsConstants;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -159,26 +160,28 @@ public final class TransportFreezeIndexAction extends
                 final Metadata.Builder builder = Metadata.builder(currentState.metadata());
                 ClusterBlocks.Builder blocks = ClusterBlocks.builder().blocks(currentState.blocks());
                 for (Index index : concreteIndices) {
-                    IndexMetadata meta = currentState.metadata().getIndexSafe(index);
-                    if (meta.getState() != IndexMetadata.State.CLOSE) {
+                    final IndexMetadata indexMetadata = currentState.metadata().getIndexSafe(index);
+                    if (indexMetadata.getState() != IndexMetadata.State.CLOSE) {
                         throw new IllegalStateException("index [" + index.getName() + "] is not closed");
                     }
-                    final IndexMetadata.Builder imdBuilder = IndexMetadata.builder(meta);
-                    imdBuilder.settingsVersion(meta.getSettingsVersion() + 1);
-                    final Settings.Builder settingsBuilder =
-                        Settings.builder()
-                            .put(currentState.metadata().index(index).getSettings())
-                            .put(FrozenEngine.INDEX_FROZEN.getKey(), request.freeze())
-                            .put(IndexSettings.INDEX_SEARCH_THROTTLED.getKey(), request.freeze());
+                    final Settings.Builder settingsBuilder = Settings.builder().put(indexMetadata.getSettings());
                     if (request.freeze()) {
+                        settingsBuilder.put(FrozenEngine.INDEX_FROZEN.getKey(), true);
+                        settingsBuilder.put(IndexSettings.INDEX_SEARCH_THROTTLED.getKey(), true);
                         settingsBuilder.put("index.blocks.write", true);
                         blocks.addIndexBlock(index.getName(), IndexMetadata.INDEX_WRITE_BLOCK);
                     } else {
-                        settingsBuilder.remove("index.blocks.write");
-                        blocks.removeIndexBlock(index.getName(), IndexMetadata.INDEX_WRITE_BLOCK);
+                        settingsBuilder.remove(FrozenEngine.INDEX_FROZEN.getKey());
+                        settingsBuilder.remove(IndexSettings.INDEX_SEARCH_THROTTLED.getKey());
+                        if (SearchableSnapshotsConstants.isSearchableSnapshotStore(indexMetadata.getSettings()) == false) {
+                            settingsBuilder.remove("index.blocks.write");
+                            blocks.removeIndexBlock(index.getName(), IndexMetadata.INDEX_WRITE_BLOCK);
+                        }
                     }
-                    imdBuilder.settings(settingsBuilder);
-                    builder.put(imdBuilder.build(), true);
+                    builder.put(IndexMetadata.builder(indexMetadata)
+                        .settingsVersion(indexMetadata.getSettingsVersion() + 1)
+                        .settings(settingsBuilder)
+                        .build(), true);
                 }
                 return ClusterState.builder(currentState).blocks(blocks).metadata(builder).build();
             }


### PR DESCRIPTION
Unfreezing a snapshot backed index does not work well 
because the unfreeze action always removes the 
index.blocks.write block, causing shards to be failed 
when the cluster state is applied on data nodes. This 
is because searchable snapshots shards always 
expect the index.blocks.write to be set to true.

This commit changes the freeze/unfreeze action 
so that the write block is not removed when 
unfreezing searchable snapshots indices. It also 
changes the toggling of index.frozen and 
index.search.throttled settings so that they are 
just removed (instead of being turned to false) 
when unfreezing.

Backport of #73368