### PR TITLE
Fix Snapshots Recording Incorrect Max. Segment Counts

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/snapshots/BlobStoreIncrementalityIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/snapshots/BlobStoreIncrementalityIT.java
@@ -19,6 +19,7 @@ import org.elasticsearch.action.bulk.BulkRequest;
 import org.elasticsearch.action.bulk.BulkRequestBuilder;
 import org.elasticsearch.action.bulk.BulkResponse;
 import org.elasticsearch.action.index.IndexRequest;
+import org.elasticsearch.action.support.WriteRequest;
 import org.elasticsearch.client.Requests;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.routing.UnassignedInfo;
@@ -196,10 +197,10 @@ public class BlobStoreIncrementalityIT extends AbstractSnapshotIntegTestCase {
 
         // create a situation where we temporarily have a bunch of segments until the merges can catch up
         long id = 0;
-        final int rounds = scaledRandomIntBetween(50, 300);
+        final int rounds = scaledRandomIntBetween(3, 5);
         for (int i = 0; i < rounds; ++i) {
             final int numDocs = scaledRandomIntBetween(100, 1000);
-            BulkRequestBuilder request = client().prepareBulk();
+            BulkRequestBuilder request = client().prepareBulk().setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE);
             for (int j = 0; j < numDocs; ++j) {
                 request.add(
                     Requests.indexRequest(indexName)
@@ -208,7 +209,6 @@ public class BlobStoreIncrementalityIT extends AbstractSnapshotIntegTestCase {
                 );
             }
             assertNoFailures(request.get());
-            refresh();
         }
 
         // snapshot with a bunch of unmerged segments

--- a/server/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
+++ b/server/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
@@ -2773,7 +2773,7 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
                 final ShardSnapshotResult shardSnapshotResult = new ShardSnapshotResult(
                     indexGeneration,
                     ByteSizeValue.ofBytes(blobStoreIndexShardSnapshot.totalSize()),
-                    snapshotIndexCommit.getSegmentCount()
+                    getSegmentInfoFileCount(blobStoreIndexShardSnapshot.indexFiles())
                 );
                 snapshotStatus.moveToDone(threadPool.absoluteTimeInMillis(), shardSnapshotResult);
                 context.onResponse(shardSnapshotResult);


### PR DESCRIPTION
If sequence numbers are equal across snapshots (and thus no files get written to the repository)
the segment count in the index commit is not reliable as it may have changed due to background merges.
=> fixed by always using the segment count determined from the file names in the snapshot instead

closes #74249

I'm not the biggest fan of my test here to be honest, but I couldn't find a way to have more fine grained control over background merges  so I went with this rather brute force approach (alternative test suggestions very welcome :)). The test does however reproduce the problem reliable in 100% of runs for me.