### PR TITLE
[DOCS] Add performance info for runtime fields

### DIFF
--- a/docs/reference/mapping/runtime.asciidoc
+++ b/docs/reference/mapping/runtime.asciidoc
@@ -43,8 +43,15 @@ runtime fields allows for a smaller index and faster ingest time, which
 combined use less resources and reduce your operating costs.
 
 [discrete]
-[[runtime-performance]]
-=== Performance
+[[runtime-incentives]]
+=== Incentives
+Runtime fields can replace many of the ways you can use scripting with the
+`_search` API. How you use a runtime field is impacted by the number of
+documents that the included script runs against. For example, if you're using
+the `fields` parameter on the `_search` API to 
+<<runtime-retrieving-fields,retrieve the values of a runtime field>>, the script
+returns only the top hits just like script fields do.
+
 You can use <<script-fields,script fields>> to access values in `_source` and
 return calculated values based on a script valuation. Runtime fields have these
 same capabilities, but provide greater flexibility because you can query and
@@ -59,19 +66,13 @@ field values and they are available everywhere, such as
 <<search-aggregations, aggregations>>.
 
 You can also use scripts to <<script-based-sorting,sort search results>>, but
-but that same script works exactly the same in a runtime field.
+that same script works exactly the same in a runtime field.
 
 If you move a script from any of these sections in a search request to a
 runtime field that is retrieving values from the same number of documents, the
 performance should be about the same. The performance for these features is
 largely dependent upon the calculations that the included script is running and
 how many documents the script runs against. 
-
-How you use a runtime field determines the number of documents that the included
-script runs against. For example, if you're using the fields parameter on the
-`_search` API to 
-<<runtime-retrieving-fields,retrieve the values of a runtime field>>, the script
-returns only the top hits just like script fields do.
 
 [discrete]
 [[runtime-compromises]]

--- a/docs/reference/mapping/runtime.asciidoc
+++ b/docs/reference/mapping/runtime.asciidoc
@@ -43,6 +43,28 @@ runtime fields allows for a smaller index and faster ingest time, which
 combined use less resources and reduce your operating costs.
 
 [discrete]
+[[runtime-performance]]
+=== Performance
+You can use <<script-fields,script fields>> to access values in `_source` and
+return calculated values based on a script valuation. Runtime fields have these
+same capabilities, but provide greater flexibility because you can query and
+aggregate on runtime fields in a search request. Script fields can only fetch
+values.
+
+Similarly, you could write a <<query-dsl-script-query,script query>> that
+filters documents in a search request based on a script. Runtime fields provide
+a very similar feature that is more flexible. You write a script to create
+field values and they are available everywhere, such as
+<<search-fields,`fields`>>, <<query-dsl, all queries>>, and
+<<search-aggregations, aggregations>>.
+
+If you move a script from the `script_fields` parameter of a search request (or
+from a script query) to a runtime field that is retrieving values from the same
+number of documents, the performance should be about the same. The performance
+for these features is largely dependent upon the calculations that the included
+script is running and how many documents the script runs against. 
+
+[discrete]
 [[runtime-compromises]]
 === Compromises
 Runtime fields use less disk space and provide flexibility in how you access

--- a/docs/reference/mapping/runtime.asciidoc
+++ b/docs/reference/mapping/runtime.asciidoc
@@ -58,11 +58,20 @@ field values and they are available everywhere, such as
 <<search-fields,`fields`>>, <<query-dsl, all queries>>, and
 <<search-aggregations, aggregations>>.
 
-If you move a script from the `script_fields` parameter of a search request (or
-from a script query) to a runtime field that is retrieving values from the same
-number of documents, the performance should be about the same. The performance
-for these features is largely dependent upon the calculations that the included
-script is running and how many documents the script runs against. 
+You can also use scripts to <<script-based-sorting,sort search results>>, but
+but that same script works exactly the same in a runtime field.
+
+If you move a script from any of these sections in a search request to a
+runtime field that is retrieving values from the same number of documents, the
+performance should be about the same. The performance for these features is
+largely dependent upon the calculations that the included script is running and
+how many documents the script runs against. 
+
+How you use a runtime field determines the number of documents that the included
+script runs against. For example, if you're using the fields parameter on the
+`_search` API to 
+<<runtime-retrieving-fields,retrieve the values of a runtime field>>, the script
+returns only the top hits just like script fields do.
 
 [discrete]
 [[runtime-compromises]]

--- a/docs/reference/search/search-your-data/sort-search-results.asciidoc
+++ b/docs/reference/search/search-your-data/sort-search-results.asciidoc
@@ -591,6 +591,7 @@ The final distance for a document will then be `min`/`max`/`avg` (defined via `m
 
 
 [discrete]
+[[script-based-sorting]]
 === Script Based Sorting
 
 Allow to sort based on custom scripts, here is an example:


### PR DESCRIPTION
Adds information about performance of runtime fields in relation to similar places where scripts can be used.

Preview link: https://elasticsearch_74454.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/runtime.html#runtime-performance