### PR TITLE
RuntimeField to expose more than one MappedFieldType (#73900)

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/mapper/AbstractScriptFieldType.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/AbstractScriptFieldType.java
@@ -28,6 +28,7 @@ import org.elasticsearch.search.lookup.SearchLookup;
 import java.io.IOException;
 import java.time.ZoneId;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
@@ -58,8 +59,8 @@ abstract class AbstractScriptFieldType<LeafFactory> extends MappedFieldType impl
     }
 
     @Override
-    public final MappedFieldType asMappedFieldType() {
-        return this;
+    public final Collection<MappedFieldType> asMappedFieldTypes() {
+        return Collections.singleton(this);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/index/mapper/DocumentParser.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DocumentParser.java
@@ -885,9 +885,11 @@ public final class DocumentParser {
         // if a leaf field is not mapped, and is defined as a runtime field, then we
         // don't create a dynamic mapping for it and don't index it.
         String fieldPath = context.path().pathAsText(fieldName);
-        RuntimeField runtimeField = context.root().getRuntimeField(fieldPath);
-        if (runtimeField != null) {
-            return new NoOpFieldMapper(subfields[subfields.length - 1], runtimeField.asMappedFieldType().name());
+        MappedFieldType fieldType = context.mappingLookup().getFieldType(fieldPath);
+        if (fieldType != null) {
+            //we haven't found a mapper with this name above, which means if a field type is found it is for sure a runtime field.
+            assert fieldType.hasDocValues() == false && fieldType.isAggregatable() && fieldType.isSearchable();
+            return new NoOpFieldMapper(subfields[subfields.length - 1], fieldType.name());
         }
         return null;
     }

--- a/server/src/main/java/org/elasticsearch/index/mapper/FieldTypeLookup.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/FieldTypeLookup.java
@@ -80,10 +80,9 @@ final class FieldTypeLookup {
             }
         }
 
-        for (RuntimeField runtimeField : runtimeFields) {
-            MappedFieldType runtimeFieldType = runtimeField.asMappedFieldType();
+        for (MappedFieldType fieldType : RuntimeField.collectFieldTypes(runtimeFields).values()) {
             //this will override concrete fields with runtime fields that have the same name
-            fullNameToFieldType.put(runtimeFieldType.name(), runtimeFieldType);
+            fullNameToFieldType.put(fieldType.name(), fieldType);
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/index/mapper/RuntimeField.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/RuntimeField.java
@@ -12,12 +12,14 @@ import org.elasticsearch.common.xcontent.ToXContentFragment;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 
 import java.io.IOException;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 
 /**
  * Definition of a runtime field that can be defined as part of the runtime section of the index mappings
@@ -51,10 +53,10 @@ public interface RuntimeField extends ToXContentFragment {
     String typeName();
 
     /**
-     * Exposes the {@link MappedFieldType} backing this runtime field, used to execute queries, run aggs etc.
-     * @return the {@link MappedFieldType} backing this runtime field
+     * Exposes the {@link MappedFieldType}s backing this runtime field, used to execute queries, run aggs etc.
+     * @return the {@link MappedFieldType}s backing this runtime field
      */
-    MappedFieldType asMappedFieldType();
+    Collection<MappedFieldType> asMappedFieldTypes();
 
     /**
      *  For runtime fields the {@link RuntimeField.Parser} returns directly the {@link MappedFieldType}.
@@ -174,5 +176,32 @@ public interface RuntimeField extends ToXContentFragment {
             }
         }
         return Collections.unmodifiableMap(runtimeFields);
+    }
+
+    /**
+     * Collect and return all {@link MappedFieldType} exposed by the provided {@link RuntimeField}s.
+     * Note that validation is performed to make sure that there are no name clashes among the collected runtime fields.
+     * This is because runtime fields with the same name are not accepted as part of the same section.
+     * @param runtimeFields the runtime to extract the mapped field types from
+     * @return the collected mapped field types
+     */
+    static Map<String, MappedFieldType> collectFieldTypes(Collection<RuntimeField> runtimeFields) {
+        return runtimeFields.stream()
+            .flatMap(runtimeField -> {
+                List<String> names = runtimeField.asMappedFieldTypes().stream().map(MappedFieldType::name)
+                    .filter(name -> name.equals(runtimeField.name()) == false
+                        && (name.startsWith(runtimeField.name() + ".") == false
+                        || name.length() > runtimeField.name().length() + 1 == false))
+                    .collect(Collectors.toList());
+                if (names.isEmpty() == false) {
+                    throw new IllegalStateException("Found sub-fields with name not belonging to the parent field they are part of "
+                        + names);
+                }
+                return runtimeField.asMappedFieldTypes().stream();
+            })
+            .collect(Collectors.toMap(MappedFieldType::name, mappedFieldType -> mappedFieldType,
+                (t, t2) -> {
+                    throw new IllegalArgumentException("Found two runtime fields with same name [" + t.name() + "]");
+                }));
     }
 }

--- a/server/src/main/java/org/elasticsearch/index/query/SearchExecutionContext.java
+++ b/server/src/main/java/org/elasticsearch/index/query/SearchExecutionContext.java
@@ -663,12 +663,7 @@ public class SearchExecutionContext extends QueryRewriteContext {
         }
         Map<String, RuntimeField> runtimeFields = RuntimeField.parseRuntimeFields(new HashMap<>(runtimeMappings),
             mapperService.parserContext(), false);
-        Map<String, MappedFieldType> runtimeFieldTypes = new HashMap<>();
-        for (RuntimeField runtimeField : runtimeFields.values()) {
-            MappedFieldType fieldType = runtimeField.asMappedFieldType();
-            runtimeFieldTypes.put(fieldType.name(), fieldType);
-        }
-        return Collections.unmodifiableMap(runtimeFieldTypes);
+        return RuntimeField.collectFieldTypes(runtimeFields.values());
     }
 
     /**

--- a/server/src/test/java/org/elasticsearch/index/mapper/MappingLookupTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/MappingLookupTests.java
@@ -48,7 +48,7 @@ public class MappingLookupTests extends ESTestCase {
         assertEquals(0, size(mappingLookup.fieldMappers()));
         assertEquals(0, mappingLookup.objectMappers().size());
         assertNull(mappingLookup.getMapper("test"));
-        assertThat(mappingLookup.fieldTypesLookup().get("test"), instanceOf(TestRuntimeField.class));
+        assertThat(mappingLookup.fieldTypesLookup().get("test"), instanceOf(TestRuntimeField.TestRuntimeFieldType.class));
     }
 
     public void testRuntimeFieldLeafOverride() {
@@ -58,7 +58,7 @@ public class MappingLookupTests extends ESTestCase {
         assertThat(mappingLookup.getMapper("test"), instanceOf(MockFieldMapper.class));
         assertEquals(1, size(mappingLookup.fieldMappers()));
         assertEquals(0, mappingLookup.objectMappers().size());
-        assertThat(mappingLookup.fieldTypesLookup().get("test"), instanceOf(TestRuntimeField.class));
+        assertThat(mappingLookup.fieldTypesLookup().get("test"), instanceOf(TestRuntimeField.TestRuntimeFieldType.class));
     }
 
     public void testSubfieldOverride() {
@@ -73,7 +73,7 @@ public class MappingLookupTests extends ESTestCase {
         assertThat(mappingLookup.getMapper("object.subfield"), instanceOf(MockFieldMapper.class));
         assertEquals(1, size(mappingLookup.fieldMappers()));
         assertEquals(1, mappingLookup.objectMappers().size());
-        assertThat(mappingLookup.fieldTypesLookup().get("object.subfield"), instanceOf(TestRuntimeField.class));
+        assertThat(mappingLookup.fieldTypesLookup().get("object.subfield"), instanceOf(TestRuntimeField.TestRuntimeFieldType.class));
     }
 
     public void testAnalyzers() throws IOException {

--- a/server/src/test/java/org/elasticsearch/index/mapper/TestRuntimeField.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/TestRuntimeField.java
@@ -12,16 +12,27 @@ import org.apache.lucene.search.Query;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.index.query.SearchExecutionContext;
 
-import java.io.IOException;
+import java.util.Collection;
 import java.util.Collections;
 
-public class TestRuntimeField extends MappedFieldType implements RuntimeField {
-
+public final class TestRuntimeField implements RuntimeField {
+    private final String name;
     private final String type;
+    private final Collection<MappedFieldType> subfields;
 
     public TestRuntimeField(String name, String type) {
-        super(name, false, false, false, TextSearchInfo.NONE, Collections.emptyMap());
+        this(name, type, Collections.singleton(new TestRuntimeFieldType(name, type)));
+    }
+
+    public TestRuntimeField(String name, String type, Collection<MappedFieldType> subfields) {
+        this.name = name;
         this.type = type;
+        this.subfields = subfields;
+    }
+
+    @Override
+    public String name() {
+        return name;
     }
 
     @Override
@@ -30,22 +41,36 @@ public class TestRuntimeField extends MappedFieldType implements RuntimeField {
     }
 
     @Override
-    public MappedFieldType asMappedFieldType() {
-        return this;
+    public Collection<MappedFieldType> asMappedFieldTypes() {
+        return subfields;
     }
 
     @Override
-    public ValueFetcher valueFetcher(SearchExecutionContext context, String format) {
-        throw new UnsupportedOperationException();
+    public void doXContentBody(XContentBuilder builder, Params params) {
+
     }
 
-    @Override
-    public Query termQuery(Object value, SearchExecutionContext context) {
-        return null;
-    }
+    public static class TestRuntimeFieldType extends MappedFieldType {
+        private final String type;
 
-    @Override
-    public void doXContentBody(XContentBuilder builder, Params params) throws IOException {
+        public TestRuntimeFieldType(String name, String type) {
+            super(name, false, false, false, TextSearchInfo.NONE, Collections.emptyMap());
+            this.type = type;
+        }
 
+        @Override
+        public ValueFetcher valueFetcher(SearchExecutionContext context, String format) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public String typeName() {
+            return type;
+        }
+
+        @Override
+        public Query termQuery(Object value, SearchExecutionContext context) {
+            return null;
+        }
     }
 }

--- a/server/src/test/java/org/elasticsearch/index/query/SearchExecutionContextTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/SearchExecutionContextTests.java
@@ -471,7 +471,7 @@ public class SearchExecutionContextTests extends ESTestCase {
     }
 
     private static RuntimeField runtimeField(String name, BiFunction<LeafSearchLookup, Integer, String> runtimeDocValues) {
-        return new TestRuntimeField(name, null) {
+        TestRuntimeField.TestRuntimeFieldType fieldType = new TestRuntimeField.TestRuntimeFieldType(name, null) {
             @Override
             public IndexFieldData.Builder fielddataBuilder(String fullyQualifiedIndexName,
                                                            Supplier<SearchLookup> searchLookup) {
@@ -560,6 +560,7 @@ public class SearchExecutionContextTests extends ESTestCase {
                 };
             }
         };
+        return new TestRuntimeField(name, null, Collections.singleton(fieldType));
     }
 
     private static List<String> collect(String field, SearchExecutionContext searchExecutionContext) throws IOException {


### PR DESCRIPTION
Up until now, there was a 1:1 relationship between a RuntimeField and a MappedFieldType. Actually, the two were only recently split to support emitting multiple fields from a single runtime script. The next step is to change the signature of asMappedFieldType to make it return multiple sub-fields. The leaf fields that are supported to-date will return a collection with a single item, but the upcoming runtime "object" field will return as many subfields as are listed in its definition.

Together with this, we are introducing two consistency checks:
- sub-fields exposed by a RuntimeField either have its same name, or belong to its namespace (e.g. object.subfield)
- there can't be two mapped field types with the same name as part of the same runtime section, overrides happen defining the same field in two different sections (index mappings and search request)
