### PR TITLE
[DOCS] [7.13] Add missing dynamic runtime option (#74294)

### DIFF
--- a/docs/reference/mapping/types/object.asciidoc
+++ b/docs/reference/mapping/types/object.asciidoc
@@ -82,7 +82,7 @@ The following parameters are accepted by `object` fields:
 <<dynamic,`dynamic`>>::
 
     Whether or not new `properties` should be added dynamically
-    to an existing object. Accepts `true` (default), `false`
+    to an existing object. Accepts `true` (default), `runtime`, `false`
     and `strict`.
 
 <<enabled,`enabled`>>::


### PR DESCRIPTION
Backports the following commits to 7.13:
 - [DOCS] add missing dynamic runtime option (#74294)