### PR TITLE
[DOCS] Clarify supported fields for `top_metrics` agg

### DIFF
--- a/docs/reference/aggregations/metrics/top-metrics-aggregation.asciidoc
+++ b/docs/reference/aggregations/metrics/top-metrics-aggregation.asciidoc
@@ -80,10 +80,9 @@ metrics by requesting a list of metrics like `"metrics": [{"field": "m"}, {"fiel
 * <<keyword,keywords>>
 * <<number,numbers>>
 
-<<runtime,Runtime fields>> of corresponding types, except `keyword` runtime
-fields, are also supported. `metrics.field` doesn't support fields with
-<<array,array values>>. A `top_metric` aggregation on array values may return
-inconsistent results.
+Except keywords, <<runtime,runtime fields>> of corresponding types are also
+supported. `metrics.field` doesn't support fields with <<array,array values>>. A
+`top_metric` aggregation on array values may return inconsistent results.
 
 The following example runs a `top_metrics` aggregation on several field types.
 

--- a/docs/reference/aggregations/metrics/top-metrics-aggregation.asciidoc
+++ b/docs/reference/aggregations/metrics/top-metrics-aggregation.asciidoc
@@ -80,9 +80,10 @@ metrics by requesting a list of metrics like `"metrics": [{"field": "m"}, {"fiel
 * <<keyword,keywords>>
 * <<number,numbers>>
 
-<<runtime,Runtime fields>> of corresponding types are also supported.
-`metrics.field` doesn't support fields with <<array,array values>>. A
-`top_metric` aggregation on array values may return inconsistent results.
+<<runtime,Runtime fields>> of corresponding types, except `keyword` runtime
+fields, are also supported. `metrics.field` doesn't support fields with
+<<array,array values>>. A `top_metric` aggregation on array values may return
+inconsistent results.
 
 The following example runs a `top_metrics` aggregation on several field types.
 

--- a/docs/reference/aggregations/metrics/top-metrics-aggregation.asciidoc
+++ b/docs/reference/aggregations/metrics/top-metrics-aggregation.asciidoc
@@ -80,7 +80,7 @@ metrics by requesting a list of metrics like `"metrics": [{"field": "m"}, {"fiel
 * <<keyword,keywords>>
 * <<number,numbers>>
 
-Excluding keywords, <<runtime,runtime fields>> for corresponding types are also
+<<runtime,Runtime fields>> for corresponding types, excluding keywords, are also
 supported. `metrics.field` doesn't support fields with <<array,array values>>. A
 `top_metric` aggregation on array values may return inconsistent results.
 

--- a/docs/reference/aggregations/metrics/top-metrics-aggregation.asciidoc
+++ b/docs/reference/aggregations/metrics/top-metrics-aggregation.asciidoc
@@ -80,7 +80,7 @@ metrics by requesting a list of metrics like `"metrics": [{"field": "m"}, {"fiel
 * <<keyword,keywords>>
 * <<number,numbers>>
 
-Except keywords, <<runtime,runtime fields>> of corresponding types are also
+Excluding keywords, <<runtime,runtime fields>> for corresponding types are also
 supported. `metrics.field` doesn't support fields with <<array,array values>>. A
 `top_metric` aggregation on array values may return inconsistent results.
 

--- a/docs/reference/aggregations/metrics/top-metrics-aggregation.asciidoc
+++ b/docs/reference/aggregations/metrics/top-metrics-aggregation.asciidoc
@@ -80,7 +80,7 @@ metrics by requesting a list of metrics like `"metrics": [{"field": "m"}, {"fiel
 * <<keyword,keywords>>
 * <<number,numbers>>
 
-<<runtime,Runtime fields>> for corresponding types, excluding keywords, are also
+Except for keywords, <<runtime,runtime fields>> for corresponding types are also
 supported. `metrics.field` doesn't support fields with <<array,array values>>. A
 `top_metric` aggregation on array values may return inconsistent results.
 

--- a/docs/reference/aggregations/metrics/top-metrics-aggregation.asciidoc
+++ b/docs/reference/aggregations/metrics/top-metrics-aggregation.asciidoc
@@ -70,8 +70,8 @@ request. So,
 ==== `metrics`
 
 `metrics` selects the fields of the "top" document to return. You can request
-a single metric with something like `"metric": {"field": "m"}` or multiple
-metrics by requesting a list of metrics like `"metric": [{"field": "m"}, {"field": "i"}`.
+a single metric with something like `"metrics": {"field": "m"}` or multiple
+metrics by requesting a list of metrics like `"metrics": [{"field": "m"}, {"field": "i"}`.
 
 `metrics.field` supports the following field types:
 

--- a/docs/reference/aggregations/metrics/top-metrics-aggregation.asciidoc
+++ b/docs/reference/aggregations/metrics/top-metrics-aggregation.asciidoc
@@ -72,8 +72,19 @@ request. So,
 `metrics` selects the fields of the "top" document to return. You can request
 a single metric with something like `"metric": {"field": "m"}` or multiple
 metrics by requesting a list of metrics like `"metric": [{"field": "m"}, {"field": "i"}`.
-The fields can be <<number,numbers>>, <<keyword,keywords>>, or <<ip,ips>>.
-Here is a more complete example:
+
+`metrics.field` supports the following field types:
+
+* <<boolean,`boolean`>>
+* <<ip,`ip`>>
+* <<keyword,keywords>>
+* <<number,numbers>>
+
+<<runtime,Runtime fields>> of corresponding types are also supported.
+`metrics.field` doesn't support fields with <<array,array values>>. A
+`top_metric` aggregation on array values may return inconsistent results.
+
+The following example runs a `top_metrics` aggregation on several field types.
 
 [source,console,id=search-aggregations-metrics-top-metrics-list-of-metrics]
 ----


### PR DESCRIPTION
Changes:
* Notes `metrics.field` supports `boolean` fields and runtime fields.
* Notes `metrics.field` doesn't support array values.

Closes #72889

### Preview
https://elasticsearch_73907.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/search-aggregations-metrics-top-metrics.html#_metrics