### PR TITLE
[Test] Avoid use the same token name in different tests

### DIFF
--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/SecurityDocumentationIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/SecurityDocumentationIT.java
@@ -2614,7 +2614,6 @@ public class SecurityDocumentationIT extends ESRestHighLevelClientTestCase {
         }
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/74278")
     public void testCreateServiceAccountToken() throws IOException {
         RestHighLevelClient client = highLevelClient();
         {
@@ -2723,7 +2722,6 @@ public class SecurityDocumentationIT extends ESRestHighLevelClientTestCase {
         }
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/74278")
     public void testGetServiceAccountCredentials() throws IOException {
         RestHighLevelClient client = highLevelClient();
         final CreateServiceAccountTokenRequest createServiceAccountTokenRequest =

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/SecurityDocumentationIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/SecurityDocumentationIT.java
@@ -2725,10 +2725,10 @@ public class SecurityDocumentationIT extends ESRestHighLevelClientTestCase {
     public void testGetServiceAccountCredentials() throws IOException {
         RestHighLevelClient client = highLevelClient();
         final CreateServiceAccountTokenRequest createServiceAccountTokenRequest =
-            new CreateServiceAccountTokenRequest("elastic", "fleet-server", "token1");
+            new CreateServiceAccountTokenRequest("elastic", "fleet-server", "token2");
         final CreateServiceAccountTokenResponse createServiceAccountTokenResponse =
             client.security().createServiceAccountToken(createServiceAccountTokenRequest, RequestOptions.DEFAULT);
-        assertThat(createServiceAccountTokenResponse.getName(), equalTo("token1"));
+        assertThat(createServiceAccountTokenResponse.getName(), equalTo("token2"));
 
         {
             // tag::get-service-account-credentials-request
@@ -2750,7 +2750,7 @@ public class SecurityDocumentationIT extends ESRestHighLevelClientTestCase {
             // end::get-service-account-credentials-response
             assertThat(principal, equalTo("elastic/fleet-server"));
             assertThat(serviceTokenInfos.size(), equalTo(1));
-            assertThat(tokenName, equalTo("token1"));
+            assertThat(tokenName, equalTo("token2"));
             assertThat(tokenSource, equalTo("index"));
         }
 
@@ -2784,7 +2784,7 @@ public class SecurityDocumentationIT extends ESRestHighLevelClientTestCase {
             assertNotNull(future.actionGet());
             assertThat(future.actionGet().getPrincipal(), equalTo("elastic/fleet-server"));
             assertThat(future.actionGet().getServiceTokenInfos().size(), equalTo(1));
-            assertThat(future.actionGet().getServiceTokenInfos().get(0), equalTo(new ServiceTokenInfo("token1", "index")));
+            assertThat(future.actionGet().getServiceTokenInfos().get(0), equalTo(new ServiceTokenInfo("token2", "index")));
         }
     }
 


### PR DESCRIPTION
The name `token1` is used in both `testGetServiceAccountCredentials` and `testCreateServiceAccountToken`. There are times when the two tests are not fully isolated. This leads to test failure because indexing of the service token document must be an `op_create`. This PR fixes the failure by using a different token name in `testGetServiceAccountCredentials`.

Resolves: #74278