### PR TITLE
[7.x] Add meta field to deprecation issue definition.

### DIFF
--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/migration/DeprecationInfoResponse.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/migration/DeprecationInfoResponse.java
@@ -128,16 +128,25 @@ public class DeprecationInfoResponse {
         private static final ParseField MESSAGE = new ParseField("message");
         private static final ParseField URL = new ParseField("url");
         private static final ParseField DETAILS = new ParseField("details");
+        private static final ParseField META = new ParseField("_meta");
 
         static final ConstructingObjectParser<DeprecationIssue, Void> PARSER =
-            new ConstructingObjectParser<>("deprecation_issue", true,
-                a -> new DeprecationIssue(Level.fromString((String) a[0]), (String) a[1], (String) a[2], (String) a[3]));
+            new ConstructingObjectParser<>("deprecation_issue", true, args -> {
+                String logLevel = (String) args[0];
+                String message = (String) args[1];
+                String url = (String) args[2];
+                String details = (String) args[3];
+                @SuppressWarnings("unchecked")
+                Map<String, Object> meta = (Map<String, Object>) args[4];
+                return new DeprecationIssue(Level.fromString(logLevel), message, url, details, meta);
+            });
 
         static {
             PARSER.declareString(ConstructingObjectParser.constructorArg(), LEVEL);
             PARSER.declareString(ConstructingObjectParser.constructorArg(), MESSAGE);
             PARSER.declareString(ConstructingObjectParser.constructorArg(), URL);
             PARSER.declareString(ConstructingObjectParser.optionalConstructorArg(), DETAILS);
+            PARSER.declareObject(ConstructingObjectParser.optionalConstructorArg(), (p, c) -> p.map(), META);
         }
 
         public enum Level {
@@ -159,12 +168,14 @@ public class DeprecationInfoResponse {
         private final String message;
         private final String url;
         private final String details;
+        private final Map<String, Object> meta;
 
-        public DeprecationIssue(Level level, String message, String url, @Nullable String details) {
+        public DeprecationIssue(Level level, String message, String url, @Nullable String details, @Nullable Map<String, Object> meta) {
             this.level = level;
             this.message = message;
             this.url = url;
             this.details = details;
+            this.meta = meta;
         }
 
         public Level getLevel() {
@@ -183,6 +194,10 @@ public class DeprecationInfoResponse {
             return details;
         }
 
+        public Map<String, Object> getMeta() {
+            return meta;
+        }
+
         @Override
         public boolean equals(Object o) {
             if (this == o) {
@@ -195,12 +210,13 @@ public class DeprecationInfoResponse {
             return Objects.equals(level, that.level) &&
                 Objects.equals(message, that.message) &&
                 Objects.equals(url, that.url) &&
-                Objects.equals(details, that.details);
+                Objects.equals(details, that.details) &&
+                Objects.equals(meta, that.meta);
         }
 
         @Override
         public int hashCode() {
-            return Objects.hash(level, message, url, details);
+            return Objects.hash(level, message, url, details, meta);
         }
     }
 }

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/migration/DeprecationInfoResponseTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/migration/DeprecationInfoResponseTests.java
@@ -9,6 +9,7 @@
 package org.elasticsearch.client.migration;
 
 import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.core.Tuple;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.EqualsHashCodeTestUtils;
 
@@ -69,8 +70,11 @@ public class DeprecationInfoResponseTests extends ESTestCase {
             .field("level", issue.getLevel())
             .field("message", issue.getMessage())
             .field("url", issue.getUrl());
-        if (issue.getDetails()!= null) {
+        if (issue.getDetails() != null) {
             builder.field("details", issue.getDetails());
+        }
+        if (issue.getMeta() != null) {
+            builder.field("_meta", issue.getMeta());
         }
         builder.endObject();
     }
@@ -94,7 +98,8 @@ public class DeprecationInfoResponseTests extends ESTestCase {
             list.add(new DeprecationInfoResponse.DeprecationIssue(randomFrom(WARNING, CRITICAL),
                 randomAlphaOfLength(5),
                 randomAlphaOfLength(5),
-                randomBoolean() ? randomAlphaOfLength(5) : null));
+                randomBoolean() ? randomAlphaOfLength(5) : null,
+                randomBoolean() ? randomMap(1, 5, () -> new Tuple<>(randomAlphaOfLength(4), randomAlphaOfLength(4))) : null));
         }
         return list;
     }

--- a/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
@@ -880,11 +880,11 @@ public abstract class ESTestCase extends LuceneTestCase {
         return list;
     }
 
-    public static <K, V> Map<K, V> randomMap(int minListSize, int maxListSize, Supplier<Tuple<K, V>> valueConstructor) {
-        final int size = randomIntBetween(minListSize, maxListSize);
+    public static <K, V> Map<K, V> randomMap(int minMapSize, int maxMapSize, Supplier<Tuple<K, V>> entryConstructor) {
+        final int size = randomIntBetween(minMapSize, maxMapSize);
         Map<K, V> list = new HashMap<>(size);
         for (int i = 0; i < size; i++) {
-            Tuple<K, V> entry = valueConstructor.get();
+            Tuple<K, V> entry = entryConstructor.get();
             list.put(entry.v1(), entry.v2());
         }
         return list;

--- a/x-pack/plugin/deprecation/qa/rest/src/javaRestTest/java/org/elasticsearch/xpack/deprecation/MlDeprecationIT.java
+++ b/x-pack/plugin/deprecation/qa/rest/src/javaRestTest/java/org/elasticsearch/xpack/deprecation/MlDeprecationIT.java
@@ -24,6 +24,7 @@ import org.elasticsearch.client.ml.job.config.Job;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 import org.elasticsearch.common.xcontent.XContentType;
+import org.elasticsearch.core.Map;
 import org.elasticsearch.search.SearchModule;
 import org.elasticsearch.test.rest.ESRestTestCase;
 
@@ -31,6 +32,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
 
 public class MlDeprecationIT extends ESRestTestCase {
@@ -101,6 +103,7 @@ public class MlDeprecationIT extends ESRestTestCase {
             response.getMlSettingsIssues().get(0).getMessage(),
             containsString("model snapshot [1] for job [deprecation_check_job] needs to be deleted or upgraded")
         );
+        assertThat(response.getMlSettingsIssues().get(0).getMeta(), equalTo(Map.of("job_id", jobId, "snapshot_id", "1")));
         hlrc.close();
     }
 

--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/ClusterDeprecationChecks.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/ClusterDeprecationChecks.java
@@ -61,7 +61,8 @@ public class ClusterDeprecationChecks {
                 "User-Agent ingest plugin will always use ECS-formatted output",
                 "https://www.elastic.co/guide/en/elasticsearch/reference/master/breaking-changes-8.0.html" +
                     "#ingest-user-agent-ecs-always",
-                "Ingest pipelines " + pipelinesWithDeprecatedEcsConfig + " uses the [ecs] option which needs to be removed to work in 8.0");
+                "Ingest pipelines " + pipelinesWithDeprecatedEcsConfig +
+                    " uses the [ecs] option which needs to be removed to work in 8.0", null);
         }
         return null;
     }
@@ -92,7 +93,7 @@ public class ClusterDeprecationChecks {
                 "Index templates " + templatesOverLimit + " have a number of fields which exceeds the automatic field expansion " +
                     "limit of [" + maxClauseCount + "] and does not have [" + IndexSettings.DEFAULT_FIELD_SETTING.getKey() + "] set, " +
                     "which may cause queries which use automatic field expansion, such as query_string, simple_query_string, and " +
-                    "multi_match to fail if fields are not explicitly specified in the query.");
+                    "multi_match to fail if fields are not explicitly specified in the query.", null);
         }
         return null;
     }
