### PR TITLE
Split GeometryParser into parser and serializer

### DIFF
--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/action/PainlessExecuteAction.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/action/PainlessExecuteAction.java
@@ -38,8 +38,8 @@ import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.geo.GeoJsonGeometryFormat;
 import org.elasticsearch.common.geo.GeoPoint;
-import org.elasticsearch.common.geo.GeometryFormat;
-import org.elasticsearch.common.geo.GeometryParser;
+import org.elasticsearch.common.geo.GeometrySerializer;
+import org.elasticsearch.common.geo.GeometrySerializerFactory;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -53,7 +53,6 @@ import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.XContentType;
-import org.elasticsearch.geometry.Geometry;
 import org.elasticsearch.geometry.Point;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.index.IndexService;
@@ -589,10 +588,10 @@ public class PainlessExecuteAction extends ActionType<PainlessExecuteAction.Resp
                     List<GeoPoint> points = new ArrayList<>();
                     geoPointFieldScript.runGeoPointForDoc(0, gp -> points.add(new GeoPoint(gp)));
                     // convert geo points to the standard format of the fields api
-                    GeometryFormat<Geometry> gf = new GeometryParser(true, true, true).geometryFormat(GeoJsonGeometryFormat.NAME);
+                    GeometrySerializer gs = GeometrySerializerFactory.INSTANCE.geometrySerializer(GeoJsonGeometryFormat.NAME);
                     List<Object> objects = new ArrayList<>();
                     for (GeoPoint gp : points) {
-                        objects.add(gf.toXContentAsObject(new Point(gp.getLon(), gp.getLat())));
+                        objects.add(gs.toXContentAsObject(new Point(gp.getLon(), gp.getLat())));
                     }
                     return new Response(objects);
                 }, indexService);

--- a/server/src/main/java/org/elasticsearch/common/geo/GeoJsonGeometryFormat.java
+++ b/server/src/main/java/org/elasticsearch/common/geo/GeoJsonGeometryFormat.java
@@ -15,7 +15,7 @@ import org.elasticsearch.geometry.Geometry;
 
 import java.io.IOException;
 
