### PR TITLE
Remove some trivial dependencies on geo legacy code

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/geo/GeoJson.java
+++ b/server/src/main/java/org/elasticsearch/common/geo/GeoJson.java
@@ -11,7 +11,6 @@ package org.elasticsearch.common.geo;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.ElasticsearchParseException;
 import org.elasticsearch.common.ParseField;
-import org.elasticsearch.common.geo.parsers.ShapeParser;
 import org.elasticsearch.common.unit.DistanceUnit;
 import org.elasticsearch.common.xcontent.ConstructingObjectParser;
 import org.elasticsearch.common.xcontent.ObjectParser;
@@ -95,7 +94,7 @@ public final class GeoJson {
             @Override
             public XContentBuilder visit(Circle circle) throws IOException {
                 builder.field(FIELD_RADIUS.getPreferredName(), DistanceUnit.METERS.toString(circle.getRadiusMeters()));
-                builder.field(ShapeParser.FIELD_COORDINATES.getPreferredName());
+                builder.field(FIELD_COORDINATES.getPreferredName());
                 return coordinatesToXContent(circle.getY(), circle.getX(), circle.getZ());
             }
 
@@ -110,7 +109,7 @@ public final class GeoJson {
 
             @Override
             public XContentBuilder visit(Line line) throws IOException {
-                builder.field(ShapeParser.FIELD_COORDINATES.getPreferredName());
+                builder.field(FIELD_COORDINATES.getPreferredName());
                 return coordinatesToXContent(line);
             }
 
@@ -121,7 +120,7 @@ public final class GeoJson {
 
             @Override
             public XContentBuilder visit(MultiLine multiLine) throws IOException {
-                builder.field(ShapeParser.FIELD_COORDINATES.getPreferredName());
+                builder.field(FIELD_COORDINATES.getPreferredName());
                 builder.startArray();
                 for (int i = 0; i < multiLine.size(); i++) {
                     coordinatesToXContent(multiLine.get(i));
@@ -131,7 +130,7 @@ public final class GeoJson {
 
             @Override
             public XContentBuilder visit(MultiPoint multiPoint) throws IOException {
-                builder.startArray(ShapeParser.FIELD_COORDINATES.getPreferredName());
+                builder.startArray(FIELD_COORDINATES.getPreferredName());
                 for (int i = 0; i < multiPoint.size(); i++) {
                     Point p = multiPoint.get(i);
                     builder.startArray().value(p.getX()).value(p.getY());
@@ -145,7 +144,7 @@ public final class GeoJson {
 
             @Override
             public XContentBuilder visit(MultiPolygon multiPolygon) throws IOException {
-                builder.startArray(ShapeParser.FIELD_COORDINATES.getPreferredName());
+                builder.startArray(FIELD_COORDINATES.getPreferredName());
                 for (int i = 0; i < multiPolygon.size(); i++) {
                     builder.startArray();
                     coordinatesToXContent(multiPolygon.get(i));
@@ -156,13 +155,13 @@ public final class GeoJson {
 
             @Override
             public XContentBuilder visit(Point point) throws IOException {
-                builder.field(ShapeParser.FIELD_COORDINATES.getPreferredName());
+                builder.field(FIELD_COORDINATES.getPreferredName());
                 return coordinatesToXContent(point.getY(), point.getX(), point.getZ());
             }
 
             @Override
             public XContentBuilder visit(Polygon polygon) throws IOException {
-                builder.startArray(ShapeParser.FIELD_COORDINATES.getPreferredName());
+                builder.startArray(FIELD_COORDINATES.getPreferredName());
                 coordinatesToXContent(polygon.getPolygon());
                 for (int i = 0; i < polygon.getNumberOfHoles(); i++) {
                     coordinatesToXContent(polygon.getHole(i));
@@ -172,7 +171,7 @@ public final class GeoJson {
 
             @Override
             public XContentBuilder visit(Rectangle rectangle) throws IOException {
-                builder.startArray(ShapeParser.FIELD_COORDINATES.getPreferredName());
+                builder.startArray(FIELD_COORDINATES.getPreferredName());
                 coordinatesToXContent(rectangle.getMaxY(), rectangle.getMinX(), rectangle.getMinZ()); // top left
                 coordinatesToXContent(rectangle.getMinY(), rectangle.getMaxX(), rectangle.getMaxZ()); // bottom right
                 return builder.endArray();
@@ -221,7 +220,7 @@ public final class GeoJson {
             @Override
             public Void visit(Circle circle) {
                 root.put(FIELD_RADIUS.getPreferredName(), DistanceUnit.METERS.toString(circle.getRadiusMeters()));
-                root.put(ShapeParser.FIELD_COORDINATES.getPreferredName(), coordinatesToList(circle.getY(), circle.getX(), circle.getZ()));
+                root.put(FIELD_COORDINATES.getPreferredName(), coordinatesToList(circle.getY(), circle.getX(), circle.getZ()));
                 return null;
             }
 
@@ -238,7 +237,7 @@ public final class GeoJson {
 
             @Override
             public Void visit(Line line) {
-                root.put(ShapeParser.FIELD_COORDINATES.getPreferredName(), coordinatesToList(line));
+                root.put(FIELD_COORDINATES.getPreferredName(), coordinatesToList(line));
                 return null;
             }
 
@@ -253,7 +252,7 @@ public final class GeoJson {
                 for (int i = 0; i < multiLine.size(); i++) {
                     lines.add(coordinatesToList(multiLine.get(i)));
                 }
-                root.put(ShapeParser.FIELD_COORDINATES.getPreferredName(), lines);
+                root.put(FIELD_COORDINATES.getPreferredName(), lines);
                 return null;
             }
 
@@ -270,7 +269,7 @@ public final class GeoJson {
                     }
                     points.add(point);
                 }
-                root.put(ShapeParser.FIELD_COORDINATES.getPreferredName(), points);
+                root.put(FIELD_COORDINATES.getPreferredName(), points);
                 return null;
             }
 
@@ -280,13 +279,13 @@ public final class GeoJson {
                 for (int i = 0; i < multiPolygon.size(); i++) {
                     polygons.add(coordinatesToList(multiPolygon.get(i)));
                 }
-                root.put(ShapeParser.FIELD_COORDINATES.getPreferredName(), polygons);
+                root.put(FIELD_COORDINATES.getPreferredName(), polygons);
                 return null;
             }
 
             @Override
             public Void visit(Point point) {
-                root.put(ShapeParser.FIELD_COORDINATES.getPreferredName(), coordinatesToList(point.getY(), point.getX(), point.getZ()));
+                root.put(FIELD_COORDINATES.getPreferredName(), coordinatesToList(point.getY(), point.getX(), point.getZ()));
                 return null;
             }
 
@@ -297,7 +296,7 @@ public final class GeoJson {
                 for (int i = 0; i < polygon.getNumberOfHoles(); i++) {
                     coords.add(coordinatesToList(polygon.getHole(i)));
                 }
-                root.put(ShapeParser.FIELD_COORDINATES.getPreferredName(), coords);
+                root.put(FIELD_COORDINATES.getPreferredName(), coords);
                 return null;
             }
 
@@ -306,7 +305,7 @@ public final class GeoJson {
                 List<Object> coords = new ArrayList<>(2);
                 coords.add(coordinatesToList(rectangle.getMaxY(), rectangle.getMinX(), rectangle.getMinZ())); // top left
                 coords.add(coordinatesToList(rectangle.getMinY(), rectangle.getMaxX(), rectangle.getMaxZ())); // bottom right
-                root.put(ShapeParser.FIELD_COORDINATES.getPreferredName(), coords);
+                root.put(FIELD_COORDINATES.getPreferredName(), coords);
                 return null;
             }
 

--- a/server/src/main/java/org/elasticsearch/index/mapper/GeoShapeIndexer.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/GeoShapeIndexer.java
@@ -14,7 +14,6 @@ import org.apache.lucene.geo.GeoEncodingUtils;
 import org.apache.lucene.index.IndexableField;
 import org.elasticsearch.common.geo.GeoLineDecomposer;
 import org.elasticsearch.common.geo.GeoPolygonDecomposer;
-import org.elasticsearch.common.geo.GeoShapeType;
 import org.elasticsearch.common.geo.GeoShapeUtils;
 import org.elasticsearch.common.geo.GeoUtils;
 import org.elasticsearch.geometry.Circle;
@@ -29,6 +28,7 @@ import org.elasticsearch.geometry.MultiPolygon;
 import org.elasticsearch.geometry.Point;
 import org.elasticsearch.geometry.Polygon;
 import org.elasticsearch.geometry.Rectangle;
+import org.elasticsearch.geometry.ShapeType;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -58,7 +58,7 @@ public class GeoShapeIndexer {
         return geometry.visit(new GeometryVisitor<>() {
             @Override
             public Geometry visit(Circle circle) {
-                throw new UnsupportedOperationException(GeoShapeType.CIRCLE + " geometry is not supported");
+                throw new UnsupportedOperationException(ShapeType.CIRCLE + " geometry is not supported");
             }
 
             @Override

--- a/server/src/test/java/org/elasticsearch/common/geo/GeometryIndexerTests.java
+++ b/server/src/test/java/org/elasticsearch/common/geo/GeometryIndexerTests.java
@@ -24,6 +24,7 @@ import org.elasticsearch.geometry.MultiPolygon;
 import org.elasticsearch.geometry.Point;
 import org.elasticsearch.geometry.Polygon;
 import org.elasticsearch.geometry.Rectangle;
+import org.elasticsearch.geometry.ShapeType;
 import org.elasticsearch.index.mapper.GeoShapeIndexer;
 import org.elasticsearch.test.ESTestCase;
 import org.locationtech.spatial4j.exception.InvalidShapeException;
@@ -46,7 +47,7 @@ public class GeometryIndexerTests extends ESTestCase {
     public void testCircle() {
         UnsupportedOperationException ex =
             expectThrows(UnsupportedOperationException.class, () -> indexer.prepareForIndexing(new Circle(2, 1, 3)));
-        assertEquals(GeoShapeType.CIRCLE + " geometry is not supported", ex.getMessage());
+        assertEquals(ShapeType.CIRCLE + " geometry is not supported", ex.getMessage());
     }
 
     public void testCollection() {


### PR DESCRIPTION
Currently the code under `org.elasticsearch.common.geo.parsers` and `org.elasticsearch.common.geo.builders`, and the class `GeoShapeType` can be considered legacy and we should try to remove any dependency.

This is a small step removing some trivial ones.