### PR TITLE
[Transform] Align transform checkpoint range with date_histogram interval for better performance

### DIFF
--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/transform/transforms/SettingsConfig.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/transform/transforms/SettingsConfig.java
@@ -207,8 +207,8 @@ public class SettingsConfig implements ToXContentObject {
          *
          * An explicit `null` resets to default.
          *
-         * @param interimResults true if dates should be written as epoch_millis.
-         * @return the {@link Builder} with datesAsEpochMilli set.
+         * @param interimResults true if interim results should be written.
+         * @return the {@link Builder} with interimResults set.
          */
         public Builder setInterimResults(Boolean interimResults) {
             this.interimResults = interimResults == null ? DEFAULT_INTERIM_RESULTS : interimResults ? 1 : 0;

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/transform/transforms/SettingsConfig.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/transform/transforms/SettingsConfig.java
@@ -203,10 +203,7 @@ public class SettingsConfig implements ToXContentObject {
         }
 
         /**
-         * Whether to write the output of a date aggregation as millis since epoch or as formatted string (ISO format).
-         *
-         * Transforms created before 7.11 write dates as epoch_millis. The new default is ISO string.
-         * You can use this setter to configure the old style writing as epoch millis.
+         * Whether to write interim results in transform checkpoints.
          *
          * An explicit `null` resets to default.
          *

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/transform/transforms/SettingsConfigTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/transform/transforms/SettingsConfigTests.java
@@ -30,6 +30,7 @@ public class SettingsConfigTests extends AbstractXContentTestCase<SettingsConfig
         return new SettingsConfig(
             randomBoolean() ? null : randomIntBetween(10, 10_000),
             randomBoolean() ? null : randomFloat(),
+            randomBoolean() ? null : randomIntBetween(-1, 1),
             randomBoolean() ? null : randomIntBetween(-1, 1)
         );
     }
@@ -72,6 +73,7 @@ public class SettingsConfigTests extends AbstractXContentTestCase<SettingsConfig
         assertThat(settingsAsMap.getOrDefault("max_page_search_size", "not_set"), equalTo("not_set"));
         assertNull(settingsAsMap.getOrDefault("docs_per_second", "not_set"));
         assertThat(settingsAsMap.getOrDefault("dates_as_epoch_millis", "not_set"), equalTo("not_set"));
+        assertThat(settingsAsMap.getOrDefault("interim_results", "not_set"), equalTo("not_set"));
 
         config = fromString("{\"dates_as_epoch_millis\" : null}");
         assertFalse(config.getDatesAsEpochMillis());
@@ -80,6 +82,16 @@ public class SettingsConfigTests extends AbstractXContentTestCase<SettingsConfig
         assertThat(settingsAsMap.getOrDefault("max_page_search_size", "not_set"), equalTo("not_set"));
         assertThat(settingsAsMap.getOrDefault("docs_per_second", "not_set"), equalTo("not_set"));
         assertNull(settingsAsMap.getOrDefault("dates_as_epoch_millis", "not_set"));
+        assertThat(settingsAsMap.getOrDefault("interim_results", "not_set"), equalTo("not_set"));
+
+        config = fromString("{\"interim_results\" : null}");
+        assertFalse(config.getInterimResults());
+
+        settingsAsMap = xContentToMap(config);
+        assertThat(settingsAsMap.getOrDefault("max_page_search_size", "not_set"), equalTo("not_set"));
+        assertThat(settingsAsMap.getOrDefault("docs_per_second", "not_set"), equalTo("not_set"));
+        assertThat(settingsAsMap.getOrDefault("dates_as_epoch_millis", "not_set"), equalTo("not_set"));
+        assertNull(settingsAsMap.getOrDefault("interim_results", "not_set"));
     }
 
     public void testExplicitNullOnWriteBuilder() throws IOException {
@@ -91,10 +103,12 @@ public class SettingsConfigTests extends AbstractXContentTestCase<SettingsConfig
         assertNull(settingsAsMap.getOrDefault("max_page_search_size", "not_set"));
         assertThat(settingsAsMap.getOrDefault("docs_per_second", "not_set"), equalTo("not_set"));
         assertThat(settingsAsMap.getOrDefault("dates_as_epoch_millis", "not_set"), equalTo("not_set"));
+        assertThat(settingsAsMap.getOrDefault("interim_results", "not_set"), equalTo("not_set"));
 
         SettingsConfig emptyConfig = new SettingsConfig.Builder().build();
         assertNull(emptyConfig.getMaxPageSearchSize());
         assertNull(emptyConfig.getDatesAsEpochMillis());
+        assertNull(emptyConfig.getInterimResults());
 
         settingsAsMap = xContentToMap(emptyConfig);
         assertTrue(settingsAsMap.isEmpty());
@@ -106,6 +120,7 @@ public class SettingsConfigTests extends AbstractXContentTestCase<SettingsConfig
         assertThat(settingsAsMap.getOrDefault("max_page_search_size", "not_set"), equalTo("not_set"));
         assertNull(settingsAsMap.getOrDefault("docs_per_second", "not_set"));
         assertThat(settingsAsMap.getOrDefault("dates_as_epoch_millis", "not_set"), equalTo("not_set"));
+        assertThat(settingsAsMap.getOrDefault("interim_results", "not_set"), equalTo("not_set"));
 
         config = new SettingsConfig.Builder().setDatesAsEpochMillis(null).build();
         // returns false, however it's `null` as in "use default", checked next
@@ -115,6 +130,17 @@ public class SettingsConfigTests extends AbstractXContentTestCase<SettingsConfig
         assertThat(settingsAsMap.getOrDefault("max_page_search_size", "not_set"), equalTo("not_set"));
         assertThat(settingsAsMap.getOrDefault("docs_per_second", "not_set"), equalTo("not_set"));
         assertNull(settingsAsMap.getOrDefault("dates_as_epoch_millis", "not_set"));
+        assertThat(settingsAsMap.getOrDefault("interim_results", "not_set"), equalTo("not_set"));
+
+        config = new SettingsConfig.Builder().setInterimResults(null).build();
+        // returns false, however it's `null` as in "use default", checked next
+        assertFalse(config.getInterimResults());
+
+        settingsAsMap = xContentToMap(config);
+        assertThat(settingsAsMap.getOrDefault("max_page_search_size", "not_set"), equalTo("not_set"));
+        assertThat(settingsAsMap.getOrDefault("docs_per_second", "not_set"), equalTo("not_set"));
+        assertThat(settingsAsMap.getOrDefault("dates_as_epoch_millis", "not_set"), equalTo("not_set"));
+        assertNull(settingsAsMap.getOrDefault("interim_results", "not_set"));
     }
 
     private Map<String, Object> xContentToMap(ToXContent xcontent) throws IOException {

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/transform/transforms/hlrc/SettingsConfigTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/transform/transforms/hlrc/SettingsConfigTests.java
@@ -23,6 +23,7 @@ public class SettingsConfigTests extends AbstractResponseTestCase<
         return new org.elasticsearch.xpack.core.transform.transforms.SettingsConfig(
             randomBoolean() ? null : randomIntBetween(10, 10_000),
             randomBoolean() ? null : randomFloat(),
+            randomBoolean() ? null : randomIntBetween(0, 1),
             randomBoolean() ? null : randomIntBetween(0, 1)
         );
     }
@@ -34,6 +35,7 @@ public class SettingsConfigTests extends AbstractResponseTestCase<
         assertEquals(serverTestInstance.getMaxPageSearchSize(), clientInstance.getMaxPageSearchSize());
         assertEquals(serverTestInstance.getDocsPerSecond(), clientInstance.getDocsPerSecond());
         assertEquals(serverTestInstance.getDatesAsEpochMillis(), clientInstance.getDatesAsEpochMillis());
+        assertEquals(serverTestInstance.getInterimResults(), clientInstance.getInterimResults());
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/TransformField.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/TransformField.java
@@ -37,6 +37,7 @@ public final class TransformField {
     public static final ParseField MAX_PAGE_SEARCH_SIZE = new ParseField("max_page_search_size");
     public static final ParseField DOCS_PER_SECOND = new ParseField("docs_per_second");
     public static final ParseField DATES_AS_EPOCH_MILLIS = new ParseField("dates_as_epoch_millis");
+    public static final ParseField INTERIM_RESULTS = new ParseField("interim_results");
     public static final ParseField FIELD = new ParseField("field");
     public static final ParseField SYNC = new ParseField("sync");
     public static final ParseField TIME = new ParseField("time");

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/transforms/SettingsConfig.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/transforms/SettingsConfig.java
@@ -34,12 +34,13 @@ public class SettingsConfig implements Writeable, ToXContentObject {
     private static final int DEFAULT_MAX_PAGE_SEARCH_SIZE = -1;
     private static final float DEFAULT_DOCS_PER_SECOND = -1F;
     private static final int DEFAULT_DATES_AS_EPOCH_MILLIS = -1;
+    private static final int DEFAULT_INTERIM_RESULTS = -1;
 
     private static ConstructingObjectParser<SettingsConfig, Void> createParser(boolean lenient) {
         ConstructingObjectParser<SettingsConfig, Void> parser = new ConstructingObjectParser<>(
             "transform_config_settings",
             lenient,
-            args -> new SettingsConfig((Integer) args[0], (Float) args[1], (Integer) args[2])
+            args -> new SettingsConfig((Integer) args[0], (Float) args[1], (Integer) args[2], (Integer) args[3])
         );
         parser.declareIntOrNull(optionalConstructorArg(), DEFAULT_MAX_PAGE_SEARCH_SIZE, TransformField.MAX_PAGE_SEARCH_SIZE);
         parser.declareFloatOrNull(optionalConstructorArg(), DEFAULT_DOCS_PER_SECOND, TransformField.DOCS_PER_SECOND);
@@ -50,25 +51,39 @@ public class SettingsConfig implements Writeable, ToXContentObject {
             TransformField.DATES_AS_EPOCH_MILLIS,
             ValueType.BOOLEAN_OR_NULL
         );
+        // this boolean requires 4 possible values: true, false, not_specified, default, therefore using a custom parser
+        parser.declareField(
+            optionalConstructorArg(),
+            p -> p.currentToken() == XContentParser.Token.VALUE_NULL ? DEFAULT_INTERIM_RESULTS : p.booleanValue() ? 1 : 0,
+            TransformField.INTERIM_RESULTS,
+            ValueType.BOOLEAN_OR_NULL
+        );
         return parser;
     }
 
     private final Integer maxPageSearchSize;
     private final Float docsPerSecond;
     private final Integer datesAsEpochMillis;
+    private final Integer interimResults;
 
     public SettingsConfig() {
-        this(null, null, (Integer) null);
+        this(null, null, (Integer) null, (Integer) null);
     }
 
-    public SettingsConfig(Integer maxPageSearchSize, Float docsPerSecond, Boolean datesAsEpochMillis) {
-        this(maxPageSearchSize, docsPerSecond, datesAsEpochMillis == null ? null : datesAsEpochMillis ? 1 : 0);
+    public SettingsConfig(Integer maxPageSearchSize, Float docsPerSecond, Boolean datesAsEpochMillis, Boolean interimResults) {
+        this(
+            maxPageSearchSize,
+            docsPerSecond,
+            datesAsEpochMillis == null ? null : datesAsEpochMillis ? 1 : 0,
+            interimResults == null ? null : interimResults ? 1 : 0
+        );
     }
 
-    public SettingsConfig(Integer maxPageSearchSize, Float docsPerSecond, Integer datesAsEpochMillis) {
+    public SettingsConfig(Integer maxPageSearchSize, Float docsPerSecond, Integer datesAsEpochMillis, Integer interimResults) {
         this.maxPageSearchSize = maxPageSearchSize;
         this.docsPerSecond = docsPerSecond;
         this.datesAsEpochMillis = datesAsEpochMillis;
+        this.interimResults = interimResults;
     }
 
     public SettingsConfig(final StreamInput in) throws IOException {
@@ -78,6 +93,11 @@ public class SettingsConfig implements Writeable, ToXContentObject {
             this.datesAsEpochMillis = in.readOptionalInt();
         } else {
             this.datesAsEpochMillis = DEFAULT_DATES_AS_EPOCH_MILLIS;
+        }
+        if (in.getVersion().onOrAfter(Version.CURRENT)) {  // TODO: 7.15
+            this.interimResults = in.readOptionalInt();
+        } else {
+            this.interimResults = DEFAULT_INTERIM_RESULTS;
         }
     }
 
@@ -95,6 +115,14 @@ public class SettingsConfig implements Writeable, ToXContentObject {
 
     public Integer getDatesAsEpochMillisForUpdate() {
         return datesAsEpochMillis;
+    }
+
+    public Boolean getInterimResults() {
+        return interimResults != null ? interimResults > 0 : null;
+    }
+
+    public Integer getInterimResultsForUpdate() {
+        return interimResults;
     }
 
     public ActionRequestValidationException validate(ActionRequestValidationException validationException) {
@@ -118,6 +146,9 @@ public class SettingsConfig implements Writeable, ToXContentObject {
         if (out.getVersion().onOrAfter(Version.V_7_11_0)) {
             out.writeOptionalInt(datesAsEpochMillis);
         }
+        if (out.getVersion().onOrAfter(Version.CURRENT)) {  // TODO: 7.15
+            out.writeOptionalInt(interimResults);
+        }
     }
 
     @Override
@@ -132,6 +163,9 @@ public class SettingsConfig implements Writeable, ToXContentObject {
         }
         if (datesAsEpochMillis != null && (datesAsEpochMillis.equals(DEFAULT_DATES_AS_EPOCH_MILLIS) == false)) {
             builder.field(TransformField.DATES_AS_EPOCH_MILLIS.getPreferredName(), datesAsEpochMillis > 0 ? true : false);
+        }
+        if (interimResults != null && (interimResults.equals(DEFAULT_INTERIM_RESULTS) == false)) {
+            builder.field(TransformField.INTERIM_RESULTS.getPreferredName(), interimResults > 0 ? true : false);
         }
         builder.endObject();
         return builder;
@@ -149,12 +183,13 @@ public class SettingsConfig implements Writeable, ToXContentObject {
         SettingsConfig that = (SettingsConfig) other;
         return Objects.equals(maxPageSearchSize, that.maxPageSearchSize)
             && Objects.equals(docsPerSecond, that.docsPerSecond)
-            && Objects.equals(datesAsEpochMillis, that.datesAsEpochMillis);
+            && Objects.equals(datesAsEpochMillis, that.datesAsEpochMillis)
+            && Objects.equals(interimResults, that.interimResults);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(maxPageSearchSize, docsPerSecond, datesAsEpochMillis);
+        return Objects.hash(maxPageSearchSize, docsPerSecond, datesAsEpochMillis, interimResults);
     }
 
     @Override
@@ -170,6 +205,7 @@ public class SettingsConfig implements Writeable, ToXContentObject {
         private Integer maxPageSearchSize;
         private Float docsPerSecond;
         private Integer datesAsEpochMillis;
+        private Integer interimResults;
 
         /**
          * Default builder
@@ -185,6 +221,7 @@ public class SettingsConfig implements Writeable, ToXContentObject {
             this.maxPageSearchSize = base.maxPageSearchSize;
             this.docsPerSecond = base.docsPerSecond;
             this.datesAsEpochMillis = base.datesAsEpochMillis;
+            this.interimResults = base.interimResults;
         }
 
         /**
@@ -232,6 +269,19 @@ public class SettingsConfig implements Writeable, ToXContentObject {
         }
 
         /**
+         * TODO: Comment
+         *
+         * An explicit `null` resets to default.
+         *
+         * @param interimResults true if TODO
+         * @return the {@link Builder} with interimResults set.
+         */
+        public Builder setInterimResults(Boolean interimResults) {
+            this.interimResults = interimResults == null ? DEFAULT_INTERIM_RESULTS : interimResults ? 1 : 0;
+            return this;
+        }
+
+        /**
          * Update settings according to given settings config.
          *
          * @param update update settings
@@ -253,12 +303,17 @@ public class SettingsConfig implements Writeable, ToXContentObject {
                     ? null
                     : update.getDatesAsEpochMillisForUpdate();
             }
+            if (update.getInterimResultsForUpdate() != null)  {
+                this.interimResults = update.getInterimResultsForUpdate().equals(DEFAULT_INTERIM_RESULTS)
+                    ? null
+                    : update.getInterimResultsForUpdate();
+            }
 
             return this;
         }
 
         public SettingsConfig build() {
-            return new SettingsConfig(maxPageSearchSize, docsPerSecond, datesAsEpochMillis);
+            return new SettingsConfig(maxPageSearchSize, docsPerSecond, datesAsEpochMillis, interimResults);
         }
     }
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/transforms/SettingsConfig.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/transforms/SettingsConfig.java
@@ -269,11 +269,11 @@ public class SettingsConfig implements Writeable, ToXContentObject {
         }
 
         /**
-         * TODO: Comment
+         * Whether to write interim results in transform checkpoints.
          *
          * An explicit `null` resets to default.
          *
-         * @param interimResults true if TODO
+         * @param interimResults true if interim results should be written.
          * @return the {@link Builder} with interimResults set.
          */
         public Builder setInterimResults(Boolean interimResults) {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/transforms/TransformCheckpoint.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/transforms/TransformCheckpoint.java
@@ -8,12 +8,12 @@
 package org.elasticsearch.xpack.core.transform.transforms;
 
 import org.elasticsearch.ElasticsearchParseException;
-import org.elasticsearch.common.xcontent.ParseField;
 import org.elasticsearch.common.ParsingException;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.xcontent.ConstructingObjectParser;
+import org.elasticsearch.common.xcontent.ParseField;
 import org.elasticsearch.common.xcontent.ToXContentObject;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/transforms/TransformConfig.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/transforms/TransformConfig.java
@@ -538,7 +538,8 @@ public class TransformConfig extends AbstractDiffable<TransformConfig> implement
                 new SettingsConfig(
                     maxPageSearchSize,
                     builder.getSettings().getDocsPerSecond(),
-                    builder.getSettings().getDatesAsEpochMillis()
+                    builder.getSettings().getDatesAsEpochMillis(),
+                    builder.getSettings().getInterimResults()
                 )
             );
         }
@@ -546,7 +547,22 @@ public class TransformConfig extends AbstractDiffable<TransformConfig> implement
         // 2. set dates_as_epoch_millis to true for transforms < 7.11 to keep BWC
         if (builder.getVersion() != null && builder.getVersion().before(Version.V_7_11_0)) {
             builder.setSettings(
-                new SettingsConfig(builder.getSettings().getMaxPageSearchSize(), builder.getSettings().getDocsPerSecond(), true)
+                new SettingsConfig(
+                    builder.getSettings().getMaxPageSearchSize(),
+                    builder.getSettings().getDocsPerSecond(),
+                    true,
+                    builder.getSettings().getInterimResults())
+            );
+        }
+
+        // 3. set interim_results to true for transforms < 7.15 to keep BWC
+        if (builder.getVersion() != null && builder.getVersion().before(Version.CURRENT)) {  // TODO: 7.15
+            builder.setSettings(
+                new SettingsConfig(
+                    builder.getSettings().getMaxPageSearchSize(),
+                    builder.getSettings().getDocsPerSecond(),
+                    builder.getSettings().getDatesAsEpochMillis(),
+                    true)
             );
         }
 

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/transform/transforms/SettingsConfigTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/transform/transforms/SettingsConfigTests.java
@@ -33,12 +33,13 @@ public class SettingsConfigTests extends AbstractSerializingTransformTestCase<Se
         return new SettingsConfig(
             randomBoolean() ? null : randomIntBetween(10, 10_000),
             randomBoolean() ? null : randomFloat(),
+            randomBoolean() ? null : randomIntBetween(0, 1),
             randomBoolean() ? null : randomIntBetween(0, 1)
         );
     }
 
     public static SettingsConfig randomNonEmptySettingsConfig() {
-        return new SettingsConfig(randomIntBetween(10, 10_000), randomFloat(), randomIntBetween(0, 1));
+        return new SettingsConfig(randomIntBetween(10, 10_000), randomFloat(), randomIntBetween(0, 1), randomIntBetween(0, 1));
     }
 
     @Before
