### PR TITLE
Add explicit tests for dynamic template validation on bad mapping parameters

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/mapper/DynamicFieldsBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DynamicFieldsBuilder.java
@@ -193,8 +193,7 @@ final class DynamicFieldsBuilder {
         String mappingType = dynamicTemplate.mappingType(dynamicType);
         Map<String, Object> mapping = dynamicTemplate.mappingForName(name, dynamicType);
         if (dynamicTemplate.isRuntimeMapping()) {
-            Mapper.TypeParser.ParserContext parserContext = context.parserContext(dateFormatter);
-            parserContext = parserContext.createDynamicTemplateFieldContext(parserContext);
+            Mapper.TypeParser.ParserContext parserContext = context.dynamicTemplateParserContext(dateFormatter);
             RuntimeField.Parser parser = parserContext.runtimeFieldParser(mappingType);
             String fullName = context.path().pathAsText(name);
             if (parser == null) {
@@ -226,8 +225,7 @@ final class DynamicFieldsBuilder {
                                                Map<String, Object> mapping,
                                                DateFormatter dateFormatter,
                                                ParseContext context) {
-        Mapper.TypeParser.ParserContext parserContext = context.parserContext(dateFormatter);
-        parserContext = parserContext.createDynamicTemplateFieldContext(parserContext);
+        Mapper.TypeParser.ParserContext parserContext = context.dynamicTemplateParserContext(dateFormatter);
         Mapper.TypeParser typeParser = parserContext.typeParser(mappingType);
         if (typeParser == null) {
             throw new MapperParsingException("failed to find type parsed [" + mappingType + "] for [" + name + "]");

--- a/server/src/main/java/org/elasticsearch/index/mapper/DynamicFieldsBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DynamicFieldsBuilder.java
@@ -194,6 +194,7 @@ final class DynamicFieldsBuilder {
         Map<String, Object> mapping = dynamicTemplate.mappingForName(name, dynamicType);
         if (dynamicTemplate.isRuntimeMapping()) {
             Mapper.TypeParser.ParserContext parserContext = context.parserContext(dateFormatter);
+            parserContext = parserContext.createDynamicTemplateFieldContext(parserContext);
             RuntimeField.Parser parser = parserContext.runtimeFieldParser(mappingType);
             String fullName = context.path().pathAsText(name);
             if (parser == null) {

--- a/server/src/main/java/org/elasticsearch/index/mapper/Mapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/Mapper.java
@@ -144,8 +144,8 @@ public abstract class Mapper implements ToXContentFragment, Iterable<Mapper> {
                 return new MultiFieldParserContext(in);
             }
 
-            ParserContext createDynamicTemplateFieldContext(ParserContext in) {
-                return new DynamicTemplateParserContext(in);
+            ParserContext createDynamicTemplateFieldContext() {
+                return new DynamicTemplateParserContext(this);
             }
 
             private static class MultiFieldParserContext extends ParserContext {

--- a/server/src/main/java/org/elasticsearch/index/mapper/ParseContext.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/ParseContext.java
@@ -164,8 +164,8 @@ public abstract class ParseContext {
         }
 
         @Override
-        public Mapper.TypeParser.ParserContext parserContext(DateFormatter dateFormatter) {
-            return in.parserContext(dateFormatter);
+        public Mapper.TypeParser.ParserContext dynamicTemplateParserContext(DateFormatter dateFormatter) {
+            return in.dynamicTemplateParserContext(dateFormatter);
         }
 
         @Override
@@ -336,8 +336,8 @@ public abstract class ParseContext {
         }
 
         @Override
-        public Mapper.TypeParser.ParserContext parserContext(DateFormatter dateFormatter) {
-            return parserContextFunction.apply(dateFormatter);
+        public Mapper.TypeParser.ParserContext dynamicTemplateParserContext(DateFormatter dateFormatter) {
+            return parserContextFunction.apply(dateFormatter).createDynamicTemplateFieldContext();
         }
 
         @Override
@@ -548,7 +548,7 @@ public abstract class ParseContext {
      */
     public abstract Collection<String> getFieldNames();
 
-    public abstract Mapper.TypeParser.ParserContext parserContext(DateFormatter dateFormatter);
+    public abstract Mapper.TypeParser.ParserContext dynamicTemplateParserContext(DateFormatter dateFormatter);
 
     /**
      * Return a new context that will be within a copy-to operation.

--- a/server/src/main/java/org/elasticsearch/index/mapper/RuntimeField.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/RuntimeField.java
@@ -8,7 +8,6 @@
 
 package org.elasticsearch.index.mapper;
 
-import org.elasticsearch.common.logging.DeprecationLogger;
 import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.ToXContentFragment;
 import org.elasticsearch.common.xcontent.XContentBuilder;
@@ -64,8 +63,6 @@ public interface RuntimeField extends ToXContentFragment {
     abstract class Builder implements ToXContent {
         final String name;
         final Parameter<Map<String, String>> meta = Parameter.metaParam();
-
-        private static final DeprecationLogger deprecationLogger = DeprecationLogger.getLogger(RuntimeField.class);
 
         protected Builder(String name) {
             this.name = name;

--- a/server/src/main/java/org/elasticsearch/index/mapper/RuntimeField.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/RuntimeField.java
@@ -8,8 +8,6 @@
 
 package org.elasticsearch.index.mapper;
 
-import org.elasticsearch.Version;
-import org.elasticsearch.common.logging.DeprecationCategory;
 import org.elasticsearch.common.logging.DeprecationLogger;
 import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.ToXContentFragment;
@@ -104,18 +102,6 @@ public interface RuntimeField extends ToXContentFragment {
                 final Object propNode = entry.getValue();
                 Parameter<?> parameter = paramsMap.get(propName);
                 if (parameter == null) {
-                    if (parserContext.isFromDynamicTemplate() && parserContext.indexVersionCreated().before(Version.V_8_0_0)) {
-                        // The parameter is unknown, but this mapping is from a dynamic template.
-                        // Until 7.x it was possible to use unknown parameters there, so for bwc we need to ignore it
-                        deprecationLogger.deprecate(DeprecationCategory.API, propName,
-                            "Parameter [{}] is used in a dynamic template mapping and has no effect on type [{}]. "
-                                + "Usage will result in an error in future major versions and should be removed.",
-                            propName,
-                            type
-                        );
-                        iterator.remove();
-                        continue;
-                    }
                     throw new MapperParsingException(
                         "unknown parameter [" + propName + "] on runtime field [" + name + "] of type [" + type + "]"
                     );

--- a/server/src/test/java/org/elasticsearch/index/mapper/DynamicTemplatesTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/DynamicTemplatesTests.java
@@ -11,9 +11,14 @@ package org.elasticsearch.index.mapper;
 import org.apache.lucene.index.IndexOptions;
 import org.apache.lucene.index.IndexableField;
 import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.Version;
 import org.elasticsearch.index.mapper.ParseContext.Document;
+import org.elasticsearch.test.VersionUtils;
+
+import java.io.IOException;
 
 import static org.elasticsearch.test.StreamsUtils.copyToStringFromClasspath;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.notNullValue;
 
@@ -158,5 +163,111 @@ public class DynamicTemplatesTests extends MapperServiceTestCase {
 
         fieldMapper = mapperService.documentMapper().mappers().getMapper("multi2.org");
         assertNotNull(fieldMapper);
+    }
+
+    public void testDynamicMapperWithBadMapping() throws IOException {
+        {
+            // in 7.x versions this will issue a deprecation warning
+            Version version = VersionUtils.randomCompatibleVersion(random(), Version.V_7_0_0);
+            DocumentMapper mapper = createDocumentMapper(version, topMapping(b -> {
+                b.startArray("dynamic_templates");
+                {
+                    b.startObject();
+                    {
+                        b.startObject("test");
+                        {
+                            b.field("match_mapping_type", "string");
+                            b.startObject("mapping").field("badparam", false).endObject();
+                        }
+                        b.endObject();
+                    }
+                    b.endObject();
+                }
+                b.endArray();
+            }));
+            assertWarnings(
+                "dynamic template [test] has invalid content [{\"match_mapping_type\":\"string\",\"mapping\":{\"badparam\":false}}], " +
+                "attempted to validate it with the following match_mapping_type: [string], last error: " +
+                "[unknown parameter [badparam] on mapper [__dynamic__test] of type [null]]");
+
+            mapper.parse(source(b -> b.field("field", "foo")));
+            assertWarnings("Parameter [badparam] is used in a dynamic template mapping and has no effect on type [null]. " +
+                    "Usage will result in an error in future major versions and should be removed.");
+        }
+
+        {
+            // in 8.x it will error out
+            Exception e = expectThrows(MapperParsingException.class, () -> createMapperService(topMapping(b -> {
+                b.startArray("dynamic_templates");
+                {
+                    b.startObject();
+                    {
+                        b.startObject("test");
+                        {
+                            b.field("match_mapping_type", "string");
+                            b.startObject("mapping").field("badparam", false).endObject();
+                        }
+                        b.endObject();
+                    }
+                    b.endObject();
+                }
+                b.endArray();
+            })));
+            assertThat(e.getMessage(), containsString("dynamic template [test] has invalid content"));
+            assertThat(e.getCause().getMessage(), containsString("badparam"));
+        }
+    }
+
+    public void testDynamicRuntimeWithBadMapping() throws IOException {
+        {
+            // in 7.x versions this will issue a deprecation warning
+            Version version = VersionUtils.randomCompatibleVersion(random(), Version.V_7_0_0);
+            DocumentMapper mapper = createDocumentMapper(version, topMapping(b -> {
+                b.startArray("dynamic_templates");
+                {
+                    b.startObject();
+                    {
+                        b.startObject("test");
+                        {
+                            b.field("match_mapping_type", "string");
+                            b.startObject("runtime").field("badparam", false).endObject();
+                        }
+                        b.endObject();
+                    }
+                    b.endObject();
+                }
+                b.endArray();
+            }));
+            assertWarnings(
+                "dynamic template [test] has invalid content [{\"match_mapping_type\":\"string\",\"runtime\":{\"badparam\":false}}], " +
+                "attempted to validate it with the following match_mapping_type: [string], last error: " +
+                "[unknown parameter [badparam] on runtime field [__dynamic__test] of type [null]]");
+
+            mapper.parse(source(b -> b.field("field", "foo")));
+            assertWarnings(
+                "Parameter [badparam] is used in a dynamic template mapping and has no effect on type [null]. " +
+                "Usage will result in an error in future major versions and should be removed.");
+        }
+        {
+            // in 8.x it will error out
+            Exception e = expectThrows(MapperParsingException.class, () -> createMapperService(topMapping(b -> {
+                b.startArray("dynamic_templates");
+                {
+                    b.startObject();
+                    {
+                        b.startObject("test");
+                        {
+                            b.field("match_mapping_type", "string");
+                            b.startObject("runtime").field("badparam", false).endObject();
+                        }
+                        b.endObject();
+                    }
+                    b.endObject();
+                }
+                b.endArray();
+            })));
+            assertThat(e.getMessage(), containsString("dynamic template [test] has invalid content"));
+            assertThat(e.getCause().getMessage(), containsString("badparam"));
+        }
     }
 }

--- a/server/src/test/java/org/elasticsearch/index/mapper/DynamicTemplatesTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/DynamicTemplatesTests.java
@@ -218,56 +218,24 @@ public class DynamicTemplatesTests extends MapperServiceTestCase {
         }
     }
 
-    public void testDynamicRuntimeWithBadMapping() throws IOException {
-        {
-            // in 7.x versions this will issue a deprecation warning
-            Version version = VersionUtils.randomCompatibleVersion(random(), Version.V_7_0_0);
-            DocumentMapper mapper = createDocumentMapper(version, topMapping(b -> {
-                b.startArray("dynamic_templates");
+    public void testDynamicRuntimeWithBadMapping() {
+        Exception e = expectThrows(MapperParsingException.class, () -> createMapperService(topMapping(b -> {
+            b.startArray("dynamic_templates");
+            {
+                b.startObject();
                 {
-                    b.startObject();
+                    b.startObject("test");
                     {
-                        b.startObject("test");
-                        {
-                            b.field("match_mapping_type", "string");
-                            b.startObject("runtime").field("badparam", false).endObject();
-                        }
-                        b.endObject();
+                        b.field("match_mapping_type", "string");
+                        b.startObject("runtime").field("badparam", false).endObject();
                     }
                     b.endObject();
                 }
-                b.endArray();
-            }));
-            assertWarnings(
-                "dynamic template [test] has invalid content [{\"match_mapping_type\":\"string\",\"runtime\":{\"badparam\":false}}], " +
-                "attempted to validate it with the following match_mapping_type: [string], last error: " +
-                "[unknown parameter [badparam] on runtime field [__dynamic__test] of type [null]]");
-
-            mapper.parse(source(b -> b.field("field", "foo")));
-            assertWarnings(
-                "Parameter [badparam] is used in a dynamic template mapping and has no effect on type [null]. " +
-                "Usage will result in an error in future major versions and should be removed.");
-        }
-        {
-            // in 8.x it will error out
-            Exception e = expectThrows(MapperParsingException.class, () -> createMapperService(topMapping(b -> {
-                b.startArray("dynamic_templates");
-                {
-                    b.startObject();
-                    {
-                        b.startObject("test");
-                        {
-                            b.field("match_mapping_type", "string");
-                            b.startObject("runtime").field("badparam", false).endObject();
-                        }
-                        b.endObject();
-                    }
-                    b.endObject();
-                }
-                b.endArray();
-            })));
-            assertThat(e.getMessage(), containsString("dynamic template [test] has invalid content"));
-            assertThat(e.getCause().getMessage(), containsString("badparam"));
-        }
+                b.endObject();
+            }
+            b.endArray();
+        })));
+        assertThat(e.getMessage(), containsString("dynamic template [test] has invalid content"));
+        assertThat(e.getCause().getMessage(), containsString("badparam"));
     }
 }

--- a/server/src/test/java/org/elasticsearch/index/mapper/ParametrizedMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/ParametrizedMapperTests.java
@@ -208,7 +208,7 @@ public class ParametrizedMapperTests extends MapperServiceTestCase {
             throw new UnsupportedOperationException();
         });
         if (fromDynamicTemplate) {
-            pc = pc.createDynamicTemplateFieldContext(pc);
+            pc = pc.createDynamicTemplateFieldContext();
         }
         return (TestMapper) new TypeParser()
             .parse("field", XContentHelper.convertToMap(JsonXContent.jsonXContent, mapping, true), pc)


### PR DESCRIPTION
When a dynamic template is applied to a 7.x index, we do some validation checks
against the generated mappings and issue a deprecation warning if the validation
fails.  We had some tests that were checking this at a low level, but nothing that
exercised the full logic.

When dynamic runtimes were added, we expected this behaviour to carry over; 
however, a bug in building the ParserContext to pass to the runtime Builder meant
that we would instead always throw an error.  In fact, erroring here is a good result,
as the only reason we issue a deprecation warning for non-runtime fields is to
preserve backward compatibility; given that runtime fields are new, it has never
been possible to add a bad dynamic runtime template.

This commit adds specific tests for both situations.  It ensures that the parser
context passed to a runtime builder will know that it is in a dynamic context,
but it also removes the version check and deprecation warning, as they were
never actually triggered and we can be stricter here.