### PR TITLE
[ML] Adding a boolean "cleared" field to notifications index

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/notifications/NotificationsIndex.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/notifications/NotificationsIndex.java
@@ -11,7 +11,7 @@ import org.elasticsearch.xpack.core.template.TemplateUtils;
 
 public final class NotificationsIndex {
 
-    public static final String NOTIFICATIONS_INDEX = ".ml-notifications-000001";
+    public static final String NOTIFICATIONS_INDEX = ".ml-notifications-000002";
 
     private static final String RESOURCE_PATH = "/org/elasticsearch/xpack/core/ml/";
     private static final String MAPPINGS_VERSION_VARIABLE = "xpack.ml.version";

--- a/x-pack/plugin/core/src/main/resources/org/elasticsearch/xpack/core/ml/notifications_index_legacy_template.json
+++ b/x-pack/plugin/core/src/main/resources/org/elasticsearch/xpack/core/ml/notifications_index_legacy_template.json
@@ -2,7 +2,7 @@
   "order" : 0,
   "version" : ${xpack.ml.version.id},
   "index_patterns" : [
-    ".ml-notifications-000001"
+    ".ml-notifications-000002"
   ],
   "settings" : {
     "index" : {

--- a/x-pack/plugin/core/src/main/resources/org/elasticsearch/xpack/core/ml/notifications_index_mappings.json
+++ b/x-pack/plugin/core/src/main/resources/org/elasticsearch/xpack/core/ml/notifications_index_mappings.json
@@ -27,6 +27,9 @@
     },
     "job_type": {
       "type": "keyword"
+    },
+    "cleared": {
+      "type": "boolean"
     }
   }
 }

--- a/x-pack/plugin/core/src/main/resources/org/elasticsearch/xpack/core/ml/notifications_index_template.json
+++ b/x-pack/plugin/core/src/main/resources/org/elasticsearch/xpack/core/ml/notifications_index_template.json
@@ -2,7 +2,7 @@
   "priority" : 2147483647,
   "version" : ${xpack.ml.version.id},
   "index_patterns" : [
-    ".ml-notifications-000001"
+    ".ml-notifications-000002"
   ],
   "template" : {
     "settings" : {

--- a/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/AnnotationIndexIT.java
+++ b/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/AnnotationIndexIT.java
@@ -61,7 +61,7 @@ public class AnnotationIndexIT extends MlSingleNodeTestCase {
         AnomalyDetectionAuditor auditor = new AnomalyDetectionAuditor(client(), getInstanceFromNode(ClusterService.class));
         auditor.info("whatever", "blah");
 
-        // Creating a document in the .ml-notifications-000001 index should cause .ml-annotations
+        // Creating a document in the .ml-notifications-000002 index should cause .ml-annotations
         // to be created, as it should get created as soon as any other ML index exists
 
         assertBusy(() -> {
@@ -78,7 +78,7 @@ public class AnnotationIndexIT extends MlSingleNodeTestCase {
             AnomalyDetectionAuditor auditor = new AnomalyDetectionAuditor(client(), getInstanceFromNode(ClusterService.class));
             auditor.info("whatever", "blah");
 
-            // Creating a document in the .ml-notifications-000001 index would normally cause .ml-annotations
+            // Creating a document in the .ml-notifications-000002 index would normally cause .ml-annotations
             // to be created, but in this case it shouldn't as we're doing an upgrade
 
             assertBusy(() -> {

--- a/x-pack/qa/src/main/java/org/elasticsearch/xpack/test/rest/IndexMappingTemplateAsserter.java
+++ b/x-pack/qa/src/main/java/org/elasticsearch/xpack/test/rest/IndexMappingTemplateAsserter.java
@@ -75,7 +75,7 @@ public class IndexMappingTemplateAsserter {
         assertComposableTemplateMatchesIndexMappings(client, ".ml-state", ".ml-state-000001", true, Collections.emptySet(), false);
         // Depending on the order Full Cluster restart tests are run there may not be an notifications index yet
         assertComposableTemplateMatchesIndexMappings(client,
-            ".ml-notifications-000001", ".ml-notifications-000001", true, notificationsIndexExceptions, false);
+            ".ml-notifications-000002", ".ml-notifications-000002", true, notificationsIndexExceptions, false);
         // .ml-annotations-6 does not use a template
         // .ml-anomalies-shared uses a template but will have dynamically updated mappings as new jobs are opened
 


### PR DESCRIPTION
This is to support https://github.com/elastic/kibana/issues/18328.

The "cleared" field will not be set by the backend.  The mapping
will exist so that the UI can set "cleared: true" for notifications
that a user decides should no longer be displayed in the UI.  The
UI will treat "false" and "not present" identically for this field.
This mapping will only apply for notifications written by version
7.14 and above.  Notifications indices used by older versions of
the product will not contain the mapping, so these notifications
will not be clearable.

Backport of #74376