### PR TITLE
[Transform] Small cleanup in transform indexer code

### DIFF
--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/ClientTransformIndexer.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/ClientTransformIndexer.java
@@ -163,7 +163,7 @@ class ClientTransformIndexer extends TransformIndexer {
                         Exception firstException = deduplicatedFailures.values().iterator().next().getFailure().getCause();
                         nextPhase.onFailure(
                             new BulkIndexingException(
-                                "Bulk index experienced [{}] failures. Significant falures: {}",
+                                "Bulk index experienced [{}] failures.{}",
                                 firstException,
                                 false,
                                 failureCount,
@@ -185,7 +185,7 @@ class ClientTransformIndexer extends TransformIndexer {
 
                         nextPhase.onFailure(
                             new BulkIndexingException(
-                                "Bulk index experienced [{}] failures and at least 1 irrecoverable [{}]. Other failures: {}",
+                                "Bulk index experienced [{}] failures and at least 1 irrecoverable [{}].{}",
                                 irrecoverableException,
                                 true,
                                 failureCount,

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/ClientTransformIndexer.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/ClientTransformIndexer.java
@@ -157,13 +157,13 @@ class ClientTransformIndexer extends TransformIndexer {
                         deduplicatedFailures.values()
                     );
                     if (irrecoverableException == null) {
-                        String failureMessage = getBulkIndexDetailedFailureMessage(" Significant failures: ", deduplicatedFailures);
-                        logger.debug("[{}] Bulk index experienced [{}] failures.{}", getJobId(), failureCount, failureMessage);
+                        String failureMessage = getBulkIndexDetailedFailureMessage("Significant failures: ", deduplicatedFailures);
+                        logger.debug("[{}] Bulk index experienced [{}] failures. {}", getJobId(), failureCount, failureMessage);
 
                         Exception firstException = deduplicatedFailures.values().iterator().next().getFailure().getCause();
                         nextPhase.onFailure(
                             new BulkIndexingException(
-                                "Bulk index experienced [{}] failures.{}",
+                                "Bulk index experienced [{}] failures. {}",
                                 firstException,
                                 false,
                                 failureCount,
@@ -172,11 +172,11 @@ class ClientTransformIndexer extends TransformIndexer {
                         );
                     } else {
                         deduplicatedFailures.remove(irrecoverableException.getClass().getSimpleName());
-                        String failureMessage = getBulkIndexDetailedFailureMessage(" Other failures: ", deduplicatedFailures);
+                        String failureMessage = getBulkIndexDetailedFailureMessage("Other failures: ", deduplicatedFailures);
                         irrecoverableException = decorateBulkIndexException(irrecoverableException);
 
                         logger.debug(
-                            "[{}] Bulk index experienced [{}] failures and at least 1 irrecoverable [{}].{}",
+                            "[{}] Bulk index experienced [{}] failures and at least 1 irrecoverable [{}]. {}",
                             getJobId(),
                             failureCount,
                             ExceptionRootCauseFinder.getDetailedMessage(irrecoverableException),
@@ -185,7 +185,7 @@ class ClientTransformIndexer extends TransformIndexer {
 
                         nextPhase.onFailure(
                             new BulkIndexingException(
-                                "Bulk index experienced [{}] failures and at least 1 irrecoverable [{}].{}",
+                                "Bulk index experienced [{}] failures and at least 1 irrecoverable [{}]. {}",
                                 irrecoverableException,
                                 true,
                                 failureCount,

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/ClientTransformIndexer.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/ClientTransformIndexer.java
@@ -195,7 +195,6 @@ class ClientTransformIndexer extends TransformIndexer {
                         );
                     }
                 } else {
-                    auditBulkFailures = true;
                     nextPhase.onResponse(bulkResponse);
                 }
             }, nextPhase::onFailure)

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/TransformIndexer.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/TransformIndexer.java
@@ -94,7 +94,6 @@ public abstract class TransformIndexer extends AsyncTwoPhaseIndexer<TransformInd
 
     protected volatile TransformConfig transformConfig;
     private volatile TransformProgress progress;
-    protected volatile boolean auditBulkFailures = true;
     // Indicates that the source has changed for the current run
     protected volatile boolean hasSourceChanged = true;
 
@@ -522,7 +521,6 @@ public abstract class TransformIndexer extends AsyncTwoPhaseIndexer<TransformInd
                 auditor.info(getJobId(), "Finished indexing for transform checkpoint [" + checkpoint + "].");
             }
             logger.debug("[{}] finished indexing for transform checkpoint [{}].", getJobId(), checkpoint);
-            auditBulkFailures = true;
             if (context.shouldStopAtCheckpoint()) {
                 stop();
             }
@@ -1049,14 +1047,12 @@ public abstract class TransformIndexer extends AsyncTwoPhaseIndexer<TransformInd
         if (newPageSize < MINIMUM_PAGE_SIZE) {
             String message = TransformMessages.getMessage(TransformMessages.LOG_TRANSFORM_PIVOT_LOW_PAGE_SIZE_FAILURE, pageSize);
             failIndexer(message);
-            return;
+        } else {
+            String message = TransformMessages.getMessage(TransformMessages.LOG_TRANSFORM_PIVOT_REDUCE_PAGE_SIZE, pageSize, newPageSize);
+            auditor.info(getJobId(), message);
+            logger.info("[{}] {}", getJobId(), message);
+            pageSize = newPageSize;
         }
-
-        String message = TransformMessages.getMessage(TransformMessages.LOG_TRANSFORM_PIVOT_REDUCE_PAGE_SIZE, pageSize, newPageSize);
-        auditor.info(getJobId(), message);
-        logger.info("[{}] {}", getJobId(), message);
-        pageSize = newPageSize;
-        return;
     }
 
     /**


### PR DESCRIPTION
This PR:
- removes unused `auditBulkFailures` member variable
- removes misleading redundant prefixes in log messages