### PR TITLE
Always handle non-complete AsyncActionStep execution

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/RolloverStep.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/RolloverStep.java
@@ -97,7 +97,11 @@ public class RolloverStep extends AsyncActionStep {
         getClient().admin().indices().rolloverIndex(rolloverRequest,
             ActionListener.wrap(response -> {
                 assert response.isRolledOver() : "the only way this rollover call should fail is with an exception";
-                listener.onResponse(response.isRolledOver());
+                if (response.isRolledOver()) {
+                    listener.onResponse(true);
+                } else {
+                    listener.onFailure(new IllegalStateException("unexepected exception on unconditional rollover"));
+                }
             }, listener::onFailure));
     }
 

--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/IndexLifecycleRunner.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/IndexLifecycleRunner.java
@@ -303,6 +303,12 @@ class IndexLifecycleRunner {
                                 // index since it will be... deleted.
                                 registerDeleteOperation(indexMetadata);
                             }
+                        } else {
+                            // All steps *should* return true for complete, or invoke listener.onFailure
+                            // with a useful exception. In the case that they don't, we move to error
+                            // step here with a generic exception
+                            moveToErrorStep(indexMetadata.getIndex(), policy, currentStep.getKey(),
+                                new IllegalStateException("unknown exception for step " + currentStep.getKey() + " in policy " + policy));
                         }
                     }
 


### PR DESCRIPTION
This commit ensures that `IndexLifecycleRunner` will always handle the execution of an
`AsyncActionStep`, regardless of it's returned status. In the event that it does not complete, the
index will move into the ERROR step with an exception, rather than being stuck in the step without a
way to execute the AsyncActionStep.

This also updates `CreateSnapshotStep` and `RolloverStep` to call `onFailure` with more helpful
exceptions rather than potentially returning `false` to the runner.

Resolves #73794
