### PR TITLE
Cache API key hashing results on creation time (#74106)

### DIFF
--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/authc/ApiKeyIntegTests.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/authc/ApiKeyIntegTests.java
@@ -1003,6 +1003,7 @@ public class ApiKeyIntegTests extends SecurityIntegTestCase {
         final Settings settings = internalCluster().getInstance(Settings.class, nodeName);
         final int allocatedProcessors = EsExecutors.allocatedProcessors(settings);
         final ThreadPool threadPool = internalCluster().getInstance(ThreadPool.class, nodeName);
+        final ApiKeyService apiKeyService = internalCluster().getInstance(ApiKeyService.class, nodeName);
 
         final RoleDescriptor descriptor = new RoleDescriptor("auth_only", new String[] { }, null, null);
         final Client client = client().filterWithHeader(
@@ -1016,6 +1017,8 @@ public class ApiKeyIntegTests extends SecurityIntegTestCase {
 
         assertNotNull(createApiKeyResponse.getId());
         assertNotNull(createApiKeyResponse.getKey());
+        // Clear the auth cache to force recompute the expensive hash which requires the crypto thread pool
+        apiKeyService.getApiKeyAuthCache().invalidateAll();
 
         final List<NodeInfo> nodeInfos = client().admin().cluster().prepareNodesInfo().get().getNodes().stream()
             .filter(nodeInfo -> nodeInfo.getNode().getName().equals(nodeName))

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/ApiKeyService.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/ApiKeyService.java
@@ -286,7 +286,8 @@ public class ApiKeyService {
                     Version.V_6_7_0);
         }
 
-        try (XContentBuilder builder = newDocument(apiKey, request.getName(), authentication, roleDescriptorSet, created, expiration,
+        try (XContentBuilder builder = newDocument(apiKey, request.getName(), authentication,
+            roleDescriptorSet, created, expiration,
             request.getRoleDescriptors(), version, request.getMetadata())) {
 
             final IndexRequest indexRequest =
@@ -299,8 +300,13 @@ public class ApiKeyService {
             securityIndex.prepareIndexIfNeededThenExecute(listener::onFailure, () ->
                 executeAsyncWithOrigin(client, SECURITY_ORIGIN, BulkAction.INSTANCE, bulkRequest,
                     TransportSingleItemBulkWriteAction.<IndexResponse>wrapBulkResponse(ActionListener.wrap(
-                        indexResponse -> listener.onResponse(
-                            new CreateApiKeyResponse(request.getName(), indexResponse.getId(), apiKey, expiration)),
+                        indexResponse -> {
+                            final ListenableFuture<CachedApiKeyHashResult> listenableFuture = new ListenableFuture<>();
+                            listenableFuture.onResponse(new CachedApiKeyHashResult(true, apiKey));
+                            apiKeyAuthCache.put(indexResponse.getId(), listenableFuture);
+                            listener.onResponse(
+                                new CreateApiKeyResponse(request.getName(), indexResponse.getId(), apiKey, expiration));
+                        },
                         listener::onFailure))));
         } catch (IOException e) {
             listener.onFailure(e);
@@ -311,14 +317,15 @@ public class ApiKeyService {
      * package-private for testing
      */
     XContentBuilder newDocument(SecureString apiKey, String name, Authentication authentication, Set<RoleDescriptor> userRoles,
-                                        Instant created, Instant expiration, List<RoleDescriptor> keyRoles,
-                                        Version version, @Nullable Map<String, Object> metadata) throws IOException {
+                                Instant created, Instant expiration, List<RoleDescriptor> keyRoles,
+                                Version version, @Nullable Map<String, Object> metadata) throws IOException {
         XContentBuilder builder = XContentFactory.jsonBuilder();
         builder.startObject()
             .field("doc_type", "api_key")
             .field("creation_time", created.toEpochMilli())
             .field("expiration_time", expiration == null ? null : expiration.toEpochMilli())
             .field("api_key_invalidated", false);
+
 
         byte[] utf8Bytes = null;
         final char[] keyHash = hasher.hash(apiKey);
@@ -1186,7 +1193,7 @@ public class ApiKeyService {
             this.hash = cacheHasher.hash(apiKey);
         }
 
-        private boolean verify(SecureString password) {
+        boolean verify(SecureString password) {
             return hash != null && cacheHasher.verify(password, hash);
         }
     }


### PR DESCRIPTION
The API key hashing result is now cached on the creation time of an API key,
i.e. pre-warm the cache. Previously it is cached when the API key is
authenticated for the first time. Since it is reasonable to assume that an API
key will be used shortly after its creation, this change has following
advantages:

* It removes the need for expensive pbkdf2 hashing computation on
  authentication time and therefore reduces overall server load
* It makes the first authentication faster

We expect all keys to be used, that is, caching on creation time does not
change the total number of keys need to be cached. Hence this PR does not
introduce any extra logic to fine tune whether a key should be cached (for
example, only cache if the load factor is lower than certain threshold etc.).
