### PR TITLE
[ML] Remove unnecessary creation of JobDataDeleter

### DIFF
--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/persistence/JobDataDeleter.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/persistence/JobDataDeleter.java
@@ -476,8 +476,7 @@ public class JobDataDeleter {
         executeAsyncWithOrigin(client, ML_ORIGIN, GetModelSnapshotsAction.INSTANCE, request, ActionListener.wrap(
             response -> {
                 List<ModelSnapshot> deleteCandidates = response.getPage().results();
-                JobDataDeleter deleter = new JobDataDeleter(client, jobId);
-                deleter.deleteModelSnapshots(deleteCandidates, listener);
+                deleteModelSnapshots(deleteCandidates, listener);
             },
             listener::onFailure));
     }


### PR DESCRIPTION
... in one of its own methods. This is a cleanup following
in the backport #73644.
