### PR TITLE
[ML] Closing an anomaly detection job now automatically stops its datafeed if necessary

### DIFF
--- a/docs/reference/ml/anomaly-detection/apis/close-job.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/close-job.asciidoc
@@ -26,8 +26,6 @@ operations, but you can still explore and navigate results.
 
 * Requires the `manage_ml` cluster privilege. This privilege is included in the 
 `machine_learning_admin` built-in role.
-* Before you can close an {anomaly-job}, you must stop its {dfeed}. See
-<<ml-stop-datafeed>>.
 
 [[ml-close-job-desc]]
 == {api-description-title}
@@ -35,6 +33,10 @@ operations, but you can still explore and navigate results.
 You can close multiple {anomaly-jobs} in a single API request by using a group
 name, a comma-separated list of jobs, or a wildcard expression. You can close
 all jobs by using `_all` or by specifying `*` as the `<job_id>`.
+
+If you close an {anomaly-job} whose {dfeed} is running, the request will first
+attempt to stop the {dfeed}, as though <<ml-stop-datafeed>> was called with
+the same `timeout` and `force` parameters as the close request.
 
 When you close a job, it runs housekeeping tasks such as pruning the model history,
 flushing buffers, calculating final results and persisting the model snapshots.
@@ -46,7 +48,7 @@ maintaining its meta data. Therefore it is a best practice to close jobs that
 are no longer required to process data.
 
 When a {dfeed} that has a specified end date stops, it automatically closes
-the job.
+its associated job.
 
 NOTE: If you use the `force` query parameter, the request returns without performing
 the associated actions such as flushing buffers and persisting the model snapshots.

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/DatafeedJobsIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/DatafeedJobsIT.java
@@ -537,7 +537,7 @@ public class DatafeedJobsIT extends MlNativeAutodetectIntegTestCase {
         boolean useForce = randomBoolean();
 
         client().admin().indices().prepareCreate("data")
-            .setMapping("time", "type=date")
+            .addMapping("type", "time", "type=date")
             .get();
         long numDocs = randomIntBetween(1024, 2048);
         long now = System.currentTimeMillis();

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/DatafeedJobsIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/DatafeedJobsIT.java
@@ -27,6 +27,7 @@ import org.elasticsearch.search.aggregations.AggregatorFactories;
 import org.elasticsearch.search.aggregations.bucket.composite.DateHistogramValuesSourceBuilder;
 import org.elasticsearch.search.aggregations.bucket.histogram.DateHistogramInterval;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
+import org.elasticsearch.xpack.core.ml.action.CloseJobAction;
 import org.elasticsearch.xpack.core.ml.action.DeleteDatafeedAction;
 import org.elasticsearch.xpack.core.ml.action.GetDatafeedsStatsAction;
 import org.elasticsearch.xpack.core.ml.action.GetJobsStatsAction;
@@ -505,6 +506,88 @@ public class DatafeedJobsIT extends MlNativeAutodetectIntegTestCase {
             GetDatafeedsStatsAction.Response response = client().execute(GetDatafeedsStatsAction.INSTANCE, request).actionGet();
             assertThat(response.getResponse().results().get(0).getDatafeedState(), equalTo(DatafeedState.STOPPED));
         });
