### PR TITLE
Disable transitive dependencies when resolving bwc JDBC driver artifact

### DIFF
--- a/x-pack/plugin/sql/qa/jdbc/build.gradle
+++ b/x-pack/plugin/sql/qa/jdbc/build.gradle
@@ -76,7 +76,10 @@ subprojects {
       if (bwcVersion.onOrAfter(Version.fromString("7.9.0")) && (bwcVersion.equals(VersionProperties.elasticsearchVersion) == false)) {
         String baseName = "v${bwcVersion}"
         UnreleasedVersionInfo unreleasedVersion = BuildParams.bwcVersions.unreleasedInfo(bwcVersion)
-        Configuration driverConfiguration = configurations.create("jdbcDriver${baseName}")
+        Configuration driverConfiguration = configurations.create("jdbcDriver${baseName}") {
+          // TODO: Temporary workaround for https://github.com/elastic/elasticsearch/issues/73433
+          transitive = false
+        }
         Object driverDependency = null
 
         if (unreleasedVersion) {


### PR DESCRIPTION
This is a temporary workaround for failing JDBC BWC tests against 7.13.0 due to https://github.com/elastic/elasticsearch/issues/73433. For now we can just disable transitive dependencies for the JDBC driver since it's a fat jar, and doesn't require any additional dependencies.