### PR TITLE
[master] [DOCS] Remove outdated OSS homebrew tap (#73688)

### DIFF
--- a/docs/reference/setup/install/brew.asciidoc
+++ b/docs/reference/setup/install/brew.asciidoc
@@ -13,14 +13,12 @@ brew tap elastic/tap
 -------------------------
 
 Once you've tapped the Elastic Homebrew repo, you can use `brew install` to
-install {es}:
+install the **latest version** of {es}:
 
 [source,sh]
 -------------------------
 brew install elastic/tap/elasticsearch-full
 -------------------------
-
-This installs the most recently released distribution of {es}.
 
 [[brew-layout]]
 ==== Directory layout for Homebrew installs


### PR DESCRIPTION
Backports the following commits to master:
 - [DOCS] Remove outdated OSS homebrew tap (#73688)