### PR TITLE
Update skip after backport

### DIFF
--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.aggregation/22_terms_disable_opt.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.aggregation/22_terms_disable_opt.yml
@@ -16,8 +16,8 @@ teardown:
 ---
 does not use optimization:
   - skip:
-      version: " - 7.99.99"
-      reason: setting to disable optimization added in 8.0.0 to be backported to 7.13.2
+      version: " - 7.13.1"
+      reason: setting to disable optimization added in 7.13.2
   - do:
       bulk:
         index: test


### PR DESCRIPTION
Now that we've backported #73620 we can run the bwc tests against it.
