### PR TITLE
Resurrect _xpack/rollup routes

### DIFF
--- a/x-pack/plugin/build.gradle
+++ b/x-pack/plugin/build.gradle
@@ -102,8 +102,16 @@ tasks.named("transformV7RestTests").configure({ task ->
   task.replaceKeyInDo("license.post", "xpack-license.post")
   task.replaceKeyInDo("license.post_start_basic", "xpack-license.post_start_basic")
   task.replaceKeyInDo("license.post_start_trial", "xpack-license.post_start_trial")
-
   task.addAllowedWarningRegex(".*_xpack/license.* is deprecated.*")
+
+  task.replaceKeyInDo("rollup.delete_job", "xpack-rollup.delete_job")
+  task.replaceKeyInDo("rollup.get_jobs", "xpack-rollup.get_jobs")
+  task.replaceKeyInDo("rollup.get_rollup_caps", "xpack-rollup.get_rollup_caps")
+  task.replaceKeyInDo("rollup.get_rollup_index_caps", "xpack-rollup.get_rollup_index_caps")
+  task.replaceKeyInDo("rollup.put_job", "xpack-rollup.put_job")
+  task.replaceKeyInDo("rollup.start_job", "xpack-rollup.start_job")
+  task.replaceKeyInDo("rollup.stop_job", "xpack-rollup.stop_job")
+  task.addAllowedWarningRegex(".*_xpack/rollup.* is deprecated.*")
 })
 
 tasks.named("yamlRestCompatTest").configure {

--- a/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/rest/RestDeleteRollupJobAction.java
+++ b/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/rest/RestDeleteRollupJobAction.java
@@ -9,6 +9,7 @@ package org.elasticsearch.xpack.rollup.rest;
 
 import org.elasticsearch.client.node.NodeClient;
 import org.elasticsearch.common.xcontent.ParseField;
+import org.elasticsearch.core.RestApiVersion;
 import org.elasticsearch.rest.BaseRestHandler;
 import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.rest.RestStatus;
@@ -25,7 +26,10 @@ public class RestDeleteRollupJobAction extends BaseRestHandler {
 
     @Override
     public List<Route> routes() {
-        return List.of(new Route(DELETE, "/_rollup/job/{id}"));
+        return List.of(
+            Route.builder(DELETE, "/_rollup/job/{id}")
+                .replaces(DELETE, "/_xpack/rollup/job/{id}/", RestApiVersion.V_7).build()
+        );
     }
 
     @Override

--- a/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/rest/RestGetRollupCapsAction.java
+++ b/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/rest/RestGetRollupCapsAction.java
@@ -9,6 +9,7 @@ package org.elasticsearch.xpack.rollup.rest;
 
 import org.elasticsearch.client.node.NodeClient;
 import org.elasticsearch.common.xcontent.ParseField;
+import org.elasticsearch.core.RestApiVersion;
 import org.elasticsearch.rest.BaseRestHandler;
 import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.rest.action.RestToXContentListener;
@@ -24,7 +25,9 @@ public class RestGetRollupCapsAction extends BaseRestHandler {
 
     @Override
     public List<Route> routes() {
-        return List.of(new Route(GET, "/_rollup/data/{id}"));
+        return List.of(
+            Route.builder(GET, "/_rollup/data/{id}")
+                .replaces(GET, "/_xpack/rollup/data/{id}/", RestApiVersion.V_7).build());
     }
 
     @Override

--- a/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/rest/RestGetRollupIndexCapsAction.java
+++ b/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/rest/RestGetRollupIndexCapsAction.java
@@ -9,8 +9,9 @@ package org.elasticsearch.xpack.rollup.rest;
 
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.client.node.NodeClient;
-import org.elasticsearch.common.xcontent.ParseField;
 import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.xcontent.ParseField;
+import org.elasticsearch.core.RestApiVersion;
 import org.elasticsearch.rest.BaseRestHandler;
 import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.rest.action.RestToXContentListener;
@@ -26,7 +27,10 @@ public class RestGetRollupIndexCapsAction extends BaseRestHandler {
 
     @Override
     public List<Route> routes() {
-        return List.of(new Route(GET, "/{index}/_rollup/data"));
+        return List.of(
+            Route.builder(GET, "/{index}/_rollup/data")
+                .replaces(GET, "/{index}/_xpack/rollup/data", RestApiVersion.V_7).build()
+        );
     }
 
     @Override

--- a/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/rest/RestGetRollupJobsAction.java
+++ b/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/rest/RestGetRollupJobsAction.java
@@ -9,6 +9,7 @@ package org.elasticsearch.xpack.rollup.rest;
 
 import org.elasticsearch.client.node.NodeClient;
 import org.elasticsearch.common.xcontent.ParseField;
+import org.elasticsearch.core.RestApiVersion;
 import org.elasticsearch.rest.BaseRestHandler;
 import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.rest.action.RestToXContentListener;
@@ -24,7 +25,10 @@ public class RestGetRollupJobsAction extends BaseRestHandler {
 
     @Override
     public List<Route> routes() {
-        return List.of(new Route(GET, "/_rollup/job/{id}"));
+        return List.of(
+            Route.builder(GET, "/_rollup/job/{id}")
+                .replaces(GET, "/_xpack/rollup/job/{id}/", RestApiVersion.V_7).build()
+        );
     }
 
     @Override

--- a/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/rest/RestPutRollupJobAction.java
+++ b/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/rest/RestPutRollupJobAction.java
@@ -8,6 +8,7 @@
 package org.elasticsearch.xpack.rollup.rest;
 
 import org.elasticsearch.client.node.NodeClient;
+import org.elasticsearch.core.RestApiVersion;
 import org.elasticsearch.rest.BaseRestHandler;
 import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.rest.action.RestToXContentListener;
@@ -22,7 +23,10 @@ public class RestPutRollupJobAction extends BaseRestHandler {
 
     @Override
     public List<Route> routes() {
-        return List.of(new Route(PUT, "/_rollup/job/{id}"));
+        return List.of(
+            Route.builder(PUT, "/_rollup/job/{id}")
+                .replaces(PUT, "/_xpack/rollup/job/{id}", RestApiVersion.V_7).build()
+        );
     }
 
     @Override

--- a/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/rest/RestStartRollupJobAction.java
+++ b/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/rest/RestStartRollupJobAction.java
@@ -8,6 +8,7 @@
 package org.elasticsearch.xpack.rollup.rest;
 
 import org.elasticsearch.client.node.NodeClient;
+import org.elasticsearch.core.RestApiVersion;
 import org.elasticsearch.rest.BaseRestHandler;
 import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.rest.action.RestToXContentListener;
@@ -22,7 +23,10 @@ public class RestStartRollupJobAction extends BaseRestHandler {
 
     @Override
     public List<Route> routes() {
-        return List.of(new Route(POST, "/_rollup/job/{id}/_start"));
+        return List.of(
+            Route.builder(POST, "/_rollup/job/{id}/_start")
+                .replaces(POST, "/_xpack/rollup/job/{id}/_start", RestApiVersion.V_7).build()
+        );
     }
 
     @Override

--- a/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/rest/RestStopRollupJobAction.java
+++ b/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/rest/RestStopRollupJobAction.java
@@ -8,6 +8,7 @@
 package org.elasticsearch.xpack.rollup.rest;
 
 import org.elasticsearch.client.node.NodeClient;
+import org.elasticsearch.core.RestApiVersion;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.rest.BaseRestHandler;
 import org.elasticsearch.rest.RestRequest;
@@ -23,7 +24,10 @@ public class RestStopRollupJobAction extends BaseRestHandler {
 
     @Override
     public List<Route> routes() {
-        return List.of(new Route(POST, "/_rollup/job/{id}/_stop"));
+        return List.of(
+            Route.builder(POST, "/_rollup/job/{id}/_stop")
+                .replaces(POST, "/_xpack/rollup/job/{id}/_stop", RestApiVersion.V_7).build()
+        );
     }
 
     @Override

--- a/x-pack/plugin/src/yamlRestCompatTest/resources/rest-api-spec/api/xpack-rollup.delete_job.json
+++ b/x-pack/plugin/src/yamlRestCompatTest/resources/rest-api-spec/api/xpack-rollup.delete_job.json
@@ -1,0 +1,33 @@
+{
+  "xpack-rollup.delete_job":{
+    "documentation":{
+      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/rollup-delete-job.html",
+      "description":"Deletes an existing rollup job."
+    },
+    "stability":"experimental",
+    "visibility":"public",
+    "headers":{
+      "accept": [ "application/vnd.elasticsearch+json;compatible-with=7"]
+    },
+    "url":{
+      "paths":[
+        {
+          "path":"/_xpack/rollup/job/{id}",
+          "methods":[
+            "DELETE"
+          ],
+          "parts":{
+            "id":{
+              "type":"string",
+              "description":"The ID of the job to delete"
+            }
+          },
+          "deprecated":{
+            "version":"7.0.0",
+            "description":"all _xpack prefix have been deprecated"
+          }
+        }
+      ]
+    }
+  }
+}

--- a/x-pack/plugin/src/yamlRestCompatTest/resources/rest-api-spec/api/xpack-rollup.get_jobs.json
+++ b/x-pack/plugin/src/yamlRestCompatTest/resources/rest-api-spec/api/xpack-rollup.get_jobs.json
@@ -1,0 +1,43 @@
+{
+  "xpack-rollup.get_jobs":{
+    "documentation":{
+      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/rollup-get-job.html",
+      "description":"Retrieves the configuration, stats, and status of rollup jobs."
+    },
+    "stability":"experimental",
+    "visibility":"public",
+    "headers":{
+      "accept": [ "application/vnd.elasticsearch+json;compatible-with=7"]
+    },
+    "url":{
+      "paths":[
+        {
+          "path":"/_xpack/rollup/job/{id}",
+          "methods":[
+            "GET"
+          ],
+          "parts":{
+            "id":{
+              "type":"string",
+              "description":"The ID of the job(s) to fetch. Accepts glob patterns, or left blank for all jobs"
+            }
+          },
+          "deprecated":{
+            "version":"7.0.0",
+            "description":"all _xpack prefix have been deprecated"
+          }
+        },
+        {
+          "path":"/_xpack/rollup/job/",
+          "methods":[
+            "GET"
+          ],
+          "deprecated":{
+            "version":"7.0.0",
+            "description":"all _xpack prefix have been deprecated"
+          }
+        }
+      ]
+    }
+  }
+}

--- a/x-pack/plugin/src/yamlRestCompatTest/resources/rest-api-spec/api/xpack-rollup.get_rollup_caps.json
+++ b/x-pack/plugin/src/yamlRestCompatTest/resources/rest-api-spec/api/xpack-rollup.get_rollup_caps.json
@@ -1,0 +1,43 @@
+{
+  "xpack-rollup.get_rollup_caps":{
+    "documentation":{
+      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/rollup-get-rollup-caps.html",
+      "description":"Returns the capabilities of any rollup jobs that have been configured for a specific index or index pattern."
+    },
+    "stability":"experimental",
+    "visibility":"public",
+    "headers":{
+      "accept": [ "application/vnd.elasticsearch+json;compatible-with=7"]
+    },
+    "url":{
+      "paths":[
+        {
+          "path":"/_xpack/rollup/data/{id}",
+          "methods":[
+            "GET"
+          ],
+          "parts":{
+            "id":{
+              "type":"string",
+              "description":"The ID of the index to check rollup capabilities on, or left blank for all jobs"
+            }
+          },
+          "deprecated":{
+            "version":"7.0.0",
+            "description":"all _xpack prefix have been deprecated"
+          }
+        },
+        {
+          "path":"/_xpack/rollup/data/",
+          "methods":[
+            "GET"
+          ],
+          "deprecated":{
+            "version":"7.0.0",
+            "description":"all _xpack prefix have been deprecated"
+          }
+        }
+      ]
+    }
+  }
+}

--- a/x-pack/plugin/src/yamlRestCompatTest/resources/rest-api-spec/api/xpack-rollup.get_rollup_index_caps.json
+++ b/x-pack/plugin/src/yamlRestCompatTest/resources/rest-api-spec/api/xpack-rollup.get_rollup_index_caps.json
@@ -1,0 +1,33 @@
+{
+  "xpack-rollup.get_rollup_index_caps":{
+    "documentation":{
+      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/rollup-get-rollup-index-caps.html",
+      "description":"Returns the rollup capabilities of all jobs inside of a rollup index (e.g. the index where rollup data is stored)."
+    },
+    "stability":"experimental",
+    "visibility":"public",
+    "headers":{
+      "accept": [ "application/vnd.elasticsearch+json;compatible-with=7"]
+    },
+    "url":{
+      "paths":[
+        {
+          "path":"/{index}/_xpack/rollup/data",
+          "methods":[
+            "GET"
+          ],
+          "parts":{
+            "index":{
+              "type":"string",
+              "description":"The rollup index or index pattern to obtain rollup capabilities from."
+            }
+          },
+          "deprecated":{
+            "version":"7.0.0",
+            "description":"all _xpack prefix have been deprecated"
+          }
+        }
+      ]
+    }
+  }
+}

--- a/x-pack/plugin/src/yamlRestCompatTest/resources/rest-api-spec/api/xpack-rollup.put_job.json
+++ b/x-pack/plugin/src/yamlRestCompatTest/resources/rest-api-spec/api/xpack-rollup.put_job.json
@@ -1,0 +1,38 @@
+{
+  "xpack-rollup.put_job":{
+    "documentation":{
+      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/rollup-put-job.html",
+      "description":"Creates a rollup job."
+    },
+    "stability":"experimental",
+    "visibility":"public",
+    "headers":{
+      "accept": [ "application/vnd.elasticsearch+json;compatible-with=7"],
+      "content_type": ["application/vnd.elasticsearch+json;compatible-with=7"]
+    },
+    "url":{
+      "paths":[
+        {
+          "path":"/_xpack/rollup/job/{id}",
+          "methods":[
+            "PUT"
+          ],
+          "parts":{
+            "id":{
+              "type":"string",
+              "description":"The ID of the job to create"
+            }
+          },
+          "deprecated":{
+            "version":"7.0.0",
+            "description":"all _xpack prefix have been deprecated"
+          }
+        }
+      ]
+    },
+    "body":{
+      "description":"The job configuration",
+      "required":true
+    }
+  }
+}

--- a/x-pack/plugin/src/yamlRestCompatTest/resources/rest-api-spec/api/xpack-rollup.start_job.json
+++ b/x-pack/plugin/src/yamlRestCompatTest/resources/rest-api-spec/api/xpack-rollup.start_job.json
@@ -1,0 +1,33 @@
+{
+  "xpack-rollup.start_job":{
+    "documentation":{
+      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/rollup-start-job.html",
+      "description":"Starts an existing, stopped rollup job."
+    },
+    "stability":"experimental",
+    "visibility":"public",
+    "headers":{
+      "accept": [ "application/vnd.elasticsearch+json;compatible-with=7"]
+    },
+    "url":{
+      "paths":[
+        {
+          "path":"/_xpack/rollup/job/{id}/_start",
+          "methods":[
+            "POST"
+          ],
+          "parts":{
+            "id":{
+              "type":"string",
+              "description":"The ID of the job to start"
+            }
+          },
+          "deprecated":{
+            "version":"7.0.0",
+            "description":"all _xpack prefix have been deprecated"
+          }
+        }
+      ]
+    }
+  }
+}

--- a/x-pack/plugin/src/yamlRestCompatTest/resources/rest-api-spec/api/xpack-rollup.stop_job.json
+++ b/x-pack/plugin/src/yamlRestCompatTest/resources/rest-api-spec/api/xpack-rollup.stop_job.json
@@ -1,0 +1,45 @@
+{
+  "xpack-rollup.stop_job":{
+    "documentation":{
+      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/rollup-stop-job.html",
+      "description":"Stops an existing, started rollup job."
+    },
+    "stability":"experimental",
+    "visibility":"public",
+    "headers":{
+      "accept": [ "application/vnd.elasticsearch+json;compatible-with=7"]
+    },
+    "url":{
+      "paths":[
+        {
+          "path":"/_xpack/rollup/job/{id}/_stop",
+          "methods":[
+            "POST"
+          ],
+          "parts":{
+            "id":{
+              "type":"string",
+              "description":"The ID of the job to stop"
+            }
+          },
+          "deprecated":{
+            "version":"7.0.0",
+            "description":"all _xpack prefix have been deprecated"
+          }
+        }
+      ]
+    },
+    "params":{
+      "wait_for_completion":{
+        "type":"boolean",
+        "required":false,
+        "description":"True if the API should block until the job has fully stopped, false if should be executed async. Defaults to false."
+      },
+      "timeout":{
+        "type":"time",
+        "required":false,
+        "description":"Block for (at maximum) the specified duration while waiting for the job to stop.  Defaults to 30s."
+      }
+    }
+  }
+}


### PR DESCRIPTION
Related to #51816 / #68905.

Adds back the `_xpack/rollup` routes when using rest compatibility for a request.