### PR TITLE
[7.x] [DOCS] Note get license API can return a `404` (#73951)

### DIFF
--- a/docs/reference/licensing/get-license.asciidoc
+++ b/docs/reference/licensing/get-license.asciidoc
@@ -22,6 +22,9 @@ when it expires, for example.
 For more information about the different types of licenses, see
 https://www.elastic.co/subscriptions.
 
+NOTE: If the master node is generating a new cluster state, the get license API
+may return a `404 Not Found` response. If you receive an unexpected `404`
+response after cluster startup, wait a short period and retry the request. 
 
 [discrete]
 ==== Query Parameters


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [DOCS] Note get license API can return a `404` (#73951)