### PR TITLE
Treat writtenBy as an opaque string

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/snapshots/blobstore/BlobStoreIndexShardSnapshot.java
+++ b/server/src/main/java/org/elasticsearch/index/snapshots/blobstore/BlobStoreIndexShardSnapshot.java
@@ -9,12 +9,10 @@
 package org.elasticsearch.index.snapshots.blobstore;
 
 import org.apache.lucene.util.BytesRef;
-import org.apache.lucene.util.Version;
 import org.elasticsearch.ElasticsearchParseException;
-import org.elasticsearch.common.xcontent.ParseField;
 import org.elasticsearch.common.Strings;
-import org.elasticsearch.common.lucene.Lucene;
 import org.elasticsearch.common.unit.ByteSizeValue;
+import org.elasticsearch.common.xcontent.ParseField;
 import org.elasticsearch.common.xcontent.ToXContentFragment;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
@@ -266,8 +264,7 @@ public class BlobStoreIndexShardSnapshot implements ToXContentFragment {
             long length = -1;
             String checksum = null;
             ByteSizeValue partSize = null;
-            Version writtenBy = null;
-            String writtenByStr = null;
+            String writtenBy = null;
             BytesRef metaHash = new BytesRef();
             XContentParserUtils.ensureExpectedToken(token, XContentParser.Token.START_OBJECT, parser);
             while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
@@ -286,8 +283,7 @@ public class BlobStoreIndexShardSnapshot implements ToXContentFragment {
                         } else if (PART_SIZE.equals(currentFieldName)) {
                             partSize = new ByteSizeValue(parser.longValue());
                         } else if (WRITTEN_BY.equals(currentFieldName)) {
-                            writtenByStr = parser.text();
-                            writtenBy = Lucene.parseVersionLenient(writtenByStr, null);
+                            writtenBy = parser.text();
                         } else if (META_HASH.equals(currentFieldName)) {
                             metaHash.bytes = parser.binaryValue();
                             metaHash.offset = 0;
@@ -311,7 +307,7 @@ public class BlobStoreIndexShardSnapshot implements ToXContentFragment {
             } else if (length < 0) {
                 throw new ElasticsearchParseException("missing or invalid file length");
             } else if (writtenBy == null) {
-                throw new ElasticsearchParseException("missing or invalid written_by [" + writtenByStr + "]");
+                throw new ElasticsearchParseException("missing or invalid written_by [" + writtenBy + "]");
             } else if (checksum == null) {
                 throw new ElasticsearchParseException("missing checksum for name [" + name + "]");
             }

--- a/server/src/main/java/org/elasticsearch/index/store/Store.java
+++ b/server/src/main/java/org/elasticsearch/index/store/Store.java
@@ -126,7 +126,7 @@ public class Store extends AbstractIndexShardComponent implements Closeable, Ref
 
     /**
      * Specific {@link IOContext} indicating that we will read only the Lucene file footer (containing the file checksum)
-     * See {@link MetadataSnapshot#checksumFromLuceneFile(Directory, String, Map, Logger, Version, boolean)}
+     * See {@link MetadataSnapshot#checksumFromLuceneFile}.
      */
     public static final IOContext READONCE_CHECKSUM = new IOContext(IOContext.READONCE.context);
 
@@ -835,7 +835,7 @@ public class Store extends AbstractIndexShardComponent implements Closeable, Ref
                         maxVersion = version;
                     }
                     for (String file : info.files()) {
-                        checksumFromLuceneFile(directory, file, builder, logger, version,
+                        checksumFromLuceneFile(directory, file, builder, logger, version.toString(),
                             SEGMENT_INFO_EXTENSION.equals(IndexFileNames.getExtension(file)));
                     }
                 }
@@ -843,7 +843,7 @@ public class Store extends AbstractIndexShardComponent implements Closeable, Ref
                     maxVersion = org.elasticsearch.Version.CURRENT.minimumIndexCompatibilityVersion().luceneVersion;
                 }
                 final String segmentsFile = segmentCommitInfos.getSegmentsFileName();
