### PR TITLE
[7.x] Docvalueformat errors (#73121)

### DIFF
--- a/docs/reference/aggregations/bucket/terms-aggregation.asciidoc
+++ b/docs/reference/aggregations/bucket/terms-aggregation.asciidoc
@@ -777,3 +777,34 @@ WARNING: When aggregating on multiple indices the type of the aggregated field m
 Some types are compatible with each other (`integer` and `long` or `float` and `double`) but when the types are a mix
 of decimal and non-decimal number the terms aggregation will promote the non-decimal numbers to decimal numbers.
 This can result in a loss of precision in the bucket values.
+
+[discrete]
+[[search-aggregations-bucket-terms-aggregation-troubleshooting]]
+==== Troubleshooting
+
+===== Failed Trying to Format Bytes
+When running a terms aggregation (or other aggregation, but in practice usually
+terms) over multiple indices, you may get an error that starts with "Failed
+trying to format bytes...".  This is usually caused by two of the indices not
+having the same mapping type for the field being aggregated.
+
+**Use an explicit `value_type`**
+Although it's best to correct the mappings, you can work around this issue if
+the field is unmapped in one of the indices.  Setting the `value_type` parameter
+can resolve the issue by coercing the unmapped field into the correct type.
+
+[source,console,id=terms-aggregation-value_type-example]
+----
+GET /_search
+{
+  "aggs": {
+    "ip_addresses": {
+      "terms": {
+        "field": "destination_ip",
+        "missing": "0.0.0.0",
+        "value_type": "ip"
+      }
+    }
+  }
+}
+----

--- a/server/src/main/java/org/elasticsearch/search/DocValueFormat.java
+++ b/server/src/main/java/org/elasticsearch/search/DocValueFormat.java
@@ -95,7 +95,16 @@ public interface DocValueFormat extends NamedWriteable {
         return value;
     }
 
-    DocValueFormat RAW = new DocValueFormat() {
+    DocValueFormat RAW = RawDocValueFormat.INSTANCE;
+
+    /**
+     * Singleton, stateless formatter for "Raw" values, generally taken to mean keywords and other strings.
+     */
+    class RawDocValueFormat implements DocValueFormat {
+
+        public static final DocValueFormat INSTANCE = new RawDocValueFormat();
+
+        private RawDocValueFormat() { }
 
         @Override
         public String getWriteableName() {
@@ -118,7 +127,11 @@ public interface DocValueFormat extends NamedWriteable {
 
         @Override
         public String format(BytesRef value) {
-            return value.utf8ToString();
+            try {
+                return value.utf8ToString();
+            } catch (Exception | AssertionError e) {
+                throw new IllegalArgumentException("Failed trying to format bytes as UTF8.  Possibly caused by a mapping mismatch", e);
+            }
         }
 
         @Override
@@ -154,7 +167,16 @@ public interface DocValueFormat extends NamedWriteable {
         }
     };
 
-    DocValueFormat BINARY = new DocValueFormat() {
+    DocValueFormat BINARY = BinaryDocValueFormat.INSTANCE;
+
+    /**
+     * Singleton, stateless formatter, for representing bytes as base64 strings
+     */
+    class BinaryDocValueFormat implements DocValueFormat {
+
+        public static final DocValueFormat INSTANCE = new BinaryDocValueFormat();
+
+        private BinaryDocValueFormat() {}
 
         @Override
         public String getWriteableName() {
@@ -316,7 +338,16 @@ public interface DocValueFormat extends NamedWriteable {
         }
     }
 
-    DocValueFormat GEOHASH = new DocValueFormat() {
+    DocValueFormat GEOHASH = GeoHashDocValueFormat.INSTANCE;
+
+    /**
+     * Singleton, stateless formatter for geo hash values
+     */
+    class GeoHashDocValueFormat implements DocValueFormat {
+
+        public static final DocValueFormat INSTANCE = new GeoHashDocValueFormat();
+
+        private GeoHashDocValueFormat() {}
 
         @Override
         public String getWriteableName() {
@@ -338,7 +369,12 @@ public interface DocValueFormat extends NamedWriteable {
         }
     };
 
-    DocValueFormat GEOTILE = new DocValueFormat() {
+    DocValueFormat GEOTILE = GeoTileDocValueFormat.INSTANCE;
+    class GeoTileDocValueFormat implements DocValueFormat {
+
+        public static final DocValueFormat INSTANCE = new GeoTileDocValueFormat();
+
+        private GeoTileDocValueFormat() {}
 
         @Override
         public String getWriteableName() {
@@ -360,7 +396,16 @@ public interface DocValueFormat extends NamedWriteable {
         }
     };
 
-    DocValueFormat BOOLEAN = new DocValueFormat() {
+    DocValueFormat BOOLEAN = BooleanDocValueFormat.INSTANCE;
+
+    /**
+     * Stateless, Singleton formatter for boolean values.  Parses the strings "true" and "false" as inputs.
+     */
+    class BooleanDocValueFormat implements DocValueFormat {
+
+        public static final DocValueFormat INSTANCE = new BooleanDocValueFormat();
+
+        private BooleanDocValueFormat() {}
 
         @Override
         public String getWriteableName() {
@@ -398,7 +443,16 @@ public interface DocValueFormat extends NamedWriteable {
         }
     };
 
-    DocValueFormat IP = new DocValueFormat() {
+    DocValueFormat IP = IpDocValueFormat.INSTANCE;
+
+    /**
+     * Stateless, singleton formatter for IP address data
+     */
+    class IpDocValueFormat implements DocValueFormat {
+
+        public static final DocValueFormat INSTANCE = new IpDocValueFormat();
+
+        private IpDocValueFormat() {}
 
         @Override
         public String getWriteableName() {
@@ -411,9 +465,16 @@ public interface DocValueFormat extends NamedWriteable {
 
         @Override
         public String format(BytesRef value) {
-            byte[] bytes = Arrays.copyOfRange(value.bytes, value.offset, value.offset + value.length);
-            InetAddress inet = InetAddressPoint.decode(bytes);
-            return NetworkAddress.format(inet);
+            try {
+                byte[] bytes = Arrays.copyOfRange(value.bytes, value.offset, value.offset + value.length);
+                InetAddress inet = InetAddressPoint.decode(bytes);
+                return NetworkAddress.format(inet);
+            } catch (IllegalArgumentException e) {
+                throw new IllegalArgumentException(
+                    "Failed trying to format bytes as IP address.  Possibly caused by a mapping mismatch",
+                    e
+                );
+            }
         }
 
         @Override
@@ -534,11 +595,17 @@ public interface DocValueFormat extends NamedWriteable {
         }
     };
 
+    DocValueFormat UNSIGNED_LONG_SHIFTED = UnsignedLongShiftedDocValueFormat.INSTANCE;
+
     /**
      * DocValues format for unsigned 64 bit long values,
      * that are stored as shifted signed 64 bit long values.
      */
-    DocValueFormat UNSIGNED_LONG_SHIFTED = new DocValueFormat() {
+    class UnsignedLongShiftedDocValueFormat implements DocValueFormat {
+
+        public static final DocValueFormat INSTANCE = new UnsignedLongShiftedDocValueFormat();
+
+        private UnsignedLongShiftedDocValueFormat() {}
 
         @Override
         public String getWriteableName() {


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Docvalueformat errors (#73121)