### PR TITLE
[7.x] [DOCS] Note circuit breakers reject requests with 429 HTTP status code (#69864)

### DIFF
--- a/docs/reference/how-to/fix-common-cluster-issues.asciidoc
+++ b/docs/reference/how-to/fix-common-cluster-issues.asciidoc
@@ -21,7 +21,8 @@ memory pressure if usage consistently exceeds 85%.
 
 **Error messages**
 
-If a request triggers a circuit breaker, {es} returns an error.
+If a request triggers a circuit breaker, {es} returns an error with a `429` HTTP
+status code.
 
 [source,js]
 ----

--- a/docs/reference/modules/indices/circuit_breaker.asciidoc
+++ b/docs/reference/modules/indices/circuit_breaker.asciidoc
@@ -8,6 +8,8 @@ Except where noted otherwise, these settings can be dynamically updated on a
 live cluster with the <<cluster-update-settings,cluster-update-settings>> API.
 // end::circuit-breaker-description-tag[]
 
+For information about circuit breaker errors, see <<circuit-breaker-errors>>.
+
 [[parent-circuit-breaker]]
 [discrete]
 ==== Parent circuit breaker


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [DOCS] Note circuit breakers reject requests with 429 HTTP status code (#69864)