### PR TITLE
Fix Snapshot Docs Listing Query Params in Body Incorrectly (#74196)

### DIFF
--- a/docs/reference/snapshot-restore/apis/get-snapshot-api.asciidoc
+++ b/docs/reference/snapshot-restore/apis/get-snapshot-api.asciidoc
@@ -73,8 +73,10 @@ NOTE: Using `_all` in a request fails if any snapshots are unavailable.
 Set <<get-snapshot-api-ignore-unavailable,`ignore_unavailable`>> to `true` to return only available snapshots.
 
 [role="child_attributes"]
-[[get-snapshot-api-request-body]]
-==== {api-request-body-title}
+[[get-snapshot-api-query-params]]
+==== {api-query-parms-title}
+
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=master-timeout]
 
 [[get-snapshot-api-ignore-unavailable]]
 `ignore_unavailable`::

--- a/docs/reference/snapshot-restore/apis/get-snapshot-status-api.asciidoc
+++ b/docs/reference/snapshot-restore/apis/get-snapshot-status-api.asciidoc
@@ -115,8 +115,10 @@ To retrieve a list of all snapshots in a specified repository, omit this paramet
 NOTE: Wildcard (`*`) expressions are not supported for `<snapshot>`.
 
 [role="child_attributes"]
-[[get-snapshot-status-api-request-body]]
-==== {api-request-body-title}
+[[get-snapshot-status-api-query-params]]
+==== {api-query-parms-title}
+
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=master-timeout]
 
 `ignore_unavailable`::
 (Optional, Boolean)


### PR DESCRIPTION
Both of these APIs don't parse request bodies, the parameters are all taken
from the query string. Also, included the master timeout param include
as it was missing here also.

backport of #74196