### PR TITLE
[ML] Parse timeout in model deployment APIs

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/ml.infer_trained_model_deployment.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/ml.infer_trained_model_deployment.json
@@ -25,6 +25,13 @@
           }
         }
       ]
+    },
+    "params":{
+      "timeout":{
+        "type":"time",
+        "required":false,
+        "description":"Controls the time to wait for the inference result"
+      }
     }
   }
 }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/ml.start_trained_model_deployment.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/ml.start_trained_model_deployment.json
@@ -30,7 +30,7 @@
       "timeout":{
         "type":"time",
         "required":false,
-        "description":"Controls the time to wait until the model is deployed. Defaults to 20 seconds"
+        "description":"Controls the time to wait until the model is deployed"
       }
     }
   }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/ml.start_trained_model_deployment.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/ml.start_trained_model_deployment.json
@@ -25,6 +25,13 @@
           }
         }
       ]
+    },
+    "params":{
+      "timeout":{
+        "type":"time",
+        "required":false,
+        "description":"Controls the time to wait until the model is deployed. Defaults to 20 seconds"
+      }
     }
   }
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/InferTrainedModelDeploymentAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/InferTrainedModelDeploymentAction.java
@@ -10,6 +10,7 @@ package org.elasticsearch.xpack.core.ml.action;
 import org.elasticsearch.action.ActionType;
 import org.elasticsearch.action.support.tasks.BaseTasksRequest;
 import org.elasticsearch.action.support.tasks.BaseTasksResponse;
+import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.xcontent.ParseField;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -19,6 +20,7 @@ import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.ToXContentObject;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.xpack.core.ml.inference.results.InferenceResults;
 
@@ -39,17 +41,25 @@ public class InferTrainedModelDeploymentAction extends ActionType<InferTrainedMo
 
     public static class Request extends BaseTasksRequest<Request> implements ToXContentObject {
 
-        public static final String DEPLOYMENT_ID = "deployment_id";
+        public static final ParseField DEPLOYMENT_ID = new ParseField("deployment_id");
         public static final ParseField INPUT = new ParseField("input");
+        public static final ParseField TIMEOUT = new ParseField("timeout");
 
-        private static final ObjectParser<Request, Void> PARSER = new ObjectParser<>(NAME, Request::new);
+        private static final TimeValue DEFAULT_TIMEOUT = TimeValue.timeValueSeconds(10);
+
+        static final ObjectParser<Request, Void> PARSER = new ObjectParser<>(NAME, Request::new);
         static {
+            PARSER.declareString(Request::setDeploymentId, DEPLOYMENT_ID);
             PARSER.declareString((request, inputs) -> request.input = inputs, INPUT);
+            PARSER.declareString((r, value) -> r.setTimeout(TimeValue.parseTimeValue(value, TIMEOUT.getPreferredName())),
+                TIMEOUT);
         }
 
         public static Request parseRequest(String deploymentId, XContentParser parser) {
             Request r = PARSER.apply(parser, null);
-            r.deploymentId = deploymentId;
+            if (deploymentId != null) {
+                r.deploymentId = deploymentId;
+            }
             return r;
         }
 
@@ -59,7 +69,7 @@ public class InferTrainedModelDeploymentAction extends ActionType<InferTrainedMo
         private Request() {
         }
 
-        public Request(String deploymentId, String input) {
+        Request(String deploymentId, String input) {
             this.deploymentId = Objects.requireNonNull(deploymentId);
             this.input = Objects.requireNonNull(input);
         }
@@ -74,8 +84,21 @@ public class InferTrainedModelDeploymentAction extends ActionType<InferTrainedMo
             return deploymentId;
         }
 
+        private void setDeploymentId(String deploymentId) {
+            this.deploymentId = deploymentId;
+        }
+
         public String getInput() {
             return input;
+        }
+
+        @Override
+        public TimeValue getTimeout() {
+            TimeValue tv = super.getTimeout();
+            if (tv == null) {
+                return DEFAULT_TIMEOUT;
+            }
+            return tv;
         }
 
         @Override
@@ -88,8 +111,9 @@ public class InferTrainedModelDeploymentAction extends ActionType<InferTrainedMo
         @Override
         public XContentBuilder toXContent(XContentBuilder builder, ToXContent.Params params) throws IOException {
             builder.startObject();
-            builder.field(DEPLOYMENT_ID, deploymentId);
+            builder.field(DEPLOYMENT_ID.getPreferredName(), deploymentId);
             builder.field(INPUT.getPreferredName(), input);
+            builder.field(TIMEOUT.getPreferredName(), getTimeout().getStringRep());
             builder.endObject();
             return builder;
         }
@@ -105,12 +129,18 @@ public class InferTrainedModelDeploymentAction extends ActionType<InferTrainedMo
             if (o == null || getClass() != o.getClass()) return false;
             InferTrainedModelDeploymentAction.Request that = (InferTrainedModelDeploymentAction.Request) o;
             return Objects.equals(deploymentId, that.deploymentId)
-                && Objects.equals(input, that.input);
+                && Objects.equals(input, that.input)
+                && Objects.equals(getTimeout(), that.getTimeout());
         }
 
         @Override
         public int hashCode() {
-            return Objects.hash(deploymentId, input);
+            return Objects.hash(deploymentId, input, getTimeout());
+        }
+
+        @Override
+        public String toString() {
+            return Strings.toString(this);
         }
     }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/InferTrainedModelDeploymentAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/InferTrainedModelDeploymentAction.java
