### PR TITLE
Mute flaky security that fail with "unrecognized algorithm name"

### DIFF
--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/FIPS140SecureSettingsBootstrapCheckTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/FIPS140SecureSettingsBootstrapCheckTests.java
@@ -9,6 +9,7 @@ import org.apache.lucene.codecs.CodecUtil;
 import org.apache.lucene.store.IOContext;
 import org.apache.lucene.store.IndexOutput;
 import org.apache.lucene.store.SimpleFSDirectory;
+import org.elasticsearch.bootstrap.JavaVersion;
 import org.elasticsearch.common.settings.KeyStoreWrapper;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.env.Environment;
@@ -27,6 +28,8 @@ import java.util.Base64;
 public class FIPS140SecureSettingsBootstrapCheckTests extends AbstractBootstrapCheckTestCase {
 
     public void testLegacySecureSettingsIsNotAllowed() throws Exception {
+        assumeFalse("JDK bug JDK-8266279, https://github.com/elastic/elasticsearch/issues/68995",
+            JavaVersion.current().compareTo(JavaVersion.parse("8")) == 0);
         assumeFalse("Can't run in a FIPS JVM, PBE is not available", inFipsJvm());
         final Settings.Builder builder = Settings.builder()
             .put("path.home", createTempDir())

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/saml/SamlMetadataCommandTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/saml/SamlMetadataCommandTests.java
@@ -8,6 +8,7 @@ package org.elasticsearch.xpack.security.authc.saml;
 import joptsimple.OptionSet;
 
 import org.elasticsearch.ExceptionsHelper;
+import org.elasticsearch.bootstrap.JavaVersion;
 import org.elasticsearch.cli.MockTerminal;
 import org.elasticsearch.cli.UserException;
 import org.elasticsearch.common.collect.Tuple;
@@ -550,6 +551,8 @@ public class SamlMetadataCommandTests extends SamlTestCase {
     }
 
     public void testDefaultOptionsWithSigningAndMultipleEncryptionKeys() throws Exception {
+        assumeFalse("JDK bug JDK-8266279, https://github.com/elastic/elasticsearch/issues/68995",
+            JavaVersion.current().compareTo(JavaVersion.parse("8")) == 0);
         final Path dir = createTempDir();
 
         final Path ksEncryptionFile = dir.resolve("saml-encryption.p12");


### PR DESCRIPTION
These tests have been failing for the past few weeks on certain Java 8 JDKs (zulu and adaptopenjdk, to be specific).

@albertzaharovits analyzed the JDK bug here: https://github.com/elastic/elasticsearch/issues/72359

@ywangd discussed the specific 6.8 failures here: https://github.com/elastic/elasticsearch/issues/68995#issuecomment-836579972

Other similar tests were muted here: https://github.com/elastic/elasticsearch/issues/73314