### PR TITLE
DynamicFieldType to expose its known subfields names (#73530)

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/mapper/DynamicFieldType.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DynamicFieldType.java
@@ -8,6 +8,9 @@
 
 package org.elasticsearch.index.mapper;
 
+import java.util.Collections;
+import java.util.Set;
+
 /**
  * Defines a MappedFieldType that exposes dynamic child field types
  *
@@ -31,4 +34,13 @@ public interface DynamicFieldType {
      */
     MappedFieldType getChildFieldType(String path);
 
+    /**
+     * Returns the subfields that this dynamic field is known to hold. Not all the sub-fields are necessarily known in advance,
+     * but this method makes the ones that are known in advance discoverable, so that for instance they can then be returned by field_caps
+     * when using wildcards to match field names.
+     * @return a set of field names that this dynamic field is known to resolve
+     */
+    default Set<String> getKnownSubfields() {
+        return Collections.emptySet();
+    }
 }

--- a/server/src/main/java/org/elasticsearch/index/mapper/FieldTypeLookup.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/FieldTypeLookup.java
@@ -162,8 +162,17 @@ final class FieldTypeLookup {
      * twice.
      */
     Collection<MappedFieldType> getMatchingFieldTypes(String pattern) {
-        if ("*".equals(pattern)) {
-            return fullNameToFieldType.values();
+        if (Regex.isMatchAllPattern(pattern)) {
+            if (dynamicFieldTypes.isEmpty()) {
+                return fullNameToFieldType.values();
+            }
+            List<MappedFieldType> fieldTypes = new ArrayList<>(fullNameToFieldType.values());
+            for (DynamicFieldType dynamicFieldType : dynamicFieldTypes.values()) {
+                for (String subfield : dynamicFieldType.getKnownSubfields()) {
+                    fieldTypes.add(dynamicFieldType.getChildFieldType(subfield));
+                }
+            }
+            return fieldTypes;
         }
         if (Regex.isSimpleMatchPattern(pattern) == false) {
             // no wildcards
@@ -176,6 +185,15 @@ final class FieldTypeLookup {
                 matchingFields.add(fullNameToFieldType.get(field));
             }
         }
+        for (Map.Entry<String, DynamicFieldType> dynamicFieldTypeEntry : dynamicFieldTypes.entrySet()) {
+            String parentName = dynamicFieldTypeEntry.getKey();
+            DynamicFieldType dynamicFieldType = dynamicFieldTypeEntry.getValue();
+            for (String subfield : dynamicFieldType.getKnownSubfields()) {
+                if (Regex.simpleMatch(pattern, parentName + "." + subfield)) {
+                    matchingFields.add(dynamicFieldType.getChildFieldType(subfield));
+                }
+            }
+        }
         return matchingFields;
     }
 
@@ -185,8 +203,19 @@ final class FieldTypeLookup {
      * All field names in the returned set are guaranteed to resolve to a field
      */
     Set<String> getMatchingFieldNames(String pattern) {
-        if ("*".equals(pattern)) {
-            return fullNameToFieldType.keySet();
+        if (Regex.isMatchAllPattern(pattern)) {
+            if (dynamicFieldTypes.isEmpty()) {
+                return fullNameToFieldType.keySet();
+            }
+            Set<String> fieldNames = new HashSet<>(fullNameToFieldType.keySet());
+            for (Map.Entry<String, DynamicFieldType> dynamicFieldTypeEntry : dynamicFieldTypes.entrySet()) {
+                String parentName = dynamicFieldTypeEntry.getKey();
+                DynamicFieldType dynamicFieldType = dynamicFieldTypeEntry.getValue();
+                for (String subfield : dynamicFieldType.getKnownSubfields()) {
+                    fieldNames.add(parentName + "." + subfield);
+                }
+            }
+            return Collections.unmodifiableSet(fieldNames);
         }
         if (Regex.isSimpleMatchPattern(pattern) == false) {
             // no wildcards
@@ -196,6 +225,15 @@ final class FieldTypeLookup {
         for (String field : fullNameToFieldType.keySet()) {
             if (Regex.simpleMatch(pattern, field)) {
                 matchingFields.add(field);
+            }
+        }
+        for (Map.Entry<String, DynamicFieldType> dynamicFieldTypeEntry : dynamicFieldTypes.entrySet()) {
+            String parentName = dynamicFieldTypeEntry.getKey();
+            for (String subfield : dynamicFieldTypeEntry.getValue().getKnownSubfields()) {
+                String fullPath = parentName + "." + subfield;
+                if (Regex.simpleMatch(pattern, fullPath)) {
+                    matchingFields.add(fullPath);
+                }
             }
         }
         return matchingFields;

--- a/server/src/test/java/org/elasticsearch/index/mapper/TestDynamicRuntimeField.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/TestDynamicRuntimeField.java
@@ -10,12 +10,22 @@ package org.elasticsearch.index.mapper;
 
 import org.elasticsearch.common.xcontent.XContentBuilder;
 
+import java.util.Collections;
+import java.util.Map;
+import java.util.Set;
+
 public class TestDynamicRuntimeField implements RuntimeField, DynamicFieldType {
 
     private final String name;
+    private final Map<String, MappedFieldType> subfields;
 
     public TestDynamicRuntimeField(String name) {
+        this(name, Collections.emptyMap());
+    }
+
+    public TestDynamicRuntimeField(String name, Map<String, MappedFieldType> subfields) {
         this.name = name;
+        this.subfields = subfields;
     }
 
     @Override
@@ -40,6 +50,14 @@ public class TestDynamicRuntimeField implements RuntimeField, DynamicFieldType {
 
     @Override
     public MappedFieldType getChildFieldType(String path) {
+        if (subfields.containsKey(path)) {
+            return subfields.get(path);
+        }
         return new KeywordScriptFieldType(name + "." + path);
+    }
+
+    @Override
+    public Set<String> getKnownSubfields() {
+        return subfields.keySet();
     }
 }


### PR DESCRIPTION
We use DynamicFieldType to dynamically resolve fields names at their lookup. This is currently used by the flattened field mapper and we intend to use it to expose emitting multiple fields from a runtime field scripts. Those multiple sub-fields will be resolved dynamically, but we need to make a distinction between sub-fields that are known in advance, which we would like to be discoverable e.g. through field_caps at all times, and additional sub-fields that may be resolved at lookup time but are not necessarily known in advance.

For this we are introducing a new method to DynamicFieldType that FieldTypeLookup consults in its getMatchingFieldNames and getMatchingFieldTypes method when the argument is a wilcard pattern.