### PR TITLE
[7.x] Tidy up deprecation code.

### DIFF
--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/migration/DeprecationInfoResponse.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/migration/DeprecationInfoResponse.java
@@ -59,7 +59,7 @@ public class DeprecationInfoResponse {
 
     private static List<DeprecationIssue> parseDeprecationIssues(XContentParser parser) throws IOException {
         List<DeprecationIssue> issues = new ArrayList<>();
-        XContentParser.Token token = null;
+        XContentParser.Token token;
         while ((token = parser.nextToken()) != XContentParser.Token.END_ARRAY) {
             if (token == XContentParser.Token.START_OBJECT) {
                 issues.add(DeprecationIssue.PARSER.parse(parser, null));
@@ -116,8 +116,7 @@ public class DeprecationInfoResponse {
 
     @Override
     public String toString() {
-        return clusterSettingsIssues.toString() + ":" + nodeSettingsIssues.toString() + ":" + indexSettingsIssues.toString() +
-            ":" + mlSettingsIssues.toString();
+        return clusterSettingsIssues + ":" + nodeSettingsIssues + ":" + indexSettingsIssues + ":" + mlSettingsIssues;
     }
 
     /**
@@ -156,10 +155,10 @@ public class DeprecationInfoResponse {
             }
         }
 
-        private Level level;
-        private String message;
-        private String url;
-        private String details;
+        private final Level level;
+        private final String message;
+        private final String url;
+        private final String details;
 
         public DeprecationIssue(Level level, String message, String url, @Nullable String details) {
             this.level = level;

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/deprecation/DeprecationIssue.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/deprecation/DeprecationIssue.java
@@ -59,15 +59,10 @@ public class DeprecationIssue implements Writeable, ToXContentObject {
         }
     }
 
-    private Level level;
-    private String message;
-    private String url;
-    private String details;
-
-    // pkg-private for tests
-    DeprecationIssue() {
-
-    }
+    private final Level level;
+    private final String message;
+    private final String url;
+    private final String details;
 
     public DeprecationIssue(Level level, String message, String url, @Nullable String details) {
         this.level = level;

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/deprecation/NodesDeprecationCheckAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/deprecation/NodesDeprecationCheckAction.java
@@ -52,7 +52,7 @@ public class NodesDeprecationCheckAction extends ActionType<NodesDeprecationChec
     }
 
     public static class NodeResponse extends BaseNodeResponse {
-        private List<DeprecationIssue> deprecationIssues;
+        private final List<DeprecationIssue> deprecationIssues;
 
         public NodeResponse(StreamInput in) throws IOException {
             super(in);

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/deprecation/DeprecationChecksTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/deprecation/DeprecationChecksTests.java
@@ -8,7 +8,6 @@ package org.elasticsearch.xpack.core.deprecation;
 
 import org.elasticsearch.test.ESTestCase;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Supplier;
@@ -17,7 +16,7 @@ import static org.hamcrest.core.IsEqual.equalTo;
 
 public class DeprecationChecksTests extends ESTestCase {
 
-    public void testFilterChecks() throws IOException {
+    public void testFilterChecks() {
         DeprecationIssue issue = DeprecationIssueTests.createTestInstance();
         int numChecksPassed = randomIntBetween(0, 5);
         int numChecksFailed = 10 - numChecksPassed;

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/deprecation/DeprecationInfoActionResponseTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/deprecation/DeprecationInfoActionResponseTests.java
@@ -8,7 +8,6 @@ package org.elasticsearch.xpack.core.deprecation;
 
 import org.elasticsearch.ElasticsearchStatusException;
 import org.elasticsearch.Version;
-import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
@@ -23,8 +22,6 @@ import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.indices.TestIndexNameExpressionResolver;
 import org.elasticsearch.test.AbstractWireSerializingTestCase;
-import org.elasticsearch.xpack.core.ml.datafeed.DatafeedConfig;
-import org.elasticsearch.xpack.core.ml.datafeed.DatafeedConfigTests;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -86,10 +83,7 @@ public class DeprecationInfoActionResponseTests extends AbstractWireSerializingT
         DiscoveryNode discoveryNode = DiscoveryNode.createLocal(Settings.EMPTY,
             new TransportAddress(TransportAddress.META_ADDRESS, 9300), "test");
         ClusterState state = ClusterState.builder(ClusterName.DEFAULT).metadata(metadata).build();
-        List<DatafeedConfig> datafeeds = Collections.singletonList(DatafeedConfigTests.createRandomizedDatafeedConfig("foo"));
         IndexNameExpressionResolver resolver = TestIndexNameExpressionResolver.newInstance();
-        IndicesOptions indicesOptions = IndicesOptions.fromOptions(false, false,
-            true, true);
         boolean clusterIssueFound = randomBoolean();
         boolean nodeIssueFound = randomBoolean();
         boolean indexIssueFound = randomBoolean();


### PR DESCRIPTION
Backporting #74065 to 7.x branch.

Removed unused code and made fields immutable.