### PR TITLE
GeoShapeIndexer#prepareForIndex should be called for computing the doc value centroid (#73856)

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/mapper/GeoShapeFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/GeoShapeFieldMapper.java
@@ -202,7 +202,7 @@ public class GeoShapeFieldMapper extends AbstractShapeGeometryFieldMapper<Geomet
         if (geometry == null) {
             return;
         }
-        context.doc().addAll(indexer.indexShape(geometry));
+        context.doc().addAll(indexer.indexShape(indexer.prepareForIndexing(geometry)));
         context.addToFieldNames(fieldType().name());
     }
 

--- a/server/src/main/java/org/elasticsearch/index/mapper/GeoShapeIndexer.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/GeoShapeIndexer.java
@@ -168,11 +168,10 @@ public class GeoShapeIndexer {
     }
 
     public List<IndexableField> indexShape(Geometry shape) {
-        LuceneGeometryIndexer visitor = new LuceneGeometryIndexer(name);
-        shape = prepareForIndexing(shape);
         if (shape == null) {
             return Collections.emptyList();
         }
+        LuceneGeometryIndexer visitor = new LuceneGeometryIndexer(name);
         shape.visit(visitor);
         return visitor.fields();
     }

--- a/x-pack/plugin/spatial/src/internalClusterTest/java/org/elasticsearch/xpack/spatial/search/GeoShapeScriptDocValuesIT.java
+++ b/x-pack/plugin/spatial/src/internalClusterTest/java/org/elasticsearch/xpack/spatial/search/GeoShapeScriptDocValuesIT.java
@@ -22,6 +22,8 @@ import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.geo.GeometryTestUtils;
 import org.elasticsearch.geometry.Geometry;
+import org.elasticsearch.geometry.LinearRing;
+import org.elasticsearch.geometry.Polygon;
 import org.elasticsearch.geometry.utils.WellKnownText;
 import org.elasticsearch.index.fielddata.ScriptDocValues;
 import org.elasticsearch.index.mapper.GeoShapeIndexer;
@@ -147,6 +149,15 @@ public class GeoShapeScriptDocValuesIT extends ESSingleNodeTestCase {
                 return true;
             }
         }, () -> GeometryTestUtils.randomGeometry(false)));
+        doTestGeometry(geometry);
+    }
+
+    public void testPolygonDateline() throws Exception {
+        Geometry geometry = new Polygon(new LinearRing(new double[]{170, 190, 190, 170, 170}, new double[]{-5, -5, 5, 5, -5}));
+        doTestGeometry(geometry);
+    }
+
+    private void doTestGeometry(Geometry geometry) throws IOException  {
         client().prepareIndex("test", "_doc").setId("1")
             .setSource(jsonBuilder().startObject()
                 .field("name", "TestPosition")

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/mapper/GeoShapeWithDocValuesFieldMapper.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/mapper/GeoShapeWithDocValuesFieldMapper.java
@@ -210,6 +210,7 @@ public class GeoShapeWithDocValuesFieldMapper extends AbstractShapeGeometryField
         if (geometry == null) {
             return;
         }
+        geometry = indexer.prepareForIndexing(geometry);
         List<IndexableField> fields = indexer.indexShape(geometry);
         if (fieldType().isSearchable()) {
             context.doc().addAll(fields);

--- a/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/ingest/CircleProcessorTests.java
+++ b/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/ingest/CircleProcessorTests.java
@@ -226,7 +226,7 @@ public class CircleProcessorTests extends ESTestCase {
         try (Directory dir = newDirectory(); RandomIndexWriter w = new RandomIndexWriter(random(), dir)) {
             Document doc = new Document();
             GeoShapeIndexer indexer = new GeoShapeIndexer(true, fieldName);
-            for (IndexableField field : indexer.indexShape(geometry)) {
+            for (IndexableField field : indexer.indexShape(indexer.prepareForIndexing(geometry))) {
                 doc.add(field);
             }
             w.addDocument(doc);


### PR DESCRIPTION
The refactor in #71696 introduced a bug where computing the centroid of a shape is done on the original shape. Therefore for shapes that crosses the dateline, the computation of the centroid might be wrong.

This PR reverts that part of the logic again so the centroid is computed on the processed shape.

backport of #73856