### PR TITLE
[7.x] Expose shard migration status in Node Shutdown Status API (#73873)

### DIFF
--- a/x-pack/plugin/shutdown/src/main/java/org/elasticsearch/xpack/shutdown/TransportGetShutdownStatusAction.java
+++ b/x-pack/plugin/shutdown/src/main/java/org/elasticsearch/xpack/shutdown/TransportGetShutdownStatusAction.java
@@ -7,9 +7,13 @@
 
 package org.elasticsearch.xpack.shutdown;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.master.TransportMasterNodeAction;
+import org.elasticsearch.cluster.ClusterInfoService;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.block.ClusterBlockException;
 import org.elasticsearch.cluster.block.ClusterBlockLevel;
@@ -19,9 +23,18 @@ import org.elasticsearch.cluster.metadata.ShutdownPersistentTasksStatus;
 import org.elasticsearch.cluster.metadata.ShutdownPluginsStatus;
 import org.elasticsearch.cluster.metadata.ShutdownShardMigrationStatus;
 import org.elasticsearch.cluster.metadata.SingleNodeShutdownMetadata;
+import org.elasticsearch.cluster.routing.ShardRouting;
+import org.elasticsearch.cluster.routing.ShardRoutingState;
+import org.elasticsearch.cluster.routing.allocation.AllocationDecision;
+import org.elasticsearch.cluster.routing.allocation.AllocationService;
+import org.elasticsearch.cluster.routing.allocation.RoutingAllocation;
+import org.elasticsearch.cluster.routing.allocation.decider.AllocationDeciders;
 import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.core.Tuple;
 import org.elasticsearch.shutdown.PluginShutdownService;
+import org.elasticsearch.snapshots.SnapshotsInfoService;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 
@@ -30,12 +43,18 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 public class TransportGetShutdownStatusAction extends TransportMasterNodeAction<
     GetShutdownStatusAction.Request,
     GetShutdownStatusAction.Response> {
+    private static final Logger logger = LogManager.getLogger(TransportGetShutdownStatusAction.class);
 
+    private final AllocationDeciders allocationDeciders;
+    private final AllocationService allocationService;
+    private final ClusterInfoService clusterInfoService;
+    private final SnapshotsInfoService snapshotsInfoService;
     private final PluginShutdownService pluginShutdownService;
 
     @Inject
@@ -45,6 +64,10 @@ public class TransportGetShutdownStatusAction extends TransportMasterNodeAction<
         ThreadPool threadPool,
         ActionFilters actionFilters,
         IndexNameExpressionResolver indexNameExpressionResolver,
+        AllocationService allocationService,
+        AllocationDeciders allocationDeciders,
+        ClusterInfoService clusterInfoService,
+        SnapshotsInfoService snapshotsInfoService,
         PluginShutdownService pluginShutdownService
     ) {
         super(
@@ -58,7 +81,10 @@ public class TransportGetShutdownStatusAction extends TransportMasterNodeAction<
             GetShutdownStatusAction.Response::new,
             ThreadPool.Names.SAME
         );
-
+        this.allocationService = allocationService;
+        this.allocationDeciders = allocationDeciders;
+        this.clusterInfoService = clusterInfoService;
+        this.snapshotsInfoService = snapshotsInfoService;
         this.pluginShutdownService = pluginShutdownService;
     }
 
@@ -80,7 +106,15 @@ public class TransportGetShutdownStatusAction extends TransportMasterNodeAction<
                 .map(
                     ns -> new SingleNodeShutdownStatus(
                         ns,
-                        new ShutdownShardMigrationStatus(),
+                        shardMigrationStatus(
+                            state,
+                            ns.getNodeId(),
+                            ns.getType(),
+                            allocationDeciders,
+                            clusterInfoService,
+                            snapshotsInfoService,
+                            allocationService
+                        ),
                         new ShutdownPersistentTasksStatus(),
                         new ShutdownPluginsStatus(pluginShutdownService.readyToShutdown(ns.getNodeId(), ns.getType()))
                     )
@@ -96,7 +130,15 @@ public class TransportGetShutdownStatusAction extends TransportMasterNodeAction<
                 .map(
                     ns -> new SingleNodeShutdownStatus(
                         ns,
-                        new ShutdownShardMigrationStatus(),
+                        shardMigrationStatus(
+                            state,
+                            ns.getNodeId(),
+                            ns.getType(),
+                            allocationDeciders,
+                            clusterInfoService,
+                            snapshotsInfoService,
+                            allocationService
+                        ),
                         new ShutdownPersistentTasksStatus(),
                         new ShutdownPluginsStatus(pluginShutdownService.readyToShutdown(ns.getNodeId(), ns.getType()))
                     )
@@ -107,6 +149,109 @@ public class TransportGetShutdownStatusAction extends TransportMasterNodeAction<
         }
 
         listener.onResponse(response);
+    }
+
+    // pkg-private for testing
+    static ShutdownShardMigrationStatus shardMigrationStatus(
+        ClusterState currentState,
+        String nodeId,
+        SingleNodeShutdownMetadata.Type shutdownType,
+        AllocationDeciders allocationDeciders,
+        ClusterInfoService clusterInfoService,
+        SnapshotsInfoService snapshotsInfoService,
+        AllocationService allocationService
+    ) {
+        // Only REMOVE-type shutdowns will try to move shards, so RESTART-type shutdowns should immediately complete
+        if (SingleNodeShutdownMetadata.Type.RESTART.equals(shutdownType)) {
+            return new ShutdownShardMigrationStatus(
+                SingleNodeShutdownMetadata.Status.COMPLETE,
+                0,
+                "no shard relocation is necessary for a node restart"
+            );
+        }
+
+        // First, check if there are any shards currently on this node, and if there are any relocating shards
+        int startedShards = currentState.getRoutingNodes().node(nodeId).numberOfShardsWithState(ShardRoutingState.STARTED);
+        int relocatingShards = currentState.getRoutingNodes().node(nodeId).numberOfShardsWithState(ShardRoutingState.RELOCATING);
+        int initializingShards = currentState.getRoutingNodes().node(nodeId).numberOfShardsWithState(ShardRoutingState.INITIALIZING);
+        int totalRemainingShards = relocatingShards + startedShards + initializingShards;
+
+        // If there's relocating shards, or no shards on this node, we'll just use the number of shards left to move
+        if (relocatingShards > 0 || totalRemainingShards == 0) {
+            SingleNodeShutdownMetadata.Status shardStatus = totalRemainingShards == 0
+                ? SingleNodeShutdownMetadata.Status.COMPLETE
+                : SingleNodeShutdownMetadata.Status.IN_PROGRESS;
+            return new ShutdownShardMigrationStatus(shardStatus, totalRemainingShards);
+        } else if (initializingShards > 0 && relocatingShards == 0 && startedShards == 0) {
+            // If there's only initializing shards left, return now with a note that only initializing shards are left
+            return new ShutdownShardMigrationStatus(
+                SingleNodeShutdownMetadata.Status.IN_PROGRESS,
+                totalRemainingShards,
+                "all remaining shards are currently INITIALIZING and must finish before they can be moved off this node"
+            );
+        }
+
+        // If there's no relocating shards and shards still on this node, we need to figure out why
+        final RoutingAllocation allocation = new RoutingAllocation(
+            allocationDeciders,
+            currentState.getRoutingNodes(),
+            currentState,
+            clusterInfoService.getClusterInfo(),
+            snapshotsInfoService.snapshotShardSizes(),
+            System.nanoTime()
+        );
+        allocation.setDebugMode(RoutingAllocation.DebugMode.EXCLUDE_YES_DECISIONS);
+
+        // Explain shard allocations until we find one that can't move, then stop (as `findFirst` short-circuits)
+        final Optional<ShardRouting> unmovableShard = currentState.getRoutingNodes()
+            .node(nodeId)
+            .shardsWithState(ShardRoutingState.STARTED)
+            .stream()
+            .map(shardRouting -> new Tuple<>(shardRouting, allocationService.explainShardAllocation(shardRouting, allocation)))
+            // Given that we're checking the status of a node that's shutting down, no shards should be allowed to remain
+            .filter(pair -> {
+                assert pair.v2().getMoveDecision().canRemain() == false
+                    : "shard [" + pair + "] can remain on node [" + nodeId + "], but that node is shutting down";
+                return pair.v2().getMoveDecision().canRemain() == false;
+            })
+            // It's okay if some are throttled, they'll move eventually
+            .filter(pair -> pair.v2().getMoveDecision().getAllocationDecision().equals(AllocationDecision.THROTTLED) == false)
+            // These shards will move as soon as possible
+            .filter(pair -> pair.v2().getMoveDecision().getAllocationDecision().equals(AllocationDecision.YES) == false)
+            .peek(pair -> {
+                if (logger.isTraceEnabled()) { // don't serialize the decision unless we have to
+                    logger.trace(
+                        "node [{}] shutdown of type [{}] stalled: found shard [{}][{}] from index [{}] with negative decision: [{}]",
+                        nodeId,
+                        shutdownType,
+                        pair.v1().getId(),
+                        pair.v1().primary() ? "primary" : "replica",
+                        pair.v1().shardId().getIndexName(),
+                        Strings.toString(pair.v2())
+                    );
+                }
+            })
+            .map(Tuple::v1)
+            .findFirst();
+
+        if (unmovableShard.isPresent()) {
+            // We found a shard that can't be moved, so shard relocation is stalled. Blame the unmovable shard.
+            ShardRouting shardRouting = unmovableShard.get();
+
+            return new ShutdownShardMigrationStatus(
+                SingleNodeShutdownMetadata.Status.STALLED,
+                totalRemainingShards,
+                new ParameterizedMessage(
+                    "shard [{}] [{}] of index [{}] cannot move, see Cluster Allocation Explain API for details",
+                    shardRouting.shardId().getId(),
+                    shardRouting.primary() ? "primary" : "replica",
+                    shardRouting.index().getName()
+                ).getFormattedMessage()
+            );
+        } else {
+            // We couldn't find any shards that can't be moved, so we're just waiting for other recoveries or initializing shards
+            return new ShutdownShardMigrationStatus(SingleNodeShutdownMetadata.Status.IN_PROGRESS, totalRemainingShards);
+        }
     }
 
     @Override

--- a/x-pack/plugin/shutdown/src/test/java/org/elasticsearch/xpack/shutdown/GetShutdownStatusResponseTests.java
+++ b/x-pack/plugin/shutdown/src/test/java/org/elasticsearch/xpack/shutdown/GetShutdownStatusResponseTests.java
@@ -57,7 +57,7 @@ public class GetShutdownStatusResponseTests extends AbstractWireSerializingTestC
     public static SingleNodeShutdownStatus randomNodeShutdownStatus() {
         return new SingleNodeShutdownStatus(
             randomNodeShutdownMetadata(),
-            new ShutdownShardMigrationStatus(),
+            new ShutdownShardMigrationStatus(randomStatus(), randomNonNegativeLong()),
             new ShutdownPersistentTasksStatus(),
             new ShutdownPluginsStatus(randomBoolean())
         );

--- a/x-pack/plugin/shutdown/src/test/java/org/elasticsearch/xpack/shutdown/TransportGetShutdownStatusActionTests.java
+++ b/x-pack/plugin/shutdown/src/test/java/org/elasticsearch/xpack/shutdown/TransportGetShutdownStatusActionTests.java
@@ -1,0 +1,461 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.shutdown;
+
+import org.elasticsearch.Version;
+import org.elasticsearch.cluster.ClusterInfoService;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.EmptyClusterInfoService;
+import org.elasticsearch.cluster.metadata.IndexMetadata;
+import org.elasticsearch.cluster.metadata.Metadata;
+import org.elasticsearch.cluster.metadata.NodesShutdownMetadata;
+import org.elasticsearch.cluster.metadata.ShutdownShardMigrationStatus;
+import org.elasticsearch.cluster.metadata.SingleNodeShutdownMetadata;
+import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.node.DiscoveryNodes;
+import org.elasticsearch.cluster.routing.IndexRoutingTable;
+import org.elasticsearch.cluster.routing.RoutingNode;
+import org.elasticsearch.cluster.routing.RoutingTable;
+import org.elasticsearch.cluster.routing.ShardRouting;
+import org.elasticsearch.cluster.routing.ShardRoutingState;
+import org.elasticsearch.cluster.routing.TestShardRouting;
+import org.elasticsearch.cluster.routing.allocation.AllocationService;
+import org.elasticsearch.cluster.routing.allocation.RoutingAllocation;
+import org.elasticsearch.cluster.routing.allocation.allocator.BalancedShardsAllocator;
+import org.elasticsearch.cluster.routing.allocation.decider.AllocationDecider;
+import org.elasticsearch.cluster.routing.allocation.decider.AllocationDeciders;
+import org.elasticsearch.cluster.routing.allocation.decider.Decision;
+import org.elasticsearch.cluster.routing.allocation.decider.NodeShutdownAllocationDecider;
+import org.elasticsearch.common.collect.ImmutableOpenMap;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.transport.TransportAddress;
+import org.elasticsearch.index.Index;
+import org.elasticsearch.index.shard.ShardId;
+import org.elasticsearch.node.Node;
+import org.elasticsearch.snapshots.InternalSnapshotsInfoService;
+import org.elasticsearch.snapshots.SnapshotShardSizeInfo;
+import org.elasticsearch.snapshots.SnapshotsInfoService;
+import org.elasticsearch.test.ESTestCase;
+import org.hamcrest.Matcher;
+import org.junit.Before;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+
+public class TransportGetShutdownStatusActionTests extends ESTestCase {
+    public static final String SHUTTING_DOWN_NODE_ID = "node1";
+    public static final String LIVE_NODE_ID = "node2";
+    public static final String OTHER_LIVE_NODE_ID = "node3";
+
+    private final AtomicReference<TestDecider> canAllocate = new AtomicReference<>();
+    private final AtomicReference<TestDecider> canRemain = new AtomicReference<>();
+
+    private ClusterInfoService clusterInfoService;
+    private AllocationDeciders allocationDeciders;
+    private AllocationService allocationService;
+    private SnapshotsInfoService snapshotsInfoService;
+
+    @FunctionalInterface
+    private interface TestDecider {
+        Decision test(ShardRouting shardRouting, RoutingNode node, RoutingAllocation allocation);
+    }
+
+    @Before
+    private void setup() {
+        canAllocate.set((r, n, a) -> { throw new UnsupportedOperationException("canAllocate not initiated in this test"); });
+        canRemain.set((r, n, a) -> { throw new UnsupportedOperationException("canRemain not initiated in this test"); });
+
+        clusterInfoService = EmptyClusterInfoService.INSTANCE;
+        allocationDeciders = new AllocationDeciders(List.of(new NodeShutdownAllocationDecider(), new AllocationDecider() {
+            @Override
+            public Decision canAllocate(ShardRouting shardRouting, RoutingNode node, RoutingAllocation allocation) {
+                return canAllocate.get().test(shardRouting, node, allocation);
+            }
+
+            @Override
+            public Decision canRebalance(ShardRouting shardRouting, RoutingAllocation allocation) {
+                // No behavior should change based on rebalance decisions
+                return Decision.NO;
+            }
+
+            @Override
+            public Decision canRemain(ShardRouting shardRouting, RoutingNode node, RoutingAllocation allocation) {
+                return canRemain.get().test(shardRouting, node, allocation);
+            }
+
+            @Override
+            public Decision shouldAutoExpandToNode(IndexMetadata indexMetadata, DiscoveryNode node, RoutingAllocation allocation) {
+                // No behavior relevant to these tests should change based on auto expansion decisions
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public Decision canRebalance(RoutingAllocation allocation) {
+                // No behavior should change based on rebalance decisions
+                return Decision.NO;
+            }
+        }));
+        snapshotsInfoService = () -> new SnapshotShardSizeInfo(
+            new ImmutableOpenMap.Builder<InternalSnapshotsInfoService.SnapshotShard, Long>().build()
+        );
+        allocationService = new AllocationService(
+            allocationDeciders,
+            new BalancedShardsAllocator(Settings.EMPTY),
+            clusterInfoService,
+            snapshotsInfoService
+        );
+    }
+
+    /**
+     * Ensures we have sane behavior if there are no indices anywhere.
+     */
+    public void testEmptyCluster() {
+        RoutingTable routingTable = RoutingTable.EMPTY_ROUTING_TABLE;
+        ClusterState state = createTestClusterState(routingTable, Collections.emptyList(), SingleNodeShutdownMetadata.Type.REMOVE);
+
+        ShutdownShardMigrationStatus status = TransportGetShutdownStatusAction.shardMigrationStatus(
+            state,
+            SHUTTING_DOWN_NODE_ID,
+            SingleNodeShutdownMetadata.Type.REMOVE,
+            allocationDeciders,
+            clusterInfoService,
+            snapshotsInfoService,
+            allocationService
+        );
+
+        assertShardMigration(status, SingleNodeShutdownMetadata.Status.COMPLETE, 0, nullValue());
+    }
+
+    /**
+     * Restart-type shutdowns don't migrate shards, so we should always report the migration status as complete
+     */
+    public void testRestartAlwaysComplete() {
+        Index index = new Index(randomAlphaOfLength(5), randomAlphaOfLengthBetween(1, 20));
+        IndexMetadata imd = generateIndexMetadata(index, 3, 0);
+        IndexRoutingTable indexRoutingTable = IndexRoutingTable.builder(index)
+            .addShard(TestShardRouting.newShardRouting(new ShardId(index, 0), LIVE_NODE_ID, true, ShardRoutingState.STARTED))
+            .addShard(TestShardRouting.newShardRouting(new ShardId(index, 1), SHUTTING_DOWN_NODE_ID, true, ShardRoutingState.STARTED))
+            .addShard(TestShardRouting.newShardRouting(new ShardId(index, 2), SHUTTING_DOWN_NODE_ID, true, ShardRoutingState.STARTED))
+            .build();
+
+        RoutingTable.Builder routingTable = RoutingTable.builder();
+        routingTable.add(indexRoutingTable);
+        ClusterState state = createTestClusterState(routingTable.build(), List.of(imd), SingleNodeShutdownMetadata.Type.RESTART);
+
+        ShutdownShardMigrationStatus status = TransportGetShutdownStatusAction.shardMigrationStatus(
+            state,
+            SHUTTING_DOWN_NODE_ID,
+            SingleNodeShutdownMetadata.Type.RESTART,
+            allocationDeciders,
+            clusterInfoService,
+            snapshotsInfoService,
+            allocationService
+        );
+
+        assertShardMigration(
+            status,
+            SingleNodeShutdownMetadata.Status.COMPLETE,
+            0,
+            is("no shard relocation is necessary for a node restart")
+        );
+    }
+
+    /**
+     * Only slightly more complex than the previous case, tests that things are correctly reported as COMPLETE if there are no shards left
+     * on the node.
+     */
+    public void testComplete() {
+        Index index = new Index(randomAlphaOfLength(5), randomAlphaOfLengthBetween(1, 20));
+        IndexMetadata imd = generateIndexMetadata(index, 3, 0);
+        IndexRoutingTable indexRoutingTable = IndexRoutingTable.builder(index)
+            .addShard(TestShardRouting.newShardRouting(new ShardId(index, 0), LIVE_NODE_ID, true, ShardRoutingState.STARTED))
+            .addShard(TestShardRouting.newShardRouting(new ShardId(index, 1), LIVE_NODE_ID, true, ShardRoutingState.STARTED))
+            .addShard(TestShardRouting.newShardRouting(new ShardId(index, 2), LIVE_NODE_ID, true, ShardRoutingState.STARTED))
+            .build();
+
+        RoutingTable.Builder routingTable = RoutingTable.builder();
+        routingTable.add(indexRoutingTable);
+        ClusterState state = createTestClusterState(routingTable.build(), List.of(imd), SingleNodeShutdownMetadata.Type.REMOVE);
+
+        ShutdownShardMigrationStatus status = TransportGetShutdownStatusAction.shardMigrationStatus(
+            state,
+            SHUTTING_DOWN_NODE_ID,
+            SingleNodeShutdownMetadata.Type.REMOVE,
+            allocationDeciders,
+            clusterInfoService,
+            snapshotsInfoService,
+            allocationService
+        );
+
+        assertShardMigration(status, SingleNodeShutdownMetadata.Status.COMPLETE, 0, nullValue());
+    }
+
+    /**
+     * Ensures that we properly detect "in progress" migrations while there are shards relocating off the node that's shutting down.
+     */
+    public void testInProgressWithRelocatingShards() {
+        Index index = new Index(randomAlphaOfLength(5), randomAlphaOfLengthBetween(1, 20));
+        IndexMetadata imd = generateIndexMetadata(index, 3, 0);
+        IndexRoutingTable indexRoutingTable = IndexRoutingTable.builder(index)
+            .addShard(TestShardRouting.newShardRouting(new ShardId(index, 0), LIVE_NODE_ID, true, ShardRoutingState.STARTED))
+            .addShard(
+                TestShardRouting.newShardRouting(
+                    new ShardId(index, 1),
+                    SHUTTING_DOWN_NODE_ID,
+                    LIVE_NODE_ID,
+                    true,
+                    ShardRoutingState.RELOCATING
+                )
+            )
+            .addShard(
+                TestShardRouting.newShardRouting(
+                    new ShardId(index, 2),
+                    SHUTTING_DOWN_NODE_ID,
+                    true,
+                    randomFrom(ShardRoutingState.STARTED, ShardRoutingState.INITIALIZING) // Should have 2 shards remaining either way
+                )
+            )
+            .build();
+
+        RoutingTable.Builder routingTable = RoutingTable.builder();
+        routingTable.add(indexRoutingTable);
+        ClusterState state = createTestClusterState(routingTable.build(), List.of(imd), SingleNodeShutdownMetadata.Type.REMOVE);
+
+        ShutdownShardMigrationStatus status = TransportGetShutdownStatusAction.shardMigrationStatus(
+            state,
+            SHUTTING_DOWN_NODE_ID,
+            SingleNodeShutdownMetadata.Type.REMOVE,
+            allocationDeciders,
+            clusterInfoService,
+            snapshotsInfoService,
+            allocationService
+        );
+
+        assertShardMigration(status, SingleNodeShutdownMetadata.Status.IN_PROGRESS, 2, nullValue());
+    }
+
+    /**
+     * Ensures that we correctly report "in progress", not "stalled", when there are no shards relocating off the node that's shutting down,
+     * but there is nothing preventing shards from moving other than that there are already too many ongoing recoveries.
+     */
+    public void testInProgressWithShardsMovingBetweenOtherNodes() {
+        Index index = new Index(randomAlphaOfLength(5), randomAlphaOfLengthBetween(1, 20));
+        IndexMetadata imd = generateIndexMetadata(index, 3, 0);
+        IndexRoutingTable indexRoutingTable = IndexRoutingTable.builder(index)
+            .addShard(TestShardRouting.newShardRouting(new ShardId(index, 0), LIVE_NODE_ID, true, ShardRoutingState.STARTED))
+            .addShard(
+                TestShardRouting.newShardRouting(
+                    new ShardId(index, 1),
+                    OTHER_LIVE_NODE_ID,
+                    LIVE_NODE_ID,
+                    true,
+                    ShardRoutingState.RELOCATING
+                )
+            )
+            .addShard(TestShardRouting.newShardRouting(new ShardId(index, 2), SHUTTING_DOWN_NODE_ID, true, ShardRoutingState.STARTED))
+            .build();
+
+        // This canAllocate decider simulates the ThrottlingAllocationDecider if LIVE_NODE has a maximum incoming recoveries of 1
+        canAllocate.set((r, n, a) -> {
+            if (n.nodeId().equals(LIVE_NODE_ID)) {
+                return Decision.THROTTLE;
+            } else if (n.nodeId().equals(SHUTTING_DOWN_NODE_ID)) {
+                return Decision.NO;
+            } else {
+                return Decision.YES;
+            }
+        });
+        // And the remain decider simulates NodeShutdownAllocationDecider
+        canRemain.set((r, n, a) -> n.nodeId().equals(SHUTTING_DOWN_NODE_ID) ? Decision.NO : Decision.YES);
+
+        RoutingTable.Builder routingTable = RoutingTable.builder();
+        routingTable.add(indexRoutingTable);
+        ClusterState state = createTestClusterState(routingTable.build(), List.of(imd), SingleNodeShutdownMetadata.Type.REMOVE);
+
+        ShutdownShardMigrationStatus status = TransportGetShutdownStatusAction.shardMigrationStatus(
+            state,
+            SHUTTING_DOWN_NODE_ID,
+            SingleNodeShutdownMetadata.Type.REMOVE,
+            allocationDeciders,
+            clusterInfoService,
+            snapshotsInfoService,
+            allocationService
+        );
+
+        assertShardMigration(status, SingleNodeShutdownMetadata.Status.IN_PROGRESS, 1, nullValue());
+    }
+
+    /**
+     * Ensure we can detect stalled migrations, defined as the inability to move remaining shards off a shutting-down node due to allocation
+     * deciders.
+     */
+    public void testStalled() {
+        Index index = new Index(randomAlphaOfLength(5), randomAlphaOfLengthBetween(1, 20));
+        IndexMetadata imd = generateIndexMetadata(index, 3, 0);
+        IndexRoutingTable indexRoutingTable = IndexRoutingTable.builder(index)
+            .addShard(TestShardRouting.newShardRouting(new ShardId(index, 0), LIVE_NODE_ID, true, ShardRoutingState.STARTED))
+            .addShard(TestShardRouting.newShardRouting(new ShardId(index, 1), LIVE_NODE_ID, true, ShardRoutingState.STARTED))
+            .addShard(TestShardRouting.newShardRouting(new ShardId(index, 2), SHUTTING_DOWN_NODE_ID, true, ShardRoutingState.STARTED))
+            .build();
+
+        // Force a decision of NO for all moves and new allocations, simulating a decider that's stuck
+        canAllocate.set((r, n, a) -> Decision.NO);
+        // And the remain decider simulates NodeShutdownAllocationDecider
+        canRemain.set((r, n, a) -> n.nodeId().equals(SHUTTING_DOWN_NODE_ID) ? Decision.NO : Decision.YES);
+
+        RoutingTable.Builder routingTable = RoutingTable.builder();
+        routingTable.add(indexRoutingTable);
+        ClusterState state = createTestClusterState(routingTable.build(), List.of(imd), SingleNodeShutdownMetadata.Type.REMOVE);
+
+        ShutdownShardMigrationStatus status = TransportGetShutdownStatusAction.shardMigrationStatus(
+            state,
+            SHUTTING_DOWN_NODE_ID,
+            SingleNodeShutdownMetadata.Type.REMOVE,
+            allocationDeciders,
+            clusterInfoService,
+            snapshotsInfoService,
+            allocationService
+        );
+
+        assertShardMigration(
+            status,
+            SingleNodeShutdownMetadata.Status.STALLED,
+            1,
+            allOf(containsString(index.getName()), containsString("[2] [primary]"))
+        );
+    }
+
+    public void testOnlyInitializingShardsRemaining() {
+        Index index = new Index(randomAlphaOfLength(5), randomAlphaOfLengthBetween(1, 20));
+        IndexMetadata imd = generateIndexMetadata(index, 3, 0);
+        IndexRoutingTable indexRoutingTable = IndexRoutingTable.builder(index)
+            .addShard(TestShardRouting.newShardRouting(new ShardId(index, 0), LIVE_NODE_ID, true, ShardRoutingState.STARTED))
+            .addShard(TestShardRouting.newShardRouting(new ShardId(index, 1), SHUTTING_DOWN_NODE_ID, true, ShardRoutingState.INITIALIZING))
+            .addShard(TestShardRouting.newShardRouting(new ShardId(index, 2), SHUTTING_DOWN_NODE_ID, true, ShardRoutingState.INITIALIZING))
+            .build();
+
+        RoutingTable.Builder routingTable = RoutingTable.builder();
+        routingTable.add(indexRoutingTable);
+        ClusterState state = createTestClusterState(routingTable.build(), List.of(imd), SingleNodeShutdownMetadata.Type.REMOVE);
+
+        ShutdownShardMigrationStatus status = TransportGetShutdownStatusAction.shardMigrationStatus(
+            state,
+            SHUTTING_DOWN_NODE_ID,
+            SingleNodeShutdownMetadata.Type.REMOVE,
+            allocationDeciders,
+            clusterInfoService,
+            snapshotsInfoService,
+            allocationService
+        );
+
+        assertShardMigration(
+            status,
+            SingleNodeShutdownMetadata.Status.IN_PROGRESS,
+            2,
+            equalTo("all remaining shards are currently INITIALIZING and must finish before they can be moved off this node")
+        );
+    }
+
+    private IndexMetadata generateIndexMetadata(Index index, int numberOfShards, int numberOfReplicas) {
+        return IndexMetadata.builder(index.getName())
+            .settings(
+                Settings.builder()
+                    .put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT.id)
+                    .put(IndexMetadata.SETTING_INDEX_UUID, index.getUUID())
+            )
+            .numberOfShards(numberOfShards)
+            .numberOfReplicas(numberOfReplicas)
+            .build();
+    }
+
+    private void assertShardMigration(
+        ShutdownShardMigrationStatus status,
+        SingleNodeShutdownMetadata.Status expectedStatus,
+        long expectedShardsRemaining,
+        Matcher<? super String> explanationMatcher
+    ) {
+        assertThat(status.getStatus(), equalTo(expectedStatus));
+        assertThat(status.getShardsRemaining(), equalTo(expectedShardsRemaining));
+        assertThat(status.getExplanation(), explanationMatcher);
+    }
+
+    private ClusterState createTestClusterState(
+        RoutingTable indexRoutingTable,
+        List<IndexMetadata> indices,
+        SingleNodeShutdownMetadata.Type shutdownType
+    ) {
+        ImmutableOpenMap.Builder<String, IndexMetadata> indicesTable = ImmutableOpenMap.<String, IndexMetadata>builder();
+        indices.forEach(imd -> { indicesTable.fPut(imd.getIndex().getName(), imd); });
+
+        return ClusterState.builder(ClusterState.EMPTY_STATE)
+            .metadata(
+                Metadata.builder()
+                    .indices(indicesTable.build())
+                    .putCustom(
+                        NodesShutdownMetadata.TYPE,
+                        new NodesShutdownMetadata(
+                            Collections.singletonMap(
+                                SHUTTING_DOWN_NODE_ID,
+                                SingleNodeShutdownMetadata.builder()
+                                    .setType(shutdownType)
+                                    .setStartedAtMillis(randomNonNegativeLong())
+                                    .setReason(this.getTestName())
+                                    .setNodeId(SHUTTING_DOWN_NODE_ID)
+                                    .build()
+                            )
+                        )
+                    )
+            )
+            .nodes(
+                DiscoveryNodes.builder()
+                    .add(
+                        DiscoveryNode.createLocal(
+                            Settings.builder()
+                                .put(Settings.builder().build())
+                                .put(Node.NODE_NAME_SETTING.getKey(), SHUTTING_DOWN_NODE_ID)
+                                .build(),
+                            new TransportAddress(TransportAddress.META_ADDRESS, 9200),
+                            SHUTTING_DOWN_NODE_ID
+                        )
+                    )
+                    .add(
+                        DiscoveryNode.createLocal(
+                            Settings.builder().put(Settings.builder().build()).put(Node.NODE_NAME_SETTING.getKey(), LIVE_NODE_ID).build(),
+                            new TransportAddress(TransportAddress.META_ADDRESS, 9201),
+                            LIVE_NODE_ID
+                        )
+                    )
+                    .add(
+                        DiscoveryNode.createLocal(
+                            Settings.builder()
+                                .put(Settings.builder().build())
+                                .put(Node.NODE_NAME_SETTING.getKey(), OTHER_LIVE_NODE_ID)
+                                .build(),
+                            new TransportAddress(TransportAddress.META_ADDRESS, 9202),
+                            OTHER_LIVE_NODE_ID
+                        )
+                    )
+            )
+            .routingTable(indexRoutingTable)
+            .build();
+    }
+
+    private static class TestSnapshotInfoService implements SnapshotsInfoService {
+        @Override
+        public SnapshotShardSizeInfo snapshotShardSizes() {
+            return new SnapshotShardSizeInfo(new ImmutableOpenMap.Builder<InternalSnapshotsInfoService.SnapshotShard, Long>().build());
+        }
+    }
+}


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Expose shard migration status in Node Shutdown Status API (#73873)