### PR TITLE
[ML] Feed errors starting the PyTorch process back to caller

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/deployment/TrainedModelDeploymentState.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/deployment/TrainedModelDeploymentState.java
@@ -16,7 +16,7 @@ import java.util.Locale;
 
 public enum TrainedModelDeploymentState implements Writeable {
 
-    STARTING, STARTED, STOPPING, STOPPED;
+    STARTING, STARTED, STOPPING, STOPPED, FAILED;
 
     public static TrainedModelDeploymentState fromString(String name) {
         return valueOf(name.trim().toUpperCase(Locale.ROOT));

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/messages/Messages.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/messages/Messages.java
@@ -113,7 +113,7 @@ public final class Messages {
         "Configuration [{0}] requires minimum node version [{1}] (current minimum node version [{2}]";
     public static final String MODEL_DEFINITION_NOT_FOUND = "Could not find trained model definition [{0}]";
     public static final String MODEL_METADATA_NOT_FOUND = "Could not find trained model metadata {0}";
-    public static final String TASK_CONFIG_NOT_FOUND = "Could not find task config for model [{0}]";
+    public static final String TASK_CONFIG_NOT_FOUND = "[{0}] Could not find task configuration document [{1}] for model ";
     public static final String INFERENCE_CANNOT_DELETE_ML_MANAGED_MODEL =
         "Unable to delete model [{0}] as it is required by machine learning";
     public static final String MODEL_DEFINITION_TRUNCATED =

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/PyTorchModelIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/PyTorchModelIT.java
@@ -88,6 +88,7 @@ public class PyTorchModelIT extends ESRestTestCase {
         createModelStoreIndex();
         putTaskConfig();
         putModelDefinition();
+        refreshModelStoreIndex();
         createTrainedModel();
         startDeployment();
         try {
@@ -165,6 +166,11 @@ public class PyTorchModelIT extends ESRestTestCase {
             "        }\n" +
             "    }" +
             "}");
+        client().performRequest(request);
+    }
+
+    private void refreshModelStoreIndex() throws IOException {
+        Request request = new Request("POST", "/" + MODEL_INDEX + "/_refresh");
         client().performRequest(request);
     }
 

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/PyTorchModelIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/PyTorchModelIT.java
@@ -83,7 +83,6 @@ public class PyTorchModelIT extends ESRestTestCase {
         RAW_MODEL_SIZE = Base64.getDecoder().decode(BASE_64_ENCODED_MODEL).length;
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/73769")
     public void testEvaluate() throws IOException {
         createModelStoreIndex();
         putTaskConfig();

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportStartTrainedModelDeploymentAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportStartTrainedModelDeploymentAction.java
@@ -26,7 +26,6 @@ import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.TimeValue;
-import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 import org.elasticsearch.license.LicenseUtils;
 import org.elasticsearch.license.XPackLicenseState;
 import org.elasticsearch.persistent.AllocatedPersistentTask;
@@ -74,21 +73,18 @@ public class TransportStartTrainedModelDeploymentAction
     private final XPackLicenseState licenseState;
     private final Client client;
     private final PersistentTasksService persistentTasksService;
-    private final NamedXContentRegistry xContentRegistry;
 
     @Inject
     public TransportStartTrainedModelDeploymentAction(TransportService transportService, Client client, ClusterService clusterService,
                                                       ThreadPool threadPool, ActionFilters actionFilters, XPackLicenseState licenseState,
                                                       IndexNameExpressionResolver indexNameExpressionResolver,
-                                                      PersistentTasksService persistentTasksService,
-                                                      NamedXContentRegistry xContentRegistry) {
+                                                      PersistentTasksService persistentTasksService) {
         super(StartTrainedModelDeploymentAction.NAME, transportService, clusterService, threadPool, actionFilters,
             StartTrainedModelDeploymentAction.Request::new, indexNameExpressionResolver, NodeAcknowledgedResponse::new,
             ThreadPool.Names.SAME);
         this.licenseState = Objects.requireNonNull(licenseState);
         this.client = Objects.requireNonNull(client);
         this.persistentTasksService = Objects.requireNonNull(persistentTasksService);
-        this.xContentRegistry = Objects.requireNonNull(xContentRegistry);
     }
 
     @Override
@@ -162,7 +158,7 @@ public class TransportStartTrainedModelDeploymentAction
                 @Override
                 public void onResponse(PersistentTasksCustomMetadata.PersistentTask<PersistentTaskParams> persistentTask) {
                     if (predicate.exception != null) {
-                        cancelDeploymentStart(task, predicate.exception, listener);
+                        cancelFailedDeployment(task, predicate.exception, listener);
                     } else {
                         listener.onResponse(new NodeAcknowledgedResponse(true, predicate.node));
                     }
@@ -175,14 +171,14 @@ public class TransportStartTrainedModelDeploymentAction
             });
     }
 
-    private void cancelDeploymentStart(
+    private void cancelFailedDeployment(
         PersistentTasksCustomMetadata.PersistentTask<TaskParams> persistentTask, Exception exception,
         ActionListener<NodeAcknowledgedResponse> listener) {
         persistentTasksService.sendRemoveRequest(persistentTask.getId(), ActionListener.wrap(
             pTask -> listener.onFailure(exception),
             e -> {
                 logger.error(
-                    new ParameterizedMessage("[{}] Failed to cancel persistent task that could not be assigned due to [{}]",
+                    new ParameterizedMessage("[{}] Failed to cancel persistent task that had failed with the reason [{}]",
                         persistentTask.getParams().getModelId(), exception.getMessage()),
                     e
                 );
@@ -238,6 +234,9 @@ public class TransportStartTrainedModelDeploymentAction
                 case STOPPING:
                 case STOPPED:
                     return false;
+                case FAILED:
+                    exception = ExceptionsHelper.serverError("Deployment failed with reason [{}]", reason);
+                    return true;
                 default:
                     exception = ExceptionsHelper.serverError("Unexpected task state [{}] with reason [{}] while waiting to be started",
                         taskState.getState(), reason);

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportStartTrainedModelDeploymentAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportStartTrainedModelDeploymentAction.java
@@ -235,7 +235,7 @@ public class TransportStartTrainedModelDeploymentAction
                 case STOPPED:
                     return false;
                 case FAILED:
-                    exception = ExceptionsHelper.serverError("Deployment failed with reason [{}]", reason);
+                    exception = ExceptionsHelper.serverError("Deployment failed with reason: {}", reason);
                     return true;
                 default:
                     exception = ExceptionsHelper.serverError("Unexpected task state [{}] with reason [{}] while waiting to be started",

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/deployment/DeploymentManager.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/deployment/DeploymentManager.java
@@ -12,21 +12,21 @@ import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.apache.lucene.util.SetOnce;
 import org.elasticsearch.ElasticsearchStatusException;
-import org.elasticsearch.ResourceNotFoundException;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.search.SearchAction;
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.common.bytes.BytesReference;
-import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.common.util.concurrent.AbstractRunnable;
 import org.elasticsearch.common.xcontent.LoggingDeprecationHandler;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.XContentType;
+import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.index.query.IdsQueryBuilder;
+import org.elasticsearch.persistent.PersistentTasksCustomMetadata;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.threadpool.ThreadPool;
@@ -45,6 +45,7 @@ import org.elasticsearch.xpack.ml.inference.pytorch.process.PyTorchStateStreamer
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.Locale;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -89,25 +90,27 @@ public class DeploymentManager {
             throw ExceptionsHelper.serverError("[{}] Could not create process as one already exists", task.getModelId());
         }
 
+        String taskConfigDocId = NlpTaskConfig.documentId(task.getModelId());
+
         ActionListener<Boolean> modelLoadedListener = ActionListener.wrap(
             success -> {
                 executorServiceForProcess.execute(() -> processContext.resultProcessor.process(processContext.process.get()));
 
-                TrainedModelDeploymentTaskState startedState = new TrainedModelDeploymentTaskState(
-                    TrainedModelDeploymentState.STARTED, task.getAllocationId(), null);
-                task.updatePersistentTaskState(startedState, ActionListener.wrap(
+                setTaskStateToStarted(task, ActionListener.wrap(
                     response -> logger.info("[{}] trained model loaded", task.getModelId()),
-                    task::markAsFailed
+                    e -> failTask(task,
+                        String.format(Locale.ROOT, "[%s] error setting task state to [%s] [%s]",
+                            task.getModelId(), TrainedModelDeploymentState.STARTED, e))
                 ));
             },
-            e -> failTask(task, e)
+            e -> failTask(task,
+                String.format(Locale.ROOT, "[%s] error loading model [%s]", task.getModelId(), e))
         );
 
         ActionListener<SearchResponse> configListener = ActionListener.wrap(
             searchResponse -> {
                 if (searchResponse.getHits().getHits().length == 0) {
-                    failTask(task, new ResourceNotFoundException(
-                        Messages.getMessage(Messages.TASK_CONFIG_NOT_FOUND, task.getModelId())));
+                    failTask(task, Messages.getMessage(Messages.TASK_CONFIG_NOT_FOUND, task.getModelId(), taskConfigDocId));
                     return;
                 }
 
@@ -117,16 +120,17 @@ public class DeploymentManager {
                 processContext.startProcess();
                 processContext.loadModel(modelLoadedListener);
             },
-            e -> failTask(task, e)
+            e -> failTask(task,
+                String.format(Locale.ROOT, "[%s] search for task config failed with error [%s]", task.getModelId(), e))
         );
 
-        SearchRequest searchRequest = taskConfigSearchRequest(task.getModelId(), task.getIndex());
+        SearchRequest searchRequest = taskConfigSearchRequest(taskConfigDocId, task.getIndex());
         executeAsyncWithOrigin(client, ML_ORIGIN, SearchAction.INSTANCE, searchRequest, configListener);
     }
 
-    private SearchRequest taskConfigSearchRequest(String modelId, String index) {
+    private SearchRequest taskConfigSearchRequest(String documentId, String index) {
         return client.prepareSearch(index)
-            .setQuery(new IdsQueryBuilder().addIds(NlpTaskConfig.documentId(modelId)))
+            .setQuery(new IdsQueryBuilder().addIds(documentId))
             .setSize(1)
             .setTrackTotalHits(false)
             .request();
@@ -222,9 +226,22 @@ public class DeploymentManager {
         }
     }
 
-    private void failTask(TrainedModelDeploymentTask task, Exception e) {
-        logger.error(new ParameterizedMessage("[{}] failing model deployment task with error: ", task.getModelId()), e);
-        task.markAsFailed(e);
+    private void setTaskStateToStarted(TrainedModelDeploymentTask task,
+                                     ActionListener<PersistentTasksCustomMetadata.PersistentTask<?>> listener) {
+        TrainedModelDeploymentTaskState startedState = new TrainedModelDeploymentTaskState(
+            TrainedModelDeploymentState.STARTED, task.getAllocationId(), null);
+        task.updatePersistentTaskState(startedState, listener);
+    }
+    private void failTask(TrainedModelDeploymentTask task,
+                          String reason) {
+        TrainedModelDeploymentTaskState taskState =
+            new TrainedModelDeploymentTaskState(TrainedModelDeploymentState.FAILED, task.getAllocationId(), reason);
+
+        task.updatePersistentTaskState(taskState, ActionListener.wrap(
+            persistentTask -> {},
+            e -> logger.error(new ParameterizedMessage("[{}] error setting model deployment state to failed. " +
+                "Failure reason: [{}]", task.getModelId(), reason), e)
+        ));
     }
 
     class ProcessContext {

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/deployment/DeploymentManager.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/deployment/DeploymentManager.java
@@ -234,6 +234,9 @@ public class DeploymentManager {
     }
     private void failTask(TrainedModelDeploymentTask task,
                           String reason) {
+
+        logger.error("[{}] failed with reason [{}]", task.getModelId(), reason);
+
         TrainedModelDeploymentTaskState taskState =
             new TrainedModelDeploymentTaskState(TrainedModelDeploymentState.FAILED, task.getAllocationId(), reason);
 

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/nlp/TaskType.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/nlp/TaskType.java
@@ -14,7 +14,7 @@ import java.util.Locale;
 
 public enum TaskType {
 
-    TOKEN_CLASSIFICATION {
+    TOKEN_CLASSIFICATION { // TODO rename to NER. This is specifically a NER task
         public NlpTask.Processor createProcessor(BertTokenizer tokenizer) throws IOException {
             return new NerProcessor(tokenizer);
         }

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/ml/3rd_party_deployment.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/ml/3rd_party_deployment.yml
@@ -1,5 +1,5 @@
 ---
-"Test start deployment":
+"Test start deployment fails with missing task config":
 
   - do:
       ml.put_trained_model:
@@ -25,11 +25,6 @@
           }
 
   - do:
-      ml.get_trained_models:
+      catch: /\[distilbert-finetuned-sst\] search for task config failed with error/
+      ml.start_trained_model_deployment:
         model_id: distilbert-finetuned-sst
-  - match: { trained_model_configs.0.location.index.model_id: distilbert-finetuned-sst }
-
-#  - do:
-#      ml.start_deployment:
-#        model_id: distilbert-finetuned-sst
-


### PR DESCRIPTION
There are number of things that can go wrong launching the pytorch native process and loading a model. Most errors are due to mis-configuration and are easily resolved if a user can see the error message in the response of the `_start` deployment API call rather than buried in the log. 

Using the persistent tasks framework the process for this is:
1. The master node receives the `_start` request allocates the task and updates the clusterstate
2. The `_start` request waits for a change in status of the persistent task 
3. Some other node notices the new task and starts executing the task
4. The native process is launched and model loaded
5. If successful the p. task status is set to `STARTED`
    - The `_start` request on the master node notices the new status and returns success
6. If an error occurs the p. task status is set to `FAILED` and a failure reason added to the p. task state
    - The `_start` request on the master node notices the `FAILED` state and extracts the failure reason
    - The p. task is now removed from the clusterstate
    - The `_start` request returns an error with the failure reason

This is slightly different to AD jobs where the AutoDetectProcessManager first sets the job state to `FAILED` with a reason which is noticed by the `_open` request then AutoDetectProcessManager removes the p. task. Here is p. task is removed in the transport handler I found the flow of this code easier to follow. 

This change also fixes a test failure in PyTorchModelIT by adding an index refresh so the task configuration document is detected. 

Closes #73769

Non issue as this is iterating on a feature in un released code