### PR TITLE
[7.x] Shadowed dependencies should be hidden from pom dependencies (#73467)

### DIFF
--- a/buildSrc/src/integTest/groovy/org/elasticsearch/gradle/PublishPluginFuncTest.groovy
+++ b/buildSrc/src/integTest/groovy/org/elasticsearch/gradle/PublishPluginFuncTest.groovy
@@ -51,6 +51,127 @@ class PublishPluginFuncTest extends AbstractGradleFuncTest {
         )
     }
 
+    def "hides runtime dependencies and handles shadow dependencies"() {
+        given:
+        buildFile << """
+            plugins {
+                id 'elasticsearch.java'
+                id 'elasticsearch.publish'
+                id 'com.github.johnrengelman.shadow'
+            }
+            
+            repositories {
+                mavenCentral()
+            }
+            
+            dependencies {
+                implementation 'org.slf4j:log4j-over-slf4j:1.7.30'
+                shadow 'org.slf4j:slf4j-api:1.7.30'
+            }
+
+            publishing {
+                 repositories {
+                    maven {
+                        url = "\$buildDir/repo"
+                    }
+                 }
+            }
+            version = "1.0"
+            group = 'org.acme' 
+            description = 'some description'       
+        """
+
+        when:
+        def result = gradleRunner('assemble', '--stacktrace').build()
+
+        then:
+        result.task(":generatePom").outcome == TaskOutcome.SUCCESS
+        file("build/distributions/hello-world-1.0-original.jar").exists()
+        file("build/distributions/hello-world-1.0.jar").exists()
+        file("build/distributions/hello-world-1.0-javadoc.jar").exists()
+        file("build/distributions/hello-world-1.0-sources.jar").exists()
+        file("build/distributions/hello-world-1.0.pom").exists()
+        assertXmlEquals(file("build/distributions/hello-world-1.0.pom").text, """
+            <project xmlns="http://maven.apache.org/POM/4.0.0" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+              <modelVersion>4.0.0</modelVersion>
+              <groupId>org.acme</groupId>
+              <artifactId>hello-world</artifactId>
+              <version>1.0</version>
+              <name>hello-world</name>
+              <description>some description</description>
+              <dependencies>
+                <dependency>
+                  <groupId>org.slf4j</groupId>
+                  <artifactId>slf4j-api</artifactId>
+                  <version>1.7.30</version>
+                  <scope>runtime</scope>
+                </dependency>
+              </dependencies>
+            </project>"""
+        )
+    }
+
+    def "handles project shadow dependencies"() {
+        given:
+        settingsFile << "include ':someLib'"
+        file('someLib').mkdirs()
+        buildFile << """
+            plugins {
+                id 'elasticsearch.java'
+                id 'elasticsearch.publish'
+                id 'com.github.johnrengelman.shadow'
+            }
+
+            dependencies {
+                shadow project(":someLib")            
+            }
+            publishing {
+                 repositories {
+                    maven {
+                        url = "\$buildDir/repo"
+                    }
+                 }
+            }
+
+            allprojects {
+                apply plugin: 'elasticsearch.java'
+                version = "1.0"
+                group = 'org.acme' 
+            }
+
+            description = 'some description'       
+        """
+
+        when:
+        def result = gradleRunner(':assemble', '--stacktrace').build()
+
+        then:
+        result.task(":generatePom").outcome == TaskOutcome.SUCCESS
+        file("build/distributions/hello-world-1.0-original.jar").exists()
+        file("build/distributions/hello-world-1.0.jar").exists()
+        file("build/distributions/hello-world-1.0-javadoc.jar").exists()
+        file("build/distributions/hello-world-1.0-sources.jar").exists()
+        file("build/distributions/hello-world-1.0.pom").exists()
+        assertXmlEquals(file("build/distributions/hello-world-1.0.pom").text, """
+            <project xmlns="http://maven.apache.org/POM/4.0.0" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+              <modelVersion>4.0.0</modelVersion>
+              <groupId>org.acme</groupId>
+              <artifactId>hello-world</artifactId>
+              <version>1.0</version>
+              <name>hello-world</name>
+              <description>some description</description>
+              <dependencies>
+                <dependency>
+                  <groupId>org.acme</groupId>
+                  <artifactId>someLib</artifactId>
+                  <version>1.0</version>
+                  <scope>runtime</scope>
+                </dependency>
+              </dependencies>
+            </project>"""
+        )
+    }
+
     def "generates artifacts for shadowed elasticsearch plugin"() {
         given:
         file('license.txt') << "License file"


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Shadowed dependencies should be hidden from pom dependencies (#73467)