### PR TITLE
Move and rename ParserContext

### DIFF
--- a/modules/percolator/src/main/java/org/elasticsearch/percolator/PercolatorFieldMapper.java
+++ b/modules/percolator/src/main/java/org/elasticsearch/percolator/PercolatorFieldMapper.java
@@ -34,7 +34,6 @@ import org.elasticsearch.Version;
 import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.common.ParsingException;
 import org.elasticsearch.common.bytes.BytesReference;
-import org.elasticsearch.core.Tuple;
 import org.elasticsearch.common.hash.MurmurHash3;
 import org.elasticsearch.common.io.stream.OutputStreamStreamOutput;
 import org.elasticsearch.common.lucene.search.Queries;
@@ -42,6 +41,7 @@ import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.XContentLocation;
 import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.core.Tuple;
 import org.elasticsearch.index.mapper.BinaryFieldMapper;
 import org.elasticsearch.index.mapper.ContentPath;
 import org.elasticsearch.index.mapper.FieldMapper;
@@ -49,6 +49,7 @@ import org.elasticsearch.index.mapper.KeywordFieldMapper;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.Mapper;
 import org.elasticsearch.index.mapper.MapperParsingException;
+import org.elasticsearch.index.mapper.MappingsParserContext;
 import org.elasticsearch.index.mapper.NumberFieldMapper;
 import org.elasticsearch.index.mapper.ParseContext;
 import org.elasticsearch.index.mapper.RangeFieldMapper;
@@ -61,9 +62,9 @@ import org.elasticsearch.index.query.BoostingQueryBuilder;
 import org.elasticsearch.index.query.ConstantScoreQueryBuilder;
 import org.elasticsearch.index.query.DisMaxQueryBuilder;
 import org.elasticsearch.index.query.QueryBuilder;
-import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.index.query.QueryShardException;
 import org.elasticsearch.index.query.Rewriteable;
+import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.index.query.functionscore.FunctionScoreQueryBuilder;
 
 import java.io.ByteArrayOutputStream;
