### PR TITLE
[7.x] Disable transitive dependencies when resolving bwc JDBC driver artifact (#73448)

### DIFF
--- a/x-pack/plugin/sql/qa/jdbc/build.gradle
+++ b/x-pack/plugin/sql/qa/jdbc/build.gradle
@@ -76,7 +76,10 @@ subprojects {
       if (bwcVersion.onOrAfter(Version.fromString("7.9.0"))) {
         String baseName = "v${bwcVersion}"
         UnreleasedVersionInfo unreleasedVersion = BuildParams.bwcVersions.unreleasedInfo(bwcVersion)
-        Configuration driverConfiguration = configurations.create("jdbcDriver${baseName}")
+        Configuration driverConfiguration = configurations.create("jdbcDriver${baseName}") {
+          // TODO: Temporary workaround for https://github.com/elastic/elasticsearch/issues/73433
+          transitive = false
+        }
         Object driverDependency = null
 
         if (unreleasedVersion) {


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Disable transitive dependencies when resolving bwc JDBC driver artifact (#73448)