### PR TITLE
Deprecate setting version on analyzers

### DIFF
--- a/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/ArabicAnalyzerProvider.java
+++ b/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/ArabicAnalyzerProvider.java
@@ -26,7 +26,6 @@ public class ArabicAnalyzerProvider extends AbstractIndexAnalyzerProvider<Arabic
             Analysis.parseStopWords(env, settings, ArabicAnalyzer.getDefaultStopSet()),
             Analysis.parseStemExclusion(settings, CharArraySet.EMPTY_SET)
         );
-        arabicAnalyzer.setVersion(version);
     }
 
     @Override

--- a/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/ArmenianAnalyzerProvider.java
+++ b/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/ArmenianAnalyzerProvider.java
@@ -26,7 +26,6 @@ public class ArmenianAnalyzerProvider extends AbstractIndexAnalyzerProvider<Arme
             Analysis.parseStopWords(env, settings, ArmenianAnalyzer.getDefaultStopSet()),
             Analysis.parseStemExclusion(settings, CharArraySet.EMPTY_SET)
         );
-        analyzer.setVersion(version);
     }
 
     @Override

--- a/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/BasqueAnalyzerProvider.java
+++ b/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/BasqueAnalyzerProvider.java
@@ -26,7 +26,6 @@ public class BasqueAnalyzerProvider extends AbstractIndexAnalyzerProvider<Basque
             Analysis.parseStopWords(env, settings, BasqueAnalyzer.getDefaultStopSet()),
             Analysis.parseStemExclusion(settings, CharArraySet.EMPTY_SET)
         );
-        analyzer.setVersion(version);
     }
 
     @Override

--- a/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/BengaliAnalyzerProvider.java
+++ b/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/BengaliAnalyzerProvider.java
@@ -26,7 +26,6 @@ public class BengaliAnalyzerProvider extends AbstractIndexAnalyzerProvider<Benga
             Analysis.parseStopWords(env, settings, BengaliAnalyzer.getDefaultStopSet()),
             Analysis.parseStemExclusion(settings, CharArraySet.EMPTY_SET)
         );
-        analyzer.setVersion(version);
     }
 
     @Override

--- a/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/BrazilianAnalyzerProvider.java
+++ b/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/BrazilianAnalyzerProvider.java
@@ -26,7 +26,6 @@ public class BrazilianAnalyzerProvider extends AbstractIndexAnalyzerProvider<Bra
             Analysis.parseStopWords(env, settings, BrazilianAnalyzer.getDefaultStopSet()),
             Analysis.parseStemExclusion(settings, CharArraySet.EMPTY_SET)
         );
-        analyzer.setVersion(version);
     }
 
     @Override

--- a/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/BulgarianAnalyzerProvider.java
+++ b/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/BulgarianAnalyzerProvider.java
@@ -26,7 +26,6 @@ public class BulgarianAnalyzerProvider extends AbstractIndexAnalyzerProvider<Bul
             Analysis.parseStopWords(env, settings, BulgarianAnalyzer.getDefaultStopSet()),
             Analysis.parseStemExclusion(settings, CharArraySet.EMPTY_SET)
         );
-        analyzer.setVersion(version);
     }
 
     @Override

--- a/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/CatalanAnalyzerProvider.java
+++ b/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/CatalanAnalyzerProvider.java
@@ -26,7 +26,6 @@ public class CatalanAnalyzerProvider extends AbstractIndexAnalyzerProvider<Catal
             Analysis.parseStopWords(env, settings, CatalanAnalyzer.getDefaultStopSet()),
             Analysis.parseStemExclusion(settings, CharArraySet.EMPTY_SET)
         );
-        analyzer.setVersion(version);
     }
 
     @Override

--- a/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/ChineseAnalyzerProvider.java
+++ b/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/ChineseAnalyzerProvider.java
@@ -26,7 +26,6 @@ public class ChineseAnalyzerProvider extends AbstractIndexAnalyzerProvider<Stand
         super(indexSettings, name, settings);
         // old index: best effort
         analyzer = new StandardAnalyzer(EnglishAnalyzer.ENGLISH_STOP_WORDS_SET);
-        analyzer.setVersion(version);
 
     }
 

--- a/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/CjkAnalyzerProvider.java
+++ b/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/CjkAnalyzerProvider.java
@@ -25,7 +25,6 @@ public class CjkAnalyzerProvider extends AbstractIndexAnalyzerProvider<CJKAnalyz
         CharArraySet stopWords = Analysis.parseStopWords(env, settings, CJKAnalyzer.getDefaultStopSet());
 
         analyzer = new CJKAnalyzer(stopWords);
