### PR TITLE
Add deprecation info check for monitoring exporter password

### DIFF
--- a/x-pack/plugin/deprecation/build.gradle
+++ b/x-pack/plugin/deprecation/build.gradle
@@ -12,5 +12,5 @@ addQaCheckDependencies()
 
 dependencies {
   compileOnly project(":x-pack:plugin:core")
+  implementation project(path: xpackModule('monitoring'))
 }
-

--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/DeprecationChecks.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/DeprecationChecks.java
@@ -89,7 +89,8 @@ public class DeprecationChecks {
                     NodeDeprecationChecks::checkDataPathsList,
                     NodeDeprecationChecks::checkBootstrapSystemCallFilterSetting,
                     NodeDeprecationChecks::checkSharedDataPathSetting,
-                    NodeDeprecationChecks::checkSingleDataNodeWatermarkSetting
+                    NodeDeprecationChecks::checkSingleDataNodeWatermarkSetting,
+                    NodeDeprecationChecks::checkMonitoringExporterPassword
                 )
             ).collect(Collectors.toList());
         }

--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/NodeDeprecationChecks.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/NodeDeprecationChecks.java
@@ -32,8 +32,10 @@ import org.elasticsearch.xpack.core.security.authc.RealmConfig;
 import org.elasticsearch.xpack.core.security.authc.RealmSettings;
 import org.elasticsearch.xpack.core.security.authc.esnative.NativeRealmSettings;
 import org.elasticsearch.xpack.core.security.authc.file.FileRealmSettings;
+import org.elasticsearch.xpack.monitoring.exporter.http.HttpExporter;
 
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
@@ -502,5 +504,32 @@ class NodeDeprecationChecks {
 
 
         return null;
+    }
+
+    static DeprecationIssue checkMonitoringExporterPassword(
+        final Settings settings,
+        final PluginsAndModules pluginsAndModules,
+        ClusterState cs
+    ) {
+        List<Setting<?>> passwords = HttpExporter.AUTH_PASSWORD_SETTING.getAllConcreteSettings(settings)
+            .sorted(Comparator.comparing(Setting::getKey)).collect(Collectors.toList());
+
+        if (passwords.isEmpty()) {
+            return null;
+        }
+
+        final String passwordSettings = passwords.stream().map(Setting::getKey).collect(Collectors.joining(","));
+        final String message = String.format(
+            Locale.ROOT,
+            "non-secure passwords for monitoring exporters [%s] are deprecated and will be removed in the next major version",
+            passwordSettings
+        );
+        final String details = String.format(
+            Locale.ROOT,
+            "replace the non-secure monitoring exporter password setting(s) [%s] with their secure 'auth.secure_password' replacement",
+            passwordSettings
+        );
+        final String url = "https://www.elastic.co/guide/en/elasticsearch/reference/7.7/monitoring-settings.html#http-exporter-settings";
+        return new DeprecationIssue(DeprecationIssue.Level.CRITICAL, message, url, details);
     }
 }

--- a/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/NodeDeprecationChecksTests.java
+++ b/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/NodeDeprecationChecksTests.java
@@ -714,4 +714,43 @@ public class NodeDeprecationChecksTests extends ESTestCase {
             master, node1, master)),
             equalTo(deprecationIssue));
     }
+
+    public void testMonitoringExporterPassword() {
+        // test for presence of deprecated exporter passwords
+        final int numExporterPasswords = randomIntBetween(1, 3);
+        final String[] exporterNames = new String[numExporterPasswords];
+        final Settings.Builder b = Settings.builder();
+        for (int k = 0; k < numExporterPasswords; k++) {
+            exporterNames[k] = randomAlphaOfLength(5);
+            b.put("xpack.monitoring.exporters." + exporterNames[k] + ".auth.password", "_pass");
+        }
+        final Settings settings = b.build();
+
+        DeprecationIssue issue = NodeDeprecationChecks.checkMonitoringExporterPassword(settings, null, null);
+        final String expectedUrl =
+            "https://www.elastic.co/guide/en/elasticsearch/reference/7.7/monitoring-settings.html#http-exporter-settings";
+        final String joinedNames = Arrays
+            .stream(exporterNames)
+            .map(s -> "xpack.monitoring.exporters." + s + ".auth.password")
+            .sorted()
+            .collect(Collectors.joining(","));
+
+        assertThat(issue, equalTo(new DeprecationIssue(
+            DeprecationIssue.Level.CRITICAL,
+            String.format(
+                Locale.ROOT,
+                "non-secure passwords for monitoring exporters [%s] are deprecated and will be removed in the next major version",
+                joinedNames
+            ),
+            expectedUrl,
+            String.format(
+                Locale.ROOT,
+                "replace the non-secure monitoring exporter password setting(s) [%s] with their secure 'auth.secure_password' replacement",
+                joinedNames
+            ))));
+
+        // test for absence of deprecated exporter passwords
+        issue = NodeDeprecationChecks.checkMonitoringExporterPassword(Settings.builder().build(), null, null);
+        assertThat(issue, nullValue());
+    }
 }


### PR DESCRIPTION
The `AUTH_PASSWORD` setting for monitoring exporters was deprecated in https://github.com/elastic/elasticsearch/pull/50919 but never added to the deprecation info API. This PR needs to be merged directly to 7.x as the setting has already been removed from the `master` branch.

Supersedes #73742
