### PR TITLE
Retry ILM force merge step on shard failures

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/ForceMergeStep.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/ForceMergeStep.java
@@ -6,20 +6,29 @@
  */
 package org.elasticsearch.xpack.core.ilm;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.admin.indices.forcemerge.ForceMergeRequest;
+import org.elasticsearch.action.support.DefaultShardOperationFailedException;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.ClusterStateObserver;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
+import org.elasticsearch.common.Strings;
 
+import java.util.Arrays;
+import java.util.Locale;
 import java.util.Objects;
+import java.util.stream.Collectors;
 
 /**
  * Invokes a force merge on a single index.
  */
 public class ForceMergeStep extends AsyncActionStep {
+
     public static final String NAME = "forcemerge";
+    private static final Logger logger = LogManager.getLogger(ForceMergeStep.class);
     private final int maxNumSegments;
 
     public ForceMergeStep(StepKey key, StepKey nextStepKey, Client client, int maxNumSegments) {
@@ -39,10 +48,29 @@ public class ForceMergeStep extends AsyncActionStep {
     @Override
     public void performAction(IndexMetadata indexMetadata, ClusterState currentState,
                               ClusterStateObserver observer, ActionListener<Boolean> listener) {
-        ForceMergeRequest request = new ForceMergeRequest(indexMetadata.getIndex().getName());
+        String indexName = indexMetadata.getIndex().getName();
+        ForceMergeRequest request = new ForceMergeRequest(indexName);
         request.maxNumSegments(maxNumSegments);
         getClient().admin().indices()
-            .forceMerge(request, ActionListener.wrap(response -> listener.onResponse(true),
+            .forceMerge(request, ActionListener.wrap(
+                response -> {
+                    if (response.getFailedShards() == 0) {
+                        listener.onResponse(true);
+                    } else {
+                        DefaultShardOperationFailedException[] failures = response.getShardFailures();
+                        String policyName = LifecycleSettings.LIFECYCLE_NAME_SETTING.get(indexMetadata.getSettings());
+                        String errorMessage =
+                            String.format(Locale.ROOT, "index [%s] in policy [%s] encountered failures [%s] on step [%s]",
+                                indexName, policyName,
+                                failures == null ? "n/a" : Strings.collectionToDelimitedString(Arrays.stream(failures)
+                                    .map(Strings::toString)
+                                    .collect(Collectors.toList()), ","),
+                                NAME);
+                        logger.warn(errorMessage);
+                        // let's report it as a failure and retry
+                        listener.onFailure(new IllegalStateException(errorMessage));
+                    }
+                },
                 listener::onFailure));
     }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/ForceMergeStep.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/ForceMergeStep.java
@@ -8,6 +8,7 @@ package org.elasticsearch.xpack.core.ilm;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.admin.indices.forcemerge.ForceMergeRequest;
 import org.elasticsearch.action.support.DefaultShardOperationFailedException;
@@ -68,7 +69,7 @@ public class ForceMergeStep extends AsyncActionStep {
                                 NAME);
                         logger.warn(errorMessage);
                         // let's report it as a failure and retry
-                        listener.onFailure(new IllegalStateException(errorMessage));
+                        listener.onFailure(new ElasticsearchException(errorMessage));
                     }
                 },
                 listener::onFailure));

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/ForceMergeStepTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/ForceMergeStepTests.java
@@ -7,17 +7,25 @@
 package org.elasticsearch.xpack.core.ilm;
 
 
+import org.apache.lucene.util.SetOnce;
 import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.admin.indices.forcemerge.ForceMergeRequest;
 import org.elasticsearch.action.admin.indices.forcemerge.ForceMergeResponse;
+import org.elasticsearch.action.support.DefaultShardOperationFailedException;
 import org.elasticsearch.action.support.PlainActionFuture;
+import org.elasticsearch.cluster.ClusterName;
+import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
+import org.elasticsearch.cluster.metadata.Metadata;
+import org.elasticsearch.index.Index;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.xpack.core.ilm.Step.StepKey;
 import org.mockito.Mockito;
 
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
 import static org.mockito.Matchers.any;
 
 public class ForceMergeStepTests extends AbstractStepTestCase<ForceMergeStep> {
@@ -104,5 +112,58 @@ public class ForceMergeStepTests extends AbstractStepTestCase<ForceMergeStep> {
         ForceMergeStep step = new ForceMergeStep(stepKey, nextStepKey, client, maxNumSegments);
         assertSame(exception, expectThrows(Exception.class, () -> PlainActionFuture.<Boolean, Exception>get(
             f -> step.performAction(indexMetadata, null, null, f))));
+    }
+
+    public void testForcemergeFailsOnSomeShards() {
+        int numberOfShards = randomIntBetween(2, 5);
+        IndexMetadata indexMetadata = IndexMetadata.builder(randomAlphaOfLength(10))
+            .settings(settings(Version.CURRENT).put(LifecycleSettings.LIFECYCLE_NAME, "ilmPolicy"))
+            .numberOfShards(numberOfShards).numberOfReplicas(randomIntBetween(0, 5)).build();
+        Index index = indexMetadata.getIndex();
+        ForceMergeResponse forceMergeResponse = Mockito.mock(ForceMergeResponse.class);
+        Mockito.when(forceMergeResponse.getTotalShards()).thenReturn(numberOfShards);
+        Mockito.when(forceMergeResponse.getFailedShards()).thenReturn(numberOfShards - 1);
+        Mockito.when(forceMergeResponse.getStatus()).thenReturn(RestStatus.BAD_REQUEST);
+        Mockito.when(forceMergeResponse.getSuccessfulShards()).thenReturn(1);
+        Mockito.when(forceMergeResponse.getShardFailures()).thenReturn(new DefaultShardOperationFailedException[]{
+            new DefaultShardOperationFailedException(index.getName(), 0, new IllegalArgumentException("couldn't merge"))});
+
+        Step.StepKey stepKey = randomStepKey();
+        StepKey nextStepKey = randomStepKey();
+
+        Mockito.doAnswer(invocationOnMock -> {
+            @SuppressWarnings("unchecked")
+            ActionListener<ForceMergeResponse> listener = (ActionListener<ForceMergeResponse>) invocationOnMock.getArguments()[1];
+            listener.onResponse(forceMergeResponse);
+            return null;
+        }).when(indicesClient).forceMerge(any(), any());
+
+        SetOnce<IllegalStateException> failedStep = new SetOnce<>();
+
+        ClusterState state =
+            ClusterState.builder(ClusterName.DEFAULT).metadata(Metadata.builder().put(indexMetadata, true).build()).build();
+        ForceMergeStep step = new ForceMergeStep(stepKey, nextStepKey, client, 1);
+        step.performAction(indexMetadata, state, null, new ActionListener<>() {
+            @Override
+            public void onResponse(Boolean aBoolean) {
+                throw new AssertionError("unexpected method call [onResponse]. expecting [onFailure]");
+            }
+
+            @Override
+            public void onFailure(Exception e) {
+                assert e instanceof IllegalStateException : "step must report " + IllegalStateException.class.getSimpleName() +
+                    " but was " + e;
+                failedStep.set((IllegalStateException) e);
+            }
+        });
+
+        assertThat(failedStep.get(), notNullValue());
+        assertThat(failedStep.get().getMessage(),
+            is(
+                "index [" + index.getName() + "] in policy [ilmPolicy] encountered failures [{\"shard\":0,\"index\":\"" +
+                    index.getName() + "\",\"status\":\"BAD_REQUEST\",\"reason\":{\"type\":\"illegal_argument_exception\"," +
+                    "\"reason\":\"couldn't merge\"}}] on step [forcemerge]"
+            )
+        );
     }
 }


### PR DESCRIPTION
This makes the forcemerge step inspect the response of the forcemerge
operation and retry if there are any failed shards.

Closes #73142