### PR TITLE
Apply runtime mappings directly to MappingLookup

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/IndexService.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexService.java
@@ -602,7 +602,7 @@ public class IndexService extends AbstractIndexComponent implements IndicesClust
             indexCache.bitsetFilterCache(),
             indexFieldData::getForField,
             mapperService(),
-            mapperService().mappingLookup(),
+            mapperService().mappingLookup(runtimeMappings),
             similarityService(),
             scriptService,
             xContentRegistry,
@@ -613,8 +613,7 @@ public class IndexService extends AbstractIndexComponent implements IndicesClust
             clusterAlias,
             indexNameMatcher,
             allowExpensiveQueries,
-            valuesSourceRegistry,
-            runtimeMappings
+            valuesSourceRegistry
         );
     }
 

--- a/server/src/main/java/org/elasticsearch/index/mapper/MapperService.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/MapperService.java
@@ -41,6 +41,7 @@ import java.io.Closeable;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -364,6 +365,14 @@ public class MapperService extends AbstractIndexComponent implements Closeable {
     public MappingLookup mappingLookup() {
         DocumentMapper mapper = this.mapper;
         return mapper == null ? MappingLookup.EMPTY : mapper.mappers();
+    }
+
+    /**
+     * Exposes a snapshot of the mappings for the current index and applies the provided runtime mappings on top of it.
+     */
+    public MappingLookup mappingLookup(Map<String, Object> runtimeMappings) {
+        return mappingLookup().withRuntimeMappings(
+            RuntimeField.parseRuntimeFields(new HashMap<>(runtimeMappings), parserContext(), false).values());
     }
 
     /**

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataCreateIndexServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataCreateIndexServiceTests.java
@@ -90,7 +90,6 @@ import static org.elasticsearch.cluster.metadata.MetadataCreateIndexService.clus
 import static org.elasticsearch.cluster.metadata.MetadataCreateIndexService.getIndexNumberOfRoutingShards;
 import static org.elasticsearch.cluster.metadata.MetadataCreateIndexService.parseV1Mappings;
 import static org.elasticsearch.cluster.metadata.MetadataCreateIndexService.resolveAndValidateAliases;
-
 import static org.elasticsearch.index.IndexSettings.INDEX_SOFT_DELETES_SETTING;
 import static org.elasticsearch.indices.ShardLimitValidatorTests.createTestShardLimitService;
 import static org.hamcrest.Matchers.endsWith;
@@ -119,7 +118,7 @@ public class MetadataCreateIndexServiceTests extends ESTestCase {
         searchExecutionContext = new SearchExecutionContext(0, 0,
             new IndexSettings(IndexMetadata.builder("test").settings(indexSettings).build(), indexSettings),
             null, null, null, null, null, null, xContentRegistry(), writableRegistry(),
-            null, null, () -> randomNonNegativeLong(), null, null, () -> true, null, emptyMap());
+            null, null, () -> randomNonNegativeLong(), null, null, () -> true, null);
     }
 
     private ClusterState createClusterState(String name, int numShards, int numReplicas, Settings settings) {

--- a/server/src/test/java/org/elasticsearch/index/mapper/DateFieldTypeTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/DateFieldTypeTests.java
@@ -47,8 +47,6 @@ import java.time.ZoneOffset;
 import java.util.Collections;
 import java.util.List;
 
-import static java.util.Collections.emptyMap;
-
 public class DateFieldTypeTests extends FieldTypeTestCase {
 
     private static final long nowInMillis = 0;
@@ -156,7 +154,7 @@ public class DateFieldTypeTests extends FieldTypeTestCase {
         SearchExecutionContext context = new SearchExecutionContext(0, 0,
                 new IndexSettings(IndexMetadata.builder("foo").settings(indexSettings).build(), indexSettings),
                 null, null, null, null, null, null,
-                xContentRegistry(), writableRegistry(), null, null, () -> nowInMillis, null, null, () -> true, null, emptyMap());
+                xContentRegistry(), writableRegistry(), null, null, () -> nowInMillis, null, null, () -> true, null);
         MappedFieldType ft = new DateFieldType("field");
         String date = "2015-10-12T14:10:55";
         long instant = DateFormatters.from(DateFieldMapper.DEFAULT_DATE_TIME_FORMATTER.parse(date)).toInstant().toEpochMilli();
@@ -178,7 +176,7 @@ public class DateFieldTypeTests extends FieldTypeTestCase {
         SearchExecutionContext context = new SearchExecutionContext(0, 0,
                 new IndexSettings(IndexMetadata.builder("foo").settings(indexSettings).build(), indexSettings),
                 null, null, null, null, null, null, xContentRegistry(), writableRegistry(),
-                null, null, () -> nowInMillis, null, null, () -> true, null, emptyMap());
+                null, null, () -> nowInMillis, null, null, () -> true, null);
         MappedFieldType ft = new DateFieldType("field");
         String date1 = "2015-10-12T14:10:55";
         String date2 = "2016-04-28T11:33:52";
@@ -222,7 +220,7 @@ public class DateFieldTypeTests extends FieldTypeTestCase {
 
         SearchExecutionContext context = new SearchExecutionContext(0, 0, indexSettings,
             null, null, null, null, null, null, xContentRegistry(), writableRegistry(),
-            null, null, () -> 0L, null, null, () -> true, null, emptyMap());
+            null, null, () -> 0L, null, null, () -> true, null);
 
         MappedFieldType ft = new DateFieldType("field");
         String date1 = "2015-10-12T14:10:55";

--- a/server/src/test/java/org/elasticsearch/index/mapper/FieldNamesFieldTypeTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/FieldNamesFieldTypeTests.java
@@ -22,7 +22,6 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static java.util.Collections.emptyList;
-import static java.util.Collections.emptyMap;
 
 public class FieldNamesFieldTypeTests extends ESTestCase {
 
@@ -37,7 +36,7 @@ public class FieldNamesFieldTypeTests extends ESTestCase {
         MappingLookup mappingLookup = MappingLookup.fromMappers(Mapping.EMPTY, mappers, emptyList(), emptyList());
         SearchExecutionContext searchExecutionContext = new SearchExecutionContext(0, 0,
                 indexSettings, null, null, null, mappingLookup,
-                null, null, null, null, null, null, () -> 0L, null, null, () -> true, null, emptyMap());
+                null, null, null, null, null, null, () -> 0L, null, null, () -> true, null);
                 Query termQuery = fieldNamesFieldType.termQuery("field_name", searchExecutionContext);
         assertEquals(new TermQuery(new Term(FieldNamesFieldMapper.CONTENT_TYPE, "field_name")), termQuery);
         assertWarnings("terms query on the _field_names field is deprecated and will be removed, use exists query instead");

--- a/server/src/test/java/org/elasticsearch/index/mapper/IndexFieldTypeTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/IndexFieldTypeTests.java
@@ -20,7 +20,6 @@ import org.elasticsearch.test.ESTestCase;
 
 import java.util.function.Predicate;
 
-import static java.util.Collections.emptyMap;
 import static org.hamcrest.Matchers.containsString;
 
 public class IndexFieldTypeTests extends ESTestCase {
@@ -59,6 +58,6 @@ public class IndexFieldTypeTests extends ESTestCase {
 
         Predicate<String> indexNameMatcher = pattern -> Regex.simpleMatch(pattern, "index");
         return new SearchExecutionContext(0, 0, indexSettings, null, null, null, null, null, null, xContentRegistry(), writableRegistry(),
-            null, null, System::currentTimeMillis, null, indexNameMatcher, () -> true, null, emptyMap());
+            null, null, System::currentTimeMillis, null, indexNameMatcher, () -> true, null);
     }
 }

--- a/server/src/test/java/org/elasticsearch/index/mapper/MappingLookupTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/MappingLookupTests.java
@@ -77,6 +77,32 @@ public class MappingLookupTests extends ESTestCase {
         assertThat(mappingLookup.fieldTypesLookup().get("object.subfield"), instanceOf(TestRuntimeField.class));
     }
 
+    public void testWithRuntimeMappings() {
+        MockFieldMapper fieldMapper = new MockFieldMapper("field");
+        MappingLookup mappingLookup = createMappingLookup(
+            Collections.singletonList(fieldMapper),
+            Collections.emptyList(),
+            Collections.singletonList(new TestRuntimeField("runtime", "type"))
+        );
+        {
+            MappingLookup withRuntimeMappings = mappingLookup.withRuntimeMappings(Collections.emptySet());
+            assertSame(mappingLookup, withRuntimeMappings);
+        }
+        {
+            TestRuntimeField testRuntimeField = new TestRuntimeField("test", "test");
+            MappingLookup withRuntimeMappings = mappingLookup.withRuntimeMappings(Collections.singleton(testRuntimeField));
+            assertSame(mappingLookup.getMapping(), withRuntimeMappings.getMapping());
+            assertSame(mappingLookup.fieldMappers(), withRuntimeMappings.fieldMappers());
+            assertSame(mappingLookup.objectMappers(), withRuntimeMappings.objectMappers());
+            assertSame(mappingLookup.indexTimeLookup(), withRuntimeMappings.indexTimeLookup());
+            assertSame(mappingLookup.indexTimeScriptMappers(), withRuntimeMappings.indexTimeScriptMappers());
+            assertSame(mappingLookup.hasNested(), withRuntimeMappings.hasNested());
+            assertEquals("test", withRuntimeMappings.getFieldType("test").typeName());
+            assertEquals("type", withRuntimeMappings.getFieldType("runtime").typeName());
+            assertEquals("faketype", withRuntimeMappings.getFieldType("field").typeName());
+        }
+    }
+
     public void testAnalyzers() throws IOException {
         FakeFieldType fieldType1 = new FakeFieldType("field1");
         FieldMapper fieldMapper1 = new FakeFieldMapper(fieldType1, "index1");

--- a/server/src/test/java/org/elasticsearch/index/mapper/NumberFieldTypeTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/NumberFieldTypeTests.java
@@ -55,7 +55,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.function.Supplier;
 
-import static java.util.Collections.emptyMap;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
@@ -464,7 +463,7 @@ public class NumberFieldTypeTests extends FieldTypeTestCase {
 
         SearchExecutionContext context = new SearchExecutionContext(0, 0, indexSettings,
             null, null, null, null, null, null, xContentRegistry(), writableRegistry(),
-            null, null, () -> 0L, null, null, () -> true, null, emptyMap());
+            null, null, () -> 0L, null, null, () -> true, null);
 
         final int iters = 10;
         for (int iter = 0; iter < iters; ++iter) {

--- a/server/src/test/java/org/elasticsearch/index/mapper/RangeFieldTypeTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/RangeFieldTypeTests.java
@@ -29,8 +29,8 @@ import org.elasticsearch.common.time.DateFormatter;
 import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.mapper.DateFieldMapper.DateFieldType;
 import org.elasticsearch.index.mapper.RangeFieldMapper.RangeFieldType;
-import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.index.query.QueryShardException;
+import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.test.IndexSettingsModule;
 import org.joda.time.DateTime;
 import org.junit.Before;
@@ -41,7 +41,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
-import static java.util.Collections.emptyMap;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.instanceOf;
 
@@ -203,7 +202,7 @@ public class RangeFieldTypeTests extends FieldTypeTestCase {
             .put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT).build();
         IndexSettings idxSettings = IndexSettingsModule.newIndexSettings(randomAlphaOfLengthBetween(1, 10), indexSettings);
         return new SearchExecutionContext(0, 0, idxSettings, null, null, null, null, null, null,
-            xContentRegistry(), writableRegistry(), null, null, () -> nowInMillis, null, null, () -> true, null, emptyMap());
+            xContentRegistry(), writableRegistry(), null, null, () -> nowInMillis, null, null, () -> true, null);
     }
 
     public void testDateRangeQueryUsingMappingFormat() {

--- a/server/src/test/java/org/elasticsearch/index/query/RangeQueryRewriteTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/RangeQueryRewriteTests.java
@@ -19,8 +19,6 @@ import org.elasticsearch.index.mapper.MappedFieldType.Relation;
 import org.elasticsearch.index.mapper.MapperService.MergeReason;
 import org.elasticsearch.test.ESSingleNodeTestCase;
 
-import static java.util.Collections.emptyMap;
-
 // The purpose of this test case is to test RangeQueryBuilder.getRelation()
 // Whether it should return INTERSECT/DISJOINT/WITHIN is already tested in
 // RangeQueryBuilderTests
@@ -47,8 +45,7 @@ public class RangeQueryRewriteTests extends ESSingleNodeTestCase {
             null,
             null,
             () -> true,
-            null,
-            emptyMap()
+            null
         );
         RangeQueryBuilder range = new RangeQueryBuilder("foo");
         assertEquals(Relation.DISJOINT, range.getRelation(context));
@@ -67,7 +64,7 @@ public class RangeQueryRewriteTests extends ESSingleNodeTestCase {
                 new CompressedXContent(mapping), MergeReason.MAPPING_UPDATE);
         QueryRewriteContext context = new SearchExecutionContext(0, 0, indexService.getIndexSettings(), null, null,
             indexService.mapperService(), indexService.mapperService().mappingLookup(), null, null, xContentRegistry(), writableRegistry(),
-                null, null, null, null, null, () -> true, null, emptyMap());
+                null, null, null, null, null, () -> true, null);
         RangeQueryBuilder range = new RangeQueryBuilder("foo");
         // can't make assumptions on a missing reader, so it must return INTERSECT
         assertEquals(Relation.INTERSECTS, range.getRelation(context));
@@ -103,8 +100,7 @@ public class RangeQueryRewriteTests extends ESSingleNodeTestCase {
             null,
             null,
             () -> true,
-            null,
-            emptyMap()
+            null
         );
         RangeQueryBuilder range = new RangeQueryBuilder("foo");
         // no values -> DISJOINT

--- a/server/src/test/java/org/elasticsearch/index/query/SearchExecutionContextTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/SearchExecutionContextTests.java
@@ -217,8 +217,7 @@ public class SearchExecutionContextTests extends ESTestCase {
             null,
             null,
             () -> true,
-            null,
-            emptyMap()
+            null
         );
 
         assertTrue(context.indexSortedOnField("sort_field"));
@@ -419,6 +418,8 @@ public class SearchExecutionContextTests extends ESTestCase {
         IndexSettings indexSettings = new IndexSettings(indexMetadata, Settings.EMPTY);
         MapperService mapperService = createMapperService(indexSettings);
         final long nowInMillis = randomNonNegativeLong();
+        Collection<RuntimeField> runtimeFields = RuntimeField.parseRuntimeFields(new HashMap<>(runtimeMappings),
+            mapperService.parserContext(), false).values();
         return new SearchExecutionContext(
             0,
             0,
@@ -426,7 +427,7 @@ public class SearchExecutionContextTests extends ESTestCase {
             null,
             (mappedFieldType, idxName, searchLookup) -> mappedFieldType.fielddataBuilder(idxName, searchLookup).build(null, null),
             mapperService,
-            mappingLookup,
+            mappingLookup.withRuntimeMappings(runtimeFields),
             null,
             null,
             NamedXContentRegistry.EMPTY,
@@ -437,8 +438,7 @@ public class SearchExecutionContextTests extends ESTestCase {
             clusterAlias,
             null,
             () -> true,
-            null,
-            runtimeMappings
+            null
         );
     }
 

--- a/server/src/test/java/org/elasticsearch/search/fetch/subphase/FieldFetcherTests.java
+++ b/server/src/test/java/org/elasticsearch/search/fetch/subphase/FieldFetcherTests.java
@@ -30,7 +30,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
-import static java.util.Collections.emptyMap;
 import static org.elasticsearch.common.xcontent.ObjectPath.eval;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.equalTo;
@@ -990,8 +989,7 @@ public class FieldFetcherTests extends MapperServiceTestCase {
             null,
             null,
             null,
-            null,
-            emptyMap()
+            null
         );
     }
 }

--- a/server/src/test/java/org/elasticsearch/search/fetch/subphase/highlight/HighlightBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/search/fetch/subphase/highlight/HighlightBuilderTests.java
@@ -32,8 +32,8 @@ import org.elasticsearch.index.mapper.TextFieldMapper;
 import org.elasticsearch.index.query.IdsQueryBuilder;
 import org.elasticsearch.index.query.MatchAllQueryBuilder;
 import org.elasticsearch.index.query.QueryBuilder;
-import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.index.query.Rewriteable;
+import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.index.query.TermQueryBuilder;
 import org.elasticsearch.search.SearchModule;
 import org.elasticsearch.search.fetch.subphase.highlight.HighlightBuilder.BoundaryScannerType;
@@ -57,7 +57,6 @@ import java.util.function.BiConsumer;
 import java.util.function.Function;
 
 import static java.util.Collections.emptyList;
-import static java.util.Collections.emptyMap;
 import static org.elasticsearch.search.fetch.subphase.highlight.AbstractHighlighterBuilder.MAX_ANALYZED_OFFSET_FIELD;
 import static org.elasticsearch.test.EqualsHashCodeTestUtils.checkEqualsAndHashCode;
 import static org.hamcrest.Matchers.containsString;
@@ -269,7 +268,7 @@ public class HighlightBuilderTests extends ESTestCase {
         // shard context will only need indicesQueriesRegistry for building Query objects nested in highlighter
         SearchExecutionContext mockContext = new SearchExecutionContext(0, 0, idxSettings,
                 null, null, null, null, null, null, xContentRegistry(), namedWriteableRegistry,
-                null, null, System::currentTimeMillis, null, null, () -> true, null, emptyMap()) {
+                null, null, System::currentTimeMillis, null, null, () -> true, null) {
             @Override
             public MappedFieldType getFieldType(String name) {
                 TextFieldMapper.Builder builder = new TextFieldMapper.Builder(name, createDefaultIndexAnalyzers());

--- a/server/src/test/java/org/elasticsearch/search/rescore/QueryRescorerBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/search/rescore/QueryRescorerBuilderTests.java
@@ -31,8 +31,8 @@ import org.elasticsearch.index.mapper.TextFieldMapper;
 import org.elasticsearch.index.query.MatchAllQueryBuilder;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.index.query.QueryRewriteContext;
-import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.index.query.Rewriteable;
+import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.search.SearchModule;
 import org.elasticsearch.search.rescore.QueryRescorer.QueryRescoreContext;
 import org.elasticsearch.test.ESTestCase;
@@ -43,7 +43,6 @@ import org.junit.BeforeClass;
 import java.io.IOException;
 
 import static java.util.Collections.emptyList;
-import static java.util.Collections.emptyMap;
 import static org.elasticsearch.test.EqualsHashCodeTestUtils.checkEqualsAndHashCode;
 import static org.hamcrest.Matchers.containsString;
 
@@ -132,7 +131,7 @@ public class QueryRescorerBuilderTests extends ESTestCase {
         // shard context will only need indicesQueriesRegistry for building Query objects nested in query rescorer
         SearchExecutionContext mockContext = new SearchExecutionContext(0, 0, idxSettings,
             null, null, null, null, null, null,
-            xContentRegistry(), namedWriteableRegistry, null, null, () -> nowInMillis, null, null, () -> true, null, emptyMap()) {
+            xContentRegistry(), namedWriteableRegistry, null, null, () -> nowInMillis, null, null, () -> true, null) {
             @Override
             public MappedFieldType getFieldType(String name) {
                 TextFieldMapper.Builder builder = new TextFieldMapper.Builder(name, createDefaultIndexAnalyzers());
@@ -176,7 +175,7 @@ public class QueryRescorerBuilderTests extends ESTestCase {
         // shard context will only need indicesQueriesRegistry for building Query objects nested in query rescorer
         SearchExecutionContext mockContext = new SearchExecutionContext(0, 0, idxSettings,
                 null, null, null, null, null, null,
-                xContentRegistry(), namedWriteableRegistry, null, null, () -> nowInMillis, null, null, () -> true, null, emptyMap()) {
+                xContentRegistry(), namedWriteableRegistry, null, null, () -> nowInMillis, null, null, () -> true, null) {
             @Override
             public MappedFieldType getFieldType(String name) {
                 TextFieldMapper.Builder builder = new TextFieldMapper.Builder(name, createDefaultIndexAnalyzers());

--- a/server/src/test/java/org/elasticsearch/search/sort/AbstractSortTestCase.java
+++ b/server/src/test/java/org/elasticsearch/search/sort/AbstractSortTestCase.java
@@ -35,8 +35,8 @@ import org.elasticsearch.index.mapper.ObjectMapper.Nested;
 import org.elasticsearch.index.query.IdsQueryBuilder;
 import org.elasticsearch.index.query.MatchAllQueryBuilder;
 import org.elasticsearch.index.query.QueryBuilder;
-import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.index.query.Rewriteable;
+import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.index.query.TermQueryBuilder;
 import org.elasticsearch.script.MockScriptEngine;
 import org.elasticsearch.script.ScriptEngine;
@@ -58,7 +58,6 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 
 import static java.util.Collections.emptyList;
-import static java.util.Collections.emptyMap;
 import static org.elasticsearch.test.EqualsHashCodeTestUtils.checkEqualsAndHashCode;
 
 public abstract class AbstractSortTestCase<T extends SortBuilder<T>> extends ESTestCase {
@@ -191,7 +190,7 @@ public abstract class AbstractSortTestCase<T extends SortBuilder<T>> extends EST
         };
         return new SearchExecutionContext(0, 0, idxSettings, bitsetFilterCache, indexFieldDataLookup,
                 null, null, null, scriptService, xContentRegistry(), namedWriteableRegistry, null, searcher,
-                () -> randomNonNegativeLong(), null, null, () -> true, null, emptyMap()) {
+                () -> randomNonNegativeLong(), null, null, () -> true, null) {
 
             @Override
             public MappedFieldType getFieldType(String name) {

--- a/server/src/test/java/org/elasticsearch/search/suggest/AbstractSuggestionBuilderTestCase.java
+++ b/server/src/test/java/org/elasticsearch/search/suggest/AbstractSuggestionBuilderTestCase.java
@@ -50,7 +50,6 @@ import java.util.HashMap;
 import java.util.List;
 
 import static java.util.Collections.emptyList;
-import static java.util.Collections.emptyMap;
 import static org.elasticsearch.common.lucene.BytesRefs.toBytesRef;
 import static org.elasticsearch.test.EqualsHashCodeTestUtils.checkEqualsAndHashCode;
 import static org.mockito.Matchers.any;
@@ -175,7 +174,7 @@ public abstract class AbstractSuggestionBuilderTestCase<SB extends SuggestionBui
             MappingLookup lookup = MappingLookup.fromMappers(Mapping.EMPTY, mappers, emptyList(), emptyList());
             SearchExecutionContext mockContext = new SearchExecutionContext(0, 0, idxSettings, null,
                 null, mapperService, lookup, null, scriptService, xContentRegistry(), namedWriteableRegistry, null, null,
-                    System::currentTimeMillis, null, null, () -> true, null, emptyMap());
+                    System::currentTimeMillis, null, null, () -> true, null);
 
             SuggestionContext suggestionContext = suggestionBuilder.build(mockContext);
             assertEquals(toBytesRef(suggestionBuilder.text()), suggestionContext.getText());
@@ -211,7 +210,7 @@ public abstract class AbstractSuggestionBuilderTestCase<SB extends SuggestionBui
 
         SearchExecutionContext mockContext = new SearchExecutionContext(0, 0, idxSettings,  null,
             null, mock(MapperService.class), MappingLookup.EMPTY, null, null, xContentRegistry(), namedWriteableRegistry, null, null,
-            System::currentTimeMillis, null, null, () -> true, null, emptyMap());
+            System::currentTimeMillis, null, null, () -> true, null);
         if (randomBoolean()) {
             mockContext.setAllowUnmappedFields(randomBoolean());
         }

--- a/test/framework/src/main/java/org/elasticsearch/search/aggregations/AggregatorTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/search/aggregations/AggregatorTestCase.java
@@ -138,7 +138,6 @@ import java.util.Set;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 
-import static java.util.Collections.emptyMap;
 import static java.util.Collections.singletonList;
 import static java.util.stream.Collectors.toList;
 import static org.elasticsearch.test.InternalAggregationTestCase.DEFAULT_MAX_BUCKETS;
@@ -275,8 +274,7 @@ public abstract class AggregatorTestCase extends ESTestCase {
             null,
             null,
             () -> true,
-            valuesSourceRegistry,
-            emptyMap()
+            valuesSourceRegistry
         );
 
         MultiBucketConsumer consumer = new MultiBucketConsumer(maxBucket, breakerService.getBreaker(CircuitBreaker.REQUEST));

--- a/test/framework/src/main/java/org/elasticsearch/test/AbstractBuilderTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/AbstractBuilderTestCase.java
@@ -419,8 +419,7 @@ public abstract class AbstractBuilderTestCase extends ESTestCase {
                 null,
                 indexNameMatcher(),
                 () -> true,
-                null,
-                emptyMap()
+                null
             );
         }
 

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/cluster/routing/allocation/mapper/DataTierFieldTypeTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/cluster/routing/allocation/mapper/DataTierFieldTypeTests.java
@@ -26,7 +26,6 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.function.Predicate;
 
-import static java.util.Collections.emptyMap;
 import static java.util.Collections.singletonList;
 import static org.hamcrest.Matchers.containsString;
 
@@ -127,8 +126,7 @@ public class DataTierFieldTypeTests extends MapperServiceTestCase {
             null,
             indexNameMatcher,
             () -> true,
-            null,
-            emptyMap()
+            null
         );
     }
 
@@ -143,6 +141,6 @@ public class DataTierFieldTypeTests extends MapperServiceTestCase {
         IndexSettings indexSettings = new IndexSettings(indexMetadata, Settings.EMPTY);
         return new SearchExecutionContext(0, 0, indexSettings, null, null, null, null, null, null,
             xContentRegistry(), writableRegistry(), null, null, System::currentTimeMillis, null,
-            value -> true, () -> true, null, emptyMap());
+            value -> true, () -> true, null);
     }
 }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/accesscontrol/DocumentSubsetBitsetCacheTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/accesscontrol/DocumentSubsetBitsetCacheTests.java
@@ -64,7 +64,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static java.util.Collections.emptyList;
-import static java.util.Collections.emptyMap;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
@@ -570,7 +569,7 @@ public class DocumentSubsetBitsetCacheTests extends ESTestCase {
 
             final SearchExecutionContext searchExecutionContext = new SearchExecutionContext(shardId.id(), 0, indexSettings,
                 null, null, null, mappingLookup, null, null, xContentRegistry(), writableRegistry(),
-                client, new IndexSearcher(directoryReader), () -> nowInMillis, null, null, () -> true, null, emptyMap());
+                client, new IndexSearcher(directoryReader), () -> nowInMillis, null, null, () -> true, null);
 
             context = new TestIndexContext(directory, iw, directoryReader, searchExecutionContext, leaf);
             return context;

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/accesscontrol/SecurityIndexReaderWrapperIntegrationTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/accesscontrol/SecurityIndexReaderWrapperIntegrationTests.java
@@ -59,7 +59,6 @@ import java.util.concurrent.Executors;
 import java.util.stream.Collectors;
 
 import static java.util.Collections.emptyList;
-import static java.util.Collections.emptyMap;
 import static java.util.Collections.singleton;
 import static java.util.Collections.singletonMap;
 import static org.hamcrest.Matchers.containsInAnyOrder;
@@ -89,7 +88,7 @@ public class SecurityIndexReaderWrapperIntegrationTests extends AbstractBuilderT
         final long nowInMillis = randomNonNegativeLong();
         SearchExecutionContext realSearchExecutionContext = new SearchExecutionContext(shardId.id(), 0, indexSettings,
                 null, null, null, mappingLookup, null, null, xContentRegistry(), writableRegistry(),
-                client, null, () -> nowInMillis, null, null, () -> true, null, emptyMap());
+                client, null, () -> nowInMillis, null, null, () -> true, null);
         SearchExecutionContext searchExecutionContext = spy(realSearchExecutionContext);
         DocumentSubsetBitsetCache bitsetCache = new DocumentSubsetBitsetCache(Settings.EMPTY, Executors.newSingleThreadExecutor());
         XPackLicenseState licenseState = mock(XPackLicenseState.class);
@@ -218,7 +217,7 @@ public class SecurityIndexReaderWrapperIntegrationTests extends AbstractBuilderT
         final long nowInMillis = randomNonNegativeLong();
         SearchExecutionContext realSearchExecutionContext = new SearchExecutionContext(shardId.id(), 0, indexSettings,
                 null, null, null, mappingLookup, null, null, xContentRegistry(), writableRegistry(),
-                client, null, () -> nowInMillis, null, null, () -> true, null, emptyMap());
+                client, null, () -> nowInMillis, null, null, () -> true, null);
         SearchExecutionContext searchExecutionContext = spy(realSearchExecutionContext);
         DocumentSubsetBitsetCache bitsetCache = new DocumentSubsetBitsetCache(Settings.EMPTY, Executors.newSingleThreadExecutor());
 

--- a/x-pack/plugin/rollup/src/test/java/org/elasticsearch/xpack/rollup/job/RollupIndexerIndexingTests.java
+++ b/x-pack/plugin/rollup/src/test/java/org/elasticsearch/xpack/rollup/job/RollupIndexerIndexingTests.java
@@ -78,7 +78,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 
-import static java.util.Collections.emptyMap;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.core.IsInstanceOf.instanceOf;
 import static org.hamcrest.number.OrderingComparison.greaterThan;
@@ -92,7 +91,7 @@ public class RollupIndexerIndexingTests extends AggregatorTestCase {
         settings = createIndexSettings();
         searchExecutionContext = new SearchExecutionContext(0, 0, settings,
             null, null, null, null, null, null,
-            null, null, null, null, () -> 0L, null, null, () -> true, null, emptyMap());
+            null, null, null, null, () -> 0L, null, null, () -> true, null);
     }
 
     public void testSimpleDateHisto() throws Exception {

--- a/x-pack/plugin/wildcard/src/test/java/org/elasticsearch/xpack/wildcard/mapper/WildcardFieldMapperTests.java
+++ b/x-pack/plugin/wildcard/src/test/java/org/elasticsearch/xpack/wildcard/mapper/WildcardFieldMapperTests.java
@@ -61,6 +61,7 @@ import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.search.lookup.SearchLookup;
 import org.elasticsearch.search.sort.FieldSortBuilder;
+import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.IndexSettingsModule;
 import org.elasticsearch.xpack.wildcard.Wildcard;
 import org.elasticsearch.xpack.wildcard.mapper.WildcardFieldMapper.Builder;
@@ -74,7 +75,6 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.function.Supplier;
 
-import static java.util.Collections.emptyMap;
 import static org.hamcrest.Matchers.equalTo;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -106,7 +106,7 @@ public class WildcardFieldMapperTests extends MapperTestCase {
     protected boolean supportsStoredFields() {
         return false;
     }
-    
+
     @Override
     @Before
     public void setUp() throws Exception {
@@ -934,7 +934,7 @@ public class WildcardFieldMapperTests extends MapperTestCase {
         };
         return new SearchExecutionContext(0, 0, idxSettings, bitsetFilterCache, indexFieldDataLookup,
                 null, null, null, null, xContentRegistry(), null, null, null,
-                () -> randomNonNegativeLong(), null, null, () -> true, null, emptyMap()) {
+                ESTestCase::randomNonNegativeLong, null, null, () -> true, null) {
             @Override
             public MappedFieldType getFieldType(String name) {
                 return provideMappedFieldType(name);


### PR DESCRIPTION
SearchExecutionContext currently holds the runtime mappings and each field type lookup, or calls to getMatchingFieldNames or getMatchingFieldTypes, needs to have the runtime mappings applied first, as runtime mappings have the precedence when they have the same name as fields that come from the index mappings (runtime or not).

This caused code duplication, as the logic in those three methods is exactly the same that we already have in FieldTypeLookup. Also, we recently enhanced FieldTypeLookup to apply dynamic field types provided with the runtime section, and the same needs to be then also applied to SearchExecutionContext so that it supports dynamic runtime fields as well.

To address this problem, SearchExecutionContext has now access to a copy of MappingLookup with the runtime mappings applied to it, which is exactly the same MappingLookup as the original one, besides the FieldTypeLookup which is a copy of the original one with the runtime mappings applied on top.
