### PR TITLE
Fix testPersistentCacheCleanUpAfterRelocation

### DIFF
--- a/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/cache/full/SearchableSnapshotsPersistentCacheIntegTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/cache/full/SearchableSnapshotsPersistentCacheIntegTests.java
@@ -23,6 +23,7 @@ import org.elasticsearch.indices.IndicesService;
 import org.elasticsearch.indices.recovery.RecoveryState;
 import org.elasticsearch.repositories.fs.FsRepository;
 import org.elasticsearch.snapshots.SnapshotInfo;
+import org.elasticsearch.test.BackgroundIndexer;
 import org.elasticsearch.test.InternalTestCluster;
 import org.elasticsearch.xpack.core.searchablesnapshots.SearchableSnapshotsConstants;
 import org.elasticsearch.xpack.searchablesnapshots.BaseSearchableSnapshotsIntegTestCase;
@@ -173,12 +174,20 @@ public class SearchableSnapshotsPersistentCacheIntegTests extends BaseSearchable
         createRepository(fsRepoName, FsRepository.TYPE);
 
         final String indexName = prefix + "index";
-        createAndPopulateIndex(
+        createIndex(
             indexName,
             Settings.builder()
                 .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 3)
                 .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, randomIntBetween(0, 1))
+                .build()
         );
+        ensureGreen(indexName);
+
+        final int numDocs = scaledRandomIntBetween(1_000, 5_000);
+        try (BackgroundIndexer indexer = new BackgroundIndexer(indexName, "_doc", client(), numDocs)) {
+            waitForDocs(numDocs, indexer);
+        }
+        refresh(indexName);
 
         final String snapshotName = prefix + "snapshot";
         createFullSnapshot(fsRepoName, snapshotName);


### PR DESCRIPTION
The test SearchableSnapshotsPersistentCacheIntegTests.testPersistentCacheCleanUpAfterRelocation rarely fails after the snapshot is mounted for the first time and the test waits for the persistent cache to have at least 1 doc:

```
               if (indicesService.hasIndex(mountedIndex)) {
                    assertBusy(() -> {
                        CacheService cacheService = internalCluster().getInstance(CacheService.class, node.getName());
                        cacheService.synchronizeCache();

Here >>>>               assertThat(cacheService.getPersistentCache().getNumDocs(), greaterThan(0L));
                        dataNodes.add(node);
                    });
                }
```

This situation happens when a low number of docs are indexed and one (or more) of the 3 shards receive no documents.

This pull request changes the test to index more documents (1K+) so that all shards have documents, and thus cache files to synchronize and to make persistent in the persistent cache.

I chose the easy way here, we could also index docs and check shard stats until every shards have at least 1 doc.

Closes #74360