### PR TITLE
[DOCS] Adds defaults to get ML results APIs

### DIFF
--- a/docs/reference/ml/anomaly-detection/apis/get-bucket.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/get-bucket.asciidoc
@@ -44,32 +44,37 @@ specify this parameter, the API returns information about all buckets.
 
 `anomaly_score`::
 (Optional, double) Returns buckets with anomaly scores greater or equal than
-this value.
+this value. Defaults to `0.0`.
 
 `desc`::
-(Optional, Boolean) If true, the buckets are sorted in descending order.
+(Optional, Boolean) If true, the buckets are sorted in descending order. Defaults to `false`.
 
 `end`::
 (Optional, string) Returns buckets with timestamps earlier than this time.
+Defaults to `-1`, which means it is unset and results are not limited to 
+specific timestamps.
 
 `exclude_interim`::
 (Optional, Boolean)
 include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=exclude-interim-results]
 
 `expand`::
-(Optional, Boolean) If true, the output includes anomaly records.
+(Optional, Boolean) If true, the output includes anomaly records. Defaults to `false`.
 
 `page`.`from`::
-(Optional, integer) Skips the specified number of buckets.
+(Optional, integer) Skips the specified number of buckets. Defaults to `0`.
+
 `page`.`size`::
-(Optional, integer) Specifies the maximum number of buckets to obtain.
+(Optional, integer) Specifies the maximum number of buckets to obtain. Defaults to `100`.
 
 `sort`::
 (Optional, string) Specifies the sort field for the requested buckets. By
 default, the buckets are sorted by the `timestamp` field.
 
 `start`::
-(Optional, string) Returns buckets with timestamps after this time.
+(Optional, string) Returns buckets with timestamps after this time. Defaults to 
+`-1`, which means it is unset and results are not limited to specific 
+timestamps.
 
 [role="child_attributes"]
 [[ml-get-bucket-results]]

--- a/docs/reference/ml/anomaly-detection/apis/get-calendar-event.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/get-calendar-event.asciidoc
@@ -44,7 +44,7 @@ include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=calendar-id]
 
 `end`::
     (Optional, string) Specifies to get events with timestamps earlier than this
-    time. Defaults to `null`, which means it is unset and results are not
+    time. Defaults to unset, which means results are not
     limited to specific timestamps.
 
 `from`::

--- a/docs/reference/ml/anomaly-detection/apis/get-calendar-event.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/get-calendar-event.asciidoc
@@ -44,16 +44,20 @@ include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=calendar-id]
 
 `end`::
     (Optional, string) Specifies to get events with timestamps earlier than this
-    time.
+    time. Defaults to `null`, which means it is unset and results are not
+    limited to specific timestamps.
 
 `from`::
-    (Optional, integer) Skips the specified number of events.
+    (Optional, integer) Skips the specified number of events. Defaults to `0`.
 
 `size`::
     (Optional, integer) Specifies the maximum number of events to obtain.
+    Defaults to `100`.
 
 `start`::
     (Optional, string) Specifies to get events with timestamps after this time.
+    Defaults to `null`, which means it is unset and results are not limited to
+    specific timestamps.
 
 [[ml-get-calendar-event-results]]
 == {api-response-body-title}

--- a/docs/reference/ml/anomaly-detection/apis/get-calendar-event.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/get-calendar-event.asciidoc
@@ -56,7 +56,7 @@ include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=calendar-id]
 
 `start`::
     (Optional, string) Specifies to get events with timestamps after this time.
-    Defaults to `null`, which means it is unset and results are not limited to
+    Defaults to unset, which means results are not limited to
     specific timestamps.
 
 [[ml-get-calendar-event-results]]

--- a/docs/reference/ml/anomaly-detection/apis/get-calendar.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/get-calendar.asciidoc
@@ -43,10 +43,11 @@ include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=calendar-id]
 == {api-request-body-title}
 
 `page`.`from`::
-    (Optional, integer) Skips the specified number of calendars.
+    (Optional, integer) Skips the specified number of calendars. Defaults to `0`.
 
 `page`.`size`::
     (Optional, integer) Specifies the maximum number of calendars to obtain.
+    Defaults to `0`.
 
 [[ml-get-calendar-results]]
 == {api-response-body-title}

--- a/docs/reference/ml/anomaly-detection/apis/get-category.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/get-category.asciidoc
@@ -53,9 +53,11 @@ specified partition.
 == {api-request-body-title}
 
 `page`.`from`::
-(Optional, integer) Skips the specified number of categories.
+(Optional, integer) Skips the specified number of categories. Defaults to `0`.
+
 `page`.`size`::
-(Optional, integer) Specifies the maximum number of categories to obtain.
+(Optional, integer) Specifies the maximum number of categories to obtain. 
+Defaults to `100`.
 
 `partition_field_value`::
 (Optional, string) Only return categories for the specified partition.

