### PR TITLE
[7.x] [DOCS] Fix `_tasks` API endpoint reference (#73379)

### DIFF
--- a/docs/reference/docs/reindex.asciidoc
+++ b/docs/reference/docs/reindex.asciidoc
@@ -140,7 +140,7 @@ through every document in the source query.
 If the request contains `wait_for_completion=false`, {es}
 performs some preflight checks, launches the request, and returns a
 <<tasks,`task`>> you can use to cancel or get the status of the task.
-{es} creates a record of this task as a document at `.tasks/_doc/${taskId}`.
+{es} creates a record of this task as a document at `_tasks/<task_id>`.
 When you are done with a task, you should delete the task document so
 {es} can reclaim the space.
 


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [DOCS] Fix `_tasks` API endpoint reference (#73379)