### PR TITLE
[DOCS] Fix deprecated script cache settings

### DIFF
--- a/docs/reference/scripting/using.asciidoc
+++ b/docs/reference/scripting/using.asciidoc
@@ -406,8 +406,8 @@ small.
 
 All scripts are cached by default so that they only need to be recompiled
 when updates occur. By default, scripts do not have a time-based expiration.
-You can change this behavior by using the `script.cache.expire` setting.
-Use the `script.cache.max_size` setting to configure the size of the cache.
+You can change this behavior by using the `script.context.$CONTEXT.cache_expire` setting.
+Use the `script.context.$CONTEXT.cache_max_size` setting to configure the size of the cache.
 
 NOTE: The size of scripts is limited to 65,535 bytes. Set the value of `script.max_size_in_bytes` to increase that soft limit. If your scripts are
 really large, then consider using a


### PR DESCRIPTION
### Change
Replace deprecated `script.cache.*` settings with `script.context.$context.cache_*` in documentation.

### Details
This relates to #50152 and #55038.  Starting in 7.9, the [breaking change](https://www.elastic.co/guide/en/elasticsearch/reference/7.13/breaking-changes-7.9.html) of context specific script cache settings was added.  However, the <https://www.elastic.co/guide/en/elasticsearch/reference/current/scripts-and-search-speed.html> page still references the old setting names.

> All scripts are cached by default so that they only need to be recompiled when updates occur. By default, scripts do not have a time-based expiration. You can change this behavior by using the `script.cache.expire` setting. Use the `script.cache.max_size` setting to configure the size of the cache.