### PR TITLE
[Testing] Refactor RestActionTests to cover all rest methods

### DIFF
--- a/server/src/test/java/org/elasticsearch/rest/action/document/RestGetActionTests.java
+++ b/server/src/test/java/org/elasticsearch/rest/action/document/RestGetActionTests.java
@@ -35,19 +35,16 @@ public class RestGetActionTests extends RestActionTestCase {
         });
     }
 
-    public void testTypeInPathWithGet() {
-        FakeRestRequest.Builder deprecatedRequest = new FakeRestRequest.Builder(xContentRegistry()).withHeaders(
-            Map.of("Content-Type", contentTypeHeader, "Accept", contentTypeHeader)
-        ).withPath("/some_index/some_type/some_id");
-        dispatchRequest(deprecatedRequest.withMethod(RestRequest.Method.GET).build());
-        assertWarnings(RestGetAction.TYPES_DEPRECATION_MESSAGE);
+    public void testTypeInPath() {
+        testTypeInPath(RestRequest.Method.GET);
+        testTypeInPath(RestRequest.Method.HEAD);
     }
 
-    public void testTypeInPathWithHead() {
+    private void testTypeInPath(RestRequest.Method head) {
         FakeRestRequest.Builder deprecatedRequest = new FakeRestRequest.Builder(xContentRegistry()).withHeaders(
             Map.of("Content-Type", contentTypeHeader, "Accept", contentTypeHeader)
         ).withPath("/some_index/some_type/some_id");
-        dispatchRequest(deprecatedRequest.withMethod(RestRequest.Method.HEAD).build());
+        dispatchRequest(deprecatedRequest.withMethod(head).build());
         assertWarnings(RestGetAction.TYPES_DEPRECATION_MESSAGE);
     }
 }

--- a/server/src/test/java/org/elasticsearch/rest/action/document/RestGetActionTests.java
+++ b/server/src/test/java/org/elasticsearch/rest/action/document/RestGetActionTests.java
@@ -40,7 +40,7 @@ public class RestGetActionTests extends RestActionTestCase {
         testTypeInPath(RestRequest.Method.HEAD);
     }
 
-    private void testTypeInPath(RestRequest.Method head) {
+    private void testTypeInPath(RestRequest.Method method) {
         FakeRestRequest.Builder deprecatedRequest = new FakeRestRequest.Builder(xContentRegistry()).withHeaders(
             Map.of("Content-Type", contentTypeHeader, "Accept", contentTypeHeader)
         ).withPath("/some_index/some_type/some_id");

--- a/server/src/test/java/org/elasticsearch/rest/action/document/RestGetActionTests.java
+++ b/server/src/test/java/org/elasticsearch/rest/action/document/RestGetActionTests.java
@@ -44,7 +44,7 @@ public class RestGetActionTests extends RestActionTestCase {
         FakeRestRequest.Builder deprecatedRequest = new FakeRestRequest.Builder(xContentRegistry()).withHeaders(
             Map.of("Content-Type", contentTypeHeader, "Accept", contentTypeHeader)
         ).withPath("/some_index/some_type/some_id");
-        dispatchRequest(deprecatedRequest.withMethod(head).build());
+        dispatchRequest(deprecatedRequest.withMethod(method).build());
         assertWarnings(RestGetAction.TYPES_DEPRECATION_MESSAGE);
     }
 }

--- a/server/src/test/java/org/elasticsearch/rest/action/document/RestGetSourceActionTests.java
+++ b/server/src/test/java/org/elasticsearch/rest/action/document/RestGetSourceActionTests.java
@@ -25,6 +25,7 @@ import org.junit.AfterClass;
 import org.junit.Before;
 import org.mockito.Mockito;
 
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -92,53 +93,34 @@ public class RestGetSourceActionTests extends RestActionTestCase {
     /**
      * test deprecation is logged if type is used in path
      */
-    public void testTypeInGetPath() {
-        RestRequest request = new FakeRestRequest.Builder(xContentRegistry())
-            .withHeaders(Map.of("Accept", compatibleMediaType))
-            .withMethod(RestRequest.Method.HEAD)
-            .withPath("/some_index/some_type/id/_source")
-            .build();
-        dispatchRequest(request);
-        assertWarnings(RestGetSourceAction.TYPES_DEPRECATION_MESSAGE);
-    }
-
-    public void testTypeInHeadPath() {
-        RestRequest request = new FakeRestRequest.Builder(xContentRegistry())
-            .withHeaders(Map.of("Accept", compatibleMediaType))
-            .withMethod(RestRequest.Method.GET)
-            .withPath("/some_index/some_type/id/_source")
-            .build();
-        dispatchRequest(request);
-        assertWarnings(RestGetSourceAction.TYPES_DEPRECATION_MESSAGE);
+    public void testTypeInPath() {
+        for (RestRequest.Method method : Arrays.asList(RestRequest.Method.GET, RestRequest.Method.HEAD)) {
+            RestRequest request = new FakeRestRequest.Builder(xContentRegistry())
+                .withHeaders(Map.of("Accept", compatibleMediaType))
+                .withMethod(method)
+                .withPath("/some_index/some_type/id/_source")
+                .build();
+            dispatchRequest(request);
+            assertWarnings(RestGetSourceAction.TYPES_DEPRECATION_MESSAGE);
+        }
     }
 
     /**
      * test deprecation is logged if type is used as parameter
      */
-    public void testTypeParameterAndGet() {
+    public void testTypeParameter() {
         Map<String, String> params = new HashMap<>();
         params.put("type", "some_type");
-        RestRequest request = new FakeRestRequest.Builder(xContentRegistry())
-            .withHeaders(Map.of("Accept", compatibleMediaType))
-            .withMethod(RestRequest.Method.GET)
-            .withPath("/some_index/_source/id")
-            .withParams(params)
-            .build();
-        dispatchRequest(request);
-        assertWarnings(RestGetSourceAction.TYPES_DEPRECATION_MESSAGE);
-    }
-
-    public void testTypeParameterAndHead() {
-        Map<String, String> params = new HashMap<>();
-        params.put("type", "some_type");
-        RestRequest request = new FakeRestRequest.Builder(xContentRegistry())
-            .withHeaders(Map.of("Accept", compatibleMediaType))
-            .withMethod(RestRequest.Method.HEAD)
-            .withPath("/some_index/_source/id")
-            .withParams(params)
-            .build();
-        dispatchRequest(request);
-        assertWarnings(RestGetSourceAction.TYPES_DEPRECATION_MESSAGE);
+        for (RestRequest.Method method : Arrays.asList(RestRequest.Method.GET, RestRequest.Method.HEAD)) {
+            RestRequest request = new FakeRestRequest.Builder(xContentRegistry())
+                .withHeaders(Map.of("Accept", compatibleMediaType))
+                .withMethod(method)
+                .withPath("/some_index/_source/id")
+                .withParams(params)
+                .build();
+            dispatchRequest(request);
+            assertWarnings(RestGetSourceAction.TYPES_DEPRECATION_MESSAGE);
+        }
     }
 
 }


### PR DESCRIPTION
Refactoring RestGetActionTests and RestGestSourceActionTests to remove
duplicated code. Previously the tests would fail if rest request was
sent twice to RestController. This was fixed in #74293 and the
refactoring is possible now

<!--
Thank you for your interest in and contributing to Elasticsearch! There
are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.
-->

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/elasticsearch/blob/master/CONTRIBUTING.md)?
- If submitting code, have you built your formula locally prior to submission with `gradle check`?
- If submitting code, is your pull request against master? Unless there is a good reason otherwise, we prefer pull requests against master and will backport as needed.
- If submitting code, have you checked that your submission is for an [OS and architecture that we support](https://www.elastic.co/support/matrix#show_os)?
- If you are submitting this code for a class then read our [policy](https://github.com/elastic/elasticsearch/blob/master/CONTRIBUTING.md#contributing-as-part-of-a-class) for that.
