### PR TITLE
Avoid unused sourcesets and tasks in javaRestTest plugin

### DIFF
--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/test/rest/JavaRestTestPlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/test/rest/JavaRestTestPlugin.java
@@ -8,7 +8,7 @@
 
 package org.elasticsearch.gradle.internal.test.rest;
 
-import org.elasticsearch.gradle.internal.ElasticsearchJavaPlugin;
+import org.elasticsearch.gradle.internal.ElasticsearchJavaBasePlugin;
 import org.elasticsearch.gradle.internal.InternalTestClustersPlugin;
 import org.elasticsearch.gradle.internal.test.RestIntegTestTask;
 import org.elasticsearch.gradle.internal.test.RestTestBasePlugin;
@@ -33,7 +33,7 @@ public class JavaRestTestPlugin implements Plugin<Project> {
 
     @Override
     public void apply(Project project) {
-        project.getPluginManager().apply(ElasticsearchJavaPlugin.class);
+        project.getPluginManager().apply(ElasticsearchJavaBasePlugin.class);
         project.getPluginManager().apply(RestTestBasePlugin.class);
         project.getPluginManager().apply(InternalTestClustersPlugin.class);
 

--- a/x-pack/plugin/ilm/qa/multi-node/build.gradle
+++ b/x-pack/plugin/ilm/qa/multi-node/build.gradle
@@ -7,10 +7,6 @@ dependencies {
   javaRestTestImplementation(testArtifact(project(xpackModule('core'))))
 }
 
-// let the javaRestTest see the classpath of main
-GradleUtils.extendSourceSet(project, "main", "javaRestTest", tasks.named("javaRestTest"))
-
-
 File repoDir = file("$buildDir/testclusters/repo")
 
 tasks.named("javaRestTest").configure {

--- a/x-pack/plugin/security/qa/service-account/build.gradle
+++ b/x-pack/plugin/security/qa/service-account/build.gradle
@@ -4,8 +4,6 @@ dependencies {
   javaRestTestImplementation project(':x-pack:plugin:core')
   javaRestTestImplementation project(':client:rest-high-level')
   javaRestTestImplementation project(':x-pack:plugin:security')
-  // let the javaRestTest see the classpath of main
-  javaRestTestImplementation project.sourceSets.main.runtimeClasspath
 }
 
 testClusters.javaRestTest {

--- a/x-pack/plugin/security/qa/tls-basic/build.gradle
+++ b/x-pack/plugin/security/qa/tls-basic/build.gradle
@@ -3,8 +3,8 @@ apply plugin: 'elasticsearch.java-rest-test'
 import org.elasticsearch.gradle.internal.info.BuildParams
 
 dependencies {
-  testImplementation(testArtifact(project(xpackModule('security'))))
-  testImplementation(testArtifact(project(xpackModule('core'))))
+  javaRestTestImplementation(testArtifact(project(xpackModule('security'))))
+  javaRestTestImplementation(testArtifact(project(xpackModule('core'))))
 }
 
 if (BuildParams.inFipsJvm){

--- a/x-pack/plugin/transform/qa/multi-node-tests/build.gradle
+++ b/x-pack/plugin/transform/qa/multi-node-tests/build.gradle
@@ -16,11 +16,10 @@ tasks.register("copyKeyCerts", Copy) {
   }
   into keystoreDir
 }
-// Add keys and cets to test classpath: it expects it there
-sourceSets.test.resources.srcDir(keystoreDir)
-tasks.named("processTestResources").configure { dependsOn("copyKeyCerts") }
-tasks.named("processJavaRestTestResources").configure { dependsOn("copyKeyCerts") }
+// Add keys and cets to javaRestTest classpath: it expects it there
+sourceSets.javaRestTest.resources.srcDir(keystoreDir)
 
+tasks.named("processJavaRestTestResources").configure { dependsOn("copyKeyCerts") }
 tasks.named("javaRestTest").configure { dependsOn "copyKeyCerts" }
 
 testClusters.javaRestTest {


### PR DESCRIPTION
We only need the javaRestTest sourceSet and can avoid main and test sourceSet by
just using the new introduced ElasticsearchJavaBase instead of ElasticsearchJava plugin.
This reduces overall configuration again by avoiding creating unrequited sourceSets and 
registering according tasks.