### PR TITLE
Fix testIsNotTierOnlyDecision

### DIFF
--- a/x-pack/plugin/autoscaling/src/test/java/org/elasticsearch/xpack/autoscaling/storage/ReactiveStorageDeciderServiceTests.java
+++ b/x-pack/plugin/autoscaling/src/test/java/org/elasticsearch/xpack/autoscaling/storage/ReactiveStorageDeciderServiceTests.java
@@ -160,7 +160,13 @@ public class ReactiveStorageDeciderServiceTests extends AutoscalingTestCase {
                     decision.add(new Decision.Single(Decision.Type.NO, DataTierAllocationDecider.NAME, "test"));
                 }
             } else {
-                decision.add(new Decision.Single(Decision.Type.NO, randomFrom(SOME_ALLOCATION_DECIDERS), "test"));
+                decision.add(
+                    new Decision.Single(
+                        Decision.Type.NO,
+                        randomValueOtherThan(SameShardAllocationDecider.NAME, () -> randomFrom(SOME_ALLOCATION_DECIDERS)),
+                        "test"
+                    )
+                );
             }
         } else if (randomBoolean()) {
             decision.add(new Decision.Single(Decision.Type.YES, FilterAllocationDecider.NAME, "test"));


### PR DESCRIPTION
The test would fail 2 percent of the time due to using the same-shard
allocation decider to make it a "not tier only decision". That decider
is however ignored here and the test has been adjusted to not use that
decider.

Related to #74086

Example build failure:
https://gradle-enterprise.elastic.co/s/tom2ijzuzimby