### PR TITLE
[7.x] Trigger a reroute after registering a node for removal (#73449)

### DIFF
--- a/x-pack/plugin/shutdown/qa/multi-node/src/javaRestTest/java/org/elasticsearch/xpack/shutdown/NodeShutdownIT.java
+++ b/x-pack/plugin/shutdown/qa/multi-node/src/javaRestTest/java/org/elasticsearch/xpack/shutdown/NodeShutdownIT.java
@@ -29,21 +29,13 @@ public class NodeShutdownIT extends ESRestTestCase {
 
     @SuppressWarnings("unchecked")
     public void testCRUD() throws Exception {
-        Request nodesRequest = new Request("GET", "_nodes");
-        Map<String, Object> nodesResponse = responseAsMap(client().performRequest(nodesRequest));
-        Map<String, Object> nodesObject = (Map<String, Object>) nodesResponse.get("nodes");
-
-        String nodeIdToShutdown = randomFrom(nodesObject.keySet());
-        String reason = "testing node shutdown crud: " + randomAlphaOfLength(5);
+        String nodeIdToShutdown = getRandomNodeId();
         String type = randomFrom("RESTART", "REMOVE");
 
         // Ensure if we do a GET before the cluster metadata is set up, we don't get an error
         assertNoShuttingDownNodes(nodeIdToShutdown);
 
-        // Put a shutdown request
-        Request putShutdown = new Request("PUT", "_nodes/" + nodeIdToShutdown + "/shutdown");
-        putShutdown.setJsonEntity("{\"type\":  \"" + type + "\", \"reason\":  \"" + reason + "\"}");
-        assertOK(client().performRequest(putShutdown));
+        putNodeShutdown(nodeIdToShutdown, type);
 
         // Ensure we can read it back
         {
@@ -53,7 +45,7 @@ public class NodeShutdownIT extends ESRestTestCase {
             assertThat(nodesArray, hasSize(1));
             assertThat(nodesArray.get(0).get("node_id"), equalTo(nodeIdToShutdown));
             assertThat(nodesArray.get(0).get("type"), equalTo(type));
-            assertThat(nodesArray.get(0).get("reason"), equalTo(reason));
+            assertThat(nodesArray.get(0).get("reason"), equalTo(this.getTestName()));
         }
 
         // Delete it and make sure it's deleted
@@ -67,26 +59,122 @@ public class NodeShutdownIT extends ESRestTestCase {
      */
     @SuppressWarnings("unchecked")
     public void testAllocationPreventedForRemoval() throws Exception {
-        Request nodesRequest = new Request("GET", "_nodes");
-        Map<String, Object> nodesResponse = responseAsMap(client().performRequest(nodesRequest));
-        Map<String, Object> nodesObject = (Map<String, Object>) nodesResponse.get("nodes");
+        String nodeIdToShutdown = getRandomNodeId();
+        putNodeShutdown(nodeIdToShutdown, "REMOVE");
 
-        String nodeIdToShutdown = randomFrom(nodesObject.keySet());
-        String reason = "testing node shutdown allocation rules";
-        String type = "REMOVE";
-
-        // Put a shutdown request
-        Request putShutdown = new Request("PUT", "_nodes/" + nodeIdToShutdown + "/shutdown");
-        putShutdown.setJsonEntity("{\"type\":  \"" + type + "\", \"reason\":  \"" + reason + "\"}");
-        assertOK(client().performRequest(putShutdown));
-
-        // Create an index with 1s/2r
+        // Create an index with enough replicas to ensure one would normally be allocated to each node
         final String indexName = "test-idx";
         Request createIndexRequest = new Request("PUT", indexName);
         createIndexRequest.setJsonEntity("{\"settings\":  {\"number_of_shards\": 1, \"number_of_replicas\": 3}}");
         assertOK(client().performRequest(createIndexRequest));
 
         // Watch to ensure no shards gets allocated to the node that's shutting down
+        assertUnassignedShard(nodeIdToShutdown, indexName);
+
+        // Now that we know all shards of the test index are assigned except one,
+        // make sure it's unassigned because of the allocation decider.
+        Request allocationExplainRequest = new Request("GET", "_cluster/allocation/explain");
+        allocationExplainRequest.setJsonEntity("{\"index\": \"" + indexName + "\", \"shard\":  0, \"primary\":  false}");
+        Map<String, Object> allocationExplainMap = entityAsMap(client().performRequest(allocationExplainRequest));
+        List<Map<String, Object>> decisions = (List<Map<String, Object>>) allocationExplainMap.get("node_allocation_decisions");
+        assertThat(decisions, notNullValue());
+
+        Optional<Map<String, Object>> maybeDecision = decisions.stream()
+            .filter(decision -> nodeIdToShutdown.equals(decision.get("node_id")))
+            .findFirst();
+        assertThat("expected decisions for node, but not found", maybeDecision.isPresent(), is(true));
+
+        Map<String, Object> decision = maybeDecision.get();
+        assertThat("node should have deciders", decision.containsKey("deciders"), is(true));
+
+        List<Map<String, Object>> deciders = (List<Map<String, Object>>) decision.get("deciders");
+        assertThat(
+            "the node_shutdown allocation decider should have decided NO",
+            deciders.stream()
+                .filter(decider -> "node_shutdown".equals(decider.get("decider")))
+                .allMatch(decider -> "NO".equals(decider.get("decision"))),
+            is(true)
+        );
+    }
+
+    /**
+     * Checks that a reroute is started immediately after registering a node shutdown, so that shards will actually start moving off of
+     * the node immediately, rather than waiting for something to trigger it.
+     */
+    @SuppressWarnings("unchecked")
+    public void testRerouteStartedOnRemoval() throws Exception {
+        String nodeIdToShutdown = getRandomNodeId();
+
+        final String indexName = "test-idx";
+        Request createIndexRequest = new Request("PUT", indexName);
+        createIndexRequest.setJsonEntity("{\"settings\":  {\"number_of_shards\": 4, \"number_of_replicas\": 0}}");
+        assertOK(client().performRequest(createIndexRequest));
+
+        ensureGreen(indexName);
+
+        // Check to ensure there's a shard on the node we want to shut down
+        Request checkShardsRequest = new Request("GET", "_cat/shards/" + indexName);
+        checkShardsRequest.addParameter("format", "json");
+        checkShardsRequest.addParameter("h", "index,shard,prirep,id,state");
+
+        // Double check that there's actually a shard on the node we want to shut down
+        {
+            List<Object> shardsResponse = entityAsList(client().performRequest(checkShardsRequest));
+            final long shardsOnNodeToShutDown = shardsResponse.stream()
+                .map(shard -> (Map<String, Object>) shard)
+                .filter(shard -> nodeIdToShutdown.equals(shard.get("id")))
+                .filter(shard -> "STARTED".equals(shard.get("state")))
+                .count();
+            assertThat(shardsOnNodeToShutDown, is(1L));
+        }
+
+        // Register the shutdown
+        putNodeShutdown(nodeIdToShutdown, "REMOVE");
+
+        // assertBusy waiting for the shard to no longer be on that node
+        assertBusy(() -> {
+            List<Object> shardsResponse = entityAsList(client().performRequest(checkShardsRequest));
+            final long shardsOnNodeToShutDown = shardsResponse.stream()
+                .map(shard -> (Map<String, Object>) shard)
+                .filter(shard -> nodeIdToShutdown.equals(shard.get("id")))
+                .filter(shard -> "STARTED".equals(shard.get("state")))
+                .count();
+            assertThat(shardsOnNodeToShutDown, is(0L));
+        });
+    }
+
+    public void testShardsCanBeAllocatedAfterShutdownDeleted() throws Exception {
+        String nodeIdToShutdown = getRandomNodeId();
+        putNodeShutdown(nodeIdToShutdown, "REMOVE");
+
+        // Create an index with enough replicas to ensure one would normally be allocated to each node
+        final String indexName = "test-idx";
+        Request createIndexRequest = new Request("PUT", indexName);
+        createIndexRequest.setJsonEntity("{\"settings\":  {\"number_of_shards\": 1, \"number_of_replicas\": 3}}");
+        assertOK(client().performRequest(createIndexRequest));
+
+        // Watch to ensure no shards gets allocated to the node that's shutting down
+        assertUnassignedShard(nodeIdToShutdown, indexName);
+
+        // Delete the shutdown
+        Request deleteRequest = new Request("DELETE", "_nodes/" + nodeIdToShutdown + "/shutdown");
+        assertOK(client().performRequest(deleteRequest));
+        assertNoShuttingDownNodes(nodeIdToShutdown);
+
+        // Check that the shard is assigned now
+        ensureGreen(indexName);
+    }
+
+    @SuppressWarnings("unchecked")
+    private void assertNoShuttingDownNodes(String nodeIdToShutdown) throws IOException {
+        Request getShutdownStatus = new Request("GET", "_nodes/" + nodeIdToShutdown + "/shutdown");
+        Map<String, Object> statusResponse = responseAsMap(client().performRequest(getShutdownStatus));
+        List<Map<String, Object>> nodesArray = (List<Map<String, Object>>) statusResponse.get("nodes");
+        assertThat(nodesArray, empty());
+    }
+
+    @SuppressWarnings("unchecked")
+    private void assertUnassignedShard(String nodeIdToShutdown, String indexName) throws Exception {
         Request checkShardsRequest = new Request("GET", "_cat/shards/" + indexName);
         checkShardsRequest.addParameter("format", "json");
         checkShardsRequest.addParameter("h", "index,shard,prirep,id,state");
@@ -113,39 +201,24 @@ public class NodeShutdownIT extends ESRestTestCase {
             assertThat(unassignedShards, equalTo(1));
             assertThat(startedShards, equalTo(3));
         });
-        // Now that we know all shards of the test index are assigned except one,
-        // make sure it's unassigned because of the allocation decider.
+    }
 
-        Request allocationExplainRequest = new Request("GET", "_cluster/allocation/explain");
-        allocationExplainRequest.setJsonEntity("{\"index\": \"" + indexName + "\", \"shard\":  0, \"primary\":  false}");
-        Map<String, Object> allocationExplainMap = entityAsMap(client().performRequest(allocationExplainRequest));
-        List<Map<String, Object>> decisions = (List<Map<String, Object>>) allocationExplainMap.get("node_allocation_decisions");
-        assertThat(decisions, notNullValue());
+    private void putNodeShutdown(String nodeIdToShutdown, String type) throws IOException {
+        String reason = this.getTestName();
 
-        Optional<Map<String, Object>> maybeDecision = decisions.stream()
-            .filter(decision -> nodeIdToShutdown.equals(decision.get("node_id")))
-            .findFirst();
-        assertThat("expected decisions for node, but not found", maybeDecision.isPresent(), is(true));
-
-        Map<String, Object> decision = maybeDecision.get();
-        assertThat("node should have deciders", decision.containsKey("deciders"), is(true));
-
-        List<Map<String, Object>> deciders = (List<Map<String, Object>>) decision.get("deciders");
-        assertThat(
-            "the node_shutdown allocation decider should have decided NO",
-            deciders.stream()
-                .filter(decider -> "node_shutdown".equals(decider.get("decider")))
-                .allMatch(decider -> "NO".equals(decider.get("decision"))),
-            is(true)
-        );
+        // Put a shutdown request
+        Request putShutdown = new Request("PUT", "_nodes/" + nodeIdToShutdown + "/shutdown");
+        putShutdown.setJsonEntity("{\"type\":  \"" + type + "\", \"reason\":  \"" + reason + "\"}");
+        assertOK(client().performRequest(putShutdown));
     }
 
     @SuppressWarnings("unchecked")
-    private void assertNoShuttingDownNodes(String nodeIdToShutdown) throws IOException {
-        Request getShutdownStatus = new Request("GET", "_nodes/" + nodeIdToShutdown + "/shutdown");
-        Map<String, Object> statusResponse = responseAsMap(client().performRequest(getShutdownStatus));
-        List<Map<String, Object>> nodesArray = (List<Map<String, Object>>) statusResponse.get("nodes");
-        assertThat(nodesArray, empty());
+    private String getRandomNodeId() throws IOException {
+        Request nodesRequest = new Request("GET", "_nodes");
+        Map<String, Object> nodesResponse = responseAsMap(client().performRequest(nodesRequest));
+        Map<String, Object> nodesObject = (Map<String, Object>) nodesResponse.get("nodes");
+
+        return randomFrom(nodesObject.keySet());
     }
 
     @Override

--- a/x-pack/plugin/shutdown/src/main/java/org/elasticsearch/xpack/shutdown/TransportDeleteShutdownNodeAction.java
+++ b/x-pack/plugin/shutdown/src/main/java/org/elasticsearch/xpack/shutdown/TransportDeleteShutdownNodeAction.java
@@ -7,23 +7,29 @@
 
 package org.elasticsearch.xpack.shutdown;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.master.AcknowledgedResponse;
 import org.elasticsearch.action.support.master.AcknowledgedTransportMasterNodeAction;
-import org.elasticsearch.cluster.AckedClusterStateUpdateTask;
 import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.ClusterStateUpdateTask;
 import org.elasticsearch.cluster.block.ClusterBlockException;
 import org.elasticsearch.cluster.block.ClusterBlockLevel;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.metadata.NodesShutdownMetadata;
 import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.Priority;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 
 public class TransportDeleteShutdownNodeAction extends AcknowledgedTransportMasterNodeAction<DeleteShutdownNodeAction.Request> {
+    private static final Logger logger = LogManager.getLogger(TransportDeleteShutdownNodeAction.class);
+
     @Inject
     public TransportDeleteShutdownNodeAction(
         TransportService transportService,
@@ -57,26 +63,47 @@ public class TransportDeleteShutdownNodeAction extends AcknowledgedTransportMast
             }
         }
 
-        clusterService.submitStateUpdateTask(
-            "delete-node-shutdown-" + request.getNodeId(),
-            new AckedClusterStateUpdateTask(request, listener) {
-                @Override
-                public ClusterState execute(ClusterState currentState) throws Exception {
-                    NodesShutdownMetadata currentShutdownMetadata = currentState.metadata().custom(NodesShutdownMetadata.TYPE);
+        clusterService.submitStateUpdateTask("delete-node-shutdown-" + request.getNodeId(), new ClusterStateUpdateTask() {
+            @Override
+            public ClusterState execute(ClusterState currentState) throws Exception {
+                NodesShutdownMetadata currentShutdownMetadata = currentState.metadata().custom(NodesShutdownMetadata.TYPE);
 
-                    return ClusterState.builder(currentState)
-                        .metadata(
-                            Metadata.builder(currentState.metadata())
-                                .putCustom(
-                                    NodesShutdownMetadata.TYPE,
-                                    currentShutdownMetadata.removeSingleNodeMetadata(request.getNodeId())
-                                )
-                        )
-                        .build();
+                return ClusterState.builder(currentState)
+                    .metadata(
+                        Metadata.builder(currentState.metadata())
+                            .putCustom(NodesShutdownMetadata.TYPE, currentShutdownMetadata.removeSingleNodeMetadata(request.getNodeId()))
+                    )
+                    .build();
 
-                }
             }
-        );
+
+            @Override
+            public void onFailure(String source, Exception e) {
+                logger.error(new ParameterizedMessage("failed to delete shutdown for node [{}]", request.getNodeId()), e);
+                listener.onFailure(e);
+            }
+
+            @Override
+            public void clusterStateProcessed(String source, ClusterState oldState, ClusterState newState) {
+                clusterService.getRerouteService()
+                    .reroute("node registered for removal from cluster", Priority.NORMAL, new ActionListener<ClusterState>() {
+                        @Override
+                        public void onResponse(ClusterState clusterState) {
+                            logger.trace("started reroute after deleting node [{}}] shutdown", request.getNodeId());
+                            listener.onResponse(AcknowledgedResponse.TRUE);
+                        }
+
+                        @Override
+                        public void onFailure(Exception e) {
+                            logger.warn(
+                                new ParameterizedMessage("failed to start reroute after deleting node [{}] shutdown", request.getNodeId()),
+                                e
+                            );
+                            listener.onFailure(e);
+                        }
+                    });
+            }
+        });
     }
 
     @Override

--- a/x-pack/plugin/shutdown/src/main/java/org/elasticsearch/xpack/shutdown/TransportPutShutdownNodeAction.java
+++ b/x-pack/plugin/shutdown/src/main/java/org/elasticsearch/xpack/shutdown/TransportPutShutdownNodeAction.java
@@ -7,12 +7,15 @@
 
 package org.elasticsearch.xpack.shutdown;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.master.AcknowledgedResponse;
 import org.elasticsearch.action.support.master.AcknowledgedTransportMasterNodeAction;
-import org.elasticsearch.cluster.AckedClusterStateUpdateTask;
 import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.ClusterStateUpdateTask;
 import org.elasticsearch.cluster.block.ClusterBlockException;
 import org.elasticsearch.cluster.block.ClusterBlockLevel;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
@@ -20,6 +23,8 @@ import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.metadata.NodesShutdownMetadata;
 import org.elasticsearch.cluster.metadata.SingleNodeShutdownMetadata;
 import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.Priority;
+import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
@@ -28,6 +33,8 @@ import java.util.HashMap;
 import java.util.Objects;
 
 public class TransportPutShutdownNodeAction extends AcknowledgedTransportMasterNodeAction<PutShutdownNodeAction.Request> {
+    private static final Logger logger = LogManager.getLogger(TransportPutShutdownNodeAction.class);
+
     @Inject
     public TransportPutShutdownNodeAction(
         TransportService transportService,
@@ -51,37 +58,76 @@ public class TransportPutShutdownNodeAction extends AcknowledgedTransportMasterN
     @Override
     protected void masterOperation(PutShutdownNodeAction.Request request, ClusterState state, ActionListener<AcknowledgedResponse> listener)
         throws Exception {
-        clusterService.submitStateUpdateTask(
-            "put-node-shutdown-" + request.getNodeId(),
-            new AckedClusterStateUpdateTask(request, listener) {
-                @Override
-                public ClusterState execute(ClusterState currentState) {
-                    NodesShutdownMetadata currentShutdownMetadata = currentState.metadata().custom(NodesShutdownMetadata.TYPE);
-                    if (currentShutdownMetadata == null) {
-                        currentShutdownMetadata = new NodesShutdownMetadata(new HashMap<>());
-                    }
+        clusterService.submitStateUpdateTask("put-node-shutdown-" + request.getNodeId(), new ClusterStateUpdateTask() {
+            @Override
+            public ClusterState execute(ClusterState currentState) {
+                NodesShutdownMetadata currentShutdownMetadata = currentState.metadata().custom(NodesShutdownMetadata.TYPE);
+                if (currentShutdownMetadata == null) {
+                    currentShutdownMetadata = new NodesShutdownMetadata(new HashMap<>());
+                }
 
-                    // Verify that there's not already a shutdown metadata for this node
-                    if (Objects.nonNull(currentShutdownMetadata.getAllNodeMetadataMap().get(request.getNodeId()))) {
-                        throw new IllegalArgumentException("node [" + request.getNodeId() + "] is already shutting down");
-                    }
+                // Verify that there's not already a shutdown metadata for this node
+                if (Objects.nonNull(currentShutdownMetadata.getAllNodeMetadataMap().get(request.getNodeId()))) {
+                    logger.error(Strings.toString(currentShutdownMetadata));
+                    throw new IllegalArgumentException("node [" + request.getNodeId() + "] is already shutting down");
+                }
 
-                    SingleNodeShutdownMetadata newNodeMetadata = SingleNodeShutdownMetadata.builder()
-                        .setNodeId(request.getNodeId())
-                        .setType(request.getType())
-                        .setReason(request.getReason())
-                        .setStartedAtMillis(System.currentTimeMillis())
-                        .build();
+                SingleNodeShutdownMetadata newNodeMetadata = SingleNodeShutdownMetadata.builder()
+                    .setNodeId(request.getNodeId())
+                    .setType(request.getType())
+                    .setReason(request.getReason())
+                    .setStartedAtMillis(System.currentTimeMillis())
+                    .build();
 
-                    return ClusterState.builder(currentState)
-                        .metadata(
-                            Metadata.builder(currentState.metadata())
-                                .putCustom(NodesShutdownMetadata.TYPE, currentShutdownMetadata.putSingleNodeMetadata(newNodeMetadata))
-                        )
-                        .build();
+                return ClusterState.builder(currentState)
+                    .metadata(
+                        Metadata.builder(currentState.metadata())
+                            .putCustom(NodesShutdownMetadata.TYPE, currentShutdownMetadata.putSingleNodeMetadata(newNodeMetadata))
+                    )
+                    .build();
+            }
+
+            @Override
+            public void onFailure(String source, Exception e) {
+                logger.error(new ParameterizedMessage("failed to put shutdown for node [{}]", request.getNodeId()), e);
+                listener.onFailure(e);
+            }
+
+            @Override
+            public void clusterStateProcessed(String source, ClusterState oldState, ClusterState newState) {
+                if (SingleNodeShutdownMetadata.Type.REMOVE.equals(request.getType())) {
+                    clusterService.getRerouteService()
+                        .reroute("node registered for removal from cluster", Priority.NORMAL, new ActionListener<ClusterState>() {
+                            @Override
+                            public void onResponse(ClusterState clusterState) {
+                                logger.trace("started reroute after registering node [{}] for removal", request.getNodeId());
+                                listener.onResponse(AcknowledgedResponse.TRUE);
+                            }
+
+                            @Override
+                            public void onFailure(Exception e) {
+                                logger.warn(
+                                    new ParameterizedMessage(
+                                        "failed to start reroute after registering node [{}] for removal",
+                                        request.getNodeId()
+                                    ),
+                                    e
+                                );
+                                listener.onFailure(e);
+                            }
+                        });
+                } else {
+                    logger.trace(
+                        "not starting reroute after registering node ["
+                            + request.getNodeId()
+                            + "] for shutdown of type ["
+                            + request.getType()
+                            + "]"
+                    );
+                    listener.onResponse(AcknowledgedResponse.TRUE);
                 }
             }
-        );
+        });
     }
 
     @Override


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Trigger a reroute after registering a node for removal (#73449)