--- a/docs/reference/ml/anomaly-detection/apis/get-filter.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/get-filter.asciidoc
@@ -38,10 +38,11 @@ include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=filter-id]
 == {api-query-parms-title}
 
 `from`::
-    (Optional, integer) Skips the specified number of filters.
+    (Optional, integer) Skips the specified number of filters. Defaults to `0`.
 
 `size`::
     (Optional, integer) Specifies the maximum number of filters to obtain.
+    Defaults to `100`.
 
 [[ml-get-filter-results]]
 == {api-response-body-title}

--- a/docs/reference/ml/anomaly-detection/apis/get-influencer.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/get-influencer.asciidoc
@@ -42,6 +42,8 @@ include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=desc-results]
 
 `end`::
 (Optional, string) Returns influencers with timestamps earlier than this time.
+Defaults to `-1`, which means it is unset and results are not limited to 
+specific timestamps.
 
 `exclude_interim`::
 (Optional, Boolean)
@@ -49,19 +51,23 @@ include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=exclude-interim-results]
 
 `influencer_score`::
 (Optional, double) Returns influencers with anomaly scores greater than or
-equal to this value.
+equal to this value. Defaults to `0.0`.
 
 `page`.`from`::
-(Optional, integer) Skips the specified number of influencers.
+(Optional, integer) Skips the specified number of influencers. Defaults to `0`.
+
 `page`.`size`::
-(Optional, integer) Specifies the maximum number of influencers to obtain.
+(Optional, integer) Specifies the maximum number of influencers to obtain. 
+Defaults to `100`.
 
 `sort`::
 (Optional, string) Specifies the sort field for the requested influencers. By
 default, the influencers are sorted by the `influencer_score` value.
 
 `start`::
-(Optional, string) Returns influencers with timestamps after this time.
+(Optional, string) Returns influencers with timestamps after this time. Defaults 
+to `-1`, which means it is unset and results are not limited to specific 
+timestamps.
 
 [[ml-get-influencer-results]]
 == {api-response-body-title}

--- a/docs/reference/ml/anomaly-detection/apis/get-overall-buckets.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/get-overall-buckets.asciidoc
@@ -69,23 +69,27 @@ value.
 
 `end`::
 (Optional, string) Returns overall buckets with timestamps earlier than this
-time.
+time. Defaults to `-1`, which means it is unset and results are not limited to 
+specific timestamps.
 
 `exclude_interim`::
 (Optional, Boolean) If `true`, the output excludes interim overall buckets.
 Overall buckets are interim if any of the job buckets within the overall bucket
-interval are interim. By default, interim results are included.
+interval are interim. Defaults to `false`, which means interim results are
+included.
 
 `overall_score`::
 (Optional, double) Returns overall buckets with overall scores greater or equal
-than this value.
+than this value. Defaults to `0.0`.
 
 `start`::
-(Optional, string) Returns overall buckets with timestamps after this time.
+(Optional, string) Returns overall buckets with timestamps after this time. 
+Defaults to `-1`, which means it is unset and results are not limited to 
+specific timestamps.
 
 `top_n`::
 (Optional, integer) The number of top {anomaly-job} bucket scores to be used in
-the `overall_score` calculation. The default value is `1`.
+the `overall_score` calculation. Defaults to `1`.
 
 [[ml-get-overall-buckets-results]]
 == {api-response-body-title}

--- a/docs/reference/ml/anomaly-detection/apis/get-record.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/get-record.asciidoc
@@ -51,26 +51,31 @@ include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=desc-results]
 
 `end`::
 (Optional, string) Returns records with timestamps earlier than this time.
+Defaults to `-1`, which means it is unset and results are not limited to
+specific timestamps.
 
 `exclude_interim`::
 (Optional, Boolean)
 include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=exclude-interim-results]
 
 `page`.`from`::
-(Optional, integer) Skips the specified number of records.
+(Optional, integer) Skips the specified number of records. Defaults to `0`.
+
 `page`.`size`::
-(Optional, integer) Specifies the maximum number of records to obtain.
+(Optional, integer) Specifies the maximum number of records to obtain. Defaults
+to `100`.
 
 `record_score`::
 (Optional, double) Returns records with anomaly scores greater or equal than
-this value.
+this value. Defaults to `0.0`.
 
 `sort`::
 (Optional, string) Specifies the sort field for the requested records. By
-default, the records are sorted by the `anomaly_score` value.
+default, the records are sorted by the `record_score` value.
 
 `start`::
-(Optional, string) Returns records with timestamps after this time.
+(Optional, string) Returns records with timestamps after this time. Defaults to
+`-1`, which means it is unset and results are not limited to specific timestamps.
 
 [[ml-get-record-results]]
 == {api-response-body-title}

