### PR TITLE
[DOCS] Remove outdated OSS homebrew tap

### DIFF
--- a/docs/reference/setup/install/brew.asciidoc
+++ b/docs/reference/setup/install/brew.asciidoc
@@ -13,7 +13,7 @@ brew tap elastic/tap
 -------------------------
 
 Once you've tapped the Elastic Homebrew repo, you can use `brew install` to
-install the latest version of {es}:
+install the **latest version** of {es}:
 
 [source,sh]
 -------------------------

--- a/docs/reference/setup/install/brew.asciidoc
+++ b/docs/reference/setup/install/brew.asciidoc
@@ -13,15 +13,12 @@ brew tap elastic/tap
 -------------------------
 
 Once you've tapped the Elastic Homebrew repo, you can use `brew install` to
-install the default distribution of {es}:
+install the latest version of {es}:
 
 [source,sh]
 -------------------------
 brew install elastic/tap/elasticsearch-full
 -------------------------
-
-This installs the most recently released default distribution of {es}.
-To install the OSS distribution, specify `elastic/tap/elasticsearch-oss`.
 
 [[brew-layout]]
 ==== Directory layout for Homebrew installs


### PR DESCRIPTION
With
https://github.com/elastic/homebrew-tap/commit/230b860d950877341c9be81d3ddc378e77ee8263,
the `elastic/tap/elasticsearch-oss` tap was removed from Homebrew. This
removes outdated references to the tap from our docs.

It also notes that Homebrew installs the latest version of Elasticsearch.

### Backports
I'll backport this change to 7.10-7.1.

I'll forward-port only the "latest version" change to 8.0-7.11.

### Preview
https://elasticsearch_73688.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/7.10/brew.html