### PR TITLE
Avoid scaling empty tier unnecessarily (#74086) (#74413)

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/node/DiscoveryNodeFilters.java
+++ b/server/src/main/java/org/elasticsearch/cluster/node/DiscoveryNodeFilters.java
@@ -18,10 +18,14 @@ import org.elasticsearch.common.transport.TransportAddress;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.BiConsumer;
 import java.util.stream.Collectors;
 
 public class DiscoveryNodeFilters {
+
+    static final Set<String> NON_ATTRIBUTE_NAMES =
+        org.elasticsearch.common.collect.Set.of("_ip", "_host_ip", "_publish_ip", "host", "_id", "_name", "name");
 
     public enum OpType {
         AND,
@@ -224,6 +228,14 @@ public class DiscoveryNodeFilters {
         } else {
             return true;
         }
+    }
+
+    /**
+     *
+     * @return true if this filter only contains attribute values, i.e., no node specific info.
+     */
+    public boolean isOnlyAttributeValueFilter() {
+        return filters.keySet().stream().anyMatch(NON_ATTRIBUTE_NAMES::contains) == false;
     }
 
     /**

--- a/x-pack/plugin/autoscaling/src/internalClusterTest/java/org/elasticsearch/xpack/autoscaling/storage/ReactiveStorageIT.java
+++ b/x-pack/plugin/autoscaling/src/internalClusterTest/java/org/elasticsearch/xpack/autoscaling/storage/ReactiveStorageIT.java
@@ -174,18 +174,32 @@ public class ReactiveStorageIT extends AutoscalingStorageIntegTestCase {
         putAutoscalingPolicy("warm", DataTier.DATA_WARM);
         putAutoscalingPolicy("cold", DataTier.DATA_COLD);
 
+        // add an index using `_id` allocation to check that it does not trigger spinning up the tier.
+        assertAcked(
+            prepareCreate(randomAlphaOfLength(10).toLowerCase(Locale.ROOT)).setSettings(
+                Settings.builder()
+                    // more than 0 replica provokes the same shard decider to say no.
+                    .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, between(0, 5))
+                    .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 6)
+                    .put(INDEX_STORE_STATS_REFRESH_INTERVAL_SETTING.getKey(), "0ms")
+                    .put(IndexMetadata.INDEX_ROUTING_INCLUDE_GROUP_SETTING.getKey() + "_id", randomAlphaOfLength(5))
+                    .build()
+            ).setWaitForActiveShards(ActiveShardCount.NONE)
+        );
+
         final String indexName = randomAlphaOfLength(10).toLowerCase(Locale.ROOT);
         assertAcked(
             prepareCreate(indexName).setSettings(
                 Settings.builder()
-                    .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0)
+                    // more than 0 replica provokes the same shard decider to say no.
+                    .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, between(0, 5))
                     .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 6)
                     .put(INDEX_STORE_STATS_REFRESH_INTERVAL_SETTING.getKey(), "0ms")
                     .put(IndexMetadata.INDEX_ROUTING_INCLUDE_GROUP_SETTING.getKey() + "data_tier", "hot")
                     .build()
             )
         );
-        refresh();
+        refresh(indexName);
         assertThat(capacity().results().get("warm").requiredCapacity().total().storage().getBytes(), Matchers.equalTo(0L));
         assertThat(capacity().results().get("cold").requiredCapacity().total().storage().getBytes(), Matchers.equalTo(0L));
 

--- a/x-pack/plugin/autoscaling/src/main/java/org/elasticsearch/xpack/autoscaling/storage/ReactiveStorageDeciderService.java
+++ b/x-pack/plugin/autoscaling/src/main/java/org/elasticsearch/xpack/autoscaling/storage/ReactiveStorageDeciderService.java
@@ -17,6 +17,7 @@ import org.elasticsearch.cluster.metadata.IndexAbstraction;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.node.DiscoveryNodeFilters;
 import org.elasticsearch.cluster.node.DiscoveryNodeRole;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
 import org.elasticsearch.cluster.routing.RoutingNode;
@@ -29,6 +30,8 @@ import org.elasticsearch.cluster.routing.allocation.RoutingAllocation;
 import org.elasticsearch.cluster.routing.allocation.decider.AllocationDeciders;
 import org.elasticsearch.cluster.routing.allocation.decider.Decision;
 import org.elasticsearch.cluster.routing.allocation.decider.DiskThresholdDecider;
+import org.elasticsearch.cluster.routing.allocation.decider.FilterAllocationDecider;
+import org.elasticsearch.cluster.routing.allocation.decider.SameShardAllocationDecider;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.UUIDs;
 import org.elasticsearch.common.collect.ImmutableOpenMap;
@@ -130,12 +133,42 @@ public class ReactiveStorageDeciderService implements AutoscalingDeciderService 
     }
 
     static boolean isDiskOnlyNoDecision(Decision decision) {
-        // we consider throttling==yes, throttling should be temporary.
+        return singleNoDecision(decision, single -> true).map(DiskThresholdDecider.NAME::equals).orElse(false);
+    }
+
+    static boolean isFilterTierOnlyDecision(Decision decision, IndexMetadata indexMetadata) {
+        // only primary shards are handled here, allowing us to disregard same shard allocation decider.
+        return singleNoDecision(decision, single -> SameShardAllocationDecider.NAME.equals(single.label()) == false).filter(
+            FilterAllocationDecider.NAME::equals
+        ).map(d -> filterLooksLikeTier(indexMetadata)).orElse(false);
+    }
+
+    static boolean filterLooksLikeTier(IndexMetadata indexMetadata) {
+        return isOnlyAttributeValueFilter(indexMetadata.requireFilters())
+            && isOnlyAttributeValueFilter(indexMetadata.includeFilters())
+            && isOnlyAttributeValueFilter(indexMetadata.excludeFilters());
+    }
+
+    private static boolean isOnlyAttributeValueFilter(DiscoveryNodeFilters filters) {
+        if (filters == null) {
+            return true;
+        } else {
+            return DiscoveryNodeFilters.trimTier(filters).isOnlyAttributeValueFilter();
+        }
+    }
+
+    static Optional<String> singleNoDecision(Decision decision, Predicate<Decision> predicate) {
         List<Decision> nos = decision.getDecisions()
             .stream()
             .filter(single -> single.type() == Decision.Type.NO)
+            .filter(predicate)
             .collect(Collectors.toList());
-        return nos.size() == 1 && DiskThresholdDecider.NAME.equals(nos.get(0).label());
+
+        if (nos.size() == 1) {
+            return Optional.ofNullable(nos.get(0).label());
+        } else {
+            return Optional.empty();
+        }
     }
 
     // todo: move this to top level class.
@@ -280,7 +313,7 @@ public class ReactiveStorageDeciderService implements AutoscalingDeciderService 
          * @return true if and only if a node exists in the tier where only disk decider prevents allocation
          */
         private boolean cannotAllocateDueToStorage(ShardRouting shard, RoutingAllocation allocation) {
-            if (nodeIds.isEmpty() && isAssignedToTier(shard, allocation)) {
+            if (nodeIds.isEmpty() && needsThisTier(shard, allocation)) {
                 return true;
             }
             assert allocation.debugDecision() == false;
@@ -315,6 +348,43 @@ public class ReactiveStorageDeciderService implements AutoscalingDeciderService 
             return nodesInTier(allocation.routingNodes()).anyMatch(
                 node -> allocationDeciders.canAllocate(shard, node, allocation) != Decision.NO
             );
+        }
+
+        boolean needsThisTier(ShardRouting shard, RoutingAllocation allocation) {
+            if (isAssignedToTier(shard, allocation) == false) {
+                return false;
+            }
+            IndexMetadata indexMetadata = indexMetadata(shard, allocation);
+            Set<Decision.Type> decisionTypes = StreamSupport.stream(allocation.routingNodes().spliterator(), false)
+                .map(
+                    node -> dataTierAllocationDecider.shouldFilter(
+                        indexMetadata,
+                        node.node().getRoles(),
+                        this::highestPreferenceTier,
+                        allocation
+                    )
+                )
+                .map(Decision::type)
+                .collect(Collectors.toSet());
+            if (decisionTypes.contains(Decision.Type.NO)) {
+                // we know we have some filter and can respond. Only need this tier if ALL responses where NO.
+                return decisionTypes.size() == 1;
+            }
+
+            // check for using allocation filters for data tiers. For simplicity, only scale up new tier based on primary shard
+            if (shard.primary() == false) {
+                return false;
+            }
+            assert allocation.debugDecision() == false;
+            // enable debug decisions to see all decisions and preserve the allocation decision label
+            allocation.debugDecision(true);
+            try {
+                // check that it does not belong on any existing node, i.e., there must be only a tier like reason it cannot be allocated
+                return StreamSupport.stream(allocation.routingNodes().spliterator(), false)
+                    .anyMatch(node -> isFilterTierOnlyDecision(allocationDeciders.canAllocate(shard, node, allocation), indexMetadata));
+            } finally {
+                allocation.debugDecision(false);
+            }
         }
 
         private boolean isAssignedToTier(ShardRouting shard, RoutingAllocation allocation) {

--- a/x-pack/plugin/autoscaling/src/test/java/org/elasticsearch/xpack/autoscaling/storage/ReactiveStorageDeciderServiceTests.java
+++ b/x-pack/plugin/autoscaling/src/test/java/org/elasticsearch/xpack/autoscaling/storage/ReactiveStorageDeciderServiceTests.java
@@ -34,6 +34,7 @@ import org.elasticsearch.cluster.routing.allocation.decider.AwarenessAllocationD
 import org.elasticsearch.cluster.routing.allocation.decider.Decision;
 import org.elasticsearch.cluster.routing.allocation.decider.DiskThresholdDecider;
 import org.elasticsearch.cluster.routing.allocation.decider.EnableAllocationDecider;
+import org.elasticsearch.cluster.routing.allocation.decider.FilterAllocationDecider;
 import org.elasticsearch.cluster.routing.allocation.decider.SameShardAllocationDecider;
 import org.elasticsearch.common.UUIDs;
 import org.elasticsearch.common.collect.ImmutableOpenMap;
@@ -52,6 +53,7 @@ import org.elasticsearch.snapshots.SnapshotShardSizeInfo;
 import org.elasticsearch.xpack.autoscaling.AutoscalingTestCase;
 import org.elasticsearch.xpack.cluster.routing.allocation.DataTierAllocationDecider;
 import org.elasticsearch.xpack.cluster.routing.allocation.DataTierAllocationDeciderTests;
+import org.elasticsearch.xpack.core.DataTier;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -114,6 +116,96 @@ public class ReactiveStorageDeciderServiceTests extends AutoscalingTestCase {
             .forEach(decision::add);
 
         assertThat(ReactiveStorageDeciderService.isDiskOnlyNoDecision(decision), is(false));
+    }
+
+    public void testIsFilterTierOnlyDecision() {
+        Decision.Multi decision = new Decision.Multi();
+        if (randomBoolean()) {
+            decision.add(randomFrom(Decision.YES, Decision.ALWAYS, Decision.THROTTLE));
+        }
+        decision.add(new Decision.Single(Decision.Type.NO, FilterAllocationDecider.NAME, "test"));
+        randomSubsetOf(SOME_ALLOCATION_DECIDERS).stream()
+            .map(
+                label -> new Decision.Single(
+                    randomValueOtherThan(Decision.Type.NO, () -> randomFrom(Decision.Type.values())),
+                    label,
+                    "test " + label
+                )
+            )
+            .forEach(decision::add);
+
+        IndexMetadata indexMetadata = IndexMetadata.builder("test")
+            .settings(settings(Version.CURRENT).put(IndexMetadata.INDEX_ROUTING_INCLUDE_GROUP_PREFIX + ".data", "hot"))
+            .numberOfShards(randomIntBetween(1, 10))
+            .numberOfReplicas(randomIntBetween(1, 10))
+            .build();
+
+        assertThat(ReactiveStorageDeciderService.isFilterTierOnlyDecision(decision, indexMetadata), is(true));
+    }
+
+    public void testIsNotTierOnlyDecision() {
+        Decision.Multi decision = new Decision.Multi();
+        if (randomBoolean()) {
+            decision.add(randomFrom(Decision.YES, Decision.ALWAYS, Decision.THROTTLE, Decision.NO));
+        }
+        Settings.Builder settings = settings(Version.CURRENT);
+        if (randomBoolean()) {
+            decision.add(new Decision.Single(Decision.Type.NO, FilterAllocationDecider.NAME, "test"));
+            if (randomBoolean()) {
+                decision.add(Decision.NO);
+            } else if (randomBoolean()) {
+                if (randomBoolean()) {
+                    settings.put(IndexMetadata.INDEX_ROUTING_INCLUDE_GROUP_PREFIX + "._id", randomAlphaOfLength(5));
+                } else {
+                    decision.add(new Decision.Single(Decision.Type.NO, DataTierAllocationDecider.NAME, "test"));
+                }
+            } else {
+                decision.add(new Decision.Single(Decision.Type.NO, randomFrom(SOME_ALLOCATION_DECIDERS), "test"));
+            }
+        } else if (randomBoolean()) {
+            decision.add(new Decision.Single(Decision.Type.YES, FilterAllocationDecider.NAME, "test"));
+        }
+        randomSubsetOf(SOME_ALLOCATION_DECIDERS).stream()
+            .map(label -> new Decision.Single(randomFrom(Decision.Type.values()), label, "test " + label))
+            .forEach(decision::add);
+
+        assertThat(ReactiveStorageDeciderService.isFilterTierOnlyDecision(decision, metaWithSettings(settings)), is(false));
+    }
+
+    public void testFilterLooksLikeTier() {
+        Settings.Builder settings = settings(Version.CURRENT);
+        for (int i = 0; i < between(0, 10); ++i) {
+            String key = randomValueOtherThanMany(name -> name.startsWith("_") || name.equals("name"), () -> randomAlphaOfLength(5));
+            settings.put(
+                randomFrom(
+                    IndexMetadata.INDEX_ROUTING_INCLUDE_GROUP_PREFIX,
+                    IndexMetadata.INDEX_ROUTING_EXCLUDE_GROUP_PREFIX,
+                    IndexMetadata.INDEX_ROUTING_REQUIRE_GROUP_PREFIX
+                ) + "." + key,
+                randomAlphaOfLength(5)
+            );
+        }
+
+        assertThat(ReactiveStorageDeciderService.filterLooksLikeTier(metaWithSettings(settings)), is(true));
+
+        settings.put(
+            randomFrom(
+                IndexMetadata.INDEX_ROUTING_INCLUDE_GROUP_PREFIX,
+                IndexMetadata.INDEX_ROUTING_EXCLUDE_GROUP_PREFIX,
+                IndexMetadata.INDEX_ROUTING_REQUIRE_GROUP_PREFIX
+            ) + "." + randomFrom("_ip", "_host_ip", "_publish_ip", "host", "_id", "_name", "name"),
+            "1.2.3.4"
+        );
+
+        assertThat(ReactiveStorageDeciderService.filterLooksLikeTier(metaWithSettings(settings)), is(false));
+    }
+
+    private IndexMetadata metaWithSettings(Settings.Builder settings) {
+        return IndexMetadata.builder("test")
+            .settings(settings)
+            .numberOfShards(randomIntBetween(1, 10))
+            .numberOfReplicas(randomIntBetween(0, 10))
+            .build();
     }
 
     public void testSizeOf() {
@@ -279,6 +371,10 @@ public class ReactiveStorageDeciderServiceTests extends AutoscalingTestCase {
     }
 
     static void addNode(ClusterState.Builder stateBuilder) {
+        addNode(stateBuilder, DiscoveryNodeRole.DATA_ROLE);
+    }
+
+    static void addNode(ClusterState.Builder stateBuilder, DiscoveryNodeRole role) {
         stateBuilder.nodes(
             DiscoveryNodes.builder(stateBuilder.nodes())
                 .add(
@@ -287,7 +383,7 @@ public class ReactiveStorageDeciderServiceTests extends AutoscalingTestCase {
                         UUIDs.randomBase64UUID(),
                         buildNewFakeTransportAddress(),
                         Map.of(),
-                        org.elasticsearch.common.collect.Set.of(DiscoveryNodeRole.DATA_ROLE),
+                        org.elasticsearch.common.collect.Set.of(role),
                         Version.CURRENT
                     )
                 )
@@ -445,6 +541,122 @@ public class ReactiveStorageDeciderServiceTests extends AutoscalingTestCase {
             randomLong()
         );
         return allocationState.canRemainOnlyHighestTierPreference(shardRouting, allocation);
+    }
+
+    public void testNeedsThisTier() {
+        ClusterState.Builder stateBuilder = ClusterState.builder(ClusterName.DEFAULT);
+        addNode(stateBuilder, DiscoveryNodeRole.DATA_HOT_NODE_ROLE);
+        Metadata.Builder metaBuilder = Metadata.builder();
+        Settings.Builder settings = settings(Version.CURRENT);
+        if (randomBoolean()) {
+            settings.put(DataTierAllocationDecider.INDEX_ROUTING_PREFER, randomBoolean() ? DataTier.DATA_HOT : "data_hot,data_warm");
+        }
+        IndexMetadata indexMetadata = IndexMetadata.builder(randomAlphaOfLength(5))
+            .settings(settings)
+            .numberOfShards(10)
+            .numberOfReplicas(1)
+            .build();
+        metaBuilder.put(indexMetadata, true);
+        stateBuilder.metadata(metaBuilder);
+        ClusterState clusterState = stateBuilder.build();
+
+        ShardRouting shardRouting = TestShardRouting.newShardRouting(
+            indexMetadata.getIndex().getName(),
+            randomInt(10),
+            clusterState.nodes().iterator().next().getId(),
+            randomBoolean(),
+            ShardRoutingState.STARTED
+        );
+
+        verifyNeedsWarmTier(clusterState, shardRouting, false);
+        verifyNeedsWarmTier(addPreference(indexMetadata, clusterState, DataTier.DATA_COLD), shardRouting, false);
+        verifyNeedsWarmTier(addPreference(indexMetadata, clusterState, DataTier.DATA_WARM), shardRouting, true);
+        verifyNeedsWarmTier(addPreference(indexMetadata, clusterState, "data_warm,data_hot"), shardRouting, true);
+        verifyNeedsWarmTier(addPreference(indexMetadata, clusterState, "data_warm,data_cold"), shardRouting, true);
+    }
+
+    public void testNeedsThisTierLegacy() {
+        ClusterState.Builder stateBuilder = ClusterState.builder(ClusterName.DEFAULT);
+        addNode(stateBuilder);
+        Metadata.Builder metaBuilder = Metadata.builder();
+        Settings.Builder settings = settings(Version.CURRENT);
+        if (randomBoolean()) {
+            settings.put(IndexMetadata.INDEX_ROUTING_REQUIRE_GROUP_PREFIX + ".data", DataTier.DATA_HOT);
+        }
+        IndexMetadata indexMetadata = IndexMetadata.builder(randomAlphaOfLength(5))
+            .settings(settings)
+            .numberOfShards(10)
+            .numberOfReplicas(1)
+            .build();
+        metaBuilder.put(indexMetadata, true);
+        stateBuilder.metadata(metaBuilder);
+        ClusterState clusterState = stateBuilder.build();
+
+        boolean primary = randomBoolean();
+        ShardRouting shardRouting = TestShardRouting.newShardRouting(
+            indexMetadata.getIndex().getName(),
+            randomInt(10),
+            clusterState.nodes().iterator().next().getId(),
+            primary,
+            ShardRoutingState.STARTED
+        );
+
+        AllocationDecider noFilter = new AllocationDecider() {
+            @Override
+            public Decision canAllocate(ShardRouting shardRouting, RoutingNode node, RoutingAllocation allocation) {
+                return Decision.single(Decision.Type.NO, FilterAllocationDecider.NAME, "test");
+            }
+        };
+        AllocationDecider noSameShard = new AllocationDecider() {
+            @Override
+            public Decision canAllocate(ShardRouting shardRouting, RoutingNode node, RoutingAllocation allocation) {
+                return Decision.single(Decision.Type.NO, SameShardAllocationDecider.NAME, "test");
+            }
+        };
+        AllocationDecider no = new AllocationDecider() {
+            @Override
+            public Decision canAllocate(ShardRouting shardRouting, RoutingNode node, RoutingAllocation allocation) {
+                return Decision.single(Decision.Type.NO, AwarenessAllocationDecider.NAME, "test");
+            }
+        };
+        verifyNeedsWarmTier(clusterState, shardRouting, false);
+        verifyNeedsWarmTier(clusterState, shardRouting, primary, noFilter);
+        verifyNeedsWarmTier(clusterState, shardRouting, primary, noFilter, noSameShard);
+        verifyNeedsWarmTier(clusterState, shardRouting, false, noFilter, no);
+    }
+
+    private void verifyNeedsWarmTier(
+        ClusterState clusterState,
+        ShardRouting shardRouting,
+        boolean expected,
+        AllocationDecider... deciders
+    ) {
+        AllocationDeciders allocationDeciders = new AllocationDeciders(Arrays.asList(deciders));
+        DataTierAllocationDecider dataTierAllocationDecider = new DataTierAllocationDecider(
+            Settings.EMPTY,
+            new ClusterSettings(Settings.EMPTY, DataTierAllocationDeciderTests.ALL_SETTINGS)
+        );
+        ReactiveStorageDeciderService.AllocationState allocationState = new ReactiveStorageDeciderService.AllocationState(
+            clusterState,
+            allocationDeciders,
+            dataTierAllocationDecider,
+            new DiskThresholdSettings(Settings.EMPTY, new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS)),
+            ClusterInfo.EMPTY,
+            null,
+            org.elasticsearch.common.collect.Set.of(),
+            org.elasticsearch.common.collect.Set.of(DiscoveryNodeRole.DATA_WARM_NODE_ROLE)
+        );
+
+        RoutingAllocation allocation = new RoutingAllocation(
+            allocationDeciders,
+            clusterState.getRoutingNodes(),
+            clusterState,
+            null,
+            null,
+            randomLong()
+        );
+
+        assertThat(allocationState.needsThisTier(shardRouting, allocation), is(expected));
     }
 
     public void testMessage() {


### PR DESCRIPTION
7.13 backport of #74086

Autoscaling supports data tiers using attributes. This commit refines
the check to avoid bootstrapping a tier when a non-filter decider says
NO.

Co-authored-by: David Turner <david.turner@elastic.co>
