### PR TITLE
Remove Dead Branch from IndexMetadataGenerations#withAddedSnapshot (#73658)

### DIFF
--- a/server/src/main/java/org/elasticsearch/repositories/IndexMetaDataGenerations.java
+++ b/server/src/main/java/org/elasticsearch/repositories/IndexMetaDataGenerations.java
@@ -94,30 +94,22 @@ public final class IndexMetaDataGenerations {
      */
     public IndexMetaDataGenerations withAddedSnapshot(SnapshotId snapshotId, Map<IndexId, String> newLookup,
                                                       Map<String, String> newIdentifiers) {
-        final Map<String, String> identifierDeduplicator = new HashMap<>(this.identifiers.size());
-        for (String identifier : identifiers.keySet()) {
-            identifierDeduplicator.put(identifier, identifier);
-        }
         final Map<SnapshotId, Map<IndexId, String>> updatedIndexMetaLookup = new HashMap<>(this.lookup);
         final Map<String, String> updatedIndexMetaIdentifiers = new HashMap<>(identifiers);
         updatedIndexMetaIdentifiers.putAll(newIdentifiers);
-        updatedIndexMetaLookup.compute(snapshotId, (snId, lookup) -> {
-            if (lookup == null) {
-                if (newLookup.isEmpty()) {
-                    return null;
-                }
-                final Map<IndexId, String> fixedLookup = new HashMap<>(newLookup.size());
-                for (Map.Entry<IndexId, String> entry : newLookup.entrySet()) {
-                    final String generation = entry.getValue();
-                    fixedLookup.put(entry.getKey(), identifierDeduplicator.getOrDefault(generation, generation));
-                }
-                return Collections.unmodifiableMap(new HashMap<>(fixedLookup));
-            } else {
-                final Map<IndexId, String> updated = new HashMap<>(lookup);
-                updated.putAll(newLookup);
-                return Collections.unmodifiableMap(updated);
+        if (newLookup.isEmpty() == false) {
+            final Map<String, String> identifierDeduplicator = new HashMap<>(this.identifiers.size());
+            for (String identifier : identifiers.keySet()) {
+                identifierDeduplicator.put(identifier, identifier);
             }
-        });
+            final Map<IndexId, String> fixedLookup = new HashMap<>(newLookup.size());
+            for (Map.Entry<IndexId, String> entry : newLookup.entrySet()) {
+                final String generation = entry.getValue();
+                fixedLookup.put(entry.getKey(), identifierDeduplicator.getOrDefault(generation, generation));
+            }
+            final Map<IndexId, String> existing = updatedIndexMetaLookup.put(snapshotId, Collections.unmodifiableMap(fixedLookup));
+            assert existing == null : "unexpected existing index generation mappings " + existing;
+        }
         return new IndexMetaDataGenerations(updatedIndexMetaLookup, updatedIndexMetaIdentifiers);
     }
 


### PR DESCRIPTION
We never do (nor should) call this method to overwrite a snapshots existing entry,
checks and assertions upstream make sure of that.
=> simplified the code accordingly

backport of #73658