### PR TITLE
[7.x] Exclude invalid url-encoded strings from randomized tests (#71085)

### DIFF
--- a/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/AbstractStringProcessorTestCase.java
+++ b/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/AbstractStringProcessorTestCase.java
@@ -127,12 +127,23 @@ public abstract class AbstractStringProcessorTestCase<T> extends ESTestCase {
     }
 
     public void testTargetField() throws Exception {
-        IngestDocument ingestDocument = RandomDocumentPicks.randomIngestDocument(random(), Collections.emptyMap());
-        String fieldValue = RandomDocumentPicks.randomString(random());
-        String fieldName = RandomDocumentPicks.addRandomField(random(), ingestDocument, modifyInput(fieldValue));
+        IngestDocument ingestDocument;
+        String fieldValue;
+        String fieldName;
+        boolean ignoreMissing;
+        do {
+            ingestDocument = RandomDocumentPicks.randomIngestDocument(random(), Collections.emptyMap());
+            fieldValue = RandomDocumentPicks.randomString(random());
+            fieldName = RandomDocumentPicks.addRandomField(random(), ingestDocument, modifyInput(fieldValue));
+            ignoreMissing = randomBoolean();
+        } while (isSupportedValue(ingestDocument.getFieldValue(fieldName, Object.class, ignoreMissing)) == false);
         String targetFieldName = fieldName + "foo";
-        Processor processor = newProcessor(fieldName, randomBoolean(), targetFieldName);
+        Processor processor = newProcessor(fieldName, ignoreMissing, targetFieldName);
         processor.execute(ingestDocument);
         assertThat(ingestDocument.getFieldValue(targetFieldName, expectedResultType()), equalTo(expectedResult(fieldValue)));
+    }
+
+    protected boolean isSupportedValue(Object value) {
+        return true;
     }
 }

--- a/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/URLDecodeProcessorTests.java
+++ b/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/URLDecodeProcessorTests.java
@@ -10,6 +10,7 @@ package org.elasticsearch.ingest.common;
 
 import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
+import java.util.List;
 
 public class URLDecodeProcessorTests extends AbstractStringProcessorTestCase<String> {
     @Override
@@ -28,6 +29,32 @@ public class URLDecodeProcessorTests extends AbstractStringProcessorTestCase<Str
             return "Hello Günter" + URLDecoder.decode(input, "UTF-8");
         } catch (UnsupportedEncodingException e) {
             throw new IllegalArgumentException("invalid");
+        }
+    }
+
+    @Override
+    protected boolean isSupportedValue(Object value) {
+        // some random strings produced by the randomized test framework contain invalid URL encodings
+        if (value instanceof String) {
+            return isValidUrlEncodedString((String) value);
+        } else if (value instanceof List) {
+            for (Object o : (List) value) {
+                if ((o instanceof String) == false || isValidUrlEncodedString((String) o) == false) {
+                    return false;
+                }
+            }
+            return true;
+        } else {
+            throw new IllegalArgumentException("unexpected type");
+        }
+    }
+
+    private static boolean isValidUrlEncodedString(String s) {
+        try {
+            URLDecoder.decode(s, "UTF-8");
+            return true;
+        } catch (Exception e) {
+            return false;
         }
     }
 }


### PR DESCRIPTION
The randomized testing framework produces some input strings that are not valid URL-encoded strings so the URLDecodeProcessor correctly throws an exception. This change retries any tests that use a string that cannot be URL decoded.

Fixes #71077.

Backport of #71085