### PR TITLE
Add _meta information to built-in ILM policies

### DIFF
--- a/x-pack/plugin/core/src/main/resources/fleet-actions-results-ilm-policy.json
+++ b/x-pack/plugin/core/src/main/resources/fleet-actions-results-ilm-policy.json
@@ -17,5 +17,9 @@
         }
       }
     }
+  },
+  "_meta": {
+    "description": "default policy for fleet action results indices",
+    "managed": true
   }
 }

--- a/x-pack/plugin/core/src/main/resources/ilm-history-ilm-policy.json
+++ b/x-pack/plugin/core/src/main/resources/ilm-history-ilm-policy.json
@@ -14,5 +14,9 @@
         "delete": {}
       }
     }
+  },
+  "_meta": {
+    "description": "default policy for the ILM history indices",
+    "managed": true
   }
 }

--- a/x-pack/plugin/core/src/main/resources/logs-policy.json
+++ b/x-pack/plugin/core/src/main/resources/logs-policy.json
@@ -8,5 +8,9 @@
         }
       }
     }
+  },
+  "_meta": {
+    "description": "default policy for the logs index template installed by x-pack",
+    "managed": true
   }
 }

--- a/x-pack/plugin/core/src/main/resources/metrics-policy.json
+++ b/x-pack/plugin/core/src/main/resources/metrics-policy.json
@@ -8,5 +8,9 @@
         }
       }
     }
+  },
+  "_meta": {
+    "description": "default policy for the metrics index template installed by x-pack",
+    "managed": true
   }
 }

--- a/x-pack/plugin/core/src/main/resources/slm-history-ilm-policy.json
+++ b/x-pack/plugin/core/src/main/resources/slm-history-ilm-policy.json
@@ -14,5 +14,9 @@
         "delete": {}
       }
     }
+  },
+  "_meta": {
+    "description": "default policy for the SLM history indices",
+    "managed": true
   }
 }

--- a/x-pack/plugin/core/src/main/resources/synthetics-policy.json
+++ b/x-pack/plugin/core/src/main/resources/synthetics-policy.json
@@ -8,5 +8,9 @@
         }
       }
     }
+  },
+  "_meta": {
+    "description": "default policy for the synthetics index template installed by x-pack",
+    "managed": true
   }
 }

--- a/x-pack/plugin/core/src/main/resources/watch-history-ilm-policy.json
+++ b/x-pack/plugin/core/src/main/resources/watch-history-ilm-policy.json
@@ -6,5 +6,9 @@
         "delete": {}
       }
     }
+  },
+  "_meta": {
+    "description": "default policy for the watcher history indices",
+    "managed": true
   }
 }


### PR DESCRIPTION
We already ship templates that include the `_meta` map for things like component and composable
index templates, and we use the `"managed": true` indicator for many of our built-in items within
Elasticsearch.

This commit adds a description and managed flag to each of the ILM policies we ship by default.
