### PR TITLE
Make Parsing SnapshotInfo more Efficient

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/create/CreateSnapshotResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/create/CreateSnapshotResponse.java
@@ -54,7 +54,7 @@ public class CreateSnapshotResponse extends ActionResponse implements ToXContent
 
     public CreateSnapshotResponse(StreamInput in) throws IOException {
         super(in);
-        snapshotInfo = in.readOptionalWriteable(SnapshotInfo::new);
+        snapshotInfo = in.readOptionalWriteable(SnapshotInfo::readFrom);
     }
 
     private void setSnapshotInfoFromBuilder(SnapshotInfoBuilder snapshotInfoBuilder) {

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/get/GetSnapshotsResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/get/GetSnapshotsResponse.java
@@ -50,12 +50,12 @@ public class GetSnapshotsResponse extends ActionResponse implements ToXContentOb
 
     public GetSnapshotsResponse(StreamInput in) throws IOException {
         if (in.getVersion().onOrAfter(GetSnapshotsRequest.MULTIPLE_REPOSITORIES_SUPPORT_ADDED)) {
-            Map<String, List<SnapshotInfo>> successfulResponses = in.readMapOfLists(StreamInput::readString, SnapshotInfo::new);
+            Map<String, List<SnapshotInfo>> successfulResponses = in.readMapOfLists(StreamInput::readString, SnapshotInfo::readFrom);
             Map<String, ElasticsearchException> failedResponses = in.readMap(StreamInput::readString, StreamInput::readException);
             this.successfulResponses = Collections.unmodifiableMap(successfulResponses);
             this.failedResponses = Collections.unmodifiableMap(failedResponses);
         } else {
-            this.successfulResponses = Collections.singletonMap("unknown", in.readList(SnapshotInfo::new));
+            this.successfulResponses = Collections.singletonMap("unknown", in.readList(SnapshotInfo::readFrom));
             this.failedResponses = Collections.emptyMap();
         }
     }

--- a/server/src/main/java/org/elasticsearch/common/settings/Setting.java
+++ b/server/src/main/java/org/elasticsearch/common/settings/Setting.java
@@ -27,10 +27,10 @@ import org.elasticsearch.common.xcontent.ToXContentObject;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.common.xcontent.XContentParserUtils;
 import org.elasticsearch.common.xcontent.XContentType;
 
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.EnumSet;
@@ -1520,18 +1520,11 @@ public class Setting<T> implements ToXContentObject {
         // fromXContent doesn't use named xcontent or deprecation.
         try (XContentParser xContentParser = XContentType.JSON.xContent()
                 .createParser(NamedXContentRegistry.EMPTY, DeprecationHandler.THROW_UNSUPPORTED_OPERATION, parsableString)) {
-            XContentParser.Token token = xContentParser.nextToken();
-            if (token != XContentParser.Token.START_ARRAY) {
-                throw new IllegalArgumentException("expected START_ARRAY but got " + token);
-            }
-            ArrayList<String> list = new ArrayList<>();
-            while ((token = xContentParser.nextToken()) != XContentParser.Token.END_ARRAY) {
-                if (token != XContentParser.Token.VALUE_STRING) {
-                    throw new IllegalArgumentException("expected VALUE_STRING but got " + token);
-                }
-                list.add(xContentParser.text());
-            }
-            return list;
+            xContentParser.nextToken();
+            return XContentParserUtils.parseList(xContentParser, p -> {
+                XContentParserUtils.ensureExpectedToken(XContentParser.Token.VALUE_STRING, p.currentToken(), p);
+                return p.text();
+            });
         } catch (IOException e) {
             throw new IllegalArgumentException("failed to parse array", e);
         }

--- a/server/src/main/java/org/elasticsearch/index/snapshots/blobstore/BlobStoreIndexShardSnapshots.java
+++ b/server/src/main/java/org/elasticsearch/index/snapshots/blobstore/BlobStoreIndexShardSnapshots.java
@@ -263,11 +263,7 @@ public class BlobStoreIndexShardSnapshots implements Iterable<SnapshotFiles>, To
                             currentFieldName = parser.currentName();
                             if (ParseFields.FILES.match(currentFieldName, parser.getDeprecationHandler())
                                 && parser.nextToken() == XContentParser.Token.START_ARRAY) {
-                                List<String> fileNames = new ArrayList<>();
-                                while (parser.nextToken() != XContentParser.Token.END_ARRAY) {
-                                    fileNames.add(parser.text());
-                                }
-                                snapshotsMap.put(snapshot, fileNames);
+                                snapshotsMap.put(snapshot, XContentParserUtils.parseList(parser, XContentParser::text));
                             } else if (ParseFields.SHARD_STATE_ID.match(currentFieldName, parser.getDeprecationHandler())) {
                                 parser.nextToken();
                                 historyUUIDs.put(snapshot, parser.text());

--- a/server/src/test/java/org/elasticsearch/snapshots/SnapshotInfoWriteableTests.java
+++ b/server/src/test/java/org/elasticsearch/snapshots/SnapshotInfoWriteableTests.java
@@ -23,7 +23,7 @@ public class SnapshotInfoWriteableTests extends AbstractWireSerializingTestCase<
 
     @Override
     protected Writeable.Reader<SnapshotInfo> instanceReader() {
-        return SnapshotInfo::new;
+        return SnapshotInfo::readFrom;
     }
 
     @Override


### PR DESCRIPTION
Flatting the logic for parsing `SnapshotInfo` to go field by field like we do for `RepositoryData`
which is both easier to read and also faster (mostly when moving to batch multiple of these blobs into one
and doing on-the-fly filtering in an upcoming PR where the approach allows for more tricks).
Also, optimized/deduplicated the logic for parsing out (mostly/often) empty lists in the deserialization code
and used the new utility in a few more spots as well to save empty lists.

Lastly, fixed the at times very deeply nested `Collections.unmodifiableList(` chains that the way the duplicate constructors for x-content parsing and normal construction would cause.
