### PR TITLE
[DOCS] Update `is_write_index` example

### DIFF
--- a/docs/reference/alias.asciidoc
+++ b/docs/reference/alias.asciidoc
@@ -233,7 +233,7 @@ POST _aliases
   ]
 }
 ----
-// TEST[s/^/PUT my-index-2099.05.06-000001\nPUT my-index-2099.05.07-000002\n/]
+// TEST[s/^/PUT _data_stream\/logs-nginx.access-prod\nPUT _data_stream\/logs-my_app-default\n/]
 
 If an alias points to multiple indices or data streams and `is_write_index`
 isn't set, the alias rejects write requests. If an index alias points to one

--- a/docs/reference/alias.asciidoc
+++ b/docs/reference/alias.asciidoc
@@ -209,8 +209,8 @@ GET _alias/logs
 === Write index
 
 If an alias points to multiple indices, you can use `is_write_index` to specify
-a write index or data stream. {es} routes any write requests for the alias to this
-index or data stream.
+a write index or data stream. {es} routes any write requests for the alias to
+this index or data stream.
 
 [source,console]
 ----
@@ -235,11 +235,11 @@ POST _aliases
 ----
 // TEST[s/^/PUT my-index-2099.05.06-000001\nPUT my-index-2099.05.07-000002\n/]
 
-If an alias points to multiple data streams or indices and `is_write_index`
+If an alias points to multiple indices or data streams and `is_write_index`
 isn't set, the alias rejects write requests. If an index alias points to one
 index and `is_write_index` isn't set, the index automatically acts as the write
-index. Data stream aliases don't automatically set a write stream, even if the
-alias points to one data stream.
+index. Data stream aliases don't automatically set a write data stream, even if
+the alias points to one data stream.
 
 TIP: We recommend using data streams to store append-only time series data. If
 you frequently update or delete existing time series data, use an index alias

--- a/docs/reference/alias.asciidoc
+++ b/docs/reference/alias.asciidoc
@@ -219,14 +219,14 @@ POST _aliases
   "actions": [
     {
       "add": {
-        "index": "my-index-2099.05.06-000001",
-        "alias": "my-alias"
+        "index": "logs-nginx.access-prod",
+        "alias": "logs"
       }
     },
     {
       "add": {
-        "index": "my-index-2099.05.07-000002",
-        "alias": "my-alias",
+        "index": "logs-my_app-default",
+        "alias": "logs",
         "is_write_index": true
       }
     }
@@ -235,14 +235,16 @@ POST _aliases
 ----
 // TEST[s/^/PUT my-index-2099.05.06-000001\nPUT my-index-2099.05.07-000002\n/]
 
+If an alias points to multiple data streams or indices and `is_write_index`
+isn't set, the alias rejects write requests. If an index alias points to one
+index and `is_write_index` isn't set, the index automatically acts as the write
+index. Data stream aliases don't automatically set a write stream, even if the
+alias points to one data stream.
+
 TIP: We recommend using data streams to store append-only time series data. If
 you frequently update or delete existing time series data, use an index alias
 with a write index instead. See
 <<manage-time-series-data-without-data-streams>>.
-
-If an alias points to multiple indices with no write index, the alias rejects
-write requests. If an alias points to one index and `is_write_index` is not set,
-the index automatically acts as the write index.
 
 [discrete]
 [[filter-alias]]


### PR DESCRIPTION
Changes:
* Updates the write index snippet to use data streams
* Notes that data streams aliases don't set an implicit write stream, even if the alias points to one data stream.