### PR TITLE
[7.x] [ML] Fixing list snapshot search to handle unmapped min_version field (#74445)

### DIFF
--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/persistence/JobResultsProvider.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/persistence/JobResultsProvider.java
@@ -1082,8 +1082,10 @@ public class JobResultsProvider {
                 .order(sortDescending ? SortOrder.DESC : SortOrder.ASC);
         // `min_version` might not be present in very early snapshots.
         // Consequently, we should treat it as being at least from 6.3.0 or before
+        // Also, if no jobs have been opened since the previous versions, the .ml-anomalies-* index may not have
+        // the `min_version`.
         if (sortField.equals(ModelSnapshot.MIN_VERSION.getPreferredName())) {
-            sb.missing(Version.fromString("6.3.0"));
+            sb.missing(Version.fromString("6.3.0")).unmappedType("keyword");
         }
 
         String indexName = AnomalyDetectorsIndex.jobResultsAliasedName(jobId);


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [ML] Fixing list snapshot search to handle unmapped min_version field (#74445)