### PR TITLE
Explicitly set illegal-access to deny for tests (#72588)

### DIFF
--- a/buildSrc/src/main/java/org/elasticsearch/gradle/internal/ElasticsearchTestBasePlugin.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/internal/ElasticsearchTestBasePlugin.java
@@ -87,14 +87,16 @@ public class ElasticsearchTestBasePlugin implements Plugin<Project> {
                         test.systemProperty("java.locale.providers", "SPI,JRE");
                     } else {
                         test.systemProperty("java.locale.providers", "SPI,COMPAT");
-                        test.jvmArgs("--illegal-access=deny",
+                        test.jvmArgs(
+                            "--illegal-access=deny",
                             // TODO: only open these for mockito when it is modularized
                             "--add-opens=java.base/java.security.cert=ALL-UNNAMED",
                             "--add-opens=java.base/java.nio.channels=ALL-UNNAMED",
                             "--add-opens=java.base/java.net=ALL-UNNAMED",
                             "--add-opens=java.base/javax.net.ssl=ALL-UNNAMED",
                             "--add-opens=java.base/java.nio.file=ALL-UNNAMED",
-                            "--add-opens=java.base/java.time=ALL-UNNAMED");
+                            "--add-opens=java.base/java.time=ALL-UNNAMED"
+                        );
                     }
                 }
             });

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/internal/ElasticsearchTestBasePlugin.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/internal/ElasticsearchTestBasePlugin.java
@@ -102,6 +102,14 @@ public class ElasticsearchTestBasePlugin implements Plugin<Project> {
             test.jvmArgs(
                 "-Xmx" + System.getProperty("tests.heap.size", "512m"),
                 "-Xms" + System.getProperty("tests.heap.size", "512m"),
+                "--illegal-access=deny",
+                // TODO: only open these for mockito when it is modularized
+                "--add-opens=java.base/java.security.cert=ALL-UNNAMED",
+                "--add-opens=java.base/java.nio.channels=ALL-UNNAMED",
+                "--add-opens=java.base/java.net=ALL-UNNAMED",
+                "--add-opens=java.base/javax.net.ssl=ALL-UNNAMED",
+                "--add-opens=java.base/java.nio.file=ALL-UNNAMED",
+                "--add-opens=java.base/java.time=ALL-UNNAMED",
                 "-XX:+HeapDumpOnOutOfMemoryError"
             );
 

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/internal/ElasticsearchTestBasePlugin.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/internal/ElasticsearchTestBasePlugin.java
@@ -87,7 +87,14 @@ public class ElasticsearchTestBasePlugin implements Plugin<Project> {
                         test.systemProperty("java.locale.providers", "SPI,JRE");
                     } else {
                         test.systemProperty("java.locale.providers", "SPI,COMPAT");
-                        test.jvmArgs("--illegal-access=warn");
+                        test.jvmArgs("--illegal-access=deny",
+                            // TODO: only open these for mockito when it is modularized
+                            "--add-opens=java.base/java.security.cert=ALL-UNNAMED",
+                            "--add-opens=java.base/java.nio.channels=ALL-UNNAMED",
+                            "--add-opens=java.base/java.net=ALL-UNNAMED",
+                            "--add-opens=java.base/javax.net.ssl=ALL-UNNAMED",
+                            "--add-opens=java.base/java.nio.file=ALL-UNNAMED",
+                            "--add-opens=java.base/java.time=ALL-UNNAMED");
                     }
                 }
             });