-        analyzer.setVersion(version);
     }
 
     @Override

--- a/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/CzechAnalyzerProvider.java
+++ b/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/CzechAnalyzerProvider.java
@@ -26,7 +26,6 @@ public class CzechAnalyzerProvider extends AbstractIndexAnalyzerProvider<CzechAn
             Analysis.parseStopWords(env, settings, CzechAnalyzer.getDefaultStopSet()),
             Analysis.parseStemExclusion(settings, CharArraySet.EMPTY_SET)
         );
-        analyzer.setVersion(version);
     }
 
     @Override

--- a/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/DanishAnalyzerProvider.java
+++ b/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/DanishAnalyzerProvider.java
@@ -26,7 +26,6 @@ public class DanishAnalyzerProvider extends AbstractIndexAnalyzerProvider<Danish
             Analysis.parseStopWords(env, settings, DanishAnalyzer.getDefaultStopSet()),
             Analysis.parseStemExclusion(settings, CharArraySet.EMPTY_SET)
         );
-        analyzer.setVersion(version);
     }
 
     @Override

--- a/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/DutchAnalyzerProvider.java
+++ b/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/DutchAnalyzerProvider.java
@@ -26,7 +26,6 @@ public class DutchAnalyzerProvider extends AbstractIndexAnalyzerProvider<DutchAn
             Analysis.parseStopWords(env, settings, DutchAnalyzer.getDefaultStopSet()),
             Analysis.parseStemExclusion(settings, CharArraySet.EMPTY_SET)
         );
-        analyzer.setVersion(version);
     }
 
     @Override

--- a/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/EnglishAnalyzerProvider.java
+++ b/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/EnglishAnalyzerProvider.java
@@ -26,7 +26,6 @@ public class EnglishAnalyzerProvider extends AbstractIndexAnalyzerProvider<Engli
             Analysis.parseStopWords(env, settings, EnglishAnalyzer.getDefaultStopSet()),
             Analysis.parseStemExclusion(settings, CharArraySet.EMPTY_SET)
         );
-        analyzer.setVersion(version);
     }
 
     @Override

--- a/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/EstonianAnalyzerProvider.java
+++ b/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/EstonianAnalyzerProvider.java
@@ -26,7 +26,6 @@ public class EstonianAnalyzerProvider extends AbstractIndexAnalyzerProvider<Esto
             Analysis.parseStopWords(env, settings, EstonianAnalyzer.getDefaultStopSet()),
             Analysis.parseStemExclusion(settings, CharArraySet.EMPTY_SET)
         );
-        analyzer.setVersion(version);
     }
 
     @Override

--- a/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/FinnishAnalyzerProvider.java
+++ b/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/FinnishAnalyzerProvider.java
@@ -26,7 +26,6 @@ public class FinnishAnalyzerProvider extends AbstractIndexAnalyzerProvider<Finni
             Analysis.parseStopWords(env, settings, FinnishAnalyzer.getDefaultStopSet()),
             Analysis.parseStemExclusion(settings, CharArraySet.EMPTY_SET)
         );
-        analyzer.setVersion(version);
     }
 
     @Override

--- a/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/FrenchAnalyzerProvider.java
+++ b/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/FrenchAnalyzerProvider.java
@@ -26,7 +26,6 @@ public class FrenchAnalyzerProvider extends AbstractIndexAnalyzerProvider<French
             Analysis.parseStopWords(env, settings, FrenchAnalyzer.getDefaultStopSet()),
             Analysis.parseStemExclusion(settings, CharArraySet.EMPTY_SET)
         );
-        analyzer.setVersion(version);
     }
 
     @Override

--- a/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/GalicianAnalyzerProvider.java
+++ b/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/GalicianAnalyzerProvider.java
@@ -26,7 +26,6 @@ public class GalicianAnalyzerProvider extends AbstractIndexAnalyzerProvider<Gali
             Analysis.parseStopWords(env, settings, GalicianAnalyzer.getDefaultStopSet()),
             Analysis.parseStemExclusion(settings, CharArraySet.EMPTY_SET)
         );
-        analyzer.setVersion(version);
     }
 
     @Override

