### PR TITLE
[7.x] [DOCS] Add #71998 to 7.13.0 release notes (#73440)

### DIFF
--- a/docs/reference/release-notes/7.13.asciidoc
+++ b/docs/reference/release-notes/7.13.asciidoc
@@ -244,6 +244,9 @@ Aggregations::
 * Significant text aggregation - return empty results rather than error if field unmapped {es-pull}70778[#70778] (issue: {es-issue}69809[#69809])
 * Stop terms aggregation from losing buckets {es-pull}70493[#70493] (issues: {es-issue}68871[#68871], {es-issue}70449[#70449])
 
+Analysis::
+* Ukrainian language plugin can fill up heap {es-pull}71998[#71998]
+
 Authentication::
 * Fix inconsistency of internal user checking {es-pull}70123[#70123]
 


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [DOCS] Add #71998 to 7.13.0 release notes (#73440)