### PR TITLE
[7.13] Fix SearchableSnapshotActionIT.testConvertingSearchableSnapshotFromFullToPartial

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/CopyExecutionStateStep.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/CopyExecutionStateStep.java
@@ -78,7 +78,6 @@ public class CopyExecutionStateStep extends ClusterStateActionStep {
         String phase = targetNextStepKey.getPhase();
         String action = targetNextStepKey.getAction();
         String step = targetNextStepKey.getName();
-        long lifecycleDate = lifecycleState.getLifecycleDate();
 
         LifecycleExecutionState.Builder relevantTargetCustomData = LifecycleExecutionState.builder(lifecycleState);
         // Override the phase, action, and step for the target next StepKey

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/SearchableSnapshotAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/SearchableSnapshotAction.java
@@ -22,6 +22,7 @@ import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.license.LicenseUtils;
 import org.elasticsearch.license.XPackLicenseState;
+import org.elasticsearch.repositories.RepositoriesService;
 import org.elasticsearch.xpack.core.XPackPlugin;
 import org.elasticsearch.xpack.core.ilm.Step.StepKey;
 import org.elasticsearch.xpack.core.searchablesnapshots.MountSearchableSnapshotRequest;
@@ -132,10 +133,7 @@ public class SearchableSnapshotAction implements LifecycleAction {
                 String policyName = LifecycleSettings.LIFECYCLE_NAME_SETTING.get(indexMetadata.getSettings());
                 if (indexMetadata.getSettings().get(LifecycleSettings.SNAPSHOT_INDEX_NAME) != null) {
                     // The index is already a searchable snapshot, let's see if the repository matches
-                    // TODO: move the searchable snapshot settings into x-pack
-                    //  core in the future, so the Settings can be used instead
-                    //  of strings here
-                    String repo = indexMetadata.getSettings().get("index.store.snapshot.repository_name");
+                    String repo = indexMetadata.getSettings().get(RepositoriesService.SEARCHABLE_SNAPSHOTS_REPOSITORY_NAME_SETTING_KEY);
                     if (this.snapshotRepository.equals(repo) == false) {
                         // Okay, different repo, we need to go ahead with the searchable snapshot
                         logger.debug("[{}] action is configured for index [{}] in policy [{}] which is already mounted as a searchable " +

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/SearchableSnapshotAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/SearchableSnapshotAction.java
@@ -22,7 +22,6 @@ import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.license.LicenseUtils;
 import org.elasticsearch.license.XPackLicenseState;
-import org.elasticsearch.repositories.RepositoriesService;
 import org.elasticsearch.xpack.core.XPackPlugin;
 import org.elasticsearch.xpack.core.ilm.Step.StepKey;
 import org.elasticsearch.xpack.core.searchablesnapshots.MountSearchableSnapshotRequest;
@@ -133,7 +132,10 @@ public class SearchableSnapshotAction implements LifecycleAction {
                 String policyName = LifecycleSettings.LIFECYCLE_NAME_SETTING.get(indexMetadata.getSettings());
                 if (indexMetadata.getSettings().get(LifecycleSettings.SNAPSHOT_INDEX_NAME) != null) {
                     // The index is already a searchable snapshot, let's see if the repository matches
-                    String repo = indexMetadata.getSettings().get(RepositoriesService.SEARCHABLE_SNAPSHOTS_REPOSITORY_NAME_SETTING_KEY);
+                    // TODO: move the searchable snapshot settings into x-pack
+                    //  core in the future, so the Settings can be used instead
+                    //  of strings here
+                    String repo = indexMetadata.getSettings().get("index.store.snapshot.repository_name");
                     if (this.snapshotRepository.equals(repo) == false) {
                         // Okay, different repo, we need to go ahead with the searchable snapshot
                         logger.debug("[{}] action is configured for index [{}] in policy [{}] which is already mounted as a searchable " +

--- a/x-pack/plugin/ilm/qa/multi-node/src/javaRestTest/java/org/elasticsearch/xpack/ilm/actions/SearchableSnapshotActionIT.java
+++ b/x-pack/plugin/ilm/qa/multi-node/src/javaRestTest/java/org/elasticsearch/xpack/ilm/actions/SearchableSnapshotActionIT.java
@@ -453,6 +453,11 @@ public class SearchableSnapshotActionIT extends ESRestTestCase {
         Request hitCount = new Request("GET", "/" + searchableSnapMountedIndexName + "/_count");
         Map<String, Object> count = entityAsMap(client().performRequest(hitCount));
         assertThat("expected a single document but got: " + count, (int) count.get("count"), equalTo(1));
+
+        assertBusy(() -> assertTrue(
+            "Expecting the mounted index to be deleted and to be converted to an alias",
+            aliasExists(searchableSnapMountedIndexName, SearchableSnapshotAction.FULL_RESTORED_INDEX_PREFIX + index))
+        );
     }
 
     public void testSecondSearchableSnapshotUsingDifferentRepoThrows() throws Exception {


### PR DESCRIPTION
This failure can happen if the after test logic in 
EsRestTestCase.wipeSearchableSnapshotsIndices() 
correctly found a searchable snapshot index to 
delete but that index was already deleted and 
converted to an alias in the meanwhile, by the 
last step of the ILM searchable snapshot action 
for frozen phase.

This in-flight alias swap while the partially index 
has a completed ILM state is possible because 
of the CopyExecutionStateStep which updates 
the cluster state with completed in frozen phase 
and the alias swap request is executed after the 
updated cluster state is published.

Backport of #73888
Closes #73706