### PR TITLE
[DOCS] [7.x] Remove Beats central management (#74384)

### DIFF
--- a/x-pack/docs/en/security/securing-communications/security-basic-setup-https.asciidoc
+++ b/x-pack/docs/en/security/securing-communications/security-basic-setup-https.asciidoc
@@ -343,7 +343,6 @@ list of indices.
 | `metricbeat_setup` | Set up {metricbeat}.
 | `kibana_admin`     | Load dependencies, such as example dashboards, if available, into {kib}
 | `ingest_admin`     | Set up index templates and, if available, ingest pipelines
-| `beats_admin`      | Enroll and manage configurations in {beats} central management
 |===
 
 **Next**: <<beats-monitoring-role,Create a monitoring role>>


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Remove Beats central management (#74384)