### PR TITLE
[7.x] Service to migrate indices and ILM policies to data tiers (#73689)

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/DataTier.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/DataTier.java
@@ -18,7 +18,9 @@ import org.elasticsearch.xpack.cluster.routing.allocation.DataTierAllocationDeci
 
 import java.util.Arrays;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * The {@code DataTier} class encapsulates the formalization of the "content",
@@ -40,6 +42,10 @@ public class DataTier {
     public static final Set<String> ALL_DATA_TIERS =
         new HashSet<>(Arrays.asList(DATA_CONTENT, DATA_HOT, DATA_WARM, DATA_COLD, DATA_FROZEN));
 
+    // Represents an ordered list of data tiers from frozen to hot (or slow to fast)
+    private static final List<String> ORDERED_FROZEN_TO_HOT_TIERS =
+        org.elasticsearch.core.List.of(DataTier.DATA_FROZEN, DataTier.DATA_COLD, DataTier.DATA_WARM, DataTier.DATA_HOT);
+
     /**
      * Returns true if the given tier name is a valid tier
      */
@@ -49,6 +55,19 @@ public class DataTier {
             DATA_WARM.equals(tierName) ||
             DATA_COLD.equals(tierName) ||
             DATA_FROZEN.equals(tierName);
+    }
+
+    /**
+     * Based on the provided target tier it will return a comma separated list of preferred tiers.
+     * ie. if `data_cold` is the target tier, it will return `data_cold,data_warm,data_hot`
+     * This is usually used in conjunction with {@link DataTierAllocationDecider#INDEX_ROUTING_PREFER_SETTING}
+     */
+    public static String getPreferredTiersConfiguration(String targetTier) {
+        int indexOfTargetTier = ORDERED_FROZEN_TO_HOT_TIERS.indexOf(targetTier);
+        if (indexOfTargetTier == -1) {
+            throw new IllegalArgumentException("invalid data tier [" + targetTier + "]");
+        }
+        return ORDERED_FROZEN_TO_HOT_TIERS.stream().skip(indexOfTargetTier).collect(Collectors.joining(","));
     }
 
     /**

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/MigrateAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/MigrateAction.java
@@ -25,7 +25,8 @@ import org.elasticsearch.xpack.core.searchablesnapshots.SearchableSnapshotsConst
 import java.io.IOException;
 import java.util.List;
 import java.util.Objects;
-import java.util.stream.Collectors;
+
+import static org.elasticsearch.xpack.core.DataTier.getPreferredTiersConfiguration;
 
 /**
  * A {@link LifecycleAction} which enables or disables the automatic migration of data between
@@ -37,9 +38,6 @@ public class MigrateAction implements LifecycleAction {
 
     private static final Logger logger = LogManager.getLogger(MigrateAction.class);
     static final String CONDITIONAL_SKIP_MIGRATE_STEP = BranchingStep.NAME + "-check-skip-action";
-    // Represents an ordered list of data tiers from frozen to hot (or slow to fast)
-    private static final List<String> FROZEN_TO_HOT_TIERS =
-        org.elasticsearch.core.List.of(DataTier.DATA_FROZEN, DataTier.DATA_COLD, DataTier.DATA_WARM, DataTier.DATA_HOT);
 
     private static final ConstructingObjectParser<MigrateAction, Void> PARSER = new ConstructingObjectParser<>(NAME,
         a -> new MigrateAction(a[0] == null ? true : (boolean) a[0]));
@@ -126,19 +124,6 @@ public class MigrateAction implements LifecycleAction {
         } else {
             return org.elasticsearch.core.List.of();
         }
-    }
-
-    /**
-     * Based on the provided target tier it will return a comma separated list of preferred tiers.
-     * ie. if `data_cold` is the target tier, it will return `data_cold,data_warm,data_hot`
-     * This is usually used in conjunction with {@link DataTierAllocationDecider#INDEX_ROUTING_PREFER_SETTING}
-     */
-    static String getPreferredTiersConfiguration(String targetTier) {
-        int indexOfTargetTier = FROZEN_TO_HOT_TIERS.indexOf(targetTier);
-        if (indexOfTargetTier == -1) {
-            throw new IllegalArgumentException("invalid data tier [" + targetTier + "]");
-        }
-        return FROZEN_TO_HOT_TIERS.stream().skip(indexOfTargetTier).collect(Collectors.joining(","));
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/PhaseCacheManagement.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/PhaseCacheManagement.java
@@ -1,0 +1,245 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.core.ilm;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.message.ParameterizedMessage;
+import org.elasticsearch.client.Client;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.metadata.IndexMetadata;
+import org.elasticsearch.cluster.metadata.Metadata;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.xcontent.DeprecationHandler;
+import org.elasticsearch.common.xcontent.NamedXContentRegistry;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.common.xcontent.json.JsonXContent;
+import org.elasticsearch.core.Nullable;
+
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.Spliterators;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+
+import static org.elasticsearch.xpack.core.ilm.LifecycleExecutionState.ILM_CUSTOM_METADATA_KEY;
+
+/**
+ * We cache the currently executing ILM phase in the index metadata so the ILM execution for managed indices is not irrecoverably
+ * interrupted by a concurrent update policy that, say, would remove the current execution phase altogether.
+ * <p>
+ * This contains class contains a series of methods that help manage the cached ILM phase.
+ */
+public final class PhaseCacheManagement {
+
+    private static final Logger logger = LogManager.getLogger(PhaseCacheManagement.class);
+
+    private PhaseCacheManagement() {
+    }
+
+    /**
+     * Rereads the phase JSON for the given index, returning a new cluster state.
+     */
+    public static ClusterState refreshPhaseDefinition(final ClusterState state, final String index,
+                                                      final LifecyclePolicyMetadata updatedPolicy) {
+        final IndexMetadata idxMeta = state.metadata().index(index);
+        Metadata.Builder metadataBuilder = Metadata.builder(state.metadata());
+        refreshPhaseDefinition(metadataBuilder, idxMeta, updatedPolicy);
+        return ClusterState.builder(state).metadata(metadataBuilder).build();
+    }
+
+    /**
+     * Rereads the phase JSON for the given index, and updates the provided metadata.
+     */
+    public static void refreshPhaseDefinition(final Metadata.Builder metadataBuilder, final IndexMetadata idxMeta,
+                                              final LifecyclePolicyMetadata updatedPolicy) {
+        String index = idxMeta.getIndex().getName();
+        assert eligibleToCheckForRefresh(idxMeta) : "index " + index + " is missing crucial information needed to refresh phase definition";
+
+        logger.trace("[{}] updating cached phase definition for policy [{}]", index, updatedPolicy.getName());
+        LifecycleExecutionState currentExState = LifecycleExecutionState.fromIndexMetadata(idxMeta);
+
+        String currentPhase = currentExState.getPhase();
+        PhaseExecutionInfo pei = new PhaseExecutionInfo(updatedPolicy.getName(),
+            updatedPolicy.getPolicy().getPhases().get(currentPhase), updatedPolicy.getVersion(), updatedPolicy.getModifiedDate());
+
+        LifecycleExecutionState newExState = LifecycleExecutionState.builder(currentExState)
+            .setPhaseDefinition(Strings.toString(pei, false, false))
+            .build();
+
+        metadataBuilder.put(IndexMetadata.builder(idxMeta)
+            .putCustom(ILM_CUSTOM_METADATA_KEY, newExState.asMap()));
+    }
+
+
+    /**
+     * Ensure that we have the minimum amount of metadata necessary to check for cache phase
+     * refresh. This includes:
+     * - An execution state
+     * - Existing phase definition JSON
+     * - A current step key
+     * - A current phase in the step key
+     * - Not currently in the ERROR step
+     */
+    public static boolean eligibleToCheckForRefresh(final IndexMetadata metadata) {
+        LifecycleExecutionState executionState = LifecycleExecutionState.fromIndexMetadata(metadata);
+        if (executionState == null || executionState.getPhaseDefinition() == null) {
+            return false;
+        }
+
+        Step.StepKey currentStepKey = LifecycleExecutionState.getCurrentStepKey(executionState);
+        if (currentStepKey == null || currentStepKey.getPhase() == null) {
+            return false;
+        }
+
+        return ErrorStep.NAME.equals(currentStepKey.getName()) == false;
+    }
+
+    /**
+     * For the given new policy, returns a new cluster with all updateable indices' phase JSON refreshed.
+     */
+    public static ClusterState updateIndicesForPolicy(final ClusterState state, final NamedXContentRegistry xContentRegistry,
+                                                      final Client client, final LifecyclePolicy oldPolicy,
+                                                      final LifecyclePolicyMetadata newPolicy) {
+        Metadata.Builder mb = Metadata.builder(state.metadata());
+        if (updateIndicesForPolicy(mb, state, xContentRegistry, client, oldPolicy, newPolicy)) {
+            return ClusterState.builder(state).metadata(mb).build();
+        }
+        return state;
+    }
+
+    /**
+     * For the given new policy, update the provided metadata to reflect the refreshed phase JSON for all updateable indices.
+     * Returns true if any indices were updated and false otherwise.
+     * Users of this API should consider the returned value and only create a new {@link ClusterState} if `true` is returned.
+     */
+    public static boolean updateIndicesForPolicy(final Metadata.Builder mb, final ClusterState currentState,
+                                                 final NamedXContentRegistry xContentRegistry, final Client client,
+                                                 final LifecyclePolicy oldPolicy, final LifecyclePolicyMetadata newPolicy) {
+        assert oldPolicy.getName().equals(newPolicy.getName()) : "expected both policies to have the same id but they were: [" +
+            oldPolicy.getName() + "] vs. [" + newPolicy.getName() + "]";
+
+        // No need to update anything if the policies are identical in contents
+        if (oldPolicy.equals(newPolicy.getPolicy())) {
+            logger.debug("policy [{}] is unchanged and no phase definition refresh is needed", oldPolicy.getName());
+            return false;
+        }
+
+        final List<IndexMetadata> indicesThatCanBeUpdated =
+            StreamSupport.stream(Spliterators.spliteratorUnknownSize(currentState.metadata().indices().valuesIt(), 0), false)
+                .filter(meta -> newPolicy.getName().equals(LifecycleSettings.LIFECYCLE_NAME_SETTING.get(meta.getSettings())))
+                .filter(meta -> isIndexPhaseDefinitionUpdatable(xContentRegistry, client, meta, newPolicy.getPolicy()))
+                .collect(Collectors.toList());
+
+        final List<String> refreshedIndices = new ArrayList<>(indicesThatCanBeUpdated.size());
+        for (IndexMetadata index : indicesThatCanBeUpdated) {
+            try {
+                refreshPhaseDefinition(mb, index, newPolicy);
+                refreshedIndices.add(index.getIndex().getName());
+            } catch (Exception e) {
+                logger.warn(new ParameterizedMessage("[{}] unable to refresh phase definition for updated policy [{}]",
+                    index, newPolicy.getName()), e);
+            }
+        }
+        logger.debug("refreshed policy [{}] phase definition for [{}] indices", newPolicy.getName(), refreshedIndices.size());
+        return refreshedIndices.size() > 0;
+    }
+
+    /**
+     * Returns 'true' if the index's cached phase JSON can be safely reread, 'false' otherwise.
+     */
+    public static boolean isIndexPhaseDefinitionUpdatable(final NamedXContentRegistry xContentRegistry, final Client client,
+                                                          final IndexMetadata metadata, final LifecyclePolicy newPolicy) {
+        final String index = metadata.getIndex().getName();
+        if (eligibleToCheckForRefresh(metadata) == false) {
+            logger.debug("[{}] does not contain enough information to check for eligibility of refreshing phase", index);
+            return false;
+        }
+        final String policyId = newPolicy.getName();
+
+        final LifecycleExecutionState executionState = LifecycleExecutionState.fromIndexMetadata(metadata);
+        final Step.StepKey currentStepKey = LifecycleExecutionState.getCurrentStepKey(executionState);
+        final String currentPhase = currentStepKey.getPhase();
+
+        final Set<Step.StepKey> newStepKeys = newPolicy.toSteps(client).stream()
+            .map(Step::getKey)
+            .collect(Collectors.toCollection(LinkedHashSet::new));
+
+        if (newStepKeys.contains(currentStepKey) == false) {
+            // The index is on a step that doesn't exist in the new policy, we
+            // can't safely re-read the JSON
+            logger.debug("[{}] updated policy [{}] does not contain the current step key [{}], so the policy phase will not be refreshed",
+                index, policyId, currentStepKey);
+            return false;
+        }
+
+        final String phaseDef = executionState.getPhaseDefinition();
+        final Set<Step.StepKey> oldStepKeys = readStepKeys(xContentRegistry, client, phaseDef, currentPhase);
+        if (oldStepKeys == null) {
+            logger.debug("[{}] unable to parse phase definition for cached policy [{}], policy phase will not be refreshed",
+                index, policyId);
+            return false;
+        }
+
+        final Set<Step.StepKey> oldPhaseStepKeys = oldStepKeys.stream()
+            .filter(sk -> currentPhase.equals(sk.getPhase()))
+            .collect(Collectors.toCollection(LinkedHashSet::new));
+
+        final PhaseExecutionInfo phaseExecutionInfo = new PhaseExecutionInfo(policyId, newPolicy.getPhases().get(currentPhase), 1L, 1L);
+        final String peiJson = Strings.toString(phaseExecutionInfo);
+
+        final Set<Step.StepKey> newPhaseStepKeys = readStepKeys(xContentRegistry, client, peiJson, currentPhase);
+        if (newPhaseStepKeys == null) {
+            logger.debug(new ParameterizedMessage("[{}] unable to parse phase definition for policy [{}] " +
+                "to determine if it could be refreshed", index, policyId));
+            return false;
+        }
+
+        if (newPhaseStepKeys.equals(oldPhaseStepKeys)) {
+            // The new and old phase have the same stepkeys for this current phase, so we can
+            // refresh the definition because we know it won't change the execution flow.
+            logger.debug("[{}] updated policy [{}] contains the same phase step keys and can be refreshed", index, policyId);
+            return true;
+        } else {
+            logger.debug("[{}] updated policy [{}] has different phase step keys and will NOT refresh phase " +
+                    "definition as it differs too greatly. old: {}, new: {}",
+                index, policyId, oldPhaseStepKeys, newPhaseStepKeys);
+            return false;
+        }
+    }
+
+    /**
+     * Parse the {@code phaseDef} phase definition to get the stepkeys for the given phase.
+     * If there is an error parsing or if the phase definition is missing the required
+     * information, returns null.
+     */
+    @Nullable
+    static Set<Step.StepKey> readStepKeys(final NamedXContentRegistry xContentRegistry, final Client client,
+                                          final String phaseDef, final String currentPhase) {
+        final PhaseExecutionInfo phaseExecutionInfo;
+        try (XContentParser parser = JsonXContent.jsonXContent.createParser(xContentRegistry,
+            DeprecationHandler.THROW_UNSUPPORTED_OPERATION, phaseDef)) {
+            phaseExecutionInfo = PhaseExecutionInfo.parse(parser, currentPhase);
+        } catch (Exception e) {
+            logger.trace(new ParameterizedMessage("exception reading step keys checking for refreshability, phase definition: {}",
+                phaseDef), e);
+            return null;
+        }
+
+        if (phaseExecutionInfo == null || phaseExecutionInfo.getPhase() == null) {
+            return null;
+        }
+
+        return phaseExecutionInfo.getPhase().getActions().values().stream()
+            .flatMap(a -> a.toSteps(client, phaseExecutionInfo.getPhase().getName(), null).stream())
+            .map(Step::getKey)
+            .collect(Collectors.toCollection(LinkedHashSet::new));
+    }
+}

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/DataTierTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/DataTierTests.java
@@ -27,6 +27,11 @@ import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.StreamSupport;
 
+import static org.elasticsearch.xpack.core.DataTier.DATA_COLD;
+import static org.elasticsearch.xpack.core.DataTier.DATA_HOT;
+import static org.elasticsearch.xpack.core.DataTier.DATA_WARM;
+import static org.elasticsearch.xpack.core.DataTier.getPreferredTiersConfiguration;
+import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.Matchers.arrayContainingInAnyOrder;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.not;
@@ -129,6 +134,14 @@ public class DataTierTests extends ESTestCase {
         assertThat(node.getRoles(), not(hasItem(DiscoveryNodeRole.DATA_WARM_NODE_ROLE)));
         assertThat(node.getRoles(), not(hasItem(DiscoveryNodeRole.DATA_COLD_NODE_ROLE)));
         assertSettingDeprecationsAndWarnings(new Setting<?>[]{DiscoveryNodeRole.DATA_ROLE.legacySetting()});
+    }
+
+    public void testGetPreferredTiersConfiguration() {
+        assertThat(getPreferredTiersConfiguration(DATA_HOT), is(DATA_HOT));
+        assertThat(getPreferredTiersConfiguration(DATA_WARM), is(DATA_WARM + "," + DATA_HOT));
+        assertThat(getPreferredTiersConfiguration(DATA_COLD), is(DATA_COLD + "," + DATA_WARM + "," + DATA_HOT));
+        IllegalArgumentException exception = expectThrows(IllegalArgumentException.class, () -> getPreferredTiersConfiguration("no_tier"));
+        assertThat(exception.getMessage(), is("invalid data tier [no_tier]"));
     }
 
     private static DiscoveryNodes buildDiscoveryNodes() {

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/MigrateActionTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/MigrateActionTests.java
@@ -23,7 +23,6 @@ import static org.elasticsearch.index.IndexModule.INDEX_STORE_TYPE_SETTING;
 import static org.elasticsearch.xpack.core.DataTier.DATA_COLD;
 import static org.elasticsearch.xpack.core.DataTier.DATA_HOT;
 import static org.elasticsearch.xpack.core.DataTier.DATA_WARM;
-import static org.elasticsearch.xpack.core.ilm.MigrateAction.getPreferredTiersConfiguration;
 import static org.elasticsearch.xpack.core.ilm.TimeseriesLifecycleType.COLD_PHASE;
 import static org.elasticsearch.xpack.core.ilm.TimeseriesLifecycleType.DELETE_PHASE;
 import static org.elasticsearch.xpack.core.ilm.TimeseriesLifecycleType.HOT_PHASE;
@@ -81,14 +80,6 @@ public class MigrateActionTests extends AbstractActionTestCase<MigrateAction> {
             List<Step> steps = disabledMigrateAction.toSteps(null, phase, nextStepKey);
             assertEquals(0, steps.size());
         }
-    }
-
-    public void testGetPreferredTiersConfiguration() {
-        assertThat(getPreferredTiersConfiguration(DATA_HOT), is(DATA_HOT));
-        assertThat(getPreferredTiersConfiguration(DATA_WARM), is(DATA_WARM + "," + DATA_HOT));
-        assertThat(getPreferredTiersConfiguration(DATA_COLD), is(DATA_COLD + "," + DATA_WARM + "," + DATA_HOT));
-        IllegalArgumentException exception = expectThrows(IllegalArgumentException.class, () -> getPreferredTiersConfiguration("no_tier"));
-        assertThat(exception.getMessage(), is("invalid data tier [no_tier]"));
     }
 
     public void testMigrateActionsConfiguresTierPreference() {

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/PhaseCacheManagementTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/PhaseCacheManagementTests.java
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-package org.elasticsearch.xpack.ilm.action;
+package org.elasticsearch.xpack.core.ilm;
 
 import org.elasticsearch.Version;
 import org.elasticsearch.client.Client;
@@ -14,77 +14,144 @@ import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
+import org.elasticsearch.common.xcontent.ParseField;
+import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.test.ESTestCase;
-import org.elasticsearch.xpack.core.ilm.AllocateAction;
-import org.elasticsearch.xpack.core.ilm.AllocationRoutedStep;
-import org.elasticsearch.xpack.core.ilm.CheckNotDataStreamWriteIndexStep;
-import org.elasticsearch.xpack.core.ilm.ErrorStep;
-import org.elasticsearch.xpack.core.ilm.ForceMergeAction;
-import org.elasticsearch.xpack.core.ilm.FreezeAction;
-import org.elasticsearch.xpack.core.ilm.LifecycleAction;
-import org.elasticsearch.xpack.core.ilm.LifecycleExecutionState;
-import org.elasticsearch.xpack.core.ilm.LifecyclePolicy;
-import org.elasticsearch.xpack.core.ilm.LifecyclePolicyMetadata;
-import org.elasticsearch.xpack.core.ilm.LifecycleSettings;
-import org.elasticsearch.xpack.core.ilm.Phase;
-import org.elasticsearch.xpack.core.ilm.PhaseExecutionInfo;
-import org.elasticsearch.xpack.core.ilm.ReadOnlyAction;
-import org.elasticsearch.xpack.core.ilm.RolloverAction;
-import org.elasticsearch.xpack.core.ilm.RolloverStep;
-import org.elasticsearch.xpack.core.ilm.SegmentCountStep;
-import org.elasticsearch.xpack.core.ilm.SetPriorityAction;
-import org.elasticsearch.xpack.core.ilm.Step;
-import org.elasticsearch.xpack.core.ilm.UpdateRolloverLifecycleDateStep;
-import org.elasticsearch.xpack.core.ilm.WaitForActiveShardsStep;
-import org.elasticsearch.xpack.core.ilm.WaitForRolloverReadyStep;
-import org.elasticsearch.xpack.ilm.IndexLifecycle;
 
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
 import static org.elasticsearch.xpack.core.ilm.LifecycleExecutionState.ILM_CUSTOM_METADATA_KEY;
+import static org.elasticsearch.xpack.core.ilm.PhaseCacheManagement.eligibleToCheckForRefresh;
+import static org.elasticsearch.xpack.core.ilm.PhaseCacheManagement.isIndexPhaseDefinitionUpdatable;
+import static org.elasticsearch.xpack.core.ilm.PhaseCacheManagement.readStepKeys;
+import static org.elasticsearch.xpack.core.ilm.PhaseCacheManagement.refreshPhaseDefinition;
+import static org.elasticsearch.xpack.core.ilm.PhaseCacheManagement.updateIndicesForPolicy;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.equalTo;
 import static org.mockito.Mockito.mock;
 
-public class TransportPutLifecycleActionTests extends ESTestCase {
+public class PhaseCacheManagementTests extends ESTestCase {
+
     private static final NamedXContentRegistry REGISTRY;
     private static final Client client = mock(Client.class);
     private static final String index = "eggplant";
 
     static {
-        try (IndexLifecycle indexLifecycle = new IndexLifecycle(Settings.EMPTY)) {
-            List<NamedXContentRegistry.Entry> entries = new ArrayList<>(indexLifecycle.getNamedXContent());
-            REGISTRY = new NamedXContentRegistry(entries);
-        }
+        REGISTRY = new NamedXContentRegistry(org.elasticsearch.core.List.of(
+            new NamedXContentRegistry.Entry(LifecycleAction.class, new ParseField(RolloverAction.NAME), RolloverAction::parse),
+            new NamedXContentRegistry.Entry(LifecycleAction.class, new ParseField(SetPriorityAction.NAME), SetPriorityAction::parse),
+            new NamedXContentRegistry.Entry(LifecycleAction.class, new ParseField(ForceMergeAction.NAME), ForceMergeAction::parse),
+            new NamedXContentRegistry.Entry(LifecycleAction.class, new ParseField(AllocateAction.NAME), AllocateAction::parse))
+        );
+    }
+
+    public void testRefreshPhaseJson() {
+        LifecycleExecutionState.Builder exState = LifecycleExecutionState.builder()
+            .setPhase("hot")
+            .setAction("rollover")
+            .setStep("check-rollover-ready")
+            .setPhaseDefinition("{\n" +
+                "        \"policy\" : \"my-policy\",\n" +
+                "        \"phase_definition\" : {\n" +
+                "          \"min_age\" : \"20m\",\n" +
+                "          \"actions\" : {\n" +
+                "            \"rollover\" : {\n" +
+                "              \"max_age\" : \"5s\"\n" +
+                "            },\n" +
+                "            \"set_priority\" : {\n" +
+                "              \"priority\" : 150\n" +
+                "            }\n" +
+                "          }\n" +
+                "        },\n" +
+                "        \"version\" : 1,\n" +
+                "        \"modified_date_in_millis\" : 1578521007076\n" +
+                "      }");
+
+        IndexMetadata meta = buildIndexMetadata("my-policy", exState);
+        String index = meta.getIndex().getName();
+
+        Map<String, LifecycleAction> actions = new HashMap<>();
+        actions.put("rollover", new RolloverAction(null, null, null, 1L));
+        actions.put("set_priority", new SetPriorityAction(100));
+        Phase hotPhase = new Phase("hot", TimeValue.ZERO, actions);
+        Map<String, Phase> phases = Collections.singletonMap("hot", hotPhase);
+        LifecyclePolicy newPolicy = new LifecyclePolicy("my-policy", phases);
+        LifecyclePolicyMetadata policyMetadata = new LifecyclePolicyMetadata(newPolicy, Collections.emptyMap(), 2L, 2L);
+
+        ClusterState existingState = ClusterState.builder(ClusterState.EMPTY_STATE)
+            .metadata(Metadata.builder(Metadata.EMPTY_METADATA)
+                .put(meta, false)
+                .build())
+            .build();
+
+        ClusterState changedState = refreshPhaseDefinition(existingState, index, policyMetadata);
+
+        IndexMetadata newIdxMeta = changedState.metadata().index(index);
+        LifecycleExecutionState afterExState = LifecycleExecutionState.fromIndexMetadata(newIdxMeta);
+        Map<String, String> beforeState = new HashMap<>(exState.build().asMap());
+        beforeState.remove("phase_definition");
+        Map<String, String> afterState = new HashMap<>(afterExState.asMap());
+        afterState.remove("phase_definition");
+        // Check that no other execution state changes have been made
+        assertThat(beforeState, equalTo(afterState));
+
+        // Check that the phase definition has been refreshed
+        assertThat(afterExState.getPhaseDefinition(),
+            equalTo("{\"policy\":\"my-policy\",\"phase_definition\":{\"min_age\":\"0ms\",\"actions\":{\"rollover\":{\"max_docs\":1}," +
+                "\"set_priority\":{\"priority\":100}}},\"version\":2,\"modified_date_in_millis\":2}"));
     }
 
     public void testEligibleForRefresh() {
-        IndexMetadata meta = mkMeta().build();
-        assertFalse(TransportPutLifecycleAction.eligibleToCheckForRefresh(meta));
+        IndexMetadata meta = IndexMetadata.builder("index")
+            .settings(Settings.builder()
+                .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, randomIntBetween(1, 10))
+                .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, randomIntBetween(0, 5))
+                .put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT)
+                .put(IndexMetadata.SETTING_INDEX_UUID, randomAlphaOfLength(5)))
+            .build();
+        assertFalse(eligibleToCheckForRefresh(meta));
 
         LifecycleExecutionState state = LifecycleExecutionState.builder().build();
-        meta = mkMeta().putCustom(ILM_CUSTOM_METADATA_KEY, state.asMap()).build();
-        assertFalse(TransportPutLifecycleAction.eligibleToCheckForRefresh(meta));
+        meta = IndexMetadata.builder("index")
+            .settings(Settings.builder()
+                .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, randomIntBetween(1, 10))
+                .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, randomIntBetween(0, 5))
+                .put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT)
+                .put(IndexMetadata.SETTING_INDEX_UUID, randomAlphaOfLength(5)))
+            .putCustom(ILM_CUSTOM_METADATA_KEY, state.asMap())
+            .build();
+        assertFalse(eligibleToCheckForRefresh(meta));
 
         state = LifecycleExecutionState.builder()
             .setPhase("phase")
             .setAction("action")
             .setStep("step")
             .build();
-        meta = mkMeta().putCustom(ILM_CUSTOM_METADATA_KEY, state.asMap()).build();
-        assertFalse(TransportPutLifecycleAction.eligibleToCheckForRefresh(meta));
+        meta = IndexMetadata.builder("index")
+            .settings(Settings.builder()
+                .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, randomIntBetween(1, 10))
+                .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, randomIntBetween(0, 5))
+                .put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT)
+                .put(IndexMetadata.SETTING_INDEX_UUID, randomAlphaOfLength(5)))
+            .putCustom(ILM_CUSTOM_METADATA_KEY, state.asMap())
+            .build();
+        assertFalse(eligibleToCheckForRefresh(meta));
 
         state = LifecycleExecutionState.builder()
             .setPhaseDefinition("{}")
             .build();
