### PR TITLE
[7.x] [DOCS] Note remote reindex does not support slicing (#73959)

### DIFF
--- a/docs/reference/docs/reindex.asciidoc
+++ b/docs/reference/docs/reindex.asciidoc
@@ -221,9 +221,11 @@ Reindex supports <<slice-scroll>> to parallelize the reindexing process.
 This parallelization can improve efficiency and provide a convenient way to
 break the request down into smaller parts.
 
+// tag::remote-reindex-slicing[]
 NOTE: Reindexing from remote clusters does not support
-<<docs-reindex-manual-slice, manual>> or
-<<docs-reindex-automatic-slice, automatic slicing>>.
+<<docs-reindex-manual-slice, manual>> or <<docs-reindex-automatic-slice,
+automatic slicing>>.
+// end::remote-reindex-slicing[]
 
 [[docs-reindex-manual-slice]]
 ====== Manual slicing
@@ -1029,9 +1031,7 @@ example, you cannot reindex from a 7.x cluster into a 6.x cluster.
 To enable queries sent to older versions of Elasticsearch the `query` parameter
 is sent directly to the remote host without validation or modification.
 
-NOTE: Reindexing from remote clusters does not support
-<<docs-reindex-manual-slice, manual>> or
-<<docs-reindex-automatic-slice, automatic slicing>>.
+include::{es-ref-dir}/docs/reindex.asciidoc[tag=remote-reindex-slicing]
 
 Reindexing from a remote server uses an on-heap buffer that defaults to a
 maximum size of 100mb. If the remote index includes very large documents you'll

--- a/docs/reference/upgrade/reindex_upgrade.asciidoc
+++ b/docs/reference/upgrade/reindex_upgrade.asciidoc
@@ -158,7 +158,9 @@ cluster and remove nodes from the old one.
   faster reindexing.
 
 .. Use the <<docs-reindex,`reindex` API>> to pull documents from the
-  remote index into the new {version} index:
+remote index into the new {version} index.
++
+include::{es-ref-dir}/docs/reindex.asciidoc[tag=remote-reindex-slicing]
 +
 --
 [source,console]


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [DOCS] Note remote reindex does not support slicing (#73959)