### PR TITLE
Simplify dynamic template parser context creation

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/mapper/DocumentParser.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DocumentParser.java
@@ -47,12 +47,12 @@ import java.util.function.Function;
 public final class DocumentParser {
 
     private final NamedXContentRegistry xContentRegistry;
-    private final Function<DateFormatter, Mapper.TypeParser.ParserContext> dateParserContext;
+    private final Function<DateFormatter, Mapper.TypeParser.ParserContext.DynamicTemplateParserContext> dateParserContext;
     private final IndexSettings indexSettings;
     private final IndexAnalyzers indexAnalyzers;
 
     DocumentParser(NamedXContentRegistry xContentRegistry,
-                   Function<DateFormatter, Mapper.TypeParser.ParserContext> dateParserContext,
+                   Function<DateFormatter, Mapper.TypeParser.ParserContext.DynamicTemplateParserContext> dateParserContext,
                    IndexSettings indexSettings,
                    IndexAnalyzers indexAnalyzers) {
         this.xContentRegistry = xContentRegistry;

--- a/server/src/main/java/org/elasticsearch/index/mapper/DocumentParser.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DocumentParser.java
@@ -47,12 +47,12 @@ import java.util.function.Function;
 public final class DocumentParser {
 
     private final NamedXContentRegistry xContentRegistry;
-    private final Function<DateFormatter, Mapper.TypeParser.ParserContext.DynamicTemplateParserContext> dateParserContext;
+    private final Function<DateFormatter, Mapper.TypeParser.ParserContext> dateParserContext;
     private final IndexSettings indexSettings;
     private final IndexAnalyzers indexAnalyzers;
 
     DocumentParser(NamedXContentRegistry xContentRegistry,
-                   Function<DateFormatter, Mapper.TypeParser.ParserContext.DynamicTemplateParserContext> dateParserContext,
+                   Function<DateFormatter, Mapper.TypeParser.ParserContext> dateParserContext,
                    IndexSettings indexSettings,
                    IndexAnalyzers indexAnalyzers) {
         this.xContentRegistry = xContentRegistry;

--- a/server/src/main/java/org/elasticsearch/index/mapper/Mapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/Mapper.java
@@ -144,10 +144,6 @@ public abstract class Mapper implements ToXContentFragment, Iterable<Mapper> {
                 return new MultiFieldParserContext(in);
             }
 
-            ParserContext createDynamicTemplateFieldContext() {
-                return new DynamicTemplateParserContext(this);
-            }
-
             private static class MultiFieldParserContext extends ParserContext {
                 MultiFieldParserContext(ParserContext in) {
                     super(in.similarityLookupService, in.typeParsers, in.runtimeFieldParsers, in.indexVersionCreated,
@@ -159,8 +155,8 @@ public abstract class Mapper implements ToXContentFragment, Iterable<Mapper> {
                 public boolean isWithinMultiField() { return true; }
             }
 
-            private static class DynamicTemplateParserContext extends ParserContext {
-                DynamicTemplateParserContext(ParserContext in) {
+            public static class DynamicTemplateParserContext extends ParserContext {
+                public DynamicTemplateParserContext(ParserContext in) {
                     super(in.similarityLookupService, in.typeParsers, in.runtimeFieldParsers, in.indexVersionCreated,
                         in.searchExecutionContextSupplier, in.dateFormatter, in.scriptCompiler, in.indexAnalyzers, in.indexSettings,
                         in.idFieldDataEnabled);

--- a/server/src/main/java/org/elasticsearch/index/mapper/Mapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/Mapper.java
@@ -155,8 +155,8 @@ public abstract class Mapper implements ToXContentFragment, Iterable<Mapper> {
                 public boolean isWithinMultiField() { return true; }
             }
 
-            public static class DynamicTemplateParserContext extends ParserContext {
-                public DynamicTemplateParserContext(ParserContext in) {
+            static class DynamicTemplateParserContext extends ParserContext {
+                DynamicTemplateParserContext(ParserContext in) {
                     super(in.similarityLookupService, in.typeParsers, in.runtimeFieldParsers, in.indexVersionCreated,
                         in.searchExecutionContextSupplier, in.dateFormatter, in.scriptCompiler, in.indexAnalyzers, in.indexSettings,
                         in.idFieldDataEnabled);

--- a/server/src/main/java/org/elasticsearch/index/mapper/MapperService.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/MapperService.java
@@ -111,7 +111,9 @@ public class MapperService extends AbstractIndexComponent implements Closeable {
             dateFormatter -> new Mapper.TypeParser.ParserContext(similarityService::getSimilarity, mapperRegistry.getMapperParsers()::get,
                 mapperRegistry.getRuntimeFieldParsers()::get, indexVersionCreated, searchExecutionContextSupplier, dateFormatter,
                 scriptCompiler, indexAnalyzers, indexSettings, idFieldDataEnabled);
-        this.documentParser = new DocumentParser(xContentRegistry, parserContextFunction, indexSettings, indexAnalyzers);
+        this.documentParser = new DocumentParser(xContentRegistry,
+            dateFormatter -> new Mapper.TypeParser.ParserContext.DynamicTemplateParserContext(parserContextFunction.apply(dateFormatter)),
+            indexSettings, indexAnalyzers);
         Map<String, MetadataFieldMapper.TypeParser> metadataMapperParsers =
             mapperRegistry.getMetadataMapperParsers(indexSettings.getIndexVersionCreated());
         this.parserContextSupplier = () -> parserContextFunction.apply(null);

--- a/server/src/main/java/org/elasticsearch/index/mapper/ParseContext.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/ParseContext.java
@@ -164,7 +164,7 @@ public abstract class ParseContext {
         }
 
         @Override
-        public Mapper.TypeParser.ParserContext.DynamicTemplateParserContext dynamicTemplateParserContext(DateFormatter dateFormatter) {
+        public Mapper.TypeParser.ParserContext dynamicTemplateParserContext(DateFormatter dateFormatter) {
             return in.dynamicTemplateParserContext(dateFormatter);
         }
 
@@ -298,7 +298,7 @@ public abstract class ParseContext {
         private final MappingLookup mappingLookup;
         private final IndexSettings indexSettings;
         private final IndexAnalyzers indexAnalyzers;
-        private final Function<DateFormatter, Mapper.TypeParser.ParserContext.DynamicTemplateParserContext> parserContextFunction;
+        private final Function<DateFormatter, Mapper.TypeParser.ParserContext> parserContextFunction;
         private final ContentPath path = new ContentPath(0);
         private final XContentParser parser;
         private final Document document;
@@ -319,7 +319,7 @@ public abstract class ParseContext {
         public InternalParseContext(MappingLookup mappingLookup,
                                     IndexSettings indexSettings,
                                     IndexAnalyzers indexAnalyzers,
-                                    Function<DateFormatter, Mapper.TypeParser.ParserContext.DynamicTemplateParserContext> parserContext,
+                                    Function<DateFormatter, Mapper.TypeParser.ParserContext> parserContext,
                                     SourceToParse source,
                                     XContentParser parser) {
             this.mappingLookup = mappingLookup;
@@ -336,7 +336,7 @@ public abstract class ParseContext {
         }
 
         @Override
-        public Mapper.TypeParser.ParserContext.DynamicTemplateParserContext dynamicTemplateParserContext(DateFormatter dateFormatter) {
+        public Mapper.TypeParser.ParserContext dynamicTemplateParserContext(DateFormatter dateFormatter) {
             return parserContextFunction.apply(dateFormatter);
         }
 
@@ -548,7 +548,7 @@ public abstract class ParseContext {
      */
     public abstract Collection<String> getFieldNames();
 
-    public abstract Mapper.TypeParser.ParserContext.DynamicTemplateParserContext dynamicTemplateParserContext(DateFormatter dateFormatter);
+    public abstract Mapper.TypeParser.ParserContext dynamicTemplateParserContext(DateFormatter dateFormatter);
 
     /**
      * Return a new context that will be within a copy-to operation.

--- a/server/src/main/java/org/elasticsearch/index/mapper/ParseContext.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/ParseContext.java
@@ -164,7 +164,7 @@ public abstract class ParseContext {
         }
 
         @Override
-        public Mapper.TypeParser.ParserContext dynamicTemplateParserContext(DateFormatter dateFormatter) {
+        public Mapper.TypeParser.ParserContext.DynamicTemplateParserContext dynamicTemplateParserContext(DateFormatter dateFormatter) {
             return in.dynamicTemplateParserContext(dateFormatter);
         }
 
@@ -298,7 +298,7 @@ public abstract class ParseContext {
         private final MappingLookup mappingLookup;
         private final IndexSettings indexSettings;
         private final IndexAnalyzers indexAnalyzers;
-        private final Function<DateFormatter, Mapper.TypeParser.ParserContext> parserContextFunction;
+        private final Function<DateFormatter, Mapper.TypeParser.ParserContext.DynamicTemplateParserContext> parserContextFunction;
         private final ContentPath path = new ContentPath(0);
         private final XContentParser parser;
         private final Document document;
@@ -319,13 +319,13 @@ public abstract class ParseContext {
         public InternalParseContext(MappingLookup mappingLookup,
                                     IndexSettings indexSettings,
                                     IndexAnalyzers indexAnalyzers,
-                                    Function<DateFormatter, Mapper.TypeParser.ParserContext> parserContextFunction,
+                                    Function<DateFormatter, Mapper.TypeParser.ParserContext.DynamicTemplateParserContext> parserContext,
                                     SourceToParse source,
                                     XContentParser parser) {
             this.mappingLookup = mappingLookup;
             this.indexSettings = indexSettings;
             this.indexAnalyzers = indexAnalyzers;
-            this.parserContextFunction = parserContextFunction;
+            this.parserContextFunction = parserContext;
             this.parser = parser;
             this.document = new Document();
             this.documents.add(document);
@@ -336,8 +336,8 @@ public abstract class ParseContext {
         }
 
         @Override
-        public Mapper.TypeParser.ParserContext dynamicTemplateParserContext(DateFormatter dateFormatter) {
-            return parserContextFunction.apply(dateFormatter).createDynamicTemplateFieldContext();
+        public Mapper.TypeParser.ParserContext.DynamicTemplateParserContext dynamicTemplateParserContext(DateFormatter dateFormatter) {
+            return parserContextFunction.apply(dateFormatter);
         }
 
         @Override
@@ -548,7 +548,7 @@ public abstract class ParseContext {
      */
     public abstract Collection<String> getFieldNames();
 
-    public abstract Mapper.TypeParser.ParserContext dynamicTemplateParserContext(DateFormatter dateFormatter);
+    public abstract Mapper.TypeParser.ParserContext.DynamicTemplateParserContext dynamicTemplateParserContext(DateFormatter dateFormatter);
 
     /**
      * Return a new context that will be within a copy-to operation.

--- a/server/src/test/java/org/elasticsearch/index/mapper/ParametrizedMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/ParametrizedMapperTests.java
@@ -208,7 +208,7 @@ public class ParametrizedMapperTests extends MapperServiceTestCase {
             throw new UnsupportedOperationException();
         });
         if (fromDynamicTemplate) {
-            pc = pc.createDynamicTemplateFieldContext();
+            pc = new Mapper.TypeParser.ParserContext.DynamicTemplateParserContext(pc);
         }
         return (TestMapper) new TypeParser()
             .parse("field", XContentHelper.convertToMap(JsonXContent.jsonXContent, mapping, true), pc)


### PR DESCRIPTION
DocumentParser takes care of parsing documents and applying dynamic mapping updates for each new field it encounters, if applicable, as well as applying the matching dynamic templates.

To do this, it needs to be able to parse mappings, which requires a ParserContext that the ParseContext exposes given a DateFormatter. So far, we have carried around a function that allows to create a new ParserContext given a date formatter, and then call a specific method that allows to wrap it to provide a special parser context that is specific for dynamic templates, which is needed to make some decisions down the line based on whether mappings come from dynamic templates or not.

This commit tries to simplify this by exposing the specific dynamic template parser context only to the document parse context, as that's all it needs. We recently ended up using the wrong context and with this change it would not be possible. 

Relates to #74177