### PR TITLE
Speed up Slow FlushIT (#74013)

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/indices/flush/FlushIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/indices/flush/FlushIT.java
@@ -399,8 +399,13 @@ public class FlushIT extends ESIntegTestCase {
 
     public void testFlushOnInactive() throws Exception {
         final String indexName = "flush_on_inactive";
-        List<String> dataNodes = internalCluster().startDataOnlyNodes(2, Settings.builder()
-            .put(IndexingMemoryController.SHARD_INACTIVE_TIME_SETTING.getKey(), randomTimeValue(10, 1000, "ms")).build());
+        List<String> dataNodes = internalCluster().startDataOnlyNodes(
+            2,
+            Settings.builder()
+                .put(IndexingMemoryController.SHARD_INACTIVE_TIME_SETTING.getKey(), randomTimeValue(10, 1000, "ms"))
+                .put(IndexingMemoryController.SHARD_MEMORY_INTERVAL_TIME_SETTING.getKey(), randomTimeValue(10, 1000, "ms"))
+                .build()
+        );
         assertAcked(client().admin().indices().prepareCreate(indexName).setSettings(Settings.builder()
             .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1).put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 1)
             .put(IndexSettings.INDEX_TRANSLOG_SYNC_INTERVAL_SETTING.getKey(), randomTimeValue(200, 500, "ms"))


### PR DESCRIPTION
This test regularly takes almost `10s` because 5s default check interval
would cause a long wait until the idle check even runs. This in turn would
cause the busy assert to backoff to a long wait, causing this test to generally
hold up the build worker it runs on => shorter check interval.

backport of #74013