### PR TITLE
[7.x] ILM mount snapshot step does need to set index.shard.check_on_startup

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/MountSnapshotStep.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/MountSnapshotStep.java
@@ -15,7 +15,6 @@ import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.xpack.cluster.routing.allocation.DataTierAllocationDecider;
 import org.elasticsearch.xpack.core.DataTier;
@@ -103,8 +102,7 @@ public class MountSnapshotStep extends AsyncRetryDuringSnapshotActionStep {
             indexName = snapshotIndexName;
         }
 
-        Settings.Builder settingsBuilder = Settings.builder();
-        settingsBuilder.put(IndexSettings.INDEX_CHECK_ON_STARTUP.getKey(), Boolean.FALSE.toString());
+        final Settings.Builder settingsBuilder = Settings.builder();
         // if we are mounting a searchable snapshot in the hot phase, then the index should be pinned to the hot nodes
         if (TimeseriesLifecycleType.HOT_PHASE.equals(this.getKey().getPhase())) {
             settingsBuilder.put(DataTierAllocationDecider.INDEX_ROUTING_PREFER, DataTier.DATA_HOT);


### PR DESCRIPTION
Now the Mount API overrides the index.shard.check_on_startup
setting value to false, there's no need for MountSnapshotStep
to set it explicitly.

Backport of #74283
Relates #74235