### PR TITLE
[DOCS] Clarify criteria for restore completion

### DIFF
--- a/docs/reference/snapshot-restore/apis/restore-snapshot-api.asciidoc
+++ b/docs/reference/snapshot-restore/apis/restore-snapshot-api.asciidoc
@@ -106,7 +106,11 @@ include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=master-timeout]
 
 `wait_for_completion`::
 (Optional, Boolean) If `true`, the request returns a response when the restore
-operation completes. If `false`, the request returns a response when the restore
+operation completes. The operation completes once it attempts all
+<<_monitoring_restore_operations,recovery and replication steps>>. This applies
+even if one or more of the steps fail.
++
+If `false`, the request returns a response when the restore
 operation initializes. Defaults to `false`.
 
 [role="child_attributes"]

--- a/docs/reference/snapshot-restore/apis/restore-snapshot-api.asciidoc
+++ b/docs/reference/snapshot-restore/apis/restore-snapshot-api.asciidoc
@@ -106,8 +106,8 @@ include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=master-timeout]
 
 `wait_for_completion`::
 (Optional, Boolean) If `true`, the request returns a response when the restore
-operation completes. The operation completes once it attempts all
-<<_monitoring_restore_operations,recovery and replication steps>>.
+operation completes. A restore operation is considered complete once it attempts
+all <<_monitoring_restore_operations,recovery and replication steps>>.
 +
 If `false`, the request returns a response when the restore
 operation initializes. Defaults to `false`.

--- a/docs/reference/snapshot-restore/apis/restore-snapshot-api.asciidoc
+++ b/docs/reference/snapshot-restore/apis/restore-snapshot-api.asciidoc
@@ -106,8 +106,9 @@ include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=master-timeout]
 
 `wait_for_completion`::
 (Optional, Boolean) If `true`, the request returns a response when the restore
-operation completes. A restore operation is considered complete once it attempts
-all <<_monitoring_restore_operations,shard recovery and replication steps>>.
+operation completes. The operation is complete when it finishes all attempts to
+<<_monitoring_restore_operations,recover primary shards>>. This applies even if
+one or more of the attempts fail.
 +
 If `false`, the request returns a response when the restore
 operation initializes. Defaults to `false`.

--- a/docs/reference/snapshot-restore/apis/restore-snapshot-api.asciidoc
+++ b/docs/reference/snapshot-restore/apis/restore-snapshot-api.asciidoc
@@ -107,8 +107,7 @@ include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=master-timeout]
 `wait_for_completion`::
 (Optional, Boolean) If `true`, the request returns a response when the restore
 operation completes. The operation completes once it attempts all
-<<_monitoring_restore_operations,recovery and replication steps>>. This applies
-even if one or more of the steps fail.
+<<_monitoring_restore_operations,recovery and replication steps>>.
 +
 If `false`, the request returns a response when the restore
 operation initializes. Defaults to `false`.

--- a/docs/reference/snapshot-restore/apis/restore-snapshot-api.asciidoc
+++ b/docs/reference/snapshot-restore/apis/restore-snapshot-api.asciidoc
@@ -107,7 +107,7 @@ include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=master-timeout]
 `wait_for_completion`::
 (Optional, Boolean) If `true`, the request returns a response when the restore
 operation completes. A restore operation is considered complete once it attempts
-all <<_monitoring_restore_operations,recovery and replication steps>>.
+all <<_monitoring_restore_operations,shard recovery and replication steps>>.
 +
 If `false`, the request returns a response when the restore
 operation initializes. Defaults to `false`.

--- a/docs/reference/snapshot-restore/apis/restore-snapshot-api.asciidoc
+++ b/docs/reference/snapshot-restore/apis/restore-snapshot-api.asciidoc
@@ -107,8 +107,8 @@ include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=master-timeout]
 `wait_for_completion`::
 (Optional, Boolean) If `true`, the request returns a response when the restore
 operation completes. The operation is complete when it finishes all attempts to
-<<_monitoring_restore_operations,recover primary shards>>. This applies even if
-one or more of the attempts fail.
+<<_monitoring_restore_operations,recover primary shards>> for restored indices.
+This applies even if one or more of the recovery attempts fail.
 +
 If `false`, the request returns a response when the restore
 operation initializes. Defaults to `false`.

--- a/docs/reference/snapshot-restore/monitor-snapshot-restore.asciidoc
+++ b/docs/reference/snapshot-restore/monitor-snapshot-restore.asciidoc
@@ -143,8 +143,8 @@ process that creates the required number of replicas. When all required
 replicas are created, the cluster switches to the `green` states.
 
 NOTE: A restore operation doesn't require a specific cluster health status to
-complete. A restore completes once it attempts all recovery and replication
-steps. This applies even if one or more of the steps fail.
+complete. A restore operation completes once it attempts all recovery and
+replication steps. This applies even if one or more of the steps fail.
 
 The cluster health operation provides only a high level status of the restore process. It's possible to get more
 detailed insight into the current state of the recovery process by using <<indices-recovery, index recovery>> and

--- a/docs/reference/snapshot-restore/monitor-snapshot-restore.asciidoc
+++ b/docs/reference/snapshot-restore/monitor-snapshot-restore.asciidoc
@@ -142,6 +142,10 @@ primary shards is completed, {es} switches to the standard replication
 process that creates the required number of replicas. When all required
 replicas are created, the cluster switches to the `green` states.
 
+NOTE: A restore operation doesn't require a specific cluster health status to
+complete. A restore completes once it attempts all recovery and replication
+steps. This applies even if one or more of the steps fail.
+
 The cluster health operation provides only a high level status of the restore process. It's possible to get more
 detailed insight into the current state of the recovery process by using <<indices-recovery, index recovery>> and
 <<cat-recovery, cat recovery>> APIs.

--- a/docs/reference/snapshot-restore/monitor-snapshot-restore.asciidoc
+++ b/docs/reference/snapshot-restore/monitor-snapshot-restore.asciidoc
@@ -142,10 +142,6 @@ primary shards is completed, {es} switches to the standard replication
 process that creates the required number of replicas. When all required
 replicas are created, the cluster switches to the `green` states.
 
-NOTE: A restore operation doesn't require a specific cluster health status to
-complete. A restore operation completes once it attempts all recovery and
-replication steps. This applies even if one or more of the steps fail.
-
 The cluster health operation provides only a high level status of the restore process. It's possible to get more
 detailed insight into the current state of the recovery process by using <<indices-recovery, index recovery>> and
 <<cat-recovery, cat recovery>> APIs.


### PR DESCRIPTION
A restore operation is complete when all attempts to recover primary shards have finished, even if unsuccessful.

Closes #70854

### Preview
https://elasticsearch_74094.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/restore-snapshot-api.html#restore-snapshot-api-query-params