### PR TITLE
Fix java compatibility for build-tools-internal

### DIFF
--- a/build-tools-internal/build.gradle
+++ b/build-tools-internal/build.gradle
@@ -165,9 +165,9 @@ if (JavaVersion.current() < JavaVersion.VERSION_11) {
   throw new GradleException('At least Java 11 is required to build elasticsearch gradle tools')
 }
 
-def minCompilerJava = JavaVersion.toVersion(file('src/main/resources/minimumCompilerVersion').text)
-targetCompatibility = minCompilerJava
-sourceCompatibility = minCompilerJava
+def minimumJava = JavaVersion.toVersion(file('src/main/resources/minimumRuntimeVersion').text)
+targetCompatibility = minimumJava
+sourceCompatibility = minimumJava
 
 sourceSets {
   integTest {


### PR DESCRIPTION
This was accidentally set to 15. 

- should be 11 not 15 taken from the minimumRuntimeVersion file and not from minimumCompilerVersion
- this also fixes the checkstyle ides setup