### PR TITLE
[7.x] [DOCS] Remove 7.13.2 coming tag (#74030)

### DIFF
--- a/docs/reference/release-notes/7.13.asciidoc
+++ b/docs/reference/release-notes/7.13.asciidoc
@@ -1,8 +1,6 @@
 [[release-notes-7.13.2]]
 == {es} version 7.13.2
 
-coming[7.13.2]
-
 Also see <<breaking-changes-7.13,Breaking changes in 7.13>>.
 
 [[bug-7.13.2]]


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [DOCS] Remove 7.13.2 coming tag (#74030)