@@ -126,7 +127,7 @@ public class ClusterDeprecationChecks {
                     "https://www.elastic.co/guide/en/elasticsearch/reference/master/breaking-changes-8.0.html#fieldnames-enabling",
                     "Index templates " + templatesContainingFieldNames + " use the deprecated `enable` setting for the `"
                             + FieldNamesFieldMapper.NAME + "` field. Using this setting in new index mappings will throw an error "
-                                    + "in the next major version and needs to be removed from existing mappings and templates.");
+                                    + "in the next major version and needs to be removed from existing mappings and templates.", null);
         }
         return null;
     }
@@ -164,7 +165,7 @@ public class ClusterDeprecationChecks {
                 "https://www.elastic.co/guide/en/elasticsearch/reference/master/breaking-changes-8.0.html" +
                     "#ilm-poll-interval-limit",
                 "The Index Lifecycle Management poll interval setting [" + LIFECYCLE_POLL_INTERVAL_SETTING.getKey() + "] is " +
-                    "currently set to [" + pollIntervalString + "], but must be 1s or greater");
+                    "currently set to [" + pollIntervalString + "], but must be 1s or greater", null);
         }
         return null;
     }
@@ -185,7 +186,7 @@ public class ClusterDeprecationChecks {
             "Some index templates contain multiple mapping types",
             "https://www.elastic.co/guide/en/elasticsearch/reference/master/removal-of-types.html",
             "Index templates " + templatesWithMultipleTypes
-            + " define multiple types and so will cause errors when used in index creation"
-            );
+            + " define multiple types and so will cause errors when used in index creation",
+            null);
     }
 }

--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/DeprecationInfoAction.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/DeprecationInfoAction.java
@@ -73,7 +73,7 @@ public class DeprecationInfoAction extends ActionType<DeprecationInfoAction.Resp
                 DeprecationIssue issue = entry.getKey();
                 String details = issue.getDetails() != null ? issue.getDetails() + " " : "";
                 return new DeprecationIssue(issue.getLevel(), issue.getMessage(), issue.getUrl(),
-                    details + "(nodes impacted: " + entry.getValue() + ")");
+                    details + "(nodes impacted: " + entry.getValue() + ")", issue.getMeta());
             }).collect(Collectors.toList());
     }
 

--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/DeprecationIssue.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/DeprecationIssue.java
@@ -6,7 +6,7 @@
  */
 package org.elasticsearch.xpack.deprecation;
 
-
+import org.elasticsearch.Version;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -17,6 +17,7 @@ import org.elasticsearch.common.xcontent.XContentBuilder;
 
 import java.io.IOException;
 import java.util.Locale;
+import java.util.Map;
 import java.util.Objects;
 
 /**
@@ -63,12 +64,14 @@ public class DeprecationIssue implements Writeable, ToXContentObject {
     private final String message;
     private final String url;
     private final String details;
+    private final Map<String, Object> meta;
 
-    public DeprecationIssue(Level level, String message, String url, @Nullable String details) {
+    public DeprecationIssue(Level level, String message, String url, @Nullable String details, @Nullable Map<String, Object> meta) {
         this.level = level;
         this.message = message;
         this.url = url;
         this.details = details;
+        this.meta = meta;
     }
 
     public DeprecationIssue(StreamInput in) throws IOException {
@@ -76,8 +79,8 @@ public class DeprecationIssue implements Writeable, ToXContentObject {
         message = in.readString();
         url = in.readString();
         details = in.readOptionalString();
+        meta = in.getVersion().onOrAfter(Version.V_7_14_0) ? in.readMap() : null;
     }
-
 
     public Level getLevel() {
         return level;
@@ -95,12 +98,23 @@ public class DeprecationIssue implements Writeable, ToXContentObject {
         return details;
     }
 
+    /**
+     * @return custom metadata, which allows the ui to display additional details
+     *         without parsing the deprecation message itself.
+     */
+    public Map<String, Object> getMeta() {
+        return meta;
+    }
+
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         level.writeTo(out);
         out.writeString(message);
         out.writeString(url);
         out.writeOptionalString(details);
+        if (out.getVersion().onOrAfter(Version.V_7_14_0)) {
+            out.writeMap(meta);
+        }
     }
 
     @Override
@@ -111,6 +125,9 @@ public class DeprecationIssue implements Writeable, ToXContentObject {
             .field("url", url);
         if (details != null) {
             builder.field("details", details);
+        }
+        if (meta != null) {
+            builder.field("_meta", meta);
         }
         return builder.endObject();
     }
@@ -127,12 +144,13 @@ public class DeprecationIssue implements Writeable, ToXContentObject {
         return Objects.equals(level, that.level) &&
             Objects.equals(message, that.message) &&
             Objects.equals(url, that.url) &&
-            Objects.equals(details, that.details);
+            Objects.equals(details, that.details) &&
+            Objects.equals(meta, that.meta);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(level, message, url, details);
+        return Objects.hash(level, message, url, details, meta);
     }
 
     @Override

--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/IndexDeprecationChecks.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/IndexDeprecationChecks.java
@@ -106,7 +106,7 @@ public class IndexDeprecationChecks {
                     "Index created before 7.0",
                     "https://www.elastic.co/guide/en/elasticsearch/reference/master/" +
                         "breaking-changes-8.0.html",
-                    "This index was created using version: " + createdWith);
+                    "This index was created using version: " + createdWith, null);
         }
         return null;
     }
@@ -130,7 +130,7 @@ public class IndexDeprecationChecks {
                     "This index has [" + fieldCount.get() + "] fields, which exceeds the automatic field expansion limit of 1024 " +
                         "and does not have [" + IndexSettings.DEFAULT_FIELD_SETTING.getKey() + "] set, which may cause queries which use " +
                         "automatic field expansion, such as query_string, simple_query_string, and multi_match to fail if fields are not " +
-                        "explicitly specified in the query.");
+                        "explicitly specified in the query.", null);
             }
         }
         return null;
