### PR TITLE
[7.x] Fix mapping error to indicate values field (#74132)

### DIFF
--- a/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/mapper/HistogramFieldMapper.java
+++ b/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/mapper/HistogramFieldMapper.java
@@ -260,7 +260,7 @@ public class HistogramFieldMapper extends FieldMapper {
                         if (val < previousVal) {
                             // values must be in increasing order
                             throw new MapperParsingException("error parsing field ["
-                                + name() + "], ["+ COUNTS_FIELD + "] values must be in increasing order, got [" + val +
+                                + name() + "], ["+ VALUES_FIELD + "] values must be in increasing order, got [" + val +
                                 "] but previous value was [" + previousVal +"]");
                         }
                         values.add(val);

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/analytics/histogram.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/analytics/histogram.yml
@@ -20,7 +20,13 @@ setup:
           - '{"latency": {"values" : [0.1, 0.2, 0.3, 0.4, 0.5], "counts" : [3, 7, 23, 12, 6]}}'
           - '{"index": {}}'
           - '{"latency": {"values" : [0, 0.1, 0.2, 0.3, 0.4, 0.5], "counts" : [3, 2, 5, 10, 1, 8]}}'
-
+---
+"Histogram requires values in increasing order":
+  - do:
+      catch: / error parsing field \[latency\], \[values\] values must be in increasing order, got \[0.2\] but previous value was \[1.0\]/
+      index:
+        index: test
+        body: {"latency": {"values" : [1.0, 0.2, 0.3, 0.4, 0.5], "counts" : [3, 7, 23, 12, 6]}}
 ---
 "Histogram Aggregations":
 

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/analytics/histogram.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/analytics/histogram.yml
@@ -23,7 +23,7 @@ setup:
 ---
 "Histogram requires values in increasing order":
   - do:
-      catch: / error parsing field \[latency\], \[values\] values must be in increasing order, got \[0.2\] but previous value was \[1.0\]/
+      catch: /error parsing field \[latency\], \[values\] values must be in increasing order/
       index:
         index: test
         body: {"latency": {"values" : [1.0, 0.2, 0.3, 0.4, 0.5], "counts" : [3, 7, 23, 12, 6]}}


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Fix mapping error to indicate values field (#74132)