### PR TITLE
[7.13] Always handle non-complete AsyncActionStep execution (#73796)

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/RolloverStep.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/RolloverStep.java
@@ -97,7 +97,11 @@ public class RolloverStep extends AsyncActionStep {
         getClient().admin().indices().rolloverIndex(rolloverRequest,
             ActionListener.wrap(response -> {
                 assert response.isRolledOver() : "the only way this rollover call should fail is with an exception";
-                listener.onResponse(response.isRolledOver());
+                if (response.isRolledOver()) {
+                    listener.onResponse(true);
+                } else {
+                    listener.onFailure(new IllegalStateException("unexepected exception on unconditional rollover"));
+                }
             }, listener::onFailure));
     }
 

--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/IndexLifecycleRunner.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/IndexLifecycleRunner.java
@@ -303,6 +303,12 @@ class IndexLifecycleRunner {
                                 // index since it will be... deleted.
                                 registerDeleteOperation(indexMetadata);
                             }
+                        } else {
+                            // All steps *should* return true for complete, or invoke listener.onFailure
+                            // with a useful exception. In the case that they don't, we move to error
+                            // step here with a generic exception
+                            moveToErrorStep(indexMetadata.getIndex(), policy, currentStep.getKey(),
+                                new IllegalStateException("unknown exception for step " + currentStep.getKey() + " in policy " + policy));
                         }
                     }
 


### PR DESCRIPTION
Backports the following commits to 7.13:
 - Always handle non-complete AsyncActionStep execution (#73796)