### PR TITLE
[DOCS] Mark unfreeze API as deprecated

### DIFF
--- a/docs/reference/indices/apis/unfreeze.asciidoc
+++ b/docs/reference/indices/apis/unfreeze.asciidoc
@@ -6,6 +6,10 @@
 <titleabbrev>Unfreeze index</titleabbrev>
 ++++
 
+// tag::unfreeze-api-dep[]
+deprecated::[7.14, Frozen indices are no longer useful due to https://www.elastic.co/blog/significantly-decrease-your-elasticsearch-heap-memory-usage[recent improvements in heap memory usage].]
+// end::unfreeze-api-dep[]
+
 Unfreezes an index.
 
 [[unfreeze-index-api-request]]

--- a/docs/reference/indices/apis/unfreeze.asciidoc
+++ b/docs/reference/indices/apis/unfreeze.asciidoc
@@ -6,9 +6,7 @@
 <titleabbrev>Unfreeze index</titleabbrev>
 ++++
 
-// tag::unfreeze-api-dep[]
 deprecated::[7.14, Frozen indices are no longer useful due to https://www.elastic.co/blog/significantly-decrease-your-elasticsearch-heap-memory-usage[recent improvements in heap memory usage].]
-// end::unfreeze-api-dep[]
 
 Unfreezes an index.
 


### PR DESCRIPTION
We decided to deprecate both the `freeze` and `unfreeze` APIs in https://github.com/elastic/elasticsearch/pull/72618.

Relates to #70192

Preview: https://elasticsearch_73505.docs-preview.app.elstc.co/diff