### PR TITLE
Tighten up write permissions in Docker image

### DIFF
--- a/distribution/docker/src/docker/Dockerfile
+++ b/distribution/docker/src/docker/Dockerfile
@@ -230,17 +230,18 @@ RUN tar -zxf /opt/elasticsearch.tar.gz --strip-components=1
 COPY ${config_dir}/elasticsearch.yml config/
 COPY ${config_dir}/log4j2.properties config/log4j2.docker.properties
 
-# 1. Configure the distribution for Docker
-# 2. Ensure directories are created. Most already are, but make sure
-# 3. Apply correct permissions
-# 4. Move the distribution's default logging config aside
-# 5. Move the generated docker logging config so that it is the default
-# 6. Apply more correct permissions
-# 7. The JDK's directories' permissions don't allow `java` to be executed under a different
-#    group to the default. Fix this.
-# 8. Ensure that there are no files with setuid or setgid, in order to mitigate "stackclash" attacks.
-# 9. Ensure all files are world-readable by default. It should be possible to
-#    examine the contents of the image under any UID:GID
+#  1. Configure the distribution for Docker
+#  2. Ensure directories are created. Most already are, but make sure
+#  3. Apply correct permissions
+#  4. Move the distribution's default logging config aside
+#  5. Generate a docker logging config, to be used by default
+#  6. Apply more correct permissions
+#  7. The JDK's directories' permissions don't allow `java` to be executed under a different
+#     group to the default. Fix this.
+#  8. Remove write permissions from all files under `lib`, `bin`, `jdk` and `modules`
+#  9. Ensure that there are no files with setuid or setgid, in order to mitigate "stackclash" attacks.
+# 10. Ensure all files are world-readable by default. It should be possible to
+#     examine the contents of the image under any UID:GID
 RUN sed -i -e 's/ES_DISTRIBUTION_TYPE=tar/ES_DISTRIBUTION_TYPE=docker/' bin/elasticsearch-env && \\
     mkdir -p config/jvm.options.d data logs plugins && \\
     chmod 0775 config config/jvm.options.d data logs plugins && \\
@@ -248,6 +249,7 @@ RUN sed -i -e 's/ES_DISTRIBUTION_TYPE=tar/ES_DISTRIBUTION_TYPE=docker/' bin/elas
     mv config/log4j2.docker.properties config/log4j2.properties && \\
     chmod 0660 config/elasticsearch.yml config/log4j2*.properties && \\
     find ./jdk -type d -exec chmod 0755 {} + && \\
+    chmod -R a-w lib bin jdk modules && \\
     find . -xdev -perm -4000 -exec chmod ug-s {} + && \\
     find . -type f -exec chmod o+r {} +
 

