### PR TITLE
[7.x] [DOCS] Add missing `xpack` role (#74331)

### DIFF
--- a/docs/reference/ingest/apis/enrich/index.asciidoc
+++ b/docs/reference/ingest/apis/enrich/index.asciidoc
@@ -1,3 +1,4 @@
+[role="xpack"]
 [[enrich-apis]]
 == Enrich APIs
 


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [DOCS] Add missing`xpack` role (#74331)