### PR TITLE
[7.13] [DOCS] Clarify supported fields for `top_metrics` agg (#73907)

### DIFF
--- a/docs/reference/aggregations/metrics/top-metrics-aggregation.asciidoc
+++ b/docs/reference/aggregations/metrics/top-metrics-aggregation.asciidoc
@@ -70,10 +70,21 @@ request. So,
 ==== `metrics`
 
 `metrics` selects the fields of the "top" document to return. You can request
-a single metric with something like `"metric": {"field": "m"}` or multiple
-metrics by requesting a list of metrics like `"metric": [{"field": "m"}, {"field": "i"}`.
-The fields can be <<number,numbers>>, <<keyword,keywords>>, or <<ip,ips>>.
-Here is a more complete example:
+a single metric with something like `"metrics": {"field": "m"}` or multiple
+metrics by requesting a list of metrics like `"metrics": [{"field": "m"}, {"field": "i"}`.
+
+`metrics.field` supports the following field types:
+
+* <<boolean,`boolean`>>
+* <<ip,`ip`>>
+* <<keyword,keywords>>
+* <<number,numbers>>
+
+Except for keywords, <<runtime,runtime fields>> for corresponding types are also
+supported. `metrics.field` doesn't support fields with <<array,array values>>. A
+`top_metric` aggregation on array values may return inconsistent results.
+
+The following example runs a `top_metrics` aggregation on several field types.
 
 [source,console,id=search-aggregations-metrics-top-metrics-list-of-metrics]
 ----


### PR DESCRIPTION
Backports the following commits to 7.13:
 - [DOCS] Clarify supported fields for `top_metrics` agg (#73907)