@@ -151,7 +151,7 @@ public class IndexDeprecationChecks {
                     "Date field format uses patterns which has changed meaning in 7.0",
                     "https://www.elastic.co/guide/en/elasticsearch/reference/7.0/breaking-changes-7.0.html#breaking_70_java_time_changes",
                     "This index has date fields with deprecated formats: " + fields + ". "
-                        + JodaDeprecationPatterns.USE_NEW_FORMAT_SPECIFIERS);
+                        + JodaDeprecationPatterns.USE_NEW_FORMAT_SPECIFIERS, null);
             }
         }
         return null;
@@ -173,7 +173,7 @@ public class IndexDeprecationChecks {
                 "Multi-fields within multi-fields",
                 "https://www.elastic.co/guide/en/elasticsearch/reference/master/breaking-changes-8.0.html" +
                     "#_defining_multi_fields_within_multi_fields",
-                "The names of fields that contain chained multi-fields: " + issues.toString());
+                "The names of fields that contain chained multi-fields: " + issues, null);
         }
         return null;
     }
@@ -201,7 +201,8 @@ public class IndexDeprecationChecks {
                     "Index mapping contains explicit `_field_names` enabling settings.",
                     "https://www.elastic.co/guide/en/elasticsearch/reference/master/breaking-changes-8.0.html" +
                             "#fieldnames-enabling",
-                    "The index mapping contains a deprecated `enabled` setting for `_field_names` that should be removed moving foward.");
+                    "The index mapping contains a deprecated `enabled` setting for `_field_names` that should be removed moving foward.",
+                null);
         }
         return null;
     }
@@ -262,7 +263,7 @@ public class IndexDeprecationChecks {
                     "translog retention settings are ignored",
                     "https://www.elastic.co/guide/en/elasticsearch/reference/current/index-modules-translog.html",
                     "translog retention settings [index.translog.retention.size] and [index.translog.retention.age] are ignored " +
-                        "because translog is no longer used in peer recoveries with soft-deletes enabled (default in 7.0 or later)");
+                        "because translog is no longer used in peer recoveries with soft-deletes enabled (default in 7.0 or later)", null);
             }
         }
         return null;
@@ -275,7 +276,7 @@ public class IndexDeprecationChecks {
             final String url = "https://www.elastic.co/guide/en/elasticsearch/reference/7.13/" +
                 "breaking-changes-7.13.html#deprecate-shared-data-path-setting";
             final String details = "Found index data path configured. Discontinue use of this setting.";
-            return new DeprecationIssue(DeprecationIssue.Level.CRITICAL, message, url, details);
+            return new DeprecationIssue(DeprecationIssue.Level.CRITICAL, message, url, details, null);
         }
         return null;
     }
@@ -296,7 +297,7 @@ public class IndexDeprecationChecks {
 
             final String details = String.format(Locale.ROOT, "Found [%s] configured. Discontinue use of this setting. Use thresholds.",
                 setting.getKey());
-            return new DeprecationIssue(DeprecationIssue.Level.WARNING, message, url, details);
+            return new DeprecationIssue(DeprecationIssue.Level.WARNING, message, url, details, null);
         }
         return null;
     }

--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/MlDeprecationChecker.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/MlDeprecationChecker.java
@@ -12,6 +12,7 @@ import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 import org.elasticsearch.common.xcontent.XContentElasticsearchExtension;
+import org.elasticsearch.core.Map;
 import org.elasticsearch.xpack.core.XPackSettings;
 import org.elasticsearch.xpack.core.action.util.PageParams;
 import org.elasticsearch.xpack.core.ml.action.GetDatafeedsAction;
@@ -35,7 +36,7 @@ public class MlDeprecationChecker implements DeprecationChecker {
             return Optional.of(new DeprecationIssue(DeprecationIssue.Level.WARNING,
                 "Datafeed [" + datafeedConfig.getId() + "] uses deprecated query options",
                 "https://www.elastic.co/guide/en/elasticsearch/reference/master/breaking-changes-7.0.html#breaking_70_search_changes",
-                deprecations.toString()));
+                deprecations.toString(), null));
         }
     }
 
@@ -47,7 +48,7 @@ public class MlDeprecationChecker implements DeprecationChecker {
             return Optional.of(new DeprecationIssue(DeprecationIssue.Level.WARNING,
                 "Datafeed [" + datafeedConfig.getId() + "] uses deprecated aggregation options",
                 "https://www.elastic.co/guide/en/elasticsearch/reference/master/breaking-changes-7.0.html" +
-                    "#breaking_70_aggregations_changes", deprecations.toString()));
+                    "#breaking_70_aggregations_changes", deprecations.toString(), null));
         }
     }
 
@@ -75,8 +76,8 @@ public class MlDeprecationChecker implements DeprecationChecker {
                     modelSnapshot.getJobId()
                 ),
                 "https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-upgrade-job-model-snapshot.html",
-                details.toString()
-               )
+                details.toString(),
+                Map.of("job_id", modelSnapshot.getJobId(), "snapshot_id", modelSnapshot.getSnapshotId()))
             );
         }
         return Optional.empty();

--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/NodeDeprecationChecks.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/NodeDeprecationChecks.java
@@ -88,7 +88,8 @@ class NodeDeprecationChecks {
             DeprecationIssue.Level.CRITICAL,
             "Realm order will be required in next major release.",
             "https://www.elastic.co/guide/en/elasticsearch/reference/7.7/breaking-changes-7.7.html#deprecate-missing-realm-order",
-            details
+            details,
+            null
         );
     }
 
@@ -122,7 +123,8 @@ class NodeDeprecationChecks {
             DeprecationIssue.Level.CRITICAL,
             "Realm orders must be unique in next major release.",
             "https://www.elastic.co/guide/en/elasticsearch/reference/7.7/breaking-changes-7.7.html#deprecate-duplicated-realm-orders",
-            details
+            details,
+            null
         );
     }
 
@@ -173,7 +175,8 @@ class NodeDeprecationChecks {
             DeprecationIssue.Level.WARNING,
             "File and/or native realms are enabled by default in next major release.",
             "https://www.elastic.co/guide/en/elasticsearch/reference/7.13/deprecated-7.13.html#implicitly-disabled-basic-realms",
-            details
+            details,
+            null
         );
 
     }
@@ -204,7 +207,8 @@ class NodeDeprecationChecks {
                     reservedPrefixedRealmIdentifiers.stream()
                         .map(rid -> RealmSettings.PREFIX + rid.getType() + "." + rid.getName())
                         .sorted()
-                        .collect(Collectors.joining("; ")))
+                        .collect(Collectors.joining("; "))),
+                null
             );
         }
     }
@@ -363,7 +367,7 @@ class NodeDeprecationChecks {
             value,
             replacementSettingKey,
             replacementValue.apply(value, settings));
