### PR TITLE
[7.x] Refactor uri_parts processor so it can be exposed in Painless (#73344)

### DIFF
--- a/modules/ingest-common/src/main/java/org/elasticsearch/ingest/common/UriPartsProcessor.java
+++ b/modules/ingest-common/src/main/java/org/elasticsearch/ingest/common/UriPartsProcessor.java
@@ -57,19 +57,8 @@ public class UriPartsProcessor extends AbstractProcessor {
     @Override
     public IngestDocument execute(IngestDocument ingestDocument) throws Exception {
         String value = ingestDocument.getFieldValue(field, String.class);
+        Map<String, Object> uriParts = apply(value);
 
-        URI uri = null;
-        URL url = null;
-        try {
-            uri = new URI(value);
-        } catch (URISyntaxException e) {
-            try {
-                url = new URL(value);
-            } catch (MalformedURLException e2) {
-                throw new IllegalArgumentException("unable to parse URI [" + value + "]");
-            }
-        }
-        Map<String, Object> uriParts = getUriParts(uri, url);
         if (keepOriginal) {
             uriParts.put("original", value);
         }
@@ -79,6 +68,21 @@ public class UriPartsProcessor extends AbstractProcessor {
         }
         ingestDocument.setFieldValue(targetField, uriParts);
         return ingestDocument;
+    }
+
+    public static Map<String, Object> apply(String urlString) {
+        URI uri = null;
+        URL url = null;
+        try {
+            uri = new URI(urlString);
+        } catch (URISyntaxException e) {
+            try {
+                url = new URL(urlString);
+            } catch (MalformedURLException e2) {
+                throw new IllegalArgumentException("unable to parse URI [" + urlString + "]");
+            }
+        }
+        return getUriParts(uri, url);
     }
 
     @SuppressForbidden(reason = "URL.getPath is used only if URI.getPath is unavailable")


### PR DESCRIPTION
Adds a `static apply(String param)` method similar to the one in the [lowercase processor](https://github.com/elastic/elasticsearch/blob/master/modules/ingest-common/src/main/java/org/elasticsearch/ingest/common/LowercaseProcessor.java#L27) so that the URI parts processor functionality can be exposed in Painless.

Relates to #73346

Backport of #73344