### PR TITLE
Avoid numerical errors during testing in vector tile factories

### DIFF
--- a/x-pack/plugin/vector-tile/src/main/java/org/elasticsearch/xpack/vectortile/feature/SimpleFeatureFactory.java
+++ b/x-pack/plugin/vector-tile/src/main/java/org/elasticsearch/xpack/vectortile/feature/SimpleFeatureFactory.java
@@ -26,12 +26,10 @@ public class SimpleFeatureFactory {
     public SimpleFeatureFactory(int z, int x, int y, int extent) {
         this.extent = extent;
         final Rectangle rectangle = FeatureFactoryUtils.getTileBounds(z, x, y);
-        // This calculation mimics what mapbox vector tile library is doing. It avoids numerical
-        // errors during testing.
         final double xDiff = rectangle.getMaxLon() - rectangle.getMinLon();
-        pointXScale = 1d / (xDiff / (double) extent);
+        pointXScale = (double) extent / xDiff;
         final double yDiff = rectangle.getMaxLat() - rectangle.getMinLat();
-        pointYScale = -1d / (yDiff / (double) extent);
+        pointYScale = (double) -extent / yDiff;
         pointXTranslate = -pointXScale * rectangle.getMinX();
         pointYTranslate = -pointYScale * rectangle.getMinY();
     }

--- a/x-pack/plugin/vector-tile/src/main/java/org/elasticsearch/xpack/vectortile/feature/SimpleFeatureFactory.java
+++ b/x-pack/plugin/vector-tile/src/main/java/org/elasticsearch/xpack/vectortile/feature/SimpleFeatureFactory.java
@@ -26,10 +26,8 @@ public class SimpleFeatureFactory {
     public SimpleFeatureFactory(int z, int x, int y, int extent) {
         this.extent = extent;
         final Rectangle rectangle = FeatureFactoryUtils.getTileBounds(z, x, y);
-        final double xDiff = rectangle.getMaxLon() - rectangle.getMinLon();
-        pointXScale = (double) extent / xDiff;
-        final double yDiff = rectangle.getMaxLat() - rectangle.getMinLat();
-        pointYScale = (double) -extent / yDiff;
+        pointXScale = (double) extent / (rectangle.getMaxLon() - rectangle.getMinLon());
+        pointYScale = (double) -extent / (rectangle.getMaxLat() - rectangle.getMinLat());
         pointXTranslate = -pointXScale * rectangle.getMinX();
         pointYTranslate = -pointYScale * rectangle.getMinY();
     }

--- a/x-pack/plugin/vector-tile/src/test/java/org/elasticsearch/xpack/vectortile/feature/FeatureFactoryTests.java
+++ b/x-pack/plugin/vector-tile/src/test/java/org/elasticsearch/xpack/vectortile/feature/FeatureFactoryTests.java
@@ -44,6 +44,25 @@ public class FeatureFactoryTests extends ESTestCase {
         }
     }
 
+    public void testIssue74341() {
+        int z = 1;
+        int x = 0;
+        int y = 0;
+        int extent = 1730;
+        double lon = -171.0;
+        double lat = 0.9999999403953552;
+        SimpleFeatureFactory builder = new SimpleFeatureFactory(z, x, y, extent);
+        FeatureFactory factory = new FeatureFactory(z, x, y, extent);
+        VectorTile.Tile.Feature.Builder featureBuilder = VectorTile.Tile.Feature.newBuilder();
+        builder.point(featureBuilder, lon, lat);
+        byte[] b1 = featureBuilder.build().toByteArray();
+        Point point = new Point(lon, lat);
+        List<VectorTile.Tile.Feature> features = factory.getFeatures(point, new UserDataIgnoreConverter());
+        assertThat(features.size(), Matchers.equalTo(1));
+        byte[] b2 = features.get(0).toByteArray();
+        assertArrayEquals(b1, b2);
+    }
+
     public void testRectangle() {
         int z = randomIntBetween(1, 10);
         int x = randomIntBetween(0, (1 << z) - 1);

--- a/x-pack/plugin/vector-tile/src/test/java/org/elasticsearch/xpack/vectortile/feature/FeatureFactoryTests.java
+++ b/x-pack/plugin/vector-tile/src/test/java/org/elasticsearch/xpack/vectortile/feature/FeatureFactoryTests.java
@@ -17,6 +17,7 @@ import org.elasticsearch.search.aggregations.bucket.geogrid.GeoTileUtils;
 import org.elasticsearch.test.ESTestCase;
 import org.hamcrest.Matchers;
 
+import java.util.Arrays;
 import java.util.List;
 
 public class FeatureFactoryTests extends ESTestCase {
@@ -26,6 +27,8 @@ public class FeatureFactoryTests extends ESTestCase {
         int x = randomIntBetween(0, (1 << z) - 1);
         int y = randomIntBetween(0, (1 << z) - 1);
         int extent = randomIntBetween(1 << 8, 1 << 14);
+        // check if we might have numerical error due to floating point arithmetic
+        assumeFalse("", hasNumericalError(z, x, y, extent));
         Rectangle rectangle = GeoTileUtils.toBoundingBox(x, y, z);
         SimpleFeatureFactory builder = new SimpleFeatureFactory(z, x, y, extent);
         FeatureFactory factory = new FeatureFactory(z, x, y, extent);
@@ -49,6 +52,8 @@ public class FeatureFactoryTests extends ESTestCase {
         int x = 0;
         int y = 0;
         int extent = 1730;
+        // this is the typical case we need to guard from.
+        assertThat(hasNumericalError(z, x, y, extent), Matchers.equalTo(true));
         double lon = -171.0;
         double lat = 0.9999999403953552;
         SimpleFeatureFactory builder = new SimpleFeatureFactory(z, x, y, extent);
@@ -60,7 +65,14 @@ public class FeatureFactoryTests extends ESTestCase {
         List<VectorTile.Tile.Feature> features = factory.getFeatures(point, new UserDataIgnoreConverter());
         assertThat(features.size(), Matchers.equalTo(1));
         byte[] b2 = features.get(0).toByteArray();
-        assertArrayEquals(b1, b2);
+        assertThat(Arrays.equals(b1, b2), Matchers.equalTo(false));
+    }
+
+    private boolean hasNumericalError(int z, int x, int y, int extent) {
+        final Rectangle rectangle = FeatureFactoryUtils.getTileBounds(z, x, y);
+        final double xDiff = rectangle.getMaxLon() - rectangle.getMinLon();
+        final double yDiff = rectangle.getMaxLat() - rectangle.getMinLat();
+        return (double) -extent / yDiff != -1d / (yDiff / (double) extent) || (double) extent / xDiff != 1d / (xDiff / (double) extent);
     }
 
     public void testRectangle() {


### PR DESCRIPTION
There are currently two types of factories, one that uses map box vector tile library to generate vector tile features and a second one that it generates the features natively. In order to produce the same result in both libraries we need to make sure we do the computation using the same steps so there are no differences due to numerical errors.

fixes https://github.com/elastic/elasticsearch/issues/74341