@@ -45,7 +45,7 @@ public class InferTrainedModelDeploymentAction extends ActionType<InferTrainedMo
         public static final ParseField INPUT = new ParseField("input");
         public static final ParseField TIMEOUT = new ParseField("timeout");
 
-        private static final TimeValue DEFAULT_TIMEOUT = TimeValue.timeValueSeconds(10);
+        public static final TimeValue DEFAULT_TIMEOUT = TimeValue.timeValueSeconds(10);
 
         static final ObjectParser<Request, Void> PARSER = new ObjectParser<>(NAME, Request::new);
         static {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/StartTrainedModelDeploymentAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/StartTrainedModelDeploymentAction.java
@@ -42,8 +42,8 @@ public class StartTrainedModelDeploymentAction extends ActionType<NodeAcknowledg
 
     public static class Request extends MasterNodeRequest<Request> implements ToXContentObject {
 
-        private static final ParseField MODEL_ID = new ParseField("model_id");
-        private static final ParseField TIMEOUT = new ParseField("timeout");
+        public static final ParseField MODEL_ID = new ParseField("model_id");
+        public static final ParseField TIMEOUT = new ParseField("timeout");
 
         private String modelId;
         private TimeValue timeout = DEFAULT_TIMEOUT;

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/InferTrainedModelDeploymentRequestsTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/InferTrainedModelDeploymentRequestsTests.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.core.ml.action;
+
+import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.test.AbstractSerializingTestCase;
+
+import java.io.IOException;
+
+public class InferTrainedModelDeploymentRequestsTests extends AbstractSerializingTestCase<InferTrainedModelDeploymentAction.Request> {
+    @Override
+    protected InferTrainedModelDeploymentAction.Request doParseInstance(XContentParser parser) throws IOException {
+        return InferTrainedModelDeploymentAction.Request.parseRequest(null, parser);
+    }
+
+    @Override
+    protected Writeable.Reader<InferTrainedModelDeploymentAction.Request> instanceReader() {
+        return InferTrainedModelDeploymentAction.Request::new;
+    }
+
+    @Override
+    protected InferTrainedModelDeploymentAction.Request createTestInstance() {
+        InferTrainedModelDeploymentAction.Request request =
+            new InferTrainedModelDeploymentAction.Request(randomAlphaOfLength(4), randomAlphaOfLength(6));
+        if (randomBoolean()) {
+            request.setTimeout(randomTimeValue());
+        }
+        return request;
+    }
+}

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/InferTrainedModelDeploymentRequestsTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/InferTrainedModelDeploymentRequestsTests.java
@@ -33,4 +33,8 @@ public class InferTrainedModelDeploymentRequestsTests extends AbstractSerializin
         }
         return request;
     }
+
+    public void testTimeoutNotNull() {
+        assertNotNull(createTestInstance().getTimeout());
+    }
 }

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/PyTorchModelIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/PyTorchModelIT.java
@@ -169,7 +169,7 @@ public class PyTorchModelIT extends ESRestTestCase {
     }
 
     private void startDeployment() throws IOException {
-        Request request = new Request("POST", "/_ml/trained_models/" + MODEL_ID + "/deployment/_start");
+        Request request = new Request("POST", "/_ml/trained_models/" + MODEL_ID + "/deployment/_start?timeout=40s");
         Response response = client().performRequest(request);
         logger.info("Start response: " + EntityUtils.toString(response.getEntity()));
     }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportInferTrainedModelDeploymentAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportInferTrainedModelDeploymentAction.java
