### PR TITLE
Move hashing on API key creation to crypto thread pool (#74165)

### DIFF
--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/authc/ApiKeyIntegTests.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/authc/ApiKeyIntegTests.java
@@ -998,7 +998,7 @@ public class ApiKeyIntegTests extends SecurityIntegTestCase {
         assertApiKeyNotCreated(client,"key-5");
     }
 
-    public void testAuthenticationReturns429WhenThreadPoolIsSaturated() throws IOException, InterruptedException, ExecutionException {
+    public void testCreationAndAuthenticationReturns429WhenThreadPoolIsSaturated() throws Exception {
         final String nodeName = randomFrom(internalCluster().getNodeNames());
         final Settings settings = internalCluster().getInstance(Settings.class, nodeName);
         final int allocatedProcessors = EsExecutors.allocatedProcessors(settings);
@@ -1059,9 +1059,17 @@ public class ApiKeyIntegTests extends SecurityIntegTestCase {
             final Request authRequest = new Request("GET", "_security/_authenticate");
             authRequest.setOptions(RequestOptions.DEFAULT.toBuilder().addHeader(
                 "Authorization", "ApiKey " + base64ApiKeyKeyValue).build());
-            final ResponseException responseException = expectThrows(ResponseException.class, () -> restClient.performRequest(authRequest));
-            assertThat(responseException.getMessage(), containsString("429 Too Many Requests"));
-            assertThat(responseException.getResponse().getStatusLine().getStatusCode(), is(429));
+            final ResponseException e1 = expectThrows(ResponseException.class, () -> restClient.performRequest(authRequest));
+            assertThat(e1.getMessage(), containsString("429 Too Many Requests"));
+            assertThat(e1.getResponse().getStatusLine().getStatusCode(), is(429));
+
+            final Request createApiKeyRequest = new Request("POST", "_security/api_key");
+            createApiKeyRequest.setJsonEntity("{\"name\":\"key\"}");
+            createApiKeyRequest.setOptions(createApiKeyRequest.getOptions().toBuilder()
+                .addHeader("Authorization", basicAuthHeaderValue(TEST_SUPERUSER, TEST_PASSWORD_SECURE_STRING)));
+            final ResponseException e2 = expectThrows(ResponseException.class, () -> restClient.performRequest(createApiKeyRequest));
+            assertThat(e2.getMessage(), containsString("429 Too Many Requests"));
+            assertThat(e2.getResponse().getStatusLine().getStatusCode(), is(429));
         } finally {
             blockingLatch.countDown();
             if (lastTaskFuture != null) {

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/ApiKeyServiceTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/ApiKeyServiceTests.java
@@ -399,7 +399,8 @@ public class ApiKeyServiceTests extends ESTestCase {
                 AuthenticationType.ANONYMOUS), Collections.emptyMap());
         }
         final Map<String, Object> metadata = ApiKeyTests.randomMetadata();
-        XContentBuilder docSource = service.newDocument(new SecureString(key.toCharArray()), "test", authentication,
+        XContentBuilder docSource = service.newDocument(
+            getFastStoredHashAlgoForTests().hash(new SecureString(key.toCharArray())),"test", authentication,
             Collections.singleton(SUPERUSER_ROLE_DESCRIPTOR), Instant.now(), Instant.now().plus(expiry), keyRoles,
             Version.CURRENT, metadata);
         if (invalidated) {
@@ -976,6 +977,25 @@ public class ApiKeyServiceTests extends ESTestCase {
         assertThat(authenticationResult.getMessage(), containsString("server is too busy to respond"));
     }
 
+    public void testCreationWillFailIfHashingThreadPoolIsSaturated() {
+        final EsRejectedExecutionException rejectedExecutionException = new EsRejectedExecutionException("rejected");
+        final ExecutorService mockExecutorService = mock(ExecutorService.class);
+        when(threadPool.executor(SECURITY_CRYPTO_THREAD_POOL_NAME)).thenReturn(mockExecutorService);
+        Mockito.doAnswer(invocationOnMock -> {
+            final AbstractRunnable actionRunnable = (AbstractRunnable) invocationOnMock.getArguments()[0];
+            actionRunnable.onRejection(rejectedExecutionException);
+            return null;
+        }).when(mockExecutorService).execute(any(Runnable.class));
+
+        final Authentication authentication = mock(Authentication.class);
+        final CreateApiKeyRequest createApiKeyRequest = new CreateApiKeyRequest(randomAlphaOfLengthBetween(3, 8), null, null);
+        ApiKeyService service = createApiKeyService(Settings.EMPTY);
+        final PlainActionFuture<CreateApiKeyResponse> future = new PlainActionFuture<>();
+        service.createApiKey(authentication, createApiKeyRequest, org.elasticsearch.core.Set.of(), future);
+        final EsRejectedExecutionException e = expectThrows(EsRejectedExecutionException.class, future::actionGet);
+        assertThat(e, is(rejectedExecutionException));
+    }
+
     public void testCachedApiKeyValidationWillNotBeBlockedByUnCachedApiKey() throws IOException, ExecutionException, InterruptedException {
         final String apiKey1 = randomAlphaOfLength(16);
         final ApiKeyCredentials creds = new ApiKeyCredentials(randomAlphaOfLength(12), new SecureString(apiKey1.toCharArray()));
@@ -1130,7 +1150,7 @@ public class ApiKeyServiceTests extends ESTestCase {
                                                                 List<RoleDescriptor> keyRoles,
                                                                 Version version) throws Exception {
             XContentBuilder keyDocSource = apiKeyService.newDocument(
-                new SecureString(randomAlphaOfLength(16).toCharArray()), "test", authentication,
+                getFastStoredHashAlgoForTests().hash(new SecureString(randomAlphaOfLength(16).toCharArray())), "test", authentication,
                 userRoles, Instant.now(), Instant.now().plus(Duration.ofSeconds(3600)), keyRoles, Version.CURRENT,
                 randomBoolean() ? null : org.elasticsearch.core.Map.of(
                     randomAlphaOfLengthBetween(3, 8), randomAlphaOfLengthBetween(3, 8)));


### PR DESCRIPTION
The changes in #74106 make API keys cached on creation time. It helps avoid the
expensive hashing operation on initial authentication when a request using the
key hits the same node that creates the key. Since the more expensive hashing
on authentication time is handled by a dedicated "crypto" thread pool (#58090),
it is expected that usage of the "crypto" thread pool to be reduced.

This PR moves the hashing on creation time to the "crypto" thread pool so that
a similar (before #74106) usage level of "crypto" thread pool is maintained. It
also has the benefit to avoid costly operations in the transport_worker thread,
which is generally preferred.

Relates: #74106