-        return new DeprecationIssue(DeprecationIssue.Level.CRITICAL, message, url, details);
+        return new DeprecationIssue(DeprecationIssue.Level.CRITICAL, message, url, details, null);
     }
 
     private static DeprecationIssue checkDeprecatedSetting(
@@ -406,7 +410,7 @@ class NodeDeprecationChecks {
             replacementSettingKey,
             replacementValue.apply(value, settings),
             star);
-        return new DeprecationIssue(DeprecationIssue.Level.CRITICAL, message, url, details);
+        return new DeprecationIssue(DeprecationIssue.Level.CRITICAL, message, url, details, null);
     }
 
     static DeprecationIssue checkRemovedSetting(final Settings settings, final Setting<?> removedSetting, final String url) {
@@ -419,7 +423,7 @@ class NodeDeprecationChecks {
             String.format(Locale.ROOT, "setting [%s] is deprecated and will be removed in the next major version", removedSettingKey);
         final String details =
             String.format(Locale.ROOT, "the setting [%s] is currently set to [%s], remove this setting", removedSettingKey, value);
-        return new DeprecationIssue(DeprecationIssue.Level.CRITICAL, message, url, details);
+        return new DeprecationIssue(DeprecationIssue.Level.CRITICAL, message, url, details, null);
     }
 
     static DeprecationIssue javaVersionCheck(Settings nodeSettings, PluginsAndModules plugins, final ClusterState clusterState) {
@@ -431,7 +435,8 @@ class NodeDeprecationChecks {
                 "https://www.elastic.co/guide/en/elasticsearch/reference/master/breaking-changes-8.0.html#breaking_80_packaging_changes",
                 "Java 11 will be required for future versions of Elasticsearch, this node is running version ["
                     + javaVersion.toString() + "]. Consider switching to a distribution of Elasticsearch with a bundled JDK. "
-                    + "If you are already using a distribution with a bundled JDK, ensure the JAVA_HOME environment variable is not set.");
+                    + "If you are already using a distribution with a bundled JDK, ensure the JAVA_HOME environment variable is not set.",
+                null);
         }
         return null;
     }
@@ -442,7 +447,8 @@ class NodeDeprecationChecks {
             return new DeprecationIssue(DeprecationIssue.Level.CRITICAL,
                 "multiple [path.data] entries are deprecated, use a single data directory",
                 "https://www.elastic.co/guide/en/elasticsearch/reference/master/breaking-changes-8.0.html#breaking_80_packaging_changes",
-                "Multiple data paths are deprecated. Instead, use RAID or other system level features to utilize multiple disks.");
+                "Multiple data paths are deprecated. Instead, use RAID or other system level features to utilize multiple disks.",
+            null);
         }
         return null;
     }
@@ -452,7 +458,7 @@ class NodeDeprecationChecks {
             return new DeprecationIssue(DeprecationIssue.Level.CRITICAL,
                 "[path.data] in a list is deprecated, use a string value",
                 "https://www.elastic.co/guide/en/elasticsearch/reference/master/breaking-changes-8.0.html#breaking_80_packaging_changes",
-                "Configuring [path.data] with a list is deprecated. Instead specify as a string value.");
+                "Configuring [path.data] with a list is deprecated. Instead specify as a string value.", null);
         }
         return null;
     }
@@ -465,7 +471,7 @@ class NodeDeprecationChecks {
             final String url = "https://www.elastic.co/guide/en/elasticsearch/reference/7.13/" +
                 "breaking-changes-7.13.html#deprecate-shared-data-path-setting";
             final String details = "Found shared data path configured. Discontinue use of this setting.";
-            return new DeprecationIssue(DeprecationIssue.Level.CRITICAL, message, url, details);
+            return new DeprecationIssue(DeprecationIssue.Level.CRITICAL, message, url, details, null);
         }
         return null;
     }
@@ -479,7 +485,8 @@ class NodeDeprecationChecks {
                 String.format(Locale.ROOT, "setting [%s=false] is deprecated and will not be available in a future version", key),
                 "https://www.elastic.co/guide/en/elasticsearch/reference/7.14/" +
                     "breaking-changes-7.14.html#deprecate-single-data-node-watermark",
-                String.format(Locale.ROOT, "found [%s] configured to false. Discontinue use of this setting or set it to true.", key)
+                String.format(Locale.ROOT, "found [%s] configured to false. Discontinue use of this setting or set it to true.", key),
+                null
             );
         }
 
@@ -495,7 +502,8 @@ class NodeDeprecationChecks {
                 String.format(Locale.ROOT, "found [%s] defaulting to false on a single data node cluster." +
                         " Set it to true to avoid this warning." +
                         " Consider using [%s] to disable disk based allocation", key,
-                    disableDiskDecider)
+                    disableDiskDecider),
+                null
             );
 
         }
@@ -532,6 +540,6 @@ class NodeDeprecationChecks {
             passwordSettings
         );
         final String url = "https://www.elastic.co/guide/en/elasticsearch/reference/7.7/monitoring-settings.html#http-exporter-settings";
-        return new DeprecationIssue(DeprecationIssue.Level.CRITICAL, message, url, details);
+        return new DeprecationIssue(DeprecationIssue.Level.CRITICAL, message, url, details, null);
     }
 }

--- a/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/ClusterDeprecationChecksTests.java
+++ b/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/ClusterDeprecationChecksTests.java
@@ -85,7 +85,7 @@ public class ClusterDeprecationChecksTests extends ESTestCase {
             "User-Agent ingest plugin will always use ECS-formatted output",
             "https://www.elastic.co/guide/en/elasticsearch/reference/master/breaking-changes-8.0.html" +
                 "#ingest-user-agent-ecs-always",
-            "Ingest pipelines [ecs_false, ecs_true] uses the [ecs] option which needs to be removed to work in 8.0");
+            "Ingest pipelines [ecs_false, ecs_true] uses the [ecs] option which needs to be removed to work in 8.0", null);
         assertEquals(singletonList(expected), issues);
     }
 
@@ -157,7 +157,7 @@ public class ClusterDeprecationChecksTests extends ESTestCase {
             "Index templates " + Collections.singletonList(tooManyFieldsTemplate) + " have a number of fields which exceeds the " +
                 "automatic field expansion limit of [1024] and does not have [" + IndexSettings.DEFAULT_FIELD_SETTING.getKey() + "] set, " +
                 "which may cause queries which use automatic field expansion, such as query_string, simple_query_string, and multi_match " +
-                "to fail if fields are not explicitly specified in the query.");
+                "to fail if fields are not explicitly specified in the query.", null);
         assertEquals(singletonList(expected), issues);
     }
 