+    }
+
+    public void testCloseJobStopsRealtimeDatafeed() throws Exception {
+        String jobId = "realtime-close-job";
+        String datafeedId = jobId + "-datafeed";
+        startRealtime(jobId);
+
+        try {
+            CloseJobAction.Response closeJobResponse = closeJob(jobId);
+            assertTrue(closeJobResponse.isClosed());
+        } catch (Exception e) {
+            NodesHotThreadsResponse nodesHotThreadsResponse = client().admin().cluster().prepareNodesHotThreads().get();
+            int i = 0;
+            for (NodeHotThreads nodeHotThreads : nodesHotThreadsResponse.getNodes()) {
+                logger.info(i++ + ":\n" +nodeHotThreads.getHotThreads());
+            }
+            throw e;
+        }
+        assertBusy(() -> {
+            GetDatafeedsStatsAction.Request request = new GetDatafeedsStatsAction.Request(datafeedId);
+            GetDatafeedsStatsAction.Response response = client().execute(GetDatafeedsStatsAction.INSTANCE, request).actionGet();
+            assertThat(response.getResponse().results().get(0).getDatafeedState(), equalTo(DatafeedState.STOPPED));
+        });
+    }
+
+    public void testCloseJobStopsLookbackOnlyDatafeed() throws Exception {
+        String jobId = "lookback-close-job";
+        String datafeedId = jobId + "-datafeed";
+        boolean useForce = randomBoolean();
+
+        client().admin().indices().prepareCreate("data")
+            .setMapping("time", "type=date")
+            .get();
+        long numDocs = randomIntBetween(1024, 2048);
+        long now = System.currentTimeMillis();
+        long oneWeekAgo = now - 604800000;
+        long twoWeeksAgo = oneWeekAgo - 604800000;
+        indexDocs(logger, "data", numDocs, twoWeeksAgo, oneWeekAgo);
+
+        Job.Builder job = createScheduledJob(jobId);
+        PutJobAction.Response putJobResponse = putJob(job);
+        assertThat(putJobResponse.getResponse().getJobVersion(), equalTo(Version.CURRENT));
+        openJob(job.getId());
+        assertBusy(() -> assertEquals(getJobStats(job.getId()).get(0).getState(), JobState.OPENED));
+
+        DatafeedConfig.Builder datafeedConfigBuilder = createDatafeedBuilder(datafeedId, jobId, Collections.singletonList("data"));
+        // Use lots of chunks to maximise the chance that we can close the job before the lookback completes
+        datafeedConfigBuilder.setChunkingConfig(ChunkingConfig.newManual(new TimeValue(1, TimeUnit.SECONDS)));
+        DatafeedConfig datafeedConfig = datafeedConfigBuilder.build();
+        putDatafeed(datafeedConfig);
+        startDatafeed(datafeedConfig.getId(), 0L, now);
+        assertBusy(() -> {
+            DataCounts dataCounts = getDataCounts(job.getId());
+            assertThat(dataCounts.getProcessedRecordCount(), greaterThan(0L));
+        }, 60, TimeUnit.SECONDS);
+
+        try {
+            CloseJobAction.Response closeJobResponse = closeJob(jobId, useForce);
+            assertTrue(closeJobResponse.isClosed());
+        } catch (Exception e) {
+            NodesHotThreadsResponse nodesHotThreadsResponse = client().admin().cluster().prepareNodesHotThreads().get();
+            int i = 0;
+            for (NodeHotThreads nodeHotThreads : nodesHotThreadsResponse.getNodes()) {
+                logger.info(i++ + ":\n" +nodeHotThreads.getHotThreads());
+            }
+            throw e;
+        }
+        GetDatafeedsStatsAction.Request request = new GetDatafeedsStatsAction.Request(datafeedId);
+        GetDatafeedsStatsAction.Response response = client().execute(GetDatafeedsStatsAction.INSTANCE, request).actionGet();
+        assertThat(response.getResponse().results().get(0).getDatafeedState(), equalTo(DatafeedState.STOPPED));
+
+        if (useForce) {
+            // It's possible that the datafeed ran to completion before we force closed the job.
+            // (We tried to avoid this by setting a small chunk size, but it's not impossible.)
+            // If the datafeed ran to completion then there could legitimately be a model snapshot
+            // even though we force closed the job, so we cannot assert in that case.
+            if (getDataCounts(job.getId()).getProcessedRecordCount() < numDocs) {
+                assertThat(getModelSnapshots(jobId), hasSize(0));
+            }
+        } else {
+            assertThat(getModelSnapshots(jobId), hasSize(1));
+        }
     }
 
     public void testRealtime_noDataAndAutoStop() throws Exception {

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportCloseJobAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportCloseJobAction.java
@@ -16,7 +16,9 @@ import org.elasticsearch.action.ActionListenerResponseHandler;
 import org.elasticsearch.action.FailedNodeException;
 import org.elasticsearch.action.TaskOperationFailure;
 import org.elasticsearch.action.support.ActionFilters;
+import org.elasticsearch.action.support.GroupedActionListener;
 import org.elasticsearch.action.support.tasks.TransportTasksAction;
+import org.elasticsearch.client.Client;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
 import org.elasticsearch.cluster.service.ClusterService;
@@ -24,14 +26,18 @@ import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.util.concurrent.AbstractRunnable;
 import org.elasticsearch.common.util.concurrent.AtomicArray;
+import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.discovery.MasterNotDiscoveredException;
 import org.elasticsearch.persistent.PersistentTasksCustomMetadata;
 import org.elasticsearch.persistent.PersistentTasksService;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
+import org.elasticsearch.xpack.core.ClientHelper;
 import org.elasticsearch.xpack.core.ml.MlTasks;
 import org.elasticsearch.xpack.core.ml.action.CloseJobAction;
+import org.elasticsearch.xpack.core.ml.action.IsolateDatafeedAction;
+import org.elasticsearch.xpack.core.ml.action.StopDatafeedAction;
 import org.elasticsearch.xpack.core.ml.datafeed.DatafeedState;
 import org.elasticsearch.xpack.core.ml.job.config.JobState;
 import org.elasticsearch.xpack.core.ml.job.config.JobTaskState;
@@ -57,6 +63,7 @@ public class TransportCloseJobAction extends TransportTasksAction<JobTask, Close
     private static final Logger logger = LogManager.getLogger(TransportCloseJobAction.class);
 
     private final ThreadPool threadPool;
+    private final Client client;
     private final ClusterService clusterService;
     private final AnomalyDetectionAuditor auditor;
     private final PersistentTasksService persistentTasksService;
@@ -64,7 +71,7 @@ public class TransportCloseJobAction extends TransportTasksAction<JobTask, Close
     private final DatafeedConfigProvider datafeedConfigProvider;
 
     @Inject
-    public TransportCloseJobAction(TransportService transportService, ThreadPool threadPool, ActionFilters actionFilters,
+    public TransportCloseJobAction(TransportService transportService, Client client, ThreadPool threadPool, ActionFilters actionFilters,
                                    ClusterService clusterService, AnomalyDetectionAuditor auditor,
                                    PersistentTasksService persistentTasksService, JobConfigProvider jobConfigProvider,
                                    DatafeedConfigProvider datafeedConfigProvider) {
@@ -72,6 +79,7 @@ public class TransportCloseJobAction extends TransportTasksAction<JobTask, Close
         super(CloseJobAction.NAME, clusterService, transportService, actionFilters,
             CloseJobAction.Request::new, CloseJobAction.Response::new, CloseJobAction.Response::new, ThreadPool.Names.SAME);
         this.threadPool = threadPool;
+        this.client = client;
         this.clusterService = clusterService;
         this.auditor = auditor;
         this.persistentTasksService = persistentTasksService;
@@ -100,32 +108,37 @@ public class TransportCloseJobAction extends TransportTasksAction<JobTask, Close
              * criteria (e.g. open datafeed), fail immediately, do not close any
              * job
              *
-             * 2. Internally a task request is created for every open job, so there
+             * 2. If any of the jobs to be closed have running datafeeds, these
+             * are stopped first, using the same level of force as the close request
+             *
+             * 3. Internally a task request is created for every open job, so there
              * are n inner tasks for 1 user request
              *
-             * 3. No task is created for closing jobs but those will be waited on
+             * 4. No task is created for closing jobs but those will be waited on
              *
-             * 4. Collect n inner task results or failures and send 1 outer
+             * 5. Collect n inner task results or failures and send 1 outer
              * result/failure
              */
+            final boolean isForce = request.isForce();
+            final TimeValue timeout = request.getCloseTimeout();
 
             PersistentTasksCustomMetadata tasksMetadata = state.getMetadata().custom(PersistentTasksCustomMetadata.TYPE);
             jobConfigProvider.expandJobsIds(request.getJobId(),
                 request.allowNoMatch(),
                 true,
                 tasksMetadata,
-                request.isForce(),
+                isForce,
                 ActionListener.wrap(
-                    expandedJobIds -> {
-                        validate(expandedJobIds, request.isForce(), tasksMetadata, ActionListener.wrap(
-                            response -> {
+                    expandedJobIds -> validate(expandedJobIds, isForce, tasksMetadata, ActionListener.wrap(
+                        response -> stopDatafeedsIfNecessary(response, isForce, timeout, tasksMetadata, ActionListener.wrap(
+                            bool -> {
                                 request.setOpenJobIds(response.openJobIds.toArray(new String[0]));
                                 if (response.openJobIds.isEmpty() && response.closingJobIds.isEmpty()) {
                                     listener.onResponse(new CloseJobAction.Response(true));
                                     return;
                                 }
 
-                                if (request.isForce()) {
+                                if (isForce) {
                                     List<String> jobIdsToForceClose = new ArrayList<>(response.openJobIds);
                                     jobIdsToForceClose.addAll(response.closingJobIds);
                                     forceCloseJob(state, request, jobIdsToForceClose, listener);
@@ -172,12 +185,12 @@ public class TransportCloseJobAction extends TransportTasksAction<JobTask, Close
 
                                     normalCloseJob(state, task, request, response.openJobIds, response.closingJobIds, listener);
                                 }
-                                },
+                            },
                             listener::onFailure
-                    ));
-                    },
-                listener::onFailure
-            ));
+                        )),
+                        listener::onFailure)),
+                    listener::onFailure
+                ));
         }
     }
 
