### PR TITLE
Fix clone API settings docs bug

### DIFF
--- a/docs/reference/indices/clone-index.asciidoc
+++ b/docs/reference/indices/clone-index.asciidoc
@@ -56,16 +56,19 @@ and then the previous write index can be cloned.
 Use the clone index API to clone an existing index into a new index, where each
 original primary shard is cloned into a new primary shard in the new index.
 
-IMPORTANT: {es} doesn't apply index templates to the resulting index. The API
+[IMPORTANT]
+====
+{es} doesn't apply index templates to the resulting index. The API
 also doesn't copy index metadata from the original index. Index metadata
 includes aliases, {ilm-init} phase definitions, and {ccr-init} follower
 information. For example, if you clone a {ccr-init} follower index, the
 resulting clone won't be a follower index.
-+
+
 The clone API copies most index settings from the source index to the resulting
 index, with the exception of `index.number_of_replicas` and
 `index.auto_expand_replicas`. To set the number of replicas in the resulting
 index, configure these settings in the clone request.
+====
 
 [[cloning-works]]
 ===== How cloning works

--- a/docs/reference/indices/clone-index.asciidoc
+++ b/docs/reference/indices/clone-index.asciidoc
@@ -57,10 +57,15 @@ Use the clone index API to clone an existing index into a new index, where each
 original primary shard is cloned into a new primary shard in the new index.
 
 IMPORTANT: {es} doesn't apply index templates to the resulting index. The API
-also doesn't copy index settings or metadata from the original index. Index
-metadata includes aliases, {ilm-init} phase definitions, and {ccr-init} follower
+also doesn't copy index metadata from the original index. Index metadata
+includes aliases, {ilm-init} phase definitions, and {ccr-init} follower
 information. For example, if you clone a {ccr-init} follower index, the
 resulting clone won't be a follower index.
++
+The clone API copies most index settings from the source index to the resulting
+index, with the exception of `index.number_of_replicas` and
+`index.auto_expand_replicas`. To set the number of replicas in the resulting
+index, configure these settings in the clone request.
 
 [[cloning-works]]
 ===== How cloning works


### PR DESCRIPTION
In #74138 we noted that index settings aren't copied in a clone. In fact
that's not true, we copy everything except explicitly-excluded ones,
`number_of_replicas` and `auto_expand_replicas`. This fixes the mistake.