### PR TITLE
[6.8] Mute failing MixedClusterClientYamlTestSuiteIT test {p0=indices.split/20_source_mapping/Split index ignores target template mapping} test

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.split/20_source_mapping.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.split/20_source_mapping.yml
@@ -1,8 +1,8 @@
 ---
 "Split index ignores target template mapping":
   - skip:
-      version: " - 6.3.99"
-      reason: expects warnings that pre-6.4.0 will not send
+      version: all
+      reason: https://github.com/elastic/elasticsearch/issues/74197 (was 'expects warnings that pre-6.4.0 will not send')
       features: "warnings"
 
   # create index


### PR DESCRIPTION
Relates to #74197

Backport of #74198