### PR TITLE
Fix repo name at allocation time

### DIFF
--- a/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/SearchableSnapshotsIntegTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/SearchableSnapshotsIntegTests.java
@@ -938,6 +938,10 @@ public class SearchableSnapshotsIntegTests extends BaseSearchableSnapshotsIntegT
 
         assertTotalHits(restoredIndexName, originalAllHits, originalBarHits);
 
+        internalCluster().fullRestart();
+        ensureGreen(restoredIndexName);
+        assertTotalHits(restoredIndexName, originalAllHits, originalBarHits);
+
         final IllegalArgumentException remountException = expectThrows(IllegalArgumentException.class, () -> {
             try {
                 mountSnapshot(


### PR DESCRIPTION
Today when allocating a previously-allocated searchable snapshot shard
we simulate a recovery source which refers to the repository named in
the index metadata. This doesn't work if the repository was renamed
since the index was mounted, which particularly may occur if the index
was itself restored from a snapshot.

With this commit we instead set up the recovery source to refer to the
repository whose UUID matches the one in the index metadata. We rely on
such a repository existing at allocation time; if it does not then the
shards are not allocated.