@@ -256,7 +256,7 @@ public class ClusterDeprecationChecksTests extends ESTestCase {
                 "https://www.elastic.co/guide/en/elasticsearch/reference/master/breaking-changes-8.0.html" +
                     "#ilm-poll-interval-limit",
                 "The Index Lifecycle Management poll interval setting [" + LIFECYCLE_POLL_INTERVAL_SETTING.getKey() + "] is " +
-                    "currently set to [" + tooLowInterval + "], but must be 1s or greater");
+                    "currently set to [" + tooLowInterval + "], but must be 1s or greater", null);
             List<DeprecationIssue> issues = DeprecationChecks.filterChecks(CLUSTER_SETTINGS_CHECKS, c -> c.apply(badState));
             assertEquals(singletonList(expected), issues);
         }

--- a/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/DeprecationChecksTests.java
+++ b/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/DeprecationChecksTests.java
@@ -7,6 +7,7 @@
 
 package org.elasticsearch.xpack.deprecation;
 
+import org.elasticsearch.core.Tuple;
 import org.elasticsearch.test.ESTestCase;
 
 import java.util.ArrayList;
@@ -35,6 +36,6 @@ public class DeprecationChecksTests extends ESTestCase {
     private static DeprecationIssue createRandomDeprecationIssue() {
         String details = randomBoolean() ? randomAlphaOfLength(10) : null;
         return new DeprecationIssue(randomFrom(DeprecationIssue.Level.values()), randomAlphaOfLength(10),
-            randomAlphaOfLength(10), details);
+            randomAlphaOfLength(10), details, randomMap(1, 5, () -> Tuple.tuple(randomAlphaOfLength(4), randomAlphaOfLength(4))));
     }
 }

--- a/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/DeprecationInfoActionResponseTests.java
+++ b/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/DeprecationInfoActionResponseTests.java
@@ -123,7 +123,7 @@ public class DeprecationInfoActionResponseTests extends AbstractWireSerializingT
         if (nodeIssueFound) {
             String details = foundIssue.getDetails() != null ? foundIssue.getDetails() + " " : "";
             DeprecationIssue mergedFoundIssue = new DeprecationIssue(foundIssue.getLevel(), foundIssue.getMessage(), foundIssue.getUrl(),
-                details + "(nodes impacted: [" + discoveryNode.getName() + "])");
+                details + "(nodes impacted: [" + discoveryNode.getName() + "])", foundIssue.getMeta());
             assertThat(response.getNodeSettingsIssues(), equalTo(Collections.singletonList(mergedFoundIssue)));
         } else {
             assertTrue(response.getNodeSettingsIssues().isEmpty());

--- a/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/DeprecationIssueTests.java
+++ b/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/DeprecationIssueTests.java
@@ -12,6 +12,7 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.common.xcontent.XContentHelper;
+import org.elasticsearch.core.Tuple;
 import org.elasticsearch.test.ESTestCase;
 import org.junit.Before;
 
@@ -23,12 +24,13 @@ import static org.elasticsearch.xpack.deprecation.DeprecationIssue.Level;
 import static org.hamcrest.core.IsEqual.equalTo;
 
 public class DeprecationIssueTests extends ESTestCase {
-    DeprecationIssue issue;
+
+    private DeprecationIssue issue;
 
     static DeprecationIssue createTestInstance() {
         String details = randomBoolean() ? randomAlphaOfLength(10) : null;
         return new DeprecationIssue(randomFrom(Level.values()), randomAlphaOfLength(10),
-            randomAlphaOfLength(10), details);
+            randomAlphaOfLength(10), details, randomMap(1, 5, () -> Tuple.tuple(randomAlphaOfLength(4), randomAlphaOfLength(4))));
     }
 
     @Before
@@ -37,7 +39,8 @@ public class DeprecationIssueTests extends ESTestCase {
     }
 
     public void testEqualsAndHashCode() {
-        DeprecationIssue other = new DeprecationIssue(issue.getLevel(), issue.getMessage(), issue.getUrl(), issue.getDetails());
+        DeprecationIssue other =
+            new DeprecationIssue(issue.getLevel(), issue.getMessage(), issue.getUrl(), issue.getDetails(), issue.getMeta());
         assertThat(issue, equalTo(other));
         assertThat(other, equalTo(issue));
         assertThat(issue.hashCode(), equalTo(other.hashCode()));
@@ -62,7 +65,9 @@ public class DeprecationIssueTests extends ESTestCase {
             assertTrue(toXContentMap.containsKey("details"));
         }
         String details = (String) toXContentMap.get("details");
-        DeprecationIssue other = new DeprecationIssue(Level.fromString(level), message, url, details);
+        @SuppressWarnings("unchecked")
+        Map<String, Object> meta = (Map<String, Object>) toXContentMap.get("_meta");
+        DeprecationIssue other = new DeprecationIssue(Level.fromString(level), message, url, details, meta);
         assertThat(issue, equalTo(other));
     }
 }

--- a/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/IndexDeprecationChecksTests.java
+++ b/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/IndexDeprecationChecksTests.java
@@ -49,7 +49,7 @@ public class IndexDeprecationChecksTests extends ESTestCase {
             "Index created before 7.0",
             "https://www.elastic.co/guide/en/elasticsearch/reference/master/" +
                 "breaking-changes-8.0.html",
-            "This index was created using version: " + createdWith);
+            "This index was created using version: " + createdWith, null);
         List<DeprecationIssue> issues = DeprecationChecks.filterChecks(INDEX_SETTINGS_CHECKS, c -> c.apply(indexMetadata));
         assertEquals(singletonList(expected), issues);
     }
@@ -105,7 +105,7 @@ public class IndexDeprecationChecksTests extends ESTestCase {
             "This index has [" + fieldCount + "] fields, which exceeds the automatic field expansion limit of 1024 " +
                 "and does not have [" + IndexSettings.DEFAULT_FIELD_SETTING.getKey() + "] set, which may cause queries which use " +
                 "automatic field expansion, such as query_string, simple_query_string, and multi_match to fail if fields are not " +
-                "explicitly specified in the query.");
+                "explicitly specified in the query.", null);
         List<DeprecationIssue> issues = DeprecationChecks.filterChecks(INDEX_SETTINGS_CHECKS, c -> c.apply(tooManyFieldsIndex));
         assertEquals(singletonList(expected), issues);
 
@@ -163,7 +163,7 @@ public class IndexDeprecationChecksTests extends ESTestCase {
             "Multi-fields within multi-fields",
             "https://www.elastic.co/guide/en/elasticsearch/reference/master/breaking-changes-8.0.html" +
                 "#_defining_multi_fields_within_multi_fields",
-            "The names of fields that contain chained multi-fields: [[type: _doc, field: invalid-field]]");
+            "The names of fields that contain chained multi-fields: [[type: _doc, field: invalid-field]]", null);
         assertEquals(singletonList(expected), issues);
     }
 
