### PR TITLE
Increment Request Before Serializing it in OutboundHandler

### DIFF
--- a/server/src/main/java/org/elasticsearch/transport/BytesTransportRequest.java
+++ b/server/src/main/java/org/elasticsearch/transport/BytesTransportRequest.java
@@ -67,7 +67,7 @@ public class BytesTransportRequest extends TransportRequest implements RefCounte
 
     @Override
     public boolean tryIncRef() {
-        return bytes.decRef();
+        return bytes.tryIncRef();
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/transport/OutboundHandler.java
+++ b/server/src/main/java/org/elasticsearch/transport/OutboundHandler.java
@@ -68,8 +68,14 @@ final class OutboundHandler {
         Version version = Version.min(this.version, channelVersion);
         OutboundMessage.Request message =
             new OutboundMessage.Request(threadPool.getThreadContext(), request, version, action, requestId, isHandshake, compressRequest);
-        ActionListener<Void> listener = ActionListener.wrap(() ->
-            messageListener.onRequestSent(node, requestId, action, request, options));
+        request.incRef();
+        ActionListener<Void> listener = ActionListener.wrap(() -> {
+            try {
+                messageListener.onRequestSent(node, requestId, action, request, options);
+            } finally {
+                request.decRef();
+            }
+        });
         sendMessage(channel, message, listener);
     }
 

--- a/server/src/main/java/org/elasticsearch/transport/OutboundHandler.java
+++ b/server/src/main/java/org/elasticsearch/transport/OutboundHandler.java
@@ -11,6 +11,7 @@ package org.elasticsearch.transport;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.message.ParameterizedMessage;
+import org.apache.lucene.store.AlreadyClosedException;
 import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.cluster.node.DiscoveryNode;
@@ -68,7 +69,10 @@ final class OutboundHandler {
         Version version = Version.min(this.version, channelVersion);
         OutboundMessage.Request message =
             new OutboundMessage.Request(threadPool.getThreadContext(), request, version, action, requestId, isHandshake, compressRequest);
-        request.incRef();
+        if (request.tryIncRef() == false) {
+            assert false : "request [" + request + "] has been released already";
+            throw new AlreadyClosedException("request [" + request + "] has been released already");
+        }
         ActionListener<Void> listener = ActionListener.wrap(() -> {
             try {
                 messageListener.onRequestSent(node, requestId, action, request, options);


### PR DESCRIPTION
If there are outside ways by which a request can be decremented (e.g.
due to cancelling a recovery concurrently) we may run into a situation where
we try to send a `refcount == 0` request. We have to avoid this by incrementing
a request before serializing and decrementing after it returns to make sure we
don't corrupt the request bytes while they're being serialized
or sent over the wire.

Closes #74253