-        meta = mkMeta().putCustom(ILM_CUSTOM_METADATA_KEY, state.asMap()).build();
-        assertFalse(TransportPutLifecycleAction.eligibleToCheckForRefresh(meta));
+        meta = IndexMetadata.builder("index")
+            .settings(Settings.builder()
+                .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, randomIntBetween(1, 10))
+                .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, randomIntBetween(0, 5))
+                .put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT)
+                .put(IndexMetadata.SETTING_INDEX_UUID, randomAlphaOfLength(5)))
+            .putCustom(ILM_CUSTOM_METADATA_KEY, state.asMap())
+            .build();
+        assertFalse(eligibleToCheckForRefresh(meta));
 
         state = LifecycleExecutionState.builder()
             .setPhase("phase")
@@ -92,8 +159,15 @@ public class TransportPutLifecycleActionTests extends ESTestCase {
             .setStep(ErrorStep.NAME)
             .setPhaseDefinition("{}")
             .build();
-        meta = mkMeta().putCustom(ILM_CUSTOM_METADATA_KEY, state.asMap()).build();
-        assertFalse(TransportPutLifecycleAction.eligibleToCheckForRefresh(meta));
+        meta = IndexMetadata.builder("index")
+            .settings(Settings.builder()
+                .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, randomIntBetween(1, 10))
+                .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, randomIntBetween(0, 5))
+                .put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT)
+                .put(IndexMetadata.SETTING_INDEX_UUID, randomAlphaOfLength(5)))
+            .putCustom(ILM_CUSTOM_METADATA_KEY, state.asMap())
+            .build();
+        assertFalse(eligibleToCheckForRefresh(meta));
 
         state = LifecycleExecutionState.builder()
             .setPhase("phase")
