### PR TITLE
[7.x] [DOCS] Fix typo in CCR connect example (#74100)

### DIFF
--- a/docs/reference/ccr/getting-started.asciidoc
+++ b/docs/reference/ccr/getting-started.asciidoc
@@ -99,7 +99,7 @@ image::images/ccr-tutorial-clusters.png[ClusterA contains the leader index and C
 To configure a remote cluster from Stack Management in {kib}:
 
 . Select *Remote Clusters* from the side navigation.
-. Specify the IP address or host name of the remote cluster (ClusterB),
+. Specify the IP address or host name of the remote cluster (`ClusterA`),
 followed by the transport port of the remote cluster (defaults to `9300`). For
 example, `192.168.1.1:9300`.
 


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [DOCS] Fix typo in CCR connect example (#74100)