### PR TITLE
[7.13] [DOCS] Add missing request section for delete stored script API (#74240)

### DIFF
--- a/docs/reference/scripting/apis/delete-stored-script-api.asciidoc
+++ b/docs/reference/scripting/apis/delete-stored-script-api.asciidoc
@@ -29,6 +29,11 @@ DELETE _scripts/my-stored-script
 ----
 // TEST[continued]
 
+[[delete-stored-script-api-request]]
+==== {api-request-title}
+
+`DELETE _scripts/<script-id>`
+
 [[delete-stored-script-api-prereqs]]
 ==== {api-prereq-title}
 


### PR DESCRIPTION
Backports the following commits to 7.13:
 - [DOCS] Add missing request section for delete stored script API (#74240)