### PR TITLE
Deprecations for single data node setting

### DIFF
--- a/client/rest-high-level/build.gradle
+++ b/client/rest-high-level/build.gradle
@@ -116,4 +116,6 @@ testClusters.all {
 
   setting 'xpack.searchable.snapshot.shared_cache.size', '1mb'
   setting 'xpack.searchable.snapshot.shared_cache.region_size', '16kb'
+
+  setting 'cluster.routing.allocation.disk.watermark.enable_for_single_data_node', 'true'
 }

--- a/docs/reference/migration/migrate_7_14.asciidoc
+++ b/docs/reference/migration/migrate_7_14.asciidoc
@@ -55,4 +55,20 @@ cluster then you must upgrade the affected nodes. Once upgraded, they will join
 the cluster again.
 ====
 
+[discrete]
+[[breaking_714_core_deprecations]]
+=== Core deprecations
+
+[discrete]
+[[deprecate-single-data-node-watermark]]
+.Setting `cluster.routing.allocation.disk.watermark.enable_for_single_data_node=false` is deprecated.
+[%collapsible]
+====
+*Details* +
+The setting `cluster.routing.allocation.disk.watermark.enable_for_single_data_node`
+should never be explicitly set to false. In 8.0, the only legal value will be
+true. In a future release, the setting will be removed completely, with same
+behavior as if the setting was `true`.
+====
+
 // end::notable-breaking-changes[]

--- a/docs/reference/migration/migrate_7_14.asciidoc
+++ b/docs/reference/migration/migrate_7_14.asciidoc
@@ -70,10 +70,16 @@ should never be explicitly set to false. In 8.0, the only legal value will be
 true. In a future release, the setting will be removed completely, with same
 behavior as if the setting was `true`.
 
-If the old behavior is desired for a single data node cluster, disk based
-allocation can be disabled by setting
-`cluster.routing.allocation.disk.threshold_enabled: false`
+*Impact* +
 
+If your cluster has a single data node then set
+`cluster.routing.allocation.disk.watermark.enable_for_single_data_node: true`
+to opt in to the future behaviour today. If you wish to disable the disk
+watermarks then set `cluster.routing.allocation.disk.threshold_enabled: false`.
+
+If your cluster has multiple data nodes then the
+`cluster.routing.allocation.disk.watermark.enable_for_single_data_node` setting
+has no effect and you should discontinue its use.
 ====
 
 // end::notable-breaking-changes[]

