### PR TITLE
Added search support to add a custom cache key for the request cache

### DIFF
--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/AsyncSearchRequestConverters.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/AsyncSearchRequestConverters.java
@@ -59,6 +59,9 @@ final class AsyncSearchRequestConverters {
         if (request.getRequestCache() != null) {
             params.withRequestCache(request.getRequestCache());
         }
+        if (request.getRequestCacheKey() != null) {
+            params.withRequestCacheKey(request.getRequestCacheKey());
+        }
         if (request.getAllowPartialSearchResults() != null) {
             params.withAllowPartialResults(request.getAllowPartialSearchResults());
         }

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/RequestConverters.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/RequestConverters.java
@@ -413,6 +413,10 @@ final class RequestConverters {
         if (searchRequest.requestCache() != null) {
             params.withRequestCache(searchRequest.requestCache());
         }
+        if (searchRequest.requestCacheKey() != null) {
+            params.withRequestCacheKey(searchRequest.requestCacheKey());
+        }
+
         if (searchRequest.allowPartialSearchResults() != null) {
             params.withAllowPartialResults(searchRequest.allowPartialSearchResults());
         }
@@ -905,6 +909,10 @@ final class RequestConverters {
 
         Params withRequestCache(boolean requestCache) {
             return putParam("request_cache", Boolean.toString(requestCache));
+        }
+
+        Params withRequestCacheKey(String requestCacheKey) {
+            return putParam("request_cache_key", requestCacheKey);
         }
 
         Params withAllowPartialResults(boolean allowPartialSearchResults) {

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/asyncsearch/SubmitAsyncSearchRequest.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/asyncsearch/SubmitAsyncSearchRequest.java
@@ -207,6 +207,15 @@ public class SubmitAsyncSearchRequest implements Validatable {
         return this.searchRequest.requestCache();
     }
 
+
+    public void setRequestCacheKey(String requestCacheKey) {
+        this.searchRequest.requestCacheKey(requestCacheKey);
+    }
+
+    public String getRequestCacheKey() {
+        return this.searchRequest.requestCacheKey();
+    }
+
     /**
      * Returns the number of shard requests that should be executed concurrently on a single node.
      * The default is {@code 5}.

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/AsyncSearchRequestConvertersTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/AsyncSearchRequestConvertersTests.java
@@ -94,6 +94,10 @@ public class AsyncSearchRequestConvertersTests extends ESTestCase {
             expectedParams.put("request_cache", Boolean.toString(request.getRequestCache()));
         }
         if (randomBoolean()) {
+            request.setRequestCacheKey(randomInt() + "");
+            expectedParams.put("request_cache_key", request.getRequestCacheKey());
+        }
+        if (randomBoolean()) {
             request.setBatchedReduceSize(randomIntBetween(2, Integer.MAX_VALUE));
             expectedParams.put("batched_reduce_size", Integer.toString(request.getBatchedReduceSize()));
         }

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/RequestConvertersTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/RequestConvertersTests.java
@@ -1960,6 +1960,10 @@ public class RequestConvertersTests extends ESTestCase {
             expectedParams.put("request_cache", Boolean.toString(searchRequest.requestCache()));
         }
         if (randomBoolean()) {
+            searchRequest.requestCacheKey(randomInt() + "");
+            expectedParams.put("request_cache_key", searchRequest.requestCacheKey());
+        }
+        if (randomBoolean()) {
             searchRequest.allowPartialSearchResults(randomBoolean());
             expectedParams.put("allow_partial_search_results", Boolean.toString(searchRequest.allowPartialSearchResults()));
         }

--- a/docs/reference/modules/indices/request_cache.asciidoc
+++ b/docs/reference/modules/indices/request_cache.asciidoc
@@ -105,13 +105,32 @@ query-string parameter detailed here.
 [discrete]
 ==== Cache key
 
-The whole JSON body is used as the cache key. This means that if the JSON
+By default, the whole JSON body is used as the cache key. This means that if the JSON
 changes -- for instance if keys are output in a different order -- then the
 cache key will not be recognised.
 
 TIP: Most JSON libraries support a _canonical_ mode which ensures that JSON
 keys are always emitted in the same order. This canonical mode can be used in
 the application to ensure that a request is always serialized in the same way.
+
+Alternatively, you could specify a custom cache key:
+[source,console]
+-----------------------------
+GET /my-index-000001/_search?request_cache=true&request_cache_key=xyz
+{
+  "size": 0,
+  "aggs": {
+    "popular_colors": {
+      "terms": {
+        "field": "colors"
+      }
+    }
+  }
+}
+-----------------------------
+// TEST[continued]
+Specifying a custom cache key is useful if you have large requests
+as it can minify the memory usage of the request cache.
 
 [discrete]
 ==== Cache settings

--- a/server/src/main/java/org/elasticsearch/action/search/SearchRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/search/SearchRequest.java
@@ -78,6 +78,7 @@ public class SearchRequest extends ActionRequest implements IndicesRequest.Repla
     private SearchSourceBuilder source;
 
     private Boolean requestCache;
+    private String requestCacheKey;
 
     private Boolean allowPartialSearchResults;
 
@@ -548,6 +549,20 @@ public class SearchRequest extends ActionRequest implements IndicesRequest.Repla
 
     public Boolean requestCache() {
         return this.requestCache;
+    }
+
+    /**
+     * Sets a custom request cache key for this request. By default, the entire search
+     * will be used as a cache key. Useful if you are sending really large searches to
+     * minimize memory usage in the request cache.
+     */
+    public SearchRequest requestCacheKey(String requestCacheKey) {
+        this.requestCacheKey = requestCacheKey;
+        return this;
+    }
+
+    public String requestCacheKey() {
+        return this.requestCacheKey;
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/action/search/SearchRequestBuilder.java
+++ b/server/src/main/java/org/elasticsearch/action/search/SearchRequestBuilder.java
@@ -510,6 +510,16 @@ public class SearchRequestBuilder extends ActionRequestBuilder<SearchRequest, Se
         return this;
     }
 
+    /**
+     * Sets a custom request cache key for this request. By default, the entire search
+     * will be used as a cache key. Useful if you are sending really large searches to
+     * minimize memory usage in the request cache.
+     */
+    public SearchRequestBuilder setRequestCacheKey(String requestCacheKey) {
+        request.requestCacheKey(requestCacheKey);
+        return this;
+    }
+
 
     /**
      * Sets if this request should allow partial results.  (If method is not called,

--- a/server/src/main/java/org/elasticsearch/rest/action/search/RestSearchAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/search/RestSearchAction.java
@@ -173,6 +173,7 @@ public class RestSearchAction extends BaseRestHandler {
         }
         parseSearchSource(searchRequest.source(), request, setSize);
         searchRequest.requestCache(request.paramAsBoolean("request_cache", searchRequest.requestCache()));
+        searchRequest.requestCacheKey(request.param("request_cache_key", searchRequest.requestCacheKey()));
 
         String scroll = request.param("scroll");
         if (scroll != null) {

--- a/server/src/test/java/org/elasticsearch/action/search/SearchRequestTests.java
+++ b/server/src/test/java/org/elasticsearch/action/search/SearchRequestTests.java
@@ -218,6 +218,8 @@ public class SearchRequestTests extends AbstractSearchTestCase {
         mutators.add(() -> mutation.preference(randomValueOtherThan(searchRequest.preference(), () -> randomAlphaOfLengthBetween(3, 10))));
         mutators.add(() -> mutation.routing(randomValueOtherThan(searchRequest.routing(), () -> randomAlphaOfLengthBetween(3, 10))));
         mutators.add(() -> mutation.requestCache((randomValueOtherThan(searchRequest.requestCache(), ESTestCase::randomBoolean))));
+        mutators.add(() -> mutation.requestCacheKey((randomValueOtherThan(searchRequest.requestCacheKey(),
+                () -> randomAlphaOfLengthBetween(3, 40)))));
         mutators.add(() -> mutation
                 .scroll(randomValueOtherThan(searchRequest.scroll(), () -> new Scroll(new TimeValue(randomNonNegativeLong() % 100000)))));
         mutators.add(() -> mutation.searchType(randomValueOtherThan(searchRequest.searchType(),

--- a/test/framework/src/main/java/org/elasticsearch/search/RandomSearchRequestGenerator.java
+++ b/test/framework/src/main/java/org/elasticsearch/search/RandomSearchRequestGenerator.java
@@ -93,6 +93,9 @@ public class RandomSearchRequestGenerator {
             searchRequest.requestCache(randomBoolean());
         }
         if (randomBoolean()) {
+            searchRequest.requestCacheKey(randomAlphaOfLengthBetween(3, 40));
+        }
+        if (randomBoolean()) {
             searchRequest.routing(randomAlphaOfLengthBetween(3, 10));
         }
         if (randomBoolean()) {

--- a/x-pack/plugin/async-search/src/test/java/org/elasticsearch/xpack/search/RestSubmitAsyncSearchActionTests.java
+++ b/x-pack/plugin/async-search/src/test/java/org/elasticsearch/xpack/search/RestSubmitAsyncSearchActionTests.java
@@ -53,6 +53,7 @@ public class RestSubmitAsyncSearchActionTests extends RestActionTestCase {
                 assertThat(submitRequest.getSearchRequest().isCcsMinimizeRoundtrips(), equalTo(false));
                 assertThat(submitRequest.getSearchRequest().getBatchedReduceSize(), equalTo(5));
                 assertThat(submitRequest.getSearchRequest().requestCache(), equalTo(true));
+                assertThat(submitRequest.getSearchRequest().requestCacheKey(), equalTo(null));
                 assertThat(submitRequest.getSearchRequest().getPreFilterShardSize().intValue(), equalTo(1));
                 executeCalled.set(true);
                 return new AsyncSearchResponse("", randomBoolean(), randomBoolean(), 0L, 0L);

--- a/x-pack/plugin/async-search/src/test/java/org/elasticsearch/xpack/search/SubmitAsyncSearchRequestTests.java
+++ b/x-pack/plugin/async-search/src/test/java/org/elasticsearch/xpack/search/SubmitAsyncSearchRequestTests.java
@@ -58,6 +58,10 @@ public class SubmitAsyncSearchRequestTests extends AbstractWireSerializingTransf
             searchRequest.getSearchRequest().requestCache(randomBoolean());
         }
         if (randomBoolean()) {
+            searchRequest.getSearchRequest()
+                    .requestCacheKey(randomAlphaOfLengthBetween(3, 40));
+        }
+        if (randomBoolean()) {
             searchRequest.getSearchRequest().searchType(randomFrom(SearchType.DFS_QUERY_THEN_FETCH, SearchType.QUERY_THEN_FETCH));
         }
         if (randomBoolean()) {


### PR DESCRIPTION
This adds the ability to add a custom cache key for the shard request cache. The default behavior has been to use the entire search json as the cache key, but that's quite inefficient for large queries. This gives users the ability to reduce the memory usage of the request cache by calculating some hash of their own and sending that along with the search request.

If no request_cache_key is specified, the old behavior will be used, ie using the search json as cache key.

Closes #74061