### PR TITLE
Write async response directly to XContent to reduce memory

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/async/AsyncTaskIndexService.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/async/AsyncTaskIndexService.java
@@ -25,10 +25,10 @@ import org.elasticsearch.client.OriginSettingClient;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.TriFunction;
-import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.io.stream.OutputStreamStreamOutput;
+import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.core.Tuple;
 import org.elasticsearch.common.io.stream.ByteBufferStreamInput;
-import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.io.stream.NamedWriteableAwareStreamInput;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -47,10 +47,10 @@ import org.elasticsearch.xpack.core.security.authc.Authentication;
 import org.elasticsearch.xpack.core.security.authc.support.AuthenticationContextSerializer;
 
 import java.io.IOException;
+import java.io.OutputStream;
 import java.nio.ByteBuffer;
 import java.util.Base64;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
@@ -191,15 +191,24 @@ public final class AsyncTaskIndexService<R extends AsyncResponse<R>> {
                                Map<String, String> headers,
                                R response,
                                ActionListener<IndexResponse> listener) throws IOException {
-        Map<String, Object> source = new HashMap<>();
-        source.put(HEADERS_FIELD, headers);
-        source.put(EXPIRATION_TIME_FIELD, response.getExpirationTime());
-        source.put(RESULT_FIELD, encodeResponse(response));
-        IndexRequest indexRequest = new IndexRequest(index)
-            .create(true)
-            .id(docId)
-            .source(source, XContentType.JSON);
-        createIndexIfNecessary(ActionListener.wrap(v -> clientWithOrigin.index(indexRequest, listener), listener::onFailure));
+        createIndexIfNecessary(listener.delegateFailure((ignored, l) -> {
+            // TODO: Integrate with circuit breaker
+            try {
+                final XContentBuilder source = XContentFactory.jsonBuilder()
+                    .startObject()
+                    .field(HEADERS_FIELD, headers)
+                    .field(EXPIRATION_TIME_FIELD, response.getExpirationTime())
+                    .directFieldAsBase64(RESULT_FIELD, os -> writeResponse(response, os))
+                    .endObject();
+                final IndexRequest indexRequest = new IndexRequest(index)
+                    .create(true)
+                    .id(docId)
+                    .source(source);
+                clientWithOrigin.index(indexRequest, listener);
+            } catch (Exception e) {
+                listener.onFailure(e);
+            }
+        }));
     }
 
     /**
@@ -209,21 +218,24 @@ public final class AsyncTaskIndexService<R extends AsyncResponse<R>> {
                             Map<String, List<String>> responseHeaders,
                             R response,
                             ActionListener<UpdateResponse> listener) {
-        try {
-            Map<String, Object> source = new HashMap<>();
-            source.put(RESPONSE_HEADERS_FIELD, responseHeaders);
-            source.put(RESULT_FIELD, encodeResponse(response));
-            UpdateRequest request = new UpdateRequest()
-                .index(index)
-                .id(docId)
-                .doc(source, XContentType.JSON)
-                .retryOnConflict(5);
-            // updates create the index automatically if it doesn't exist so we force the creation
-            // preemptively.
-            createIndexIfNecessary(ActionListener.wrap(v -> clientWithOrigin.update(request, listener), listener::onFailure));
-        } catch(Exception e) {
-            listener.onFailure(e);
-        }
+        createIndexIfNecessary(listener.delegateFailure((ignored, l) -> {
+            try {
+                // TODO: Integrate with circuit breaker
+                final XContentBuilder source = XContentFactory.jsonBuilder()
+                    .startObject()
+                    .field(RESPONSE_HEADERS_FIELD, responseHeaders)
+                    .directFieldAsBase64(RESULT_FIELD, os -> writeResponse(response, os))
+                    .endObject();
+                final UpdateRequest request = new UpdateRequest()
+                    .index(index)
+                    .id(docId)
+                    .doc(source)
+                    .retryOnConflict(5);
+                clientWithOrigin.update(request, listener);
+            } catch (Exception e) {
+                listener.onFailure(e);
+            }
+        }));
     }
 
     /**
@@ -468,21 +480,17 @@ public final class AsyncTaskIndexService<R extends AsyncResponse<R>> {
         return origin.canAccessResourcesOf(current);
     }
 
-    /**
-     * Encode the provided response in a binary form using base64 encoding.
-     */
-    String encodeResponse(R response) throws IOException {
-        try (BytesStreamOutput out = new BytesStreamOutput()) {
-            Version.writeVersion(Version.CURRENT, out);
-            response.writeTo(out);
-            return Base64.getEncoder().encodeToString(BytesReference.toBytes(out.bytes()));
-        }
+    private void writeResponse(R response, OutputStream os) throws IOException {
+        final OutputStreamStreamOutput out = new OutputStreamStreamOutput(os);
+        Version.writeVersion(Version.CURRENT, out);
+        response.writeTo(out);
     }
 
     /**
      * Decode the provided base-64 bytes into a {@link AsyncSearchResponse}.
      */
     R decodeResponse(String value) throws IOException {
+        // TODO: Integrate with the circuit breaker
         try (ByteBufferStreamInput buf = new ByteBufferStreamInput(ByteBuffer.wrap(Base64.getDecoder().decode(value)))) {
             try (StreamInput in = new NamedWriteableAwareStreamInput(buf, registry)) {
                 in.setVersion(Version.readVersion(in));

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/async/AsyncSearchIndexServiceTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/async/AsyncSearchIndexServiceTests.java
@@ -19,7 +19,7 @@ import org.elasticsearch.transport.TransportService;
 import org.junit.Before;
 
 import java.io.IOException;
-import java.util.Map;
+import java.util.Collections;
 import java.util.Objects;
 
 import static org.elasticsearch.xpack.core.ClientHelper.ASYNC_SEARCH_ORIGIN;
@@ -101,7 +101,7 @@ public class AsyncSearchIndexServiceTests extends ESSingleNodeTestCase {
                 new TaskId(randomAlphaOfLength(10), randomNonNegativeLong()));
 
             PlainActionFuture<IndexResponse> createFuture = new PlainActionFuture<>();
-            indexService.createResponse(executionId.getDocId(), Map.of(), initialResponse, createFuture);
+            indexService.createResponse(executionId.getDocId(), Collections.emptyMap(), initialResponse, createFuture);
             assertThat(createFuture.actionGet().getResult(), equalTo(DocWriteResponse.Result.CREATED));
 
             if (randomBoolean()) {
@@ -116,7 +116,7 @@ public class AsyncSearchIndexServiceTests extends ESSingleNodeTestCase {
                     testMessage = randomAlphaOfLength(10);
                     TestAsyncResponse updateResponse = new TestAsyncResponse(testMessage, randomLong());
                     PlainActionFuture<UpdateResponse> updateFuture = new PlainActionFuture<>();
-                    indexService.updateResponse(executionId.getDocId(), Map.of(), updateResponse, updateFuture);
+                    indexService.updateResponse(executionId.getDocId(), Collections.emptyMap(), updateResponse, updateFuture);
                     updateFuture.actionGet();
                 } else {
                     expirationTime = randomLong();


### PR DESCRIPTION
Backport of #73707

This change tries to write an async response directly to XContent in
Base64 to avoid using multiple buffers.

