### PR TITLE
Disable query cache for FunctionScoreQuery and ScriptScoreQuery

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/lucene/search/function/FunctionScoreQuery.java
+++ b/server/src/main/java/org/elasticsearch/common/lucene/search/function/FunctionScoreQuery.java
@@ -340,9 +340,8 @@ public class FunctionScoreQuery extends Query {
 
         @Override
         public boolean isCacheable(LeafReaderContext ctx) {
-            // If minScore is not null, then matches depend on statistics of the
-            // top-level reader.
-            return minScore == null;
+            // the sub-query/filters should be cached independently when the score is not needed.
+            return false;
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/common/lucene/search/function/ScriptScoreQuery.java
+++ b/server/src/main/java/org/elasticsearch/common/lucene/search/function/ScriptScoreQuery.java
@@ -151,8 +151,8 @@ public class ScriptScoreQuery extends Query {
 
             @Override
             public boolean isCacheable(LeafReaderContext ctx) {
-                // If minScore is not null, then matches depend on statistics of the top-level reader.
-                return minScore == null;
+                // the sub-query should be cached independently when the score is not needed
+                return false;
             }
         };
     }

--- a/server/src/test/java/org/elasticsearch/index/query/functionscore/FunctionScoreQueryBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/functionscore/FunctionScoreQueryBuilderTests.java
@@ -839,15 +839,15 @@ public class FunctionScoreQueryBuilderTests extends AbstractQueryTestCase<Functi
         if (rewriteQuery instanceof MatchNoneQueryBuilder) {
             requestCache = true;
         }
-        assertEquals("query should " + (requestCache ? "" : "not") + " be eligible for the request cache: " + queryBuilder.toString(), requestCache,
-                context.isCacheable());
+        assertEquals("query should " + (requestCache ? "" : "not") + " be eligible for the request cache: " + queryBuilder.toString(),
+            requestCache, context.isCacheable());
 
         // test query cache
         if (rewriteQuery instanceof MatchNoneQueryBuilder == false) {
             Query luceneQuery = rewriteQuery.toQuery(context);
             Weight queryWeight = context.searcher().createWeight(searcher.rewrite(luceneQuery), ScoreMode.COMPLETE, 1.0f);
             for (LeafReaderContext ctx : context.getIndexReader().leaves()) {
-                assertFalse("" + searcher.rewrite(luceneQuery) + " " + rewriteQuery.toString(), queryWeight.isCacheable(ctx));
+                assertFalse(queryWeight.isCacheable(ctx));
             }
         }
 
@@ -858,7 +858,8 @@ public class FunctionScoreQueryBuilderTests extends AbstractQueryTestCase<Functi
         context = createSearchExecutionContext(searcher);
         rewriteQuery = rewriteQuery(queryBuilder, new SearchExecutionContext(context));
         assertNotNull(rewriteQuery.toQuery(context));
-        assertTrue("function script query should be eligible for the request cache: " + queryBuilder.toString(), context.isCacheable());
+        assertTrue("function script query should be eligible for the request cache: " + queryBuilder.toString(),
+            context.isCacheable());
 
         // test query cache
         if (rewriteQuery instanceof MatchNoneQueryBuilder == false) {
@@ -875,7 +876,8 @@ public class FunctionScoreQueryBuilderTests extends AbstractQueryTestCase<Functi
         context = createSearchExecutionContext(searcher);
         rewriteQuery = rewriteQuery(queryBuilder, new SearchExecutionContext(context));
         assertNotNull(rewriteQuery.toQuery(context));
-        assertFalse("function random query should not be eligible for the request cache: " + queryBuilder.toString(), context.isCacheable());
+        assertFalse("function random query should not be eligible for the request cache: " + queryBuilder.toString(),
+            context.isCacheable());
 
         // test query cache
         if (rewriteQuery instanceof MatchNoneQueryBuilder == false) {

--- a/server/src/test/java/org/elasticsearch/index/query/functionscore/FunctionScoreQueryBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/functionscore/FunctionScoreQueryBuilderTests.java
@@ -10,11 +10,18 @@ package org.elasticsearch.index.query.functionscore;
 
 import com.fasterxml.jackson.core.JsonParseException;
 
+import org.apache.lucene.document.Document;
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.index.RandomIndexWriter;
 import org.apache.lucene.index.Term;
+import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.MatchAllDocsQuery;
 import org.apache.lucene.search.MatchNoDocsQuery;
 import org.apache.lucene.search.Query;
+import org.apache.lucene.search.ScoreMode;
 import org.apache.lucene.search.TermQuery;
+import org.apache.lucene.search.Weight;
+import org.apache.lucene.store.Directory;
 import org.elasticsearch.common.ParsingException;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.bytes.BytesReference;
@@ -70,6 +77,7 @@ import static org.elasticsearch.index.query.functionscore.ScoreFunctionBuilders.
 import static org.hamcrest.Matchers.closeTo;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.nullValue;
 
@@ -815,34 +823,70 @@ public class FunctionScoreQueryBuilderTests extends AbstractQueryTestCase<Functi
      */
     @Override
     public void testCacheability() throws IOException {
+        Directory directory = newDirectory();
+        RandomIndexWriter iw = new RandomIndexWriter(random(), directory);
+        iw.addDocument(new Document());
+        final IndexSearcher searcher = new IndexSearcher(iw.getReader());
+        iw.close();
+        assertThat(searcher.getIndexReader().leaves().size(), greaterThan(0));
+
         FunctionScoreQueryBuilder queryBuilder = createTestQueryBuilder();
-        boolean isCacheable = isCacheable(queryBuilder);
-        SearchExecutionContext context = createSearchExecutionContext();
+        boolean requestCache = isCacheable(queryBuilder);
+        SearchExecutionContext context = createSearchExecutionContext(searcher);
         QueryBuilder rewriteQuery = rewriteQuery(queryBuilder, new SearchExecutionContext(context));
         assertNotNull(rewriteQuery.toQuery(context));
-        // we occasionally need to update the expected "isCacheable" flag after rewrite for MatchNoneQueryBuilder
+        // we occasionally need to update the expected request cache flag after rewrite to MatchNoneQueryBuilder
         if (rewriteQuery instanceof MatchNoneQueryBuilder) {
-            isCacheable = true;
+            requestCache = true;
         }
-        assertEquals("query should " + (isCacheable ? "" : "not") + " be cacheable: " + queryBuilder.toString(), isCacheable,
+        assertEquals("query should " + (requestCache ? "" : "not") + " be eligible for the request cache: " + queryBuilder.toString(), requestCache,
                 context.isCacheable());
+
+        // test query cache
+        if (rewriteQuery instanceof MatchNoneQueryBuilder == false) {
+            Query luceneQuery = rewriteQuery.toQuery(context);
+            Weight queryWeight = context.searcher().createWeight(searcher.rewrite(luceneQuery), ScoreMode.COMPLETE, 1.0f);
+            for (LeafReaderContext ctx : context.getIndexReader().leaves()) {
+                assertFalse("" + searcher.rewrite(luceneQuery) + " " + rewriteQuery.toString(), queryWeight.isCacheable(ctx));
+            }
+        }
 
         ScoreFunctionBuilder<?> scriptScoreFunction = new ScriptScoreFunctionBuilder(
                 new Script(ScriptType.INLINE, MockScriptEngine.NAME, "1", Collections.emptyMap()));
         queryBuilder = new FunctionScoreQueryBuilder(new FilterFunctionBuilder[] {
             new FilterFunctionBuilder(RandomQueryBuilder.createQuery(random()), scriptScoreFunction) });
-        context = createSearchExecutionContext();
+        context = createSearchExecutionContext(searcher);
         rewriteQuery = rewriteQuery(queryBuilder, new SearchExecutionContext(context));
         assertNotNull(rewriteQuery.toQuery(context));
-        assertTrue("function script query should be cacheable" + queryBuilder.toString(), context.isCacheable());
+        assertTrue("function script query should be eligible for the request cache: " + queryBuilder.toString(), context.isCacheable());
+
+        // test query cache
+        if (rewriteQuery instanceof MatchNoneQueryBuilder == false) {
+            Query luceneQuery = rewriteQuery.toQuery(context);
+            Weight queryWeight = context.searcher().createWeight(searcher.rewrite(luceneQuery), ScoreMode.COMPLETE, 1.0f);
+            for (LeafReaderContext ctx : context.getIndexReader().leaves()) {
+                assertFalse(queryWeight.isCacheable(ctx));
+            }
+        }
 
         RandomScoreFunctionBuilder randomScoreFunctionBuilder = new RandomScoreFunctionBuilderWithFixedSeed();
         queryBuilder = new FunctionScoreQueryBuilder(new FilterFunctionBuilder[] {
             new FilterFunctionBuilder(RandomQueryBuilder.createQuery(random()), randomScoreFunctionBuilder) });
-        context = createSearchExecutionContext();
+        context = createSearchExecutionContext(searcher);
         rewriteQuery = rewriteQuery(queryBuilder, new SearchExecutionContext(context));
         assertNotNull(rewriteQuery.toQuery(context));
-        assertFalse("function random query should not be cacheable: " + queryBuilder.toString(), context.isCacheable());
+        assertFalse("function random query should not be eligible for the request cache: " + queryBuilder.toString(), context.isCacheable());
+
+        // test query cache
+        if (rewriteQuery instanceof MatchNoneQueryBuilder == false) {
+            Query luceneQuery = rewriteQuery.toQuery(context);
+            Weight queryWeight = context.searcher().createWeight(searcher.rewrite(luceneQuery), ScoreMode.COMPLETE, 1.0f);
+            for (LeafReaderContext ctx : context.getIndexReader().leaves()) {
+                assertFalse(queryWeight.isCacheable(ctx));
+            }
+        }
+        searcher.getIndexReader().close();
+        directory.close();
     }
 
     private boolean isCacheable(FunctionScoreQueryBuilder queryBuilder) {


### PR DESCRIPTION
This commit disables the query cache for the `FunctionScoreQuery` and the
`ScriptScoreQuery`. These queries are not meant to be cached. If the score
is not needed, we'll now cache the sub-query and filters independently since
we don't want to keep an unused script in the cache.

Closes #73925