### PR TITLE
Fix extra line in build.gradle from spatial module

### DIFF
--- a/x-pack/plugin/spatial/build.gradle
+++ b/x-pack/plugin/spatial/build.gradle
@@ -14,7 +14,6 @@ dependencies {
   compileOnly project(path: xpackModule('core'))
   testImplementation(testArtifact(project(xpackModule('core'))))
   yamlRestTestImplementation(testArtifact(project(xpackModule('core'))))
-  restTestConfig project(path: ':modules:geo', configuration: 'restTests')
   api project(path: ':modules:geo')
   restTestConfig project(path: ':modules:geo', configuration: 'restTests')
 }


### PR DESCRIPTION
Fix leftover when we moved vector tiles to its own module. This change makes the file the same as the one in the master branch.