### PR TITLE
Fix AutoFollowCoordinatorTests#testExcludedPatternIndicesAreNotAutoFollowed

### DIFF
--- a/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/action/AutoFollowCoordinatorTests.java
+++ b/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/action/AutoFollowCoordinatorTests.java
@@ -2051,7 +2051,6 @@ public class AutoFollowCoordinatorTests extends ESTestCase {
         }
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/73797")
     public void testExcludedPatternIndicesAreNotAutoFollowed() {
         final Client client = mock(Client.class);
         when(client.getRemoteClusterClient(anyString())).thenReturn(client);
@@ -2086,15 +2085,11 @@ public class AutoFollowCoordinatorTests extends ESTestCase {
                         Map.of(pattern, Map.of()))))
             .build();
 
-        ClusterState remoteState = null;
+        ClusterState remoteState = ClusterState.EMPTY_STATE;
         final int nbLeaderIndices = randomIntBetween(0, 15);
         for (int i = 0; i < nbLeaderIndices; i++) {
             String indexName = "docs-" + i;
-            if (remoteState == null) {
-                remoteState = createRemoteClusterState(indexName, true);
-            } else {
-                remoteState = createRemoteClusterState(remoteState, indexName);
-            }
+            remoteState = createRemoteClusterState(remoteState, indexName);
         }
 
         final int nbLeaderExcludedIndices = randomIntBetween(1, 15);


### PR DESCRIPTION
Use an empty ClusterState as a base cluster state to take into account
the case where no leader candidate indices are created

Closes #73797
Relates #72935