### PR TITLE
ApiKeyAuthCache now expires after access instead of write (#73982)

### DIFF
--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/ApiKeyService.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/ApiKeyService.java
@@ -213,7 +213,7 @@ public class ApiKeyService {
         final Integer maximumWeight = CACHE_MAX_KEYS_SETTING.get(settings);
         if (ttl.getNanos() > 0) {
             this.apiKeyAuthCache = CacheBuilder.<String, ListenableFuture<CachedApiKeyHashResult>>builder()
-                .setExpireAfterWrite(ttl)
+                .setExpireAfterAccess(ttl)
                 .setMaximumWeight(maximumWeight)
                 .build();
             final TimeValue doc_ttl = DOC_CACHE_TTL_SETTING.get(settings);
@@ -459,6 +459,9 @@ public class ApiKeyService {
                     }
                     validator.accept(apiKeyDoc);
                 } else {
+                    if (apiKeyAuthCache != null) {
+                        apiKeyAuthCache.invalidate(docId);
+                    }
                     listener.onResponse(
                         AuthenticationResult.unsuccessful("unable to find apikey with id " + credentials.getId(), null));
                 }
@@ -603,6 +606,9 @@ public class ApiKeyService {
         } else if (apiKeyDoc.invalidated == null) {
             listener.onResponse(AuthenticationResult.unsuccessful("api key document is missing invalidated field", null));
         } else if (apiKeyDoc.invalidated) {
+            if (apiKeyAuthCache != null) {
+                apiKeyAuthCache.invalidate(docId);
+            }
             listener.onResponse(AuthenticationResult.unsuccessful("api key has been invalidated", null));
         } else {
             if (apiKeyDoc.hash == null) {
@@ -672,6 +678,11 @@ public class ApiKeyService {
     // pkg private for testing
     CachedApiKeyHashResult getFromCache(String id) {
         return apiKeyAuthCache == null ? null : FutureUtils.get(apiKeyAuthCache.get(id), 0L, TimeUnit.MILLISECONDS);
+    }
+
+    // pkg private for testing
+    Cache<String, ListenableFuture<CachedApiKeyHashResult>> getApiKeyAuthCache() {
+        return apiKeyAuthCache;
     }
 
     // pkg private for testing

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/ApiKeyServiceTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/ApiKeyServiceTests.java
@@ -91,6 +91,7 @@ import java.util.concurrent.Semaphore;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
+import static org.elasticsearch.index.mapper.MapperService.SINGLE_MAPPING_NAME;
 import static org.elasticsearch.index.seqno.SequenceNumbers.UNASSIGNED_PRIMARY_TERM;
 import static org.elasticsearch.index.seqno.SequenceNumbers.UNASSIGNED_SEQ_NO;
 import static org.elasticsearch.test.SecurityIntegTestCase.getFastStoredHashAlgoForTests;
@@ -873,7 +874,7 @@ public class ApiKeyServiceTests extends ESTestCase {
         service.getApiKeyAuthCache().put(docId, new ListenableFuture<>());
         assertNotNull(service.getApiKeyAuthCache().get(docId));
         SecurityMocks.mockGetRequest(client, SECURITY_MAIN_ALIAS, docId,
-            new GetResult(INTERNAL_SECURITY_MAIN_INDEX_7, docId, UNASSIGNED_SEQ_NO, UNASSIGNED_PRIMARY_TERM,
+            new GetResult(INTERNAL_SECURITY_MAIN_INDEX_7, SINGLE_MAPPING_NAME, docId, UNASSIGNED_SEQ_NO, UNASSIGNED_PRIMARY_TERM,
                 randomLongBetween(0, 9), false, null, null, null));
         PlainActionFuture<AuthenticationResult> future = new PlainActionFuture<>();
         service.loadApiKeyAndValidateCredentials(threadContext, apiKeyCredentials, future);

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/ApiKeyServiceTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/ApiKeyServiceTests.java
@@ -19,6 +19,7 @@ import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.util.concurrent.ListenableFuture;
 import org.elasticsearch.core.Tuple;
 import org.elasticsearch.common.settings.SecureString;
 import org.elasticsearch.common.settings.Settings;
@@ -33,6 +34,7 @@ import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.common.xcontent.json.JsonXContent;
+import org.elasticsearch.index.get.GetResult;
 import org.elasticsearch.license.XPackLicenseState;
 import org.elasticsearch.test.ClusterServiceUtils;
 import org.elasticsearch.test.ESTestCase;
@@ -89,11 +91,15 @@ import java.util.concurrent.Semaphore;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
+import static org.elasticsearch.index.seqno.SequenceNumbers.UNASSIGNED_PRIMARY_TERM;
+import static org.elasticsearch.index.seqno.SequenceNumbers.UNASSIGNED_SEQ_NO;
 import static org.elasticsearch.test.SecurityIntegTestCase.getFastStoredHashAlgoForTests;
 import static org.elasticsearch.test.TestMatchers.throwableWithMessage;
 import static org.elasticsearch.xpack.core.security.authc.AuthenticationField.API_KEY_LIMITED_ROLE_DESCRIPTORS_KEY;
 import static org.elasticsearch.xpack.core.security.authc.AuthenticationField.API_KEY_ROLE_DESCRIPTORS_KEY;
 import static org.elasticsearch.xpack.core.security.authz.store.ReservedRolesStore.SUPERUSER_ROLE_DESCRIPTOR;
+import static org.elasticsearch.xpack.core.security.index.RestrictedIndicesNames.INTERNAL_SECURITY_MAIN_INDEX_7;
+import static org.elasticsearch.xpack.core.security.index.RestrictedIndicesNames.SECURITY_MAIN_ALIAS;
 import static org.elasticsearch.xpack.security.Security.SECURITY_CRYPTO_THREAD_POOL_NAME;
 import static org.elasticsearch.xpack.security.authc.ApiKeyService.API_KEY_METADATA_KEY;
 import static org.hamcrest.Matchers.anEmptyMap;
@@ -428,11 +434,14 @@ public class ApiKeyServiceTests extends ESTestCase {
 
         apiKeyDoc = buildApiKeyDoc(hash, -1, true);
         creds = new ApiKeyService.ApiKeyCredentials(randomAlphaOfLength(12), new SecureString(randomAlphaOfLength(15).toCharArray()));
+        service.getApiKeyAuthCache().put(creds.getId(), new ListenableFuture<>());
+        assertNotNull(service.getApiKeyAuthCache().get(creds.getId()));
         future = new PlainActionFuture<>();
         service.validateApiKeyCredentials(creds.getId(), apiKeyDoc, creds, Clock.systemUTC(), future);
         result = future.get();
         assertNotNull(result);
         assertFalse(result.isAuthenticated());
+        assertNull(service.getApiKeyAuthCache().get(creds.getId()));
     }
 
     public void testGetRolesForApiKeyNotInContext() throws Exception {
@@ -853,6 +862,22 @@ public class ApiKeyServiceTests extends ESTestCase {
         final AuthenticationResult authResult5 = future5.get();
         assertSame(AuthenticationResult.Status.SUCCESS, authResult5.getStatus());
         checkAuthApiKeyMetadata(metadata4, authResult5);
+    }
+
+    public void testWillInvalidateAuthCacheWhenDocNotFound() {
+        ApiKeyService service = createApiKeyService(Settings.EMPTY);
+        final ThreadContext threadContext = threadPool.getThreadContext();
+        final String docId = randomAlphaOfLength(16);
+        final String apiKey = randomAlphaOfLength(16);
+        ApiKeyCredentials apiKeyCredentials = new ApiKeyCredentials(docId, new SecureString(apiKey.toCharArray()));
+        service.getApiKeyAuthCache().put(docId, new ListenableFuture<>());
+        assertNotNull(service.getApiKeyAuthCache().get(docId));
+        SecurityMocks.mockGetRequest(client, SECURITY_MAIN_ALIAS, docId,
+            new GetResult(INTERNAL_SECURITY_MAIN_INDEX_7, docId, UNASSIGNED_SEQ_NO, UNASSIGNED_PRIMARY_TERM,
+                randomLongBetween(0, 9), false, null, null, null));
+        PlainActionFuture<AuthenticationResult> future = new PlainActionFuture<>();
+        service.loadApiKeyAndValidateCredentials(threadContext, apiKeyCredentials, future);
+        assertNull(service.getApiKeyAuthCache().get(docId));
     }
 
     public void testWillGetLookedUpByRealmNameIfExists() {


### PR DESCRIPTION
API key authCache is set to expire after write (by default 24 hours).
ExpireAfterWrite is generally preferred over expireAfterAccess because it
guarantees stale entries get evicted eventually in edge cases, e.g. when the
cache misses a notification from the cluster.

However, things are a bit different for the authCache. There is an additional
roundtrip to the security index for fetching the API key document. If the
document does not exists (removed due to expiration) or is invalidated, the
authentication fails earlier on without even consulting the authCache. This
means the stale entries won't cause any security issues when they exist.
Therefore, this PR changes the authCache to be expire after access, which helps
preventing potential cyclic surge of expensive hash computations especially
when a large number of API keys are in use.

To further help the cache efficiency, this PR also actively invalidates the
authCache if the document is either not found or invalidated so it does not
have to wait for 24 hour to happen. Note that these are all edge cases and we
don't expect them to happen often (if at all).