### PR TITLE
[7.x] Specify concrete index in top metrics test (#73641)

### DIFF
--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/analytics/top_metrics.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/analytics/top_metrics.yml
@@ -18,6 +18,7 @@
 
   - do:
       search:
+        index: test
         size: 0
         body:
           aggs:
@@ -45,6 +46,7 @@
 
   - do:
       search:
+        index: test
         body:
           aggs:
             tm:
@@ -87,6 +89,7 @@
 
   - do:
       search:
+        index: test
         size: 0
         body:
           aggs:
@@ -101,6 +104,7 @@
 
   - do:
       search:
+        index: test
         body:
           aggs:
             tm:
@@ -141,6 +145,7 @@
 
   - do:
       search:
+        index: test
         size: 0
         body:
           aggs:
@@ -155,6 +160,7 @@
 
   - do:
       search:
+        index: test
         body:
           aggs:
             tm:
@@ -228,6 +234,7 @@
 
   - do:
       search:
+        index: test
         size: 0
         body:
           query:
@@ -258,6 +265,7 @@
 
   - do:
       search:
+        index: test
         size: 0
         body:
           aggs:
@@ -340,6 +348,7 @@
 
   - do:
       search:
+        index: test
         size: 0
         body:
           aggs:
@@ -355,6 +364,7 @@
 
   - do:
       search:
+        index: test
         size: 0
         body:
           aggs:
@@ -403,6 +413,7 @@
 
   - do:
       search:
+        index: test
         size: 0
         body:
           aggs:
@@ -426,6 +437,7 @@
 
   - do:
       search:
+        index: test
         size: 0
         body:
           aggs:
@@ -475,6 +487,7 @@
 
   - do:
       search:
+        index: test
         size: 0
         body:
           aggs:
@@ -505,6 +518,7 @@
           - '{"ip": "192.168.0.2", "date": "2020-01-01T03:01:01"}'
   - do:
       search:
+        index: test
         size: 0
         body:
           aggs:
@@ -554,6 +568,7 @@
   - do:
       catch: bad_request
       search:
+        index: test
         size: 0
         body:
           aggs:
@@ -574,6 +589,7 @@
 
   - do:
       search:
+        index: test
         size: 0
         body:
           aggs:
@@ -607,6 +623,7 @@
 
   - do:
       search:
+        index: test
         size: 0
         body:
           aggs:
@@ -641,6 +658,7 @@
   - do:
       catch: /top_metrics can only collect bytes that have segment ordinals but Field \[species\] of type \[keyword\] does not/
       search:
+        index: test
         size: 0
         body:
           runtime_mappings:
@@ -673,6 +691,7 @@
 
   - do:
       search:
+        index: test
         size: 0
         body:
           aggs:


### PR DESCRIPTION
Otherwise it might fail on system indices in 7.x

Fixes #73176