@@ -102,14 +109,6 @@ public class ElasticsearchTestBasePlugin implements Plugin<Project> {
             test.jvmArgs(
                 "-Xmx" + System.getProperty("tests.heap.size", "512m"),
                 "-Xms" + System.getProperty("tests.heap.size", "512m"),
-                "--illegal-access=deny",
-                // TODO: only open these for mockito when it is modularized
-                "--add-opens=java.base/java.security.cert=ALL-UNNAMED",
-                "--add-opens=java.base/java.nio.channels=ALL-UNNAMED",
-                "--add-opens=java.base/java.net=ALL-UNNAMED",
-                "--add-opens=java.base/javax.net.ssl=ALL-UNNAMED",
-                "--add-opens=java.base/java.nio.file=ALL-UNNAMED",
-                "--add-opens=java.base/java.time=ALL-UNNAMED",
                 "-XX:+HeapDumpOnOutOfMemoryError"
             );
 

--- a/plugins/repository-hdfs/build.gradle
+++ b/plugins/repository-hdfs/build.gradle
@@ -200,7 +200,9 @@ for (String integTestTaskName : ['integTestHa', 'integTestSecure', 'integTestSec
           nonInputProperties.systemProperty "test.krb5.principal.es", "elasticsearch@${realm}"
           nonInputProperties.systemProperty "test.krb5.principal.hdfs", "hdfs/hdfs.build.elastic.co@${realm}"
           jvmArgs "-Djava.security.krb5.conf=${krb5conf}",
-                  "--add-exports=java.security.jgss/sun.security.krb5=ALL-UNNAMED"
+          if (BuildParams.getRuntimeJavaVersion() >= JavaVersion.VERSION_1_9) {
+            jvmArgs "--add-exports=java.security.jgss/sun.security.krb5=ALL-UNNAMED"
+          }
           nonInputProperties.systemProperty(
             "test.krb5.keytab.hdfs",
             project(':test:fixtures:krb5kdc-fixture').ext.krb5Keytabs("hdfs", "hdfs_hdfs.build.elastic.co.keytab")

--- a/plugins/repository-hdfs/build.gradle
+++ b/plugins/repository-hdfs/build.gradle
@@ -199,7 +199,8 @@ for (String integTestTaskName : ['integTestHa', 'integTestSecure', 'integTestSec
         if (disabledIntegTestTaskNames.contains(name) == false) {
           nonInputProperties.systemProperty "test.krb5.principal.es", "elasticsearch@${realm}"
           nonInputProperties.systemProperty "test.krb5.principal.hdfs", "hdfs/hdfs.build.elastic.co@${realm}"
-          jvmArgs "-Djava.security.krb5.conf=${krb5conf}"
+          jvmArgs "-Djava.security.krb5.conf=${krb5conf}",
+                  "--add-exports=java.security.jgss/sun.security.krb5=ALL-UNNAMED"
           nonInputProperties.systemProperty(
             "test.krb5.keytab.hdfs",
             project(':test:fixtures:krb5kdc-fixture').ext.krb5Keytabs("hdfs", "hdfs_hdfs.build.elastic.co.keytab")

--- a/plugins/repository-hdfs/build.gradle
+++ b/plugins/repository-hdfs/build.gradle
@@ -199,7 +199,7 @@ for (String integTestTaskName : ['integTestHa', 'integTestSecure', 'integTestSec
         if (disabledIntegTestTaskNames.contains(name) == false) {
           nonInputProperties.systemProperty "test.krb5.principal.es", "elasticsearch@${realm}"
           nonInputProperties.systemProperty "test.krb5.principal.hdfs", "hdfs/hdfs.build.elastic.co@${realm}"
-          jvmArgs "-Djava.security.krb5.conf=${krb5conf}",
+          jvmArgs "-Djava.security.krb5.conf=${krb5conf}"
           if (BuildParams.getRuntimeJavaVersion() >= JavaVersion.VERSION_1_9) {
             jvmArgs "--add-exports=java.security.jgss/sun.security.krb5=ALL-UNNAMED"
           }


### PR DESCRIPTION
Since Java 16, the default value for illegal-access is deny. This means
the latest release of Elasticsearch, and all current integration tests,
run with deny (since we don't explicitly set it in jvm options). Yet
tests run with illegal-access=warn, for legacy reasons. #71908
proposed to remove the setting from test jvms, but concerns were raised
there about whether this would cause some test failures.

This commit explicitly sets tests to deny. This has the added benefit
that any failures will be caught even when running tests with older
jvms.