@@ -14,7 +14,6 @@ import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.tasks.TransportTasksAction;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.inject.Inject;
-import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.persistent.PersistentTasksCustomMetadata;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.threadpool.ThreadPool;
@@ -71,8 +70,7 @@ public class TransportInferTrainedModelDeploymentAction extends TransportTasksAc
     @Override
     protected void taskOperation(InferTrainedModelDeploymentAction.Request request, TrainedModelDeploymentTask task,
                                  ActionListener<InferTrainedModelDeploymentAction.Response> listener) {
-        TimeValue timeout = request.getTimeout() == null ? TimeValue.timeValueSeconds(10) : request.getTimeout();
-        task.infer(request.getInput(), timeout,
+        task.infer(request.getInput(), request.getTimeout(),
             ActionListener.wrap(
                 pyTorchResult -> listener.onResponse(new InferTrainedModelDeploymentAction.Response(pyTorchResult)),
                 listener::onFailure)

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/rest/inference/RestInferTrainedModelDeploymentAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/rest/inference/RestInferTrainedModelDeploymentAction.java
@@ -8,6 +8,7 @@
 package org.elasticsearch.xpack.ml.rest.inference;
 
 import org.elasticsearch.client.node.NodeClient;
+import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.rest.BaseRestHandler;
 import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.rest.action.RestToXContentListener;
@@ -46,6 +47,12 @@ public class RestInferTrainedModelDeploymentAction extends BaseRestHandler {
         }
         InferTrainedModelDeploymentAction.Request request =
             InferTrainedModelDeploymentAction.Request.parseRequest(deploymentId, restRequest.contentParser());
+
+        if (restRequest.hasParam(InferTrainedModelDeploymentAction.Request.TIMEOUT.getPreferredName())) {
+            TimeValue inferTimeout = restRequest.paramAsTime(InferTrainedModelDeploymentAction.Request.TIMEOUT.getPreferredName(),
+                InferTrainedModelDeploymentAction.Request.DEFAULT_TIMEOUT);
+            request.setTimeout(inferTimeout);
+        }
 
         return channel -> client.execute(InferTrainedModelDeploymentAction.INSTANCE, request, new RestToXContentListener<>(channel));
     }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/rest/inference/RestStartTrainedModelDeploymentAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/rest/inference/RestStartTrainedModelDeploymentAction.java
@@ -8,11 +8,11 @@
 package org.elasticsearch.xpack.ml.rest.inference;
 
 import org.elasticsearch.client.node.NodeClient;
+import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.rest.BaseRestHandler;
 import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.rest.action.RestToXContentListener;
 import org.elasticsearch.xpack.core.ml.action.StartTrainedModelDeploymentAction;
-import org.elasticsearch.xpack.core.ml.inference.TrainedModelConfig;
 import org.elasticsearch.xpack.ml.MachineLearning;
 
 import java.io.IOException;
@@ -32,13 +32,20 @@ public class RestStartTrainedModelDeploymentAction extends BaseRestHandler {
     public List<Route> routes() {
         return Collections.singletonList(
             new Route(POST,
-                MachineLearning.BASE_PATH + "trained_models/{" + TrainedModelConfig.MODEL_ID.getPreferredName() + "}/deployment/_start"));
+                MachineLearning.BASE_PATH + "trained_models/{" +
+                    StartTrainedModelDeploymentAction.Request.MODEL_ID.getPreferredName() + "}/deployment/_start"));
     }
 
     @Override
     protected RestChannelConsumer prepareRequest(RestRequest restRequest, NodeClient client) throws IOException {
-        String modelId = restRequest.param(TrainedModelConfig.MODEL_ID.getPreferredName());
+        String modelId = restRequest.param(StartTrainedModelDeploymentAction.Request.MODEL_ID.getPreferredName());
         StartTrainedModelDeploymentAction.Request request = new StartTrainedModelDeploymentAction.Request(modelId);
+        if (restRequest.hasParam(StartTrainedModelDeploymentAction.Request.TIMEOUT.getPreferredName())) {
+            TimeValue openTimeout = restRequest.paramAsTime(StartTrainedModelDeploymentAction.Request.TIMEOUT.getPreferredName(),
+                StartTrainedModelDeploymentAction.DEFAULT_TIMEOUT);
+            request.setTimeout(openTimeout);
+        }
+
         return channel -> client.execute(StartTrainedModelDeploymentAction.INSTANCE, request, new RestToXContentListener<>(channel));
     }
 }


### PR DESCRIPTION
`timeout` is a common parameter for our APIs but it was not being parsed and set on the start trained model deployment request or in infer.

The test `PyTorchModelIT` is muted on the main branch at the moment but I unmuted the test to verify the parameter is being consumed. 

Non-issue as this is a bug fix in unreleased code.