### PR TITLE
[DOCS] Fix ILM action order

### DIFF
--- a/docs/reference/ilm/ilm-index-lifecycle.asciidoc
+++ b/docs/reference/ilm/ilm-index-lifecycle.asciidoc
@@ -81,7 +81,7 @@ the rollover criteria, it could be 20 minutes before the rollover is complete.
 === Phase actions
 
 {ilm-init} supports the following actions in each phase. {ilm-init} executes the
-actions in order listed.
+actions in the order listed.
 
 * Hot
   - <<ilm-set-priority,Set Priority>>

--- a/docs/reference/ilm/ilm-index-lifecycle.asciidoc
+++ b/docs/reference/ilm/ilm-index-lifecycle.asciidoc
@@ -80,14 +80,14 @@ the rollover criteria, it could be 20 minutes before the rollover is complete.
 [[ilm-phase-actions]]
 === Phase actions
 
-{ilm-init} supports the following actions in each phase, which will be executed in their listed order.
+{ilm-init} supports the following actions in each phase. {ilm-init} executes the
+actions in order listed.
 
 * Hot
   - <<ilm-set-priority,Set Priority>>
   - <<ilm-unfollow,Unfollow>>
   - <<ilm-rollover,Rollover>>
   - <<ilm-readonly,Read-Only>>
-  - <<ilm-rollup, Rollup ILM>>
   - <<ilm-shrink,Shrink>>
   - <<ilm-forcemerge,Force Merge>>
   - <<ilm-searchable-snapshot, Searchable Snapshot>>
@@ -107,7 +107,6 @@ the rollover criteria, it could be 20 minutes before the rollover is complete.
   - <<ilm-allocate,Allocate>>
   - <<ilm-migrate,Migrate>>
   - <<ilm-freeze,Freeze>>
-  - <<ilm-rollup, Rollup ILM>>
 * Frozen
   - <<ilm-searchable-snapshot, Searchable Snapshot>>
 * Delete

--- a/docs/reference/ilm/ilm-index-lifecycle.asciidoc
+++ b/docs/reference/ilm/ilm-index-lifecycle.asciidoc
@@ -80,15 +80,17 @@ the rollover criteria, it could be 20 minutes before the rollover is complete.
 [[ilm-phase-actions]]
 === Phase actions
 
-{ilm-init} supports the following actions in each phase.
+{ilm-init} supports the following actions in each phase, which will be executed in their listed order.
 
 * Hot
   - <<ilm-set-priority,Set Priority>>
   - <<ilm-unfollow,Unfollow>>
   - <<ilm-rollover,Rollover>>
   - <<ilm-readonly,Read-Only>>
+  - <<ilm-rollup, Rollup ILM>>
   - <<ilm-shrink,Shrink>>
   - <<ilm-forcemerge,Force Merge>>
+  - <<ilm-searchable-snapshot, Searchable Snapshot>>
 * Warm
   - <<ilm-set-priority,Set Priority>>
   - <<ilm-unfollow,Unfollow>>
@@ -100,10 +102,12 @@ the rollover criteria, it could be 20 minutes before the rollover is complete.
 * Cold
   - <<ilm-set-priority,Set Priority>>
   - <<ilm-unfollow,Unfollow>>
+  - <<ilm-readonly,Read-Only>>
+  - <<ilm-searchable-snapshot, Searchable Snapshot>>
   - <<ilm-allocate,Allocate>>
   - <<ilm-migrate,Migrate>>
   - <<ilm-freeze,Freeze>>
-  - <<ilm-searchable-snapshot, Searchable Snapshot>>
+  - <<ilm-rollup, Rollup ILM>>
 * Frozen
   - <<ilm-searchable-snapshot, Searchable Snapshot>>
 * Delete


### PR DESCRIPTION
Hiya! Following [this code](https://github.com/elastic/elasticsearch/blob/master/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/TimeseriesLifecycleType.java#L54) I believe these are the necessary changes to bring the doc into alignment. Also I don't know how to link Rollup ILM as an action, but its not referenced so I put a formatted placeholder of `<<ilm-rollup, Rollup ILM>>`. Kindly validate before updating. Thanks!