### PR TITLE
Improve check_on_startup docs and logging

### DIFF
--- a/docs/reference/index-modules.asciidoc
+++ b/docs/reference/index-modules.asciidoc
@@ -69,19 +69,6 @@ document distribution. See the
 breaking change].
 ====
 
-`index.shard.check_on_startup`::
-
-Whether or not shards should be checked for corruption before opening. When
-corruption is detected, it will prevent the shard from being opened.
-Accepts:
-`false`::: (default) Don't check for corruption when opening a shard.
-`checksum`::: Check for physical corruption.
-`true`::: Check for both physical and logical corruption. This is much more
-expensive in terms of CPU and memory usage.
-+
-WARNING: Expert only. Checking shards may take a lot of time on large
-indices.
-
 [[index-codec]] `index.codec`::
 
     The +default+ value compresses stored data with LZ4
@@ -129,6 +116,45 @@ to incomplete history on the leader. Defaults to `12h`.
     returned by default when using a wildcard expression. This behavior is controlled
     per request through the use of the `expand_wildcards` parameter. Possible values are
     `true` and `false` (default).
+
+[[index-shard-check-on-startup]] `index.shard.check_on_startup`::
++
+====
+WARNING: Expert users only. This setting enables some very expensive processing
+at shard startup and is only ever useful while diagnosing a problem in your
+cluster. If you do use it you should do so only temporarily and must remove it
+once it is no longer needed.
+
+{es} automatically performs integrity checks on the contents of shards at
+various points during their lifecycle. For instance, it verifies the checksum
+of every file transferred when recovering a replica or taking a snapshot. It
+also verifies the integrity of many important files when opening a shard, which
+happens when starting up a node and when finishing a shard recovery or
+relocation. You can therefore manually verify the integrity of a whole shard
+while it is running by taking a snapshot of it into a fresh repository or by
+recovering it onto a fresh node.
+
+This setting determines whether {es} performs additional integrity checks while
+opening a shard. If these checks detect corruption then they will prevent the
+shard from being opened. It accepts the following values:
+
+`false`::: Don't perform additional checks for corruption when opening a shard.
+This is the default and recommended behaviour.
+
+`checksum`::: Verify that the checksum of every file in the shard matches its
+contents. This will detect cases where the data read from disk differ from the
+data that {es} originally wrote, for instance due to undetected disk corruption
+or other hardware failures. These checks require reading the entire shard from
+disk which takes substantial time and IO bandwidth and may affect cluster
+performance by evicting important data from your filesystem cache.
+
+`true`::: Performs the same checks as `checksum` and also checks for logical
+inconsistencies in the shard, which could for instance be caused by the data
+being corrupted while it was being written due to faulty RAM or other hardware
+failures. These checks require reading the entire shard from disk which takes
+substantial time and IO bandwidth, and then performing various checks on the
+contents of the shard which take substantial time, CPU and memory.
+====
 
 [discrete]
 [[dynamic-index-settings]]

--- a/docs/reference/index-modules.asciidoc
+++ b/docs/reference/index-modules.asciidoc
@@ -122,7 +122,7 @@ to incomplete history on the leader. Defaults to `12h`.
 ====
 WARNING: Expert users only. This setting enables some very expensive processing
 at shard startup and is only ever useful while diagnosing a problem in your
-cluster. If you do use it you should do so only temporarily and must remove it
+cluster. If you do use it, you should do so only temporarily and remove it
 once it is no longer needed.
 
 {es} automatically performs integrity checks on the contents of shards at


### PR DESCRIPTION
Today we don't really describe why using `index.shard.check_on_startup`
is such a bad idea, or what to do instead. This commit expands the docs
to clarify what it does, why it's not really necessary and what to do
instead. It also now logs a warning every time the startup checks run to
encourage users to stop using this setting.