@@ -101,35 +175,42 @@ public class TransportPutLifecycleActionTests extends ESTestCase {
             .setStep("step")
             .setPhaseDefinition("{}")
             .build();
-        meta = mkMeta().putCustom(ILM_CUSTOM_METADATA_KEY, state.asMap()).build();
-        assertTrue(TransportPutLifecycleAction.eligibleToCheckForRefresh(meta));
+        meta = IndexMetadata.builder("index")
+            .settings(Settings.builder()
+                .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, randomIntBetween(1, 10))
+                .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, randomIntBetween(0, 5))
+                .put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT)
+                .put(IndexMetadata.SETTING_INDEX_UUID, randomAlphaOfLength(5)))
+            .putCustom(ILM_CUSTOM_METADATA_KEY, state.asMap())
+            .build();
+        assertTrue(eligibleToCheckForRefresh(meta));
     }
 
     public void testReadStepKeys() {
-        assertNull(TransportPutLifecycleAction.readStepKeys(REGISTRY, client, "{}", "phase"));
-        assertNull(TransportPutLifecycleAction.readStepKeys(REGISTRY, client, "aoeu", "phase"));
-        assertNull(TransportPutLifecycleAction.readStepKeys(REGISTRY, client, "", "phase"));
+        assertNull(readStepKeys(REGISTRY, client, "{}", "phase"));
+        assertNull(readStepKeys(REGISTRY, client, "aoeu", "phase"));
+        assertNull(readStepKeys(REGISTRY, client, "", "phase"));
 
-        assertThat(TransportPutLifecycleAction.readStepKeys(REGISTRY, client, "{\n" +
-            "        \"policy\": \"my_lifecycle3\",\n" +
-            "        \"phase_definition\": { \n" +
-            "          \"min_age\": \"0ms\",\n" +
-            "          \"actions\": {\n" +
-            "            \"rollover\": {\n" +
-            "              \"max_age\": \"30s\"\n" +
-            "            }\n" +
-            "          }\n" +
-            "        },\n" +
-            "        \"version\": 3, \n" +
-            "        \"modified_date_in_millis\": 1539609701576 \n" +
-            "      }", "phase"),
+        assertThat(readStepKeys(REGISTRY, client, "{\n" +
+                "        \"policy\": \"my_lifecycle3\",\n" +
+                "        \"phase_definition\": { \n" +
+                "          \"min_age\": \"0ms\",\n" +
+                "          \"actions\": {\n" +
+                "            \"rollover\": {\n" +
+                "              \"max_age\": \"30s\"\n" +
+                "            }\n" +
+                "          }\n" +
+                "        },\n" +
+                "        \"version\": 3, \n" +
+                "        \"modified_date_in_millis\": 1539609701576 \n" +
+                "      }", "phase"),
             contains(new Step.StepKey("phase", "rollover", WaitForRolloverReadyStep.NAME),
                 new Step.StepKey("phase", "rollover", RolloverStep.NAME),
                 new Step.StepKey("phase", "rollover", WaitForActiveShardsStep.NAME),
                 new Step.StepKey("phase", "rollover", UpdateRolloverLifecycleDateStep.NAME),
                 new Step.StepKey("phase", "rollover", RolloverAction.INDEXING_COMPLETE_STEP_NAME)));
 
-        assertThat(TransportPutLifecycleAction.readStepKeys(REGISTRY, client, "{\n" +
+        assertThat(readStepKeys(REGISTRY, client, "{\n" +
                 "        \"policy\" : \"my_lifecycle3\",\n" +
                 "        \"phase_definition\" : {\n" +
                 "          \"min_age\" : \"20m\",\n" +
@@ -154,17 +235,13 @@ public class TransportPutLifecycleActionTests extends ESTestCase {
 
         Map<String, LifecycleAction> actions = new HashMap<>();
         actions.put("forcemerge", new ForceMergeAction(5, null));
-        actions.put("freeze", new FreezeAction());
         actions.put("allocate", new AllocateAction(1, null, null, null));
         PhaseExecutionInfo pei = new PhaseExecutionInfo("policy", new Phase("wonky", TimeValue.ZERO, actions), 1, 1);
         String phaseDef = Strings.toString(pei);
         logger.info("--> phaseDef: {}", phaseDef);
 
-        assertThat(TransportPutLifecycleAction.readStepKeys(REGISTRY, client, phaseDef, "phase"),
+        assertThat(readStepKeys(REGISTRY, client, phaseDef, "phase"),
             contains(
-                new Step.StepKey("phase", "freeze", FreezeAction.CONDITIONAL_SKIP_FREEZE_STEP),
-                new Step.StepKey("phase", "freeze", CheckNotDataStreamWriteIndexStep.NAME),
-                new Step.StepKey("phase", "freeze", FreezeAction.NAME),
                 new Step.StepKey("phase", "allocate", AllocateAction.NAME),
                 new Step.StepKey("phase", "allocate", AllocationRoutedStep.NAME),
                 new Step.StepKey("phase", "forcemerge", ForceMergeAction.CONDITIONAL_SKIP_FORCE_MERGE_STEP),
@@ -212,7 +289,7 @@ public class TransportPutLifecycleActionTests extends ESTestCase {
             Map<String, Phase> phases = Collections.singletonMap("hot", hotPhase);
             LifecyclePolicy newPolicy = new LifecyclePolicy("my-policy", phases);
 
-            assertTrue(TransportPutLifecycleAction.isIndexPhaseDefinitionUpdatable(REGISTRY, client, meta, newPolicy));
+            assertTrue(isIndexPhaseDefinitionUpdatable(REGISTRY, client, meta, newPolicy));
         }
 
         // Failure case, can't update because the step we're currently on has been removed in the new policy
@@ -249,7 +326,7 @@ public class TransportPutLifecycleActionTests extends ESTestCase {
             Map<String, Phase> phases = Collections.singletonMap("hot", hotPhase);
             LifecyclePolicy newPolicy = new LifecyclePolicy("my-policy", phases);
 
-            assertFalse(TransportPutLifecycleAction.isIndexPhaseDefinitionUpdatable(REGISTRY, client, meta, newPolicy));
+            assertFalse(isIndexPhaseDefinitionUpdatable(REGISTRY, client, meta, newPolicy));
         }
 
         // Failure case, can't update because the future step has been deleted
@@ -286,7 +363,7 @@ public class TransportPutLifecycleActionTests extends ESTestCase {
             Map<String, Phase> phases = Collections.singletonMap("hot", hotPhase);
             LifecyclePolicy newPolicy = new LifecyclePolicy("my-policy", phases);
 
-            assertFalse(TransportPutLifecycleAction.isIndexPhaseDefinitionUpdatable(REGISTRY, client, meta, newPolicy));
+            assertFalse(isIndexPhaseDefinitionUpdatable(REGISTRY, client, meta, newPolicy));
         }
 
         // Failure case, index doesn't have enough info to check
@@ -321,7 +398,7 @@ public class TransportPutLifecycleActionTests extends ESTestCase {
             Map<String, Phase> phases = Collections.singletonMap("hot", hotPhase);
             LifecyclePolicy newPolicy = new LifecyclePolicy("my-policy", phases);
 
-            assertFalse(TransportPutLifecycleAction.isIndexPhaseDefinitionUpdatable(REGISTRY, client, meta, newPolicy));
+            assertFalse(isIndexPhaseDefinitionUpdatable(REGISTRY, client, meta, newPolicy));
         }
 
         // Failure case, the phase JSON is unparseable
@@ -344,66 +421,8 @@ public class TransportPutLifecycleActionTests extends ESTestCase {
             Map<String, Phase> phases = Collections.singletonMap("hot", hotPhase);
             LifecyclePolicy newPolicy = new LifecyclePolicy("my-policy", phases);
 
-            assertFalse(TransportPutLifecycleAction.isIndexPhaseDefinitionUpdatable(REGISTRY, client, meta, newPolicy));
+            assertFalse(isIndexPhaseDefinitionUpdatable(REGISTRY, client, meta, newPolicy));
         }
-    }
-
-    public void testRefreshPhaseJson() {
-        LifecycleExecutionState exState = LifecycleExecutionState.builder()
-            .setPhase("hot")
-            .setAction("rollover")
-            .setStep("check-rollover-ready")
-            .setPhaseDefinition("{\n" +
-                "        \"policy\" : \"my-policy\",\n" +
-                "        \"phase_definition\" : {\n" +
-                "          \"min_age\" : \"20m\",\n" +
-                "          \"actions\" : {\n" +
-                "            \"rollover\" : {\n" +
-                "              \"max_age\" : \"5s\"\n" +
-                "            },\n" +
-                "            \"set_priority\" : {\n" +
-                "              \"priority\" : 150\n" +
-                "            }\n" +
-                "          }\n" +
-                "        },\n" +
-                "        \"version\" : 1,\n" +
-                "        \"modified_date_in_millis\" : 1578521007076\n" +
-                "      }")
-            .build();
-
-        IndexMetadata meta = mkMeta()
-            .putCustom(ILM_CUSTOM_METADATA_KEY, exState.asMap())
-            .build();
-
-        Map<String, LifecycleAction> actions = new HashMap<>();
-        actions.put("rollover", new RolloverAction(null, null, null, 1L));
-        actions.put("set_priority", new SetPriorityAction(100));
-        Phase hotPhase = new Phase("hot", TimeValue.ZERO, actions);
-        Map<String, Phase> phases = Collections.singletonMap("hot", hotPhase);
-        LifecyclePolicy newPolicy = new LifecyclePolicy("my-policy", phases);
-        LifecyclePolicyMetadata policyMetadata = new LifecyclePolicyMetadata(newPolicy, Collections.emptyMap(), 2L, 2L);
-
-        ClusterState existingState = ClusterState.builder(ClusterState.EMPTY_STATE)
-            .metadata(Metadata.builder(Metadata.EMPTY_METADATA)
-                .put(meta, false)
-                .build())
-            .build();
-
-        ClusterState changedState = TransportPutLifecycleAction.refreshPhaseDefinition(existingState, index, policyMetadata);
-
-        IndexMetadata newIdxMeta = changedState.metadata().index(index);
-        LifecycleExecutionState afterExState = LifecycleExecutionState.fromIndexMetadata(newIdxMeta);
-        Map<String, String> beforeState = new HashMap<>(exState.asMap());
-        beforeState.remove("phase_definition");
-        Map<String, String> afterState = new HashMap<>(afterExState.asMap());
-        afterState.remove("phase_definition");
-        // Check that no other execution state changes have been made
-        assertThat(beforeState, equalTo(afterState));
-
-        // Check that the phase definition has been refreshed
-        assertThat(afterExState.getPhaseDefinition(),
-            equalTo("{\"policy\":\"my-policy\",\"phase_definition\":{\"min_age\":\"0ms\",\"actions\":{\"rollover\":{\"max_docs\":1}," +
-                "\"set_priority\":{\"priority\":100}}},\"version\":2,\"modified_date_in_millis\":2}"));
     }
 
     public void testUpdateIndicesForPolicy() {
@@ -419,7 +438,7 @@ public class TransportPutLifecycleActionTests extends ESTestCase {
             .putCustom(ILM_CUSTOM_METADATA_KEY, exState.asMap())
             .build();
 
-        assertTrue(TransportPutLifecycleAction.eligibleToCheckForRefresh(meta));
+        assertTrue(eligibleToCheckForRefresh(meta));
 
         Map<String, LifecycleAction> oldActions = new HashMap<>();
         oldActions.put("rollover", new RolloverAction(null, null, null, 1L));
@@ -436,7 +455,7 @@ public class TransportPutLifecycleActionTests extends ESTestCase {
         LifecyclePolicy newPolicy = new LifecyclePolicy("my-policy", phases);
         LifecyclePolicyMetadata policyMetadata = new LifecyclePolicyMetadata(newPolicy, Collections.emptyMap(), 2L, 2L);
 
-        assertTrue(TransportPutLifecycleAction.isIndexPhaseDefinitionUpdatable(REGISTRY, client, meta, newPolicy));
+        assertTrue(isIndexPhaseDefinitionUpdatable(REGISTRY, client, meta, newPolicy));
 
         ClusterState existingState = ClusterState.builder(ClusterState.EMPTY_STATE)
             .metadata(Metadata.builder(Metadata.EMPTY_METADATA)
@@ -445,8 +464,7 @@ public class TransportPutLifecycleActionTests extends ESTestCase {
             .build();
 
         logger.info("--> update for unchanged policy");
-        ClusterState updatedState = TransportPutLifecycleAction.updateIndicesForPolicy(existingState, REGISTRY,
-            client, oldPolicy, policyMetadata);
+        ClusterState updatedState = updateIndicesForPolicy(existingState, REGISTRY, client, oldPolicy, policyMetadata);
 
         // No change, because the policies were identical
         assertThat(updatedState, equalTo(existingState));
@@ -460,7 +478,7 @@ public class TransportPutLifecycleActionTests extends ESTestCase {
         policyMetadata = new LifecyclePolicyMetadata(newPolicy, Collections.emptyMap(), 2L, 2L);
 
         logger.info("--> update with changed policy, but not configured in settings");
-        updatedState = TransportPutLifecycleAction.updateIndicesForPolicy(existingState, REGISTRY, client, oldPolicy, policyMetadata);
+        updatedState = updateIndicesForPolicy(existingState, REGISTRY, client, oldPolicy, policyMetadata);
 
         // No change, because the index doesn't have a lifecycle.name setting for this policy
         assertThat(updatedState, equalTo(existingState));
@@ -481,7 +499,7 @@ public class TransportPutLifecycleActionTests extends ESTestCase {
             .build();
 
         logger.info("--> update with changed policy and this index has the policy");
-        updatedState = TransportPutLifecycleAction.updateIndicesForPolicy(existingState, REGISTRY, client, oldPolicy, policyMetadata);
+        updatedState = updateIndicesForPolicy(existingState, REGISTRY, client, oldPolicy, policyMetadata);
 
         IndexMetadata newIdxMeta = updatedState.metadata().index(index);
         LifecycleExecutionState afterExState = LifecycleExecutionState.fromIndexMetadata(newIdxMeta);
@@ -498,6 +516,15 @@ public class TransportPutLifecycleActionTests extends ESTestCase {
                 "\"set_priority\":{\"priority\":150}}},\"version\":2,\"modified_date_in_millis\":2}"));
     }
 
+    private IndexMetadata buildIndexMetadata(String policy, LifecycleExecutionState.Builder lifecycleState) {
+        return IndexMetadata.builder("index")
+            .settings(settings(Version.CURRENT).put(LifecycleSettings.LIFECYCLE_NAME, policy))
+            .numberOfShards(randomIntBetween(1, 5))
+            .numberOfReplicas(randomIntBetween(0, 5))
+            .putCustom(ILM_CUSTOM_METADATA_KEY, lifecycleState.build().asMap())
+            .build();
+    }
+
     private static IndexMetadata.Builder mkMeta() {
         return IndexMetadata.builder(index)
             .settings(Settings.builder()
@@ -506,4 +533,5 @@ public class TransportPutLifecycleActionTests extends ESTestCase {
                 .put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT)
                 .put(IndexMetadata.SETTING_INDEX_UUID, randomAlphaOfLength(5)));
     }
+
 }

--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/cluster/metadata/MetadataMigrateToDataTiersRoutingService.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/cluster/metadata/MetadataMigrateToDataTiersRoutingService.java
@@ -1,0 +1,492 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.cluster.metadata;
+
+import com.carrotsearch.hppc.cursors.ObjectObjectCursor;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.elasticsearch.client.Client;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.metadata.IndexMetadata;
+import org.elasticsearch.cluster.metadata.Metadata;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.xcontent.NamedXContentRegistry;
+import org.elasticsearch.core.Nullable;
+import org.elasticsearch.core.Tuple;
+import org.elasticsearch.xpack.core.DataTier;
+import org.elasticsearch.xpack.core.ilm.AllocateAction;
+import org.elasticsearch.xpack.core.ilm.IndexLifecycleMetadata;
+import org.elasticsearch.xpack.core.ilm.LifecycleAction;
+import org.elasticsearch.xpack.core.ilm.LifecycleExecutionState;
+import org.elasticsearch.xpack.core.ilm.LifecyclePolicy;
+import org.elasticsearch.xpack.core.ilm.LifecyclePolicyMetadata;
+import org.elasticsearch.xpack.core.ilm.LifecycleSettings;
+import org.elasticsearch.xpack.core.ilm.MigrateAction;
+import org.elasticsearch.xpack.core.ilm.Phase;
+import org.elasticsearch.xpack.core.ilm.PhaseExecutionInfo;
+import org.elasticsearch.xpack.core.ilm.Step;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.SortedMap;
+import java.util.Spliterators;
+import java.util.TreeMap;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+
+import static org.elasticsearch.cluster.metadata.IndexMetadata.INDEX_ROUTING_EXCLUDE_GROUP_SETTING;
+import static org.elasticsearch.cluster.metadata.IndexMetadata.INDEX_ROUTING_INCLUDE_GROUP_SETTING;
+import static org.elasticsearch.cluster.metadata.IndexMetadata.INDEX_ROUTING_REQUIRE_GROUP_SETTING;
+import static org.elasticsearch.xpack.cluster.routing.allocation.DataTierAllocationDecider.INDEX_ROUTING_PREFER;
+import static org.elasticsearch.xpack.core.ilm.LifecycleExecutionState.ILM_CUSTOM_METADATA_KEY;
+import static org.elasticsearch.xpack.core.ilm.OperationMode.STOPPED;
+import static org.elasticsearch.xpack.core.ilm.PhaseCacheManagement.updateIndicesForPolicy;
+import static org.elasticsearch.xpack.ilm.IndexLifecycleTransition.moveStateToNextActionAndUpdateCachedPhase;
+
+/**
+ * Exposes the necessary methods to migrate a system's elasticsearch abstractions to use data tiers for index allocation routing.
+ */
+public final class MetadataMigrateToDataTiersRoutingService {
+
+    public static final String DEFAULT_NODE_ATTRIBUTE_NAME = "data";
+    private static final Logger logger = LogManager.getLogger(MetadataMigrateToDataTiersRoutingService.class);
+
+    private MetadataMigrateToDataTiersRoutingService() {
+    }
+
+    /**
+     * Migrates the elasticsearch abstractions to use data tiers for allocation routing.
+     * This will:
+     * - remove the given V1 index template if it exists.
+     *
+     * - loop through the existing ILM policies and look at the configured {@link AllocateAction}s. If they define *any* routing rules
+     * based on the provided node attribute name (we look at include, exclude, and require rules) *ALL* the rules in the allocate action
+     * will be removed. All the rules are removed in order to allow for ILM to inject the {@link MigrateAction}.
+     * So for eg. this action:
+     *      allocate {
+     *          number_of_replicas: 0,
+     *          require: {data: warm},
+     *          include: {rack: one}
+     *      }
+     *  will become
+     *      allocate {
+     *          number_of_replicas: 0
+     *      }
+     *  Note that if the `allocate` action doesn't define any `number_of_replicas` it will be removed completely from the migrated policy.
+     *  As part of migrating the ILM policies we also update the cached phase definition for the managed indices to reflect the migrated
+     *  policy phase.
+     *
+     *  - loop through all the indices convert the index.routing.allocation.require.{nodeAttrName} or
+     *  index.routing.allocation.include.{nodeAttrName} setting (if present) to the corresponding data tier `_tier_preference` routing.
+     *  We are only able to convert the `frozen`, `cold`, `warm`, or `hot` setting values to the `_tier_preference`. If other
+     *  configuration values are present eg ("the_warm_nodes") the index will not be migrated.
+     *  If the require or include setting is successfully migrated to _tier_preference, the **other** routing settings for the
+     *  provided attribute are also removed (if present).
+     *  Eg. if we manage to migrate the `index.routing.allocation.require.data` setting, but the index also has configured
+     *  `index.routing.allocation.include.data` and `index.routing.allocation.exclude.data`, the
+     *  migrated settings will contain `index.routing.allocation.include._tier_preference` configured to the corresponding
+     *  `index.routing.allocation.require.data` value, with `index.routing.allocation.include.data` and
+     *  `index.routing.allocation.exclude.data` being removed.
+     *  Settings:
+     *    {
+     *      index.routing.allocation.require.data: "warm",
+     *      index.routing.allocation.include.data: "rack1",
+     *      index.routing.allocation.exclude.data: "rack2,rack3"
+     *    }
+     *  will be migrated to:
+     *    {
+     *        index.routing.allocation.include._tier_preference: "data_warm,data_hot"
+     *    }
+     *
+     * If no @param nodeAttrName is provided "data" will be used.
+     * If no @param indexTemplateToDelete is provided, no index templates will be deleted.
+     *
+     * This returns a new {@link ClusterState} representing the migrated state that is ready to use data tiers for index and
+     * ILM routing allocations. It also returns a summary of the affected abstractions encapsulated in {@link MigratedEntities}
+     */
+    public static Tuple<ClusterState, MigratedEntities> migrateToDataTiersRouting(ClusterState currentState,
+                                                                                  @Nullable String nodeAttrName,
+                                                                                  @Nullable String indexTemplateToDelete,
+                                                                                  NamedXContentRegistry xContentRegistry, Client client) {
+        IndexLifecycleMetadata currentMetadata = currentState.metadata().custom(IndexLifecycleMetadata.TYPE);
+        if (currentMetadata != null && currentMetadata.getOperationMode() != STOPPED) {
+            throw new IllegalStateException("stop ILM before migrating to data tiers, current state is [" +
+                currentMetadata.getOperationMode() + "]");
+        }
+
+        Metadata.Builder mb = Metadata.builder(currentState.metadata());
+        String removedIndexTemplateName = null;
+        if (Strings.hasText(indexTemplateToDelete)) {
+            if (currentState.metadata().getTemplates().containsKey(indexTemplateToDelete)) {
+                mb.removeTemplate(indexTemplateToDelete);
+                logger.debug("removing legacy template [{}]", indexTemplateToDelete);
+                removedIndexTemplateName = indexTemplateToDelete;
+            } else {
+                logger.debug("legacy template [{}] does not exist", indexTemplateToDelete);
+            }
+        }
+
+        String attribute = nodeAttrName;
+        if (Strings.isNullOrEmpty(nodeAttrName)) {
+            attribute = DEFAULT_NODE_ATTRIBUTE_NAME;
+        }
+        List<String> migratedPolicies = migrateIlmPolicies(mb, currentState, attribute, xContentRegistry, client);
+        // Creating an intermediary cluster state view as when migrating policy we also update the cachesd phase definition stored in the
+        // index metadata so the metadata.builder will probably contain an already updated view over the indices metadata which we don't
+        // want to lose when migrating the indices settings
+        ClusterState intermediateState = ClusterState.builder(currentState).metadata(mb).build();
+        mb = Metadata.builder(intermediateState.metadata());
+        List<String> migratedIndices = migrateIndices(mb, intermediateState, attribute);
+        return Tuple.tuple(ClusterState.builder(currentState).metadata(mb).build(),
+            new MigratedEntities(removedIndexTemplateName, migratedIndices, migratedPolicies));
+    }
+
+    /**
+     * Iterate through the existing ILM policies and look at the configured {@link AllocateAction}s. If they define *any* routing rules
+     * based on the provided node attribute name (we look at include, exclude, and require rules) *ALL* the rules in the allocate
+     * action will be removed. All the rules are removed in order to allow for ILM to inject the {@link MigrateAction}.
+     * This also iterates through all the indices that are executing a given *migrated* policy and refreshes the cached phase definition
+     * for each of these managed indices.
+     */
+    static List<String> migrateIlmPolicies(Metadata.Builder mb, ClusterState currentState, String nodeAttrName,
+                                           NamedXContentRegistry xContentRegistry, Client client) {
+        IndexLifecycleMetadata currentLifecycleMetadata = currentState.metadata().custom(IndexLifecycleMetadata.TYPE);
+        if (currentLifecycleMetadata == null) {
+            return Collections.emptyList();
+        }
+
+        List<String> migratedPolicies = new ArrayList<>();
+        Map<String, LifecyclePolicyMetadata> currentPolicies = currentLifecycleMetadata.getPolicyMetadatas();
+        SortedMap<String, LifecyclePolicyMetadata> newPolicies = new TreeMap<>(currentPolicies);
+        for (Map.Entry<String, LifecyclePolicyMetadata> policyMetadataEntry : currentPolicies.entrySet()) {
+            LifecyclePolicy newLifecyclePolicy = migrateSingleILMPolicy(nodeAttrName, policyMetadataEntry.getValue().getPolicy());
+            if (newLifecyclePolicy != null) {
+                // we updated at least one phase
+                long nextVersion = policyMetadataEntry.getValue().getVersion() + 1L;
+                LifecyclePolicyMetadata newPolicyMetadata = new LifecyclePolicyMetadata(newLifecyclePolicy,
+                    policyMetadataEntry.getValue().getHeaders(), nextVersion, Instant.now().toEpochMilli());
+                LifecyclePolicyMetadata oldPolicyMetadata = newPolicies.put(policyMetadataEntry.getKey(), newPolicyMetadata);
+                assert oldPolicyMetadata != null :
+                    "we must only update policies, not create new ones, but " + policyMetadataEntry.getKey() + " didn't exist";
+
+                refreshCachedPhases(mb, currentState, oldPolicyMetadata, newPolicyMetadata, xContentRegistry, client);
+                migratedPolicies.add(policyMetadataEntry.getKey());
+            }
+        }
+
+        if (migratedPolicies.size() > 0) {
+            IndexLifecycleMetadata newMetadata = new IndexLifecycleMetadata(newPolicies, currentLifecycleMetadata.getOperationMode());
+            mb.putCustom(IndexLifecycleMetadata.TYPE, newMetadata);
+        }
+        return migratedPolicies;
+    }
+
+    /**
+     * Refreshed the cached ILM phase definition for the indices managed by the migrated policy.
+     */
+    static void refreshCachedPhases(Metadata.Builder mb, ClusterState currentState, LifecyclePolicyMetadata oldPolicyMetadata,
+                                    LifecyclePolicyMetadata newPolicyMetadata, NamedXContentRegistry xContentRegistry,
+                                    Client client) {
+        // this performs a walk through the managed indices and safely updates the cached phase (ie. for the phases we did not
+        // remove the allocate action)
+        updateIndicesForPolicy(mb, currentState, xContentRegistry, client, oldPolicyMetadata.getPolicy(), newPolicyMetadata);
+
+        LifecyclePolicy newLifecyclePolicy = newPolicyMetadata.getPolicy();
+        List<String> migratedPhasesWithoutAllocateAction =
+            getMigratedPhasesWithoutAllocateAction(oldPolicyMetadata.getPolicy(), newLifecyclePolicy);
+
+        if (migratedPhasesWithoutAllocateAction.size() > 0) {
+            logger.debug("the updated policy [{}] does not contain the allocate action in phases [{}] anymore",
+                newLifecyclePolicy.getName(), migratedPhasesWithoutAllocateAction);
+            // if we removed the allocate action in any phase we won't be able to perform a safe update of the ilm cached phase (as
+            // defined by {@link PhaseCacheManagement#isIndexPhaseDefinitionUpdatable} because the number of steps in the new phase is
+            // not the same as in the cached phase) so let's forcefully (and still safely :) ) refresh the cached phase for the managed
+            // indices in these phases.
+            refreshCachedPhaseForPhasesWithoutAllocateAction(mb, currentState, oldPolicyMetadata.getPolicy(), newPolicyMetadata,
+                migratedPhasesWithoutAllocateAction, client);
+        }
+    }
+
+    /**
+     * Refresh the cached phase definition for those indices currently in one of the phases we migrated by removing the allocate action.
+     * This refresh can be executed in two ways, depending where exactly within such a migrated phase is currently the managed index.
+     * 1) if the index is in the allocate action, we'll move the ILM execution state for this index into the first step of the next
+     * action of the phase (note that even if the allocate action was the only action defined in a phase we have a complete action we
+     * inject at the end of every phase)
+     * 2) if the index is anywhere else in the phase, we simply update the cached phase definition to reflect the migrated phase
+     */
+    private static void refreshCachedPhaseForPhasesWithoutAllocateAction(Metadata.Builder mb, ClusterState currentState,
+                                                                         LifecyclePolicy oldPolicy,
+                                                                         LifecyclePolicyMetadata newPolicyMetadata,
+                                                                         List<String> phasesWithoutAllocateAction, Client client) {
+        String policyName = oldPolicy.getName();
+        final List<IndexMetadata> managedIndices =
+            StreamSupport.stream(Spliterators.spliteratorUnknownSize(currentState.metadata().indices().valuesIt(), 0), false)
+                .filter(meta -> policyName.equals(LifecycleSettings.LIFECYCLE_NAME_SETTING.get(meta.getSettings())))
+                .collect(Collectors.toList());
+
+        for (IndexMetadata indexMetadata : managedIndices) {
+            LifecycleExecutionState currentExState = LifecycleExecutionState.fromIndexMetadata(indexMetadata);
+
+            if (currentExState != null) {
+                Step.StepKey currentStepKey = LifecycleExecutionState.getCurrentStepKey(currentExState);
+                if (currentStepKey != null && phasesWithoutAllocateAction.contains(currentStepKey.getPhase())) {
+                    // the index is in a phase that doesn't contain the allocate action anymore
+                    if (currentStepKey.getAction().equals(AllocateAction.NAME)) {
+                        // this index is in the middle of executing the allocate action - which doesn't exist in the updated policy
+                        // anymore so let's try to move the index to the next action
+
+                        LifecycleExecutionState newLifecycleState = moveStateToNextActionAndUpdateCachedPhase(indexMetadata,
+                            currentExState, System::currentTimeMillis, oldPolicy, newPolicyMetadata, client);
+                        if (currentExState.equals(newLifecycleState) == false) {
+                            mb.put(IndexMetadata.builder(indexMetadata).putCustom(ILM_CUSTOM_METADATA_KEY, newLifecycleState.asMap()));
+                        }
+                    } else {
+                        // if the index is not in the allocate action, we're going to perform a cached phase update (which is "unsafe" by
+                        // the rules defined in {@link PhaseCacheManagement#isIndexPhaseDefinitionUpdatable} but in our case it is safe
+                        // as the migration would've only removed the allocate action and the current index is not in the middle of
+                        // executing the allocate action, we made sure of that)
+
+                        LifecycleExecutionState.Builder updatedState = LifecycleExecutionState.builder(currentExState);
+                        PhaseExecutionInfo phaseExecutionInfo = new PhaseExecutionInfo(newPolicyMetadata.getPolicy().getName(),
+                            newPolicyMetadata.getPolicy().getPhases().get(currentStepKey.getPhase()), newPolicyMetadata.getVersion(),
+                            newPolicyMetadata.getModifiedDate());
+                        String newPhaseDefinition = Strings.toString(phaseExecutionInfo, false, false);
+                        updatedState.setPhaseDefinition(newPhaseDefinition);
+
+                        logger.debug("updating the cached phase definition for index [{}], current step [{}] in policy " +
+                            "[{}] to [{}]", indexMetadata.getIndex().getName(), currentStepKey, policyName, newPhaseDefinition);
+                        mb.put(IndexMetadata.builder(indexMetadata)
+                            .putCustom(ILM_CUSTOM_METADATA_KEY, updatedState.build().asMap()));
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * Returns a list of phases that had an allocate action defined in the old policy, but don't have it anymore in the new policy
+     * (ie. they were allocate actions that only specified attribute based routing, without any number of replicas configuration and we
+     * removed them as part of the migration of ILM policies to data tiers in order to allow ILM to inject the migrate action)
+     */
+    private static List<String> getMigratedPhasesWithoutAllocateAction(LifecyclePolicy oldPolicy, LifecyclePolicy newLifecyclePolicy) {
+        List<String> oldPhasesWithAllocateAction = new ArrayList<>(oldPolicy.getPhases().size());
+        for (Map.Entry<String, Phase> phaseEntry : oldPolicy.getPhases().entrySet()) {
+            if (phaseEntry.getValue().getActions().containsKey(AllocateAction.NAME)) {
+                oldPhasesWithAllocateAction.add(phaseEntry.getKey());
+            }
+        }
+
+        List<String> migratedPhasesWithoutAllocateAction = new ArrayList<>(oldPhasesWithAllocateAction.size());
+        for (String phaseWithAllocateAction : oldPhasesWithAllocateAction) {
+            Phase phase = newLifecyclePolicy.getPhases().get(phaseWithAllocateAction);
+            assert phase != null : "the migration service should not remove an entire phase altogether";
+            if (phase.getActions().containsKey(AllocateAction.NAME) == false) {
+                // the updated policy doesn't have the allocate action defined in this phase anymore
+                migratedPhasesWithoutAllocateAction.add(phaseWithAllocateAction);
+            }
+        }
+        return migratedPhasesWithoutAllocateAction;
+    }
+
+    /**
+     * Migrates a single ILM policy from defining {@link AllocateAction}s in order to configure shard allocation routing based on the
+     * provided node attribute name towards allowing ILM to inject the {@link MigrateAction}.
+     *
+     * Returns the migrated ILM policy.
+     */
+    @Nullable
+    private static LifecyclePolicy migrateSingleILMPolicy(String nodeAttrName, LifecyclePolicy lifecyclePolicy) {
+        LifecyclePolicy newLifecyclePolicy = null;
+        for (Map.Entry<String, Phase> phaseEntry : lifecyclePolicy.getPhases().entrySet()) {
+            Phase phase = phaseEntry.getValue();
+            AllocateAction allocateAction = (AllocateAction) phase.getActions().get(AllocateAction.NAME);
+            if (allocateActionDefinesRoutingRules(nodeAttrName, allocateAction)) {
+                Map<String, LifecycleAction> actionMap = new HashMap<>(phase.getActions());
+                // this phase contains an allocate action that defines a require rule for the attribute name so we'll remove all the
+                // rules to allow for the migrate action to be injected
+                if (allocateAction.getNumberOfReplicas() != null) {
+                    // keep the number of replicas configuration
+                    AllocateAction updatedAllocateAction =
+                        new AllocateAction(allocateAction.getNumberOfReplicas(), null, null, null);
+                    actionMap.put(allocateAction.getWriteableName(), updatedAllocateAction);
+                    logger.debug("ILM policy [{}], phase [{}]: updated the allocate action to [{}]", lifecyclePolicy.getName(),
+                        phase.getName(), allocateAction);
+                } else {
+                    // remove the action altogether
+                    actionMap.remove(allocateAction.getWriteableName());
+                    logger.debug("ILM policy [{}], phase [{}]: removed the allocate action", lifecyclePolicy.getName(),
+                        phase.getName());
+                }
+
+                Phase updatedPhase = new Phase(phase.getName(), phase.getMinimumAge(), actionMap);
+                Map<String, Phase> updatedPhases =
+                    new HashMap<>(newLifecyclePolicy == null ? lifecyclePolicy.getPhases() : newLifecyclePolicy.getPhases());
+                updatedPhases.put(phaseEntry.getKey(), updatedPhase);
+                newLifecyclePolicy = new LifecyclePolicy(lifecyclePolicy.getName(), updatedPhases);
+            }
+        }
+        return newLifecyclePolicy;
+    }
+
+    /**
+     * Returns true of the provided {@link AllocateAction} defines any index allocation rules.
+     */
+    static boolean allocateActionDefinesRoutingRules(String nodeAttrName, @Nullable AllocateAction allocateAction) {
+        return allocateAction != null && (allocateAction.getRequire().get(nodeAttrName) != null ||
+            allocateAction.getInclude().get(nodeAttrName) != null ||
+            allocateAction.getExclude().get(nodeAttrName) != null);
+    }
+
+    /**
+     * Iterates through the existing indices and migrates them away from using attribute based routing using the provided node
+     * attribute name towards the tier preference routing.
+     * Returns a list of the migrated indices.
+     */
+    static List<String> migrateIndices(Metadata.Builder mb, ClusterState currentState, String nodeAttrName) {
+        List<String> migratedIndices = new ArrayList<>();
+        String nodeAttrIndexRequireRoutingSetting = INDEX_ROUTING_REQUIRE_GROUP_SETTING.getKey() + nodeAttrName;
+        String nodeAttrIndexIncludeRoutingSetting = INDEX_ROUTING_INCLUDE_GROUP_SETTING.getKey() + nodeAttrName;
+        String nodeAttrIndexExcludeRoutingSetting = INDEX_ROUTING_EXCLUDE_GROUP_SETTING.getKey() + nodeAttrName;
+        for (ObjectObjectCursor<String, IndexMetadata> index : currentState.metadata().indices()) {
+            IndexMetadata indexMetadata = index.value;
+            Settings currentSettings = indexMetadata.getSettings();
+            Settings newSettings = maybeMigrateRoutingSettingToTierPreference(nodeAttrIndexRequireRoutingSetting, indexMetadata);
+            if (newSettings.equals(currentSettings)) {
+                // migrating based on the `require` setting was not successful so let's check if the index used the `include` routing
+                // setting to configure the allocations and try to migrate it
+                newSettings = maybeMigrateRoutingSettingToTierPreference(nodeAttrIndexIncludeRoutingSetting, indexMetadata);
+            }
+
+            if (newSettings.equals(currentSettings) == false) {
+                // we converted either the require or the include routing setting to tier preference
+                // so let's clear all the routing settings for the given attribute
+                Settings.Builder finalSettings = Settings.builder().put(newSettings);
+                finalSettings.remove(nodeAttrIndexExcludeRoutingSetting);
+                finalSettings.remove(nodeAttrIndexRequireRoutingSetting);
+                finalSettings.remove(nodeAttrIndexIncludeRoutingSetting);
+
+                mb.put(IndexMetadata.builder(indexMetadata)
+                    .settings(finalSettings)
+                    .settingsVersion(indexMetadata.getSettingsVersion() + 1));
+                migratedIndices.add(indexMetadata.getIndex().getName());
+            }
+        }
+        return migratedIndices;
+    }
+
+    /**
+     * Attempts to migrate the value of the given attribute routing setting to the _tier_preference equivalent. The provided setting
+     * needs to be configured and have one of the supported values (hot, warm, cold, or frozen) in order for the migration to be preformed.
+     * If the migration is successful the provided setting will be removed.
+     *
+     * If the migration is **not** executed the current index settings is returned, otherwise the updated settings are returned
+     */
+    private static Settings maybeMigrateRoutingSettingToTierPreference(String attributeBasedRoutingSettingName,
+                                                                       IndexMetadata indexMetadata) {
+        Settings currentIndexSettings = indexMetadata.getSettings();
+        if (currentIndexSettings.keySet().contains(attributeBasedRoutingSettingName) == false) {
+            return currentIndexSettings;
+        }
+        // look at the value, get the correct tiers config and update the settings and index metadata
+        Settings.Builder newSettingsBuilder = Settings.builder().put(currentIndexSettings);
+        String indexName = indexMetadata.getIndex().getName();
+        if (currentIndexSettings.keySet().contains(INDEX_ROUTING_PREFER)) {
+            newSettingsBuilder.remove(attributeBasedRoutingSettingName);
+            logger.debug("index [{}]: removed setting [{}]", indexName, attributeBasedRoutingSettingName);
+        } else {
+            // parse the custom attribute routing into the corresponding tier preference and configure it
+            String attributeValue = currentIndexSettings.get(attributeBasedRoutingSettingName);
+            String convertedTierPreference = convertAttributeValueToTierPreference(attributeValue);
+            if (convertedTierPreference != null) {
+                newSettingsBuilder.put(INDEX_ROUTING_PREFER, convertedTierPreference);
+                newSettingsBuilder.remove(attributeBasedRoutingSettingName);
+                logger.debug("index [{}]: removed setting [{}]", indexName, attributeBasedRoutingSettingName);
+                logger.debug("index [{}]: configured setting [{}] to [{}]", indexName,
+                    INDEX_ROUTING_PREFER, convertedTierPreference);
+            } else {
+                // log warning and do *not* remove setting, return the settings unchanged
+                logger.warn("index [{}]: could not convert attribute based setting [{}] value of [{}] to a tier preference " +
+                        "configuration. the only known values are: {}", indexName,
+                    attributeBasedRoutingSettingName, attributeValue, "hot,warm,cold, and frozen");
+                return currentIndexSettings;
+            }
+        }
+        return newSettingsBuilder.build();
+    }
+
+    /**
+     * Converts the provided node attribute value to the corresponding `_tier_preference` configuration.
+     * Known (and convertible) attribute values are:
+     * * hot
+     * * warm
+     * * cold
+     * * frozen
+     * and the corresponding tier preference setting values are, respectively:
+     * * data_hot
+     * * data_warm,data_hot
+     * * data_cold,data_warm,data_hot
+     * * data_frozen,data_cold,data_warm,data_hot
+     * <p>
+     * This returns `null` if an unknown attribute value is received.
+     */
+    @Nullable
+    static String convertAttributeValueToTierPreference(String nodeAttributeValue) {
+        String targetTier = "data_" + nodeAttributeValue;
+        // handle the `content` accidental node attribute value which would match a data tier but doesn't fall into the hot/warm/cold
+        // (given we're _migrating_ to data tiers we won't catch this accidental tier which didn't exist as a concept before the
+        // formalisation of data tiers)
+        if (DataTier.validTierName(targetTier) == false || targetTier.equals(DataTier.DATA_CONTENT)) {
+            return null;
+        }
+        return DataTier.getPreferredTiersConfiguration(targetTier);
+    }
+
+    /**
+     * Represents the elasticsearch abstractions that were, in some way, migrated such that the system is managing indices lifecycles and
+     * allocations using data tiers.
+     */
+    public static final class MigratedEntities {
+        @Nullable
+        public final String removedIndexTemplateName;
+        public final List<String> migratedIndices;
+        public final List<String> migratedPolicies;
+
+        public MigratedEntities(@Nullable String removedIndexTemplateName, List<String> migratedIndices, List<String> migratedPolicies) {
+            this.removedIndexTemplateName = removedIndexTemplateName;
+            this.migratedIndices = Collections.unmodifiableList(migratedIndices);
+            this.migratedPolicies = Collections.unmodifiableList(migratedPolicies);
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            MigratedEntities that = (MigratedEntities) o;
+            return Objects.equals(removedIndexTemplateName, that.removedIndexTemplateName) &&
+                Objects.equals(migratedIndices, that.migratedIndices) &&
+                Objects.equals(migratedPolicies, that.migratedPolicies);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(removedIndexTemplateName, migratedIndices, migratedPolicies);
+        }
+    }
+}

--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/IndexLifecycleTransition.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/IndexLifecycleTransition.java
@@ -11,6 +11,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.support.TransportAction;
+import org.elasticsearch.client.Client;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.Metadata;
@@ -27,6 +28,7 @@ import org.elasticsearch.xpack.core.ilm.IndexLifecycleMetadata;
 import org.elasticsearch.xpack.core.ilm.InitializePolicyContextStep;
 import org.elasticsearch.xpack.core.ilm.InitializePolicyException;
 import org.elasticsearch.xpack.core.ilm.LifecycleExecutionState;
+import org.elasticsearch.xpack.core.ilm.LifecyclePolicy;
 import org.elasticsearch.xpack.core.ilm.LifecyclePolicyMetadata;
 import org.elasticsearch.xpack.core.ilm.LifecycleSettings;
 import org.elasticsearch.xpack.core.ilm.Phase;
@@ -39,6 +41,7 @@ import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.function.BiFunction;
 import java.util.function.LongSupplier;
 
@@ -258,6 +261,71 @@ public final class IndexLifecycleTransition {
         if (currentStep == null || currentStep.getAction().equals(newStep.getAction()) == false) {
             updatedState.setActionTime(nowAsMillis);
         }
+        return updatedState.build();
+    }
+
+    /**
+     * Transition the managed index to the first step of the next action in the current phase and update the cached phase definition for
+     * the index to reflect the new phase definition.
+     *
+     * The intended purpose of this method is to help with the situations where a policy is updated and we need to update the cached
+     * phase for the indices that are currently executing an action that was potentially removed in the new policy.
+     *
+     * Returns the same {@link LifecycleExecutionState} if the transition is not possible or the new execution state otherwise.
+     */
+    public static LifecycleExecutionState moveStateToNextActionAndUpdateCachedPhase(IndexMetadata indexMetadata,
+                                                                                    LifecycleExecutionState existingState,
+                                                                                    LongSupplier nowSupplier, LifecyclePolicy oldPolicy,
+                                                                                    LifecyclePolicyMetadata newPolicyMetadata,
+                                                                                    Client client) {
+        String policyName = LifecycleSettings.LIFECYCLE_NAME_SETTING.get(indexMetadata.getSettings());
+        Step.StepKey currentStepKey = LifecycleExecutionState.getCurrentStepKey(existingState);
+        if (currentStepKey == null) {
+            logger.warn("unable to identify what the current step is for index [{}] as part of policy [{}]. the " +
+                "cached phase definition will not be updated for this index", indexMetadata.getIndex().getName(), policyName);
+            return existingState;
+        }
+
+        List<Step> policySteps = oldPolicy.toSteps(client);
+        Optional<Step> currentStep = policySteps.stream()
+            .filter(step -> step.getKey().equals(currentStepKey))
+            .findFirst();
+
+        if (currentStep.isPresent() == false) {
+            logger.warn("unable to find current step [{}] for index [{}] as part of policy [{}]. the cached phase definition will not be " +
+                "updated for this index", currentStepKey, indexMetadata.getIndex().getName(), policyName);
+            return existingState;
+        }
+
+        int indexOfCurrentStep = policySteps.indexOf(currentStep.get());
+        assert indexOfCurrentStep != -1 : "the current step must be part of the old policy";
+
+        Optional<Step> nextStepInActionAfterCurrent = policySteps.stream()
+            .skip(indexOfCurrentStep)
+            .filter(step -> step.getKey().getAction().equals(currentStepKey.getAction()) == false)
+            .findFirst();
+
+        assert nextStepInActionAfterCurrent.isPresent() : "there should always be a complete step at the end of every phase";
+        Step.StepKey nextStep = nextStepInActionAfterCurrent.get().getKey();
+        logger.debug("moving index [{}] in policy [{}] out of step [{}] to new step [{}]",
+            indexMetadata.getIndex().getName(), policyName, currentStepKey, nextStep);
+
+        long nowAsMillis = nowSupplier.getAsLong();
+        LifecycleExecutionState.Builder updatedState = LifecycleExecutionState.builder(existingState);
+        updatedState.setPhase(nextStep.getPhase());
+        updatedState.setAction(nextStep.getAction());
+        updatedState.setActionTime(nowAsMillis);
+        updatedState.setStep(nextStep.getName());
+        updatedState.setStepTime(nowAsMillis);
+        updatedState.setFailedStep(null);
+        updatedState.setStepInfo(null);
+        updatedState.setIsAutoRetryableError(null);
+        updatedState.setFailedStepRetryCount(null);
+
+        PhaseExecutionInfo phaseExecutionInfo = new PhaseExecutionInfo(newPolicyMetadata.getPolicy().getName(),
+            newPolicyMetadata.getPolicy().getPhases().get(currentStepKey.getPhase()), newPolicyMetadata.getVersion(),
+            newPolicyMetadata.getModifiedDate());
+        updatedState.setPhaseDefinition(Strings.toString(phaseExecutionInfo, false, false));
         return updatedState.build();
     }
 

--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/action/TransportPutLifecycleAction.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/action/TransportPutLifecycleAction.java
@@ -19,45 +19,31 @@ import org.elasticsearch.cluster.AckedClusterStateUpdateTask;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.block.ClusterBlockException;
 import org.elasticsearch.cluster.block.ClusterBlockLevel;
-import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.service.ClusterService;
-import org.elasticsearch.core.Nullable;
-import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.inject.Inject;
-import org.elasticsearch.common.xcontent.DeprecationHandler;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
-import org.elasticsearch.common.xcontent.XContentParser;
-import org.elasticsearch.common.xcontent.json.JsonXContent;
 import org.elasticsearch.license.XPackLicenseState;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.xpack.core.ClientHelper;
-import org.elasticsearch.xpack.core.ilm.ErrorStep;
 import org.elasticsearch.xpack.core.ilm.IndexLifecycleMetadata;
-import org.elasticsearch.xpack.core.ilm.LifecycleExecutionState;
 import org.elasticsearch.xpack.core.ilm.LifecyclePolicy;
 import org.elasticsearch.xpack.core.ilm.LifecyclePolicyMetadata;
-import org.elasticsearch.xpack.core.ilm.LifecycleSettings;
 import org.elasticsearch.xpack.core.ilm.Phase;
-import org.elasticsearch.xpack.core.ilm.PhaseExecutionInfo;
 import org.elasticsearch.xpack.core.ilm.SearchableSnapshotAction;
-import org.elasticsearch.xpack.core.ilm.Step;
 import org.elasticsearch.xpack.core.ilm.action.PutLifecycleAction;
 import org.elasticsearch.xpack.core.ilm.action.PutLifecycleAction.Request;
-import org.elasticsearch.xpack.ilm.IndexLifecycleTransition;
 
 import java.time.Instant;
-import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.SortedMap;
-import java.util.Spliterators;
 import java.util.TreeMap;
 import java.util.stream.Collectors;
-import java.util.stream.StreamSupport;
+
+import static org.elasticsearch.xpack.core.ilm.PhaseCacheManagement.updateIndicesForPolicy;
 
 /**
  * This class is responsible for bootstrapping {@link IndexLifecycleMetadata} into the cluster-state, as well
@@ -138,175 +124,6 @@ public class TransportPutLifecycleAction extends TransportMasterNodeAction<Reque
                         }
                     }
                 });
-    }
-
-    /**
-     * Ensure that we have the minimum amount of metadata necessary to check for cache phase
-     * refresh. This includes:
-     * - An execution state
-     * - Existing phase definition JSON
-     * - A current step key
-     * - A current phase in the step key
-     * - Not currently in the ERROR step
-     */
-    static boolean eligibleToCheckForRefresh(final IndexMetadata metadata) {
-        LifecycleExecutionState executionState = LifecycleExecutionState.fromIndexMetadata(metadata);
-        if (executionState == null || executionState.getPhaseDefinition() == null) {
-            return false;
-        }
-
-        Step.StepKey currentStepKey = LifecycleExecutionState.getCurrentStepKey(executionState);
-        if (currentStepKey == null || currentStepKey.getPhase() == null) {
-            return false;
-        }
-
-        return ErrorStep.NAME.equals(currentStepKey.getName()) == false;
-    }
-
-    /**
-     * Parse the {@code phaseDef} phase definition to get the stepkeys for the given phase.
-     * If there is an error parsing or if the phase definition is missing the required
-     * information, returns null.
-     */
-    @Nullable
-    static Set<Step.StepKey> readStepKeys(final NamedXContentRegistry xContentRegistry, final Client client,
-                                          final String phaseDef, final String currentPhase) {
-        final PhaseExecutionInfo phaseExecutionInfo;
-        try (XContentParser parser = JsonXContent.jsonXContent.createParser(xContentRegistry,
-            DeprecationHandler.THROW_UNSUPPORTED_OPERATION, phaseDef)) {
-            phaseExecutionInfo = PhaseExecutionInfo.parse(parser, currentPhase);
-        } catch (Exception e) {
-            logger.trace(new ParameterizedMessage("exception reading step keys checking for refreshability, phase definition: {}",
-                phaseDef), e);
-            return null;
-        }
-
-        if (phaseExecutionInfo == null || phaseExecutionInfo.getPhase() == null) {
-            return null;
-        }
-
-        return phaseExecutionInfo.getPhase().getActions().values().stream()
-            .flatMap(a -> a.toSteps(client, phaseExecutionInfo.getPhase().getName(), null).stream())
-            .map(Step::getKey)
-            .collect(Collectors.toCollection(LinkedHashSet::new));
-    }
-
-    /**
-     * Returns 'true' if the index's cached phase JSON can be safely reread, 'false' otherwise.
-     */
-    static boolean isIndexPhaseDefinitionUpdatable(final NamedXContentRegistry xContentRegistry, final Client client,
-                                                   final IndexMetadata metadata, final LifecyclePolicy newPolicy) {
-        final String index = metadata.getIndex().getName();
-        if (eligibleToCheckForRefresh(metadata) == false) {
-            logger.debug("[{}] does not contain enough information to check for eligibility of refreshing phase", index);
-            return false;
-        }
-        final String policyId = newPolicy.getName();
-
-        final LifecycleExecutionState executionState = LifecycleExecutionState.fromIndexMetadata(metadata);
-        final Step.StepKey currentStepKey = LifecycleExecutionState.getCurrentStepKey(executionState);
-        final String currentPhase = currentStepKey.getPhase();
-
-        final Set<Step.StepKey> newStepKeys = newPolicy.toSteps(client).stream()
-            .map(Step::getKey)
-            .collect(Collectors.toCollection(LinkedHashSet::new));
-
-        if (newStepKeys.contains(currentStepKey) == false) {
-            // The index is on a step that doesn't exist in the new policy, we
-            // can't safely re-read the JSON
-            logger.debug("[{}] updated policy [{}] does not contain the current step key [{}], so the policy phase will not be refreshed",
-                index, policyId, currentStepKey);
-            return false;
-        }
-
-        final String phaseDef = executionState.getPhaseDefinition();
-        final Set<Step.StepKey> oldStepKeys = readStepKeys(xContentRegistry, client, phaseDef, currentPhase);
-        if (oldStepKeys == null) {
-            logger.debug("[{}] unable to parse phase definition for cached policy [{}], policy phase will not be refreshed",
-                index, policyId);
-            return false;
-        }
-
-        final Set<Step.StepKey> oldPhaseStepKeys = oldStepKeys.stream()
-            .filter(sk -> currentPhase.equals(sk.getPhase()))
-            .collect(Collectors.toCollection(LinkedHashSet::new));
-
-        final PhaseExecutionInfo phaseExecutionInfo = new PhaseExecutionInfo(policyId, newPolicy.getPhases().get(currentPhase), 1L, 1L);
-        final String peiJson = Strings.toString(phaseExecutionInfo);
-
-        final Set<Step.StepKey> newPhaseStepKeys = readStepKeys(xContentRegistry, client, peiJson, currentPhase);
-        if (newPhaseStepKeys == null) {
-            logger.debug(new ParameterizedMessage("[{}] unable to parse phase definition for policy [{}] " +
-                "to determine if it could be refreshed", index, policyId));
-            return false;
-        }
-
-        if (newPhaseStepKeys.equals(oldPhaseStepKeys)) {
-            // The new and old phase have the same stepkeys for this current phase, so we can
-            // refresh the definition because we know it won't change the execution flow.
-            logger.debug("[{}] updated policy [{}] contains the same phase step keys and can be refreshed", index, policyId);
-            return true;
-        } else {
-            logger.debug("[{}] updated policy [{}] has different phase step keys and will NOT refresh phase " +
-                    "definition as it differs too greatly. old: {}, new: {}",
-                index, policyId, oldPhaseStepKeys, newPhaseStepKeys);
-            return false;
-        }
-    }
-
-    /**
-     * Rereads the phase JSON for the given index, returning a new cluster state.
-     */
-    static ClusterState refreshPhaseDefinition(final ClusterState state, final String index, final LifecyclePolicyMetadata updatedPolicy) {
-        final IndexMetadata idxMeta = state.metadata().index(index);
-        assert eligibleToCheckForRefresh(idxMeta) : "index " + index + " is missing crucial information needed to refresh phase definition";
-
-        logger.trace("[{}] updating cached phase definition for policy [{}]", index, updatedPolicy.getName());
-        LifecycleExecutionState currentExState = LifecycleExecutionState.fromIndexMetadata(idxMeta);
-
-        String currentPhase = currentExState.getPhase();
-        PhaseExecutionInfo pei = new PhaseExecutionInfo(updatedPolicy.getName(),
-            updatedPolicy.getPolicy().getPhases().get(currentPhase), updatedPolicy.getVersion(), updatedPolicy.getModifiedDate());
-
-        LifecycleExecutionState newExState = LifecycleExecutionState.builder(currentExState)
-            .setPhaseDefinition(Strings.toString(pei, false, false))
-            .build();
-
-        return IndexLifecycleTransition.newClusterStateWithLifecycleState(idxMeta.getIndex(), state, newExState).build();
-    }
-
-    /**
-     * For the given new policy, returns a new cluster with all updateable indices' phase JSON refreshed.
-     */
-    static ClusterState updateIndicesForPolicy(final ClusterState state, final NamedXContentRegistry xContentRegistry, final Client client,
-                                               final LifecyclePolicy oldPolicy, final LifecyclePolicyMetadata newPolicy) {
-        assert oldPolicy.getName().equals(newPolicy.getName()) : "expected both policies to have the same id but they were: [" +
-            oldPolicy.getName() + "] vs. [" + newPolicy.getName() + "]";
-
-        // No need to update anything if the policies are identical in contents
-        if (oldPolicy.equals(newPolicy.getPolicy())) {
-            logger.debug("policy [{}] is unchanged and no phase definition refresh is needed", oldPolicy.getName());
-            return state;
-        }
-
-        final List<String> indicesThatCanBeUpdated =
-            StreamSupport.stream(Spliterators.spliteratorUnknownSize(state.metadata().indices().valuesIt(), 0), false)
-                .filter(meta -> newPolicy.getName().equals(LifecycleSettings.LIFECYCLE_NAME_SETTING.get(meta.getSettings())))
-                .filter(meta -> isIndexPhaseDefinitionUpdatable(xContentRegistry, client, meta, newPolicy.getPolicy()))
-                .map(meta -> meta.getIndex().getName())
-                .collect(Collectors.toList());
-
-        ClusterState updatedState = state;
-        for (String index : indicesThatCanBeUpdated) {
-            try {
-                updatedState = refreshPhaseDefinition(updatedState, index, newPolicy);
-            } catch (Exception e) {
-                logger.warn(new ParameterizedMessage("[{}] unable to refresh phase definition for updated policy [{}]",
-                    index, newPolicy.getName()), e);
-            }
-        }
-
-        return updatedState;
     }
 
     @Override

--- a/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/cluster/metadata/MetadataMigrateToDataTiersRoutingServiceTests.java
+++ b/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/cluster/metadata/MetadataMigrateToDataTiersRoutingServiceTests.java
@@ -1,0 +1,728 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.cluster.metadata;
+
+import org.elasticsearch.Version;
+import org.elasticsearch.client.Client;
+import org.elasticsearch.cluster.ClusterName;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.metadata.ComposableIndexTemplate;
+import org.elasticsearch.cluster.metadata.IndexMetadata;
+import org.elasticsearch.cluster.metadata.IndexTemplateMetadata;
+import org.elasticsearch.cluster.metadata.Metadata;
+import org.elasticsearch.cluster.metadata.Template;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.xcontent.NamedXContentRegistry;
+import org.elasticsearch.common.xcontent.ParseField;
+import org.elasticsearch.common.xcontent.XContentHelper;
+import org.elasticsearch.common.xcontent.XContentType;
+import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.core.Tuple;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.cluster.metadata.MetadataMigrateToDataTiersRoutingService.MigratedEntities;
+import org.elasticsearch.xpack.core.ilm.AllocateAction;
+import org.elasticsearch.xpack.core.ilm.IndexLifecycleMetadata;
+import org.elasticsearch.xpack.core.ilm.LifecycleAction;
+import org.elasticsearch.xpack.core.ilm.LifecycleExecutionState;
+import org.elasticsearch.xpack.core.ilm.LifecyclePolicy;
+import org.elasticsearch.xpack.core.ilm.LifecyclePolicyMetadata;
+import org.elasticsearch.xpack.core.ilm.LifecycleSettings;
+import org.elasticsearch.xpack.core.ilm.OperationMode;
+import org.elasticsearch.xpack.core.ilm.Phase;
+import org.elasticsearch.xpack.core.ilm.SetPriorityAction;
+import org.elasticsearch.xpack.core.ilm.ShrinkAction;
+import org.junit.Before;
+
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import static org.elasticsearch.cluster.metadata.IndexMetadata.INDEX_ROUTING_EXCLUDE_GROUP_SETTING;
+import static org.elasticsearch.cluster.metadata.IndexMetadata.INDEX_ROUTING_INCLUDE_GROUP_SETTING;
+import static org.elasticsearch.cluster.metadata.IndexMetadata.INDEX_ROUTING_REQUIRE_GROUP_SETTING;
+import static org.elasticsearch.xpack.cluster.metadata.MetadataMigrateToDataTiersRoutingService.allocateActionDefinesRoutingRules;
+import static org.elasticsearch.xpack.cluster.metadata.MetadataMigrateToDataTiersRoutingService.convertAttributeValueToTierPreference;
+import static org.elasticsearch.xpack.cluster.metadata.MetadataMigrateToDataTiersRoutingService.migrateIlmPolicies;
+import static org.elasticsearch.xpack.cluster.metadata.MetadataMigrateToDataTiersRoutingService.migrateIndices;
+import static org.elasticsearch.xpack.cluster.metadata.MetadataMigrateToDataTiersRoutingService.migrateToDataTiersRouting;
+import static org.elasticsearch.xpack.cluster.routing.allocation.DataTierAllocationDecider.INDEX_ROUTING_PREFER;
+import static org.elasticsearch.xpack.core.ilm.LifecycleExecutionState.ILM_CUSTOM_METADATA_KEY;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+import static org.mockito.Mockito.mock;
+
+public class MetadataMigrateToDataTiersRoutingServiceTests extends ESTestCase {
+
+    private static final String DATA_ROUTING_REQUIRE_SETTING = INDEX_ROUTING_REQUIRE_GROUP_SETTING.getKey() + "data";
+    private static final String DATA_ROUTING_EXCLUDE_SETTING = INDEX_ROUTING_EXCLUDE_GROUP_SETTING.getKey() + "data";
+    private static final String DATA_ROUTING_INCLUDE_SETTING = INDEX_ROUTING_INCLUDE_GROUP_SETTING.getKey() + "data";
+    private static final String BOX_ROUTING_REQUIRE_SETTING = INDEX_ROUTING_REQUIRE_GROUP_SETTING.getKey() + "box";
+    private static final NamedXContentRegistry REGISTRY;
+
+    static {
+        REGISTRY = new NamedXContentRegistry(org.elasticsearch.core.List.of(
+            new NamedXContentRegistry.Entry(LifecycleAction.class, new ParseField(ShrinkAction.NAME), ShrinkAction::parse),
+            new NamedXContentRegistry.Entry(LifecycleAction.class, new ParseField(AllocateAction.NAME), AllocateAction::parse)
+        ));
+    }
+
+    private String lifecycleName;
+    private String indexName;
+    private Client client;
+
+    @Before
+    public void setupTestEntities() {
+        lifecycleName = randomAlphaOfLengthBetween(10, 15);
+        indexName = randomAlphaOfLengthBetween(10, 15);
+        client = mock(Client.class);
+        logger.info("--> running [{}] with indexName [{}] and ILM policy [{}]", getTestName(), indexName, lifecycleName);
+    }
+
+    public void testMigrateIlmPolicyForIndexWithoutILMMetadata() {
+        ShrinkAction shrinkAction = new ShrinkAction(2, null);
+        AllocateAction warmAllocateAction = new AllocateAction(null, org.elasticsearch.core.Map.of("data", "warm"), null,
+            org.elasticsearch.core.Map.of("rack", "rack1"));
+        AllocateAction coldAllocateAction = new AllocateAction(0, null, null, org.elasticsearch.core.Map.of("data", "cold"));
+        SetPriorityAction warmSetPriority = new SetPriorityAction(100);
+        LifecyclePolicyMetadata policyMetadata = getWarmColdPolicyMeta(warmSetPriority, shrinkAction, warmAllocateAction,
+            coldAllocateAction);
+
+        ClusterState state = ClusterState.builder(ClusterName.DEFAULT).metadata(Metadata.builder()
+            .putCustom(IndexLifecycleMetadata.TYPE, new IndexLifecycleMetadata(
+                Collections.singletonMap(policyMetadata.getName(), policyMetadata), OperationMode.STOPPED))
+            .put(IndexMetadata.builder(indexName).settings(getBaseIndexSettings())).build())
+            .build();
+
+        Metadata.Builder newMetadata = Metadata.builder(state.metadata());
+        List<String> migratedPolicies = migrateIlmPolicies(newMetadata, state, "data", REGISTRY, client);
+        assertThat(migratedPolicies.size(), is(1));
+        assertThat(migratedPolicies.get(0), is(lifecycleName));
+
+        ClusterState newState = ClusterState.builder(state).metadata(newMetadata).build();
+        IndexLifecycleMetadata updatedLifecycleMetadata = newState.metadata().custom(IndexLifecycleMetadata.TYPE);
+        LifecyclePolicy lifecyclePolicy = updatedLifecycleMetadata.getPolicies().get(lifecycleName);
+        Map<String, LifecycleAction> warmActions = lifecyclePolicy.getPhases().get("warm").getActions();
+        assertThat("allocate action in the warm phase didn't specify any number of replicas so it must be removed",
+            warmActions.size(), is(2));
+        assertThat(warmActions.get(shrinkAction.getWriteableName()), is(shrinkAction));
+        assertThat(warmActions.get(warmSetPriority.getWriteableName()), is(warmSetPriority));
+
+        Map<String, LifecycleAction> coldActions = lifecyclePolicy.getPhases().get("cold").getActions();
+        assertThat(coldActions.size(), is(1));
+        AllocateAction migratedColdAllocateAction = (AllocateAction) coldActions.get(coldAllocateAction.getWriteableName());
+        assertThat(migratedColdAllocateAction.getNumberOfReplicas(), is(0));
+        assertThat(migratedColdAllocateAction.getRequire().size(), is(0));
+    }
+
+    @SuppressWarnings("unchecked")
+    public void testMigrateIlmPolicyRefreshesCachedPhase() {
+        ShrinkAction shrinkAction = new ShrinkAction(2, null);
+        AllocateAction warmAllocateAction = new AllocateAction(null, org.elasticsearch.core.Map.of("data", "warm"), null,
+            org.elasticsearch.core.Map.of("rack", "rack1"));
+        AllocateAction coldAllocateAction = new AllocateAction(0, null, null, org.elasticsearch.core.Map.of("data", "cold"));
+        SetPriorityAction warmSetPriority = new SetPriorityAction(100);
+        LifecyclePolicyMetadata policyMetadata = getWarmColdPolicyMeta(warmSetPriority, shrinkAction, warmAllocateAction,
+            coldAllocateAction);
+
+        {
+            // index is in the cold phase and the migrated allocate action is not removed
+            LifecycleExecutionState preMigrationExecutionState = LifecycleExecutionState.builder()
+                .setPhase("cold")
+                .setAction("allocate")
+                .setStep("allocate")
+                .setPhaseDefinition(getColdPhaseDefinition())
+                .build();
+
+            IndexMetadata.Builder indexMetadata = IndexMetadata.builder(indexName).settings(getBaseIndexSettings())
+                .putCustom(ILM_CUSTOM_METADATA_KEY, preMigrationExecutionState.asMap());
+
+            ClusterState state = ClusterState.builder(ClusterName.DEFAULT).metadata(Metadata.builder()
+                .putCustom(IndexLifecycleMetadata.TYPE, new IndexLifecycleMetadata(
+                    Collections.singletonMap(policyMetadata.getName(), policyMetadata), OperationMode.STOPPED))
+                .put(indexMetadata).build())
+                .build();
+
+            Metadata.Builder newMetadata = Metadata.builder(state.metadata());
+            List<String> migratedPolicies = migrateIlmPolicies(newMetadata, state, "data", REGISTRY, client);
+
+            assertThat(migratedPolicies.get(0), is(lifecycleName));
+            ClusterState newState = ClusterState.builder(state).metadata(newMetadata).build();
+            LifecycleExecutionState newLifecycleState = LifecycleExecutionState.fromIndexMetadata(newState.metadata().index(indexName));
+
+            Map<String, Object> migratedPhaseDefAsMap = getPhaseDefinitionAsMap(newLifecycleState);
+
+            // expecting the phase definition to be refreshed with the migrated phase representation
+            // ie. allocate action does not contain any allocation rules
+            Map<String, Object> actions = (Map<String, Object>) migratedPhaseDefAsMap.get("actions");
+            assertThat(actions.size(), is(1));
+            Map<String, Object> allocateDef = (Map<String, Object>) actions.get(AllocateAction.NAME);
+            assertThat(allocateDef, notNullValue());
+            assertThat(allocateDef.get("include"), is(Collections.emptyMap()));
+            assertThat(allocateDef.get("exclude"), is(Collections.emptyMap()));
+            assertThat(allocateDef.get("require"), is(Collections.emptyMap()));
+        }
+
+        {
+            // index is in the warm phase executing the allocate action, the migrated allocate action is removed
+            LifecycleExecutionState preMigrationExecutionState = LifecycleExecutionState.builder()
+                .setPhase("warm")
+                .setAction("allocate")
+                .setStep("allocate")
+                .setPhaseDefinition(getWarmPhaseDef())
+                .build();
+
+            IndexMetadata.Builder indexMetadata = IndexMetadata.builder(indexName).settings(getBaseIndexSettings())
+                .putCustom(ILM_CUSTOM_METADATA_KEY, preMigrationExecutionState.asMap());
+
+            ClusterState state = ClusterState.builder(ClusterName.DEFAULT).metadata(Metadata.builder()
+                .putCustom(IndexLifecycleMetadata.TYPE, new IndexLifecycleMetadata(
+                    Collections.singletonMap(policyMetadata.getName(), policyMetadata), OperationMode.STOPPED))
+                .put(indexMetadata).build())
+                .build();
+
+            Metadata.Builder newMetadata = Metadata.builder(state.metadata());
+            List<String> migratedPolicies = migrateIlmPolicies(newMetadata, state, "data", REGISTRY, client);
+
+            assertThat(migratedPolicies.get(0), is(lifecycleName));
+            ClusterState newState = ClusterState.builder(state).metadata(newMetadata).build();
+            LifecycleExecutionState newLifecycleState = LifecycleExecutionState.fromIndexMetadata(newState.metadata().index(indexName));
+
+            Map<String, Object> migratedPhaseDefAsMap = getPhaseDefinitionAsMap(newLifecycleState);
+
+            // expecting the phase definition to be refreshed with the index being in the shrink action
+            Map<String, Object> actions = (Map<String, Object>) migratedPhaseDefAsMap.get("actions");
+            assertThat(actions.size(), is(2));
+            Map<String, Object> allocateDef = (Map<String, Object>) actions.get(AllocateAction.NAME);
+            assertThat(allocateDef, nullValue());
+            assertThat(newLifecycleState.getAction(), is(ShrinkAction.NAME));
+            assertThat(newLifecycleState.getStep(), is(ShrinkAction.CONDITIONAL_SKIP_SHRINK_STEP));
+
+            Map<String, Object> shrinkDef = (Map<String, Object>) actions.get(ShrinkAction.NAME);
+            assertThat(shrinkDef.get("number_of_shards"), is(2));
+            Map<String, Object> setPriorityDef = (Map<String, Object>) actions.get(SetPriorityAction.NAME);
+            assertThat(setPriorityDef.get("priority"), is(100));
+        }
+
+        {
+            // index is in the warm phase executing the set priority action (executes BEFORE allocate), the migrated allocate action is
+            // removed
+            LifecycleExecutionState preMigrationExecutionState = LifecycleExecutionState.builder()
+                .setPhase("warm")
+                .setAction(SetPriorityAction.NAME)
+                .setStep(SetPriorityAction.NAME)
+                .setPhaseDefinition(getWarmPhaseDef())
+                .build();
+
+            IndexMetadata.Builder indexMetadata = IndexMetadata.builder(indexName).settings(getBaseIndexSettings())
+                .putCustom(ILM_CUSTOM_METADATA_KEY, preMigrationExecutionState.asMap());
+
+            ClusterState state = ClusterState.builder(ClusterName.DEFAULT).metadata(Metadata.builder()
+                .putCustom(IndexLifecycleMetadata.TYPE, new IndexLifecycleMetadata(
+                    Collections.singletonMap(policyMetadata.getName(), policyMetadata), OperationMode.STOPPED))
+                .put(indexMetadata).build())
+                .build();
+
+            Metadata.Builder newMetadata = Metadata.builder(state.metadata());
+            List<String> migratedPolicies = migrateIlmPolicies(newMetadata, state, "data", REGISTRY, client);
+
+            assertThat(migratedPolicies.get(0), is(lifecycleName));
+            ClusterState newState = ClusterState.builder(state).metadata(newMetadata).build();
+            LifecycleExecutionState newLifecycleState = LifecycleExecutionState.fromIndexMetadata(newState.metadata().index(indexName));
+            Map<String, Object> migratedPhaseDefAsMap = getPhaseDefinitionAsMap(newLifecycleState);
+
+            // expecting the phase definition to be refreshed with the index being in the set_priority action
+            Map<String, Object> actions = (Map<String, Object>) migratedPhaseDefAsMap.get("actions");
+            assertThat(actions.size(), is(2));
+            Map<String, Object> allocateDef = (Map<String, Object>) actions.get(AllocateAction.NAME);
+            assertThat(allocateDef, nullValue());
+            Map<String, Object> shrinkDef = (Map<String, Object>) actions.get(ShrinkAction.NAME);
+            assertThat(shrinkDef.get("number_of_shards"), is(2));
+            Map<String, Object> setPriorityDef = (Map<String, Object>) actions.get(SetPriorityAction.NAME);
+            assertThat(setPriorityDef.get("priority"), is(100));
+            assertThat(newLifecycleState.getAction(), is(SetPriorityAction.NAME));
+            assertThat(newLifecycleState.getStep(), is(SetPriorityAction.NAME));
+        }
+
+        {
+            // index is in the warm phase executing the shrink action (executes AFTER allocate), the migrated allocate action is
+            // removed
+            LifecycleExecutionState preMigrationExecutionState = LifecycleExecutionState.builder()
+                .setPhase("warm")
+                .setAction(ShrinkAction.NAME)
+                .setStep(ShrinkAction.CONDITIONAL_SKIP_SHRINK_STEP)
+                .setPhaseDefinition(getWarmPhaseDef())
+                .build();
+
+            IndexMetadata.Builder indexMetadata = IndexMetadata.builder(indexName).settings(getBaseIndexSettings())
+                .putCustom(ILM_CUSTOM_METADATA_KEY, preMigrationExecutionState.asMap());
+
+            ClusterState state = ClusterState.builder(ClusterName.DEFAULT).metadata(Metadata.builder()
+                .putCustom(IndexLifecycleMetadata.TYPE, new IndexLifecycleMetadata(
+                    Collections.singletonMap(policyMetadata.getName(), policyMetadata), OperationMode.STOPPED))
+                .put(indexMetadata).build())
+                .build();
+
+            Metadata.Builder newMetadata = Metadata.builder(state.metadata());
+            List<String> migratedPolicies = migrateIlmPolicies(newMetadata, state, "data", REGISTRY, client);
+
+            assertThat(migratedPolicies.get(0), is(lifecycleName));
+            ClusterState newState = ClusterState.builder(state).metadata(newMetadata).build();
+            LifecycleExecutionState newLifecycleState = LifecycleExecutionState.fromIndexMetadata(newState.metadata().index(indexName));
+
+            Map<String, Object> migratedPhaseDefAsMap = getPhaseDefinitionAsMap(newLifecycleState);
+
+            // expecting the phase definition to be refreshed with the index being in the shrink action
+            Map<String, Object> actions = (Map<String, Object>) migratedPhaseDefAsMap.get("actions");
+            assertThat(actions.size(), is(2));
+            Map<String, Object> allocateDef = (Map<String, Object>) actions.get(AllocateAction.NAME);
+            assertThat(allocateDef, nullValue());
+            assertThat(newLifecycleState.getAction(), is(ShrinkAction.NAME));
+            assertThat(newLifecycleState.getStep(), is(ShrinkAction.CONDITIONAL_SKIP_SHRINK_STEP));
+
+            Map<String, Object> shrinkDef = (Map<String, Object>) actions.get(ShrinkAction.NAME);
+            assertThat(shrinkDef.get("number_of_shards"), is(2));
+            Map<String, Object> setPriorityDef = (Map<String, Object>) actions.get(SetPriorityAction.NAME);
+            assertThat(setPriorityDef.get("priority"), is(100));
+        }
+    }
+
+    private Settings.Builder getBaseIndexSettings() {
+        return Settings.builder()
+            .put(LifecycleSettings.LIFECYCLE_NAME, lifecycleName)
+            .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, randomIntBetween(1, 10))
+            .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, randomIntBetween(0, 5))
+            .put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT);
+    }
+
+    public void testAllocateActionDefinesRoutingRules() {
+        assertThat(allocateActionDefinesRoutingRules("data", new AllocateAction(null, org.elasticsearch.core.Map.of("data", "cold"), null,
+            null)), is(true));
+        assertThat(allocateActionDefinesRoutingRules("data", new AllocateAction(null, null, org.elasticsearch.core.Map.of("data", "cold"),
+            null)), is(true));
+        assertThat(allocateActionDefinesRoutingRules("data",
+            new AllocateAction(null, org.elasticsearch.core.Map.of("another_attribute", "rack1"), null,
+                org.elasticsearch.core.Map.of("data", "cold"))),
+            is(true));
+        assertThat(allocateActionDefinesRoutingRules("data", new AllocateAction(null, null, null,
+                org.elasticsearch.core.Map.of("another_attribute", "cold"))),
+            is(false));
+        assertThat(allocateActionDefinesRoutingRules("data", null), is(false));
+    }
+
+    public void testConvertAttributeValueToTierPreference() {
+        assertThat(convertAttributeValueToTierPreference("frozen"), is("data_frozen,data_cold,data_warm,data_hot"));
+        assertThat(convertAttributeValueToTierPreference("cold"), is("data_cold,data_warm,data_hot"));
+        assertThat(convertAttributeValueToTierPreference("warm"), is("data_warm,data_hot"));
+        assertThat(convertAttributeValueToTierPreference("hot"), is("data_hot"));
+        assertThat(convertAttributeValueToTierPreference("content"), nullValue());
+        assertThat(convertAttributeValueToTierPreference("rack1"), nullValue());
+    }
+
+    public void testMigrateIndices() {
+        {
+            // index with `warm` data attribute is migrated to the equivalent _tier_preference routing
+            IndexMetadata.Builder indexWitWarmDataAttribute =
+                IndexMetadata.builder("indexWitWarmDataAttribute").settings(getBaseIndexSettings().put(DATA_ROUTING_REQUIRE_SETTING,
+                    "warm"));
+            ClusterState state =
+                ClusterState.builder(ClusterName.DEFAULT).metadata(Metadata.builder().put(indexWitWarmDataAttribute)).build();
+
+            Metadata.Builder mb = Metadata.builder(state.metadata());
+
+            List<String> migratedIndices = migrateIndices(mb, state, "data");
+            assertThat(migratedIndices.size(), is(1));
+            assertThat(migratedIndices.get(0), is("indexWitWarmDataAttribute"));
+
+            ClusterState migratedState = ClusterState.builder(ClusterName.DEFAULT).metadata(mb).build();
+            IndexMetadata migratedIndex = migratedState.metadata().index("indexWitWarmDataAttribute");
+            assertThat(migratedIndex.getSettings().get(DATA_ROUTING_REQUIRE_SETTING), nullValue());
+            assertThat(migratedIndex.getSettings().get(INDEX_ROUTING_PREFER), is("data_warm,data_hot"));
+        }
+
+        {
+            // test the migration of the `include.data` configuration to the equivalent _tier_preference routing
+            IndexMetadata.Builder indexWitWarmDataAttribute =
+                IndexMetadata.builder("indexWitWarmDataAttribute").settings(getBaseIndexSettings().put(DATA_ROUTING_INCLUDE_SETTING,
+                    "warm"));
+            ClusterState state =
+                ClusterState.builder(ClusterName.DEFAULT).metadata(Metadata.builder().put(indexWitWarmDataAttribute)).build();
+
+            Metadata.Builder mb = Metadata.builder(state.metadata());
+
+            List<String> migratedIndices = migrateIndices(mb, state, "data");
+            assertThat(migratedIndices.size(), is(1));
+            assertThat(migratedIndices.get(0), is("indexWitWarmDataAttribute"));
+
+            ClusterState migratedState = ClusterState.builder(ClusterName.DEFAULT).metadata(mb).build();
+            IndexMetadata migratedIndex = migratedState.metadata().index("indexWitWarmDataAttribute");
+            assertThat(migratedIndex.getSettings().get(DATA_ROUTING_INCLUDE_SETTING), nullValue());
+            assertThat(migratedIndex.getSettings().get(INDEX_ROUTING_PREFER), is("data_warm,data_hot"));
+        }
+
+        {
+            // since the index has a _tier_preference configuration the migrated index should still contain it and have the `data`
+            // attributes routing removed
+            IndexMetadata.Builder indexWithTierPreferenceAndDataAttribute =
+                IndexMetadata.builder("indexWithTierPreferenceAndDataAttribute").settings(getBaseIndexSettings()
+                    .put(DATA_ROUTING_REQUIRE_SETTING, "cold")
+                    .put(DATA_ROUTING_INCLUDE_SETTING, "hot")
+                    .put(INDEX_ROUTING_PREFER, "data_warm,data_hot")
+                );
+            ClusterState state =
+                ClusterState.builder(ClusterName.DEFAULT).metadata(Metadata.builder().put(indexWithTierPreferenceAndDataAttribute)).build();
+
+            Metadata.Builder mb = Metadata.builder(state.metadata());
+
+            List<String> migratedIndices = migrateIndices(mb, state, "data");
+            assertThat(migratedIndices.size(), is(1));
+            assertThat(migratedIndices.get(0), is("indexWithTierPreferenceAndDataAttribute"));
+
+            ClusterState migratedState = ClusterState.builder(ClusterName.DEFAULT).metadata(mb).build();
+            IndexMetadata migratedIndex = migratedState.metadata().index("indexWithTierPreferenceAndDataAttribute");
+            assertThat(migratedIndex.getSettings().get(DATA_ROUTING_REQUIRE_SETTING), nullValue());
+            assertThat(migratedIndex.getSettings().get(DATA_ROUTING_INCLUDE_SETTING), nullValue());
+            assertThat(migratedIndex.getSettings().get(INDEX_ROUTING_PREFER), is("data_warm,data_hot"));
+        }
+
+        {
+            // like above, test a combination of node attribute and _tier_preference routings configured for the original index, but this
+            // time using the `include.data` setting
+            IndexMetadata.Builder indexWithTierPreferenceAndDataAttribute =
+                IndexMetadata.builder("indexWithTierPreferenceAndDataAttribute").settings(getBaseIndexSettings()
+                    .put(DATA_ROUTING_INCLUDE_SETTING, "cold")
+                    .put(INDEX_ROUTING_PREFER, "data_warm,data_hot")
+                );
+            ClusterState state =
+                ClusterState.builder(ClusterName.DEFAULT).metadata(Metadata.builder().put(indexWithTierPreferenceAndDataAttribute)).build();
+
+            Metadata.Builder mb = Metadata.builder(state.metadata());
+
+            List<String> migratedIndices = migrateIndices(mb, state, "data");
+            assertThat(migratedIndices.size(), is(1));
+            assertThat(migratedIndices.get(0), is("indexWithTierPreferenceAndDataAttribute"));
+
+            ClusterState migratedState = ClusterState.builder(ClusterName.DEFAULT).metadata(mb).build();
+            IndexMetadata migratedIndex = migratedState.metadata().index("indexWithTierPreferenceAndDataAttribute");
+            assertThat(migratedIndex.getSettings().get(DATA_ROUTING_INCLUDE_SETTING), nullValue());
+            assertThat(migratedIndex.getSettings().get(INDEX_ROUTING_PREFER), is("data_warm,data_hot"));
+        }
+
+        {
+            // index with an unknown `data` attribute routing value should **not** be migrated
+            IndexMetadata.Builder indexWithUnknownDataAttribute =
+                IndexMetadata.builder("indexWithUnknownDataAttribute").settings(getBaseIndexSettings().put(DATA_ROUTING_REQUIRE_SETTING,
+                    "something_else"));
+            ClusterState state =
+                ClusterState.builder(ClusterName.DEFAULT).metadata(Metadata.builder().put(indexWithUnknownDataAttribute)).build();
+
+            Metadata.Builder mb = Metadata.builder(state.metadata());
+            List<String> migratedIndices = migrateIndices(mb, state, "data");
+            assertThat(migratedIndices.size(), is(0));
+
+            ClusterState migratedState = ClusterState.builder(ClusterName.DEFAULT).metadata(mb).build();
+            IndexMetadata migratedIndex = migratedState.metadata().index("indexWithUnknownDataAttribute");
+            assertThat(migratedIndex.getSettings().get(DATA_ROUTING_REQUIRE_SETTING), is("something_else"));
+        }
+
+        {
+            // index with data and another attribute should only see the data attribute removed and the corresponding tier_preference
+            // configured
+            IndexMetadata.Builder indexDataAndBoxAttribute =
+                IndexMetadata.builder("indexWithDataAndBoxAttribute").settings(getBaseIndexSettings().put(DATA_ROUTING_REQUIRE_SETTING,
+                    "warm").put(BOX_ROUTING_REQUIRE_SETTING, "box1"));
+
+            ClusterState state =
+                ClusterState.builder(ClusterName.DEFAULT).metadata(Metadata.builder().put(indexDataAndBoxAttribute)).build();
+
+            Metadata.Builder mb = Metadata.builder(state.metadata());
+            List<String> migratedIndices = migrateIndices(mb, state, "data");
+            assertThat(migratedIndices.size(), is(1));
+            assertThat(migratedIndices.get(0), is("indexWithDataAndBoxAttribute"));
+
+            ClusterState migratedState = ClusterState.builder(ClusterName.DEFAULT).metadata(mb).build();
+            IndexMetadata migratedIndex = migratedState.metadata().index("indexWithDataAndBoxAttribute");
+            assertThat(migratedIndex.getSettings().get(DATA_ROUTING_REQUIRE_SETTING), nullValue());
+            assertThat(migratedIndex.getSettings().get(BOX_ROUTING_REQUIRE_SETTING), is("box1"));
+            assertThat(migratedIndex.getSettings().get(INDEX_ROUTING_PREFER), is("data_warm,data_hot"));
+        }
+
+        {
+            // index that doesn't have any data attribute routing but has another attribute should not see any change
+            IndexMetadata.Builder indexBoxAttribute =
+                IndexMetadata.builder("indexWithBoxAttribute").settings(getBaseIndexSettings().put(BOX_ROUTING_REQUIRE_SETTING, "warm"));
+
+            ClusterState state =
+                ClusterState.builder(ClusterName.DEFAULT).metadata(Metadata.builder().put(indexBoxAttribute)).build();
+
+            Metadata.Builder mb = Metadata.builder(state.metadata());
+            List<String> migratedIndices = migrateIndices(mb, state, "data");
+            assertThat(migratedIndices.size(), is(0));
+
+            ClusterState migratedState = ClusterState.builder(ClusterName.DEFAULT).metadata(mb).build();
+            IndexMetadata migratedIndex = migratedState.metadata().index("indexWithBoxAttribute");
+            assertThat(migratedIndex.getSettings().get(DATA_ROUTING_REQUIRE_SETTING), nullValue());
+            assertThat(migratedIndex.getSettings().get(BOX_ROUTING_REQUIRE_SETTING), is("warm"));
+            assertThat(migratedIndex.getSettings().get(INDEX_ROUTING_PREFER), nullValue());
+        }
+
+        {
+            IndexMetadata.Builder indexNoRoutingAttribute =
+                IndexMetadata.builder("indexNoRoutingAttribute").settings(getBaseIndexSettings());
+
+            ClusterState state =
+                ClusterState.builder(ClusterName.DEFAULT).metadata(Metadata.builder().put(indexNoRoutingAttribute)).build();
+
+            Metadata.Builder mb = Metadata.builder(state.metadata());
+            List<String> migratedIndices = migrateIndices(mb, state, "data");
+            assertThat(migratedIndices.size(), is(0));
+
+            ClusterState migratedState = ClusterState.builder(ClusterName.DEFAULT).metadata(mb).build();
+            IndexMetadata migratedIndex = migratedState.metadata().index("indexNoRoutingAttribute");
+            assertThat(migratedIndex.getSettings().get(DATA_ROUTING_REQUIRE_SETTING), nullValue());
+            assertThat(migratedIndex.getSettings().get(BOX_ROUTING_REQUIRE_SETTING), nullValue());
+            assertThat(migratedIndex.getSettings().get(INDEX_ROUTING_PREFER), nullValue());
+        }
+    }
+
+    public void testRequireAttributeIndexSettingTakesPriorityOverInclude() {
+        IndexMetadata.Builder indexWithAllRoutingSettings =
+            IndexMetadata.builder("indexWithAllRoutingSettings")
+                .settings(getBaseIndexSettings()
+                    .put(DATA_ROUTING_REQUIRE_SETTING, "warm")
+                    .put(DATA_ROUTING_INCLUDE_SETTING, "cold")
+                    .put(DATA_ROUTING_EXCLUDE_SETTING, "hot")
+                );
+        ClusterState state =
+            ClusterState.builder(ClusterName.DEFAULT).metadata(Metadata.builder().put(indexWithAllRoutingSettings)).build();
+
+        Metadata.Builder mb = Metadata.builder(state.metadata());
+
+        List<String> migratedIndices = migrateIndices(mb, state, "data");
+        assertThat(migratedIndices.size(), is(1));
+        assertThat(migratedIndices.get(0), is("indexWithAllRoutingSettings"));
+
+        ClusterState migratedState = ClusterState.builder(ClusterName.DEFAULT).metadata(mb).build();
+        IndexMetadata migratedIndex = migratedState.metadata().index("indexWithAllRoutingSettings");
+        assertThat(migratedIndex.getSettings().get(DATA_ROUTING_INCLUDE_SETTING), nullValue());
+        assertThat(migratedIndex.getSettings().get(DATA_ROUTING_REQUIRE_SETTING), nullValue());
+        assertThat(migratedIndex.getSettings().get(DATA_ROUTING_EXCLUDE_SETTING), nullValue());
+        assertThat(migratedIndex.getSettings().get(INDEX_ROUTING_PREFER), is("data_warm,data_hot"));
+    }
+
+    public void testMigrateToDataTiersRouting() {
+        AllocateAction allocateActionWithDataAttribute = new AllocateAction(null, org.elasticsearch.core.Map.of("data", "warm"), null,
+            org.elasticsearch.core.Map.of("rack", "rack1"));
+        AllocateAction allocateActionWithOtherAttribute = new AllocateAction(0, null, null, org.elasticsearch.core.Map.of("other", "cold"));
+
+        LifecyclePolicy policyToMigrate = new LifecyclePolicy(lifecycleName,
+            org.elasticsearch.core.Map.of("warm",
+                new Phase("warm", TimeValue.ZERO, org.elasticsearch.core.Map.of(allocateActionWithDataAttribute.getWriteableName(),
+                    allocateActionWithDataAttribute))));
+        LifecyclePolicyMetadata policyWithDataAttribute = new LifecyclePolicyMetadata(policyToMigrate, Collections.emptyMap(),
+            randomNonNegativeLong(), randomNonNegativeLong());
+
+        LifecyclePolicy shouldntBeMigratedPolicy = new LifecyclePolicy("dont-migrate",
+            org.elasticsearch.core.Map.of("warm",
+                new Phase("warm", TimeValue.ZERO, org.elasticsearch.core.Map.of(allocateActionWithOtherAttribute.getWriteableName(),
+                    allocateActionWithOtherAttribute))));
+        LifecyclePolicyMetadata policyWithOtherAttribute = new LifecyclePolicyMetadata(shouldntBeMigratedPolicy, Collections.emptyMap(),
+            randomNonNegativeLong(), randomNonNegativeLong());
+
+
+        IndexMetadata.Builder indexWithUnknownDataAttribute =
+            IndexMetadata.builder("indexWithUnknownDataAttribute").settings(getBaseIndexSettings().put(DATA_ROUTING_REQUIRE_SETTING,
+                "something_else"));
+        IndexMetadata.Builder indexWitWarmDataAttribute =
+            IndexMetadata.builder("indexWitWarmDataAttribute").settings(getBaseIndexSettings().put(DATA_ROUTING_REQUIRE_SETTING, "warm"));
+
+        ClusterState state = ClusterState.builder(ClusterName.DEFAULT).metadata(Metadata.builder()
+            .putCustom(IndexLifecycleMetadata.TYPE, new IndexLifecycleMetadata(
+                org.elasticsearch.core.Map.of(policyToMigrate.getName(), policyWithDataAttribute, shouldntBeMigratedPolicy.getName(),
+                    policyWithOtherAttribute),
+                OperationMode.STOPPED))
+            .put(IndexTemplateMetadata.builder("catch-all").patterns(org.elasticsearch.core.List.of("*"))
+                .settings(Settings.builder().put(DATA_ROUTING_REQUIRE_SETTING, "hot"))
+                .build())
+            .put(IndexTemplateMetadata.builder("other-template").patterns(org.elasticsearch.core.List.of("other-*"))
+                .settings(Settings.builder().put(DATA_ROUTING_REQUIRE_SETTING, "hot"))
+                .build())
+            .put(indexWithUnknownDataAttribute).put(indexWitWarmDataAttribute))
+            .build();
+
+        {
+            Tuple<ClusterState, MigratedEntities> migratedEntitiesTuple =
+                migrateToDataTiersRouting(state, "data", "catch-all", REGISTRY, client);
+
+            MigratedEntities migratedEntities = migratedEntitiesTuple.v2();
+            assertThat(migratedEntities.removedIndexTemplateName, is("catch-all"));
+            assertThat(migratedEntities.migratedPolicies.size(), is(1));
+            assertThat(migratedEntities.migratedPolicies.get(0), is(lifecycleName));
+            assertThat(migratedEntities.migratedIndices.size(), is(1));
+            assertThat(migratedEntities.migratedIndices.get(0), is("indexWitWarmDataAttribute"));
+
+            ClusterState newState = migratedEntitiesTuple.v1();
+            assertThat(newState.metadata().getTemplates().size(), is(1));
+            assertThat(newState.metadata().getTemplates().get("catch-all"), nullValue());
+            assertThat(newState.metadata().getTemplates().get("other-template"), notNullValue());
+        }
+
+        {
+            // let's test a null template name to make sure nothing is removed
+            Tuple<ClusterState, MigratedEntities> migratedEntitiesTuple =
+                migrateToDataTiersRouting(state, "data", null, REGISTRY, client);
+
+            MigratedEntities migratedEntities = migratedEntitiesTuple.v2();
+            assertThat(migratedEntities.removedIndexTemplateName, nullValue());
+            assertThat(migratedEntities.migratedPolicies.size(), is(1));
+            assertThat(migratedEntities.migratedPolicies.get(0), is(lifecycleName));
+            assertThat(migratedEntities.migratedIndices.size(), is(1));
+            assertThat(migratedEntities.migratedIndices.get(0), is("indexWitWarmDataAttribute"));
+
+            ClusterState newState = migratedEntitiesTuple.v1();
+            assertThat(newState.metadata().getTemplates().size(), is(2));
+            assertThat(newState.metadata().getTemplates().get("catch-all"), notNullValue());
+            assertThat(newState.metadata().getTemplates().get("other-template"), notNullValue());
+        }
+
+        {
+            // let's test a null node attribute parameter defaults to "data"
+            Tuple<ClusterState, MigratedEntities> migratedEntitiesTuple =
+                migrateToDataTiersRouting(state, null, null, REGISTRY, client);
+
+            MigratedEntities migratedEntities = migratedEntitiesTuple.v2();
+            assertThat(migratedEntities.migratedPolicies.size(), is(1));
+            assertThat(migratedEntities.migratedPolicies.get(0), is(lifecycleName));
+            assertThat(migratedEntities.migratedIndices.size(), is(1));
+            assertThat(migratedEntities.migratedIndices.get(0), is("indexWitWarmDataAttribute"));
+
+            IndexMetadata migratedIndex = migratedEntitiesTuple.v1().metadata().index("indexWitWarmDataAttribute");
+            assertThat(migratedIndex.getSettings().get(INDEX_ROUTING_PREFER), is("data_warm,data_hot"));
+        }
+    }
+
+    public void testMigrateToDataTiersRoutingRequiresILMStopped() {
+        {
+            ClusterState ilmRunningState = ClusterState.builder(ClusterName.DEFAULT).metadata(Metadata.builder()
+                .putCustom(IndexLifecycleMetadata.TYPE, new IndexLifecycleMetadata(
+                    org.elasticsearch.core.Map.of(), OperationMode.RUNNING)))
+                .build();
+            IllegalStateException illegalStateException = expectThrows(IllegalStateException.class,
+                () -> migrateToDataTiersRouting(ilmRunningState, "data", "catch-all", REGISTRY, client));
+            assertThat(illegalStateException.getMessage(), is("stop ILM before migrating to data tiers, current state is [RUNNING]"));
+        }
+
+        {
+            ClusterState ilmStoppingState = ClusterState.builder(ClusterName.DEFAULT).metadata(Metadata.builder()
+                .putCustom(IndexLifecycleMetadata.TYPE, new IndexLifecycleMetadata(
+                    org.elasticsearch.core.Map.of(), OperationMode.STOPPING)))
+                .build();
+            IllegalStateException illegalStateException = expectThrows(IllegalStateException.class,
+                () -> migrateToDataTiersRouting(ilmStoppingState, "data", "catch-all", REGISTRY, client));
+            assertThat(illegalStateException.getMessage(), is("stop ILM before migrating to data tiers, current state is [STOPPING]"));
+        }
+
+        {
+            ClusterState ilmStoppedState = ClusterState.builder(ClusterName.DEFAULT).metadata(Metadata.builder()
+                .putCustom(IndexLifecycleMetadata.TYPE, new IndexLifecycleMetadata(
+                    org.elasticsearch.core.Map.of(), OperationMode.STOPPED)))
+                .build();
+            Tuple<ClusterState, MigratedEntities> migratedState = migrateToDataTiersRouting(ilmStoppedState, "data", "catch-all",
+                REGISTRY, client);
+            assertThat(migratedState.v2().migratedIndices, empty());
+            assertThat(migratedState.v2().migratedPolicies, empty());
+            assertThat(migratedState.v2().removedIndexTemplateName, nullValue());
+        }
+    }
+
+    public void testMigrationDoesNotRemoveComposableTemplates() {
+        ComposableIndexTemplate composableIndexTemplate = new ComposableIndexTemplate.Builder()
+            .indexPatterns(Collections.singletonList("*"))
+            .template(new Template(Settings.builder().put(DATA_ROUTING_REQUIRE_SETTING, "hot").build(), null, null))
+            .build();
+
+        String composableTemplateName = "catch-all-composable-template";
+        ClusterState clusterState = ClusterState.builder(ClusterName.DEFAULT).metadata(Metadata.builder()
+            .put(composableTemplateName, composableIndexTemplate).build())
+            .build();
+        Tuple<ClusterState, MigratedEntities> migratedEntitiesTuple =
+            migrateToDataTiersRouting(clusterState, "data", composableTemplateName, REGISTRY, client);
+        assertThat(migratedEntitiesTuple.v2().removedIndexTemplateName, nullValue());
+        assertThat(migratedEntitiesTuple.v1().metadata().templatesV2().get(composableTemplateName), is(composableIndexTemplate));
+    }
+
+    private LifecyclePolicyMetadata getWarmColdPolicyMeta(SetPriorityAction setPriorityAction, ShrinkAction shrinkAction,
+                                                          AllocateAction warmAllocateAction, AllocateAction coldAllocateAction) {
+        LifecyclePolicy policy = new LifecyclePolicy(lifecycleName,
+            org.elasticsearch.core.Map.of("warm",
+                new Phase("warm", TimeValue.ZERO, org.elasticsearch.core.Map.of(shrinkAction.getWriteableName(), shrinkAction,
+                    warmAllocateAction.getWriteableName(), warmAllocateAction, setPriorityAction.getWriteableName(), setPriorityAction)),
+                "cold",
+                new Phase("cold", TimeValue.ZERO, org.elasticsearch.core.Map.of(coldAllocateAction.getWriteableName(), coldAllocateAction))
+            ));
+        return new LifecyclePolicyMetadata(policy, Collections.emptyMap(),
+            randomNonNegativeLong(), randomNonNegativeLong());
+    }
+
+    private String getWarmPhaseDef() {
+        return "{\n" +
+            "        \"policy\" : \"" + lifecycleName + "\",\n" +
+            "        \"phase_definition\" : {\n" +
+            "          \"min_age\" : \"0m\",\n" +
+            "          \"actions\" : {\n" +
+            "            \"allocate\" : {\n" +
+            "              \"number_of_replicas\" : \"0\",\n" +
+            "              \"require\" : {\n" +
+            "                \"data\": \"cold\"\n" +
+            "              }\n" +
+            "            },\n" +
+            "            \"set_priority\": {\n" +
+            "              \"priority\": 100 \n" +
+            "            },\n" +
+            "            \"shrink\": {\n" +
+            "              \"number_of_shards\": 2 \n" +
+            "            }\n" +
+            "          }\n" +
+            "        },\n" +
+            "        \"version\" : 1,\n" +
+            "        \"modified_date_in_millis\" : 1578521007076\n" +
+            "      }";
+    }
+
+    private String getColdPhaseDefinition() {
+        return "{\n" +
+            "        \"policy\" : \"" + lifecycleName + "\",\n" +
+            "        \"phase_definition\" : {\n" +
+            "          \"min_age\" : \"0m\",\n" +
+            "          \"actions\" : {\n" +
+            "            \"allocate\" : {\n" +
+            "              \"number_of_replicas\" : \"0\",\n" +
+            "              \"require\" : {\n" +
+            "                \"data\": \"cold\"\n" +
+            "              }\n" +
+            "            }\n" +
+            "          }\n" +
+            "        },\n" +
+            "        \"version\" : 1,\n" +
+            "        \"modified_date_in_millis\" : 1578521007076\n" +
+            "      }";
+    }
+
+    @SuppressWarnings("unchecked")
+    private Map<String, Object> getPhaseDefinitionAsMap(LifecycleExecutionState newLifecycleState) {
+        XContentType entityContentType = XContentType.fromMediaType("application/json");
+        return (Map<String, Object>) XContentHelper.convertToMap(entityContentType.xContent(),
+            new ByteArrayInputStream(newLifecycleState.getPhaseDefinition().getBytes(StandardCharsets.UTF_8)),
+            false)
+            .get("phase_definition");
+    }
+
+}

--- a/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/ilm/IndexLifecycleTransitionTests.java
+++ b/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/ilm/IndexLifecycleTransitionTests.java
@@ -9,19 +9,21 @@ package org.elasticsearch.xpack.ilm;
 
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.Version;
+import org.elasticsearch.client.Client;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.ToXContentObject;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.json.JsonXContent;
+import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.client.NoOpClient;
 import org.elasticsearch.xpack.core.ilm.AbstractStepTestCase;
 import org.elasticsearch.xpack.core.ilm.ErrorStep;
 import org.elasticsearch.xpack.core.ilm.IndexLifecycleMetadata;
@@ -35,7 +37,9 @@ import org.elasticsearch.xpack.core.ilm.MockAction;
 import org.elasticsearch.xpack.core.ilm.MockStep;
 import org.elasticsearch.xpack.core.ilm.OperationMode;
 import org.elasticsearch.xpack.core.ilm.Phase;
+import org.elasticsearch.xpack.core.ilm.PhaseCompleteStep;
 import org.elasticsearch.xpack.core.ilm.RolloverAction;
+import org.elasticsearch.xpack.core.ilm.SetPriorityAction;
 import org.elasticsearch.xpack.core.ilm.Step;
 
 import java.io.IOException;
@@ -48,11 +52,15 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import static org.elasticsearch.xpack.core.ilm.LifecycleExecutionState.ILM_CUSTOM_METADATA_KEY;
-import static org.elasticsearch.xpack.ilm.LifecyclePolicyTestsUtils.newTestLifecyclePolicy;
+import static org.elasticsearch.xpack.core.ilm.PhaseCacheManagement.eligibleToCheckForRefresh;
+import static org.elasticsearch.xpack.core.ilm.PhaseCacheManagement.refreshPhaseDefinition;
 import static org.elasticsearch.xpack.ilm.IndexLifecycleRunnerTests.createOneStepPolicyStepRegistry;
+import static org.elasticsearch.xpack.ilm.IndexLifecycleTransition.moveStateToNextActionAndUpdateCachedPhase;
+import static org.elasticsearch.xpack.ilm.LifecyclePolicyTestsUtils.newTestLifecyclePolicy;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
 
 public class IndexLifecycleTransitionTests extends ESTestCase {
@@ -638,6 +646,227 @@ public class IndexLifecycleTransitionTests extends ESTestCase {
             nextClusterState, now);
         LifecycleExecutionState executionState = LifecycleExecutionState.fromIndexMetadata(nextClusterState.metadata().index(indexName));
         assertThat(executionState.getFailedStepRetryCount(), is(1));
+    }
+
+    public void testRefreshPhaseJson() {
+        LifecycleExecutionState.Builder exState = LifecycleExecutionState.builder()
+            .setPhase("hot")
+            .setAction("rollover")
+            .setStep("check-rollover-ready")
+            .setPhaseDefinition("{\n" +
+                "        \"policy\" : \"my-policy\",\n" +
+                "        \"phase_definition\" : {\n" +
+                "          \"min_age\" : \"20m\",\n" +
+                "          \"actions\" : {\n" +
+                "            \"rollover\" : {\n" +
+                "              \"max_age\" : \"5s\"\n" +
+                "            },\n" +
+                "            \"set_priority\" : {\n" +
+                "              \"priority\" : 150\n" +
+                "            }\n" +
+                "          }\n" +
+                "        },\n" +
+                "        \"version\" : 1,\n" +
+                "        \"modified_date_in_millis\" : 1578521007076\n" +
+                "      }");
+
+        IndexMetadata meta = buildIndexMetadata("my-policy", exState);
+        String index = meta.getIndex().getName();
+
+        Map<String, LifecycleAction> actions = new HashMap<>();
+        actions.put("rollover", new RolloverAction(null, null, null, 1L));
+        actions.put("set_priority", new SetPriorityAction(100));
+        Phase hotPhase = new Phase("hot", TimeValue.ZERO, actions);
+        Map<String, Phase> phases = Collections.singletonMap("hot", hotPhase);
+        LifecyclePolicy newPolicy = new LifecyclePolicy("my-policy", phases);
+        LifecyclePolicyMetadata policyMetadata = new LifecyclePolicyMetadata(newPolicy, Collections.emptyMap(), 2L, 2L);
+
+        ClusterState existingState = ClusterState.builder(ClusterState.EMPTY_STATE)
+            .metadata(Metadata.builder(Metadata.EMPTY_METADATA)
+                .put(meta, false)
+                .build())
+            .build();
+
+        ClusterState changedState = refreshPhaseDefinition(existingState, index, policyMetadata);
+
+        IndexMetadata newIdxMeta = changedState.metadata().index(index);
+        LifecycleExecutionState afterExState = LifecycleExecutionState.fromIndexMetadata(newIdxMeta);
+        Map<String, String> beforeState = new HashMap<>(exState.build().asMap());
+        beforeState.remove("phase_definition");
+        Map<String, String> afterState = new HashMap<>(afterExState.asMap());
+        afterState.remove("phase_definition");
+        // Check that no other execution state changes have been made
+        assertThat(beforeState, equalTo(afterState));
+
+        // Check that the phase definition has been refreshed
+        assertThat(afterExState.getPhaseDefinition(),
+            equalTo("{\"policy\":\"my-policy\",\"phase_definition\":{\"min_age\":\"0ms\",\"actions\":{\"rollover\":{\"max_docs\":1}," +
+                "\"set_priority\":{\"priority\":100}}},\"version\":2,\"modified_date_in_millis\":2}"));
+    }
+
+    public void testEligibleForRefresh() {
+        IndexMetadata meta = IndexMetadata.builder("index")
+            .settings(Settings.builder()
+                .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, randomIntBetween(1, 10))
+                .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, randomIntBetween(0, 5))
+                .put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT)
+                .put(IndexMetadata.SETTING_INDEX_UUID, randomAlphaOfLength(5)))
+            .build();
+        assertFalse(eligibleToCheckForRefresh(meta));
+
+        LifecycleExecutionState state = LifecycleExecutionState.builder().build();
+        meta = IndexMetadata.builder("index")
+            .settings(Settings.builder()
+                .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, randomIntBetween(1, 10))
+                .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, randomIntBetween(0, 5))
+                .put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT)
+                .put(IndexMetadata.SETTING_INDEX_UUID, randomAlphaOfLength(5)))
+            .putCustom(ILM_CUSTOM_METADATA_KEY, state.asMap())
+            .build();
+        assertFalse(eligibleToCheckForRefresh(meta));
+
+        state = LifecycleExecutionState.builder()
+            .setPhase("phase")
+            .setAction("action")
+            .setStep("step")
+            .build();
+        meta = IndexMetadata.builder("index")
+            .settings(Settings.builder()
+                .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, randomIntBetween(1, 10))
+                .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, randomIntBetween(0, 5))
+                .put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT)
+                .put(IndexMetadata.SETTING_INDEX_UUID, randomAlphaOfLength(5)))
+            .putCustom(ILM_CUSTOM_METADATA_KEY, state.asMap())
+            .build();
+        assertFalse(eligibleToCheckForRefresh(meta));
+
+        state = LifecycleExecutionState.builder()
+            .setPhaseDefinition("{}")
+            .build();
+        meta = IndexMetadata.builder("index")
+            .settings(Settings.builder()
+                .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, randomIntBetween(1, 10))
+                .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, randomIntBetween(0, 5))
+                .put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT)
+                .put(IndexMetadata.SETTING_INDEX_UUID, randomAlphaOfLength(5)))
+            .putCustom(ILM_CUSTOM_METADATA_KEY, state.asMap())
+            .build();
+        assertFalse(eligibleToCheckForRefresh(meta));
+
+        state = LifecycleExecutionState.builder()
+            .setPhase("phase")
+            .setAction("action")
+            .setStep(ErrorStep.NAME)
+            .setPhaseDefinition("{}")
+            .build();
+        meta = IndexMetadata.builder("index")
+            .settings(Settings.builder()
+                .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, randomIntBetween(1, 10))
+                .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, randomIntBetween(0, 5))
+                .put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT)
+                .put(IndexMetadata.SETTING_INDEX_UUID, randomAlphaOfLength(5)))
+            .putCustom(ILM_CUSTOM_METADATA_KEY, state.asMap())
+            .build();
+        assertFalse(eligibleToCheckForRefresh(meta));
+
+        state = LifecycleExecutionState.builder()
+            .setPhase("phase")
+            .setAction("action")
+            .setStep("step")
+            .setPhaseDefinition("{}")
+            .build();
+        meta = IndexMetadata.builder("index")
+            .settings(Settings.builder()
+                .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, randomIntBetween(1, 10))
+                .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, randomIntBetween(0, 5))
+                .put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT)
+                .put(IndexMetadata.SETTING_INDEX_UUID, randomAlphaOfLength(5)))
+            .putCustom(ILM_CUSTOM_METADATA_KEY, state.asMap())
+            .build();
+        assertTrue(eligibleToCheckForRefresh(meta));
+    }
+
+    public void testMoveStateToNextActionAndUpdateCachedPhase() {
+        LifecycleExecutionState.Builder currentExecutionState = LifecycleExecutionState.builder()
+            .setPhase("hot")
+            .setAction("rollover")
+            .setStep("check-rollover-ready")
+            .setPhaseDefinition("{\n" +
+                "        \"policy\" : \"my-policy\",\n" +
+                "        \"phase_definition\" : {\n" +
+                "          \"min_age\" : \"20m\",\n" +
+                "          \"actions\" : {\n" +
+                "            \"rollover\" : {\n" +
+                "              \"max_age\" : \"5s\"\n" +
+                "            },\n" +
+                "            \"set_priority\" : {\n" +
+                "              \"priority\" : 150\n" +
+                "            }\n" +
+                "          }\n" +
+                "        },\n" +
+                "        \"version\" : 1,\n" +
+                "        \"modified_date_in_millis\" : 1578521007076\n" +
+                "      }");
+
+        IndexMetadata meta = buildIndexMetadata("my-policy", currentExecutionState);
+
+        Map<String, LifecycleAction> actions = new HashMap<>();
+        actions.put("rollover", new RolloverAction(null, null, null, 1L));
+        actions.put("set_priority", new SetPriorityAction(100));
+        Phase hotPhase = new Phase("hot", TimeValue.ZERO, actions);
+        Map<String, Phase> phases = Collections.singletonMap("hot", hotPhase);
+        LifecyclePolicy currentPolicy = new LifecyclePolicy("my-policy", phases);
+
+        {
+            // test index is in step for action that was removed in the updated policy
+            // the expected new state is that the index was moved into the next *action* and its cached phase definition updated to reflect
+            // the updated policy
+            Map<String, LifecycleAction> actionsWithoutRollover = new HashMap<>();
+            actionsWithoutRollover.put("set_priority", new SetPriorityAction(100));
+            Phase hotPhaseNoRollover = new Phase("hot", TimeValue.ZERO, actionsWithoutRollover);
+            Map<String, Phase> phasesNoRollover = Collections.singletonMap("hot", hotPhaseNoRollover);
+            LifecyclePolicyMetadata updatedPolicyMetadata = new LifecyclePolicyMetadata(new LifecyclePolicy("my-policy",
+                phasesNoRollover), Collections.emptyMap(), 2L, 2L);
+
+            try (Client client = new NoOpClient(getTestName())) {
+                LifecycleExecutionState newState = moveStateToNextActionAndUpdateCachedPhase(meta,
+                    LifecycleExecutionState.fromIndexMetadata(meta), System::currentTimeMillis, currentPolicy, updatedPolicyMetadata,
+                    client);
+
+                Step.StepKey hotPhaseCompleteStepKey = PhaseCompleteStep.finalStep("hot").getKey();
+                assertThat(newState.getAction(), is(hotPhaseCompleteStepKey.getAction()));
+                assertThat(newState.getStep(), is(hotPhaseCompleteStepKey.getName()));
+                assertThat("the cached phase should not contain rollover anymore", newState.getPhaseDefinition(),
+                    not(containsString(RolloverAction.NAME)));
+            }
+        }
+
+        {
+            // test that the index is in an action that still exists in the update policy
+            // the expected new state is that the index is moved into the next action (could be the complete one) and the cached phase
+            // definition is updated
+            Map<String, LifecycleAction> actionsWitoutSetPriority = new HashMap<>();
+            actionsWitoutSetPriority.put("rollover", new RolloverAction(null, null, null, 1L));
+            Phase hotPhaseNoSetPriority = new Phase("hot", TimeValue.ZERO, actionsWitoutSetPriority);
+            Map<String, Phase> phasesWithoutSetPriority = Collections.singletonMap("hot", hotPhaseNoSetPriority);
+            LifecyclePolicyMetadata updatedPolicyMetadata = new LifecyclePolicyMetadata(new LifecyclePolicy("my-policy",
+                phasesWithoutSetPriority), Collections.emptyMap(), 2L, 2L);
+
+            try (Client client = new NoOpClient(getTestName())) {
+                LifecycleExecutionState newState = moveStateToNextActionAndUpdateCachedPhase(meta,
+                    LifecycleExecutionState.fromIndexMetadata(meta), System::currentTimeMillis, currentPolicy, updatedPolicyMetadata,
+                    client);
+
+                Step.StepKey hotPhaseCompleteStepKey = PhaseCompleteStep.finalStep("hot").getKey();
+                // the state was still moved into the next action, even if the updated policy still contained the action the index was
+                // currently executing
+                assertThat(newState.getAction(), is(hotPhaseCompleteStepKey.getAction()));
+                assertThat(newState.getStep(), is(hotPhaseCompleteStepKey.getName()));
+                assertThat(newState.getPhaseDefinition(), containsString(RolloverAction.NAME));
+                assertThat("the cached phase should not contain set_priority anymore", newState.getPhaseDefinition(),
+                    not(containsString(SetPriorityAction.NAME)));
+            }
+        }
     }
 
     private static LifecyclePolicy createPolicy(String policyName, Step.StepKey safeStep, Step.StepKey unsafeStep) {


### PR DESCRIPTION
This adds a service that migrates the indices and ILM policies away from
custom node attribute allocation routing to data tiers. Optionally, it also
deletes one legacy index template.

(cherry picked from commit 6285fac67951f2159b051b7923b0e07efbcaf74a)
Signed-off-by: Andrei Dan <andrei.dan@elastic.co>

Backport of #73689