### PR TITLE
[7.x] [DOCS] Note bulk API supports `application/json` content type (#73949)

### DIFF
--- a/docs/reference/docs/bulk.asciidoc
+++ b/docs/reference/docs/bulk.asciidoc
@@ -89,9 +89,9 @@ has the same semantics as the standard delete API.
 [NOTE]
 ====
 The final line of data must end with a newline character `\n`. 
-Each newline character may be preceded by a carriage return `\r`. 
-When sending requests to the `_bulk` endpoint,
-the `Content-Type` header should be set to `application/x-ndjson`.
+Each newline character may be preceded by a carriage return `\r`.
+When sending NDJSON data to the `_bulk` endpoint, use a `Content-Type` header of
+`application/json` or `application/x-ndjson`.
 ====
 
 Because this format uses literal `\n`'s as delimiters, 


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [DOCS] Note bulk API supports `application/json` content type (#73949)