### PR TITLE
Fix error when fetching values for parent ID join field

### DIFF
--- a/modules/parent-join/src/main/java/org/elasticsearch/join/mapper/ParentIdFieldMapper.java
+++ b/modules/parent-join/src/main/java/org/elasticsearch/join/mapper/ParentIdFieldMapper.java
@@ -26,6 +26,7 @@ import org.elasticsearch.search.aggregations.support.CoreValuesSourceType;
 import org.elasticsearch.search.lookup.SearchLookup;
 
 import java.util.Collections;
+import java.util.List;
 import java.util.function.Supplier;
 
 /**
@@ -73,7 +74,9 @@ public final class ParentIdFieldMapper extends FieldMapper {
 
         @Override
         public ValueFetcher valueFetcher(SearchExecutionContext context, String format) {
-            throw new UnsupportedOperationException("Cannot fetch values for internal field [" + typeName() + "].");
+            // Although this is an internal field, we return it in the list of all field types. So we
+            // provide an empty value fetcher here of throwing an error.
+            return lookup -> List.of();
         }
 
         @Override

--- a/modules/parent-join/src/main/java/org/elasticsearch/join/mapper/ParentJoinFieldMapper.java
+++ b/modules/parent-join/src/main/java/org/elasticsearch/join/mapper/ParentJoinFieldMapper.java
@@ -151,6 +151,9 @@ public final class ParentJoinFieldMapper extends FieldMapper {
 
         @Override
         public ValueFetcher valueFetcher(SearchExecutionContext context, String format) {
+            if (format != null) {
+                throw new IllegalArgumentException("Field [" + name() + "] of type [" + typeName() + "] doesn't support formats.");
+            }
             return SourceValueFetcher.identity(name(), context, format);
         }
 

--- a/modules/parent-join/src/test/java/org/elasticsearch/join/mapper/JoinFieldTypeTests.java
+++ b/modules/parent-join/src/test/java/org/elasticsearch/join/mapper/JoinFieldTypeTests.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.join.mapper;
+
+import org.elasticsearch.index.mapper.ContentPath;
+import org.elasticsearch.index.mapper.FieldTypeTestCase;
+import org.elasticsearch.index.mapper.MappedFieldType;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+public class JoinFieldTypeTests extends FieldTypeTestCase {
+
+    public void testFetchSourceValue() throws IOException {
+        MappedFieldType fieldType = new ParentJoinFieldMapper.Builder("field").build(new ContentPath()).fieldType();
+
+        Map<String, String> parentValue = Map.of("relation", "parent");
+        assertEquals(List.of(parentValue), fetchSourceValue(fieldType, parentValue));
+
+        Map<String, String> childValue = Map.of("relation", "child", "parent", "1");
+        assertEquals(List.of(childValue), fetchSourceValue(fieldType, childValue));
+
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class,
+            () -> fetchSourceValue(fieldType, parentValue, "format"));
+        assertEquals("Field [field] of type [join] doesn't support formats.", e.getMessage());
+    }
+}

--- a/modules/parent-join/src/test/java/org/elasticsearch/join/mapper/ParentIdFieldTypeTests.java
+++ b/modules/parent-join/src/test/java/org/elasticsearch/join/mapper/ParentIdFieldTypeTests.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.join.mapper;
+
+import org.elasticsearch.index.mapper.FieldTypeTestCase;
+import org.elasticsearch.index.mapper.MappedFieldType;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+public class ParentIdFieldTypeTests extends FieldTypeTestCase {
+
+    public void testFetchSourceValue() throws IOException {
+        // The parent join ID is an internal field type and we don't return any values for it.
+        MappedFieldType fieldType = new ParentIdFieldMapper.ParentIdFieldType("field#parent", true);
+
+        Map<String, String> parentValue = Map.of("relation", "parent");
+        assertEquals(List.of(), fetchSourceValue(fieldType, parentValue));
+
+        Map<String, String> childValue = Map.of("relation", "child", "parent", "1");
+        assertEquals(List.of(), fetchSourceValue(fieldType, childValue));
+    }
+}

--- a/modules/parent-join/src/yamlRestTest/resources/rest-api-spec/test/20_parent_join.yml
+++ b/modules/parent-join/src/yamlRestTest/resources/rest-api-spec/test/20_parent_join.yml
@@ -99,6 +99,27 @@ teardown:
     - match: { hits.hits.1._source.join_field.parent: "1" }
 
 ---
+"Test field retrieval":
+  - skip:
+      version: " - 7.99.99"
+      reason: bugfix is not yet backported
+  - do:
+      search:
+        body:
+          sort: [ "id" ]
+          fields: ["*"]
+
+  - match: { hits.total.value: 6 }
+  - match: { hits.hits.0._index: "test" }
+  - match: { hits.hits.0._id: "1" }
+  - match: { hits.hits.0.fields.join_field.0.name: "parent" }
+  - match: { hits.hits.5._index: "test" }
+  - match: { hits.hits.5._id: "6" }
+  - match: { hits.hits.5.fields.join_field.0.name: "grand_child" }
+  - match: { hits.hits.5.fields.join_field.0.parent: "5" }
+
+
+---
 "HasChild disallow expensive queries":
   - skip:
       version: " - 7.6.99"


### PR DESCRIPTION
The parent ID join field is an internal field that links child documents to
their parent. Although it's internal, we include it when listing all field
types. This means a search with `"fields": ["*"]` can attempt to fetch values
from the parent ID field and fail.

This PR applies a simple fix to return an empty result instead of failing.