@@ -78,6 +79,9 @@ public class SettingsConfigTests extends AbstractSerializingTransformTestCase<Se
 
         assertThat(fromString("{\"dates_as_epoch_millis\" : null}").getDatesAsEpochMillisForUpdate(), equalTo(-1));
         assertNull(fromString("{}").getDatesAsEpochMillisForUpdate());
+
+        assertThat(fromString("{\"interim_results\" : null}").getInterimResultsForUpdate(), equalTo(-1));
+        assertNull(fromString("{}").getInterimResultsForUpdate());
     }
 
     public void testUpdateUsingBuilder() throws IOException {

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/transform/transforms/TransformConfigUpdateTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/transform/transforms/TransformConfigUpdateTests.java
@@ -150,37 +150,38 @@ public class TransformConfigUpdateTests extends AbstractWireSerializingTransform
             randomBoolean() ? null : Version.V_7_2_0.toString()
         );
 
-        TransformConfigUpdate update = new TransformConfigUpdate(
-            null,
-            null,
-            null,
-            null,
-            null,
-            new SettingsConfig(4_000, null, (Boolean) null, null),
-            null
-        );
+        TransformConfigUpdate update =
+            new TransformConfigUpdate(null, null, null, null, null, new SettingsConfig(4_000, null, (Boolean) null, null), null);
         TransformConfig updatedConfig = update.apply(config);
 
         // for settings we allow partial updates, so changing 1 setting should not overwrite the other
         // the parser handles explicit nulls, tested in @link{SettingsConfigTests}
         assertThat(updatedConfig.getSettings().getMaxPageSearchSize(), equalTo(4_000));
         assertThat(updatedConfig.getSettings().getDocsPerSecond(), equalTo(config.getSettings().getDocsPerSecond()));
