### PR TITLE
[7.x] [DOCS] Note `include_aliases` supports data stream aliases (#73687)

### DIFF
--- a/docs/reference/snapshot-restore/apis/restore-snapshot-api.asciidoc
+++ b/docs/reference/snapshot-restore/apis/restore-snapshot-api.asciidoc
@@ -125,14 +125,8 @@ A comma-separated list of index settings that should not be restored from a snap
 
 `include_aliases`::
 (Optional, Boolean)
-If `true`, index aliases from the original snapshot are restored.
-Defaults to `true`.
-+
-If `false`, prevents index aliases from being restored together with associated
-indices.
-+
-This option doesn't affect data stream aliases. Restoring a data stream
-restores its aliases.
+If `true`, the request restores aliases for any restored data streams and
+indices. If `false`, the request doesn't restore aliases. Defaults to `true`.
 
 [[restore-snapshot-api-include-global-state]]
 `include_global_state`::

--- a/docs/reference/snapshot-restore/restore-snapshot.asciidoc
+++ b/docs/reference/snapshot-restore/restore-snapshot.asciidoc
@@ -73,9 +73,8 @@ name. If no index template matches the stream, it cannot
 ====
 // end::rename-restored-data-stream-tag[]
 
-To prevent index aliases from being restored together with associated indices,
-set `include_aliases` to `false`. This option doesn't affect data stream
-aliases. Restoring a data stream restores its aliases.
+To prevent aliases from being restored with their associated data streams and
+indices, set `include_aliases` to `false`.
 
 [source,console]
 -----------------------------------


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [DOCS] Note `include_aliases` supports data stream aliases (#73687)