### PR TITLE
[7.x] Update set.asciidoc (#73577)

### DIFF
--- a/docs/reference/ingest/processors/set.asciidoc
+++ b/docs/reference/ingest/processors/set.asciidoc
@@ -24,7 +24,7 @@ include::common-options.asciidoc[]
 [source,js]
 --------------------------------------------------
 {
-  "description" : "sets the value of count to 1"
+  "description" : "sets the value of count to 1",
   "set": {
     "field": "count",
     "value": 1


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Update set.asciidoc (#73577)

Closes #74035