### PR TITLE
Use compiler version for gradle code

### DIFF
--- a/build-tools-internal/build.gradle
+++ b/build-tools-internal/build.gradle
@@ -165,9 +165,9 @@ if (JavaVersion.current() < JavaVersion.VERSION_11) {
   throw new GradleException('At least Java 11 is required to build elasticsearch gradle tools')
 }
 
-def minRuntimeJava = JavaVersion.toVersion(file('src/main/resources/minimumRuntimeVersion').text)
-targetCompatibility = minRuntimeJava
-sourceCompatibility = minRuntimeJava
+def minCompilerJava = JavaVersion.toVersion(file('src/main/resources/minimumCompilerVersion').text)
+targetCompatibility = minCompilerJava
+sourceCompatibility = minCompilerJava
 
 sourceSets {
   integTest {


### PR DESCRIPTION
The minimum compiler version is that which we require a developer to use
when building Elasticsearch. This version is updated as newer versions
of Java are released. In contrast, the minimum runtime version is that
which Elasticsearch itself needs. In 7.x this is Java 8, and in master
this is Java 11. Historically the version we require for gradle code has
had to be the minimum runtime version since all the gradle code was
distributed for plugin developers.

Now that the external build tools is separated from our internal tools,
the internal tools are no longer bound by that runtime requirement.
Instead, they can use the latest Java, so that we can use new features
within our internal tools. This commit switches the source compatibiltiy
version for the internal build tools to use the minimum compiler version.