### PR TITLE
Resurrect _xpack/license routes

### DIFF
--- a/x-pack/plugin/build.gradle
+++ b/x-pack/plugin/build.gradle
@@ -94,6 +94,18 @@ tasks.named("yamlRestTest").configure {
   dependsOn "copyExtraResources"
 }
 
+tasks.named("transformV7RestTests").configure({ task ->
+  task.replaceKeyInDo("license.delete", "xpack-license.delete")
+  task.replaceKeyInDo("license.get", "xpack-license.get")
+  task.replaceKeyInDo("license.get_basic_status", "xpack-license.get_basic_status")
+  task.replaceKeyInDo("license.get_trial_status", "xpack-license.get_trial_status")
+  task.replaceKeyInDo("license.post", "xpack-license.post")
+  task.replaceKeyInDo("license.post_start_basic", "xpack-license.post_start_basic")
+  task.replaceKeyInDo("license.post_start_trial", "xpack-license.post_start_trial")
+
+  task.addAllowedWarningRegex(".*_xpack/license.* is deprecated.*")
+})
+
 tasks.named("yamlRestCompatTest").configure {
   /*
    * We have to disable setting the number of available processors as tests in the same JVM randomize processors and will step on each

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/license/RestDeleteLicenseAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/license/RestDeleteLicenseAction.java
@@ -8,6 +8,7 @@
 package org.elasticsearch.license;
 
 import org.elasticsearch.client.node.NodeClient;
+import org.elasticsearch.core.RestApiVersion;
 import org.elasticsearch.protocol.xpack.license.DeleteLicenseRequest;
 import org.elasticsearch.rest.BaseRestHandler;
 import org.elasticsearch.rest.RestRequest;
@@ -24,7 +25,10 @@ public class RestDeleteLicenseAction extends BaseRestHandler {
 
     @Override
     public List<Route> routes() {
-        return List.of(new Route(DELETE, "/_license"));
+        return List.of(
+            Route.builder(DELETE, "/_license")
+                .replaces(DELETE, "/_xpack/license", RestApiVersion.V_7).build()
+        );
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/license/RestGetBasicStatus.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/license/RestGetBasicStatus.java
@@ -8,6 +8,7 @@
 package org.elasticsearch.license;
 
 import org.elasticsearch.client.node.NodeClient;
+import org.elasticsearch.core.RestApiVersion;
 import org.elasticsearch.rest.BaseRestHandler;
 import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.rest.action.RestToXContentListener;
@@ -22,7 +23,10 @@ public class RestGetBasicStatus extends BaseRestHandler {
 
     @Override
     public List<Route> routes() {
-        return List.of(new Route(GET, "/_license/basic_status"));
+        return List.of(
+            Route.builder(GET, "/_license/basic_status")
+                .replaces(GET, "/_xpack/license/basic_status", RestApiVersion.V_7).build()
+        );
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/license/RestGetLicenseAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/license/RestGetLicenseAction.java
@@ -12,6 +12,7 @@ import org.elasticsearch.common.logging.DeprecationCategory;
 import org.elasticsearch.common.logging.DeprecationLogger;
 import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.core.RestApiVersion;
 import org.elasticsearch.protocol.xpack.license.GetLicenseRequest;
 import org.elasticsearch.rest.BaseRestHandler;
 import org.elasticsearch.rest.BytesRestResponse;
@@ -36,7 +37,10 @@ public class RestGetLicenseAction extends BaseRestHandler {
 
     @Override
     public List<Route> routes() {
-        return List.of(new Route(GET, "/_license"));
+        return List.of(
+            Route.builder(GET, "/_license")
+                .replaces(GET, "/_xpack/license", RestApiVersion.V_7).build()
+        );
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/license/RestGetTrialStatus.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/license/RestGetTrialStatus.java
@@ -8,6 +8,7 @@
 package org.elasticsearch.license;
 
 import org.elasticsearch.client.node.NodeClient;
+import org.elasticsearch.core.RestApiVersion;
 import org.elasticsearch.rest.BaseRestHandler;
 import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.rest.action.RestToXContentListener;
@@ -22,7 +23,10 @@ public class RestGetTrialStatus extends BaseRestHandler {
 
     @Override
     public List<Route> routes() {
-        return List.of(new Route(GET, "/_license/trial_status"));
+        return List.of(
+            Route.builder(GET, "/_license/trial_status")
+                .replaces(GET, "/_xpack/license/trial_status", RestApiVersion.V_7).build()
+        );
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/license/RestPostStartBasicLicense.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/license/RestPostStartBasicLicense.java
@@ -8,6 +8,7 @@
 package org.elasticsearch.license;
 
 import org.elasticsearch.client.node.NodeClient;
+import org.elasticsearch.core.RestApiVersion;
 import org.elasticsearch.rest.BaseRestHandler;
 import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.rest.action.RestStatusToXContentListener;
@@ -23,7 +24,10 @@ public class RestPostStartBasicLicense extends BaseRestHandler {
 
     @Override
     public List<Route> routes() {
-        return List.of(new Route(POST, "/_license/start_basic"));
+        return List.of(
+            Route.builder(POST, "/_license/start_basic")
+                .replaces(POST, "/_xpack/license/start_basic", RestApiVersion.V_7).build()
+        );
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/license/RestPostStartTrialLicense.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/license/RestPostStartTrialLicense.java
@@ -9,6 +9,7 @@ package org.elasticsearch.license;
 
 import org.elasticsearch.client.node.NodeClient;
 import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.core.RestApiVersion;
 import org.elasticsearch.rest.BaseRestHandler;
 import org.elasticsearch.rest.BytesRestResponse;
 import org.elasticsearch.rest.RestRequest;
@@ -27,7 +28,10 @@ public class RestPostStartTrialLicense extends BaseRestHandler {
 
     @Override
     public List<Route> routes() {
-        return List.of(new Route(POST, "/_license/start_trial"));
+        return List.of(
+            Route.builder(POST, "/_license/start_trial")
+                .replaces(POST, "/_xpack/license/start_trial", RestApiVersion.V_7).build()
+        );
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/license/RestPutLicenseAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/license/RestPutLicenseAction.java
@@ -8,6 +8,7 @@
 package org.elasticsearch.license;
 
 import org.elasticsearch.client.node.NodeClient;
+import org.elasticsearch.core.RestApiVersion;
 import org.elasticsearch.rest.BaseRestHandler;
 import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.rest.action.RestToXContentListener;
@@ -26,8 +27,11 @@ public class RestPutLicenseAction extends BaseRestHandler {
     public List<Route> routes() {
         // TODO: remove POST endpoint?
         return List.of(
-            new Route(POST, "/_license"),
-            new Route(PUT, "/_license"));
+            Route.builder(POST, "/_license")
+                .replaces(POST, "/_xpack/license", RestApiVersion.V_7).build(),
+            Route.builder(PUT, "/_license")
+                .replaces(PUT, "/_xpack/license", RestApiVersion.V_7).build()
+        );
     }
 
     @Override

--- a/x-pack/plugin/src/yamlRestCompatTest/resources/rest-api-spec/api/xpack-license.delete.json
+++ b/x-pack/plugin/src/yamlRestCompatTest/resources/rest-api-spec/api/xpack-license.delete.json
@@ -1,0 +1,27 @@
+{
+  "xpack-license.delete":{
+    "documentation":{
+      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/delete-license.html",
+      "description":"Deletes licensing information for the cluster"
+    },
+    "stability":"stable",
+    "visibility":"public",
+    "headers":{
+      "accept": [ "application/vnd.elasticsearch+json;compatible-with=7"]
+    },
+    "url":{
+      "paths":[
+        {
+          "path":"/_xpack/license",
+          "methods":[
+            "DELETE"
+          ],
+          "deprecated":{
+            "version":"7.0.0",
+            "description":"all _xpack prefix have been deprecated"
+          }
+        }
+      ]
+    }
+  }
+}

--- a/x-pack/plugin/src/yamlRestCompatTest/resources/rest-api-spec/api/xpack-license.get.json
+++ b/x-pack/plugin/src/yamlRestCompatTest/resources/rest-api-spec/api/xpack-license.get.json
@@ -1,0 +1,38 @@
+{
+  "xpack-license.get":{
+    "documentation":{
+      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/get-license.html",
+      "description":"Retrieves licensing information for the cluster"
+    },
+    "stability":"stable",
+    "visibility":"public",
+    "headers":{
+      "accept": [ "application/vnd.elasticsearch+json;compatible-with=7"]
+    },
+    "url":{
+      "paths":[
+        {
+          "path":"/_xpack/license",
+          "methods":[
+            "GET"
+          ],
+          "deprecated":{
+            "version":"7.0.0",
+            "description":"all _xpack prefix have been deprecated"
+          }
+        }
+      ]
+    },
+    "params":{
+      "local":{
+        "type":"boolean",
+        "description":"Return local information, do not retrieve the state from master node (default: false)"
+      },
+      "accept_enterprise":{
+        "type":"boolean",
+        "description":"Supported for backwards compatibility with 7.x. If this param is used it must be set to true",
+        "deprecated":true
+      }
+    }
+  }
+}

--- a/x-pack/plugin/src/yamlRestCompatTest/resources/rest-api-spec/api/xpack-license.get_basic_status.json
+++ b/x-pack/plugin/src/yamlRestCompatTest/resources/rest-api-spec/api/xpack-license.get_basic_status.json
@@ -1,0 +1,28 @@
+{
+  "xpack-license.get_basic_status":{
+    "documentation":{
+      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/get-basic-status.html",
+      "description":"Retrieves information about the status of the basic license."
+    },
+    "stability":"stable",
+    "visibility":"public",
+    "headers":{
+      "accept": [ "application/vnd.elasticsearch+json;compatible-with=7"]
+    },
+    "url":{
+      "paths":[
+        {
+          "path":"/_xpack/license/basic_status",
+          "methods":[
+            "GET"
+          ],
+          "deprecated":{
+            "version":"7.0.0",
+            "description":"all _xpack prefix have been deprecated"
+          }
+        }
+      ]
+    },
+    "params":{}
+  }
+}

--- a/x-pack/plugin/src/yamlRestCompatTest/resources/rest-api-spec/api/xpack-license.get_trial_status.json
+++ b/x-pack/plugin/src/yamlRestCompatTest/resources/rest-api-spec/api/xpack-license.get_trial_status.json
@@ -1,0 +1,28 @@
+{
+  "xpack-license.get_trial_status":{
+    "documentation":{
+      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/get-trial-status.html",
+      "description":"Retrieves information about the status of the trial license."
+    },
+    "stability":"stable",
+    "visibility":"public",
+    "headers":{
+      "accept": [ "application/vnd.elasticsearch+json;compatible-with=7"]
+    },
+    "url":{
+      "paths":[
+        {
+          "path":"/_xpack/license/trial_status",
+          "methods":[
+            "GET"
+          ],
+          "deprecated":{
+            "version":"7.0.0",
+            "description":"all _xpack prefix have been deprecated"
+          }
+        }
+      ]
+    },
+    "params":{}
+  }
+}

--- a/x-pack/plugin/src/yamlRestCompatTest/resources/rest-api-spec/api/xpack-license.post.json
+++ b/x-pack/plugin/src/yamlRestCompatTest/resources/rest-api-spec/api/xpack-license.post.json
@@ -1,0 +1,38 @@
+{
+  "xpack-license.post":{
+    "documentation":{
+      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/update-license.html",
+      "description":"Updates the license for the cluster."
+    },
+    "stability":"stable",
+    "visibility":"public",
+    "headers":{
+      "accept": [ "application/vnd.elasticsearch+json;compatible-with=7"],
+      "content_type": ["application/vnd.elasticsearch+json;compatible-with=7"]
+    },
+    "url":{
+      "paths":[
+        {
+          "path":"/_xpack/license",
+          "methods":[
+            "PUT",
+            "POST"
+          ],
+          "deprecated":{
+            "version":"7.0.0",
+            "description":"all _xpack prefix have been deprecated"
+          }
+        }
+      ]
+    },
+    "params":{
+      "acknowledge":{
+        "type":"boolean",
+        "description":"whether the user has acknowledged acknowledge messages (default: false)"
+      }
+    },
+    "body":{
+      "description":"licenses to be installed"
+    }
+  }
+}

--- a/x-pack/plugin/src/yamlRestCompatTest/resources/rest-api-spec/api/xpack-license.post_start_basic.json
+++ b/x-pack/plugin/src/yamlRestCompatTest/resources/rest-api-spec/api/xpack-license.post_start_basic.json
@@ -1,0 +1,33 @@
+{
+  "xpack-license.post_start_basic":{
+    "documentation":{
+      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/start-basic.html",
+      "description":"Starts an indefinite basic license."
+    },
+    "stability":"stable",
+    "visibility":"public",
+    "headers":{
+      "accept": [ "application/vnd.elasticsearch+json;compatible-with=7"]
+    },
+    "url":{
+      "paths":[
+        {
+          "path":"/_xpack/license/start_basic",
+          "methods":[
+            "POST"
+          ],
+          "deprecated":{
+            "version":"7.0.0",
+            "description":"all _xpack prefix have been deprecated"
+          }
+        }
+      ]
+    },
+    "params":{
+      "acknowledge":{
+        "type":"boolean",
+        "description":"whether the user has acknowledged acknowledge messages (default: false)"
+      }
+    }
+  }
+}

--- a/x-pack/plugin/src/yamlRestCompatTest/resources/rest-api-spec/api/xpack-license.post_start_trial.json
+++ b/x-pack/plugin/src/yamlRestCompatTest/resources/rest-api-spec/api/xpack-license.post_start_trial.json
@@ -1,0 +1,37 @@
+{
+  "xpack-license.post_start_trial":{
+    "documentation":{
+      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/start-trial.html",
+      "description":"starts a limited time trial license."
+    },
+    "stability":"stable",
+    "visibility":"public",
+    "headers":{
+      "accept": [ "application/vnd.elasticsearch+json;compatible-with=7"]
+    },
+    "url":{
+      "paths":[
+        {
+          "path":"/_xpack/license/start_trial",
+          "methods":[
+            "POST"
+          ],
+          "deprecated":{
+            "version":"7.0.0",
+            "description":"all _xpack prefix have been deprecated"
+          }
+        }
+      ]
+    },
+    "params":{
+      "type":{
+        "type":"string",
+        "description":"The type of trial license to generate (default: \"trial\")"
+      },
+      "acknowledge":{
+        "type":"boolean",
+        "description":"whether the user has acknowledged acknowledge messages (default: false)"
+      }
+    }
+  }
+}


### PR DESCRIPTION
Related to #51816 / #68905.

Adds back the `_xpack/license` routes when using rest compatibility for a request.