### PR TITLE
SQL: Fix querying of indices without columns (#74312)

### DIFF
--- a/x-pack/plugin/sql/qa/jdbc/src/main/java/org/elasticsearch/xpack/sql/qa/jdbc/JdbcErrorsTestCase.java
+++ b/x-pack/plugin/sql/qa/jdbc/src/main/java/org/elasticsearch/xpack/sql/qa/jdbc/JdbcErrorsTestCase.java
@@ -40,18 +40,6 @@ public abstract class JdbcErrorsTestCase extends JdbcIntegrationTestCase {
         }
     }
 
-    public void testSelectFromEmptyIndex() throws IOException, SQLException {
-        // Create an index without any types
-        Request request = new Request("PUT", "/test");
-        request.setJsonEntity("{}");
-        client().performRequest(request);
-
-        try (Connection c = esJdbc()) {
-            SQLException e = expectThrows(SQLException.class, () -> c.prepareStatement("SELECT * FROM test").executeQuery());
-            assertEquals("Found 1 problem\nline 1:8: Cannot determine columns for [*]", e.getMessage());
-        }
-    }
-
     public void testSelectColumnFromEmptyIndex() throws IOException, SQLException {
         Request request = new Request("PUT", "/test");
         request.setJsonEntity("{}");

--- a/x-pack/plugin/sql/qa/server/src/main/java/org/elasticsearch/xpack/sql/qa/ErrorsTestCase.java
+++ b/x-pack/plugin/sql/qa/server/src/main/java/org/elasticsearch/xpack/sql/qa/ErrorsTestCase.java
@@ -18,8 +18,6 @@ public interface ErrorsTestCase {
 
     void testSelectColumnFromMissingIndex() throws Exception;
 
-    void testSelectFromEmptyIndex() throws Exception;
-
     void testSelectColumnFromEmptyIndex() throws Exception;
 
     void testSelectMissingField() throws Exception;

--- a/x-pack/plugin/sql/qa/server/src/main/java/org/elasticsearch/xpack/sql/qa/cli/ErrorsTestCase.java
+++ b/x-pack/plugin/sql/qa/server/src/main/java/org/elasticsearch/xpack/sql/qa/cli/ErrorsTestCase.java
@@ -44,17 +44,6 @@ public abstract class ErrorsTestCase extends CliIntegrationTestCase implements o
     }
 
     @Override
-    public void testSelectFromEmptyIndex() throws Exception {
-        // Create an index without any types
-        Request request = new Request("PUT", "/test");
-        request.setJsonEntity("{}");
-        client().performRequest(request);
-
-        assertFoundOneProblem(command("SELECT * FROM test"));
-        assertEquals("line 1:8: Cannot determine columns for [*]" + END, readLine());
-    }
-
-    @Override
     public void testSelectColumnFromEmptyIndex() throws Exception {
         Request request = new Request("PUT", "/test");
         request.setJsonEntity("{}");

--- a/x-pack/plugin/sql/qa/server/src/main/java/org/elasticsearch/xpack/sql/qa/jdbc/DataLoader.java
+++ b/x-pack/plugin/sql/qa/server/src/main/java/org/elasticsearch/xpack/sql/qa/jdbc/DataLoader.java
@@ -72,6 +72,15 @@ public class DataLoader {
         // frozen index
         loadEmpDatasetIntoEs(client, "frozen_emp", "employees");
         freeze(client, "frozen_emp");
+        loadNoColsDatasetIntoEs(client, "empty_mapping");
+    }
+
+    private static void loadNoColsDatasetIntoEs(RestClient client, String index) throws Exception {
+        createEmptyIndex(client, index);
+        Request request = new Request("POST", "/" + index + "/_bulk");
+        request.addParameter("refresh", "true");
+        request.setJsonEntity("{\"index\":{}\n{}\n" + "{\"index\":{}\n{}\n");
+        client.performRequest(request);
     }
 
     public static void loadDocsDatasetIntoEs(RestClient client) throws Exception {

--- a/x-pack/plugin/sql/qa/server/src/main/java/org/elasticsearch/xpack/sql/qa/jdbc/SqlSpecTestCase.java
+++ b/x-pack/plugin/sql/qa/server/src/main/java/org/elasticsearch/xpack/sql/qa/jdbc/SqlSpecTestCase.java
@@ -32,7 +32,10 @@ public abstract class SqlSpecTestCase extends SpecBaseIntegrationTestCase {
     private String query;
 
     @ClassRule
-    public static LocalH2 H2 = new LocalH2(c -> c.createStatement().execute("RUNSCRIPT FROM 'classpath:/setup_test_emp.sql'"));
+    public static LocalH2 H2 = new LocalH2((c) -> {
+        c.createStatement().execute("RUNSCRIPT FROM 'classpath:/setup_test_emp.sql'");
+        c.createStatement().execute("RUNSCRIPT FROM 'classpath:/setup_empty_mapping.sql'");
+    });
 
     @ParametersFactory(argumentFormatting = PARAM_FORMATTING)
     public static List<Object[]> readScriptSpec() throws Exception {

--- a/x-pack/plugin/sql/qa/server/src/main/java/org/elasticsearch/xpack/sql/qa/rest/RestSqlTestCase.java
+++ b/x-pack/plugin/sql/qa/server/src/main/java/org/elasticsearch/xpack/sql/qa/rest/RestSqlTestCase.java
@@ -345,16 +345,6 @@ public abstract class RestSqlTestCase extends BaseRestSqlTestCase implements Err
     }
 
     @Override
-    public void testSelectFromEmptyIndex() throws Exception {
-        // Create an index without any types
-        Request request = new Request("PUT", "/test");
-        request.setJsonEntity("{}");
-        client().performRequest(request);
-        String mode = randomFrom("jdbc", "plain");
-        expectBadRequest(() -> runSql(mode, "SELECT * FROM test"), containsString("1:8: Cannot determine columns for [*]"));
-    }
-
-    @Override
     public void testSelectColumnFromEmptyIndex() throws Exception {
         Request request = new Request("PUT", "/test");
         request.setJsonEntity("{}");

--- a/x-pack/plugin/sql/qa/server/src/main/resources/command.csv-spec
+++ b/x-pack/plugin/sql/qa/server/src/main/resources/command.csv-spec
@@ -223,13 +223,14 @@ TODAY          |SCALAR
 showTables
 SHOW TABLES;
 
-       name    |  type |  kind   
+       name    |  type |  kind
+empty_mapping  |TABLE  |INDEX
 logs           |TABLE  |INDEX
 logs_nanos     |TABLE  |INDEX
 test_alias     |VIEW   |ALIAS
-test_alias_emp |VIEW   |ALIAS 
-test_emp       |TABLE  |INDEX  
-test_emp_copy  |TABLE  |INDEX  
+test_alias_emp |VIEW   |ALIAS
+test_emp       |TABLE  |INDEX
+test_emp_copy  |TABLE  |INDEX
 ;
 
 showTablesSimpleLike
@@ -381,4 +382,20 @@ languages           |TINYINT        |byte
 last_name           |VARCHAR        |text
 last_name.keyword   |VARCHAR        |keyword
 salary              |INTEGER        |integer
+;
+
+
+describeNoCols
+DESCRIBE "empty_mapping";
+
+        column:s      |     type:s    |    mapping:s
+----------------------+---------------+---------------
+;
+
+
+showColumnsInNoCols
+SHOW COLUMNS IN "empty_mapping";
+
+        column:s      |     type:s    |    mapping:s
+----------------------+---------------+---------------
 ;

--- a/x-pack/plugin/sql/qa/server/src/main/resources/empty-mapping.csv-spec
+++ b/x-pack/plugin/sql/qa/server/src/main/resources/empty-mapping.csv-spec
@@ -1,0 +1,28 @@
+
+// the following queries all return no rows in H2
+
+selectConstAggregationWithGroupBy
+SELECT 1 a, COUNT(*) b, MAX(1) c FROM empty_mapping GROUP BY a;
+
+       a:i     |       b:l     |       c:i
+---------------+---------------+---------------
+1              |2              |1
+;
+
+subselectWithConst
+SELECT 1, * FROM (SELECT * FROM empty_mapping) s;
+
+       1:i
+---------------
+1
+1
+;
+
+subselectWithInnerConst
+SELECT * FROM (SELECT 1, * FROM empty_mapping) s;
+
+       1:i
+---------------
+1
+1
+;

--- a/x-pack/plugin/sql/qa/server/src/main/resources/empty-mapping.sql-spec
+++ b/x-pack/plugin/sql/qa/server/src/main/resources/empty-mapping.sql-spec
@@ -1,0 +1,22 @@
+selectStar
+SELECT * FROM empty_mapping;
+selectStarWithFilter
+SELECT * FROM empty_mapping WHERE 2 > 1;
+selectStarWithFilterAndLimit
+SELECT * FROM empty_mapping WHERE 1 > 2 LIMIT 10;
+
+selectCount
+SELECT COUNT(*) FROM empty_mapping;
+// awaits fix: https://github.com/elastic/elasticsearch/issues/74311
+// selectCountWithWhere
+// SELECT COUNT(*) FROM empty_mapping WHERE 1 + 1 = 3;
+
+selectConst
+SELECT 1, 2, 3 FROM empty_mapping;
+selectConstAggregation
+SELECT MAX(1), SUM(2) FROM empty_mapping;
+
+// fails in H2 with a syntax error but cannot be tested in CSV spec because datasets without columns cannot be parsed
+// awaits fix: https://github.com/elastic/elasticsearch/issues/39895 (latest H2 version can run the query)
+// subselect
+// SELECT * FROM (SELECT * FROM empty_mapping) s;

--- a/x-pack/plugin/sql/qa/server/src/main/resources/setup_empty_mapping.sql
+++ b/x-pack/plugin/sql/qa/server/src/main/resources/setup_empty_mapping.sql
@@ -1,0 +1,5 @@
+DROP TABLE IF EXISTS "empty_mapping";
+CREATE TABLE "empty_mapping" ();
+
+INSERT INTO "empty_mapping" DEFAULT VALUES;
+INSERT INTO "empty_mapping" DEFAULT VALUES;

--- a/x-pack/plugin/sql/qa/server/src/main/resources/setup_test_emp.sql
+++ b/x-pack/plugin/sql/qa/server/src/main/resources/setup_test_emp.sql
@@ -1,7 +1,7 @@
 DROP TABLE IF EXISTS "test_emp";
 CREATE TABLE "test_emp" (
                     "birth_date" TIMESTAMP WITH TIME ZONE,
-                    "emp_no" INT, 
+                    "emp_no" INT,
                     "first_name" VARCHAR(50),
                     "gender" VARCHAR(1),
                     "hire_date" TIMESTAMP WITH TIME ZONE,
@@ -11,3 +11,4 @@ CREATE TABLE "test_emp" (
                     "salary" INT
                    )
    AS SELECT birth_date, emp_no, first_name, gender, hire_date, languages, last_name, CONCAT(first_name, ' ', last_name) AS name, salary FROM CSVREAD('classpath:/employees.csv');
+

--- a/x-pack/plugin/sql/qa/server/src/main/resources/slow/frozen.csv-spec
+++ b/x-pack/plugin/sql/qa/server/src/main/resources/slow/frozen.csv-spec
@@ -7,14 +7,15 @@
 showTables
 SHOW TABLES INCLUDE FROZEN;
 
-       name        | type  |  kind   
+       name        | type  |  kind
+empty_mapping      |TABLE  |INDEX
 frozen_emp         |TABLE  |FROZEN INDEX
 logs               |TABLE  |INDEX
 logs_nanos         |TABLE  |INDEX
 test_alias         |VIEW   |ALIAS
-test_alias_emp     |VIEW   |ALIAS 
-test_emp           |TABLE  |INDEX  
-test_emp_copy      |TABLE  |INDEX  
+test_alias_emp     |VIEW   |ALIAS
+test_emp           |TABLE  |INDEX
+test_emp_copy      |TABLE  |INDEX
 ;
 
 columnFromFrozen
@@ -31,18 +32,18 @@ F
 percentileFrozen
 SELECT gender, PERCENTILE(emp_no, 92.45) p1 FROM FROZEN frozen_emp GROUP BY gender;
 
-gender:s             | p1:d     
-null                 |10018.745 
+gender:s             | p1:d
+null                 |10018.745
 F                    |10098.0085
-M                    |10091.393 
+M                    |10091.393
 ;
 
 countFromFrozen
 SELECT gender, COUNT(*) AS c FROM FROZEN frozen_emp GROUP BY gender;
 
 gender:s       | c:l
-null           |10             
-F              |33             
+null           |10
+F              |33
 M              |57
 ;
 

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/analysis/analyzer/Analyzer.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/analysis/analyzer/Analyzer.java
@@ -417,12 +417,9 @@ public class Analyzer extends RuleExecutor<LogicalPlan> {
             for (NamedExpression ne : projections) {
                 if (ne instanceof UnresolvedStar) {
                     List<NamedExpression> expanded = expandStar((UnresolvedStar) ne, output);
+
                     // the field exists, but cannot be expanded (no sub-fields)
-                    if (expanded.isEmpty()) {
-                        result.add(ne);
-                    } else {
-                        result.addAll(expanded);
-                    }
+                    result.addAll(expanded);
                 } else if (ne instanceof UnresolvedAlias) {
                     UnresolvedAlias ua = (UnresolvedAlias) ne;
                     if (ua.child() instanceof UnresolvedStar) {
@@ -442,7 +439,7 @@ public class Analyzer extends RuleExecutor<LogicalPlan> {
             // a qualifier is specified - since this is a star, it should be a CompoundDataType
             if (us.qualifier() != null) {
                 // resolve the so-called qualifier first
-                // since this is an unresolved start we don't know whether it's a path or an actual qualifier
+                // since this is an unresolved star we don't know whether it's a path or an actual qualifier
                 Attribute q = resolveAgainstList(us.qualifier(), output, true);
 
                 // the wildcard couldn't be expanded because the field doesn't exist at all
@@ -454,6 +451,10 @@ public class Analyzer extends RuleExecutor<LogicalPlan> {
                 // qualifier is unknown (e.g. unsupported type), bail out early
                 else if (q.resolved() == false) {
                     return singletonList(q);
+                }
+                // qualifier resolves to a non-struct field and cannot be expanded
+                else if (DataTypes.isPrimitive(q.dataType())) {
+                    return singletonList(us);
                 }
 
                 // now use the resolved 'qualifier' to match

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/querydsl/container/QueryContainer.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/querydsl/container/QueryContainer.java
@@ -182,7 +182,9 @@ public class QueryContainer {
      */
     public BitSet columnMask(List<Attribute> columns) {
         BitSet mask = new BitSet(fields.size());
-        aliasName(columns.get(0));
+        if (columns.size() > 0) {
+            aliasName(columns.get(0));
+        }
 
         for (Attribute column : columns) {
             Expression expression = aliases.resolve(column, column);

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/analysis/analyzer/FieldAttributeTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/analysis/analyzer/FieldAttributeTests.java
@@ -27,6 +27,7 @@ import org.elasticsearch.xpack.sql.expression.function.SqlFunctionRegistry;
 import org.elasticsearch.xpack.sql.parser.SqlParser;
 import org.elasticsearch.xpack.sql.stats.Metrics;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -299,6 +300,17 @@ public class FieldAttributeTests extends ESTestCase {
         VerificationException ex = expectThrows(VerificationException.class, () ->
             plan("SELECT LENGTH(CONCAT(missing, 'x')) + 1 AS missing FROM test WHERE missing = 0"));
         assertEquals("Found 1 problem\nline 1:22: Unknown column [missing]", ex.getMessage());
+    }
+
+    public void testExpandStarOnIndexWithoutColumns() {
+        EsIndex test = new EsIndex("test", Collections.emptyMap());
+        getIndexResult = IndexResolution.valid(test);
+        analyzer = new Analyzer(SqlTestUtils.TEST_CFG, functionRegistry, getIndexResult, verifier);
+
+        LogicalPlan plan = plan("SELECT * FROM test");
+
+        assertThat(plan, instanceOf(Project.class));
+        assertTrue(((Project) plan).projections().isEmpty());
     }
 
 }


### PR DESCRIPTION
Fixes #53001

Adds support for querying indices without columns. Previously, such queries failed.

(cherry picked from commit 6f93303c36fe8d86548f1fbacdb3a67d04f55a27)