--- a/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/GermanAnalyzerProvider.java
+++ b/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/GermanAnalyzerProvider.java
@@ -26,7 +26,6 @@ public class GermanAnalyzerProvider extends AbstractIndexAnalyzerProvider<German
             Analysis.parseStopWords(env, settings, GermanAnalyzer.getDefaultStopSet()),
             Analysis.parseStemExclusion(settings, CharArraySet.EMPTY_SET)
         );
-        analyzer.setVersion(version);
     }
 
     @Override

--- a/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/GreekAnalyzerProvider.java
+++ b/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/GreekAnalyzerProvider.java
@@ -23,7 +23,6 @@ public class GreekAnalyzerProvider extends AbstractIndexAnalyzerProvider<GreekAn
         super(indexSettings, name, settings);
         analyzer = new GreekAnalyzer(
             Analysis.parseStopWords(env, settings, GreekAnalyzer.getDefaultStopSet()));
-        analyzer.setVersion(version);
     }
 
     @Override

--- a/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/HindiAnalyzerProvider.java
+++ b/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/HindiAnalyzerProvider.java
@@ -26,7 +26,6 @@ public class HindiAnalyzerProvider extends AbstractIndexAnalyzerProvider<HindiAn
             Analysis.parseStopWords(env, settings, HindiAnalyzer.getDefaultStopSet()),
             Analysis.parseStemExclusion(settings, CharArraySet.EMPTY_SET)
         );
-        analyzer.setVersion(version);
     }
 
     @Override

--- a/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/HungarianAnalyzerProvider.java
+++ b/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/HungarianAnalyzerProvider.java
@@ -26,7 +26,6 @@ public class HungarianAnalyzerProvider extends AbstractIndexAnalyzerProvider<Hun
             Analysis.parseStopWords(env, settings, HungarianAnalyzer.getDefaultStopSet()),
             Analysis.parseStemExclusion(settings, CharArraySet.EMPTY_SET)
         );
-        analyzer.setVersion(version);
     }
 
     @Override

--- a/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/IndonesianAnalyzerProvider.java
+++ b/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/IndonesianAnalyzerProvider.java
@@ -26,7 +26,6 @@ public class IndonesianAnalyzerProvider extends AbstractIndexAnalyzerProvider<In
             Analysis.parseStopWords(env, settings, IndonesianAnalyzer.getDefaultStopSet()),
             Analysis.parseStemExclusion(settings, CharArraySet.EMPTY_SET)
         );
-        analyzer.setVersion(version);
     }
 
     @Override

--- a/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/IrishAnalyzerProvider.java
+++ b/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/IrishAnalyzerProvider.java
@@ -29,7 +29,6 @@ public class IrishAnalyzerProvider extends AbstractIndexAnalyzerProvider<IrishAn
             Analysis.parseStopWords(env, settings, IrishAnalyzer.getDefaultStopSet()),
             Analysis.parseStemExclusion(settings, CharArraySet.EMPTY_SET)
         );
-        analyzer.setVersion(version);
     }
 
     @Override

--- a/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/ItalianAnalyzerProvider.java
+++ b/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/ItalianAnalyzerProvider.java
@@ -26,7 +26,6 @@ public class ItalianAnalyzerProvider extends AbstractIndexAnalyzerProvider<Itali
             Analysis.parseStopWords(env, settings, ItalianAnalyzer.getDefaultStopSet()),
             Analysis.parseStemExclusion(settings, CharArraySet.EMPTY_SET)
         );
-        analyzer.setVersion(version);
     }
 
     @Override

--- a/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/LatvianAnalyzerProvider.java
+++ b/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/LatvianAnalyzerProvider.java
@@ -26,7 +26,6 @@ public class LatvianAnalyzerProvider extends AbstractIndexAnalyzerProvider<Latvi
             Analysis.parseStopWords(env, settings, LatvianAnalyzer.getDefaultStopSet()),
             Analysis.parseStemExclusion(settings, CharArraySet.EMPTY_SET)
         );
-        analyzer.setVersion(version);
     }
 
     @Override

--- a/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/LithuanianAnalyzerProvider.java
+++ b/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/LithuanianAnalyzerProvider.java
@@ -29,7 +29,6 @@ public class LithuanianAnalyzerProvider extends AbstractIndexAnalyzerProvider<Li
             Analysis.parseStopWords(env, settings, LithuanianAnalyzer.getDefaultStopSet()),
             Analysis.parseStemExclusion(settings, CharArraySet.EMPTY_SET)
         );
-        analyzer.setVersion(version);
     }
 
     @Override

