### PR TITLE
[ML] Remove undocumented functionality from YAML tests

### DIFF
--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/ml/delete_expired_data.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/ml/delete_expired_data.yml
@@ -14,7 +14,6 @@ setup:
                 "detectors" :[{"function":"metric","field_name":"responsetime","by_field_name":"airline"}]
             },
             "data_description" : {
-                "field_delimiter":",",
                 "time_field":"time",
                 "time_format":"yyyy-MM-dd HH:mm:ssX"
             },
@@ -35,7 +34,6 @@ setup:
                 "detectors" :[{"function":"metric","field_name":"responsetime","by_field_name":"airline"}]
             },
             "data_description" : {
-                "field_delimiter":",",
                 "time_field":"time",
                 "time_format":"yyyy-MM-dd HH:mm:ssX"
             },

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/ml/filter_crud.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/ml/filter_crud.yml
@@ -241,7 +241,6 @@ setup:
                   ]}]
             },
             "data_description" : {
-                "field_delimiter":",",
                 "time_field":"time",
                 "time_format":"yyyy-MM-dd HH:mm:ssX"
             }

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/ml/jobs_crud.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/ml/jobs_crud.yml
@@ -69,7 +69,6 @@
                 "detectors" :[{"function":"metric","field_name":"responsetime","by_field_name":"airline"}]
             },
             "data_description" : {
-                "field_delimiter":",",
                 "time_field":"time",
                 "time_format":"yyyy-MM-dd HH:mm:ssX"
             }
@@ -223,7 +222,6 @@
                 "detectors" :[{"function":"metric","field_name":"responsetime","by_field_name":"airline"}]
             },
             "data_description" : {
-                "field_delimiter":",",
                 "time_field":"time",
                 "time_format":"yyyy-MM-dd HH:mm:ssX"
             }
@@ -242,7 +240,6 @@
                 "detectors" :[{"function":"metric","field_name":"responsetime","by_field_name":"airline"}]
             },
             "data_description" : {
-                "field_delimiter":",",
                 "time_field":"time",
                 "time_format":"yyyy-MM-dd HH:mm:ssX"
             }
@@ -262,7 +259,6 @@
                 "detectors" :[{"function":"metric","field_name":"responsetime","by_field_name":"airline"}]
             },
             "data_description" : {
-                "field_delimiter":",",
                 "time_field":"time",
                 "time_format":"yyyy-MM-dd HH:mm:ssX"
             }
@@ -282,7 +278,6 @@
                 "detectors" :[{"function":"metric","field_name":"responsetime","by_field_name":"airline"}]
             },
             "data_description" : {
-                "field_delimiter":",",
                 "time_field":"time",
                 "time_format":"yyyy-MM-dd HH:mm:ssX"
             }
@@ -300,7 +295,6 @@
                 "detectors" :[{"function":"metric","field_name":"responsetime","by_field_name":"airline"}]
             },
             "data_description" : {
-                "field_delimiter":",",
                 "time_field":"time",
                 "time_format":"yyyy-MM-dd HH:mm:ssX"
             }
@@ -321,7 +315,6 @@
                 "categorization_filters" : ["cat1.*", "cat2.*"]
             },
             "data_description" : {
-              "field_delimiter":","
             },
             "model_plot_config": {
               "enabled": true,

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/ml/reset_job.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/ml/reset_job.yml
@@ -14,7 +14,6 @@ setup:
                 "detectors" :[{"function":"count"}]
             },
             "data_description" : {
-                "field_delimiter":",",
                 "time_field":"time",
                 "time_format":"yyyy-MM-dd HH:mm:ssX"
             }

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/ml/revert_model_snapshot.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/ml/revert_model_snapshot.yml
@@ -15,7 +15,6 @@ setup:
                 "detectors" :[{"function":"metric","field_name":"responsetime","by_field_name":"airline"}]
             },
             "data_description" : {
-                "field_delimiter":",",
                 "time_field":"time",
                 "time_format":"yyyy-MM-dd HH:mm:ssX"
             }

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/ml/validate.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/ml/validate.yml
@@ -9,8 +9,7 @@
               "detectors": [{"function": "metric", "field_name": "responsetime", "by_field_name": "airline"}]
             },
             "data_description": {
-              "format": "delimited",
-              "field_delimiter": ",",
+              "format": "xcontent",
               "time_field": "time",
               "time_format": "yyyy-MM-dd HH:mm:ssX"
             }
@@ -30,7 +29,6 @@
             },
             "data_description": {
               "format": "wrong",
-              "field_delimiter": ",",
               "time_field": "time",
               "time_format": "yyyy-MM-dd HH:mm:ssX"
             }
@@ -48,8 +46,7 @@
               "detectors": [{"function": "metric", "field_name": "responsetime", "by_field_name": "airline"}]
             },
             "data_description": {
-              "format": "delimited",
-              "field_delimiter": ",",
+              "format": "xcontent",
               "time_field": "time",
               "time_format": "yyyy-MM-dd HH:mm:ssX"
             }
@@ -69,8 +66,7 @@
               "detectors": [{"function": "metric", "field_name": "responsetime", "by_field_name": "airline"}]
             },
             "data_description": {
-              "format": "delimited",
-              "field_delimiter": ",",
+              "format": "xcontent",
               "time_field": "time",
               "time_format": "yyyy-MM-dd HH:mm:ssX"
             }


### PR DESCRIPTION
This change adjusts the ML YAML tests in 7.x so that they
do not use undocumented features that are being removed
from master. The tests that have been modified had no
reason to use undocumented fields in order to test what
they were supposed to be testing. Making these tests use
only documented functionality means that they can remain
unmuted in the REST compatibility layer testing on the
master branch.

One test remains in 7.x that uses the undocumented delimited
input feature (in jobs_crud.yml). This test will be excluded
from the REST compatibility layer testing on the master
branch.

Relates #74188