@@ -216,7 +216,7 @@ public class IndexDeprecationChecksTests extends ESTestCase {
                 "suggestion: 'C' century of era is no longer supported." +
                 "; "+
                 "'Y' year-of-era should be replaced with 'y'. Use 'Y' for week-based-year.]"+
-                "]. "+ JodaDeprecationPatterns.USE_NEW_FORMAT_SPECIFIERS);
+                "]. "+ JodaDeprecationPatterns.USE_NEW_FORMAT_SPECIFIERS, null);
         List<DeprecationIssue> issues = DeprecationChecks.filterChecks(INDEX_SETTINGS_CHECKS, c -> c.apply(simpleIndex));
         assertThat(issues, hasItem(expected));
     }
@@ -238,7 +238,7 @@ public class IndexDeprecationChecksTests extends ESTestCase {
             "This index has date fields with deprecated formats: ["+
                 "[type: _doc, field: date_time_field_Y, format: dd-YYYY||MM-YYYY, " +
                 "suggestion: 'Y' year-of-era should be replaced with 'y'. Use 'Y' for week-based-year.]"+
-                "]. "+ JodaDeprecationPatterns.USE_NEW_FORMAT_SPECIFIERS);
+                "]. "+ JodaDeprecationPatterns.USE_NEW_FORMAT_SPECIFIERS, null);
         List<DeprecationIssue> issues = DeprecationChecks.filterChecks(INDEX_SETTINGS_CHECKS, c -> c.apply(simpleIndex));
         assertThat(issues, hasItem(expected));
     }
@@ -260,7 +260,7 @@ public class IndexDeprecationChecksTests extends ESTestCase {
             "This index has date fields with deprecated formats: ["+
                 "[type: _doc, field: date_time_field_Y, format: strictWeekyearWeek||MM-YYYY, " +
                 "suggestion: 'Y' year-of-era should be replaced with 'y'. Use 'Y' for week-based-year.]"+
-                "]. "+ JodaDeprecationPatterns.USE_NEW_FORMAT_SPECIFIERS);
+                "]. "+ JodaDeprecationPatterns.USE_NEW_FORMAT_SPECIFIERS, null);
         List<DeprecationIssue> issues = DeprecationChecks.filterChecks(INDEX_SETTINGS_CHECKS, c -> c.apply(simpleIndex));
         assertThat(issues, hasItem(expected));
     }
@@ -314,7 +314,7 @@ public class IndexDeprecationChecksTests extends ESTestCase {
                 "[type: _doc, field: date_time_field_z, format: HH:mmz, " +
                 "suggestion: 'z' time zone text. Will print 'Z' for Zulu given UTC timezone." +
                 "]"+
-                "]. "+ JodaDeprecationPatterns.USE_NEW_FORMAT_SPECIFIERS);
+                "]. "+ JodaDeprecationPatterns.USE_NEW_FORMAT_SPECIFIERS, null);
         List<DeprecationIssue> issues = DeprecationChecks.filterChecks(INDEX_SETTINGS_CHECKS, c -> c.apply(simpleIndex));
         assertThat(issues, hasItem(expected));
     }
@@ -341,7 +341,7 @@ public class IndexDeprecationChecksTests extends ESTestCase {
                 "'C' century of era is no longer supported.; " +
                 "'x' weak-year should be replaced with 'Y'. Use 'x' for zone-offset." +
                 "]"+
-                "]. "+ JodaDeprecationPatterns.USE_NEW_FORMAT_SPECIFIERS);
+                "]. "+ JodaDeprecationPatterns.USE_NEW_FORMAT_SPECIFIERS, null);
         List<DeprecationIssue> issues = DeprecationChecks.filterChecks(INDEX_SETTINGS_CHECKS, c -> c.apply(simpleIndex));
         assertThat(issues, hasItem(expected));
     }
@@ -403,7 +403,7 @@ public class IndexDeprecationChecksTests extends ESTestCase {
                 "translog retention settings are ignored",
                 "https://www.elastic.co/guide/en/elasticsearch/reference/current/index-modules-translog.html",
                 "translog retention settings [index.translog.retention.size] and [index.translog.retention.age] are ignored " +
-                    "because translog is no longer used in peer recoveries with soft-deletes enabled (default in 7.0 or later)")
+                    "because translog is no longer used in peer recoveries with soft-deletes enabled (default in 7.0 or later)", null)
         ));
     }
 
@@ -456,8 +456,8 @@ public class IndexDeprecationChecksTests extends ESTestCase {
             new DeprecationIssue(DeprecationIssue.Level.CRITICAL,
                 "setting [index.data_path] is deprecated and will be removed in a future version",
                 expectedUrl,
-                "Found index data path configured. Discontinue use of this setting."
-        )));
+                "Found index data path configured. Discontinue use of this setting.",
+                null)));
     }
 
     public void testSlowLogLevel() {
@@ -472,12 +472,12 @@ public class IndexDeprecationChecksTests extends ESTestCase {
             new DeprecationIssue(DeprecationIssue.Level.WARNING,
                 "setting [index.search.slowlog.level] is deprecated and will be removed in a future version",
                 expectedUrl,
-                "Found [index.search.slowlog.level] configured. Discontinue use of this setting. Use thresholds."
+                "Found [index.search.slowlog.level] configured. Discontinue use of this setting. Use thresholds.", null
             ),
             new DeprecationIssue(DeprecationIssue.Level.WARNING,
                 "setting [index.indexing.slowlog.level] is deprecated and will be removed in a future version",
                 expectedUrl,
-                "Found [index.indexing.slowlog.level] configured. Discontinue use of this setting. Use thresholds."
+                "Found [index.indexing.slowlog.level] configured. Discontinue use of this setting. Use thresholds.", null
             )));
     }
 }

--- a/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/NodeDeprecationChecksTests.java
+++ b/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/NodeDeprecationChecksTests.java
@@ -70,7 +70,8 @@ public class NodeDeprecationChecksTests extends ESTestCase {
             "https://www.elastic.co/guide/en/elasticsearch/reference/master/breaking-changes-8.0.html#breaking_80_packaging_changes",
             "Java 11 will be required for future versions of Elasticsearch, this node is running version ["
                 + JavaVersion.current().toString() + "]. Consider switching to a distribution of Elasticsearch with a bundled JDK. "
-                + "If you are already using a distribution with a bundled JDK, ensure the JAVA_HOME environment variable is not set.");
+                + "If you are already using a distribution with a bundled JDK, ensure the JAVA_HOME environment variable is not set.",
+            null);
 
         if (isJvmEarlierThan11()) {
             assertThat(issues, hasItem(expected));
@@ -88,7 +89,7 @@ public class NodeDeprecationChecksTests extends ESTestCase {
             DeprecationIssue.Level.CRITICAL,
             "setting [pidfile] is deprecated in favor of setting [node.pidfile]",
             "https://www.elastic.co/guide/en/elasticsearch/reference/7.4/breaking-changes-7.4.html#deprecate-pidfile",
-            "the setting [pidfile] is currently set to [" + pidfile + "], instead set [node.pidfile] to [" + pidfile + "]");
+            "the setting [pidfile] is currently set to [" + pidfile + "], instead set [node.pidfile] to [" + pidfile + "]", null);
         assertThat(issues, hasItem(expected));
         assertSettingDeprecationsAndWarnings(new Setting<?>[]{Environment.PIDFILE_SETTING});
     }
