### PR TITLE
[7.x] [DOCS] Fix create component template API request path (#72874)

### DIFF
--- a/docs/reference/indices/get-component-template.asciidoc
+++ b/docs/reference/indices/get-component-template.asciidoc
@@ -44,7 +44,7 @@ GET /_component_template/template_1
 [[get-component-template-api-request]]
 ==== {api-request-title}
 
-`GET /_component-template/<component-template>`
+`GET /_component_template/<component-template>`
 
 [[get-component-template-api-prereqs]]
 ==== {api-prereq-title}


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [DOCS] Fix create component template API request path (#72874)