@@ -194,7 +207,6 @@ public class TransportCloseJobAction extends TransportTasksAction<JobTask, Close
      * Separate the job Ids into open and closing job Ids and validate.
      * If a job is failed it is will not be closed unless the force parameter
      * in request is true.
-     * It is an error if the datafeed the job uses is not stopped
      *
      * @param expandedJobIds The job ids
      * @param forceClose Force close the job(s)
@@ -204,51 +216,124 @@ public class TransportCloseJobAction extends TransportTasksAction<JobTask, Close
     void validate(Collection<String> expandedJobIds, boolean forceClose, PersistentTasksCustomMetadata tasksMetadata,
                   ActionListener<OpenAndClosingIds> listener) {
 
-        checkDatafeedsHaveStopped(expandedJobIds, tasksMetadata, ActionListener.wrap(
-                response -> {
-                    OpenAndClosingIds ids = new OpenAndClosingIds();
-                    List<String> failedJobs = new ArrayList<>();
+        OpenAndClosingIds ids = new OpenAndClosingIds();
+        List<String> failedJobs = new ArrayList<>();
 
-                    for (String jobId : expandedJobIds) {
-                        addJobAccordingToState(jobId, tasksMetadata, ids.openJobIds, ids.closingJobIds, failedJobs);
-                    }
+        for (String jobId : expandedJobIds) {
+            addJobAccordingToState(jobId, tasksMetadata, ids.openJobIds, ids.closingJobIds, failedJobs);
+        }
 
-                    if (forceClose == false && failedJobs.size() > 0) {
-                        if (expandedJobIds.size() == 1) {
-                            listener.onFailure(
-                                    ExceptionsHelper.conflictStatusException("cannot close job [{}] because it failed, use force close",
-                                            expandedJobIds.iterator().next()));
-                            return;
+        if (forceClose == false && failedJobs.size() > 0) {
+            if (expandedJobIds.size() == 1) {
+                listener.onFailure(
+                    ExceptionsHelper.conflictStatusException("cannot close job [{}] because it failed, use force close",
+                        expandedJobIds.iterator().next()));
+                return;
+            }
+            listener.onFailure(
+                ExceptionsHelper.conflictStatusException("one or more jobs have state failed, use force close"));
+            return;
+        }
+
+        // If there are failed jobs force close is true
+        ids.openJobIds.addAll(failedJobs);
+        listener.onResponse(ids);
+    }
+
+    void stopDatafeedsIfNecessary(OpenAndClosingIds jobIds, boolean isForce, TimeValue timeout, PersistentTasksCustomMetadata tasksMetadata,
+                                  ActionListener<Boolean> listener) {
+        datafeedConfigProvider.findDatafeedsForJobIds(jobIds.openJobIds, ActionListener.wrap(
+                datafeedIds -> {
+                    List<String> runningDatafeedIds = datafeedIds
+                        .stream()
+                        .filter(datafeedId -> MlTasks.getDatafeedState(datafeedId, tasksMetadata) != DatafeedState.STOPPED)
+                        .collect(Collectors.toList());
+                    if (runningDatafeedIds.isEmpty()) {
+                        listener.onResponse(false);
+                    } else {
+                        if (isForce) {
+                            // A datafeed with an end time will gracefully close its job when it stops even if it was force stopped.
+                            // If we didn't do anything about this then it would turn requests to force close jobs into normal close
+                            // requests for those datafeeds, which is undesirable - the caller specifically asked for the job to be
+                            // closed forcefully, skipping the final state persistence to save time.  Therefore, before stopping the
+                            // datafeeds in this case we isolate them.  An isolated datafeed will NOT close its associated job under
+                            // any circumstances.  The downside of doing this is that if the stop datafeeds call fails then this API
+                            // will not have closed any jobs, but will have isolated one or more datafeeds, so the failure will have
+                            // an unexpected side effect.  Hopefully the project to combine jobs and datafeeds will be able to improve
+                            // on this.
+                            isolateDatafeeds(jobIds.openJobIds, runningDatafeedIds, ActionListener.wrap(
+                                r -> stopDatafeeds(runningDatafeedIds, true, timeout, listener),
+                                // As things stand this will never be called - see the comment in isolateDatafeeds() for why
+                                listener::onFailure
+                            ));
+                        } else {
+                            stopDatafeeds(runningDatafeedIds, false, timeout, listener);
                         }
-                        listener.onFailure(
-                                ExceptionsHelper.conflictStatusException("one or more jobs have state failed, use force close"));
-                        return;
                     }
-
-                    // If there are failed jobs force close is true
-                    ids.openJobIds.addAll(failedJobs);
-                    listener.onResponse(ids);
                 },
                 listener::onFailure
         ));
     }
 
-    void checkDatafeedsHaveStopped(Collection<String> jobIds, PersistentTasksCustomMetadata tasksMetadata,
-                                   ActionListener<Boolean> listener) {
-        datafeedConfigProvider.findDatafeedsForJobIds(jobIds, ActionListener.wrap(
-                datafeedIds -> {
-                    for (String datafeedId : datafeedIds) {
-                        DatafeedState datafeedState = MlTasks.getDatafeedState(datafeedId, tasksMetadata);
-                        if (datafeedState != DatafeedState.STOPPED) {
-                            listener.onFailure(ExceptionsHelper.conflictStatusException(
-                                "cannot close job datafeed [{}] hasn't been stopped", datafeedId));
-                            return;
-                        }
-                    }
-                    listener.onResponse(Boolean.TRUE);
-                },
-                listener::onFailure
-        ));
+    private void stopDatafeeds(List<String> runningDatafeedIds, boolean isForce, TimeValue timeout,
+                               ActionListener<Boolean> listener) {
+        StopDatafeedAction.Request request = new StopDatafeedAction.Request(String.join(",", runningDatafeedIds));
+        request.setForce(isForce);
+        request.setStopTimeout(timeout);
+        ClientHelper.executeAsyncWithOrigin(
+            client,
+            ClientHelper.ML_ORIGIN,
+            StopDatafeedAction.INSTANCE,
+            request,
+            ActionListener.wrap(
+                r -> listener.onResponse(r.isStopped()),
+                e -> listener.onFailure(ExceptionsHelper.conflictStatusException(
+                    "failed to close jobs as one or more had started datafeeds that could not be stopped: " +
+                        "started datafeeds [{}], error stopping them [{}]", e, request.getDatafeedId(), e.getMessage())
+                )
+            )
+        );
+    }
+
+    void isolateDatafeeds(List<String> openJobs, List<String> runningDatafeedIds, ActionListener<Void> listener) {
+
+        GroupedActionListener<IsolateDatafeedAction.Response> groupedListener = new GroupedActionListener<IsolateDatafeedAction.Response>(
+            ActionListener.wrap(
+                c -> listener.onResponse(null),
+                e -> {
+                    // This is deliberately NOT an error.  The reasoning is as follows:
+                    // - Isolate datafeed just sets a flag on the datafeed, so cannot fail IF it reaches the running datafeed code
+                    // - If the request fails because it cannot get to a node running the datafeed then that will be because either:
+                    //   1. The datafeed isn't assigned to a node
+                    //   2. There's no master node
+                    // - But because close job runs on the master node, it cannot be option 2 - this code is running there
+                    // - In the case where a datafeed isn't assigned to a node, stop and force stop, with and without isolation, are
+                    //   all the same
+                    // - So we might as well move onto the next step, which is to force stop these same datafeeds (we know this because
+                    //   this is a specialist internal method of closing a job, not a generic isolation method)
+                    // - Force stopping the datafeeds operates purely on the master node (i.e. the current node where this code is
+                    //   running), and is a simple cluster state update, so will not fail in the same way
+                    // Unfortunately there is still a race condition here, which is that the datafeed could get assigned to a node
+                    // after the isolation request fails but before we follow up with the force close.  In this case force stopping
+                    // the datafeed will gracefully close the associated job if the datafeed has an end time, which is not what we
+                    // want.  But this will be a rare edge case.  Hopefully the loopholes can be closed during the job/datafeed
+                    // unification project.  In the meantime we'll log at a level that is usually enabled, to make diagnosing the
+                    // race condition easier.
+                    logger.info("could not isolate all datafeeds while force closing jobs " + openJobs, e);
+                    listener.onResponse(null);
+                }
+            ),
+            runningDatafeedIds.size());
+
+        for (String runningDatafeedId : runningDatafeedIds) {
+            IsolateDatafeedAction.Request request = new IsolateDatafeedAction.Request(runningDatafeedId);
+            ClientHelper.executeAsyncWithOrigin(
+                client,
+                ClientHelper.ML_ORIGIN,
+                IsolateDatafeedAction.INSTANCE,
+                request,
+                groupedListener);
+        }
     }
 
     static void addJobAccordingToState(String jobId, PersistentTasksCustomMetadata tasksMetadata,
@@ -360,7 +445,7 @@ public class TransportCloseJobAction extends TransportTasksAction<JobTask, Close
                 throw org.elasticsearch.ExceptionsHelper
                         .convertToElastic(failedNodeExceptions.get(0));
             } else {
-                // This can happen we the actual task in the node no longer exists,
+                // This can happen when the actual task in the node no longer exists,
                 // which means the job(s) have already been closed.
                 return new CloseJobAction.Response(true);
             }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportIsolateDatafeedAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportIsolateDatafeedAction.java
@@ -52,22 +52,26 @@ public class TransportIsolateDatafeedAction extends TransportTasksAction<Transpo
     protected IsolateDatafeedAction.Response newResponse(IsolateDatafeedAction.Request request, List<IsolateDatafeedAction.Response> tasks,
                                                          List<TaskOperationFailure> taskOperationFailures,
                                                          List<FailedNodeException> failedNodeExceptions) {
+        // We only let people isolate one datafeed at a time, so each list will be empty or contain one item
+        assert tasks.size() <= 1 : "more than 1 item in tasks: " + tasks.size();
+        assert taskOperationFailures.size() <= 1 : "more than 1 item in taskOperationFailures: " + taskOperationFailures.size();
+        assert failedNodeExceptions.size() <= 1 : "more than 1 item in failedNodeExceptions: " + failedNodeExceptions.size();
         if (taskOperationFailures.isEmpty() == false) {
             throw org.elasticsearch.ExceptionsHelper
                     .convertToElastic(taskOperationFailures.get(0).getCause());
         } else if (failedNodeExceptions.isEmpty() == false) {
             throw org.elasticsearch.ExceptionsHelper
                     .convertToElastic(failedNodeExceptions.get(0));
-        } else {
-            return new IsolateDatafeedAction.Response(false);
+        } else if (tasks.isEmpty() == false) {
+            return tasks.get(0);
         }
+        return new IsolateDatafeedAction.Response(false);
     }
 
     @Override
     protected void taskOperation(IsolateDatafeedAction.Request request, TransportStartDatafeedAction.DatafeedTask datafeedTask,
                                  ActionListener<IsolateDatafeedAction.Response> listener) {
         datafeedTask.isolate();
-        listener.onResponse(new IsolateDatafeedAction.Response(false));
+        listener.onResponse(new IsolateDatafeedAction.Response(true));
     }
-
 }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/DatafeedJob.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/DatafeedJob.java
@@ -287,11 +287,7 @@ class DatafeedJob {
      *         otherwise <code>false</code> is returned
      */
     public boolean stop() {
-        if (running.compareAndSet(true, false)) {
-            return true;
-        } else {
-            return false;
-        }
+        return running.compareAndSet(true, false);
     }
 
     public boolean isRunning() {

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/action/TransportCloseJobActionTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/action/TransportCloseJobActionTests.java
@@ -9,10 +9,14 @@ package org.elasticsearch.xpack.ml.action;
 import org.elasticsearch.ElasticsearchStatusException;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.ActionFilters;
+import org.elasticsearch.client.Client;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.concurrent.ThreadContext;
+import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.persistent.PersistentTasksCustomMetadata;
 import org.elasticsearch.persistent.PersistentTasksCustomMetadata.Assignment;
 import org.elasticsearch.persistent.PersistentTasksService;
@@ -25,7 +29,9 @@ import org.elasticsearch.xpack.core.ml.MlMetadata;
 import org.elasticsearch.xpack.core.ml.MlTasks;
 import org.elasticsearch.xpack.core.ml.action.CloseJobAction;
 import org.elasticsearch.xpack.core.ml.action.CloseJobAction.Request;
+import org.elasticsearch.xpack.core.ml.action.IsolateDatafeedAction;
 import org.elasticsearch.xpack.core.ml.action.StartDatafeedAction;
+import org.elasticsearch.xpack.core.ml.action.StopDatafeedAction;
 import org.elasticsearch.xpack.core.ml.datafeed.DatafeedState;
 import org.elasticsearch.xpack.core.ml.job.config.JobState;
 import org.elasticsearch.xpack.ml.datafeed.persistence.DatafeedConfigProvider;
@@ -52,19 +58,26 @@ import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyBoolean;
+import static org.mockito.Matchers.same;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 public class TransportCloseJobActionTests extends ESTestCase {
 
     private ClusterService clusterService;
+    private Client client;
     private JobConfigProvider jobConfigProvider;
     private DatafeedConfigProvider datafeedConfigProvider;
 
     @Before
-    private void setupMocks() {
+    public void setupMocks() {
         clusterService = mock(ClusterService.class);
+        ThreadPool threadPool = mock(ThreadPool.class);
+        when(threadPool.getThreadContext()).thenReturn(new ThreadContext(Settings.EMPTY));
+        client = mock(Client.class);
+        when(client.threadPool()).thenReturn(threadPool);
         jobConfigProvider = mock(JobConfigProvider.class);
         datafeedConfigProvider = mock(DatafeedConfigProvider.class);
     }
@@ -89,45 +102,82 @@ public class TransportCloseJobActionTests extends ESTestCase {
         assertThat(closingJobIds, contains("closing-job"));
     }
 
-    public void testValidate_datafeedState() {
-        final PersistentTasksCustomMetadata.Builder startDataFeedTaskBuilder =  PersistentTasksCustomMetadata.builder();
+    @SuppressWarnings("unchecked")
+    public void testStopDatafeedsIfNecessary() {
+        final PersistentTasksCustomMetadata.Builder datafeedStartedTaskBuilder = PersistentTasksCustomMetadata.builder();
         String jobId = "job-with-started-df";
         String datafeedId = "df1";
-        addJobTask(jobId, null, JobState.OPENED, startDataFeedTaskBuilder);
-        addTask(datafeedId, 0L, null, DatafeedState.STARTED, startDataFeedTaskBuilder);
+        addJobTask(jobId, null, JobState.OPENED, datafeedStartedTaskBuilder);
+        addTask(datafeedId, 0L, null, DatafeedState.STARTED, datafeedStartedTaskBuilder);
 
         mockDatafeedConfigFindDatafeeds(Collections.singleton(datafeedId));
+        mockClientStopDatafeed();
 
         TransportCloseJobAction closeJobAction = createAction();
 
         AtomicReference<Exception> exceptionHolder = new AtomicReference<>();
-        AtomicReference<TransportCloseJobAction.OpenAndClosingIds> responseHolder = new AtomicReference<>();
-        ActionListener<TransportCloseJobAction.OpenAndClosingIds> listener = ActionListener.wrap(
-                responseHolder::set,
-                exceptionHolder::set
-        );
+        AtomicBoolean responseHolder = new AtomicBoolean();
+        ActionListener<Boolean> listener = ActionListener.wrap(responseHolder::set, exceptionHolder::set);
 
-        closeJobAction.validate(Arrays.asList(jobId), false, startDataFeedTaskBuilder.build(), listener);
+        TransportCloseJobAction.OpenAndClosingIds openAndClosingIds = new TransportCloseJobAction.OpenAndClosingIds();
+        openAndClosingIds.openJobIds = Collections.singletonList(jobId);
 
-        assertNull(responseHolder.get());
-        assertNotNull(exceptionHolder.get());
-        assertThat(exceptionHolder.get(), instanceOf(ElasticsearchStatusException.class));
-        ElasticsearchStatusException esException = (ElasticsearchStatusException) exceptionHolder.get();
-        assertEquals(RestStatus.CONFLICT, esException.status());
-        assertEquals("cannot close job datafeed [df1] hasn't been stopped", esException.getMessage());
+        closeJobAction.stopDatafeedsIfNecessary(openAndClosingIds, false, TimeValue.ZERO, datafeedStartedTaskBuilder.build(), listener);
 
-        final PersistentTasksCustomMetadata.Builder dataFeedNotStartedTaskBuilder =  PersistentTasksCustomMetadata.builder();
-        addJobTask(jobId, null, JobState.OPENED, dataFeedNotStartedTaskBuilder);
+        assertTrue(responseHolder.get());
+        assertNull(exceptionHolder.get());
+
+        final PersistentTasksCustomMetadata.Builder datafeedNotStartedTaskBuilder = PersistentTasksCustomMetadata.builder();
+        addJobTask(jobId, null, JobState.OPENED, datafeedNotStartedTaskBuilder);
         if (randomBoolean()) {
-            addTask(datafeedId, 0L, null, DatafeedState.STOPPED, dataFeedNotStartedTaskBuilder);
+            addTask(datafeedId, 0L, null, DatafeedState.STOPPED, datafeedNotStartedTaskBuilder);
         }
 
         exceptionHolder.set(null);
-        closeJobAction.validate(Arrays.asList(jobId), false, dataFeedNotStartedTaskBuilder.build(), listener);
+        closeJobAction.stopDatafeedsIfNecessary(openAndClosingIds, false, TimeValue.ZERO, datafeedNotStartedTaskBuilder.build(), listener);
+        assertFalse(responseHolder.get());
         assertNull(exceptionHolder.get());
-        assertNotNull(responseHolder.get());
-        assertThat(responseHolder.get().openJobIds, contains(jobId));
-        assertThat(responseHolder.get().closingJobIds, empty());
+        verify(client).execute(same(StopDatafeedAction.INSTANCE), any(StopDatafeedAction.Request.class), any(ActionListener.class));
+    }
+
+    @SuppressWarnings("unchecked")
+    public void testStopDatafeedsIfNecessaryWithForce() {
+        final PersistentTasksCustomMetadata.Builder datafeedStartedTaskBuilder = PersistentTasksCustomMetadata.builder();
+        String jobId = "job-with-started-df";
+        String datafeedId = "df1";
+        addJobTask(jobId, null, JobState.OPENED, datafeedStartedTaskBuilder);
+        addTask(datafeedId, 0L, null, DatafeedState.STARTED, datafeedStartedTaskBuilder);
+
+        mockDatafeedConfigFindDatafeeds(Collections.singleton(datafeedId));
+        mockClientStopDatafeed();
+        mockClientIsolateDatafeed();
+
+        TransportCloseJobAction closeJobAction = createAction();
+
+        AtomicReference<Exception> exceptionHolder = new AtomicReference<>();
+        AtomicBoolean responseHolder = new AtomicBoolean();
+        ActionListener<Boolean> listener = ActionListener.wrap(responseHolder::set, exceptionHolder::set);
+
+        TransportCloseJobAction.OpenAndClosingIds openAndClosingIds = new TransportCloseJobAction.OpenAndClosingIds();
+        openAndClosingIds.openJobIds = Collections.singletonList(jobId);
+
+        closeJobAction.stopDatafeedsIfNecessary(openAndClosingIds, true, TimeValue.ZERO, datafeedStartedTaskBuilder.build(), listener);
+
+        assertTrue(responseHolder.get());
+        assertNull(exceptionHolder.get());
+
+        final PersistentTasksCustomMetadata.Builder datafeedNotStartedTaskBuilder = PersistentTasksCustomMetadata.builder();
+        addJobTask(jobId, null, JobState.OPENED, datafeedNotStartedTaskBuilder);
+        if (randomBoolean()) {
+            addTask(datafeedId, 0L, null, DatafeedState.STOPPED, datafeedNotStartedTaskBuilder);
+        }
+
+        exceptionHolder.set(null);
+        closeJobAction.stopDatafeedsIfNecessary(openAndClosingIds, false, TimeValue.ZERO, datafeedNotStartedTaskBuilder.build(), listener);
+        assertFalse(responseHolder.get());
+        assertNull(exceptionHolder.get());
+        verify(client).execute(same(IsolateDatafeedAction.INSTANCE), any(IsolateDatafeedAction.Request.class), any(ActionListener.class));
+        verify(client).execute(same(StopDatafeedAction.INSTANCE), any(StopDatafeedAction.Request.class), any(ActionListener.class));
     }
 
     public void testValidate_givenFailedJob() {
@@ -146,7 +196,7 @@ public class TransportCloseJobActionTests extends ESTestCase {
         );
 
         // force close so not an error for the failed job
-        closeJobAction.validate(Arrays.asList("job_id_failed"), true, tasksBuilder.build(), listener);
+        closeJobAction.validate(Collections.singletonList("job_id_failed"), true, tasksBuilder.build(), listener);
         assertNull(exceptionHolder.get());
         assertNotNull(responseHolder.get());
         assertThat(responseHolder.get().openJobIds, contains("job_id_failed"));
@@ -154,7 +204,7 @@ public class TransportCloseJobActionTests extends ESTestCase {
 
         // not a force close so is an error
         responseHolder.set(null);
-        closeJobAction.validate(Arrays.asList("job_id_failed"), false, tasksBuilder.build(), listener);
+        closeJobAction.validate(Collections.singletonList("job_id_failed"), false, tasksBuilder.build(), listener);
         assertNull(responseHolder.get());
         assertNotNull(exceptionHolder.get());
         assertThat(exceptionHolder.get(), instanceOf(ElasticsearchStatusException.class));
@@ -192,16 +242,16 @@ public class TransportCloseJobActionTests extends ESTestCase {
         assertEquals(Arrays.asList("job_id_open-1", "job_id_open-2"), responseHolder.get().openJobIds);
         assertEquals(Collections.emptyList(), responseHolder.get().closingJobIds);
 
-        closeJobAction.validate(Arrays.asList("job_id_closing"), false, tasks, listener);
+        closeJobAction.validate(Collections.singletonList("job_id_closing"), false, tasks, listener);
         assertNull(exceptionHolder.get());
         assertNotNull(responseHolder.get());
         assertEquals(Collections.emptyList(), responseHolder.get().openJobIds);
-        assertEquals(Arrays.asList("job_id_closing"), responseHolder.get().closingJobIds);
+        assertEquals(Collections.singletonList("job_id_closing"), responseHolder.get().closingJobIds);
 
-        closeJobAction.validate(Arrays.asList("job_id_open-1"), false, tasks, listener);
+        closeJobAction.validate(Collections.singletonList("job_id_open-1"), false, tasks, listener);
         assertNull(exceptionHolder.get());
         assertNotNull(responseHolder.get());
-        assertEquals(Arrays.asList("job_id_open-1"), responseHolder.get().openJobIds);
+        assertEquals(Collections.singletonList("job_id_open-1"), responseHolder.get().openJobIds);
         assertEquals(Collections.emptyList(), responseHolder.get().closingJobIds);
     }
 
@@ -238,7 +288,6 @@ public class TransportCloseJobActionTests extends ESTestCase {
             @Override
             public void onFailure(Exception e) {
                 assertNull(e.getMessage(), e);
-
             }
         });
 
@@ -275,9 +324,9 @@ public class TransportCloseJobActionTests extends ESTestCase {
     }
 
     private TransportCloseJobAction createAction() {
-        return new TransportCloseJobAction(mock(TransportService.class), mock(ThreadPool.class), mock(ActionFilters.class),
-                clusterService, mock(AnomalyDetectionAuditor.class), mock(PersistentTasksService.class),
-                jobConfigProvider, datafeedConfigProvider);
+        return new TransportCloseJobAction(mock(TransportService.class), client, mock(ThreadPool.class),
+            mock(ActionFilters.class), clusterService, mock(AnomalyDetectionAuditor.class), mock(PersistentTasksService.class),
+            jobConfigProvider, datafeedConfigProvider);
     }
 
     @SuppressWarnings("unchecked")
@@ -300,4 +349,25 @@ public class TransportCloseJobActionTests extends ESTestCase {
         }).when(jobConfigProvider).expandJobsIds(any(), anyBoolean(), anyBoolean(), any(), anyBoolean(), any(ActionListener.class));
     }
 
+    @SuppressWarnings("unchecked")
+    private void mockClientStopDatafeed() {
+        doAnswer(invocation -> {
+            ActionListener<StopDatafeedAction.Response> listener =
+                (ActionListener<StopDatafeedAction.Response>) invocation.getArguments()[2];
+            listener.onResponse(new StopDatafeedAction.Response(true));
+
+            return null;
+        }).when(client).execute(same(StopDatafeedAction.INSTANCE), any(StopDatafeedAction.Request.class), any(ActionListener.class));
+    }
+
+    @SuppressWarnings("unchecked")
+    private void mockClientIsolateDatafeed() {
+        doAnswer(invocation -> {
+            ActionListener<IsolateDatafeedAction.Response> listener =
+                (ActionListener<IsolateDatafeedAction.Response>) invocation.getArguments()[2];
+            listener.onResponse(new IsolateDatafeedAction.Response(true));
+
+            return null;
+        }).when(client).execute(same(IsolateDatafeedAction.INSTANCE), any(IsolateDatafeedAction.Request.class), any(ActionListener.class));
+    }
 }


### PR DESCRIPTION
Previously it was a requirement of the close job API that if the
job had an associated datafeed that that datafeed was stopped
before the job could be closed. Experience has shown that this
is just a pedantic nuisance. If a user closes the job without
first stopping the datafeed then it's just a mistake, and they
then have to make two further calls, to stop the datafeed and
then attempt to close the job again.

This PR changes the behaviour so that if you ask to close a job
whose datafeed is running then the datafeed gets stopped first
as part of the same call. Datafeeds are stopped with the same
level of force as the job close request specified.

Backport of #74257