### PR TITLE
Test instance with a map is used with unique keys

### DIFF
--- a/server/src/test/java/org/elasticsearch/index/get/DocumentFieldTests.java
+++ b/server/src/test/java/org/elasticsearch/index/get/DocumentFieldTests.java
@@ -10,11 +10,11 @@ package org.elasticsearch.index.get;
 
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.bytes.BytesReference;
-import org.elasticsearch.core.Tuple;
 import org.elasticsearch.common.document.DocumentField;
 import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.XContentType;
+import org.elasticsearch.core.Tuple;
 import org.elasticsearch.index.mapper.IgnoredFieldMapper;
 import org.elasticsearch.indices.IndicesModule;
 import org.elasticsearch.test.ESTestCase;
@@ -123,7 +123,7 @@ public class DocumentFieldTests extends ESTestCase {
                     DocumentField listField = new DocumentField(randomAlphaOfLength(5), listValues);
                     return Tuple.tuple(listField, listField);
                 case 2:
-                    List<Object> objectValues = randomList(1, 5, () -> mapWithRandomKeys());
+                    List<Object> objectValues = randomList(1, 5, () -> mapWithUniqueKeys());
                     DocumentField objectField = new DocumentField(randomAlphaOfLength(5), objectValues);
                     return Tuple.tuple(objectField, objectField);
                 default:
@@ -132,13 +132,9 @@ public class DocumentFieldTests extends ESTestCase {
         }
     }
 
-    public static Map<String, Object> mapWithRandomKeys() {
-        String k1 = randomAlphaOfLength(5);
-        String k2 = randomValueOtherThan(k1, () -> randomAlphaOfLength(5));
-        String k3 = randomValueOtherThanMany(t -> t.equals(k1) || t.equals(k2), () -> randomAlphaOfLength(5));
-
-        return Map.of(k1, randomInt(),
-            k2, randomBoolean(),
-            k3, randomAlphaOfLength(10));
+    public static Map<String, Object> mapWithUniqueKeys() {
+        return Map.of("key1", randomInt(),
+            "key2", randomBoolean(),
+            "key3", randomAlphaOfLength(10));
     }
 }

--- a/server/src/test/java/org/elasticsearch/index/get/DocumentFieldTests.java
+++ b/server/src/test/java/org/elasticsearch/index/get/DocumentFieldTests.java
@@ -123,15 +123,22 @@ public class DocumentFieldTests extends ESTestCase {
                     DocumentField listField = new DocumentField(randomAlphaOfLength(5), listValues);
                     return Tuple.tuple(listField, listField);
                 case 2:
-                    List<Object> objectValues = randomList(1, 5, () ->
-                        Map.of(randomAlphaOfLength(5), randomInt(),
-                            randomAlphaOfLength(5), randomBoolean(),
-                            randomAlphaOfLength(5), randomAlphaOfLength(10)));
+                    List<Object> objectValues = randomList(1, 5, () -> mapWithRandomKeys());
                     DocumentField objectField = new DocumentField(randomAlphaOfLength(5), objectValues);
                     return Tuple.tuple(objectField, objectField);
                 default:
                     throw new IllegalStateException();
             }
         }
+    }
+
+    public static Map<String, Object> mapWithRandomKeys() {
+        String k1 = randomAlphaOfLength(5);
+        String k2 = randomValueOtherThan(k1, () -> randomAlphaOfLength(5));
+        String k3 = randomValueOtherThanMany(t -> t.equals(k1) || t.equals(k2), () -> randomAlphaOfLength(5));
+
+        return Map.of(k1, randomInt(),
+            k2, randomBoolean(),
+            k3, randomAlphaOfLength(10));
     }
 }


### PR DESCRIPTION
in a very unlikely scenario a map could be created with duplicated keys.
Resulting in Map.of throwing exception

closes #73948

<!--
Thank you for your interest in and contributing to Elasticsearch! There
are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.
-->

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/elasticsearch/blob/master/CONTRIBUTING.md)?
- If submitting code, have you built your formula locally prior to submission with `gradle check`?
- If submitting code, is your pull request against master? Unless there is a good reason otherwise, we prefer pull requests against master and will backport as needed.
- If submitting code, have you checked that your submission is for an [OS and architecture that we support](https://www.elastic.co/support/matrix#show_os)?
- If you are submitting this code for a class then read our [policy](https://github.com/elastic/elasticsearch/blob/master/CONTRIBUTING.md#contributing-as-part-of-a-class) for that.
