### PR TITLE
Log at DEBUG only on disconnect during cancellation

### DIFF
--- a/server/src/main/java/org/elasticsearch/transport/TcpTransport.java
+++ b/server/src/main/java/org/elasticsearch/transport/TcpTransport.java
@@ -244,6 +244,15 @@ public abstract class TcpTransport extends AbstractLifecycleComponent implements
             TcpChannel channel = channel(options.type());
             outboundHandler.sendRequest(node, channel, requestId, action, request, options, getVersion(), compress, false);
         }
+
+        @Override
+        public String toString() {
+            final StringBuilder stringBuilder = new StringBuilder();
+            stringBuilder.append("NodeChannels[");
+            node.appendDescriptionWithoutAttributes(stringBuilder);
+            stringBuilder.append("]");
+            return stringBuilder.toString();
+        }
     }
 
     // This allows transport implementations to potentially override specific connection profiles. This

--- a/server/src/main/java/org/elasticsearch/transport/TransportService.java
+++ b/server/src/main/java/org/elasticsearch/transport/TransportService.java
@@ -126,6 +126,11 @@ public class TransportService extends AbstractLifecycleComponent
         @Override
         public void close() {
         }
+
+        @Override
+        public String toString() {
+            return "local node connection";
+        }
     };
 
     /**

--- a/server/src/test/java/org/elasticsearch/tasks/BanFailureLoggingTests.java
+++ b/server/src/test/java/org/elasticsearch/tasks/BanFailureLoggingTests.java
@@ -1,0 +1,205 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.tasks;
+
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.elasticsearch.Version;
+import org.elasticsearch.action.admin.cluster.node.tasks.TaskManagerTestCase;
+import org.elasticsearch.action.support.PlainActionFuture;
+import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.logging.Loggers;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.core.internal.io.IOUtils;
+import org.elasticsearch.test.MockLogAppender;
+import org.elasticsearch.test.junit.annotations.TestLogging;
+import org.elasticsearch.test.transport.MockTransportService;
+import org.elasticsearch.test.transport.StubbableTransport;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.transport.AbstractSimpleTransportTestCase;
+import org.elasticsearch.transport.NodeDisconnectedException;
+import org.elasticsearch.transport.TransportException;
+import org.elasticsearch.transport.TransportRequest;
+import org.elasticsearch.transport.TransportRequestOptions;
+import org.elasticsearch.transport.TransportResponse;
+import org.elasticsearch.transport.TransportResponseHandler;
+
+import java.io.Closeable;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Function;
+
+import static org.hamcrest.Matchers.anyOf;
+import static org.hamcrest.Matchers.instanceOf;
+
+public class BanFailureLoggingTests extends TaskManagerTestCase {
+
+    @TestLogging(reason = "testing logging at DEBUG", value = "org.elasticsearch.tasks.TaskCancellationService:DEBUG")
+    public void testLogsAtDebugOnDisconnectionDuringBan() throws Exception {
+        runTest(
+            (connection, requestId, action, request, options) -> {
+                if (action.equals(TaskCancellationService.BAN_PARENT_ACTION_NAME)) {
+                    connection.close();
+                }
+                connection.sendRequest(requestId, action, request, options);
+            },
+            childNode -> new MockLogAppender.SeenEventExpectation(
+                "cannot send message",
+                TaskCancellationService.class.getName(),
+                Level.DEBUG,
+                "*cannot send ban for tasks*" + childNode.getId() + "*"));
+    }
+
+    @TestLogging(reason = "testing logging at DEBUG", value = "org.elasticsearch.tasks.TaskCancellationService:DEBUG")
+    public void testLogsAtDebugOnDisconnectionDuringBanRemoval() throws Exception {
+        final AtomicInteger banCount = new AtomicInteger();
+        runTest(
+            (connection, requestId, action, request, options) -> {
+                if (action.equals(TaskCancellationService.BAN_PARENT_ACTION_NAME) && banCount.incrementAndGet() >= 2) {
+                    connection.close();
+                }
+                connection.sendRequest(requestId, action, request, options);
+            },
+            childNode -> new MockLogAppender.SeenEventExpectation(
+                "cannot send message",
+                TaskCancellationService.class.getName(),
+                Level.DEBUG,
+                "*failed to remove ban for tasks*" + childNode.getId() + "*"));
+    }
+
+    private void runTest(
+        StubbableTransport.SendRequestBehavior sendRequestBehavior,
+        Function<DiscoveryNode, MockLogAppender.SeenEventExpectation> expectation) throws Exception {
+
+        final ArrayList<Closeable> resources = new ArrayList<>(3);
+
+        try {
+
+            final MockTransportService parentTransportService = MockTransportService.createNewService(
+                Settings.EMPTY,
+                Version.CURRENT,
+                threadPool);
+            resources.add(parentTransportService);
+            parentTransportService.getTaskManager().setTaskCancellationService(new TaskCancellationService(parentTransportService));
+            parentTransportService.start();
+            parentTransportService.acceptIncomingRequests();
+
+            final MockTransportService childTransportService = MockTransportService.createNewService(
+                Settings.EMPTY,
+                Version.CURRENT,
+                threadPool);
+            resources.add(childTransportService);
+            childTransportService.getTaskManager().setTaskCancellationService(new TaskCancellationService(childTransportService));
+            childTransportService.registerRequestHandler(
+                "internal:testAction[c]",
+                ThreadPool.Names.MANAGEMENT, // busy-wait for cancellation but not on a transport thread
+                (StreamInput in) -> new TransportRequest.Empty(in) {
+                    @Override
+                    public Task createTask(long id, String type, String action, TaskId parentTaskId, Map<String, String> headers) {
+                        return new CancellableTask(id, type, action, "", parentTaskId, headers);
+                    }
+                },
+                (request, channel, task) -> {
+                    final CancellableTask cancellableTask = (CancellableTask) task;
+                    assertBusy(() -> assertTrue(cancellableTask.isCancelled()));
+                    channel.sendResponse(new TaskCancelledException("task cancelled"));
+                });
+
+            childTransportService.start();
+            childTransportService.acceptIncomingRequests();
+
+            parentTransportService.addSendBehavior(sendRequestBehavior);
+
+            AbstractSimpleTransportTestCase.connectToNode(parentTransportService, childTransportService.getLocalDiscoNode());
+
+            final CancellableTask parentTask = (CancellableTask) parentTransportService.getTaskManager().register(
+                "transport",
+                "internal:testAction",
+                new ParentRequest());
+
+            parentTransportService.sendChildRequest(
+                childTransportService.getLocalDiscoNode(),
+                "internal:testAction[c]",
+                TransportRequest.Empty.INSTANCE,
+                parentTask,
+                TransportRequestOptions.EMPTY,
+                new ChildResponseHandler(() -> parentTransportService.getTaskManager().unregister(parentTask)));
+
+            MockLogAppender appender = new MockLogAppender();
+            appender.start();
+            resources.add(appender::stop);
+            Loggers.addAppender(LogManager.getLogger(TaskCancellationService.class), appender);
+            resources.add(() -> Loggers.removeAppender(LogManager.getLogger(TaskCancellationService.class), appender));
+
+            appender.addExpectation(expectation.apply(childTransportService.getLocalDiscoNode()));
+
+            final PlainActionFuture<Void> cancellationFuture = new PlainActionFuture<>();
+            parentTransportService.getTaskManager().cancelTaskAndDescendants(parentTask, "test", true, cancellationFuture);
+            try {
+                cancellationFuture.actionGet(TimeValue.timeValueSeconds(5));
+            } catch (NodeDisconnectedException e) {
+                // acceptable; we mostly ignore the result of cancellation anyway
+            }
+
+            // assert busy since failure to remove a ban may be logged after cancellation completed
+            assertBusy(appender::assertAllExpectationsMatched);
+        } finally {
+            Collections.reverse(resources);
+            IOUtils.close(resources);
+        }
+    }
+
+    private static class ParentRequest implements TaskAwareRequest {
+        @Override
+        public void setParentTask(TaskId taskId) {
+            fail("setParentTask should not be called");
+        }
+
+        @Override
+        public TaskId getParentTask() {
+            return TaskId.EMPTY_TASK_ID;
+        }
+
+        @Override
+        public Task createTask(long id, String type, String action, TaskId parentTaskId, Map<String, String> headers) {
+            return new CancellableTask(id, type, action, "", parentTaskId, headers);
+        }
+    }
+
+    private static class ChildResponseHandler implements TransportResponseHandler<TransportResponse.Empty> {
+        private final Runnable onException;
+
+        ChildResponseHandler(Runnable onException) {
+            this.onException = onException;
+        }
+
+        @Override
+        public void handleResponse(TransportResponse.Empty response) {
+            fail("should not get successful response");
+        }
+
+        @Override
+        public void handleException(TransportException exp) {
+            assertThat(exp.unwrapCause(), anyOf(
+                instanceOf(TaskCancelledException.class),
+                instanceOf(NodeDisconnectedException.class)));
+            onException.run();
+        }
+
+        @Override
+        public TransportResponse.Empty read(StreamInput in) {
+            return TransportResponse.Empty.INSTANCE;
+        }
+    }
+
+}

--- a/test/framework/src/main/java/org/elasticsearch/test/transport/StubbableTransport.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/transport/StubbableTransport.java
@@ -253,6 +253,11 @@ public class StubbableTransport implements Transport {
         public Transport.Connection getConnection() {
             return connection;
         }
+
+        @Override
+        public String toString() {
+            return "WrappedConnection[" + connection + "]";
+        }
     }
 
     @FunctionalInterface


### PR DESCRIPTION
If a `NodeDisconnectedException` happens when sending a ban for a task
then today we log a message at `INFO` or `WARN` indicating that the ban
failed, but we don't indicate why. The message also uses a default
`toString()` for an inner class which is unhelpful.

Ban failures during disconnections are benign and somewhat expected, and
task cancellation respects disconnections anyway (#65443). There's not
much the user can do about these messages either, and they can be
confusing and draw attention away from the real problem.

With this commit we log the failure messages at `DEBUG` on
disconnections, and include the exception details. We also include the
exception message for other kinds of failures, and we fix up a few cases
where a useless default `toString()` implementation was used in log
messages.

Slightly relates #72968 in that these messages tend to obscure a
connectivity issue.