### PR TITLE
[7.x] [Monitoring] Monitor beat version (#73932)

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/monitoring/exporter/MonitoringTemplateUtils.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/monitoring/exporter/MonitoringTemplateUtils.java
@@ -32,7 +32,7 @@ public final class MonitoringTemplateUtils {
      * Note that the templates were last updated in 7.11.0, but the versions were not updated, meaning that upgrades
      * to 7.11.0 would not have updated the templates. See https://github.com/elastic/elasticsearch/pull/69317.
      */
-    public static final int LAST_UPDATED_VERSION = Version.V_7_12_0.id;
+    public static final int LAST_UPDATED_VERSION = Version.V_7_14_0.id;
 
     /**
      * Current version of templates used in their name to differentiate from breaking changes (separate from product version).

--- a/x-pack/plugin/core/src/main/resources/monitoring-alerts-7.json
+++ b/x-pack/plugin/core/src/main/resources/monitoring-alerts-7.json
@@ -1,6 +1,6 @@
 {
   "index_patterns": [ ".monitoring-alerts-${monitoring.template.version}" ],
-  "version": 7120099,
+  "version": 7140099,
   "settings": {
     "index": {
       "number_of_shards": 1,

--- a/x-pack/plugin/core/src/main/resources/monitoring-beats.json
+++ b/x-pack/plugin/core/src/main/resources/monitoring-beats.json
@@ -9,7 +9,7 @@
     "index.number_of_replicas": 0,
     "index.number_of_shards": 1
   },
-  "version": 7120099,
+  "version": 7140099,
   "mappings": {
     "_doc": {
       "dynamic": false,
@@ -291,6 +291,9 @@
                               "type": "long"
                             }
                           }
+                        },
+                        "version": {
+                          "type": "keyword"
                         }
                       }
                     },

--- a/x-pack/plugin/core/src/main/resources/monitoring-es.json
+++ b/x-pack/plugin/core/src/main/resources/monitoring-es.json
@@ -1,6 +1,6 @@
 {
   "index_patterns": [ ".monitoring-es-${monitoring.template.version}-*" ],
-  "version": 7120099,
+  "version": 7140099,
   "settings": {
     "index.number_of_shards": 1,
     "index.number_of_replicas": 0,

--- a/x-pack/plugin/core/src/main/resources/monitoring-kibana.json
+++ b/x-pack/plugin/core/src/main/resources/monitoring-kibana.json
@@ -1,6 +1,6 @@
 {
   "index_patterns": [ ".monitoring-kibana-${monitoring.template.version}-*" ],
-  "version": 7120099,
+  "version": 7140099,
   "settings": {
     "index.number_of_shards": 1,
     "index.number_of_replicas": 0,

--- a/x-pack/plugin/core/src/main/resources/monitoring-logstash.json
+++ b/x-pack/plugin/core/src/main/resources/monitoring-logstash.json
@@ -1,6 +1,6 @@
 {
   "index_patterns": [ ".monitoring-logstash-${monitoring.template.version}-*" ],
-  "version": 7120099,
+  "version": 7140099,
   "settings": {
     "index.number_of_shards": 1,
     "index.number_of_replicas": 0,


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [Monitoring] Monitor beat version (#73932)