-                checksumFromLuceneFile(directory, segmentsFile, builder, logger, maxVersion, true);
+                checksumFromLuceneFile(directory, segmentsFile, builder, logger, maxVersion.toString(), true);
             } catch (CorruptIndexException | IndexNotFoundException | IndexFormatTooOldException | IndexFormatTooNewException ex) {
                 // we either know the index is corrupted or it's just not there
                 throw ex;
@@ -869,7 +869,7 @@ public class Store extends AbstractIndexShardComponent implements Closeable, Ref
         }
 
         private static void checksumFromLuceneFile(Directory directory, String file, Map<String, StoreFileMetadata> builder,
-                Logger logger, Version version, boolean readFileAsHash) throws IOException {
+                Logger logger, String version, boolean readFileAsHash) throws IOException {
             final String checksum;
             final BytesRefBuilder fileHash = new BytesRefBuilder();
             try (IndexInput in = directory.openInput(file, READONCE_CHECKSUM)) {

--- a/server/src/main/java/org/elasticsearch/index/store/StoreFileMetadata.java
+++ b/server/src/main/java/org/elasticsearch/index/store/StoreFileMetadata.java
@@ -11,7 +11,6 @@ package org.elasticsearch.index.store;
 import org.apache.lucene.codecs.CodecUtil;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.Version;
-import org.elasticsearch.Assertions;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;

--- a/server/src/main/java/org/elasticsearch/index/store/StoreFileMetadata.java
+++ b/server/src/main/java/org/elasticsearch/index/store/StoreFileMetadata.java
@@ -11,6 +11,7 @@ package org.elasticsearch.index.store;
 import org.apache.lucene.codecs.CodecUtil;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.Version;
+import org.elasticsearch.Assertions;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
@@ -29,15 +30,16 @@ public class StoreFileMetadata implements Writeable {
 
     private final String checksum;
 
-    private final Version writtenBy;
+    private final String writtenBy;
 
     private final BytesRef hash;
 
-    public StoreFileMetadata(String name, long length, String checksum, Version writtenBy) {
+    public StoreFileMetadata(String name, long length, String checksum, String writtenBy) {
         this(name, length, checksum, writtenBy, null);
     }
 
-    public StoreFileMetadata(String name, long length, String checksum, Version writtenBy, BytesRef hash) {
+    public StoreFileMetadata(String name, long length, String checksum, String writtenBy, BytesRef hash) {
+        assert assertValidWrittenBy(writtenBy);
         this.name = Objects.requireNonNull(name, "name must not be null");
         this.length = length;
         this.checksum = Objects.requireNonNull(checksum, "checksum must not be null");
@@ -52,11 +54,7 @@ public class StoreFileMetadata implements Writeable {
         name = in.readString();
         length = in.readVLong();
         checksum = in.readString();
-        try {
-            writtenBy = Version.parse(in.readString());
-        } catch (ParseException e) {
-            throw new AssertionError(e);
-        }
+        writtenBy = in.readString();
         hash = in.readBytesRef();
     }
 
@@ -65,7 +63,7 @@ public class StoreFileMetadata implements Writeable {
         out.writeString(name);
         out.writeVLong(length);
         out.writeString(checksum);
-        out.writeString(writtenBy.toString());
+        out.writeString(writtenBy);
         out.writeBytesRef(hash);
     }
 
@@ -127,13 +125,13 @@ public class StoreFileMetadata implements Writeable {
 
     @Override
     public String toString() {
-        return "name [" + name + "], length [" + length + "], checksum [" + checksum + "], writtenBy [" + writtenBy + "]" ;
+        return "name [" + name + "], length [" + length + "], checksum [" + checksum + "], writtenBy [" + writtenBy + "]";
     }
 
     /**
-     * Returns the Lucene version this file has been written by or <code>null</code> if unknown
+     * Returns a String representation of the Lucene version this file has been written by or <code>null</code> if unknown
      */
-    public Version writtenBy() {
+    public String writtenBy() {
         return writtenBy;
     }
 
@@ -143,5 +141,14 @@ public class StoreFileMetadata implements Writeable {
      */
     public BytesRef hash() {
         return hash;
+    }
+
+    private static boolean assertValidWrittenBy(String writtenBy) {
+        try {
+            Version.parse(writtenBy);
+        } catch (ParseException e) {
+            throw new AssertionError("invalid writtenBy: " + writtenBy, e);
+        }
+        return true;
     }
 }

--- a/server/src/main/java/org/elasticsearch/indices/recovery/RecoveryFileChunkRequest.java
+++ b/server/src/main/java/org/elasticsearch/indices/recovery/RecoveryFileChunkRequest.java
@@ -8,11 +8,9 @@
 
 package org.elasticsearch.indices.recovery;
 
-import org.apache.lucene.util.Version;
 import org.elasticsearch.common.bytes.ReleasableBytesReference;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
-import org.elasticsearch.common.lucene.Lucene;
 import org.elasticsearch.core.RefCounted;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.index.store.StoreFileMetadata;
@@ -34,13 +32,12 @@ public final class RecoveryFileChunkRequest extends RecoveryTransportRequest imp
         super(in);
         recoveryId = in.readLong();
         shardId = new ShardId(in);
-        String name = in.readString();
+        final String name = in.readString();
         position = in.readVLong();
-        long length = in.readVLong();
-        String checksum = in.readString();
+        final long length = in.readVLong();
+        final String checksum = in.readString();
         content = in.readReleasableBytesReference();
-        Version writtenBy = Lucene.parseVersionLenient(in.readString(), null);
-        assert writtenBy != null;
+        final String writtenBy = in.readString();
         metadata = new StoreFileMetadata(name, length, checksum, writtenBy);
         lastChunk = in.readBoolean();
         totalTranslogOps = in.readVInt();
@@ -103,7 +100,7 @@ public final class RecoveryFileChunkRequest extends RecoveryTransportRequest imp
         out.writeVLong(metadata.length());
         out.writeString(metadata.checksum());
         out.writeBytesReference(content);
-        out.writeString(metadata.writtenBy().toString());
+        out.writeString(metadata.writtenBy());
         out.writeBoolean(lastChunk);
         out.writeVInt(totalTranslogOps);
         out.writeLong(sourceThrottleTimeInNanos);

--- a/server/src/test/java/org/elasticsearch/gateway/ReplicaShardAllocatorTests.java
+++ b/server/src/test/java/org/elasticsearch/gateway/ReplicaShardAllocatorTests.java
@@ -63,8 +63,8 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
 
 public class ReplicaShardAllocatorTests extends ESAllocationTestCase {
-    private static final org.apache.lucene.util.Version MIN_SUPPORTED_LUCENE_VERSION = org.elasticsearch.Version.CURRENT
-        .minimumIndexCompatibilityVersion().luceneVersion;
+    private static final String MIN_SUPPORTED_LUCENE_VERSION = Version.CURRENT.minimumIndexCompatibilityVersion().luceneVersion.toString();
+
     private final ShardId shardId = new ShardId("test", "_na_", 0);
     private final DiscoveryNode node1 = newNode("node1");
     private final DiscoveryNode node2 = newNode("node2");

--- a/server/src/test/java/org/elasticsearch/index/snapshots/blobstore/FileInfoTests.java
+++ b/server/src/test/java/org/elasticsearch/index/snapshots/blobstore/FileInfoTests.java
@@ -160,8 +160,12 @@ public class FileInfoTests extends ESTestCase {
         assertEquals(numBytes, 35);
         final int numIters = randomIntBetween(10, 100);
         for (int j = 0; j < numIters; j++) {
-            StoreFileMetadata metadata
-                = new StoreFileMetadata("foo", randomIntBetween(0, 1000), "666", MIN_SUPPORTED_LUCENE_VERSION.toString());
+            StoreFileMetadata metadata = new StoreFileMetadata(
+                "foo",
+                randomIntBetween(0, 1000),
+                "666",
+                MIN_SUPPORTED_LUCENE_VERSION.toString()
+            );
             info = new BlobStoreIndexShardSnapshot.FileInfo("foo", metadata, new ByteSizeValue(randomIntBetween(1, 1000)));
             numBytes = 0;
             for (int i = 0; i < info.numberOfParts(); i++) {

--- a/server/src/test/java/org/elasticsearch/index/snapshots/blobstore/FileInfoTests.java
+++ b/server/src/test/java/org/elasticsearch/index/snapshots/blobstore/FileInfoTests.java
@@ -43,7 +43,7 @@ public class FileInfoTests extends ESTestCase {
                 "foobar",
                 Math.abs(randomLong()),
                 randomAlphaOfLengthBetween(1, 10),
-                Version.LATEST,
+                Version.LATEST.toString(),
                 hash
             );
             ByteSizeValue size = new ByteSizeValue(Math.abs(randomLong()));
@@ -139,7 +139,7 @@ public class FileInfoTests extends ESTestCase {
     public void testGetPartSize() {
         BlobStoreIndexShardSnapshot.FileInfo info = new BlobStoreIndexShardSnapshot.FileInfo(
             "foo",
-            new StoreFileMetadata("foo", 36, "666", MIN_SUPPORTED_LUCENE_VERSION),
+            new StoreFileMetadata("foo", 36, "666", MIN_SUPPORTED_LUCENE_VERSION.toString()),
             new ByteSizeValue(6)
         );
         int numBytes = 0;
@@ -150,7 +150,7 @@ public class FileInfoTests extends ESTestCase {
 
         info = new BlobStoreIndexShardSnapshot.FileInfo(
             "foo",
-            new StoreFileMetadata("foo", 35, "666", MIN_SUPPORTED_LUCENE_VERSION),
+            new StoreFileMetadata("foo", 35, "666", MIN_SUPPORTED_LUCENE_VERSION.toString()),
             new ByteSizeValue(6)
         );
         numBytes = 0;
@@ -160,7 +160,8 @@ public class FileInfoTests extends ESTestCase {
         assertEquals(numBytes, 35);
         final int numIters = randomIntBetween(10, 100);
         for (int j = 0; j < numIters; j++) {
-            StoreFileMetadata metadata = new StoreFileMetadata("foo", randomIntBetween(0, 1000), "666", MIN_SUPPORTED_LUCENE_VERSION);
+            StoreFileMetadata metadata
+                = new StoreFileMetadata("foo", randomIntBetween(0, 1000), "666", MIN_SUPPORTED_LUCENE_VERSION.toString());
             info = new BlobStoreIndexShardSnapshot.FileInfo("foo", metadata, new ByteSizeValue(randomIntBetween(1, 1000)));
             numBytes = 0;
             for (int i = 0; i < info.numberOfParts(); i++) {

--- a/server/src/test/java/org/elasticsearch/index/snapshots/blobstore/FileInfoTests.java
+++ b/server/src/test/java/org/elasticsearch/index/snapshots/blobstore/FileInfoTests.java
@@ -64,7 +64,7 @@ public class FileInfoTests extends ESTestCase {
             assertThat(info.partSize(), equalTo(parsedInfo.partSize()));
             assertThat(parsedInfo.metadata().hash().length, equalTo(hash.length));
             assertThat(parsedInfo.metadata().hash(), equalTo(hash));
-            assertThat(parsedInfo.metadata().writtenBy(), equalTo(Version.LATEST));
+            assertThat(parsedInfo.metadata().writtenBy(), equalTo(Version.LATEST.toString()));
             assertThat(parsedInfo.isSame(info.metadata()), is(true));
         }
     }
@@ -123,7 +123,7 @@ public class FileInfoTests extends ESTestCase {
                 assertThat(length, equalTo(parsedInfo.length()));
                 assertEquals("666", parsedInfo.checksum());
                 assertEquals("666", parsedInfo.metadata().checksum());
-                assertEquals(Version.LATEST, parsedInfo.metadata().writtenBy());
+                assertEquals(Version.LATEST.toString(), parsedInfo.metadata().writtenBy());
             } else {
                 try (XContentParser parser = createParser(JsonXContent.jsonXContent, xContent)) {
                     parser.nextToken();

--- a/server/src/test/java/org/elasticsearch/index/store/StoreTests.java
+++ b/server/src/test/java/org/elasticsearch/index/store/StoreTests.java
@@ -335,7 +335,7 @@ public class StoreTests extends ESTestCase {
             try (IndexInput input = store.directory().openInput(meta.name(), IOContext.DEFAULT)) {
                 String checksum = Store.digestToString(CodecUtil.retrieveChecksum(input));
                 assertThat("File: " + meta.name() + " has a different checksum", meta.checksum(), equalTo(checksum));
-                assertThat(meta.writtenBy(), equalTo(Version.LATEST));
+                assertThat(meta.writtenBy(), equalTo(Version.LATEST.toString()));
                 if (meta.name().endsWith(".si") || meta.name().startsWith("segments_")) {
                     assertThat(meta.hash().length, greaterThan(0));
                 }

--- a/server/src/test/java/org/elasticsearch/index/store/StoreTests.java
+++ b/server/src/test/java/org/elasticsearch/index/store/StoreTests.java
@@ -158,7 +158,7 @@ public class StoreTests extends ESTestCase {
         BytesRef ref = new BytesRef(scaledRandomIntBetween(1, 1024));
         long length = indexInput.length();
         IndexOutput verifyingOutput = new Store.LuceneVerifyingIndexOutput(new StoreFileMetadata("foo1.bar", length, checksum,
-            MIN_SUPPORTED_LUCENE_VERSION), dir.createOutput("foo1.bar", IOContext.DEFAULT));
+            MIN_SUPPORTED_LUCENE_VERSION.toString()), dir.createOutput("foo1.bar", IOContext.DEFAULT));
         while (length > 0) {
             if (random().nextInt(10) == 0) {
                 verifyingOutput.writeByte(indexInput.readByte());
@@ -191,7 +191,7 @@ public class StoreTests extends ESTestCase {
         Directory dir = newDirectory();
         IndexOutput verifyingOutput =
             new Store.LuceneVerifyingIndexOutput(new StoreFileMetadata("foo.bar", 0, Store.digestToString(0),
-                MIN_SUPPORTED_LUCENE_VERSION),
+                MIN_SUPPORTED_LUCENE_VERSION.toString()),
                 dir.createOutput("foo1.bar", IOContext.DEFAULT));
         try {
             Store.verify(verifyingOutput);
@@ -221,7 +221,7 @@ public class StoreTests extends ESTestCase {
         BytesRef ref = new BytesRef(scaledRandomIntBetween(1, 1024));
         long length = indexInput.length();
         IndexOutput verifyingOutput = new Store.LuceneVerifyingIndexOutput(new StoreFileMetadata("foo1.bar", length, checksum,
-            MIN_SUPPORTED_LUCENE_VERSION), dir.createOutput("foo1.bar", IOContext.DEFAULT));
+            MIN_SUPPORTED_LUCENE_VERSION.toString()), dir.createOutput("foo1.bar", IOContext.DEFAULT));
         length -= 8; // we write the checksum in the try / catch block below
         while (length > 0) {
             if (random().nextInt(10) == 0) {
@@ -276,7 +276,7 @@ public class StoreTests extends ESTestCase {
         Directory dir = newDirectory();
         int length = scaledRandomIntBetween(10, 1024);
         IndexOutput verifyingOutput = new Store.LuceneVerifyingIndexOutput(new StoreFileMetadata("foo1.bar", length, "",
-            MIN_SUPPORTED_LUCENE_VERSION), dir.createOutput("foo1.bar", IOContext.DEFAULT));
+            MIN_SUPPORTED_LUCENE_VERSION.toString()), dir.createOutput("foo1.bar", IOContext.DEFAULT));
         try {
             while (length > 0) {
                 verifyingOutput.writeByte((byte) random().nextInt());
@@ -828,9 +828,9 @@ public class StoreTests extends ESTestCase {
 
     protected Store.MetadataSnapshot createMetadataSnapshot() {
         StoreFileMetadata storeFileMetadata1 =
-            new StoreFileMetadata("segments", 1, "666", MIN_SUPPORTED_LUCENE_VERSION);
+            new StoreFileMetadata("segments", 1, "666", MIN_SUPPORTED_LUCENE_VERSION.toString());
         StoreFileMetadata storeFileMetadata2 =
-            new StoreFileMetadata("no_segments", 1, "666", MIN_SUPPORTED_LUCENE_VERSION);
+            new StoreFileMetadata("no_segments", 1, "666", MIN_SUPPORTED_LUCENE_VERSION.toString());
         Map<String, StoreFileMetadata> storeFileMetadataMap = new HashMap<>();
         storeFileMetadataMap.put(storeFileMetadata1.name(), storeFileMetadata1);
         storeFileMetadataMap.put(storeFileMetadata2.name(), storeFileMetadata2);

--- a/server/src/test/java/org/elasticsearch/indices/recovery/RecoverySourceHandlerTests.java
+++ b/server/src/test/java/org/elasticsearch/indices/recovery/RecoverySourceHandlerTests.java
@@ -832,7 +832,7 @@ public class RecoverySourceHandlerTests extends ESTestCase {
             CRC32 digest = new CRC32();
             digest.update(buffer, 0, buffer.length);
             StoreFileMetadata md = new StoreFileMetadata("test-" + i, buffer.length + 8,
-                Store.digestToString(digest.getValue()), org.apache.lucene.util.Version.LATEST);
+                Store.digestToString(digest.getValue()), org.apache.lucene.util.Version.LATEST.toString());
             try (OutputStream out = new IndexOutputOutputStream(store.createVerifyingOutput(md.name(), md, IOContext.DEFAULT))) {
                 out.write(buffer);
                 out.write(Numbers.longToBytes(digest.getValue()));

--- a/server/src/test/java/org/elasticsearch/indices/recovery/RecoveryStatusTests.java
+++ b/server/src/test/java/org/elasticsearch/indices/recovery/RecoveryStatusTests.java
@@ -28,8 +28,11 @@ public class RecoveryStatusTests extends ESSingleNodeTestCase {
         IndexShard indexShard = service.getShardOrNull(0);
         MultiFileWriter multiFileWriter = new MultiFileWriter(indexShard.store(),
             indexShard.recoveryState().getIndex(), "recovery.test.", logger, () -> {});
-        try (IndexOutput indexOutput = multiFileWriter.openAndPutIndexOutput("foo.bar",
-            new StoreFileMetadata("foo.bar", 8 + CodecUtil.footerLength(), "9z51nw", MIN_SUPPORTED_LUCENE_VERSION), indexShard.store())) {
+        try (IndexOutput indexOutput = multiFileWriter.openAndPutIndexOutput(
+            "foo.bar",
+            new StoreFileMetadata("foo.bar", 8 + CodecUtil.footerLength(), "9z51nw", MIN_SUPPORTED_LUCENE_VERSION.toString()),
+            indexShard.store())) {
+
             indexOutput.writeInt(1);
             IndexOutput openIndexOutput = multiFileWriter.getOpenIndexOutput("foo.bar");
             assertSame(openIndexOutput, indexOutput);
@@ -38,8 +41,10 @@ public class RecoveryStatusTests extends ESSingleNodeTestCase {
         }
 
         try {
-            multiFileWriter.openAndPutIndexOutput("foo.bar", new StoreFileMetadata("foo.bar", 8 + CodecUtil.footerLength(), "9z51nw",
-                MIN_SUPPORTED_LUCENE_VERSION), indexShard.store());
+            multiFileWriter.openAndPutIndexOutput(
+                "foo.bar",
+                new StoreFileMetadata("foo.bar", 8 + CodecUtil.footerLength(), "9z51nw", MIN_SUPPORTED_LUCENE_VERSION.toString()),
+                indexShard.store());
             fail("file foo.bar is already opened and registered");
         } catch (IllegalStateException ex) {
             assertEquals("output for file [foo.bar] has already been created", ex.getMessage());

--- a/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/store/SearchableSnapshotDirectoryStatsTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/store/SearchableSnapshotDirectoryStatsTests.java
@@ -638,7 +638,12 @@ public class SearchableSnapshotDirectoryStatsTests extends AbstractSearchableSna
 
         final String blobName = randomUnicodeOfLength(10);
         final BlobContainer blobContainer = singleBlobContainer(blobName, fileContent);
-        final StoreFileMetadata metadata = new StoreFileMetadata(fileName, fileContent.length, fileChecksum, Version.CURRENT.luceneVersion);
+        final StoreFileMetadata metadata = new StoreFileMetadata(
+            fileName,
+            fileContent.length,
+            fileChecksum,
+            Version.CURRENT.luceneVersion.toString()
+        );
         final List<FileInfo> files = List.of(new FileInfo(blobName, metadata, new ByteSizeValue(fileContent.length)));
         final BlobStoreIndexShardSnapshot snapshot = new BlobStoreIndexShardSnapshot(snapshotId.getName(), 0L, files, 0L, 0L, 0, 0L);
         final Path shardDir = shardPath(shardId);

--- a/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/store/SearchableSnapshotDirectoryTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/store/SearchableSnapshotDirectoryTests.java
@@ -720,7 +720,7 @@ public class SearchableSnapshotDirectoryTests extends AbstractSearchableSnapshot
                 randomFiles.add(
                     new BlobStoreIndexShardSnapshot.FileInfo(
                         blobName,
-                        new StoreFileMetadata(fileName, input.length, checksum, Version.CURRENT.luceneVersion),
+                        new StoreFileMetadata(fileName, input.length, checksum, Version.CURRENT.luceneVersion.toString()),
                         new ByteSizeValue(input.length)
                     )
                 );

--- a/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/store/input/CachedBlobContainerIndexInputTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/store/input/CachedBlobContainerIndexInputTests.java
@@ -70,7 +70,12 @@ public class CachedBlobContainerIndexInputTests extends AbstractSearchableSnapsh
                 final byte[] input = bytes.v2();
                 final String checksum = bytes.v1();
                 final String blobName = randomUnicodeOfLength(10);
-                final StoreFileMetadata metadata = new StoreFileMetadata(fileName, input.length, checksum, Version.CURRENT.luceneVersion);
+                final StoreFileMetadata metadata = new StoreFileMetadata(
+                    fileName,
+                    input.length,
+                    checksum,
+                    Version.CURRENT.luceneVersion.toString()
+                );
 
                 final int partSize = randomBoolean() ? input.length : randomIntBetween(1, input.length);
 
@@ -185,7 +190,12 @@ public class CachedBlobContainerIndexInputTests extends AbstractSearchableSnapsh
             final byte[] input = bytes.v2();
             final String checksum = bytes.v1();
             final String blobName = randomUnicodeOfLength(10);
-            final StoreFileMetadata metadata = new StoreFileMetadata(fileName, input.length, checksum, Version.CURRENT.luceneVersion);
+            final StoreFileMetadata metadata = new StoreFileMetadata(
+                fileName,
+                input.length,
+                checksum,
+                Version.CURRENT.luceneVersion.toString()
+            );
 
             final BlobStoreIndexShardSnapshot snapshot = new BlobStoreIndexShardSnapshot(
                 snapshotId.getName(),

--- a/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/store/input/DirectBlobContainerIndexInputTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/store/input/DirectBlobContainerIndexInputTests.java
@@ -67,7 +67,7 @@ public class DirectBlobContainerIndexInputTests extends ESIndexInputTestCase {
         final String fileName = randomAlphaOfLength(5) + randomFileExtension();
         final FileInfo fileInfo = new FileInfo(
             randomAlphaOfLength(5),
-            new StoreFileMetadata(fileName, input.length, checksum, Version.LATEST),
+            new StoreFileMetadata(fileName, input.length, checksum, Version.LATEST.toString()),
             partSize == input.length
                 ? randomFrom(
                     new ByteSizeValue(partSize, ByteSizeUnit.BYTES),

--- a/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/store/input/FrozenIndexInputTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/store/input/FrozenIndexInputTests.java
@@ -54,7 +54,7 @@ public class FrozenIndexInputTests extends AbstractSearchableSnapshotsTestCase {
 
         final FileInfo fileInfo = new FileInfo(
             randomAlphaOfLength(10),
-            new StoreFileMetadata(fileName, fileData.length, checksum, Version.CURRENT.luceneVersion),
+            new StoreFileMetadata(fileName, fileData.length, checksum, Version.CURRENT.luceneVersion.toString()),
             new ByteSizeValue(fileData.length)
         );
 


### PR DESCRIPTION
Today `StoreFileMetadata#writtenBy` is a `Version`, but sent over the
wire as a `String`. It's included in every file chunk sent during
recovery, but parsing it uses `String#replaceFirst` a few times, which
is nontrivial, representing >50% of the time it takes to deserialize a
`RecoveryFileChunkRequest`. Moreover the value isn't actually used for
anything so the parsing is wasted work.

With this commit we treat this field as an opaque string, avoiding the
unnecessary parsing effort. We don't remove it because it appears in
e.g. a snapshot repository, where it may be useful for debugging.