### PR TITLE
[master] [DOCS] Fix typo (#73337)

### DIFF
--- a/x-pack/docs/en/security/securing-communications/security-basic-setup-https.asciidoc
+++ b/x-pack/docs/en/security/securing-communications/security-basic-setup-https.asciidoc
@@ -596,7 +596,7 @@ See {metricbeat-ref}/configuration-ssl.html[Configure SSL for {metricbeat}].
 +
 [source,shell]
 ----
-/.metricbeat -e
+./metricbeat -e
 ----
 +
 `-e` is optional and sends output to standard error instead of the configured


### PR DESCRIPTION
Backports the following commits to master:
 - [DOCS] Fix typo (#73337)