--- a/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/NorwegianAnalyzerProvider.java
+++ b/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/NorwegianAnalyzerProvider.java
@@ -26,7 +26,6 @@ public class NorwegianAnalyzerProvider extends AbstractIndexAnalyzerProvider<Nor
             Analysis.parseStopWords(env, settings, NorwegianAnalyzer.getDefaultStopSet()),
             Analysis.parseStemExclusion(settings, CharArraySet.EMPTY_SET)
         );
-        analyzer.setVersion(version);
     }
 
     @Override

--- a/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/PersianAnalyzerProvider.java
+++ b/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/PersianAnalyzerProvider.java
@@ -22,7 +22,6 @@ public class PersianAnalyzerProvider extends AbstractIndexAnalyzerProvider<Persi
     PersianAnalyzerProvider(IndexSettings indexSettings, Environment env, String name, Settings settings) {
         super(indexSettings, name, settings);
         analyzer = new PersianAnalyzer(Analysis.parseStopWords(env, settings, PersianAnalyzer.getDefaultStopSet()));
-        analyzer.setVersion(version);
     }
 
     @Override

--- a/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/PortugueseAnalyzerProvider.java
+++ b/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/PortugueseAnalyzerProvider.java
@@ -26,7 +26,6 @@ public class PortugueseAnalyzerProvider extends AbstractIndexAnalyzerProvider<Po
             Analysis.parseStopWords(env, settings, PortugueseAnalyzer.getDefaultStopSet()),
             Analysis.parseStemExclusion(settings, CharArraySet.EMPTY_SET)
         );
-        analyzer.setVersion(version);
     }
 
     @Override

--- a/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/RomanianAnalyzerProvider.java
+++ b/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/RomanianAnalyzerProvider.java
@@ -26,7 +26,6 @@ public class RomanianAnalyzerProvider extends AbstractIndexAnalyzerProvider<Roma
             Analysis.parseStopWords(env, settings, RomanianAnalyzer.getDefaultStopSet()),
             Analysis.parseStemExclusion(settings, CharArraySet.EMPTY_SET)
         );
-        analyzer.setVersion(version);
     }
 
     @Override

--- a/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/RussianAnalyzerProvider.java
+++ b/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/RussianAnalyzerProvider.java
@@ -26,7 +26,6 @@ public class RussianAnalyzerProvider extends AbstractIndexAnalyzerProvider<Russi
             Analysis.parseStopWords(env, settings, RussianAnalyzer.getDefaultStopSet()),
             Analysis.parseStemExclusion(settings, CharArraySet.EMPTY_SET)
         );
-        analyzer.setVersion(version);
     }
 
     @Override

--- a/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/SnowballAnalyzerProvider.java
+++ b/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/SnowballAnalyzerProvider.java
@@ -51,7 +51,6 @@ public class SnowballAnalyzerProvider extends AbstractIndexAnalyzerProvider<Snow
         CharArraySet stopWords = Analysis.parseStopWords(env, settings, defaultStopwords);
 
         analyzer = new SnowballAnalyzer(language, stopWords);
-        analyzer.setVersion(version);
     }
 
     @Override

--- a/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/SoraniAnalyzerProvider.java
+++ b/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/SoraniAnalyzerProvider.java
@@ -29,7 +29,6 @@ public class SoraniAnalyzerProvider extends AbstractIndexAnalyzerProvider<Sorani
             Analysis.parseStopWords(env, settings, SoraniAnalyzer.getDefaultStopSet()),
             Analysis.parseStemExclusion(settings, CharArraySet.EMPTY_SET)
         );
-        analyzer.setVersion(version);
     }
 
     @Override

--- a/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/SpanishAnalyzerProvider.java
+++ b/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/SpanishAnalyzerProvider.java
@@ -26,7 +26,6 @@ public class SpanishAnalyzerProvider extends AbstractIndexAnalyzerProvider<Spani
             Analysis.parseStopWords(env, settings, SpanishAnalyzer.getDefaultStopSet()),
             Analysis.parseStemExclusion(settings, CharArraySet.EMPTY_SET)
         );
-        analyzer.setVersion(version);
     }
 
     @Override

--- a/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/SwedishAnalyzerProvider.java
+++ b/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/SwedishAnalyzerProvider.java
@@ -26,7 +26,6 @@ public class SwedishAnalyzerProvider extends AbstractIndexAnalyzerProvider<Swedi
             Analysis.parseStopWords(env, settings, SwedishAnalyzer.getDefaultStopSet()),
             Analysis.parseStemExclusion(settings, CharArraySet.EMPTY_SET)
         );
