### PR TITLE
Consolidate data stream alias logic

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/metadata/DataStreamAlias.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/DataStreamAlias.java
@@ -79,7 +79,7 @@ public class DataStreamAlias extends AbstractDiffable<DataStreamAlias> implement
      * Write requests targeting this instance will resolve the write index
      * of the write data stream this alias is referring to.
      *
-     * Note that the write data stream is also included in @{link {@link #getDataStreams()}}.
+     * Note that the write data stream is also included in {@link #getDataStreams()}.
      */
     public String getWriteDataStream() {
         return writeDataStream;

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/DataStreamAlias.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/DataStreamAlias.java
@@ -14,15 +14,19 @@ import org.elasticsearch.common.ParsingException;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.xcontent.ConstructingObjectParser;
-import org.elasticsearch.common.xcontent.ToXContentObject;
+import org.elasticsearch.common.xcontent.ToXContentFragment;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
 
 import java.io.IOException;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
+import java.util.Set;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
 
-public class DataStreamAlias extends AbstractDiffable<DataStreamAlias> implements ToXContentObject {
+public class DataStreamAlias extends AbstractDiffable<DataStreamAlias> implements ToXContentFragment {
 
     public static final ParseField DATA_STREAMS_FIELD = new ParseField("data_streams");
     public static final ParseField WRITE_DATA_STREAM_FIELD = new ParseField("write_data_stream");
@@ -47,6 +51,7 @@ public class DataStreamAlias extends AbstractDiffable<DataStreamAlias> implement
         this.name = Objects.requireNonNull(name);
         this.dataStreams = List.copyOf(dataStreams);
         this.writeDataStream = writeDataStream;
+        assert writeDataStream == null || dataStreams.contains(writeDataStream);
     }
 
     public DataStreamAlias(StreamInput in) throws IOException {
@@ -55,16 +60,134 @@ public class DataStreamAlias extends AbstractDiffable<DataStreamAlias> implement
         this.writeDataStream = in.readOptionalString();
     }
 
+    /**
+     * Returns the name of this data stream alias.
+     */
     public String getName() {
         return name;
     }
 
+    /**
+     * Returns the data streams that are referenced
+     */
     public List<String> getDataStreams() {
         return dataStreams;
     }
 
+    /**
+     * Returns the write data stream this data stream alias is referring to.
+     * Write requests targeting this instance will resolve the write index
+     * of the write data stream this alias is referring to.
+     *
+     * Note that the write data stream is also included in @{link {@link #getDataStreams()}}.
+     */
     public String getWriteDataStream() {
         return writeDataStream;
+    }
+
+    /**
+     * Returns a new {@link DataStreamAlias} instance with the provided data stream name added to it as a new member.
+     * If the provided isWriteDataStream is set to <code>true</code> then the provided data stream is also set as write data stream.
+     * If the provided isWriteDataStream is set to <code>false</code> and the provided data stream is also the write data stream of
+     * this instance then the returned data stream alias instance's write data stream is unset.
+     *
+     * The same instance is returned if the attempted addition of the provided data stream didn't change this instance.
+     */
+    public DataStreamAlias addDataStream(String dataStream, Boolean isWriteDataStream) {
+        String writeDataStream = this.writeDataStream;
+        if (isWriteDataStream != null) {
+            if (isWriteDataStream) {
+                writeDataStream = dataStream;
+            } else {
+                if (dataStream.equals(writeDataStream)) {
+                    writeDataStream = null;
+                }
+            }
+        }
+
+        Set<String> dataStreams = new HashSet<>(this.dataStreams);
+        boolean added = dataStreams.add(dataStream);
+        if (added || Objects.equals(this.writeDataStream, writeDataStream) == false) {
+            return new DataStreamAlias(name, List.copyOf(dataStreams), writeDataStream);
+        } else {
+            return this;
+        }
+    }
+
+    /**
+     * Returns a {@link DataStreamAlias} instance based on this instance but with the specified data stream no longer referenced.
+     * Returns <code>null</code> if because of the removal of the provided data stream name a new instance wouldn't reference to
+     * any data stream. The same instance is returned if the attempted removal of the provided data stream didn't change this instance.
+     */
+    public DataStreamAlias removeDataStream(String dataStream) {
+        Set<String> dataStreams = new HashSet<>(this.dataStreams);
+        boolean removed = dataStreams.remove(dataStream);
+        if (removed == false) {
+            return this;
+        }
+
+        if (dataStreams.isEmpty()) {
+            return null;
+        } else {
+            String writeDataStream = this.writeDataStream;
+            if (dataStream.equals(writeDataStream)) {
+                writeDataStream = null;
+            }
+            return new DataStreamAlias(name, List.copyOf(dataStreams), writeDataStream);
+        }
+    }
+
+    /**
+     * Returns a new {@link DataStreamAlias} instance that contains a new intersection
+     * of data streams from this instance and the provided filter.
+     *
+     * The write data stream gets set to null in the returned instance if the write
+     * data stream no longer appears in the intersection.
+     */
+    public DataStreamAlias intersect(Predicate<String> filter) {
+        List<String> intersectingDataStreams = this.dataStreams.stream()
+            .filter(filter)
+            .collect(Collectors.toList());
+        String writeDataStream = this.writeDataStream;
+        if (intersectingDataStreams.contains(writeDataStream) == false) {
+            writeDataStream = null;
+        }
+        return new DataStreamAlias(this.name, intersectingDataStreams, writeDataStream);
+    }
+
+    /**
+     * Returns a new {@link DataStreamAlias} instance containing data streams referenced in this instance
+     * and the other instance. If this instance doesn't have a write data stream then the write index of
+     * the other data stream becomes the write data stream of the returned instance.
+     */
+    public DataStreamAlias merge(DataStreamAlias other) {
+        Set<String> mergedDataStreams = new HashSet<>(other.getDataStreams());
+        mergedDataStreams.addAll(this.getDataStreams());
+
+        String writeDataStream = this.writeDataStream;
+        if (writeDataStream == null) {
+            if (other.getWriteDataStream() != null && mergedDataStreams.contains(other.getWriteDataStream())) {
+                writeDataStream = other.getWriteDataStream();
+            }
+        }
+
+        return new DataStreamAlias(this.name, List.copyOf(mergedDataStreams), writeDataStream);
+    }
+
+    /**
+     * Returns a new instance with potentially renamed data stream names and write data stream name.
+     * If a data stream name matches with the provided rename pattern then it is renamed according
+     * to the provided rename replacement.
+     */
+    public DataStreamAlias renameDataStreams(String renamePattern, String renameReplacement) {
+        List<String> renamedDataStreams = this.dataStreams.stream()
+            .map(s -> s.replaceAll(renamePattern, renameReplacement))
+            .collect(Collectors.toList());
+        String writeDataStream = this.writeDataStream;
+        if (writeDataStream != null) {
+            writeDataStream = writeDataStream.replaceAll(renamePattern, renameReplacement);
+        }
+        return new DataStreamAlias(this.name, renamedDataStreams, writeDataStream);
     }
 
     public static Diff<DataStreamAlias> readDiffFrom(StreamInput in) throws IOException {

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/Metadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/Metadata.java
@@ -1196,20 +1196,7 @@ public class Metadata implements Iterable<IndexMetadata>, Diffable<Metadata>, To
                 String writeDataStream = isWriteDataStream != null && isWriteDataStream ? dataStream : null;
                 alias = new DataStreamAlias(aliasName, List.of(dataStream), writeDataStream);
             } else {
-                Set<String> dataStreams = new HashSet<>(alias.getDataStreams());
-                String writeDataStream = alias.getWriteDataStream();
-                if (isWriteDataStream == null || isWriteDataStream == false) {
-                    if (dataStream.equals(writeDataStream)) {
-                        writeDataStream = null;
-                    }
-                } else if (isWriteDataStream) {
-                    writeDataStream = dataStream;
-                }
-                boolean added = dataStreams.add(dataStream);
-                if (added == false && Objects.equals(alias.getWriteDataStream(), writeDataStream)) {
-                    return false;
-                }
-                alias = new DataStreamAlias(aliasName, List.copyOf(dataStreams), writeDataStream);
+                alias = alias.addDataStream(dataStream, isWriteDataStream);
             }
             dataStreamAliases.put(aliasName, alias);
 
@@ -1232,18 +1219,14 @@ public class Metadata implements Iterable<IndexMetadata>, Diffable<Metadata>, To
             Set<String> aliasesToDelete = new HashSet<>();
             List<DataStreamAlias> aliasesToUpdate = new ArrayList<>();
             for (var alias : existingDataStreamAliases.values()) {
-                Set<String> dataStreams = new HashSet<>(alias.getDataStreams());
-                if (dataStreams.contains(name)) {
-                    dataStreams.remove(name);
-                    if (dataStreams.isEmpty()) {
-                        aliasesToDelete.add(alias.getName());
-                    } else {
-                        String writeDataStream = alias.getWriteDataStream();
-                        if (dataStreams.contains(writeDataStream) == false) {
-                            writeDataStream = null;
-                        }
-                        aliasesToUpdate.add(new DataStreamAlias(alias.getName(), List.copyOf(dataStreams), writeDataStream));
+                DataStreamAlias copy = alias.removeDataStream(name);
+                if (copy != null) {
+                    if (copy == alias) {
+                        continue;
                     }
+                    aliasesToUpdate.add(copy);
+                } else {
+                    aliasesToDelete.add(alias.getName());
                 }
             }
             for (DataStreamAlias alias : aliasesToUpdate) {
@@ -1269,19 +1252,15 @@ public class Metadata implements Iterable<IndexMetadata>, Diffable<Metadata>, To
             } else if (existing == null) {
                 return false;
             }
-            Set<String> dataStreams = new HashSet<>(existing.getDataStreams());
-            dataStreams.remove(dataStreamName);
-            if (dataStreams.isEmpty()) {
-                dataStreamAliases.remove(aliasName);
-            } else {
-                String writeDataStream = existing.getWriteDataStream();
-                if (dataStreamName.equals(writeDataStream)) {
-                    writeDataStream = null;
-                }
-                dataStreamAliases.put(aliasName,
-                    new DataStreamAlias(existing.getName(), List.copyOf(dataStreams), writeDataStream));
+            DataStreamAlias copy = existing.removeDataStream(dataStreamName);
+            if (copy == existing) {
+                return false;
             }
-
+            if (copy != null) {
+                dataStreamAliases.put(aliasName, copy);
+            } else {
+                dataStreamAliases.remove(aliasName);
+            }
             Map<String, DataStream> existingDataStream =
                 Optional.ofNullable((DataStreamMetadata) this.customs.get(DataStreamMetadata.TYPE))
                     .map(dsmd -> new HashMap<>(dsmd.dataStreams()))

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/Metadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/Metadata.java
@@ -1196,7 +1196,11 @@ public class Metadata implements Iterable<IndexMetadata>, Diffable<Metadata>, To
                 String writeDataStream = isWriteDataStream != null && isWriteDataStream ? dataStream : null;
                 alias = new DataStreamAlias(aliasName, List.of(dataStream), writeDataStream);
             } else {
-                alias = alias.addDataStream(dataStream, isWriteDataStream);
+                DataStreamAlias copy = alias.addDataStream(dataStream, isWriteDataStream);
+                if (copy == alias) {
+                    return false;
+                }
+                alias = copy;
             }
             dataStreamAliases.put(aliasName, alias);
 

--- a/server/src/main/java/org/elasticsearch/snapshots/RestoreService.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/RestoreService.java
@@ -466,15 +466,8 @@ public class RestoreService implements ClusterStateApplier {
                 dataStreamAliases = new HashMap<>();
                 final Map<String, DataStreamAlias> dataStreamAliasesInSnapshot = globalMetadata.dataStreamAliases();
                 for (DataStreamAlias alias : dataStreamAliasesInSnapshot.values()) {
-                    List<String> intersectingDataStreams = alias.getDataStreams().stream()
-                        .filter(requestedDataStreams::contains)
-                        .collect(Collectors.toList());
-                    String writeDateStream = alias.getWriteDataStream();
-                    if (intersectingDataStreams.contains(writeDateStream) == false) {
-                        writeDateStream = null;
-                    }
-                    if (intersectingDataStreams.isEmpty() == false) {
-                        DataStreamAlias copy = new DataStreamAlias(alias.getName(), intersectingDataStreams, writeDateStream);
+                    DataStreamAlias copy = alias.intersect(requestedDataStreams::contains);
+                    if (copy.getDataStreams().isEmpty() == false) {
                         dataStreamAliases.put(alias.getName(), copy);
                     }
                 }
@@ -1199,14 +1192,7 @@ public class RestoreService implements ClusterStateApplier {
                 // Optionally rename the data stream names for each alias
                 .map(alias -> {
                     if (request.renamePattern() != null && request.renameReplacement() != null) {
-                        List<String> renamedDataStreams = alias.getDataStreams().stream()
-                            .map(s -> s.replaceAll(request.renamePattern(), request.renameReplacement()))
-                            .collect(Collectors.toList());
-                        String writeDataStream = alias.getWriteDataStream();
-                        if (writeDataStream != null) {
-                            writeDataStream = writeDataStream.replaceAll(request.renamePattern(), request.renameReplacement());
-                        }
-                        return new DataStreamAlias(alias.getName(), renamedDataStreams, writeDataStream);
+                        return alias.renameDataStreams(request.renamePattern(), request.renameReplacement());
                     } else {
                         return alias;
                     }
@@ -1214,18 +1200,7 @@ public class RestoreService implements ClusterStateApplier {
                     final DataStreamAlias current = updatedDataStreamAliases.putIfAbsent(alias.getName(), alias);
                     if (current != null) {
                         // Merge data stream alias from snapshot with an existing data stream aliases in target cluster:
-                        Set<String> mergedDataStreams = new HashSet<>(current.getDataStreams());
-                        mergedDataStreams.addAll(alias.getDataStreams());
-
-                        String writeDataStream = alias.getWriteDataStream();
-                        if (writeDataStream == null) {
-                            if (current.getWriteDataStream() != null && mergedDataStreams.contains(current.getWriteDataStream())) {
-                                writeDataStream = current.getWriteDataStream();
-                            }
-                        }
-
-                        DataStreamAlias newInstance =
-                            new DataStreamAlias(alias.getName(), List.copyOf(mergedDataStreams), writeDataStream);
+                        DataStreamAlias newInstance = alias.merge(current);
                         updatedDataStreamAliases.put(alias.getName(), newInstance);
                     }
                 });

--- a/server/src/main/java/org/elasticsearch/snapshots/SnapshotsService.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/SnapshotsService.java
@@ -2425,16 +2425,8 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
 
         return dataStreamAliases.values().stream()
             .filter(alias -> alias.getDataStreams().stream().anyMatch(dataStreams::containsKey))
-            .map(alias -> {
-                List<String> intersectingDataStreams = alias.getDataStreams().stream()
-                    .filter(dataStreams::containsKey)
-                    .collect(Collectors.toList());
-                String writeDataStream = alias.getWriteDataStream();
-                if (intersectingDataStreams.contains(writeDataStream) == false) {
-                    writeDataStream = null;
-                }
-                return new DataStreamAlias(alias.getName(), intersectingDataStreams, writeDataStream);
-            }).collect(Collectors.toMap(DataStreamAlias::getName, Function.identity()));
+            .map(alias -> alias.intersect(dataStreams::containsKey))
+            .collect(Collectors.toMap(DataStreamAlias::getName, Function.identity()));
     }
 
     /**

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/DataStreamAliasTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/DataStreamAliasTests.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.cluster.metadata;
+
+import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.test.AbstractSerializingTestCase;
+
+import java.io.IOException;
+import java.util.List;
+
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.Matchers.sameInstance;
+
+public class DataStreamAliasTests extends AbstractSerializingTestCase<DataStreamAlias> {
+
+    @Override
+    protected DataStreamAlias doParseInstance(XContentParser parser) throws IOException {
+        parser.nextToken();
+        parser.nextToken();
+        return DataStreamAlias.fromXContent(parser);
+    }
+
+    @Override
+    protected Writeable.Reader<DataStreamAlias> instanceReader() {
+        return DataStreamAlias::new;
+    }
+
+    @Override
+    protected DataStreamAlias createTestInstance() {
+        return DataStreamTestHelper.randomAliasInstance();
+    }
+
+    public void testAddDataStream() {
+        // Add ds-3 to alias, a different instance is returned with ds-3 as one of the data streams being referred to
+        DataStreamAlias alias = new DataStreamAlias("my-alias", List.of("ds-1", "ds-2"), null);
+        DataStreamAlias result = alias.addDataStream("ds-3", null);
+        assertThat(result.getDataStreams(), containsInAnyOrder("ds-1", "ds-2", "ds-3"));
+        assertThat(result.getWriteDataStream(), nullValue());
+        // Add ds-3 to alias as write data stream, same as above but the returned instance also refers to ds-3 as write data stream
+        result = alias.addDataStream("ds-3", true);
+        assertThat(result.getDataStreams(), containsInAnyOrder("ds-1", "ds-2", "ds-3"));
+        assertThat(result.getWriteDataStream(), equalTo("ds-3"));
+        // Add ds-2 as data stream, which is already referred to by this alias. The same instance is returned to signal a noop.
+        result = alias.addDataStream("ds-2", null);
+        assertThat(result, sameInstance(alias));
+        // Add ds-2 as non write data stream, which is already referred to by this alias. The same instance is returned to signal a noop.
+        result = alias.addDataStream("ds-2", false);
+        assertThat(result, sameInstance(alias));
+        // Add ds-2 as write data stream, which is already referred to by this alias, but not as write data stream,
+        // an updated instance should be returned.
+        result = alias.addDataStream("ds-2", true);
+        assertThat(result, not(sameInstance(alias)));
+        assertThat(result.getWriteDataStream(), equalTo("ds-2"));
+        // Add ds-2 as write non data stream, which is already referred to by this alias, but as write data stream,
+        // an updated instance should be returned.
+        alias = new DataStreamAlias("my-alias", List.of("ds-1", "ds-2"), "ds-2");
+        result = alias.addDataStream("ds-2", false);
+        assertThat(result, not(sameInstance(alias)));
+        assertThat(result.getWriteDataStream(), nullValue());
+    }
+
+    public void testRemoveDataStream() {
+        // Remove a referenced data stream:
+        DataStreamAlias alias = new DataStreamAlias("my-alias", List.of("ds-1", "ds-2"), null);
+        DataStreamAlias result = alias.removeDataStream("ds-2");
+        assertThat(result, not(sameInstance(alias)));
+        assertThat(result.getDataStreams(), containsInAnyOrder("ds-1"));
+        assertThat(result.getWriteDataStream(), nullValue());
+        // Remove the data stream that is also referenced as write data stream:
+        alias = new DataStreamAlias("my-alias", List.of("ds-1", "ds-2"), "ds-2");
+        result = alias.removeDataStream("ds-2");
+        assertThat(result, not(sameInstance(alias)));
+        assertThat(result.getDataStreams(), containsInAnyOrder("ds-1"));
+        assertThat(result.getWriteDataStream(), nullValue());
+        // Removing the last referenced data stream name, return null to signal the entire alias can be removed.
+        alias = new DataStreamAlias("my-alias", List.of("ds-1"), null);
+        result = alias.removeDataStream("ds-1");
+        assertThat(result, nullValue());
+        // Removing a non referenced data stream name, signal noop, by returning the same instance
+        alias = new DataStreamAlias("my-alias", List.of("ds-1"), null);
+        result = alias.removeDataStream("ds-2");
+        assertThat(result, sameInstance(alias));
+    }
+
+    public void testIntersect() {
+        {
+            DataStreamAlias alias1 = new DataStreamAlias("my-alias", List.of("ds-1", "ds-2"), null);
+            DataStreamAlias alias2 = new DataStreamAlias("my-alias", List.of("ds-2", "ds-3"), null);
+            DataStreamAlias result = alias1.intersect(s -> alias2.getDataStreams().contains(s));
+            assertThat(result.getDataStreams(), containsInAnyOrder("ds-2"));
+            assertThat(result.getWriteDataStream(), nullValue());
+        }
+        {
+            DataStreamAlias alias1 = new DataStreamAlias("my-alias", List.of("ds-1", "ds-2"), "ds-2");
+            DataStreamAlias alias2 = new DataStreamAlias("my-alias", List.of("ds-2", "ds-3"), null);
+            DataStreamAlias result = alias1.intersect(s -> alias2.getDataStreams().contains(s));
+            assertThat(result.getDataStreams(), containsInAnyOrder("ds-2"));
+            assertThat(result.getWriteDataStream(), equalTo("ds-2"));
+        }
+        {
+            DataStreamAlias alias1 = new DataStreamAlias("my-alias", List.of("ds-1", "ds-2"), null);
+            DataStreamAlias alias2 = new DataStreamAlias("my-alias", List.of("ds-2", "ds-3"), "ds-3");
+            DataStreamAlias result = alias1.intersect(s -> alias2.getDataStreams().contains(s));
+            assertThat(result.getDataStreams(), containsInAnyOrder("ds-2"));
+            assertThat(result.getWriteDataStream(), nullValue());
+        }
+        {
+            DataStreamAlias alias1 = new DataStreamAlias("my-alias", List.of("ds-1", "ds-2", "ds-3"), "ds-3");
+            DataStreamAlias alias2 = new DataStreamAlias("my-alias", List.of("ds-2", "ds-3"), "ds-2");
+            DataStreamAlias result = alias1.intersect(s -> alias2.getDataStreams().contains(s));
+            assertThat(result.getDataStreams(), containsInAnyOrder("ds-2", "ds-3"));
+            assertThat(result.getWriteDataStream(), equalTo("ds-3"));
+        }
+    }
+
+    public void testMerge() {
+        {
+            DataStreamAlias alias1 = new DataStreamAlias("my-alias", List.of("ds-1", "ds-2"), null);
+            DataStreamAlias alias2 = new DataStreamAlias("my-alias", List.of("ds-2", "ds-3"), null);
+            DataStreamAlias result = alias1.merge(alias2);
+            assertThat(result.getDataStreams(), containsInAnyOrder("ds-1", "ds-2", "ds-3"));
+            assertThat(result.getWriteDataStream(), nullValue());
+        }
+        {
+            DataStreamAlias alias1 = new DataStreamAlias("my-alias", List.of("ds-1", "ds-2"), "ds-2");
+            DataStreamAlias alias2 = new DataStreamAlias("my-alias", List.of("ds-2", "ds-3"), null);
+            DataStreamAlias result = alias1.merge(alias2);
+            assertThat(result.getDataStreams(), containsInAnyOrder("ds-1", "ds-2", "ds-3"));
+            assertThat(result.getWriteDataStream(), equalTo("ds-2"));
+        }
+        {
+            DataStreamAlias alias1 = new DataStreamAlias("my-alias", List.of("ds-1", "ds-2"), "ds-2");
+            DataStreamAlias alias2 = new DataStreamAlias("my-alias", List.of("ds-2", "ds-3"), "ds-3");
+            DataStreamAlias result = alias1.merge(alias2);
+            assertThat(result.getDataStreams(), containsInAnyOrder("ds-1", "ds-2", "ds-3"));
+            assertThat(result.getWriteDataStream(), equalTo("ds-2"));
+        }
+        {
+            DataStreamAlias alias1 = new DataStreamAlias("my-alias", List.of("ds-1", "ds-2"), null);
+            DataStreamAlias alias2 = new DataStreamAlias("my-alias", List.of("ds-2", "ds-3"), "ds-3");
+            DataStreamAlias result = alias1.merge(alias2);
+            assertThat(result.getDataStreams(), containsInAnyOrder("ds-1", "ds-2", "ds-3"));
+            assertThat(result.getWriteDataStream(), equalTo("ds-3"));
+        }
+    }
+
+    public void testRenameDataStreams() {
+        DataStreamAlias alias = new DataStreamAlias("my-alias", List.of("ds-1", "ds-2"), "ds-2");
+        DataStreamAlias result = alias.renameDataStreams("ds-2", "ds-3");
+        assertThat(result.getDataStreams(), containsInAnyOrder("ds-1", "ds-3"));
+        assertThat(result.getWriteDataStream(), equalTo("ds-3"));
+    }
+}

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataTests.java
@@ -1386,9 +1386,11 @@ public class MetadataTests extends ESTestCase {
         assertThat(metadata.dataStreamAliases().get("logs-postgres").getWriteDataStream(), equalTo("logs-postgres-replicated"));
         assertThat(metadata.dataStreamAliases().get("logs-postgres").getDataStreams(), containsInAnyOrder("logs-postgres-replicated"));
 
-        // Unset write flag
         mdBuilder = Metadata.builder(metadata);
-        assertThat(mdBuilder.put("logs-postgres", "logs-postgres-replicated", randomBoolean() ? null : false), is(true));
+        // Side check: null value isn't changing anything:
+        assertThat(mdBuilder.put("logs-postgres", "logs-postgres-replicated", null), is(false));
+        // Unset write flag
+        assertThat(mdBuilder.put("logs-postgres", "logs-postgres-replicated", false), is(true));
         metadata = mdBuilder.build();
         assertThat(metadata.dataStreamAliases().get("logs-postgres"), notNullValue());
         assertThat(metadata.dataStreamAliases().get("logs-postgres").getWriteDataStream(), nullValue());
@@ -1410,7 +1412,7 @@ public class MetadataTests extends ESTestCase {
 
         // change write flag:
         mdBuilder = Metadata.builder(metadata);
-        assertThat(mdBuilder.put("logs-postgres", "logs-postgres-primary", randomBoolean() ? null : false), is(true));
+        assertThat(mdBuilder.put("logs-postgres", "logs-postgres-primary", false), is(true));
         assertThat(mdBuilder.put("logs-postgres", "logs-postgres-replicated", true), is(true));
         metadata = mdBuilder.build();
         assertThat(metadata.dataStreamAliases().get("logs-postgres"), notNullValue());


### PR DESCRIPTION
Move data stream alias logic that was scattered in several places to the `DataStreamAlias` class.

Relates to #66163