### PR TITLE
[7.x] Prevent deletion of repositories that are used by snapshot backed indices

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/snapshots/SharedClusterSnapshotRestoreIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/snapshots/SharedClusterSnapshotRestoreIT.java
@@ -846,7 +846,8 @@ public class SharedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTestCas
             fail("shouldn't be able to delete in-use repository");
         } catch (Exception ex) {
             logger.info("--> in-use repository deletion failed");
-            assertThat(ex.getMessage(), containsString("trying to modify or unregister repository that is currently used"));
+            assertThat(ex.getMessage(),
+                equalTo("trying to modify or unregister repository [test-repo] that is currently used (snapshot is in progress)"));
         }
 
         logger.info("--> trying to move repository to another location");

--- a/server/src/main/java/org/elasticsearch/repositories/RepositoriesService.java
+++ b/server/src/main/java/org/elasticsearch/repositories/RepositoriesService.java
@@ -26,6 +26,7 @@ import org.elasticsearch.cluster.RepositoryCleanupInProgress;
 import org.elasticsearch.cluster.RestoreInProgress;
 import org.elasticsearch.cluster.SnapshotDeletionsInProgress;
 import org.elasticsearch.cluster.SnapshotsInProgress;
+import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.metadata.RepositoriesMetadata;
 import org.elasticsearch.cluster.metadata.RepositoryMetadata;
@@ -40,6 +41,7 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.util.concurrent.ConcurrentCollections;
 import org.elasticsearch.core.internal.io.IOUtils;
+import org.elasticsearch.index.Index;
 import org.elasticsearch.repositories.blobstore.MeteredBlobStoreRepository;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
