### PR TITLE
Rename AsyncLucenePersistedState to AsyncPersistedState

### DIFF
--- a/server/src/main/java/org/elasticsearch/gateway/GatewayMetaState.java
+++ b/server/src/main/java/org/elasticsearch/gateway/GatewayMetaState.java
@@ -122,7 +122,7 @@ public class GatewayMetaState implements Closeable {
                     if (DiscoveryNode.isMasterNode(settings)) {
                         persistedState = new LucenePersistedState(persistedClusterStateService, currentTerm, clusterState);
                     } else {
-                        persistedState = new AsyncLucenePersistedState(settings, transportService.getThreadPool(),
+                        persistedState = new AsyncPersistedState(settings, transportService.getThreadPool(),
                             new LucenePersistedState(persistedClusterStateService, currentTerm, clusterState));
                     }
                     if (DiscoveryNode.canContainData(settings)) {
@@ -244,16 +244,16 @@ public class GatewayMetaState implements Closeable {
     // visible for testing
     public boolean allPendingAsyncStatesWritten() {
         final PersistedState ps = persistedState.get();
-        if (ps instanceof AsyncLucenePersistedState) {
-            return ((AsyncLucenePersistedState) ps).allPendingAsyncStatesWritten();
+        if (ps instanceof AsyncPersistedState) {
+            return ((AsyncPersistedState) ps).allPendingAsyncStatesWritten();
         } else {
             return true;
         }
     }
 
-    static class AsyncLucenePersistedState extends InMemoryPersistedState {
+    static class AsyncPersistedState extends InMemoryPersistedState {
 
-        private static final Logger logger = LogManager.getLogger(AsyncLucenePersistedState.class);
+        private static final Logger logger = LogManager.getLogger(AsyncPersistedState.class);
 
         static final String THREAD_NAME = "AsyncLucenePersistedState#updateTask";
 
@@ -265,7 +265,7 @@ public class GatewayMetaState implements Closeable {
 
         private final Object mutex = new Object();
 
-        AsyncLucenePersistedState(Settings settings, ThreadPool threadPool, PersistedState persistedState) {
+        AsyncPersistedState(Settings settings, ThreadPool threadPool, PersistedState persistedState) {
             super(persistedState.getCurrentTerm(), persistedState.getLastAcceptedState());
             final String nodeName = Objects.requireNonNull(Node.NODE_NAME_SETTING.get(settings));
             threadPoolExecutor = EsExecutors.newFixed(

--- a/server/src/test/java/org/elasticsearch/gateway/GatewayMetaStatePersistedStateTests.java
+++ b/server/src/test/java/org/elasticsearch/gateway/GatewayMetaStatePersistedStateTests.java
@@ -348,7 +348,7 @@ public class GatewayMetaStatePersistedStateTests extends ESTestCase {
             gateway.start(settings, transportService, clusterService,
                 new MetaStateService(nodeEnvironment, xContentRegistry()), null, null, persistedClusterStateService);
             final CoordinationState.PersistedState persistedState = gateway.getPersistedState();
-            assertThat(persistedState, instanceOf(GatewayMetaState.AsyncLucenePersistedState.class));
+            assertThat(persistedState, instanceOf(GatewayMetaState.AsyncPersistedState.class));
 
             //generate random coordinationMetadata with different lastAcceptedConfiguration and lastCommittedConfiguration
             CoordinationMetadata coordinationMetadata;
@@ -368,9 +368,9 @@ public class GatewayMetaStatePersistedStateTests extends ESTestCase {
             CoordinationMetadata persistedCoordinationMetadata =
                 persistedClusterStateService.loadOnDiskState().metadata.coordinationMetadata();
             assertThat(persistedCoordinationMetadata.getLastAcceptedConfiguration(),
-                equalTo(GatewayMetaState.AsyncLucenePersistedState.staleStateConfiguration));
+                equalTo(GatewayMetaState.AsyncPersistedState.staleStateConfiguration));
             assertThat(persistedCoordinationMetadata.getLastCommittedConfiguration(),
-                equalTo(GatewayMetaState.AsyncLucenePersistedState.staleStateConfiguration));
+                equalTo(GatewayMetaState.AsyncPersistedState.staleStateConfiguration));
 
             persistedState.markLastAcceptedStateAsCommitted();
             assertBusy(() -> assertTrue(gateway.allPendingAsyncStatesWritten()));
@@ -384,9 +384,9 @@ public class GatewayMetaStatePersistedStateTests extends ESTestCase {
             assertClusterStateEqual(expectedClusterState, persistedState.getLastAcceptedState());
             persistedCoordinationMetadata = persistedClusterStateService.loadOnDiskState().metadata.coordinationMetadata();
             assertThat(persistedCoordinationMetadata.getLastAcceptedConfiguration(),
-                equalTo(GatewayMetaState.AsyncLucenePersistedState.staleStateConfiguration));
+                equalTo(GatewayMetaState.AsyncPersistedState.staleStateConfiguration));
             assertThat(persistedCoordinationMetadata.getLastCommittedConfiguration(),
-                equalTo(GatewayMetaState.AsyncLucenePersistedState.staleStateConfiguration));
+                equalTo(GatewayMetaState.AsyncPersistedState.staleStateConfiguration));
             assertTrue(persistedClusterStateService.loadOnDiskState().metadata.clusterUUIDCommitted());
 
             // generate a series of updates and check if batching works
@@ -417,7 +417,7 @@ public class GatewayMetaStatePersistedStateTests extends ESTestCase {
 
             try (CoordinationState.PersistedState reloadedPersistedState = newGatewayPersistedState()) {
                 assertEquals(currentTerm, reloadedPersistedState.getCurrentTerm());
-                assertClusterStateEqual(GatewayMetaState.AsyncLucenePersistedState.resetVotingConfiguration(state),
+                assertClusterStateEqual(GatewayMetaState.AsyncPersistedState.resetVotingConfiguration(state),
                     reloadedPersistedState.getLastAcceptedState());
                 assertNotNull(reloadedPersistedState.getLastAcceptedState().metadata().index(indexName));
             }


### PR DESCRIPTION
This class actually has nothing to do with Lucene. This commit adjusts the name to match.