-        analyzer.setVersion(version);
     }
 
     @Override

--- a/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/ThaiAnalyzerProvider.java
+++ b/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/ThaiAnalyzerProvider.java
@@ -23,7 +23,6 @@ public class ThaiAnalyzerProvider extends AbstractIndexAnalyzerProvider<ThaiAnal
         super(indexSettings, name, settings);
         analyzer = new ThaiAnalyzer(
             Analysis.parseStopWords(env, settings, ThaiAnalyzer.getDefaultStopSet()));
-        analyzer.setVersion(version);
     }
 
     @Override

--- a/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/TurkishAnalyzerProvider.java
+++ b/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/TurkishAnalyzerProvider.java
@@ -26,7 +26,6 @@ public class TurkishAnalyzerProvider extends AbstractIndexAnalyzerProvider<Turki
             Analysis.parseStopWords(env, settings, TurkishAnalyzer.getDefaultStopSet()),
             Analysis.parseStemExclusion(settings, CharArraySet.EMPTY_SET)
         );
-        analyzer.setVersion(version);
     }
 
     @Override

--- a/modules/analysis-common/src/test/java/org/elasticsearch/analysis/common/CompoundAnalysisTests.java
+++ b/modules/analysis-common/src/test/java/org/elasticsearch/analysis/common/CompoundAnalysisTests.java
@@ -55,6 +55,7 @@ public class CompoundAnalysisTests extends ESTestCase {
             MatcherAssert.assertThat(terms,
                     hasItems("donau", "dampf", "schiff", "donaudampfschiff", "spargel", "creme", "suppe", "spargelcremesuppe"));
         }
+        assertWarnings("Setting [version] on analysis component [custom7] has no effect and is deprecated");
     }
 
     private List<String> analyze(Settings settings, String analyzerName, String text) throws IOException {

--- a/plugins/analysis-stempel/src/main/java/org/elasticsearch/index/analysis/pl/PolishAnalyzerProvider.java
+++ b/plugins/analysis-stempel/src/main/java/org/elasticsearch/index/analysis/pl/PolishAnalyzerProvider.java
@@ -22,7 +22,6 @@ public class PolishAnalyzerProvider extends AbstractIndexAnalyzerProvider<Polish
         super(indexSettings, name, settings);
 
         analyzer = new PolishAnalyzer(PolishAnalyzer.getDefaultStopSet());
-        analyzer.setVersion(version);
     }
 
     @Override

--- a/plugins/analysis-ukrainian/src/main/java/org/elasticsearch/index/analysis/UkrainianAnalyzerProvider.java
+++ b/plugins/analysis-ukrainian/src/main/java/org/elasticsearch/index/analysis/UkrainianAnalyzerProvider.java
@@ -25,7 +25,6 @@ public class UkrainianAnalyzerProvider extends AbstractIndexAnalyzerProvider<XUk
             Analysis.parseStopWords(env, settings, UkrainianMorfologikAnalyzer.getDefaultStopSet()),
             Analysis.parseStemExclusion(settings, CharArraySet.EMPTY_SET)
         );
-        analyzer.setVersion(version);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/index/analysis/AbstractIndexAnalyzerProvider.java
+++ b/server/src/main/java/org/elasticsearch/index/analysis/AbstractIndexAnalyzerProvider.java
@@ -9,7 +9,6 @@
 package org.elasticsearch.index.analysis;
 
 import org.apache.lucene.analysis.Analyzer;
-import org.apache.lucene.util.Version;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.AbstractIndexComponent;
 import org.elasticsearch.index.IndexSettings;