@@ -51,11 +53,13 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static java.util.Collections.unmodifiableMap;
+import static org.elasticsearch.index.IndexModule.INDEX_STORE_TYPE_SETTING;
 
 /**
  * Service responsible for maintaining and providing access to snapshot repositories on nodes.
@@ -69,6 +73,9 @@ public class RepositoriesService extends AbstractLifecycleComponent implements C
 
     public static final Setting<Integer> REPOSITORIES_STATS_ARCHIVE_MAX_ARCHIVED_STATS =
         Setting.intSetting("repositories.stats.archive.max_archived_stats", 100, 0, Setting.Property.NodeScope);
+
+    public static final String SEARCHABLE_SNAPSHOTS_REPOSITORY_NAME_SETTING_KEY = "index.store.snapshot.repository_name";
+    public static final String SEARCHABLE_SNAPSHOTS_REPOSITORY_UUID_SETTING_KEY = "index.store.snapshot.repository_uuid";
 
     private final Map<String, Repository.Factory> typesRegistry;
     private final Map<String, Repository.Factory> internalTypesRegistry;
@@ -148,18 +155,18 @@ public class RepositoriesService extends AbstractLifecycleComponent implements C
             // When verification has completed, get the repository data for the first time
             final StepListener<RepositoryData> getRepositoryDataStep = new StepListener<>();
             verifyStep.whenComplete(ignored -> threadPool.generic().execute(
-                    ActionRunnable.wrap(getRepositoryDataStep, l -> repository(request.name()).getRepositoryData(l))), listener::onFailure);
+                ActionRunnable.wrap(getRepositoryDataStep, l -> repository(request.name()).getRepositoryData(l))), listener::onFailure);
 
             // When the repository metadata is ready, update the repository UUID stored in the cluster state, if available
             final StepListener<Void> updateRepoUuidStep = new StepListener<>();
             getRepositoryDataStep.whenComplete(
-                    repositoryData -> updateRepositoryUuidInMetadata(clusterService, request.name(), repositoryData, updateRepoUuidStep),
-                    listener::onFailure);
+                repositoryData -> updateRepositoryUuidInMetadata(clusterService, request.name(), repositoryData, updateRepoUuidStep),
+                listener::onFailure);
 
             // Finally respond to the outer listener with the response from the original cluster state update
             updateRepoUuidStep.whenComplete(
-                    ignored -> acknowledgementStep.addListener(listener),
-                    listener::onFailure);
+                ignored -> acknowledgementStep.addListener(listener),
+                listener::onFailure);
 
         } else {
             acknowledgementStep.addListener(listener);
@@ -234,10 +241,10 @@ public class RepositoriesService extends AbstractLifecycleComponent implements C
      *                 thread
      */
     public static void updateRepositoryUuidInMetadata(
-            ClusterService clusterService,
-            final String repositoryName,
-            RepositoryData repositoryData,
-            ActionListener<Void> listener) {
+        ClusterService clusterService,
+        final String repositoryName,
+        RepositoryData repositoryData,
+        ActionListener<Void> listener) {
 
         final String repositoryUuid = repositoryData.getUuid();
         if (repositoryUuid.equals(RepositoryData.MISSING_UUID)) {
@@ -246,7 +253,7 @@ public class RepositoriesService extends AbstractLifecycleComponent implements C
         }
 
         final RepositoriesMetadata currentReposMetadata
-                = clusterService.state().metadata().custom(RepositoriesMetadata.TYPE, RepositoriesMetadata.EMPTY);
+            = clusterService.state().metadata().custom(RepositoriesMetadata.TYPE, RepositoriesMetadata.EMPTY);
         final RepositoryMetadata repositoryMetadata = currentReposMetadata.repository(repositoryName);
         if (repositoryMetadata == null || repositoryMetadata.uuid().equals(repositoryUuid)) {
             listener.onResponse(null);
@@ -254,33 +261,33 @@ public class RepositoriesService extends AbstractLifecycleComponent implements C
         }
 
         clusterService.submitStateUpdateTask("update repository UUID [" + repositoryName + "] to [" + repositoryUuid + "]",
-                new ClusterStateUpdateTask() {
-                    @Override
-                    public ClusterState execute(ClusterState currentState) {
-                        final RepositoriesMetadata currentReposMetadata
-                                = currentState.metadata().custom(RepositoriesMetadata.TYPE, RepositoriesMetadata.EMPTY);
+            new ClusterStateUpdateTask() {
+                @Override
+                public ClusterState execute(ClusterState currentState) {
+                    final RepositoriesMetadata currentReposMetadata
+                        = currentState.metadata().custom(RepositoriesMetadata.TYPE, RepositoriesMetadata.EMPTY);
 
-                        final RepositoryMetadata repositoryMetadata = currentReposMetadata.repository(repositoryName);
-                        if (repositoryMetadata == null || repositoryMetadata.uuid().equals(repositoryUuid)) {
-                            return currentState;
-                        } else {
-                            final RepositoriesMetadata newReposMetadata = currentReposMetadata.withUuid(repositoryName, repositoryUuid);
-                            final Metadata.Builder metadata
-                                    = Metadata.builder(currentState.metadata()).putCustom(RepositoriesMetadata.TYPE, newReposMetadata);
-                            return ClusterState.builder(currentState).metadata(metadata).build();
-                        }
+                    final RepositoryMetadata repositoryMetadata = currentReposMetadata.repository(repositoryName);
+                    if (repositoryMetadata == null || repositoryMetadata.uuid().equals(repositoryUuid)) {
+                        return currentState;
+                    } else {
+                        final RepositoriesMetadata newReposMetadata = currentReposMetadata.withUuid(repositoryName, repositoryUuid);
+                        final Metadata.Builder metadata
+                            = Metadata.builder(currentState.metadata()).putCustom(RepositoriesMetadata.TYPE, newReposMetadata);
+                        return ClusterState.builder(currentState).metadata(metadata).build();
                     }
+                }
 
-                    @Override
-                    public void onFailure(String source, Exception e) {
-                        listener.onFailure(e);
-                    }
+                @Override
+                public void onFailure(String source, Exception e) {
+                    listener.onFailure(e);
+                }
 
-                    @Override
-                    public void clusterStateProcessed(String source, ClusterState oldState, ClusterState newState) {
-                        listener.onResponse(null);
-                    }
-                });
+                @Override
+                public void clusterStateProcessed(String source, ClusterState oldState, ClusterState newState) {
+                    listener.onResponse(null);
+                }
+            });
     }
 
     /**
@@ -308,6 +315,7 @@ public class RepositoriesService extends AbstractLifecycleComponent implements C
                         for (RepositoryMetadata repositoryMetadata : repositories.repositories()) {
                             if (Regex.simpleMatch(request.name(), repositoryMetadata.name())) {
                                 ensureRepositoryNotInUse(currentState, repositoryMetadata.name());
+                                ensureNoSearchableSnapshotsIndicesInUse(currentState, repositoryMetadata);
                                 deletedRepositories.add(repositoryMetadata.name());
                                 changed = true;
                             } else {
@@ -382,8 +390,8 @@ public class RepositoriesService extends AbstractLifecycleComponent implements C
 
     public static boolean isDedicatedVotingOnlyNode(Set<DiscoveryNodeRole> roles) {
         return roles.contains(DiscoveryNodeRole.MASTER_ROLE)
-                && roles.stream().noneMatch(DiscoveryNodeRole::canContainData)
-                && roles.stream().anyMatch(role -> role.roleName().equals("voting_only"));
+            && roles.stream().noneMatch(DiscoveryNodeRole::canContainData)
+            && roles.stream().anyMatch(role -> role.roleName().equals("voting_only"));
     }
 
     /**
@@ -397,7 +405,7 @@ public class RepositoriesService extends AbstractLifecycleComponent implements C
         try {
             final ClusterState state = event.state();
             final RepositoriesMetadata oldMetadata =
-                    event.previousState().getMetadata().custom(RepositoriesMetadata.TYPE, RepositoriesMetadata.EMPTY);
+                event.previousState().getMetadata().custom(RepositoriesMetadata.TYPE, RepositoriesMetadata.EMPTY);
             final RepositoriesMetadata newMetadata = state.getMetadata().custom(RepositoriesMetadata.TYPE, RepositoriesMetadata.EMPTY);
 
             // Check if repositories got changed
@@ -444,7 +452,7 @@ public class RepositoriesService extends AbstractLifecycleComponent implements C
                             // TODO: this catch is bogus, it means the old repo is already closed,
                             // but we have nothing to replace it
                             logger.warn(() -> new ParameterizedMessage("failed to change repository [{}]",
-                                    repositoryMetadata.name()), ex);
+                                repositoryMetadata.name()), ex);
                         }
                     }
                 } else {
@@ -556,7 +564,9 @@ public class RepositoriesService extends AbstractLifecycleComponent implements C
         }
     }
 
-    /** Closes the given repository. */
+    /**
+     * Closes the given repository.
+     */
     private void closeRepository(Repository repository) {
         logger.debug("closing repository [{}][{}]", repository.getMetadata().type(), repository.getMetadata().name());
         repository.close();
@@ -608,45 +618,74 @@ public class RepositoriesService extends AbstractLifecycleComponent implements C
     }
 
     private static void ensureRepositoryNotInUse(ClusterState clusterState, String repository) {
-        if (isRepositoryInUse(clusterState, repository)) {
-            throw new IllegalStateException("trying to modify or unregister repository that is currently used");
-        }
-    }
-
-    /**
-     * Checks if a repository is currently in use by one of the snapshots
-     *
-     * @param clusterState cluster state
-     * @param repository   repository id
-     * @return true if repository is currently in use by one of the running snapshots
-     */
-    private static boolean isRepositoryInUse(ClusterState clusterState, String repository) {
         final SnapshotsInProgress snapshots = clusterState.custom(SnapshotsInProgress.TYPE, SnapshotsInProgress.EMPTY);
         for (SnapshotsInProgress.Entry snapshot : snapshots.entries()) {
             if (repository.equals(snapshot.snapshot().getRepository())) {
-                return true;
+                throw newRepositoryInUseException(repository, "snapshot is in progress");
             }
         }
         for (SnapshotDeletionsInProgress.Entry entry :
             clusterState.custom(SnapshotDeletionsInProgress.TYPE, SnapshotDeletionsInProgress.EMPTY).getEntries()) {
             if (entry.repository().equals(repository)) {
-                return true;
+                throw newRepositoryInUseException(repository, "snapshot deletion is in progress");
             }
         }
         for (RepositoryCleanupInProgress.Entry entry :
             clusterState.custom(RepositoryCleanupInProgress.TYPE, RepositoryCleanupInProgress.EMPTY).entries()) {
             if (entry.repository().equals(repository)) {
-                return true;
+                throw newRepositoryInUseException(repository, "repository clean up is in progress");
             }
         }
         for (RestoreInProgress.Entry entry : clusterState.custom(RestoreInProgress.TYPE, RestoreInProgress.EMPTY)) {
             if (repository.equals(entry.snapshot().getRepository())) {
-                return true;
+                throw newRepositoryInUseException(repository, "snapshot restore is in progress");
+            }
+        }
+    }
+
+    private static void ensureNoSearchableSnapshotsIndicesInUse(ClusterState clusterState, RepositoryMetadata repositoryMetadata) {
+        long count = 0L;
+        List<Index> indices = null;
+        for (IndexMetadata indexMetadata : clusterState.metadata()) {
+            if (indexSettingsMatchRepositoryMetadata(indexMetadata.getSettings(), repositoryMetadata)) {
+                if (indices == null) {
+                    indices = new ArrayList<>();
+                }
+                if (indices.size() < 5) {
+                    indices.add(indexMetadata.getIndex());
+                }
+                count += 1L;
+            }
+        }
+        if (indices != null && indices.isEmpty() == false) {
+            throw newRepositoryInUseException(repositoryMetadata.name(), "found " + count
+                + " searchable snapshots indices that use the repository: "
+                + Strings.collectionToCommaDelimitedString(indices)
+                + (count > indices.size() ? ",..." : "")
+            );
+        }
+    }
+
+    private static boolean indexSettingsMatchRepositoryMetadata(Settings indexSettings, RepositoryMetadata repositoryMetadata) {
+        if ("snapshot".equals(INDEX_STORE_TYPE_SETTING.get(indexSettings))) {
+            final String indexRepositoryUuid = indexSettings.get(SEARCHABLE_SNAPSHOTS_REPOSITORY_UUID_SETTING_KEY);
+            if (Strings.hasLength(indexRepositoryUuid)) {
+                return Objects.equals(repositoryMetadata.uuid(), indexRepositoryUuid);
+            } else {
+                return Objects.equals(repositoryMetadata.name(), indexSettings.get(SEARCHABLE_SNAPSHOTS_REPOSITORY_NAME_SETTING_KEY));
             }
         }
         return false;
     }
 
