### PR TITLE
Added name restrictions for the Composite Aggregation value source and the respective test

### DIFF
--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/composite/CompositeValuesSourceParserHelper.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/composite/CompositeValuesSourceParserHelper.java
@@ -83,13 +83,14 @@ public class CompositeValuesSourceParserHelper {
     }
 
     public static CompositeValuesSourceBuilder<?> fromXContent(XContentParser parser) throws IOException {
-        Matcher validAggMatcher = AggregatorFactories.VALID_AGG_NAME.matcher("");
         XContentParser.Token token = parser.currentToken();
         ensureExpectedToken(XContentParser.Token.START_OBJECT, token, parser);
         token = parser.nextToken();
         ensureExpectedToken(XContentParser.Token.FIELD_NAME, token, parser);
         String name = parser.currentName();
-        if (validAggMatcher.reset(name).matches() == false) {
+        Matcher validAggMatcher = AggregatorFactories.VALID_AGG_NAME.matcher(name);
+
+        if (validAggMatcher.matches() == false) {
             throw new ParsingException(parser.getTokenLocation(), "Invalid source name [" + name
                 + "]. Source names can contain any character except '[', ']', and '>'");
         }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/composite/CompositeValuesSourceParserHelper.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/composite/CompositeValuesSourceParserHelper.java
@@ -88,7 +88,6 @@ public class CompositeValuesSourceParserHelper {
         token = parser.nextToken();
         ensureExpectedToken(XContentParser.Token.FIELD_NAME, token, parser);
         String name = parser.currentName();
-
         Matcher validAggMatcher = AggregatorFactories.VALID_AGG_NAME.matcher(name);
 
         if (validAggMatcher.matches() == false) {

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/composite/CompositeValuesSourceParserHelper.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/composite/CompositeValuesSourceParserHelper.java
@@ -19,9 +19,11 @@ import org.elasticsearch.common.xcontent.ToXContent.Params;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.script.Script;
+import org.elasticsearch.search.aggregations.AggregatorFactories;
 import org.elasticsearch.search.aggregations.support.ValueType;
 
 import java.io.IOException;
+import java.util.regex.Matcher;
 
 import static org.elasticsearch.common.xcontent.XContentParserUtils.ensureExpectedToken;
 
@@ -81,11 +83,16 @@ public class CompositeValuesSourceParserHelper {
     }
 
     public static CompositeValuesSourceBuilder<?> fromXContent(XContentParser parser) throws IOException {
+        Matcher validAggMatcher = AggregatorFactories.VALID_AGG_NAME.matcher("");
         XContentParser.Token token = parser.currentToken();
         ensureExpectedToken(XContentParser.Token.START_OBJECT, token, parser);
         token = parser.nextToken();
         ensureExpectedToken(XContentParser.Token.FIELD_NAME, token, parser);
         String name = parser.currentName();
+        if (validAggMatcher.reset(name).matches() == false) {
+            throw new ParsingException(parser.getTokenLocation(), "Invalid source name [" + name
+                + "]. Source names can contain any character except '[', ']', and '>'");
+        }
         token = parser.nextToken();
         ensureExpectedToken(XContentParser.Token.START_OBJECT, token, parser);
         token = parser.nextToken();

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/composite/CompositeAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/composite/CompositeAggregatorTests.java
@@ -2503,7 +2503,6 @@ public class CompositeAggregatorTests  extends AggregatorTestCase {
         }
     }
 
-
     public void testInvalidCompositeValueSourceName() throws IOException {
         String invalidName = randomAlphaOfLengthBetween(0, 5)
             + ILLEGAL_FIELD_NAME_CHARACTERS[randomIntBetween(0, ILLEGAL_FIELD_NAME_CHARACTERS.length - 1)]

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/composite/CompositeAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/composite/CompositeAggregatorTests.java
@@ -2503,7 +2503,7 @@ public class CompositeAggregatorTests  extends AggregatorTestCase {
         }
     }
 
-    public void testInvalidCompositeValueSourceNames() throws IOException {
+    public void testInvalidCompositeValueSourceName() throws IOException {
         String invalidName = randomAlphaOfLengthBetween(0, 5)
             + ILLEGAL_FIELD_NAME_CHARACTERS[randomIntBetween(0, ILLEGAL_FIELD_NAME_CHARACTERS.length - 1)]
             + randomAlphaOfLengthBetween(0, 5);

--- a/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/job/RollupIndexer.java
+++ b/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/job/RollupIndexer.java
@@ -58,7 +58,7 @@ import static org.elasticsearch.xpack.core.rollup.RollupField.formatFieldName;
  * An abstract implementation of {@link AsyncTwoPhaseIndexer} that builds a rollup index incrementally.
  */
 public abstract class RollupIndexer extends AsyncTwoPhaseIndexer<Map<String, Object>, RollupIndexerJobStats> {
-    static final String AGGREGATION_NAME = RollupField.NAME.replaceAll("[\\[\\]\\>]","");
+    static final String AGGREGATION_NAME = RollupField.NAME;
 
     private final RollupJob job;
     private final CompositeAggregationBuilder compositeBuilder;

--- a/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/job/RollupIndexer.java
+++ b/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/job/RollupIndexer.java
@@ -58,7 +58,7 @@ import static org.elasticsearch.xpack.core.rollup.RollupField.formatFieldName;
  * An abstract implementation of {@link AsyncTwoPhaseIndexer} that builds a rollup index incrementally.
  */
 public abstract class RollupIndexer extends AsyncTwoPhaseIndexer<Map<String, Object>, RollupIndexerJobStats> {
-    static final String AGGREGATION_NAME = RollupField.NAME;
+    static final String AGGREGATION_NAME = RollupField.NAME.replaceAll("[\\[\\]\\>]","");
 
     private final RollupJob job;
     private final CompositeAggregationBuilder compositeBuilder;


### PR DESCRIPTION
Closes #42339

Adds name restrictions for the CompositeAggregation value source. I had issues while testing because for
some reason the parser was not set to the starting token. I fixed that in my test because I didn't want to
change intended behaviour, but maybe this should be fixed in CompositeValuesSourceParserHelper.

This PR is not ready to merge yet, since I still have to test the side affects in the RollUpGroups. I am not
sure about my solution, but until now I've translated the RollUpField name to a safe alternative using the replaceAll() method.
I would appreciate the feedback so that I can continue working on this issue.
