### PR TITLE
Verify that main info response returns correct product headers

### DIFF
--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/RestHighLevelClient.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/RestHighLevelClient.java
@@ -2018,10 +2018,8 @@ public class RestHighLevelClient implements Closeable {
 
         ListenableFuture<Optional<String>> versionCheck = getVersionValidationFuture();
 
-        // Create a future that tracks cancellation of this method's result so that we can register a listener that forwards cancellation
-        // to the actual LLRC request. This future is completed (with a null value) if the result is cancelled.
-        // Note that cancelling the result leads to completing this future and not cancelling it. This is because the future API allows
-        // listening to completion but not to cancellation.
+        // Create a future that tracks cancellation of this method's result and forwards cancellation to the actual LLRC request. This
+        // future is completed successfully if the result is cancelled.
         CompletableFuture<Void> cancelFlag = new CompletableFuture<Void>();
         Cancellable result = new Cancellable() {
             @Override

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/RestHighLevelClient.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/RestHighLevelClient.java
@@ -2108,6 +2108,8 @@ public class RestHighLevelClient implements Closeable {
 
                 // Asynchronously call the info endpoint and complete the future with the version validation result.
                 Request req = new Request("GET", "/");
+                // These status codes are nominal in the context of product version verification
+                req.addParameter("ignore", "401,403");
                 client.performRequestAsync(req, new ResponseListener() {
                     @Override
                     public void onSuccess(Response response) {
@@ -2124,6 +2126,7 @@ public class RestHighLevelClient implements Closeable {
 
                     @Override
                     public void onFailure(Exception exception) {
+
                         // Fail the requests (this one and the ones waiting for it) and clear the future
                         // so that we retry the next time the client executes a request.
                         versionValidationFuture = null;
@@ -2142,6 +2145,7 @@ public class RestHighLevelClient implements Closeable {
      * @return an optional string. If empty, version is compatible. Otherwise, it's the message to return to the application.
      */
     private Optional<String> getVersionValidation(Response response) throws IOException {
+        // Let requests go through if the client doesn't have permissions for the info endpoint.
         int statusCode = response.getStatusLine().getStatusCode();
         if (statusCode == 401 || statusCode == 403) {
             return Optional.empty();

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/RestHighLevelClient.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/RestHighLevelClient.java
@@ -2180,23 +2180,22 @@ public class RestHighLevelClient implements Closeable {
             return Optional.of("Elasticsearch version 6 or more is required");
         }
 
-        if (major == 6) {
-            return Optional.empty();
-        }
-
-        String responseFlavor = mainResponse.getVersion().getBuildFlavor();
-        if ("default".equals(responseFlavor) == false) {
-            // Flavor is unknown when running tests, and non-mocked responses will return an unknown flavor
-            if (Build.CURRENT.flavor() != Build.Flavor.UNKNOWN || "unknown".equals(responseFlavor) == false) {
-                return Optional.of("Invalid or missing build flavor [" + responseFlavor + "]");
+        if (major == 6 || (major == 7 && minor < 14)) {
+            if ("You Know, for Search".equalsIgnoreCase(mainResponse.getTagline()) == false) {
+                return Optional.of("Invalid or missing tagline [" + mainResponse.getTagline() + "]");
             }
-        }
 
-        if ("You Know, for Search".equalsIgnoreCase(mainResponse.getTagline()) == false) {
-            return Optional.of("Invalid or missing tagline [" + mainResponse.getTagline() + "]");
-        }
+            if (major == 7) {
+                // >= 7.0 and < 7.14
+                String responseFlavor = mainResponse.getVersion().getBuildFlavor();
+                if ("default".equals(responseFlavor) == false) {
+                    // Flavor is unknown when running tests, and non-mocked responses will return an unknown flavor
+                    if (Build.CURRENT.flavor() != Build.Flavor.UNKNOWN || "unknown".equals(responseFlavor) == false) {
+                        return Optional.of("Invalid or missing build flavor [" + responseFlavor + "]");
+                    }
+                }
+            }
 
-        if (major == 7 && minor < 14) {
             return Optional.empty();
         }
 

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/RestHighLevelClient.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/RestHighLevelClient.java
@@ -67,6 +67,7 @@ import org.elasticsearch.client.core.MultiTermVectorsResponse;
 import org.elasticsearch.client.core.TermVectorsRequest;
 import org.elasticsearch.client.core.TermVectorsResponse;
 import org.elasticsearch.client.tasks.TaskSubmissionResponse;
+import org.elasticsearch.common.util.concurrent.FutureUtils;
 import org.elasticsearch.core.CheckedConsumer;
 import org.elasticsearch.core.CheckedFunction;
 import org.elasticsearch.common.xcontent.ParseField;
@@ -2025,7 +2026,7 @@ public class RestHighLevelClient implements Closeable {
             @Override
             public void cancel() {
                 // Raise the flag by completing the future
-                cancellationForwarder.cancel(false);
+                FutureUtils.cancel(cancellationForwarder);
             }
 
             @Override

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/RestHighLevelClient.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/RestHighLevelClient.java
@@ -2172,7 +2172,20 @@ public class RestHighLevelClient implements Closeable {
         if (major < 6) {
             return Optional.of("Elasticsearch version 6 or more is required");
         }
-        if (major == 6 || (major == 7 && minor < 14)) {
+
+        if (major == 6) {
+            return Optional.empty();
+        }
+
+        if ("default".equals(Build.CURRENT.flavor()) && "default".equals(mainResponse.getVersion().getBuildFlavor()) == false) {
+            return Optional.of("Invalid or missing build flavor [" + mainResponse.getVersion().getBuildFlavor() + "]");
+        }
+
+        if ("You Know, for Search".equalsIgnoreCase(mainResponse.getTagline()) == false) {
+            return Optional.of("Invalid or missing tagline [" + mainResponse.getTagline() + "]");
+        }
+
+        if (major == 7 && minor < 14) {
             return Optional.empty();
         }
 

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/RestHighLevelClient.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/RestHighLevelClient.java
@@ -2184,8 +2184,12 @@ public class RestHighLevelClient implements Closeable {
             return Optional.empty();
         }
 
-        if ("default".equals(Build.CURRENT.flavor()) && "default".equals(mainResponse.getVersion().getBuildFlavor()) == false) {
-            return Optional.of("Invalid or missing build flavor [" + mainResponse.getVersion().getBuildFlavor() + "]");
+        String responseFlavor = mainResponse.getVersion().getBuildFlavor();
+        if ("default".equals(responseFlavor) == false) {
+            // Flavor is unknown when running tests, and non-mocked responses will return an unknown flavor
+            if (Build.CURRENT.flavor() != Build.Flavor.UNKNOWN || "unknown".equals(responseFlavor) == false) {
+                return Optional.of("Invalid or missing build flavor [" + responseFlavor + "]");
+            }
         }
 
         if ("You Know, for Search".equalsIgnoreCase(mainResponse.getTagline()) == false) {

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/CustomRestHighLevelClientTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/CustomRestHighLevelClientTests.java
@@ -29,6 +29,7 @@ import org.elasticsearch.core.SuppressForbidden;
 import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.RequestMatcher;
 import org.junit.Before;
 
 import java.io.IOException;
@@ -44,6 +45,7 @@ import static java.util.Collections.emptySet;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.hasSize;
 import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.argThat;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -61,17 +63,18 @@ public class CustomRestHighLevelClientTests extends ESTestCase {
     public void initClients() throws IOException {
         if (restHighLevelClient == null) {
             final RestClient restClient = mock(RestClient.class);
+            RestHighLevelClientTests.mockGetRoot(restClient);
             restHighLevelClient = new CustomRestClient(restClient);
 
             doAnswer(inv -> mockPerformRequest((Request) inv.getArguments()[0]))
                     .when(restClient)
-                    .performRequest(any(Request.class));
+                    .performRequest(argThat(new RequestMatcher("GET", ENDPOINT)));
 
             doAnswer(inv -> mockPerformRequestAsync(
                         ((Request) inv.getArguments()[0]),
                         (ResponseListener) inv.getArguments()[1]))
                     .when(restClient)
-                    .performRequestAsync(any(Request.class), any(ResponseListener.class));
+                    .performRequestAsync(argThat(new RequestMatcher("GET", ENDPOINT)), any(ResponseListener.class));
         }
     }
 

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/MockRestHighLevelTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/MockRestHighLevelTests.java
@@ -34,6 +34,7 @@ public class MockRestHighLevelTests extends ESTestCase {
     @Before
     private void setupClient() throws IOException {
         final RestClient mockClient = mock(RestClient.class);
+        RestHighLevelClientTests.mockGetRoot(mockClient);
         final Response mockResponse = mock(Response.class);
 
         when(mockResponse.getHost()).thenReturn(new HttpHost("localhost", 9200));

--- a/client/rest-high-level/src/test/java/org/elasticsearch/test/RequestMatcher.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/test/RequestMatcher.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.test;
+
+import org.elasticsearch.client.Request;
+import org.hamcrest.BaseMatcher;
+import org.hamcrest.Description;
+
+/**
+ * A Harmcrest matcher for request method and endpoint
+ */
+public class RequestMatcher extends BaseMatcher<Request> {
+
+    private final String method;
+    private final String endpoint;
+
+    public RequestMatcher(String method, String endpoint) {
+        this.method = method;
+        this.endpoint = endpoint;
+    }
+
+    @Override
+    public boolean matches(Object actual) {
+        if (actual instanceof Request) {
+            Request req = (Request) actual;
+            return method.equals(req.getMethod()) && endpoint.equals(req.getEndpoint());
+        }
+        return false;
+    }
+
+    @Override
+    public void describeTo(Description description) {
+        description
+            .appendText("request to ")
+            .appendText(method)
+            .appendText(" ")
+            .appendText(endpoint);
+    }
+}


### PR DESCRIPTION
Follow-up to #73434

Ensures that High Level Rest Client is running against a verified
Elasticsearch. When the first request is sent on HLRC, a request to the
info endpoint is made first to verify the product identification and
version.