+    private static IllegalStateException newRepositoryInUseException(String repository, String reason) {
+        return new IllegalStateException("trying to modify or unregister repository ["
+            + repository
+            + "] that is currently used ("
+            + reason
+            + ')'
+        );
+    }
 
     @Override
     protected void doStart() {

--- a/test/framework/src/main/java/org/elasticsearch/snapshots/AbstractSnapshotIntegTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/snapshots/AbstractSnapshotIntegTestCase.java
@@ -277,10 +277,16 @@ public abstract class AbstractSnapshotIntegTestCase extends ESIntegTestCase {
         AbstractSnapshotIntegTestCase.<MockRepository>getRepositoryOnNode(repository, node).unblock();
     }
 
-    protected void createRepository(String repoName, String type, Settings.Builder settings) {
-        logger.info("--> creating repository [{}] [{}]", repoName, type);
+    protected void createRepository(String repoName, String type, Settings.Builder settings, boolean verify) {
+        logger.info("--> creating or updating repository [{}] [{}]", repoName, type);
         assertAcked(clusterAdmin().preparePutRepository(repoName)
-            .setType(type).setSettings(settings));
+            .setVerify(verify)
+            .setType(type)
+            .setSettings(settings));
+    }
+
+    protected void createRepository(String repoName, String type, Settings.Builder settings) {
+        createRepository(repoName, type, settings, true);
     }
 
     protected void createRepository(String repoName, String type, Path location) {

--- a/x-pack/plugin/searchable-snapshots/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/repository.yml
+++ b/x-pack/plugin/searchable-snapshots/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/repository.yml
@@ -1,0 +1,95 @@
+---
+setup:
+
+  - do:
+      indices.create:
+        index: docs
+        body:
+          settings:
+            number_of_shards:   1
+            number_of_replicas: 0
+
+  - do:
+      bulk:
+        body:
+          - index:
+              _index: docs
+              _id:    1
+          - field: foo
+          - index:
+              _index: docs
+              _id:    2
+          - field: bar
+          - index:
+              _index: docs
+              _id:    3
+          - field: baz
+
+  - do:
+      snapshot.create_repository:
+        repository: repository-fs
+        body:
+          type: fs
+          settings:
+            location: "repository-fs"
+
+  # Remove the snapshot if a previous test failed to delete it.
+  # Useful for third party tests that runs the test against a real external service.
+  - do:
+      snapshot.delete:
+        repository: repository-fs
+        snapshot: snapshot
+        ignore: 404
+
+  - do:
+      snapshot.create:
+        repository: repository-fs
+        snapshot: snapshot
+        wait_for_completion: true
+
+  - do:
+      indices.delete:
+        index: docs
+
+---
+"Delete repository when a snapshot is mounted as an index":
+  - skip:
+      version: " - 7.99.99"
+      reason: "starting 8.0, an error occurs when a repository used by snapshot backed indices is deleted"
+
+  - do:
+      searchable_snapshots.mount:
+        repository: repository-fs
+        snapshot: snapshot
+        wait_for_completion: true
+        body:
+          index: docs
+          renamed_index: mounted-docs
+
+  - match: { snapshot.snapshot: snapshot }
+  - match: { snapshot.shards.failed: 0 }
+  - match: { snapshot.shards.successful: 1 }
+
+  # Returns an illegal state exception
+  - do:
+      catch: request
+      snapshot.delete_repository:
+        repository: repository-fs
+
+  - do:
+      search:
+        index: mounted-docs
+        body:
+          query:
+            match_all: { }
+
+  - match: { hits.total.value: 3 }
+
+  - do:
+      indices.delete:
+        index: mounted-docs
+
+  - do:
+      snapshot.delete_repository:
+        repository: repository-fs
+

--- a/x-pack/plugin/searchable-snapshots/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/repository.yml
+++ b/x-pack/plugin/searchable-snapshots/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/repository.yml
@@ -54,8 +54,8 @@ setup:
 ---
 "Delete repository when a snapshot is mounted as an index":
   - skip:
-      version: " - 7.99.99"
-      reason: "starting 8.0, an error occurs when a repository used by snapshot backed indices is deleted"
+      version: " - 7.13.99"
+      reason: "starting 7.14.0, an error occurs when a repository used by snapshot backed indices is deleted"
 
   - do:
       searchable_snapshots.mount:

--- a/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/SearchableSnapshotsRepositoryIntegTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/SearchableSnapshotsRepositoryIntegTests.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.searchablesnapshots;
+
+import org.apache.lucene.search.TotalHits;
+import org.elasticsearch.action.admin.cluster.snapshots.restore.RestoreSnapshotResponse;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.unit.ByteSizeValue;
+import org.elasticsearch.repositories.fs.FsRepository;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Locale;
+
+import static org.elasticsearch.cluster.metadata.IndexMetadata.INDEX_NUMBER_OF_SHARDS_SETTING;
+import static org.elasticsearch.index.IndexSettings.INDEX_SOFT_DELETES_SETTING;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCount;
+import static org.elasticsearch.xpack.core.searchablesnapshots.MountSearchableSnapshotRequest.Storage;
+import static org.hamcrest.Matchers.containsString;
+
+public class SearchableSnapshotsRepositoryIntegTests extends BaseFrozenSearchableSnapshotsIntegTestCase {
+
+    public void testRepositoryUsedBySearchableSnapshotCanBeUpdatedButNotUnregistered() throws Exception {
+        final String repositoryName = randomAlphaOfLength(10).toLowerCase(Locale.ROOT);
+        final Settings.Builder repositorySettings = randomRepositorySettings();
+        createRepository(repositoryName, FsRepository.TYPE, repositorySettings);
+
+        final String indexName = randomAlphaOfLength(10).toLowerCase(Locale.ROOT);
+        createAndPopulateIndex(
+            indexName,
+            Settings.builder().put(INDEX_NUMBER_OF_SHARDS_SETTING.getKey(), 1).put(INDEX_SOFT_DELETES_SETTING.getKey(), true)
+        );
+
+        final TotalHits totalHits = internalCluster().client()
+            .prepareSearch(indexName)
+            .setTrackTotalHits(true)
+            .get()
+            .getHits()
+            .getTotalHits();
+
+        final String snapshotName = randomAlphaOfLength(10).toLowerCase(Locale.ROOT);
+        createSnapshot(repositoryName, snapshotName, List.of(indexName));
+        assertAcked(client().admin().indices().prepareDelete(indexName));
+
+        final int nbMountedIndices = 1;
+        randomIntBetween(1, 5);
+        final String[] mountedIndices = new String[nbMountedIndices];
+
+        for (int i = 0; i < nbMountedIndices; i++) {
+            Storage storage = randomFrom(Storage.values());
+            String restoredIndexName = (storage == Storage.FULL_COPY ? "fully-mounted-" : "partially-mounted-") + indexName + '-' + i;
+            mountSnapshot(repositoryName, snapshotName, indexName, restoredIndexName, Settings.EMPTY, storage);
+            assertHitCount(client().prepareSearch(restoredIndexName).setTrackTotalHits(true).get(), totalHits.value);
+            mountedIndices[i] = restoredIndexName;
+        }
+
+        assertAcked(
+            clusterAdmin().preparePutRepository(repositoryName)
+                .setType(FsRepository.TYPE)
+                .setSettings(
+                    Settings.builder()
+                        .put(repositorySettings.build())
+                        .put(FsRepository.REPOSITORIES_CHUNK_SIZE_SETTING.getKey(), ByteSizeValue.ofMb(1L))
+                        .build()
+                )
+        );
+
+        final String updatedRepositoryName;
+        if (randomBoolean()) {
+            final String snapshotWithMountedIndices = snapshotName + "-with-mounted-indices";
+            createSnapshot(repositoryName, snapshotWithMountedIndices, Arrays.asList(mountedIndices));
+            assertAcked(client().admin().indices().prepareDelete(mountedIndices));
+            assertAcked(clusterAdmin().prepareDeleteRepository(repositoryName));
+
+            updatedRepositoryName = repositoryName + "-with-mounted-indices";
+            createRepository(updatedRepositoryName, FsRepository.TYPE, repositorySettings, randomBoolean());
+
+            final RestoreSnapshotResponse restoreResponse = clusterAdmin().prepareRestoreSnapshot(
+                updatedRepositoryName,
+                snapshotWithMountedIndices
+            ).setWaitForCompletion(true).setIndices(mountedIndices).get();
+            assertEquals(restoreResponse.getRestoreInfo().totalShards(), restoreResponse.getRestoreInfo().successfulShards());
+        } else {
+            updatedRepositoryName = repositoryName;
+        }
+
+        for (int i = 0; i < nbMountedIndices; i++) {
+            IllegalStateException exception = expectThrows(
+                IllegalStateException.class,
+                () -> clusterAdmin().prepareDeleteRepository(updatedRepositoryName).get()
+            );
+            assertThat(
+                exception.getMessage(),
+                containsString(
+                    "trying to modify or unregister repository ["
+                        + updatedRepositoryName
+                        + "] that is currently used (found "
+                        + (nbMountedIndices - i)
+                        + " searchable snapshots indices that use the repository:"
+                )
+            );
+            assertAcked(client().admin().indices().prepareDelete(mountedIndices[i]));
+        }
+
+        assertAcked(clusterAdmin().prepareDeleteRepository(updatedRepositoryName));
+    }
+}

--- a/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/SearchableSnapshotsRepositoryIntegTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/SearchableSnapshotsRepositoryIntegTests.java
@@ -15,7 +15,6 @@ import org.elasticsearch.repositories.fs.FsRepository;
 
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.List;
 import java.util.Locale;
 
 import static org.elasticsearch.cluster.metadata.IndexMetadata.INDEX_NUMBER_OF_SHARDS_SETTING;

--- a/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/SearchableSnapshotsRepositoryIntegTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/SearchableSnapshotsRepositoryIntegTests.java
@@ -14,6 +14,7 @@ import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.repositories.fs.FsRepository;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 
@@ -45,7 +46,7 @@ public class SearchableSnapshotsRepositoryIntegTests extends BaseFrozenSearchabl
             .getTotalHits();
 
         final String snapshotName = randomAlphaOfLength(10).toLowerCase(Locale.ROOT);
-        createSnapshot(repositoryName, snapshotName, List.of(indexName));
+        createSnapshot(repositoryName, snapshotName, Collections.singletonList(indexName));
         assertAcked(client().admin().indices().prepareDelete(indexName));
 
         final int nbMountedIndices = 1;

--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/SearchableSnapshots.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/SearchableSnapshots.java
@@ -137,13 +137,13 @@ import static org.elasticsearch.xpack.searchablesnapshots.SearchableSnapshotsUti
 public class SearchableSnapshots extends Plugin implements IndexStorePlugin, EnginePlugin, ActionPlugin, ClusterPlugin, SystemIndexPlugin {
 
     public static final Setting<String> SNAPSHOT_REPOSITORY_NAME_SETTING = Setting.simpleString(
-        "index.store.snapshot.repository_name",
+        RepositoriesService.SEARCHABLE_SNAPSHOTS_REPOSITORY_NAME_SETTING_KEY,
         Setting.Property.IndexScope,
         Setting.Property.PrivateIndex,
         Setting.Property.NotCopyableOnResize
     );
     public static final Setting<String> SNAPSHOT_REPOSITORY_UUID_SETTING = Setting.simpleString(
-        "index.store.snapshot.repository_uuid",
+        RepositoriesService.SEARCHABLE_SNAPSHOTS_REPOSITORY_UUID_SETTING_KEY,
         Setting.Property.IndexScope,
         Setting.Property.PrivateIndex,
         Setting.Property.NotCopyableOnResize

--- a/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/AbstractSearchableSnapshotsRestTestCase.java
+++ b/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/AbstractSearchableSnapshotsRestTestCase.java
@@ -158,6 +158,9 @@ public abstract class AbstractSearchableSnapshotsRestTestCase extends ESRestTest
 
         testCaseBody.runTest(restoredIndexName, numDocs);
 
+        logger.info("deleting mounted index [{}]", indexName);
+        deleteIndex(restoredIndexName);
+
         logger.info("deleting snapshot [{}]", SNAPSHOT_NAME);
         deleteSnapshot(SNAPSHOT_NAME, false);
     }


### PR DESCRIPTION
This commit adds a simple check that prevents to delete 
a repository that is required by an existing searchable 
snapshot index within the same cluster.

Backport of #73714