@@ -17,8 +16,6 @@ import org.elasticsearch.index.IndexSettings;
 public abstract class AbstractIndexAnalyzerProvider<T extends Analyzer> extends AbstractIndexComponent implements AnalyzerProvider<T> {
 
     private final String name;
-
-    protected final Version version;
 
     /**
      * Constructs a new analyzer component, with the index name and its settings and the analyzer name.
@@ -29,7 +26,7 @@ public abstract class AbstractIndexAnalyzerProvider<T extends Analyzer> extends 
     public AbstractIndexAnalyzerProvider(IndexSettings indexSettings, String name, Settings settings) {
         super(indexSettings);
         this.name = name;
-        this.version = Analysis.parseAnalysisVersion(this.indexSettings, settings, logger);
+        Analysis.checkForDeprecatedVersion(name, settings);
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/index/analysis/AbstractTokenFilterFactory.java
+++ b/server/src/main/java/org/elasticsearch/index/analysis/AbstractTokenFilterFactory.java
@@ -8,7 +8,6 @@
 
 package org.elasticsearch.index.analysis;
 
-import org.apache.lucene.util.Version;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.AbstractIndexComponent;
 import org.elasticsearch.index.IndexSettings;

--- a/server/src/main/java/org/elasticsearch/index/analysis/AbstractTokenFilterFactory.java
+++ b/server/src/main/java/org/elasticsearch/index/analysis/AbstractTokenFilterFactory.java
@@ -17,20 +17,14 @@ public abstract class AbstractTokenFilterFactory extends AbstractIndexComponent 
 
     private final String name;
 
-    protected final Version version;
-
     public AbstractTokenFilterFactory(IndexSettings indexSettings, String name, Settings settings) {
         super(indexSettings);
         this.name = name;
-        this.version = Analysis.parseAnalysisVersion(indexSettings, settings, logger);
+        Analysis.checkForDeprecatedVersion(name, settings);
     }
 
     @Override
     public String name() {
         return this.name;
-    }
-
-    public final Version version() {
-        return version;
     }
 }

--- a/server/src/main/java/org/elasticsearch/index/analysis/AbstractTokenizerFactory.java
+++ b/server/src/main/java/org/elasticsearch/index/analysis/AbstractTokenizerFactory.java
@@ -8,7 +8,6 @@
 
 package org.elasticsearch.index.analysis;
 
-import org.apache.lucene.util.Version;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.AbstractIndexComponent;
 import org.elasticsearch.index.IndexSettings;

--- a/server/src/main/java/org/elasticsearch/index/analysis/AbstractTokenizerFactory.java
+++ b/server/src/main/java/org/elasticsearch/index/analysis/AbstractTokenizerFactory.java
@@ -14,17 +14,13 @@ import org.elasticsearch.index.AbstractIndexComponent;
 import org.elasticsearch.index.IndexSettings;
 
 public abstract class AbstractTokenizerFactory extends AbstractIndexComponent implements TokenizerFactory {
-    protected final Version version;
+
     private final String name;
 
     public AbstractTokenizerFactory(IndexSettings indexSettings, Settings settings, String name) {
         super(indexSettings);
-        this.version = Analysis.parseAnalysisVersion(indexSettings, settings, logger);
+        Analysis.checkForDeprecatedVersion(name, settings);
         this.name = name;
-    }
-
-    public final Version version() {
-        return version;
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/index/analysis/Analysis.java
+++ b/server/src/main/java/org/elasticsearch/index/analysis/Analysis.java
@@ -8,7 +8,6 @@
 
 package org.elasticsearch.index.analysis;
 
-import org.apache.logging.log4j.Logger;
 import org.apache.lucene.analysis.CharArraySet;
 import org.apache.lucene.analysis.ar.ArabicAnalyzer;
 import org.apache.lucene.analysis.bg.BulgarianAnalyzer;
@@ -44,14 +43,11 @@ import org.apache.lucene.analysis.ru.RussianAnalyzer;
 import org.apache.lucene.analysis.sv.SwedishAnalyzer;
 import org.apache.lucene.analysis.th.ThaiAnalyzer;
 import org.apache.lucene.analysis.tr.TurkishAnalyzer;
-import org.apache.lucene.util.Version;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.logging.DeprecationCategory;
 import org.elasticsearch.common.logging.DeprecationLogger;
-import org.elasticsearch.common.lucene.Lucene;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.env.Environment;
-import org.elasticsearch.index.IndexSettings;
 
 import java.io.BufferedReader;
 import java.io.IOException;

--- a/server/src/main/java/org/elasticsearch/index/analysis/Analysis.java
+++ b/server/src/main/java/org/elasticsearch/index/analysis/Analysis.java
@@ -46,6 +46,8 @@ import org.apache.lucene.analysis.th.ThaiAnalyzer;
 import org.apache.lucene.analysis.tr.TurkishAnalyzer;
 import org.apache.lucene.util.Version;
 import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.logging.DeprecationCategory;
+import org.elasticsearch.common.logging.DeprecationLogger;
 import org.elasticsearch.common.lucene.Lucene;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.env.Environment;
@@ -69,19 +71,17 @@ import static java.util.Map.entry;
 
 public class Analysis {
 
-    public static Version parseAnalysisVersion(IndexSettings indexSettings, Settings settings, Logger logger) {
-        // check for explicit version on the specific analyzer component
+    private static final DeprecationLogger DEPRECATION_LOGGER = DeprecationLogger.getLogger(Analysis.class);
+
+    public static void checkForDeprecatedVersion(String name, Settings settings) {
         String sVersion = settings.get("version");
         if (sVersion != null) {
-            return Lucene.parseVersion(sVersion, Version.LATEST, logger);
+            DEPRECATION_LOGGER.deprecate(
+                DeprecationCategory.ANALYSIS,
+                "analyzer.version",
+                "Setting [version] on analysis component [" + name + "] has no effect and is deprecated"
+            );
         }
-        // check for explicit version on the index itself as default for all analysis components
-        sVersion = indexSettings.getSettings().get("index.analysis.version");
-        if (sVersion != null) {
-            return Lucene.parseVersion(sVersion, Version.LATEST, logger);
-        }
-        // resolve the analysis version based on the version the index was created with
-        return indexSettings.getIndexVersionCreated().luceneVersion;
     }
 
     public static CharArraySet parseStemExclusion(Settings settings, CharArraySet defaultStemExclusion) {

--- a/server/src/main/java/org/elasticsearch/index/analysis/SimpleAnalyzerProvider.java
+++ b/server/src/main/java/org/elasticsearch/index/analysis/SimpleAnalyzerProvider.java
@@ -20,7 +20,6 @@ public class SimpleAnalyzerProvider extends AbstractIndexAnalyzerProvider<Simple
     public SimpleAnalyzerProvider(IndexSettings indexSettings, Environment environment, String name, Settings settings) {
         super(indexSettings, name, settings);
         this.simpleAnalyzer = new SimpleAnalyzer();
-        this.simpleAnalyzer.setVersion(version);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/index/analysis/StandardAnalyzerProvider.java
+++ b/server/src/main/java/org/elasticsearch/index/analysis/StandardAnalyzerProvider.java
@@ -24,7 +24,6 @@ public class StandardAnalyzerProvider extends AbstractIndexAnalyzerProvider<Stan
         CharArraySet stopWords = Analysis.parseStopWords(env, settings, defaultStopwords);
         int maxTokenLength = settings.getAsInt("max_token_length", StandardAnalyzer.DEFAULT_MAX_TOKEN_LENGTH);
         standardAnalyzer = new StandardAnalyzer(stopWords);
-        standardAnalyzer.setVersion(version);
         standardAnalyzer.setMaxTokenLength(maxTokenLength);
     }
 

--- a/server/src/main/java/org/elasticsearch/index/analysis/StopAnalyzerProvider.java
+++ b/server/src/main/java/org/elasticsearch/index/analysis/StopAnalyzerProvider.java
@@ -24,7 +24,6 @@ public class StopAnalyzerProvider extends AbstractIndexAnalyzerProvider<StopAnal
         CharArraySet stopWords = Analysis.parseStopWords(
             env, settings, EnglishAnalyzer.ENGLISH_STOP_WORDS_SET);
         this.stopAnalyzer = new StopAnalyzer(stopWords);
-        this.stopAnalyzer.setVersion(version);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/index/analysis/WhitespaceAnalyzerProvider.java
+++ b/server/src/main/java/org/elasticsearch/index/analysis/WhitespaceAnalyzerProvider.java
@@ -20,7 +20,6 @@ public class WhitespaceAnalyzerProvider extends AbstractIndexAnalyzerProvider<Wh
     public WhitespaceAnalyzerProvider(IndexSettings indexSettings, Environment environment, String name, Settings settings) {
         super(indexSettings, name, settings);
         this.analyzer = new WhitespaceAnalyzer();
-        this.analyzer.setVersion(version);
     }
 
     @Override

--- a/server/src/test/java/org/elasticsearch/index/analysis/AnalysisTests.java
+++ b/server/src/test/java/org/elasticsearch/index/analysis/AnalysisTests.java
@@ -8,14 +8,10 @@
 
 package org.elasticsearch.index.analysis;
 
-import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.analysis.CharArraySet;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.env.Environment;
 import org.elasticsearch.env.TestEnvironment;
-import org.elasticsearch.index.Index;
-import org.elasticsearch.index.IndexSettings;
-import org.elasticsearch.indices.IndicesModule;
 import org.elasticsearch.test.ESTestCase;
 
 import java.io.BufferedWriter;

--- a/server/src/test/java/org/elasticsearch/index/analysis/AnalysisTests.java
+++ b/server/src/test/java/org/elasticsearch/index/analysis/AnalysisTests.java
@@ -8,10 +8,14 @@
 
 package org.elasticsearch.index.analysis;
 
+import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.analysis.CharArraySet;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.env.Environment;
 import org.elasticsearch.env.TestEnvironment;
+import org.elasticsearch.index.Index;
+import org.elasticsearch.index.IndexSettings;
+import org.elasticsearch.indices.IndicesModule;
 import org.elasticsearch.test.ESTestCase;
 
 import java.io.BufferedWriter;
@@ -94,6 +98,5 @@ public class AnalysisTests extends ESTestCase {
         Environment env = TestEnvironment.newEnvironment(nodeSettings);
         List<String> wordList = Analysis.getWordList(env, nodeSettings, "foo.bar");
         assertEquals(Arrays.asList("hello", "world"), wordList);
-
     }
 }

--- a/server/src/test/java/org/elasticsearch/indices/analysis/AnalysisModuleTests.java
+++ b/server/src/test/java/org/elasticsearch/indices/analysis/AnalysisModuleTests.java
@@ -117,6 +117,7 @@ public class AnalysisModuleTests extends ESTestCase {
     public void testSimpleConfigurationYaml() throws IOException {
         Settings settings = loadFromClasspath("/org/elasticsearch/index/analysis/test1.yml");
         testSimpleConfiguration(settings);
+        assertWarnings("Setting [version] on analysis component [custom7] has no effect and is deprecated");
     }
 
     public void testVersionedAnalyzers() throws Exception {

--- a/server/src/test/java/org/elasticsearch/indices/analysis/AnalysisModuleTests.java
+++ b/server/src/test/java/org/elasticsearch/indices/analysis/AnalysisModuleTests.java
@@ -33,7 +33,6 @@ import org.elasticsearch.index.analysis.CharFilterFactory;
 import org.elasticsearch.index.analysis.CustomAnalyzer;
 import org.elasticsearch.index.analysis.IndexAnalyzers;
 import org.elasticsearch.index.analysis.MyFilterTokenFilterFactory;
-import org.elasticsearch.index.analysis.NamedAnalyzer;
 import org.elasticsearch.index.analysis.PreConfiguredCharFilter;
 import org.elasticsearch.index.analysis.PreConfiguredTokenFilter;
 import org.elasticsearch.index.analysis.PreConfiguredTokenizer;

--- a/server/src/test/java/org/elasticsearch/indices/analysis/AnalysisModuleTests.java
+++ b/server/src/test/java/org/elasticsearch/indices/analysis/AnalysisModuleTests.java
@@ -131,22 +131,8 @@ public class AnalysisModuleTests extends ESTestCase {
         AnalysisRegistry newRegistry = getNewRegistry(settings2);
         IndexAnalyzers indexAnalyzers = getIndexAnalyzers(newRegistry, settings2);
 
-        // registry always has the current version
-        assertThat(newRegistry.getAnalyzer("default"), is(instanceOf(NamedAnalyzer.class)));
-        NamedAnalyzer defaultNamedAnalyzer = (NamedAnalyzer) newRegistry.getAnalyzer("default");
-        assertThat(defaultNamedAnalyzer.analyzer(), is(instanceOf(StandardAnalyzer.class)));
-        assertEquals(Version.CURRENT.luceneVersion, defaultNamedAnalyzer.analyzer().getVersion());
-
-        // analysis service has the expected version
-        assertThat(indexAnalyzers.get("standard").analyzer(), is(instanceOf(StandardAnalyzer.class)));
-        assertEquals(version.luceneVersion,
-                indexAnalyzers.get("standard").analyzer().getVersion());
-        assertEquals(version.luceneVersion,
-                indexAnalyzers.get("stop").analyzer().getVersion());
-
         assertThat(indexAnalyzers.get("custom7").analyzer(), is(instanceOf(StandardAnalyzer.class)));
-        assertEquals(org.apache.lucene.util.Version.fromBits(3,6,0),
-                indexAnalyzers.get("custom7").analyzer().getVersion());
+        assertWarnings("Setting [version] on analysis component [custom7] has no effect and is deprecated");
     }
 
     private void testSimpleConfiguration(Settings settings) throws IOException {


### PR DESCRIPTION
The `version` field on all lucene Analyzers is unused, and is being removed
in lucene 9.  This commit deprecates setting a version on an analyzer in
index settings and removes the related calls to `Analyzer.setVersion()`