### PR TITLE
[DOCS] Clone index API doesn't apply index templates or settings

### DIFF
--- a/docs/reference/indices/clone-index.asciidoc
+++ b/docs/reference/indices/clone-index.asciidoc
@@ -56,10 +56,11 @@ and then the previous write index can be cloned.
 Use the clone index API to clone an existing index into a new index, where each
 original primary shard is cloned into a new primary shard in the new index.
 
-IMPORTANT: Cloning doesn't copy index metadata. This metadata includes aliases,
-{ilm-init} phase definitions, and {ccr-init} follower information. For example,
-if you clone a {ccr-init} follower index, the resulting clone won't be a
-follower index.
+IMPORTANT: {es} doesn't apply index templates to the resulting index. The API
+also doesn't copy index settings or metadata from the original index. Index
+metadata includes aliases, {ilm-init} phase definitions, and {ccr-init} follower
+information. For example, if you clone a {ccr-init} follower index, the
+resulting clone won't be a follower index.
 
 [[cloning-works]]
 ===== How cloning works


### PR DESCRIPTION
Changes:
* Notes that Elasticsearch doesn't apply index templates to cloned indices.
* Notes the clone API doesn't copy index settings.

Closes #74135

### Preview
https://elasticsearch_74138.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/indices-clone-index.html#clone-index-api-desc