### PR TITLE
[7.x] Fix UBI source URL (#74357)

### DIFF
--- a/distribution/build.gradle
+++ b/distribution/build.gradle
@@ -49,7 +49,7 @@ tasks.register("generateDependenciesReport", ConcatFilesTask) {
     '8',
     'https://catalog.redhat.com/software/containers/ubi8/ubi-minimal/5c359a62bed8bd75a2c3fba8',
     'Custom;https://www.redhat.com/licenses/EULA_Red_Hat_Universal_Base_Image_English_20190422.pdf',
-    'https://oss-dependencies.elastic.co/redhat/ubi/ubi-minimal-8-source.tar.gz'
+    'https://oss-dependencies.elastic.co/red-hat-universal-base-image-minimal/8/ubi-minimal-8-source.tar.gz'
   ]
   additionalLines << rhelUbiFields.join(',')
 }


### PR DESCRIPTION
This commit fix the source URL for UBI image to ensure that it stays
 consistent with the one generated in
 https://artifacts.elastic.co/reports/dependencies/dependencies-current.html

Backport #74357