### PR TITLE
Introduce specialized getMatchingFieldTypes that takes a predicate

### DIFF
--- a/benchmarks/src/main/java/org/elasticsearch/benchmark/search/aggregations/AggConstructionContentionBenchmark.java
+++ b/benchmarks/src/main/java/org/elasticsearch/benchmark/search/aggregations/AggConstructionContentionBenchmark.java
@@ -72,6 +72,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
+import java.util.function.Predicate;
 
 /**
  * Benchmarks the overhead of constructing {@link Aggregator}s in many
@@ -213,7 +214,7 @@ public class AggConstructionContentionBenchmark {
         }
 
         @Override
-        public Collection<MappedFieldType> getMatchingFieldTypes(String pattern) {
+        public Collection<MappedFieldType> getMatchingFieldTypes(Predicate<MappedFieldType> predicate) {
             throw new UnsupportedOperationException();
         }
 

--- a/modules/parent-join/src/main/java/org/elasticsearch/join/mapper/ParentJoinFieldMapper.java
+++ b/modules/parent-join/src/main/java/org/elasticsearch/join/mapper/ParentJoinFieldMapper.java
@@ -36,7 +36,6 @@ import org.elasticsearch.search.lookup.SearchLookup;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -291,31 +290,11 @@ public final class ParentJoinFieldMapper extends FieldMapper {
     }
 
     @Override
-    protected void doValidate(MappingLookup mappers) {
-        List<String> joinFields = getJoinFieldTypes(mappers.getAllFieldTypes()).stream()
-            .map(JoinFieldType::name)
-            .collect(Collectors.toList());
+    protected void doValidate(MappingLookup mappingLookup) {
+        List<String> joinFields = mappingLookup.getMatchingFieldTypes(ft -> ft instanceof JoinFieldType)
+            .stream().map(MappedFieldType::name).collect(Collectors.toList());
         if (joinFields.size() > 1) {
             throw new IllegalArgumentException("Only one [parent-join] field can be defined per index, got " + joinFields);
         }
-    }
-
-    static JoinFieldType getJoinFieldType(Collection<MappedFieldType> fieldTypes) {
-        for (MappedFieldType ft : fieldTypes) {
-            if (ft instanceof JoinFieldType) {
-                return (JoinFieldType) ft;
-            }
-        }
-        return null;
-    }
-
-    private List<JoinFieldType> getJoinFieldTypes(Collection<MappedFieldType> fieldTypes) {
-        final List<JoinFieldType> joinFields = new ArrayList<>();
-        for (MappedFieldType ft : fieldTypes) {
-            if (ft instanceof JoinFieldType) {
-                joinFields.add((JoinFieldType) ft);
-            }
-        }
-        return joinFields;
     }
 }

--- a/modules/parent-join/src/test/java/org/elasticsearch/join/mapper/ParentJoinFieldMapperTests.java
+++ b/modules/parent-join/src/test/java/org/elasticsearch/join/mapper/ParentJoinFieldMapperTests.java
@@ -47,7 +47,7 @@ public class ParentJoinFieldMapperTests extends MapperServiceTestCase {
         }));
         DocumentMapper docMapper = mapperService.documentMapper();
 
-        Joiner joiner = Joiner.getJoiner(mapperService.mappingLookup().getAllFieldTypes());
+        Joiner joiner = Joiner.getJoiner(mapperService.mappingLookup()::getMatchingFieldTypes);
         assertNotNull(joiner);
         assertEquals("join_field", joiner.getJoinField());
 
@@ -233,7 +233,7 @@ public class ParentJoinFieldMapperTests extends MapperServiceTestCase {
             b.endObject();
         }));
 
-        Joiner joiner = Joiner.getJoiner(mapperService.mappingLookup().getAllFieldTypes());
+        Joiner joiner = Joiner.getJoiner(mapperService.mappingLookup()::getMatchingFieldTypes);
         assertNotNull(joiner);
         assertEquals("join_field", joiner.getJoinField());
         assertTrue(joiner.childTypeExists("child2"));
@@ -259,7 +259,7 @@ public class ParentJoinFieldMapperTests extends MapperServiceTestCase {
             }
             b.endObject();
         }));
-        joiner = Joiner.getJoiner(mapperService.mappingLookup().getAllFieldTypes());
+        joiner = Joiner.getJoiner(mapperService.mappingLookup()::getMatchingFieldTypes);
         assertNotNull(joiner);
         assertEquals("join_field", joiner.getJoinField());
         assertTrue(joiner.childTypeExists("child2"));

--- a/server/src/main/java/org/elasticsearch/index/mapper/FieldTypeLookup.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/FieldTypeLookup.java
@@ -19,6 +19,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * An immutable container for looking up {@link MappedFieldType}s by their name.
@@ -145,6 +148,19 @@ final class FieldTypeLookup {
                 return dft.getChildFieldType(key);
             }
         }
+    }
+
+    Collection<MappedFieldType> getMatchingFieldTypes(Predicate<MappedFieldType> predicate) {
+        if (dynamicFieldTypes.isEmpty()) {
+            return fullNameToFieldType.values().stream().filter(predicate).collect(Collectors.toList());
+        }
+        return Stream.concat(dynamicFieldTypes.values().stream().flatMap(dft -> {
+            List<MappedFieldType> childFieldTypes = new ArrayList<>();
+            for (String knownSubfield : dft.getKnownSubfields()) {
+                childFieldTypes.add(dft.getChildFieldType(knownSubfield));
+            }
+            return childFieldTypes.stream();
+        }), fullNameToFieldType.values().stream()).filter(predicate).collect(Collectors.toList());
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/index/mapper/FieldTypeLookup.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/FieldTypeLookup.java
@@ -153,7 +153,7 @@ final class FieldTypeLookup {
     /**
      * Returns all the mapped field types matching the provided predicate.
      * Note that only known sub-fields are exposed from {@link DynamicFieldType} implementations by calling
-     * @link DynamicFieldType#getKnownSubfields()}. Any other field that may be dynamically available but
+     * {@link DynamicFieldType#getKnownSubfields()}. Any other field that may be dynamically available but
      * is not known in advance will not be returned by this method.
      *
      * @param predicate the predicate

--- a/server/src/main/java/org/elasticsearch/index/mapper/FieldTypeLookup.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/FieldTypeLookup.java
@@ -150,6 +150,15 @@ final class FieldTypeLookup {
         }
     }
 
+    /**
+     * Returns all the mapped field types matching the provided predicate.
+     * Note that only known sub-fields are exposed from {@link DynamicFieldType} implementations by calling
+     * @link DynamicFieldType#getKnownSubfields()}. Any other field that may be dynamically available but
+     * is not known in advance will not be returned by this method.
+     *
+     * @param predicate the predicate
+     * @return the matching mapped field types
+     */
     Collection<MappedFieldType> getMatchingFieldTypes(Predicate<MappedFieldType> predicate) {
         if (dynamicFieldTypes.isEmpty()) {
             return fullNameToFieldType.values().stream().filter(predicate).collect(Collectors.toList());

--- a/server/src/main/java/org/elasticsearch/index/mapper/MapperService.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/MapperService.java
@@ -48,7 +48,6 @@ import java.util.Objects;
 import java.util.function.BooleanSupplier;
 import java.util.function.Function;
 import java.util.function.Supplier;
-import java.util.stream.Collectors;
 
 public class MapperService extends AbstractIndexComponent implements Closeable {
 
@@ -373,9 +372,7 @@ public class MapperService extends AbstractIndexComponent implements Closeable {
         if (this.mapper == null) {
             return Collections.emptySet();
         }
-        return this.mapper.mappers().getAllFieldTypes().stream()
-            .filter(MappedFieldType::eagerGlobalOrdinals)
-            .collect(Collectors.toList());
+        return this.mapper.mappers().getMatchingFieldTypes(MappedFieldType::eagerGlobalOrdinals);
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/index/mapper/MappingLookup.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/MappingLookup.java
@@ -315,9 +315,13 @@ public final class MappingLookup {
     }
 
     /**
-     * Return all field types that match the provided predicate
+     * Returns all the mapped field types matching the provided predicate.
+     * Note that only known sub-fields are exposed from {@link DynamicFieldType} implementations by calling
+     * @link DynamicFieldType#getKnownSubfields()}. Any other field that may be dynamically available but
+     * is not known in advance will not be returned by this method.
+     *
      * @param predicate the predicate
-     * @return the matching field types
+     * @return the matching mapped field types
      */
     public Collection<MappedFieldType> getMatchingFieldTypes(Predicate<MappedFieldType> predicate) {
         return fieldTypeLookup.getMatchingFieldTypes(predicate);

--- a/server/src/main/java/org/elasticsearch/index/mapper/MappingLookup.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/MappingLookup.java
@@ -20,6 +20,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
+import java.util.function.Predicate;
 import java.util.stream.Stream;
 
 /**
@@ -314,10 +315,12 @@ public final class MappingLookup {
     }
 
     /**
-     * @return all mapped field types
+     * Return all field types that match the provided predicate
+     * @param predicate the predicate
+     * @return the matching field types
      */
-    public Collection<MappedFieldType> getAllFieldTypes() {
-        return fieldTypeLookup.getMatchingFieldTypes("*");
+    public Collection<MappedFieldType> getMatchingFieldTypes(Predicate<MappedFieldType> predicate) {
+        return fieldTypeLookup.getMatchingFieldTypes(predicate);
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/index/mapper/MappingLookup.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/MappingLookup.java
@@ -317,7 +317,7 @@ public final class MappingLookup {
     /**
      * Returns all the mapped field types matching the provided predicate.
      * Note that only known sub-fields are exposed from {@link DynamicFieldType} implementations by calling
-     * @link DynamicFieldType#getKnownSubfields()}. Any other field that may be dynamically available but
+     * {@link DynamicFieldType#getKnownSubfields()}. Any other field that may be dynamically available but
      * is not known in advance will not be returned by this method.
      *
      * @param predicate the predicate

--- a/server/src/main/java/org/elasticsearch/index/query/SearchExecutionContext.java
+++ b/server/src/main/java/org/elasticsearch/index/query/SearchExecutionContext.java
@@ -334,7 +334,7 @@ public class SearchExecutionContext extends QueryRewriteContext {
     /**
      * Returns all the mapped field types matching the provided predicate.
      * Note that only known sub-fields are exposed from {@link DynamicFieldType} implementations by calling
-     * @link DynamicFieldType#getKnownSubfields()}. Any other field that may be dynamically available but
+     * {@link DynamicFieldType#getKnownSubfields()}. Any other field that may be dynamically available but
      * is not known in advance will not be returned by this method.
      * Also, note that runtime mappings are not taken into account and will not be returned by this method, hence this
      * method should be used only in scenarios where runtime fields defined in the search request are not applicable.

--- a/server/src/main/java/org/elasticsearch/index/query/SearchExecutionContext.java
+++ b/server/src/main/java/org/elasticsearch/index/query/SearchExecutionContext.java
@@ -331,10 +331,14 @@ public class SearchExecutionContext extends QueryRewriteContext {
     }
 
     /**
-     * @return all mapped field types, including runtime fields defined in the request
+     * Return all field types that match the provided predicate.
+     * Note that runtime mappings are not included, hence this method should be used only in scenarios where
+     * runtime fields defined in the search request are not applicable.
+     * @param predicate the predicate
+     * @return the matching field types
      */
-    public Collection<MappedFieldType> getAllFieldTypes() {
-        return getMatchingFieldTypes("*");
+    public Collection<MappedFieldType> getMatchingFieldTypes(Predicate<MappedFieldType> predicate) {
+        return mappingLookup.getMatchingFieldTypes(predicate);
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/index/query/SearchExecutionContext.java
+++ b/server/src/main/java/org/elasticsearch/index/query/SearchExecutionContext.java
@@ -35,6 +35,7 @@ import org.elasticsearch.index.analysis.NamedAnalyzer;
 import org.elasticsearch.index.cache.bitset.BitsetFilterCache;
 import org.elasticsearch.index.fielddata.IndexFieldData;
 import org.elasticsearch.index.mapper.ContentPath;
+import org.elasticsearch.index.mapper.DynamicFieldType;
 import org.elasticsearch.index.mapper.FieldMapper;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.Mapper;
@@ -331,11 +332,15 @@ public class SearchExecutionContext extends QueryRewriteContext {
     }
 
     /**
-     * Return all field types that match the provided predicate.
-     * Note that runtime mappings are not included, hence this method should be used only in scenarios where
-     * runtime fields defined in the search request are not applicable.
+     * Returns all the mapped field types matching the provided predicate.
+     * Note that only known sub-fields are exposed from {@link DynamicFieldType} implementations by calling
+     * @link DynamicFieldType#getKnownSubfields()}. Any other field that may be dynamically available but
+     * is not known in advance will not be returned by this method.
+     * Also, note that runtime mappings are not taken into account and will not be returned by this method, hence this
+     * method should be used only in scenarios where runtime fields defined in the search request are not applicable.
+     *
      * @param predicate the predicate
-     * @return the matching field types
+     * @return the matching mapped field types
      */
     public Collection<MappedFieldType> getMatchingFieldTypes(Predicate<MappedFieldType> predicate) {
         return mappingLookup.getMatchingFieldTypes(predicate);

--- a/server/src/main/java/org/elasticsearch/search/aggregations/support/AggregationContext.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/support/AggregationContext.java
@@ -24,8 +24,8 @@ import org.elasticsearch.index.fielddata.IndexFieldData;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.ObjectMapper;
 import org.elasticsearch.index.query.QueryBuilder;
-import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.index.query.Rewriteable;
+import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.index.query.support.NestedScope;
 import org.elasticsearch.script.Script;
 import org.elasticsearch.script.ScriptContext;
@@ -46,6 +46,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.function.Function;
 import java.util.function.LongSupplier;
+import java.util.function.Predicate;
 import java.util.function.Supplier;
 
 /**
@@ -112,9 +113,13 @@ public abstract class AggregationContext implements Releasable {
     public abstract MappedFieldType getFieldType(String path);
 
     /**
-     * Returns the registered mapped field types.
+     * Return all field types that match the provided predicate.
+     * Note that runtime mappings are not included, hence this method should be used only in scenarios where
+     * runtime fields defined in the search request are not applicable.
+     * @param predicate the predicate
+     * @return the matching field types
      */
-    public abstract Collection<MappedFieldType> getMatchingFieldTypes(String pattern);
+    public abstract Collection<MappedFieldType> getMatchingFieldTypes(Predicate<MappedFieldType> predicate);
 
     /**
      * Returns true if the field identified by the provided name is mapped, false otherwise
@@ -346,8 +351,8 @@ public abstract class AggregationContext implements Releasable {
         }
 
         @Override
-        public Collection<MappedFieldType> getMatchingFieldTypes(String pattern) {
-            return context.getMatchingFieldTypes(pattern);
+        public Collection<MappedFieldType> getMatchingFieldTypes(Predicate<MappedFieldType> predicate) {
+            return context.getMatchingFieldTypes(predicate);
         }
 
         @Override

--- a/server/src/test/java/org/elasticsearch/index/query/SearchExecutionContextTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/SearchExecutionContextTests.java
@@ -363,9 +363,6 @@ public class SearchExecutionContextTests extends ESTestCase {
         Collection<MappedFieldType> matches = context.getMatchingFieldTypes("ca*");
         assertThat(matches, hasSize(1));
         assertThat(matches.iterator().next(), instanceOf(KeywordScriptFieldType.class));
-
-        matches = context.getAllFieldTypes();
-        assertThat(matches, hasSize(3));
     }
 
     public void testSearchRequestRuntimeFieldsWrongFormat() {

--- a/server/src/test/java/org/elasticsearch/index/query/SearchExecutionContextTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/SearchExecutionContextTests.java
@@ -363,6 +363,18 @@ public class SearchExecutionContextTests extends ESTestCase {
         Collection<MappedFieldType> matches = context.getMatchingFieldTypes("ca*");
         assertThat(matches, hasSize(1));
         assertThat(matches.iterator().next(), instanceOf(KeywordScriptFieldType.class));
+
+        {
+            Collection<MappedFieldType> matchingFieldTypes = context.getMatchingFieldTypes(ft -> true);
+            assertThat(matchingFieldTypes, hasSize(2));
+            for (MappedFieldType matchingFieldType : matchingFieldTypes) {
+                assertThat(matchingFieldType, instanceOf(MockFieldMapper.FakeFieldType.class));
+            }
+        }
+        {
+            Collection<MappedFieldType> matchingFieldTypes = context.getMatchingFieldTypes(ft -> ft.name().equals("dog"));
+            assertThat(matchingFieldTypes, hasSize(0));
+        }
     }
 
     public void testSearchRequestRuntimeFieldsWrongFormat() {

--- a/test/framework/src/main/java/org/elasticsearch/index/mapper/MapperServiceTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/mapper/MapperServiceTestCase.java
@@ -71,6 +71,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.function.BooleanSupplier;
 import java.util.function.Function;
+import java.util.function.Predicate;
 
 import static java.util.Collections.emptyList;
 import static java.util.stream.Collectors.toList;
@@ -377,7 +378,7 @@ public abstract class MapperServiceTestCase extends ESTestCase {
             }
 
             @Override
-            public Collection<MappedFieldType> getMatchingFieldTypes(String pattern) {
+            public Collection<MappedFieldType> getMatchingFieldTypes(Predicate<MappedFieldType> predicate) {
                 throw new UnsupportedOperationException();
             }
 
@@ -521,7 +522,7 @@ public abstract class MapperServiceTestCase extends ESTestCase {
         when(searchExecutionContext.getMatchingFieldNames(anyObject())).thenAnswer(
             inv -> mapperService.mappingLookup().getMatchingFieldNames(inv.getArguments()[0].toString())
         );
-        when(searchExecutionContext.getMatchingFieldTypes(anyObject())).thenAnswer(
+        when(searchExecutionContext.getMatchingFieldTypes(anyString())).thenAnswer(
             inv -> mapperService.mappingLookup().getMatchingFieldTypes(inv.getArguments()[0].toString())
         );
         when(searchExecutionContext.allowExpensiveQueries()).thenReturn(true);


### PR DESCRIPTION
We would like to reduce usages of FieldTypeLookup#getMatchingFieldTypes. The method is used for two main different reasons:
1) exists query builder to check whether a field exists or not (see #73617)
2) to iterate through all field types (`getMatchingFieldTypes("*")` is called internally) and then filter them based on different criteria: this is used to eagerly load global ordinals and find the join field type

The latter use-case could use a more specialized method, which makes it easier to trace. Additionally this scenario does not need to have runtime mappings applied in `SearchExecutionContext` which simplifies things further as the method can simply proxy to the corresponding `MappingLookup#getMatchingFieldTypes`.