### PR TITLE
[ML] Optimize inference step when there are no test docs

### DIFF
--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/steps/InferenceStep.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/steps/InferenceStep.java
@@ -63,6 +63,16 @@ public class InferenceStep extends AbstractDataFrameAnalyticsStep {
             return;
         }
 
+        if (config.getAnalysis().getTrainingPercent() == 100) {
+            // no need to run inference at all so let us skip
+            // loading the model in memory.
+            LOGGER.debug(() -> new ParameterizedMessage(
+                "[{}] Inference step completed immediately as training_percent is 100", config.getId()));
+            task.getStatsHolder().getProgressTracker().updateInferenceProgress(100);
+            listener.onResponse(new StepResponse(isTaskStopping()));
+            return;
+        }
+
         ActionListener<String> modelIdListener = ActionListener.wrap(
             modelId -> runInference(modelId, listener),
             listener::onFailure

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/steps/InferenceStep.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/steps/InferenceStep.java
@@ -27,8 +27,10 @@ import org.elasticsearch.xpack.core.ml.inference.TrainedModelConfig;
 import org.elasticsearch.xpack.core.ml.inference.persistence.InferenceIndexConstants;
 import org.elasticsearch.xpack.ml.MachineLearning;
 import org.elasticsearch.xpack.ml.dataframe.DataFrameAnalyticsTask;
+import org.elasticsearch.xpack.ml.dataframe.DestinationIndex;
 import org.elasticsearch.xpack.ml.dataframe.inference.InferenceRunner;
 import org.elasticsearch.xpack.ml.notifications.DataFrameAnalyticsAuditor;
+import org.elasticsearch.xpack.ml.utils.MlIndicesUtils;
 
 import java.util.Objects;
 
@@ -63,23 +65,30 @@ public class InferenceStep extends AbstractDataFrameAnalyticsStep {
             return;
         }
 
-        if (config.getAnalysis().getTrainingPercent() == 100) {
-            // no need to run inference at all so let us skip
-            // loading the model in memory.
-            LOGGER.debug(() -> new ParameterizedMessage(
-                "[{}] Inference step completed immediately as training_percent is 100", config.getId()));
-            task.getStatsHolder().getProgressTracker().updateInferenceProgress(100);
-            listener.onResponse(new StepResponse(isTaskStopping()));
-            return;
-        }
-
         ActionListener<String> modelIdListener = ActionListener.wrap(
             modelId -> runInference(modelId, listener),
             listener::onFailure
         );
 
+        ActionListener<Boolean> testDocsExistListener = ActionListener.wrap(
+            testDocsExist -> {
+                if (testDocsExist) {
+                    getModelId(modelIdListener);
+                } else {
+                    // no need to run inference at all so let us skip
+                    // loading the model in memory.
+                    LOGGER.debug(() -> new ParameterizedMessage(
+                        "[{}] Inference step completed immediately as there are no test docs", config.getId()));
+                    task.getStatsHolder().getProgressTracker().updateInferenceProgress(100);
+                    listener.onResponse(new StepResponse(isTaskStopping()));
+                    return;
+                }
+            },
+            listener::onFailure
+        );
+
         ActionListener<RefreshResponse> refreshDestListener = ActionListener.wrap(
-            refreshResponse -> getModelId(modelIdListener),
+            refreshResponse -> searchIfTestDocsExist(testDocsExistListener),
             listener::onFailure
         );
 
@@ -99,6 +108,20 @@ public class InferenceStep extends AbstractDataFrameAnalyticsStep {
                 }
             }
         });
+    }
+
+    private void searchIfTestDocsExist(ActionListener<Boolean> listener) {
+        SearchRequest searchRequest = new SearchRequest(config.getDest().getIndex());
+        searchRequest.indicesOptions(MlIndicesUtils.addIgnoreUnavailable(SearchRequest.DEFAULT_INDICES_OPTIONS));
+        searchRequest.source().query(QueryBuilders.boolQuery().mustNot(
+            QueryBuilders.termQuery(config.getDest().getResultsField() + "." + DestinationIndex.IS_TRAINING, true)));
+        searchRequest.source().size(0);
+        searchRequest.source().trackTotalHitsUpTo(1);
+
+        executeAsyncWithOrigin(client, ML_ORIGIN, SearchAction.INSTANCE, searchRequest, ActionListener.wrap(
+            searchResponse -> listener.onResponse(searchResponse.getHits().getTotalHits().value > 0),
+            listener::onFailure
+        ));
     }
 
     private void getModelId(ActionListener<String> listener) {


### PR DESCRIPTION
In data frame analytics, when the analysis supports inference,
`training_percent` is set to `100`, and there are no test docs
(i.e. docs missing a value for their dependent variable),
there is no need to load the model in memory only to realize
there are no documents to run inference on.

This commit optimizes the inference step in this scenario.
