### PR TITLE
[7.13] [DOCS] Remove unneeded phrase (#73752)

### DIFF
--- a/docs/java-rest/high-level/search/field-caps.asciidoc
+++ b/docs/java-rest/high-level/search/field-caps.asciidoc
@@ -7,8 +7,8 @@ The field capabilities API allows for retrieving the capabilities of fields acro
 ==== Field Capabilities Request
 
 A `FieldCapabilitiesRequest` contains a list of fields to get capabilities for,
-should be returned, plus an optional list of target indices. If no indices
-are provided, the request will be executed on all indices.
+plus an optional list of target indices. If no indices are provided, the request
+runs on all indices.
 
 Note that fields parameter supports wildcard notation. For example, providing `text_*`
 will cause all fields that match the expression to be returned.


### PR DESCRIPTION
Backports the following commits to 7.13:
 - [DOCS] Remove unneeded phrase (#73752)