### PR TITLE
Adjust some skip versions after backport

### DIFF
--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.aggregation/170_cardinality_metric.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.aggregation/170_cardinality_metric.yml
@@ -216,8 +216,8 @@ setup:
 ---
 "profiler int":
   - skip:
-      version: " - 7.99.99"
-      reason:  new info added in 8.0.0 to be backported to 7.10.0
+      version: " - 7.9.99"
+      reason: introduced in 7.10.0
   - do:
       search:
         body:
@@ -242,8 +242,8 @@ setup:
 ---
 "profiler double":
   - skip:
-      version: " - 7.99.99"
-      reason:  new info added in 8.0.0 to be backported to 7.10.0
+      version: " - 7.9.99"
+      reason: introduced in 7.10.0
   - do:
       search:
         body:
@@ -268,8 +268,8 @@ setup:
 ---
 "profiler string":
   - skip:
-      version: " - 7.99.99"
-      reason:  new info added in 8.0.0 to be backported to 7.10.0
+      version: " - 7.9.99"
+      reason: introduced in 7.10.0
   - do:
       search:
         body:

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.aggregation/30_sig_terms.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.aggregation/30_sig_terms.yml
@@ -142,7 +142,7 @@
 'Misspelled fields get "did you mean"':
   - skip:
       version: " - 7.6.99"
-      reason: Implemented in 8.0 (to be backported to 7.7)
+      reason: introduced in 7.7.0
   - do:
       catch: /\[significant_terms\] unknown field \[jlp\] did you mean \[jlh\]\?/
       search:

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.aggregation/330_auto_date_histogram.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.aggregation/330_auto_date_histogram.yml
@@ -80,8 +80,8 @@ setup:
 ---
 "profile at top level":
   - skip:
-      version: " - 7.99.99"
-      reason: Debug information added in 8.0.0 (to be backported to 7.9.0)
+      version: " - 7.9.99"
+      reason: introduced in 7.10.0
 
   - do:
       search:

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.aggregation/380_global.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.aggregation/380_global.yml
@@ -37,8 +37,8 @@ simple:
 ---
 profile:
   - skip:
-      version: " - 7.99.99"
-      reason:  fixed in 8.0.0 (to be backported to 7.13.0)
+      version: " - 7.12.99"
+      reason: fix introduced in 7.13.0
 
   - do:
       search:

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search/30_limits.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search/30_limits.yml
@@ -30,7 +30,7 @@ setup:
 
   - skip:
       version: " - 7.99.99"
-      reason: waiting for backport
+      reason: change was only made in 8.0.0
 
   - do:
       catch:      /\[from\] parameter cannot be negative but was \[-1\]/
@@ -44,7 +44,7 @@ setup:
 
   - skip:
       version: " - 7.99.99"
-      reason: waiting for backport
+      reason: change was only made in 8.0.0
 
   - do:
       catch:      /\[from\] parameter cannot be negative but was \[-1\]/

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search/330_fetch_fields.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search/330_fetch_fields.yml
@@ -858,8 +858,8 @@ Test nested field with sibling field resolving to DocValueFetcher:
 ---
 Test token_count inside nested field doesn't fail:
   - skip:
-      version: ' - 7.99.99'
-      reason:  'Added in 8.0 - change on backport'
+      version: ' - 7.11.99'
+      reason:  'fix introduced in 7.12.0'
   -  do:
         indices.create:
            index: test

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search/350_point_in_time.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search/350_point_in_time.yml
@@ -171,8 +171,8 @@ setup:
 ---
 "msearch":
   - skip:
-      version: " - 7.99.99"
-      reason: "After backport: 7.9.99 => point in time is introduced in 7.10"
+      version: " - 7.9.99"
+      reason: "point in time is introduced in 7.10"
   - do:
       open_point_in_time:
         index: "t*"


### PR DESCRIPTION
We forgot to update some skip versions in REST tests after backports. Note this
PR only targets search tests.