### PR TITLE
Copy all execution state in CopyExecutionStateStep

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/CopyExecutionStateStep.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/CopyExecutionStateStep.java
@@ -80,15 +80,11 @@ public class CopyExecutionStateStep extends ClusterStateActionStep {
         String step = targetNextStepKey.getName();
         long lifecycleDate = lifecycleState.getLifecycleDate();
 
-        LifecycleExecutionState.Builder relevantTargetCustomData = LifecycleExecutionState.builder();
-        relevantTargetCustomData.setIndexCreationDate(lifecycleDate);
-        relevantTargetCustomData.setAction(action);
+        LifecycleExecutionState.Builder relevantTargetCustomData = LifecycleExecutionState.builder(lifecycleState);
+        // Override the phase, action, and step for the target next StepKey
         relevantTargetCustomData.setPhase(phase);
+        relevantTargetCustomData.setAction(action);
         relevantTargetCustomData.setStep(step);
-        relevantTargetCustomData.setSnapshotRepository(lifecycleState.getSnapshotRepository());
-        relevantTargetCustomData.setSnapshotName(lifecycleState.getSnapshotName());
-        relevantTargetCustomData.setSnapshotIndexName(lifecycleState.getSnapshotIndexName());
-        relevantTargetCustomData.setShrinkIndexName(lifecycleState.getShrinkIndexName());
 
         Metadata.Builder newMetadata = Metadata.builder(clusterState.getMetadata())
             .put(IndexMetadata.builder(targetIndexMetadata)

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/LifecycleExecutionState.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/LifecycleExecutionState.java
@@ -371,6 +371,8 @@ public class LifecycleExecutionState {
             Objects.equals(getSnapshotRepository(), that.getSnapshotRepository()) &&
             Objects.equals(getSnapshotName(), that.getSnapshotName()) &&
             Objects.equals(getSnapshotIndexName(), that.getSnapshotIndexName()) &&
+            Objects.equals(getShrinkIndexName(), that.getShrinkIndexName()) &&
+            Objects.equals(getRollupIndexName(), that.getRollupIndexName()) &&
             Objects.equals(getPhaseDefinition(), that.getPhaseDefinition());
     }
 
@@ -378,7 +380,7 @@ public class LifecycleExecutionState {
     public int hashCode() {
         return Objects.hash(getPhase(), getAction(), getStep(), getFailedStep(), isAutoRetryableError(), getFailedStepRetryCount(),
             getStepInfo(), getPhaseDefinition(), getLifecycleDate(), getPhaseTime(), getActionTime(), getStepTime(),
-            getSnapshotRepository(), getSnapshotName(), getSnapshotIndexName());
+            getSnapshotRepository(), getSnapshotName(), getSnapshotIndexName(), getShrinkIndexName(), getRollupIndexName());
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/LifecyclePolicy.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/LifecyclePolicy.java
@@ -122,6 +122,9 @@ public class LifecyclePolicy extends AbstractDiffable<LifecyclePolicy>
         this.phases = phases;
         this.type = type;
         this.metadata = metadata;
+    }
+
+    public void validate() {
         this.type.validate(phases.values());
     }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/LifecyclePolicyUtils.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/LifecyclePolicyUtils.java
@@ -39,7 +39,9 @@ public class LifecyclePolicyUtils {
 
             try (XContentParser parser = XContentType.JSON.xContent()
                 .createParser(xContentRegistry, LoggingDeprecationHandler.THROW_UNSUPPORTED_OPERATION, source.utf8ToString())) {
-                return LifecyclePolicy.parse(parser, name);
+                LifecyclePolicy policy = LifecyclePolicy.parse(parser, name);
+                policy.validate();
+                return policy;
             }
         } catch (Exception e) {
             throw new IllegalArgumentException("unable to load policy [" + name + "] from [" + resource + "]", e);

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/action/PutLifecycleAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/action/PutLifecycleAction.java
@@ -61,6 +61,7 @@ public class PutLifecycleAction extends ActionType<AcknowledgedResponse> {
 
         @Override
         public ActionRequestValidationException validate() {
+            this.policy.validate();
             ActionRequestValidationException err = null;
             String phaseTimingErr = TimeseriesLifecycleType.validateMonotonicallyIncreasingPhaseTimings(this.policy.getPhases().values());
             if (Strings.hasText(phaseTimingErr)) {

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/LifecycleExecutionStateTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/LifecycleExecutionStateTests.java
@@ -137,52 +137,65 @@ public class LifecycleExecutionStateTests extends ESTestCase {
 
     private static LifecycleExecutionState mutate(LifecycleExecutionState toMutate) {
         LifecycleExecutionState.Builder newState = LifecycleExecutionState.builder(toMutate);
-        boolean changed = false;
-        if (randomBoolean()) {
-            newState.setPhase(randomValueOtherThan(toMutate.getPhase(), () -> randomAlphaOfLengthBetween(5, 20)));
-            changed = true;
+        switch (randomIntBetween(0, 17)) {
+            case 0:
+                newState.setPhase(randomValueOtherThan(toMutate.getPhase(), () -> randomAlphaOfLengthBetween(5, 20)));
+                break;
+            case 1:
+                newState.setAction(randomValueOtherThan(toMutate.getAction(), () -> randomAlphaOfLengthBetween(5, 20)));
+                break;
+            case 2:
+                newState.setStep(randomValueOtherThan(toMutate.getStep(), () -> randomAlphaOfLengthBetween(5, 20)));
+                break;
+            case 3:
+                newState.setPhaseDefinition(randomValueOtherThan(toMutate.getPhaseDefinition(), () -> randomAlphaOfLengthBetween(5, 20)));
+                break;
+            case 4:
+                newState.setFailedStep(randomValueOtherThan(toMutate.getFailedStep(), () -> randomAlphaOfLengthBetween(5, 20)));
+                break;
+            case 5:
+                newState.setStepInfo(randomValueOtherThan(toMutate.getStepInfo(), () -> randomAlphaOfLengthBetween(5, 20)));
+                break;
+            case 6:
+                newState.setPhaseTime(randomValueOtherThan(toMutate.getPhaseTime(), ESTestCase::randomLong));
+                break;
+            case 7:
+                newState.setActionTime(randomValueOtherThan(toMutate.getActionTime(), ESTestCase::randomLong));
+                break;
+            case 8:
+                newState.setStepTime(randomValueOtherThan(toMutate.getStepTime(), ESTestCase::randomLong));
+                break;
+            case 9:
+                newState.setIndexCreationDate(randomValueOtherThan(toMutate.getLifecycleDate(), ESTestCase::randomLong));
+                break;
+            case 10:
+                newState.setShrinkIndexName(randomValueOtherThan(toMutate.getShrinkIndexName(), () -> randomAlphaOfLengthBetween(5, 20)));
+                break;
+            case 11:
+                newState.setSnapshotRepository(randomValueOtherThan(toMutate.getSnapshotRepository(),
+                    () -> randomAlphaOfLengthBetween(5, 20)));
+                break;
+            case 12:
+                newState.setSnapshotIndexName(randomValueOtherThan(toMutate.getSnapshotIndexName(),
+                    () -> randomAlphaOfLengthBetween(5, 20)));
+                break;
+            case 13:
+                newState.setSnapshotName(randomValueOtherThan(toMutate.getSnapshotName(), () -> randomAlphaOfLengthBetween(5, 20)));
+                break;
+            case 14:
+                newState.setRollupIndexName(randomValueOtherThan(toMutate.getRollupIndexName(), () -> randomAlphaOfLengthBetween(5, 20)));
+                break;
+            case 15:
+                newState.setIsAutoRetryableError(randomValueOtherThan(toMutate.isAutoRetryableError(), ESTestCase::randomBoolean));
+                break;
+            case 16:
+                newState.setFailedStepRetryCount(randomValueOtherThan(toMutate.getFailedStepRetryCount(), ESTestCase::randomInt));
+                break;
+            case 17:
+                return LifecycleExecutionState.builder().build();
+            default:
+                throw new IllegalStateException("unknown randomization branch");
         }
-        if (randomBoolean()) {
-            newState.setAction(randomValueOtherThan(toMutate.getAction(), () -> randomAlphaOfLengthBetween(5, 20)));
-            changed = true;
-        }
-        if (randomBoolean()) {
-            newState.setStep(randomValueOtherThan(toMutate.getStep(), () -> randomAlphaOfLengthBetween(5, 20)));
-            changed = true;
-        }
-        if (randomBoolean()) {
-            newState.setPhaseDefinition(randomValueOtherThan(toMutate.getPhaseDefinition(), () -> randomAlphaOfLengthBetween(5, 20)));
-            changed = true;
-        }
-        if (randomBoolean()) {
-            newState.setFailedStep(randomValueOtherThan(toMutate.getFailedStep(), () -> randomAlphaOfLengthBetween(5, 20)));
-            changed = true;
-        }
-        if (randomBoolean()) {
-            newState.setStepInfo(randomValueOtherThan(toMutate.getStepInfo(), () -> randomAlphaOfLengthBetween(5, 20)));
-            changed = true;
-        }
-        if (randomBoolean()) {
-            newState.setPhaseTime(randomValueOtherThan(toMutate.getPhaseTime(), ESTestCase::randomLong));
-            changed = true;
-        }
-        if (randomBoolean()) {
-            newState.setActionTime(randomValueOtherThan(toMutate.getActionTime(), ESTestCase::randomLong));
-            changed = true;
-        }
-        if (randomBoolean()) {
-            newState.setStepTime(randomValueOtherThan(toMutate.getStepTime(), ESTestCase::randomLong));
-            changed = true;
-        }
-        if (randomBoolean()) {
-            newState.setIndexCreationDate(randomValueOtherThan(toMutate.getLifecycleDate(), ESTestCase::randomLong));
-            changed = true;
-        }
-
-        if (changed == false) {
-            return LifecycleExecutionState.builder().build();
-        }
-
         return newState.build();
     }
 
@@ -215,6 +228,10 @@ public class LifecycleExecutionStateTests extends ESTestCase {
         customMetadata.put("snapshot_repository", repositoryName);
         customMetadata.put("snapshot_name", snapshotName);
         customMetadata.put("snapshot_index_name", snapshotIndexName);
+        customMetadata.put("shrink_index_name", randomAlphaOfLengthBetween(5, 20));
+        customMetadata.put("rollup_index_name", randomAlphaOfLengthBetween(5, 20));
+        customMetadata.put("is_auto_retryable_error", String.valueOf(randomBoolean()));
+        customMetadata.put("failed_step_retry_count", String.valueOf(randomInt()));
         return customMetadata;
     }
 }

--- a/x-pack/plugin/ilm/qa/multi-node/src/javaRestTest/java/org/elasticsearch/xpack/ilm/actions/SearchableSnapshotActionIT.java
+++ b/x-pack/plugin/ilm/qa/multi-node/src/javaRestTest/java/org/elasticsearch/xpack/ilm/actions/SearchableSnapshotActionIT.java
@@ -11,6 +11,7 @@ import org.apache.http.entity.ContentType;
 import org.apache.http.entity.StringEntity;
 import org.elasticsearch.client.Request;
 import org.elasticsearch.client.Response;
+import org.elasticsearch.client.ResponseException;
 import org.elasticsearch.cluster.metadata.DataStream;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.Template;
@@ -215,7 +216,7 @@ public class SearchableSnapshotActionIT extends ESRestTestCase {
     }
 
     public void testCreateInvalidPolicy() {
-        IllegalArgumentException exception = expectThrows(IllegalArgumentException.class, () -> createPolicy(client(), policy,
+        ResponseException exception = expectThrows(ResponseException.class, () -> createPolicy(client(), policy,
             new Phase("hot", TimeValue.ZERO, Map.of(RolloverAction.NAME, new RolloverAction(null, null, null, 1L), SearchableSnapshotAction.NAME,
                 new SearchableSnapshotAction(randomAlphaOfLengthBetween(4, 10)))),
             new Phase("warm", TimeValue.ZERO, Map.of(ForceMergeAction.NAME, new ForceMergeAction(1, null))),
@@ -224,7 +225,7 @@ public class SearchableSnapshotActionIT extends ESRestTestCase {
             )
         );
 
-        assertThat(exception.getMessage(), is("phases [warm,cold] define one or more of [forcemerge, freeze, shrink, rollup]" +
+        assertThat(exception.getMessage(), containsString("phases [warm,cold] define one or more of [forcemerge, freeze, shrink, rollup]" +
             " actions which are not allowed after a managed index is mounted as a searchable snapshot"));
     }
 
@@ -463,7 +464,7 @@ public class SearchableSnapshotActionIT extends ESRestTestCase {
         String secondRepo = randomAlphaOfLengthBetween(10, 20);
         createSnapshotRepo(client(), snapshotRepo, randomBoolean());
         createSnapshotRepo(client(), secondRepo, randomBoolean());
-        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () ->
+        ResponseException e = expectThrows(ResponseException.class, () ->
             createPolicy(client(), policy, null, null,
                 new Phase("cold", TimeValue.ZERO,
                     singletonMap(SearchableSnapshotAction.NAME, new SearchableSnapshotAction(snapshotRepo, randomBoolean()))),


### PR DESCRIPTION
This changes the `CopyExecutionStateStep` to copy all of the existing state from the original to the
new index after a shrink or searchable snapshot ILM action.

It also has two other changes
First, it fixes issues in `LifecycleExecutionState.equals` and `hashCode` where parts were missing,
and modifies the tests better so they would catch these issues better.

Second, it moves the lifecycle policy validation out of the constructor to a new method. This is
required because `PolicyStepsRegistry` constructs a new `LifecyclePolicy` out of the cached phase
JSON combined with the policy from the cluster state. In the event that the cached JSON contains an
action that prevents subsequent actions from being defined, we need to leniently allow this
behavior, because those steps will be ignored (see #64883 for this original implementation). The
policy is still validated when loaded elsewhere however.

Resolves #73791