### PR TITLE
[7.x] Mute failing MixedClusterClientYamlTestSuiteIT test {p0=indices.split/20_source_mapping/Split index ignores target template mapping} test (#74198)

### DIFF
--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.split/20_source_mapping.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.split/20_source_mapping.yml
@@ -1,8 +1,8 @@
 ---
 "Split index ignores target template mapping":
   - skip:
-      version: " - 6.9.99"
-      reason: pre-7.0.0 will send warnings
+      version: all
+      reason: https://github.com/elastic/elasticsearch/issues/74197 (was 'pre-7.0.0 will send warnings')
       features: "warnings"
 
   # create index


### PR DESCRIPTION
Relates to #74197

Backport of #74198
