### PR TITLE
[ML] Fixing list snapshot search to handle unmapped min_version field

### DIFF
--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/persistence/JobResultsProvider.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/persistence/JobResultsProvider.java
@@ -1065,8 +1065,10 @@ public class JobResultsProvider {
                 .order(sortDescending ? SortOrder.DESC : SortOrder.ASC);
         // `min_version` might not be present in very early snapshots.
         // Consequently, we should treat it as being at least from 6.3.0 or before
+        // Also, if no jobs have been opened since the previous versions, the .ml-anomalies-* index may not have
+        // the `min_version`.
         if (sortField.equals(ModelSnapshot.MIN_VERSION.getPreferredName())) {
-            sb.missing(Version.fromString("6.3.0"));
+            sb.missing(Version.fromString("6.3.0")).unmappedType("keyword");
         }
 
         String indexName = AnomalyDetectorsIndex.jobResultsAliasedName(jobId);


### PR DESCRIPTION
It is possible that a request for model snapshots sorts by `min_type` but that field is not indexed. 

We should handle that case and set the unmappedType of `keyword`

closes https://github.com/elastic/elasticsearch/issues/74442