### PR TITLE
Introduce ElasticsearchJavaBasePlugin to simplify YamlRestTestPlugin

### DIFF
--- a/build-conventions/src/main/java/org/elasticsearch/gradle/internal/conventions/precommit/PrecommitTaskPlugin.java
+++ b/build-conventions/src/main/java/org/elasticsearch/gradle/internal/conventions/precommit/PrecommitTaskPlugin.java
@@ -12,7 +12,7 @@ import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
 import org.gradle.api.plugins.JavaBasePlugin;
-import org.gradle.api.plugins.JavaPluginConvention;
+import org.gradle.api.plugins.JavaPluginExtension;
 import org.gradle.api.tasks.TaskProvider;
 import org.gradle.api.tasks.testing.Test;
 import org.gradle.language.base.plugins.LifecycleBasePlugin;
@@ -33,7 +33,7 @@ public class PrecommitTaskPlugin implements Plugin<Project> {
                 );
         project.getPluginManager().withPlugin("java", p -> {
             // run compilation as part of precommit
-            project.getConvention().getPlugin(JavaPluginConvention.class).getSourceSets().all(sourceSet ->
+            project.getExtensions().getByType(JavaPluginExtension.class).getSourceSets().all(sourceSet ->
                     precommit.configure(t -> t.shouldRunAfter(sourceSet.getClassesTaskName()))
             );
             // make sure tests run after all precommit tasks

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/ElasticsearchJavaBasePlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/ElasticsearchJavaBasePlugin.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.gradle.internal;
+
+import org.elasticsearch.gradle.VersionProperties;
+import org.elasticsearch.gradle.internal.conventions.precommit.PrecommitTaskPlugin;
+import org.elasticsearch.gradle.internal.info.GlobalBuildInfoPlugin;
+import org.elasticsearch.gradle.internal.info.BuildParams;
+import org.elasticsearch.gradle.util.GradleUtils;
+import org.gradle.api.Action;
+import org.gradle.api.JavaVersion;
+import org.gradle.api.Plugin;
+import org.gradle.api.Project;
+import org.gradle.api.artifacts.Configuration;
+import org.gradle.api.artifacts.ResolutionStrategy;
+import org.gradle.api.plugins.JavaBasePlugin;
+import org.gradle.api.plugins.JavaPlugin;
+import org.gradle.api.plugins.JavaPluginExtension;
+import org.gradle.api.provider.Provider;
+import org.gradle.api.tasks.SourceSet;
+import org.gradle.api.tasks.SourceSetContainer;
+import org.gradle.api.tasks.compile.AbstractCompile;
+import org.gradle.api.tasks.compile.CompileOptions;
+import org.gradle.api.tasks.compile.GroovyCompile;
+import org.gradle.api.tasks.compile.JavaCompile;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Stream;
+
+
+/**
+ * A wrapper around Gradle's Java Base plugin that applies our
+ * common configuration for production code.
+ */
+public class ElasticsearchJavaBasePlugin implements Plugin<Project> {
+    @Override
+    public void apply(Project project) {
+        // make sure the global build info plugin is applied to the root project
+        project.getRootProject().getPluginManager().apply(GlobalBuildInfoPlugin.class);
+        // common repositories setup
+        project.getPluginManager().apply(JavaBasePlugin.class);
+        project.getPluginManager().apply(RepositoriesSetupPlugin.class);
+        project.getPluginManager().apply(ElasticsearchTestBasePlugin.class);
+        project.getPluginManager().apply(PrecommitTaskPlugin.class);
+
+        configureCompile(project);
+        configureInputNormalization(project);
+
+        // convenience access to common versions used in dependencies
+        project.getExtensions().getExtraProperties().set("versions", VersionProperties.getVersions());
+    }
+
+    /**
+     * Adds compiler settings to the project
+     */
+    public static void configureCompile(Project project) {
+        project.getExtensions().getExtraProperties().set("compactProfile", "full");
+
+        JavaPluginExtension java = project.getExtensions().getByType(JavaPluginExtension.class);
+        java.setSourceCompatibility(BuildParams.getMinimumRuntimeVersion());
+        java.setTargetCompatibility(BuildParams.getMinimumRuntimeVersion());
+
+        project.afterEvaluate(p -> {
+            project.getTasks().withType(JavaCompile.class).configureEach(compileTask -> {
+                CompileOptions compileOptions = compileTask.getOptions();
+                /*
+                 * -path because gradle will send in paths that don't always exist.
+                 * -missing because we have tons of missing @returns and @param.
+                 * -serial because we don't use java serialization.
+                 */
+                // don't even think about passing args with -J-xxx, oracle will ask you to submit a bug report :)
+                // fail on all javac warnings.
+                // TODO Discuss moving compileOptions.getCompilerArgs() to use provider api with Gradle team.
+                List<String> compilerArgs = compileOptions.getCompilerArgs();
+                compilerArgs.add("-Werror");
+                compilerArgs.add("-Xlint:all,-path,-serial,-options,-deprecation,-try");
+                compilerArgs.add("-Xdoclint:all");
+                compilerArgs.add("-Xdoclint:-missing");
+                // either disable annotation processor completely (default) or allow to enable them if an annotation processor is explicitly
+                // defined
+                if (compilerArgs.contains("-processor") == false) {
+                    compilerArgs.add("-proc:none");
+                }
+
+                compileOptions.setEncoding("UTF-8");
+                compileOptions.setIncremental(true);
+                // workaround for https://github.com/gradle/gradle/issues/14141
+                compileTask.getConventionMapping().map("sourceCompatibility", () -> java.getSourceCompatibility().toString());
+                compileTask.getConventionMapping().map("targetCompatibility", () -> java.getTargetCompatibility().toString());
+                compileOptions.getRelease().set(releaseVersionProviderFromCompileTask(project, compileTask));
+            });
+            // also apply release flag to groovy, which is used in build-tools
+            project.getTasks().withType(GroovyCompile.class).configureEach(compileTask -> {
+                // TODO: this probably shouldn't apply to groovy at all?
+                compileTask.getOptions().getRelease().set(releaseVersionProviderFromCompileTask(project, compileTask));
+            });
+        });
+    }
+
+
+    /**
+     * Apply runtime classpath input normalization so that changes in JAR manifests don't break build cacheability
+     */
+    public static void configureInputNormalization(Project project) {
+        project.getNormalization().getRuntimeClasspath().ignore("META-INF/MANIFEST.MF");
+    }
+
+    private static Provider<Integer> releaseVersionProviderFromCompileTask(Project project, AbstractCompile compileTask) {
+        return project.provider(() -> {
+            JavaVersion javaVersion = JavaVersion.toVersion(compileTask.getTargetCompatibility());
+            return Integer.parseInt(javaVersion.getMajorVersion());
+        });
+    }
+
+}

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/ElasticsearchJavaPlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/ElasticsearchJavaPlugin.java
@@ -52,28 +52,20 @@ import java.util.stream.Stream;
 import static org.elasticsearch.gradle.internal.conventions.util.Util.toStringable;
 
 /**
- * A wrapper around Gradle's Java plugin that applies our common configuration.
+ * A wrapper around Gradle's Java plugin that applies our
+ * common configuration for production code.
  */
 public class ElasticsearchJavaPlugin implements Plugin<Project> {
     @Override
     public void apply(Project project) {
-        // make sure the global build info plugin is applied to the root project
-        project.getRootProject().getPluginManager().apply(GlobalBuildInfoPlugin.class);
-        // common repositories setup
-        project.getPluginManager().apply(RepositoriesSetupPlugin.class);
+        project.getPluginManager().apply(ElasticsearchJavaBasePlugin.class);
         project.getPluginManager().apply(JavaLibraryPlugin.class);
-        project.getPluginManager().apply(ElasticsearchTestBasePlugin.class);
-        project.getPluginManager().apply(PrecommitTaskPlugin.class);
 
         configureConfigurations(project);
-        configureCompile(project);
-        configureInputNormalization(project);
         configureJars(project);
         configureJarManifest(project);
         configureJavadoc(project);
-
-        // convenience access to common versions used in dependencies
-        project.getExtensions().getExtraProperties().set("versions", VersionProperties.getVersions());
+        testCompileOnlyDeps(project);
     }
 
     /**
@@ -93,11 +85,6 @@ public class ElasticsearchJavaPlugin implements Plugin<Project> {
      * to iterate the transitive dependencies and add excludes.
      */
     public static void configureConfigurations(Project project) {
-        // we want to test compileOnly deps!
-        Configuration compileOnlyConfig = project.getConfigurations().getByName(JavaPlugin.COMPILE_ONLY_CONFIGURATION_NAME);
-        Configuration testImplementationConfig = project.getConfigurations().getByName(JavaPlugin.TEST_IMPLEMENTATION_CONFIGURATION_NAME);
-        testImplementationConfig.extendsFrom(compileOnlyConfig);
-
         // we are not shipping these jars, we act like dumb consumers of these things
         if (project.getPath().startsWith(":test:fixtures") || project.getPath().equals(":build-tools")) {
             return;
@@ -111,119 +98,66 @@ public class ElasticsearchJavaPlugin implements Plugin<Project> {
             configuration.resolutionStrategy(ResolutionStrategy::failOnVersionConflict);
         });
 
-        // force all dependencies added directly to compile/testImplementation to be non-transitive, except for ES itself
-        Consumer<String> disableTransitiveDeps = configName -> {
-            Configuration config = project.getConfigurations().getByName(configName);
-            config.getDependencies().all(dep -> {
-                if (dep instanceof ModuleDependency
-                    && dep instanceof ProjectDependency == false
-                    && dep.getGroup().startsWith("org.elasticsearch") == false) {
-                    ((ModuleDependency) dep).setTransitive(false);
-                }
-            });
-        };
-
         // disable transitive dependency management
         SourceSetContainer sourceSets = project.getExtensions().getByType(SourceSetContainer.class);
         sourceSets.all(sourceSet -> disableTransitiveDependenciesForSourceSet(project, sourceSet));
     }
 
-    /**
-     * Adds compiler settings to the project
-     */
-    public static void configureCompile(Project project) {
-        project.getExtensions().getExtraProperties().set("compactProfile", "full");
-
-        JavaPluginExtension java = project.getExtensions().getByType(JavaPluginExtension.class);
-        java.setSourceCompatibility(BuildParams.getMinimumRuntimeVersion());
-        java.setTargetCompatibility(BuildParams.getMinimumRuntimeVersion());
-
-        project.afterEvaluate(p -> {
-            project.getTasks().withType(JavaCompile.class).configureEach(compileTask -> {
-                CompileOptions compileOptions = compileTask.getOptions();
-                /*
-                 * -path because gradle will send in paths that don't always exist.
-                 * -missing because we have tons of missing @returns and @param.
-                 * -serial because we don't use java serialization.
-                 */
-                // don't even think about passing args with -J-xxx, oracle will ask you to submit a bug report :)
-                // fail on all javac warnings.
-                // TODO Discuss moving compileOptions.getCompilerArgs() to use provider api with Gradle team.
-                List<String> compilerArgs = compileOptions.getCompilerArgs();
-                compilerArgs.add("-Werror");
-                compilerArgs.add("-Xlint:all,-path,-serial,-options,-deprecation,-try");
-                compilerArgs.add("-Xdoclint:all");
-                compilerArgs.add("-Xdoclint:-missing");
-                // either disable annotation processor completely (default) or allow to enable them if an annotation processor is explicitly
-                // defined
-                if (compilerArgs.contains("-processor") == false) {
-                    compilerArgs.add("-proc:none");
-                }
-
-                compileOptions.setEncoding("UTF-8");
-                compileOptions.setIncremental(true);
-                // workaround for https://github.com/gradle/gradle/issues/14141
-                compileTask.getConventionMapping().map("sourceCompatibility", () -> java.getSourceCompatibility().toString());
-                compileTask.getConventionMapping().map("targetCompatibility", () -> java.getTargetCompatibility().toString());
-                compileOptions.getRelease().set(releaseVersionProviderFromCompileTask(project, compileTask));
-            });
-            // also apply release flag to groovy, which is used in build-tools
-            project.getTasks().withType(GroovyCompile.class).configureEach(compileTask -> {
-                // TODO: this probably shouldn't apply to groovy at all?
-                compileTask.getOptions().getRelease().set(releaseVersionProviderFromCompileTask(project, compileTask));
-            });
-        });
-    }
-
-    private static Provider<Integer> releaseVersionProviderFromCompileTask(Project project, AbstractCompile compileTask) {
-        return project.provider(() -> {
-            JavaVersion javaVersion = JavaVersion.toVersion(compileTask.getTargetCompatibility());
-            return Integer.parseInt(javaVersion.getMajorVersion());
-        });
-    }
-
-    /**
-     * Apply runtime classpath input normalization so that changes in JAR manifests don't break build cacheability
-     */
-    public static void configureInputNormalization(Project project) {
-        project.getNormalization().getRuntimeClasspath().ignore("META-INF/MANIFEST.MF");
+    private static void testCompileOnlyDeps(Project project) {
+        // we want to test compileOnly deps!
+        Configuration compileOnlyConfig = project.getConfigurations().getByName(JavaPlugin.COMPILE_ONLY_CONFIGURATION_NAME);
+        Configuration testImplementationConfig = project.getConfigurations().getByName(JavaPlugin.TEST_IMPLEMENTATION_CONFIGURATION_NAME);
+        testImplementationConfig.extendsFrom(compileOnlyConfig);
     }
 
     /**
      * Adds additional manifest info to jars
      */
     static void configureJars(Project project) {
-        project.getTasks().withType(Jar.class).configureEach(jarTask -> {
-            // we put all our distributable files under distributions
-            jarTask.getDestinationDirectory().set(new File(project.getBuildDir(), "distributions"));
-            // fixup the jar manifest
-            // Explicitly using an Action interface as java lambdas
-            // are not supported by Gradle up-to-date checks
-            jarTask.doFirst(new Action<Task>() {
-                @Override
-                public void execute(Task task) {
-                    // this doFirst is added before the info plugin, therefore it will run
-                    // after the doFirst added by the info plugin, and we can override attributes
-                    jarTask.getManifest()
-                        .attributes(
-                            Map.of("Build-Date", BuildParams.getBuildDate(), "Build-Java-Version", BuildParams.getGradleJavaVersion())
-                        );
+        project.getTasks()
+            .withType(Jar.class)
+            .configureEach(
+                jarTask -> {
+                    // we put all our distributable files under distributions
+                    jarTask.getDestinationDirectory().set(new File(project.getBuildDir(), "distributions"));
+                    // fixup the jar manifest
+                    // Explicitly using an Action interface as java lambdas
+                    // are not supported by Gradle up-to-date checks
+                    jarTask.doFirst(new Action<Task>() {
+                        @Override
+                        public void execute(Task task) {
+                            // this doFirst is added before the info plugin, therefore it will run
+                            // after the doFirst added by the info plugin, and we can override attributes
+                            jarTask.getManifest()
+                                .attributes(
+                                    Map.of(
+                                        "Build-Date",
+                                        BuildParams.getBuildDate(),
+                                        "Build-Java-Version",
+                                        BuildParams.getGradleJavaVersion()
+                                    )
+                                );
+                        }
+                    });
                 }
-            });
-        });
+            );
         project.getPluginManager().withPlugin("com.github.johnrengelman.shadow", p -> {
-            project.getTasks().withType(ShadowJar.class).configureEach(shadowJar -> {
-                /*
-                 * Replace the default "-all" classifier with null
-                 * which will leave the classifier off of the file name.
-                 */
-                shadowJar.getArchiveClassifier().set((String) null);
-                /*
-                 * Not all cases need service files merged but it is
-                 * better to be safe
-                 */
-                shadowJar.mergeServiceFiles();
-            });
+            project.getTasks()
+                .withType(ShadowJar.class)
+                .configureEach(
+                    shadowJar -> {
+                        /*
+                         * Replace the default "-all" classifier with null
+                         * which will leave the classifier off of the file name.
+                         */
+                        shadowJar.getArchiveClassifier().set((String) null);
+                        /*
+                         * Not all cases need service files merged but it is
+                         * better to be safe
+                         */
+                        shadowJar.mergeServiceFiles();
+                    }
+                );
             // Add "original" classifier to the non-shadowed JAR to distinguish it from the shadow JAR
             project.getTasks().named(JavaPlugin.JAR_TASK_NAME, Jar.class).configure(jar -> jar.getArchiveClassifier().set("original"));
             // Make sure we assemble the shadow jar
@@ -273,6 +207,7 @@ public class ElasticsearchJavaPlugin implements Plugin<Project> {
         Stream.of(
             sourceSet.getApiConfigurationName(),
             sourceSet.getImplementationConfigurationName(),
+            sourceSet.getImplementationConfigurationName(),
             sourceSet.getCompileOnlyConfigurationName(),
             sourceSet.getRuntimeOnlyConfigurationName()
         )
@@ -280,4 +215,5 @@ public class ElasticsearchJavaPlugin implements Plugin<Project> {
             .filter(Objects::nonNull)
             .forEach(GradleUtils::disableTransitiveDependencies);
     }
+
 }

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/ElasticsearchJavaPlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/ElasticsearchJavaPlugin.java
@@ -12,8 +12,6 @@ import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar;
 import nebula.plugin.info.InfoBrokerPlugin;
 import org.elasticsearch.gradle.VersionProperties;
 import org.elasticsearch.gradle.internal.info.BuildParams;
-import org.elasticsearch.gradle.internal.info.GlobalBuildInfoPlugin;
-import org.elasticsearch.gradle.internal.conventions.precommit.PrecommitTaskPlugin;
 import org.elasticsearch.gradle.util.GradleUtils;
 import org.elasticsearch.gradle.internal.conventions.util.Util;
 import org.gradle.api.Action;

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/ElasticsearchJavaPlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/ElasticsearchJavaPlugin.java
@@ -112,50 +112,41 @@ public class ElasticsearchJavaPlugin implements Plugin<Project> {
      * Adds additional manifest info to jars
      */
     static void configureJars(Project project) {
-        project.getTasks()
-            .withType(Jar.class)
-            .configureEach(
-                jarTask -> {
-                    // we put all our distributable files under distributions
-                    jarTask.getDestinationDirectory().set(new File(project.getBuildDir(), "distributions"));
-                    // fixup the jar manifest
-                    // Explicitly using an Action interface as java lambdas
-                    // are not supported by Gradle up-to-date checks
-                    jarTask.doFirst(new Action<Task>() {
-                        @Override
-                        public void execute(Task task) {
-                            // this doFirst is added before the info plugin, therefore it will run
-                            // after the doFirst added by the info plugin, and we can override attributes
-                            jarTask.getManifest()
-                                .attributes(
-                                    Map.of(
-                                        "Build-Date",
-                                        BuildParams.getBuildDate(),
-                                        "Build-Java-Version",
-                                        BuildParams.getGradleJavaVersion()
-                                    )
-                                );
-                        }
-                    });
+        project.getTasks().withType(Jar.class).configureEach(
+            jarTask -> {
+                // we put all our distributable files under distributions
+                jarTask.getDestinationDirectory().set(new File(project.getBuildDir(), "distributions"));
+                // fixup the jar manifest
+                // Explicitly using an Action interface as java lambdas
+                // are not supported by Gradle up-to-date checks
+                jarTask.doFirst(new Action<Task>() {
+                    @Override
+                    public void execute(Task task) {
+                        // this doFirst is added before the info plugin, therefore it will run
+                        // after the doFirst added by the info plugin, and we can override attributes
+                        jarTask.getManifest()
+                            .attributes(
+                                Map.of("Build-Date", BuildParams.getBuildDate(), "Build-Java-Version", BuildParams.getGradleJavaVersion()
+                                )
+                            );
+                    }
+                });
+            }
+        );
+        project.getPluginManager().withPlugin("com.github.johnrengelman.shadow", p -> {
+            project.getTasks().withType(ShadowJar.class).configureEach(shadowJar -> {
+                    /*
+                     * Replace the default "-all" classifier with null
+                     * which will leave the classifier off of the file name.
+                     */
+                    shadowJar.getArchiveClassifier().set((String) null);
+                    /*
+                     * Not all cases need service files merged but it is
+                     * better to be safe
+                     */
+                    shadowJar.mergeServiceFiles();
                 }
             );
-        project.getPluginManager().withPlugin("com.github.johnrengelman.shadow", p -> {
-            project.getTasks()
-                .withType(ShadowJar.class)
-                .configureEach(
-                    shadowJar -> {
-                        /*
-                         * Replace the default "-all" classifier with null
-                         * which will leave the classifier off of the file name.
-                         */
-                        shadowJar.getArchiveClassifier().set((String) null);
-                        /*
-                         * Not all cases need service files merged but it is
-                         * better to be safe
-                         */
-                        shadowJar.mergeServiceFiles();
-                    }
-                );
             // Add "original" classifier to the non-shadowed JAR to distinguish it from the shadow JAR
             project.getTasks().named(JavaPlugin.JAR_TASK_NAME, Jar.class).configure(jar -> jar.getArchiveClassifier().set("original"));
             // Make sure we assemble the shadow jar

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/rest/compat/YamlRestCompatTestPlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/rest/compat/YamlRestCompatTestPlugin.java
@@ -8,6 +8,7 @@
 
 package org.elasticsearch.gradle.internal.rest.compat;
 
+import org.elasticsearch.gradle.internal.ElasticsearchJavaBasePlugin;
 import org.elasticsearch.gradle.internal.ElasticsearchJavaPlugin;
 import org.elasticsearch.gradle.Version;
 import org.elasticsearch.gradle.VersionProperties;
@@ -59,7 +60,7 @@ public class YamlRestCompatTestPlugin implements Plugin<Project> {
         final Path compatSpecsDir = compatRestResourcesDir.resolve("yamlSpecs");
         final Path compatTestsDir = compatRestResourcesDir.resolve("yamlTests");
 
-        project.getPluginManager().apply(ElasticsearchJavaPlugin.class);
+        project.getPluginManager().apply(ElasticsearchJavaBasePlugin.class);
         project.getPluginManager().apply(TestClustersPlugin.class);
         project.getPluginManager().apply(RestTestBasePlugin.class);
         project.getPluginManager().apply(RestResourcesPlugin.class);

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/rest/compat/YamlRestCompatTestPlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/rest/compat/YamlRestCompatTestPlugin.java
@@ -9,7 +9,6 @@
 package org.elasticsearch.gradle.internal.rest.compat;
 
 import org.elasticsearch.gradle.internal.ElasticsearchJavaBasePlugin;
-import org.elasticsearch.gradle.internal.ElasticsearchJavaPlugin;
 import org.elasticsearch.gradle.Version;
 import org.elasticsearch.gradle.VersionProperties;
 import org.elasticsearch.gradle.internal.test.RestIntegTestTask;

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/test/StandaloneRestTestPlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/test/StandaloneRestTestPlugin.java
@@ -8,6 +8,7 @@
 
 package org.elasticsearch.gradle.internal.test;
 
+import org.elasticsearch.gradle.internal.ElasticsearchJavaBasePlugin;
 import org.elasticsearch.gradle.internal.ElasticsearchJavaPlugin;
 import org.elasticsearch.gradle.internal.ExportElasticsearchBuildResourcesTask;
 import org.elasticsearch.gradle.internal.RepositoriesSetupPlugin;
@@ -46,17 +47,12 @@ public class StandaloneRestTestPlugin implements Plugin<Project> {
         }
 
         project.getRootProject().getPluginManager().apply(GlobalBuildInfoPlugin.class);
-        project.getPluginManager().apply(JavaBasePlugin.class);
+        project.getPluginManager().apply(ElasticsearchJavaBasePlugin.class);
         project.getPluginManager().apply(TestClustersPlugin.class);
         project.getPluginManager().apply(RepositoriesSetupPlugin.class);
         project.getPluginManager().apply(RestTestBasePlugin.class);
 
         project.getTasks().register("buildResources", ExportElasticsearchBuildResourcesTask.class);
-        ElasticsearchJavaPlugin.configureInputNormalization(project);
-        ElasticsearchJavaPlugin.configureCompile(project);
-
-        project.getExtensions().getByType(JavaPluginExtension.class).setSourceCompatibility(BuildParams.getMinimumRuntimeVersion());
-        project.getExtensions().getByType(JavaPluginExtension.class).setTargetCompatibility(BuildParams.getMinimumRuntimeVersion());
 
         // only setup tests to build
         SourceSetContainer sourceSets = project.getExtensions().getByType(SourceSetContainer.class);

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/test/StandaloneTestPlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/test/StandaloneTestPlugin.java
@@ -30,7 +30,6 @@ public class StandaloneTestPlugin implements Plugin<Project> {
             test.mustRunAfter(project.getTasks().getByName("precommit"));
         });
 
-        ElasticsearchJavaPlugin.configureCompile(project);
         project.getTasks().named("check").configure(task -> task.dependsOn(project.getTasks().named("test")));
     }
 }

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/test/rest/RestResourcesPlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/test/rest/RestResourcesPlugin.java
@@ -83,7 +83,7 @@ public class RestResourcesPlugin implements Plugin<Project> {
         RestResourcesExtension extension = project.getExtensions().create(EXTENSION_NAME, RestResourcesExtension.class);
 
         SourceSetContainer sourceSets = project.getExtensions().getByType(SourceSetContainer.class);
-        SourceSet defaultSourceSet = sourceSets.getByName(TEST_SOURCE_SET_NAME);
+        SourceSet defaultSourceSet = sourceSets.maybeCreate(TEST_SOURCE_SET_NAME);
 
         // tests
         Configuration testConfig = project.getConfigurations().create("restTestConfig");

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/test/rest/RestTestUtil.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/test/rest/RestTestUtil.java
@@ -17,11 +17,13 @@ import org.elasticsearch.gradle.util.GradleUtils;
 import org.gradle.api.NamedDomainObjectContainer;
 import org.gradle.api.Project;
 import org.gradle.api.plugins.JavaBasePlugin;
+import org.gradle.api.plugins.JavaPlugin;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.tasks.SourceSet;
 import org.gradle.api.tasks.TaskProvider;
 import org.gradle.api.tasks.bundling.AbstractArchiveTask;
 import org.gradle.api.tasks.bundling.Zip;
+import org.gradle.api.tasks.testing.Test;
 
 /**
  * Utility class to configure the necessary tasks and dependencies.
@@ -48,7 +50,10 @@ public class RestTestUtil {
         Provider<RestIntegTestTask> testProvider = project.getTasks().register(sourceSet.getName(), RestIntegTestTask.class, testTask -> {
             testTask.setGroup(JavaBasePlugin.VERIFICATION_GROUP);
             testTask.setDescription("Runs the REST tests against an external cluster");
-            testTask.mustRunAfter(project.getTasks().named("test"));
+            project.getPlugins().withType(JavaPlugin.class, t ->
+                testTask.mustRunAfter(project.getTasks().named("test"))
+            );
+
             testTask.setTestClassesDirs(sourceSet.getOutput().getClassesDirs());
             testTask.setClasspath(sourceSet.getRuntimeClasspath());
             // if this a module or plugin, it may have an associated zip file with it's contents, add that to the test cluster

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/test/rest/YamlRestTestPlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/test/rest/YamlRestTestPlugin.java
@@ -8,6 +8,7 @@
 
 package org.elasticsearch.gradle.internal.test.rest;
 
+import org.elasticsearch.gradle.internal.ElasticsearchJavaBasePlugin;
 import org.elasticsearch.gradle.internal.ElasticsearchJavaPlugin;
 import org.elasticsearch.gradle.internal.test.RestIntegTestTask;
 import org.elasticsearch.gradle.internal.test.RestTestBasePlugin;
@@ -34,11 +35,12 @@ public class YamlRestTestPlugin implements Plugin<Project> {
     @Override
     public void apply(Project project) {
 
-        project.getPluginManager().apply(ElasticsearchJavaPlugin.class);
+        project.getPluginManager().apply(ElasticsearchJavaBasePlugin.class);
         project.getPluginManager().apply(TestClustersPlugin.class);
         project.getPluginManager().apply(RestTestBasePlugin.class);
         project.getPluginManager().apply(RestResourcesPlugin.class);
 
+        ElasticsearchJavaPlugin.configureConfigurations(project);
         // create source set
         SourceSetContainer sourceSets = project.getExtensions().getByType(SourceSetContainer.class);
         SourceSet yamlTestSourceSet = sourceSets.create(SOURCE_SET_NAME);

--- a/x-pack/plugin/rollup/qa/rest/build.gradle
+++ b/x-pack/plugin/rollup/qa/rest/build.gradle
@@ -26,8 +26,6 @@ testClusters.all {
   setting 'xpack.security.enabled', 'false'
 }
 
-tasks.named("test").configure{enabled = false }
-
 if (BuildParams.inFipsJvm){
   // This test cluster is using a BASIC license and FIPS 140 mode is not supported in BASIC
   tasks.named("yamlRestTest").configure{enabled = false }


### PR DESCRIPTION
just configuring common conventions on java based projects without
adding opinionated sourcesets. Reduces the configuration overhead for
yaml rest test only projects.

In the end we create less tasks and configure less for test only
projects.