### PR TITLE
[DOCS] Fix typo in Reindex API - Automatic slicing

### DIFF
--- a/docs/reference/docs/reindex.asciidoc
+++ b/docs/reference/docs/reindex.asciidoc
@@ -304,7 +304,7 @@ POST _reindex?slices=5&refresh
 ----------------------------------------------------------------
 // TEST[setup:my_index_big]
 
-You can also this verify works by:
+You can also verify this works by:
 
 [source,console]
 ----------------------------------------------------------------


### PR DESCRIPTION
Fixes the copy indicating how to verify if automatic slicing during reindexing succeeded.