### PR TITLE
Improve failure logging in testCorruptTranslogFiles

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/index/store/CorruptedTranslogIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/index/store/CorruptedTranslogIT.java
@@ -13,6 +13,7 @@ import org.elasticsearch.action.admin.cluster.allocation.ClusterAllocationExplai
 import org.elasticsearch.action.index.IndexRequestBuilder;
 import org.elasticsearch.action.search.SearchPhaseExecutionException;
 import org.elasticsearch.cluster.routing.UnassignedInfo;
+import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.ByteSizeUnit;
 import org.elasticsearch.common.unit.ByteSizeValue;
@@ -34,12 +35,10 @@ import java.util.Collection;
 import static org.elasticsearch.index.query.QueryBuilders.matchAllQuery;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
 
-/**
- * Integration test for corrupted translog files
- */
 @ESIntegTestCase.ClusterScope(scope = ESIntegTestCase.Scope.SUITE, numDataNodes = 0)
 public class CorruptedTranslogIT extends ESIntegTestCase {
     @Override
@@ -57,7 +56,6 @@ public class CorruptedTranslogIT extends ESIntegTestCase {
             .put(MockEngineSupport.DISABLE_FLUSH_ON_CLOSE.getKey(), true) // never flush - always recover from translog
             .put(IndexSettings.INDEX_TRANSLOG_FLUSH_THRESHOLD_SIZE_SETTING.getKey(), new ByteSizeValue(1, ByteSizeUnit.PB))));
 
-        // Index some documents
         IndexRequestBuilder[] builders = new IndexRequestBuilder[scaledRandomIntBetween(100, 1000)];
         for (int i = 0; i < builders.length; i++) {
             builders[i] = client().prepareIndex("test").setSource("foo", "bar");
@@ -76,13 +74,16 @@ public class CorruptedTranslogIT extends ESIntegTestCase {
         });
 
         assertBusy(() -> {
+            // assertBusy since the shard starts out unassigned with reason CLUSTER_RECOVERED, then it's assigned, and then it fails.
             final ClusterAllocationExplainResponse allocationExplainResponse
                 = client().admin().cluster().prepareAllocationExplain().setIndex("test").setShard(0).setPrimary(true).get();
+            final String description = Strings.toString(allocationExplainResponse.getExplanation());
             final UnassignedInfo unassignedInfo = allocationExplainResponse.getExplanation().getUnassignedInfo();
-            assertThat(unassignedInfo, not(nullValue()));
+            assertThat(description, unassignedInfo, not(nullValue()));
+            assertThat(description, unassignedInfo.getReason(), equalTo(UnassignedInfo.Reason.ALLOCATION_FAILED));
             final Throwable cause = ExceptionsHelper.unwrap(unassignedInfo.getFailure(), TranslogCorruptedException.class);
-            assertThat(cause, not(nullValue()));
-            assertThat(cause.getMessage(), containsString(translogPath.toString()));
+            assertThat(description, cause, not(nullValue()));
+            assertThat(description, cause.getMessage(), containsString(translogPath.toString()));
         });
 
         assertThat(expectThrows(SearchPhaseExecutionException.class, () -> client().prepareSearch("test").setQuery(matchAllQuery()).get())


### PR DESCRIPTION
Includes the full cluster allocation explain output in the assertion
failure message so we can see the state of the world on a failure.

Relates #72849