### PR TITLE
Reduce agg buckets only if competitive (backport of #74096)

### DIFF
--- a/server/src/main/java/org/elasticsearch/search/aggregations/BucketOrder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/BucketOrder.java
@@ -127,6 +127,11 @@ public abstract class BucketOrder implements ToXContentObject, Writeable {
     public abstract Comparator<Bucket> comparator();
 
     /**
+     * Build a comparator for {@link DelayedBucket}, a wrapper that delays bucket reduction.
+     */
+    abstract Comparator<DelayedBucket<? extends Bucket>> delayedBucketComparator();
+
+    /**
      * @return unique internal ID used for reading/writing this order from/to a stream.
      * @see InternalOrder.Streams
      */

--- a/server/src/main/java/org/elasticsearch/search/aggregations/DelayedBucket.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/DelayedBucket.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.search.aggregations;
+
+import java.util.List;
+import java.util.function.BiFunction;
+
+/**
+ * A wrapper around reducing buckets with the same key that can delay that reduction
+ * as long as possible. It's stateful and not even close to thread safe.
+ */
+public final class DelayedBucket<B extends InternalMultiBucketAggregation.InternalBucket> {
+    private final BiFunction<List<B>, InternalAggregation.ReduceContext, B> reduce;
+    private final InternalAggregation.ReduceContext reduceContext;
+    /**
+     * The buckets to reduce or {@code null} if we've already reduced the buckets.
+     */
+    private List<B> toReduce;
+    /**
+     * The result of reducing the buckets or {@code null} if they haven't yet been
+     * reduced.
+     */
+    private B reduced;
+    /**
+     * The count of documents. Calculated on the fly the first time its needed and
+     * cached.
+     */
+    private long docCount = -1;
+
+    /**
+     * Build a delayed bucket.
+     * <p>
+     * We take a {@link BiFunction} to match the signature of
+     * {@link InternalMultiBucketAggregation#reduceBucket}.
+     */
+    public DelayedBucket(
+        BiFunction<List<B>, InternalAggregation.ReduceContext, B> reduce,
+        InternalAggregation.ReduceContext reduceContext,
+        List<B> toReduce
+    ) {
+        this.reduce = reduce;
+        this.reduceContext = reduceContext;
+        this.toReduce = toReduce;
+    }
+
+    /**
+     * The reduced bucket. If the bucket hasn't been reduced already this
+     * will reduce the sub-aggs and throw out the list to reduce.
+     */
+    public B reduced() {
+        if (reduced == null) {
+            reduceContext.consumeBucketsAndMaybeBreak(1);
+            reduced = reduce.apply(toReduce, reduceContext);
+            toReduce = null;
+        }
+        return reduced;
+    }
+
+    /**
+     * Count the documents in the buckets.
+     */
+    public long getDocCount() {
+        if (docCount < 0) {
+            if (reduced == null) {
+                docCount = 0;
+                for (B bucket : toReduce) {
+                    docCount += bucket.getDocCount();
+                }
+            } else {
+                docCount = reduced.getDocCount();
+            }
+        }
+        return docCount;
+    }
+
+    /**
+     * Compare the keys of two buckets.
+     */
+    @SuppressWarnings({ "rawtypes", "unchecked" }) // The funny casting here is sad, but this is how buckets are compared.
+    int compareKey(DelayedBucket<?> rhs) {
+        return ((KeyComparable) representativeBucket()).compareKey(rhs.representativeBucket());
+    }
+
+    /**
+     * A representative of the buckets used to acess the key.
+     */
+    private B representativeBucket() {
+        return reduced == null ? toReduce.get(0) : reduced;
+    }
+
+    @Override
+    public String toString() {
+        return "Delayed[" + representativeBucket().getKeyAsString() + "]";
+    }
+
+    /**
+     * Called to mark a bucket as non-competitive so it can release it can release
+     * any sub-buckets from the breaker.
+     */
+    void nonCompetitive() {
+        if (reduced != null) {
+            // -1 for itself, -countInnerBucket for all the sub-buckets.
+            reduceContext.consumeBucketsAndMaybeBreak(-1 - InternalMultiBucketAggregation.countInnerBucket(reduced));
+        }
+    }
+}

--- a/server/src/main/java/org/elasticsearch/search/aggregations/InternalOrder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/InternalOrder.java
@@ -82,6 +82,17 @@ public abstract class InternalOrder extends BucketOrder {
         }
 
         @Override
+        Comparator<DelayedBucket<? extends Bucket>> delayedBucketComparator() {
+            Comparator<Bucket> comparator = comparator();
+            /*
+             * Reduce the buckets if we haven't already so we can get at the
+             * sub-aggregations. With enough code we could avoid this but
+             * we haven't written that code....
+             */
+            return (lhs, rhs) -> comparator.compare(lhs.reduced(), rhs.reduced());
+        }
+
+        @Override
         byte id() {
             return ID;
         }
@@ -204,6 +215,22 @@ public abstract class InternalOrder extends BucketOrder {
         }
 
         @Override
+        Comparator<DelayedBucket<? extends Bucket>> delayedBucketComparator() {
+            List<Comparator<DelayedBucket<? extends Bucket>>> comparators = orderElements.stream()
+                .map(BucketOrder::delayedBucketComparator)
+                .collect(toList());
+            return (lhs, rhs) -> {
+                for (Comparator<DelayedBucket<? extends Bucket>> c : comparators) {
+                    int result = c.compare(lhs, rhs);
+                    if (result != 0) {
+                        return result;
+                    }
+                }
+                return 0;
+            };
+        }
+
+        @Override
         public int hashCode() {
             return Objects.hash(orderElements);
         }
@@ -231,17 +258,30 @@ public abstract class InternalOrder extends BucketOrder {
         private final String key;
         private final SortOrder order;
         private final Comparator<Bucket> comparator;
+        private final Comparator<DelayedBucket<? extends Bucket>> delayedBucketCompator;
 
-        SimpleOrder(byte id, String key, SortOrder order, Comparator<Bucket> comparator) {
+        SimpleOrder(
+            byte id,
+            String key,
+            SortOrder order,
+            Comparator<Bucket> comparator,
+            Comparator<DelayedBucket<? extends Bucket>> delayedBucketCompator
+        ) {
             this.id = id;
             this.key = key;
             this.order = order;
             this.comparator = comparator;
+            this.delayedBucketCompator = delayedBucketCompator;
         }
 
         @Override
         public Comparator<Bucket> comparator() {
             return comparator;
+        }
+
+        @Override
+        Comparator<DelayedBucket<? extends Bucket>> delayedBucketComparator() {
+            return delayedBucketCompator;
         }
 
         @Override
@@ -288,28 +328,53 @@ public abstract class InternalOrder extends BucketOrder {
     /**
      * Order by the (higher) count of each bucket.
      */
-    static final InternalOrder COUNT_DESC = new SimpleOrder(COUNT_DESC_ID, "_count", SortOrder.DESC, comparingCounts().reversed());
+    static final InternalOrder COUNT_DESC = new SimpleOrder(
+        COUNT_DESC_ID,
+        "_count",
+        SortOrder.DESC,
+        comparingCounts().reversed(),
+        comparingDelayedCounts().reversed()
+    );
 
     /**
      * Order by the (lower) count of each bucket.
      */
-    static final InternalOrder COUNT_ASC = new SimpleOrder(COUNT_ASC_ID, "_count", SortOrder.ASC, comparingCounts());
+    static final InternalOrder COUNT_ASC = new SimpleOrder(
+        COUNT_ASC_ID,
+        "_count",
+        SortOrder.ASC,
+        comparingCounts(),
+        comparingDelayedCounts()
+    );
 
     /**
      * Order by the key of each bucket descending.
      */
-    static final InternalOrder KEY_DESC = new SimpleOrder(KEY_DESC_ID, "_key", SortOrder.DESC, comparingKeys().reversed());
+    static final InternalOrder KEY_DESC = new SimpleOrder(
+        KEY_DESC_ID,
+        "_key",
+        SortOrder.DESC,
+        comparingKeys().reversed(),
+        comparingDelayedKeys().reversed()
+    );
 
     /**
      * Order by the key of each bucket ascending.
      */
-    static final InternalOrder KEY_ASC = new SimpleOrder(KEY_ASC_ID, "_key", SortOrder.ASC, comparingKeys());
+    static final InternalOrder KEY_ASC = new SimpleOrder(KEY_ASC_ID, "_key", SortOrder.ASC, comparingKeys(), comparingDelayedKeys());
 
     /**
      * @return compare by {@link Bucket#getDocCount()}.
      */
     private static Comparator<Bucket> comparingCounts() {
         return Comparator.comparingLong(Bucket::getDocCount);
+    }
+
+    /**
+     * @return compare by {@link Bucket#getDocCount()} that will be in the bucket once it is reduced
+     */
+    private static Comparator<DelayedBucket<? extends Bucket>> comparingDelayedCounts() {
+        return Comparator.comparingLong(DelayedBucket::getDocCount);
     }
 
     /**
@@ -322,7 +387,14 @@ public abstract class InternalOrder extends BucketOrder {
                 return ((KeyComparable) b1).compareKey(b2);
             }
             throw new IllegalStateException("Unexpected order bucket class [" + b1.getClass() + "]");
-        };
+        };    }
+
+    /**
+     * @return compare by {@link Bucket#getKey()} that will be in the bucket once it is reduced
+     */
+    @SuppressWarnings("unchecked")
+    private static Comparator<DelayedBucket<? extends Bucket>> comparingDelayedKeys() {
+        return DelayedBucket::compareKey;
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/search/aggregations/TopBucketBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/TopBucketBuilder.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.search.aggregations;
+
+import org.apache.lucene.util.PriorityQueue;
+import org.elasticsearch.search.aggregations.bucket.MultiBucketsAggregation.Bucket;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.function.Consumer;
+
+/**
+ * Merges many buckets into the "top" buckets as sorted by {@link BucketOrder}.
+ */
+public class TopBucketBuilder<B extends InternalMultiBucketAggregation.InternalBucket> {
+    private final Consumer<DelayedBucket<B>> nonCompetitive;
+    private final PriorityQueue<DelayedBucket<B>> queue;
+
+    /**
+     * Create a {@link TopBucketBuilder} to build a list of the top buckets.
+     * @param size the requested size of the list
+     * @param order the sort order of the buckets
+     * @param nonCompetitive called with non-competitive buckets
+     */
+    public TopBucketBuilder(int size, BucketOrder order, Consumer<DelayedBucket<B>> nonCompetitive) {
+        this.nonCompetitive = nonCompetitive;
+        queue = new PriorityQueue<DelayedBucket<B>>(size) {
+            private final Comparator<DelayedBucket<? extends Bucket>> comparator = order.delayedBucketComparator();
+
+            @Override
+            protected boolean lessThan(DelayedBucket<B> a, DelayedBucket<B> b) {
+                return comparator.compare(a, b) > 0;
+            }
+        };
+    }
+
+    /**
+     * Add a bucket if it is competitive. If there isn't space but the
+     * bucket is competitive then this will drop the least competitive bucket
+     * to make room for the new bucket.
+     * <p>
+     * Instead of operating on complete buckets we this operates on a
+     * wrapper containing what we need to merge the buckets called
+     * {@link DelayedBucket}. We can evaluate some common sort criteria
+     * directly on the {@linkplain DelayedBucket}s so we only need to
+     * merge <strong>exactly</strong> the sub-buckets we need.
+     */
+    public void add(DelayedBucket<B> bucket) {
+        DelayedBucket<B> removed = queue.insertWithOverflow(bucket);
+        if (removed != null) {
+            nonCompetitive.accept(removed);
+            removed.nonCompetitive();
+        }
+    }
+
+    /**
+     * Return the most competitive buckets sorted by the comparator.
+     */
+    public List<B> build() {
+        List<B> result = new ArrayList<>(queue.size());
+        for (int i = queue.size() - 1; i >= 0; i--) {
+            result.add(queue.pop().reduced());
+        }
+        Collections.reverse(result);
+        return result;
+    }
+}

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/AbstractInternalTerms.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/AbstractInternalTerms.java
@@ -9,24 +9,25 @@
 package org.elasticsearch.search.aggregations.bucket.terms;
 
 import org.apache.lucene.util.PriorityQueue;
-import org.elasticsearch.Version;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.search.aggregations.AggregationExecutionException;
 import org.elasticsearch.search.aggregations.BucketOrder;
+import org.elasticsearch.search.aggregations.DelayedBucket;
 import org.elasticsearch.search.aggregations.InternalAggregation;
 import org.elasticsearch.search.aggregations.InternalAggregations;
 import org.elasticsearch.search.aggregations.InternalMultiBucketAggregation;
 import org.elasticsearch.search.aggregations.InternalOrder;
+import org.elasticsearch.search.aggregations.TopBucketBuilder;
 import org.elasticsearch.search.aggregations.bucket.IteratorAndCurrent;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Function;
 
 import static org.elasticsearch.search.aggregations.InternalOrder.isKeyAsc;
 import static org.elasticsearch.search.aggregations.InternalOrder.isKeyOrder;
@@ -61,11 +62,6 @@ public abstract class AbstractInternalTerms<
 
         protected abstract long getDocCountError();
     }
-
-    /**
-     * Create an array to hold some buckets. Used in collecting the results.
-     */
-    protected abstract B[] createBucketsArray(int size);
 
     /**
      * Creates InternalTerms at the end of the merge
@@ -151,8 +147,39 @@ public abstract class AbstractInternalTerms<
         }
     }
 
-    private List<B> reduceMergeSort(List<InternalAggregation> aggregations,
-                                    BucketOrder thisReduceOrder, InternalAggregation.ReduceContext reduceContext) {
+    /**
+     * Reduce the buckets of sub-aggregations.
+     * @param sink Handle the reduced buckets. Returns false if we should stop iterating the buckets, true if we should continue.
+     * @return the order we used to reduce the buckets
+     */
+    private BucketOrder reduceBuckets(
+        List<InternalAggregation> aggregations,
+        InternalAggregation.ReduceContext reduceContext,
+        Function<DelayedBucket<B>, Boolean> sink
+    ) {
+        /*
+         * Buckets returned by a partial reduce or a shard response are sorted by key since {@link Version#V_7_10_0}.
+         * That allows to perform a merge sort when reducing multiple aggregations together.
+         * For backward compatibility, we disable the merge sort and use ({@link #reduceLegacy} if any of
+         * the provided aggregations use a different {@link #reduceOrder}.
+         */
+        BucketOrder thisReduceOrder = getReduceOrder(aggregations);
+        if (isKeyOrder(thisReduceOrder)) {
+            // extract the primary sort in case this is a compound order.
+            thisReduceOrder = InternalOrder.key(isKeyAsc(thisReduceOrder));
+            reduceMergeSort(aggregations, thisReduceOrder, reduceContext, sink);
+        } else {
+            reduceLegacy(aggregations, reduceContext, sink);
+        }
+        return thisReduceOrder;
+    }
+
+    private void reduceMergeSort(
+        List<InternalAggregation> aggregations,
+        BucketOrder thisReduceOrder,
+        InternalAggregation.ReduceContext reduceContext,
+        Function<DelayedBucket<B>, Boolean> sink
+    ) {
         assert isKeyOrder(thisReduceOrder);
         final Comparator<Bucket> cmp = thisReduceOrder.comparator();
         final PriorityQueue<IteratorAndCurrent<B>> pq = new PriorityQueue<IteratorAndCurrent<B>>(aggregations.size()) {
@@ -168,21 +195,24 @@ public abstract class AbstractInternalTerms<
                 pq.add(new IteratorAndCurrent<>(terms.getBuckets().iterator()));
             }
         }
-        List<B> reducedBuckets = new ArrayList<>();
         // list of buckets coming from different shards that have the same key
-        List<B> currentBuckets = new ArrayList<>();
+        List<B> sameTermBuckets = new ArrayList<>();
         B lastBucket = null;
         while (pq.size() > 0) {
             final IteratorAndCurrent<B> top = pq.top();
             assert lastBucket == null || cmp.compare(top.current(), lastBucket) >= 0;
             if (lastBucket != null && cmp.compare(top.current(), lastBucket) != 0) {
-                // the key changes, reduce what we already buffered and reset the buffer for current buckets
-                final B reduced = reduceBucket(currentBuckets, reduceContext);
-                reducedBuckets.add(reduced);
-                currentBuckets.clear();
+                // the key changed so bundle up the last key's worth of buckets
+                boolean shouldContinue = sink.apply(
+                    new DelayedBucket<B>(AbstractInternalTerms.this::reduceBucket, reduceContext, sameTermBuckets)
+                );
+                if (false == shouldContinue) {
+                    return;
+                }
+                sameTermBuckets = new ArrayList<>();
             }
             lastBucket = top.current();
-            currentBuckets.add(top.current());
+            sameTermBuckets.add(top.current());
             if (top.hasNext()) {
                 top.next();
                 /*
@@ -197,14 +227,16 @@ public abstract class AbstractInternalTerms<
             }
         }
 
-        if (currentBuckets.isEmpty() == false) {
-            final B reduced = reduceBucket(currentBuckets, reduceContext);
-            reducedBuckets.add(reduced);
+        if (sameTermBuckets.isEmpty() == false) {
+            sink.apply(new DelayedBucket<B>(AbstractInternalTerms.this::reduceBucket, reduceContext, sameTermBuckets));
         }
-        return reducedBuckets;
     }
 
-    private List<B> reduceLegacy(List<InternalAggregation> aggregations, InternalAggregation.ReduceContext reduceContext) {
+    private void reduceLegacy(
+        List<InternalAggregation> aggregations,
+        InternalAggregation.ReduceContext reduceContext,
+        Function<DelayedBucket<B>, Boolean> sink
+    ) {
         Map<Object, List<B>> bucketMap = new HashMap<>();
         for (InternalAggregation aggregation : aggregations) {
             @SuppressWarnings("unchecked")
@@ -215,17 +247,19 @@ public abstract class AbstractInternalTerms<
                 }
             }
         }
-        List<B> reducedBuckets = new ArrayList<>();
         for (List<B> sameTermBuckets : bucketMap.values()) {
-            final B b = reduceBucket(sameTermBuckets, reduceContext);
-            reducedBuckets.add(b);
+            boolean shouldContinue = sink.apply(
+                new DelayedBucket<B>(AbstractInternalTerms.this::reduceBucket, reduceContext, sameTermBuckets)
+            );
+            if (false == shouldContinue) {
+                return;
+            }
         }
-        return reducedBuckets;
     }
 
     public InternalAggregation reduce(List<InternalAggregation> aggregations, InternalAggregation.ReduceContext reduceContext) {
         long sumDocCountError = 0;
-        long otherDocCount = 0;
+        long[] otherDocCount = new long[] {0};
         A referenceTerms = null;
         for (InternalAggregation aggregation : aggregations) {
             @SuppressWarnings("unchecked")
@@ -240,7 +274,7 @@ public abstract class AbstractInternalTerms<
                     + referenceTerms.getName() + "] because the field you gave in the aggregation query existed as two different "
                     + "types in two different indices");
             }
-            otherDocCount += terms.getSumOfOtherDocCounts();
+            otherDocCount[0] += terms.getSumOfOtherDocCounts();
             final long thisAggDocCountError = getDocCountError(terms);
             if (sumDocCountError != -1) {
                 if (thisAggDocCountError == -1) {
@@ -262,62 +296,37 @@ public abstract class AbstractInternalTerms<
             }
         }
 
-        final List<B> reducedBuckets;
-        /**
-         * Buckets returned by a partial reduce or a shard response are sorted by key since {@link Version#V_7_10_0}.
-         * That allows to perform a merge sort when reducing multiple aggregations together.
-         * For backward compatibility, we disable the merge sort and use ({@link #reduceLegacy} if any of
-         * the provided aggregations use a different {@link #reduceOrder}.
-         */
-        BucketOrder thisReduceOrder = getReduceOrder(aggregations);
-        if (isKeyOrder(thisReduceOrder)) {
-            // extract the primary sort in case this is a compound order.
-            thisReduceOrder = InternalOrder.key(isKeyAsc(thisReduceOrder));
-            reducedBuckets = reduceMergeSort(aggregations, thisReduceOrder, reduceContext);
-        } else {
-            reducedBuckets = reduceLegacy(aggregations, reduceContext);
-        }
-        final B[] list;
+        BucketOrder thisReduceOrder;
+        List<B> result;
         if (reduceContext.isFinalReduce()) {
-            final int size = Math.min(getRequiredSize(), reducedBuckets.size());
-            // final comparator
-            final BucketPriorityQueue<B> ordered = new BucketPriorityQueue<>(size, getOrder().comparator());
-            for (B bucket : reducedBuckets) {
-                if (sumDocCountError == -1) {
-                    bucket.setDocCountError(-1);
-                } else {
-                    bucket.updateDocCountError(sumDocCountError);
-                }
+            TopBucketBuilder<B> top = new TopBucketBuilder<>(getRequiredSize(), getOrder(), removed -> {
+                otherDocCount[0] += removed.getDocCount();
+            });
+            thisReduceOrder = reduceBuckets(aggregations, reduceContext, bucket -> {
                 if (bucket.getDocCount() >= getMinDocCount()) {
-                    B removed = ordered.insertWithOverflow(bucket);
-                    if (removed != null) {
-                        otherDocCount += removed.getDocCount();
-                        reduceContext.consumeBucketsAndMaybeBreak(-countInnerBucket(removed));
-                    } else {
-                        reduceContext.consumeBucketsAndMaybeBreak(1);
-                    }
-                } else {
-                    reduceContext.consumeBucketsAndMaybeBreak(-countInnerBucket(bucket));
+                    top.add(bucket);
                 }
-            }
-            list = createBucketsArray(ordered.size());
-            for (int i = ordered.size() - 1; i >= 0; i--) {
-                list[i] = ordered.pop();
-            }
+                return true;
+            });
+            result = top.build();
         } else {
-            // we can prune the list on partial reduce if the aggregation is ordered by key
-            // and not filtered (minDocCount == 0)
-            int size = isKeyOrder(getOrder()) && getMinDocCount() == 0 ? Math.min(getRequiredSize(), reducedBuckets.size()) :
-                reducedBuckets.size();
-            list = createBucketsArray(size);
-            for (int i = 0; i < size; i++) {
-                reduceContext.consumeBucketsAndMaybeBreak(1);
-                list[i] = reducedBuckets.get(i);
-                if (sumDocCountError == -1) {
-                    list[i].setDocCountError(-1);
-                } else {
-                    list[i].updateDocCountError(sumDocCountError);
-                }
+            /*
+             * We can prune the list on partial reduce if the aggregation is ordered
+             * by key and not filtered on doc count. The results come in key order
+             * so we can just stop iteration early.
+             */
+            boolean canPrune = isKeyOrder(getOrder()) && getMinDocCount() == 0;
+            result = new ArrayList<>();
+            thisReduceOrder = reduceBuckets(aggregations, reduceContext, bucket -> {
+                result.add(bucket.reduced());
+                return false == canPrune || result.size() < getRequiredSize();
+            });
+        }
+        for (B r : result) {
+            if (sumDocCountError == -1) {
+                r.setDocCountError(-1);
+            } else {
+                r.updateDocCountError(sumDocCountError);
             }
         }
         long docCountError;
@@ -326,8 +335,7 @@ public abstract class AbstractInternalTerms<
         } else {
             docCountError = aggregations.size() == 1 ? 0 : sumDocCountError;
         }
-        return create(name, Arrays.asList(list), reduceContext.isFinalReduce() ? getOrder() : thisReduceOrder, docCountError,
-            otherDocCount);
+        return create(name, result, reduceContext.isFinalReduce() ? getOrder() : thisReduceOrder, docCountError, otherDocCount[0]);
     }
 
     protected static XContentBuilder doXContentCommon(XContentBuilder builder,

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/DoubleTerms.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/DoubleTerms.java
@@ -127,11 +127,6 @@ public class DoubleTerms extends InternalMappedTerms<DoubleTerms, DoubleTerms.Bu
     }
 
     @Override
-    protected Bucket[] createBucketsArray(int size) {
-        return new Bucket[size];
-    }
-
-    @Override
     public InternalAggregation reduce(List<InternalAggregation> aggregations, ReduceContext reduceContext) {
         boolean promoteToDouble = false;
         for (InternalAggregation agg : aggregations) {

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/LongTerms.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/LongTerms.java
@@ -139,11 +139,6 @@ public class LongTerms extends InternalMappedTerms<LongTerms, LongTerms.Bucket> 
     }
 
     @Override
-    protected Bucket[] createBucketsArray(int size) {
-        return new Bucket[size];
-    }
-
-    @Override
     public InternalAggregation reduce(List<InternalAggregation> aggregations, ReduceContext reduceContext) {
         boolean unsignedLongFormat = false;
         boolean rawFormat = false;

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/StringTerms.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/StringTerms.java
@@ -133,9 +133,4 @@ public class StringTerms extends InternalMappedTerms<StringTerms, StringTerms.Bu
         return new StringTerms(name, reduceOrder, order, requiredSize, minDocCount, getMetadata(), format, shardSize,
                 showTermDocCountError, otherDocCount, buckets, docCountError);
     }
-
-    @Override
-    protected Bucket[] createBucketsArray(int size) {
-        return new Bucket[size];
-    }
 }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/UnmappedTerms.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/UnmappedTerms.java
@@ -128,9 +128,4 @@ public class UnmappedTerms extends InternalTerms<UnmappedTerms, UnmappedTerms.Bu
     public Bucket getBucketByKey(String term) {
         return null;
     }
-
-    @Override
-    protected Bucket[] createBucketsArray(int size) {
-        return new Bucket[size];
-    }
 }

--- a/server/src/test/java/org/elasticsearch/search/aggregations/DelayedBucketTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/DelayedBucketTests.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.search.aggregations;
+
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.search.DocValueFormat;
+import org.elasticsearch.search.aggregations.InternalAggregation.ReduceContext;
+import org.elasticsearch.search.aggregations.InternalMultiBucketAggregation.InternalBucket;
+import org.elasticsearch.search.aggregations.bucket.MultiBucketsAggregation.Bucket;
+import org.elasticsearch.search.aggregations.bucket.terms.StringTerms;
+import org.elasticsearch.test.ESTestCase;
+
+import java.util.List;
+import java.util.function.BiFunction;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.lessThan;
+import static org.hamcrest.Matchers.sameInstance;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+public class DelayedBucketTests extends ESTestCase {
+    public void testToString() {
+        assertThat(new DelayedBucket<>(null, null, org.elasticsearch.core.List.of(bucket("test", 1))).toString(), equalTo("Delayed[test]"));
+    }
+
+    public void testReduced() {
+        ReduceContext context = mock(ReduceContext.class);
+        DelayedBucket<?> b = new DelayedBucket<>(
+            mockReduce(context),
+            context,
+            org.elasticsearch.core.List.of(bucket("test", 1), bucket("test", 2))
+        );
+        assertThat(b.getDocCount(), equalTo(3L));
+        assertThat(b.reduced(), sameInstance(b.reduced()));
+        assertThat(b.reduced().getKeyAsString(), equalTo("test"));
+        assertThat(b.reduced().getDocCount(), equalTo(3L));
+        verify(context).consumeBucketsAndMaybeBreak(1);
+        verifyNoMoreInteractions(context);
+    }
+
+    public void testCompareKey() {
+        ReduceContext context = mock(ReduceContext.class);
+        DelayedBucket<?> a = new DelayedBucket<>(mockReduce(context), context, org.elasticsearch.core.List.of(bucket("a", 1)));
+        DelayedBucket<?> b = new DelayedBucket<>(mockReduce(context), context, org.elasticsearch.core.List.of(bucket("b", 1)));
+        if (randomBoolean()) {
+            a.reduced();
+        }
+        if (randomBoolean()) {
+            b.reduced();
+        }
+        assertThat(a.compareKey(b), lessThan(0));
+        assertThat(b.compareKey(a), greaterThan(0));
+        assertThat(a.compareKey(a), equalTo(0));
+    }
+
+    public void testNonCompetitiveNotReduced() {
+        ReduceContext context = mock(ReduceContext.class);
+        new DelayedBucket<>(mockReduce(context), context, org.elasticsearch.core.List.of(bucket("test", 1))).nonCompetitive();
+        verifyNoMoreInteractions(context);
+    }
+
+    public void testNonCompetitiveReduced() {
+        ReduceContext context = mock(ReduceContext.class);
+        DelayedBucket<?> b = new DelayedBucket<>(mockReduce(context), context, org.elasticsearch.core.List.of(bucket("test", 1)));
+        b.reduced();
+        verify(context).consumeBucketsAndMaybeBreak(1);
+        b.nonCompetitive();
+        verify(context).consumeBucketsAndMaybeBreak(-1);
+        verifyNoMoreInteractions(context);
+    }
+
+    private static InternalBucket bucket(String key, long docCount) {
+        return new StringTerms.Bucket(new BytesRef(key), docCount, InternalAggregations.EMPTY, false, 0, DocValueFormat.RAW);
+    }
+
+    static BiFunction<List<InternalBucket>, ReduceContext, InternalBucket> mockReduce(ReduceContext context) {
+        return (l, c) -> {
+            assertThat(c, sameInstance(context));
+            return bucket(l.get(0).getKeyAsString(), l.stream().mapToLong(Bucket::getDocCount).sum());
+        };
+    }
+}

--- a/server/src/test/java/org/elasticsearch/search/aggregations/TopBucketBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/TopBucketBuilderTests.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.search.aggregations;
+
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.search.DocValueFormat;
+import org.elasticsearch.search.aggregations.InternalAggregation.ReduceContext;
+import org.elasticsearch.search.aggregations.InternalMultiBucketAggregation.InternalBucket;
+import org.elasticsearch.search.aggregations.bucket.terms.StringTerms;
+import org.elasticsearch.test.ESTestCase;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+
+import static org.elasticsearch.search.aggregations.DelayedBucketTests.mockReduce;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
+import static org.mockito.Mockito.mock;
+
+public class TopBucketBuilderTests extends ESTestCase {
+    public void testSizeOne() {
+        int count = between(1, 1000);
+        ReduceContext context = mock(ReduceContext.class);
+        List<String> nonCompetitive = new ArrayList<>();
+        TopBucketBuilder<InternalBucket> builder = new TopBucketBuilder<>(1, BucketOrder.key(true), b -> nonCompetitive.add(b.toString()));
+
+        for (int i = 0; i < count; i++) {
+            builder.add(new DelayedBucket<>(mockReduce(context), context, org.elasticsearch.core.List.of(bucket(i))));
+        }
+
+        List<InternalBucket> top = builder.build();
+        assertThat(top, hasSize(1));
+        assertThat(top.get(0).getKeyAsString(), equalTo("0000"));
+        assertThat(top.get(0).getDocCount(), equalTo(1L));
+        for (int i = 1; i < count; i++) {
+            assertThat(nonCompetitive.get(i - 1), equalTo("Delayed[" + bucketKey(i) + "]"));
+        }
+    }
+
+    public void testAllCompetitive() {
+        int size = between(3, 1000);
+        int count = between(1, size);
+        ReduceContext context = mock(ReduceContext.class);
+        TopBucketBuilder<InternalBucket> builder = new TopBucketBuilder<>(
+            size,
+            BucketOrder.key(true),
+            b -> fail("unexpected uncompetitive bucket " + b)
+        );
+
+        for (int i = 0; i < count; i++) {
+            builder.add(new DelayedBucket<>(mockReduce(context), context, org.elasticsearch.core.List.of(bucket(i))));
+        }
+
+        List<InternalBucket> top = builder.build();
+        assertThat(top, hasSize(count));
+        for (int i = 0; i < count; i++) {
+            assertThat(top.get(i).getKeyAsString(), equalTo(bucketKey(i)));
+            assertThat(top.get(i).getDocCount(), equalTo(1L));
+        }
+    }
+
+    public void testSomNonCompetitive() {
+        int size = between(3, 1000);
+        int count = between(size + 1, size * 1000);
+        ReduceContext context = mock(ReduceContext.class);
+        List<String> nonCompetitive = new ArrayList<>();
+        TopBucketBuilder<InternalBucket> builder = new TopBucketBuilder<>(
+            size,
+            BucketOrder.key(true),
+            b -> nonCompetitive.add(b.toString())
+        );
+
+        for (int i = 0; i < count; i++) {
+            builder.add(new DelayedBucket<>(mockReduce(context), context, org.elasticsearch.core.List.of(bucket(i))));
+        }
+
+        List<InternalBucket> top = builder.build();
+        assertThat(top, hasSize(size));
+        for (int i = 0; i < count; i++) {
+            if (i < size) {
+                assertThat(top.get(i).getKeyAsString(), equalTo(bucketKey(i)));
+                assertThat(top.get(i).getDocCount(), equalTo(1L));
+            } else {
+                assertThat(nonCompetitive.get(i - size), equalTo("Delayed[" + bucketKey(i) + "]"));
+            }
+        }
+    }
+
+    private String bucketKey(int index) {
+        return String.format(Locale.ROOT, "%04d", index);
+    }
+
+    private InternalBucket bucket(int index) {
+        return new StringTerms.Bucket(new BytesRef(bucketKey(index)), 1, InternalAggregations.EMPTY, false, 0, DocValueFormat.RAW);
+    }
+}

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/terms/TermsAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/terms/TermsAggregatorTests.java
@@ -54,6 +54,7 @@ import org.elasticsearch.index.mapper.KeywordFieldMapper.KeywordFieldType;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.NumberFieldMapper;
 import org.elasticsearch.index.mapper.NumberFieldMapper.NumberFieldType;
+import org.elasticsearch.index.mapper.NumberFieldMapper.NumberType;
 import org.elasticsearch.index.mapper.ObjectMapper;
 import org.elasticsearch.index.mapper.RangeFieldMapper;
 import org.elasticsearch.index.mapper.RangeType;
@@ -80,6 +81,7 @@ import org.elasticsearch.search.aggregations.BucketOrder;
 import org.elasticsearch.search.aggregations.InternalAggregation;
 import org.elasticsearch.search.aggregations.InternalMultiBucketAggregation;
 import org.elasticsearch.search.aggregations.MultiBucketConsumerService;
+import org.elasticsearch.search.aggregations.MultiBucketConsumerService.TooManyBucketsException;
 import org.elasticsearch.search.aggregations.bucket.MultiBucketsAggregation;
 import org.elasticsearch.search.aggregations.bucket.filter.Filter;
 import org.elasticsearch.search.aggregations.bucket.filter.FilterAggregationBuilder;
@@ -124,6 +126,7 @@ import java.util.Map;
 import java.util.function.BiFunction;
 import java.util.function.Consumer;
 import java.util.function.Function;
+import java.util.stream.LongStream;
 
 import static java.util.Arrays.asList;
 import static java.util.Collections.singleton;
@@ -302,9 +305,7 @@ public class TermsAggregatorTests extends AggregatorTestCase {
 
     public void testManyTerms() throws Exception {
         MappedFieldType fieldType = new KeywordFieldMapper.KeywordFieldType("string", randomBoolean(), true, Collections.emptyMap());
-        TermsAggregationBuilder aggregationBuilder = new TermsAggregationBuilder("_name")
-            .executionHint(randomFrom(TermsAggregatorFactory.ExecutionMode.values()).toString())
-            .field("string");
+        TermsAggregationBuilder aggregationBuilder = new TermsAggregationBuilder("_name").executionHint(randomHint()).field("string");
         testCase(aggregationBuilder, new MatchAllDocsQuery(), iw -> {
             /*
              * index all of the fields into a single segment so our
@@ -329,6 +330,81 @@ public class TermsAggregatorTests extends AggregatorTestCase {
                 )
             );
         }, fieldType);
+    }
+
+    public void testManyTermsOrderBySubAgg() throws Exception {
+        MappedFieldType kft = new KeywordFieldMapper.KeywordFieldType("string", randomBoolean(), true, Collections.emptyMap());
+        MappedFieldType lft = new NumberFieldType("long", NumberType.LONG);
+
+        TermsAggregationBuilder aggregationBuilder = new TermsAggregationBuilder("_name")
+            .executionHint(randomHint())
+            .order(BucketOrder.aggregation("max", false))
+            .field("string")
+            .subAggregation(new MaxAggregationBuilder("max").field("long"));
+        testCase(aggregationBuilder, new MatchAllDocsQuery(), iw -> {
+            /*
+             * index all of the fields into a single segment so the
+             * collector picks up all the docs.
+             */
+            List<List<? extends IndexableField>> docs = new ArrayList<>();
+            for (int i = 0; i < TermsAggregatorFactory.MAX_ORDS_TO_TRY_FILTERS - 200; i++) {
+                String s = String.format(Locale.ROOT, "b%03d", i);
+                List<IndexableField> doc = doc(kft, s);
+                doc.add(new SortedNumericDocValuesField("long", i));
+                docs.add(doc);
+            }
+            iw.addDocuments(docs);
+        }, (StringTerms result) -> {
+            List<String> expected = LongStream.range(
+                TermsAggregatorFactory.MAX_ORDS_TO_TRY_FILTERS - 210,
+                TermsAggregatorFactory.MAX_ORDS_TO_TRY_FILTERS - 200
+            ).mapToObj(l -> String.format(Locale.ROOT, "b%03d", l)).collect(toList());
+            Collections.reverse(expected);
+            assertThat(result.getBuckets().stream().map(StringTerms.Bucket::getKey).collect(toList()), equalTo(expected));
+        }, kft, lft);
+    }
+
+    /**
+     * Tests that we don't eagerly evaluate every sub agg. It would throw
+     * a {@link TooManyBucketsException} if we built the sub-aggs eagerly.
+     */
+    public void testDelaysSubAggs() throws Exception {
+        MappedFieldType s1ft = new KeywordFieldMapper.KeywordFieldType("string1", randomBoolean(), true, Collections.emptyMap());
+        MappedFieldType s2ft = new KeywordFieldMapper.KeywordFieldType("string2", randomBoolean(), true, Collections.emptyMap());
+        TermsAggregationBuilder aggregationBuilder = new TermsAggregationBuilder("_name").executionHint(randomHint())
+            .field("string1")
+            .shardSize(1000)
+            .size(11)
+            .subAggregation(new TermsAggregationBuilder("sub").field("string2").shardSize(500));
+        withIndex(iw -> {
+            for (int i1 = 0; i1 < 1000; i1++) {
+                String s1 = String.format(Locale.ROOT, "b%03d", i1);
+                for (int i2 = 0; i2 < 50; i2++) {
+                    String s2 = String.format(Locale.ROOT, "b%03d", i2);
+                    List<IndexableField> doc = new ArrayList<>();
+                    doc.addAll(doc(s1ft, s1));
+                    doc.addAll(doc(s2ft, s2));
+                    iw.addDocument(doc);
+                    if (i1 % 100 == 7) {
+                        iw.addDocument(doc);
+                    }
+                }
+            }
+        }, searcher -> {
+            /*
+             * Use 200 max buckets rather than the default so we bump into it
+             * really fast if we eagerly create the child buckets. It also
+             * lets us create a fairly small test index.
+             */
+            int maxBuckets = 200;
+            StringTerms result = searchAndReduce(searcher, new MatchAllDocsQuery(), aggregationBuilder, maxBuckets, s1ft, s2ft);
+            assertThat(
+                result.getBuckets().stream().map(StringTerms.Bucket::getKey).collect(toList()),
+                equalTo(
+                    org.elasticsearch.core.List.of("b007", "b107", "b207", "b307", "b407", "b507", "b607", "b707", "b807", "b907", "b000")
+                )
+            );
+        });
     }
 
     private List<IndexableField> doc(MappedFieldType ft, String... values) {
@@ -1964,5 +2040,9 @@ public class TermsAggregatorTests extends AggregatorTestCase {
     @Override
     protected List<ObjectMapper> objectMappers() {
         return org.elasticsearch.core.List.of(NestedAggregatorTests.nestedObject("nested_object"));
+    }
+
+    private String randomHint() {
+        return randomFrom(TermsAggregatorFactory.ExecutionMode.values()).toString();
     }
 }

--- a/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/multiterms/InternalMultiTerms.java
+++ b/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/multiterms/InternalMultiTerms.java
@@ -328,11 +328,6 @@ public class InternalMultiTerms extends AbstractInternalTerms<InternalMultiTerms
     }
 
     @Override
-    protected Bucket[] createBucketsArray(int size) {
-        return new Bucket[size];
-    }
-
-    @Override
     protected InternalMultiTerms create(
         String name,
         List<Bucket> buckets,


### PR DESCRIPTION
This modifies the `terms` aggregation so it only reducing a bucket if we
*need* to reduce the bucket. That makes `search.maxBuckets` much more
predictable, especially when you have `terms` aggregations inside
`terms` aggregations. Aggs like that may pull back the hundreds of
thousands of buckets worth of information but only need tens of
thousands of buckets.

Without this change we'd reduce all the buckets, blow up the max bucket
counter, and then reduce it as we find that buckets aren't competitive.
With this change we fork we reduce an aggregation, check if it is
comptetive, and if it isn't we free it immediately, lowering the
pressure on `search.maxBuckets` significantly.

As a bonus for the common `key` and `count` sorts we entirely skip
reducing non-competitive buckets.

This comes at the cost of more complexity when reducing the buckets. We
try to centralize that complexity with the new `TopBucketBuilder` which
handles the reduction and `max_buckets` tracking. It isn't *super*
complex but its a pattern we use in many places.
