### PR TITLE
Change rest status code for TaskCancelledException to 400 (#73524)

### DIFF
--- a/server/src/main/java/org/elasticsearch/tasks/TaskCancelledException.java
+++ b/server/src/main/java/org/elasticsearch/tasks/TaskCancelledException.java
@@ -9,13 +9,14 @@ package org.elasticsearch.tasks;
 
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.rest.RestStatus;
 
 import java.io.IOException;
 
 /**
  * A generic exception that can be thrown by a task when it's cancelled by the task manager API
  */
-public class TaskCancelledException  extends ElasticsearchException {
+public class TaskCancelledException extends ElasticsearchException {
 
     public TaskCancelledException(String msg) {
         super(msg);
@@ -23,5 +24,14 @@ public class TaskCancelledException  extends ElasticsearchException {
 
     public TaskCancelledException(StreamInput in) throws IOException{
         super(in);
+    }
+
+    @Override
+    public RestStatus status() {
+        // Tasks are typically cancelled at the request of the client, so a 4xx status code is more accurate than the default of 500 (and
+        // means we don't log every cancellation at WARN level). There's no perfect match for cancellation in the available status codes,
+        // but (quoting RFC 7213) 400 Bad Request "indicates that the server cannot or will not process the request due to something that is
+        // perceived to be a client error" which is broad enough to be acceptable here.
+        return RestStatus.BAD_REQUEST;
     }
 }

--- a/server/src/test/java/org/elasticsearch/search/SearchServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/search/SearchServiceTests.java
@@ -1313,6 +1313,7 @@ public class SearchServiceTests extends ESSingleNodeTestCase {
             public void onFailure(Exception e) {
                 assertThat(e, is(instanceOf(TaskCancelledException.class)));
                 assertThat(e.getMessage(), is("cancelled"));
+                assertThat(((TaskCancelledException)e).status(), is(RestStatus.BAD_REQUEST));
                 assertThat(searchContextCreated.get(), is(false));
                 latch3.countDown();
             }
@@ -1336,6 +1337,7 @@ public class SearchServiceTests extends ESSingleNodeTestCase {
             public void onFailure(Exception e) {
                 assertThat(e, is(instanceOf(TaskCancelledException.class)));
                 assertThat(e.getMessage(), is("cancelled"));
+                assertThat(((TaskCancelledException)e).status(), is(RestStatus.BAD_REQUEST));
                 assertThat(searchContextCreated.get(), is(false));
                 latch4.countDown();
             }
@@ -1388,6 +1390,7 @@ public class SearchServiceTests extends ESSingleNodeTestCase {
                 Throwable cancelledExc = e.getCause().getCause();
                 assertThat(cancelledExc, is(instanceOf(TaskCancelledException.class)));
                 assertThat(cancelledExc.getMessage(), is("cancelled"));
+                assertThat(((TaskCancelledException) cancelledExc).status(), is(RestStatus.BAD_REQUEST));
                 latch.countDown();
             }
         });


### PR DESCRIPTION
Currently when a rest action receives aTaskCancelledException , the response is translated to a HTTP 500 error (INTERNAL_SERVER_ERROR). This in turn gets logged as a warning in the Elasticsearch logs.

Until now this has not been a problem, but with the introduction of #72688, this has become more probable and in application where there is a lot of cancellation it can lead to a very noise log with lots of warning messages.

Arguably, a task cancelation should not be consider a internal error as it is more normally related to something done by the client. There is no a good mapping between HTTP errors and task cancellation but after discussing with David and Armin, we think a 400 (BAD_REQUEST) is a better code for such an error.

This in turn will make the error only be log in DEBUG mode.I have label the issue as a bug.

backport #73524