### PR TITLE
[DOCS] Fix the url of Get stored script API

### DIFF
--- a/docs/reference/scripting/apis/get-stored-script-api.asciidoc
+++ b/docs/reference/scripting/apis/get-stored-script-api.asciidoc
@@ -32,7 +32,7 @@ GET _scripts/my-stored-script
 [[get-stored-script-api-request]]
 ==== {api-request-title}
 
-`GET _script/<script-id>`
+`GET _scripts/<script-id>`
 
 [[get-stored-script-api-prereqs]]
 ==== {api-prereq-title}


### PR DESCRIPTION
The url of Get stored script API is not correct in the doc.