### PR TITLE
Fix syntax for script_score example

### DIFF
--- a/docs/reference/query-dsl/function-score-query.asciidoc
+++ b/docs/reference/query-dsl/function-score-query.asciidoc
@@ -142,11 +142,15 @@ GET /_search
       "query": {
         "match": { "message": "elasticsearch" }
       },
-      "script_score": {
-        "script": {
-          "source": "Math.log(2 + doc['my-int'].value)"
+      "functions": [
+        {
+          "script_score": {
+            "script": {
+              "source": "Math.log(2 + doc['my-int'].value)"
+            }
+          }
         }
-      }
+      ]
     }
   }
 }


### PR DESCRIPTION
It was missing the "functions" object.