### PR TITLE
Fix store-smb split package

### DIFF
--- a/plugins/store-smb/build.gradle
+++ b/plugins/store-smb/build.gradle
@@ -17,8 +17,3 @@ restResources {
     include '_common', 'cluster', 'nodes', 'index', 'indices', 'get'
   }
 }
-
-tasks.named('splitPackagesAudit').configure {
-    // TODO: rename this package to be smb specific
-  ignoreClasses 'org.elasticsearch.index.store.SmbDirectoryWrapper'
-}

--- a/plugins/store-smb/src/internalClusterTest/java/org/elasticsearch/index/store/smb/AbstractAzureFsTestCase.java
+++ b/plugins/store-smb/src/internalClusterTest/java/org/elasticsearch/index/store/smb/AbstractAzureFsTestCase.java
@@ -6,7 +6,7 @@
  * Side Public License, v 1.
  */
 
-package org.elasticsearch.index.store;
+package org.elasticsearch.index.store.smb;
 
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.plugin.store.smb.SMBStorePlugin;
@@ -18,7 +18,7 @@ import java.util.Collection;
 
 import static org.hamcrest.Matchers.is;
 
-public abstract  class AbstractAzureFsTestCase extends ESIntegTestCase {
+public abstract class AbstractAzureFsTestCase extends ESIntegTestCase {
     @Override
     protected Collection<Class<? extends Plugin>> nodePlugins() {
         return Arrays.asList(SMBStorePlugin.class);

--- a/plugins/store-smb/src/internalClusterTest/java/org/elasticsearch/index/store/smb/SmbMMapFsTests.java
+++ b/plugins/store-smb/src/internalClusterTest/java/org/elasticsearch/index/store/smb/SmbMMapFsTests.java
@@ -6,17 +6,19 @@
  * Side Public License, v 1.
  */
 
-package org.elasticsearch.index.store;
+package org.elasticsearch.index.store.smb;
 
 import org.elasticsearch.common.settings.Settings;
 
 
-public class SmbSimpleFsTests extends AbstractAzureFsTestCase {
+public class SmbMMapFsTests extends AbstractAzureFsTestCase {
+
     @Override
     public Settings indexSettings() {
         return Settings.builder()
                 .put(super.indexSettings())
-                .put("index.store.type", "smb_simple_fs")
+                .put("index.store.type", "smb_mmap_fs")
                 .build();
     }
+
 }

--- a/plugins/store-smb/src/internalClusterTest/java/org/elasticsearch/index/store/smb/SmbSimpleFsTests.java
+++ b/plugins/store-smb/src/internalClusterTest/java/org/elasticsearch/index/store/smb/SmbSimpleFsTests.java
@@ -6,19 +6,17 @@
  * Side Public License, v 1.
  */
 
-package org.elasticsearch.index.store;
+package org.elasticsearch.index.store.smb;
 
 import org.elasticsearch.common.settings.Settings;
 
 
-public class SmbMMapFsTests extends AbstractAzureFsTestCase {
-
+public class SmbSimpleFsTests extends AbstractAzureFsTestCase {
     @Override
     public Settings indexSettings() {
         return Settings.builder()
                 .put(super.indexSettings())
-                .put("index.store.type", "smb_mmap_fs")
+                .put("index.store.type", "smb_simple_fs")
                 .build();
     }
-
 }

--- a/plugins/store-smb/src/main/java/org/elasticsearch/index/store/smb/SmbDirectoryWrapper.java
+++ b/plugins/store-smb/src/main/java/org/elasticsearch/index/store/smb/SmbDirectoryWrapper.java
@@ -6,7 +6,7 @@
  * Side Public License, v 1.
  */
 
-package org.elasticsearch.index.store;
+package org.elasticsearch.index.store.smb;
 
 import org.apache.lucene.store.FSDirectory;
 import org.apache.lucene.store.FilterDirectory;

--- a/plugins/store-smb/src/main/java/org/elasticsearch/index/store/smb/SmbMmapFsDirectoryFactory.java
+++ b/plugins/store-smb/src/main/java/org/elasticsearch/index/store/smb/SmbMmapFsDirectoryFactory.java
@@ -6,7 +6,7 @@
  * Side Public License, v 1.
  */
 
-package org.elasticsearch.index.store.smbmmapfs;
+package org.elasticsearch.index.store.smb;
 
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.store.LockFactory;
@@ -14,7 +14,6 @@ import org.apache.lucene.store.MMapDirectory;
 import org.elasticsearch.index.IndexModule;
 import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.store.FsDirectoryFactory;
-import org.elasticsearch.index.store.SmbDirectoryWrapper;
 
 import java.io.IOException;
 import java.nio.file.Path;

--- a/plugins/store-smb/src/main/java/org/elasticsearch/index/store/smb/SmbSimpleFsDirectoryFactory.java
+++ b/plugins/store-smb/src/main/java/org/elasticsearch/index/store/smb/SmbSimpleFsDirectoryFactory.java
@@ -6,14 +6,13 @@
  * Side Public License, v 1.
  */
 
-package org.elasticsearch.index.store.smbsimplefs;
+package org.elasticsearch.index.store.smb;
 
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.store.LockFactory;
 import org.apache.lucene.store.SimpleFSDirectory;
 import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.store.FsDirectoryFactory;
-import org.elasticsearch.index.store.SmbDirectoryWrapper;
 
 import java.io.IOException;
 import java.nio.file.Path;

--- a/plugins/store-smb/src/main/java/org/elasticsearch/plugin/store/smb/SMBStorePlugin.java
+++ b/plugins/store-smb/src/main/java/org/elasticsearch/plugin/store/smb/SMBStorePlugin.java
@@ -8,8 +8,8 @@
 
 package org.elasticsearch.plugin.store.smb;
 
-import org.elasticsearch.index.store.smbmmapfs.SmbMmapFsDirectoryFactory;
-import org.elasticsearch.index.store.smbsimplefs.SmbSimpleFsDirectoryFactory;
+import org.elasticsearch.index.store.smb.SmbMmapFsDirectoryFactory;
+import org.elasticsearch.index.store.smb.SmbSimpleFsDirectoryFactory;
 import org.elasticsearch.plugins.IndexStorePlugin;
 import org.elasticsearch.plugins.Plugin;
 

--- a/plugins/store-smb/src/test/java/org/elasticsearch/index/store/smb/SmbMMapDirectoryTests.java
+++ b/plugins/store-smb/src/test/java/org/elasticsearch/index/store/smb/SmbMMapDirectoryTests.java
@@ -6,12 +6,13 @@
  * Side Public License, v 1.
  */
 
-package org.elasticsearch.index.store;
+package org.elasticsearch.index.store.smb;
 
 import java.io.IOException;
 import java.nio.file.Path;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.store.MMapDirectory;
+import org.elasticsearch.index.store.EsBaseDirectoryTestCase;
 
 public class SmbMMapDirectoryTests extends EsBaseDirectoryTestCase {
 

--- a/plugins/store-smb/src/test/java/org/elasticsearch/index/store/smb/SmbSimpleFSDirectoryTests.java
+++ b/plugins/store-smb/src/test/java/org/elasticsearch/index/store/smb/SmbSimpleFSDirectoryTests.java
@@ -6,12 +6,13 @@
  * Side Public License, v 1.
  */
 
-package org.elasticsearch.index.store;
+package org.elasticsearch.index.store.smb;
 
 import java.io.IOException;
 import java.nio.file.Path;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.store.SimpleFSDirectory;
+import org.elasticsearch.index.store.EsBaseDirectoryTestCase;
 
 public class SmbSimpleFSDirectoryTests extends EsBaseDirectoryTestCase {
 

--- a/plugins/store-smb/src/yamlRestTest/java/org/elasticsearch/index/store/smb/StoreSmbClientYamlTestSuiteIT.java
+++ b/plugins/store-smb/src/yamlRestTest/java/org/elasticsearch/index/store/smb/StoreSmbClientYamlTestSuiteIT.java
@@ -6,7 +6,7 @@
  * Side Public License, v 1.
  */
 
-package org.elasticsearch.index.store;
+package org.elasticsearch.index.store.smb;
 
 import com.carrotsearch.randomizedtesting.annotations.Name;
 import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;


### PR DESCRIPTION
Moves the implementation of this plugin from `o.e.i.store` and misc
other places into `o.e.i.store.smb`.