### PR TITLE
Mute failing MixedClusterClientYamlTestSuiteIT test {p0=indices.split/20_source_mapping/Split index ignores target template mapping} test

### DIFF
--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.split/20_source_mapping.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.split/20_source_mapping.yml
@@ -1,5 +1,8 @@
 ---
 "Split index ignores target template mapping":
+  - skip:
+      version: all
+      reason: https://github.com/elastic/elasticsearch/issues/74197
 
   # create index
   - do:


### PR DESCRIPTION
Relates to https://github.com/elastic/elasticsearch/issues/74197