@@ -102,7 +103,8 @@ public class NodeDeprecationChecksTests extends ESTestCase {
             DeprecationIssue.Level.CRITICAL,
             "setting [processors] is deprecated in favor of setting [node.processors]",
             "https://www.elastic.co/guide/en/elasticsearch/reference/7.4/breaking-changes-7.4.html#deprecate-processors",
-            "the setting [processors] is currently set to [" + processors + "], instead set [node.processors] to [" + processors + "]");
+            "the setting [processors] is currently set to [" + processors + "], instead set [node.processors] to [" + processors + "]",
+            null);
         assertThat(issues, hasItem(expected));
         assertSettingDeprecationsAndWarnings(new Setting<?>[]{EsExecutors.PROCESSORS_SETTING});
     }
@@ -132,7 +134,8 @@ public class NodeDeprecationChecksTests extends ESTestCase {
                 Locale.ROOT,
                 "Found realms without order config: [%s]. In next major release, node will fail to start with missing realm order.",
                 RealmSettings.realmSettingPrefix(invalidRealm) + RealmSettings.ORDER_SETTING_KEY
-            )
+            ),
+            null
         ), deprecationIssues.get(0));
     }
 
@@ -362,7 +365,7 @@ public class NodeDeprecationChecksTests extends ESTestCase {
             DeprecationIssue.Level.CRITICAL,
             "setting [thread_pool.listener.queue_size] is deprecated and will be removed in the next major version",
             "https://www.elastic.co/guide/en/elasticsearch/reference/7.x/breaking-changes-7.7.html#deprecate-listener-thread-pool",
-            "the setting [thread_pool.listener.queue_size] is currently set to [" + size + "], remove this setting");
+            "the setting [thread_pool.listener.queue_size] is currently set to [" + size + "], remove this setting", null);
         assertThat(issues, hasItem(expected));
         assertSettingDeprecationsAndWarnings(new String[]{"thread_pool.listener.queue_size"});
     }
@@ -376,7 +379,7 @@ public class NodeDeprecationChecksTests extends ESTestCase {
             DeprecationIssue.Level.CRITICAL,
             "setting [thread_pool.listener.size] is deprecated and will be removed in the next major version",
             "https://www.elastic.co/guide/en/elasticsearch/reference/7.x/breaking-changes-7.7.html#deprecate-listener-thread-pool",
-            "the setting [thread_pool.listener.size] is currently set to [" + size + "], remove this setting");
+            "the setting [thread_pool.listener.size] is currently set to [" + size + "], remove this setting", null);
         assertThat(issues, hasItem(expected));
         assertSettingDeprecationsAndWarnings(new String[]{"thread_pool.listener.size"});
     }
@@ -391,7 +394,7 @@ public class NodeDeprecationChecksTests extends ESTestCase {
             "setting [script.cache.max_size] is deprecated in favor of grouped setting [script.context.*.cache_max_size]",
             "https://www.elastic.co/guide/en/elasticsearch/reference/7.9/breaking-changes-7.9.html#deprecate_general_script_cache_size",
             "the setting [script.cache.max_size] is currently set to [" + size + "], instead set [script.context.*.cache_max_size] " +
-                "to [" + size + "] where * is a script context");
+                "to [" + size + "] where * is a script context", null);
         assertThat(issues, hasItem(expected));
         assertSettingDeprecationsAndWarnings(new Setting<?>[]{ScriptService.SCRIPT_GENERAL_CACHE_SIZE_SETTING});
     }
@@ -406,7 +409,7 @@ public class NodeDeprecationChecksTests extends ESTestCase {
             "setting [script.cache.expire] is deprecated in favor of grouped setting [script.context.*.cache_expire]",
             "https://www.elastic.co/guide/en/elasticsearch/reference/7.9/breaking-changes-7.9.html#deprecate_general_script_expire",
             "the setting [script.cache.expire] is currently set to [" + expire + "], instead set [script.context.*.cache_expire] to " +
-                "[" + expire + "] where * is a script context");
+                "[" + expire + "] where * is a script context", null);
         assertThat(issues, hasItem(expected));
         assertSettingDeprecationsAndWarnings(new Setting<?>[]{ScriptService.SCRIPT_GENERAL_CACHE_EXPIRE_SETTING});
     }
@@ -421,7 +424,7 @@ public class NodeDeprecationChecksTests extends ESTestCase {
             "setting [script.max_compilations_rate] is deprecated in favor of grouped setting [script.context.*.max_compilations_rate]",
             "https://www.elastic.co/guide/en/elasticsearch/reference/7.9/breaking-changes-7.9.html#deprecate_general_script_compile_rate",
             "the setting [script.max_compilations_rate] is currently set to [" + rate +
-                "], instead set [script.context.*.max_compilations_rate] to [" + rate + "] where * is a script context");
+                "], instead set [script.context.*.max_compilations_rate] to [" + rate + "] where * is a script context", null);
         assertThat(issues, hasItem(expected));
         assertSettingDeprecationsAndWarnings(new Setting<?>[]{ScriptService.SCRIPT_GENERAL_MAX_COMPILATIONS_RATE_SETTING});
     }
@@ -441,7 +444,7 @@ public class NodeDeprecationChecksTests extends ESTestCase {
                 RemoteClusterService.ENABLE_REMOTE_CLUSTERS.getKey(),
                 value,
                 "node.remote_cluster_client"
-            ));
+            ), null);
         assertThat(issues, hasItem(expected));
         assertSettingDeprecationsAndWarnings(new Setting<?>[]{RemoteClusterService.ENABLE_REMOTE_CLUSTERS});
     }
@@ -455,7 +458,7 @@ public class NodeDeprecationChecksTests extends ESTestCase {
             DeprecationIssue.Level.CRITICAL,
             "setting [node.local_storage] is deprecated and will be removed in the next major version",
             "https://www.elastic.co/guide/en/elasticsearch/reference/7.8/breaking-changes-7.8.html#deprecate-node-local-storage",
-            "the setting [node.local_storage] is currently set to [" + value + "], remove this setting"
+            "the setting [node.local_storage] is currently set to [" + value + "], remove this setting", null
         );
         assertThat(issues, hasItem(expected));
         assertSettingDeprecationsAndWarnings(new Setting<?>[]{Node.NODE_LOCAL_STORAGE_SETTING});
