### PR TITLE
Fix error in FieldCapabilitiesResponse serialization

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -170,9 +170,9 @@ tasks.register("verifyVersions") {
  * after the backport of the backcompat code is complete.
  */
 
-boolean bwc_tests_enabled = true
+boolean bwc_tests_enabled = false
 // place a PR link here when committing bwc changes:
-String bwc_tests_disabled_issue = ""
+String bwc_tests_disabled_issue = "https://github.com/elastic/elasticsearch/pull/74504"
 /*
  * FIPS 140-2 behavior was fixed in 7.11.0. Before that there is no way to run elasticsearch in a
  * JVM that is properly configured to be in fips mode with BCFIPS. For now we need to disable

--- a/server/src/main/java/org/elasticsearch/action/fieldcaps/FieldCapabilitiesResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/fieldcaps/FieldCapabilitiesResponse.java
@@ -10,16 +10,16 @@ package org.elasticsearch.action.fieldcaps;
 
 import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionResponse;
-import org.elasticsearch.common.xcontent.ParseField;
 import org.elasticsearch.common.Strings;
-import org.elasticsearch.core.Tuple;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.xcontent.ConstructingObjectParser;
+import org.elasticsearch.common.xcontent.ParseField;
 import org.elasticsearch.common.xcontent.ToXContentObject;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.XContentParserUtils;
+import org.elasticsearch.core.Tuple;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -77,7 +77,7 @@ public class FieldCapabilitiesResponse extends ActionResponse implements ToXCont
         }
         this.responseMap = in.readMap(StreamInput::readString, FieldCapabilitiesResponse::readField);
         indexResponses = in.readList(FieldCapabilitiesIndexResponse::new);
-        if (in.getVersion().onOrAfter(Version.CURRENT)) {
+        if (in.getVersion().onOrAfter(Version.V_7_13_0)) {
             this.failures = in.readList(FieldCapabilitiesFailure::new);
         } else {
             this.failures = Collections.emptyList();
@@ -149,7 +149,7 @@ public class FieldCapabilitiesResponse extends ActionResponse implements ToXCont
         }
         out.writeMap(responseMap, StreamOutput::writeString, FieldCapabilitiesResponse::writeField);
         out.writeList(indexResponses);
-        if (out.getVersion().onOrAfter(Version.CURRENT)) {
+        if (out.getVersion().onOrAfter(Version.V_7_13_0)) {
             out.writeList(failures);
         }
     }

--- a/server/src/test/java/org/elasticsearch/action/fieldcaps/FieldCapabilitiesResponseTests.java
+++ b/server/src/test/java/org/elasticsearch/action/fieldcaps/FieldCapabilitiesResponseTests.java
@@ -126,21 +126,23 @@ public class FieldCapabilitiesResponseTests extends AbstractWireSerializingTestC
     /**
      * check that failure serialization between different minor versions after 7.13 works
      */
-    public void testMixedVersionFailureSerialization() throws IOException {
+    public void testMixedVersionFailureSerialization_post_7_13() throws IOException {
         FieldCapabilitiesResponse original = createResponseWithFailures();
         FieldCapabilitiesResponse deserialized;
+        Version outVersion = VersionUtils.randomVersionBetween(random(), Version.V_7_13_0, Version.CURRENT);
+        Version inVersion = VersionUtils.randomVersionBetween(random(), Version.V_7_13_0, Version.CURRENT);
         try (BytesStreamOutput output = new BytesStreamOutput()) {
-            Version outVersion = VersionUtils.randomVersionBetween(random(), Version.V_7_13_0, Version.CURRENT);
             output.setVersion(outVersion);
             original.writeTo(output);
             try (StreamInput in = new NamedWriteableAwareStreamInput(output.bytes().streamInput(), getNamedWriteableRegistry())) {
-                Version inVersion = VersionUtils.randomVersionBetween(random(), Version.V_7_13_0, Version.CURRENT);
+
                 in.setVersion(inVersion);
                 deserialized = new FieldCapabilitiesResponse(in);
                 assertEquals(-1, in.read());
             }
         }
         assertThat(deserialized.getIndices(), Matchers.equalTo(original.getIndices()));
+
         // only match size of failure list and indices, most exceptions don't support 'equals'
         List<FieldCapabilitiesFailure> deserializedFailures = deserialized.getFailures();
         assertEquals(deserializedFailures.size(), original.getFailures().size());
@@ -149,6 +151,44 @@ public class FieldCapabilitiesResponseTests extends AbstractWireSerializingTestC
             FieldCapabilitiesFailure deserializedFaliure = deserializedFailures.get(i);
             assertThat(deserializedFaliure.getIndices(), Matchers.equalTo(originalFailure.getIndices()));
             i++;
+        }
+    }
+
+    /**
+     * check that failure serialization to minor versions before 7.13 works without serializing the failures part
+     */
+    public void testSerialization_pre_7_13() throws IOException {
+        FieldCapabilitiesResponse original = createResponseWithFailures();
+        FieldCapabilitiesResponse deserialized;
+        Version version = VersionUtils.randomVersionBetween(random(), Version.V_7_6_0, Version.V_7_12_1);
+        try (BytesStreamOutput output = new BytesStreamOutput()) {
+            output.setVersion(version);
+            original.writeTo(output);
+            try (StreamInput in = new NamedWriteableAwareStreamInput(output.bytes().streamInput(), getNamedWriteableRegistry())) {
+                in.setVersion(version);
+                deserialized = new FieldCapabilitiesResponse(in);
+                assertEquals(-1, in.read());
+            }
+        }
+        assertThat(deserialized.getIndices(), Matchers.equalTo(original.getIndices()));
+
+        // only match size of failure list and indices, most exceptions don't support 'equals'
+        assertEquals(0, deserialized.getFailures().size());
+    }
+
+    public void testReadFromPre7_13() throws IOException {
+        String msg = "AQpzb21lLWluZGV4AgdmaWVsZC0xAQdrZXl3b3JkB2ZpZWxkLTEHa2V5d29yZAEBAQABAAEAAAdmaWVsZC0y"
+            + "AgdrZXl3b3JkB2ZpZWxkLTIHa2V5d29yZAEBAQABAAEAAARsb25nB2ZpZWxkLTIEbG9uZwEBAQABAAEAAAAAAAA=";
+        try (StreamInput in = StreamInput.wrap(java.util.Base64.getDecoder().decode(msg))) {
+            // minimum version set to 7.6 because the nested FieldCapabilities had another serialization change there
+            in.setVersion(VersionUtils.randomVersionBetween(random(), Version.V_7_6_0, Version.V_7_12_0));
+            FieldCapabilitiesResponse deserialized = new FieldCapabilitiesResponse(in);
+            assertArrayEquals(new String[]{"some-index"}, deserialized.getIndices());
+            assertEquals(2, deserialized.get().size());
+            assertNotNull(deserialized.get().get("field-1").get("keyword"));
+            assertNotNull(deserialized.get().get("field-2").get("keyword"));
+            assertEquals(0, deserialized.getIndexResponses().size());
+            assertEquals(0, deserialized.getFailures().size());
         }
     }
 

--- a/server/src/test/java/org/elasticsearch/action/fieldcaps/FieldCapabilitiesResponseTests.java
+++ b/server/src/test/java/org/elasticsearch/action/fieldcaps/FieldCapabilitiesResponseTests.java
@@ -160,7 +160,7 @@ public class FieldCapabilitiesResponseTests extends AbstractWireSerializingTestC
     public void testSerialization_pre_7_13() throws IOException {
         FieldCapabilitiesResponse original = createResponseWithFailures();
         FieldCapabilitiesResponse deserialized;
-        Version version = VersionUtils.randomVersionBetween(random(), Version.V_7_6_0, Version.V_7_12_1);
+        Version version = VersionUtils.randomVersionBetween(random(), Version.V_7_6_0, VersionUtils.getPreviousVersion(Version.V_7_13_0));
         try (BytesStreamOutput output = new BytesStreamOutput()) {
             output.setVersion(version);
             original.writeTo(output);
@@ -181,7 +181,7 @@ public class FieldCapabilitiesResponseTests extends AbstractWireSerializingTestC
             + "AgdrZXl3b3JkB2ZpZWxkLTIHa2V5d29yZAEBAQABAAEAAARsb25nB2ZpZWxkLTIEbG9uZwEBAQABAAEAAAAAAAA=";
         try (StreamInput in = StreamInput.wrap(java.util.Base64.getDecoder().decode(msg))) {
             // minimum version set to 7.6 because the nested FieldCapabilities had another serialization change there
-            in.setVersion(VersionUtils.randomVersionBetween(random(), Version.V_7_6_0, Version.V_7_12_0));
+            in.setVersion(VersionUtils.randomVersionBetween(random(), Version.V_7_6_0, VersionUtils.getPreviousVersion(Version.V_7_13_0)));
             FieldCapabilitiesResponse deserialized = new FieldCapabilitiesResponse(in);
             assertArrayEquals(new String[]{"some-index"}, deserialized.getIndices());
             assertEquals(2, deserialized.get().size());

--- a/server/src/test/java/org/elasticsearch/action/fieldcaps/FieldCapabilitiesResponseTests.java
+++ b/server/src/test/java/org/elasticsearch/action/fieldcaps/FieldCapabilitiesResponseTests.java
@@ -9,12 +9,17 @@
 package org.elasticsearch.action.fieldcaps;
 
 import org.elasticsearch.ElasticsearchExceptionTests;
+import org.elasticsearch.Version;
 import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.io.stream.BytesStreamOutput;
+import org.elasticsearch.common.io.stream.NamedWriteableAwareStreamInput;
+import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.test.AbstractWireSerializingTestCase;
+import org.elasticsearch.test.VersionUtils;
 import org.hamcrest.Matchers;
 
 import java.io.IOException;
@@ -112,6 +117,35 @@ public class FieldCapabilitiesResponseTests extends AbstractWireSerializingTestC
         assertEquals(deserializedFailures.size(), randomResponse.getFailures().size());
         int i = 0;
         for (FieldCapabilitiesFailure originalFailure : randomResponse.getFailures()) {
+            FieldCapabilitiesFailure deserializedFaliure = deserializedFailures.get(i);
+            assertThat(deserializedFaliure.getIndices(), Matchers.equalTo(originalFailure.getIndices()));
+            i++;
+        }
+    }
+
+    /**
+     * check that failure serialization between different minor versions after 7.13 works
+     */
+    public void testMixedVersionFailureSerialization() throws IOException {
+        FieldCapabilitiesResponse original = createResponseWithFailures();
+        FieldCapabilitiesResponse deserialized;
+        try (BytesStreamOutput output = new BytesStreamOutput()) {
+            Version outVersion = VersionUtils.randomVersionBetween(random(), Version.V_7_13_0, Version.CURRENT);
+            output.setVersion(outVersion);
+            original.writeTo(output);
+            try (StreamInput in = new NamedWriteableAwareStreamInput(output.bytes().streamInput(), getNamedWriteableRegistry())) {
+                Version inVersion = VersionUtils.randomVersionBetween(random(), Version.V_7_13_0, Version.CURRENT);
+                in.setVersion(inVersion);
+                deserialized = new FieldCapabilitiesResponse(in);
+                assertEquals(-1, in.read());
+            }
+        }
+        assertThat(deserialized.getIndices(), Matchers.equalTo(original.getIndices()));
+        // only match size of failure list and indices, most exceptions don't support 'equals'
+        List<FieldCapabilitiesFailure> deserializedFailures = deserialized.getFailures();
+        assertEquals(deserializedFailures.size(), original.getFailures().size());
+        int i = 0;
+        for (FieldCapabilitiesFailure originalFailure : original.getFailures()) {
             FieldCapabilitiesFailure deserializedFaliure = deserializedFailures.get(i);
             assertThat(deserializedFaliure.getIndices(), Matchers.equalTo(originalFailure.getIndices()));
             i++;


### PR DESCRIPTION
In version 7.13.0 we added failure serialization to the `_field_caps` API.
FieldCapabilitiesResponse currently has a bug here where the failures list is
serialized based on Version.CURRENT, which is different on different releases,
but instead it should be serialized/deserialized for all nodes where the version
is on or above 7.13.0.
