### PR TITLE
[7.x] [DOCS] Update snapshot/restore for data stream aliases (#73438)

### DIFF
--- a/docs/reference/snapshot-restore/apis/restore-snapshot-api.asciidoc
+++ b/docs/reference/snapshot-restore/apis/restore-snapshot-api.asciidoc
@@ -79,7 +79,7 @@ you are restoring. Existing indices can only be restored if they are
 the snapshot. The restore operation automatically opens restored indices if
 they were closed and creates new indices if they do not exist in the cluster.
 
-If a data stream is restored, its backing indices are also restored.
+If a data stream is restored, its aliases and backing indices are also restored.
 Alternatively, you can restore individual backing indices without restoring an
 entire data stream. If you restore individual backing indices, they are not
 automatically added to any existing data stream. For example, if only the
@@ -128,8 +128,11 @@ A comma-separated list of index settings that should not be restored from a snap
 If `true`, index aliases from the original snapshot are restored.
 Defaults to `true`.
 +
-If `false`, prevents aliases from being restored together with associated
+If `false`, prevents index aliases from being restored together with associated
 indices.
++
+This option doesn't affect data stream aliases. Restoring a data stream
+restores its aliases.
 
 [[restore-snapshot-api-include-global-state]]
 `include_global_state`::

--- a/docs/reference/snapshot-restore/restore-snapshot.asciidoc
+++ b/docs/reference/snapshot-restore/restore-snapshot.asciidoc
@@ -73,8 +73,9 @@ name. If no index template matches the stream, it cannot
 ====
 // end::rename-restored-data-stream-tag[]
 
-Set `include_aliases` to `false` to prevent aliases from being restored together
-with associated indices
+To prevent index aliases from being restored together with associated indices,
+set `include_aliases` to `false`. This option doesn't affect data stream
+aliases. Restoring a data stream restores its aliases.
 
 [source,console]
 -----------------------------------


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [DOCS] Update snapshot/restore for data stream aliases (#73438)