### PR TITLE
Relax data stream alias validation logic when removing an alias

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/admin/indices/alias/TransportIndicesAliasesAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/alias/TransportIndicesAliasesAction.java
@@ -98,23 +98,6 @@ public class TransportIndicesAliasesAction extends AcknowledgedTransportMasterNo
             List<String> concreteDataStreams =
                 indexNameExpressionResolver.dataStreamNames(state, request.indicesOptions(), action.indices());
             if (concreteDataStreams.size() != 0) {
-                // Fail if parameters are used that data streams don't support:
-                if (action.filter() != null) {
-                    throw new IllegalArgumentException("aliases that point to data streams don't support filters");
-                }
-                if (action.routing() != null) {
-                    throw new IllegalArgumentException("aliases that point to data streams don't support routing");
-                }
-                if (action.indexRouting() != null) {
-                    throw new IllegalArgumentException("aliases that point to data streams don't support index_routing");
-                }
-                if (action.searchRouting() != null) {
-                    throw new IllegalArgumentException("aliases that point to data streams don't support search_routing");
-                }
-                if (action.isHidden() != null) {
-                    throw new IllegalArgumentException("aliases that point to data streams don't support is_hidden");
-                }
-                // Fail if expressions match both data streams and regular indices:
                 String[] concreteIndices =
                     indexNameExpressionResolver.concreteIndexNames(state, request.indicesOptions(), true, action.indices());
                 List<String> nonBackingIndices = Arrays.stream(concreteIndices)
@@ -122,19 +105,35 @@ public class TransportIndicesAliasesAction extends AcknowledgedTransportMasterNo
                     .filter(ia -> ia.getParentDataStream() == null)
                     .map(IndexAbstraction::getName)
                     .collect(Collectors.toList());
-                if (nonBackingIndices.isEmpty() == false) {
-                    throw new IllegalArgumentException("expressions " + Arrays.toString(action.indices()) +
-                        " that match with both data streams and regular indices are disallowed");
-                }
-
                 switch (action.actionType()) {
                     case ADD:
+                        // Fail if parameters are used that data stream aliases don't support:
+                        if (action.filter() != null) {
+                            throw new IllegalArgumentException("aliases that point to data streams don't support filters");
+                        }
+                        if (action.routing() != null) {
+                            throw new IllegalArgumentException("aliases that point to data streams don't support routing");
+                        }
+                        if (action.indexRouting() != null) {
+                            throw new IllegalArgumentException("aliases that point to data streams don't support index_routing");
+                        }
+                        if (action.searchRouting() != null) {
+                            throw new IllegalArgumentException("aliases that point to data streams don't support search_routing");
+                        }
+                        if (action.isHidden() != null) {
+                            throw new IllegalArgumentException("aliases that point to data streams don't support is_hidden");
+                        }
+                        // Fail if expressions match both data streams and regular indices:
+                        if (nonBackingIndices.isEmpty() == false) {
+                            throw new IllegalArgumentException("expressions " + Arrays.toString(action.indices()) +
+                                " that match with both data streams and regular indices are disallowed");
+                        }
                         for (String dataStreamName : concreteDataStreams) {
                             for (String alias : concreteDataStreamAliases(action, state.metadata(), dataStreamName)) {
                                 finalActions.add(new AliasAction.AddDataStreamAlias(alias, dataStreamName, action.writeIndex()));
                             }
                         }
-                        break;
+                        continue;
                     case REMOVE:
                         for (String dataStreamName : concreteDataStreams) {
                             for (String alias : concreteDataStreamAliases(action, state.metadata(), dataStreamName)) {
@@ -142,11 +141,16 @@ public class TransportIndicesAliasesAction extends AcknowledgedTransportMasterNo
                                     new AliasAction.RemoveDataStreamAlias(alias, dataStreamName, action.mustExist()));
                             }
                         }
-                        break;
+                        if (nonBackingIndices.isEmpty() == false) {
+                            // Regular aliases/indices match as well with the provided expression.
+                            // (Only when adding new aliases, matching both data streams and indices is disallowed)
+                            break;
+                        } else {
+                            continue;
+                        }
                     default:
                         throw new IllegalArgumentException("Unsupported action [" + action.actionType() + "]");
                 }
-                continue;
             }
 
             final Index[] concreteIndices = indexNameExpressionResolver.concreteIndices(state, request.indicesOptions(), false,


### PR DESCRIPTION
When removing aliases allow that an alias action's index expression can match
both data streams and regular indices.

This allows api calls like `DELETE /_all/_alias/my-alias`, which can be common
in tear down / cleanup logic. In this case `my-alias` just points to regular
indices, but `_all` can be expanded to data streams too if exist. This can
then trigger validation logic that prevents adding aliases that refer to both
indices and data streams. However this api call never adds any alias, only
removes it. So failing with this validation error doesn't make much sense.

This change adjusts the validation logic so that: 'match with both data streams and
regular indices are disallowed' validation is only executed for alias actions
that add aliases.

Additionally with the change, a single alias remove action that spans across
indices and data stream aliases is allowed. For example `DELETE /_all/_alias/*`
will be allowed with this PR, which removes all aliases.

Relates to #66163