### PR TITLE
RestToXContentListener extends RestBuilderListener

### DIFF
--- a/server/src/main/java/org/elasticsearch/rest/action/RestToXContentListener.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/RestToXContentListener.java
@@ -8,7 +8,6 @@
 
 package org.elasticsearch.rest.action;
 
-import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.ToXContentObject;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.rest.BytesRestResponse;
@@ -17,18 +16,13 @@ import org.elasticsearch.rest.RestResponse;
 import org.elasticsearch.rest.RestStatus;
 
 /**
- * A REST based action listener that assumes the response is of type {@link ToXContent} and automatically
- * builds an XContent based response (wrapping the toXContent in startObject/endObject).
+ * A REST based action listener that requires the response to implement {@link ToXContentObject} and automatically
+ * builds an XContent based response.
  */
-public class RestToXContentListener<Response extends ToXContentObject> extends RestResponseListener<Response> {
+public class RestToXContentListener<Response extends ToXContentObject> extends RestBuilderListener<Response> {
 
     public RestToXContentListener(RestChannel channel) {
         super(channel);
-    }
-
-    @Override
-    public final RestResponse buildResponse(Response response) throws Exception {
-        return buildResponse(response, channel.newBuilder());
     }
 
     public RestResponse buildResponse(Response response, XContentBuilder builder) throws Exception {

--- a/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestSyncedFlushAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestSyncedFlushAction.java
@@ -22,7 +22,7 @@ import org.elasticsearch.rest.RestChannel;
 import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.rest.RestResponse;
 import org.elasticsearch.rest.RestStatus;
-import org.elasticsearch.rest.action.RestToXContentListener;
+import org.elasticsearch.rest.action.RestBuilderListener;
 
 import java.io.IOException;
 import java.util.List;
@@ -57,7 +57,7 @@ public class RestSyncedFlushAction extends BaseRestHandler {
         return channel -> client.admin().indices().flush(flushRequest, new SimulateSyncedFlushResponseListener(channel));
     }
 
-    static final class SimulateSyncedFlushResponseListener extends RestToXContentListener<FlushResponse> {
+    static final class SimulateSyncedFlushResponseListener extends RestBuilderListener<FlushResponse> {
 
         SimulateSyncedFlushResponseListener(RestChannel channel) {
             super(channel);


### PR DESCRIPTION
Today `RestBuilderListener` and `RestToXContentListener` do almost the
same thing, except that `RestBuilderListener` has some extra safety
checks to make sure that the constructed response is well-formed.
However we expect the response to be well-formed in all cases. This
commit makes `RestToXContentListener` a subclass of
`RestBuilderListener` to remove the duplication and adopt the same
safety checks.