@@ -173,7 +174,7 @@ public class PercolatorFieldMapper extends FieldMapper {
     static class TypeParser implements Mapper.TypeParser {
 
         @Override
-        public Builder parse(String name, Map<String, Object> node, ParserContext parserContext) throws MapperParsingException {
+        public Builder parse(String name, Map<String, Object> node, MappingsParserContext parserContext) throws MapperParsingException {
             return new Builder(name, parserContext.searchExecutionContext(), getMapUnmappedFieldAsText(parserContext.getSettings()));
         }
     }

--- a/modules/percolator/src/main/java/org/elasticsearch/percolator/PercolatorFieldMapper.java
+++ b/modules/percolator/src/main/java/org/elasticsearch/percolator/PercolatorFieldMapper.java
@@ -49,7 +49,7 @@ import org.elasticsearch.index.mapper.KeywordFieldMapper;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.Mapper;
 import org.elasticsearch.index.mapper.MapperParsingException;
-import org.elasticsearch.index.mapper.MappingsParserContext;
+import org.elasticsearch.index.mapper.MappingParserContext;
 import org.elasticsearch.index.mapper.NumberFieldMapper;
 import org.elasticsearch.index.mapper.ParseContext;
 import org.elasticsearch.index.mapper.RangeFieldMapper;
@@ -174,7 +174,7 @@ public class PercolatorFieldMapper extends FieldMapper {
     static class TypeParser implements Mapper.TypeParser {
 
         @Override
-        public Builder parse(String name, Map<String, Object> node, MappingsParserContext parserContext) throws MapperParsingException {
+        public Builder parse(String name, Map<String, Object> node, MappingParserContext parserContext) throws MapperParsingException {
             return new Builder(name, parserContext.searchExecutionContext(), getMapUnmappedFieldAsText(parserContext.getSettings()));
         }
     }

--- a/server/src/main/java/org/elasticsearch/index/mapper/AbstractPointGeometryFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/AbstractPointGeometryFieldMapper.java
@@ -23,7 +23,7 @@ import java.util.function.Supplier;
 public abstract class AbstractPointGeometryFieldMapper<T> extends AbstractGeometryFieldMapper<T> {
 
     public static <T> Parameter<T> nullValueParam(Function<FieldMapper, T> initializer,
-                                                  TriFunction<String, MappingsParserContext, Object, T> parser,
+                                                  TriFunction<String, MappingParserContext, Object, T> parser,
                                                   Supplier<T> def) {
         return new Parameter<T>("null_value", false, def, parser, initializer);
     }

--- a/server/src/main/java/org/elasticsearch/index/mapper/AbstractPointGeometryFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/AbstractPointGeometryFieldMapper.java
@@ -9,11 +9,10 @@ package org.elasticsearch.index.mapper;
 
 import org.elasticsearch.ElasticsearchParseException;
 import org.elasticsearch.common.CheckedBiFunction;
-import org.elasticsearch.core.CheckedConsumer;
 import org.elasticsearch.common.Explicit;
 import org.elasticsearch.common.TriFunction;
 import org.elasticsearch.common.xcontent.XContentParser;
-import org.elasticsearch.index.mapper.Mapper.TypeParser.ParserContext;
+import org.elasticsearch.core.CheckedConsumer;
 
 import java.io.IOException;
 import java.util.function.Consumer;
@@ -24,7 +23,7 @@ import java.util.function.Supplier;
 public abstract class AbstractPointGeometryFieldMapper<T> extends AbstractGeometryFieldMapper<T> {
 
     public static <T> Parameter<T> nullValueParam(Function<FieldMapper, T> initializer,
-                                                  TriFunction<String, ParserContext, Object, T> parser,
+                                                  TriFunction<String, MappingsParserContext, Object, T> parser,
                                                   Supplier<T> def) {
         return new Parameter<T>("null_value", false, def, parser, initializer);
     }

--- a/server/src/main/java/org/elasticsearch/index/mapper/AbstractScriptFieldType.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/AbstractScriptFieldType.java
@@ -228,7 +228,7 @@ abstract class AbstractScriptFieldType<LeafFactory> extends MappedFieldType impl
         abstract RuntimeField newRuntimeField(Factory scriptFactory);
 
         @Override
-        protected final RuntimeField createRuntimeField(MappingsParserContext parserContext) {
+        protected final RuntimeField createRuntimeField(MappingParserContext parserContext) {
             if (script.get() == null) {
                 return newRuntimeField(parseFromSourceFactory);
             }
@@ -250,7 +250,7 @@ abstract class AbstractScriptFieldType<LeafFactory> extends MappedFieldType impl
             return script.get();
         }
 
-        private static Script parseScript(String name, MappingsParserContext parserContext, Object scriptObject) {
+        private static Script parseScript(String name, MappingParserContext parserContext, Object scriptObject) {
             Script script = Script.parse(scriptObject);
             if (script.getType() == ScriptType.STORED) {
                 throw new IllegalArgumentException("stored scripts are not supported for runtime field [" + name + "]");

--- a/server/src/main/java/org/elasticsearch/index/mapper/AbstractScriptFieldType.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/AbstractScriptFieldType.java
@@ -228,7 +228,7 @@ abstract class AbstractScriptFieldType<LeafFactory> extends MappedFieldType impl
         abstract RuntimeField newRuntimeField(Factory scriptFactory);
 
         @Override
-        protected final RuntimeField createRuntimeField(Mapper.TypeParser.ParserContext parserContext) {
+        protected final RuntimeField createRuntimeField(MappingsParserContext parserContext) {
             if (script.get() == null) {
                 return newRuntimeField(parseFromSourceFactory);
             }
@@ -250,7 +250,7 @@ abstract class AbstractScriptFieldType<LeafFactory> extends MappedFieldType impl
             return script.get();
         }
 
-        private static Script parseScript(String name, Mapper.TypeParser.ParserContext parserContext, Object scriptObject) {
+        private static Script parseScript(String name, MappingsParserContext parserContext, Object scriptObject) {
             Script script = Script.parse(scriptObject);
             if (script.getType() == ScriptType.STORED) {
                 throw new IllegalArgumentException("stored scripts are not supported for runtime field [" + name + "]");

--- a/server/src/main/java/org/elasticsearch/index/mapper/DocumentParser.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DocumentParser.java
@@ -47,12 +47,12 @@ import java.util.function.Function;
 public final class DocumentParser {
 
     private final NamedXContentRegistry xContentRegistry;
-    private final Function<DateFormatter, Mapper.TypeParser.ParserContext> dateParserContext;
+    private final Function<DateFormatter, MappingsParserContext> dateParserContext;
     private final IndexSettings indexSettings;
     private final IndexAnalyzers indexAnalyzers;
 
     DocumentParser(NamedXContentRegistry xContentRegistry,
-                   Function<DateFormatter, Mapper.TypeParser.ParserContext> dateParserContext,
+                   Function<DateFormatter, MappingsParserContext> dateParserContext,
                    IndexSettings indexSettings,
                    IndexAnalyzers indexAnalyzers) {
         this.xContentRegistry = xContentRegistry;

--- a/server/src/main/java/org/elasticsearch/index/mapper/DocumentParser.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DocumentParser.java
@@ -47,12 +47,12 @@ import java.util.function.Function;
 public final class DocumentParser {
 
     private final NamedXContentRegistry xContentRegistry;
-    private final Function<DateFormatter, MappingsParserContext> dateParserContext;
+    private final Function<DateFormatter, MappingParserContext> dateParserContext;
     private final IndexSettings indexSettings;
     private final IndexAnalyzers indexAnalyzers;
 
     DocumentParser(NamedXContentRegistry xContentRegistry,
-                   Function<DateFormatter, MappingsParserContext> dateParserContext,
+                   Function<DateFormatter, MappingParserContext> dateParserContext,
                    IndexSettings indexSettings,
                    IndexAnalyzers indexAnalyzers) {
         this.xContentRegistry = xContentRegistry;

--- a/server/src/main/java/org/elasticsearch/index/mapper/DynamicFieldsBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DynamicFieldsBuilder.java
@@ -191,7 +191,7 @@ final class DynamicFieldsBuilder {
         String mappingType = dynamicTemplate.mappingType(dynamicType);
         Map<String, Object> mapping = dynamicTemplate.mappingForName(name, dynamicType);
         if (dynamicTemplate.isRuntimeMapping()) {
-            Mapper.TypeParser.ParserContext parserContext = context.dynamicTemplateParserContext(dateFormatter);
+            MappingsParserContext parserContext = context.dynamicTemplateParserContext(dateFormatter);
             RuntimeField.Parser parser = parserContext.runtimeFieldParser(mappingType);
             String fullName = context.path().pathAsText(name);
             if (parser == null) {
@@ -223,7 +223,7 @@ final class DynamicFieldsBuilder {
                                                Map<String, Object> mapping,
                                                DateFormatter dateFormatter,
                                                ParseContext context) {
-        Mapper.TypeParser.ParserContext parserContext = context.dynamicTemplateParserContext(dateFormatter);
+        MappingsParserContext parserContext = context.dynamicTemplateParserContext(dateFormatter);
         Mapper.TypeParser typeParser = parserContext.typeParser(mappingType);
         if (typeParser == null) {
             throw new MapperParsingException("failed to find type parsed [" + mappingType + "] for [" + name + "]");

--- a/server/src/main/java/org/elasticsearch/index/mapper/DynamicFieldsBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DynamicFieldsBuilder.java
@@ -191,7 +191,7 @@ final class DynamicFieldsBuilder {
         String mappingType = dynamicTemplate.mappingType(dynamicType);
         Map<String, Object> mapping = dynamicTemplate.mappingForName(name, dynamicType);
         if (dynamicTemplate.isRuntimeMapping()) {
-            MappingsParserContext parserContext = context.dynamicTemplateParserContext(dateFormatter);
+            MappingParserContext parserContext = context.dynamicTemplateParserContext(dateFormatter);
             RuntimeField.Parser parser = parserContext.runtimeFieldParser(mappingType);
             String fullName = context.path().pathAsText(name);
             if (parser == null) {
@@ -223,7 +223,7 @@ final class DynamicFieldsBuilder {
                                                Map<String, Object> mapping,
                                                DateFormatter dateFormatter,
                                                ParseContext context) {
-        MappingsParserContext parserContext = context.dynamicTemplateParserContext(dateFormatter);
+        MappingParserContext parserContext = context.dynamicTemplateParserContext(dateFormatter);
         Mapper.TypeParser typeParser = parserContext.typeParser(mappingType);
         if (typeParser == null) {
             throw new MapperParsingException("failed to find type parsed [" + mappingType + "] for [" + name + "]");

--- a/server/src/main/java/org/elasticsearch/index/mapper/FieldAliasMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/FieldAliasMapper.java
@@ -110,7 +110,7 @@ public final class FieldAliasMapper extends Mapper {
 
     public static class TypeParser implements Mapper.TypeParser {
         @Override
-        public Mapper.Builder parse(String name, Map<String, Object> node, MappingsParserContext parserContext)
+        public Mapper.Builder parse(String name, Map<String, Object> node, MappingParserContext parserContext)
             throws MapperParsingException {
             FieldAliasMapper.Builder builder = new FieldAliasMapper.Builder(name);
             Object pathField = node.remove(Names.PATH);

--- a/server/src/main/java/org/elasticsearch/index/mapper/FieldAliasMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/FieldAliasMapper.java
@@ -110,7 +110,7 @@ public final class FieldAliasMapper extends Mapper {
 
     public static class TypeParser implements Mapper.TypeParser {
         @Override
-        public Mapper.Builder parse(String name, Map<String, Object> node, ParserContext parserContext)
+        public Mapper.Builder parse(String name, Map<String, Object> node, MappingsParserContext parserContext)
             throws MapperParsingException {
             FieldAliasMapper.Builder builder = new FieldAliasMapper.Builder(name);
             Object pathField = node.remove(Names.PATH);

--- a/server/src/main/java/org/elasticsearch/index/mapper/FieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/FieldMapper.java
@@ -581,7 +581,7 @@ public abstract class FieldMapper extends Mapper implements Cloneable {
         public final String name;
         private final List<String> deprecatedNames = new ArrayList<>();
         private final Supplier<T> defaultValue;
-        private final TriFunction<String, MappingsParserContext, Object, T> parser;
+        private final TriFunction<String, MappingParserContext, Object, T> parser;
         private final Function<FieldMapper, T> initializer;
         private boolean acceptsNull = false;
         private Consumer<T> validator = null;
@@ -604,7 +604,7 @@ public abstract class FieldMapper extends Mapper implements Cloneable {
          * @param initializer   a function that reads a parameter value from an existing mapper
          */
         public Parameter(String name, boolean updateable, Supplier<T> defaultValue,
-                         TriFunction<String, MappingsParserContext, Object, T> parser, Function<FieldMapper, T> initializer) {
+                         TriFunction<String, MappingParserContext, Object, T> parser, Function<FieldMapper, T> initializer) {
             this.name = name;
             this.defaultValue = Objects.requireNonNull(defaultValue);
             this.value = null;
@@ -766,7 +766,7 @@ public abstract class FieldMapper extends Mapper implements Cloneable {
          * @param context   the parser context
          * @param in        the object
          */
-        public void parse(String field, MappingsParserContext context, Object in) {
+        public void parse(String field, MappingParserContext context, Object in) {
             setValue(parser.apply(field, context, in));
         }
 
@@ -1106,7 +1106,7 @@ public abstract class FieldMapper extends Mapper implements Cloneable {
          * @param parserContext     the parser context
          * @param fieldNode         the root node of the map of mappings for this field
          */
-        public final void parse(String name, MappingsParserContext parserContext, Map<String, Object> fieldNode) {
+        public final void parse(String name, MappingParserContext parserContext, Map<String, Object> fieldNode) {
             Map<String, Parameter<?>> paramsMap = new HashMap<>();
             Map<String, Parameter<?>> deprecatedParamsMap = new HashMap<>();
             for (Parameter<?> param : getParameters()) {
@@ -1210,7 +1210,7 @@ public abstract class FieldMapper extends Mapper implements Cloneable {
         }
     }
 
-    public static BiConsumer<String, MappingsParserContext> notInMultiFields(String type) {
+    public static BiConsumer<String, MappingParserContext> notInMultiFields(String type) {
         return (n, c) -> {
             if (c.isWithinMultiField()) {
                 throw new MapperParsingException("Field [" + n + "] of type [" + type + "] can't be used in multifields");
@@ -1223,27 +1223,27 @@ public abstract class FieldMapper extends Mapper implements Cloneable {
      */
     public static final class TypeParser implements Mapper.TypeParser {
 
-        private final BiFunction<String, MappingsParserContext, Builder> builderFunction;
-        private final BiConsumer<String, MappingsParserContext> contextValidator;
+        private final BiFunction<String, MappingParserContext, Builder> builderFunction;
+        private final BiConsumer<String, MappingParserContext> contextValidator;
 
         /**
          * Creates a new TypeParser
          * @param builderFunction a function that produces a Builder from a name and parsercontext
          */
-        public TypeParser(BiFunction<String, MappingsParserContext, Builder> builderFunction) {
+        public TypeParser(BiFunction<String, MappingParserContext, Builder> builderFunction) {
             this(builderFunction, (n, c) -> {});
         }
 
         public TypeParser(
-            BiFunction<String, MappingsParserContext, Builder> builderFunction,
-            BiConsumer<String, MappingsParserContext> contextValidator
+            BiFunction<String, MappingParserContext, Builder> builderFunction,
+            BiConsumer<String, MappingParserContext> contextValidator
         ) {
             this.builderFunction = builderFunction;
             this.contextValidator = contextValidator;
         }
 
         @Override
-        public Builder parse(String name, Map<String, Object> node, MappingsParserContext parserContext) throws MapperParsingException {
+        public Builder parse(String name, Map<String, Object> node, MappingParserContext parserContext) throws MapperParsingException {
             contextValidator.accept(name, parserContext);
             Builder builder = builderFunction.apply(name, parserContext);
             builder.parse(name, parserContext, node);

--- a/server/src/main/java/org/elasticsearch/index/mapper/FieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/FieldMapper.java
@@ -23,7 +23,6 @@ import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.support.AbstractXContentParser;
 import org.elasticsearch.common.xcontent.support.XContentMapValues;
 import org.elasticsearch.index.analysis.NamedAnalyzer;
-import org.elasticsearch.index.mapper.Mapper.TypeParser.ParserContext;
 import org.elasticsearch.script.Script;
 import org.elasticsearch.script.ScriptType;
 import org.elasticsearch.search.lookup.SearchLookup;
@@ -582,7 +581,7 @@ public abstract class FieldMapper extends Mapper implements Cloneable {
         public final String name;
         private final List<String> deprecatedNames = new ArrayList<>();
         private final Supplier<T> defaultValue;
-        private final TriFunction<String, ParserContext, Object, T> parser;
+        private final TriFunction<String, MappingsParserContext, Object, T> parser;
         private final Function<FieldMapper, T> initializer;
         private boolean acceptsNull = false;
         private Consumer<T> validator = null;
@@ -605,7 +604,7 @@ public abstract class FieldMapper extends Mapper implements Cloneable {
          * @param initializer   a function that reads a parameter value from an existing mapper
          */
         public Parameter(String name, boolean updateable, Supplier<T> defaultValue,
-                         TriFunction<String, ParserContext, Object, T> parser, Function<FieldMapper, T> initializer) {
+                         TriFunction<String, MappingsParserContext, Object, T> parser, Function<FieldMapper, T> initializer) {
             this.name = name;
             this.defaultValue = Objects.requireNonNull(defaultValue);
             this.value = null;
@@ -767,7 +766,7 @@ public abstract class FieldMapper extends Mapper implements Cloneable {
          * @param context   the parser context
          * @param in        the object
          */
-        public void parse(String field, ParserContext context, Object in) {
+        public void parse(String field, MappingsParserContext context, Object in) {
             setValue(parser.apply(field, context, in));
         }
 
@@ -1107,7 +1106,7 @@ public abstract class FieldMapper extends Mapper implements Cloneable {
          * @param parserContext     the parser context
          * @param fieldNode         the root node of the map of mappings for this field
          */
-        public final void parse(String name, ParserContext parserContext, Map<String, Object> fieldNode) {
+        public final void parse(String name, MappingsParserContext parserContext, Map<String, Object> fieldNode) {
             Map<String, Parameter<?>> paramsMap = new HashMap<>();
             Map<String, Parameter<?>> deprecatedParamsMap = new HashMap<>();
             for (Parameter<?> param : getParameters()) {
@@ -1211,7 +1210,7 @@ public abstract class FieldMapper extends Mapper implements Cloneable {
         }
     }
 
-    public static BiConsumer<String, ParserContext> notInMultiFields(String type) {
+    public static BiConsumer<String, MappingsParserContext> notInMultiFields(String type) {
         return (n, c) -> {
             if (c.isWithinMultiField()) {
                 throw new MapperParsingException("Field [" + n + "] of type [" + type + "] can't be used in multifields");
@@ -1224,27 +1223,27 @@ public abstract class FieldMapper extends Mapper implements Cloneable {
      */
     public static final class TypeParser implements Mapper.TypeParser {
 
-        private final BiFunction<String, ParserContext, Builder> builderFunction;
-        private final BiConsumer<String, ParserContext> contextValidator;
+        private final BiFunction<String, MappingsParserContext, Builder> builderFunction;
+        private final BiConsumer<String, MappingsParserContext> contextValidator;
 
         /**
          * Creates a new TypeParser
          * @param builderFunction a function that produces a Builder from a name and parsercontext
          */
-        public TypeParser(BiFunction<String, ParserContext, Builder> builderFunction) {
+        public TypeParser(BiFunction<String, MappingsParserContext, Builder> builderFunction) {
             this(builderFunction, (n, c) -> {});
         }
 
         public TypeParser(
-            BiFunction<String, ParserContext, Builder> builderFunction,
-            BiConsumer<String, ParserContext> contextValidator
+            BiFunction<String, MappingsParserContext, Builder> builderFunction,
+            BiConsumer<String, MappingsParserContext> contextValidator
         ) {
             this.builderFunction = builderFunction;
             this.contextValidator = contextValidator;
         }
 
         @Override
-        public Builder parse(String name, Map<String, Object> node, ParserContext parserContext) throws MapperParsingException {
+        public Builder parse(String name, Map<String, Object> node, MappingsParserContext parserContext) throws MapperParsingException {
             contextValidator.accept(name, parserContext);
             Builder builder = builderFunction.apply(name, parserContext);
             builder.parse(name, parserContext, node);

--- a/server/src/main/java/org/elasticsearch/index/mapper/Mapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/Mapper.java
@@ -32,7 +32,7 @@ public abstract class Mapper implements ToXContentFragment, Iterable<Mapper> {
     }
 
     public interface TypeParser {
-        Mapper.Builder parse(String name, Map<String, Object> node, MappingsParserContext parserContext) throws MapperParsingException;
+        Mapper.Builder parse(String name, Map<String, Object> node, MappingParserContext parserContext) throws MapperParsingException;
     }
 
     private final String simpleName;

--- a/server/src/main/java/org/elasticsearch/index/mapper/Mapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/Mapper.java
@@ -8,21 +8,10 @@
 
 package org.elasticsearch.index.mapper;
 
-import org.elasticsearch.Version;
-import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.common.time.DateFormatter;
 import org.elasticsearch.common.xcontent.ToXContentFragment;
-import org.elasticsearch.index.IndexSettings;
-import org.elasticsearch.index.analysis.IndexAnalyzers;
-import org.elasticsearch.index.query.SearchExecutionContext;
-import org.elasticsearch.index.similarity.SimilarityProvider;
-import org.elasticsearch.script.ScriptCompiler;
 
 import java.util.Map;
 import java.util.Objects;
-import java.util.function.BooleanSupplier;
-import java.util.function.Function;
-import java.util.function.Supplier;
 
 public abstract class Mapper implements ToXContentFragment, Iterable<Mapper> {
 
@@ -43,131 +32,7 @@ public abstract class Mapper implements ToXContentFragment, Iterable<Mapper> {
     }
 
     public interface TypeParser {
-
-        class ParserContext {
-
-            private final Function<String, SimilarityProvider> similarityLookupService;
-            private final Function<String, TypeParser> typeParsers;
-            private final Function<String, RuntimeField.Parser> runtimeFieldParsers;
-            private final Version indexVersionCreated;
-            private final Supplier<SearchExecutionContext> searchExecutionContextSupplier;
-            private final DateFormatter dateFormatter;
-            private final ScriptCompiler scriptCompiler;
-            private final IndexAnalyzers indexAnalyzers;
-            private final IndexSettings indexSettings;
-            private final BooleanSupplier idFieldDataEnabled;
-
-            public ParserContext(Function<String, SimilarityProvider> similarityLookupService,
-                                 Function<String, TypeParser> typeParsers,
-                                 Function<String, RuntimeField.Parser> runtimeFieldParsers,
-                                 Version indexVersionCreated,
-                                 Supplier<SearchExecutionContext> searchExecutionContextSupplier,
-                                 DateFormatter dateFormatter,
-                                 ScriptCompiler scriptCompiler,
-                                 IndexAnalyzers indexAnalyzers,
-                                 IndexSettings indexSettings,
-                                 BooleanSupplier idFieldDataEnabled) {
-                this.similarityLookupService = similarityLookupService;
-                this.typeParsers = typeParsers;
-                this.runtimeFieldParsers = runtimeFieldParsers;
-                this.indexVersionCreated = indexVersionCreated;
-                this.searchExecutionContextSupplier = searchExecutionContextSupplier;
-                this.dateFormatter = dateFormatter;
-                this.scriptCompiler = scriptCompiler;
-                this.indexAnalyzers = indexAnalyzers;
-                this.indexSettings = indexSettings;
-                this.idFieldDataEnabled = idFieldDataEnabled;
-            }
-
-            public IndexAnalyzers getIndexAnalyzers() {
-                return indexAnalyzers;
-            }
-
-            public IndexSettings getIndexSettings() {
-                return indexSettings;
-            }
-
-            public BooleanSupplier isIdFieldDataEnabled() {
-                return idFieldDataEnabled;
-            }
-
-            public Settings getSettings() {
-                return indexSettings.getSettings();
-            }
-
-            public SimilarityProvider getSimilarity(String name) {
-                return similarityLookupService.apply(name);
-            }
-
-            public TypeParser typeParser(String type) {
-                return typeParsers.apply(type);
-            }
-
-            public RuntimeField.Parser runtimeFieldParser(String type) {
-                return runtimeFieldParsers.apply(type);
-            }
-
-            public Version indexVersionCreated() {
-                return indexVersionCreated;
-            }
-
-            public Supplier<SearchExecutionContext> searchExecutionContext() {
-                return searchExecutionContextSupplier;
-            }
-
-            /**
-             * Gets an optional default date format for date fields that do not have an explicit format set
-             *
-             * If {@code null}, then date fields will default to {@link DateFieldMapper#DEFAULT_DATE_TIME_FORMATTER}.
-             */
-            public DateFormatter getDateFormatter() {
-                return dateFormatter;
-            }
-
-            public boolean isWithinMultiField() { return false; }
-
-            /**
-             * true if this pars context is coming from parsing dynamic template mappings
-             */
-            public boolean isFromDynamicTemplate() { return false; }
-
-            protected Function<String, SimilarityProvider> similarityLookupService() { return similarityLookupService; }
-
-            /**
-             * The {@linkplain ScriptCompiler} to compile scripts needed by the {@linkplain Mapper}.
-             */
-            public ScriptCompiler scriptCompiler() {
-                return scriptCompiler;
-            }
-
-            ParserContext createMultiFieldContext(ParserContext in) {
-                return new MultiFieldParserContext(in);
-            }
-
-            private static class MultiFieldParserContext extends ParserContext {
-                MultiFieldParserContext(ParserContext in) {
-                    super(in.similarityLookupService, in.typeParsers, in.runtimeFieldParsers, in.indexVersionCreated,
-                        in.searchExecutionContextSupplier, in.dateFormatter, in.scriptCompiler, in.indexAnalyzers, in.indexSettings,
-                        in.idFieldDataEnabled);
-                }
-
-                @Override
-                public boolean isWithinMultiField() { return true; }
-            }
-
-            static class DynamicTemplateParserContext extends ParserContext {
-                DynamicTemplateParserContext(ParserContext in) {
-                    super(in.similarityLookupService, in.typeParsers, in.runtimeFieldParsers, in.indexVersionCreated,
-                        in.searchExecutionContextSupplier, in.dateFormatter, in.scriptCompiler, in.indexAnalyzers, in.indexSettings,
-                        in.idFieldDataEnabled);
-                }
-
-                @Override
-                public boolean isFromDynamicTemplate() { return true; }
-            }
-        }
-
-        Mapper.Builder parse(String name, Map<String, Object> node, ParserContext parserContext) throws MapperParsingException;
+        Mapper.Builder parse(String name, Map<String, Object> node, MappingsParserContext parserContext) throws MapperParsingException;
     }
 
     private final String simpleName;

--- a/server/src/main/java/org/elasticsearch/index/mapper/MapperService.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/MapperService.java
@@ -95,7 +95,7 @@ public class MapperService extends AbstractIndexComponent implements Closeable {
     private final DocumentParser documentParser;
     private final Version indexVersionCreated;
     private final MapperRegistry mapperRegistry;
-    private final Supplier<Mapper.TypeParser.ParserContext> parserContextSupplier;
+    private final Supplier<MappingsParserContext> parserContextSupplier;
 
     private volatile DocumentMapper mapper;
 
@@ -107,12 +107,12 @@ public class MapperService extends AbstractIndexComponent implements Closeable {
         this.indexVersionCreated = indexSettings.getIndexVersionCreated();
         this.indexAnalyzers = indexAnalyzers;
         this.mapperRegistry = mapperRegistry;
-        Function<DateFormatter, Mapper.TypeParser.ParserContext> parserContextFunction =
-            dateFormatter -> new Mapper.TypeParser.ParserContext(similarityService::getSimilarity, mapperRegistry.getMapperParsers()::get,
+        Function<DateFormatter, MappingsParserContext> parserContextFunction =
+            dateFormatter -> new MappingsParserContext(similarityService::getSimilarity, mapperRegistry.getMapperParsers()::get,
                 mapperRegistry.getRuntimeFieldParsers()::get, indexVersionCreated, searchExecutionContextSupplier, dateFormatter,
                 scriptCompiler, indexAnalyzers, indexSettings, idFieldDataEnabled);
         this.documentParser = new DocumentParser(xContentRegistry,
-            dateFormatter -> new Mapper.TypeParser.ParserContext.DynamicTemplateParserContext(parserContextFunction.apply(dateFormatter)),
+            dateFormatter -> new MappingsParserContext.DynamicTemplateParserContext(parserContextFunction.apply(dateFormatter)),
             indexSettings, indexAnalyzers);
         Map<String, MetadataFieldMapper.TypeParser> metadataMapperParsers =
             mapperRegistry.getMetadataMapperParsers(indexSettings.getIndexVersionCreated());
@@ -133,7 +133,7 @@ public class MapperService extends AbstractIndexComponent implements Closeable {
         return this.indexAnalyzers.get(analyzerName);
     }
 
-    public Mapper.TypeParser.ParserContext parserContext() {
+    public MappingsParserContext parserContext() {
         return parserContextSupplier.get();
     }
 

--- a/server/src/main/java/org/elasticsearch/index/mapper/MapperService.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/MapperService.java
@@ -95,7 +95,7 @@ public class MapperService extends AbstractIndexComponent implements Closeable {
     private final DocumentParser documentParser;
     private final Version indexVersionCreated;
     private final MapperRegistry mapperRegistry;
-    private final Supplier<MappingsParserContext> parserContextSupplier;
+    private final Supplier<MappingParserContext> parserContextSupplier;
 
     private volatile DocumentMapper mapper;
 
@@ -107,12 +107,12 @@ public class MapperService extends AbstractIndexComponent implements Closeable {
         this.indexVersionCreated = indexSettings.getIndexVersionCreated();
         this.indexAnalyzers = indexAnalyzers;
         this.mapperRegistry = mapperRegistry;
-        Function<DateFormatter, MappingsParserContext> parserContextFunction =
-            dateFormatter -> new MappingsParserContext(similarityService::getSimilarity, mapperRegistry.getMapperParsers()::get,
+        Function<DateFormatter, MappingParserContext> parserContextFunction =
+            dateFormatter -> new MappingParserContext(similarityService::getSimilarity, mapperRegistry.getMapperParsers()::get,
                 mapperRegistry.getRuntimeFieldParsers()::get, indexVersionCreated, searchExecutionContextSupplier, dateFormatter,
                 scriptCompiler, indexAnalyzers, indexSettings, idFieldDataEnabled);
         this.documentParser = new DocumentParser(xContentRegistry,
-            dateFormatter -> new MappingsParserContext.DynamicTemplateParserContext(parserContextFunction.apply(dateFormatter)),
+            dateFormatter -> new MappingParserContext.DynamicTemplateParserContext(parserContextFunction.apply(dateFormatter)),
             indexSettings, indexAnalyzers);
         Map<String, MetadataFieldMapper.TypeParser> metadataMapperParsers =
             mapperRegistry.getMetadataMapperParsers(indexSettings.getIndexVersionCreated());
@@ -133,7 +133,7 @@ public class MapperService extends AbstractIndexComponent implements Closeable {
         return this.indexAnalyzers.get(analyzerName);
     }
 
-    public MappingsParserContext parserContext() {
+    public MappingParserContext parserContext() {
         return parserContextSupplier.get();
     }
 

--- a/server/src/main/java/org/elasticsearch/index/mapper/MappingParser.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/MappingParser.java
@@ -25,13 +25,13 @@ import java.util.function.Supplier;
  * Parser for {@link Mapping} provided in {@link CompressedXContent} format
  */
 public final class MappingParser {
-    private final Supplier<MappingsParserContext> parserContextSupplier;
+    private final Supplier<MappingParserContext> parserContextSupplier;
     private final RootObjectMapper.TypeParser rootObjectTypeParser = new RootObjectMapper.TypeParser();
     private final Supplier<Map<Class<? extends MetadataFieldMapper>, MetadataFieldMapper>> metadataMappersSupplier;
     private final Map<String, MetadataFieldMapper.TypeParser> metadataMapperParsers;
     private final Function<String, String> documentTypeResolver;
 
-    MappingParser(Supplier<MappingsParserContext> parserContextSupplier,
+    MappingParser(Supplier<MappingParserContext> parserContextSupplier,
                   Map<String, MetadataFieldMapper.TypeParser> metadataMapperParsers,
                   Supplier<Map<Class<? extends MetadataFieldMapper>, MetadataFieldMapper>> metadataMappersSupplier,
                   Function<String, String> documentTypeResolver) {
@@ -94,7 +94,7 @@ public final class MappingParser {
 
     private Mapping parse(String type, Map<String, Object> mapping) throws MapperParsingException {
         ContentPath contentPath = new ContentPath(1);
-        MappingsParserContext parserContext = parserContextSupplier.get();
+        MappingParserContext parserContext = parserContextSupplier.get();
         RootObjectMapper rootObjectMapper = rootObjectTypeParser.parse(type, mapping, parserContext).build(contentPath);
 
         Map<Class<? extends MetadataFieldMapper>, MetadataFieldMapper> metadataMappers = metadataMappersSupplier.get();

--- a/server/src/main/java/org/elasticsearch/index/mapper/MappingParser.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/MappingParser.java
@@ -8,10 +8,10 @@
 
 package org.elasticsearch.index.mapper;
 
-import org.elasticsearch.core.Nullable;
 import org.elasticsearch.common.compress.CompressedXContent;
 import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.common.xcontent.XContentType;
+import org.elasticsearch.core.Nullable;
 
 import java.util.Collections;
 import java.util.HashMap;
@@ -25,13 +25,13 @@ import java.util.function.Supplier;
  * Parser for {@link Mapping} provided in {@link CompressedXContent} format
  */
 public final class MappingParser {
-    private final Supplier<Mapper.TypeParser.ParserContext> parserContextSupplier;
+    private final Supplier<MappingsParserContext> parserContextSupplier;
     private final RootObjectMapper.TypeParser rootObjectTypeParser = new RootObjectMapper.TypeParser();
     private final Supplier<Map<Class<? extends MetadataFieldMapper>, MetadataFieldMapper>> metadataMappersSupplier;
     private final Map<String, MetadataFieldMapper.TypeParser> metadataMapperParsers;
     private final Function<String, String> documentTypeResolver;
 
-    MappingParser(Supplier<Mapper.TypeParser.ParserContext> parserContextSupplier,
+    MappingParser(Supplier<MappingsParserContext> parserContextSupplier,
                   Map<String, MetadataFieldMapper.TypeParser> metadataMapperParsers,
                   Supplier<Map<Class<? extends MetadataFieldMapper>, MetadataFieldMapper>> metadataMappersSupplier,
                   Function<String, String> documentTypeResolver) {
@@ -94,7 +94,7 @@ public final class MappingParser {
 
     private Mapping parse(String type, Map<String, Object> mapping) throws MapperParsingException {
         ContentPath contentPath = new ContentPath(1);
-        Mapper.TypeParser.ParserContext parserContext = parserContextSupplier.get();
+        MappingsParserContext parserContext = parserContextSupplier.get();
         RootObjectMapper rootObjectMapper = rootObjectTypeParser.parse(type, mapping, parserContext).build(contentPath);
 
         Map<Class<? extends MetadataFieldMapper>, MetadataFieldMapper> metadataMappers = metadataMappersSupplier.get();

--- a/server/src/main/java/org/elasticsearch/index/mapper/MappingParserContext.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/MappingParserContext.java
@@ -25,7 +25,7 @@ import java.util.function.Supplier;
  * Holds everything that is needed to parse mappings. This is carried around while parsing mappings whether that
  * be from a dynamic template or from index mappings themselves.
  */
-public class MappingsParserContext {
+public class MappingParserContext {
 
     private final Function<String, SimilarityProvider> similarityLookupService;
     private final Function<String, Mapper.TypeParser> typeParsers;
@@ -38,16 +38,16 @@ public class MappingsParserContext {
     private final IndexSettings indexSettings;
     private final BooleanSupplier idFieldDataEnabled;
 
-    public MappingsParserContext(Function<String, SimilarityProvider> similarityLookupService,
-                                 Function<String, Mapper.TypeParser> typeParsers,
-                                 Function<String, RuntimeField.Parser> runtimeFieldParsers,
-                                 Version indexVersionCreated,
-                                 Supplier<SearchExecutionContext> searchExecutionContextSupplier,
-                                 DateFormatter dateFormatter,
-                                 ScriptCompiler scriptCompiler,
-                                 IndexAnalyzers indexAnalyzers,
-                                 IndexSettings indexSettings,
-                                 BooleanSupplier idFieldDataEnabled) {
+    public MappingParserContext(Function<String, SimilarityProvider> similarityLookupService,
+                                Function<String, Mapper.TypeParser> typeParsers,
+                                Function<String, RuntimeField.Parser> runtimeFieldParsers,
+                                Version indexVersionCreated,
+                                Supplier<SearchExecutionContext> searchExecutionContextSupplier,
+                                DateFormatter dateFormatter,
+                                ScriptCompiler scriptCompiler,
+                                IndexAnalyzers indexAnalyzers,
+                                IndexSettings indexSettings,
+                                BooleanSupplier idFieldDataEnabled) {
         this.similarityLookupService = similarityLookupService;
         this.typeParsers = typeParsers;
         this.runtimeFieldParsers = runtimeFieldParsers;
@@ -127,12 +127,12 @@ public class MappingsParserContext {
         return scriptCompiler;
     }
 
-    MappingsParserContext createMultiFieldContext(MappingsParserContext in) {
+    MappingParserContext createMultiFieldContext(MappingParserContext in) {
         return new MultiFieldParserContext(in);
     }
 
-    private static class MultiFieldParserContext extends MappingsParserContext {
-        MultiFieldParserContext(MappingsParserContext in) {
+    private static class MultiFieldParserContext extends MappingParserContext {
+        MultiFieldParserContext(MappingParserContext in) {
             super(in.similarityLookupService, in.typeParsers, in.runtimeFieldParsers, in.indexVersionCreated,
                 in.searchExecutionContextSupplier, in.dateFormatter, in.scriptCompiler, in.indexAnalyzers, in.indexSettings,
                 in.idFieldDataEnabled);
@@ -144,8 +144,8 @@ public class MappingsParserContext {
         }
     }
 
-    static class DynamicTemplateParserContext extends MappingsParserContext {
-        DynamicTemplateParserContext(MappingsParserContext in) {
+    static class DynamicTemplateParserContext extends MappingParserContext {
+        DynamicTemplateParserContext(MappingParserContext in) {
             super(in.similarityLookupService, in.typeParsers, in.runtimeFieldParsers, in.indexVersionCreated,
                 in.searchExecutionContextSupplier, in.dateFormatter, in.scriptCompiler, in.indexAnalyzers, in.indexSettings,
                 in.idFieldDataEnabled);

--- a/server/src/main/java/org/elasticsearch/index/mapper/MappingsParserContext.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/MappingsParserContext.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.index.mapper;
+
+import org.elasticsearch.Version;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.time.DateFormatter;
+import org.elasticsearch.index.IndexSettings;
+import org.elasticsearch.index.analysis.IndexAnalyzers;
+import org.elasticsearch.index.query.SearchExecutionContext;
+import org.elasticsearch.index.similarity.SimilarityProvider;
+import org.elasticsearch.script.ScriptCompiler;
+
+import java.util.function.BooleanSupplier;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+/**
+ * Holds everything that is needed to parse mappings. This is carried around while parsing mappings whether that
+ * be from a dynamic template or from index mappings themselves.
+ */
+public class MappingsParserContext {
+
+    private final Function<String, SimilarityProvider> similarityLookupService;
+    private final Function<String, Mapper.TypeParser> typeParsers;
+    private final Function<String, RuntimeField.Parser> runtimeFieldParsers;
+    private final Version indexVersionCreated;
+    private final Supplier<SearchExecutionContext> searchExecutionContextSupplier;
+    private final DateFormatter dateFormatter;
+    private final ScriptCompiler scriptCompiler;
+    private final IndexAnalyzers indexAnalyzers;
+    private final IndexSettings indexSettings;
+    private final BooleanSupplier idFieldDataEnabled;
+
+    public MappingsParserContext(Function<String, SimilarityProvider> similarityLookupService,
+                                 Function<String, Mapper.TypeParser> typeParsers,
+                                 Function<String, RuntimeField.Parser> runtimeFieldParsers,
+                                 Version indexVersionCreated,
+                                 Supplier<SearchExecutionContext> searchExecutionContextSupplier,
+                                 DateFormatter dateFormatter,
+                                 ScriptCompiler scriptCompiler,
+                                 IndexAnalyzers indexAnalyzers,
+                                 IndexSettings indexSettings,
+                                 BooleanSupplier idFieldDataEnabled) {
+        this.similarityLookupService = similarityLookupService;
+        this.typeParsers = typeParsers;
+        this.runtimeFieldParsers = runtimeFieldParsers;
+        this.indexVersionCreated = indexVersionCreated;
+        this.searchExecutionContextSupplier = searchExecutionContextSupplier;
+        this.dateFormatter = dateFormatter;
+        this.scriptCompiler = scriptCompiler;
+        this.indexAnalyzers = indexAnalyzers;
+        this.indexSettings = indexSettings;
+        this.idFieldDataEnabled = idFieldDataEnabled;
+    }
+
+    public IndexAnalyzers getIndexAnalyzers() {
+        return indexAnalyzers;
+    }
+
+    public IndexSettings getIndexSettings() {
+        return indexSettings;
+    }
+
+    public BooleanSupplier isIdFieldDataEnabled() {
+        return idFieldDataEnabled;
+    }
+
+    public Settings getSettings() {
+        return indexSettings.getSettings();
+    }
+
+    public SimilarityProvider getSimilarity(String name) {
+        return similarityLookupService.apply(name);
+    }
+
+    public Mapper.TypeParser typeParser(String type) {
+        return typeParsers.apply(type);
+    }
+
+    public RuntimeField.Parser runtimeFieldParser(String type) {
+        return runtimeFieldParsers.apply(type);
+    }
+
+    public Version indexVersionCreated() {
+        return indexVersionCreated;
+    }
+
+    public Supplier<SearchExecutionContext> searchExecutionContext() {
+        return searchExecutionContextSupplier;
+    }
+
+    /**
+     * Gets an optional default date format for date fields that do not have an explicit format set
+     * <p>
+     * If {@code null}, then date fields will default to {@link DateFieldMapper#DEFAULT_DATE_TIME_FORMATTER}.
+     */
+    public DateFormatter getDateFormatter() {
+        return dateFormatter;
+    }
+
+    public boolean isWithinMultiField() {
+        return false;
+    }
+
+    /**
+     * true if this pars context is coming from parsing dynamic template mappings
+     */
+    public boolean isFromDynamicTemplate() {
+        return false;
+    }
+
+    protected Function<String, SimilarityProvider> similarityLookupService() {
+        return similarityLookupService;
+    }
+
+    /**
+     * The {@linkplain ScriptCompiler} to compile scripts needed by the {@linkplain Mapper}.
+     */
+    public ScriptCompiler scriptCompiler() {
+        return scriptCompiler;
+    }
+
+    MappingsParserContext createMultiFieldContext(MappingsParserContext in) {
+        return new MultiFieldParserContext(in);
+    }
+
+    private static class MultiFieldParserContext extends MappingsParserContext {
+        MultiFieldParserContext(MappingsParserContext in) {
+            super(in.similarityLookupService, in.typeParsers, in.runtimeFieldParsers, in.indexVersionCreated,
+                in.searchExecutionContextSupplier, in.dateFormatter, in.scriptCompiler, in.indexAnalyzers, in.indexSettings,
+                in.idFieldDataEnabled);
+        }
+
+        @Override
+        public boolean isWithinMultiField() {
+            return true;
+        }
+    }
+
+    static class DynamicTemplateParserContext extends MappingsParserContext {
+        DynamicTemplateParserContext(MappingsParserContext in) {
+            super(in.similarityLookupService, in.typeParsers, in.runtimeFieldParsers, in.indexVersionCreated,
+                in.searchExecutionContextSupplier, in.dateFormatter, in.scriptCompiler, in.indexAnalyzers, in.indexSettings,
+                in.idFieldDataEnabled);
+        }
+
+        @Override
+        public boolean isFromDynamicTemplate() {
+            return true;
+        }
+    }
+}

--- a/server/src/main/java/org/elasticsearch/index/mapper/MetadataFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/MetadataFieldMapper.java
@@ -27,14 +27,14 @@ public abstract class MetadataFieldMapper extends FieldMapper {
 
         @Override
         MetadataFieldMapper.Builder parse(String name, Map<String, Object> node,
-                                               ParserContext parserContext) throws MapperParsingException;
+                                               MappingsParserContext parserContext) throws MapperParsingException;
 
         /**
          * Get the default {@link MetadataFieldMapper} to use, if nothing had to be parsed.
          *
          * @param parserContext context that may be useful to build the field like analyzers
          */
-        MetadataFieldMapper getDefault(ParserContext parserContext);
+        MetadataFieldMapper getDefault(MappingsParserContext parserContext);
     }
 
     /**
@@ -61,43 +61,43 @@ public abstract class MetadataFieldMapper extends FieldMapper {
      */
     public static class FixedTypeParser implements TypeParser {
 
-        final Function<ParserContext, MetadataFieldMapper> mapperParser;
+        final Function<MappingsParserContext, MetadataFieldMapper> mapperParser;
 
-        public FixedTypeParser(Function<ParserContext, MetadataFieldMapper> mapperParser) {
+        public FixedTypeParser(Function<MappingsParserContext, MetadataFieldMapper> mapperParser) {
             this.mapperParser = mapperParser;
         }
 
         @Override
-        public Builder parse(String name, Map<String, Object> node, ParserContext parserContext) throws MapperParsingException {
+        public Builder parse(String name, Map<String, Object> node, MappingsParserContext parserContext) throws MapperParsingException {
             throw new MapperParsingException(name + " is not configurable");
         }
 
         @Override
-        public MetadataFieldMapper getDefault(ParserContext parserContext) {
+        public MetadataFieldMapper getDefault(MappingsParserContext parserContext) {
             return mapperParser.apply(parserContext);
         }
     }
 
     public static class ConfigurableTypeParser implements TypeParser {
 
-        final Function<ParserContext, MetadataFieldMapper> defaultMapperParser;
-        final Function<ParserContext, Builder> builderFunction;
+        final Function<MappingsParserContext, MetadataFieldMapper> defaultMapperParser;
+        final Function<MappingsParserContext, Builder> builderFunction;
 
-        public ConfigurableTypeParser(Function<ParserContext, MetadataFieldMapper> defaultMapperParser,
-                                      Function<ParserContext, Builder> builderFunction) {
+        public ConfigurableTypeParser(Function<MappingsParserContext, MetadataFieldMapper> defaultMapperParser,
+                                      Function<MappingsParserContext, Builder> builderFunction) {
             this.defaultMapperParser = defaultMapperParser;
             this.builderFunction = builderFunction;
         }
 
         @Override
-        public Builder parse(String name, Map<String, Object> node, ParserContext parserContext) throws MapperParsingException {
+        public Builder parse(String name, Map<String, Object> node, MappingsParserContext parserContext) throws MapperParsingException {
             Builder builder = builderFunction.apply(parserContext);
             builder.parse(name, parserContext, node);
             return builder;
         }
 
         @Override
-        public MetadataFieldMapper getDefault(ParserContext parserContext) {
+        public MetadataFieldMapper getDefault(MappingsParserContext parserContext) {
             return defaultMapperParser.apply(parserContext);
         }
     }

--- a/server/src/main/java/org/elasticsearch/index/mapper/MetadataFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/MetadataFieldMapper.java
@@ -27,14 +27,14 @@ public abstract class MetadataFieldMapper extends FieldMapper {
 
         @Override
         MetadataFieldMapper.Builder parse(String name, Map<String, Object> node,
-                                               MappingsParserContext parserContext) throws MapperParsingException;
+                                               MappingParserContext parserContext) throws MapperParsingException;
 
         /**
          * Get the default {@link MetadataFieldMapper} to use, if nothing had to be parsed.
          *
          * @param parserContext context that may be useful to build the field like analyzers
          */
-        MetadataFieldMapper getDefault(MappingsParserContext parserContext);
+        MetadataFieldMapper getDefault(MappingParserContext parserContext);
     }
 
     /**
@@ -61,43 +61,43 @@ public abstract class MetadataFieldMapper extends FieldMapper {
      */
     public static class FixedTypeParser implements TypeParser {
 
-        final Function<MappingsParserContext, MetadataFieldMapper> mapperParser;
+        final Function<MappingParserContext, MetadataFieldMapper> mapperParser;
 
-        public FixedTypeParser(Function<MappingsParserContext, MetadataFieldMapper> mapperParser) {
+        public FixedTypeParser(Function<MappingParserContext, MetadataFieldMapper> mapperParser) {
             this.mapperParser = mapperParser;
         }
 
         @Override
-        public Builder parse(String name, Map<String, Object> node, MappingsParserContext parserContext) throws MapperParsingException {
+        public Builder parse(String name, Map<String, Object> node, MappingParserContext parserContext) throws MapperParsingException {
             throw new MapperParsingException(name + " is not configurable");
         }
 
         @Override
-        public MetadataFieldMapper getDefault(MappingsParserContext parserContext) {
+        public MetadataFieldMapper getDefault(MappingParserContext parserContext) {
             return mapperParser.apply(parserContext);
         }
     }
 
     public static class ConfigurableTypeParser implements TypeParser {
 
-        final Function<MappingsParserContext, MetadataFieldMapper> defaultMapperParser;
-        final Function<MappingsParserContext, Builder> builderFunction;
+        final Function<MappingParserContext, MetadataFieldMapper> defaultMapperParser;
+        final Function<MappingParserContext, Builder> builderFunction;
 
-        public ConfigurableTypeParser(Function<MappingsParserContext, MetadataFieldMapper> defaultMapperParser,
-                                      Function<MappingsParserContext, Builder> builderFunction) {
+        public ConfigurableTypeParser(Function<MappingParserContext, MetadataFieldMapper> defaultMapperParser,
+                                      Function<MappingParserContext, Builder> builderFunction) {
             this.defaultMapperParser = defaultMapperParser;
             this.builderFunction = builderFunction;
         }
 
         @Override
-        public Builder parse(String name, Map<String, Object> node, MappingsParserContext parserContext) throws MapperParsingException {
+        public Builder parse(String name, Map<String, Object> node, MappingParserContext parserContext) throws MapperParsingException {
             Builder builder = builderFunction.apply(parserContext);
             builder.parse(name, parserContext, node);
             return builder;
         }
 
         @Override
-        public MetadataFieldMapper getDefault(MappingsParserContext parserContext) {
+        public MetadataFieldMapper getDefault(MappingParserContext parserContext) {
             return defaultMapperParser.apply(parserContext);
         }
     }

--- a/server/src/main/java/org/elasticsearch/index/mapper/ObjectMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/ObjectMapper.java
@@ -197,7 +197,10 @@ public class ObjectMapper extends Mapper implements Cloneable {
 
     public static class TypeParser implements Mapper.TypeParser {
         @Override
-        public Mapper.Builder parse(String name, Map<String, Object> node, MappingsParserContext parserContext) throws MapperParsingException {
+        public Mapper.Builder parse(String name,
+                                    Map<String, Object> node,
+                                    MappingsParserContext parserContext)
+            throws MapperParsingException {
             ObjectMapper.Builder builder = new Builder(name, parserContext.indexVersionCreated());
             parseNested(name, node, builder);
             for (Iterator<Map.Entry<String, Object>> iterator = node.entrySet().iterator(); iterator.hasNext();) {
@@ -212,7 +215,9 @@ public class ObjectMapper extends Mapper implements Cloneable {
         }
 
         @SuppressWarnings({"unchecked", "rawtypes"})
-        protected static boolean parseObjectOrDocumentTypeProperties(String fieldName, Object fieldNode, MappingsParserContext parserContext,
+        protected static boolean parseObjectOrDocumentTypeProperties(String fieldName,
+                                                                     Object fieldNode,
+                                                                     MappingsParserContext parserContext,
                                                                      ObjectMapper.Builder builder) {
             if (fieldName.equals("dynamic")) {
                 String value = fieldNode.toString();

--- a/server/src/main/java/org/elasticsearch/index/mapper/ObjectMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/ObjectMapper.java
@@ -199,7 +199,7 @@ public class ObjectMapper extends Mapper implements Cloneable {
         @Override
         public Mapper.Builder parse(String name,
                                     Map<String, Object> node,
-                                    MappingsParserContext parserContext)
+                                    MappingParserContext parserContext)
             throws MapperParsingException {
             ObjectMapper.Builder builder = new Builder(name, parserContext.indexVersionCreated());
             parseNested(name, node, builder);
@@ -217,7 +217,7 @@ public class ObjectMapper extends Mapper implements Cloneable {
         @SuppressWarnings({"unchecked", "rawtypes"})
         protected static boolean parseObjectOrDocumentTypeProperties(String fieldName,
                                                                      Object fieldNode,
-                                                                     MappingsParserContext parserContext,
+                                                                     MappingParserContext parserContext,
                                                                      ObjectMapper.Builder builder) {
             if (fieldName.equals("dynamic")) {
                 String value = fieldNode.toString();
@@ -285,7 +285,7 @@ public class ObjectMapper extends Mapper implements Cloneable {
 
         protected static void parseProperties(ObjectMapper.Builder objBuilder,
                                               Map<String, Object> propsNode,
-                                              MappingsParserContext parserContext) {
+                                              MappingParserContext parserContext) {
             Iterator<Map.Entry<String, Object>> iterator = propsNode.entrySet().iterator();
             while (iterator.hasNext()) {
                 Map.Entry<String, Object> entry = iterator.next();

--- a/server/src/main/java/org/elasticsearch/index/mapper/ObjectMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/ObjectMapper.java
@@ -283,7 +283,9 @@ public class ObjectMapper extends Mapper implements Cloneable {
             }
         }
 
-        protected static void parseProperties(ObjectMapper.Builder objBuilder, Map<String, Object> propsNode, MappingsParserContext parserContext) {
+        protected static void parseProperties(ObjectMapper.Builder objBuilder,
+                                              Map<String, Object> propsNode,
+                                              MappingsParserContext parserContext) {
             Iterator<Map.Entry<String, Object>> iterator = propsNode.entrySet().iterator();
             while (iterator.hasNext()) {
                 Map.Entry<String, Object> entry = iterator.next();

--- a/server/src/main/java/org/elasticsearch/index/mapper/ObjectMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/ObjectMapper.java
@@ -197,7 +197,7 @@ public class ObjectMapper extends Mapper implements Cloneable {
 
     public static class TypeParser implements Mapper.TypeParser {
         @Override
-        public Mapper.Builder parse(String name, Map<String, Object> node, ParserContext parserContext) throws MapperParsingException {
+        public Mapper.Builder parse(String name, Map<String, Object> node, MappingsParserContext parserContext) throws MapperParsingException {
             ObjectMapper.Builder builder = new Builder(name, parserContext.indexVersionCreated());
             parseNested(name, node, builder);
             for (Iterator<Map.Entry<String, Object>> iterator = node.entrySet().iterator(); iterator.hasNext();) {
@@ -212,7 +212,7 @@ public class ObjectMapper extends Mapper implements Cloneable {
         }
 
         @SuppressWarnings({"unchecked", "rawtypes"})
-        protected static boolean parseObjectOrDocumentTypeProperties(String fieldName, Object fieldNode, ParserContext parserContext,
+        protected static boolean parseObjectOrDocumentTypeProperties(String fieldName, Object fieldNode, MappingsParserContext parserContext,
                                                                      ObjectMapper.Builder builder) {
             if (fieldName.equals("dynamic")) {
                 String value = fieldNode.toString();
@@ -278,7 +278,7 @@ public class ObjectMapper extends Mapper implements Cloneable {
             }
         }
 
-        protected static void parseProperties(ObjectMapper.Builder objBuilder, Map<String, Object> propsNode, ParserContext parserContext) {
+        protected static void parseProperties(ObjectMapper.Builder objBuilder, Map<String, Object> propsNode, MappingsParserContext parserContext) {
             Iterator<Map.Entry<String, Object>> iterator = propsNode.entrySet().iterator();
             while (iterator.hasNext()) {
                 Map.Entry<String, Object> entry = iterator.next();

--- a/server/src/main/java/org/elasticsearch/index/mapper/ParseContext.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/ParseContext.java
@@ -164,7 +164,7 @@ public abstract class ParseContext {
         }
 
         @Override
-        public MappingsParserContext dynamicTemplateParserContext(DateFormatter dateFormatter) {
+        public MappingParserContext dynamicTemplateParserContext(DateFormatter dateFormatter) {
             return in.dynamicTemplateParserContext(dateFormatter);
         }
 
@@ -298,7 +298,7 @@ public abstract class ParseContext {
         private final MappingLookup mappingLookup;
         private final IndexSettings indexSettings;
         private final IndexAnalyzers indexAnalyzers;
-        private final Function<DateFormatter, MappingsParserContext> parserContextFunction;
+        private final Function<DateFormatter, MappingParserContext> parserContextFunction;
         private final ContentPath path = new ContentPath(0);
         private final XContentParser parser;
         private final Document document;
@@ -319,7 +319,7 @@ public abstract class ParseContext {
         public InternalParseContext(MappingLookup mappingLookup,
                                     IndexSettings indexSettings,
                                     IndexAnalyzers indexAnalyzers,
-                                    Function<DateFormatter, MappingsParserContext> parserContext,
+                                    Function<DateFormatter, MappingParserContext> parserContext,
                                     SourceToParse source,
                                     XContentParser parser) {
             this.mappingLookup = mappingLookup;
@@ -336,7 +336,7 @@ public abstract class ParseContext {
         }
 
         @Override
-        public MappingsParserContext dynamicTemplateParserContext(DateFormatter dateFormatter) {
+        public MappingParserContext dynamicTemplateParserContext(DateFormatter dateFormatter) {
             return parserContextFunction.apply(dateFormatter);
         }
 
@@ -548,7 +548,7 @@ public abstract class ParseContext {
      */
     public abstract Collection<String> getFieldNames();
 
-    public abstract MappingsParserContext dynamicTemplateParserContext(DateFormatter dateFormatter);
+    public abstract MappingParserContext dynamicTemplateParserContext(DateFormatter dateFormatter);
 
     /**
      * Return a new context that will be within a copy-to operation.

--- a/server/src/main/java/org/elasticsearch/index/mapper/ParseContext.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/ParseContext.java
@@ -164,7 +164,7 @@ public abstract class ParseContext {
         }
 
         @Override
-        public Mapper.TypeParser.ParserContext dynamicTemplateParserContext(DateFormatter dateFormatter) {
+        public MappingsParserContext dynamicTemplateParserContext(DateFormatter dateFormatter) {
             return in.dynamicTemplateParserContext(dateFormatter);
         }
 
@@ -298,7 +298,7 @@ public abstract class ParseContext {
         private final MappingLookup mappingLookup;
         private final IndexSettings indexSettings;
         private final IndexAnalyzers indexAnalyzers;
-        private final Function<DateFormatter, Mapper.TypeParser.ParserContext> parserContextFunction;
+        private final Function<DateFormatter, MappingsParserContext> parserContextFunction;
         private final ContentPath path = new ContentPath(0);
         private final XContentParser parser;
         private final Document document;
@@ -319,7 +319,7 @@ public abstract class ParseContext {
         public InternalParseContext(MappingLookup mappingLookup,
                                     IndexSettings indexSettings,
                                     IndexAnalyzers indexAnalyzers,
-                                    Function<DateFormatter, Mapper.TypeParser.ParserContext> parserContext,
+                                    Function<DateFormatter, MappingsParserContext> parserContext,
                                     SourceToParse source,
                                     XContentParser parser) {
             this.mappingLookup = mappingLookup;
@@ -336,7 +336,7 @@ public abstract class ParseContext {
         }
 
         @Override
-        public Mapper.TypeParser.ParserContext dynamicTemplateParserContext(DateFormatter dateFormatter) {
+        public MappingsParserContext dynamicTemplateParserContext(DateFormatter dateFormatter) {
             return parserContextFunction.apply(dateFormatter);
         }
 
@@ -548,7 +548,7 @@ public abstract class ParseContext {
      */
     public abstract Collection<String> getFieldNames();
 
-    public abstract Mapper.TypeParser.ParserContext dynamicTemplateParserContext(DateFormatter dateFormatter);
+    public abstract MappingsParserContext dynamicTemplateParserContext(DateFormatter dateFormatter);
 
     /**
      * Return a new context that will be within a copy-to operation.

--- a/server/src/main/java/org/elasticsearch/index/mapper/RootObjectMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/RootObjectMapper.java
@@ -142,7 +142,7 @@ public class RootObjectMapper extends ObjectMapper {
     static final class TypeParser extends ObjectMapper.TypeParser {
 
         @Override
-        public RootObjectMapper.Builder parse(String name, Map<String, Object> node, ParserContext parserContext)
+        public RootObjectMapper.Builder parse(String name, Map<String, Object> node, MappingsParserContext parserContext)
             throws MapperParsingException {
             RootObjectMapper.Builder builder = new Builder(name, parserContext.indexVersionCreated());
             Iterator<Map.Entry<String, Object>> iterator = node.entrySet().iterator();
@@ -159,7 +159,7 @@ public class RootObjectMapper extends ObjectMapper {
         }
 
         @SuppressWarnings("unchecked")
-        private boolean processField(RootObjectMapper.Builder builder, String fieldName, Object fieldNode, ParserContext parserContext) {
+        private boolean processField(RootObjectMapper.Builder builder, String fieldName, Object fieldNode, MappingsParserContext parserContext) {
             if (fieldName.equals("date_formats") || fieldName.equals("dynamic_date_formats")) {
                 if (fieldNode instanceof List) {
                     List<DateFormatter> formatters = new ArrayList<>();
@@ -382,7 +382,7 @@ public class RootObjectMapper extends ObjectMapper {
         }
     }
 
-    private static void validateDynamicTemplate(Mapper.TypeParser.ParserContext parserContext,
+    private static void validateDynamicTemplate(MappingsParserContext parserContext,
                                                 DynamicTemplate template) {
 
         if (containsSnippet(template.getMapping(), "{name}")) {

--- a/server/src/main/java/org/elasticsearch/index/mapper/RootObjectMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/RootObjectMapper.java
@@ -159,7 +159,10 @@ public class RootObjectMapper extends ObjectMapper {
         }
 
         @SuppressWarnings("unchecked")
-        private boolean processField(RootObjectMapper.Builder builder, String fieldName, Object fieldNode, MappingsParserContext parserContext) {
+        private boolean processField(RootObjectMapper.Builder builder,
+                                     String fieldName,
+                                     Object fieldNode,
+                                     MappingsParserContext parserContext) {
             if (fieldName.equals("date_formats") || fieldName.equals("dynamic_date_formats")) {
                 if (fieldNode instanceof List) {
                     List<DateFormatter> formatters = new ArrayList<>();

--- a/server/src/main/java/org/elasticsearch/index/mapper/RootObjectMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/RootObjectMapper.java
@@ -142,7 +142,7 @@ public class RootObjectMapper extends ObjectMapper {
     static final class TypeParser extends ObjectMapper.TypeParser {
 
         @Override
-        public RootObjectMapper.Builder parse(String name, Map<String, Object> node, MappingsParserContext parserContext)
+        public RootObjectMapper.Builder parse(String name, Map<String, Object> node, MappingParserContext parserContext)
             throws MapperParsingException {
             RootObjectMapper.Builder builder = new Builder(name, parserContext.indexVersionCreated());
             Iterator<Map.Entry<String, Object>> iterator = node.entrySet().iterator();
@@ -162,7 +162,7 @@ public class RootObjectMapper extends ObjectMapper {
         private boolean processField(RootObjectMapper.Builder builder,
                                      String fieldName,
                                      Object fieldNode,
-                                     MappingsParserContext parserContext) {
+                                     MappingParserContext parserContext) {
             if (fieldName.equals("date_formats") || fieldName.equals("dynamic_date_formats")) {
                 if (fieldNode instanceof List) {
                     List<DateFormatter> formatters = new ArrayList<>();
@@ -385,7 +385,7 @@ public class RootObjectMapper extends ObjectMapper {
         }
     }
 
-    private static void validateDynamicTemplate(MappingsParserContext parserContext,
+    private static void validateDynamicTemplate(MappingParserContext parserContext,
                                                 DynamicTemplate template) {
 
         if (containsSnippet(template.getMapping(), "{name}")) {

--- a/server/src/main/java/org/elasticsearch/index/mapper/RuntimeField.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/RuntimeField.java
@@ -76,7 +76,7 @@ public interface RuntimeField extends ToXContentFragment {
             return Collections.singletonList(meta);
         }
 
-        protected abstract RuntimeField createRuntimeField(Mapper.TypeParser.ParserContext parserContext);
+        protected abstract RuntimeField createRuntimeField(MappingsParserContext parserContext);
 
         @Override
         public final XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
@@ -87,7 +87,7 @@ public interface RuntimeField extends ToXContentFragment {
             return builder;
         }
 
-        public final void parse(String name, Mapper.TypeParser.ParserContext parserContext, Map<String, Object> fieldNode) {
+        public final void parse(String name, MappingsParserContext parserContext, Map<String, Object> fieldNode) {
             Map<String, Parameter<?>> paramsMap = new HashMap<>();
             for (Parameter<?> param : getParameters()) {
                 paramsMap.put(param.name, param);
@@ -124,7 +124,7 @@ public interface RuntimeField extends ToXContentFragment {
             this.builderFunction = builderFunction;
         }
 
-        RuntimeField parse(String name, Map<String, Object> node, Mapper.TypeParser.ParserContext parserContext)
+        RuntimeField parse(String name, Map<String, Object> node, MappingsParserContext parserContext)
             throws MapperParsingException {
 
             RuntimeField.Builder builder = builderFunction.apply(name);
@@ -142,7 +142,7 @@ public interface RuntimeField extends ToXContentFragment {
      * @return the parsed runtime fields
      */
     static Map<String, RuntimeField> parseRuntimeFields(Map<String, Object> node,
-                                                        Mapper.TypeParser.ParserContext parserContext,
+                                                        MappingsParserContext parserContext,
                                                         boolean supportsRemoval) {
         Map<String, RuntimeField> runtimeFields = new HashMap<>();
         Iterator<Map.Entry<String, Object>> iterator = node.entrySet().iterator();

--- a/server/src/main/java/org/elasticsearch/index/mapper/RuntimeField.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/RuntimeField.java
@@ -76,7 +76,7 @@ public interface RuntimeField extends ToXContentFragment {
             return Collections.singletonList(meta);
         }
 
-        protected abstract RuntimeField createRuntimeField(MappingsParserContext parserContext);
+        protected abstract RuntimeField createRuntimeField(MappingParserContext parserContext);
 
         @Override
         public final XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
@@ -87,7 +87,7 @@ public interface RuntimeField extends ToXContentFragment {
             return builder;
         }
 
-        public final void parse(String name, MappingsParserContext parserContext, Map<String, Object> fieldNode) {
+        public final void parse(String name, MappingParserContext parserContext, Map<String, Object> fieldNode) {
             Map<String, Parameter<?>> paramsMap = new HashMap<>();
             for (Parameter<?> param : getParameters()) {
                 paramsMap.put(param.name, param);
@@ -124,7 +124,7 @@ public interface RuntimeField extends ToXContentFragment {
             this.builderFunction = builderFunction;
         }
 
-        RuntimeField parse(String name, Map<String, Object> node, MappingsParserContext parserContext)
+        RuntimeField parse(String name, Map<String, Object> node, MappingParserContext parserContext)
             throws MapperParsingException {
 
             RuntimeField.Builder builder = builderFunction.apply(name);
@@ -142,7 +142,7 @@ public interface RuntimeField extends ToXContentFragment {
      * @return the parsed runtime fields
      */
     static Map<String, RuntimeField> parseRuntimeFields(Map<String, Object> node,
-                                                        MappingsParserContext parserContext,
+                                                        MappingParserContext parserContext,
                                                         boolean supportsRemoval) {
         Map<String, RuntimeField> runtimeFields = new HashMap<>();
         Iterator<Map.Entry<String, Object>> iterator = node.entrySet().iterator();

--- a/server/src/main/java/org/elasticsearch/index/mapper/TextFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/TextFieldMapper.java
@@ -58,7 +58,6 @@ import org.elasticsearch.index.analysis.IndexAnalyzers;
 import org.elasticsearch.index.analysis.NamedAnalyzer;
 import org.elasticsearch.index.fielddata.IndexFieldData;
 import org.elasticsearch.index.fielddata.plain.PagedBytesIndexFieldData;
-import org.elasticsearch.index.mapper.Mapper.TypeParser.ParserContext;
 import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.index.similarity.SimilarityProvider;
 import org.elasticsearch.search.aggregations.support.CoreValuesSourceType;
@@ -158,7 +157,7 @@ public class TextFieldMapper extends FieldMapper {
         }
     }
 
-    private static PrefixConfig parsePrefixConfig(String propName, ParserContext parserContext, Object propNode) {
+    private static PrefixConfig parsePrefixConfig(String propName, MappingsParserContext parserContext, Object propNode) {
         if (propNode == null) {
             return null;
         }
@@ -217,7 +216,7 @@ public class TextFieldMapper extends FieldMapper {
         Defaults.FIELDDATA_MIN_FREQUENCY, Defaults.FIELDDATA_MAX_FREQUENCY, Defaults.FIELDDATA_MIN_SEGMENT_SIZE
     );
 
-    private static FielddataFrequencyFilter parseFrequencyFilter(String name, ParserContext parserContext, Object node) {
+    private static FielddataFrequencyFilter parseFrequencyFilter(String name, MappingsParserContext parserContext, Object node) {
         Map<?,?> frequencyFilter = (Map<?, ?>) node;
         double minFrequency = XContentMapValues.nodeDoubleValue(frequencyFilter.remove("min"), 0);
         double maxFrequency = XContentMapValues.nodeDoubleValue(frequencyFilter.remove("max"), Integer.MAX_VALUE);

--- a/server/src/main/java/org/elasticsearch/index/mapper/TextFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/TextFieldMapper.java
@@ -157,7 +157,7 @@ public class TextFieldMapper extends FieldMapper {
         }
     }
 
-    private static PrefixConfig parsePrefixConfig(String propName, MappingsParserContext parserContext, Object propNode) {
+    private static PrefixConfig parsePrefixConfig(String propName, MappingParserContext parserContext, Object propNode) {
         if (propNode == null) {
             return null;
         }
@@ -216,7 +216,7 @@ public class TextFieldMapper extends FieldMapper {
         Defaults.FIELDDATA_MIN_FREQUENCY, Defaults.FIELDDATA_MAX_FREQUENCY, Defaults.FIELDDATA_MIN_SEGMENT_SIZE
     );
 
-    private static FielddataFrequencyFilter parseFrequencyFilter(String name, MappingsParserContext parserContext, Object node) {
+    private static FielddataFrequencyFilter parseFrequencyFilter(String name, MappingParserContext parserContext, Object node) {
         Map<?,?> frequencyFilter = (Map<?, ?>) node;
         double minFrequency = XContentMapValues.nodeDoubleValue(frequencyFilter.remove("min"), 0);
         double maxFrequency = XContentMapValues.nodeDoubleValue(frequencyFilter.remove("max"), Integer.MAX_VALUE);

--- a/server/src/main/java/org/elasticsearch/index/mapper/TypeParsers.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/TypeParsers.java
@@ -86,7 +86,7 @@ public class TypeParsers {
 
     @SuppressWarnings({"unchecked"})
     public static boolean parseMultiField(Consumer<FieldMapper.Builder> multiFieldsBuilder, String name,
-                                          Mapper.TypeParser.ParserContext parserContext, String propName, Object propNode) {
+                                          MappingsParserContext parserContext, String propName, Object propNode) {
         if (propName.equals("fields")) {
             if (parserContext.isWithinMultiField()) {
                 // For indices created prior to 8.0, we only emit a deprecation warning and do not fail type parsing. This is to
@@ -172,7 +172,7 @@ public class TypeParsers {
         return copyFields;
     }
 
-    public static SimilarityProvider resolveSimilarity(Mapper.TypeParser.ParserContext parserContext, String name, Object value) {
+    public static SimilarityProvider resolveSimilarity(MappingsParserContext parserContext, String name, Object value) {
         if (value == null) {
             return null;    // use default
         }

--- a/server/src/main/java/org/elasticsearch/index/mapper/TypeParsers.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/TypeParsers.java
@@ -86,7 +86,7 @@ public class TypeParsers {
 
     @SuppressWarnings({"unchecked"})
     public static boolean parseMultiField(Consumer<FieldMapper.Builder> multiFieldsBuilder, String name,
-                                          MappingsParserContext parserContext, String propName, Object propNode) {
+                                          MappingParserContext parserContext, String propName, Object propNode) {
         if (propName.equals("fields")) {
             if (parserContext.isWithinMultiField()) {
                 // For indices created prior to 8.0, we only emit a deprecation warning and do not fail type parsing. This is to
@@ -172,7 +172,7 @@ public class TypeParsers {
         return copyFields;
     }
 
-    public static SimilarityProvider resolveSimilarity(MappingsParserContext parserContext, String name, Object value) {
+    public static SimilarityProvider resolveSimilarity(MappingParserContext parserContext, String name, Object value) {
         if (value == null) {
             return null;    // use default
         }

--- a/server/src/main/java/org/elasticsearch/index/query/SearchExecutionContext.java
+++ b/server/src/main/java/org/elasticsearch/index/query/SearchExecutionContext.java
@@ -41,7 +41,7 @@ import org.elasticsearch.index.mapper.Mapper;
 import org.elasticsearch.index.mapper.MapperParsingException;
 import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.mapper.MappingLookup;
-import org.elasticsearch.index.mapper.MappingsParserContext;
+import org.elasticsearch.index.mapper.MappingParserContext;
 import org.elasticsearch.index.mapper.ObjectMapper;
 import org.elasticsearch.index.mapper.ParsedDocument;
 import org.elasticsearch.index.mapper.RuntimeField;
@@ -376,7 +376,7 @@ public class SearchExecutionContext extends QueryRewriteContext {
      * Generally used to handle unmapped fields in the context of sorting.
      */
     public MappedFieldType buildAnonymousFieldType(String type) {
-        MappingsParserContext parserContext = mapperService.parserContext();
+        MappingParserContext parserContext = mapperService.parserContext();
         Mapper.TypeParser typeParser = parserContext.typeParser(type);
         if (typeParser == null) {
             throw new IllegalArgumentException("No mapper found for type [" + type + "]");

--- a/server/src/main/java/org/elasticsearch/index/query/SearchExecutionContext.java
+++ b/server/src/main/java/org/elasticsearch/index/query/SearchExecutionContext.java
@@ -19,7 +19,6 @@ import org.apache.lucene.util.SetOnce;
 import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.client.Client;
-import org.elasticsearch.core.CheckedFunction;
 import org.elasticsearch.common.ParsingException;
 import org.elasticsearch.common.TriFunction;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
@@ -27,6 +26,7 @@ import org.elasticsearch.common.lucene.search.Queries;
 import org.elasticsearch.common.regex.Regex;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.core.CheckedFunction;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.IndexSortConfig;
@@ -41,6 +41,7 @@ import org.elasticsearch.index.mapper.Mapper;
 import org.elasticsearch.index.mapper.MapperParsingException;
 import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.mapper.MappingLookup;
+import org.elasticsearch.index.mapper.MappingsParserContext;
 import org.elasticsearch.index.mapper.ObjectMapper;
 import org.elasticsearch.index.mapper.ParsedDocument;
 import org.elasticsearch.index.mapper.RuntimeField;
@@ -375,7 +376,7 @@ public class SearchExecutionContext extends QueryRewriteContext {
      * Generally used to handle unmapped fields in the context of sorting.
      */
     public MappedFieldType buildAnonymousFieldType(String type) {
-        Mapper.TypeParser.ParserContext parserContext = mapperService.parserContext();
+        MappingsParserContext parserContext = mapperService.parserContext();
         Mapper.TypeParser typeParser = parserContext.typeParser(type);
         if (typeParser == null) {
             throw new IllegalArgumentException("No mapper found for type [" + type + "]");

--- a/server/src/test/java/org/elasticsearch/index/mapper/MappingParserTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/MappingParserTests.java
@@ -34,8 +34,8 @@ public class MappingParserTests extends MapperServiceTestCase {
         IndexAnalyzers indexAnalyzers = createIndexAnalyzers();
         SimilarityService similarityService = new SimilarityService(indexSettings, scriptService, Collections.emptyMap());
         MapperRegistry mapperRegistry = new IndicesModule(Collections.emptyList()).getMapperRegistry();
-        Supplier<MappingsParserContext> parserContextSupplier =
-            () -> new MappingsParserContext(similarityService::getSimilarity, mapperRegistry.getMapperParsers()::get,
+        Supplier<MappingParserContext> parserContextSupplier =
+            () -> new MappingParserContext(similarityService::getSimilarity, mapperRegistry.getMapperParsers()::get,
                 mapperRegistry.getRuntimeFieldParsers()::get, indexSettings.getIndexVersionCreated(),
                 () -> { throw new UnsupportedOperationException(); }, null,
                 scriptService, indexAnalyzers, indexSettings, () -> false);

--- a/server/src/test/java/org/elasticsearch/index/mapper/MappingParserTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/MappingParserTests.java
@@ -34,8 +34,8 @@ public class MappingParserTests extends MapperServiceTestCase {
         IndexAnalyzers indexAnalyzers = createIndexAnalyzers();
         SimilarityService similarityService = new SimilarityService(indexSettings, scriptService, Collections.emptyMap());
         MapperRegistry mapperRegistry = new IndicesModule(Collections.emptyList()).getMapperRegistry();
-        Supplier<Mapper.TypeParser.ParserContext> parserContextSupplier =
-            () -> new Mapper.TypeParser.ParserContext(similarityService::getSimilarity, mapperRegistry.getMapperParsers()::get,
+        Supplier<MappingsParserContext> parserContextSupplier =
+            () -> new MappingsParserContext(similarityService::getSimilarity, mapperRegistry.getMapperParsers()::get,
                 mapperRegistry.getRuntimeFieldParsers()::get, indexSettings.getIndexVersionCreated(),
                 () -> { throw new UnsupportedOperationException(); }, null,
                 scriptService, indexAnalyzers, indexSettings, () -> false);

--- a/server/src/test/java/org/elasticsearch/index/mapper/ParametrizedMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/ParametrizedMapperTests.java
@@ -138,7 +138,7 @@ public class ParametrizedMapperTests extends MapperServiceTestCase {
         @Override
         public Mapper.Builder parse(String name,
                                     Map<String, Object> node,
-                                    MappingsParserContext parserContext) throws MapperParsingException {
+                                    MappingParserContext parserContext) throws MapperParsingException {
             Builder builder = new Builder(name);
             builder.parse(name, parserContext, node);
             return builder;
@@ -197,7 +197,7 @@ public class ParametrizedMapperTests extends MapperServiceTestCase {
                 "default", new NamedAnalyzer("default", AnalyzerScope.INDEX, new StandardAnalyzer())),
             Collections.emptyMap(), Collections.emptyMap());
         when(mapperService.getIndexAnalyzers()).thenReturn(indexAnalyzers);
-        MappingsParserContext pc = new MappingsParserContext(s -> null, s -> {
+        MappingParserContext pc = new MappingParserContext(s -> null, s -> {
             if (Objects.equals("keyword", s)) {
                 return KeywordFieldMapper.PARSER;
             }
@@ -210,7 +210,7 @@ public class ParametrizedMapperTests extends MapperServiceTestCase {
             throw new UnsupportedOperationException();
         });
         if (fromDynamicTemplate) {
-            pc = new MappingsParserContext.DynamicTemplateParserContext(pc);
+            pc = new MappingParserContext.DynamicTemplateParserContext(pc);
         }
         return (TestMapper) new TypeParser()
             .parse("field", XContentHelper.convertToMap(JsonXContent.jsonXContent, mapping, true), pc)

--- a/server/src/test/java/org/elasticsearch/index/mapper/ParametrizedMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/ParametrizedMapperTests.java
@@ -136,7 +136,7 @@ public class ParametrizedMapperTests extends MapperServiceTestCase {
     public static class TypeParser implements Mapper.TypeParser {
 
         @Override
-        public Mapper.Builder parse(String name, Map<String, Object> node, ParserContext parserContext) throws MapperParsingException {
+        public Mapper.Builder parse(String name, Map<String, Object> node, MappingsParserContext parserContext) throws MapperParsingException {
             Builder builder = new Builder(name);
             builder.parse(name, parserContext, node);
             return builder;
@@ -195,7 +195,7 @@ public class ParametrizedMapperTests extends MapperServiceTestCase {
                 "default", new NamedAnalyzer("default", AnalyzerScope.INDEX, new StandardAnalyzer())),
             Collections.emptyMap(), Collections.emptyMap());
         when(mapperService.getIndexAnalyzers()).thenReturn(indexAnalyzers);
-        Mapper.TypeParser.ParserContext pc = new Mapper.TypeParser.ParserContext(s -> null, s -> {
+        MappingsParserContext pc = new MappingsParserContext(s -> null, s -> {
             if (Objects.equals("keyword", s)) {
                 return KeywordFieldMapper.PARSER;
             }
@@ -208,7 +208,7 @@ public class ParametrizedMapperTests extends MapperServiceTestCase {
             throw new UnsupportedOperationException();
         });
         if (fromDynamicTemplate) {
-            pc = new Mapper.TypeParser.ParserContext.DynamicTemplateParserContext(pc);
+            pc = new MappingsParserContext.DynamicTemplateParserContext(pc);
         }
         return (TestMapper) new TypeParser()
             .parse("field", XContentHelper.convertToMap(JsonXContent.jsonXContent, mapping, true), pc)

--- a/server/src/test/java/org/elasticsearch/index/mapper/ParametrizedMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/ParametrizedMapperTests.java
@@ -136,7 +136,9 @@ public class ParametrizedMapperTests extends MapperServiceTestCase {
     public static class TypeParser implements Mapper.TypeParser {
 
         @Override
-        public Mapper.Builder parse(String name, Map<String, Object> node, MappingsParserContext parserContext) throws MapperParsingException {
+        public Mapper.Builder parse(String name,
+                                    Map<String, Object> node,
+                                    MappingsParserContext parserContext) throws MapperParsingException {
             Builder builder = new Builder(name);
             builder.parse(name, parserContext, node);
             return builder;

--- a/server/src/test/java/org/elasticsearch/index/mapper/TextFieldAnalyzerModeTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/TextFieldAnalyzerModeTests.java
@@ -68,7 +68,7 @@ public class TextFieldAnalyzerModeTests extends ESTestCase {
 
         Map<String, Object> fieldNode = new HashMap<>();
         fieldNode.put("analyzer", "my_analyzer");
-        MappingsParserContext parserContext = mock(MappingsParserContext.class);
+        MappingParserContext parserContext = mock(MappingParserContext.class);
 
         // check AnalysisMode.ALL works
         Map<String, NamedAnalyzer> analyzers = defaultAnalyzers();
@@ -104,7 +104,7 @@ public class TextFieldAnalyzerModeTests extends ESTestCase {
             if (settingToTest.equals("search_quote_analyzer")) {
                 fieldNode.put("search_analyzer", "standard");
             }
-            MappingsParserContext parserContext = mock(MappingsParserContext.class);
+            MappingParserContext parserContext = mock(MappingParserContext.class);
 
             // check AnalysisMode.ALL and AnalysisMode.SEARCH_TIME works
             Map<String, NamedAnalyzer> analyzers = defaultAnalyzers();
@@ -143,7 +143,7 @@ public class TextFieldAnalyzerModeTests extends ESTestCase {
 
         Map<String, Object> fieldNode = new HashMap<>();
         fieldNode.put("analyzer", "my_analyzer");
-        MappingsParserContext parserContext = mock(MappingsParserContext.class);
+        MappingParserContext parserContext = mock(MappingParserContext.class);
 
         // check that "analyzer" set to AnalysisMode.INDEX_TIME is blocked if there is no search analyzer
         AnalysisMode mode = AnalysisMode.INDEX_TIME;

--- a/server/src/test/java/org/elasticsearch/index/mapper/TextFieldAnalyzerModeTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/TextFieldAnalyzerModeTests.java
@@ -68,7 +68,7 @@ public class TextFieldAnalyzerModeTests extends ESTestCase {
 
         Map<String, Object> fieldNode = new HashMap<>();
         fieldNode.put("analyzer", "my_analyzer");
-        Mapper.TypeParser.ParserContext parserContext = mock(Mapper.TypeParser.ParserContext.class);
+        MappingsParserContext parserContext = mock(MappingsParserContext.class);
 
         // check AnalysisMode.ALL works
         Map<String, NamedAnalyzer> analyzers = defaultAnalyzers();
@@ -104,7 +104,7 @@ public class TextFieldAnalyzerModeTests extends ESTestCase {
             if (settingToTest.equals("search_quote_analyzer")) {
                 fieldNode.put("search_analyzer", "standard");
             }
-            Mapper.TypeParser.ParserContext parserContext = mock(Mapper.TypeParser.ParserContext.class);
+            MappingsParserContext parserContext = mock(MappingsParserContext.class);
 
             // check AnalysisMode.ALL and AnalysisMode.SEARCH_TIME works
             Map<String, NamedAnalyzer> analyzers = defaultAnalyzers();
@@ -143,7 +143,7 @@ public class TextFieldAnalyzerModeTests extends ESTestCase {
 
         Map<String, Object> fieldNode = new HashMap<>();
         fieldNode.put("analyzer", "my_analyzer");
-        Mapper.TypeParser.ParserContext parserContext = mock(Mapper.TypeParser.ParserContext.class);
+        MappingsParserContext parserContext = mock(MappingsParserContext.class);
 
         // check that "analyzer" set to AnalysisMode.INDEX_TIME is blocked if there is no search analyzer
         AnalysisMode mode = AnalysisMode.INDEX_TIME;

--- a/server/src/test/java/org/elasticsearch/index/mapper/TypeParsersTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/TypeParsersTests.java
@@ -71,7 +71,7 @@ public class TypeParsersTests extends ESTestCase {
         IndexAnalyzers indexAnalyzers = new IndexAnalyzers(defaultAnalyzers(), Collections.emptyMap(), Collections.emptyMap());
         when(mapperService.getIndexAnalyzers()).thenReturn(indexAnalyzers);
         Version olderVersion = VersionUtils.randomPreviousCompatibleVersion(random(), Version.V_8_0_0);
-        Mapper.TypeParser.ParserContext olderContext = new Mapper.TypeParser.ParserContext(null, type -> typeParser, type -> null,
+        MappingsParserContext olderContext = new MappingsParserContext(null, type -> typeParser, type -> null,
             olderVersion, null, null, ScriptCompiler.NONE, mapperService.getIndexAnalyzers(), mapperService.getIndexSettings(), () -> {
             throw new UnsupportedOperationException();
         });
@@ -88,7 +88,7 @@ public class TypeParsersTests extends ESTestCase {
             BytesReference.bytes(mapping), true, mapping.contentType()).v2();
 
         Version version = VersionUtils.randomVersionBetween(random(), Version.V_8_0_0, Version.CURRENT);
-        Mapper.TypeParser.ParserContext context = new Mapper.TypeParser.ParserContext(null, type -> typeParser, type -> null, version,
+        MappingsParserContext context = new MappingsParserContext(null, type -> typeParser, type -> null, version,
             null, null, ScriptCompiler.NONE, mapperService.getIndexAnalyzers(), mapperService.getIndexSettings(), () -> {
             throw new UnsupportedOperationException();
         });

--- a/server/src/test/java/org/elasticsearch/index/mapper/TypeParsersTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/TypeParsersTests.java
@@ -71,7 +71,7 @@ public class TypeParsersTests extends ESTestCase {
         IndexAnalyzers indexAnalyzers = new IndexAnalyzers(defaultAnalyzers(), Collections.emptyMap(), Collections.emptyMap());
         when(mapperService.getIndexAnalyzers()).thenReturn(indexAnalyzers);
         Version olderVersion = VersionUtils.randomPreviousCompatibleVersion(random(), Version.V_8_0_0);
-        MappingsParserContext olderContext = new MappingsParserContext(null, type -> typeParser, type -> null,
+        MappingParserContext olderContext = new MappingParserContext(null, type -> typeParser, type -> null,
             olderVersion, null, null, ScriptCompiler.NONE, mapperService.getIndexAnalyzers(), mapperService.getIndexSettings(), () -> {
             throw new UnsupportedOperationException();
         });
@@ -88,7 +88,7 @@ public class TypeParsersTests extends ESTestCase {
             BytesReference.bytes(mapping), true, mapping.contentType()).v2();
 
         Version version = VersionUtils.randomVersionBetween(random(), Version.V_8_0_0, Version.CURRENT);
-        MappingsParserContext context = new MappingsParserContext(null, type -> typeParser, type -> null, version,
+        MappingParserContext context = new MappingParserContext(null, type -> typeParser, type -> null, version,
             null, null, ScriptCompiler.NONE, mapperService.getIndexAnalyzers(), mapperService.getIndexSettings(), () -> {
             throw new UnsupportedOperationException();
         });

--- a/server/src/test/java/org/elasticsearch/index/query/SearchExecutionContextTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/SearchExecutionContextTests.java
@@ -52,7 +52,7 @@ import org.elasticsearch.index.mapper.MapperRegistry;
 import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.mapper.Mapping;
 import org.elasticsearch.index.mapper.MappingLookup;
-import org.elasticsearch.index.mapper.MappingsParserContext;
+import org.elasticsearch.index.mapper.MappingParserContext;
 import org.elasticsearch.index.mapper.MetadataFieldMapper;
 import org.elasticsearch.index.mapper.MockFieldMapper;
 import org.elasticsearch.index.mapper.NumberFieldMapper;
@@ -446,7 +446,7 @@ public class SearchExecutionContextTests extends ESTestCase {
         Supplier<SearchExecutionContext> searchExecutionContextSupplier = () -> { throw new UnsupportedOperationException(); };
         MapperService mapperService = mock(MapperService.class);
         when(mapperService.getIndexAnalyzers()).thenReturn(indexAnalyzers);
-        when(mapperService.parserContext()).thenReturn(new MappingsParserContext(
+        when(mapperService.parserContext()).thenReturn(new MappingParserContext(
             null,
             mapperRegistry.getMapperParsers()::get,
             mapperRegistry.getRuntimeFieldParsers()::get,

--- a/server/src/test/java/org/elasticsearch/index/query/SearchExecutionContextTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/SearchExecutionContextTests.java
@@ -47,12 +47,12 @@ import org.elasticsearch.index.mapper.KeywordFieldMapper;
 import org.elasticsearch.index.mapper.KeywordScriptFieldType;
 import org.elasticsearch.index.mapper.LongScriptFieldType;
 import org.elasticsearch.index.mapper.MappedFieldType;
-import org.elasticsearch.index.mapper.Mapper;
 import org.elasticsearch.index.mapper.MapperParsingException;
 import org.elasticsearch.index.mapper.MapperRegistry;
 import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.mapper.Mapping;
 import org.elasticsearch.index.mapper.MappingLookup;
+import org.elasticsearch.index.mapper.MappingsParserContext;
 import org.elasticsearch.index.mapper.MetadataFieldMapper;
 import org.elasticsearch.index.mapper.MockFieldMapper;
 import org.elasticsearch.index.mapper.NumberFieldMapper;
@@ -446,7 +446,7 @@ public class SearchExecutionContextTests extends ESTestCase {
         Supplier<SearchExecutionContext> searchExecutionContextSupplier = () -> { throw new UnsupportedOperationException(); };
         MapperService mapperService = mock(MapperService.class);
         when(mapperService.getIndexAnalyzers()).thenReturn(indexAnalyzers);
-        when(mapperService.parserContext()).thenReturn(new Mapper.TypeParser.ParserContext(
+        when(mapperService.parserContext()).thenReturn(new MappingsParserContext(
             null,
             mapperRegistry.getMapperParsers()::get,
             mapperRegistry.getRuntimeFieldParsers()::get,

--- a/server/src/test/java/org/elasticsearch/indices/IndicesModuleTests.java
+++ b/server/src/test/java/org/elasticsearch/indices/IndicesModuleTests.java
@@ -18,7 +18,7 @@ import org.elasticsearch.index.mapper.KeywordFieldMapper;
 import org.elasticsearch.index.mapper.Mapper;
 import org.elasticsearch.index.mapper.MapperParsingException;
 import org.elasticsearch.index.mapper.MapperRegistry;
-import org.elasticsearch.index.mapper.MappingsParserContext;
+import org.elasticsearch.index.mapper.MappingParserContext;
 import org.elasticsearch.index.mapper.MetadataFieldMapper;
 import org.elasticsearch.index.mapper.NestedPathFieldMapper;
 import org.elasticsearch.index.mapper.RoutingFieldMapper;
@@ -48,7 +48,7 @@ public class IndicesModuleTests extends ESTestCase {
 
     private static class FakeMapperParser implements Mapper.TypeParser {
         @Override
-        public Mapper.Builder parse(String name, Map<String, Object> node, MappingsParserContext parserContext)
+        public Mapper.Builder parse(String name, Map<String, Object> node, MappingParserContext parserContext)
             throws MapperParsingException {
             return null;
         }

--- a/server/src/test/java/org/elasticsearch/indices/IndicesModuleTests.java
+++ b/server/src/test/java/org/elasticsearch/indices/IndicesModuleTests.java
@@ -18,6 +18,7 @@ import org.elasticsearch.index.mapper.KeywordFieldMapper;
 import org.elasticsearch.index.mapper.Mapper;
 import org.elasticsearch.index.mapper.MapperParsingException;
 import org.elasticsearch.index.mapper.MapperRegistry;
+import org.elasticsearch.index.mapper.MappingsParserContext;
 import org.elasticsearch.index.mapper.MetadataFieldMapper;
 import org.elasticsearch.index.mapper.NestedPathFieldMapper;
 import org.elasticsearch.index.mapper.RoutingFieldMapper;
@@ -47,7 +48,7 @@ public class IndicesModuleTests extends ESTestCase {
 
     private static class FakeMapperParser implements Mapper.TypeParser {
         @Override
-        public Mapper.Builder parse(String name, Map<String, Object> node, ParserContext parserContext)
+        public Mapper.Builder parse(String name, Map<String, Object> node, MappingsParserContext parserContext)
             throws MapperParsingException {
             return null;
         }

--- a/test/framework/src/main/java/org/elasticsearch/search/aggregations/AggregatorTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/search/aggregations/AggregatorTestCase.java
@@ -80,7 +80,7 @@ import org.elasticsearch.index.mapper.Mapper;
 import org.elasticsearch.index.mapper.MapperRegistry;
 import org.elasticsearch.index.mapper.Mapping;
 import org.elasticsearch.index.mapper.MappingLookup;
-import org.elasticsearch.index.mapper.MappingsParserContext;
+import org.elasticsearch.index.mapper.MappingParserContext;
 import org.elasticsearch.index.mapper.MockFieldMapper;
 import org.elasticsearch.index.mapper.NumberFieldMapper;
 import org.elasticsearch.index.mapper.ObjectMapper;
@@ -992,7 +992,7 @@ public abstract class AggregatorTestCase extends ESTestCase {
         iw.addDocument(doc);
     }
 
-    private static class MockParserContext extends MappingsParserContext {
+    private static class MockParserContext extends MappingParserContext {
         MockParserContext() {
             super(null, null, null, null, null, null, ScriptCompiler.NONE, null, null, null);
         }

--- a/test/framework/src/main/java/org/elasticsearch/search/aggregations/AggregatorTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/search/aggregations/AggregatorTestCase.java
@@ -80,6 +80,7 @@ import org.elasticsearch.index.mapper.Mapper;
 import org.elasticsearch.index.mapper.MapperRegistry;
 import org.elasticsearch.index.mapper.Mapping;
 import org.elasticsearch.index.mapper.MappingLookup;
+import org.elasticsearch.index.mapper.MappingsParserContext;
 import org.elasticsearch.index.mapper.MockFieldMapper;
 import org.elasticsearch.index.mapper.NumberFieldMapper;
 import org.elasticsearch.index.mapper.ObjectMapper;
@@ -991,7 +992,7 @@ public abstract class AggregatorTestCase extends ESTestCase {
         iw.addDocument(doc);
     }
 
-    private static class MockParserContext extends Mapper.TypeParser.ParserContext {
+    private static class MockParserContext extends MappingsParserContext {
         MockParserContext() {
             super(null, null, null, null, null, null, ScriptCompiler.NONE, null, null, null);
         }


### PR DESCRIPTION
ParserContext is an inner class of Mapper.TypeParser but is used outside of the context of parsing mappers, for instance also to parse runtime fields. Its purpose is to be used to parse mappings in general, and its name is confusing as it differs ever so slightly from ParseContext which is used for parsing incoming documents.

This commit moves ParserContext to be a top-level class, and renames it to MappingsParserContext.
