### PR TITLE
Update  the service account creation documentation

### DIFF
--- a/docs/plugins/repository-gcs.asciidoc
+++ b/docs/plugins/repository-gcs.asciidoc
@@ -68,10 +68,9 @@ Here is a summary of the steps:
 
 1. Connect to the https://console.cloud.google.com/[Google Cloud Platform Console].
 2. Select your project.
-3. Go to the https://console.cloud.google.com/permissions[Permission] tab.
-4. Select the https://console.cloud.google.com/permissions/serviceaccounts[Service Accounts] tab.
-5. Click *Create service account*.
-6. After the account is created, select it and download a JSON key file.
+3. Select the https://console.cloud.google.com/iam-admin/serviceaccounts[Service Accounts] tab.
+4. Click *Create service account*.
+5. After the account is created, select it and download a JSON key file.
 
 A JSON service account file looks like this:
 

--- a/docs/plugins/repository-gcs.asciidoc
+++ b/docs/plugins/repository-gcs.asciidoc
@@ -70,7 +70,9 @@ Here is a summary of the steps:
 2. Select your project.
 3. Select the https://console.cloud.google.com/iam-admin/serviceaccounts[Service Accounts] tab.
 4. Click *Create service account*.
-5. After the account is created, select it and download a JSON key file.
+5. After the account is created, select it and go to *Keys*.
+6. Select *Add Key* and then *Create new key*.
+7. Select Key Type *JSON* as P12 is unsupported.
 
 A JSON service account file looks like this:
 


### PR DESCRIPTION
There are some changes in GCP. The service accounts are now their own button and not a child under the IAM/permissions anymore.

additionally, I exchanged the dead link to the correct one.

<img width="254" alt="Screenshot 2021-05-31 at 16 02 42" src="https://user-images.githubusercontent.com/12175559/120204968-b0c3c600-c229-11eb-94a6-e6fd1acb1fc2.png">
