### PR TITLE
[6.8] OsStats must be lenient with bad data from older nodes

### DIFF
--- a/server/src/main/java/org/elasticsearch/monitor/os/OsStats.java
+++ b/server/src/main/java/org/elasticsearch/monitor/os/OsStats.java
@@ -210,6 +210,8 @@ public class OsStats implements Writeable, ToXContentFragment {
             } else {
                 // If we have a node in the cluster without the bug fix for
                 // negative memory values, we need to coerce negative values to 0 here.
+                // The relevant bug fix was added for 7.8.0 in https://github.com/elastic/elasticsearch/pull/57317
+                // and for 6.8.14 in https://github.com/elastic/elasticsearch/pull/68554
                 this.total = Math.max(0, in.readLong());
                 this.free = Math.max(0, in.readLong());
             }
@@ -278,6 +280,7 @@ public class OsStats implements Writeable, ToXContentFragment {
             } else {
                 // If we have a node in the cluster without the bug fix for
                 // negative memory values, we need to coerce negative values to 0 here.
+                // The relevant bug fix was added for 7.2.0 and 6.8.2 in https://github.com/elastic/elasticsearch/pull/42725
                 this.total = Math.max(0, in.readLong());
                 this.free = Math.max(0, in.readLong());
             }

--- a/server/src/main/java/org/elasticsearch/monitor/os/OsStats.java
+++ b/server/src/main/java/org/elasticsearch/monitor/os/OsStats.java
@@ -202,10 +202,17 @@ public class OsStats implements Writeable, ToXContentFragment {
         }
 
         public Swap(StreamInput in) throws IOException {
-            this.total = in.readLong();
-            assert total >= 0 : "expected total swap to be positive, got: " + total;
-            this.free = in.readLong();
-            assert free >= 0 : "expected free swap to be positive, got: " + total;
+            if (in.getVersion().onOrAfter(Version.V_6_8_14)) {
+                this.total = in.readLong();
+                assert total >= 0 : "expected total swap to be positive, got: " + total;
+                this.free = in.readLong();
+                assert free >= 0 : "expected free swap to be positive, got: " + total;
+            } else {
+                // If we have a node in the cluster without the bug fix for
+                // negative memory values, we need to coerce negative values to 0 here.
+                this.total = Math.max(0, in.readLong());
+                this.free = Math.max(0, in.readLong());
+            }
         }
 
         @Override
@@ -263,10 +270,17 @@ public class OsStats implements Writeable, ToXContentFragment {
         }
 
         public Mem(StreamInput in) throws IOException {
-            this.total = in.readLong();
-            assert total >= 0 : "expected total memory to be positive, got: " + total;
-            this.free = in.readLong();
-            assert free >= 0 : "expected free memory to be positive, got: " + total;
+            if (in.getVersion().onOrAfter(Version.V_6_8_2)) {
+                this.total = in.readLong();
+                assert total >= 0 : "expected total memory to be positive, got: " + total;
+                this.free = in.readLong();
+                assert free >= 0 : "expected free memory to be positive, got: " + total;
+            } else {
+                // If we have a node in the cluster without the bug fix for
+                // negative memory values, we need to coerce negative values to 0 here.
+                this.total = Math.max(0, in.readLong());
+                this.free = Math.max(0, in.readLong());
+            }
         }
 
         @Override


### PR DESCRIPTION
We've had a series of bug fixes for cases where an OsProbe gives negative values, most often just -1, to the OsStats class. We added assertions to catch cases where we were initializing OsStats with bad values. Unfortunately, these fixes turned to not be backwards-compatible. In this commit, we simply coerce bad values to 0 when data is coming from nodes that don't have the relevant bug fixes.

Relevant PRs:
* #42725
* #56435
* #57317

Fixes #73459

Backport of #73610