### PR TITLE
[7.x] Improve error message when rest api specs are missing from classpath (#73640)

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/ClientYamlTestClient.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/ClientYamlTestClient.java
@@ -259,7 +259,8 @@ public class ClientYamlTestClient implements Closeable {
     private ClientYamlSuiteRestApi restApi(String apiName) {
         ClientYamlSuiteRestApi restApi = restSpec.getApi(apiName);
         if (restApi == null) {
-            throw new IllegalArgumentException("rest api [" + apiName + "] doesn't exist in the rest spec");
+            throw new IllegalArgumentException("Rest api [" + apiName + "] cannot be found in the rest spec. Either it doesn't exist or " +
+                "is missing from the test classpath. Check the 'restResources' block of your project's build.gradle file.");
         }
         return restApi;
     }


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Improve error message when rest api specs are missing from classpath (#73640)