### PR TITLE
Fix double counting GeoTileGrid aggregation

### DIFF
--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/search/aggregations/bucket/geogrid/BoundedGeoTileGridTiler.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/search/aggregations/bucket/geogrid/BoundedGeoTileGridTiler.java
@@ -91,14 +91,12 @@ public class BoundedGeoTileGridTiler extends AbstractGeoTileGridTiler {
             for (int i = eastMinX; i < eastMaxX; i++) {
                 for (int j = minY; j < maxY; j++) {
                     assert validTile(i, j, precision);
-                    System.out.println(i + " / " + j);
                     values.add(valuesIndex++, GeoTileUtils.longEncodeTiles(precision, i, j));
                 }
             }
             for (int i = westMinX; i < westMaxX; i++) {
                 for (int j = minY; j < maxY; j++) {
                     assert validTile(i, j, precision);
-                    System.out.println(i + " / " + j);
                     values.add(valuesIndex++, GeoTileUtils.longEncodeTiles(precision, i, j));
                 }
             }

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/search/aggregations/bucket/geogrid/BoundedGeoTileGridTiler.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/search/aggregations/bucket/geogrid/BoundedGeoTileGridTiler.java
@@ -84,18 +84,21 @@ public class BoundedGeoTileGridTiler extends AbstractGeoTileGridTiler {
         // Do the same for the X dimension taking into account that the bounding box might cross the dateline.
         if (crossesDateline) {
             final int eastMinX = xTile * splits;
-            final int eastMaxX = Math.min(this.maxX, xTile * splits + splits);
             final int westMinX = Math.max(this.minX, xTile * splits);
+            // when the left and right box land in the same tile, we need to make sure we don't count then twice
+            final int eastMaxX = Math.min(westMinX, Math.min(this.maxX, xTile * splits + splits));
             final int westMaxX = xTile * splits + splits;
             for (int i = eastMinX; i < eastMaxX; i++) {
                 for (int j = minY; j < maxY; j++) {
                     assert validTile(i, j, precision);
+                    System.out.println(i + " / " + j);
                     values.add(valuesIndex++, GeoTileUtils.longEncodeTiles(precision, i, j));
                 }
             }
             for (int i = westMinX; i < westMaxX; i++) {
                 for (int j = minY; j < maxY; j++) {
                     assert validTile(i, j, precision);
+                    System.out.println(i + " / " + j);
                     values.add(valuesIndex++, GeoTileUtils.longEncodeTiles(precision, i, j));
                 }
             }

--- a/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/search/aggregations/bucket/geogrid/GeoGridTilerTestCase.java
+++ b/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/search/aggregations/bucket/geogrid/GeoGridTilerTestCase.java
@@ -100,7 +100,7 @@ public abstract class GeoGridTilerTestCase extends ESTestCase {
 
     // tests that bounding boxes of shapes crossing the dateline are correctly wrapped
     public void testGeoGridSetValuesBoundingBoxes_BoundedGeoShapeCellValues() throws Exception {
-        for (int i = 0; i < 1; i++) {
+        for (int i = 0; i < 10; i++) {
             int precision = randomIntBetween(0, 3);
             GeoShapeIndexer indexer = new GeoShapeIndexer(true, "test");
             Geometry geometry = indexer.prepareForIndexing(randomValueOtherThanMany(g -> {
@@ -122,6 +122,21 @@ public abstract class GeoGridTilerTestCase extends ESTestCase {
             int expected = expectedBuckets(value, precision, geoBoundingBox);
             assertThat(numBuckets, equalTo(expected));
         }
+    }
+
+    // tests that bounding boxes that crosses the dateline and cover all longitude values are correctly wrapped
+    public void testGeoGridSetValuesBoundingBoxes_coversAlllongitudeValues() throws Exception {
+        int precision = 3;
+        Geometry geometry = new Rectangle(-92, 180, 0.99, -89);//GeometryTestUtils.randomRectangle();
+        GeoBoundingBox geoBoundingBox = new GeoBoundingBox(new GeoPoint(5, 0.6), new GeoPoint(-5, 0.5));
+        GeoShapeValues.GeoShapeValue value = geoShapeValue(geometry);
+        GeoShapeCellValues cellValues =
+            new GeoShapeCellValues(makeGeoShapeValues(value), getBoundedGridTiler(geoBoundingBox, precision), NOOP_BREAKER);
+
+        assertTrue(cellValues.advanceExact(0));
+        int numBuckets = cellValues.docValueCount();
+        int expected = expectedBuckets(value, precision, geoBoundingBox);
+        assertThat(numBuckets, equalTo(expected));
     }
 
     public void testGeoGridSetValuesBoundingBoxes_UnboundedGeoShapeCellValues() throws Exception {

--- a/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/search/aggregations/bucket/geogrid/GeoGridTilerTestCase.java
+++ b/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/search/aggregations/bucket/geogrid/GeoGridTilerTestCase.java
@@ -125,9 +125,9 @@ public abstract class GeoGridTilerTestCase extends ESTestCase {
     }
 
     // tests that bounding boxes that crosses the dateline and cover all longitude values are correctly wrapped
-    public void testGeoGridSetValuesBoundingBoxes_coversAlllongitudeValues() throws Exception {
+    public void testGeoGridSetValuesBoundingBoxes_coversAllLongitudeValues() throws Exception {
         int precision = 3;
-        Geometry geometry = new Rectangle(-92, 180, 0.99, -89);//GeometryTestUtils.randomRectangle();
+        Geometry geometry = new Rectangle(-92, 180, 0.99, -89);
         GeoBoundingBox geoBoundingBox = new GeoBoundingBox(new GeoPoint(5, 0.6), new GeoPoint(-5, 0.5));
         GeoShapeValues.GeoShapeValue value = geoShapeValue(geometry);
         GeoShapeCellValues cellValues =


### PR DESCRIPTION
In the extreme case that a Geotile grid aggregation with a bounded box that crosses the dateline, and that bounding box edges are landing in the same tile, then it might happen that we are counting twice the same tile.

This PR makes sure this does not happen by adjusting which tiles we iterate for each side of the bounding box that crosses the dateline.

fixes https://github.com/elastic/elasticsearch/issues/74352