### PR TITLE
[7.x] Let ESRestTestCase clean up after test in 10_usage.yml (#73716)

### DIFF
--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/searchable_snapshots/10_usage.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/searchable_snapshots/10_usage.yml
@@ -50,18 +50,6 @@ setup:
   - do:
       indices.delete:
         index: docs
----
-teardown:
-
-  - do:
-      snapshot.delete:
-        repository: repository-fs
-        snapshot: snapshot
-        ignore: 404
-
-  - do:
-      snapshot.delete_repository:
-        repository: repository-fs
 
 ---
 "Tests searchable snapshots usage stats":


### PR DESCRIPTION
In #73555 we updated ESRestTestCase so that it cleans 
up the searchable snapshots indices before cleaning up 
the snapshots and repositories. This test does not require 
to delete resources itself and can let ESRestTestCase do
 the clean up in the correct order.