### PR TITLE
Move filter adapters to their own files (backport of #73720)

### DIFF
--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/filter/DocValuesFieldExistsAdapter.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/filter/DocValuesFieldExistsAdapter.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.search.aggregations.bucket.filter;
+
+import org.apache.lucene.index.FieldInfo;
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.index.PointValues;
+import org.apache.lucene.search.DocValuesFieldExistsQuery;
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.util.Bits;
+import org.elasticsearch.common.CheckedSupplier;
+
+import java.io.IOException;
+import java.util.function.BiConsumer;
+
+/**
+ * Specialized {@link QueryToFilterAdapter} for {@link DocValuesFieldExistsQuery} that reads counts from metadata.
+ */
+class DocValuesFieldExistsAdapter extends QueryToFilterAdapter<DocValuesFieldExistsQuery> {
+    private int resultsFromMetadata;
+
+    DocValuesFieldExistsAdapter(IndexSearcher searcher, String key, DocValuesFieldExistsQuery query) {
+        super(searcher, key, query);
+    }
+
+    @Override
+    long count(LeafReaderContext ctx, FiltersAggregator.Counter counter, Bits live) throws IOException {
+        if (countCanUseMetadata(counter, live) && canCountFromMetadata(ctx)) {
+            resultsFromMetadata++;
+            PointValues points = ctx.reader().getPointValues(query().getField());
+            if (points == null) {
+                return 0;
+            }
+            return points.getDocCount();
+
+        }
+        return super.count(ctx, counter, live);
+    }
+
+    @Override
+    long estimateCountCost(LeafReaderContext ctx, CheckedSupplier<Boolean, IOException> canUseMetadata) throws IOException {
+        if (canUseMetadata.get() && canCountFromMetadata(ctx)) {
+            return 0;
+        }
+        return super.estimateCountCost(ctx, canUseMetadata);
+    }
+
+    private boolean canCountFromMetadata(LeafReaderContext ctx) throws IOException {
+        FieldInfo info = ctx.reader().getFieldInfos().fieldInfo(query().getField());
+        if (info == null) {
+            // If we don't have any info then there aren't any values anyway.
+            return true;
+        }
+        return info.getPointDimensionCount() > 0;
+    }
+
+    @Override
+    void collectDebugInfo(BiConsumer<String, Object> add) {
+        super.collectDebugInfo(add);
+        add.accept("specialized_for", "docvalues_field_exists");
+        add.accept("results_from_metadata", resultsFromMetadata);
+    }
+}

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/filter/MatchAllQueryToFilterAdapter.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/filter/MatchAllQueryToFilterAdapter.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.search.aggregations.bucket.filter;
+
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.MatchAllDocsQuery;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.util.Bits;
+import org.elasticsearch.common.CheckedSupplier;
+
+import java.io.IOException;
+import java.util.function.BiConsumer;
+import java.util.function.IntPredicate;
+
+/**
+ * Filter that matches every document.
+ */
+class MatchAllQueryToFilterAdapter extends QueryToFilterAdapter<MatchAllDocsQuery> {
+    private int resultsFromMetadata;
+
+    MatchAllQueryToFilterAdapter(IndexSearcher searcher, String key, MatchAllDocsQuery query) {
+        super(searcher, key, query);
+    }
+
+    @Override
+    QueryToFilterAdapter<?> union(Query extraQuery) throws IOException {
+        return QueryToFilterAdapter.build(searcher(), key(), extraQuery);
+    }
+
+    @Override
+    IntPredicate matchingDocIds(LeafReaderContext ctx) throws IOException {
+        return l -> true;
+    }
+
+    @Override
+    long count(LeafReaderContext ctx, FiltersAggregator.Counter counter, Bits live) throws IOException {
+        if (countCanUseMetadata(counter, live)) {
+            resultsFromMetadata++;
+            return ctx.reader().maxDoc();  // TODO we could use numDocs even if live is not null because provides accurate numDocs.
+        }
+        return super.count(ctx, counter, live);
+    }
+
+    @Override
+    long estimateCountCost(LeafReaderContext ctx, CheckedSupplier<Boolean, IOException> canUseMetadata) throws IOException {
+        return canUseMetadata.get() ? 0 : ctx.reader().maxDoc();
+    }
+
+    @Override
+    void collectDebugInfo(BiConsumer<String, Object> add) {
+        super.collectDebugInfo(add);
+        add.accept("specialized_for", "match_all");
+        add.accept("results_from_metadata", resultsFromMetadata);
+    }
+}

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/filter/MatchNoneQueryToFilterAdapter.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/filter/MatchNoneQueryToFilterAdapter.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.search.aggregations.bucket.filter;
+
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.MatchNoDocsQuery;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.util.Bits;
+import org.elasticsearch.common.CheckedSupplier;
+
+import java.io.IOException;
+import java.util.function.BiConsumer;
+import java.util.function.IntPredicate;
+
+/**
+ * Special case when the filter can't match anything.
+ */
+class MatchNoneQueryToFilterAdapter extends QueryToFilterAdapter<MatchNoDocsQuery> {
+    MatchNoneQueryToFilterAdapter(IndexSearcher searcher, String key, MatchNoDocsQuery query) {
+        super(searcher, key, query);
+    }
+
+    @Override
+    QueryToFilterAdapter<?> union(Query extraQuery) throws IOException {
+        return this;
+    }
+
+    @Override
+    IntPredicate matchingDocIds(LeafReaderContext ctx) throws IOException {
+        return l -> false;
+    }
+
+    @Override
+    long count(LeafReaderContext ctx, FiltersAggregator.Counter counter, Bits live) throws IOException {
+        return 0;
+    }
+
+    @Override
+    long estimateCountCost(LeafReaderContext ctx, CheckedSupplier<Boolean, IOException> canUseMetadata) throws IOException {
+        return 0;
+    }
+
+    @Override
+    void collectDebugInfo(BiConsumer<String, Object> add) {
+        super.collectDebugInfo(add);
+        add.accept("specialized_for", "match_none");
+    }
+}

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/filter/TermQueryToFilterAdapter.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/filter/TermQueryToFilterAdapter.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.search.aggregations.bucket.filter;
+
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.TermQuery;
+import org.apache.lucene.util.Bits;
+import org.elasticsearch.common.CheckedSupplier;
+
+import java.io.IOException;
+import java.util.function.BiConsumer;
+
+/**
+ * Specialized {@link QueryToFilterAdapter} for {@link TermQuery} that reads counts from metadata.
+ */
+class TermQueryToFilterAdapter extends QueryToFilterAdapter<TermQuery> {
+    private int resultsFromMetadata;
+
+    TermQueryToFilterAdapter(IndexSearcher searcher, String key, TermQuery query) {
+        super(searcher, key, query);
+    }
+
+    @Override
+    long count(LeafReaderContext ctx, FiltersAggregator.Counter counter, Bits live) throws IOException {
+        if (countCanUseMetadata(counter, live)) {
+            resultsFromMetadata++;
+            return ctx.reader().docFreq(query().getTerm());
+        }
+        return super.count(ctx, counter, live);
+    }
+
+    @Override
+    long estimateCountCost(LeafReaderContext ctx, CheckedSupplier<Boolean, IOException> canUseMetadata) throws IOException {
+        if (canUseMetadata.get()) {
+            return 0;
+        }
+        return super.estimateCountCost(ctx, canUseMetadata);
+    }
+
+    @Override
+    void collectDebugInfo(BiConsumer<String, Object> add) {
+        super.collectDebugInfo(add);
+        add.accept("specialized_for", "term");
+        add.accept("results_from_metadata", resultsFromMetadata);
+    }
+}


### PR DESCRIPTION
This refactors a part of the `filters` aggregator into multiple files so
its a little easier to read. We ended up with more subclasses then we
expected at first.
