### PR TITLE
Adjust get alias api for write data streams

### DIFF
--- a/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestGetAliasesAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestGetAliasesAction.java
@@ -161,7 +161,7 @@ public class RestGetAliasesAction extends BaseRestHandler {
                         for (DataStreamAlias alias : entry.getValue()) {
                             builder.startObject(alias.getName());
                             if (entry.getKey().equals(alias.getWriteDataStream())) {
-                                builder.field("is_write_data_stream", true);
+                                builder.field("is_write_index", true);
                             }
                             builder.endObject();
                         }

--- a/x-pack/plugin/data-streams/qa/rest/src/javaRestTest/java/org/elasticsearch/xpack/datastreams/DataStreamsRestIT.java
+++ b/x-pack/plugin/data-streams/qa/rest/src/javaRestTest/java/org/elasticsearch/xpack/datastreams/DataStreamsRestIT.java
@@ -260,7 +260,7 @@ public class DataStreamsRestIT extends ESRestTestCase {
         Request getAliasesRequest = new Request("GET", "/_aliases");
         Map<String, Object> getAliasesResponse = entityAsMap(client().performRequest(getAliasesRequest));
         assertEquals(
-            Map.of("logs", Map.of("is_write_data_stream", true)),
+            Map.of("logs", Map.of("is_write_index", true)),
             XContentMapValues.extractValue("logs-emea.aliases", getAliasesResponse)
         );
         assertEquals(Map.of("logs", Map.of()), XContentMapValues.extractValue("logs-nasa.aliases", getAliasesResponse));
@@ -292,7 +292,7 @@ public class DataStreamsRestIT extends ESRestTestCase {
         getAliasesResponse = entityAsMap(client().performRequest(getAliasesRequest));
         assertEquals(Map.of("logs", Map.of()), XContentMapValues.extractValue("logs-emea.aliases", getAliasesResponse));
         assertEquals(
-            Map.of("logs", Map.of("is_write_data_stream", true)),
+            Map.of("logs", Map.of("is_write_index", true)),
             XContentMapValues.extractValue("logs-nasa.aliases", getAliasesResponse)
         );
     }


### PR DESCRIPTION
Use `is_write_index` instead of `is_write_data_stream` to indicate whether an data stream alias
is a write data stream alias. Although the latter is a more accurate name, the former is what is
used to turn a data stream alias into a write data stream in the indices aliases api. The design
of data stream aliases is that it looks and behaves like any other alias and
using `is_write_data_stream` would go against this design.

Also index or indices is an accepted overloaded term that can mean both regular index,
data stream or an alias in Elasticsearch APIs. By using `is_write_index`, consumers
of the get aliases API don't need to make changes.

Relates to #66163