--- a/docs/reference/migration/migrate_7_14.asciidoc
+++ b/docs/reference/migration/migrate_7_14.asciidoc
@@ -69,6 +69,11 @@ The setting `cluster.routing.allocation.disk.watermark.enable_for_single_data_no
 should never be explicitly set to false. In 8.0, the only legal value will be
 true. In a future release, the setting will be removed completely, with same
 behavior as if the setting was `true`.
+
+If the old behavior is desired for a single data node cluster, disk based
+allocation can be disabled by setting
+`cluster.routing.allocation.disk.threshold_enabled: false`
+
 ====
 
 // end::notable-breaking-changes[]

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/decider/DiskThresholdDeciderTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/decider/DiskThresholdDeciderTests.java
@@ -53,7 +53,6 @@ import org.elasticsearch.snapshots.InternalSnapshotsInfoService.SnapshotShard;
 import org.elasticsearch.snapshots.Snapshot;
 import org.elasticsearch.snapshots.SnapshotId;
 import org.elasticsearch.snapshots.SnapshotShardSizeInfo;
-import org.elasticsearch.test.MockLogAppender;
 import org.elasticsearch.test.gateway.TestGatewayAllocator;
 
 import java.util.Arrays;

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/decider/DiskThresholdDeciderTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/decider/DiskThresholdDeciderTests.java
@@ -53,6 +53,7 @@ import org.elasticsearch.snapshots.InternalSnapshotsInfoService.SnapshotShard;
 import org.elasticsearch.snapshots.Snapshot;
 import org.elasticsearch.snapshots.SnapshotId;
 import org.elasticsearch.snapshots.SnapshotShardSizeInfo;
+import org.elasticsearch.test.MockLogAppender;
 import org.elasticsearch.test.gateway.TestGatewayAllocator;
 
 import java.util.Arrays;
@@ -1131,6 +1132,17 @@ public class DiskThresholdDeciderTests extends ESAllocationTestCase {
             "the shard cannot remain on this node because it is above the high watermark cluster setting" +
                 " [cluster.routing.allocation.disk.watermark.high=70%] and there is less than the required [30.0%] free disk on node," +
                 " actual free: [20.0%]"));
+    }
+
+    public void testSingleDataNodeDeprecationWarning() {
+        Settings settings = Settings.builder()
+            .put(DiskThresholdDecider.ENABLE_FOR_SINGLE_DATA_NODE.getKey(), false)
+            .build();
+
+        new DiskThresholdDecider(settings, new ClusterSettings(settings, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS));
+
+        assertWarnings("setting [cluster.routing.allocation.disk.watermark.enable_for_single_data_node=false] is deprecated and" +
+            " will not be available in a future version");
     }
 
     public void testDiskThresholdWithSnapshotShardSizes() {

--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/DeprecationChecks.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/DeprecationChecks.java
@@ -86,7 +86,8 @@ public class DeprecationChecks {
                     NodeDeprecationChecks::checkMultipleDataPaths,
                     NodeDeprecationChecks::checkDataPathsList,
                     NodeDeprecationChecks::checkBootstrapSystemCallFilterSetting,
-                    NodeDeprecationChecks::checkSharedDataPathSetting
+                    NodeDeprecationChecks::checkSharedDataPathSetting,
+                    NodeDeprecationChecks::checkSingleDataNodeWatermarkSetting
                 )
             ).collect(Collectors.toList());
         }

--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/DeprecationChecks.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/DeprecationChecks.java
@@ -10,6 +10,7 @@ import org.elasticsearch.action.admin.cluster.node.info.PluginsAndModules;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.common.TriFunction;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.xpack.core.XPackSettings;
 import org.elasticsearch.xpack.core.deprecation.DeprecationInfoAction;
@@ -19,7 +20,6 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
-import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -42,13 +42,14 @@ public class DeprecationChecks {
             ClusterDeprecationChecks::checkTemplatesWithMultipleTypes
         ));
 
-    static final List<BiFunction<Settings, PluginsAndModules, DeprecationIssue>> NODE_SETTINGS_CHECKS;
+    static final List<TriFunction<Settings, PluginsAndModules, ClusterState, DeprecationIssue>> NODE_SETTINGS_CHECKS;
 
         static {
-            final Stream<BiFunction<Settings, PluginsAndModules, DeprecationIssue>> legacyRoleSettings = DiscoveryNode.getPossibleRoles()
+            final Stream<TriFunction<Settings, PluginsAndModules, ClusterState, DeprecationIssue>> legacyRoleSettings =
+                DiscoveryNode.getPossibleRoles()
                 .stream()
                 .filter(r -> r.legacySetting() != null)
-                .map(r -> (s, p) -> NodeDeprecationChecks.checkLegacyRoleSettings(r.legacySetting(), s, p));
+                .map(r -> (s, p, cs) -> NodeDeprecationChecks.checkLegacyRoleSettings(r.legacySetting(), s, p));
             NODE_SETTINGS_CHECKS = Stream.concat(
                 legacyRoleSettings,
                 Stream.of(
@@ -58,30 +59,30 @@ public class DeprecationChecks {
                     NodeDeprecationChecks::checkMissingRealmOrders,
                     NodeDeprecationChecks::checkUniqueRealmOrders,
                     NodeDeprecationChecks::checkImplicitlyDisabledBasicRealms,
-                    (settings, pluginsAndModules) -> NodeDeprecationChecks.checkThreadPoolListenerQueueSize(settings),
-                    (settings, pluginsAndModules) -> NodeDeprecationChecks.checkThreadPoolListenerSize(settings),
+                    (settings, pluginsAndModules, cs) -> NodeDeprecationChecks.checkThreadPoolListenerQueueSize(settings),
+                    (settings, pluginsAndModules, cs) -> NodeDeprecationChecks.checkThreadPoolListenerSize(settings),
                     NodeDeprecationChecks::checkClusterRemoteConnectSetting,
                     NodeDeprecationChecks::checkNodeLocalStorageSetting,
                     NodeDeprecationChecks::checkGeneralScriptSizeSetting,
                     NodeDeprecationChecks::checkGeneralScriptExpireSetting,
                     NodeDeprecationChecks::checkGeneralScriptCompileSettings,
-                    (settings, pluginsAndModules) -> NodeDeprecationChecks.checkNodeBasicLicenseFeatureEnabledSetting(settings,
+                    (settings, pluginsAndModules, cs) -> NodeDeprecationChecks.checkNodeBasicLicenseFeatureEnabledSetting(settings,
                         XPackSettings.ENRICH_ENABLED_SETTING),
-                    (settings, pluginsAndModules) -> NodeDeprecationChecks.checkNodeBasicLicenseFeatureEnabledSetting(settings,
+                    (settings, pluginsAndModules, cs) -> NodeDeprecationChecks.checkNodeBasicLicenseFeatureEnabledSetting(settings,
                         XPackSettings.FLATTENED_ENABLED),
-                    (settings, pluginsAndModules) -> NodeDeprecationChecks.checkNodeBasicLicenseFeatureEnabledSetting(settings,
+                    (settings, pluginsAndModules, cs) -> NodeDeprecationChecks.checkNodeBasicLicenseFeatureEnabledSetting(settings,
                         XPackSettings.INDEX_LIFECYCLE_ENABLED),
-                    (settings, pluginsAndModules) -> NodeDeprecationChecks.checkNodeBasicLicenseFeatureEnabledSetting(settings,
+                    (settings, pluginsAndModules, cs) -> NodeDeprecationChecks.checkNodeBasicLicenseFeatureEnabledSetting(settings,
                         XPackSettings.MONITORING_ENABLED),
-                    (settings, pluginsAndModules) -> NodeDeprecationChecks.checkNodeBasicLicenseFeatureEnabledSetting(settings,
+                    (settings, pluginsAndModules, cs) -> NodeDeprecationChecks.checkNodeBasicLicenseFeatureEnabledSetting(settings,
                         XPackSettings.ROLLUP_ENABLED),
-                    (settings, pluginsAndModules) -> NodeDeprecationChecks.checkNodeBasicLicenseFeatureEnabledSetting(settings,
+                    (settings, pluginsAndModules, cs) -> NodeDeprecationChecks.checkNodeBasicLicenseFeatureEnabledSetting(settings,
                         XPackSettings.SNAPSHOT_LIFECYCLE_ENABLED),
-                    (settings, pluginsAndModules) -> NodeDeprecationChecks.checkNodeBasicLicenseFeatureEnabledSetting(settings,
+                    (settings, pluginsAndModules, cs) -> NodeDeprecationChecks.checkNodeBasicLicenseFeatureEnabledSetting(settings,
                         XPackSettings.SQL_ENABLED),
-                    (settings, pluginsAndModules) -> NodeDeprecationChecks.checkNodeBasicLicenseFeatureEnabledSetting(settings,
+                    (settings, pluginsAndModules, cs) -> NodeDeprecationChecks.checkNodeBasicLicenseFeatureEnabledSetting(settings,
                         XPackSettings.TRANSFORM_ENABLED),
-                    (settings, pluginsAndModules) -> NodeDeprecationChecks.checkNodeBasicLicenseFeatureEnabledSetting(settings,
+                    (settings, pluginsAndModules, cs) -> NodeDeprecationChecks.checkNodeBasicLicenseFeatureEnabledSetting(settings,
                         XPackSettings.VECTORS_ENABLED),
                     NodeDeprecationChecks::checkMultipleDataPaths,
                     NodeDeprecationChecks::checkDataPathsList,

--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/NodeDeprecationChecks.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/NodeDeprecationChecks.java
@@ -13,8 +13,6 @@ import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodeRole;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.bootstrap.BootstrapSettings;
-import org.elasticsearch.cluster.ClusterInfo;
-import org.elasticsearch.cluster.ClusterInfoService;
 import org.elasticsearch.cluster.routing.allocation.decider.DiskThresholdDecider;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Setting.Property;
@@ -425,7 +423,8 @@ class NodeDeprecationChecks {
     }
 
     static DeprecationIssue checkSingleDataNodeWatermarkSetting(final Settings settings, final PluginsAndModules pluginsAndModules) {
-        if (DiskThresholdDecider.ENABLE_FOR_SINGLE_DATA_NODE.get(settings) == false && DiskThresholdDecider.ENABLE_FOR_SINGLE_DATA_NODE.exists(settings)) {
+        if (DiskThresholdDecider.ENABLE_FOR_SINGLE_DATA_NODE.get(settings) == false
+            && DiskThresholdDecider.ENABLE_FOR_SINGLE_DATA_NODE.exists(settings)) {
             String key = DiskThresholdDecider.ENABLE_FOR_SINGLE_DATA_NODE.getKey();
             return new DeprecationIssue(DeprecationIssue.Level.CRITICAL,
                 String.format("setting [%s=false] is deprecated and will not be available in a future version", key),

--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/NodeDeprecationChecks.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/NodeDeprecationChecks.java
@@ -13,6 +13,9 @@ import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodeRole;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.bootstrap.BootstrapSettings;
+import org.elasticsearch.cluster.ClusterInfo;
+import org.elasticsearch.cluster.ClusterInfoService;
+import org.elasticsearch.cluster.routing.allocation.decider.DiskThresholdDecider;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Setting.Property;
 import org.elasticsearch.common.settings.Settings;
@@ -418,6 +421,20 @@ class NodeDeprecationChecks {
             final String details = "Found shared data path configured. Discontinue use of this setting.";
             return new DeprecationIssue(DeprecationIssue.Level.CRITICAL, message, url, details);
         }
+        return null;
+    }
+
+    static DeprecationIssue checkSingleDataNodeWatermarkSetting(final Settings settings, final PluginsAndModules pluginsAndModules) {
+        if (DiskThresholdDecider.ENABLE_FOR_SINGLE_DATA_NODE.get(settings) == false && DiskThresholdDecider.ENABLE_FOR_SINGLE_DATA_NODE.exists(settings)) {
+            String key = DiskThresholdDecider.ENABLE_FOR_SINGLE_DATA_NODE.getKey();
+            return new DeprecationIssue(DeprecationIssue.Level.CRITICAL,
+                String.format("setting [%s=false] is deprecated and will not be available in a future version", key),
+                "https://www.elastic.co/guide/en/elasticsearch/reference/7.14/" +
+                    "breaking-changes-7.14.html#deprecate-single-data-node-watermark",
+                String.format("found [%s] configured to false. Discontinue use of this setting or set it to true.", key)
+            );
+        }
+
         return null;
     }
 }

--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/NodeDeprecationChecks.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/NodeDeprecationChecks.java
@@ -427,10 +427,10 @@ class NodeDeprecationChecks {
             && DiskThresholdDecider.ENABLE_FOR_SINGLE_DATA_NODE.exists(settings)) {
             String key = DiskThresholdDecider.ENABLE_FOR_SINGLE_DATA_NODE.getKey();
             return new DeprecationIssue(DeprecationIssue.Level.CRITICAL,
-                String.format("setting [%s=false] is deprecated and will not be available in a future version", key),
+                String.format(Locale.ROOT, "setting [%s=false] is deprecated and will not be available in a future version", key),
                 "https://www.elastic.co/guide/en/elasticsearch/reference/7.14/" +
                     "breaking-changes-7.14.html#deprecate-single-data-node-watermark",
-                String.format("found [%s] configured to false. Discontinue use of this setting or set it to true.", key)
+                String.format(Locale.ROOT, "found [%s] configured to false. Discontinue use of this setting or set it to true.", key)
             );
         }
 

--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/NodeDeprecationChecks.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/NodeDeprecationChecks.java
@@ -9,8 +9,10 @@ package org.elasticsearch.xpack.deprecation;
 
 import org.elasticsearch.action.admin.cluster.node.info.PluginsAndModules;
 import org.elasticsearch.bootstrap.JavaVersion;
+import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodeRole;
+import org.elasticsearch.cluster.routing.allocation.DiskThresholdSettings;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.bootstrap.BootstrapSettings;
 import org.elasticsearch.cluster.routing.allocation.decider.DiskThresholdDecider;
@@ -42,7 +44,7 @@ import java.util.stream.Collectors;
 
 class NodeDeprecationChecks {
 
-    static DeprecationIssue checkPidfile(final Settings settings, final PluginsAndModules pluginsAndModules) {
+    static DeprecationIssue checkPidfile(final Settings settings, final PluginsAndModules pluginsAndModules, ClusterState cs) {
         return checkDeprecatedSetting(
             settings,
             pluginsAndModules,
@@ -51,7 +53,7 @@ class NodeDeprecationChecks {
             "https://www.elastic.co/guide/en/elasticsearch/reference/7.4/breaking-changes-7.4.html#deprecate-pidfile");
     }
 
-    static DeprecationIssue checkProcessors(final Settings settings , final PluginsAndModules pluginsAndModules) {
+    static DeprecationIssue checkProcessors(final Settings settings , final PluginsAndModules pluginsAndModules, ClusterState cs) {
         return checkDeprecatedSetting(
             settings,
             pluginsAndModules,
@@ -60,7 +62,7 @@ class NodeDeprecationChecks {
             "https://www.elastic.co/guide/en/elasticsearch/reference/7.4/breaking-changes-7.4.html#deprecate-processors");
     }
 
-    static DeprecationIssue checkMissingRealmOrders(final Settings settings, final PluginsAndModules pluginsAndModules) {
+    static DeprecationIssue checkMissingRealmOrders(final Settings settings, final PluginsAndModules pluginsAndModules, ClusterState cs) {
         final Set<String> orderNotConfiguredRealms = RealmSettings.getRealmSettings(settings).entrySet()
                 .stream()
                 .filter(e -> false == e.getValue().hasValue(RealmSettings.ORDER_SETTING_KEY))
@@ -84,7 +86,7 @@ class NodeDeprecationChecks {
         );
     }
 
-    static DeprecationIssue checkUniqueRealmOrders(final Settings settings, final PluginsAndModules pluginsAndModules) {
+    static DeprecationIssue checkUniqueRealmOrders(final Settings settings, final PluginsAndModules pluginsAndModules, ClusterState cs) {
         final Map<String, List<String>> orderToRealmSettings =
             RealmSettings.getRealmSettings(settings).entrySet()
                 .stream()
@@ -117,7 +119,8 @@ class NodeDeprecationChecks {
         );
     }
 
-    static DeprecationIssue checkImplicitlyDisabledBasicRealms(final Settings settings, final PluginsAndModules pluginsAndModules) {
+    static DeprecationIssue checkImplicitlyDisabledBasicRealms(final Settings settings, final PluginsAndModules pluginsAndModules,
+                                                               ClusterState cs) {
         final Map<RealmConfig.RealmIdentifier, Settings> realmSettings = RealmSettings.getRealmSettings(settings);
         if (realmSettings.isEmpty()) {
             return null;
@@ -187,7 +190,8 @@ class NodeDeprecationChecks {
             "https://www.elastic.co/guide/en/elasticsearch/reference/7.x/breaking-changes-7.7.html#deprecate-listener-thread-pool");
     }
 
-    public static DeprecationIssue checkClusterRemoteConnectSetting(final Settings settings, final PluginsAndModules pluginsAndModules) {
+    public static DeprecationIssue checkClusterRemoteConnectSetting(final Settings settings, final PluginsAndModules pluginsAndModules,
+                                                                    ClusterState cs) {
         return checkDeprecatedSetting(
             settings,
             pluginsAndModules,
@@ -201,7 +205,8 @@ class NodeDeprecationChecks {
         );
     }
 
-    public static DeprecationIssue checkNodeLocalStorageSetting(final Settings settings, final PluginsAndModules pluginsAndModules) {
+    public static DeprecationIssue checkNodeLocalStorageSetting(final Settings settings, final PluginsAndModules pluginsAndModules,
+                                                                ClusterState cs) {
         return checkRemovedSetting(
             settings,
             Node.NODE_LOCAL_STORAGE_SETTING,
@@ -217,7 +222,8 @@ class NodeDeprecationChecks {
         );
     }
 
-    public static DeprecationIssue checkGeneralScriptSizeSetting(final Settings settings, final PluginsAndModules pluginsAndModules) {
+    public static DeprecationIssue checkGeneralScriptSizeSetting(final Settings settings, final PluginsAndModules pluginsAndModules,
+                                                                 ClusterState cs) {
         return checkDeprecatedSetting(
             settings,
             pluginsAndModules,
@@ -228,7 +234,8 @@ class NodeDeprecationChecks {
         );
     }
 
-    public static DeprecationIssue checkGeneralScriptExpireSetting(final Settings settings, final PluginsAndModules pluginsAndModules) {
+    public static DeprecationIssue checkGeneralScriptExpireSetting(final Settings settings, final PluginsAndModules pluginsAndModules,
+                                                                   ClusterState cs) {
         return checkDeprecatedSetting(
             settings,
             pluginsAndModules,
@@ -239,7 +246,8 @@ class NodeDeprecationChecks {
         );
     }
 
-    public static DeprecationIssue checkGeneralScriptCompileSettings(final Settings settings, final PluginsAndModules pluginsAndModules) {
+    public static DeprecationIssue checkGeneralScriptCompileSettings(final Settings settings, final PluginsAndModules pluginsAndModules,
+                                                                     ClusterState cs) {
         return checkDeprecatedSetting(
             settings,
             pluginsAndModules,
@@ -271,7 +279,8 @@ class NodeDeprecationChecks {
         );
     }
 
-    static DeprecationIssue checkBootstrapSystemCallFilterSetting(final Settings settings, final PluginsAndModules pluginsAndModules) {
+    static DeprecationIssue checkBootstrapSystemCallFilterSetting(final Settings settings, final PluginsAndModules pluginsAndModules,
+                                                                  ClusterState cs) {
         return checkRemovedSetting(
             settings,
             BootstrapSettings.SYSTEM_CALL_FILTER_SETTING,
@@ -375,7 +384,7 @@ class NodeDeprecationChecks {
         return new DeprecationIssue(DeprecationIssue.Level.CRITICAL, message, url, details);
     }
 
-    static DeprecationIssue javaVersionCheck(Settings nodeSettings, PluginsAndModules plugins) {
+    static DeprecationIssue javaVersionCheck(Settings nodeSettings, PluginsAndModules plugins, ClusterState state) {
         final JavaVersion javaVersion = JavaVersion.current();
 
         if (javaVersion.compareTo(JavaVersion.parse("11")) < 0) {
@@ -389,7 +398,7 @@ class NodeDeprecationChecks {
         return null;
     }
 
-    static DeprecationIssue checkMultipleDataPaths(Settings nodeSettings, PluginsAndModules plugins) {
+    static DeprecationIssue checkMultipleDataPaths(Settings nodeSettings, PluginsAndModules plugins, ClusterState state) {
         List<String> dataPaths = Environment.PATH_DATA_SETTING.get(nodeSettings);
         if (dataPaths.size() > 1) {
             return new DeprecationIssue(DeprecationIssue.Level.CRITICAL,
@@ -400,7 +409,7 @@ class NodeDeprecationChecks {
         return null;
     }
 
-    static DeprecationIssue checkDataPathsList(Settings nodeSettings, PluginsAndModules plugins) {
+    static DeprecationIssue checkDataPathsList(Settings nodeSettings, PluginsAndModules plugins, ClusterState state) {
         if (Environment.dataPathUsesList(nodeSettings)) {
             return new DeprecationIssue(DeprecationIssue.Level.CRITICAL,
                 "[path.data] in a list is deprecated, use a string value",
@@ -410,7 +419,8 @@ class NodeDeprecationChecks {
         return null;
     }
 
-    static DeprecationIssue checkSharedDataPathSetting(final Settings settings, final PluginsAndModules pluginsAndModules) {
+    static DeprecationIssue checkSharedDataPathSetting(final Settings settings, final PluginsAndModules pluginsAndModules,
+                                                       ClusterState state) {
         if (Environment.PATH_SHARED_DATA_SETTING.exists(settings)) {
             final String message = String.format(Locale.ROOT,
                 "setting [%s] is deprecated and will be removed in a future version", Environment.PATH_SHARED_DATA_SETTING.getKey());
@@ -422,7 +432,8 @@ class NodeDeprecationChecks {
         return null;
     }
 
-    static DeprecationIssue checkSingleDataNodeWatermarkSetting(final Settings settings, final PluginsAndModules pluginsAndModules) {
+    static DeprecationIssue checkSingleDataNodeWatermarkSetting(final Settings settings, final PluginsAndModules pluginsAndModules,
+                                                                ClusterState state) {
         if (DiskThresholdDecider.ENABLE_FOR_SINGLE_DATA_NODE.get(settings) == false
             && DiskThresholdDecider.ENABLE_FOR_SINGLE_DATA_NODE.exists(settings)) {
             String key = DiskThresholdDecider.ENABLE_FOR_SINGLE_DATA_NODE.getKey();
@@ -433,6 +444,24 @@ class NodeDeprecationChecks {
                 String.format(Locale.ROOT, "found [%s] configured to false. Discontinue use of this setting or set it to true.", key)
             );
         }
+
+        if (DiskThresholdDecider.ENABLE_FOR_SINGLE_DATA_NODE.get(settings) == false
+            && state.getNodes().getDataNodes().size() == 1 && state.getNodes().getLocalNode().isMasterNode()) {
+            String key = DiskThresholdDecider.ENABLE_FOR_SINGLE_DATA_NODE.getKey();
+            String disableDiskDecider = DiskThresholdSettings.CLUSTER_ROUTING_ALLOCATION_DISK_THRESHOLD_ENABLED_SETTING.getKey();
+            return new DeprecationIssue(DeprecationIssue.Level.CRITICAL,
+                String.format(Locale.ROOT, "the default value [false] of setting [%s] is deprecated and will be changed to true" +
+                    " in a future version. This cluster has only one data node and behavior will therefore change when upgrading", key),
+                "https://www.elastic.co/guide/en/elasticsearch/reference/7.14/" +
+                    "breaking-changes-7.14.html#deprecate-single-data-node-watermark",
+                String.format(Locale.ROOT, "found [%s] defaulting to false on a single data node cluster." +
+                        " Set it to true to avoid this warning." +
+                        " Consider using [%s] to disable disk based allocation", key,
+                    disableDiskDecider)
+            );
+
+        }
+
 
         return null;
     }

--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/NodeDeprecationChecks.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/NodeDeprecationChecks.java
@@ -44,7 +44,8 @@ import java.util.stream.Collectors;
 
 class NodeDeprecationChecks {
 
-    static DeprecationIssue checkPidfile(final Settings settings, final PluginsAndModules pluginsAndModules, ClusterState cs) {
+    static DeprecationIssue checkPidfile(final Settings settings, final PluginsAndModules pluginsAndModules,
+                                         final ClusterState clusterState) {
         return checkDeprecatedSetting(
             settings,
             pluginsAndModules,
@@ -53,7 +54,8 @@ class NodeDeprecationChecks {
             "https://www.elastic.co/guide/en/elasticsearch/reference/7.4/breaking-changes-7.4.html#deprecate-pidfile");
     }
 
-    static DeprecationIssue checkProcessors(final Settings settings , final PluginsAndModules pluginsAndModules, ClusterState cs) {
+    static DeprecationIssue checkProcessors(final Settings settings , final PluginsAndModules pluginsAndModules,
+                                            final ClusterState clusterState) {
         return checkDeprecatedSetting(
             settings,
             pluginsAndModules,
@@ -62,7 +64,8 @@ class NodeDeprecationChecks {
             "https://www.elastic.co/guide/en/elasticsearch/reference/7.4/breaking-changes-7.4.html#deprecate-processors");
     }
 
-    static DeprecationIssue checkMissingRealmOrders(final Settings settings, final PluginsAndModules pluginsAndModules, ClusterState cs) {
+    static DeprecationIssue checkMissingRealmOrders(final Settings settings, final PluginsAndModules pluginsAndModules,
+                                                    final ClusterState clusterState) {
         final Set<String> orderNotConfiguredRealms = RealmSettings.getRealmSettings(settings).entrySet()
                 .stream()
                 .filter(e -> false == e.getValue().hasValue(RealmSettings.ORDER_SETTING_KEY))
@@ -86,7 +89,8 @@ class NodeDeprecationChecks {
         );
     }
 
-    static DeprecationIssue checkUniqueRealmOrders(final Settings settings, final PluginsAndModules pluginsAndModules, ClusterState cs) {
+    static DeprecationIssue checkUniqueRealmOrders(final Settings settings, final PluginsAndModules pluginsAndModules,
+                                                   final ClusterState clusterState) {
         final Map<String, List<String>> orderToRealmSettings =
             RealmSettings.getRealmSettings(settings).entrySet()
                 .stream()
@@ -120,7 +124,7 @@ class NodeDeprecationChecks {
     }
 
     static DeprecationIssue checkImplicitlyDisabledBasicRealms(final Settings settings, final PluginsAndModules pluginsAndModules,
-                                                               ClusterState cs) {
+                                                               final ClusterState clusterState) {
         final Map<RealmConfig.RealmIdentifier, Settings> realmSettings = RealmSettings.getRealmSettings(settings);
         if (realmSettings.isEmpty()) {
             return null;
@@ -191,7 +195,7 @@ class NodeDeprecationChecks {
     }
 
     public static DeprecationIssue checkClusterRemoteConnectSetting(final Settings settings, final PluginsAndModules pluginsAndModules,
-                                                                    ClusterState cs) {
+                                                                    final ClusterState clusterState) {
         return checkDeprecatedSetting(
             settings,
             pluginsAndModules,
@@ -206,7 +210,7 @@ class NodeDeprecationChecks {
     }
 
     public static DeprecationIssue checkNodeLocalStorageSetting(final Settings settings, final PluginsAndModules pluginsAndModules,
-                                                                ClusterState cs) {
+                                                                final ClusterState clusterState) {
         return checkRemovedSetting(
             settings,
             Node.NODE_LOCAL_STORAGE_SETTING,
@@ -223,7 +227,7 @@ class NodeDeprecationChecks {
     }
 
     public static DeprecationIssue checkGeneralScriptSizeSetting(final Settings settings, final PluginsAndModules pluginsAndModules,
-                                                                 ClusterState cs) {
+                                                                 final ClusterState clusterState) {
         return checkDeprecatedSetting(
             settings,
             pluginsAndModules,
@@ -235,7 +239,7 @@ class NodeDeprecationChecks {
     }
 
     public static DeprecationIssue checkGeneralScriptExpireSetting(final Settings settings, final PluginsAndModules pluginsAndModules,
-                                                                   ClusterState cs) {
+                                                                   final ClusterState clusterState) {
         return checkDeprecatedSetting(
             settings,
             pluginsAndModules,
@@ -247,7 +251,7 @@ class NodeDeprecationChecks {
     }
 
     public static DeprecationIssue checkGeneralScriptCompileSettings(final Settings settings, final PluginsAndModules pluginsAndModules,
-                                                                     ClusterState cs) {
+                                                                     final ClusterState clusterState) {
         return checkDeprecatedSetting(
             settings,
             pluginsAndModules,
@@ -280,7 +284,7 @@ class NodeDeprecationChecks {
     }
 
     static DeprecationIssue checkBootstrapSystemCallFilterSetting(final Settings settings, final PluginsAndModules pluginsAndModules,
-                                                                  ClusterState cs) {
+                                                                  final ClusterState clusterState) {
         return checkRemovedSetting(
             settings,
             BootstrapSettings.SYSTEM_CALL_FILTER_SETTING,
@@ -384,7 +388,7 @@ class NodeDeprecationChecks {
         return new DeprecationIssue(DeprecationIssue.Level.CRITICAL, message, url, details);
     }
 
-    static DeprecationIssue javaVersionCheck(Settings nodeSettings, PluginsAndModules plugins, ClusterState state) {
+    static DeprecationIssue javaVersionCheck(Settings nodeSettings, PluginsAndModules plugins, final ClusterState clusterState) {
         final JavaVersion javaVersion = JavaVersion.current();
 
         if (javaVersion.compareTo(JavaVersion.parse("11")) < 0) {
@@ -398,7 +402,7 @@ class NodeDeprecationChecks {
         return null;
     }
 
-    static DeprecationIssue checkMultipleDataPaths(Settings nodeSettings, PluginsAndModules plugins, ClusterState state) {
+    static DeprecationIssue checkMultipleDataPaths(Settings nodeSettings, PluginsAndModules plugins, final ClusterState clusterState) {
         List<String> dataPaths = Environment.PATH_DATA_SETTING.get(nodeSettings);
         if (dataPaths.size() > 1) {
             return new DeprecationIssue(DeprecationIssue.Level.CRITICAL,
@@ -409,7 +413,7 @@ class NodeDeprecationChecks {
         return null;
     }
 
-    static DeprecationIssue checkDataPathsList(Settings nodeSettings, PluginsAndModules plugins, ClusterState state) {
+    static DeprecationIssue checkDataPathsList(Settings nodeSettings, PluginsAndModules plugins, final ClusterState clusterState) {
         if (Environment.dataPathUsesList(nodeSettings)) {
             return new DeprecationIssue(DeprecationIssue.Level.CRITICAL,
                 "[path.data] in a list is deprecated, use a string value",
@@ -420,7 +424,7 @@ class NodeDeprecationChecks {
     }
 
     static DeprecationIssue checkSharedDataPathSetting(final Settings settings, final PluginsAndModules pluginsAndModules,
-                                                       ClusterState state) {
+                                                       final ClusterState clusterState) {
         if (Environment.PATH_SHARED_DATA_SETTING.exists(settings)) {
             final String message = String.format(Locale.ROOT,
                 "setting [%s] is deprecated and will be removed in a future version", Environment.PATH_SHARED_DATA_SETTING.getKey());
@@ -433,7 +437,7 @@ class NodeDeprecationChecks {
     }
 
     static DeprecationIssue checkSingleDataNodeWatermarkSetting(final Settings settings, final PluginsAndModules pluginsAndModules,
-                                                                ClusterState state) {
+                                                                final ClusterState clusterState) {
         if (DiskThresholdDecider.ENABLE_FOR_SINGLE_DATA_NODE.get(settings) == false
             && DiskThresholdDecider.ENABLE_FOR_SINGLE_DATA_NODE.exists(settings)) {
             String key = DiskThresholdDecider.ENABLE_FOR_SINGLE_DATA_NODE.getKey();
@@ -446,7 +450,7 @@ class NodeDeprecationChecks {
         }
 
         if (DiskThresholdDecider.ENABLE_FOR_SINGLE_DATA_NODE.get(settings) == false
-            && state.getNodes().getDataNodes().size() == 1 && state.getNodes().getLocalNode().isMasterNode()) {
+            && clusterState.getNodes().getDataNodes().size() == 1 && clusterState.getNodes().getLocalNode().isMasterNode()) {
             String key = DiskThresholdDecider.ENABLE_FOR_SINGLE_DATA_NODE.getKey();
             String disableDiskDecider = DiskThresholdSettings.CLUSTER_ROUTING_ALLOCATION_DISK_THRESHOLD_ENABLED_SETTING.getKey();
             return new DeprecationIssue(DeprecationIssue.Level.CRITICAL,

--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/TransportNodeDeprecationCheckAction.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/TransportNodeDeprecationCheckAction.java
@@ -67,7 +67,7 @@ public class TransportNodeDeprecationCheckAction extends TransportNodesAction<No
     @Override
     protected NodesDeprecationCheckAction.NodeResponse nodeOperation(NodesDeprecationCheckAction.NodeRequest request) {
         List<DeprecationIssue> issues = DeprecationInfoAction.filterChecks(DeprecationChecks.NODE_SETTINGS_CHECKS,
-            (c) -> c.apply(settings, pluginsService.info()));
+            (c) -> c.apply(settings, pluginsService.info(), clusterService.state()));
 
         return new NodesDeprecationCheckAction.NodeResponse(transportService.getLocalNode(), issues);
     }

--- a/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/NodeDeprecationChecksTests.java
+++ b/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/NodeDeprecationChecksTests.java
@@ -612,7 +612,7 @@ public class NodeDeprecationChecksTests extends ESTestCase {
         final String expectedUrl =
             "https://www.elastic.co/guide/en/elasticsearch/reference/7.14/" +
                 "breaking-changes-7.14.html#deprecate-single-data-node-watermark";
-        assertThat(issues, contains(
+        assertThat(issues, hasItem(
             new DeprecationIssue(DeprecationIssue.Level.CRITICAL,
                 "setting [cluster.routing.allocation.disk.watermark.enable_for_single_data_node=false] is deprecated and" +
                     " will not be available in a future version",

--- a/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/NodeDeprecationChecksTests.java
+++ b/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/NodeDeprecationChecksTests.java
@@ -7,9 +7,12 @@
 
 package org.elasticsearch.xpack.deprecation;
 
+import org.elasticsearch.Version;
 import org.elasticsearch.action.admin.cluster.node.info.PluginsAndModules;
+import org.elasticsearch.action.support.replication.ClusterStateCreationUtils;
 import org.elasticsearch.bootstrap.BootstrapSettings;
 import org.elasticsearch.bootstrap.JavaVersion;
+import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodeRole;
 import org.elasticsearch.common.settings.Setting;
@@ -56,7 +59,7 @@ public class NodeDeprecationChecksTests extends ESTestCase {
         final PluginsAndModules pluginsAndModules = new PluginsAndModules(Collections.emptyList(), Collections.emptyList());
         final List<DeprecationIssue> issues = DeprecationChecks.filterChecks(
             DeprecationChecks.NODE_SETTINGS_CHECKS,
-            c -> c.apply(Settings.EMPTY, pluginsAndModules)
+            c -> c.apply(Settings.EMPTY, pluginsAndModules, ClusterState.EMPTY_STATE)
         );
 
         final DeprecationIssue expected = new DeprecationIssue(
@@ -137,7 +140,7 @@ public class NodeDeprecationChecksTests extends ESTestCase {
         final Settings settings =
             Settings.builder()
                 .put("xpack.security.authc.realms." + realmIdentifier.getType() + "." + realmIdentifier.getName() + ".enabled", "false")
-            .build();
+                .build();
         final PluginsAndModules pluginsAndModules = new PluginsAndModules(Collections.emptyList(), Collections.emptyList());
         final List<DeprecationIssue> deprecationIssues = getDeprecationIssues(settings, pluginsAndModules);
         assertTrue(deprecationIssues.isEmpty());
@@ -469,7 +472,8 @@ public class NodeDeprecationChecksTests extends ESTestCase {
         final PluginsAndModules pluginsAndModules =
             new PluginsAndModules(org.elasticsearch.common.collect.List.of(), org.elasticsearch.common.collect.List.of());
         final List<DeprecationIssue> issues =
-            DeprecationChecks.filterChecks(DeprecationChecks.NODE_SETTINGS_CHECKS, c -> c.apply(settings, pluginsAndModules));
+            DeprecationChecks.filterChecks(DeprecationChecks.NODE_SETTINGS_CHECKS,
+                c -> c.apply(settings, pluginsAndModules, ClusterState.EMPTY_STATE));
         final DeprecationIssue expected = new DeprecationIssue(
             DeprecationIssue.Level.CRITICAL,
             "setting [bootstrap.system_call_filter] is deprecated and will be removed in the next major version",
@@ -510,7 +514,7 @@ public class NodeDeprecationChecksTests extends ESTestCase {
     private List<DeprecationIssue> getDeprecationIssues(Settings settings, PluginsAndModules pluginsAndModules) {
         final List<DeprecationIssue> issues = DeprecationChecks.filterChecks(
             DeprecationChecks.NODE_SETTINGS_CHECKS,
-            c -> c.apply(settings, pluginsAndModules)
+            c -> c.apply(settings, pluginsAndModules, ClusterState.EMPTY_STATE)
         );
 
         if (isJvmEarlierThan11()) {
@@ -536,7 +540,7 @@ public class NodeDeprecationChecksTests extends ESTestCase {
 
     public void testMultipleDataPaths() {
         final Settings settings = Settings.builder().putList("path.data", Arrays.asList("d1", "d2")).build();
-        final DeprecationIssue issue = NodeDeprecationChecks.checkMultipleDataPaths(settings, null);
+        final DeprecationIssue issue = NodeDeprecationChecks.checkMultipleDataPaths(settings, null, null);
         assertThat(issue, not(nullValue()));
         assertThat(issue.getLevel(), equalTo(DeprecationIssue.Level.CRITICAL));
         assertThat(
@@ -552,13 +556,13 @@ public class NodeDeprecationChecksTests extends ESTestCase {
 
     public void testNoMultipleDataPaths() {
         Settings settings = Settings.builder().put("path.data", "data").build();
-        final DeprecationIssue issue = NodeDeprecationChecks.checkMultipleDataPaths(settings, null);
+        final DeprecationIssue issue = NodeDeprecationChecks.checkMultipleDataPaths(settings, null, null);
         assertThat(issue, nullValue());
     }
 
     public void testDataPathsList() {
         final Settings settings = Settings.builder().putList("path.data", "d1").build();
-        final DeprecationIssue issue = NodeDeprecationChecks.checkDataPathsList(settings, null);
+        final DeprecationIssue issue = NodeDeprecationChecks.checkDataPathsList(settings, null, null);
         assertThat(issue, not(nullValue()));
         assertThat(issue.getLevel(), equalTo(DeprecationIssue.Level.CRITICAL));
         assertThat(
@@ -574,7 +578,7 @@ public class NodeDeprecationChecksTests extends ESTestCase {
 
     public void testNoDataPathsListDefault() {
         final Settings settings = Settings.builder().build();
-        final DeprecationIssue issue = NodeDeprecationChecks.checkDataPathsList(settings, null);
+        final DeprecationIssue issue = NodeDeprecationChecks.checkDataPathsList(settings, null, null);
         assertThat(issue, nullValue());
     }
 
@@ -583,7 +587,7 @@ public class NodeDeprecationChecksTests extends ESTestCase {
             .put(Environment.PATH_HOME_SETTING.getKey(), createTempDir())
             .put(Environment.PATH_SHARED_DATA_SETTING.getKey(), createTempDir()).build();
 
-        DeprecationIssue issue = NodeDeprecationChecks.checkSharedDataPathSetting(settings, null);
+        DeprecationIssue issue = NodeDeprecationChecks.checkSharedDataPathSetting(settings, null, null);
         final String expectedUrl =
             "https://www.elastic.co/guide/en/elasticsearch/reference/7.13/breaking-changes-7.13.html#deprecate-shared-data-path-setting";
         assertThat(issue, equalTo(
@@ -594,13 +598,13 @@ public class NodeDeprecationChecksTests extends ESTestCase {
             )));
     }
 
-    public void testSingleDataNodeWatermarkSetting() {
+    public void testSingleDataNodeWatermarkSettingExplicit() {
         Settings settings = Settings.builder()
             .put(DiskThresholdDecider.ENABLE_FOR_SINGLE_DATA_NODE.getKey(), false)
             .build();
 
         List<DeprecationIssue> issues = DeprecationChecks.filterChecks(DeprecationChecks.NODE_SETTINGS_CHECKS, c -> c.apply(settings,
-            null));
+            null, null));
 
         final String expectedUrl =
             "https://www.elastic.co/guide/en/elasticsearch/reference/7.14/" +
@@ -616,5 +620,45 @@ public class NodeDeprecationChecksTests extends ESTestCase {
 
         assertWarnings("setting [cluster.routing.allocation.disk.watermark.enable_for_single_data_node=false] is deprecated and" +
             " will not be available in a future version");
+    }
+
+    public void testSingleDataNodeWatermarkSettingDefault() {
+        DiscoveryNode node1 = new DiscoveryNode(randomAlphaOfLength(5), buildNewFakeTransportAddress(), Version.CURRENT);
+        DiscoveryNode node2 = new DiscoveryNode(randomAlphaOfLength(5), buildNewFakeTransportAddress(), Version.CURRENT);
+        DiscoveryNode master = new DiscoveryNode(randomAlphaOfLength(6), buildNewFakeTransportAddress(), Collections.emptyMap(),
+            Collections.singleton(DiscoveryNodeRole.MASTER_ROLE),
+            Version.CURRENT);
+        ClusterStateCreationUtils.state(node1, node1, node1);
+
+        final List<DeprecationIssue> issues = DeprecationChecks.filterChecks(DeprecationChecks.NODE_SETTINGS_CHECKS,
+            c -> c.apply(Settings.EMPTY,
+                null, ClusterStateCreationUtils.state(node1, node1, node1)));
+
+        final String expectedUrl =
+            "https://www.elastic.co/guide/en/elasticsearch/reference/7.14/" +
+                "breaking-changes-7.14.html#deprecate-single-data-node-watermark";
+        DeprecationIssue deprecationIssue = new DeprecationIssue(DeprecationIssue.Level.CRITICAL,
+            "the default value [false] of setting [cluster.routing.allocation.disk.watermark.enable_for_single_data_node]" +
+                " is deprecated and will be changed to true in a future version." +
+                " This cluster has only one data node and behavior will therefore change when upgrading",
+            expectedUrl,
+            "found [cluster.routing.allocation.disk.watermark.enable_for_single_data_node] defaulting to false" +
+                " on a single data node cluster. Set it to true to avoid this warning." +
+                " Consider using [cluster.routing.allocation.disk.threshold_enabled] to disable disk based allocation"
+        );
+
+        assertThat(issues, hasItem(deprecationIssue));
+
+        assertThat(NodeDeprecationChecks.checkSingleDataNodeWatermarkSetting(Settings.EMPTY, null, ClusterStateCreationUtils.state(master
+            , master, master)),
+            nullValue());
+
+        assertThat(NodeDeprecationChecks.checkSingleDataNodeWatermarkSetting(Settings.EMPTY, null, ClusterStateCreationUtils.state(node1,
+            node1, node1, node2)),
+            nullValue());
+
+        assertThat(NodeDeprecationChecks.checkSingleDataNodeWatermarkSetting(Settings.EMPTY, null, ClusterStateCreationUtils.state(node1,
+            master, node1, master)),
+            equalTo(deprecationIssue));
     }
 }

--- a/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/NodeDeprecationChecksTests.java
+++ b/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/NodeDeprecationChecksTests.java
@@ -32,7 +32,6 @@ import java.util.List;
 import java.util.Locale;
 import java.util.stream.Collectors;
 
-import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
@@ -41,14 +40,8 @@ import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.Matchers.startsWith;
 
-import java.util.List;
 
 import org.elasticsearch.cluster.routing.allocation.decider.DiskThresholdDecider;
-import org.elasticsearch.common.settings.Setting;
-import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.env.Environment;
-import org.elasticsearch.test.ESTestCase;
-import org.elasticsearch.xpack.core.deprecation.DeprecationIssue;
 
 public class NodeDeprecationChecksTests extends ESTestCase {
 


### PR DESCRIPTION
In #55805, we added a setting to allow single data node clusters to
respect the high watermark. This commit adds deprecation warnings to 7.x
to ensure we can make only true valid in 8.0.
