### PR TITLE
Ignore 404-Not Found exceptions when cleaning up resources after tests

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/test/rest/ESRestTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/ESRestTestCase.java
@@ -811,8 +811,14 @@ public abstract class ESRestTestCase extends ESTestCase {
         Map<String, ?> indices = (Map<String, ?>) XContentMapValues.extractValue("metadata.indices", entityAsMap(response));
         if (indices != null) {
             for (String index : indices.keySet()) {
-                assertAcked("Failed to delete searchable snapshot index [" + index + ']',
-                    adminClient().performRequest(new Request("DELETE", index)));
+                try {
+                    assertAcked("Failed to delete searchable snapshot index [" + index + ']',
+                        adminClient().performRequest(new Request("DELETE", index)));
+                } catch (ResponseException e) {
+                    if (isNotFoundResponseException(e) == false) {
+                        throw e;
+                    }
+                }
             }
         }
     }
@@ -1764,5 +1770,13 @@ public abstract class ESRestTestCase extends ESTestCase {
             }
         });
         request.setOptions(options);
+    }
+
+    protected static boolean isNotFoundResponseException(IOException ioe) {
+        if (ioe instanceof ResponseException) {
+            Response response = ((ResponseException) ioe).getResponse();
+            return response.getStatusLine().getStatusCode() == 404;
+        }
+        return false;
     }
 }

--- a/x-pack/plugin/ccr/qa/multi-cluster/src/test/java/org/elasticsearch/xpack/ccr/AutoFollowIT.java
+++ b/x-pack/plugin/ccr/qa/multi-cluster/src/test/java/org/elasticsearch/xpack/ccr/AutoFollowIT.java
@@ -922,7 +922,6 @@ public class AutoFollowIT extends ESCCRRestTestCase {
         for (String index : indices) {
             try {
                 deleteIndex(client, index);
-                deleteIndex(client, index);
             } catch (IOException e) {
                 if (isNotFoundResponseException(e)) {
                     continue;

--- a/x-pack/plugin/ccr/qa/multi-cluster/src/test/java/org/elasticsearch/xpack/ccr/AutoFollowIT.java
+++ b/x-pack/plugin/ccr/qa/multi-cluster/src/test/java/org/elasticsearch/xpack/ccr/AutoFollowIT.java
@@ -903,6 +903,9 @@ public class AutoFollowIT extends ESCCRRestTestCase {
             try {
                 deleteAutoFollowPattern(client, autoFollowPattern);
             } catch (IOException e) {
+                if (isNotFoundResponseException(e)) {
+                    continue;
+                }
                 logger.warn(() -> new ParameterizedMessage("failed to delete auto-follow pattern [{}] after test", autoFollowPattern), e);
             }
         }
@@ -910,13 +913,20 @@ public class AutoFollowIT extends ESCCRRestTestCase {
             try {
                 deleteDataStream(client, dataStream);
             } catch (IOException e) {
+                if (isNotFoundResponseException(e)) {
+                    continue;
+                }
                 logger.warn(() -> new ParameterizedMessage("failed to delete data stream [{}] after test", dataStream), e);
             }
         }
         for (String index : indices) {
             try {
                 deleteIndex(client, index);
+                deleteIndex(client, index);
             } catch (IOException e) {
+                if (isNotFoundResponseException(e)) {
+                    continue;
+                }
                 logger.warn(() -> new ParameterizedMessage("failed to delete index [{}] after test", index), e);
             }
         }


### PR DESCRIPTION
We're doing some clean up logic to delete indices, data streams, auto-follow patterns or searchable snapshot indices in some test classes after a test case is executed. Today we either fail or log a warning if the clean up failed but I think we should simply ignore the 404 - Not Found response exception, like we do in other places for regular indices. 

Note that this change applies only:
- when cleaning up searchable snapshots indices in `ESRestTestCase`
- when cleaning up indices, data streams and auto-follow pattern in `AutoFollowIT`