+        assertThat(updatedConfig.getSettings().getDatesAsEpochMillis(), equalTo(config.getSettings().getDatesAsEpochMillis()));
+        assertThat(updatedConfig.getSettings().getInterimResults(), equalTo(config.getSettings().getInterimResults()));
 
         update = new TransformConfigUpdate(null, null, null, null, null, new SettingsConfig(null, 43.244F, (Boolean) null, null), null);
         updatedConfig = update.apply(updatedConfig);
         assertThat(updatedConfig.getSettings().getMaxPageSearchSize(), equalTo(4_000));
         assertThat(updatedConfig.getSettings().getDocsPerSecond(), equalTo(43.244F));
+        assertThat(updatedConfig.getSettings().getDatesAsEpochMillis(), equalTo(config.getSettings().getDatesAsEpochMillis()));
+        assertThat(updatedConfig.getSettings().getInterimResults(), equalTo(config.getSettings().getInterimResults()));
 
         // now reset to default using the magic -1
         update = new TransformConfigUpdate(null, null, null, null, null, new SettingsConfig(-1, null, (Boolean) null, null), null);
         updatedConfig = update.apply(updatedConfig);
         assertNull(updatedConfig.getSettings().getMaxPageSearchSize());
         assertThat(updatedConfig.getSettings().getDocsPerSecond(), equalTo(43.244F));