--- a/docs/reference/ml/anomaly-detection/apis/get-snapshot.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/get-snapshot.asciidoc
@@ -45,23 +45,29 @@ by specifying `*` as the `<snapshot_id>`, or by omitting the `<snapshot_id>`.
 == {api-request-body-title}
 
 `desc`::
-  (Optional, Boolean) If true, the results are sorted in descending order.
+  (Optional, Boolean) If true, the results are sorted in descending order. 
+  Defaults to `false`.
 
 `end`::
   (Optional, date) Returns snapshots with timestamps earlier than this time.
+  Defaults to `null`, which means it is unset and results are not limited to
+  specific timestamps.
 
 `from`::
-  (Optional, integer) Skips the specified number of snapshots.
+  (Optional, integer) Skips the specified number of snapshots. Defaults to `0`.
 
 `size`::
   (Optional, integer) Specifies the maximum number of snapshots to obtain.
+  Defaults to `100`.
 
 `sort`::
   (Optional, string) Specifies the sort field for the requested snapshots. By
   default, the snapshots are sorted by their timestamp.
 
 `start`::
-  (Optional, string) Returns snapshots with timestamps after this time.
+  (Optional, string) Returns snapshots with timestamps after this time. Defaults
+  to `null`, which means it is unset and results are not limited to specific
+  timestamps.
 
 [role="child_attributes"]
 [[ml-get-snapshot-results]]

--- a/docs/reference/ml/anomaly-detection/apis/get-snapshot.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/get-snapshot.asciidoc
@@ -50,8 +50,7 @@ by specifying `*` as the `<snapshot_id>`, or by omitting the `<snapshot_id>`.
 
 `end`::
   (Optional, date) Returns snapshots with timestamps earlier than this time.
-  Defaults to `null`, which means it is unset and results are not limited to
-  specific timestamps.
+  Defaults to unset, which means results are not limited to specific timestamps.
 
 `from`::
   (Optional, integer) Skips the specified number of snapshots. Defaults to `0`.
@@ -66,8 +65,7 @@ by specifying `*` as the `<snapshot_id>`, or by omitting the `<snapshot_id>`.
 
 `start`::
   (Optional, string) Returns snapshots with timestamps after this time. Defaults
-  to `null`, which means it is unset and results are not limited to specific
-  timestamps.
+  to unset, which means results are not limited to specific timestamps.
 
 [role="child_attributes"]
 [[ml-get-snapshot-results]]

--- a/docs/reference/ml/ml-shared.asciidoc
+++ b/docs/reference/ml/ml-shared.asciidoc
@@ -774,8 +774,7 @@ working with both over and by fields, then you can set `exclude_frequent` to
 end::exclude-frequent[]
 
 tag::exclude-interim-results[]
-If `true`, the output excludes interim results. By default, interim results are
-included.
+If `true`, the output excludes interim results. Defaults to `false`.
 end::exclude-interim-results[]
 
 tag::failed-category-count[]

--- a/docs/reference/ml/ml-shared.asciidoc
+++ b/docs/reference/ml/ml-shared.asciidoc
@@ -774,7 +774,7 @@ working with both over and by fields, then you can set `exclude_frequent` to
 end::exclude-frequent[]
 
 tag::exclude-interim-results[]
-If `true`, the output excludes interim results. Defaults to `false`.
+If `true`, the output excludes interim results. Defaults to `false`, which means interim results are included.
 end::exclude-interim-results[]
 
 tag::failed-category-count[]


### PR DESCRIPTION
This PR updates the "get buckets", "get influencers", "get overall buckets" and "get records" API documentation with information about the default values for the optional properties, which are gleaned from https://github.com/elastic/elasticsearch/blob/master/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/persistence/BucketsQueryBuilder.java, https://github.com/elastic/elasticsearch/blob/master/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/persistence/InfluencersQueryBuilder.java, and https://github.com/elastic/elasticsearch/blob/master/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/persistence/RecordsQueryBuilder.java

It also updates the "get model snapshots", "get scheduled events", "get calendars", "get filters" API documentation with information about the "from" and "size" defaults that seem to take the default values (https://github.com/elastic/elasticsearch/blob/master/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/action/util/PageParams.java) per https://github.com/elastic/elasticsearch/blob/master/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/rest/modelsnapshots/RestGetModelSnapshotsAction.java, https://github.com/elastic/elasticsearch/blob/master/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/rest/calendar/RestGetCalendarEventsAction.java, https://github.com/elastic/elasticsearch/blob/master/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/rest/calendar/RestGetCalendarsAction.java, https://github.com/elastic/elasticsearch/blob/master/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/rest/filter/RestGetFiltersAction.java

## Preview

https://elasticsearch_73540.docs-preview.app.elstc.co/diff