@@ -484,7 +487,7 @@ public class NodeDeprecationChecksTests extends ESTestCase {
                 "setting [" + deprecatedSetting.getKey() + "] is deprecated and will be removed in the next major version",
                 "https://www.elastic.co/guide/en/elasticsearch/reference/7.8/breaking-changes-7.8.html" +
                     "#deprecate-basic-license-feature-enabled",
-                "the setting [" + deprecatedSetting.getKey() + "] is currently set to [" + value + "], remove this setting"
+                "the setting [" + deprecatedSetting.getKey() + "] is currently set to [" + value + "], remove this setting", null
             );
             assertThat(issues, hasItem(expected));
             assertSettingDeprecationsAndWarnings(new Setting<?>[]{deprecatedSetting});
@@ -510,7 +513,7 @@ public class NodeDeprecationChecksTests extends ESTestCase {
                 "setting [" + legacyRoleSetting.getKey() + "] is deprecated in favor of setting [node.roles]",
                 "https://www.elastic.co/guide/en/elasticsearch/reference/master/breaking-changes-8.0.html#breaking_80_settings_changes",
                 "the setting [" + legacyRoleSetting.getKey() + "] is currently set to ["
-                    + value + "], instead set [node.roles] to [" + roles + "]"
+                    + value + "], instead set [node.roles] to [" + roles + "]", null
             );
             assertThat(issues, hasItem(expected));
             assertSettingDeprecationsAndWarnings(new Setting<?>[]{legacyRoleSetting});
@@ -530,7 +533,8 @@ public class NodeDeprecationChecksTests extends ESTestCase {
             DeprecationIssue.Level.CRITICAL,
             "setting [bootstrap.system_call_filter] is deprecated and will be removed in the next major version",
             "https://www.elastic.co/guide/en/elasticsearch/reference/7.13/breaking-changes-7.13.html#deprecate-system-call-filter-setting",
-            "the setting [bootstrap.system_call_filter] is currently set to [" + boostrapSystemCallFilter + "], remove this setting");
+            "the setting [bootstrap.system_call_filter] is currently set to [" + boostrapSystemCallFilter + "], remove this setting",
+            null);
         assertThat(issues, hasItem(expected));
         assertSettingDeprecationsAndWarnings(new Setting<?>[]{BootstrapSettings.SYSTEM_CALL_FILTER_SETTING});
     }
@@ -646,8 +650,8 @@ public class NodeDeprecationChecksTests extends ESTestCase {
             new DeprecationIssue(DeprecationIssue.Level.CRITICAL,
                 "setting [path.shared_data] is deprecated and will be removed in a future version",
                 expectedUrl,
-                "Found shared data path configured. Discontinue use of this setting."
-            )));
+                "Found shared data path configured. Discontinue use of this setting.",
+                null)));
     }
 
     public void testSingleDataNodeWatermarkSettingExplicit() {
@@ -667,7 +671,8 @@ public class NodeDeprecationChecksTests extends ESTestCase {
                     " will not be available in a future version",
                 expectedUrl,
                 "found [cluster.routing.allocation.disk.watermark.enable_for_single_data_node] configured to false." +
-                    " Discontinue use of this setting or set it to true."
+                    " Discontinue use of this setting or set it to true.",
+                null
             )));
 
         assertWarnings("setting [cluster.routing.allocation.disk.watermark.enable_for_single_data_node=false] is deprecated and" +
@@ -696,8 +701,7 @@ public class NodeDeprecationChecksTests extends ESTestCase {
             expectedUrl,
             "found [cluster.routing.allocation.disk.watermark.enable_for_single_data_node] defaulting to false" +
                 " on a single data node cluster. Set it to true to avoid this warning." +
-                " Consider using [cluster.routing.allocation.disk.threshold_enabled] to disable disk based allocation"
-        );
+                " Consider using [cluster.routing.allocation.disk.threshold_enabled] to disable disk based allocation", null);
 
         assertThat(issues, hasItem(deprecationIssue));
 
@@ -746,7 +750,7 @@ public class NodeDeprecationChecksTests extends ESTestCase {
                 Locale.ROOT,
                 "replace the non-secure monitoring exporter password setting(s) [%s] with their secure 'auth.secure_password' replacement",
                 joinedNames
-            ))));
+            ), null)));
 
         // test for absence of deprecated exporter passwords
         issue = NodeDeprecationChecks.checkMonitoringExporterPassword(Settings.builder().build(), null, null);

--- a/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/TransportDeprecationInfoActionTests.java
+++ b/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/TransportDeprecationInfoActionTests.java
@@ -17,6 +17,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
+import static java.util.Collections.singletonList;
+import static java.util.Collections.singletonMap;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
@@ -29,9 +31,8 @@ public class TransportDeprecationInfoActionTests extends ESTestCase {
         PlainActionFuture<Map<String, List<DeprecationIssue>>> future = new PlainActionFuture<>();
         TransportDeprecationInfoAction.pluginSettingIssues(Arrays.asList(
             new NamedChecker("foo", Collections.emptyList(), false),
-            new NamedChecker("bar",
-                Collections.singletonList(new DeprecationIssue(DeprecationIssue.Level.WARNING, "bar msg", "", null)),
-                false)),
+            new NamedChecker("bar", singletonList(new DeprecationIssue(DeprecationIssue.Level.WARNING, "bar msg", "", "details",
+                singletonMap("key", "value"))), false)),
             components,
             future
             );
@@ -39,6 +40,8 @@ public class TransportDeprecationInfoActionTests extends ESTestCase {
         assertThat(issueMap.size(), equalTo(2));
         assertThat(issueMap.get("foo"), is(empty()));
         assertThat(issueMap.get("bar").get(0).getMessage(), equalTo("bar msg"));
+        assertThat(issueMap.get("bar").get(0).getDetails(), equalTo("details"));
+        assertThat(issueMap.get("bar").get(0).getMeta(), equalTo(singletonMap("key", "value")));
     }
 
     public void testPluginSettingIssuesWithFailures() {
@@ -47,7 +50,7 @@ public class TransportDeprecationInfoActionTests extends ESTestCase {
         TransportDeprecationInfoAction.pluginSettingIssues(Arrays.asList(
             new NamedChecker("foo", Collections.emptyList(), false),
             new NamedChecker("bar",
-                Collections.singletonList(new DeprecationIssue(DeprecationIssue.Level.WARNING, "bar msg", "", null)),
+                singletonList(new DeprecationIssue(DeprecationIssue.Level.WARNING, "bar msg", "", null, null)),
                 true)),
             components,
             future


### PR DESCRIPTION
Backport #74085 to 7.x branch.

This will allow components to add custom metadata to deprecation issues.
This make extracting additional details about deprecations more robust,
otherwise these details need to be parsed from the deprecation message field.

Adjusted the ml model snapshot deprecation to use custom metadata, and
included the job id and snapshot id as custom metadata.

Closes #73089