### PR TITLE
Service Accounts - Enable rest compat tests

### DIFF
--- a/x-pack/plugin/build.gradle
+++ b/x-pack/plugin/build.gradle
@@ -163,8 +163,7 @@ tasks.named("yamlRestCompatTest").configure {
     'vectors/40_sparse_vector_special_cases/Query vector has different dimensions from documents\' vectors',
     'vectors/40_sparse_vector_special_cases/Sparse vectors should error with dense vector functions',
     'vectors/40_sparse_vector_special_cases/Vectors of different dimensions and data types',
-    'vectors/50_vector_stats/Usage stats on vector fields',
-    'service_accounts/10_basic/*'
+    'vectors/50_vector_stats/Usage stats on vector fields'
   ])
 
   systemProperty 'tests.rest.blacklist', restTestBlacklist.join(',')


### PR DESCRIPTION
Changes are backported and the rest compat tests can now be enabled.

