### PR TITLE
[TEST] rework tests for #74234

### DIFF
--- a/server/src/main/java/org/elasticsearch/script/AbstractFieldScript.java
+++ b/server/src/main/java/org/elasticsearch/script/AbstractFieldScript.java
@@ -109,7 +109,9 @@ public abstract class AbstractFieldScript {
     protected abstract void emitFromObject(Object v);
 
     protected final void emitFromSource() {
+        System.out.println("emitFromSource");
         for (Object v : extractFromSource(fieldName)) {
+            System.out.println("value " + v + " - field: " + fieldName);
             emitFromObject(v);
         }
     }

--- a/server/src/main/java/org/elasticsearch/script/AbstractFieldScript.java
+++ b/server/src/main/java/org/elasticsearch/script/AbstractFieldScript.java
@@ -109,9 +109,7 @@ public abstract class AbstractFieldScript {
     protected abstract void emitFromObject(Object v);
 
     protected final void emitFromSource() {
-        System.out.println("emitFromSource");
         for (Object v : extractFromSource(fieldName)) {
-            System.out.println("value " + v + " - field: " + fieldName);
             emitFromObject(v);
         }
     }


### PR DESCRIPTION
Two IT tests added as part of #74234 have turned out to be flaky in that they rely on dynamic mappings updated to be available after indexing documents. This commit reworks them to instead use search and check what gets returned instead of checking what get mappings returns and doing a string comparison.