### PR TITLE
[7.x] Add `data-streams-mappings` to isXPackTemplate method (#73633)

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/test/rest/ESRestTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/ESRestTestCase.java
@@ -1583,6 +1583,7 @@ public abstract class ESRestTestCase extends ESTestCase {
             case "ilm-history":
             case "logstash-index-template":
             case "security-index-template":
+            case "data-streams-mappings":
                 return true;
             default:
                 return false;


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Add `data-streams-mappings` to isXPackTemplate method (#73633)