### PR TITLE
Fix split package with voting-only nodes

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/cluster/coordination/AbstractCoordinatorTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/cluster/coordination/AbstractCoordinatorTestCase.java
@@ -231,7 +231,7 @@ public class AbstractCoordinatorTestCase extends ESTestCase {
             // then wait for the new leader to commit a state without the old leader
             + DEFAULT_CLUSTER_STATE_UPDATE_DELAY;
 
-    class Cluster implements Releasable {
+    public class Cluster implements Releasable {
 
         static final long EXTREME_DELAY_VARIABILITY = 10000L;
         static final long DEFAULT_DELAY_VARIABILITY = 100L;
@@ -261,7 +261,7 @@ public class AbstractCoordinatorTestCase extends ESTestCase {
             this(initialNodeCount, true, Settings.EMPTY);
         }
 
-        Cluster(int initialNodeCount, boolean allNodesMasterEligible, Settings nodeSettings) {
+        public Cluster(int initialNodeCount, boolean allNodesMasterEligible, Settings nodeSettings) {
             this(initialNodeCount, allNodesMasterEligible, nodeSettings, () -> new StatusInfo(HEALTHY, "healthy-info"));
         }
 
@@ -326,7 +326,7 @@ public class AbstractCoordinatorTestCase extends ESTestCase {
             return clusterNodes.size();
         }
 
-        void runRandomly() {
+        public void runRandomly() {
             runRandomly(true, true, EXTREME_DELAY_VARIABILITY);
         }
 
@@ -495,7 +495,7 @@ public class AbstractCoordinatorTestCase extends ESTestCase {
             }
         }
 
-        void stabilise() {
+        public void stabilise() {
             stabilise(DEFAULT_STABILISATION_TIME);
         }
 
@@ -653,7 +653,7 @@ public class AbstractCoordinatorTestCase extends ESTestCase {
                 (n1.nodeHealthService.getHealth().getStatus() == HEALTHY && n2.nodeHealthService.getHealth().getStatus() == HEALTHY);
         }
 
-        ClusterNode getAnyLeader() {
+        public ClusterNode getAnyLeader() {
             List<ClusterNode> allLeaders = clusterNodes.stream().filter(ClusterNode::isLeader).collect(Collectors.toList());
             assertThat("leaders", allLeaders, not(empty()));
             return randomFrom(allLeaders);
@@ -883,7 +883,7 @@ public class AbstractCoordinatorTestCase extends ESTestCase {
             }
         }
 
-        class ClusterNode {
+        public class ClusterNode {
             private final Logger logger = LogManager.getLogger(ClusterNode.class);
 
             private final int nodeIndex;
@@ -1019,7 +1019,7 @@ public class AbstractCoordinatorTestCase extends ESTestCase {
                 return localNode.getId();
             }
 
-            DiscoveryNode getLocalNode() {
+            public DiscoveryNode getLocalNode() {
                 return localNode;
             }
 

--- a/test/framework/src/main/java/org/elasticsearch/cluster/coordination/CoordinationStateTestCluster.java
+++ b/test/framework/src/main/java/org/elasticsearch/cluster/coordination/CoordinationStateTestCluster.java
@@ -138,7 +138,7 @@ public class CoordinationStateTestCluster {
     final CoordinationMetadata.VotingConfiguration initialConfiguration;
     final long initialValue;
 
-    CoordinationStateTestCluster(List<DiscoveryNode> nodes, ElectionStrategy electionStrategy) {
+    public CoordinationStateTestCluster(List<DiscoveryNode> nodes, ElectionStrategy electionStrategy) {
         this.electionStrategy = electionStrategy;
         messages = new ArrayList<>();
 
@@ -203,7 +203,7 @@ public class CoordinationStateTestCluster {
         }
     }
 
-    void runRandomly() {
+    public void runRandomly() {
         final int iterations = 10000;
         final long maxTerm = 4;
         long nextTerm = 1;

--- a/x-pack/plugin/voting-only-node/build.gradle
+++ b/x-pack/plugin/voting-only-node/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'elasticsearch.internal-cluster-test'
 esplugin {
   name 'x-pack-voting-only-node'
   description 'Elasticsearch Expanded Pack Plugin - Voting-only node'
-  classname 'org.elasticsearch.cluster.coordination.VotingOnlyNodePlugin'
+  classname 'org.elasticsearch.cluster.coordination.votingonly.VotingOnlyNodePlugin'
   extendedPlugins = ['x-pack-core']
 }
 

--- a/x-pack/plugin/voting-only-node/build.gradle
+++ b/x-pack/plugin/voting-only-node/build.gradle
@@ -11,9 +11,3 @@ dependencies {
   compileOnly project(path: xpackModule('core'))
   testImplementation(testArtifact(project(xpackModule('core'))))
 }
-
-tasks.named('splitPackagesAudit').configure {
-  // o.e.cluster is owned by server, rename these
-  ignoreClasses 'org.elasticsearch.cluster.coordination.VotingOnlyNodeFeatureSet',
-    'org.elasticsearch.cluster.coordination.VotingOnlyNodePlugin'
-}

--- a/x-pack/plugin/voting-only-node/src/internalClusterTest/java/org/elasticsearch/cluster/coordination/votingonly/VotingOnlyNodePluginTests.java
+++ b/x-pack/plugin/voting-only-node/src/internalClusterTest/java/org/elasticsearch/cluster/coordination/votingonly/VotingOnlyNodePluginTests.java
@@ -4,7 +4,7 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-package org.elasticsearch.cluster.coordination;
+package org.elasticsearch.cluster.coordination.votingonly;
 
 import org.elasticsearch.Version;
 import org.elasticsearch.action.admin.cluster.repositories.verify.VerifyRepositoryResponse;

--- a/x-pack/plugin/voting-only-node/src/main/java/org/elasticsearch/cluster/coordination/votingonly/VotingOnlyNodeFeatureSet.java
+++ b/x-pack/plugin/voting-only-node/src/main/java/org/elasticsearch/cluster/coordination/votingonly/VotingOnlyNodeFeatureSet.java
@@ -4,7 +4,7 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-package org.elasticsearch.cluster.coordination;
+package org.elasticsearch.cluster.coordination.votingonly;
 
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.ActionFilters;

--- a/x-pack/plugin/voting-only-node/src/main/java/org/elasticsearch/cluster/coordination/votingonly/VotingOnlyNodePlugin.java
+++ b/x-pack/plugin/voting-only-node/src/main/java/org/elasticsearch/cluster/coordination/votingonly/VotingOnlyNodePlugin.java
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-package org.elasticsearch.cluster.coordination;
+package org.elasticsearch.cluster.coordination.votingonly;
 
 import org.apache.lucene.util.SetOnce;
 import org.elasticsearch.ElasticsearchException;
@@ -14,7 +14,9 @@ import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.cluster.coordination.CoordinationMetadata.VotingConfiguration;
 import org.elasticsearch.cluster.coordination.CoordinationState.VoteCollection;
-import org.elasticsearch.cluster.coordination.VotingOnlyNodeFeatureSet.UsageTransportAction;
+import org.elasticsearch.cluster.coordination.ElectionStrategy;
+import org.elasticsearch.cluster.coordination.Join;
+import org.elasticsearch.cluster.coordination.PublicationTransportHandler;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodeRole;
@@ -98,7 +100,7 @@ public class VotingOnlyNodePlugin extends Plugin implements DiscoveryPlugin, Net
     @Override
     public List<ActionHandler<? extends ActionRequest, ? extends ActionResponse>> getActions() {
         return Arrays.asList(
-            new ActionHandler<>(XPackUsageFeatureAction.VOTING_ONLY, UsageTransportAction.class),
+            new ActionHandler<>(XPackUsageFeatureAction.VOTING_ONLY, VotingOnlyNodeFeatureSet.UsageTransportAction.class),
             new ActionHandler<>(XPackInfoFeatureAction.VOTING_ONLY, VotingOnlyNodeFeatureSet.UsageInfoAction.class)
         );
     }

--- a/x-pack/plugin/voting-only-node/src/test/java/org/elasticsearch/cluster/coordination/votingonly/LocalStateVotingOnlyNodePlugin.java
+++ b/x-pack/plugin/voting-only-node/src/test/java/org/elasticsearch/cluster/coordination/votingonly/LocalStateVotingOnlyNodePlugin.java
@@ -4,7 +4,7 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-package org.elasticsearch.cluster.coordination;
+package org.elasticsearch.cluster.coordination.votingonly;
 
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.xpack.core.LocalStateCompositeXPackPlugin;

--- a/x-pack/plugin/voting-only-node/src/test/java/org/elasticsearch/cluster/coordination/votingonly/VotingOnlyNodeCoordinationStateTests.java
+++ b/x-pack/plugin/voting-only-node/src/test/java/org/elasticsearch/cluster/coordination/votingonly/VotingOnlyNodeCoordinationStateTests.java
@@ -4,9 +4,10 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-package org.elasticsearch.cluster.coordination;
+package org.elasticsearch.cluster.coordination.votingonly;
 
 import org.elasticsearch.Version;
+import org.elasticsearch.cluster.coordination.CoordinationStateTestCluster;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodeRole;
 import org.elasticsearch.test.ESTestCase;

--- a/x-pack/plugin/voting-only-node/src/test/java/org/elasticsearch/cluster/coordination/votingonly/VotingOnlyNodeCoordinatorTests.java
+++ b/x-pack/plugin/voting-only-node/src/test/java/org/elasticsearch/cluster/coordination/votingonly/VotingOnlyNodeCoordinatorTests.java
@@ -4,9 +4,11 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-package org.elasticsearch.cluster.coordination;
+package org.elasticsearch.cluster.coordination.votingonly;
 
 import org.elasticsearch.Version;
+import org.elasticsearch.cluster.coordination.AbstractCoordinatorTestCase;
+import org.elasticsearch.cluster.coordination.ElectionStrategy;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodeRole;
 import org.elasticsearch.common.UUIDs;


### PR DESCRIPTION
Moves the implementation of voting-only nodes to the
`o.e.c.c.votingonly` package.