### PR TITLE
[DOCS] add missing dynamic runtime option

### DIFF
--- a/docs/reference/mapping/types/object.asciidoc
+++ b/docs/reference/mapping/types/object.asciidoc
@@ -82,7 +82,7 @@ The following parameters are accepted by `object` fields:
 <<dynamic,`dynamic`>>::
 
     Whether or not new `properties` should be added dynamically
-    to an existing object. Accepts `true` (default), `false`
+    to an existing object. Accepts `true` (default), `runtime`, `false`
     and `strict`.
 
 <<enabled,`enabled`>>::


### PR DESCRIPTION
The object field docs are listing the possible values for the dynamic option, but are missing the `runtime` value.