### PR TITLE
Preserve field mappings from user agent processor when ECS is disabled

### DIFF
--- a/modules/ingest-user-agent/src/main/java/org/elasticsearch/ingest/useragent/UserAgentProcessor.java
+++ b/modules/ingest-user-agent/src/main/java/org/elasticsearch/ingest/useragent/UserAgentProcessor.java
@@ -211,23 +211,20 @@ public class UserAgentProcessor extends AbstractProcessor {
                         }
                         break;
                     case DEVICE:
-                        Map<String, String> deviceDetails = new HashMap<>(1);
                         if (uaClient.device != null && uaClient.device.name != null) {
-                            deviceDetails.put("name", uaClient.device.name);
-                            if (extractDeviceType) {
-                                deviceDetails.put("type", uaClient.deviceType);
-                            }
+                            uaDetails.put("device", uaClient.device.name);
                         } else {
-                            deviceDetails.put("name", "Other");
-                            if (extractDeviceType) {
-                                if (uaClient.deviceType != null) {
-                                    deviceDetails.put("type", uaClient.deviceType);
-                                } else {
-                                    deviceDetails.put("type", "Other");
-                                }
-                            }
+                            uaDetails.put("device", "Other");
                         }
-                        uaDetails.put("device", deviceDetails);
+
+                        if (extractDeviceType) {
+                            if (uaClient.deviceType != null) {
+                                uaDetails.put("device_type", uaClient.deviceType);
+                            } else {
+                                uaDetails.put("device_type", "Other");
+                            }
+
+                        }
                         break;
                 }
             }

--- a/modules/ingest-user-agent/src/test/java/org/elasticsearch/ingest/useragent/UserAgentProcessorTests.java
+++ b/modules/ingest-user-agent/src/test/java/org/elasticsearch/ingest/useragent/UserAgentProcessorTests.java
@@ -274,4 +274,33 @@ public class UserAgentProcessorTests extends ESTestCase {
         device.put("name", "Other");
         assertThat(target.get("device"), is(device));
     }
+
+    @SuppressWarnings("unchecked")
+    public void testExtractDeviceTypeAndEcsDisabled() {
+        Map<String, Object> document = new HashMap<>();
+        document.put("source_field",
+            "Something I made up v42.0.1");
+        IngestDocument ingestDocument = RandomDocumentPicks.randomIngestDocument(random(), document);
+
+        InputStream regexStream = UserAgentProcessor.class.getResourceAsStream("/regexes.yml");
+        InputStream deviceTypeRegexStream = UserAgentProcessor.class.getResourceAsStream("/device_type_regexes.yml");
+        UserAgentParser parser = new UserAgentParser(randomAlphaOfLength(10), regexStream, deviceTypeRegexStream, new UserAgentCache(1000));
+        UserAgentProcessor processor = new UserAgentProcessor(randomAlphaOfLength(10), null, "source_field", "target_field", parser,
+            EnumSet.allOf(UserAgentProcessor.Property.class), true, false, false);
+        processor.execute(ingestDocument);
+        Map<String, Object> data = ingestDocument.getSourceAndMetadata();
+
+        assertThat(data, hasKey("target_field"));
+        Map<String, Object> target = (Map<String, Object>) data.get("target_field");
+
+        assertThat(target.get("name"), is("Other"));
+        assertNull(target.get("major"));
+        assertNull(target.get("minor"));
+        assertNull(target.get("patch"));
+        assertNull(target.get("build"));
+        assertThat(target.get("os"), is("Other"));
+        assertThat(target.get("device"), is("Other"));
+        assertThat(target.get("device_type"), is("Other"));
+    }
+
 }


### PR DESCRIPTION
Needs to be merged directly to `7.x` as the option to disable ECS was removed in 8.0.

Fixes #73780