### PR TITLE
Cleanup QA projects build scripts

### DIFF
--- a/plugins/examples/build.gradle
+++ b/plugins/examples/build.gradle
@@ -1,14 +1,12 @@
 import org.elasticsearch.gradle.internal.info.BuildParams
 // Subprojects aren't published so do not assemble
-gradle.projectsEvaluated {
-  subprojects {
-    project.tasks.matching { it.name.equals('assemble') }.configureEach {
+subprojects {
+  project.tasks.matching { it.name.equals('assemble') }.configureEach {
+    enabled = false
+  }
+  if (BuildParams.inFipsJvm) {
+    project.tasks.configureEach {
       enabled = false
-    }
-    if (BuildParams.inFipsJvm) {
-      project.tasks.configureEach {
-        enabled = false
-      }
     }
   }
 }

--- a/x-pack/plugin/async-search/qa/build.gradle
+++ b/x-pack/plugin/async-search/qa/build.gradle
@@ -1,8 +1,0 @@
-import org.elasticsearch.gradle.internal.test.RestIntegTestTask
-
-apply plugin: 'elasticsearch.build'
-tasks.named("test").configure { enabled = false }
-
-dependencies {
-  api project(':test:framework')
-}

--- a/x-pack/plugin/async-search/qa/security/build.gradle
+++ b/x-pack/plugin/async-search/qa/security/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'elasticsearch.java-rest-test'
 dependencies {
   javaRestTestImplementation(testArtifact(project(xpackModule('core'))))
   javaRestTestImplementation project(xpackModule('async-search'))
-  javaRestTestImplementation project(':x-pack:plugin:async-search:qa')
+  javaRestTestImplementation project(':test:framework')
 }
 
 testClusters.all {

--- a/x-pack/plugin/autoscaling/qa/build.gradle
+++ b/x-pack/plugin/autoscaling/qa/build.gradle
@@ -1,6 +1,0 @@
-apply plugin: 'elasticsearch.build'
-tasks.named("test").configure { enabled = false }
-
-dependencies {
-  api project(':test:framework')
-}

--- a/x-pack/plugin/enrich/qa/build.gradle
+++ b/x-pack/plugin/enrich/qa/build.gradle
@@ -1,8 +1,0 @@
-import org.elasticsearch.gradle.internal.test.RestIntegTestTask
-
-apply plugin: 'elasticsearch.build'
-tasks.named("test").configure { enabled = false }
-
-dependencies {
-  api project(':test:framework')
-}

--- a/x-pack/plugin/eql/qa/build.gradle
+++ b/x-pack/plugin/eql/qa/build.gradle
@@ -1,8 +1,0 @@
-import org.elasticsearch.gradle.internal.test.RestIntegTestTask
-
-apply plugin: 'elasticsearch.build'
-tasks.named("test").configure { enabled = false }
-
-dependencies {
-  api project(':test:framework')
-}

--- a/x-pack/plugin/fleet/qa/build.gradle
+++ b/x-pack/plugin/fleet/qa/build.gradle
@@ -1,6 +1,0 @@
-apply plugin: 'elasticsearch.build'
-tasks.named("test").configure { enabled = false }
-
-dependencies {
-  api project(':test:framework')
-}

--- a/x-pack/plugin/repositories-metering-api/qa/build.gradle
+++ b/x-pack/plugin/repositories-metering-api/qa/build.gradle
@@ -1,6 +1,0 @@
-apply plugin: 'elasticsearch.build'
-tasks.named("test").configure { enabled = false }
-
-dependencies {
-  api project(':test:framework')
-}

--- a/x-pack/plugin/searchable-snapshots/qa/build.gradle
+++ b/x-pack/plugin/searchable-snapshots/qa/build.gradle
@@ -1,6 +1,0 @@
-apply plugin: 'elasticsearch.build'
-tasks.named("test").configure { enabled = false }
-
-dependencies {
-  api project(':test:framework')
-}

--- a/x-pack/plugin/snapshot-repo-test-kit/qa/build.gradle
+++ b/x-pack/plugin/snapshot-repo-test-kit/qa/build.gradle
@@ -1,6 +1,0 @@
-apply plugin: 'elasticsearch.build'
-tasks.named("test").configure { enabled = false }
-
-dependencies {
-  api project(':test:framework')
-}

--- a/x-pack/plugin/transform/qa/build.gradle
+++ b/x-pack/plugin/transform/qa/build.gradle
@@ -1,13 +1,11 @@
 /* Remove assemble on all qa projects because we don't need to publish
  * artifacts for them. */
-gradle.projectsEvaluated {
-  subprojects {
-    project.tasks.matching { it.name.equals('assemble') }.configureEach {
-      enabled = false
-    }
+subprojects {
+  project.tasks.matching { it.name.equals('assemble') }.configureEach {
+    enabled = false
+  }
 
-    project.tasks.matching { it.name.equals('dependenciesInfo') }.configureEach {
-      enabled = false
-    }
+  project.tasks.matching { it.name.equals('dependenciesInfo') }.configureEach {
+    enabled = false
   }
 }


### PR DESCRIPTION
Aiming for configuring less during the build, 
this removes non required configuration from qa build scripts that do not 
contain any sources. We also remove a few non required afterEvaluate hooks