### PR TITLE
[ML] Use configurable class labels for SA and NER results

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/results/SentimentAnalysisResults.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/results/SentimentAnalysisResults.java
@@ -20,34 +20,46 @@ public class SentimentAnalysisResults implements InferenceResults {
 
     public static final String NAME = "sentiment_analysis_result";
 
-    static final String POSITIVE_SCORE = "positive_score";
-    static final String NEGATIVE_SCORE = "negative_score";
+    private final String class1Label;
+    private final String class2Label;
+    private final double class1Score;
+    private final double class2Score;
 
-    private final double positiveScore;
-    private final double negativeScore;
-
-    public SentimentAnalysisResults(double positiveScore, double negativeScore) {
-        this.positiveScore = positiveScore;
-        this.negativeScore = negativeScore;
+    public SentimentAnalysisResults(String class1Label, double class1Score,
+                                    String class2Label, double class2Score) {
+        this.class1Label = class1Label;
+        this.class1Score = class1Score;
+        this.class2Label = class2Label;
+        this.class2Score = class2Score;
     }
 
     public SentimentAnalysisResults(StreamInput in) throws IOException {
-        positiveScore = in.readDouble();
-        negativeScore = in.readDouble();
+        class1Label = in.readString();
+        class1Score = in.readDouble();
+        class2Label = in.readString();
+        class2Score = in.readDouble();
     }
 
-    public double getPositiveScore() {
-        return positiveScore;
+    public String getClass1Label() {
+        return class1Label;
     }
 
-    public double getNegativeScore() {
-        return negativeScore;
+    public double getClass1Score() {
+        return class1Score;
+    }
+
+    public String getClass2Label() {
+        return class2Label;
+    }
+
+    public double getClass2Score() {
+        return class2Score;
     }
 
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
-        builder.field(POSITIVE_SCORE, positiveScore);
-        builder.field(NEGATIVE_SCORE, negativeScore);
+        builder.field(class1Label, class1Score);
+        builder.field(class2Label, class2Score);
         return builder;
     }
 
@@ -58,21 +70,23 @@ public class SentimentAnalysisResults implements InferenceResults {
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        out.writeDouble(positiveScore);
-        out.writeDouble(negativeScore);
+        out.writeString(class1Label);
+        out.writeDouble(class1Score);
+        out.writeString(class2Label);
+        out.writeDouble(class2Score);
     }
 
     @Override
     public Map<String, Object> asMap() {
         Map<String, Object> map = new LinkedHashMap<>();
-        map.put(POSITIVE_SCORE, positiveScore);
-        map.put(NEGATIVE_SCORE, negativeScore);
+        map.put(class1Label, class1Score);
+        map.put(class2Label, class2Score);
         return map;
     }
 
     @Override
     public Object predictedValue() {
-        return positiveScore;
+        return class1Score;
     }
 
     @Override
@@ -80,12 +94,14 @@ public class SentimentAnalysisResults implements InferenceResults {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         SentimentAnalysisResults that = (SentimentAnalysisResults) o;
-        return Double.compare(that.positiveScore, positiveScore) == 0 &&
-            Double.compare(that.negativeScore, negativeScore) == 0;
+        return Double.compare(that.class1Score, class1Score) == 0 &&
+            Double.compare(that.class2Score, class2Score) == 0 &&
+            Objects.equals(this.class1Label, that.class1Label) &&
+            Objects.equals(this.class2Label, that.class2Label);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(positiveScore, negativeScore);
+        return Objects.hash(class1Label, class1Score, class2Label, class2Score);
     }
 }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/results/SentimentAnalysisResultsTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/results/SentimentAnalysisResultsTests.java
@@ -23,16 +23,15 @@ public class SentimentAnalysisResultsTests extends AbstractWireSerializingTestCa
 
     @Override
     protected SentimentAnalysisResults createTestInstance() {
-        return new SentimentAnalysisResults(randomDouble(), randomDouble());
+        return new SentimentAnalysisResults(randomAlphaOfLength(6), randomDouble(),
+            randomAlphaOfLength(6), randomDouble());
     }
 
     public void testAsMap() {
-        SentimentAnalysisResults testInstance = createTestInstance();
+        SentimentAnalysisResults testInstance = new SentimentAnalysisResults("foo", 1.0, "bar", 0.0);
         Map<String, Object> asMap = testInstance.asMap();
         assertThat(asMap.keySet(), hasSize(2));
-        assertThat(testInstance.getPositiveScore(),
-            closeTo((Double)asMap.get(SentimentAnalysisResults.POSITIVE_SCORE), 0.0001));
-        assertThat(testInstance.getNegativeScore(),
-            closeTo((Double)asMap.get(SentimentAnalysisResults.NEGATIVE_SCORE), 0.0001));
+        assertThat(1.0, closeTo((Double)asMap.get("foo"), 0.0001));
+        assertThat(0.0, closeTo((Double)asMap.get("bar"), 0.0001));
     }
 }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/nlp/NerProcessor.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/nlp/NerProcessor.java
@@ -7,11 +7,16 @@
 
 package org.elasticsearch.xpack.ml.inference.nlp;
 
+import org.elasticsearch.common.ValidationException;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.core.Nullable;
 import org.elasticsearch.xpack.ml.inference.nlp.tokenizers.BertTokenizer;
 
 import java.io.IOException;
+import java.util.Arrays;
+import java.util.EnumSet;
+import java.util.List;
 import java.util.Locale;
 
 public class NerProcessor implements NlpTask.Processor {
@@ -57,11 +62,56 @@ public class NerProcessor implements NlpTask.Processor {
         }
     }
 
-
     private final BertRequestBuilder bertRequestBuilder;
+    private final List<String> classificationLabels;
+    private final IobTag[] iobMap;
 
-    NerProcessor(BertTokenizer tokenizer) {
+    NerProcessor(BertTokenizer tokenizer, @Nullable List<String> classificationLabels) {
         this.bertRequestBuilder = new BertRequestBuilder(tokenizer);
+        this.classificationLabels = classificationLabels;
+        validate();
+        iobMap = buildIobMap(classificationLabels);
+    }
+
+    /**
+     * Checks labels are valid entity tags and none are duplicated
+     */
+    private void validate() {
+        if (classificationLabels == null || classificationLabels.isEmpty()) {
+            return;
+        }
+
+        ValidationException ve = new ValidationException();
+        EnumSet<IobTag> tags = EnumSet.noneOf(IobTag.class);
+        for (String label : classificationLabels) {
+            try {
+                IobTag iobTag = IobTag.valueOf(label);
+                if (tags.contains(iobTag)) {
+                    ve.addValidationError("the classification label [" + label + "] is duplicated in the list " + classificationLabels);
+                }
+                tags.add(iobTag);
+            } catch (IllegalArgumentException iae) {
+                ve.addValidationError("classification label [" + label + "] is not an entity I-O-B tag.");
+            }
+        }
+
+        if (ve.validationErrors().isEmpty() == false) {
+            ve.addValidationError("Valid entity I-O-B tags are " + Arrays.toString(IobTag.values()));
+            throw ve;
+        }
+    }
+
+    static IobTag[] buildIobMap(List<String> classificationLabels) {
+        if (classificationLabels == null || classificationLabels.isEmpty()) {
+            return IobTag.values();
+        }
+
+        IobTag[] map = new IobTag[classificationLabels.size()];
+        for (int i=0; i<classificationLabels.size(); i++) {
+            map[i] = IobTag.valueOf(classificationLabels.get(i));
+        }
+
+        return map;
     }
 
     @Override
@@ -76,6 +126,6 @@ public class NerProcessor implements NlpTask.Processor {
 
     @Override
     public NlpTask.ResultProcessor getResultProcessor() {
-        return new NerResultProcessor(bertRequestBuilder.getTokenization());
+        return new NerResultProcessor(bertRequestBuilder.getTokenization(), iobMap);
     }
 }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/nlp/NerProcessor.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/nlp/NerProcessor.java
@@ -63,20 +63,18 @@ public class NerProcessor implements NlpTask.Processor {
     }
 
     private final BertRequestBuilder bertRequestBuilder;
-    private final List<String> classificationLabels;
     private final IobTag[] iobMap;
 
     NerProcessor(BertTokenizer tokenizer, @Nullable List<String> classificationLabels) {
         this.bertRequestBuilder = new BertRequestBuilder(tokenizer);
-        this.classificationLabels = classificationLabels;
-        validate();
+        validate(classificationLabels);
         iobMap = buildIobMap(classificationLabels);
     }
 
     /**
      * Checks labels are valid entity tags and none are duplicated
      */
-    private void validate() {
+    private void validate(List<String> classificationLabels) {
         if (classificationLabels == null || classificationLabels.isEmpty()) {
             return;
         }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/nlp/NerResultProcessor.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/nlp/NerResultProcessor.java
@@ -21,9 +21,11 @@ import java.util.Objects;
 class NerResultProcessor implements NlpTask.ResultProcessor {
 
     private final BertTokenizer.TokenizationResult tokenization;
+    private final NerProcessor.IobTag[] iobMap;
 
-    NerResultProcessor(BertTokenizer.TokenizationResult tokenization) {
+    NerResultProcessor(BertTokenizer.TokenizationResult tokenization, NerProcessor.IobTag[] iobMap) {
         this.tokenization = Objects.requireNonNull(tokenization);
+        this.iobMap = iobMap;
     }
 
     @Override
@@ -69,7 +71,7 @@ class NerResultProcessor implements NlpTask.ResultProcessor {
                 String endTokenWord = tokenization.getTokens().get(endTokenIndex).substring(2);
                 word.append(endTokenWord);
             }
-            double[] avgScores = Arrays.copyOf(scores[startTokenIndex], NerProcessor.IobTag.values().length);
+            double[] avgScores = Arrays.copyOf(scores[startTokenIndex], iobMap.length);
             for (int i = startTokenIndex + 1; i <= endTokenIndex; i++) {
                 for (int j = 0; j < scores[i].length; j++) {
                     avgScores[j] += scores[i][j];
@@ -83,7 +85,7 @@ class NerResultProcessor implements NlpTask.ResultProcessor {
             }
             int maxScoreIndex = NlpHelpers.argmax(avgScores);
             double score = avgScores[maxScoreIndex];
-            taggedTokens.add(new TaggedToken(word.toString(), NerProcessor.IobTag.values()[maxScoreIndex], score));
+            taggedTokens.add(new TaggedToken(word.toString(), iobMap[maxScoreIndex], score));
             startTokenIndex = endTokenIndex + 1;
         }
         return taggedTokens;

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/nlp/NlpTask.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/nlp/NlpTask.java
@@ -7,6 +7,7 @@
 
 package org.elasticsearch.xpack.ml.inference.nlp;
 
+import org.elasticsearch.common.ValidationException;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.xpack.ml.inference.deployment.PyTorchResult;
 import org.elasticsearch.xpack.core.ml.inference.results.InferenceResults;
@@ -16,20 +17,25 @@ import java.io.IOException;
 
 public class NlpTask {
 
-    private final TaskType taskType;
+    private final NlpTaskConfig config;
     private final BertTokenizer tokenizer;
 
     public static NlpTask fromConfig(NlpTaskConfig config) {
-        return new NlpTask(config.getTaskType(), config.buildTokenizer());
+        return new NlpTask(config);
     }
 
-    private NlpTask(TaskType taskType, BertTokenizer tokenizer) {
-        this.taskType = taskType;
-        this.tokenizer = tokenizer;
+    private NlpTask(NlpTaskConfig config) {
+        this.config = config;
+        this.tokenizer = config.buildTokenizer();
     }
 
-    public Processor createProcessor() throws IOException {
-        return taskType.createProcessor(tokenizer);
+    /**
+     * Create and validate the NLP Processor
+     * @return
+     * @throws ValidationException if the validation fails
+     */
+    public Processor createProcessor() throws ValidationException {
+        return config.getTaskType().createProcessor(tokenizer, config.getClassificationLabels());
     }
 
     public interface RequestBuilder {
@@ -42,7 +48,7 @@ public class NlpTask {
 
     public interface Processor {
         /**
-         * Validate the task input.
+         * Validate the task input string.
          * Throws an exception if the inputs fail validation
          *
          * @param inputs Text to validate

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/nlp/SentimentAnalysisProcessor.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/nlp/SentimentAnalysisProcessor.java
@@ -7,9 +7,11 @@
 
 package org.elasticsearch.xpack.ml.inference.nlp;
 
+import org.elasticsearch.common.ValidationException;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentFactory;
+import org.elasticsearch.core.Nullable;
 import org.elasticsearch.xpack.core.ml.inference.results.InferenceResults;
 import org.elasticsearch.xpack.core.ml.inference.results.SentimentAnalysisResults;
 import org.elasticsearch.xpack.core.ml.inference.results.WarningInferenceResults;
@@ -18,14 +20,34 @@ import org.elasticsearch.xpack.ml.inference.nlp.tokenizers.BertTokenizer;
 
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.List;
+import java.util.Locale;
 
 public class SentimentAnalysisProcessor implements NlpTask.Processor {
 
     private final BertTokenizer tokenizer;
+    private final List<String> classLabels;
 
-    SentimentAnalysisProcessor(BertTokenizer tokenizer) {
+    SentimentAnalysisProcessor(BertTokenizer tokenizer, @Nullable List<String> classLabels) {
         this.tokenizer = tokenizer;
+        if (classLabels == null || classLabels.isEmpty()) {
+            this.classLabels = List.of("negative", "positive");
+        } else {
+            this.classLabels = classLabels;
+        }
+
+        validate();
     }
+
+    private void validate() {
+        if (classLabels.size() != 2) {
+            throw new ValidationException().addValidationError(
+                String.format(Locale.ROOT, "Sentiment analysis requires exactly 2 [%s]. Invalid labels %s",
+                    NlpTaskConfig.CLASSIFICATION_LABELS, classLabels)
+            );
+        }
+    }
+
     @Override
     public void validateInputs(String inputs) {
         // nothing to validate
@@ -56,7 +78,9 @@ public class SentimentAnalysisProcessor implements NlpTask.Processor {
         }
 
         double[] normalizedScores = NlpHelpers.convertToProbabilitiesBySoftMax(pyTorchResult.getInferenceResult()[0]);
-        return new SentimentAnalysisResults(normalizedScores[1], normalizedScores[0]);
+        // the second score is usually the positive score so put that first
+        return new SentimentAnalysisResults(classLabels.get(1), normalizedScores[1],
+            classLabels.get(0), normalizedScores[0]);
     }
 
     static BytesReference jsonRequest(int[] tokens, String requestId) throws IOException {

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/nlp/SentimentAnalysisProcessor.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/nlp/SentimentAnalysisProcessor.java
@@ -79,6 +79,7 @@ public class SentimentAnalysisProcessor implements NlpTask.Processor {
 
         double[] normalizedScores = NlpHelpers.convertToProbabilitiesBySoftMax(pyTorchResult.getInferenceResult()[0]);
         // the second score is usually the positive score so put that first
+        // so it comes first in the results doc
         return new SentimentAnalysisResults(classLabels.get(1), normalizedScores[1],
             classLabels.get(0), normalizedScores[0]);
     }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/nlp/TaskType.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/nlp/TaskType.java
@@ -14,7 +14,7 @@ import java.util.Locale;
 
 public enum TaskType {
 
-    TOKEN_CLASSIFICATION { // TODO rename to NER. This is specifically a NER task
+    NER {
         public NlpTask.Processor createProcessor(BertTokenizer tokenizer) throws IOException {
             return new NerProcessor(tokenizer);
         }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/nlp/TaskType.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/nlp/TaskType.java
@@ -9,33 +9,37 @@ package org.elasticsearch.xpack.ml.inference.nlp;
 
 import org.elasticsearch.xpack.ml.inference.nlp.tokenizers.BertTokenizer;
 
-import java.io.IOException;
+import java.util.List;
 import java.util.Locale;
 
 public enum TaskType {
 
     NER {
-        public NlpTask.Processor createProcessor(BertTokenizer tokenizer) throws IOException {
-            return new NerProcessor(tokenizer);
+        @Override
+        public NlpTask.Processor createProcessor(BertTokenizer tokenizer, List<String> classificationLabels) {
+            return new NerProcessor(tokenizer, classificationLabels);
         }
     },
     SENTIMENT_ANALYSIS {
-        public NlpTask.Processor createProcessor(BertTokenizer tokenizer) throws IOException {
-            return new SentimentAnalysisProcessor(tokenizer);
+        @Override
+        public NlpTask.Processor createProcessor(BertTokenizer tokenizer, List<String> classificationLabels) {
+            return new SentimentAnalysisProcessor(tokenizer, classificationLabels);
         }
     },
     FILL_MASK {
-        public NlpTask.Processor createProcessor(BertTokenizer tokenizer) throws IOException {
+        @Override
+        public NlpTask.Processor createProcessor(BertTokenizer tokenizer, List<String> classificationLabels) {
             return new FillMaskProcessor(tokenizer);
         }
     },
     BERT_PASS_THROUGH {
-        public NlpTask.Processor createProcessor(BertTokenizer tokenizer) throws IOException {
+        @Override
+        public NlpTask.Processor createProcessor(BertTokenizer tokenizer, List<String> classificationLabels) {
             return new PassThroughProcessor(tokenizer);
         }
     };
 
-    public NlpTask.Processor createProcessor(BertTokenizer tokenizer) throws IOException {
+    public NlpTask.Processor createProcessor(BertTokenizer tokenizer, List<String> classificationLabels) {
         throw new UnsupportedOperationException("json request must be specialised for task type [" + this.name() + "]");
     }
 

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/nlp/NerProcessorTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/nlp/NerProcessorTests.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.ml.inference.nlp;
+
+import org.elasticsearch.common.ValidationException;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.ml.inference.nlp.tokenizers.BertTokenizer;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.mockito.Mockito.mock;
+
+public class NerProcessorTests extends ESTestCase {
+
+    public void testBuildIobMap_WithDefault() {
+        NerProcessor.IobTag[] map = NerProcessor.buildIobMap(randomBoolean() ? null : Collections.emptyList());
+        for (int i=0; i<map.length; i++) {
+            assertEquals(i, map[i].ordinal());
+        }
+    }
+
+    public void testBuildIobMap_Reordered() {
+        NerProcessor.IobTag[] tags = new NerProcessor.IobTag[]{
+            NerProcessor.IobTag.I_MISC,
+            NerProcessor.IobTag.O,
+            NerProcessor.IobTag.B_MISC,
+            NerProcessor.IobTag.I_PER
+        };
+
+        List<String> classLabels = Arrays.stream(tags).map(NerProcessor.IobTag::toString).collect(Collectors.toList());
+        NerProcessor.IobTag[] map = NerProcessor.buildIobMap(classLabels);
+        for (int i=0; i<map.length; i++) {
+            assertNotEquals(i, map[i].ordinal());
+        }
+        assertArrayEquals(tags, map);
+    }
+
+    public void testValidate_DuplicateLabels() {
+        NerProcessor.IobTag[] tags = new NerProcessor.IobTag[]{
+            NerProcessor.IobTag.I_MISC,
+            NerProcessor.IobTag.B_MISC,
+            NerProcessor.IobTag.B_MISC,
+            NerProcessor.IobTag.O,
+        };
+
+        List<String> classLabels = Arrays.stream(tags).map(NerProcessor.IobTag::toString).collect(Collectors.toList());
+
+        ValidationException ve = expectThrows(ValidationException.class, () -> new NerProcessor(mock(BertTokenizer.class), classLabels));
+        assertThat(ve.getMessage(),
+            containsString("the classification label [B_MISC] is duplicated in the list [I_MISC, B_MISC, B_MISC, O]"));
+    }
+
+    public void testValidate_NotAEntityLabel() {
+        List<String> classLabels = List.of("foo", NerProcessor.IobTag.B_MISC.toString());
+
+        ValidationException ve = expectThrows(ValidationException.class, () -> new NerProcessor(mock(BertTokenizer.class), classLabels));
+        assertThat(ve.getMessage(), containsString("classification label [foo] is not an entity I-O-B tag"));
+        assertThat(ve.getMessage(),
+            containsString("Valid entity I-O-B tags are [O, B_MISC, I_MISC, B_PER, I_PER, B_ORG, I_ORG, B_LOC, I_LOC]"));
+    }
+}

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/nlp/NlpTaskConfigTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/nlp/NlpTaskConfigTests.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.ml.inference.nlp;
+
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.test.AbstractXContentTestCase;
+
+import java.io.IOException;
+
+public class NlpTaskConfigTests extends AbstractXContentTestCase<NlpTaskConfig> {
+
+    private final boolean lenient = randomBoolean();
+
+    @Override
+    protected NlpTaskConfig createTestInstance() {
+        NlpTaskConfig.Builder builder = new NlpTaskConfig.Builder()
+            .setVocabulary(randomList(10, () -> randomAlphaOfLength(7)))
+            .setDoLowerCase(randomBoolean())
+            .setWithSpecialTokens(randomBoolean());
+
+        TaskType taskType = randomFrom(TaskType.values());
+        builder.setTaskType(taskType);
+        if (taskType == TaskType.SENTIMENT_ANALYSIS || taskType == TaskType.NER) {
+            if (randomBoolean()) {
+                builder.setClassificationLabels(randomList(1, 3, () -> randomAlphaOfLength(7)));
+            }
+        }
+
+        return builder.build();
+    }
+
+    @Override
+    protected NlpTaskConfig doParseInstance(XContentParser parser) throws IOException {
+        return NlpTaskConfig.fromXContent(parser, lenient);
+    }
+
+    @Override
+    protected boolean supportsUnknownFields() {
+        return lenient;
+    }
+}

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/ml/3rd_party_deployment.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/ml/3rd_party_deployment.yml
@@ -25,6 +25,6 @@
           }
 
   - do:
-      catch: /\[distilbert-finetuned-sst\] search for task config failed with error/
+      catch: /\[distilbert-finetuned-sst\] creating NLP task from configuration failed with error/
       ml.start_trained_model_deployment:
         model_id: distilbert-finetuned-sst


### PR DESCRIPTION
`classification_labels` is a new array field in the task config, it must have the same length as the number of output classes.

For example, given a sentiment analysis task the output labels can be change from the defaults ('positive', 'negative'):
```
{
  "task_type": "sentiment_analysis",
  "classification_labels": ["sad", "happy"],
  "vocab": [
 ....
}
```

And the output is 
```
POST _ml/trained_models/distilbert-finetuned-sst/deployment/_infer 
{
 "input": "I love you."
}

{
  "happy" : 0.9998486920335018,
  "sad" : 1.513079664982733E-4
}
```

The order of the labels is important, the first maps to class 1 the second class 2 etc.

For **Named Entity Recognition** tasks valid class labels are limited to the set of known entity labels `[O, B_MISC, I_MISC, B_PER, I_PER, B_ORG, I_ORG, B_LOC, I_LOC]`, the advantage here is that the order of those labels can be changed solving the problem described in #74361


The change also renames the `token_classification` task type to `ner`.

Closes #74401
Closes #74361