### PR TITLE
Make methods in GeoJson and WellKnownText static (#73805)

### DIFF
--- a/libs/geo/src/main/java/org/elasticsearch/geometry/Circle.java
+++ b/libs/geo/src/main/java/org/elasticsearch/geometry/Circle.java
@@ -114,7 +114,7 @@ public class Circle implements Geometry {
 
     @Override
     public String toString() {
-        return WellKnownText.INSTANCE.toWKT(this);
+        return WellKnownText.toWKT(this);
     }
 
     @Override

--- a/libs/geo/src/main/java/org/elasticsearch/geometry/GeometryCollection.java
+++ b/libs/geo/src/main/java/org/elasticsearch/geometry/GeometryCollection.java
@@ -89,6 +89,6 @@ public class GeometryCollection<G extends Geometry> implements Geometry, Iterabl
 
     @Override
     public String toString() {
-        return WellKnownText.INSTANCE.toWKT(this);
+        return WellKnownText.toWKT(this);
     }
 }

--- a/libs/geo/src/main/java/org/elasticsearch/geometry/GeometryVisitor.java
+++ b/libs/geo/src/main/java/org/elasticsearch/geometry/GeometryVisitor.java
@@ -31,7 +31,7 @@ import org.elasticsearch.geometry.utils.WellKnownText;
  * The Visitor Pattern replaces this structure with Interface inheritance making it easier to identify all places that are using this
  * structure, and making a shape a compile-time failure instead of runtime.
  * <p>
- * See {@link WellKnownText#toWKT(Geometry, StringBuilder)} for an example of how this interface is used.
+ * See {@link WellKnownText#toWKT(Geometry)} for an example of how this interface is used.
  *
  * @see <a href="https://en.wikipedia.org/wiki/Visitor_pattern">Visitor Pattern</a>
  */

--- a/libs/geo/src/main/java/org/elasticsearch/geometry/Line.java
+++ b/libs/geo/src/main/java/org/elasticsearch/geometry/Line.java
@@ -151,6 +151,6 @@ public class Line implements Geometry {
 
     @Override
     public String toString() {
-        return WellKnownText.INSTANCE.toWKT(this);
+        return WellKnownText.toWKT(this);
     }
 }

--- a/libs/geo/src/main/java/org/elasticsearch/geometry/Point.java
+++ b/libs/geo/src/main/java/org/elasticsearch/geometry/Point.java
@@ -110,7 +110,7 @@ public class Point implements Geometry {
 
     @Override
     public String toString() {
-        return WellKnownText.INSTANCE.toWKT(this);
+        return WellKnownText.toWKT(this);
     }
 
 }

--- a/libs/geo/src/main/java/org/elasticsearch/geometry/Rectangle.java
+++ b/libs/geo/src/main/java/org/elasticsearch/geometry/Rectangle.java
@@ -133,7 +133,7 @@ public class Rectangle implements Geometry {
 
     @Override
     public String toString() {
-        return WellKnownText.INSTANCE.toWKT(this);
+        return WellKnownText.toWKT(this);
     }
 
 

--- a/libs/geo/src/main/java/org/elasticsearch/geometry/utils/GeographyValidator.java
+++ b/libs/geo/src/main/java/org/elasticsearch/geometry/utils/GeographyValidator.java
@@ -27,6 +27,9 @@ import org.elasticsearch.geometry.Rectangle;
  */
 public class GeographyValidator implements GeometryValidator {
 
+    private static final GeometryValidator TRUE = new GeographyValidator(true);
+    private static final GeometryValidator FALSE = new GeographyValidator(false);
+
     /**
      * Minimum longitude value.
      */
@@ -49,8 +52,12 @@ public class GeographyValidator implements GeometryValidator {
 
     private final boolean ignoreZValue;
 
-    public GeographyValidator(boolean ignoreZValue) {
+    protected GeographyValidator(boolean ignoreZValue) {
         this.ignoreZValue = ignoreZValue;
+    }
+
+    public static GeometryValidator instance(boolean ignoreZValue) {
+        return ignoreZValue ? TRUE : FALSE;
     }
 
     /**

--- a/libs/geo/src/main/java/org/elasticsearch/geometry/utils/StandardValidator.java
+++ b/libs/geo/src/main/java/org/elasticsearch/geometry/utils/StandardValidator.java
@@ -26,10 +26,17 @@ import org.elasticsearch.geometry.Rectangle;
  */
 public class StandardValidator implements GeometryValidator {
 
+    private static final GeometryValidator TRUE = new StandardValidator(true);
+    private static final GeometryValidator FALSE = new StandardValidator(false);
+
     private final boolean ignoreZValue;
 
-    public StandardValidator(boolean ignoreZValue) {
+    private StandardValidator(boolean ignoreZValue) {
        this.ignoreZValue = ignoreZValue;
+    }
+
+    public static GeometryValidator instance(boolean ignoreZValue) {
+        return ignoreZValue ? TRUE : FALSE;
     }
 
     protected void checkZ(double zValue) {

--- a/libs/geo/src/test/java/org/elasticsearch/geometry/BaseGeometryTestCase.java
+++ b/libs/geo/src/test/java/org/elasticsearch/geometry/BaseGeometryTestCase.java
@@ -33,10 +33,9 @@ abstract class BaseGeometryTestCase<T extends Geometry> extends AbstractWireTest
     @SuppressWarnings("unchecked")
     @Override
     protected T copyInstance(T instance, Version version) throws IOException {
-        WellKnownText wkt = new WellKnownText(true, new GeographyValidator(true));
-        String text = wkt.toWKT(instance);
+        String text = WellKnownText.toWKT(instance);
         try {
-            return (T) wkt.fromWKT(text);
+            return (T) WellKnownText.fromWKT(GeographyValidator.instance(true), true, text);
         } catch (ParseException e) {
             throw new ElasticsearchException(e);
         }

--- a/libs/geo/src/test/java/org/elasticsearch/geometry/CircleTests.java
+++ b/libs/geo/src/test/java/org/elasticsearch/geometry/CircleTests.java
@@ -28,19 +28,19 @@ public class CircleTests extends BaseGeometryTestCase<Circle> {
     }
 
     public void testBasicSerialization() throws IOException, ParseException {
-        WellKnownText wkt = new WellKnownText(true, new GeographyValidator(true));
-        assertEquals("CIRCLE (20.0 10.0 15.0)", wkt.toWKT(new Circle(20, 10, 15)));
-        assertEquals(new Circle(20, 10, 15), wkt.fromWKT("circle (20.0 10.0 15.0)"));
+        GeometryValidator validator =  GeographyValidator.instance(true);
+        assertEquals("CIRCLE (20.0 10.0 15.0)", WellKnownText.toWKT(new Circle(20, 10, 15)));
+        assertEquals(new Circle(20, 10, 15), WellKnownText.fromWKT(validator, true, "circle (20.0 10.0 15.0)"));
 
-        assertEquals("CIRCLE (20.0 10.0 15.0 25.0)", wkt.toWKT(new Circle(20, 10, 25, 15)));
-        assertEquals(new Circle(20, 10, 25, 15), wkt.fromWKT("circle (20.0 10.0 15.0 25.0)"));
+        assertEquals("CIRCLE (20.0 10.0 15.0 25.0)", WellKnownText.toWKT(new Circle(20, 10, 25, 15)));
+        assertEquals(new Circle(20, 10, 25, 15), WellKnownText.fromWKT(validator, true, "circle (20.0 10.0 15.0 25.0)"));
 
-        assertEquals("CIRCLE EMPTY", wkt.toWKT(Circle.EMPTY));
-        assertEquals(Circle.EMPTY, wkt.fromWKT("CIRCLE EMPTY)"));
+        assertEquals("CIRCLE EMPTY", WellKnownText.toWKT(Circle.EMPTY));
+        assertEquals(Circle.EMPTY, WellKnownText.fromWKT(validator, true, "CIRCLE EMPTY)"));
     }
 
     public void testInitValidation() {
-        GeometryValidator validator = new GeographyValidator(true);
+        GeometryValidator validator = GeographyValidator.instance(true);
         IllegalArgumentException ex = expectThrows(IllegalArgumentException.class, () -> validator.validate(new Circle(20, 10, -1)));
         assertEquals("Circle radius [-1.0] cannot be negative", ex.getMessage());
 
@@ -50,9 +50,9 @@ public class CircleTests extends BaseGeometryTestCase<Circle> {
         ex = expectThrows(IllegalArgumentException.class, () -> validator.validate(new Circle(200, 10, 1)));
         assertEquals("invalid longitude 200.0; must be between -180.0 and 180.0", ex.getMessage());
 
-        ex = expectThrows(IllegalArgumentException.class, () -> new StandardValidator(false).validate(new Circle(200, 10, 1, 20)));
+        ex = expectThrows(IllegalArgumentException.class, () -> StandardValidator.instance(false).validate(new Circle(200, 10, 1, 20)));
         assertEquals("found Z value [1.0] but [ignore_z_value] parameter is [false]", ex.getMessage());
 
-        new StandardValidator(true).validate(new Circle(200, 10, 1, 20));
+        StandardValidator.instance(true).validate(new Circle(200, 10, 1, 20));
     }
 }

--- a/libs/geo/src/test/java/org/elasticsearch/geometry/GeometryCollectionTests.java
+++ b/libs/geo/src/test/java/org/elasticsearch/geometry/GeometryCollectionTests.java
@@ -10,6 +10,7 @@ package org.elasticsearch.geometry;
 
 import org.elasticsearch.geo.GeometryTestUtils;
 import org.elasticsearch.geometry.utils.GeographyValidator;
+import org.elasticsearch.geometry.utils.GeometryValidator;
 import org.elasticsearch.geometry.utils.StandardValidator;
 import org.elasticsearch.geometry.utils.WellKnownText;
 
@@ -25,15 +26,15 @@ public class GeometryCollectionTests extends BaseGeometryTestCase<GeometryCollec
     }
 
     public void testBasicSerialization() throws IOException, ParseException {
-        WellKnownText wkt = new WellKnownText(true, new GeographyValidator(true));
+        GeometryValidator validator = GeographyValidator.instance(true);
         assertEquals("GEOMETRYCOLLECTION (POINT (20.0 10.0),POINT EMPTY)",
-            wkt.toWKT(new GeometryCollection<Geometry>(Arrays.asList(new Point(20, 10), Point.EMPTY))));
+            WellKnownText.toWKT(new GeometryCollection<Geometry>(Arrays.asList(new Point(20, 10), Point.EMPTY))));
 
         assertEquals(new GeometryCollection<Geometry>(Arrays.asList(new Point(20, 10), Point.EMPTY)),
-            wkt.fromWKT("GEOMETRYCOLLECTION (POINT (20.0 10.0),POINT EMPTY)"));
+            WellKnownText.fromWKT(validator, true, "GEOMETRYCOLLECTION (POINT (20.0 10.0),POINT EMPTY)"));
 
-        assertEquals("GEOMETRYCOLLECTION EMPTY", wkt.toWKT(GeometryCollection.EMPTY));
-        assertEquals(GeometryCollection.EMPTY, wkt.fromWKT("GEOMETRYCOLLECTION EMPTY)"));
+        assertEquals("GEOMETRYCOLLECTION EMPTY", WellKnownText.toWKT(GeometryCollection.EMPTY));
+        assertEquals(GeometryCollection.EMPTY, WellKnownText.fromWKT(validator, true, "GEOMETRYCOLLECTION EMPTY)"));
     }
 
     @SuppressWarnings("ConstantConditions")
@@ -48,10 +49,10 @@ public class GeometryCollectionTests extends BaseGeometryTestCase<GeometryCollec
             Arrays.asList(new Point(20, 10), new Point(20, 10, 30))));
         assertEquals("all elements of the collection should have the same number of dimension", ex.getMessage());
 
-        ex = expectThrows(IllegalArgumentException.class, () -> new StandardValidator(false).validate(
+        ex = expectThrows(IllegalArgumentException.class, () -> StandardValidator.instance(false).validate(
             new GeometryCollection<Geometry>(Collections.singletonList(new Point(20, 10, 30)))));
         assertEquals("found Z value [30.0] but [ignore_z_value] parameter is [false]", ex.getMessage());
 
-        new StandardValidator(true).validate(new GeometryCollection<Geometry>(Collections.singletonList(new Point(20, 10, 30))));
+        StandardValidator.instance(true).validate(new GeometryCollection<Geometry>(Collections.singletonList(new Point(20, 10, 30))));
     }
 }

--- a/libs/geo/src/test/java/org/elasticsearch/geometry/GeometryValidatorTests.java
+++ b/libs/geo/src/test/java/org/elasticsearch/geometry/GeometryValidatorTests.java
@@ -84,33 +84,32 @@ public class GeometryValidatorTests extends ESTestCase {
     }
 
     public void testNoopValidator() throws Exception {
-        WellKnownText parser = new WellKnownText(true, new NoopValidator());
-        parser.fromWKT("CIRCLE (10000 20000 30000)");
-        parser.fromWKT("POINT (10000 20000)");
-        parser.fromWKT("LINESTRING (10000 20000, 0 0)");
-        parser.fromWKT("POLYGON ((300 100, 400 200, 500 300, 300 100), (50 150, 250 150, 200 100))");
-        parser.fromWKT("MULTIPOINT (10000 20000, 20000 30000)");
+        GeometryValidator validator = new NoopValidator();
+        WellKnownText.fromWKT(validator, true, "CIRCLE (10000 20000 30000)");
+        WellKnownText.fromWKT(validator, true, "POINT (10000 20000)");
+        WellKnownText.fromWKT(validator, true, "LINESTRING (10000 20000, 0 0)");
+        WellKnownText.fromWKT(validator, true, "POLYGON ((300 100, 400 200, 500 300, 300 100), (50 150, 250 150, 200 100))");
+        WellKnownText.fromWKT(validator, true, "MULTIPOINT (10000 20000, 20000 30000)");
     }
 
     public void testOneValidator() throws Exception {
-        WellKnownText parser = new WellKnownText(true, new OneValidator());
-        parser.fromWKT("POINT (0 1)");
-        parser.fromWKT("POINT (0 1 0.5)");
+        GeometryValidator validator = new OneValidator();
+        WellKnownText.fromWKT(validator, true, "POINT (0 1)");
+        WellKnownText.fromWKT(validator, true, "POINT (0 1 0.5)");
         IllegalArgumentException ex;
-        ex = expectThrows(IllegalArgumentException.class, () -> parser.fromWKT("CIRCLE (1 2 3)"));
+        ex = expectThrows(IllegalArgumentException.class, () -> WellKnownText.fromWKT(validator, true, "CIRCLE (1 2 3)"));
         assertEquals("invalid latitude 2.0; must be between -1.0 and 1.0", ex.getMessage());
-        ex = expectThrows(IllegalArgumentException.class, () -> parser.fromWKT("POINT (2 1)"));
+        ex = expectThrows(IllegalArgumentException.class, () -> WellKnownText.fromWKT(validator, true, "POINT (2 1)"));
         assertEquals("invalid longitude 2.0; must be between -1.0 and 1.0", ex.getMessage());
-        ex = expectThrows(IllegalArgumentException.class, () -> parser.fromWKT("LINESTRING (1 -1 0, 0 0 2)"));
+        ex = expectThrows(IllegalArgumentException.class, () -> WellKnownText.fromWKT(validator, true, "LINESTRING (1 -1 0, 0 0 2)"));
         assertEquals("invalid altitude 2.0; must be between -1.0 and 1.0", ex.getMessage());
-        ex = expectThrows(IllegalArgumentException.class, () -> parser.fromWKT("POLYGON ((0.3 0.1, 0.4 0.2, 5 0.3, 0.3 0.1))"));
+        ex = expectThrows(IllegalArgumentException.class, () ->
+            WellKnownText.fromWKT(validator, true, "POLYGON ((0.3 0.1, 0.4 0.2, 5 0.3, 0.3 0.1))"));
         assertEquals("invalid longitude 5.0; must be between -1.0 and 1.0", ex.getMessage());
-        ex = expectThrows(IllegalArgumentException.class, () -> parser.fromWKT(
-            "POLYGON ((0.3 0.1, 0.4 0.2, 0.5 0.3, 0.3 0.1), (0.5 1.5, 2.5 1.5, 2.0 1.0))"));
+        ex = expectThrows(IllegalArgumentException.class, () ->
+            WellKnownText.fromWKT(validator, true, "POLYGON ((0.3 0.1, 0.4 0.2, 0.5 0.3, 0.3 0.1), (0.5 1.5, 2.5 1.5, 2.0 1.0))"));
         assertEquals("invalid latitude 1.5; must be between -1.0 and 1.0", ex.getMessage());
-        ex = expectThrows(IllegalArgumentException.class, () -> parser.fromWKT("MULTIPOINT (0 1, -2 1)"));
+        ex = expectThrows(IllegalArgumentException.class, () -> WellKnownText.fromWKT(validator, true, "MULTIPOINT (0 1, -2 1)"));
         assertEquals("invalid longitude -2.0; must be between -1.0 and 1.0", ex.getMessage());
     }
-
-
 }

--- a/libs/geo/src/test/java/org/elasticsearch/geometry/LineTests.java
+++ b/libs/geo/src/test/java/org/elasticsearch/geometry/LineTests.java
@@ -24,21 +24,21 @@ public class LineTests extends BaseGeometryTestCase<Line> {
     }
 
     public void testBasicSerialization() throws IOException, ParseException {
-        WellKnownText wkt = new WellKnownText(true, new GeographyValidator(true));
-        assertEquals("LINESTRING (3.0 1.0, 4.0 2.0)", wkt.toWKT(new Line(new double[]{3, 4}, new double[]{1, 2})));
-        assertEquals(new Line(new double[]{3, 4}, new double[]{1, 2}), wkt.fromWKT("LINESTRING (3 1, 4 2)"));
+        GeometryValidator validator = GeographyValidator.instance(true);
+        assertEquals("LINESTRING (3.0 1.0, 4.0 2.0)", WellKnownText.toWKT(new Line(new double[]{3, 4}, new double[]{1, 2})));
+        assertEquals(new Line(new double[]{3, 4}, new double[]{1, 2}), WellKnownText.fromWKT(validator, true, "LINESTRING (3 1, 4 2)"));
 
-        assertEquals("LINESTRING (3.0 1.0 5.0, 4.0 2.0 6.0)", wkt.toWKT(new Line(new double[]{3, 4}, new double[]{1, 2},
+        assertEquals("LINESTRING (3.0 1.0 5.0, 4.0 2.0 6.0)", WellKnownText.toWKT(new Line(new double[]{3, 4}, new double[]{1, 2},
             new double[]{5, 6})));
         assertEquals(new Line(new double[]{3, 4}, new double[]{1, 2}, new double[]{6, 5}),
-            wkt.fromWKT("LINESTRING (3 1 6, 4 2 5)"));
+            WellKnownText.fromWKT(validator, true, "LINESTRING (3 1 6, 4 2 5)"));
 
-        assertEquals("LINESTRING EMPTY", wkt.toWKT(Line.EMPTY));
-        assertEquals(Line.EMPTY, wkt.fromWKT("LINESTRING EMPTY)"));
+        assertEquals("LINESTRING EMPTY", WellKnownText.toWKT(Line.EMPTY));
+        assertEquals(Line.EMPTY, WellKnownText.fromWKT(validator, true, "LINESTRING EMPTY)"));
     }
 
     public void testInitValidation() {
-        GeometryValidator validator = new GeographyValidator(true);
+        GeometryValidator validator = GeographyValidator.instance(true);
         IllegalArgumentException ex = expectThrows(IllegalArgumentException.class,
             () -> validator.validate(new Line(new double[]{3}, new double[]{1})));
         assertEquals("at least two points in the line is required", ex.getMessage());
@@ -51,16 +51,16 @@ public class LineTests extends BaseGeometryTestCase<Line> {
             () -> validator.validate(new Line(new double[]{3, 4, 5, 3}, new double[]{1, 100, 3, 1})));
         assertEquals("invalid latitude 100.0; must be between -90.0 and 90.0", ex.getMessage());
 
-        ex = expectThrows(IllegalArgumentException.class, () -> new StandardValidator(false).validate(
+        ex = expectThrows(IllegalArgumentException.class, () -> StandardValidator.instance(false).validate(
             new Line(new double[]{3, 4}, new double[]{1, 2}, new double[]{6, 5})));
         assertEquals("found Z value [6.0] but [ignore_z_value] parameter is [false]", ex.getMessage());
 
-        new StandardValidator(true).validate(new Line(new double[]{3, 4}, new double[]{1, 2}, new double[]{6, 5}));
+        StandardValidator.instance(true).validate(new Line(new double[]{3, 4}, new double[]{1, 2}, new double[]{6, 5}));
     }
 
     public void testWKTValidation() {
         IllegalArgumentException ex = expectThrows(IllegalArgumentException.class,
-            () -> new WellKnownText(randomBoolean(), new GeographyValidator(false)).fromWKT("linestring (3 1 6, 4 2 5)"));
+            () -> WellKnownText.fromWKT(GeographyValidator.instance(false), randomBoolean(), "linestring (3 1 6, 4 2 5)"));
         assertEquals("found Z value [6.0] but [ignore_z_value] parameter is [false]", ex.getMessage());
     }
 }

--- a/libs/geo/src/test/java/org/elasticsearch/geometry/LinearRingTests.java
+++ b/libs/geo/src/test/java/org/elasticsearch/geometry/LinearRingTests.java
@@ -18,13 +18,12 @@ public class LinearRingTests extends ESTestCase {
 
     public void testBasicSerialization() {
         UnsupportedOperationException ex = expectThrows(UnsupportedOperationException.class,
-            () -> new WellKnownText(true, new GeographyValidator(true))
-                .toWKT(new LinearRing(new double[]{3, 4, 5, 3}, new double[]{1, 2, 3, 1})));
+            () -> WellKnownText.toWKT(new LinearRing(new double[]{3, 4, 5, 3}, new double[]{1, 2, 3, 1})));
         assertEquals("line ring cannot be serialized using WKT", ex.getMessage());
     }
 
     public void testInitValidation() {
-        GeometryValidator validator = new GeographyValidator(true);
+        GeometryValidator validator = GeographyValidator.instance(true);
         IllegalArgumentException ex = expectThrows(IllegalArgumentException.class,
             () -> validator.validate(new LinearRing(new double[]{3, 4, 5}, new double[]{1, 2, 3})));
         assertEquals("first and last points of the linear ring must be the same (it must close itself): x[0]=3.0 x[2]=5.0 y[0]=1.0 " +
@@ -49,11 +48,12 @@ public class LinearRingTests extends ESTestCase {
             () -> validator.validate(new LinearRing(new double[]{3, 4, 5, 3}, new double[]{1, 100, 3, 1})));
         assertEquals("invalid latitude 100.0; must be between -90.0 and 90.0", ex.getMessage());
 
-        ex = expectThrows(IllegalArgumentException.class, () -> new StandardValidator(false).validate(
+        ex = expectThrows(IllegalArgumentException.class, () -> StandardValidator.instance(false).validate(
             new LinearRing(new double[]{3, 4, 5, 3}, new double[]{1, 2, 3, 1}, new double[]{1, 1, 1, 1})));
         assertEquals("found Z value [1.0] but [ignore_z_value] parameter is [false]", ex.getMessage());
 
-        new StandardValidator(true).validate(new LinearRing(new double[]{3, 4, 5, 3}, new double[]{1, 2, 3, 1}, new double[]{1, 1, 1, 1}));
+        StandardValidator.instance(true).validate(
+            new LinearRing(new double[]{3, 4, 5, 3}, new double[]{1, 2, 3, 1}, new double[]{1, 1, 1, 1}));
     }
 
     public void testVisitor() {

--- a/libs/geo/src/test/java/org/elasticsearch/geometry/MultiLineTests.java
+++ b/libs/geo/src/test/java/org/elasticsearch/geometry/MultiLineTests.java
@@ -10,6 +10,7 @@ package org.elasticsearch.geometry;
 
 import org.elasticsearch.geo.GeometryTestUtils;
 import org.elasticsearch.geometry.utils.GeographyValidator;
+import org.elasticsearch.geometry.utils.GeometryValidator;
 import org.elasticsearch.geometry.utils.StandardValidator;
 import org.elasticsearch.geometry.utils.WellKnownText;
 
@@ -32,22 +33,22 @@ public class MultiLineTests extends BaseGeometryTestCase<MultiLine> {
     }
 
     public void testBasicSerialization() throws IOException, ParseException {
-        WellKnownText wkt = new WellKnownText(true, new GeographyValidator(true));
-        assertEquals("MULTILINESTRING ((3.0 1.0, 4.0 2.0))", wkt.toWKT(
+        GeometryValidator validator = GeographyValidator.instance(true);
+        assertEquals("MULTILINESTRING ((3.0 1.0, 4.0 2.0))", WellKnownText.toWKT(
             new MultiLine(Collections.singletonList(new Line(new double[]{3, 4}, new double[]{1, 2})))));
         assertEquals(new MultiLine(Collections.singletonList(new Line(new double[]{3, 4}, new double[]{1, 2}))),
-            wkt.fromWKT("MULTILINESTRING ((3 1, 4 2))"));
+            WellKnownText.fromWKT(validator, true, "MULTILINESTRING ((3 1, 4 2))"));
 
-        assertEquals("MULTILINESTRING EMPTY", wkt.toWKT(MultiLine.EMPTY));
-        assertEquals(MultiLine.EMPTY, wkt.fromWKT("MULTILINESTRING EMPTY)"));
+        assertEquals("MULTILINESTRING EMPTY", WellKnownText.toWKT(MultiLine.EMPTY));
+        assertEquals(MultiLine.EMPTY, WellKnownText.fromWKT(validator, true, "MULTILINESTRING EMPTY)"));
     }
 
     public void testValidation() {
-        IllegalArgumentException ex = expectThrows(IllegalArgumentException.class, () -> new StandardValidator(false).validate(
+        IllegalArgumentException ex = expectThrows(IllegalArgumentException.class, () -> StandardValidator.instance(false).validate(
             new MultiLine(Collections.singletonList(new Line(new double[]{3, 4}, new double[]{1, 2}, new double[]{6, 5})))));
         assertEquals("found Z value [6.0] but [ignore_z_value] parameter is [false]", ex.getMessage());
 
-        new StandardValidator(true).validate(
+        StandardValidator.instance(true).validate(
             new MultiLine(Collections.singletonList(new Line(new double[]{3, 4}, new double[]{1, 2}, new double[]{6, 5}))));
     }
 }

--- a/libs/geo/src/test/java/org/elasticsearch/geometry/MultiPointTests.java
+++ b/libs/geo/src/test/java/org/elasticsearch/geometry/MultiPointTests.java
@@ -10,6 +10,7 @@ package org.elasticsearch.geometry;
 
 import org.elasticsearch.geo.GeometryTestUtils;
 import org.elasticsearch.geometry.utils.GeographyValidator;
+import org.elasticsearch.geometry.utils.GeometryValidator;
 import org.elasticsearch.geometry.utils.StandardValidator;
 import org.elasticsearch.geometry.utils.WellKnownText;
 
@@ -33,31 +34,31 @@ public class MultiPointTests extends BaseGeometryTestCase<MultiPoint> {
     }
 
     public void testBasicSerialization() throws IOException, ParseException {
-        WellKnownText wkt = new WellKnownText(true, new GeographyValidator(true));
-        assertEquals("MULTIPOINT (2.0 1.0)", wkt.toWKT(
+        GeometryValidator validator = GeographyValidator.instance(true);
+        assertEquals("MULTIPOINT (2.0 1.0)", WellKnownText.toWKT(
             new MultiPoint(Collections.singletonList(new Point(2, 1)))));
         assertEquals(new MultiPoint(Collections.singletonList(new Point(2, 1))),
-            wkt.fromWKT("MULTIPOINT (2 1)"));
+            WellKnownText.fromWKT(validator, true, "MULTIPOINT (2 1)"));
 
         assertEquals("MULTIPOINT (2.0 1.0, 3.0 4.0)",
-            wkt.toWKT(new MultiPoint(Arrays.asList(new Point(2, 1), new Point(3, 4)))));
+            WellKnownText.toWKT(new MultiPoint(Arrays.asList(new Point(2, 1), new Point(3, 4)))));
         assertEquals(new MultiPoint(Arrays.asList(new Point(2, 1), new Point(3, 4))),
-            wkt.fromWKT("MULTIPOINT (2 1, 3 4)"));
+            WellKnownText.fromWKT(validator, true, "MULTIPOINT (2 1, 3 4)"));
 
         assertEquals("MULTIPOINT (2.0 1.0 10.0, 3.0 4.0 20.0)",
-            wkt.toWKT(new MultiPoint(Arrays.asList(new Point(2, 1, 10), new Point(3, 4, 20)))));
+            WellKnownText.toWKT(new MultiPoint(Arrays.asList(new Point(2, 1, 10), new Point(3, 4, 20)))));
         assertEquals(new MultiPoint(Arrays.asList(new Point(2, 1, 10), new Point(3, 4, 20))),
-            wkt.fromWKT("MULTIPOINT (2 1 10, 3 4 20)"));
+            WellKnownText.fromWKT(validator, true, "MULTIPOINT (2 1 10, 3 4 20)"));
 
-        assertEquals("MULTIPOINT EMPTY", wkt.toWKT(MultiPoint.EMPTY));
-        assertEquals(MultiPoint.EMPTY, wkt.fromWKT("MULTIPOINT EMPTY)"));
+        assertEquals("MULTIPOINT EMPTY", WellKnownText.toWKT(MultiPoint.EMPTY));
+        assertEquals(MultiPoint.EMPTY, WellKnownText.fromWKT(validator, true, "MULTIPOINT EMPTY)"));
     }
 
     public void testValidation() {
-        IllegalArgumentException ex = expectThrows(IllegalArgumentException.class, () -> new StandardValidator(false).validate(
+        IllegalArgumentException ex = expectThrows(IllegalArgumentException.class, () -> StandardValidator.instance(false).validate(
             new MultiPoint(Collections.singletonList(new Point(2, 1, 3)))));
         assertEquals("found Z value [3.0] but [ignore_z_value] parameter is [false]", ex.getMessage());
 
-        new StandardValidator(true).validate(new MultiPoint(Collections.singletonList(new Point(2, 1, 3))));
+        StandardValidator.instance(true).validate(new MultiPoint(Collections.singletonList(new Point(2, 1, 3))));
     }
 }

--- a/libs/geo/src/test/java/org/elasticsearch/geometry/MultiPolygonTests.java
+++ b/libs/geo/src/test/java/org/elasticsearch/geometry/MultiPolygonTests.java
@@ -10,6 +10,7 @@ package org.elasticsearch.geometry;
 
 import org.elasticsearch.geo.GeometryTestUtils;
 import org.elasticsearch.geometry.utils.GeographyValidator;
+import org.elasticsearch.geometry.utils.GeometryValidator;
 import org.elasticsearch.geometry.utils.StandardValidator;
 import org.elasticsearch.geometry.utils.WellKnownText;
 
@@ -32,26 +33,26 @@ public class MultiPolygonTests extends BaseGeometryTestCase<MultiPolygon> {
     }
 
     public void testBasicSerialization() throws IOException, ParseException {
-        WellKnownText wkt = new WellKnownText(true, new GeographyValidator(true));
+        GeometryValidator validator = GeographyValidator.instance(true);
         assertEquals("MULTIPOLYGON (((3.0 1.0, 4.0 2.0, 5.0 3.0, 3.0 1.0)))",
-            wkt.toWKT(new MultiPolygon(Collections.singletonList(
+            WellKnownText.toWKT(new MultiPolygon(Collections.singletonList(
                 new Polygon(new LinearRing(new double[]{3, 4, 5, 3}, new double[]{1, 2, 3, 1}))))));
         assertEquals(new MultiPolygon(Collections.singletonList(
             new Polygon(new LinearRing(new double[]{3, 4, 5, 3}, new double[]{1, 2, 3, 1})))),
-            wkt.fromWKT("MULTIPOLYGON (((3.0 1.0, 4.0 2.0, 5.0 3.0, 3.0 1.0)))"));
+            WellKnownText.fromWKT(validator, true, "MULTIPOLYGON (((3.0 1.0, 4.0 2.0, 5.0 3.0, 3.0 1.0)))"));
 
-        assertEquals("MULTIPOLYGON EMPTY", wkt.toWKT(MultiPolygon.EMPTY));
-        assertEquals(MultiPolygon.EMPTY, wkt.fromWKT("MULTIPOLYGON EMPTY)"));
+        assertEquals("MULTIPOLYGON EMPTY", WellKnownText.toWKT(MultiPolygon.EMPTY));
+        assertEquals(MultiPolygon.EMPTY, WellKnownText.fromWKT(validator, true, "MULTIPOLYGON EMPTY)"));
     }
 
     public void testValidation() {
-        IllegalArgumentException ex = expectThrows(IllegalArgumentException.class, () -> new StandardValidator(false).validate(
+        IllegalArgumentException ex = expectThrows(IllegalArgumentException.class, () -> StandardValidator.instance(false).validate(
             new MultiPolygon(Collections.singletonList(
                 new Polygon(new LinearRing(new double[]{3, 4, 5, 3}, new double[]{1, 2, 3, 1}, new double[]{1, 2, 3, 1}))
             ))));
         assertEquals("found Z value [1.0] but [ignore_z_value] parameter is [false]", ex.getMessage());
 
-        new StandardValidator(true).validate(
+        StandardValidator.instance(true).validate(
             new MultiPolygon(Collections.singletonList(
                 new Polygon(new LinearRing(new double[]{3, 4, 5, 3}, new double[]{1, 2, 3, 1}, new double[]{1, 2, 3, 1})))));
     }

--- a/libs/geo/src/test/java/org/elasticsearch/geometry/PointTests.java
+++ b/libs/geo/src/test/java/org/elasticsearch/geometry/PointTests.java
@@ -24,34 +24,34 @@ public class PointTests extends BaseGeometryTestCase<Point> {
     }
 
     public void testBasicSerialization() throws IOException, ParseException {
-        WellKnownText wkt = new WellKnownText(true, new GeographyValidator(true));
-        assertEquals("POINT (20.0 10.0)", wkt.toWKT(new Point(20, 10)));
-        assertEquals(new Point(20, 10), wkt.fromWKT("point (20.0 10.0)"));
+        GeometryValidator validator = GeographyValidator.instance(true);
+        assertEquals("POINT (20.0 10.0)", WellKnownText.toWKT(new Point(20, 10)));
+        assertEquals(new Point(20, 10), WellKnownText.fromWKT(validator, true, "point (20.0 10.0)"));
 
-        assertEquals("POINT (20.0 10.0 100.0)", wkt.toWKT(new Point(20, 10, 100)));
-        assertEquals(new Point(20, 10, 100), wkt.fromWKT("POINT (20.0 10.0 100.0)"));
+        assertEquals("POINT (20.0 10.0 100.0)", WellKnownText.toWKT(new Point(20, 10, 100)));
+        assertEquals(new Point(20, 10, 100), WellKnownText.fromWKT(validator, true, "POINT (20.0 10.0 100.0)"));
 
-        assertEquals("POINT EMPTY", wkt.toWKT(Point.EMPTY));
-        assertEquals(Point.EMPTY, wkt.fromWKT("POINT EMPTY)"));
+        assertEquals("POINT EMPTY", WellKnownText.toWKT(Point.EMPTY));
+        assertEquals(Point.EMPTY, WellKnownText.fromWKT(validator, true, "POINT EMPTY)"));
     }
 
     public void testInitValidation() {
-        GeometryValidator validator = new GeographyValidator(true);
+        GeometryValidator validator = GeographyValidator.instance(true);
         IllegalArgumentException ex = expectThrows(IllegalArgumentException.class, () -> validator.validate(new Point(10, 100)));
         assertEquals("invalid latitude 100.0; must be between -90.0 and 90.0", ex.getMessage());
 
         ex = expectThrows(IllegalArgumentException.class, () -> validator.validate(new Point(500, 10)));
         assertEquals("invalid longitude 500.0; must be between -180.0 and 180.0", ex.getMessage());
 
-        ex = expectThrows(IllegalArgumentException.class, () -> new StandardValidator(false).validate(new Point(2, 1, 3)));
+        ex = expectThrows(IllegalArgumentException.class, () -> StandardValidator.instance(false).validate(new Point(2, 1, 3)));
         assertEquals("found Z value [3.0] but [ignore_z_value] parameter is [false]", ex.getMessage());
 
-        new StandardValidator(true).validate(new Point(2, 1, 3));
+        StandardValidator.instance(true).validate(new Point(2, 1, 3));
     }
 
     public void testWKTValidation() {
         IllegalArgumentException ex = expectThrows(IllegalArgumentException.class,
-            () -> new WellKnownText(randomBoolean(), new GeographyValidator(false)).fromWKT("point (20.0 10.0 100.0)"));
+            () -> WellKnownText.fromWKT(GeographyValidator.instance(false), randomBoolean(), "point (20.0 10.0 100.0)"));
         assertEquals("found Z value [100.0] but [ignore_z_value] parameter is [false]", ex.getMessage());
     }
 }

--- a/libs/geo/src/test/java/org/elasticsearch/geometry/PolygonTests.java
+++ b/libs/geo/src/test/java/org/elasticsearch/geometry/PolygonTests.java
@@ -10,6 +10,7 @@ package org.elasticsearch.geometry;
 
 import org.elasticsearch.geo.GeometryTestUtils;
 import org.elasticsearch.geometry.utils.GeographyValidator;
+import org.elasticsearch.geometry.utils.GeometryValidator;
 import org.elasticsearch.geometry.utils.StandardValidator;
 import org.elasticsearch.geometry.utils.WellKnownText;
 
@@ -24,28 +25,28 @@ public class PolygonTests extends BaseGeometryTestCase<Polygon> {
     }
 
     public void testBasicSerialization() throws IOException, ParseException {
-        WellKnownText wkt = new WellKnownText(true, new GeographyValidator(true));
+        GeometryValidator validator = GeographyValidator.instance(true);
         assertEquals("POLYGON ((3.0 1.0, 4.0 2.0, 5.0 3.0, 3.0 1.0))",
-            wkt.toWKT(new Polygon(new LinearRing(new double[]{3, 4, 5, 3}, new double[]{1, 2, 3, 1}))));
+            WellKnownText.toWKT(new Polygon(new LinearRing(new double[]{3, 4, 5, 3}, new double[]{1, 2, 3, 1}))));
         assertEquals(new Polygon(new LinearRing(new double[]{3, 4, 5, 3}, new double[]{1, 2, 3, 1})),
-            wkt.fromWKT("POLYGON ((3 1, 4 2, 5 3, 3 1))"));
+            WellKnownText.fromWKT(validator, true, "POLYGON ((3 1, 4 2, 5 3, 3 1))"));
 
         assertEquals("POLYGON ((3.0 1.0 5.0, 4.0 2.0 4.0, 5.0 3.0 3.0, 3.0 1.0 5.0))",
-            wkt.toWKT(new Polygon(new LinearRing(new double[]{3, 4, 5, 3}, new double[]{1, 2, 3, 1}, new double[]{5, 4, 3, 5}))));
+            WellKnownText.toWKT(new Polygon(new LinearRing(new double[]{3, 4, 5, 3}, new double[]{1, 2, 3, 1}, new double[]{5, 4, 3, 5}))));
         assertEquals(new Polygon(new LinearRing(new double[]{3, 4, 5, 3}, new double[]{1, 2, 3, 1}, new double[]{5, 4, 3, 5})),
-            wkt.fromWKT("POLYGON ((3 1 5, 4 2 4, 5 3 3, 3 1 5))"));
+            WellKnownText.fromWKT(validator, true, "POLYGON ((3 1 5, 4 2 4, 5 3 3, 3 1 5))"));
 
         // Auto closing in coerce mode
         assertEquals(new Polygon(new LinearRing(new double[]{3, 4, 5, 3}, new double[]{1, 2, 3, 1})),
-            wkt.fromWKT("POLYGON ((3 1, 4 2, 5 3))"));
+            WellKnownText.fromWKT(validator, true, "POLYGON ((3 1, 4 2, 5 3))"));
         assertEquals(new Polygon(new LinearRing(new double[]{3, 4, 5, 3}, new double[]{1, 2, 3, 1}, new double[]{5, 4, 3, 5})),
-            wkt.fromWKT("POLYGON ((3 1 5, 4 2 4, 5 3 3))"));
+            WellKnownText.fromWKT(validator, true, "POLYGON ((3 1 5, 4 2 4, 5 3 3))"));
         assertEquals(new Polygon(new LinearRing(new double[]{3, 4, 5, 3}, new double[]{1, 2, 3, 1}),
             Collections.singletonList(new LinearRing(new double[]{0.5, 2.5, 2.0, 0.5}, new double[]{1.5, 1.5, 1.0, 1.5}))),
-            wkt.fromWKT("POLYGON ((3 1, 4 2, 5 3, 3 1), (0.5 1.5, 2.5 1.5, 2.0 1.0))"));
+            WellKnownText.fromWKT(validator, true, "POLYGON ((3 1, 4 2, 5 3, 3 1), (0.5 1.5, 2.5 1.5, 2.0 1.0))"));
 
-        assertEquals("POLYGON EMPTY", wkt.toWKT(Polygon.EMPTY));
-        assertEquals(Polygon.EMPTY, wkt.fromWKT("POLYGON EMPTY)"));
+        assertEquals("POLYGON EMPTY", WellKnownText.toWKT(Polygon.EMPTY));
+        assertEquals(Polygon.EMPTY, WellKnownText.fromWKT(validator, true, "POLYGON EMPTY)"));
     }
 
     public void testInitValidation() {
@@ -62,26 +63,26 @@ public class PolygonTests extends BaseGeometryTestCase<Polygon> {
                 Collections.singletonList(new LinearRing(new double[]{3, 4, 5, 3}, new double[]{1, 2, 3, 1}))));
         assertEquals("holes must have the same number of dimensions as the polygon", ex.getMessage());
 
-        ex = expectThrows(IllegalArgumentException.class, () -> new StandardValidator(false).validate(
+        ex = expectThrows(IllegalArgumentException.class, () -> StandardValidator.instance(false).validate(
             new Polygon(new LinearRing(new double[]{3, 4, 5, 3}, new double[]{1, 2, 3, 1}, new double[]{1, 2, 3, 1}))));
         assertEquals("found Z value [1.0] but [ignore_z_value] parameter is [false]", ex.getMessage());
 
-        new StandardValidator(true).validate(
+        StandardValidator.instance(true).validate(
                 new Polygon(new LinearRing(new double[]{3, 4, 5, 3}, new double[]{1, 2, 3, 1}, new double[]{1, 2, 3, 1})));
     }
 
     public void testWKTValidation() {
         IllegalArgumentException ex = expectThrows(IllegalArgumentException.class,
-            () -> new WellKnownText(false, new GeographyValidator(true)).fromWKT("polygon ((3 1 5, 4 2 4, 5 3 3))"));
+            () -> WellKnownText.fromWKT(GeographyValidator.instance(true), false, "polygon ((3 1 5, 4 2 4, 5 3 3))"));
         assertEquals("first and last points of the linear ring must be the same (it must close itself): " +
             "x[0]=3.0 x[2]=5.0 y[0]=1.0 y[2]=3.0 z[0]=5.0 z[2]=3.0", ex.getMessage());
 
         ex = expectThrows(IllegalArgumentException.class,
-            () -> new WellKnownText(randomBoolean(), new GeographyValidator(false)).fromWKT("polygon ((3 1 5, 4 2 4, 5 3 3, 3 1 5))"));
+            () -> WellKnownText.fromWKT(GeographyValidator.instance(false), randomBoolean(), "polygon ((3 1 5, 4 2 4, 5 3 3, 3 1 5))"));
         assertEquals("found Z value [5.0] but [ignore_z_value] parameter is [false]", ex.getMessage());
 
         ex = expectThrows(IllegalArgumentException.class,
-            () -> new WellKnownText(false, new GeographyValidator(randomBoolean())).fromWKT(
+            () ->  WellKnownText.fromWKT(GeographyValidator.instance(randomBoolean()), false,
                 "polygon ((3 1, 4 2, 5 3, 3 1), (0.5 1.5, 2.5 1.5, 2.0 1.0))"));
         assertEquals("first and last points of the linear ring must be the same (it must close itself): " +
             "x[0]=0.5 x[2]=2.0 y[0]=1.5 y[2]=1.0", ex.getMessage());

--- a/libs/geo/src/test/java/org/elasticsearch/geometry/RectangleTests.java
+++ b/libs/geo/src/test/java/org/elasticsearch/geometry/RectangleTests.java
@@ -25,16 +25,16 @@ public class RectangleTests extends BaseGeometryTestCase<Rectangle> {
     }
 
     public void testBasicSerialization() throws IOException, ParseException {
-        WellKnownText wkt = new WellKnownText(true, new GeographyValidator(true));
-        assertEquals("BBOX (10.0, 20.0, 40.0, 30.0)", wkt.toWKT(new Rectangle(10, 20, 40, 30)));
-        assertEquals(new Rectangle(10, 20, 40, 30), wkt.fromWKT("BBOX (10.0, 20.0, 40.0, 30.0)"));
+        GeometryValidator validator = GeographyValidator.instance(true);
+        assertEquals("BBOX (10.0, 20.0, 40.0, 30.0)", WellKnownText.toWKT(new Rectangle(10, 20, 40, 30)));
+        assertEquals(new Rectangle(10, 20, 40, 30), WellKnownText.fromWKT(validator, true, "BBOX (10.0, 20.0, 40.0, 30.0)"));
 
-        assertEquals("BBOX EMPTY", wkt.toWKT(Rectangle.EMPTY));
-        assertEquals(Rectangle.EMPTY, wkt.fromWKT("BBOX EMPTY)"));
+        assertEquals("BBOX EMPTY", WellKnownText.toWKT(Rectangle.EMPTY));
+        assertEquals(Rectangle.EMPTY, WellKnownText.fromWKT(validator, true, "BBOX EMPTY)"));
     }
 
     public void testInitValidation() {
-        GeometryValidator validator = new GeographyValidator(true);
+        GeometryValidator validator = GeographyValidator.instance(true);
         IllegalArgumentException ex = expectThrows(IllegalArgumentException.class,
             () -> validator.validate(new Rectangle(2, 3, 100, 1)));
         assertEquals("invalid latitude 100.0; must be between -90.0 and 90.0", ex.getMessage());
@@ -51,10 +51,10 @@ public class RectangleTests extends BaseGeometryTestCase<Rectangle> {
             () -> validator.validate(new Rectangle(2, 3, 2, 1, 5, Double.NaN)));
         assertEquals("only one z value is specified", ex.getMessage());
 
-        ex = expectThrows(IllegalArgumentException.class, () -> new StandardValidator(false).validate(
+        ex = expectThrows(IllegalArgumentException.class, () -> StandardValidator.instance(false).validate(
             new Rectangle(50, 10, 40, 30, 20, 60)));
         assertEquals("found Z value [20.0] but [ignore_z_value] parameter is [false]", ex.getMessage());
 
-        new StandardValidator(true).validate(new Rectangle(50, 10, 40, 30, 20, 60));
+        StandardValidator.instance(true).validate(new Rectangle(50, 10, 40, 30, 20, 60));
     }
 }

--- a/server/src/main/java/org/elasticsearch/common/geo/GeoBoundingBox.java
+++ b/server/src/main/java/org/elasticsearch/common/geo/GeoBoundingBox.java
@@ -30,7 +30,6 @@ import java.util.Objects;
  * that deal with extents/rectangles representing rectangular areas of interest.
  */
 public class GeoBoundingBox implements ToXContentFragment, Writeable {
-    private static final WellKnownText WKT_PARSER = new WellKnownText(true, new StandardValidator(true));
     static final ParseField TOP_RIGHT_FIELD = new ParseField("top_right");
     static final ParseField BOTTOM_LEFT_FIELD = new ParseField("bottom_left");
     static final ParseField TOP_FIELD = new ParseField("top");
@@ -183,7 +182,7 @@ public class GeoBoundingBox implements ToXContentFragment, Writeable {
                 token = parser.nextToken();
                 if (WKT_FIELD.match(currentFieldName, parser.getDeprecationHandler())) {
                     try {
-                        Geometry geometry = WKT_PARSER.fromWKT(parser.text());
+                        Geometry geometry = WellKnownText.fromWKT(StandardValidator.instance(true), true, parser.text());
                         if (ShapeType.ENVELOPE.equals(geometry.type()) == false) {
                             throw new ElasticsearchParseException("failed to parse WKT bounding box. ["
                                 + geometry.type() + "] found. expected [" + ShapeType.ENVELOPE + "]");

--- a/server/src/main/java/org/elasticsearch/common/geo/GeoJsonGeometryFormat.java
+++ b/server/src/main/java/org/elasticsearch/common/geo/GeoJsonGeometryFormat.java
@@ -12,16 +12,21 @@ import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.geometry.Geometry;
+import org.elasticsearch.geometry.utils.GeometryValidator;
 
 import java.io.IOException;
 
 public class GeoJsonGeometryFormat implements GeometryFormat<Geometry> {
     public static final String NAME = "geojson";
 
-    private final GeoJson geoJsonParser;
+    private final GeometryValidator validator;
+    private final boolean coerce;
+    private final boolean rightOrientation;
 
-    public GeoJsonGeometryFormat(GeoJson geoJsonParser) {
-        this.geoJsonParser = geoJsonParser;
+    public GeoJsonGeometryFormat(GeometryValidator validator, boolean coerce, boolean rightOrientation) {
+        this.validator = validator;
+        this.coerce = coerce;
+        this.rightOrientation = rightOrientation;
     }
 
     @Override
@@ -34,7 +39,7 @@ public class GeoJsonGeometryFormat implements GeometryFormat<Geometry> {
         if (parser.currentToken() == XContentParser.Token.VALUE_NULL) {
             return null;
         }
-        return geoJsonParser.fromXContent(parser);
+        return GeoJson.fromXContent(validator, coerce, rightOrientation, parser);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/common/geo/GeoPoint.java
+++ b/server/src/main/java/org/elasticsearch/common/geo/GeoPoint.java
@@ -114,8 +114,7 @@ public class GeoPoint implements ToXContentFragment {
     private GeoPoint resetFromWKT(String value, boolean ignoreZValue) {
         Geometry geometry;
         try {
-            geometry = new WellKnownText(false, new GeographyValidator(ignoreZValue))
-                .fromWKT(value);
+            geometry = WellKnownText.fromWKT(GeographyValidator.instance(ignoreZValue), false, value);
         } catch (Exception e) {
             throw new ElasticsearchParseException("Invalid WKT format", e);
         }

--- a/server/src/main/java/org/elasticsearch/common/geo/WKTGeometryFormat.java
+++ b/server/src/main/java/org/elasticsearch/common/geo/WKTGeometryFormat.java
@@ -12,6 +12,7 @@ import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.geometry.Geometry;
+import org.elasticsearch.geometry.utils.GeometryValidator;
 import org.elasticsearch.geometry.utils.WellKnownText;
 
 import java.io.IOException;
@@ -20,10 +21,12 @@ import java.text.ParseException;
 public class WKTGeometryFormat implements GeometryFormat<Geometry> {
     public static final String NAME = "wkt";
 
-    private final WellKnownText wellKnownTextParser;
+    private final GeometryValidator validator;
+    private final boolean coerce;
 
-    public WKTGeometryFormat(WellKnownText wellKnownTextParser) {
-        this.wellKnownTextParser = wellKnownTextParser;
+    public WKTGeometryFormat(GeometryValidator validator, boolean coerce) {
+        this.validator = validator;
+        this.coerce = coerce;
     }
 
     @Override
@@ -36,13 +39,13 @@ public class WKTGeometryFormat implements GeometryFormat<Geometry> {
         if (parser.currentToken() == XContentParser.Token.VALUE_NULL) {
             return null;
         }
-        return wellKnownTextParser.fromWKT(parser.text());
+        return WellKnownText.fromWKT(validator, coerce, parser.text());
     }
 
     @Override
     public XContentBuilder toXContent(Geometry geometry, XContentBuilder builder, ToXContent.Params params) throws IOException {
         if (geometry != null) {
-            return builder.value(wellKnownTextParser.toWKT(geometry));
+            return builder.value(WellKnownText.toWKT(geometry));
         } else {
             return builder.nullValue();
         }
@@ -50,6 +53,6 @@ public class WKTGeometryFormat implements GeometryFormat<Geometry> {
 
     @Override
     public String toXContentAsObject(Geometry geometry) {
-        return wellKnownTextParser.toWKT(geometry);
+        return WellKnownText.toWKT(geometry);
     }
 }

--- a/server/src/test/java/org/elasticsearch/common/geo/BaseGeoParsingTestCase.java
+++ b/server/src/test/java/org/elasticsearch/common/geo/BaseGeoParsingTestCase.java
@@ -65,7 +65,7 @@ abstract class BaseGeoParsingTestCase extends ESTestCase {
     protected void assertGeometryEquals(org.elasticsearch.geometry.Geometry expected, XContentBuilder geoJson) throws IOException {
         try (XContentParser parser = createParser(geoJson)) {
             parser.nextToken();
-            assertEquals(expected, new GeoJson(true, false, new GeographyValidator(false)).fromXContent(parser));
+            assertEquals(expected, GeoJson.fromXContent(GeographyValidator.instance(false), false, true, parser));
         }
     }
 

--- a/server/src/test/java/org/elasticsearch/common/geo/GeoJsonParserTests.java
+++ b/server/src/test/java/org/elasticsearch/common/geo/GeoJsonParserTests.java
@@ -63,7 +63,7 @@ public class GeoJsonParserTests extends BaseGeoParsingTestCase {
         Line expected = new Line(new double[] { 100.0, 101.0}, new double[] {0.0, 1.0});
         try (XContentParser parser = createParser(lineGeoJson)) {
             parser.nextToken();
-            assertEquals(expected, new GeoJson(false, false, new GeographyValidator(true)).fromXContent(parser));
+            assertEquals(expected, GeoJson.fromXContent(GeographyValidator.instance(true), false, false, parser));
         }
     }
 
@@ -115,7 +115,8 @@ public class GeoJsonParserTests extends BaseGeoParsingTestCase {
 
         try (XContentParser parser = createParser(pointGeoJson)) {
             parser.nextToken();
-            expectThrows(XContentParseException.class, () -> new GeoJson(false, false, new GeographyValidator(false)).fromXContent(parser));
+            expectThrows(XContentParseException.class, () ->
+                GeoJson.fromXContent(GeographyValidator.instance(false), false, false, parser));
             assertNull(parser.nextToken());
         }
 
@@ -131,7 +132,8 @@ public class GeoJsonParserTests extends BaseGeoParsingTestCase {
 
         try (XContentParser parser = createParser(lineGeoJson)) {
             parser.nextToken();
-            expectThrows(XContentParseException.class, () -> new GeoJson(false, false, new GeographyValidator(false)).fromXContent(parser));
+            expectThrows(XContentParseException.class, () ->
+                GeoJson.fromXContent(GeographyValidator.instance(false), false, false, parser));
             assertNull(parser.nextToken());
         }
     }
@@ -169,7 +171,8 @@ public class GeoJsonParserTests extends BaseGeoParsingTestCase {
                 .endObject();
         try (XContentParser parser = createParser(multilinesGeoJson)) {
             parser.nextToken();
-            expectThrows(XContentParseException.class, () -> new GeoJson(false, false, new GeographyValidator(false)).fromXContent(parser));
+            expectThrows(XContentParseException.class, () ->
+                GeoJson.fromXContent(GeographyValidator.instance(false), false, false, parser));
             assertNull(parser.nextToken());
         }
 
@@ -180,7 +183,8 @@ public class GeoJsonParserTests extends BaseGeoParsingTestCase {
                 .endObject();
         try (XContentParser parser = createParser(multilinesGeoJson)) {
             parser.nextToken();
-            expectThrows(XContentParseException.class, () -> new GeoJson(false, false, new GeographyValidator(false)).fromXContent(parser));
+            expectThrows(XContentParseException.class, () ->
+                GeoJson.fromXContent(GeographyValidator.instance(false), false, false, parser));
             assertNull(parser.nextToken());
         }
     }
@@ -229,7 +233,7 @@ public class GeoJsonParserTests extends BaseGeoParsingTestCase {
         ));
         try (XContentParser parser = createParser(polygonGeoJson)) {
             parser.nextToken();
-            assertEquals(expected, new GeoJson(true, false, new GeographyValidator(true)).fromXContent(parser));
+            assertEquals(expected, GeoJson.fromXContent(GeographyValidator.instance(true), false, true, parser));
         }
     }
 
@@ -249,7 +253,8 @@ public class GeoJsonParserTests extends BaseGeoParsingTestCase {
             .endObject();
         try (XContentParser parser = createParser(polygonGeoJson)) {
             parser.nextToken();
-            expectThrows(XContentParseException.class, () -> new GeoJson(true, false, new GeographyValidator(true)).fromXContent(parser));
+            expectThrows(XContentParseException.class, () ->
+                GeoJson.fromXContent(GeographyValidator.instance(true), false, true, parser));
             assertNull(parser.nextToken());
         }
     }
@@ -265,7 +270,8 @@ public class GeoJsonParserTests extends BaseGeoParsingTestCase {
                 .endObject();
         try (XContentParser parser = createParser(invalidPoint1)) {
             parser.nextToken();
-            expectThrows(XContentParseException.class, () -> new GeoJson(true, false, new GeographyValidator(false)).fromXContent(parser));
+            expectThrows(XContentParseException.class, () ->
+                GeoJson.fromXContent(GeographyValidator.instance(false), false, true, parser));
             assertNull(parser.nextToken());
         }
 
@@ -278,7 +284,8 @@ public class GeoJsonParserTests extends BaseGeoParsingTestCase {
                 .endObject();
         try (XContentParser parser = createParser(invalidPoint2)) {
             parser.nextToken();
-            expectThrows(XContentParseException.class, () -> new GeoJson(true, false, new GeographyValidator(false)).fromXContent(parser));
+            expectThrows(XContentParseException.class, () ->
+                GeoJson.fromXContent(GeographyValidator.instance(false), false, true, parser));
             assertNull(parser.nextToken());
         }
     }
@@ -292,7 +299,7 @@ public class GeoJsonParserTests extends BaseGeoParsingTestCase {
                 .endObject();
         try (XContentParser parser = createParser(invalidMultipoint1)) {
             parser.nextToken();
-            expectThrows(XContentParseException.class, () -> new GeoJson(true, false, new GeographyValidator(false)).fromXContent(parser));
+            expectThrows(XContentParseException.class, () -> GeoJson.fromXContent(GeographyValidator.instance(false), false, true, parser));
             assertNull(parser.nextToken());
         }
 
@@ -305,7 +312,8 @@ public class GeoJsonParserTests extends BaseGeoParsingTestCase {
                 .endObject();
         try (XContentParser parser = createParser(invalidMultipoint2)) {
             parser.nextToken();
-            expectThrows(XContentParseException.class, () -> new GeoJson(true, false, new GeographyValidator(false)).fromXContent(parser));
+            expectThrows(XContentParseException.class, () ->
+                GeoJson.fromXContent(GeographyValidator.instance(false), false, true, parser));
             assertNull(parser.nextToken());
         }
 
@@ -319,7 +327,8 @@ public class GeoJsonParserTests extends BaseGeoParsingTestCase {
                 .endObject();
         try (XContentParser parser = createParser(invalidMultipoint3)) {
             parser.nextToken();
-            expectThrows(XContentParseException.class, () -> new GeoJson(true, false, new GeographyValidator(false)).fromXContent(parser));
+            expectThrows(XContentParseException.class, () ->
+                GeoJson.fromXContent(GeographyValidator.instance(false), false, true, parser));
             assertNull(parser.nextToken());
         }
     }
@@ -360,7 +369,8 @@ public class GeoJsonParserTests extends BaseGeoParsingTestCase {
 
         try (XContentParser parser = createParser(JsonXContent.jsonXContent, multiPolygonGeoJson)) {
             parser.nextToken();
-            expectThrows(XContentParseException.class, () -> new GeoJson(true, false, new GeographyValidator(false)).fromXContent(parser));
+            expectThrows(XContentParseException.class, () ->
+                GeoJson.fromXContent(GeographyValidator.instance(false), false, true, parser));
             assertNull(parser.nextToken());
         }
    }
@@ -381,7 +391,8 @@ public class GeoJsonParserTests extends BaseGeoParsingTestCase {
                 .endObject());
         try (XContentParser parser = createParser(JsonXContent.jsonXContent, invalidPoly)) {
             parser.nextToken();
-            expectThrows(XContentParseException.class, () -> new GeoJson(true, false, new GeographyValidator(false)).fromXContent(parser));
+            expectThrows(XContentParseException.class, () ->
+                GeoJson.fromXContent(GeographyValidator.instance(false), false, true, parser));
             assertNull(parser.nextToken());
         }
 
@@ -396,7 +407,8 @@ public class GeoJsonParserTests extends BaseGeoParsingTestCase {
 
         try (XContentParser parser = createParser(JsonXContent.jsonXContent, invalidPoly)) {
             parser.nextToken();
-            expectThrows(XContentParseException.class, () -> new GeoJson(true, false, new GeographyValidator(false)).fromXContent(parser));
+            expectThrows(XContentParseException.class, () ->
+                GeoJson.fromXContent(GeographyValidator.instance(false), false, true, parser));
             assertNull(parser.nextToken());
         }
 
@@ -411,7 +423,8 @@ public class GeoJsonParserTests extends BaseGeoParsingTestCase {
 
         try (XContentParser parser = createParser(JsonXContent.jsonXContent, invalidPoly)) {
             parser.nextToken();
-            expectThrows(XContentParseException.class, () -> new GeoJson(true, false, new GeographyValidator(false)).fromXContent(parser));
+            expectThrows(XContentParseException.class, () ->
+                GeoJson.fromXContent(GeographyValidator.instance(false), false, true, parser));
             assertNull(parser.nextToken());
         }
 
@@ -426,7 +439,8 @@ public class GeoJsonParserTests extends BaseGeoParsingTestCase {
 
         try (XContentParser parser = createParser(JsonXContent.jsonXContent, invalidPoly)) {
             parser.nextToken();
-            expectThrows(XContentParseException.class, () -> new GeoJson(true, false, new GeographyValidator(false)).fromXContent(parser));
+            expectThrows(XContentParseException.class, () ->
+                GeoJson.fromXContent(GeographyValidator.instance(false), false, true, parser));
             assertNull(parser.nextToken());
         }
 
@@ -439,7 +453,8 @@ public class GeoJsonParserTests extends BaseGeoParsingTestCase {
 
         try (XContentParser parser = createParser(JsonXContent.jsonXContent, invalidPoly)) {
             parser.nextToken();
-            expectThrows(XContentParseException.class, () -> new GeoJson(true, false, new GeographyValidator(false)).fromXContent(parser));
+            expectThrows(XContentParseException.class, () ->
+                GeoJson.fromXContent(GeographyValidator.instance(false), false, true, parser));
             assertNull(parser.nextToken());
         }
 
@@ -450,7 +465,8 @@ public class GeoJsonParserTests extends BaseGeoParsingTestCase {
 
         try (XContentParser parser = createParser(JsonXContent.jsonXContent, invalidPoly)) {
             parser.nextToken();
-            expectThrows(XContentParseException.class, () -> new GeoJson(true, false, new GeographyValidator(false)).fromXContent(parser));
+            expectThrows(XContentParseException.class, () ->
+                GeoJson.fromXContent(GeographyValidator.instance(false), false, true, parser));
             assertNull(parser.nextToken());
         }
 
@@ -463,7 +479,8 @@ public class GeoJsonParserTests extends BaseGeoParsingTestCase {
 
         try (XContentParser parser = createParser(JsonXContent.jsonXContent, invalidPoly)) {
             parser.nextToken();
-            expectThrows(XContentParseException.class, () -> new GeoJson(true, false, new GeographyValidator(false)).fromXContent(parser));
+            expectThrows(XContentParseException.class, () ->
+                GeoJson.fromXContent(GeographyValidator.instance(false), false, true, parser));
             assertNull(parser.nextToken());
         }
     }
@@ -699,7 +716,8 @@ public class GeoJsonParserTests extends BaseGeoParsingTestCase {
 
         try (XContentParser parser = createParser(tooLittlePointGeoJson)) {
             parser.nextToken();
-            expectThrows(XContentParseException.class, () -> new GeoJson(true, false, new GeographyValidator(false)).fromXContent(parser));
+            expectThrows(XContentParseException.class, () ->
+                GeoJson.fromXContent(GeographyValidator.instance(false), false, true, parser));
             assertNull(parser.nextToken());
         }
 
@@ -712,7 +730,8 @@ public class GeoJsonParserTests extends BaseGeoParsingTestCase {
 
         try (XContentParser parser = createParser(emptyPointGeoJson)) {
             parser.nextToken();
-            expectThrows(XContentParseException.class, () -> new GeoJson(true, false, new GeographyValidator(false)).fromXContent(parser));
+            expectThrows(XContentParseException.class, () ->
+                GeoJson.fromXContent(GeographyValidator.instance(false), false, true, parser));
             assertNull(parser.nextToken());
         }
     }
@@ -738,7 +757,8 @@ public class GeoJsonParserTests extends BaseGeoParsingTestCase {
             parser.nextToken(); // foo
             parser.nextToken(); // start object
             parser.nextToken(); // start object
-            expectThrows(XContentParseException.class, () -> new GeoJson(true, false, new GeographyValidator(false)).fromXContent(parser));
+            expectThrows(XContentParseException.class, () ->
+                GeoJson.fromXContent(GeographyValidator.instance(false), false, true, parser));
             assertEquals(XContentParser.Token.END_OBJECT, parser.nextToken()); // end of the document
             assertNull(parser.nextToken()); // no more elements afterwards
         }

--- a/server/src/test/java/org/elasticsearch/common/geo/GeoJsonSerializationTests.java
+++ b/server/src/test/java/org/elasticsearch/common/geo/GeoJsonSerializationTests.java
@@ -44,7 +44,6 @@ public class GeoJsonSerializationTests extends ESTestCase {
     private static class GeometryWrapper implements ToXContentObject {
 
         private final Geometry geometry;
-        private static final GeoJson PARSER = new GeoJson(true, false, new GeographyValidator(true));
 
         GeometryWrapper(Geometry geometry) {
             this.geometry = geometry;
@@ -57,7 +56,7 @@ public class GeoJsonSerializationTests extends ESTestCase {
 
         public static GeometryWrapper fromXContent(XContentParser parser) throws IOException {
             parser.nextToken();
-            return new GeometryWrapper(PARSER.fromXContent(parser));
+            return new GeometryWrapper(GeoJson.fromXContent(GeographyValidator.instance(true), false, true, parser));
         }
 
         @Override

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/extractor/GeoShapeField.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/extractor/GeoShapeField.java
@@ -28,8 +28,6 @@ public class GeoShapeField extends SourceField {
 
     private static final Set<String> TYPES = Collections.singleton(TYPE);
 
-    private static final WellKnownText wkt = new WellKnownText(true, new StandardValidator(true));
-
     public GeoShapeField(String name) {
         super(name, TYPES);
     }
@@ -59,7 +57,7 @@ public class GeoShapeField extends SourceField {
     private String handleString(String geoString) {
         try {
             if (geoString.startsWith("POINT")) { // Entry is of the form "POINT (-77.03653 38.897676)"
-                Geometry geometry = wkt.fromWKT(geoString);
+                Geometry geometry = WellKnownText.fromWKT(StandardValidator.instance(true), true, geoString);
                 if (geometry.type() != ShapeType.POINT) {
                     throw new IllegalArgumentException("Unexpected non-point geo_shape type: " + geometry.type().name());
                 }

--- a/x-pack/plugin/spatial/src/internalClusterTest/java/org/elasticsearch/xpack/spatial/search/GeoShapeScriptDocValuesIT.java
+++ b/x-pack/plugin/spatial/src/internalClusterTest/java/org/elasticsearch/xpack/spatial/search/GeoShapeScriptDocValuesIT.java
@@ -161,7 +161,7 @@ public class GeoShapeScriptDocValuesIT extends ESSingleNodeTestCase {
         client().prepareIndex("test", "_doc").setId("1")
             .setSource(jsonBuilder().startObject()
                 .field("name", "TestPosition")
-                .field("location", WellKnownText.INSTANCE.toWKT(geometry))
+                .field("location", WellKnownText.toWKT(geometry))
                 .endObject())
             .get();
 

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/common/CartesianPoint.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/common/CartesianPoint.java
@@ -105,8 +105,7 @@ public class CartesianPoint implements ToXContentFragment {
     private CartesianPoint resetFromWKT(String value, boolean ignoreZValue) {
         Geometry geometry;
         try {
-            geometry = new WellKnownText(false, new StandardValidator(ignoreZValue))
-                .fromWKT(value);
+            geometry = WellKnownText.fromWKT(StandardValidator.instance(ignoreZValue), false, value);
         } catch (Exception e) {
             throw new ElasticsearchParseException("Invalid WKT format", e);
         }

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/fielddata/GeoShapeValues.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/fielddata/GeoShapeValues.java
@@ -10,11 +10,11 @@ package org.elasticsearch.xpack.spatial.index.fielddata;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.xcontent.ToXContentFragment;
 import org.elasticsearch.common.xcontent.XContentBuilder;
-import org.elasticsearch.index.mapper.GeoShapeIndexer;
 import org.elasticsearch.geometry.Geometry;
 import org.elasticsearch.geometry.Rectangle;
 import org.elasticsearch.geometry.utils.GeographyValidator;
 import org.elasticsearch.geometry.utils.WellKnownText;
+import org.elasticsearch.index.mapper.GeoShapeIndexer;
 import org.elasticsearch.search.aggregations.support.ValuesSourceType;
 import org.elasticsearch.xpack.spatial.index.mapper.BinaryGeoShapeDocValuesField;
 import org.elasticsearch.xpack.spatial.search.aggregations.support.GeoShapeValuesSourceType;
@@ -84,7 +84,6 @@ public abstract class GeoShapeValues {
     /** thin wrapper around a {@link GeometryDocValueReader} which encodes / decodes values using
      * the Geo decoder */
     public static class GeoShapeValue implements ToXContentFragment {
-        private static final WellKnownText MISSING_GEOMETRY_PARSER = new WellKnownText(true, new GeographyValidator(true));
         private static final GeoShapeIndexer MISSING_GEOSHAPE_INDEXER = new GeoShapeIndexer(true, "missing");
         private final GeometryDocValueReader reader;
         private final BoundingBox boundingBox;
@@ -142,7 +141,8 @@ public abstract class GeoShapeValues {
 
         public static GeoShapeValue missing(String missing) {
             try {
-                final Geometry geometry = MISSING_GEOSHAPE_INDEXER.prepareForIndexing(MISSING_GEOMETRY_PARSER.fromWKT(missing));
+                final Geometry geometry =
+                    MISSING_GEOSHAPE_INDEXER.prepareForIndexing(WellKnownText.fromWKT(GeographyValidator.instance(true), true, missing));
                 final BinaryGeoShapeDocValuesField field = new BinaryGeoShapeDocValuesField("missing");
                 field.add(MISSING_GEOSHAPE_INDEXER.indexShape(geometry), geometry);
                 final GeoShapeValue value = new GeoShapeValue();

--- a/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/index/fielddata/CentroidCalculatorTests.java
+++ b/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/index/fielddata/CentroidCalculatorTests.java
@@ -50,8 +50,8 @@ public class CentroidCalculatorTests extends ESTestCase {
     }
 
     public void testPolygonWithSmallTrianglesOfZeroWeight() throws Exception {
-        Geometry geometry = new WellKnownText(false, new GeographyValidator(true))
-            .fromWKT("POLYGON((-4.385064 55.2259599,-4.385056 55.2259224,-4.3850466 55.2258994,-4.3849755 55.2258574," +
+        Geometry geometry = WellKnownText.fromWKT(GeographyValidator.instance(true), false,
+                "POLYGON((-4.385064 55.2259599,-4.385056 55.2259224,-4.3850466 55.2258994,-4.3849755 55.2258574," +
                 "-4.3849339 55.2258589,-4.3847033 55.2258742,-4.3846805 55.2258818,-4.3846282 55.2259132,-4.3846215 55.2259247," +
                 "-4.3846121 55.2259683,-4.3846147 55.2259798,-4.3846369 55.2260157,-4.3846472 55.2260241," +
                 "-4.3846697 55.2260409,-4.3846952 55.2260562,-4.384765 55.22608,-4.3848199 55.2260861,-4.3848481 55.2260845," +

--- a/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/ingest/CircleProcessorTests.java
+++ b/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/ingest/CircleProcessorTests.java
@@ -27,7 +27,6 @@ import org.elasticsearch.geometry.Circle;
 import org.elasticsearch.geometry.Geometry;
 import org.elasticsearch.geometry.Point;
 import org.elasticsearch.geometry.Polygon;
-import org.elasticsearch.geometry.utils.StandardValidator;
 import org.elasticsearch.geometry.utils.WellKnownText;
 import org.elasticsearch.index.mapper.GeoShapeIndexer;
 import org.elasticsearch.index.mapper.MappedFieldType;
@@ -59,7 +58,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 public class CircleProcessorTests extends ESTestCase {
-    private static final WellKnownText WKT = new WellKnownText(true, new StandardValidator(true));
 
     public void testNumSides() {
         double radiusDistanceMeters = randomDoubleBetween(0.01, 6371000, true);
@@ -132,13 +130,13 @@ public class CircleProcessorTests extends ESTestCase {
     public void testWKT() {
         Circle circle = new Circle(101.0, 0.0, 2);
         HashMap<String, Object> map = new HashMap<>();
-        map.put("field", WKT.toWKT(circle));
+        map.put("field", WellKnownText.toWKT(circle));
         Geometry expectedPoly = SpatialUtils.createRegularGeoShapePolygon(circle, 4);
         IngestDocument ingestDocument = new IngestDocument(map, Collections.emptyMap());
         CircleProcessor processor = new CircleProcessor("tag", null, "field", "field",false, 2, GEO_SHAPE);
         processor.execute(ingestDocument);
         String polyString = ingestDocument.getFieldValue("field", String.class);
-        assertThat(polyString, equalTo(WKT.toWKT(expectedPoly)));
+        assertThat(polyString, equalTo(WellKnownText.toWKT(expectedPoly)));
     }
 
     public void testInvalidWKT() {

--- a/x-pack/plugin/sql/jdbc/src/main/java/org/elasticsearch/xpack/sql/jdbc/TypeConverter.java
+++ b/x-pack/plugin/sql/jdbc/src/main/java/org/elasticsearch/xpack/sql/jdbc/TypeConverter.java
@@ -57,8 +57,6 @@ import static org.elasticsearch.xpack.sql.jdbc.JdbcDateUtils.timeAsTime;
  */
 final class TypeConverter {
 
-    private static WellKnownText WKT = new WellKnownText(true, new StandardValidator(true));
-
     private TypeConverter() {}
 
     /**
@@ -257,7 +255,7 @@ final class TypeConverter {
             case GEO_SHAPE:
             case SHAPE:
                 try {
-                    return WKT.fromWKT(v.toString());
+                    return WellKnownText.fromWKT(StandardValidator.instance(true), true, v.toString());
                 } catch (IOException | ParseException ex) {
                     throw new SQLException("Cannot parse geo_shape", ex);
                 }

--- a/x-pack/plugin/sql/qa/server/src/main/java/org/elasticsearch/xpack/sql/qa/jdbc/JdbcAssert.java
+++ b/x-pack/plugin/sql/qa/server/src/main/java/org/elasticsearch/xpack/sql/qa/jdbc/JdbcAssert.java
@@ -58,8 +58,6 @@ public class JdbcAssert {
 
     private static final IntObjectHashMap<EsType> SQL_TO_TYPE = new IntObjectHashMap<>();
 
-    private static final WellKnownText WKT = new WellKnownText(true, new StandardValidator(true));
-
     static {
         for (EsType type : EsType.values()) {
             SQL_TO_TYPE.putIfAbsent(type.getVendorTypeNumber().intValue(), type);
@@ -315,7 +313,7 @@ public class JdbcAssert {
                         if (actualObject instanceof Geometry) {
                             // We need to convert the expected object to libs/geo Geometry for comparision
                             try {
-                                expectedObject = WKT.fromWKT(expectedObject.toString());
+                                expectedObject = WellKnownText.fromWKT(StandardValidator.instance(true), true, expectedObject.toString());
                             } catch (IOException | ParseException ex) {
                                 fail(ex.getMessage());
                             }

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/literal/geo/GeoShape.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/literal/geo/GeoShape.java
@@ -29,8 +29,6 @@ import org.elasticsearch.geometry.MultiPolygon;
 import org.elasticsearch.geometry.Point;
 import org.elasticsearch.geometry.Polygon;
 import org.elasticsearch.geometry.Rectangle;
-import org.elasticsearch.geometry.utils.GeometryValidator;
-import org.elasticsearch.geometry.utils.StandardValidator;
 import org.elasticsearch.geometry.utils.WellKnownText;
 import org.elasticsearch.xpack.ql.QlIllegalArgumentException;
 import org.elasticsearch.xpack.ql.expression.gen.processor.ConstantNamedWriteable;
@@ -52,11 +50,7 @@ public class GeoShape implements ToXContentFragment, ConstantNamedWriteable {
 
     private final Geometry shape;
 
-    private static final GeometryValidator validator = new StandardValidator(true);
-
     private static final GeometryParser GEOMETRY_PARSER = new GeometryParser(true, true, true);
-
-    private static final WellKnownText WKT_PARSER = new WellKnownText(true, validator);
 
     public GeoShape(double lon, double lat) {
         shape = new Point(lon, lat);
@@ -81,17 +75,17 @@ public class GeoShape implements ToXContentFragment, ConstantNamedWriteable {
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        out.writeString(WKT_PARSER.toWKT(shape));
+        out.writeString(WellKnownText.toWKT(shape));
     }
 
     @Override
     public String toString() {
-        return WKT_PARSER.toWKT(shape);
+        return WellKnownText.toWKT(shape);
     }
 
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
-        return builder.value(WKT_PARSER.toWKT(shape));
+        return builder.value(WellKnownText.toWKT(shape));
     }
 
     public Geometry toGeometry() {


### PR DESCRIPTION
 GeoJson and WellKnownText are utility classes to serialise / deserialise GeoJSON and WKT respectively. In order to use them, we need to instantiate an object with the parameters that are used while reading a geometry. This change makes all methods on the utility class static and adds the need parameters for reading geometries as method parameters.

In addition, GeometryValidators are classes that can work pretty well under singleton pattern. Therefore we change as well StandardValidator and GeographyValidator to work under that pattern.

backport #73805