### PR TITLE
Make GeometryCollection Immutable

### DIFF
--- a/docs/changelog/73946.yaml
+++ b/docs/changelog/73946.yaml
@@ -1,0 +1,5 @@
+pr: 73946
+summary: Make `GeometryCollection` Immutable
+area: Geo
+type: bug
+issues: []

--- a/libs/geo/src/main/java/org/elasticsearch/geometry/GeometryCollection.java
+++ b/libs/geo/src/main/java/org/elasticsearch/geometry/GeometryCollection.java
@@ -38,7 +38,7 @@ public class GeometryCollection<G extends Geometry> implements Geometry, Iterabl
                 throw new IllegalArgumentException("all elements of the collection should have the same number of dimension");
             }
         }
-        this.shapes = shapes;
+        this.shapes = List.copyOf(shapes);
     }
 
     @Override

--- a/libs/geo/src/test/java/org/elasticsearch/geometry/GeometryCollectionTests.java
+++ b/libs/geo/src/test/java/org/elasticsearch/geometry/GeometryCollectionTests.java
@@ -16,8 +16,10 @@ import org.elasticsearch.geometry.utils.WellKnownText;
 
 import java.io.IOException;
 import java.text.ParseException;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
 
 public class GeometryCollectionTests extends BaseGeometryTestCase<GeometryCollection<Geometry>> {
     @Override
@@ -54,5 +56,15 @@ public class GeometryCollectionTests extends BaseGeometryTestCase<GeometryCollec
         assertEquals("found Z value [30.0] but [ignore_z_value] parameter is [false]", ex.getMessage());
 
         StandardValidator.instance(true).validate(new GeometryCollection<Geometry>(Collections.singletonList(new Point(20, 10, 30))));
+    }
+
+    public void testImmutable() {
+        List<Geometry> geometries = new ArrayList<>();
+        geometries.add(new Point(20, 10));
+        GeometryCollection<Geometry> gc = new GeometryCollection<>(geometries);
+        assertEquals(1, gc.size());
+        geometries.add(new Point(10, 20));
+        // modifying the original list should not modify the geometry collection
+        assertEquals(1, gc.size());
     }
 }


### PR DESCRIPTION
Currently hen creating a geometry collection, we just copy a reference of the provided list. Therefore if the list is changed externally, then the collection might change. I think collections should not change after creation, so this PR copies the list instead.