### PR TITLE
[Test] Bump timeout from 100 to 200 ms for the 2nd auth.

### DIFF
--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/ApiKeyServiceTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/ApiKeyServiceTests.java
@@ -698,7 +698,7 @@ public class ApiKeyServiceTests extends ESTestCase {
         assertThat(authResult1.isAuthenticated(), is(true));
         checkAuthApiKeyMetadata(metadata, authResult1);
 
-        final AuthenticationResult authResult2 = future2.actionGet(TimeValue.timeValueMillis(100));
+        final AuthenticationResult authResult2 = future2.actionGet(TimeValue.timeValueMillis(200));
         assertThat(authResult2.isAuthenticated(), is(true));
         checkAuthApiKeyMetadata(metadata, authResult2);
 


### PR DESCRIPTION
This test failure happens fairly rarely, roughly once per month,
including on PRs and 6.8 branch. It almost requires no change. Hence
this PR only bumps the timeout for just another 100 ms. It does not
increases the timeout by too much because that would otherwise hide
other real problems, e.g. 2nd auth taking too long is likely an issue
for the caching mechanism.

Resolves: #70160
