### PR TITLE
[7.x] [DOCS] Add placeholder for 7.13.2 release notes (#74028)

### DIFF
--- a/docs/reference/release-notes.asciidoc
+++ b/docs/reference/release-notes.asciidoc
@@ -6,6 +6,7 @@
 
 This section summarizes the changes in each release.
 
+* <<release-notes-7.13.2>>
 * <<release-notes-7.13.1>>
 * <<release-notes-7.13.0>>
 * <<release-notes-7.12.1>>

--- a/docs/reference/release-notes/7.13.asciidoc
+++ b/docs/reference/release-notes/7.13.asciidoc
@@ -1,3 +1,8 @@
+[[release-notes-7.13.2]]
+== {es} version 7.13.2
+
+coming::[7.13.2]
+
 [[release-notes-7.13.1]]
 == {es} version 7.13.1
 


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [DOCS] Add placeholder for 7.13.2 release notes (#74028)