### PR TITLE
[DOCS] Document how to switch ILM policies

### DIFF
--- a/docs/reference/data-streams/change-mappings-and-settings.asciidoc
+++ b/docs/reference/data-streams/change-mappings-and-settings.asciidoc
@@ -320,6 +320,10 @@ PUT /my-data-stream/_settings
 ----
 --
 
+IMPORTANT: To change the `index.lifecycle.name` setting, first use the
+<<ilm-remove-policy,remove policy API>> to remove the existing {ilm-init}
+policy. See <<switch-lifecycle-policies>>.
+
 [discrete]
 [[change-static-index-setting-for-a-data-stream]]
 === Change a static index setting for a data stream

--- a/docs/reference/ilm/set-up-lifecycle-policy.asciidoc
+++ b/docs/reference/ilm/set-up-lifecycle-policy.asciidoc
@@ -273,13 +273,11 @@ PUT mylogs-pre-ilm*/_settings <1>
 [[switch-lifecycle-policies]]
 ==== Switch lifecycle policies
 
-To switch an index's lifecycle policy, first use the <<ilm-remove-policy,remove
-policy API>> to remove the existing policy. Target a data stream or alias to
-remove the policies of all its indices.
+To switch an index's lifecycle policy, follow these steps:
 
-WARNING: Don't assign a new policy without first removing the existing policy.
-This can cause <<ilm-phase-execution,phase execution>> to silently fail.
-
+. Remove the existing policy using the <<ilm-remove-policy,remove policy API>>.
+Target a data stream or alias to remove the policies of all its indices.
++
 [source,console]
 ----
 POST logs-my_app-default/_ilm/remove
@@ -287,8 +285,41 @@ POST logs-my_app-default/_ilm/remove
 // TEST[continued]
 // TEST[s/^/PUT _data_stream\/logs-my_app-default\n/]
 
-Then use <<indices-update-settings,update settings API>> to assign a new policy.
+. The remove policy API removes all {ilm-init} metadata from the index and
+doesn't consider the index's lifecycle status. This can leave indices in an
+undesired state.
++
+--
+For example, the <<ilm-forcemerge,`forcemerge`>> action temporarily closes an
+index before reopening it. Removing an index's {ilm-init} policy during a
+`forcemerge` can leave the index closed indefinitely.
+
+After policy removal, use the <<indices-get-index,get index API>> to check an
+index's state . Target a data stream or alias to get the state of all its
+indices.
+
+[source,console]
+----
+GET logs-my_app-default
+----
+// TEST[continued]
+
+You can then change the index as needed. For example, you can re-open any
+closed indices using the <<indices-open-close,open index API>>.
+
+[source,console]
+----
+POST logs-my_app-default/_open
+----
+// TEST[continued]
+--
+
+. Assign a new policy using the <<indices-update-settings,update settings API>>.
 Target a data stream or alias to assign a policy to all its indices.
++
+--
+WARNING: Don't assign a new policy without first removing the existing policy.
+This can cause <<ilm-phase-execution,phase execution>> to silently fail.
 
 [source,console]
 ----
@@ -303,3 +334,4 @@ PUT logs-my_app-default/_settings
 ----
 // TEST[continued]
 // TEST[s/new-lifecycle-policy/mylogs_policy_existing/]
+--

--- a/docs/reference/ilm/set-up-lifecycle-policy.asciidoc
+++ b/docs/reference/ilm/set-up-lifecycle-policy.asciidoc
@@ -268,3 +268,38 @@ PUT mylogs-pre-ilm*/_settings <1>
 // TEST[continued]
 
 <1> Updates all indices with names that start with `mylogs-pre-ilm`
+
+[discrete]
+[[switch-lifecycle-policies]]
+==== Switch lifecycle policies
+
+To switch an index's lifecycle policy, first use the <<ilm-remove-policy,remove
+policy API>> to remove the existing policy. Target a data stream or alias to
+remove the policies of all its indices.
+
+WARNING: Don't assign a new policy without first removing the existing policy.
+This can cause <<ilm-phase-execution,phase execution>> to silently fail.
+
+[source,console]
+----
+POST logs-my_app-default/_ilm/remove
+----
+// TEST[continued]
+// TEST[s/^/PUT _data_stream\/logs-my_app-default\n/]
+
+Then use <<indices-update-settings,update settings API>> to assign a new policy.
+Target a data stream or alias to assign a policy to all its indices.
+
+[source,console]
+----
+PUT logs-my_app-default/_settings
+{
+  "index": {
+    "lifecycle": {
+      "name": "new-lifecycle-policy"
+    }
+  }
+}
+----
+// TEST[continued]
+// TEST[s/new-lifecycle-policy/mylogs_policy_existing/]


### PR DESCRIPTION
To switch an index's lifecycle policy, you must first remove the existing policy. Otherwise, phase execution for the index may silently fail.

Closes #70151

### Preview
* Switch ILM policy: https://elasticsearch_73967.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/set-up-lifecycle-policy.html#switch-lifecycle-policies
* Change dynamic index setting for a data stream: https://elasticsearch_73967.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/data-streams-change-mappings-and-settings.html#change-dynamic-index-setting-for-a-data-stream