### PR TITLE
Pin Alpine Linux version in Docker builds

### DIFF
--- a/distribution/docker/build.gradle
+++ b/distribution/docker/build.gradle
@@ -295,7 +295,7 @@ void addBuildDockerImageTask(Architecture architecture, DockerBase base) {
         baseImages = [baseImage]
         buildArgs = buildArgsMap
       } else if (base == DockerBase.CENTOS) {
-        baseImages = ['alpine:latest', base.image]
+        baseImages = ['alpine:3.13', base.image]
       } else {
         baseImages = [base.image]
       }

--- a/distribution/docker/src/docker/Dockerfile
+++ b/distribution/docker/src/docker/Dockerfile
@@ -72,7 +72,7 @@ RUN chmod 0755 /bin/tini
 # Stage 1. Build curl statically. Installing it from RPM on CentOS pulls in too
 # many dependencies.
 ################################################################################
-FROM alpine:latest AS curl
+FROM alpine:3.13 AS curl
 
 ENV VERSION 7.71.0
 ENV TARBALL_URL https://curl.haxx.se/download/curl-\${VERSION}.tar.xz
@@ -102,7 +102,7 @@ RUN gpg --import --always-trust "curl-gpg.pub" && \\
 RUN set -e ; \\
     tar xfJ "\${TARBALL_PATH}" ; \\
     cd "curl-\${VERSION}" ; \\
-    if ! ./configure --disable-dependency-tracking --with-openssl --disable-shared --with-ca-fallback --with-ca-bundle=/etc/pki/tls/certs/ca-bundle.crt ; then \\
+    if ! ./configure --disable-shared --with-ca-fallback --with-ca-bundle=/etc/pki/tls/certs/ca-bundle.crt ; then \\
         [[ -e config.log ]] && cat config.log ; \\
         exit 1 ; \\
     fi ; \\

--- a/distribution/docker/src/docker/Dockerfile
+++ b/distribution/docker/src/docker/Dockerfile
@@ -74,7 +74,7 @@ RUN chmod 0755 /bin/tini
 ################################################################################
 FROM alpine:latest AS curl
 
-ENV VERSION 7.71.0
+ENV VERSION 7.77.0
 ENV TARBALL_URL https://curl.haxx.se/download/curl-\${VERSION}.tar.xz
 ENV TARBALL_PATH curl-\${VERSION}.tar.xz
 
@@ -102,7 +102,7 @@ RUN gpg --import --always-trust "curl-gpg.pub" && \\
 RUN set -e ; \\
     tar xfJ "\${TARBALL_PATH}" ; \\
     cd "curl-\${VERSION}" ; \\
-    if ! ./configure --disable-shared --with-ca-fallback --with-ca-bundle=/etc/pki/tls/certs/ca-bundle.crt ; then \\
+    if ! ./configure --with-openssl --disable-shared --with-ca-fallback --with-ca-bundle=/etc/pki/tls/certs/ca-bundle.crt ; then \\
         [[ -e config.log ]] && cat config.log ; \\
         exit 1 ; \\
     fi ; \\

--- a/distribution/docker/src/docker/Dockerfile
+++ b/distribution/docker/src/docker/Dockerfile
@@ -99,11 +99,15 @@ RUN gpg --import --always-trust "curl-gpg.pub" && \\
     gpg --verify "\${TARBALL_PATH}.asc" "\${TARBALL_PATH}"
 
 # Unpack and build
-RUN tar xfJ "\${TARBALL_PATH}" && \\
-    cd "curl-\${VERSION}" && \\
-    ./configure --disable-shared --with-ca-fallback --with-ca-bundle=/etc/pki/tls/certs/ca-bundle.crt && \\
-    make curl_LDFLAGS="-all-static" && \\
-    cp src/curl /work/curl && \\
+RUN set -e ; \\
+    tar xfJ "\${TARBALL_PATH}" ; \\
+    cd "curl-\${VERSION}" ; \\
+    if ! ./configure --disable-shared --with-ca-fallback --with-ca-bundle=/etc/pki/tls/certs/ca-bundle.crt ; then \\
+        [[ -e config.log ]] && cat config.log ; \\
+        exit 1 ; \\
+    fi ; \\
+    make curl_LDFLAGS="-all-static" ; \\
+    cp src/curl /work/curl ; \\
     strip /work/curl
 
 ################################################################################

--- a/distribution/docker/src/docker/Dockerfile
+++ b/distribution/docker/src/docker/Dockerfile
@@ -102,7 +102,7 @@ RUN gpg --import --always-trust "curl-gpg.pub" && \\
 RUN set -e ; \\
     tar xfJ "\${TARBALL_PATH}" ; \\
     cd "curl-\${VERSION}" ; \\
-    if ! ./configure --with-openssl --disable-shared --with-ca-fallback --with-ca-bundle=/etc/pki/tls/certs/ca-bundle.crt ; then \\
+    if ! ./configure --disable-dependency-tracking --with-openssl --disable-shared --with-ca-fallback --with-ca-bundle=/etc/pki/tls/certs/ca-bundle.crt ; then \\
         [[ -e config.log ]] && cat config.log ; \\
         exit 1 ; \\
     fi ; \\

--- a/distribution/docker/src/docker/Dockerfile
+++ b/distribution/docker/src/docker/Dockerfile
@@ -74,7 +74,7 @@ RUN chmod 0755 /bin/tini
 ################################################################################
 FROM alpine:latest AS curl
 
-ENV VERSION 7.77.0
+ENV VERSION 7.71.0
 ENV TARBALL_URL https://curl.haxx.se/download/curl-\${VERSION}.tar.xz
 ENV TARBALL_PATH curl-\${VERSION}.tar.xz
 

--- a/qa/os/src/test/java/org/elasticsearch/packaging/util/Docker.java
+++ b/qa/os/src/test/java/org/elasticsearch/packaging/util/Docker.java
@@ -330,7 +330,7 @@ public class Docker {
         args.add("--volume \"" + localPath.getParent() + ":" + containerPath.getParent() + "\"");
 
         // Use a lightweight musl libc based small image
-        args.add("alpine");
+        args.add("alpine:3.13");
 
         // And run inline commands via the POSIX shell
         args.add("/bin/sh -c \"" + shellCmd + "\"");


### PR DESCRIPTION
[Alpine Linux 3.14.0 is incompatible with older versions of Docker](https://wiki.alpinelinux.org/wiki/Release_Notes_for_Alpine_3.14.0#faccessat2), so pin the
version that we use to 3.13. At some point in the future, it will
be possible to upgrade Alpine.

Also when compiling `curl`, if the configure step fails and a `config.log`
file exists, then dump it out before exiting to assist diagnosis.