--- a/qa/os/src/test/java/org/elasticsearch/packaging/test/DockerTests.java
+++ b/qa/os/src/test/java/org/elasticsearch/packaging/test/DockerTests.java
@@ -101,7 +101,7 @@ public class DockerTests extends PackagingTestCase {
      * Checks that the Docker image can be run, and that it passes various checks.
      */
     public void test010Install() {
-        verifyContainerInstallation(installation, distribution());
+        verifyContainerInstallation(installation);
     }
 
     /**

--- a/qa/os/src/test/java/org/elasticsearch/packaging/test/PackagingTestCase.java
+++ b/qa/os/src/test/java/org/elasticsearch/packaging/test/PackagingTestCase.java
@@ -221,7 +221,7 @@ public abstract class PackagingTestCase extends Assert {
             case DOCKER_UBI:
             case DOCKER_IRON_BANK:
                 installation = Docker.runContainer(distribution);
-                Docker.verifyContainerInstallation(installation, distribution);
+                Docker.verifyContainerInstallation(installation);
                 break;
             default:
                 throw new IllegalStateException("Unknown Elasticsearch packaging type.");

--- a/qa/os/src/test/java/org/elasticsearch/packaging/util/Docker.java
+++ b/qa/os/src/test/java/org/elasticsearch/packaging/util/Docker.java
@@ -29,9 +29,9 @@ import java.util.stream.Stream;
 
 import static java.nio.file.attribute.PosixFilePermissions.fromString;
 import static org.elasticsearch.packaging.util.DockerRun.getImageName;
+import static org.elasticsearch.packaging.util.FileMatcher.p555;
 import static org.elasticsearch.packaging.util.FileMatcher.p644;
 import static org.elasticsearch.packaging.util.FileMatcher.p664;
-import static org.elasticsearch.packaging.util.FileMatcher.p755;
 import static org.elasticsearch.packaging.util.FileMatcher.p770;
 import static org.elasticsearch.packaging.util.FileMatcher.p775;
 import static org.elasticsearch.packaging.util.FileUtils.getCurrentVersion;
@@ -443,9 +443,8 @@ public class Docker {
     /**
      * Perform a variety of checks on an installation. If the current distribution is not OSS, additional checks are carried out.
      * @param installation the installation to verify
-     * @param distribution the distribution to verify
      */
-    public static void verifyContainerInstallation(Installation installation, Distribution distribution) {
+    public static void verifyContainerInstallation(Installation installation) {
         verifyOssInstallation(installation);
         verifyDefaultInstallation(installation);
     }
@@ -460,14 +459,12 @@ public class Docker {
 
         Stream.of(es.home, es.data, es.logs, es.config, es.plugins).forEach(dir -> assertPermissionsAndOwnership(dir, p775));
 
-        Stream.of(es.modules).forEach(dir -> assertPermissionsAndOwnership(dir, p755));
+        Stream.of(es.bin, es.bundledJdk, es.lib, es.modules).forEach(dir -> assertPermissionsAndOwnership(dir, p555));
 
         Stream.of("elasticsearch.yml", "jvm.options", "log4j2.properties")
             .forEach(configFile -> assertPermissionsAndOwnership(es.config(configFile), p664));
 
         assertThat(dockerShell.run(es.bin("elasticsearch-keystore") + " list").stdout, containsString("keystore.seed"));
-
-        Stream.of(es.bin, es.lib).forEach(dir -> assertPermissionsAndOwnership(dir, p755));
 
         Stream.of(
             "elasticsearch",
@@ -477,7 +474,7 @@ public class Docker {
             "elasticsearch-node",
             "elasticsearch-plugin",
             "elasticsearch-shard"
-        ).forEach(executable -> assertPermissionsAndOwnership(es.bin(executable), p755));
+        ).forEach(executable -> assertPermissionsAndOwnership(es.bin(executable), p555));
 
         Stream.of("LICENSE.txt", "NOTICE.txt", "README.asciidoc").forEach(doc -> assertPermissionsAndOwnership(es.home.resolve(doc), p644));
 
@@ -506,11 +503,11 @@ public class Docker {
             "x-pack-env",
             "x-pack-security-env",
             "x-pack-watcher-env"
-        ).forEach(executable -> assertPermissionsAndOwnership(es.bin(executable), p755));
+        ).forEach(executable -> assertPermissionsAndOwnership(es.bin(executable), p555));
 
         // at this time we only install the current version of archive distributions, but if that changes we'll need to pass
         // the version through here
-        assertPermissionsAndOwnership(es.bin("elasticsearch-sql-cli-" + getCurrentVersion() + ".jar"), p755);
+        assertPermissionsAndOwnership(es.bin("elasticsearch-sql-cli-" + getCurrentVersion() + ".jar"), p555);
 
         Stream.of("role_mapping.yml", "roles.yml", "users", "users_roles")
             .forEach(configFile -> assertPermissionsAndOwnership(es.config(configFile), p664));

--- a/qa/os/src/test/java/org/elasticsearch/packaging/util/Docker.java
+++ b/qa/os/src/test/java/org/elasticsearch/packaging/util/Docker.java
@@ -509,7 +509,10 @@ public class Docker {
         // the version through here
         assertPermissionsAndOwnership(es.bin("elasticsearch-sql-cli-" + getCurrentVersion() + ".jar"), p555);
 
-        final String architecture = System.getProperty("os.arch", "x86_64");
+        String architecture = System.getProperty("os.arch", "x86_64");
+        if (architecture.equals("amd64")) {
+            architecture = "x86_64";
+        }
         Stream.of("autodetect", "categorize", "controller", "data_frame_analyzer", "normalize", "pytorch_inference")
             .forEach(executableName -> {
                 final Path executablePath = es.modules.resolve("x-pack-ml/platform/linux-" + architecture + "/bin/" + executableName);

--- a/qa/os/src/test/java/org/elasticsearch/packaging/util/Docker.java
+++ b/qa/os/src/test/java/org/elasticsearch/packaging/util/Docker.java
@@ -509,10 +509,7 @@ public class Docker {
         // the version through here
         assertPermissionsAndOwnership(es.bin("elasticsearch-sql-cli-" + getCurrentVersion() + ".jar"), p555);
 
-        String architecture = System.getProperty("os.arch", "x86_64");
-        if (architecture.equals("amd64")) {
-            architecture = "x86_64";
-        }
+        final String architecture = getArchitecture();
         Stream.of("autodetect", "categorize", "controller", "data_frame_analyzer", "normalize", "pytorch_inference")
             .forEach(executableName -> {
                 final Path executablePath = es.modules.resolve("x-pack-ml/platform/linux-" + architecture + "/bin/" + executableName);
@@ -625,5 +622,13 @@ public class Docker {
      */
     public static void restartContainer() {
         sh.run("docker restart " + containerId);
+    }
+
+    private static String getArchitecture() {
+        String architecture = System.getProperty("os.arch", "x86_64");
+        if (architecture.equals("amd64")) {
+            architecture = "x86_64";
+        }
+        return architecture;
     }
 }

--- a/qa/os/src/test/java/org/elasticsearch/packaging/util/Docker.java
+++ b/qa/os/src/test/java/org/elasticsearch/packaging/util/Docker.java
@@ -509,6 +509,13 @@ public class Docker {
         // the version through here
         assertPermissionsAndOwnership(es.bin("elasticsearch-sql-cli-" + getCurrentVersion() + ".jar"), p555);
 
+        final String architecture = System.getProperty("os.arch", "x86_64");
+        Stream.of("autodetect", "categorize", "controller", "data_frame_analyzer", "normalize", "pytorch_inference")
+            .forEach(executableName -> {
+                final Path executablePath = es.modules.resolve("x-pack-ml/platform/linux-" + architecture + "/bin/" + executableName);
+                assertPermissionsAndOwnership(executablePath, p555);
+            });
+
         Stream.of("role_mapping.yml", "roles.yml", "users", "users_roles")
             .forEach(configFile -> assertPermissionsAndOwnership(es.config(configFile), p664));
     }

--- a/qa/os/src/test/java/org/elasticsearch/packaging/util/FileMatcher.java
+++ b/qa/os/src/test/java/org/elasticsearch/packaging/util/FileMatcher.java
@@ -37,6 +37,7 @@ public class FileMatcher extends TypeSafeMatcher<Path> {
         Directory
     }
 
+    public static final Set<PosixFilePermission> p555 = fromString("r-xr-xr-x");
     public static final Set<PosixFilePermission> p775 = fromString("rwxrwxr-x");
     public static final Set<PosixFilePermission> p770 = fromString("rwxrwx---");
     public static final Set<PosixFilePermission> p755 = fromString("rwxr-xr-x");


### PR DESCRIPTION
Recursively remove write access from the `bin`, `jdk`, `lib` and
`modules` directories, since this access is not required, and removing
it makes it harder to exploit other issues in an ES distribution.

This PR contains just the first commit from #70635, since we want to merge
a minimal fix for the next release.