### PR TITLE
DynamicFieldType to expose its known subfields names

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/mapper/DynamicFieldType.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DynamicFieldType.java
@@ -8,6 +8,9 @@
 
 package org.elasticsearch.index.mapper;
 
+import java.util.Collections;
+import java.util.Set;
+
 /**
  * Defines a MappedFieldType that exposes dynamic child field types
  *
@@ -31,4 +34,13 @@ public interface DynamicFieldType {
      */
     MappedFieldType getChildFieldType(String path);
 
+    /**
+     * Returns the subfields that this dynamic field is known to hold. Not all the sub-fields are necessarily known in advance,
+     * but this method makes the ones that are known in advance discoverable, so that for instance they can then be returned by field_caps
+     * when using wildcards to match field names.
+     * @return a set of field names that this dynamic field is known to resolve
+     */
+    default Set<String> getKnownSubfields() {
+        return Collections.emptySet();
+    }
 }

--- a/server/src/main/java/org/elasticsearch/index/mapper/FieldTypeLookup.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/FieldTypeLookup.java
@@ -155,8 +155,17 @@ final class FieldTypeLookup {
      * twice.
      */
     Collection<MappedFieldType> getMatchingFieldTypes(String pattern) {
-        if ("*".equals(pattern)) {
-            return fullNameToFieldType.values();
+        if (Regex.isMatchAllPattern(pattern)) {
+            if (dynamicFieldTypes.isEmpty()) {
+                return fullNameToFieldType.values();
+            }
+            List<MappedFieldType> fieldTypes = new ArrayList<>(fullNameToFieldType.values());
+            for (DynamicFieldType dynamicFieldType : dynamicFieldTypes.values()) {
+                for (String subfield : dynamicFieldType.getKnownSubfields()) {
+                    fieldTypes.add(dynamicFieldType.getChildFieldType(subfield));
+                }
+            }
+            return fieldTypes;
         }
         if (Regex.isSimpleMatchPattern(pattern) == false) {
             // no wildcards
@@ -169,6 +178,15 @@ final class FieldTypeLookup {
                 matchingFields.add(fullNameToFieldType.get(field));
             }
         }
+        for (Map.Entry<String, DynamicFieldType> dynamicFieldTypeEntry : dynamicFieldTypes.entrySet()) {
+            String parentName = dynamicFieldTypeEntry.getKey();
+            DynamicFieldType dynamicFieldType = dynamicFieldTypeEntry.getValue();
+            for (String subfield : dynamicFieldType.getKnownSubfields()) {
+                if (Regex.simpleMatch(pattern, parentName + "." + subfield)) {
+                    matchingFields.add(dynamicFieldType.getChildFieldType(subfield));
+                }
+            }
+        }
         return matchingFields;
     }
 
@@ -178,8 +196,19 @@ final class FieldTypeLookup {
      * All field names in the returned set are guaranteed to resolve to a field
      */
     Set<String> getMatchingFieldNames(String pattern) {
-        if ("*".equals(pattern)) {
-            return fullNameToFieldType.keySet();
+        if (Regex.isMatchAllPattern(pattern)) {
+            if (dynamicFieldTypes.isEmpty()) {
+                return fullNameToFieldType.keySet();
+            }
+            Set<String> fieldNames = new HashSet<>(fullNameToFieldType.keySet());
+            for (Map.Entry<String, DynamicFieldType> dynamicFieldTypeEntry : dynamicFieldTypes.entrySet()) {
+                String parentName = dynamicFieldTypeEntry.getKey();
+                DynamicFieldType dynamicFieldType = dynamicFieldTypeEntry.getValue();
+                for (String subfield : dynamicFieldType.getKnownSubfields()) {
+                    fieldNames.add(parentName + "." + subfield);
+                }
+            }
+            return Collections.unmodifiableSet(fieldNames);
         }
         if (Regex.isSimpleMatchPattern(pattern) == false) {
             // no wildcards
@@ -189,6 +218,15 @@ final class FieldTypeLookup {
         for (String field : fullNameToFieldType.keySet()) {
             if (Regex.simpleMatch(pattern, field)) {
                 matchingFields.add(field);
+            }
+        }
+        for (Map.Entry<String, DynamicFieldType> dynamicFieldTypeEntry : dynamicFieldTypes.entrySet()) {
+            String parentName = dynamicFieldTypeEntry.getKey();
+            for (String subfield : dynamicFieldTypeEntry.getValue().getKnownSubfields()) {
+                String fullPath = parentName + "." + subfield;
+                if (Regex.simpleMatch(pattern, fullPath)) {
+                    matchingFields.add(fullPath);
+                }
             }
         }
         return matchingFields;

--- a/server/src/test/java/org/elasticsearch/index/mapper/FieldTypeLookupTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/FieldTypeLookupTests.java
@@ -25,6 +25,7 @@ import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.hasSize;
 
 public class FieldTypeLookupTests extends ESTestCase {
@@ -62,19 +63,18 @@ public class FieldTypeLookupTests extends ESTestCase {
         FieldAliasMapper alias1 = new FieldAliasMapper("food", "food", "foo");
         FieldAliasMapper alias2 = new FieldAliasMapper("barometer", "barometer", "bar");
 
-        FieldTypeLookup lookup = new FieldTypeLookup(List.of(field1, field2), List.of(alias1, alias2), List.of());
+        TestDynamicRuntimeField dynamicRuntimeField = new TestDynamicRuntimeField("baro",
+            Collections.singletonMap("meter", new TestRuntimeField("meter", "test")));
+
+        FieldTypeLookup lookup = new FieldTypeLookup(List.of(field1, field2), List.of(alias1, alias2), List.of(dynamicRuntimeField));
 
         Collection<String> names = lookup.getMatchingFieldNames("b*");
-
-        assertFalse(names.contains("foo"));
-        assertFalse(names.contains("food"));
-        assertTrue(names.contains("bar"));
-        assertTrue(names.contains("barometer"));
+        assertThat(names, containsInAnyOrder("bar", "barometer", "baro.meter"));
 
         Collection<MappedFieldType> fieldTypes = lookup.getMatchingFieldTypes("b*");
-        assertThat(fieldTypes, hasSize(2));     // both "bar" and "barometer" get returned as field types
+        assertThat(fieldTypes, hasSize(3));     // both "bar" and "barometer" get returned as field types
         Set<String> matchedNames = fieldTypes.stream().map(MappedFieldType::name).collect(Collectors.toSet());
-        assertThat(matchedNames, contains("bar"));  // but they both resolve to "bar" so we only have one name
+        assertThat(matchedNames, containsInAnyOrder("bar", "meter"));
     }
 
     public void testSourcePathWithMultiFields() {

--- a/server/src/test/java/org/elasticsearch/index/mapper/TestDynamicRuntimeField.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/TestDynamicRuntimeField.java
@@ -10,12 +10,22 @@ package org.elasticsearch.index.mapper;
 
 import org.elasticsearch.common.xcontent.XContentBuilder;
 
+import java.util.Collections;
+import java.util.Map;
+import java.util.Set;
+
 public class TestDynamicRuntimeField implements RuntimeField, DynamicFieldType {
 
     private final String name;
+    private final Map<String, MappedFieldType> subfields;
 
     public TestDynamicRuntimeField(String name) {
+        this(name, Collections.emptyMap());
+    }
+
+    public TestDynamicRuntimeField(String name, Map<String, MappedFieldType> subfields) {
         this.name = name;
+        this.subfields = subfields;
     }
 
     @Override
@@ -40,6 +50,14 @@ public class TestDynamicRuntimeField implements RuntimeField, DynamicFieldType {
 
     @Override
     public MappedFieldType getChildFieldType(String path) {
+        if (subfields.containsKey(path)) {
+            return subfields.get(path);
+        }
         return new KeywordScriptFieldType(name + "." + path);
+    }
+
+    @Override
+    public Set<String> getKnownSubfields() {
+        return subfields.keySet();
     }
 }


### PR DESCRIPTION
We use DynamicFieldType to dynamically resolve fields names at their lookup. This is currently used by the flattened field mapper and we intend to use it to expose emitting multiple fields from a runtime field scripts. Those multiple sub-fields will be resolved dynamically, but we need to make a distinction between sub-fields that are known in advance, which we would like to be discoverable e.g. through field_caps at all times, and additional sub-fields that may be resolved at lookup time but are not necessarily known in advance.

For this we are introducing a new method to DynamicFieldType that FieldTypeLookup consults in its getMatchingFieldNames and getMatchingFieldTypes method when the argument is a wilcard pattern.
