### PR TITLE
[7.x] [ML] makes Job.Builder not implement ToXContentObject (#73974)

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/PutJobAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/PutJobAction.java
@@ -35,7 +35,7 @@ public class PutJobAction extends ActionType<PutJobAction.Response> {
         super(NAME, Response::new);
     }
 
-    public static class Request extends AcknowledgedRequest<Request> implements ToXContentObject {
+    public static class Request extends AcknowledgedRequest<Request> {
 
         public static Request parseRequest(String jobId, XContentParser parser) {
             Job.Builder jobBuilder = Job.STRICT_PARSER.apply(parser, null);
@@ -94,12 +94,6 @@ public class PutJobAction extends ActionType<PutJobAction.Response> {
         }
 
         @Override
-        public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
-            jobBuilder.toXContent(builder, params);
-            return builder;
-        }
-
-        @Override
         public boolean equals(Object o) {
             if (this == o) return true;
             if (o == null || getClass() != o.getClass()) return false;
@@ -110,11 +104,6 @@ public class PutJobAction extends ActionType<PutJobAction.Response> {
         @Override
         public int hashCode() {
             return Objects.hash(jobBuilder);
-        }
-
-        @Override
-        public final String toString() {
-            return Strings.toString(this);
         }
     }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/config/Job.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/config/Job.java
@@ -685,7 +685,7 @@ public class Job extends AbstractDiffable<Job> implements Writeable, ToXContentO
         return compatibleTypes;
     }
 
-    public static class Builder implements Writeable, ToXContentObject {
+    public static class Builder implements Writeable {
 
         private String id;
         private String jobType = ANOMALY_DETECTOR_JOB_TYPE;
@@ -1001,75 +1001,6 @@ public class Job extends AbstractDiffable<Job> implements Writeable, ToXContentO
             if (out.getVersion().onOrAfter(Version.V_7_5_0)) {
                 out.writeBoolean(allowLazyOpen);
             }
-        }
-
-        @Override
-        public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
-            builder.startObject();
-            if (id != null) {
-                builder.field(ID.getPreferredName(), id);
-            }
-            builder.field(JOB_TYPE.getPreferredName(), jobType);
-            if (jobVersion != null) {
-                builder.field(JOB_VERSION.getPreferredName(), jobVersion);
-            }
-            if (description != null) {
-                builder.field(DESCRIPTION.getPreferredName(), description);
-            }
-            if (createTime != null) {
-                builder.field(CREATE_TIME.getPreferredName(), createTime.getTime());
-            }
-            if (finishedTime != null) {
-                builder.field(FINISHED_TIME.getPreferredName(), finishedTime.getTime());
-            }
-            if (analysisConfig != null) {
-                builder.field(ANALYSIS_CONFIG.getPreferredName(), analysisConfig, params);
-            }
-            if (analysisLimits != null) {
-                builder.field(ANALYSIS_LIMITS.getPreferredName(), analysisLimits, params);
-            }
-            if (dataDescription != null) {
-                builder.field(DATA_DESCRIPTION.getPreferredName(), dataDescription, params);
-            }
-            if (modelPlotConfig != null) {
-                builder.field(MODEL_PLOT_CONFIG.getPreferredName(), modelPlotConfig, params);
-            }
-            if (renormalizationWindowDays != null) {
-                builder.field(RENORMALIZATION_WINDOW_DAYS.getPreferredName(), renormalizationWindowDays);
-            }
-            if (backgroundPersistInterval != null) {
-                builder.field(BACKGROUND_PERSIST_INTERVAL.getPreferredName(), backgroundPersistInterval.getStringRep());
-            }
-            if (modelSnapshotRetentionDays != null) {
-                builder.field(MODEL_SNAPSHOT_RETENTION_DAYS.getPreferredName(), modelSnapshotRetentionDays);
-            }
-            if (dailyModelSnapshotRetentionAfterDays != null) {
-                builder.field(DAILY_MODEL_SNAPSHOT_RETENTION_AFTER_DAYS.getPreferredName(), dailyModelSnapshotRetentionAfterDays);
-            }
-            if (resultsRetentionDays != null) {
-                builder.field(RESULTS_RETENTION_DAYS.getPreferredName(), resultsRetentionDays);
-            }
-            if (customSettings != null) {
-                builder.field(CUSTOM_SETTINGS.getPreferredName(), customSettings);
-            }
-            if (modelSnapshotId != null) {
-                builder.field(MODEL_SNAPSHOT_ID.getPreferredName(), modelSnapshotId);
-            }
-            if (modelSnapshotMinVersion != null) {
-                builder.field(MODEL_SNAPSHOT_MIN_VERSION.getPreferredName(), modelSnapshotMinVersion);
-            }
-            if (resultsIndexName != null) {
-                builder.field(RESULTS_INDEX_NAME.getPreferredName(), resultsIndexName);
-            }
-            if (deleting) {
-                builder.field(DELETING.getPreferredName(), deleting);
-            }
-            if (allowLazyOpen) {
-                builder.field(ALLOW_LAZY_OPEN.getPreferredName(), allowLazyOpen);
-            }
-
-            builder.endObject();
-            return builder;
         }
 
         @Override

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/PutJobActionRequestTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/PutJobActionRequestTests.java
@@ -6,22 +6,15 @@
  */
 package org.elasticsearch.xpack.core.ml.action;
 
-import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.io.stream.Writeable;
-import org.elasticsearch.common.xcontent.XContentHelper;
-import org.elasticsearch.common.xcontent.XContentParser;
-import org.elasticsearch.common.xcontent.XContentType;
-import org.elasticsearch.test.AbstractSerializingTestCase;
+import org.elasticsearch.test.AbstractWireSerializingTestCase;
 import org.elasticsearch.xpack.core.ml.action.PutJobAction.Request;
 import org.elasticsearch.xpack.core.ml.job.config.Job;
-
-import java.io.IOException;
-import java.util.Date;
 
 import static org.elasticsearch.xpack.core.ml.job.config.JobTests.buildJobBuilder;
 import static org.elasticsearch.xpack.core.ml.job.config.JobTests.randomValidJobId;
 
-public class PutJobActionRequestTests extends AbstractSerializingTestCase<Request> {
+public class PutJobActionRequestTests extends AbstractWireSerializingTestCase<Request> {
 
     private final String jobId = randomValidJobId();
 
@@ -36,21 +29,4 @@ public class PutJobActionRequestTests extends AbstractSerializingTestCase<Reques
         return Request::new;
     }
 
-    @Override
-    protected boolean supportsUnknownFields() {
-        return false;
-    }
-
-    @Override
-    protected Request doParseInstance(XContentParser parser) {
-        return Request.parseRequest(jobId, parser);
-    }
-
-    public void testParseRequest_InvalidCreateSetting() throws IOException {
-        Job.Builder jobConfiguration = buildJobBuilder(jobId, null);
-        jobConfiguration.setFinishedTime(new Date());
-        BytesReference bytes = XContentHelper.toXContent(jobConfiguration, XContentType.JSON, false);
-        XContentParser parser = createParser(XContentType.JSON.xContent(), bytes);
-        expectThrows(IllegalArgumentException.class, () -> Request.parseRequest(jobId, parser));
-    }
 }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/ValidateJobConfigActionRequestTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/ValidateJobConfigActionRequestTests.java
@@ -43,7 +43,7 @@ public class ValidateJobConfigActionRequestTests extends AbstractWireSerializing
         jobConfiguration.setFinishedTime(new Date());
 
         XContentBuilder builder = XContentFactory.contentBuilder(XContentType.JSON);
-        XContentBuilder xContentBuilder = jobConfiguration.toXContent(builder, ToXContent.EMPTY_PARAMS);
+        XContentBuilder xContentBuilder = jobConfiguration.build(new Date()).toXContent(builder, ToXContent.EMPTY_PARAMS);
         XContentParser parser = XContentFactory.xContent(XContentType.JSON)
                 .createParser(NamedXContentRegistry.EMPTY, DeprecationHandler.THROW_UNSUPPORTED_OPERATION,
                         BytesReference.bytes(xContentBuilder).streamInput());

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/config/JobBuilderTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/config/JobBuilderTests.java
@@ -8,8 +8,7 @@ package org.elasticsearch.xpack.ml.job.config;
 
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.core.TimeValue;
-import org.elasticsearch.common.xcontent.XContentParser;
-import org.elasticsearch.test.AbstractSerializingTestCase;
+import org.elasticsearch.test.AbstractWireSerializingTestCase;
 import org.elasticsearch.xpack.core.ml.job.config.AnalysisConfigTests;
 import org.elasticsearch.xpack.core.ml.job.config.AnalysisLimitsTests;
 import org.elasticsearch.xpack.core.ml.job.config.DataDescription;
@@ -21,7 +20,7 @@ import java.util.Date;
 
 import static org.elasticsearch.xpack.core.ml.job.config.JobTests.randomValidJobId;
 
-public class JobBuilderTests extends AbstractSerializingTestCase<Job.Builder> {
+public class JobBuilderTests extends AbstractWireSerializingTestCase<Job.Builder> {
     @Override
     protected Job.Builder createTestInstance() {
         Job.Builder builder = new Job.Builder();
@@ -84,8 +83,4 @@ public class JobBuilderTests extends AbstractSerializingTestCase<Job.Builder> {
         return Job.Builder::new;
     }
 
-    @Override
-    protected Job.Builder doParseInstance(XContentParser parser) {
-        return Job.STRICT_PARSER.apply(parser, null);
-    }
 }

--- a/x-pack/qa/full-cluster-restart/src/test/java/org/elasticsearch/xpack/restart/MlMigrationFullClusterRestartIT.java
+++ b/x-pack/qa/full-cluster-restart/src/test/java/org/elasticsearch/xpack/restart/MlMigrationFullClusterRestartIT.java
@@ -11,7 +11,6 @@ import org.elasticsearch.client.Request;
 import org.elasticsearch.client.Response;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.common.xcontent.support.XContentMapValues;
 import org.elasticsearch.search.aggregations.AggregationBuilders;
@@ -21,10 +20,6 @@ import org.elasticsearch.search.aggregations.metrics.MaxAggregationBuilder;
 import org.elasticsearch.upgrades.AbstractFullClusterRestartTestCase;
 import org.elasticsearch.xpack.core.ml.MlTasks;
 import org.elasticsearch.xpack.core.ml.datafeed.DatafeedConfig;
-import org.elasticsearch.xpack.core.ml.job.config.AnalysisConfig;
-import org.elasticsearch.xpack.core.ml.job.config.DataDescription;
-import org.elasticsearch.xpack.core.ml.job.config.Detector;
-import org.elasticsearch.xpack.core.ml.job.config.Job;
 import org.elasticsearch.xpack.test.rest.XPackRestTestConstants;
 import org.elasticsearch.xpack.test.rest.XPackRestTestHelper;
 import org.junit.Before;
@@ -98,18 +93,7 @@ public class MlMigrationFullClusterRestartIT extends AbstractFullClusterRestartT
 
     private void oldClusterTests() throws IOException {
         // create jobs and datafeeds
-        Detector.Builder d = new Detector.Builder("metric", "responsetime");
-        d.setByFieldName("airline");
-        AnalysisConfig.Builder analysisConfig = new AnalysisConfig.Builder(Collections.singletonList(d.build()));
-        analysisConfig.setBucketSpan(TimeValue.timeValueMinutes(10));
-
-        Job.Builder closedJob = new Job.Builder(OLD_CLUSTER_CLOSED_JOB_ID);
-        closedJob.setAnalysisConfig(analysisConfig);
-        closedJob.setDataDescription(new DataDescription.Builder());
-
-        Request putClosedJob = new Request("PUT", "/_xpack/ml/anomaly_detectors/" + OLD_CLUSTER_CLOSED_JOB_ID);
-        putClosedJob.setJsonEntity(Strings.toString(closedJob));
-        client().performRequest(putClosedJob);
+        putJob(OLD_CLUSTER_CLOSED_JOB_ID);
 
         DatafeedConfig.Builder stoppedDfBuilder = new DatafeedConfig.Builder(OLD_CLUSTER_STOPPED_DATAFEED_ID, OLD_CLUSTER_CLOSED_JOB_ID);
         if (getOldClusterVersion().before(Version.V_6_6_0)) {
@@ -122,13 +106,7 @@ public class MlMigrationFullClusterRestartIT extends AbstractFullClusterRestartT
         client().performRequest(putStoppedDatafeed);
 
         // open job and started datafeed
-        Job.Builder openJob = new Job.Builder(OLD_CLUSTER_OPEN_JOB_ID);
-        openJob.setAnalysisConfig(analysisConfig);
-        openJob.setDataDescription(new DataDescription.Builder());
-        Request putOpenJob = new Request("PUT", "_xpack/ml/anomaly_detectors/" + OLD_CLUSTER_OPEN_JOB_ID);
-        putOpenJob.setJsonEntity(Strings.toString(openJob));
-        client().performRequest(putOpenJob);
-
+        putJob(OLD_CLUSTER_OPEN_JOB_ID);
         Request openOpenJob = new Request("POST", "_xpack/ml/anomaly_detectors/" + OLD_CLUSTER_OPEN_JOB_ID + "/_open");
         client().performRequest(openOpenJob);
 
@@ -277,5 +255,24 @@ public class MlMigrationFullClusterRestartIT extends AbstractFullClusterRestartT
         MaxAggregationBuilder maxTime = AggregationBuilders.max("time").field("time").subAggregation(airline);
         dfBuilder.setParsedAggregations(AggregatorFactories.builder().addAggregator(
                 AggregationBuilders.histogram("time").interval(300000).subAggregation(maxTime).field("time")));
+    }
+
+    private void putJob(String jobId) throws IOException {
+        String jobConfig =
+            "{\n" +
+                "    \"job_id\": \"" + jobId + "\",\n" +
+                "    \"analysis_config\": {\n" +
+                "        \"bucket_span\": \"10m\",\n" +
+                "        \"detectors\": [{\n" +
+                "            \"function\": \"metric\",\n" +
+                "            \"by_field_name\": \"airline\",\n" +
+                "            \"field_name\": \"responsetime\"\n" +
+                "        }]\n" +
+                "    },\n" +
+                "    \"data_description\": {}\n" +
+                "}";
+        Request putClosedJob = new Request("PUT", "/_xpack/ml/anomaly_detectors/" + jobId);
+        putClosedJob.setJsonEntity(jobConfig);
+        client().performRequest(putClosedJob);
     }
 }


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [ML] makes Job.Builder not implement ToXContentObject (#73974)