### PR TITLE
Disable BWC testing for ILM _meta backport

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -170,9 +170,9 @@ tasks.register("verifyVersions") {
  * after the backport of the backcompat code is complete.
  */
 
-boolean bwc_tests_enabled = true
+boolean bwc_tests_enabled = false
 // place a PR link here when committing bwc changes:
-String bwc_tests_disabled_issue = ""
+String bwc_tests_disabled_issue = "https://github.com/elastic/elasticsearch/pull/73624"
 /*
  * FIPS 140-2 behavior was fixed in 7.11.0. Before that there is no way to run elasticsearch in a
  * JVM that is properly configured to be in fips mode with BCFIPS. For now we need to disable


### PR DESCRIPTION
This commit disables BWC tests until the PRs adding `_meta` to ILM policies can be backported and
version constants added.

Relates: #73515, #73624
