### PR TITLE
Adding priority list and executing description to the pending tasks doc

### DIFF
--- a/docs/reference/cluster/pending.asciidoc
+++ b/docs/reference/cluster/pending.asciidoc
@@ -50,7 +50,7 @@ include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=master-timeout]
     the task queue.
     
 `priority`::
-    (string) The priority of the pending task. The hierachy of pending tasks execution are `IMMEDIATE` > `URGENT` > `HIGH` > `NORMAL` > `LOW` > `LANGUID`. 
+    (string) The priority of the pending task. The valid priorities in descending priority order are: `IMMEDIATE` > `URGENT` > `HIGH` > `NORMAL` > `LOW` > `LANGUID`. 
     
 `source`::
     (string) A general description of the cluster task that may include a reason 

--- a/docs/reference/cluster/pending.asciidoc
+++ b/docs/reference/cluster/pending.asciidoc
@@ -56,6 +56,9 @@ include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=master-timeout]
     (string) A general description of the cluster task that may include a reason 
     and origin. 
     
+`executing`::
+    (boolean) True or false, indicating whether the pending tasks is currently getting executed or not.
+    
 `time_in_queue_millis`::
     (integer) The time expressed in milliseconds since the task is waiting for 
     being performed.
@@ -78,6 +81,7 @@ However, if there are tasks queued up, the response will look similar like this:
          "insert_order": 101,
          "priority": "URGENT",
          "source": "create-index [foo_9], cause [api]",
+         "executing" : true,
          "time_in_queue_millis": 86,
          "time_in_queue": "86ms"
       },
@@ -85,6 +89,7 @@ However, if there are tasks queued up, the response will look similar like this:
          "insert_order": 46,
          "priority": "HIGH",
          "source": "shard-started ([foo_2][1], node[tMTocMvQQgGCkj7QDHl3OA], [P], s[INITIALIZING]), reason [after recovery from shard_store]",
+         "executing" : false,
          "time_in_queue_millis": 842,
          "time_in_queue": "842ms"
       },
@@ -92,6 +97,7 @@ However, if there are tasks queued up, the response will look similar like this:
          "insert_order": 45,
          "priority": "HIGH",
          "source": "shard-started ([foo_2][0], node[tMTocMvQQgGCkj7QDHl3OA], [P], s[INITIALIZING]), reason [after recovery from shard_store]",
+         "executing" : false,
          "time_in_queue_millis": 858,
          "time_in_queue": "858ms"
       }

--- a/docs/reference/cluster/pending.asciidoc
+++ b/docs/reference/cluster/pending.asciidoc
@@ -50,7 +50,7 @@ include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=master-timeout]
     the task queue.
     
 `priority`::
-    (string) The priority of the pending task.
+    (string) The priority of the pending task. The hierachy of pending tasks execution are `IMMEDIATE` > `URGENT` > `HIGH` > `NORMAL` > `LOW` > `LANGUID`. 
     
 `source`::
     (string) A general description of the cluster task that may include a reason 


### PR DESCRIPTION
This PR added two items: 
1. As per following discussion and code evidence:
https://github.com/elastic/elasticsearch/pull/19448#discussion_r70969307
> We should never rely on the ordinal for any enum anywhere, it's just a maintenance burden should the enum ever change. The tests here do ensure that the values are in the right order though: IMMEDIATE < URGENT < HIGH < NORMAL < LOW < LANGUID. I think that's all we need?

https://github.com/elastic/elasticsearch/blob/917fea7c5d0ea31ae1ccf301298f5f006216bb9f/core/src/main/java/org/elasticsearch/common/Priority.java#L29-L34

We should clarify the pending task order verbatem. Note the order in the doc is the opposite of the order listed above. But code read differently from human understanding, so I think the order listed in the doc is more intuitive to the user. Feel free to modify so that it would help users understand the API output and troubleshooting blocking issues. 

_Pending tasks with lower priority will not be executed until the higher priority tasks have been accomplished._ <--- wondering if we need to add that into the doc as well?


2. The `executing` field has been added since 2014 by https://github.com/elastic/elasticsearch/pull/6744, but for some reason, it was never documented. Added the corresponding description and insert into the response body.

> the pending tasks api will now include the current executing tasks (with a proper marker boolean flag)
this will also help in tests that wait for no pending tasks, to also wait till the current executing task is done
