### PR TITLE
Cleanup root build script

### DIFF
--- a/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/test/rest/YamlRestCompatTestPluginFuncTest.groovy
+++ b/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/test/rest/YamlRestCompatTestPluginFuncTest.groovy
@@ -44,7 +44,7 @@ class YamlRestCompatTestPluginFuncTest extends AbstractRestResourcesFuncTest {
         """
 
         when:
-        def result = gradleRunner("yamlRestCompatTest").build()
+        def result = gradleRunner("yamlRestCompatTest", '--stacktrace').build()
 
         then:
         result.task(':yamlRestCompatTest').outcome == TaskOutcome.NO_SOURCE

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/InternalDistributionDownloadPlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/InternalDistributionDownloadPlugin.java
@@ -39,8 +39,6 @@ import static org.elasticsearch.gradle.util.GradleUtils.projectDependency;
  */
 public class InternalDistributionDownloadPlugin implements InternalPlugin {
 
-    private BwcVersions bwcVersions = null;
-
     @Override
     public void apply(Project project) {
         // this is needed for isInternal
@@ -54,7 +52,6 @@ public class InternalDistributionDownloadPlugin implements InternalPlugin {
         distributionDownloadPlugin.setDockerAvailability(
             dockerSupport.map(dockerSupportService -> dockerSupportService.getDockerAvailability().isAvailable)
         );
-        this.bwcVersions = BuildParams.getBwcVersions();
         registerInternalDistributionResolutions(DistributionDownloadPlugin.getRegistrationsContainer(project));
     }
 
@@ -78,7 +75,7 @@ public class InternalDistributionDownloadPlugin implements InternalPlugin {
         }));
 
         resolutions.register("bwc", distributionResolution -> distributionResolution.setResolver((project, distribution) -> {
-            BwcVersions.UnreleasedVersionInfo unreleasedInfo = bwcVersions.unreleasedInfo(Version.fromString(distribution.getVersion()));
+            BwcVersions.UnreleasedVersionInfo unreleasedInfo = BuildParams.getBwcVersions().unreleasedInfo(Version.fromString(distribution.getVersion()));
             if (unreleasedInfo != null) {
                 if (distribution.getBundledJdk() == false) {
                     throw new GradleException(
@@ -109,7 +106,6 @@ public class InternalDistributionDownloadPlugin implements InternalPlugin {
         } else {
             return distributionProjectName;
         }
-
     }
 
     private static String distributionProjectPath(ElasticsearchDistribution distribution) {

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/test/RestTestBasePlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/test/RestTestBasePlugin.java
@@ -10,6 +10,7 @@ package org.elasticsearch.gradle.internal.test;
 
 import org.elasticsearch.gradle.internal.ElasticsearchTestBasePlugin;
 import org.elasticsearch.gradle.internal.FixtureStop;
+import org.elasticsearch.gradle.internal.InternalTestClustersPlugin;
 import org.elasticsearch.gradle.testclusters.ElasticsearchCluster;
 import org.elasticsearch.gradle.testclusters.StandaloneRestIntegTestTask;
 import org.elasticsearch.gradle.testclusters.TestClustersPlugin;
@@ -24,7 +25,7 @@ public class RestTestBasePlugin implements Plugin<Project> {
 
     @Override
     public void apply(Project project) {
-        project.getPluginManager().apply(TestClustersPlugin.class);
+        project.getPluginManager().apply(InternalTestClustersPlugin.class);
         project.getPluginManager().apply(ElasticsearchTestBasePlugin.class);
         project.getTasks().withType(RestIntegTestTask.class).configureEach(restIntegTestTask -> {
             @SuppressWarnings("unchecked")

--- a/build-tools/src/main/java/org/elasticsearch/gradle/testclusters/TestClustersPlugin.java
+++ b/build-tools/src/main/java/org/elasticsearch/gradle/testclusters/TestClustersPlugin.java
@@ -11,6 +11,7 @@ import org.elasticsearch.gradle.DistributionDownloadPlugin;
 import org.elasticsearch.gradle.ReaperPlugin;
 import org.elasticsearch.gradle.ReaperService;
 import org.elasticsearch.gradle.util.GradleUtils;
+import org.gradle.api.Action;
 import org.gradle.api.NamedDomainObjectContainer;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
@@ -120,6 +121,7 @@ public class TestClustersPlugin implements Plugin<Project> {
             );
         });
         project.getExtensions().add(EXTENSION_NAME, container);
+        container.all(cluster -> cluster.systemProperty("ingest.geoip.downloader.enabled.default", "false"));
         return container;
     }
 

--- a/build-tools/src/main/java/org/elasticsearch/gradle/util/GradleUtils.java
+++ b/build-tools/src/main/java/org/elasticsearch/gradle/util/GradleUtils.java
@@ -49,23 +49,8 @@ public abstract class GradleUtils {
         return project.getConvention().getPlugin(JavaPluginConvention.class).getSourceSets();
     }
 
-    public static <T extends Task> TaskProvider<T> maybeRegister(TaskContainer tasks, String name, Class<T> clazz, Action<T> action) {
-        try {
-            return tasks.named(name, clazz);
-        } catch (UnknownTaskException e) {
-            return tasks.register(name, clazz, action);
-        }
-    }
-
     public static void maybeConfigure(TaskContainer tasks, String name, Action<? super Task> config) {
-        TaskProvider<?> task;
-        try {
-            task = tasks.named(name);
-        } catch (UnknownTaskException e) {
-            return;
-        }
-
-        task.configure(config);
+        tasks.matching(t -> t.getName().equals(name)).configureEach( t-> config.execute(t));
     }
 
     public static <T extends Task> void maybeConfigure(

--- a/build.gradle
+++ b/build.gradle
@@ -45,44 +45,11 @@ plugins {
   id "com.diffplug.spotless" version "5.12.5" apply false
 }
 
-
-// common maven publishing configuration
-allprojects {
-  group = 'org.elasticsearch'
-  version = VersionProperties.elasticsearch
-  description = "Elasticsearch subproject ${project.path}"
-}
-
 String licenseCommit
 if (VersionProperties.elasticsearch.toString().endsWith('-SNAPSHOT')) {
   licenseCommit = BuildParams.gitRevision ?: "master" // leniency for non git builds
 } else {
   licenseCommit = "v${version}"
-}
-
-subprojects {
-  // We disable this plugin for now till we shaked out the issues we see
-  // e.g. see https://github.com/elastic/elasticsearch/issues/72169
-  // apply plugin:'elasticsearch.internal-test-rerun'
-
-  plugins.withType(BuildPlugin).whenPluginAdded {
-    project.licenseFile = project.rootProject.file('licenses/SSPL-1.0+ELASTIC-LICENSE-2.0.txt')
-    project.noticeFile = project.rootProject.file('NOTICE.txt')
-  }
-
-  plugins.withType(InternalPluginBuildPlugin).whenPluginAdded {
-    project.dependencies {
-      compileOnly project(":server")
-      testImplementation project(":test:framework")
-    }
-  }
-
-  // Ultimately the RestTestBase Plugin should apply the InternalTestClusters Plugin itself instead of TestClusters
-  // but this requires major rework on the func test infrastructure.
-  // TODO: This will be addressed once we have https://github.com/elastic/elasticsearch/issues/71593 resolved
-  project.plugins.withType(RestTestBasePlugin) {
-    project.plugins.apply(InternalTestClustersPlugin)
-  }
 }
 
 /**
@@ -115,27 +82,11 @@ tasks.register("updateCIBwcVersions") {
   }
 }
 
-// build metadata from previous build, contains eg hashes for bwc builds
-String buildMetadataValue = System.getenv('BUILD_METADATA')
-if (buildMetadataValue == null) {
-  buildMetadataValue = ''
-}
+//TODO port buildMetaData to use provider api
+String buildMetadataValue = providers.environmentVariable('BUILD_METADATA').forUseAtConfigurationTime().orElse("").get()
 Map<String, String> buildMetadataMap = buildMetadataValue.tokenize(';').collectEntries {
   def (String key, String value) = it.split('=')
   return [key, value]
-}
-
-// injecting groovy property variables into all projects
-allprojects {
-  project.ext {
-    // for ide hacks...
-    isEclipse = System.getProperty("eclipse.launcher") != null ||   // Detects gradle launched from Eclipse's IDE
-      System.getProperty("eclipse.application") != null ||    // Detects gradle launched from the Eclipse compiler server
-      gradle.startParameter.taskNames.contains('eclipse') ||  // Detects gradle launched from the command line to do eclipse stuff
-      gradle.startParameter.taskNames.contains('cleanEclipse')
-
-    buildMetadata = buildMetadataMap
-  }
 }
 
 tasks.register("verifyVersions") {
@@ -197,25 +148,40 @@ if (project.gradle.startParameter.taskNames.find { it.startsWith("checkPart") } 
   bwc_tests_enabled = false
 }
 
-subprojects {
-  ext.bwc_tests_enabled = bwc_tests_enabled
-}
+allprojects {
+  // common maven publishing configuration
+  group = 'org.elasticsearch'
+  version = VersionProperties.elasticsearch
+  description = "Elasticsearch subproject ${project.path}"
 
-tasks.register("verifyBwcTestsEnabled") {
-  doLast {
-    if (bwc_tests_enabled == false) {
-      throw new GradleException('Bwc tests are disabled. They must be re-enabled after completing backcompat behavior backporting.')
+  // We disable this plugin for now till we shaked out the issues we see
+  // e.g. see https://github.com/elastic/elasticsearch/issues/72169
+  // apply plugin:'elasticsearch.internal-test-rerun'
+  plugins.withType(BuildPlugin).whenPluginAdded {
+    project.licenseFile = project.rootProject.file('licenses/SSPL-1.0+ELASTIC-LICENSE-2.0.txt')
+    project.noticeFile = project.rootProject.file('NOTICE.txt')
+  }
+
+  plugins.withType(InternalPluginBuildPlugin).whenPluginAdded {
+    project.dependencies {
+      compileOnly project(":server")
+      testImplementation project(":test:framework")
     }
   }
-}
 
-tasks.register("branchConsistency") {
-  description 'Ensures this branch is internally consistent. For example, that versions constants match released versions.'
-  group 'Verification'
-  dependsOn ":verifyVersions", ":verifyBwcTestsEnabled"
-}
+  // injecting groovy property variables into all projects
+  project.ext {
+    // for ide hacks...
+    isEclipse = System.getProperty("eclipse.launcher") != null ||   // Detects gradle launched from Eclipse's IDE
+            System.getProperty("eclipse.application") != null ||    // Detects gradle launched from the Eclipse compiler server
+            gradle.startParameter.taskNames.contains('eclipse') ||  // Detects gradle launched from the command line to do eclipse stuff
+            gradle.startParameter.taskNames.contains('cleanEclipse')
 
-allprojects {
+    buildMetadata = buildMetadataMap
+  }
+
+  ext.bwc_tests_enabled = bwc_tests_enabled
+
   // ignore missing javadocs
   tasks.withType(Javadoc).configureEach { Javadoc javadoc ->
     // the -quiet here is because of a bug in gradle, in that adding a string option
@@ -227,7 +193,75 @@ allprojects {
     javadoc.options.addStringOption('Xdoclint:all,-missing', '-quiet')
   }
 
+  // eclipse configuration
+  apply plugin: 'elasticsearch.eclipse'
+
+  /*
+   * Allow accessing com/sun/net/httpserver in projects that have
+   * configured forbidden apis to allow it.
+   */
+  plugins.withType(ForbiddenApisPlugin) {
+    eclipse.classpath.file.whenMerged { classpath ->
+      if (false == forbiddenApisTest.bundledSignatures.contains('jdk-non-portable')) {
+        classpath.entries
+                .findAll { it.kind == "con" && it.toString().contains("org.eclipse.jdt.launching.JRE_CONTAINER") }
+                .each {
+                  it.accessRules.add(new AccessRule("accessible", "com/sun/net/httpserver/*"))
+                }
+      }
+    }
+  }
+  
+  tasks.register('resolveAllDependencies', org.elasticsearch.gradle.internal.ResolveAllDependencies) {
+    configs = project.configurations
+    if (project.path.contains("fixture")) {
+      dependsOn tasks.withType(ComposePull)
+    }
+  }
+
+  def checkPart1 = tasks.register('checkPart1')
+  def checkPart2 = tasks.register('checkPart2')
+  plugins.withId('lifecycle-base') {
+    if (project.path.startsWith(":x-pack:")) {
+      checkPart2.configure { dependsOn 'check' }
+    } else {
+      checkPart1.configure { dependsOn 'check' }
+    }
+  }
+
+  project.ext.disableTasks = { String... tasknames ->
+    for (String taskname : tasknames) {
+      project.tasks.named(taskname).configure { enabled = false }
+    }
+  }
+
   project.afterEvaluate {
+    // Ensure similar tasks in dependent projects run first. The projectsEvaluated here is
+    // important because, while dependencies.all will pickup future dependencies,
+    // it is not necessarily true that the task exists in both projects at the time
+    // the dependency is added.
+    if (project.path == ':test:framework') {
+      // :test:framework:test cannot run before and after :server:test
+      return
+    }
+    tasks.matching { it.name.equals('integTest')}.configureEach {integTestTask ->
+      integTestTask.mustRunAfter tasks.matching { it.name.equals("test") }
+    }
+
+    configurations.matching { it.canBeResolved }.all { Configuration configuration ->
+      dependencies.matching { it instanceof ProjectDependency }.all { ProjectDependency dep ->
+        Project upstreamProject = dep.dependencyProject
+        if (project.path != upstreamProject?.path) {
+          for (String taskName : ['test', 'integTest']) {
+            project.tasks.matching { it.name == taskName }.configureEach {task ->
+              task.shouldRunAfter(upstreamProject.tasks.matching { upStreamTask -> upStreamTask.name == taskName })
+            }
+          }
+        }
+      }
+    }
+
+
     // Handle javadoc dependencies across projects. Order matters: the linksOffline for
     // org.elasticsearch:elasticsearch must be the last one or all the links for the
     // other packages (e.g org.elasticsearch.client) will point to server rather than
@@ -265,72 +299,54 @@ allprojects {
       }
       boolean hasShadow = project.plugins.hasPlugin(ShadowPlugin)
       project.configurations.compileClasspath.dependencies
-        .findAll()
-        .toSorted(sortClosure)
-        .each({ c -> depJavadocClosure(hasShadow, c) })
+              .findAll()
+              .toSorted(sortClosure)
+              .each({ c -> depJavadocClosure(hasShadow, c) })
       project.configurations.compileOnly.dependencies
-        .findAll()
-        .toSorted(sortClosure)
-        .each({ c -> depJavadocClosure(false, c) })
+              .findAll()
+              .toSorted(sortClosure)
+              .each({ c -> depJavadocClosure(false, c) })
       if (hasShadow) {
         // include any dependencies for shadow JAR projects that are *not* bundled in the shadow JAR
         project.configurations.shadow.dependencies
-          .findAll()
-          .toSorted(sortClosure)
-          .each({ c -> depJavadocClosure(false, c) })
+                .findAll()
+                .toSorted(sortClosure)
+                .each({ c -> depJavadocClosure(false, c) })
       }
+    }
+
+    /*
+     * Remove assemble/dependenciesInfo on all qa projects because we don't
+     * need to publish artifacts for them.
+     */
+    if (project.name.equals('qa') || project.path.contains(':qa:')) {
+      maybeConfigure(project.tasks, 'assemble') {
+        it.enabled = false
+      }
+      maybeConfigure(project.tasks, 'dependenciesInfo') {
+        it.enabled = false
+      }
+      maybeConfigure(project.tasks, 'dependenciesGraph') {
+        it.enabled = false
+      }
+    }
+  }
+
+}
+
+
+tasks.register("verifyBwcTestsEnabled") {
+  doLast {
+    if (bwc_tests_enabled == false) {
+      throw new GradleException('Bwc tests are disabled. They must be re-enabled after completing backcompat behavior backporting.')
     }
   }
 }
 
-// Ensure similar tasks in dependent projects run first. The projectsEvaluated here is
-// important because, while dependencies.all will pickup future dependencies,
-// it is not necessarily true that the task exists in both projects at the time
-// the dependency is added.
-gradle.projectsEvaluated {
-  allprojects {
-    if (project.path == ':test:framework') {
-      // :test:framework:test cannot run before and after :server:test
-      return
-    }
-    tasks.matching { it.name.equals('integTest')}.configureEach {integTestTask ->
-      integTestTask.mustRunAfter tasks.matching { it.name.equals("test") }
-    }
-
-    configurations.matching { it.canBeResolved }.all { Configuration configuration ->
-      dependencies.matching { it instanceof ProjectDependency }.all { ProjectDependency dep ->
-        Project upstreamProject = dep.dependencyProject
-        if (project.path != upstreamProject?.path) {
-          for (String taskName : ['test', 'integTest']) {
-            project.tasks.matching { it.name == taskName }.configureEach {task ->
-              task.shouldRunAfter(upstreamProject.tasks.matching { upStreamTask -> upStreamTask.name == taskName })
-            }
-          }
-        }
-      }
-    }
-  }
-}
-
-// eclipse configuration
-allprojects {
-  apply plugin: 'elasticsearch.eclipse'
-
-  /*
-   * Allow accessing com/sun/net/httpserver in projects that have
-   * configured forbidden apis to allow it.
-   */
-  plugins.withType(ForbiddenApisPlugin) {
-    eclipse.classpath.file.whenMerged { classpath ->
-      if (false == forbiddenApisTest.bundledSignatures.contains('jdk-non-portable')) {
-        classpath.entries
-          .findAll { it.kind == "con" && it.toString().contains("org.eclipse.jdt.launching.JRE_CONTAINER") }
-          .each {
-            it.accessRules.add(new AccessRule("accessible", "com/sun/net/httpserver/*"))
-          }
-      }
-    }
-  }
+tasks.register("branchConsistency") {
+  description 'Ensures this branch is internally consistent. For example, that versions constants match released versions.'
+  group 'Verification'
+  dependsOn ":verifyVersions", ":verifyBwcTestsEnabled"
 }
 
 tasks.named("wrapper").configure {
@@ -351,23 +367,6 @@ tasks.named("wrapper").configure {
 }
 
 gradle.projectsEvaluated {
-  subprojects {
-    /*
-     * Remove assemble/dependenciesInfo on all qa projects because we don't
-     * need to publish artifacts for them.
-     */
-    if (project.name.equals('qa') || project.path.contains(':qa:')) {
-      maybeConfigure(project.tasks, 'assemble') {
-        it.enabled = false
-      }
-      maybeConfigure(project.tasks, 'dependenciesInfo') {
-        it.enabled = false
-      }
-      maybeConfigure(project.tasks, 'dependenciesGraph') {
-        it.enabled = false
-      }
-    }
-  }
   // Having the same group and name for distinct projects causes Gradle to consider them equal when resolving
   // dependencies leading to hard to debug failures. Run a check across all project to prevent this from happening.
   // see: https://github.com/gradle/gradle/issues/847
@@ -384,49 +383,6 @@ gradle.projectsEvaluated {
     }
   }
 }
-
-allprojects {
-  tasks.register('resolveAllDependencies', org.elasticsearch.gradle.internal.ResolveAllDependencies) {
-    configs = project.configurations
-    if (project.path.contains("fixture")) {
-      dependsOn tasks.withType(ComposePull)
-    }
-  }
-
-  // helper task to print direct dependencies of a single task
-  project.tasks.addRule("Pattern: <taskName>Dependencies") { String taskName ->
-    if (taskName.endsWith("Dependencies") == false) {
-      return
-    }
-    if (project.tasks.findByName(taskName) != null) {
-      return
-    }
-    String realTaskName = taskName.substring(0, taskName.length() - "Dependencies".length())
-    Task realTask = project.tasks.findByName(realTaskName)
-    if (realTask == null) {
-      return
-    }
-    project.tasks.register(taskName) {
-      doLast {
-        println("${realTask.path} dependencies:")
-        for (Task dep : realTask.getTaskDependencies().getDependencies(realTask)) {
-          println("  - ${dep.path}")
-        }
-      }
-    }
-  }
-
-  def checkPart1 = tasks.register('checkPart1')
-  def checkPart2 = tasks.register('checkPart2')
-  plugins.withId('lifecycle-base') {
-    if (project.path.startsWith(":x-pack:")) {
-      checkPart2.configure { dependsOn 'check' }
-    } else {
-      checkPart1.configure { dependsOn 'check' }
-    }
-  }
-}
-
 
 tasks.register("precommit") {
   dependsOn gradle.includedBuild('build-tools').task(':precommit')
@@ -452,20 +408,4 @@ tasks.named("eclipse").configure {
   dependsOn gradle.includedBuild('build-conventions').task(':eclipse')
   dependsOn gradle.includedBuild('build-tools').task(':eclipse')
   dependsOn gradle.includedBuild('build-tools-internal').task(':eclipse')
-}
-
-subprojects {
-  project.ext.disableTasks = { String... tasknames ->
-    for (String taskname : tasknames) {
-      project.tasks.named(taskname).configure { enabled = false }
-    }
-  }
-}
-
-subprojects { Project subproj ->
-  plugins.withType(TestClustersPlugin).whenPluginAdded {
-    testClusters.all {
-      systemProperty "ingest.geoip.downloader.enabled.default", "false"
-    }
-  }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -9,22 +9,18 @@
 import com.avast.gradle.dockercompose.tasks.ComposePull
 import com.github.jengelman.gradle.plugins.shadow.ShadowPlugin
 import de.thetaphi.forbiddenapis.gradle.ForbiddenApisPlugin
-import org.apache.tools.ant.taskdefs.condition.Os
 import org.elasticsearch.gradle.internal.BuildPlugin
 import org.elasticsearch.gradle.Version
 import org.elasticsearch.gradle.VersionProperties
 import org.elasticsearch.gradle.internal.info.BuildParams
 import org.elasticsearch.gradle.plugin.PluginBuildPlugin
 import org.gradle.plugins.ide.eclipse.model.AccessRule
-import org.gradle.plugins.ide.eclipse.model.SourceFolder
 import org.gradle.util.DistributionLocator
 import org.gradle.util.GradleVersion
 import static org.elasticsearch.gradle.util.GradleUtils.maybeConfigure
 import org.gradle.plugins.ide.eclipse.model.ProjectDependency
-import org.elasticsearch.gradle.testclusters.TestClustersPlugin
-import org.elasticsearch.gradle.internal.test.RestTestBasePlugin
 import org.elasticsearch.gradle.internal.InternalPluginBuildPlugin
-import org.elasticsearch.gradle.internal.InternalTestClustersPlugin
+import org.elasticsearch.gradle.internal.ResolveAllDependencies
 
 plugins {
   id 'lifecycle-base'
@@ -212,7 +208,7 @@ allprojects {
     }
   }
   
-  tasks.register('resolveAllDependencies', org.elasticsearch.gradle.internal.ResolveAllDependencies) {
+  tasks.register('resolveAllDependencies', ResolveAllDependencies) {
     configs = project.configurations
     if (project.path.contains("fixture")) {
       dependsOn tasks.withType(ComposePull)

--- a/build.gradle
+++ b/build.gradle
@@ -235,6 +235,22 @@ allprojects {
     }
   }
 
+  /*
+   * Remove assemble/dependenciesInfo on all qa projects because we don't
+   * need to publish artifacts for them.
+   */
+  if (project.name.equals('qa') || project.path.contains(':qa:')) {
+    maybeConfigure(project.tasks, 'assemble') {
+      it.enabled = false
+    }
+    maybeConfigure(project.tasks, 'dependenciesInfo') {
+      it.enabled = false
+    }
+    maybeConfigure(project.tasks, 'dependenciesGraph') {
+      it.enabled = false
+    }
+  }
+
   project.afterEvaluate {
     // Ensure similar tasks in dependent projects run first. The projectsEvaluated here is
     // important because, while dependencies.all will pickup future dependencies,
@@ -312,22 +328,6 @@ allprojects {
                 .findAll()
                 .toSorted(sortClosure)
                 .each({ c -> depJavadocClosure(false, c) })
-      }
-    }
-
-    /*
-     * Remove assemble/dependenciesInfo on all qa projects because we don't
-     * need to publish artifacts for them.
-     */
-    if (project.name.equals('qa') || project.path.contains(':qa:')) {
-      maybeConfigure(project.tasks, 'assemble') {
-        it.enabled = false
-      }
-      maybeConfigure(project.tasks, 'dependenciesInfo') {
-        it.enabled = false
-      }
-      maybeConfigure(project.tasks, 'dependenciesGraph') {
-        it.enabled = false
       }
     }
   }


### PR DESCRIPTION
- No manual show task dependencies logic needed. we can use build scans instead for that.
- Move common plugin configuration into according plugins
- Reduce overall callbacks in root script, remove unneeded logic in afterEvaluate hooks