### PR TITLE
[Doc]Missing xpack role in enrich API

### DIFF
--- a/docs/reference/ingest/apis/enrich/index.asciidoc
+++ b/docs/reference/ingest/apis/enrich/index.asciidoc
@@ -1,3 +1,4 @@
+[role="xpack"]
 [[enrich-apis]]
 == Enrich APIs
 


### PR DESCRIPTION
Missing xpack role in enrich API

https://www.elastic.co/guide/en/elasticsearch/reference/master/enrich-apis.html