### PR TITLE
Change year max digits for strict_date_optional_time and date_optional_time backports(#73034)

### DIFF
--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/ml/calendars/ScheduledEventTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/ml/calendars/ScheduledEventTests.java
@@ -9,6 +9,7 @@
 package org.elasticsearch.client.ml.calendars;
 
 import org.elasticsearch.common.Nullable;
+import org.elasticsearch.common.time.DateUtils;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.test.AbstractXContentTestCase;
 
@@ -17,8 +18,9 @@ import java.util.Date;
 public class ScheduledEventTests extends AbstractXContentTestCase<ScheduledEvent> {
 
     public static ScheduledEvent testInstance(String calendarId, @Nullable String eventId) {
-        Date start = new Date(randomNonNegativeLong());
-        Date end = new Date(start.getTime() + randomIntBetween(1, 10000) * 1000);
+        int duration = randomIntBetween(1, 10000) * 1000;
+        Date start = new Date(randomLongBetween(1, DateUtils.MAX_MILLIS_BEFORE_9999) - duration );
+        Date end = new Date(start.getTime() + duration);
 
         return new ScheduledEvent(randomAlphaOfLength(10), start, end, calendarId, eventId);
     }

--- a/server/src/main/java/org/elasticsearch/common/time/DateFormatters.java
+++ b/server/src/main/java/org/elasticsearch/common/time/DateFormatters.java
@@ -59,8 +59,21 @@ public class DateFormatters {
         .toFormatter(Locale.ROOT)
         .withResolverStyle(ResolverStyle.STRICT);
 
+    private static final DateTimeFormatter STRICT_YEAR_MONTH_DAY_PRINTER = new DateTimeFormatterBuilder()
+        .appendValue(ChronoField.YEAR, 4, 9, SignStyle.EXCEEDS_PAD)
+        .optionalStart()
+        .appendLiteral("-")
+        .appendValue(MONTH_OF_YEAR, 2, 2, SignStyle.NOT_NEGATIVE)
+        .optionalStart()
+        .appendLiteral('-')
+        .appendValue(DAY_OF_MONTH, 2, 2, SignStyle.NOT_NEGATIVE)
+        .optionalEnd()
+        .optionalEnd()
+        .toFormatter(Locale.ROOT)
+        .withResolverStyle(ResolverStyle.STRICT);
+
     private static final DateTimeFormatter STRICT_YEAR_MONTH_DAY_FORMATTER = new DateTimeFormatterBuilder()
-        .appendValue(ChronoField.YEAR, 4, 10, SignStyle.EXCEEDS_PAD)
+        .appendValue(ChronoField.YEAR, 4, 4, SignStyle.EXCEEDS_PAD)
         .optionalStart()
         .appendLiteral("-")
         .appendValue(MONTH_OF_YEAR, 2, 2, SignStyle.NOT_NEGATIVE)
@@ -83,7 +96,7 @@ public class DateFormatters {
         .withResolverStyle(ResolverStyle.STRICT);
 
     private static final DateTimeFormatter STRICT_DATE_OPTIONAL_TIME_PRINTER = new DateTimeFormatterBuilder()
-        .append(STRICT_YEAR_MONTH_DAY_FORMATTER)
+        .append(STRICT_YEAR_MONTH_DAY_PRINTER)
         .appendLiteral('T')
         .optionalStart()
         .appendValue(HOUR_OF_DAY, 2, 2, SignStyle.NOT_NEGATIVE)
@@ -166,7 +179,7 @@ public class DateFormatters {
         .withResolverStyle(ResolverStyle.STRICT);
 
     private static final DateTimeFormatter STRICT_DATE_OPTIONAL_TIME_PRINTER_NANOS = new DateTimeFormatterBuilder()
-        .append(STRICT_YEAR_MONTH_DAY_FORMATTER)
+        .append(STRICT_YEAR_MONTH_DAY_PRINTER)
         .appendLiteral('T')
         .optionalStart()
         .appendValue(HOUR_OF_DAY, 2, 2, SignStyle.NOT_NEGATIVE)
@@ -578,7 +591,7 @@ public class DateFormatters {
      */
     private static final DateFormatter STRICT_YEAR_MONTH = new JavaDateFormatter("strict_year_month",
         new DateTimeFormatterBuilder()
-            .appendValue(ChronoField.YEAR, 4, 10, SignStyle.EXCEEDS_PAD)
+            .appendValue(ChronoField.YEAR, 4, 4, SignStyle.EXCEEDS_PAD)
             .appendLiteral("-")
             .appendValue(MONTH_OF_YEAR, 2, 2, SignStyle.NOT_NEGATIVE)
             .toFormatter(Locale.ROOT)
@@ -588,7 +601,7 @@ public class DateFormatters {
      * A strict formatter that formats or parses a year, such as '2011'.
      */
     private static final DateFormatter STRICT_YEAR = new JavaDateFormatter("strict_year", new DateTimeFormatterBuilder()
-        .appendValue(ChronoField.YEAR, 4, 10, SignStyle.EXCEEDS_PAD)
+        .appendValue(ChronoField.YEAR, 4, 4, SignStyle.EXCEEDS_PAD)
         .toFormatter(Locale.ROOT)
         .withResolverStyle(ResolverStyle.STRICT));
 
@@ -630,7 +643,7 @@ public class DateFormatters {
     );
 
     private static final DateTimeFormatter STRICT_ORDINAL_DATE_TIME_NO_MILLIS_BASE = new DateTimeFormatterBuilder()
-        .appendValue(ChronoField.YEAR, 4, 10, SignStyle.EXCEEDS_PAD)
+        .appendValue(ChronoField.YEAR, 4, 4, SignStyle.EXCEEDS_PAD)
         .appendLiteral('-')
         .appendValue(DAY_OF_YEAR, 3, 3, SignStyle.NOT_NEGATIVE)
         .appendLiteral('T')
@@ -761,7 +774,7 @@ public class DateFormatters {
         new JavaDateFormatter("strict_hour_minute", DateTimeFormatter.ofPattern("HH:mm", Locale.ROOT));
 
     private static final DateTimeFormatter STRICT_ORDINAL_DATE_TIME_PRINTER = new DateTimeFormatterBuilder()
-        .appendValue(ChronoField.YEAR, 4, 10, SignStyle.EXCEEDS_PAD)
+        .appendValue(ChronoField.YEAR, 4, 4, SignStyle.EXCEEDS_PAD)
         .appendLiteral('-')
         .appendValue(DAY_OF_YEAR, 3, 3, SignStyle.NOT_NEGATIVE)
         .appendLiteral('T')
@@ -775,7 +788,7 @@ public class DateFormatters {
         .withResolverStyle(ResolverStyle.STRICT);
 
     private static final DateTimeFormatter STRICT_ORDINAL_DATE_TIME_FORMATTER_BASE = new DateTimeFormatterBuilder()
-        .appendValue(ChronoField.YEAR, 4, 10, SignStyle.EXCEEDS_PAD)
+        .appendValue(ChronoField.YEAR, 4, 4, SignStyle.EXCEEDS_PAD)
         .appendLiteral('-')
         .appendValue(DAY_OF_YEAR, 3, 3, SignStyle.NOT_NEGATIVE)
         .appendLiteral('T')
@@ -1016,7 +1029,7 @@ public class DateFormatters {
 
     private static final DateTimeFormatter STRICT_ORDINAL_DATE_FORMATTER = new DateTimeFormatterBuilder()
         .parseCaseInsensitive()
-        .appendValue(ChronoField.YEAR, 4, 10, SignStyle.EXCEEDS_PAD)
+        .appendValue(ChronoField.YEAR, 4, 4, SignStyle.EXCEEDS_PAD)
         .appendLiteral('-')
         .appendValue(DAY_OF_YEAR, 3)
         .optionalStart()
@@ -1042,7 +1055,7 @@ public class DateFormatters {
     /////////////////////////////////////////
 
     private static final DateTimeFormatter DATE_FORMATTER = new DateTimeFormatterBuilder()
-        .appendValue(ChronoField.YEAR, 1, 5, SignStyle.NORMAL)
+        .appendValue(ChronoField.YEAR, 1, 9, SignStyle.NORMAL)
         .optionalStart()
         .appendLiteral('-')
         .appendValue(MONTH_OF_YEAR, 1, 2, SignStyle.NOT_NEGATIVE)

--- a/server/src/main/java/org/elasticsearch/common/time/DateUtils.java
+++ b/server/src/main/java/org/elasticsearch/common/time/DateUtils.java
@@ -29,6 +29,9 @@ import static org.elasticsearch.common.time.DateUtilsRounding.getYear;
 import static org.elasticsearch.common.time.DateUtilsRounding.utcMillisAtStartOfYear;
 
 public class DateUtils {
+    public static  final long MAX_MILLIS_BEFORE_9999 = 253402300799999L; // end of year 9999
+    public static  final long MAX_MILLIS_BEFORE_MINUS_9999 = -377705116800000L; // beginning of year -9999
+
     public static DateTimeZone zoneIdToDateTimeZone(ZoneId zoneId) {
         if (zoneId == null) {
             return null;

--- a/server/src/test/java/org/elasticsearch/common/joda/JavaJodaTimeDuellingTests.java
+++ b/server/src/test/java/org/elasticsearch/common/joda/JavaJodaTimeDuellingTests.java
@@ -19,6 +19,7 @@ import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.joda.time.format.DateTimeFormat;
 import org.joda.time.format.ISODateTimeFormat;
+import org.junit.Assert;
 import org.junit.BeforeClass;
 
 import java.time.ZoneId;
@@ -52,6 +53,18 @@ public class JavaJodaTimeDuellingTests extends ESTestCase {
     public void testIncorrectFormat() {
         assertParseException("2021-01-01T23-35-00Z", "strict_date_optional_time||epoch_millis");
         assertParseException("2021-01-01T23-35-00Z", "strict_date_optional_time");
+    }
+
+    public void testMinMillis() {
+        String jodaFormatted = Joda.forPattern("strict_date_optional_time").formatMillis(Long.MIN_VALUE);
+        String javaFormatted = DateFormatter.forPattern("strict_date_optional_time").formatMillis(Long.MIN_VALUE);
+        Assert.assertEquals(jodaFormatted, javaFormatted);
+    }
+    public void testYearParsing() {
+        //this one is considered a year
+        assertSameDate("1234", "strict_date_optional_time||epoch_millis");
+        //this one is considered a 12345milliseconds since epoch
+        assertSameDate("12345", "strict_date_optional_time||epoch_millis");
     }
 
     public void testTimezoneParsing() {

--- a/server/src/test/java/org/elasticsearch/common/time/DateFormattersTests.java
+++ b/server/src/test/java/org/elasticsearch/common/time/DateFormattersTests.java
@@ -90,8 +90,8 @@ public class DateFormattersTests extends ESTestCase {
     public void testPrintersLongMinMaxValue() {
         for (FormatNames format : FormatNames.values()) {
             DateFormatter formatter = DateFormatters.forPattern(format.getSnakeCaseName());
-            formatter.format(DateFieldMapper.Resolution.MILLISECONDS.toInstant(Long.MIN_VALUE));
-            formatter.format(DateFieldMapper.Resolution.MILLISECONDS.toInstant(Long.MAX_VALUE));
+            formatter.format(DateFieldMapper.Resolution.MILLISECONDS.toInstant(DateUtils.MAX_MILLIS_BEFORE_MINUS_9999));
+            formatter.format(DateFieldMapper.Resolution.MILLISECONDS.toInstant(DateUtils.MAX_MILLIS_BEFORE_9999));
         }
         assertWarnings("Format name \"week_year\" is deprecated and will be removed in a future version. Use \"weekyear\" format instead");
     }

--- a/server/src/test/java/org/elasticsearch/common/time/JavaDateMathParserTests.java
+++ b/server/src/test/java/org/elasticsearch/common/time/JavaDateMathParserTests.java
@@ -311,10 +311,10 @@ public class JavaDateMathParserTests extends ESTestCase {
         long datetime = parser.parse("1418248078", () -> 0).toEpochMilli();
         assertDateEquals(datetime, "1418248078", "2014-12-10T21:47:58.000");
 
-        // a timestamp before 100000 is a year
+        // for date_optional_time a timestamp with more than 9digits is epoch
         assertDateMathEquals("9999", "9999-01-01T00:00:00.000");
         assertDateMathEquals("10000", "10000-01-01T00:00:00.000");
-        assertDateMathEquals("100000", "1970-01-01T00:01:40.000");
+        assertDateMathEquals("1000000000", "1970-01-12T13:46:40.000Z");
 
         // but 10000 with T is still a date format
         assertDateMathEquals("10000-01-01T", "10000-01-01T00:00:00.000");

--- a/server/src/test/java/org/elasticsearch/index/mapper/DateFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/DateFieldMapperTests.java
@@ -139,15 +139,17 @@ public class DateFieldMapperTests extends MapperTestCase {
 
     public void testIgnoreMalformed() throws IOException {
         testIgnoreMalformedForValue("2016-03-99",
-                "failed to parse date field [2016-03-99] with format [strict_date_optional_time||epoch_millis]");
+            "failed to parse date field [2016-03-99] with format [strict_date_optional_time||epoch_millis]",
+            "strict_date_optional_time||epoch_millis");
         testIgnoreMalformedForValue("-2147483648",
-                "Invalid value for Year (valid values -999999999 - 999999999): -2147483648");
-        testIgnoreMalformedForValue("-522000000", "long overflow");
+            "failed to parse date field [-2147483648] with format [strict_date_optional_time||epoch_millis]",
+            "strict_date_optional_time||epoch_millis");
+        testIgnoreMalformedForValue("-522000000", "long overflow", "date_optional_time");
     }
 
-    private void testIgnoreMalformedForValue(String value, String expectedCause) throws IOException {
+    private void testIgnoreMalformedForValue(String value, String expectedCause, String dateFormat) throws IOException {
 
-        DocumentMapper mapper = createDocumentMapper(fieldMapping(this::minimalMapping));
+        DocumentMapper mapper = createDocumentMapper(fieldMapping((builder)-> dateFieldMapping(builder, dateFormat)));
 
         MapperParsingException e = expectThrows(MapperParsingException.class,
             () -> mapper.parse(source(b -> b.field("field", value))));
@@ -157,6 +159,7 @@ public class DateFieldMapperTests extends MapperTestCase {
 
         DocumentMapper mapper2 = createDocumentMapper(fieldMapping(b -> b
             .field("type", "date")
+            .field("format", dateFormat)
             .field("ignore_malformed", true)));
 
         ParsedDocument doc = mapper2.parse(source(b -> b.field("field", value)));
@@ -166,6 +169,11 @@ public class DateFieldMapperTests extends MapperTestCase {
         assertArrayEquals(new String[] { "field" }, TermVectorsService.getValues(doc.rootDoc().getFields("_ignored")));
     }
 
+    private void dateFieldMapping(XContentBuilder builder, String dateFormat) throws IOException {
+         builder.field("type", "date");
+         builder.field("format", dateFormat);
+
+    }
     public void testChangeFormat() throws IOException {
 
         DocumentMapper mapper = createDocumentMapper(fieldMapping(b -> b

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/histogram/LongBoundsTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/histogram/LongBoundsTests.java
@@ -12,6 +12,7 @@ import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.time.DateFormatter;
+import org.elasticsearch.common.time.DateUtils;
 import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
@@ -44,8 +45,8 @@ public class LongBoundsTests extends ESTestCase {
      * Construct a random {@link LongBounds} in pre-parsed form.
      */
     public static LongBounds randomParsedExtendedBounds() {
-        long maxDateValue = 253402300799999L; // end of year 9999
-        long minDateValue = -377705116800000L; // beginning of year -9999
+        long maxDateValue = DateUtils.MAX_MILLIS_BEFORE_9999;
+        long minDateValue = DateUtils.MAX_MILLIS_BEFORE_MINUS_9999; // beginning of year -9999
         if (randomBoolean()) {
             // Construct with one missing bound
             if (randomBoolean()) {

--- a/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
@@ -916,6 +916,13 @@ public abstract class ESTestCase extends LuceneTestCase {
     }
 
     /**
+     * generate a random epoch millis in a range 1 to 9999-12-31T23:59:59.999
+     */
+    public long randomMillisUpToYear9999() {
+        return randomLongBetween(1, DateUtils.MAX_MILLIS_BEFORE_9999);
+    }
+
+    /**
      * generate a random TimeZone from the ones available in java.util
      */
     public static TimeZone randomTimeZone() {

--- a/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/topmetrics/InternalTopMetricsTests.java
+++ b/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/topmetrics/InternalTopMetricsTests.java
@@ -13,6 +13,7 @@ import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.time.DateFormatter;
+import org.elasticsearch.common.time.DateUtils;
 import org.elasticsearch.common.util.CollectionUtils;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 import org.elasticsearch.index.mapper.DateFieldMapper;
@@ -36,6 +37,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
 import java.util.stream.IntStream;
@@ -264,15 +266,18 @@ public class InternalTopMetricsTests extends InternalAggregationTestCase<Interna
 
     @Override
     protected InternalTopMetrics createTestInstance(String name, Map<String, Object> metadata) {
-        return createTestInstance(name, metadata, InternalAggregationTestCase::randomNumericDocValueFormat);
+        return createTestInstance(name, metadata, InternalAggregationTestCase::randomNumericDocValueFormat,
+            InternalTopMetricsTests::randomSortValue);
     }
 
     private InternalTopMetrics createTestInstance(String name,
-            Map<String, Object> metadata, Supplier<DocValueFormat> randomDocValueFormat) {
+            Map<String, Object> metadata, Supplier<DocValueFormat> randomDocValueFormat,
+                                                  Function<DocValueFormat,SortValue> sortValueSupplier) {
         int metricCount = between(1, 5);
         List<String> metricNames = randomMetricNames(metricCount);
         int size = between(1, 100);
-        List<InternalTopMetrics.TopMetric> topMetrics = randomTopMetrics(randomDocValueFormat, between(0, size), metricCount);
+        List<InternalTopMetrics.TopMetric> topMetrics = randomTopMetrics(randomDocValueFormat, between(0, size), metricCount,
+            sortValueSupplier);
         return new InternalTopMetrics(name, sortOrder, metricNames, size, topMetrics, metadata);
     }
 
@@ -302,7 +307,8 @@ public class InternalTopMetricsTests extends InternalAggregationTestCase<Interna
             int fixedSize = size;
             int fixedMetricsSize = metricNames.size();
             topMetrics = randomValueOtherThan(topMetrics, () -> randomTopMetrics(
-                    InternalAggregationTestCase::randomNumericDocValueFormat, between(1, fixedSize), fixedMetricsSize));
+                    InternalAggregationTestCase::randomNumericDocValueFormat, between(1, fixedSize), fixedMetricsSize,
+                InternalTopMetricsTests::randomSortValue));
             break;
         default:
             throw new IllegalArgumentException("bad mutation");
@@ -316,7 +322,8 @@ public class InternalTopMetricsTests extends InternalAggregationTestCase<Interna
      * implement {@link Object#equals(Object)}.
      */
     public void testFromXContentDates() throws IOException {
-        InternalTopMetrics aggregation = createTestInstance(randomAlphaOfLength(3), emptyMap(), InternalTopMetricsTests::strictDateTime);
+        InternalTopMetrics aggregation = createTestInstance(randomAlphaOfLength(3),
+            emptyMap(), InternalTopMetricsTests::strictDateTime, InternalTopMetricsTests::randomSortValue);
         ParsedAggregation parsedAggregation = parseAndAssert(aggregation, randomBoolean(), randomBoolean());
         assertFromXContent(aggregation, parsedAggregation);
     }
@@ -360,7 +367,8 @@ public class InternalTopMetricsTests extends InternalAggregationTestCase<Interna
                 randomTopMetrics(
                     InternalAggregationTestCase::randomNumericDocValueFormat,
                     between(0, prototype.getSize()),
-                    prototype.getMetricNames().size()
+                    prototype.getMetricNames().size(),
+                    InternalTopMetricsTests::randomSortValue
                 ),
                 prototype.getMetadata()
             )
@@ -382,12 +390,16 @@ public class InternalTopMetricsTests extends InternalAggregationTestCase<Interna
         assertThat(reduced.getTopMetrics(), equalTo(winners));
     }
 
-    private List<InternalTopMetrics.TopMetric> randomTopMetrics(
-            Supplier<DocValueFormat> randomDocValueFormat, int length, int metricCount) {
+    private List<InternalTopMetrics.TopMetric> randomTopMetrics(Supplier<DocValueFormat> randomDocValueFormat, int length, int metricCount,
+            Function<DocValueFormat,SortValue> sortValueSupplier) {
         return IntStream.range(0, length)
-                .mapToObj(i -> new InternalTopMetrics.TopMetric(
-                        randomDocValueFormat.get(), randomSortValue(), randomMetricValues(randomDocValueFormat, metricCount)
-                ))
+                .mapToObj(i -> {
+                    DocValueFormat docValueFormat = randomDocValueFormat.get();
+                    return new InternalTopMetrics.TopMetric(
+                        docValueFormat, sortValueSupplier.apply(docValueFormat),
+                        randomMetricValues(randomDocValueFormat, metricCount, sortValueSupplier)
+                    );
+                })
                 .sorted((lhs, rhs) -> sortOrder.reverseMul() * lhs.getSortValue().compareTo(rhs.getSortValue()))
                 .collect(toList());
     }
@@ -400,9 +412,13 @@ public class InternalTopMetricsTests extends InternalAggregationTestCase<Interna
         return new ArrayList<>(names);
     }
 
-    private List<InternalTopMetrics.MetricValue> randomMetricValues(Supplier<DocValueFormat> randomDocValueFormat, int metricCount) {
+    private List<InternalTopMetrics.MetricValue> randomMetricValues(Supplier<DocValueFormat> randomDocValueFormat, int metricCount,
+                                                                    Function<DocValueFormat,SortValue> sortValueSupplier) {
         return IntStream.range(0, metricCount)
-                .mapToObj(i -> new InternalTopMetrics.MetricValue(randomDocValueFormat.get(), randomSortValue()))
+                .mapToObj(i -> {
+                    DocValueFormat format = randomDocValueFormat.get();
+                    return new InternalTopMetrics.MetricValue(format, sortValueSupplier.apply(format));
+                })
                 .collect(toList());
     }
 
@@ -418,6 +434,18 @@ public class InternalTopMetricsTests extends InternalAggregationTestCase<Interna
         }
         return SortValue.from(randomDouble());
     }
+
+    private static SortValue randomSortValue(DocValueFormat docValueFormat) {
+        if(docValueFormat instanceof DocValueFormat.DateTime){
+            if (randomBoolean()) {
+                return SortValue.from(randomLongBetween(DateUtils.MAX_MILLIS_BEFORE_MINUS_9999, DateUtils.MAX_MILLIS_BEFORE_9999));
+            }
+            return SortValue.from(
+                randomDoubleBetween(DateUtils.MAX_MILLIS_BEFORE_MINUS_9999, DateUtils.MAX_MILLIS_BEFORE_9999, true));
+        }
+       return randomSortValue();
+    }
+
 
     @Override
     protected Predicate<String> excludePathsFromXContentInsertion() {

--- a/x-pack/plugin/autoscaling/src/internalClusterTest/java/org/elasticsearch/xpack/autoscaling/storage/ProactiveStorageIT.java
+++ b/x-pack/plugin/autoscaling/src/internalClusterTest/java/org/elasticsearch/xpack/autoscaling/storage/ProactiveStorageIT.java
@@ -77,10 +77,7 @@ public class ProactiveStorageIT extends AutoscalingStorageIntegTestCase {
                     .mapToObj(
                         unused -> client().prepareIndex(dsName, "_doc")
                             .setCreate(true)
-                            .setSource(
-                                "@timestamp",
-                                DateFieldMapper.DEFAULT_DATE_TIME_FORMATTER.formatMillis(randomLongBetween(1, Long.MAX_VALUE / 2))
-                            )
+                            .setSource("@timestamp", DateFieldMapper.DEFAULT_DATE_TIME_FORMATTER.formatMillis(randomMillisUpToYear9999()))
                     )
                     .toArray(IndexRequestBuilder[]::new)
             );

--- a/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/MonitoringTestUtils.java
+++ b/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/MonitoringTestUtils.java
@@ -25,7 +25,7 @@ import static org.elasticsearch.test.ESTestCase.buildNewFakeTransportAddress;
 public final class MonitoringTestUtils {
 
     // maximum number of milliseconds before a five digit year comes in, which could change formatting
-    private static  final long MAX_MILLIS_BEFORE_10000 = 253402300799999L;
+    public static  final long MAX_MILLIS_BEFORE_10000 = 253402300799999L;
 
     private MonitoringTestUtils() {
     }

--- a/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/exporter/BaseMonitoringDocTestCase.java
+++ b/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/exporter/BaseMonitoringDocTestCase.java
@@ -10,6 +10,7 @@ import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.UUIDs;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
+import org.elasticsearch.common.time.DateUtils;
 import org.elasticsearch.common.transport.TransportAddress;
 import org.elasticsearch.common.xcontent.LoggingDeprecationHandler;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
@@ -57,7 +58,7 @@ public abstract class BaseMonitoringDocTestCase<T extends MonitoringDoc> extends
     public void setUp() throws Exception {
         super.setUp();
         cluster = UUIDs.randomBase64UUID();
-        timestamp = frequently() ? randomNonNegativeLong() : 0L;
+        timestamp = frequently() ? randomLongBetween(1, DateUtils.MAX_MILLIS_BEFORE_9999) : 0L;
         interval = randomNonNegativeLong();
         node = frequently() ? MonitoringTestUtils.randomMonitoringNode(random()) : null;
         system = randomFrom(MonitoredSystem.values());

--- a/x-pack/plugin/sql/qa/jdbc/src/main/java/org/elasticsearch/xpack/sql/qa/jdbc/JdbcTestUtils.java
+++ b/x-pack/plugin/sql/qa/jdbc/src/main/java/org/elasticsearch/xpack/sql/qa/jdbc/JdbcTestUtils.java
@@ -7,6 +7,7 @@
 package org.elasticsearch.xpack.sql.qa.jdbc;
 
 import org.elasticsearch.Version;
+import org.elasticsearch.common.time.DateUtils;
 import org.elasticsearch.xpack.sql.proto.StringUtils;
 
 import java.sql.Date;

--- a/x-pack/plugin/sql/qa/jdbc/src/main/java/org/elasticsearch/xpack/sql/qa/jdbc/PreparedStatementTestCase.java
+++ b/x-pack/plugin/sql/qa/jdbc/src/main/java/org/elasticsearch/xpack/sql/qa/jdbc/PreparedStatementTestCase.java
@@ -8,6 +8,7 @@ package org.elasticsearch.xpack.sql.qa.jdbc;
 
 import org.elasticsearch.common.collect.Tuple;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.time.DateUtils;
 
 import java.io.IOException;
 import java.math.BigDecimal;
@@ -56,7 +57,7 @@ public abstract class PreparedStatementTestCase extends JdbcIntegrationTestCase 
         byte byteVal = randomByte();
         short shortVal = randomShort();
         BigDecimal bigDecimalVal = BigDecimal.valueOf(randomDouble());
-        long millis = randomNonNegativeLong();
+        long millis = randomLongBetween(1, DateUtils.MAX_MILLIS_BEFORE_9999);
         Calendar calendarVal = Calendar.getInstance(randomTimeZone(), Locale.ROOT);
         Timestamp timestampVal = new Timestamp(millis);
         Timestamp timestampValWithCal = new Timestamp(JdbcTestUtils.convertFromCalendarToUTC(timestampVal.getTime(), calendarVal));
@@ -136,7 +137,7 @@ public abstract class PreparedStatementTestCase extends JdbcIntegrationTestCase 
     }
 
     public void testDatetime() throws IOException, SQLException {
-        long randomMillis = randomNonNegativeLong();
+        long randomMillis = randomLongBetween(1, DateUtils.MAX_MILLIS_BEFORE_9999);
         setupIndexForDateTimeTests(randomMillis);
 
         try (Connection connection = esJdbc()) {
@@ -209,7 +210,7 @@ public abstract class PreparedStatementTestCase extends JdbcIntegrationTestCase 
     }
 
     public void testDate() throws IOException, SQLException {
-        long randomMillis = randomNonNegativeLong();
+        long randomMillis = randomLongBetween(1, DateUtils.MAX_MILLIS_BEFORE_9999);
         setupIndexForDateTimeTests(randomMillis);
 
         try (Connection connection = esJdbc()) {
@@ -233,7 +234,7 @@ public abstract class PreparedStatementTestCase extends JdbcIntegrationTestCase 
     }
 
     public void testTime() throws IOException, SQLException {
-        long randomMillis = randomNonNegativeLong();
+        long randomMillis = randomLongBetween(1, DateUtils.MAX_MILLIS_BEFORE_9999);
         setupIndexForDateTimeTests(randomMillis);
 
         try (Connection connection = esJdbc()) {

--- a/x-pack/plugin/sql/qa/jdbc/src/main/java/org/elasticsearch/xpack/sql/qa/jdbc/ResultSetTestCase.java
+++ b/x-pack/plugin/sql/qa/jdbc/src/main/java/org/elasticsearch/xpack/sql/qa/jdbc/ResultSetTestCase.java
@@ -249,7 +249,7 @@ public abstract class ResultSetTestCase extends JdbcIntegrationTestCase {
         double doubleNotByte = randomDoubleBetween(Byte.MAX_VALUE + 1, Double.MAX_VALUE, true);
         float floatNotByte = randomFloatBetween(Byte.MAX_VALUE + 1, Float.MAX_VALUE);
         String randomString = randomUnicodeOfCodepointLengthBetween(128, 256);
-        long randomDate = randomNonNegativeLong();
+        long randomDate = randomMillisUpToYear9999();
 
         String doubleErrorMessage = (doubleNotByte > Long.MAX_VALUE || doubleNotByte < Long.MIN_VALUE)
             ? Double.toString(doubleNotByte)
@@ -379,7 +379,7 @@ public abstract class ResultSetTestCase extends JdbcIntegrationTestCase {
         double doubleNotShort = randomDoubleBetween(Short.MAX_VALUE + 1, Double.MAX_VALUE, true);
         float floatNotShort = randomFloatBetween(Short.MAX_VALUE + 1, Float.MAX_VALUE);
         String randomString = randomUnicodeOfCodepointLengthBetween(128, 256);
-        long randomDate = randomNonNegativeLong();
+        long randomDate = randomMillisUpToYear9999();
 
         String doubleErrorMessage = (doubleNotShort > Long.MAX_VALUE || doubleNotShort < Long.MIN_VALUE)
             ? Double.toString(doubleNotShort)
@@ -502,7 +502,7 @@ public abstract class ResultSetTestCase extends JdbcIntegrationTestCase {
         double doubleNotInt = randomDoubleBetween(getMaxIntPlusOne().doubleValue(), Double.MAX_VALUE, true);
         float floatNotInt = randomFloatBetween(getMaxIntPlusOne().floatValue(), Float.MAX_VALUE);
         String randomString = randomUnicodeOfCodepointLengthBetween(128, 256);
-        long randomDate = randomNonNegativeLong();
+        long randomDate = randomMillisUpToYear9999();
 
         String doubleErrorMessage = (doubleNotInt > Long.MAX_VALUE || doubleNotInt < Long.MIN_VALUE)
             ? Double.toString(doubleNotInt)
@@ -615,7 +615,7 @@ public abstract class ResultSetTestCase extends JdbcIntegrationTestCase {
         double doubleNotLong = randomDoubleBetween(getMaxLongPlusOne(), Double.MAX_VALUE, true);
         float floatNotLong = randomFloatBetween(getMaxLongPlusOne().floatValue(), Float.MAX_VALUE);
         String randomString = randomUnicodeOfCodepointLengthBetween(128, 256);
-        long randomDate = randomNonNegativeLong();
+        long randomDate = randomMillisUpToYear9999();
 
         index("test", "1", builder -> {
             builder.field("test_double", doubleNotLong);
@@ -719,7 +719,7 @@ public abstract class ResultSetTestCase extends JdbcIntegrationTestCase {
         });
 
         String randomString = randomUnicodeOfCodepointLengthBetween(128, 256);
-        long randomDate = randomNonNegativeLong();
+        long randomDate = randomMillisUpToYear9999();
 
         index("test", "1", builder -> {
             builder.field("test_keyword", randomString);
@@ -802,7 +802,7 @@ public abstract class ResultSetTestCase extends JdbcIntegrationTestCase {
         });
 
         String randomString = randomUnicodeOfCodepointLengthBetween(128, 256);
-        long randomDate = randomNonNegativeLong();
+        long randomDate = randomMillisUpToYear9999();
 
         index("test", "1", builder -> {
             builder.field("test_keyword", randomString);
@@ -1010,7 +1010,7 @@ public abstract class ResultSetTestCase extends JdbcIntegrationTestCase {
         });
 
         String randomString = randomUnicodeOfCodepointLengthBetween(128, 256);
-        long randomDate = randomNonNegativeLong();
+        long randomDate = randomMillisUpToYear9999();
 
         index("test", "1", builder -> {
             builder.field("test_keyword", randomString);
@@ -1046,9 +1046,9 @@ public abstract class ResultSetTestCase extends JdbcIntegrationTestCase {
             builder.startObject("test_date").field("type", "date").endObject();
             builder.startObject("test_date_nanos").field("type", "date_nanos").endObject();
         });
-        long randomDate1 = randomNonNegativeLong();
+        long randomDate1 = randomMillisUpToYear9999();
         long randomDateNanos1 = randomTimeInNanos();
-        long randomDate2 = randomNonNegativeLong();
+        long randomDate2 = randomMillisUpToYear9999();
         long randomDateNanos2 = randomTimeInNanos();
 
         // true values
@@ -1157,7 +1157,7 @@ public abstract class ResultSetTestCase extends JdbcIntegrationTestCase {
     }
 
     public void testGettingDateWithoutCalendar() throws Exception {
-        long randomLongDate = randomNonNegativeLong();
+        long randomLongDate = randomMillisUpToYear9999();
         setupDataForDateTimeTests(randomLongDate);
 
         doWithQuery(SELECT_ALL_FIELDS, results -> {
@@ -1182,7 +1182,7 @@ public abstract class ResultSetTestCase extends JdbcIntegrationTestCase {
     public void testGettingDateWithoutCalendarWithNanos() throws Exception {
         assumeTrue("Driver version [" + JDBC_DRIVER_VERSION + "] doesn't support DATETIME with nanosecond resolution]",
                 versionSupportsDateNanos());
-        long randomLongDate = randomNonNegativeLong();
+        long randomLongDate = randomMillisUpToYear9999();
         long randomLongDateNanos = randomTimeInNanos();
         setupDataForDateTimeTests(randomLongDate, randomLongDateNanos);
 
@@ -1206,7 +1206,7 @@ public abstract class ResultSetTestCase extends JdbcIntegrationTestCase {
     }
 
     public void testGettingDateWithCalendar() throws Exception {
-        long randomLongDate = randomNonNegativeLong();
+        long randomLongDate = randomMillisUpToYear9999();
         setupDataForDateTimeTests(randomLongDate);
 
         String anotherTZId = randomValueOtherThan(timeZoneId, JdbcIntegrationTestCase::randomKnownTimeZone);
@@ -1237,7 +1237,7 @@ public abstract class ResultSetTestCase extends JdbcIntegrationTestCase {
     public void testGettingDateWithCalendarWithNanos() throws Exception {
         assumeTrue("Driver version [" + JDBC_DRIVER_VERSION + "] doesn't support DATETIME with nanosecond resolution]",
                 versionSupportsDateNanos());
-        long randomLongDate = randomNonNegativeLong();
+        long randomLongDate = randomMillisUpToYear9999();
         long randomLongDateNanos = randomTimeInNanos();
         setupDataForDateTimeTests(randomLongDate, randomLongDateNanos);
 
@@ -1266,7 +1266,7 @@ public abstract class ResultSetTestCase extends JdbcIntegrationTestCase {
     }
 
     public void testGettingTimeWithoutCalendar() throws Exception {
-        long randomLongDate = randomNonNegativeLong();
+        long randomLongDate = randomMillisUpToYear9999();
         setupDataForDateTimeTests(randomLongDate);
 
         doWithQuery(SELECT_ALL_FIELDS, results -> {
@@ -1290,7 +1290,7 @@ public abstract class ResultSetTestCase extends JdbcIntegrationTestCase {
     public void testGettingTimeWithoutCalendarWithNanos() throws Exception {
         assumeTrue("Driver version [" + JDBC_DRIVER_VERSION + "] doesn't support DATETIME with nanosecond resolution]",
                 versionSupportsDateNanos());
-        long randomLongDate = randomNonNegativeLong();
+        long randomLongDate = randomMillisUpToYear9999();
         long randomLongDateNanos = randomTimeInNanos();
         setupDataForDateTimeTests(randomLongDate, randomLongDateNanos);
 
@@ -1313,7 +1313,7 @@ public abstract class ResultSetTestCase extends JdbcIntegrationTestCase {
     }
 
     public void testGettingTimeWithCalendar() throws Exception {
-        long randomLongDate = randomNonNegativeLong();
+        long randomLongDate = randomMillisUpToYear9999();
         setupDataForDateTimeTests(randomLongDate);
 
         String anotherTZId = randomValueOtherThan(timeZoneId, JdbcIntegrationTestCase::randomKnownTimeZone);
@@ -1343,7 +1343,7 @@ public abstract class ResultSetTestCase extends JdbcIntegrationTestCase {
     public void testGettingTimeWithCalendarWithNanos() throws Exception {
         assumeTrue("Driver version [" + JDBC_DRIVER_VERSION + "] doesn't support DATETIME with nanosecond resolution]",
                 versionSupportsDateNanos());
-        long randomLongDate = randomNonNegativeLong();
+        long randomLongDate = randomMillisUpToYear9999();
         long randomLongDateNanos = randomTimeInNanos();
         setupDataForDateTimeTests(randomLongDate, randomLongDateNanos);
 
@@ -1371,7 +1371,7 @@ public abstract class ResultSetTestCase extends JdbcIntegrationTestCase {
     }
 
     public void testGettingTimestampWithoutCalendar() throws Exception {
-        long randomLongDate = randomNonNegativeLong();
+        long randomLongDate = randomMillisUpToYear9999();
         long randomLongDateNanos = randomTimeInNanos();
         setupDataForDateTimeTests(randomLongDate, randomLongDateNanos);
 
@@ -1394,7 +1394,7 @@ public abstract class ResultSetTestCase extends JdbcIntegrationTestCase {
     public void testGettingTimestampWithoutCalendarWithNanos() throws Exception {
         assumeTrue("Driver version [" + JDBC_DRIVER_VERSION + "] doesn't support DATETIME with nanosecond resolution]",
                 versionSupportsDateNanos());
-        long randomLongDate = randomNonNegativeLong();
+        long randomLongDate = randomMillisUpToYear9999();
         long randomLongDateNanos = randomTimeInNanos();
         setupDataForDateTimeTests(randomLongDate, randomLongDateNanos);
 
@@ -1416,7 +1416,7 @@ public abstract class ResultSetTestCase extends JdbcIntegrationTestCase {
     public void testGettingTimestampWithoutCalendarWithNanosAgainstDriverWithoutSupport() throws Exception {
         assumeFalse("Driver version [" + JDBC_DRIVER_VERSION + "] supports DATETIME with nanosecond resolution]",
                 versionSupportsDateNanos());
-        long randomLongDate = randomNonNegativeLong();
+        long randomLongDate = randomMillisUpToYear9999();
         long randomLongDateNanos = randomTimeInNanos();
         setupDataForDateTimeTests(randomLongDate, randomLongDateNanos);
 
@@ -1431,7 +1431,7 @@ public abstract class ResultSetTestCase extends JdbcIntegrationTestCase {
     }
 
     public void testGettingTimestampWithCalendar() throws IOException, SQLException {
-        long randomLongDate = randomNonNegativeLong();
+        long randomLongDate = randomMillisUpToYear9999();
         long randomLongDateNanos = randomTimeInNanos();
         setupDataForDateTimeTests(randomLongDate, randomLongDateNanos);
 
@@ -1454,7 +1454,7 @@ public abstract class ResultSetTestCase extends JdbcIntegrationTestCase {
     public void testGettingTimestampWithCalendar_DateNanos() throws IOException, SQLException {
         assumeTrue("Driver version [" + JDBC_DRIVER_VERSION + "] doesn't support DATETIME with nanosecond resolution]",
                 versionSupportsDateNanos());
-        long randomLongDate = randomNonNegativeLong();
+        long randomLongDate = randomMillisUpToYear9999();
         long randomLongDateNanos = randomTimeInNanos();
         setupDataForDateTimeTests(randomLongDate, randomLongDateNanos);
 
@@ -1704,7 +1704,7 @@ public abstract class ResultSetTestCase extends JdbcIntegrationTestCase {
         double d = randomDouble();
         float f = randomFloat();
         boolean randomBool = randomBoolean();
-        long randomLongDate = randomNonNegativeLong();
+        long randomLongDate = randomMillisUpToYear9999();
         String randomString = randomUnicodeOfCodepointLengthBetween(128, 256);
 
         index("test", "1", builder -> {


### PR DESCRIPTION


We changed the default joda behaviour in strict_date_optional_time to
max 4 digits in a year. Java.time implementation should behave the same way.
At the same time date_optional_time should have 9digits for year part.

closes #52396
closes #72191
backports #73034

<!--
Thank you for your interest in and contributing to Elasticsearch! There
are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.
-->

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/elasticsearch/blob/master/CONTRIBUTING.md)?
- If submitting code, have you built your formula locally prior to submission with `gradle check`?
- If submitting code, is your pull request against master? Unless there is a good reason otherwise, we prefer pull requests against master and will backport as needed.
- If submitting code, have you checked that your submission is for an [OS and architecture that we support](https://www.elastic.co/support/matrix#show_os)?
- If you are submitting this code for a class then read our [policy](https://github.com/elastic/elasticsearch/blob/master/CONTRIBUTING.md#contributing-as-part-of-a-class) for that.
