### PR TITLE
Fix HLRC compatibility with Java 8

### DIFF
--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/RestHighLevelClient.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/RestHighLevelClient.java
@@ -2043,7 +2043,7 @@ public class RestHighLevelClient implements Closeable {
         versionCheck.addListener(new ActionListener<Optional<String>>() {
             @Override
             public void onResponse(Optional<String> validation) {
-                if (validation.isEmpty()) {
+                if (validation.isPresent() == false) {
                     // Send the request and propagate cancellation
                     Cancellable call = client.performRequestAsync(request, listener);
                     cancellationForwarder.whenComplete((r, t) ->
@@ -2078,7 +2078,7 @@ public class RestHighLevelClient implements Closeable {
             throw new ElasticsearchException(e);
         }
 
-        if (versionValidation.isEmpty()) {
+        if (versionValidation.isPresent() == false) {
             return client.performRequest(request);
         } else {
             throw new ElasticsearchException(versionValidation.get());


### PR DESCRIPTION
Follow-up to #73910

Removes the use of `Optional.isEmpty()` that was added in Java 11. HLRC targets Java 8 where we only have `Optional.isPresent()`

This was caught by the `7.x` build in the #74272 backport, but this check apparently isn't enforced in `master`. I opened #74289 to track this discrepancy.