### PR TITLE
[7.13] [DOCS] EQL: Note EQL uses `fields` parameter (#74194)

### DIFF
--- a/docs/reference/eql/syntax.asciidoc
+++ b/docs/reference/eql/syntax.asciidoc
@@ -795,6 +795,15 @@ For a list of supported pipes, see <<eql-pipe-ref>>.
 EQL does not support the following features and syntax.
 
 [discrete]
+[[eql-uses-fields-parameter]]
+==== EQL uses the `fields` parameter
+
+EQL retrieves field values using the search API's <<search-fields-param,`fields`
+parameter>>. Any limitations on the `fields` parameter also apply to EQL
+queries. For example, if `_source` is disabled for any returned fields or at
+index level, the values cannot be retrieved.
+
+[discrete]
 [[eql-compare-fields]]
 ==== Comparing fields
 


### PR DESCRIPTION
Backports the following commits to 7.13:
 - [DOCS] EQL: Note EQL uses `fields` parameter (#74194)