### PR TITLE
[Backport 7.13] [DOCS] Fix client_authentication setting default

### DIFF
--- a/docs/reference/settings/ssl-settings.asciidoc
+++ b/docs/reference/settings/ssl-settings.asciidoc
@@ -19,7 +19,7 @@ from client connections. Valid values are `required`, `optional`, and `none`.
 `required` forces a client to present a certificate, while `optional`
 requests a client certificate but the client is not required to present one.
 ifndef::client-auth-default[]
-Defaults to `none`.
+Defaults to `required`.
 endif::client-auth-default[]
 ifdef::client-auth-default[]
 Defaults to +{client-auth-default}+.


### PR DESCRIPTION
The value of `*.ssl.client_authentication` is `required` for
everything except `xpack.security.http.ssl.client_authentication`, for
which is it `none`.

The doc template for this setting was configured to have a default
value, and allow an override. However, the default was set to `none`
when it should have been `required`.

The override for `http` was correctly set to `none` (but that didn't
really do anything, since that was the same as the default).

This commit changes the default to `required`, which matches the code
(see `XPackSettings.CLIENT_AUTH_DEFAULT`), and leaves the override for
http as `none` (see `XPackSettings.HTTP_CLIENT_AUTH_DEFAULT`).

Backport of: #73743
