### PR TITLE
[DOCS] Remove `geo_bounding_box` query's `type` parameter

### DIFF
--- a/docs/reference/migration/migrate_8_0/search.asciidoc
+++ b/docs/reference/migration/migrate_8_0/search.asciidoc
@@ -173,5 +173,16 @@ If you query date fields without a specified `format`, check if the values in yo
 actually meant to be milliseconds-since-epoch and use a numeric value in this case. If not, use
 a string value which gets parsed by either the date format set on the field in the mappings or
 by `strict_date_optional_time` by default.
+====
 
+.The `geo_bounding_box` query's `type` parameter has been removed.
+[%collapsible]
+====
+*Details* +
+The `geo_bounding_box` query's `type` parameter was deprecated in 7.14.0 and has
+been removed in 8.0.0. This parameter is a no-op and has no effect on the query.
+
+*Impact* +
+Discontinue use of the `type` parameter. `geo_bounding_box` queries that include
+this parameter will return an error.
 ====

--- a/docs/reference/query-dsl/geo-bounding-box-query.asciidoc
+++ b/docs/reference/query-dsl/geo-bounding-box-query.asciidoc
@@ -161,18 +161,14 @@ GET my_locations,my_geoshapes/_search
 ==== Query Options
 
 [cols="<,<",options="header",]
-|=======================================================================
+|====
 |Option |Description
 |`_name` |Optional name field to identify the filter
 
 |`validation_method` |Set to `IGNORE_MALFORMED` to
 accept geo points with invalid latitude or longitude, set to
 `COERCE` to also try to infer correct latitude or longitude. (default is `STRICT`).
-
-|`type` |Set to one of `indexed` or `memory` to defines whether this filter will
-be executed in memory or indexed. See <<geo-bbox-type,Type>> below for further details
-Default is `memory`.
-|=======================================================================
+|====
 
 [[query-dsl-geo-bounding-box-query-accepted-formats]]
 [discrete]
@@ -387,46 +383,6 @@ GET my_locations/_search
 The filter can work with multiple locations / points per document. Once
 a single location / point matches the filter, the document will be
 included in the filter
-
-[discrete]
-[[geo-bbox-type]]
-==== Type
-
-The type of the bounding box execution by default is set to `memory`,
-which means in memory checks if the doc falls within the bounding box
-range. In some cases, an `indexed` option will perform faster (but note
-that the `geo_point` type must have lat and lon indexed in this case).
-Note, when using the indexed option, multi locations per document field
-are not supported. Here is an example:
-
-[source,console]
---------------------------------------------------
-GET my_locations/_search
-{
-  "query": {
-    "bool": {
-      "must": {
-        "match_all": {}
-      },
-      "filter": {
-        "geo_bounding_box": {
-          "pin.location": {
-            "top_left": {
-              "lat": 40.73,
-              "lon": -74.1
-            },
-            "bottom_right": {
-              "lat": 40.10,
-              "lon": -71.12
-            }
-          },
-          "type": "indexed"
-        }
-      }
-    }
-  }
-}
---------------------------------------------------
 
 [discrete]
 ==== Ignore Unmapped


### PR DESCRIPTION
The `geo_bounding_box` query's `type` parameter is currently ignored and has no
effect on the query. This documents the removal of the parameter in 8.0.0.

Relates to #70561.

### Preview
* 8.0 migration guide: https://elasticsearch_74008.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/migrating-8.0.html#breaking_80_search_changes
* Geo-bounding box query: https://elasticsearch_74008.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/query-dsl-geo-bounding-box-query.html#_query_options