### PR TITLE
[Backport] Improve error when handling unexpected wildcards

### DIFF
--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/AuthorizationService.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/AuthorizationService.java
@@ -288,7 +288,7 @@ public class AuthorizationService {
                     authzIndicesListener));
             final AsyncSupplier<ResolvedIndices> resolvedIndicesAsyncSupplier = new CachingAsyncSupplier<>((resolvedIndicesListener) -> {
                 authorizedIndicesSupplier.getAsync(ActionListener.wrap(authorizedIndices -> {
-                    resolveIndexNames(request, metadata, authorizedIndices, resolvedIndicesListener);
+                    resolveIndexNames(action, request, metadata, authorizedIndices, resolvedIndicesListener);
                 }, e -> {
                     auditTrail.accessDenied(requestId, authentication, action, request, authzInfo);
                     if (e instanceof IndexNotFoundException) {
@@ -495,9 +495,10 @@ public class AuthorizationService {
             resolvedIndicesAsyncSupplier.getAsync(ActionListener.wrap(overallResolvedIndices -> {
                 final Set<String> localIndices = new HashSet<>(overallResolvedIndices.getLocal());
                 for (BulkItemRequest item : request.items()) {
+                    final String itemAction = getAction(item);
                     String resolvedIndex = resolvedIndexNames.computeIfAbsent(item.index(), key -> {
                         final ResolvedIndices resolvedIndices =
-                            indicesAndAliasesResolver.resolveIndicesAndAliases(item.request(), metadata, authorizedIndices);
+                            indicesAndAliasesResolver.resolveIndicesAndAliases(itemAction, item.request(), metadata, authorizedIndices);
                         if (resolvedIndices.getRemote().size() != 0) {
                             throw illegalArgument("Bulk item should not write to remote indices, but request writes to "
                                 + String.join(",", resolvedIndices.getRemote()));
@@ -514,7 +515,6 @@ public class AuthorizationService {
                         return resolved;
                     });
 
-                    final String itemAction = getAction(item);
                     actionToIndicesMap.compute(itemAction, (key, resolvedIndicesSet) -> {
                         final Set<String> localSet = resolvedIndicesSet != null ? resolvedIndicesSet : new HashSet<>();
                         localSet.add(resolvedIndex);
@@ -595,9 +595,9 @@ public class AuthorizationService {
         throw new IllegalArgumentException("No equivalent action for opType [" + docWriteRequest.opType() + "]");
     }
 
-    private void resolveIndexNames(TransportRequest request, Metadata metadata, Set<String> authorizedIndices,
+    private void resolveIndexNames(String action, TransportRequest request, Metadata metadata, Set<String> authorizedIndices,
                                    ActionListener<ResolvedIndices> listener) {
-        listener.onResponse(indicesAndAliasesResolver.resolve(request, metadata, authorizedIndices));
+        listener.onResponse(indicesAndAliasesResolver.resolve(action, request, metadata, authorizedIndices));
     }
 
     private void putTransientIfNonExisting(String key, Object value) {

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/IndicesAndAliasesResolver.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/IndicesAndAliasesResolver.java
@@ -23,6 +23,7 @@ import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.collect.ImmutableOpenMap;
 import org.elasticsearch.common.regex.Regex;
 import org.elasticsearch.common.settings.ClusterSettings;
@@ -46,6 +47,7 @@ import java.util.Set;
 import java.util.SortedMap;
 import java.util.concurrent.CopyOnWriteArraySet;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static org.elasticsearch.xpack.core.security.authz.IndicesAndAliasesResolverField.NO_INDEX_PLACEHOLDER;
 
@@ -94,12 +96,12 @@ class IndicesAndAliasesResolver {
      * Otherwise, <em>N</em> will be added to the <em>local</em> index list.
      */
 
-    ResolvedIndices resolve(TransportRequest request, Metadata metadata, Set<String> authorizedIndices) {
+    ResolvedIndices resolve(String action, TransportRequest request, Metadata metadata, Set<String> authorizedIndices) {
         if (request instanceof IndicesAliasesRequest) {
             ResolvedIndices.Builder resolvedIndicesBuilder = new ResolvedIndices.Builder();
             IndicesAliasesRequest indicesAliasesRequest = (IndicesAliasesRequest) request;
             for (IndicesRequest indicesRequest : indicesAliasesRequest.getAliasActions()) {
-                final ResolvedIndices resolved = resolveIndicesAndAliases(indicesRequest, metadata, authorizedIndices);
+                final ResolvedIndices resolved = resolveIndicesAndAliases(action, indicesRequest, metadata, authorizedIndices);
                 resolvedIndicesBuilder.addLocal(resolved.getLocal());
                 resolvedIndicesBuilder.addRemote(resolved.getRemote());
             }
@@ -110,11 +112,12 @@ class IndicesAndAliasesResolver {
         if (request instanceof IndicesRequest == false) {
             throw new IllegalStateException("Request [" + request + "] is not an Indices request, but should be.");
         }
-        return resolveIndicesAndAliases((IndicesRequest) request, metadata, authorizedIndices);
+        return resolveIndicesAndAliases(action, (IndicesRequest) request, metadata, authorizedIndices);
     }
 
 
-    ResolvedIndices resolveIndicesAndAliases(IndicesRequest indicesRequest, Metadata metadata, Set<String> authorizedIndices) {
+    ResolvedIndices resolveIndicesAndAliases(String action, IndicesRequest indicesRequest, Metadata metadata,
+                                             Set<String> authorizedIndices) {
         final ResolvedIndices.Builder resolvedIndicesBuilder = new ResolvedIndices.Builder();
         boolean indicesReplacedWithNoIndices = false;
         if (indicesRequest instanceof PutMappingRequest && ((PutMappingRequest) indicesRequest).getConcreteIndex() != null) {
@@ -182,16 +185,38 @@ class IndicesAndAliasesResolver {
                 replaceable.indices(resolvedIndicesBuilder.build().toArray());
             }
         } else {
-            if (containsWildcards(indicesRequest)) {
-                throw new IllegalStateException("There are no external requests known to support wildcards that don't support replacing " +
-                        "their indices");
+            final String[] indices = indicesRequest.indices();
+            if (indices == null || indices.length == 0) {
+                throw new IllegalArgumentException("the action " + action + " requires explicit index names, but none were provided");
             }
+            if (IndexNameExpressionResolver.isAllIndices(Arrays.asList(indices))) {
+                throw new IllegalArgumentException(
+                    "the action "
+                        + action
+                        + " does not support accessing all indices;"
+                        + " the provided index expression ["
+                        + Strings.arrayToCommaDelimitedString(indices)
+                        + "] is not allowed"
+                );
+            }
+            final List<String> wildcards = Stream.of(indices).filter(Regex::isSimpleMatchPattern).collect(Collectors.toList());
+            if (wildcards.isEmpty() == false) {
+                throw new IllegalArgumentException(
+                    "the action "
+                        + action
+                        + " does not support wildcards;"
+                        + " the provided index expression(s) ["
+                        + Strings.collectionToCommaDelimitedString(wildcards)
+                        + "] are not allowed"
+                );
+            }
+
             //NOTE: shard level requests do support wildcards (as they hold the original indices options) but don't support
             // replacing their indices.
             //That is fine though because they never contain wildcards, as they get replaced as part of the authorization of their
             //corresponding parent request on the coordinating node. Hence wildcards don't need to get replaced nor exploded for
             // shard level requests.
-            for (String name : indicesRequest.indices()) {
+            for (String name : indices) {
                 resolvedIndicesBuilder.addLocal(nameExpressionResolver.resolveDateMathExpression(name));
             }
         }
@@ -334,18 +359,6 @@ class IndicesAndAliasesResolver {
         }
 
         return finalAliases;
-    }
-
-    private boolean containsWildcards(IndicesRequest indicesRequest) {
-        if (IndexNameExpressionResolver.isAllIndices(indicesList(indicesRequest.indices()))) {
-            return true;
-        }
-        for (String index : indicesRequest.indices()) {
-            if (Regex.isSimpleMatchPattern(index)) {
-                return true;
-            }
-        }
-        return false;
     }
 
     private static List<String> indicesList(String[] list) {

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/IndicesAndAliasesResolverTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/IndicesAndAliasesResolverTests.java
@@ -88,6 +88,7 @@ import java.util.Map;
 import java.util.Set;
 
 import static org.elasticsearch.cluster.metadata.DataStreamTestHelper.createTimestampField;
+import static org.elasticsearch.test.TestMatchers.throwableWithMessage;
 import static org.elasticsearch.xpack.core.security.index.RestrictedIndicesNames.SECURITY_MAIN_ALIAS;
 import static org.elasticsearch.xpack.security.authz.AuthorizedIndicesTests.getRequestInfo;
 import static org.hamcrest.CoreMatchers.instanceOf;
@@ -305,16 +306,23 @@ public class IndicesAndAliasesResolverTests extends ESTestCase {
     public void testWildcardsAreNotAllowedInShardLevelRequests() {
         ShardSearchRequest request = mock(ShardSearchRequest.class);
         when(request.indices()).thenReturn(new String[]{"index*"});
-        IllegalStateException illegalStateException = expectThrows(IllegalStateException.class,
-                () -> resolveIndices(request, buildAuthorizedIndices(userDashIndices, SearchAction.NAME))
-                        .getLocal());
-        assertEquals("There are no external requests known to support wildcards that don't support replacing their indices",
-                illegalStateException.getMessage());
+        IllegalArgumentException exception = expectThrows(
+            IllegalArgumentException.class,
+            () -> resolveIndices(SearchAction.NAME + "[s]", request, buildAuthorizedIndices(userDashIndices, SearchAction.NAME)).getLocal()
+        );
+        assertThat(
+            exception,
+            throwableWithMessage(
+                "the action indices:data/read/search[s] does not support wildcards;"
+                    + " the provided index expression(s) [index*] are not allowed"
+            )
+        );
     }
 
     public void testAllIsNotAllowedInShardLevelRequests() {
         ShardSearchRequest request = mock(ShardSearchRequest.class);
-        if (randomBoolean()) {
+        final boolean literalAll = randomBoolean();
+        if (literalAll) {
             when(request.indices()).thenReturn(new String[]{"_all"});
         } else {
             if (randomBoolean()) {
@@ -323,11 +331,20 @@ public class IndicesAndAliasesResolverTests extends ESTestCase {
                 when(request.indices()).thenReturn(null);
             }
         }
-        IllegalStateException illegalStateException = expectThrows(IllegalStateException.class,
-                () -> resolveIndices(request, buildAuthorizedIndices(userDashIndices, SearchAction.NAME))
-                        .getLocal());
-        assertEquals("There are no external requests known to support wildcards that don't support replacing their indices",
-                illegalStateException.getMessage());
+        IllegalArgumentException exception = expectThrows(
+            IllegalArgumentException.class,
+            () -> resolveIndices(SearchAction.NAME + "[s]", request, buildAuthorizedIndices(userDashIndices, SearchAction.NAME)).getLocal()
+        );
+
+        assertThat(
+            exception,
+            literalAll
+                ? throwableWithMessage(
+                    "the action indices:data/read/search[s] does not support accessing all indices;"
+                        + " the provided index expression [_all] is not allowed"
+                )
+                : throwableWithMessage("the action indices:data/read/search[s] requires explicit index names, but none were provided")
+        );
     }
 
     public void testExplicitDashIndices() {
@@ -1505,7 +1522,8 @@ public class IndicesAndAliasesResolverTests extends ESTestCase {
         SearchRequest searchRequest = new SearchRequest();
         searchRequest.indicesOptions(IndicesOptions.fromOptions(false, false, true, true, true));
         Set<String> authorizedIndices = buildAuthorizedIndices(user, SearchAction.NAME);
-        ResolvedIndices resolvedIndices = defaultIndicesResolver.resolveIndicesAndAliases(searchRequest, metadata, authorizedIndices);
+        ResolvedIndices resolvedIndices
+            = defaultIndicesResolver.resolveIndicesAndAliases(SearchAction.NAME, searchRequest, metadata, authorizedIndices);
         assertThat(resolvedIndices.getLocal(), containsInAnyOrder("bar", "bar-closed", "foofoobar", "foobarfoo", "foofoo", "foofoo-closed",
             "hidden-open", "hidden-closed", ".hidden-open", ".hidden-closed", "date-hidden-" + todaySuffix,
             "date-hidden-" + tomorrowSuffix));
@@ -1514,7 +1532,7 @@ public class IndicesAndAliasesResolverTests extends ESTestCase {
         // open + hidden
         searchRequest = new SearchRequest();
         searchRequest.indicesOptions(IndicesOptions.fromOptions(false, false, true, false, true));
-        resolvedIndices = defaultIndicesResolver.resolveIndicesAndAliases(searchRequest, metadata, authorizedIndices);
+        resolvedIndices = defaultIndicesResolver.resolveIndicesAndAliases(SearchAction.NAME, searchRequest, metadata, authorizedIndices);
         assertThat(resolvedIndices.getLocal(),
             containsInAnyOrder("bar", "foofoobar", "foobarfoo", "foofoo", "hidden-open", ".hidden-open", "date-hidden-" + todaySuffix,
                 "date-hidden-" + tomorrowSuffix));
@@ -1524,7 +1542,7 @@ public class IndicesAndAliasesResolverTests extends ESTestCase {
         searchRequest = new SearchRequest(randomFrom(".h*", ".hid*"));
         searchRequest.indicesOptions(IndicesOptions.fromOptions(false, false, true, false, false));
         authorizedIndices = buildAuthorizedIndices(user, SearchAction.NAME);
-        resolvedIndices = defaultIndicesResolver.resolveIndicesAndAliases(searchRequest, metadata, authorizedIndices);
+        resolvedIndices = defaultIndicesResolver.resolveIndicesAndAliases(SearchAction.NAME, searchRequest, metadata, authorizedIndices);
         assertThat(resolvedIndices.getLocal(), containsInAnyOrder(".hidden-open"));
         assertThat(resolvedIndices.getRemote(), emptyIterable());
 
@@ -1532,7 +1550,7 @@ public class IndicesAndAliasesResolverTests extends ESTestCase {
         searchRequest = new SearchRequest();
         searchRequest.indicesOptions(IndicesOptions.fromOptions(false, false, false, true, true, true, false, true, false));
         authorizedIndices = buildAuthorizedIndices(user, SearchAction.NAME);
-        resolvedIndices = defaultIndicesResolver.resolveIndicesAndAliases(searchRequest, metadata, authorizedIndices);
+        resolvedIndices = defaultIndicesResolver.resolveIndicesAndAliases(SearchAction.NAME, searchRequest, metadata, authorizedIndices);
         assertThat(resolvedIndices.getLocal(), containsInAnyOrder("bar-closed", "foofoo-closed", "hidden-closed", ".hidden-closed"));
         assertThat(resolvedIndices.getRemote(), emptyIterable());
 
@@ -1540,7 +1558,7 @@ public class IndicesAndAliasesResolverTests extends ESTestCase {
         searchRequest = new SearchRequest(randomFrom(".h*", ".hid*"));
         searchRequest.indicesOptions(IndicesOptions.fromOptions(false, false, false, true, false));
         authorizedIndices = buildAuthorizedIndices(user, SearchAction.NAME);
-        resolvedIndices = defaultIndicesResolver.resolveIndicesAndAliases(searchRequest, metadata, authorizedIndices);
+        resolvedIndices = defaultIndicesResolver.resolveIndicesAndAliases(SearchAction.NAME, searchRequest, metadata, authorizedIndices);
         assertThat(resolvedIndices.getLocal(), containsInAnyOrder(".hidden-closed"));
         assertThat(resolvedIndices.getRemote(), emptyIterable());
 
@@ -1548,14 +1566,14 @@ public class IndicesAndAliasesResolverTests extends ESTestCase {
         searchRequest = new SearchRequest();
         searchRequest.indicesOptions(IndicesOptions.fromOptions(false, true, false, false, false, true, false, true, false));
         authorizedIndices = buildAuthorizedIndices(user, SearchAction.NAME);
-        resolvedIndices = defaultIndicesResolver.resolveIndicesAndAliases(searchRequest, metadata, authorizedIndices);
+        resolvedIndices = defaultIndicesResolver.resolveIndicesAndAliases(SearchAction.NAME, searchRequest, metadata, authorizedIndices);
         assertThat(resolvedIndices.getLocal(), contains("-*"));
         assertThat(resolvedIndices.getRemote(), emptyIterable());
 
         // date math with default indices options
         searchRequest = new SearchRequest("<date-hidden-{now/d}>");
         authorizedIndices = buildAuthorizedIndices(user, SearchAction.NAME);
-        resolvedIndices = defaultIndicesResolver.resolveIndicesAndAliases(searchRequest, metadata, authorizedIndices);
+        resolvedIndices = defaultIndicesResolver.resolveIndicesAndAliases(SearchAction.NAME, searchRequest, metadata, authorizedIndices);
         assertThat(resolvedIndices.getLocal(), contains(oneOf("date-hidden-" + todaySuffix, "date-hidden-" + tomorrowSuffix)));
         assertThat(resolvedIndices.getRemote(), emptyIterable());
     }
@@ -1567,14 +1585,15 @@ public class IndicesAndAliasesResolverTests extends ESTestCase {
         // Visible only
         SearchRequest searchRequest = new SearchRequest();
         searchRequest.indicesOptions(IndicesOptions.fromOptions(false, false, true, false, false));
-        ResolvedIndices resolvedIndices = defaultIndicesResolver.resolveIndicesAndAliases(searchRequest, metadata, authorizedIndices);
+        ResolvedIndices resolvedIndices
+            = defaultIndicesResolver.resolveIndicesAndAliases(SearchAction.NAME, searchRequest, metadata, authorizedIndices);
         assertThat(resolvedIndices.getLocal(), containsInAnyOrder("alias-visible", "alias-visible-mixed"));
         assertThat(resolvedIndices.getRemote(), emptyIterable());
 
         // Include hidden explicitly
         searchRequest = new SearchRequest();
         searchRequest.indicesOptions(IndicesOptions.fromOptions(false, false, true, false, true));
-        resolvedIndices = defaultIndicesResolver.resolveIndicesAndAliases(searchRequest, metadata, authorizedIndices);
+        resolvedIndices = defaultIndicesResolver.resolveIndicesAndAliases(SearchAction.NAME, searchRequest, metadata, authorizedIndices);
         assertThat(resolvedIndices.getLocal(),
             containsInAnyOrder("alias-visible", "alias-visible-mixed", "alias-hidden", ".alias-hidden", "hidden-open"));
         assertThat(resolvedIndices.getRemote(), emptyIterable());
@@ -1582,28 +1601,28 @@ public class IndicesAndAliasesResolverTests extends ESTestCase {
         // Include hidden with a wildcard
         searchRequest = new SearchRequest("alias-h*");
         searchRequest.indicesOptions(IndicesOptions.fromOptions(false, false, true, false, true));
-        resolvedIndices = defaultIndicesResolver.resolveIndicesAndAliases(searchRequest, metadata, authorizedIndices);
+        resolvedIndices = defaultIndicesResolver.resolveIndicesAndAliases(SearchAction.NAME, searchRequest, metadata, authorizedIndices);
         assertThat(resolvedIndices.getLocal(), containsInAnyOrder("alias-hidden"));
         assertThat(resolvedIndices.getRemote(), emptyIterable());
 
         // Dot prefix, implicitly including hidden
         searchRequest = new SearchRequest(".a*");
         searchRequest.indicesOptions(IndicesOptions.fromOptions(false, false, true, false, false));
-        resolvedIndices = defaultIndicesResolver.resolveIndicesAndAliases(searchRequest, metadata, authorizedIndices);
+        resolvedIndices = defaultIndicesResolver.resolveIndicesAndAliases(SearchAction.NAME, searchRequest, metadata, authorizedIndices);
         assertThat(resolvedIndices.getLocal(), containsInAnyOrder(".alias-hidden"));
         assertThat(resolvedIndices.getRemote(), emptyIterable());
 
         // Make sure ignoring aliases works (visible only)
         searchRequest = new SearchRequest();
         searchRequest.indicesOptions(IndicesOptions.fromOptions(false, true, true, false, false, true, false, true, false));
-        resolvedIndices = defaultIndicesResolver.resolveIndicesAndAliases(searchRequest, metadata, authorizedIndices);
+        resolvedIndices = defaultIndicesResolver.resolveIndicesAndAliases(SearchAction.NAME, searchRequest, metadata, authorizedIndices);
         assertThat(resolvedIndices.getLocal(), contains("-*"));
         assertThat(resolvedIndices.getRemote(), emptyIterable());
 
         // Make sure ignoring aliases works (including hidden)
         searchRequest = new SearchRequest();
         searchRequest.indicesOptions(IndicesOptions.fromOptions(false, false, true, false, true, true, false, true, false));
-        resolvedIndices = defaultIndicesResolver.resolveIndicesAndAliases(searchRequest, metadata, authorizedIndices);
+        resolvedIndices = defaultIndicesResolver.resolveIndicesAndAliases(SearchAction.NAME, searchRequest, metadata, authorizedIndices);
         assertThat(resolvedIndices.getLocal(), containsInAnyOrder("hidden-open"));
         assertThat(resolvedIndices.getRemote(), emptyIterable());
     }
@@ -1617,7 +1636,12 @@ public class IndicesAndAliasesResolverTests extends ESTestCase {
             searchRequest.indices("logs-*");
             searchRequest.indicesOptions(IndicesOptions.fromOptions(false, false, true, false, false, true, true, true, true));
             final Set<String> authorizedIndices = buildAuthorizedIndices(user, SearchAction.NAME, searchRequest);
-            ResolvedIndices resolvedIndices = defaultIndicesResolver.resolveIndicesAndAliases(searchRequest, metadata, authorizedIndices);
+            ResolvedIndices resolvedIndices = defaultIndicesResolver.resolveIndicesAndAliases(
+                SearchAction.NAME,
+                searchRequest,
+                metadata,
+                authorizedIndices
+            );
             assertThat(resolvedIndices.getLocal(), contains("logs-foobar"));
             assertThat(resolvedIndices.getRemote(), emptyIterable());
 
@@ -1625,7 +1649,12 @@ public class IndicesAndAliasesResolverTests extends ESTestCase {
             searchRequest = new SearchRequest();
             searchRequest.indices("logs-*");
             searchRequest.indicesOptions(IndicesOptions.fromOptions(false, true, true, false, false, true, true, true, true));
-            resolvedIndices = defaultIndicesResolver.resolveIndicesAndAliases(searchRequest, metadata, authorizedIndices);
+            resolvedIndices = defaultIndicesResolver.resolveIndicesAndAliases(
+                SearchAction.NAME,
+                searchRequest,
+                metadata,
+                authorizedIndices
+            );
             // if data streams are to be ignored then this happens in IndexNameExpressionResolver:
             assertThat(resolvedIndices.getLocal(), contains("logs-foobar"));
             assertThat(resolvedIndices.getRemote(), emptyIterable());
@@ -1638,7 +1667,12 @@ public class IndicesAndAliasesResolverTests extends ESTestCase {
             searchRequest.indices("logs-*");
             searchRequest.indicesOptions(IndicesOptions.fromOptions(false, false, true, false, false, true, true, true, true));
             final Set<String> authorizedIndices = buildAuthorizedIndices(user, SearchAction.NAME, searchRequest);
-            ResolvedIndices resolvedIndices = defaultIndicesResolver.resolveIndicesAndAliases(searchRequest, metadata, authorizedIndices);
+            ResolvedIndices resolvedIndices = defaultIndicesResolver.resolveIndicesAndAliases(
+                SearchAction.NAME,
+                searchRequest,
+                metadata,
+                authorizedIndices
+            );
             assertThat(resolvedIndices.getLocal(), containsInAnyOrder("logs-foo", "logs-foobar"));
             assertThat(resolvedIndices.getRemote(), emptyIterable());
         }
@@ -1665,7 +1699,11 @@ public class IndicesAndAliasesResolverTests extends ESTestCase {
 
         // neither data streams nor their backing indices will be in the resolved list unless the backing indices matched the requested
         // pattern
-        ResolvedIndices resolvedIndices = defaultIndicesResolver.resolveIndicesAndAliases(request, metadata, authorizedIndices);
+        ResolvedIndices resolvedIndices = defaultIndicesResolver.resolveIndicesAndAliases(
+            GetAliasesAction.NAME,
+            request,
+            metadata,
+            authorizedIndices);
         for (String dsName : dataStreams) {
             assertThat(resolvedIndices.getLocal(), hasItem(dsName));
             DataStream dataStream = metadata.dataStreams().get(dsName);
@@ -1695,7 +1733,12 @@ public class IndicesAndAliasesResolverTests extends ESTestCase {
 
         // neither data streams nor their backing indices will be in the resolved list since the backing indices do not match the
         // requested name(s)
-        ResolvedIndices resolvedIndices = defaultIndicesResolver.resolveIndicesAndAliases(request, metadata, authorizedIndices);
+        ResolvedIndices resolvedIndices = defaultIndicesResolver.resolveIndicesAndAliases(
+            GetAliasesAction.NAME,
+            request,
+            metadata,
+            authorizedIndices
+        );
         assertThat(resolvedIndices.getLocal(), hasItem(dataStreamName));
         for (Index i : dataStream.getIndices()) {
             assertThat(resolvedIndices.getLocal(), hasItem(i.getName()));
@@ -1721,7 +1764,12 @@ public class IndicesAndAliasesResolverTests extends ESTestCase {
 
         // data streams without their backing indices will be in the resolved list since the backing indices do not match the requested
         // pattern
-        ResolvedIndices resolvedIndices = defaultIndicesResolver.resolveIndicesAndAliases(request, metadata, authorizedIndices);
+        ResolvedIndices resolvedIndices = defaultIndicesResolver.resolveIndicesAndAliases(
+            SearchAction.NAME,
+            request,
+            metadata,
+            authorizedIndices
+        );
         assertThat(resolvedIndices.getLocal(), hasItem("logs-foo"));
         assertThat(resolvedIndices.getLocal(), hasItem("logs-foobar"));
         assertThat(resolvedIndices.getLocal(), hasItem("logs-00001"));
@@ -1752,7 +1800,12 @@ public class IndicesAndAliasesResolverTests extends ESTestCase {
             assertThat(authorizedIndices, hasItem(i.getName()));
         }
 
-        ResolvedIndices resolvedIndices = defaultIndicesResolver.resolveIndicesAndAliases(request, metadata, authorizedIndices);
+        ResolvedIndices resolvedIndices = defaultIndicesResolver.resolveIndicesAndAliases(
+            SearchAction.NAME,
+            request,
+            metadata,
+            authorizedIndices
+        );
         // data streams without their backing indices will be in the resolved list since the backing indices do not match the requested
         // name
         assertThat(resolvedIndices.getLocal(), hasItem(dataStreamName));
@@ -1780,7 +1833,12 @@ public class IndicesAndAliasesResolverTests extends ESTestCase {
 
         // data streams should _not_ be included in the resolved list because they do not match the pattern but their backing indices
         // should be in the resolved list because they match the pattern and are authorized via extension from their parent data stream
-        ResolvedIndices resolvedIndices = defaultIndicesResolver.resolveIndicesAndAliases(request, metadata, authorizedIndices);
+        ResolvedIndices resolvedIndices = defaultIndicesResolver.resolveIndicesAndAliases(
+            SearchAction.NAME,
+            request,
+            metadata,
+            authorizedIndices
+        );
         for (String dsName : expectedDataStreams) {
             DataStream dataStream = metadata.dataStreams().get(dsName);
             assertThat(resolvedIndices.getLocal(), not(hasItem(dsName)));
@@ -1809,7 +1867,12 @@ public class IndicesAndAliasesResolverTests extends ESTestCase {
 
         // neither data streams nor their backing indices will be in the resolved list since the request does not support data streams
         // and the backing indices do not match the requested name
-        ResolvedIndices resolvedIndices = defaultIndicesResolver.resolveIndicesAndAliases(request, metadata, authorizedIndices);
+        ResolvedIndices resolvedIndices = defaultIndicesResolver.resolveIndicesAndAliases(
+            GetAliasesAction.NAME,
+            request,
+            metadata,
+            authorizedIndices
+        );
         assertThat(resolvedIndices.getLocal(), hasItem(dataStreamName));
         for (Index i : dataStream.getIndices()) {
             assertThat(resolvedIndices.getLocal(), hasItem(i.getName()));
@@ -1835,7 +1898,12 @@ public class IndicesAndAliasesResolverTests extends ESTestCase {
 
         // only the backing indices will be in the resolved list since the request does not support data streams
         // but the backing indices match the requested pattern
-        ResolvedIndices resolvedIndices = defaultIndicesResolver.resolveIndicesAndAliases(request, metadata, authorizedIndices);
+        ResolvedIndices resolvedIndices = defaultIndicesResolver.resolveIndicesAndAliases(
+            SearchAction.NAME,
+            request,
+            metadata,
+            authorizedIndices
+        );
         assertThat(resolvedIndices.getLocal(), not(hasItem(dataStream.getName())));
         for (Index i : dataStream.getIndices()) {
             assertThat(authorizedIndices, hasItem(i.getName()));
@@ -1857,7 +1925,12 @@ public class IndicesAndAliasesResolverTests extends ESTestCase {
 
         // only the single backing index will be in the resolved list since the request does not support data streams
         // but one of the backing indices matched the requested pattern
-        ResolvedIndices resolvedIndices = defaultIndicesResolver.resolveIndicesAndAliases(request, metadata, authorizedIndices);
+        ResolvedIndices resolvedIndices = defaultIndicesResolver.resolveIndicesAndAliases(
+            SearchAction.NAME,
+            request,
+            metadata,
+            authorizedIndices
+        );
         assertThat(resolvedIndices.getLocal(), not(hasItem("logs-foobar")));
         assertThat(resolvedIndices.getLocal(), contains(DataStream.getDefaultBackingIndexName("logs-foobar", 1)));
     }
@@ -1881,7 +1954,12 @@ public class IndicesAndAliasesResolverTests extends ESTestCase {
 
         // only the backing indices will be in the resolved list since the request does not support data streams
         // but the backing indices match the requested pattern
-        ResolvedIndices resolvedIndices = defaultIndicesResolver.resolveIndicesAndAliases(request, metadata, authorizedIndices);
+        ResolvedIndices resolvedIndices = defaultIndicesResolver.resolveIndicesAndAliases(
+            GetAliasesAction.NAME,
+            request,
+            metadata,
+            authorizedIndices
+        );
         assertThat(resolvedIndices.getLocal(), not(hasItem(dataStream.getName())));
         for (Index i : dataStream.getIndices()) {
             assertThat(authorizedIndices, hasItem(i.getName()));
@@ -1903,7 +1981,12 @@ public class IndicesAndAliasesResolverTests extends ESTestCase {
 
         // only the single backing index will be in the resolved list since the request does not support data streams
         // but one of the backing indices matched the requested pattern
-        ResolvedIndices resolvedIndices = defaultIndicesResolver.resolveIndicesAndAliases(request, metadata, authorizedIndices);
+        ResolvedIndices resolvedIndices = defaultIndicesResolver.resolveIndicesAndAliases(
+            GetAliasesAction.NAME,
+            request,
+            metadata,
+            authorizedIndices
+        );
         assertThat(resolvedIndices.getLocal(), not(hasItem("logs-foobar")));
         assertThat(resolvedIndices.getLocal(), contains(DataStream.getDefaultBackingIndexName("logs-foobar", 1)));
     }
@@ -1928,7 +2011,11 @@ public class IndicesAndAliasesResolverTests extends ESTestCase {
     }
 
     private ResolvedIndices resolveIndices(TransportRequest request, Set<String> authorizedIndices) {
-        return defaultIndicesResolver.resolve(request, this.metadata, authorizedIndices);
+        return resolveIndices("indices:/" + randomAlphaOfLength(8), request, authorizedIndices);
+    }
+
+    private ResolvedIndices resolveIndices(String action, TransportRequest request, Set<String> authorizedIndices) {
+        return defaultIndicesResolver.resolve(action, request, this.metadata, authorizedIndices);
     }
 
     private static void assertNoIndices(IndicesRequest.Replaceable request, ResolvedIndices resolvedIndices) {


### PR DESCRIPTION
Security actively prevents wildcards (as well as empty indices
and explicit '_all') from being sent to actions that don't support
replacing their index names. For example

    GET /a*/_doc/1

This is so that we don't end up in a situation where an action
resolves wildcards in a non-security aware way.

The error message that was returned in these cases was not meaningful
to clients, and has been a regular source of confusion.
This commit changes the error messages that are returned in this case.

Backport of: #73079