+        assertThat(updatedConfig.getSettings().getDatesAsEpochMillis(), equalTo(config.getSettings().getDatesAsEpochMillis()));
+        assertThat(updatedConfig.getSettings().getInterimResults(), equalTo(config.getSettings().getInterimResults()));
 
         update = new TransformConfigUpdate(null, null, null, null, null, new SettingsConfig(-1, -1F, (Boolean) null, null), null);
         updatedConfig = update.apply(updatedConfig);
         assertNull(updatedConfig.getSettings().getMaxPageSearchSize());
         assertNull(updatedConfig.getSettings().getDocsPerSecond());
+        assertThat(updatedConfig.getSettings().getDatesAsEpochMillis(), equalTo(config.getSettings().getDatesAsEpochMillis()));
+        assertThat(updatedConfig.getSettings().getInterimResults(), equalTo(config.getSettings().getInterimResults()));
     }
 
     public void testApplyWithSyncChange() {

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/transform/transforms/TransformConfigUpdateTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/transform/transforms/TransformConfigUpdateTests.java
@@ -106,7 +106,7 @@ public class TransformConfigUpdateTests extends AbstractWireSerializingTransform
         TimeValue frequency = TimeValue.timeValueSeconds(10);
         SyncConfig syncConfig = new TimeSyncConfig("time_field", TimeValue.timeValueSeconds(30));
         String newDescription = "new description";
-        SettingsConfig settings = new SettingsConfig(4_000, 4_000.400F, true);
+        SettingsConfig settings = new SettingsConfig(4_000, 4_000.400F, true, true);
         RetentionPolicyConfig retentionPolicyConfig = new TimeRetentionPolicyConfig("time_field", new TimeValue(60_000));
         update = new TransformConfigUpdate(
             sourceConfig,
@@ -156,7 +156,7 @@ public class TransformConfigUpdateTests extends AbstractWireSerializingTransform
             null,
             null,
             null,
-            new SettingsConfig(4_000, null, (Boolean) null),
+            new SettingsConfig(4_000, null, (Boolean) null, null),
             null
         );
         TransformConfig updatedConfig = update.apply(config);
@@ -166,18 +166,18 @@ public class TransformConfigUpdateTests extends AbstractWireSerializingTransform
         assertThat(updatedConfig.getSettings().getMaxPageSearchSize(), equalTo(4_000));
         assertThat(updatedConfig.getSettings().getDocsPerSecond(), equalTo(config.getSettings().getDocsPerSecond()));
 
-        update = new TransformConfigUpdate(null, null, null, null, null, new SettingsConfig(null, 43.244F, (Boolean) null), null);
+        update = new TransformConfigUpdate(null, null, null, null, null, new SettingsConfig(null, 43.244F, (Boolean) null, null), null);
         updatedConfig = update.apply(updatedConfig);
         assertThat(updatedConfig.getSettings().getMaxPageSearchSize(), equalTo(4_000));
         assertThat(updatedConfig.getSettings().getDocsPerSecond(), equalTo(43.244F));
 
         // now reset to default using the magic -1
-        update = new TransformConfigUpdate(null, null, null, null, null, new SettingsConfig(-1, null, (Boolean) null), null);
+        update = new TransformConfigUpdate(null, null, null, null, null, new SettingsConfig(-1, null, (Boolean) null, null), null);
         updatedConfig = update.apply(updatedConfig);
         assertNull(updatedConfig.getSettings().getMaxPageSearchSize());
         assertThat(updatedConfig.getSettings().getDocsPerSecond(), equalTo(43.244F));
 
-        update = new TransformConfigUpdate(null, null, null, null, null, new SettingsConfig(-1, -1F, (Boolean) null), null);
+        update = new TransformConfigUpdate(null, null, null, null, null, new SettingsConfig(-1, -1F, (Boolean) null, null), null);
         updatedConfig = update.apply(updatedConfig);
         assertNull(updatedConfig.getSettings().getMaxPageSearchSize());
         assertNull(updatedConfig.getSettings().getDocsPerSecond());

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/transform/transforms/pivot/GroupConfigTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/transform/transforms/pivot/GroupConfigTests.java
@@ -66,7 +66,7 @@ public class GroupConfigTests extends AbstractSerializingTestCase<GroupConfig> {
         return new GroupConfig(source, groups);
     }
 
-    private static SingleGroupSource randomSingleGroupSource(Version version) {
+    public static SingleGroupSource randomSingleGroupSource(Version version) {
         Type type = randomFrom(SingleGroupSource.Type.values());
         switch (type) {
             case TERMS:

--- a/x-pack/plugin/core/src/test/resources/rest-api-spec/schema/transform_config.schema.json
+++ b/x-pack/plugin/core/src/test/resources/rest-api-spec/schema/transform_config.schema.json
@@ -180,6 +180,12 @@
           "title": "docs per second",
           "type": "number"
         },
+        "interim_results": {
+          "$id": "#root/settings/interim_results",
+          "title": "interim results",
+          "type": "boolean",
+          "default": false
+        },
         "max_page_search_size": {
           "$id": "#root/settings/max_page_search_size",
           "title": "max page search size",

--- a/x-pack/plugin/transform/src/internalClusterTest/java/org/elasticsearch/xpack/transform/checkpoint/TransformCheckpointServiceNodeTests.java
+++ b/x-pack/plugin/transform/src/internalClusterTest/java/org/elasticsearch/xpack/transform/checkpoint/TransformCheckpointServiceNodeTests.java
@@ -59,6 +59,7 @@ import org.junit.AfterClass;
 import org.junit.Before;
 
 import java.nio.file.Path;
+import java.time.Clock;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -143,6 +144,7 @@ public class TransformCheckpointServiceNodeTests extends TransformSingleNodeTest
         // use a mock for the checkpoint service
         TransformAuditor mockAuditor = mock(TransformAuditor.class);
         transformCheckpointService = new TransformCheckpointService(
+            Clock.systemUTC(),
             Settings.EMPTY,
             new ClusterService(Settings.EMPTY, new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS), null),
             transformsConfigManager,

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/Transform.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/Transform.java
@@ -264,7 +264,8 @@ public class Transform extends Plugin implements SystemIndexPlugin, PersistentTa
     ) {
         TransformConfigManager configManager = new IndexBasedTransformConfigManager(client, xContentRegistry);
         TransformAuditor auditor = new TransformAuditor(client, clusterService.getNodeName(), clusterService);
-        TransformCheckpointService checkpointService = new TransformCheckpointService(settings, clusterService, configManager, auditor);
+        TransformCheckpointService checkpointService =
+            new TransformCheckpointService(Clock.systemUTC(), settings, clusterService, configManager, auditor);
         SchedulerEngine scheduler = new SchedulerEngine(settings, Clock.systemUTC());
 
         transformServices.set(new TransformServices(configManager, checkpointService, auditor, scheduler));

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/checkpoint/RemoteClusterResolver.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/checkpoint/RemoteClusterResolver.java
@@ -33,15 +33,15 @@ class RemoteClusterResolver extends RemoteClusterAware {
             this.remoteIndicesPerClusterAlias = remoteIndicesPerClusterAlias;
         }
 
-        public Map<String, List<String>> getRemoteIndicesPerClusterAlias() {
+        Map<String, List<String>> getRemoteIndicesPerClusterAlias() {
             return remoteIndicesPerClusterAlias;
         }
 
-        public List<String> getLocalIndices() {
+        List<String> getLocalIndices() {
             return localIndices;
         }
 
-        public int numClusters() {
+        int numClusters() {
             return remoteIndicesPerClusterAlias.size() + (localIndices.isEmpty() ? 0 : 1);
         }
     }

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/checkpoint/TimeBasedCheckpointProvider.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/checkpoint/TimeBasedCheckpointProvider.java
@@ -123,11 +123,10 @@ class TimeBasedCheckpointProvider extends DefaultCheckpointProvider {
             return timestamp;
         }
         Map.Entry<String, SingleGroupSource> topLevelGroupEntry = groups.entrySet().iterator().next();
-        if (topLevelGroupEntry.getValue() instanceof DateHistogramGroupSource) {
-            DateHistogramGroupSource dateHistogramGroupSource = (DateHistogramGroupSource) topLevelGroupEntry.getValue();
-            long interval = dateHistogramGroupSource.getInterval().getInterval().estimateMillis();
-            timestamp -= timestamp % interval;
+        if ((topLevelGroupEntry.getValue() instanceof DateHistogramGroupSource) == false) {
+            return timestamp;
         }
-        return timestamp;
+        DateHistogramGroupSource dateHistogramGroupSource = (DateHistogramGroupSource) topLevelGroupEntry.getValue();
+        return dateHistogramGroupSource.getRounding().round(timestamp);
     }
 }

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/checkpoint/TimeBasedCheckpointProvider.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/checkpoint/TimeBasedCheckpointProvider.java
@@ -27,6 +27,7 @@ import org.elasticsearch.xpack.transform.notifications.TransformAuditor;
 import org.elasticsearch.xpack.transform.persistence.TransformConfigManager;
 
 import java.time.Clock;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Function;
 import java.util.Map;
@@ -136,7 +137,7 @@ class TimeBasedCheckpointProvider extends DefaultCheckpointProvider {
             groups.values().stream()
                 .filter(DateHistogramGroupSource.class::isInstance)
                 .map(DateHistogramGroupSource.class::cast)
-                .filter(group -> group.getField().equals(transformConfig.getSyncConfig().getField()))
+                .filter(group -> Objects.equals(group.getField(), transformConfig.getSyncConfig().getField()))
                 .findFirst();
         if (dateHistogramGroupSource.isEmpty()) {
             return identity();

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/checkpoint/TimeBasedCheckpointProvider.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/checkpoint/TimeBasedCheckpointProvider.java
@@ -112,6 +112,9 @@ class TimeBasedCheckpointProvider extends DefaultCheckpointProvider {
      * @return timestamp aligned with date histogram interval
      */
     private static long alignTimestamp(long timestamp, TransformConfig transformConfig) {
+        if (Boolean.FALSE.equals(transformConfig.getSettings().getInterimResults()) == false) {
+            return timestamp;
+        }
         if (transformConfig.getPivotConfig() == null) {
             return timestamp;
         }

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/checkpoint/DefaultCheckpointProviderTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/checkpoint/DefaultCheckpointProviderTests.java
@@ -225,6 +225,7 @@ public class DefaultCheckpointProviderTests extends ESTestCase {
         doAnswer(withResponse(indicesStatsResponse)).when(client).execute(eq(IndicesStatsAction.INSTANCE), any(), any());
 
         DefaultCheckpointProvider provider = new DefaultCheckpointProvider(
+            clock,
             client,
             remoteClusterResolver,
             transformConfigManager,

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/checkpoint/TimeBasedCheckpointProviderTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/checkpoint/TimeBasedCheckpointProviderTests.java
@@ -271,7 +271,7 @@ public class TimeBasedCheckpointProviderTests extends ESTestCase {
             null,
             false,
             new DateHistogramGroupSource.FixedInterval(new DateHistogramInterval(dateHistogramInterval.getStringRep())),
-            randomBoolean() ? randomZone() : null
+            null
         );
         Supplier<SingleGroupSource> singleGroupSourceSupplier =
             new Supplier<>() {

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/checkpoint/TimeBasedCheckpointProviderTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/checkpoint/TimeBasedCheckpointProviderTests.java
@@ -35,6 +35,7 @@ import org.elasticsearch.search.SearchHits;
 import org.elasticsearch.search.aggregations.bucket.histogram.DateHistogramInterval;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.xpack.core.transform.transforms.SettingsConfig;
 import org.elasticsearch.xpack.core.transform.transforms.TimeSyncConfig;
 import org.elasticsearch.xpack.core.transform.transforms.TransformCheckpoint;
 import org.elasticsearch.xpack.core.transform.transforms.TransformConfig;
@@ -264,6 +265,7 @@ public class TimeBasedCheckpointProviderTests extends ESTestCase {
                 null // deprecated
             );
         return new TransformConfig.Builder(TransformConfigTests.randomTransformConfig(transformId))
+            .setSettings(new SettingsConfig.Builder().setInterimResults(false).build())
             .setPivotConfig(pivotConfigWithDateHistogramSource)
             .setSyncConfig(new TimeSyncConfig("@timestamp", delay))
             .build();

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/checkpoint/TimeBasedCheckpointProviderTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/checkpoint/TimeBasedCheckpointProviderTests.java
@@ -1,0 +1,301 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.transform.checkpoint;
+
+import org.apache.lucene.search.TotalHits;
+import org.apache.lucene.util.SetOnce;
+import org.elasticsearch.Version;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.LatchedActionListener;
+import org.elasticsearch.action.admin.indices.get.GetIndexAction;
+import org.elasticsearch.action.admin.indices.get.GetIndexResponse;
+import org.elasticsearch.action.admin.indices.stats.IndicesStatsAction;
+import org.elasticsearch.action.admin.indices.stats.IndicesStatsResponse;
+import org.elasticsearch.action.admin.indices.stats.ShardStats;
+import org.elasticsearch.action.search.SearchAction;
+import org.elasticsearch.action.search.SearchRequest;
+import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.action.search.SearchResponseSections;
+import org.elasticsearch.action.search.ShardSearchFailure;
+import org.elasticsearch.client.Client;
+import org.elasticsearch.common.collect.ImmutableOpenMap;
+import org.elasticsearch.common.settings.ClusterSettings;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.concurrent.ThreadContext;
+import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.core.Tuple;
+import org.elasticsearch.index.query.BoolQueryBuilder;
+import org.elasticsearch.index.query.RangeQueryBuilder;
+import org.elasticsearch.search.SearchHits;
+import org.elasticsearch.search.aggregations.bucket.histogram.DateHistogramInterval;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.xpack.core.transform.transforms.TimeSyncConfig;
+import org.elasticsearch.xpack.core.transform.transforms.TransformCheckpoint;
+import org.elasticsearch.xpack.core.transform.transforms.TransformConfig;
+import org.elasticsearch.xpack.core.transform.transforms.TransformConfigTests;
+import org.elasticsearch.xpack.core.transform.transforms.pivot.AggregationConfigTests;
+import org.elasticsearch.xpack.core.transform.transforms.pivot.DateHistogramGroupSource;
+import org.elasticsearch.xpack.core.transform.transforms.pivot.GroupConfigTests;
+import org.elasticsearch.xpack.core.transform.transforms.pivot.PivotConfig;
+import org.elasticsearch.xpack.core.transform.transforms.pivot.SingleGroupSource;
+import org.elasticsearch.xpack.transform.notifications.MockTransformAuditor;
+import org.elasticsearch.xpack.transform.persistence.IndexBasedTransformConfigManager;
+import org.junit.Before;
+import org.mockito.ArgumentCaptor;
+import org.mockito.stubbing.Answer;
+
+import java.time.Clock;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
+
+import static java.util.Collections.emptyMap;
+import static org.elasticsearch.core.Tuple.tuple;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class TimeBasedCheckpointProviderTests extends ESTestCase {
+
+    private Clock clock;
+    private Client client;
+    private IndexBasedTransformConfigManager transformConfigManager;
+    private MockTransformAuditor transformAuditor;
+
+    @Before
+    public void setUpMocks() {
+        clock = mock(Clock.class);
+        when(clock.millis()).thenReturn(123456789L);
+        client = mock(Client.class);
+        ThreadPool threadPool = mock(ThreadPool.class);
+        when(threadPool.getThreadContext()).thenReturn(new ThreadContext(Settings.EMPTY));
+        when(client.threadPool()).thenReturn(threadPool);
+        transformConfigManager = mock(IndexBasedTransformConfigManager.class);
+        transformAuditor = MockTransformAuditor.createMockAuditor();
+    }
+
+    public void testSourceHasChanged_NotChanged() throws InterruptedException {
+        testSourceHasChanged(
+            0,
+            false,
+            TransformCheckpoint.EMPTY,
+            TimeValue.timeValueMinutes(10),
+            TimeValue.ZERO,
+            tuple(0L, 123000000L));
+    }
+
+    public void testSourceHasChanged_Changed() throws InterruptedException {
+        testSourceHasChanged(
+            1,
+            true,
+            TransformCheckpoint.EMPTY,
+            TimeValue.timeValueMinutes(10),
+            TimeValue.ZERO,
+            tuple(0L, 123000000L)
+        );
+    }
+
+    public void testSourceHasChanged_UnfinishedCheckpoint() throws InterruptedException {
+        testSourceHasChanged(
+            0,
+            false,
+            new TransformCheckpoint("", 100000000L, 7, emptyMap(), null),
+            TimeValue.timeValueMinutes(10),
+            TimeValue.ZERO,
+            tuple(0L, 123000000L)
+        );
+    }
+
+    public void testSourceHasChanged_SubsequentCheckpoint() throws InterruptedException {
+        testSourceHasChanged(
+            0,
+            false,
+            new TransformCheckpoint("", 100000000L, 7, emptyMap(), 120000000L),
+            TimeValue.timeValueMinutes(10),
+            TimeValue.ZERO,
+            tuple(120000000L, 123000000L)
+        );
+    }
+
+    public void testSourceHasChanged_WithDelay() throws InterruptedException {
+        testSourceHasChanged(
+            0,
+            false,
+            new TransformCheckpoint("", 100000000L, 7, emptyMap(), 120000000L),
+            TimeValue.timeValueMinutes(10),
+            TimeValue.timeValueMinutes(5),
+            tuple(120000000L, 122700000L)  // 122700000L = 123456789 - 123456789 % (10*60*1000) - (5*60*1000)
+        );
+    }
+
+    private void testSourceHasChanged(long totalHits,
+                                      boolean expectedHasChangedValue,
+                                      TransformCheckpoint lastCheckpoint,
+                                      TimeValue dateHistogramInterval,
+                                      TimeValue delay,
+                                      Tuple<Long, Long> expectedRangeQueryBounds) throws InterruptedException {
+        doAnswer(withResponse(newSearchResponse(totalHits))).when(client).execute(eq(SearchAction.INSTANCE), any(), any());
+        String transformId = getTestName();
+        TransformConfig transformConfig = newTransformConfigWithTopLevelDateHistogram(transformId, dateHistogramInterval, delay);
+        TimeBasedCheckpointProvider provider = newCheckpointProvider(transformConfig);
+
+        SetOnce<Boolean> hasChangedHolder = new SetOnce<>();
+        SetOnce<Exception> exceptionHolder = new SetOnce<>();
+        CountDownLatch latch = new CountDownLatch(1);
+        provider.sourceHasChanged(
+            lastCheckpoint,
+            new LatchedActionListener<>(ActionListener.wrap(hasChangedHolder::set, exceptionHolder::set), latch)
+        );
+        assertThat(latch.await(100, TimeUnit.MILLISECONDS), is(true));
+
+        ArgumentCaptor<SearchRequest> searchRequestArgumentCaptor = ArgumentCaptor.forClass(SearchRequest.class);
+        verify(client).execute(eq(SearchAction.INSTANCE), searchRequestArgumentCaptor.capture(), any());
+        SearchRequest searchRequest = searchRequestArgumentCaptor.getValue();
+        BoolQueryBuilder boolQuery = (BoolQueryBuilder) searchRequest.source().query();
+        RangeQueryBuilder rangeQuery = (RangeQueryBuilder) boolQuery.filter().get(1);
+        assertThat(rangeQuery.from(), is(equalTo(expectedRangeQueryBounds.v1())));
+        assertThat(rangeQuery.to(), is(equalTo(expectedRangeQueryBounds.v2())));
+
+        assertThat(hasChangedHolder.get(), is(equalTo(expectedHasChangedValue)));
+        assertThat(exceptionHolder.get(), is(nullValue()));
+    }
+
+    public void testCreateNextCheckpoint_NoDelay() throws InterruptedException {
+        String transformId = getTestName();
+        testCreateNextCheckpoint(
+            transformId,
+            TimeValue.timeValueMinutes(10),
+            TimeValue.ZERO,
+            new TransformCheckpoint(transformId, 100000000L, 7, emptyMap(), 120000000L),
+            new TransformCheckpoint(transformId, 123000000L, 8, emptyMap(), 123000000L));
+    }
+
+    public void testCreateNextCheckpoint_WithDelay() throws InterruptedException {
+        String transformId = getTestName();
+        testCreateNextCheckpoint(
+            transformId,
+            TimeValue.timeValueMinutes(10),
+            TimeValue.timeValueMinutes(5),
+            new TransformCheckpoint(transformId, 100000000L, 7, emptyMap(), 120000000L),
+            new TransformCheckpoint(transformId, 123000000L, 8, emptyMap(), 122700000L));  // 122700000 = 123000000 - 5*60*1000
+    }
+
+    private void testCreateNextCheckpoint(String transformId,
+                                          TimeValue dateHistogramInterval,
+                                          TimeValue delay,
+                                          TransformCheckpoint lastCheckpoint,
+                                          TransformCheckpoint expectedNextCheckpoint) throws InterruptedException {
+        GetIndexResponse getIndexResponse =
+            new GetIndexResponse(
+                new String[] { "some-index" },
+                ImmutableOpenMap.of(),
+                ImmutableOpenMap.of(),
+                ImmutableOpenMap.of(),
+                ImmutableOpenMap.of(),
+                ImmutableOpenMap.of());
+        doAnswer(withResponse(getIndexResponse)).when(client).execute(eq(GetIndexAction.INSTANCE), any(), any());
+        IndicesStatsResponse indicesStatsResponse = mock(IndicesStatsResponse.class);
+        when(indicesStatsResponse.getShards()).thenReturn(new ShardStats[0]);
+        when(indicesStatsResponse.getFailedShards()).thenReturn(0);
+        doAnswer(withResponse(indicesStatsResponse)).when(client).execute(eq(IndicesStatsAction.INSTANCE), any(), any());
+
+        TransformConfig transformConfig = newTransformConfigWithTopLevelDateHistogram(transformId, dateHistogramInterval, delay);
+        TimeBasedCheckpointProvider provider = newCheckpointProvider(transformConfig);
+
+        SetOnce<TransformCheckpoint> checkpointHolder = new SetOnce<>();
+        SetOnce<Exception> exceptionHolder = new SetOnce<>();
+        CountDownLatch latch = new CountDownLatch(1);
+        provider.createNextCheckpoint(
+            lastCheckpoint,
+            new LatchedActionListener<>(ActionListener.wrap(checkpointHolder::set, exceptionHolder::set), latch)
+        );
+        assertThat(latch.await(100, TimeUnit.MILLISECONDS), is(true));
+        assertThat(checkpointHolder.get(), is(equalTo(expectedNextCheckpoint)));
+        assertThat(exceptionHolder.get(), is(nullValue()));
+    }
+
+    private TimeBasedCheckpointProvider newCheckpointProvider(TransformConfig transformConfig) {
+        return new TimeBasedCheckpointProvider(
+            clock,
+            client,
+            new RemoteClusterResolver(Settings.EMPTY, new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS)),
+            transformConfigManager,
+            transformAuditor,
+            transformConfig
+        );
+    }
+
+    private static TransformConfig newTransformConfigWithTopLevelDateHistogram(String transformId,
+                                                                               TimeValue dateHistogramInterval,
+                                                                               TimeValue delay) {
+        DateHistogramGroupSource dateHistogramGroupSource = new DateHistogramGroupSource(
+            randomAlphaOfLength(10),
+            null,
+            false,
+            new DateHistogramGroupSource.FixedInterval(new DateHistogramInterval(dateHistogramInterval.getStringRep())),
+            randomBoolean() ? randomZone() : null
+        );
+        Supplier<SingleGroupSource> singleGroupSourceSupplier =
+            new Supplier<>() {
+                int groupCount = 0;
+                @Override
+                public SingleGroupSource get() {
+                    return ++groupCount == 1
+                        ? dateHistogramGroupSource
+                        : GroupConfigTests.randomSingleGroupSource(Version.CURRENT);
+                }
+            };
+        PivotConfig pivotConfigWithDateHistogramSource =
+            new PivotConfig(
+                GroupConfigTests.randomGroupConfig(singleGroupSourceSupplier),
+                AggregationConfigTests.randomAggregationConfig(),
+                null // deprecated
+            );
+        return new TransformConfig.Builder(TransformConfigTests.randomTransformConfig(transformId))
+            .setPivotConfig(pivotConfigWithDateHistogramSource)
+            .setSyncConfig(new TimeSyncConfig("@timestamp", delay))
+            .build();
+    }
+
+    private static SearchResponse newSearchResponse(long totalHits) {
+        return new SearchResponse(
+            new SearchResponseSections(
+                new SearchHits(SearchHits.EMPTY, new TotalHits(totalHits, TotalHits.Relation.EQUAL_TO), 0),
+                null,
+                null,
+                false,
+                false,
+                null,
+                0
+            ),
+            null,
+            1,
+            1,
+            0,
+            0,
+            ShardSearchFailure.EMPTY_ARRAY,
+            null
+        );
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <Response> Answer<Response> withResponse(Response response) {
+        return invocationOnMock -> {
+            ActionListener<Response> listener = (ActionListener<Response>) invocationOnMock.getArguments()[2];
+            listener.onResponse(response);
+            return null;
+        };
+    }
+}

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/TransformIndexerFailureHandlingTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/TransformIndexerFailureHandlingTests.java
@@ -309,7 +309,7 @@ public class TransformIndexerFailureHandlingTests extends ESTestCase {
             randomPivotConfig(),
             null,
             randomBoolean() ? null : randomAlphaOfLengthBetween(1, 1000),
-            new SettingsConfig(pageSize, null, (Boolean) null),
+            new SettingsConfig(pageSize, null, (Boolean) null, null),
             null,
             null,
             null
@@ -383,7 +383,7 @@ public class TransformIndexerFailureHandlingTests extends ESTestCase {
             randomPivotConfig(),
             null,
             randomBoolean() ? null : randomAlphaOfLengthBetween(1, 1000),
-            new SettingsConfig(pageSize, null, (Boolean) null),
+            new SettingsConfig(pageSize, null, (Boolean) null, null),
             null,
             null,
             null
@@ -446,7 +446,7 @@ public class TransformIndexerFailureHandlingTests extends ESTestCase {
             randomPivotConfig(),
             null,
             randomBoolean() ? null : randomAlphaOfLengthBetween(1, 1000),
-            new SettingsConfig(pageSize, null, (Boolean) null),
+            new SettingsConfig(pageSize, null, (Boolean) null, null),
             null,
             null,
             null

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/TransformIndexerStateTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/TransformIndexerStateTests.java
@@ -505,7 +505,7 @@ public class TransformIndexerStateTests extends ESTestCase {
             randomPivotConfig(),
             null,
             randomBoolean() ? null : randomAlphaOfLengthBetween(1, 1000),
-            new SettingsConfig(null, Float.valueOf(1.0f), (Boolean) null),
+            new SettingsConfig(null, Float.valueOf(1.0f), (Boolean) null, (Boolean) null),
             null,
             null,
             null

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/TransformPersistentTasksExecutorTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/TransformPersistentTasksExecutorTests.java
@@ -42,6 +42,7 @@ import org.elasticsearch.xpack.transform.notifications.TransformAuditor;
 import org.elasticsearch.xpack.transform.persistence.IndexBasedTransformConfigManager;
 import org.elasticsearch.xpack.transform.persistence.TransformInternalIndexTests;
 
+import java.time.Clock;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -401,6 +402,7 @@ public class TransformPersistentTasksExecutorTests extends ESTestCase {
         TransformAuditor mockAuditor = mock(TransformAuditor.class);
         IndexBasedTransformConfigManager transformsConfigManager = new IndexBasedTransformConfigManager(client, xContentRegistry());
         TransformCheckpointService transformCheckpointService = new TransformCheckpointService(
+            Clock.systemUTC(),
             Settings.EMPTY,
             new ClusterService(Settings.EMPTY, new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS), null),
             transformsConfigManager,

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/TransformTaskTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/TransformTaskTests.java
@@ -39,6 +39,7 @@ import org.elasticsearch.xpack.transform.persistence.TransformConfigManager;
 import org.junit.After;
 import org.junit.Before;
 
+import java.time.Clock;
 import java.util.Collections;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -76,6 +77,7 @@ public class TransformTaskTests extends ESTestCase {
         TransformAuditor auditor = MockTransformAuditor.createMockAuditor();
         TransformConfigManager transformsConfigManager = new InMemoryTransformConfigManager();
         TransformCheckpointService transformsCheckpointService = new TransformCheckpointService(
+            Clock.systemUTC(),
             Settings.EMPTY,
             new ClusterService(Settings.EMPTY, new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS), null),
             transformsConfigManager,


### PR DESCRIPTION
This PR makes the checkpoint boundaries aligned with top-level `date_histogram` bucket boundaries.
The optimization is applied only when the transform config has `date_histogram` as the first group in the `group_by` list.

Relates https://github.com/elastic/elasticsearch/issues/62746