### PR TITLE
Add `data-streams-mappings` to isXPackTemplate method

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/test/rest/ESRestTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/ESRestTestCase.java
@@ -1507,6 +1507,7 @@ public abstract class ESRestTestCase extends ESTestCase {
             case "ilm-history":
             case "logstash-index-template":
             case "security-index-template":
+            case "data-streams-mappings":
                 return true;
             default:
                 return false;


### PR DESCRIPTION
This template was added in #64978, however, there can be some test failures if we try to remove
built-in templates. It was missing from the list and now needs to be added back.
