### PR TITLE
Remove BuildParams.isInternal

### DIFF
--- a/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/fixtures/AbstractRestResourcesFuncTest.groovy
+++ b/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/fixtures/AbstractRestResourcesFuncTest.groovy
@@ -11,9 +11,9 @@ package org.elasticsearch.gradle.fixtures;
 
 abstract class AbstractRestResourcesFuncTest extends AbstractGradleFuncTest {
 
-    void setupRestResources(List<String> apis, List<String> tests = [], List<String> xpackTests = []) {
+    def setup() {
         addSubProject(":test:framework") << "apply plugin: 'elasticsearch.java'"
-        addSubProject(":distribution:archives:integ-test-zip") << "configurations { extracted }"
+
         addSubProject(":rest-api-spec") << """
         configurations { restSpecs\nrestTests }
         artifacts {
@@ -21,12 +21,18 @@ abstract class AbstractRestResourcesFuncTest extends AbstractGradleFuncTest {
           restTests(new File(projectDir, "src/yamlRestTest/resources/rest-api-spec/test"))
         }
         """
+
         addSubProject(":x-pack:plugin") << """
         configurations { restXpackSpecs\nrestXpackTests }
         artifacts {
           restXpackTests(new File(projectDir, "src/yamlRestTest/resources/rest-api-spec/test"))
         }
         """
+
+        addSubProject(":distribution:archives:integ-test-zip") << "configurations { extracted }"
+    }
+
+    void setupRestResources(List<String> apis, List<String> tests = [], List<String> xpackTests = []) {
 
         xpackTests.each { test ->
             file("x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/" + test) << ""

--- a/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/PublishPluginFuncTest.groovy
+++ b/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/PublishPluginFuncTest.groovy
@@ -17,6 +17,10 @@ import spock.lang.IgnoreRest
 
 class PublishPluginFuncTest extends AbstractGradleFuncTest {
 
+    def setup() {
+        // required for JarHell to work
+        addSubProject(":libs:elasticsearch-core") << "apply plugin:'java'"
+    }
     def "artifacts and tweaked pom is published"() {
         given:
         buildFile << """

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/info/BuildParams.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/info/BuildParams.java
@@ -9,6 +9,7 @@ package org.elasticsearch.gradle.internal.info;
 
 import org.elasticsearch.gradle.internal.BwcVersions;
 import org.gradle.api.JavaVersion;
+import org.gradle.api.provider.Provider;
 
 import java.io.File;
 import java.lang.reflect.Modifier;
@@ -34,10 +35,9 @@ public class BuildParams {
     private static ZonedDateTime buildDate;
     private static String testSeed;
     private static Boolean isCi;
-    private static Boolean isInternal;
     private static Integer defaultParallel;
     private static Boolean isSnapshotBuild;
-    private static BwcVersions bwcVersions;
+    private static Provider<BwcVersions> bwcVersions;
 
     /**
      * Initialize global build parameters. This method accepts and a initialization function which in turn accepts a
@@ -100,7 +100,7 @@ public class BuildParams {
     }
 
     public static BwcVersions getBwcVersions() {
-        return value(bwcVersions);
+        return value(bwcVersions).get();
     }
 
     public static String getTestSeed() {
@@ -109,10 +109,6 @@ public class BuildParams {
 
     public static Boolean isCi() {
         return value(isCi);
-    }
-
-    public static Boolean isInternal() {
-        return value(isInternal);
     }
 
     public static Integer getDefaultParallel() {
@@ -141,36 +137,6 @@ public class BuildParams {
     private static String propertyName(String methodName) {
         String propertyName = methodName.startsWith("is") ? methodName.substring("is".length()) : methodName.substring("get".length());
         return propertyName.substring(0, 1).toLowerCase() + propertyName.substring(1);
-    }
-
-    public static InternalMarker withInternalBuild(Runnable configBlock) {
-        if (isInternal()) {
-            configBlock.run();
-            return InternalMarker.INTERNAL;
-        } else {
-            return InternalMarker.EXTERNAL;
-        }
-    }
-
-    public enum InternalMarker {
-        INTERNAL(true),
-        EXTERNAL(false);
-
-        private final boolean internal;
-
-        InternalMarker(boolean internal) {
-            this.internal = internal;
-        }
-
-        public void orElse(Runnable configBlock) {
-            if (internal == false) {
-                configBlock.run();
-            }
-        }
-
-        public boolean isInternal() {
-            return internal;
-        }
     }
 
     public static class MutableBuildParams {
@@ -250,10 +216,6 @@ public class BuildParams {
             BuildParams.isCi = isCi;
         }
 
-        public void setIsInternal(Boolean isInternal) {
-            BuildParams.isInternal = requireNonNull(isInternal);
-        }
-
         public void setDefaultParallel(int defaultParallel) {
             BuildParams.defaultParallel = defaultParallel;
         }
@@ -262,7 +224,7 @@ public class BuildParams {
             BuildParams.isSnapshotBuild = isSnapshotBuild;
         }
 
-        public void setBwcVersions(BwcVersions bwcVersions) {
+        public void setBwcVersions(Provider<BwcVersions> bwcVersions) {
             BuildParams.bwcVersions = requireNonNull(bwcVersions);
         }
     }

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/info/GlobalBuildInfoPlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/info/GlobalBuildInfoPlugin.java
@@ -90,9 +90,6 @@ public class GlobalBuildInfoPlugin implements Plugin<Project> {
         GitInfo gitInfo = GitInfo.gitInfo(rootDir);
 
         BuildParams.init(params -> {
-            // Initialize global build parameters
-            boolean isInternal = GlobalBuildInfoPlugin.class.getResource("/buildSrc.marker") != null && explicitDisabledInternal(project) == false;
-
             params.reset();
             params.setRuntimeJavaHome(runtimeJavaHome);
             params.setRuntimeJavaVersion(determineJavaVersion("runtime java.home", runtimeJavaHome, minimumRuntimeVersion));
@@ -108,28 +105,17 @@ public class GlobalBuildInfoPlugin implements Plugin<Project> {
             params.setBuildDate(ZonedDateTime.now(ZoneOffset.UTC));
             params.setTestSeed(getTestSeed());
             params.setIsCi(System.getenv("JENKINS_URL") != null);
-            params.setIsInternal(isInternal);
             params.setDefaultParallel(ParallelDetector.findDefaultParallel(project));
             params.setInFipsJvm(Util.getBooleanProperty("tests.fips.enabled", false));
             params.setIsSnapshotBuild(Util.getBooleanProperty("build.snapshot", true));
-            if (isInternal) {
-                params.setBwcVersions(resolveBwcVersions(rootDir));
-            }
+            params.setBwcVersions(providers.provider(() -> resolveBwcVersions(rootDir)));
         });
 
-        // When building Elasticsearch, enforce the minimum compiler version
-        BuildParams.withInternalBuild(() -> assertMinimumCompilerVersion(minimumCompilerVersion));
+        // Enforce the minimum compiler version
+        assertMinimumCompilerVersion(minimumCompilerVersion);
 
         // Print global build info header just before task execution
         project.getGradle().getTaskGraph().whenReady(graph -> logGlobalBuildInfo());
-    }
-
-    @NotNull
-    private Boolean explicitDisabledInternal(Project project) {
-        return project.getProviders().systemProperty("test.external")
-                .forUseAtConfigurationTime()
-                .map(sysProp -> sysProp.equals("true"))
-                .getOrElse(false);
     }
 
     private String formatJavaVendorDetails(JvmInstallationMetadata runtimeJdkMetaData) {

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/precommit/JarHellPrecommitPlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/precommit/JarHellPrecommitPlugin.java
@@ -9,7 +9,6 @@
 package org.elasticsearch.gradle.internal.precommit;
 
 import org.elasticsearch.gradle.internal.conventions.precommit.PrecommitPlugin;
-import org.elasticsearch.gradle.internal.info.BuildParams;
 import org.elasticsearch.gradle.jarhell.JarHellPlugin;
 import org.elasticsearch.gradle.jarhell.JarHellTask;
 import org.gradle.api.Project;
@@ -21,7 +20,7 @@ public class JarHellPrecommitPlugin extends PrecommitPlugin {
     public TaskProvider<? extends Task> createTask(Project project) {
         project.getPluginManager().apply(JarHellPlugin.class);
 
-        if (BuildParams.isInternal() && project.getPath().equals(":libs:elasticsearch-core") == false) {
+        if (project.getPath().equals(":libs:elasticsearch-core") == false) {
             // ideally we would configure this as a default dependency. But Default dependencies do not work correctly
             // with gradle project dependencies as they're resolved to late in the build and don't setup according task
             // dependencies properly

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/precommit/ThirdPartyAuditPrecommitPlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/precommit/ThirdPartyAuditPrecommitPlugin.java
@@ -32,8 +32,7 @@ public class ThirdPartyAuditPrecommitPlugin extends PrecommitPlugin implements I
         project.getConfigurations().create("forbiddenApisCliJar");
         project.getDependencies().add("forbiddenApisCliJar", "de.thetaphi:forbiddenapis:3.1");
         Configuration jdkJarHellConfig = project.getConfigurations().create(JDK_JAR_HELL_CONFIG_NAME);
-        if (BuildParams.isInternal() && project.getPath().equals(LIBS_ELASTICSEARCH_CORE_PROJECT_PATH) == false) {
-            // External plugins will depend on this already via transitive dependencies.
+        if (project.getPath().equals(LIBS_ELASTICSEARCH_CORE_PROJECT_PATH) == false) {
             // Internal projects are not all plugins, so make sure the check is available
             // we are not doing this for this project itself to avoid jar hell with itself
             project.getDependencies().add(JDK_JAR_HELL_CONFIG_NAME, project.project(LIBS_ELASTICSEARCH_CORE_PROJECT_PATH));

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/rest/compat/YamlRestCompatTestPlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/rest/compat/YamlRestCompatTestPlugin.java
@@ -180,7 +180,6 @@ public class YamlRestCompatTestPlugin implements Plugin<Project> {
             testTask.onlyIf(t -> isEnabled(project));
         });
 
-        // setup the dependencies
         setupDependencies(project, yamlCompatTestSourceSet);
 
         // setup IDE

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/test/StandaloneRestTestPlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/test/StandaloneRestTestPlugin.java
@@ -86,6 +86,6 @@ public class StandaloneRestTestPlugin implements Plugin<Project> {
                 "TEST",
                 Map.of("plus", Arrays.asList(project.getConfigurations().getByName(JavaPlugin.TEST_RUNTIME_CLASSPATH_CONFIGURATION_NAME)))
             );
-        BuildParams.withInternalBuild(() -> InternalPrecommitTasks.create(project, false));
+        InternalPrecommitTasks.create(project, false);
     }
 }

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/test/rest/CopyRestTestsTask.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/test/rest/CopyRestTestsTask.java
@@ -7,8 +7,6 @@
  */
 package org.elasticsearch.gradle.internal.test.rest;
 
-import org.elasticsearch.gradle.VersionProperties;
-import org.elasticsearch.gradle.internal.info.BuildParams;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.file.ArchiveOperations;
 import org.gradle.api.file.DirectoryProperty;
@@ -59,14 +57,12 @@ public class CopyRestTestsTask extends DefaultTask {
     private final PatternFilterable xpackPatternSet;
     private final ProjectLayout projectLayout;
     private final FileSystemOperations fileSystemOperations;
-    private final ArchiveOperations archiveOperations;
 
     @Inject
     public CopyRestTestsTask(
         ProjectLayout projectLayout,
         Factory<PatternSet> patternSetFactory,
         FileSystemOperations fileSystemOperations,
-        ArchiveOperations archiveOperations,
         ObjectFactory objectFactory
     ) {
         this.includeCore = objectFactory.listProperty(String.class);
@@ -76,7 +72,6 @@ public class CopyRestTestsTask extends DefaultTask {
         this.xpackPatternSet = patternSetFactory.create();
         this.projectLayout = projectLayout;
         this.fileSystemOperations = fileSystemOperations;
-        this.archiveOperations = archiveOperations;
     }
 
     @Input
@@ -99,12 +94,8 @@ public class CopyRestTestsTask extends DefaultTask {
             xpackFileTree = xpackConfigToFileTree.apply(xpackConfig).matching(xpackPatternSet);
         }
         if (includeCore.get().isEmpty() == false) {
-            if (BuildParams.isInternal()) {
-                corePatternSet.setIncludes(includeCore.get().stream().map(prefix -> prefix + "*/**").collect(Collectors.toList()));
-                coreFileTree = coreConfigToFileTree.apply(coreConfig).matching(corePatternSet); // directory on disk
-            } else {
-                coreFileTree = coreConfig.getAsFileTree(); // jar file
-            }
+            corePatternSet.setIncludes(includeCore.get().stream().map(prefix -> prefix + "*/**").collect(Collectors.toList()));
+            coreFileTree = coreConfigToFileTree.apply(coreConfig).matching(corePatternSet); // directory on disk
         }
         FileCollection fileCollection = additionalConfig == null
             ? projectLayout.files(coreFileTree, xpackFileTree)
@@ -131,27 +122,12 @@ public class CopyRestTestsTask extends DefaultTask {
 
         // only copy core tests if explicitly instructed
         if (includeCore.get().isEmpty() == false) {
-            if (BuildParams.isInternal()) {
-                getLogger().debug("Rest tests for project [{}] will be copied to the test resources.", projectPath);
-                fileSystemOperations.copy(c -> {
-                    c.from(coreConfigToFileTree.apply(coreConfig));
-                    c.into(restTestOutputDir);
-                    c.include(corePatternSet.getIncludes());
-                });
-            } else {
-                getLogger().debug(
-                    "Rest tests for project [{}] will be copied to the test resources from the published jar (version: [{}]).",
-                    projectPath,
-                    VersionProperties.getElasticsearch()
-                );
-                fileSystemOperations.copy(c -> {
-                    c.from(archiveOperations.zipTree(coreConfig.getSingleFile())); // jar file
-                    c.into(outputResourceDir);
-                    c.include(
-                        includeCore.get().stream().map(prefix -> REST_TEST_PREFIX + "/" + prefix + "*/**").collect(Collectors.toList())
-                    );
-                });
-            }
+            getLogger().debug("Rest tests for project [{}] will be copied to the test resources.", projectPath);
+            fileSystemOperations.copy(c -> {
+                c.from(coreConfigToFileTree.apply(coreConfig));
+                c.into(restTestOutputDir);
+                c.include(corePatternSet.getIncludes());
+            });
         }
         // only copy x-pack tests if explicitly instructed
         if (includeXpack.get().isEmpty() == false) {
@@ -195,13 +171,4 @@ public class CopyRestTestsTask extends DefaultTask {
         this.additionalConfigToFileTree = additionalConfigToFileTree;
     }
 
-    @Internal
-    public FileCollection getCoreConfig() {
-        return coreConfig;
-    }
-
-    @Internal
-    public FileCollection getXpackConfig() {
-        return xpackConfig;
-    }
 }

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/test/rest/RestResourcesExtension.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/test/rest/RestResourcesExtension.java
@@ -33,10 +33,6 @@ public class RestResourcesExtension {
     }
 
     void restTests(Action<? super XpackRestResourcesSpec> spec) {
-        if (BuildParams.isInternal() == false) {
-            // TODO: Separate this out into an "internal" plugin so we don't even expose this API to external folks
-            throw new UnsupportedOperationException("Including tests is not supported from external builds.");
-        }
         spec.execute(restTests);
     }
 

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/test/rest/RestResourcesPlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/test/rest/RestResourcesPlugin.java
@@ -7,8 +7,6 @@
  */
 package org.elasticsearch.gradle.internal.test.rest;
 
-import org.elasticsearch.gradle.VersionProperties;
-import org.elasticsearch.gradle.internal.info.BuildParams;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.artifacts.Configuration;
@@ -90,31 +88,23 @@ public class RestResourcesPlugin implements Plugin<Project> {
         // tests
         Configuration testConfig = project.getConfigurations().create("restTestConfig");
         Configuration xpackTestConfig = project.getConfigurations().create("restXpackTestConfig");
-        if (BuildParams.isInternal()) {
-            // core
-            Dependency restTestdependency = project.getDependencies()
+        // core
+        Dependency restTestdependency = project.getDependencies()
                 .project(Map.of("path", ":rest-api-spec", "configuration", "restTests"));
-            project.getDependencies().add(testConfig.getName(), restTestdependency);
-            // x-pack
-            Dependency restXPackTestdependency = project.getDependencies()
+        project.getDependencies().add(testConfig.getName(), restTestdependency);
+        // x-pack
+        Dependency restXPackTestdependency = project.getDependencies()
                 .project(Map.of("path", ":x-pack:plugin", "configuration", "restXpackTests"));
-            project.getDependencies().add(xpackTestConfig.getName(), restXPackTestdependency);
-        } else {
-            Dependency dependency = project.getDependencies()
-                .create("org.elasticsearch:rest-api-spec:" + VersionProperties.getElasticsearch());
-            project.getDependencies().add(testConfig.getName(), dependency);
-        }
+        project.getDependencies().add(xpackTestConfig.getName(), restXPackTestdependency);
 
         project.getConfigurations().create("restTests");
         project.getConfigurations().create("restXpackTests");
 
         Provider<CopyRestTestsTask> copyRestYamlTestTask = project.getTasks()
             .register(COPY_YAML_TESTS_TASK, CopyRestTestsTask.class, task -> {
-                if (BuildParams.isInternal()) {
-                    task.dependsOn(testConfig, xpackTestConfig);
-                    task.setCoreConfig(testConfig);
-                    task.setXpackConfig(xpackTestConfig);
-                }
+                task.dependsOn(testConfig, xpackTestConfig);
+                task.setCoreConfig(testConfig);
+                task.setXpackConfig(xpackTestConfig);
                 // If this is the rest spec project, don't copy the tests again
                 if (project.getPath().equals(":rest-api-spec") == false) {
                     task.getIncludeCore().set(extension.getRestTests().getIncludeCore());
@@ -125,16 +115,9 @@ public class RestResourcesPlugin implements Plugin<Project> {
 
         // api
         Configuration specConfig = project.getConfigurations().create("restSpec"); // name chosen for passivity
-        if (BuildParams.isInternal()) {
-            Dependency restSpecDependency = project.getDependencies()
+        Dependency restSpecDependency = project.getDependencies()
                 .project(Map.of("path", ":rest-api-spec", "configuration", "restSpecs"));
-            project.getDependencies().add(specConfig.getName(), restSpecDependency);
-        } else {
-            Dependency dependency = project.getDependencies()
-                .create("org.elasticsearch:rest-api-spec:" + VersionProperties.getElasticsearch());
-            project.getDependencies().add(specConfig.getName(), dependency);
-        }
-
+        project.getDependencies().add(specConfig.getName(), restSpecDependency);
         project.getConfigurations().create("restSpecs");
 
         Provider<CopyRestApiTask> copyRestYamlApiTask = project.getTasks()

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/test/rest/RestTestUtil.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/test/rest/RestTestUtil.java
@@ -28,14 +28,15 @@ import org.gradle.api.tasks.bundling.Zip;
  */
 public class RestTestUtil {
 
-    private RestTestUtil() {}
+    private RestTestUtil() {
+    }
 
     public static ElasticsearchCluster createTestCluster(Project project, SourceSet sourceSet) {
         // eagerly create the testCluster container so it is easily available for configuration
         @SuppressWarnings("unchecked")
         NamedDomainObjectContainer<ElasticsearchCluster> testClusters = (NamedDomainObjectContainer<ElasticsearchCluster>) project
-            .getExtensions()
-            .getByName(TestClustersPlugin.EXTENSION_NAME);
+                .getExtensions()
+                .getByName(TestClustersPlugin.EXTENSION_NAME);
         return testClusters.create(sourceSet.getName());
     }
 
@@ -69,15 +70,7 @@ public class RestTestUtil {
      * Setup the dependencies needed for the REST tests.
      */
     public static void setupDependencies(Project project, SourceSet sourceSet) {
-        BuildParams.withInternalBuild(
-            () -> { project.getDependencies().add(sourceSet.getImplementationConfigurationName(), project.project(":test:framework")); }
-        ).orElse(() -> {
-            project.getDependencies()
-                .add(
-                    sourceSet.getImplementationConfigurationName(),
-                    "org.elasticsearch.test:framework:" + VersionProperties.getElasticsearch()
-                );
-        });
+        project.getDependencies().add(sourceSet.getImplementationConfigurationName(), project.project(":test:framework"));
     }
 
 }

--- a/build-tools-internal/src/test/java/org/elasticsearch/gradle/AbstractDistributionDownloadPluginTests.java
+++ b/build-tools-internal/src/test/java/org/elasticsearch/gradle/AbstractDistributionDownloadPluginTests.java
@@ -59,10 +59,9 @@ public class AbstractDistributionDownloadPluginTests extends GradleUnitTestCase 
         Version version,
         ElasticsearchDistributionType type,
         ElasticsearchDistribution.Platform platform,
-        BwcVersions bwcVersions,
-        boolean isInternal
+        BwcVersions bwcVersions
     ) {
-        Project project = createProject(bwcVersions, isInternal);
+        Project project = createProject(bwcVersions);
         Project archiveProject = ProjectBuilder.builder().withParent(bwcProject).withName(projectName).build();
         archiveProject.getConfigurations().create(config);
         archiveProject.getArtifacts().add(config, new File("doesnotmatter"));
@@ -94,9 +93,8 @@ public class AbstractDistributionDownloadPluginTests extends GradleUnitTestCase 
         }).maybeFreeze();
     }
 
-    protected Project createProject(BwcVersions bwcVersions, boolean isInternal) {
+    protected Project createProject(BwcVersions bwcVersions) {
         rootProject = ProjectBuilder.builder().build();
-        BuildParams.init(params -> params.setIsInternal(isInternal));
         Project distributionProject = ProjectBuilder.builder().withParent(rootProject).withName("distribution").build();
         archivesProject = ProjectBuilder.builder().withParent(distributionProject).withName("archives").build();
         packagesProject = ProjectBuilder.builder().withParent(distributionProject).withName("packages").build();

--- a/build-tools-internal/src/test/java/org/elasticsearch/gradle/DistributionDownloadPluginTests.java
+++ b/build-tools-internal/src/test/java/org/elasticsearch/gradle/DistributionDownloadPluginTests.java
@@ -21,7 +21,7 @@ public class DistributionDownloadPluginTests extends AbstractDistributionDownloa
 
     public void testVersionDefault() {
         ElasticsearchDistribution distro = checkDistro(
-            createProject(null, false),
+            createProject(null),
             "testdistro",
             null,
             ElasticsearchDistributionTypes.ARCHIVE,
@@ -33,7 +33,7 @@ public class DistributionDownloadPluginTests extends AbstractDistributionDownloa
 
     public void testBadVersionFormat() {
         assertDistroError(
-            createProject(null, false),
+            createProject(null),
             "testdistro",
             "badversion",
             ElasticsearchDistributionTypes.ARCHIVE,
@@ -44,13 +44,13 @@ public class DistributionDownloadPluginTests extends AbstractDistributionDownloa
     }
 
     public void testTypeDefault() {
-        ElasticsearchDistribution distro = checkDistro(createProject(null, false), "testdistro", "5.0.0", null, Platform.LINUX, true);
+        ElasticsearchDistribution distro = checkDistro(createProject(null), "testdistro", "5.0.0", null, Platform.LINUX, true);
         assertEquals(distro.getType(), ElasticsearchDistributionTypes.ARCHIVE);
     }
 
     public void testPlatformDefault() {
         ElasticsearchDistribution distro = checkDistro(
-            createProject(null, false),
+            createProject(null),
             "testdistro",
             "5.0.0",
             ElasticsearchDistributionTypes.ARCHIVE,
@@ -62,7 +62,7 @@ public class DistributionDownloadPluginTests extends AbstractDistributionDownloa
 
     public void testPlatformForIntegTest() {
         assertDistroError(
-            createProject(null, false),
+            createProject(null),
             "testdistro",
             "5.0.0",
             ElasticsearchDistributionTypes.INTEG_TEST_ZIP,
@@ -74,7 +74,7 @@ public class DistributionDownloadPluginTests extends AbstractDistributionDownloa
 
     public void testBundledJdkDefault() {
         ElasticsearchDistribution distro = checkDistro(
-            createProject(null, false),
+            createProject(null),
             "testdistro",
             "5.0.0",
             ElasticsearchDistributionTypes.ARCHIVE,
@@ -86,7 +86,7 @@ public class DistributionDownloadPluginTests extends AbstractDistributionDownloa
 
     public void testBundledJdkForIntegTest() {
         assertDistroError(
-            createProject(null, false),
+            createProject(null),
             "testdistro",
             "5.0.0",
             ElasticsearchDistributionTypes.INTEG_TEST_ZIP,
@@ -97,7 +97,7 @@ public class DistributionDownloadPluginTests extends AbstractDistributionDownloa
     }
 
     public void testLocalCurrentVersionIntegTestZip() {
-        Project project = createProject(BWC_MINOR, true);
+        Project project = createProject(BWC_MINOR);
         Project archiveProject = ProjectBuilder.builder().withParent(archivesProject).withName("integ-test-zip").build();
         archiveProject.getConfigurations().create("default");
         archiveProject.getArtifacts().add("default", new File("doesnotmatter"));
@@ -108,7 +108,7 @@ public class DistributionDownloadPluginTests extends AbstractDistributionDownloa
         for (Platform platform : Platform.values()) {
             for (boolean bundledJdk : new boolean[] { true, false }) {
                 // create a new project in each iteration, so that we know we are resolving the only additional project being created
-                Project project = createProject(BWC_MINOR, true);
+                Project project = createProject(BWC_MINOR);
                 String projectName = projectName(platform.toString(), bundledJdk);
                 projectName += (platform == Platform.WINDOWS ? "-zip" : "-tar");
                 Project archiveProject = ProjectBuilder.builder().withParent(archivesProject).withName(projectName).build();
@@ -132,10 +132,10 @@ public class DistributionDownloadPluginTests extends AbstractDistributionDownloa
             String configName = projectName(platform.toString(), true);
             configName += (platform == Platform.WINDOWS ? "-zip" : "-tar");
             ElasticsearchDistributionType archiveType = ElasticsearchDistributionTypes.ARCHIVE;
-            checkBwc("minor", configName, BWC_MINOR_VERSION, archiveType, platform, BWC_MINOR, true);
-            checkBwc("staged", configName, BWC_STAGED_VERSION, archiveType, platform, BWC_STAGED, true);
-            checkBwc("bugfix", configName, BWC_BUGFIX_VERSION, archiveType, platform, BWC_BUGFIX, true);
-            checkBwc("maintenance", configName, BWC_MAINTENANCE_VERSION, archiveType, platform, BWC_MAINTENANCE, true);
+            checkBwc("minor", configName, BWC_MINOR_VERSION, archiveType, platform, BWC_MINOR);
+            checkBwc("staged", configName, BWC_STAGED_VERSION, archiveType, platform, BWC_STAGED);
+            checkBwc("bugfix", configName, BWC_BUGFIX_VERSION, archiveType, platform, BWC_BUGFIX);
+            checkBwc("maintenance", configName, BWC_MAINTENANCE_VERSION, archiveType, platform, BWC_MAINTENANCE);
         }
     }
 

--- a/build-tools-internal/src/test/java/org/elasticsearch/gradle/internal/InternalDistributionDownloadPluginTests.java
+++ b/build-tools-internal/src/test/java/org/elasticsearch/gradle/internal/InternalDistributionDownloadPluginTests.java
@@ -23,7 +23,7 @@ public class InternalDistributionDownloadPluginTests extends AbstractDistributio
         ElasticsearchDistributionType[] types = { InternalElasticsearchDistributionTypes.RPM, InternalElasticsearchDistributionTypes.DEB };
         for (ElasticsearchDistributionType packageType : types) {
             for (boolean bundledJdk : new boolean[] { true, false }) {
-                Project project = createProject(BWC_MINOR, true);
+                Project project = createProject(BWC_MINOR);
                 String projectName = projectName(packageType.toString(), bundledJdk);
                 Project packageProject = ProjectBuilder.builder().withParent(packagesProject).withName(projectName).build();
                 packageProject.getConfigurations().create("default");
@@ -38,10 +38,10 @@ public class InternalDistributionDownloadPluginTests extends AbstractDistributio
         for (ElasticsearchDistributionType packageType : types) {
             // note: no non bundled jdk for bwc
             String configName = projectName(packageType.toString(), true);
-            checkBwc("minor", configName, BWC_MINOR_VERSION, packageType, null, BWC_MINOR, true);
-            checkBwc("staged", configName, BWC_STAGED_VERSION, packageType, null, BWC_STAGED, true);
-            checkBwc("bugfix", configName, BWC_BUGFIX_VERSION, packageType, null, BWC_BUGFIX, true);
-            checkBwc("maintenance", configName, BWC_MAINTENANCE_VERSION, packageType, null, BWC_MAINTENANCE, true);
+            checkBwc("minor", configName, BWC_MINOR_VERSION, packageType, null, BWC_MINOR);
+            checkBwc("staged", configName, BWC_STAGED_VERSION, packageType, null, BWC_STAGED);
+            checkBwc("bugfix", configName, BWC_BUGFIX_VERSION, packageType, null, BWC_BUGFIX);
+            checkBwc("maintenance", configName, BWC_MAINTENANCE_VERSION, packageType, null, BWC_MAINTENANCE);
         }
     }
 }

--- a/build-tools-internal/src/testKit/elasticsearch.build/build.gradle
+++ b/build-tools-internal/src/testKit/elasticsearch.build/build.gradle
@@ -2,8 +2,6 @@ plugins {
   id 'java'
   id 'elasticsearch.global-build-info'
 }
-import org.elasticsearch.gradle.internal.info.BuildParams
-BuildParams.init { it.setIsInternal(true) }
 
 apply plugin:'elasticsearch.build'
 

--- a/build-tools-internal/src/testKit/thirdPartyAudit/build.gradle
+++ b/build-tools-internal/src/testKit/thirdPartyAudit/build.gradle
@@ -28,6 +28,10 @@ repositories {
   mavenCentral()
 }
 
+project("libs:elasticsearch-core") {
+  apply plugin:'java'
+}
+
 dependencies {
   forbiddenApisCliJar 'de.thetaphi:forbiddenapis:2.7'
   jdkJarHell 'org.elasticsearch:elasticsearch-core:current'

--- a/build-tools-internal/src/testKit/thirdPartyAudit/settings.gradle
+++ b/build-tools-internal/src/testKit/thirdPartyAudit/settings.gradle
@@ -1,1 +1,2 @@
 include 'sample_jars'
+include 'libs:elasticsearch-core'

--- a/build-tools/src/testFixtures/groovy/org/elasticsearch/gradle/fixtures/AbstractGradleFuncTest.groovy
+++ b/build-tools/src/testFixtures/groovy/org/elasticsearch/gradle/fixtures/AbstractGradleFuncTest.groovy
@@ -101,8 +101,6 @@ abstract class AbstractGradleFuncTest extends Specification {
         import org.elasticsearch.gradle.Architecture
         import org.elasticsearch.gradle.internal.info.BuildParams
 
-        BuildParams.init { it.setIsInternal(true) }
-
         import org.elasticsearch.gradle.internal.BwcVersions
         import org.elasticsearch.gradle.Version
 
@@ -113,7 +111,7 @@ abstract class AbstractGradleFuncTest extends Specification {
         )
 
         BwcVersions versions = new BwcVersions(new TreeSet<>(versionList), currentVersion)
-        BuildParams.init { it.setBwcVersions(versions) }
+        BuildParams.init { it.setBwcVersions(provider(() -> versions)) }
         """
     }
 


### PR DESCRIPTION
After breaking up build logic between internal and external we are able to remove BuildParams.isInternal()

This also makes resolving bwc versions lazy and not eager. This makes configuration of non bwc builds and 
integration tests setup easier.