### PR TITLE
[DOCS] Add `multi-field` def to glossary

### DIFF
--- a/docs/reference/glossary.asciidoc
+++ b/docs/reference/glossary.asciidoc
@@ -279,8 +279,8 @@ automatically.
 
 [[glossary-multi-field]] multi-field::
 // tag::multi-field-def[]
-A single <<glossary-field,field>> that's <<glossary-mapping,mapped>> multiple
-ways. See the {ref}/multi-fields.html[`fields` mapping parameter].
+A <<glossary-field,field>> that's <<glossary-mapping,mapped>> in multiple ways.
+See the {ref}/multi-fields.html[`fields` mapping parameter].
 // end::multi-field-def[]
 
 [[glossary-node]] node::

--- a/docs/reference/glossary.asciidoc
+++ b/docs/reference/glossary.asciidoc
@@ -277,6 +277,12 @@ Process of combining a <<glossary-shard,shard>>'s smaller Lucene
 automatically.
 // end::merge-def[]
 
+[[glossary-multi-field]] multi-field::
+// tag::multi-field-def[]
+A single <<glossary-field,field>> that's <<glossary-mapping,mapped>> multiple
+ways. See the {ref}/multi-fields.html[`fields` mapping parameter].
+// end::multi-field-def[]
+
 [[glossary-node]] node::
 // tag::node-def[]
 A single {es} server. One or more nodes can form a <<glossary-cluster,cluster>>.


### PR DESCRIPTION
Closes #74136.

### Preview
https://elasticsearch_74147.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/glossary.html#glossary-multi-field