### PR TITLE
Remove reorderParentTest that does not check across versions

### DIFF
--- a/server/src/test/java/org/elasticsearch/index/mapper/NestedObjectMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/NestedObjectMapperTests.java
@@ -824,45 +824,6 @@ public class NestedObjectMapperTests extends MapperServiceTestCase {
         }
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/73859")
-    public void testReorderParent() throws IOException {
-
-        Version version = VersionUtils.randomIndexCompatibleVersion(random());
-
-        DocumentMapper docMapper
-            = createDocumentMapper(version, mapping(b -> b.startObject("nested1").field("type", "nested").endObject()));
-
-        assertThat(docMapper.mappers().hasNested(), equalTo(true));
-        ObjectMapper mapper = docMapper.mappers().objectMappers().get("nested1");
-        assertThat(mapper, instanceOf(NestedObjectMapper.class));
-
-        ParsedDocument doc = docMapper.parse(new SourceToParse("test", "_doc", "1",
-            BytesReference.bytes(XContentFactory.jsonBuilder()
-                .startObject()
-                .field("field", "value")
-                .startArray("nested1")
-                .startObject()
-                .field("field1", "1")
-                .field("field2", "2")
-                .endObject()
-                .startObject()
-                .field("field1", "3")
-                .field("field2", "4")
-                .endObject()
-                .endArray()
-                .endObject()),
-            XContentType.JSON));
-
-        assertThat(doc.docs().size(), equalTo(3));
-        NestedObjectMapper nested1Mapper = (NestedObjectMapper) mapper;
-        assertThat(doc.docs().get(0).get("_type"), equalTo(nested1Mapper.nestedTypePath()));
-        assertThat(doc.docs().get(0).get("nested1.field1"), equalTo("1"));
-        assertThat(doc.docs().get(0).get("nested1.field2"), equalTo("2"));
-        assertThat(doc.docs().get(1).get("nested1.field1"), equalTo("3"));
-        assertThat(doc.docs().get(1).get("nested1.field2"), equalTo("4"));
-        assertThat(doc.docs().get(2).get("field"), equalTo("value"));
-    }
-
     public void testMergeChildMappings() throws IOException {
         MapperService mapperService = createMapperService(mapping(b -> {
             b.startObject("nested1");


### PR DESCRIPTION
In elasticsearch 6.5 we changed the way that nested docs are ordered, and
we have a test in NestedObjectMapperTests that specifically checks this
logic across different versions.  We also have a test in master that does not
need to check versions when checking ordering because we will only examine
indexes created in 7x or later.  This test was mistakenly backported as part
of #73058 and is removed in this commit.

Fixes #73859