### PR TITLE
Fix duplicate map key in DocumentFieldTests

### DIFF
--- a/server/src/test/java/org/elasticsearch/index/get/DocumentFieldTests.java
+++ b/server/src/test/java/org/elasticsearch/index/get/DocumentFieldTests.java
@@ -23,6 +23,7 @@ import org.elasticsearch.test.RandomObjects;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Predicate;
@@ -123,10 +124,13 @@ public class DocumentFieldTests extends ESTestCase {
                     DocumentField listField = new DocumentField(randomAlphaOfLength(5), listValues);
                     return Tuple.tuple(listField, listField);
                 case 2:
-                    List<Object> objectValues = randomList(1, 5, () ->
-                        Map.of(randomAlphaOfLength(5), randomInt(),
-                            randomAlphaOfLength(5), randomBoolean(),
-                            randomAlphaOfLength(5), randomAlphaOfLength(10)));
+                    List<Object> objectValues = randomList(1, 5, () -> {
+                        Map<String, Object> values = new HashMap<>();
+                        values.put(randomAlphaOfLength(5), randomInt());
+                        values.put(randomAlphaOfLength(5), randomBoolean());
+                        values.put(randomAlphaOfLength(5), randomAlphaOfLength(10));
+                        return values;
+                    });
                     DocumentField objectField = new DocumentField(randomAlphaOfLength(5), objectValues);
                     return Tuple.tuple(objectField, objectField);
                 default:


### PR DESCRIPTION
We can fix the issue by not generating duplicated keys in DocumentFieldTests. This commit prefers to replace Map.of() with HashMap.put() because it's simpler.

Closes #73948