### PR TITLE
[7.x] [DOCS] Note ESS must use custom bundles for custom GeoIP database files (#73978)

### DIFF
--- a/docs/reference/ingest/processors/geoip.asciidoc
+++ b/docs/reference/ingest/processors/geoip.asciidoc
@@ -12,8 +12,12 @@ The `ingest-geoip` module ships by default with the GeoLite2 City, GeoLite2 Coun
 under the CCA-ShareAlike 4.0 license. For more details see, http://dev.maxmind.com/geoip/geoip2/geolite2/
 
 The `geoip` processor can run with other city, country and ASN GeoIP2 databases
-from Maxmind. The database files must be copied into the `ingest-geoip` config
-directory located at `$ES_CONFIG/ingest-geoip`. Custom database files must be
+from Maxmind. On {ess} deployments, custom database files must be uploaded using
+a {cloud}/ec-custom-bundles.html[custom bundle]. On self-managed deployments,
+custom database files must be copied into the `ingest-geoip` config
+directory located at `$ES_CONFIG/ingest-geoip`.
+
+Custom database files must be
 stored uncompressed and the extension must be `-City.mmdb`, `-Country.mmdb`, or
 `-ASN.mmdb` to indicate the type of the database. The
 `database_file` processor option is used to specify the filename of the custom


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [DOCS] Note ESS must use custom bundles for custom GeoIP database files (#73978)