### PR TITLE
Remove deprecated string concat painless

### DIFF
--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/Location.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/Location.java
@@ -60,7 +60,7 @@ public final class Location {
 
     /** Computes the file name (mostly important for stacktraces) */
     public static String computeSourceName(String scriptName) {
-        StringBuilder fileName = new StringBuilder();
+        String fileName = "";
         // its an anonymous script, include at least a portion of the source to help identify which one it is
         // but don't create stacktraces with filenames that contain newlines or huge names.
 
@@ -77,12 +77,12 @@ public final class Location {
 
         // truncate to our limit
         limit = Math.min(limit, MAX_NAME_LENGTH);
-        fileName.append(scriptName, 0, limit);
+        fileName += scriptName.substring(0, limit);
 
         // if we truncated, make it obvious
         if (limit != scriptName.length()) {
-            fileName.append(" ...");
+            fileName += " ...";
         }
-        return fileName.toString();
+        return fileName;
     }
 }

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/MethodWriter.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/MethodWriter.java
@@ -274,21 +274,12 @@ public final class MethodWriter extends GeneratorAdapter {
      * @return the size of arguments pushed to stack (the object that does string concats, e.g. a StringBuilder)
      */
     public int writeNewStrings() {
-        if (INDY_STRING_CONCAT_BOOTSTRAP_HANDLE != null) {
             // Java 9+: we just push our argument collector onto deque
             stringConcatArgs.push(new ArrayList<>());
             return 0; // nothing added to stack
-        } else {
-            // Java 8: create a StringBuilder in bytecode
-            newInstance(STRINGBUILDER_TYPE);
-            dup();
-            invokeConstructor(STRINGBUILDER_TYPE, STRINGBUILDER_CONSTRUCTOR);
-            return 1; // StringBuilder on stack
-        }
     }
 
     public void writeAppendStrings(Class<?> clazz) {
-        if (INDY_STRING_CONCAT_BOOTSTRAP_HANDLE != null) {
             // Java 9+: record type information
             stringConcatArgs.peek().add(getType(clazz));
             // prevent too many concat args.
@@ -299,31 +290,13 @@ public final class MethodWriter extends GeneratorAdapter {
                 // add the return value type as new first param for next concat:
                 stringConcatArgs.peek().add(STRING_TYPE);
             }
-        } else {
-            // Java 8: push a StringBuilder append
-            if      (clazz == boolean.class) invokeVirtual(STRINGBUILDER_TYPE, STRINGBUILDER_APPEND_BOOLEAN);
-            else if (clazz == char.class)    invokeVirtual(STRINGBUILDER_TYPE, STRINGBUILDER_APPEND_CHAR);
-            else if (clazz == byte.class  ||
-                     clazz == short.class ||
-                     clazz == int.class)     invokeVirtual(STRINGBUILDER_TYPE, STRINGBUILDER_APPEND_INT);
-            else if (clazz == long.class)    invokeVirtual(STRINGBUILDER_TYPE, STRINGBUILDER_APPEND_LONG);
-            else if (clazz == float.class)   invokeVirtual(STRINGBUILDER_TYPE, STRINGBUILDER_APPEND_FLOAT);
-            else if (clazz == double.class)  invokeVirtual(STRINGBUILDER_TYPE, STRINGBUILDER_APPEND_DOUBLE);
-            else if (clazz == String.class)  invokeVirtual(STRINGBUILDER_TYPE, STRINGBUILDER_APPEND_STRING);
-            else                             invokeVirtual(STRINGBUILDER_TYPE, STRINGBUILDER_APPEND_OBJECT);
-        }
     }
 
     public void writeToStrings() {
-        if (INDY_STRING_CONCAT_BOOTSTRAP_HANDLE != null) {
             // Java 9+: use type information and push invokeDynamic
             final String desc = Type.getMethodDescriptor(STRING_TYPE,
                     stringConcatArgs.pop().stream().toArray(Type[]::new));
             invokeDynamic("concat", desc, INDY_STRING_CONCAT_BOOTSTRAP_HANDLE);
-        } else {
-            // Java 8: call toString() on StringBuilder
-            invokeVirtual(STRINGBUILDER_TYPE, STRINGBUILDER_TOSTRING);
-        }
     }
 
     /** Writes a dynamic binary instruction: returnType, lhs, and rhs can be different */

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/PainlessScript.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/PainlessScript.java
@@ -68,12 +68,12 @@ public interface PainlessScript {
                     // TODO: if this is still too long, truncate and use ellipses
                     String snippet = getSource().substring(startOffset, endOffset);
                     scriptStack.add(snippet);
-                    StringBuilder pointer = new StringBuilder();
+                    String pointer = "";
                     for (int i = startOffset; i < offset; i++) {
-                        pointer.append(' ');
+                        pointer += ' ';
                     }
-                    pointer.append("^---- HERE");
-                    scriptStack.add(pointer.toString());
+                    pointer += "^---- HERE";
+                    scriptStack.add(pointer);
                     pos = new ScriptException.Position(originalOffset, startOffset, endOffset);
                 }
                 break;

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/PainlessScriptEngine.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/PainlessScriptEngine.java
@@ -469,24 +469,24 @@ public final class PainlessScriptEngine implements ScriptEngine {
                     int offset = --originalOffset; // offset is 1 based, line numbers must be!
                     int startOffset = getPreviousStatement(offset);
                     int endOffset = getNextStatement(scriptSource, offset);
-                    StringBuilder snippet = new StringBuilder();
+                    String snippet = "";
                     if (startOffset > 0) {
-                        snippet.append("... ");
+                        snippet += "... ";
                     }
-                    snippet.append(scriptSource.substring(startOffset, endOffset));
+                    snippet += scriptSource.substring(startOffset, endOffset);
                     if (endOffset < scriptSource.length()) {
-                        snippet.append(" ...");
+                        snippet += " ...";
                     }
-                    scriptStack.add(snippet.toString());
-                    StringBuilder pointer = new StringBuilder();
+                    scriptStack.add(snippet);
+                    String pointer = "";
                     if (startOffset > 0) {
-                        pointer.append("    ");
+                        pointer += "    ";
                     }
                     for (int i = startOffset; i < offset; i++) {
-                        pointer.append(' ');
+                        pointer += ' ';
                     }
-                    pointer.append("^---- HERE");
-                    scriptStack.add(pointer.toString());
+                    pointer += "^---- HERE";
+                    scriptStack.add(pointer);
                     pos = new ScriptException.Position(originalOffset, startOffset, endOffset);
                 }
                 break;

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/antlr/Walker.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/antlr/Walker.java
@@ -983,16 +983,16 @@ public final class Walker extends PainlessParserBaseVisitor<ANode> {
 
     @Override
     public ANode visitNewstandardarray(NewstandardarrayContext ctx) {
-        StringBuilder type = new StringBuilder(ctx.type().getText());
+        String type = ctx.type().getText();
         List<AExpression> expressions = new ArrayList<>();
 
         for (ExpressionContext expression : ctx.expression()) {
-            type.append("[]");
+            type += "[]";
             expressions.add((AExpression)visit(expression));
         }
 
         return buildPostfixChain(
-                new ENewArray(nextIdentifier(), location(ctx), type.toString(), expressions, false), ctx.postdot(), ctx.postfix());
+                new ENewArray(nextIdentifier(), location(ctx), type, expressions, false), ctx.postdot(), ctx.postfix());
     }
 
     @Override

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/api/Augmentation.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/api/Augmentation.java
@@ -169,17 +169,17 @@ public class Augmentation {
      * with the given String as a separator between each item.
      */
     public static <T> String join(Iterable<T> receiver, String separator) {
-        StringBuilder sb = new StringBuilder();
+        String sb = "";
         boolean firstToken = true;
         for (T t : receiver) {
             if (firstToken) {
                 firstToken=false;
             } else {
-                sb.append(separator);
+                sb += separator;
             }
-            sb.append(t);
+            sb += t;
         }
-        return sb.toString();
+        return sb;
     }
 
     /**

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/lookup/PainlessLookupUtility.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/lookup/PainlessLookupUtility.java
@@ -174,7 +174,7 @@ public final class PainlessLookupUtility {
      * of classes or a mixed list of classes and types to a list of canonical type names as a string as well.
      */
     public static String typesToCanonicalTypeNames(List<Class<?>> types) {
-        StringBuilder typesStringBuilder = new StringBuilder("[");
+        String typesStringBuilder = "[";
 
         int anyTypesSize = types.size();
         int anyTypesIndex = 0;
@@ -182,16 +182,16 @@ public final class PainlessLookupUtility {
         for (Class<?> painlessType : types) {
             String canonicalTypeName = typeToCanonicalTypeName(painlessType);
 
-            typesStringBuilder.append(canonicalTypeName);
+            typesStringBuilder += canonicalTypeName;
 
             if (++anyTypesIndex < anyTypesSize) {
-                typesStringBuilder.append(",");
+                typesStringBuilder += ",";
             }
         }
 
-        typesStringBuilder.append("]");
+        typesStringBuilder += "]";
 
-        return typesStringBuilder.toString();
+        return typesStringBuilder;
     }
 
     /**

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/phase/DefaultIRTreeToASMBytesPhase.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/phase/DefaultIRTreeToASMBytesPhase.java
@@ -1555,7 +1555,7 @@ public class DefaultIRTreeToASMBytesPhase implements IRTreeVisitor<WriteScope> {
         // captures with call arguments is ambiguous so
         // additional information is encoded to indicate
         // which are values are arguments and which are captures
-        StringBuilder defCallRecipe = new StringBuilder();
+        String defCallRecipe = "";
         List<Object> boostrapArguments = new ArrayList<>();
         List<Class<?>> typeParameters = new ArrayList<>();
         int capturedCount = 0;
@@ -1583,7 +1583,7 @@ public class DefaultIRTreeToASMBytesPhase implements IRTreeVisitor<WriteScope> {
                 // total number of captures for easier capture count tracking
                 // when resolved at runtime
                 char encoding = (char)(i + capturedCount);
-                defCallRecipe.append(encoding);
+                defCallRecipe += encoding;
                 capturedCount += captureNames.size();
 
                 for (String captureName : captureNames) {
@@ -1603,7 +1603,7 @@ public class DefaultIRTreeToASMBytesPhase implements IRTreeVisitor<WriteScope> {
         Type methodType = Type.getMethodType(MethodWriter.getType(
                 irInvokeCallDefNode.getDecorationValue(IRDExpressionType.class)), asmParameterTypes);
 
-        boostrapArguments.add(0, defCallRecipe.toString());
+        boostrapArguments.add(0, defCallRecipe);
         methodWriter.invokeDefCall(methodName, methodType, DefBootstrap.METHOD_CALL, boostrapArguments.toArray());
     }
 


### PR DESCRIPTION
Removing the deprecated string builder and adding the new implementation adopted by Java 9.
And remove the conditionals that identify Java 8 and using string concatenation with +.

Closes #52601
