### PR TITLE
Upgrade Checkstyle to 8.42

### DIFF
--- a/buildSrc/src/main/resources/checkstyle_ide_fragment.xml
+++ b/buildSrc/src/main/resources/checkstyle_ide_fragment.xml
@@ -37,6 +37,6 @@
     <!-- Public methods must have JavaDoc -->
     <module name="JavadocMethod">
         <property name="severity" value="warning"/>
-        <property name="scope" value="public"/>
+        <property name="accessModifiers" value="public"/>
     </module>
 </module>

--- a/buildSrc/version.properties
+++ b/buildSrc/version.properties
@@ -4,7 +4,7 @@ lucene            = 8.9.0-snapshot-efdc43fee18
 bundled_jdk_vendor = adoptopenjdk
 bundled_jdk = 16.0.1+9
 
-checkstyle = 8.39
+checkstyle = 8.42
 
 # optional dependencies
 spatial4j         = 0.7


### PR DESCRIPTION
When instructing developers to configure tooling (like IntelliJ) to integrate with Checkstyle we have folks use the latest version, which at this time is 8.42. In that release https://github.com/checkstyle/checkstyle/issues/7417 renamed the `JavadocMethodCheck` "scope" attribute to "accessModifiers".

This pull request updates our Checkstyle version to 8.42 as well as the configuration to be compatible.

Closes https://github.com/elastic/elasticsearch/issues/73400