### PR TITLE
Add unenroll_timeout/unenrolled_reason field to Fleet system indexes

### DIFF
--- a/x-pack/plugin/core/src/main/resources/fleet-agents.json
+++ b/x-pack/plugin/core/src/main/resources/fleet-agents.json
@@ -209,6 +209,9 @@
         "unenrolled_at": {
           "type": "date"
         },
+        "unenrolled_reason": {
+          "type": "keyword"
+        },
         "unenrollment_started_at": {
           "type": "date"
         },

--- a/x-pack/plugin/core/src/main/resources/fleet-agents.json
+++ b/x-pack/plugin/core/src/main/resources/fleet-agents.json
@@ -224,6 +224,9 @@
         "user_provided_metadata": {
           "type": "object",
           "enabled": false
+        },
+        "ephemeral": {
+          "type": "boolean"
         }
       }
     }

--- a/x-pack/plugin/core/src/main/resources/fleet-agents.json
+++ b/x-pack/plugin/core/src/main/resources/fleet-agents.json
@@ -224,9 +224,6 @@
         "user_provided_metadata": {
           "type": "object",
           "enabled": false
-        },
-        "ephemeral": {
-          "type": "boolean"
         }
       }
     }

--- a/x-pack/plugin/core/src/main/resources/fleet-policies.json
+++ b/x-pack/plugin/core/src/main/resources/fleet-policies.json
@@ -28,7 +28,7 @@
         "@timestamp": {
           "type": "date"
         },
-        "ephemeral_ttl": {
+        "unenroll_timeout": {
           "type": "integer"
         }
       }

--- a/x-pack/plugin/core/src/main/resources/fleet-policies.json
+++ b/x-pack/plugin/core/src/main/resources/fleet-policies.json
@@ -28,7 +28,7 @@
         "@timestamp": {
           "type": "date"
         },
-        "enrollment_ttl": {
+        "ephemeral_ttl": {
           "type": "integer"
         }
       }

--- a/x-pack/plugin/core/src/main/resources/fleet-policies.json
+++ b/x-pack/plugin/core/src/main/resources/fleet-policies.json
@@ -27,6 +27,9 @@
         },
         "@timestamp": {
           "type": "date"
+        },
+        "enrollment_ttl": {
+          "type": "integer"
         }
       }
     }


### PR DESCRIPTION
Adds `unenroll_timeout` to `.fleet-policies` and `unenrolled_reason` to `.fleet-agents`.

Will be used by Kibana to set the `unenroll_timeout` for Elastic Agent's in a policy. Fleet Server will use this timeout to auto un-enrolling the Elastic Agent's that have not checked in after then `unenroll_timeout` setting `unenrolled_reason` to `timeout` so its clear that Fleet Server unenrolled the Elastic Agent because of `unenroll_timeout`.