### PR TITLE
[DOCS] Query strings are normalized for fuzzy (`~`) operator

### DIFF
--- a/docs/reference/query-dsl/query-string-query.asciidoc
+++ b/docs/reference/query-dsl/query-string-query.asciidoc
@@ -142,8 +142,8 @@ You can use this parameter query to search across multiple fields. See
 --
 
 `fuzziness`::
-(Optional, string) Maximum edit distance allowed for matching. See <<fuzziness>>
-for valid values and more information.
+(Optional, string) Maximum edit distance allowed for fuzzy matching. For fuzzy
+syntax, see <<query-string-fuzziness>>.
 
 `fuzzy_max_expansions`::
 (Optional, integer) Maximum number of terms to which the query expands for fuzzy

--- a/docs/reference/query-dsl/query-string-syntax.asciidoc
+++ b/docs/reference/query-dsl/query-string-syntax.asciidoc
@@ -124,10 +124,12 @@ For these queries, the query string is <<analysis-normalizers,normalized>>. Only
 per-character filters from the field's analyzer are applied. For a list of these
 filters, see <<analysis-normalizers>>.
 
-The query uses the {wikipedia}/Damerau-Levenshtein_distance[Damerau-Levenshtein
-distance] to find all terms with a maximum of two changes, where a change is the
-insertion, deletion or substitution of a single character, or transposition of
-two adjacent characters.
+The query uses the
+{wikipedia}/Damerau-Levenshtein_distance[Damerau-Levenshtein distance]
+to find all terms with a maximum of
+two changes, where a change is the insertion, deletion
+or substitution of a single character, or transposition of two adjacent
+characters.
 
 The default _edit distance_ is `2`, but an edit distance of `1` should be
 sufficient to catch 80% of all human misspellings. It can be specified as:

--- a/docs/reference/query-dsl/query-string-syntax.asciidoc
+++ b/docs/reference/query-dsl/query-string-syntax.asciidoc
@@ -121,7 +121,7 @@ You can run <<query-dsl-fuzzy-query,`fuzzy` queries>> using the `~` operator:
     quikc~ brwn~ foks~
 
 For these queries, the query string is <<analysis-normalizers,normalized>>. Only
-per-character filters from the field's analyzer are applied. For a list of these
+per-character filters from the analyzer are applied. For a list of these
 filters, see <<analysis-normalizers>>.
 
 The query uses the

--- a/docs/reference/query-dsl/query-string-syntax.asciidoc
+++ b/docs/reference/query-dsl/query-string-syntax.asciidoc
@@ -120,9 +120,9 @@ You can run <<query-dsl-fuzzy-query,`fuzzy` queries>> using the `~` operator:
 
     quikc~ brwn~ foks~
 
-For these queries, the query string is <<analysis-normalizers,normalized>>. Only
-per-character filters from the analyzer are applied. For a list of these
-filters, see <<analysis-normalizers>>.
+For these queries, the query string is <<analysis-normalizers,normalized>>. If
+present, only certain filters from the analyzer are applied. For a list of
+applicable filters, see <<analysis-normalizers>>.
 
 The query uses the
 {wikipedia}/Damerau-Levenshtein_distance[Damerau-Levenshtein distance]

--- a/docs/reference/query-dsl/query-string-syntax.asciidoc
+++ b/docs/reference/query-dsl/query-string-syntax.asciidoc
@@ -120,12 +120,14 @@ You can run <<query-dsl-fuzzy-query,`fuzzy` queries>> using the `~` operator:
 
     quikc~ brwn~ foks~
 
-For these queries, the query string is not <<analysis,analyzed>>. Instead, the
-query uses the {wikipedia}/Damerau-Levenshtein_distance[Damerau-Levenshtein distance]
-to find all terms with a maximum of
-two changes, where a change is the insertion, deletion
-or substitution of a single character, or transposition of two adjacent
-characters.
+For these queries, the query string is <<analysis-normalizers,normalized>>. Only
+per-character filters from the field's analyzer are applied. For a list of these
+filters, see <<analysis-normalizers>>.
+
+The query uses the {wikipedia}/Damerau-Levenshtein_distance[Damerau-Levenshtein
+distance] to find all terms with a maximum of two changes, where a change is the
+insertion, deletion or substitution of a single character, or transposition of
+two adjacent characters.
 
 The default _edit distance_ is `2`, but an edit distance of `1` should be
 sufficient to catch 80% of all human misspellings. It can be specified as:

--- a/docs/reference/query-dsl/query-string-syntax.asciidoc
+++ b/docs/reference/query-dsl/query-string-syntax.asciidoc
@@ -116,14 +116,12 @@ Use with caution!
 [[query-string-fuzziness]]
 ====== Fuzziness
 
-We can search for terms that are
-similar to, but not exactly like our search terms, using the ``fuzzy''
-operator:
+You can run <<query-dsl-fuzzy-query,`fuzzy` queries>> using the `~` operator:
 
     quikc~ brwn~ foks~
 
-This uses the
-{wikipedia}/Damerau-Levenshtein_distance[Damerau-Levenshtein distance]
+For these queries, the query string is not <<analysis,analyzed>>. Instead, the
+query uses the {wikipedia}/Damerau-Levenshtein_distance[Damerau-Levenshtein distance]
 to find all terms with a maximum of
 two changes, where a change is the insertion, deletion
 or substitution of a single character, or transposition of two adjacent


### PR DESCRIPTION
Notes that `fuzzy` queries made using the query string query's `~`
operator are normalized.

Closes #73299

### Preview
https://elasticsearch_73921.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/query-dsl-query-string-query.html#query-string-fuzziness