### PR TITLE
ExistsQueryBuilder to no longer rely on getMatchingFieldTypes

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/query/ExistsQueryBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/ExistsQueryBuilder.java
@@ -25,6 +25,8 @@ import org.elasticsearch.index.mapper.MappedFieldType;
 import java.io.IOException;
 import java.util.Collection;
 import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * Constructs a query that only match on documents that the field has a value in them.
@@ -67,8 +69,7 @@ public class ExistsQueryBuilder extends AbstractQueryBuilder<ExistsQueryBuilder>
     protected QueryBuilder doRewrite(QueryRewriteContext queryRewriteContext) throws IOException {
         SearchExecutionContext context = queryRewriteContext.convertToSearchExecutionContext();
         if (context != null) {
-            Collection<MappedFieldType> fields = getMappedFields(context, fieldName);
-            if (fields.isEmpty()) {
+            if (getMappedFields(context, fieldName).isEmpty()) {
                 return new MatchNoneQueryBuilder();
             }
         }
@@ -126,8 +127,8 @@ public class ExistsQueryBuilder extends AbstractQueryBuilder<ExistsQueryBuilder>
     }
 
     public static Query newFilter(SearchExecutionContext context, String fieldPattern, boolean checkRewrite) {
-
-       Collection<MappedFieldType> fields = getMappedFields(context, fieldPattern);
+       Collection<MappedFieldType> fields = getMappedFields(context, fieldPattern)
+           .stream().map(context::getFieldType).collect(Collectors.toList());
 
         if (fields.isEmpty()) {
             if (checkRewrite) {
@@ -149,14 +150,13 @@ public class ExistsQueryBuilder extends AbstractQueryBuilder<ExistsQueryBuilder>
         return new ConstantScoreQuery(boolFilterBuilder.build());
     }
 
-    private static Collection<MappedFieldType> getMappedFields(SearchExecutionContext context, String fieldPattern) {
-        Collection<MappedFieldType> fields = context.getMatchingFieldTypes(fieldPattern);
-        if (fields.isEmpty()) {
+    private static Collection<String> getMappedFields(SearchExecutionContext context, String fieldPattern) {
+        Set<String> matchingFieldNames = context.getMatchingFieldNames(fieldPattern);
+        if (matchingFieldNames.isEmpty()) {
             // might be an object field, so try matching it as an object prefix pattern
-            fields = context.getMatchingFieldTypes(fieldPattern + ".*");
+            matchingFieldNames = context.getMatchingFieldNames(fieldPattern + ".*");
         }
-
-        return fields;
+        return matchingFieldNames;
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/index/query/LegacyGeoShapeQueryProcessor.java
+++ b/server/src/main/java/org/elasticsearch/index/query/LegacyGeoShapeQueryProcessor.java
@@ -77,7 +77,7 @@ public class LegacyGeoShapeQueryProcessor  {
             // before, including creating lucene fieldcache (!)
             // in this case, execute disjoint as exists && !intersects
             BooleanQuery.Builder bool = new BooleanQuery.Builder();
-            Query exists = ExistsQueryBuilder.newFilter(context, fieldName,false);
+            Query exists = ExistsQueryBuilder.newFilter(context, fieldName, false);
             Query intersects = prefixTreeStrategy.makeQuery(getArgs(shape, ShapeRelation.INTERSECTS));
             bool.add(exists, BooleanClause.Occur.MUST);
             bool.add(intersects, BooleanClause.Occur.MUST_NOT);


### PR DESCRIPTION
We've been discussing possibly removing `FieldTypeLookup#getMatchingFieldTypes`, or at least its `SearchExecutionContext` variant that applies runtime mappings, as it adds complexity and has only a few usages.

This is another step in that direction: the exists query can rely on `getMatchingFieldNames` instead, and look up field types by name.

