### PR TITLE
Run CheckIndex on metadata index before loading (#73239)

### DIFF
--- a/server/src/main/java/org/elasticsearch/gateway/PersistedClusterStateService.java
+++ b/server/src/main/java/org/elasticsearch/gateway/PersistedClusterStateService.java
@@ -16,6 +16,7 @@ import org.apache.lucene.document.Document;
 import org.apache.lucene.document.Field;
 import org.apache.lucene.document.StoredField;
 import org.apache.lucene.document.StringField;
+import org.apache.lucene.index.CheckIndex;
 import org.apache.lucene.index.DirectoryReader;
 import org.apache.lucene.index.IndexNotFoundException;
 import org.apache.lucene.index.IndexWriter;
@@ -46,6 +47,7 @@ import org.elasticsearch.core.Nullable;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.bytes.RecyclingBytesStreamOutput;
 import org.elasticsearch.common.io.Streams;
+import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.core.Releasable;
 import org.elasticsearch.core.Releasables;
 import org.elasticsearch.common.logging.Loggers;
@@ -70,6 +72,8 @@ import org.elasticsearch.index.Index;
 import java.io.Closeable;
 import java.io.IOError;
 import java.io.IOException;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -306,6 +310,14 @@ public class PersistedClusterStateService {
      * Loads the best available on-disk cluster state. Returns {@link OnDiskState#NO_ON_DISK_STATE} if no such state was found.
      */
     public OnDiskState loadBestOnDiskState() throws IOException {
+        return loadBestOnDiskState(true);
+    }
+
+    /**
+     * Loads the best available on-disk cluster state. Returns {@link OnDiskState#NO_ON_DISK_STATE} if no such state was found.
+     * @param checkClean whether to check the index for corruption before loading, only for tests
+     */
+    OnDiskState loadBestOnDiskState(boolean checkClean) throws IOException {
         String committedClusterUuid = null;
         Path committedClusterUuidPath = null;
         OnDiskState bestOnDiskState = OnDiskState.NO_ON_DISK_STATE;
@@ -317,39 +329,63 @@ public class PersistedClusterStateService {
         for (final Path dataPath : dataPaths) {
             final Path indexPath = dataPath.resolve(METADATA_DIRECTORY_NAME);
             if (Files.exists(indexPath)) {
-                try (Directory directory = createDirectory(indexPath);
-                     DirectoryReader directoryReader = DirectoryReader.open(directory)) {
-                    final OnDiskState onDiskState = loadOnDiskState(dataPath, directoryReader);
+                try (Directory directory = createDirectory(indexPath)) {
+                if (checkClean) {
+                    try (BytesStreamOutput outputStream = new BytesStreamOutput()) {
+                        final boolean isClean;
+                        try (PrintStream printStream = new PrintStream(outputStream, true, StandardCharsets.UTF_8.name());
+                             CheckIndex checkIndex = new CheckIndex(directory)) {
+                            checkIndex.setInfoStream(printStream);
+                            checkIndex.setChecksumsOnly(true);
+                            isClean = checkIndex.checkIndex().clean;
+                        }
 
-                    if (nodeId.equals(onDiskState.nodeId) == false) {
-                        throw new IllegalStateException("unexpected node ID in metadata, found [" + onDiskState.nodeId +
-                            "] in [" + dataPath + "] but expected [" + nodeId + "]");
-                    }
-
-                    if (onDiskState.metadata.clusterUUIDCommitted()) {
-                        if (committedClusterUuid == null) {
-                            committedClusterUuid = onDiskState.metadata.clusterUUID();
-                            committedClusterUuidPath = dataPath;
-                        } else if (committedClusterUuid.equals(onDiskState.metadata.clusterUUID()) == false) {
-                            throw new IllegalStateException("mismatched cluster UUIDs in metadata, found [" + committedClusterUuid +
-                                "] in [" + committedClusterUuidPath + "] and [" + onDiskState.metadata.clusterUUID() + "] in ["
-                                + dataPath + "]");
+                        if (isClean == false) {
+                            if (logger.isErrorEnabled()) {
+                                for (final String line : outputStream.bytes().utf8ToString().split("\\r?\\n")) {
+                                    logger.error("checkIndex: {}", line);
+                                }
+                            }
+                            throw new IllegalStateException("the index containing the cluster metadata under the data path [" + dataPath +
+                                "] has been changed by an external force after it was last written by Elasticsearch and is now unreadable");
                         }
                     }
+                }
 
-                    if (maxCurrentTermOnDiskState.empty() || maxCurrentTermOnDiskState.currentTerm < onDiskState.currentTerm) {
-                        maxCurrentTermOnDiskState = onDiskState;
-                    }
 
-                    long acceptedTerm = onDiskState.metadata.coordinationMetadata().term();
-                    long maxAcceptedTerm = bestOnDiskState.metadata.coordinationMetadata().term();
-                    if (bestOnDiskState.empty()
-                        || acceptedTerm > maxAcceptedTerm
-                        || (acceptedTerm == maxAcceptedTerm
+                    try (DirectoryReader directoryReader = DirectoryReader.open(directory)) {
+                        final OnDiskState onDiskState = loadOnDiskState(dataPath, directoryReader);
+
+                        if (nodeId.equals(onDiskState.nodeId) == false) {
+                            throw new IllegalStateException("the index containing the cluster metadata under the data path [" + dataPath +
+                                "] belongs to a node with ID [" + onDiskState.nodeId + "] but this node's ID is [" + nodeId + "]");
+                        }
+
+                        if (onDiskState.metadata.clusterUUIDCommitted()) {
+                            if (committedClusterUuid == null) {
+                                committedClusterUuid = onDiskState.metadata.clusterUUID();
+                                committedClusterUuidPath = dataPath;
+                            } else if (committedClusterUuid.equals(onDiskState.metadata.clusterUUID()) == false) {
+                                throw new IllegalStateException("mismatched cluster UUIDs in metadata, found [" + committedClusterUuid +
+                                    "] in [" + committedClusterUuidPath + "] and [" + onDiskState.metadata.clusterUUID() + "] in ["
+                                    + dataPath + "]");
+                            }
+                        }
+
+                        if (maxCurrentTermOnDiskState.empty() || maxCurrentTermOnDiskState.currentTerm < onDiskState.currentTerm) {
+                            maxCurrentTermOnDiskState = onDiskState;
+                        }
+
+                        long acceptedTerm = onDiskState.metadata.coordinationMetadata().term();
+                        long maxAcceptedTerm = bestOnDiskState.metadata.coordinationMetadata().term();
+                        if (bestOnDiskState.empty()
+                            || acceptedTerm > maxAcceptedTerm
+                            || (acceptedTerm == maxAcceptedTerm
                             && (onDiskState.lastAcceptedVersion > bestOnDiskState.lastAcceptedVersion
-                                || (onDiskState.lastAcceptedVersion == bestOnDiskState.lastAcceptedVersion)
-                                    && onDiskState.currentTerm > bestOnDiskState.currentTerm))) {
-                        bestOnDiskState = onDiskState;
+                            || (onDiskState.lastAcceptedVersion == bestOnDiskState.lastAcceptedVersion)
+                            && onDiskState.currentTerm > bestOnDiskState.currentTerm))) {
+                            bestOnDiskState = onDiskState;
+                        }
                     }
                 } catch (IndexNotFoundException e) {
                     logger.debug(new ParameterizedMessage("no on-disk state at {}", indexPath), e);

--- a/server/src/test/java/org/elasticsearch/gateway/GatewayMetaStatePersistedStateTests.java
+++ b/server/src/test/java/org/elasticsearch/gateway/GatewayMetaStatePersistedStateTests.java
@@ -371,7 +371,7 @@ public class GatewayMetaStatePersistedStateTests extends ESTestCase {
             assertThat(persistedState.getLastAcceptedState().getLastAcceptedConfiguration(),
                 not(equalTo(persistedState.getLastAcceptedState().getLastCommittedConfiguration())));
             CoordinationMetadata persistedCoordinationMetadata =
-                persistedClusterStateService.loadBestOnDiskState().metadata.coordinationMetadata();
+                persistedClusterStateService.loadBestOnDiskState(false).metadata.coordinationMetadata();
             assertThat(persistedCoordinationMetadata.getLastAcceptedConfiguration(),
                 equalTo(GatewayMetaState.AsyncPersistedState.staleStateConfiguration));
             assertThat(persistedCoordinationMetadata.getLastCommittedConfiguration(),
@@ -387,12 +387,12 @@ public class GatewayMetaStatePersistedStateTests extends ESTestCase {
                     .clusterUUID(state.metadata().clusterUUID()).clusterUUIDCommitted(true).build()).build();
 
             assertClusterStateEqual(expectedClusterState, persistedState.getLastAcceptedState());
-            persistedCoordinationMetadata = persistedClusterStateService.loadBestOnDiskState().metadata.coordinationMetadata();
+            persistedCoordinationMetadata = persistedClusterStateService.loadBestOnDiskState(false).metadata.coordinationMetadata();
             assertThat(persistedCoordinationMetadata.getLastAcceptedConfiguration(),
                 equalTo(GatewayMetaState.AsyncPersistedState.staleStateConfiguration));
             assertThat(persistedCoordinationMetadata.getLastCommittedConfiguration(),
                 equalTo(GatewayMetaState.AsyncPersistedState.staleStateConfiguration));
-            assertTrue(persistedClusterStateService.loadBestOnDiskState().metadata.clusterUUIDCommitted());
+            assertTrue(persistedClusterStateService.loadBestOnDiskState(false).metadata.clusterUUIDCommitted());
 
             // generate a series of updates and check if batching works
             final String indexName = randomAlphaOfLength(10);


### PR DESCRIPTION
The metadata index is small and important and only read at startup.
Today we rely on Lucene to spot if any of its components is corrupt, but
Lucene does not necesssarily verify all checksums in order to catch a
corruption. With this commit we run `CheckIndex` on the metadata index
first, and fail on startup if a corruption is detected.

Closes #29358