### PR TITLE
[7.x] Replace missing transform id with _all wildcard (#74130)

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/action/GetTransformStatsAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/action/GetTransformStatsAction.java
@@ -59,7 +59,7 @@ public class GetTransformStatsAction extends ActionType<GetTransformStatsAction.
             } else {
                 this.id = id;
             }
-            this.expandedIds = Collections.singletonList(id);
+            this.expandedIds = Collections.singletonList(this.id);
         }
 
         public Request(StreamInput in) throws IOException {

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/transform/action/GetTransformStatsActionRequestTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/transform/action/GetTransformStatsActionRequestTests.java
@@ -15,10 +15,11 @@ import org.elasticsearch.xpack.core.transform.action.GetTransformStatsAction.Req
 public class GetTransformStatsActionRequestTests extends AbstractWireSerializingTestCase<Request> {
     @Override
     protected Request createTestInstance() {
-        if (randomBoolean()) {
-            return new Request(Metadata.ALL);
-        }
-        return new Request(randomAlphaOfLengthBetween(1, 20));
+        return new Request(
+            randomBoolean()
+                ? randomAlphaOfLengthBetween(1, 20)
+                : randomBoolean() ? Metadata.ALL : null
+        );
     }
 
     @Override


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Add test with null transform id in stats request  (#74130)