### PR TITLE
[DOCS] Note `include_aliases` supports data stream aliases

### DIFF
--- a/docs/reference/snapshot-restore/apis/restore-snapshot-api.asciidoc
+++ b/docs/reference/snapshot-restore/apis/restore-snapshot-api.asciidoc
@@ -125,14 +125,8 @@ A comma-separated list of index settings that should not be restored from a snap
 
 `include_aliases`::
 (Optional, Boolean)
-If `true`, index aliases from the original snapshot are restored.
-Defaults to `true`.
-+
-If `false`, prevents index aliases from being restored together with associated
-indices.
-+
-This option doesn't affect data stream aliases. Restoring a data stream
-restores its aliases.
+If `true`, the request restores aliases for any restored data streams and
+indices. If `false`, the request doesn't restore aliases. Defaults to `true`.
 
 [[restore-snapshot-api-include-global-state]]
 `include_global_state`::

--- a/docs/reference/snapshot-restore/restore-snapshot.asciidoc
+++ b/docs/reference/snapshot-restore/restore-snapshot.asciidoc
@@ -73,9 +73,8 @@ name. If no index template matches the stream, it cannot
 ====
 // end::rename-restored-data-stream-tag[]
 
-To prevent index aliases from being restored together with associated indices,
-set `include_aliases` to `false`. This option doesn't affect data stream
-aliases. Restoring a data stream restores its aliases.
+To prevent aliases from being restored with their associated data streams and
+indices, set `include_aliases` to `false`.
 
 [source,console]
 -----------------------------------


### PR DESCRIPTION
With #73595, data stream aliases now support the restore snapshot API's
`include_aliases` option.

### Previews
* Restore snapshot API: https://elasticsearch_73687.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/restore-snapshot-api.html#restore-snapshot-api-request-body
* Restore snapshot tutorial: https://elasticsearch_73687.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/snapshots-restore-snapshot.html