### PR TITLE
[7.x] Add unenroll_timeout/unenrolled_reason field to Fleet system indexes (#74180)

### DIFF
--- a/x-pack/plugin/core/src/main/resources/fleet-agents.json
+++ b/x-pack/plugin/core/src/main/resources/fleet-agents.json
@@ -209,6 +209,9 @@
         "unenrolled_at": {
           "type": "date"
         },
+        "unenrolled_reason": {
+          "type": "keyword"
+        },
         "unenrollment_started_at": {
           "type": "date"
         },

--- a/x-pack/plugin/core/src/main/resources/fleet-policies.json
+++ b/x-pack/plugin/core/src/main/resources/fleet-policies.json
@@ -27,6 +27,9 @@
         },
         "@timestamp": {
           "type": "date"
+        },
+        "unenroll_timeout": {
+          "type": "integer"
         }
       }
     }


### PR DESCRIPTION
Backport of #74180