### PR TITLE
[7.x] Fix testPersistentCacheCleanUpAfterRelocation

### DIFF
--- a/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/cache/full/SearchableSnapshotsPersistentCacheIntegTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/cache/full/SearchableSnapshotsPersistentCacheIntegTests.java
@@ -23,6 +23,7 @@ import org.elasticsearch.indices.IndicesService;
 import org.elasticsearch.indices.recovery.RecoveryState;
 import org.elasticsearch.repositories.fs.FsRepository;
 import org.elasticsearch.snapshots.SnapshotInfo;
+import org.elasticsearch.test.BackgroundIndexer;
 import org.elasticsearch.test.InternalTestCluster;
 import org.elasticsearch.xpack.core.searchablesnapshots.SearchableSnapshotsConstants;
 import org.elasticsearch.xpack.searchablesnapshots.BaseSearchableSnapshotsIntegTestCase;


### PR DESCRIPTION
The test SearchableSnapshotsPersistentCacheIntegTests
testPersistentCacheCleanUpAfterRelocation rarely fails
after the snapshot is mounted for the first time and the
test waits for the persistent cache to have at least 1 doc:

```
if (indicesService.hasIndex(mountedIndex)) {
     assertBusy(() -> {
     CacheService cacheService = internalCluster().getInstance(...);
     cacheService.synchronizeCache();

>>>     assertThat(cacheService.getPersistentCache().getNumDocs(), greaterThan(0L));
     dataNodes.add(node);
      });
}
```

This situation happens when a low number of docs are
ndexed and one (or more) of the 3 shards receive no
documents.

This commit changes the test to index more documents
(1K+) so that all shards have documents, and thus
cache files to synchronize and to make persistent in
the persistent cache.

Backport of #74481
Closes #74360