### PR TITLE
Make assertion less flaky in IndicesClientIT.testDataStreams().

### DIFF
--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/IndicesClientIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/IndicesClientIT.java
@@ -1643,7 +1643,8 @@ public class IndicesClientIT extends ESRestHighLevelClientTestCase {
         assertThat(dataStreamStat.getDataStream(), equalTo(dataStreamName));
         assertThat(dataStreamStat.getBackingIndices(), equalTo(1));
         assertThat(dataStreamStat.getMaximumTimestamp(), equalTo(0L)); // No data in here
-        assertThat(dataStreamStat.getStoreSize().getBytes(), not(equalTo(0L))); // but still takes up some space on disk
+        // Only asserting existence of store stats, testing any concrete value makes this test flaky.
+        assertThat(dataStreamStat.getStoreSize(), notNullValue());
 
         DeleteDataStreamRequest deleteDataStreamRequest = new DeleteDataStreamRequest(dataStreamName);
         response = execute(deleteDataStreamRequest, indices::deleteDataStream, indices::deleteDataStreamAsync);


### PR DESCRIPTION
Instead of assertion that store stats has a non zero value,
just verify that a value is returned. Verifying whether a
non value or specific value is returned, isn't the purpose
of hlrc integration tests.

Closes #60461
