### PR TITLE
Fix test assertion

### DIFF
--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.aggregation/22_terms_disable_opt.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.aggregation/22_terms_disable_opt.yml
@@ -1,23 +1,5 @@
+---
 setup:
-  - do:
-      cluster.put_settings:
-        body:
-          persistent:
-            search.aggs.rewrite_to_filter_by_filter: false
-
----
-teardown:
-  - do:
-      cluster.put_settings:
-        body:
-          persistent:
-            search.aggs.rewrite_to_filter_by_filter: null
-
----
-does not use optimization:
-  - skip:
-      version: " - 7.13.1"
-      reason: setting to disable optimization added in 7.13.2
   - do:
       bulk:
         index: test
@@ -32,6 +14,27 @@ does not use optimization:
           { "index": {} }
           { "str": "pig" }
 
+---
+teardown:
+  - do:
+      cluster.put_settings:
+        body:
+          persistent:
+            search.aggs.rewrite_to_filter_by_filter: null
+
+---
+disable optimization:
+  - skip:
+      version: " - 7.13.1"
+      reason: setting to disable optimization added in 7.13.2
+
+  - do:
+      cluster.put_settings:
+        body:
+          persistent:
+            search.aggs.rewrite_to_filter_by_filter: false
+
+
   - do:
       search:
         index: test
@@ -45,5 +48,55 @@ does not use optimization:
   - match: { aggregations.str_terms.buckets.0.key: sheep }
   - match: { aggregations.str_terms.buckets.1.key: cow }
   - match: { aggregations.str_terms.buckets.2.key: pig }
-  - match: { profile.shards.0.aggregations.0.type: GlobalOrdinalsStringTermsAggregator }
+  - match: { profile.shards.0.aggregations.0.type: /GlobalOrdinalsStringTermsAggregator.*/ } # Either the standard or low cardinality impl are fine
+  - match: { profile.shards.0.aggregations.0.description: str_terms }
+
+---
+enable optimization:
+  - skip:
+      version: " - 7.13.1"
+      reason: setting to disable optimization added in 7.13.2
+
+  - do:
+      cluster.put_settings:
+        body:
+          persistent:
+            search.aggs.rewrite_to_filter_by_filter: true
+
+  - do:
+      search:
+        index: test
+        body:
+          profile: true
+          size: 0
+          aggs:
+            str_terms:
+              terms:
+                field: str.keyword
+  - match: { aggregations.str_terms.buckets.0.key: sheep }
+  - match: { aggregations.str_terms.buckets.1.key: cow }
+  - match: { aggregations.str_terms.buckets.2.key: pig }
+  - match: { profile.shards.0.aggregations.0.type: /StringTermsAggregatorFromFilters/ }
+  - match: { profile.shards.0.aggregations.0.description: str_terms }
+
+---
+enabled by default:
+  - skip:
+      version: " - 7.13.1"
+      reason: setting to disable optimization added in 7.13.2
+
+  - do:
+      search:
+        index: test
+        body:
+          profile: true
+          size: 0
+          aggs:
+            str_terms:
+              terms:
+                field: str.keyword
+  - match: { aggregations.str_terms.buckets.0.key: sheep }
+  - match: { aggregations.str_terms.buckets.1.key: cow }
+  - match: { aggregations.str_terms.buckets.2.key: pig }
+  - match: { profile.shards.0.aggregations.0.type: /StringTermsAggregatorFromFilters/ }
   - match: { profile.shards.0.aggregations.0.description: str_terms }

--- a/x-pack/qa/runtime-fields/build.gradle
+++ b/x-pack/qa/runtime-fields/build.gradle
@@ -70,6 +70,7 @@ subprojects {
           /////// NOT SUPPORTED ///////
           'search.highlight/40_keyword_ignore/Plain Highligher should skip highlighting ignored keyword values', // The plain highlighter is incompatible with the prefix queries that we make for runtime fields, use unified highlighter instead.
           'search.aggregation/280_rare_terms/*', // Requires an index and we won't have it
+          'search.aggregation/22_terms_disable_opt/*', // Optimization requires an index and runtime fields don't have one
           // Runtime fields don't support sub-fields
           'search.aggregation/10_histogram/*',
           'suggest/50_completion_with_multi_fields/Search by suggestion on geofield-hash on sub field should work',
@@ -77,7 +78,6 @@ subprojects {
           'search.aggregation/20_terms/string profiler via global ordinals filters implementation',
           'search.aggregation/20_terms/string profiler via global ordinals native implementation',
           'search.aggregation/20_terms/Global ordinals are loaded with the global_ordinals execution hint',
-          'search.aggregation/22_terms_disable_opt/does not use optimization',
           'search.aggregation/170_cardinality_metric/profiler string',
           'search.aggregation/235_composite_sorted/*',
           //dynamic template causes a type _doc to be created, these tests use another type but only one type is allowed


### PR DESCRIPTION
We made a setting to disable an optimization because, sometimes, it
turns out to be slower. The setting gives users an "escape hatch". In
our assertion for the setting we accidentally were too specific about the
aggregator we expected to run so the test would sometimes fail
spuriously. This loosens the assertion. While we're at it, it also adds
an assertion that the optimization is enabled by default.

Closes #74374