-public class GeoJsonGeometryFormat implements GeometryFormat<Geometry> {
+public class GeoJsonGeometryFormat implements GeometryFormat, GeometrySerializer {
     public static final String NAME = "geojson";
 
     private final GeoJson geoJsonParser;

--- a/server/src/main/java/org/elasticsearch/common/geo/GeometryFormat.java
+++ b/server/src/main/java/org/elasticsearch/common/geo/GeometryFormat.java
@@ -8,17 +8,16 @@
 
 package org.elasticsearch.common.geo;
 
-import org.elasticsearch.common.xcontent.ToXContent;
-import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.geometry.Geometry;
 
 import java.io.IOException;
 import java.text.ParseException;
 
 /**
- * Geometry serializer/deserializer
+ * Geometry parser
  */
-public interface GeometryFormat<ParsedFormat> {
+public interface GeometryFormat {
 
     /**
      * The name of the format, for example 'wkt'.
@@ -28,17 +27,5 @@ public interface GeometryFormat<ParsedFormat> {
     /**
      * Parser JSON representation of a geometry
      */
-    ParsedFormat fromXContent(XContentParser parser) throws IOException, ParseException;
-
-    /**
-     * Serializes the geometry into its JSON representation
-     */
-    XContentBuilder toXContent(ParsedFormat geometry, XContentBuilder builder, ToXContent.Params params) throws IOException;
-
-    /**
-     * Serializes the geometry into a standard Java object.
-     *
-     * For example, the GeoJson format returns the geometry as a map, while WKT returns a string.
-     */
-    Object toXContentAsObject(ParsedFormat geometry);
+    Geometry fromXContent(XContentParser parser) throws IOException, ParseException;
 }

--- a/server/src/main/java/org/elasticsearch/common/geo/GeometryParser.java
+++ b/server/src/main/java/org/elasticsearch/common/geo/GeometryParser.java
@@ -53,7 +53,7 @@ public final class GeometryParser {
     /**
      * Returns a geometry format object that can parse and then serialize the object back to the same format.
      */
-    public GeometryFormat<Geometry> geometryFormat(String format) {
+    public GeometryFormat geometryFormat(String format) {
         if (format.equals(GeoJsonGeometryFormat.NAME)) {
             return new GeoJsonGeometryFormat(geoJsonParser);
         } else if (format.equals(WKTGeometryFormat.NAME)) {
@@ -67,7 +67,7 @@ public final class GeometryParser {
      * Returns a geometry format object that can parse and then serialize the object back to the same format.
      * This method automatically recognizes the format by examining the provided {@link XContentParser}.
      */
-    public GeometryFormat<Geometry> geometryFormat(XContentParser parser) {
+    public GeometryFormat geometryFormat(XContentParser parser) {
         if (parser.currentToken() == XContentParser.Token.START_OBJECT) {
             return new GeoJsonGeometryFormat(geoJsonParser);
         } else if (parser.currentToken() == XContentParser.Token.VALUE_STRING) {

--- a/server/src/main/java/org/elasticsearch/common/geo/GeometrySerializer.java
+++ b/server/src/main/java/org/elasticsearch/common/geo/GeometrySerializer.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.common.geo;
+
+import org.elasticsearch.common.xcontent.ToXContent;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.geometry.Geometry;
+
+import java.io.IOException;
+
+/**
+ * Geometry serializer
+ */
+public interface GeometrySerializer {
+
+    /**
+     * Serializes the geometry into its JSON representation
+     */
+    XContentBuilder toXContent(Geometry geometry, XContentBuilder builder, ToXContent.Params params) throws IOException;
+
+    /**
+     * Serializes the geometry into a standard Java object.
+     *
+     * For example, the GeoJson format returns the geometry as a map, while WKT returns a string.
+     */
+    Object toXContentAsObject(Geometry geometry);
+}

--- a/server/src/main/java/org/elasticsearch/common/geo/GeometrySerializerFactory.java
+++ b/server/src/main/java/org/elasticsearch/common/geo/GeometrySerializerFactory.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.common.geo;
+
+import org.elasticsearch.geometry.utils.GeometryValidator;
+import org.elasticsearch.geometry.utils.StandardValidator;
+import org.elasticsearch.geometry.utils.WellKnownText;
+
+/**
+ * An utility class with a geometry parser methods supporting different shape representation formats
+ */
+public final class GeometrySerializerFactory {
+
+    private final GeoJson geoJsonParser;
+    private final WellKnownText wellKnownTextParser;
+
+    public static final GeometrySerializerFactory INSTANCE = new GeometrySerializerFactory();
+
+    private GeometrySerializerFactory() {
+        GeometryValidator validator = new StandardValidator(true);
+        geoJsonParser = new GeoJson(true, true, validator);
+        wellKnownTextParser = new WellKnownText(true, validator);
+    }
+
+    /**
+     * Returns a geometry format object that can parse and then serialize the object back to the same format.
+     */
+    public GeometrySerializer geometrySerializer(String format) {
+        if (format.equals(GeoJsonGeometryFormat.NAME)) {
+            return new GeoJsonGeometryFormat(geoJsonParser);
+        } else if (format.equals(WKTGeometryFormat.NAME)) {
+            return new WKTGeometryFormat(wellKnownTextParser);
+        } else {
+            throw new IllegalArgumentException("Unrecognized geometry format [" + format + "].");
+        }
+    }
+}

--- a/server/src/main/java/org/elasticsearch/common/geo/WKTGeometryFormat.java
+++ b/server/src/main/java/org/elasticsearch/common/geo/WKTGeometryFormat.java
@@ -17,7 +17,7 @@ import org.elasticsearch.geometry.utils.WellKnownText;
 import java.io.IOException;
 import java.text.ParseException;
 
-public class WKTGeometryFormat implements GeometryFormat<Geometry> {
+public class WKTGeometryFormat implements GeometryFormat, GeometrySerializer {
     public static final String NAME = "wkt";
 
     private final WellKnownText wellKnownTextParser;

--- a/server/src/main/java/org/elasticsearch/index/mapper/GeoShapeParser.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/GeoShapeParser.java
@@ -11,6 +11,7 @@ package org.elasticsearch.index.mapper;
 import org.elasticsearch.ElasticsearchParseException;
 import org.elasticsearch.common.CheckedConsumer;
 import org.elasticsearch.common.geo.GeometryParser;
+import org.elasticsearch.common.geo.GeometrySerializerFactory;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.geometry.Geometry;
 
@@ -40,7 +41,7 @@ public class GeoShapeParser extends AbstractGeometryFieldMapper.Parser<Geometry>
 
     @Override
     public Object format(Geometry value, String format) {
-        return geometryParser.geometryFormat(format).toXContentAsObject(value);
+        return GeometrySerializerFactory.INSTANCE.geometrySerializer(format).toXContentAsObject(value);
     }
 
 }

--- a/server/src/main/java/org/elasticsearch/index/mapper/LegacyGeoShapeFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/LegacyGeoShapeFieldMapper.java
@@ -21,6 +21,7 @@ import org.elasticsearch.common.CheckedConsumer;
 import org.elasticsearch.common.Explicit;
 import org.elasticsearch.common.geo.GeoUtils;
 import org.elasticsearch.common.geo.GeometryParser;
+import org.elasticsearch.common.geo.GeometrySerializerFactory;
 import org.elasticsearch.common.geo.ShapeRelation;
 import org.elasticsearch.common.geo.ShapesAvailability;
 import org.elasticsearch.common.geo.SpatialStrategy;
@@ -335,8 +336,7 @@ public class LegacyGeoShapeFieldMapper extends AbstractShapeGeometryFieldMapper<
 
         @Override
         public Object format(ShapeBuilder<?, ?, ?> value, String format) {
-            Geometry geometry = value.buildGeometry();
-            return geometryParser.geometryFormat(format).toXContentAsObject(geometry);
+            return GeometrySerializerFactory.INSTANCE.geometrySerializer(format).toXContentAsObject(value.buildGeometry());
         }
     }
 

--- a/server/src/test/java/org/elasticsearch/common/geo/GeometryParserTests.java
+++ b/server/src/test/java/org/elasticsearch/common/geo/GeometryParserTests.java
@@ -44,7 +44,8 @@ public class GeometryParserTests extends ESTestCase {
             GeometryFormat format = new GeometryParser(true, randomBoolean(), randomBoolean()).geometryFormat(parser);
             assertEquals(new Point(100, 0), format.fromXContent(parser));
             XContentBuilder newGeoJson = XContentFactory.jsonBuilder();
-            format.toXContent(new Point(100, 10), newGeoJson, ToXContent.EMPTY_PARAMS);
+            GeometrySerializer serializer = GeometrySerializerFactory.INSTANCE.geometrySerializer(format.name());
+            serializer.toXContent(new Point(100, 10), newGeoJson, ToXContent.EMPTY_PARAMS);
             assertEquals("{\"type\":\"Point\",\"coordinates\":[100.0,10.0]}", Strings.toString(newGeoJson));
         }
 
@@ -105,7 +106,8 @@ public class GeometryParserTests extends ESTestCase {
             GeometryFormat format = new GeometryParser(true, randomBoolean(), randomBoolean()).geometryFormat(parser);
             assertEquals(new Point(100, 0), format.fromXContent(parser));
             XContentBuilder newGeoJson = XContentFactory.jsonBuilder().startObject().field("val");
-            format.toXContent(new Point(100, 10), newGeoJson, ToXContent.EMPTY_PARAMS);
+            GeometrySerializer serializer = GeometrySerializerFactory.INSTANCE.geometrySerializer(format.name());
+            serializer.toXContent(new Point(100, 10), newGeoJson, ToXContent.EMPTY_PARAMS);
             newGeoJson.endObject();
             assertEquals("{\"val\":\"POINT (100.0 10.0)\"}", Strings.toString(newGeoJson));
         }
@@ -140,12 +142,13 @@ public class GeometryParserTests extends ESTestCase {
 
             XContentBuilder newGeoJson = XContentFactory.jsonBuilder().startObject().field("val");
             // if we serialize non-null value - it should be serialized as geojson
-            format.toXContent(new Point(100, 10), newGeoJson, ToXContent.EMPTY_PARAMS);
+            GeometrySerializer serializer = GeometrySerializerFactory.INSTANCE.geometrySerializer(format.name());
+            serializer.toXContent(new Point(100, 10), newGeoJson, ToXContent.EMPTY_PARAMS);
             newGeoJson.endObject();
             assertEquals("{\"val\":{\"type\":\"Point\",\"coordinates\":[100.0,10.0]}}", Strings.toString(newGeoJson));
 
             newGeoJson = XContentFactory.jsonBuilder().startObject().field("val");
-            format.toXContent(null, newGeoJson, ToXContent.EMPTY_PARAMS);
+            serializer.toXContent(null, newGeoJson, ToXContent.EMPTY_PARAMS);
             newGeoJson.endObject();
             assertEquals("{\"val\":null}", Strings.toString(newGeoJson));
 

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/mapper/PointFieldMapper.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/mapper/PointFieldMapper.java
@@ -12,8 +12,7 @@ import org.apache.lucene.document.XYPointField;
 import org.apache.lucene.search.Query;
 import org.elasticsearch.common.CheckedBiFunction;
 import org.elasticsearch.common.Explicit;
-import org.elasticsearch.common.geo.GeometryFormat;
-import org.elasticsearch.common.geo.GeometryParser;
+import org.elasticsearch.common.geo.GeometrySerializerFactory;
 import org.elasticsearch.common.geo.ShapeRelation;
 import org.elasticsearch.common.logging.DeprecationCategory;
 import org.elasticsearch.common.logging.DeprecationLogger;
@@ -181,8 +180,6 @@ public class PointFieldMapper extends AbstractPointGeometryFieldMapper<Cartesian
 
     /** CartesianPoint parser implementation */
     private static class CartesianPointParser extends PointParser<CartesianPoint> {
-        // Note that this parser is only used for formatting values.
-        private final GeometryParser geometryParser;
 
         CartesianPointParser(String field,
                              Supplier<CartesianPoint> pointSupplier,
@@ -191,7 +188,6 @@ public class PointFieldMapper extends AbstractPointGeometryFieldMapper<Cartesian
                              boolean ignoreZValue,
                              boolean ignoreMalformed) {
             super(field, pointSupplier, objectParser, nullValue, ignoreZValue, ignoreMalformed);
-            this.geometryParser = new GeometryParser(true, true, true);
         }
 
         @Override
@@ -214,8 +210,7 @@ public class PointFieldMapper extends AbstractPointGeometryFieldMapper<Cartesian
 
         @Override
         public Object format(CartesianPoint value, String format) {
-            GeometryFormat<Geometry> geometryFormat = geometryParser.geometryFormat(format);
-            return geometryFormat.toXContentAsObject(new Point(value.getX(), value.getY()));
+            return GeometrySerializerFactory.INSTANCE.geometrySerializer(format).toXContentAsObject(new Point(value.getX(), value.getY()));
         }
     }
 }

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/ingest/CircleProcessor.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/ingest/CircleProcessor.java
@@ -9,6 +9,8 @@ package org.elasticsearch.xpack.spatial.ingest;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.geo.GeometryFormat;
 import org.elasticsearch.common.geo.GeometryParser;
+import org.elasticsearch.common.geo.GeometrySerializer;
+import org.elasticsearch.common.geo.GeometrySerializerFactory;
 import org.elasticsearch.common.xcontent.DeprecationHandler;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 import org.elasticsearch.common.xcontent.ToXContent;
@@ -81,7 +83,8 @@ public final class CircleProcessor extends AbstractProcessor {
             parser.nextToken(); // START_OBJECT
             parser.nextToken(); // "shape" field key
             parser.nextToken(); // shape value
-            GeometryFormat<Geometry> geometryFormat = PARSER.geometryFormat(parser);
+            GeometryFormat geometryFormat = PARSER.geometryFormat(parser);
+            GeometrySerializer geometrySerializer = GeometrySerializerFactory.INSTANCE.geometrySerializer(geometryFormat.name());
             Geometry geometry = geometryFormat.fromXContent(parser);
             if (ShapeType.CIRCLE.equals(geometry.type())) {
                 Circle circle = (Circle) geometry;
@@ -98,7 +101,7 @@ public final class CircleProcessor extends AbstractProcessor {
                         throw new IllegalStateException("invalid shape_type [" + circleShapeFieldType + "]");
                 }
                 XContentBuilder newValueBuilder = XContentFactory.jsonBuilder().startObject().field("val");
-                geometryFormat.toXContent(polygonizedCircle, newValueBuilder, ToXContent.EMPTY_PARAMS);
+                geometrySerializer.toXContent(polygonizedCircle, newValueBuilder, ToXContent.EMPTY_PARAMS);
                 newValueBuilder.endObject();
                 Map<String, Object> newObj = XContentHelper.convertToMap(
                     BytesReference.bytes(newValueBuilder), true, XContentType.JSON).v2();


### PR DESCRIPTION
Splits GeometryParser into two separate components that deal with serialization
and parsing separately. This is the first step necessary to make serialization
plugable.
