### PR TITLE
Not encoding the Api Key in Enrollment token

### DIFF
--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/enrollment/CreateEnrollmentToken.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/enrollment/CreateEnrollmentToken.java
@@ -169,7 +169,7 @@ public class CreateEnrollmentToken {
         if (Strings.isNullOrEmpty(apiKey) || Strings.isNullOrEmpty(apiId)) {
             throw new IllegalStateException("Could not create an api key.");
         }
-        return Base64.getEncoder().encodeToString((apiId + ":" + apiKey).getBytes(StandardCharsets.UTF_8));
+        return apiId + ":" + apiKey;
     }
 
     protected Tuple<List<String>, String> getNodeInfo(String user, SecureString password) throws Exception {

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/enrollment/CreateEnrollmentTokenTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/enrollment/CreateEnrollmentTokenTests.java
@@ -129,7 +129,7 @@ public class CreateEnrollmentTokenTests extends ESTestCase {
         assertEquals("8.0.0", infoNode.get("ver"));
         assertEquals("[192.168.0.1:9201, 172.16.254.1:9202, [2001:db8:0:1234:0:567:8:1]:9203]", infoNode.get("adr"));
         assertEquals("598a35cd831ee6bb90e79aa80d6b073cda88b41d", infoNode.get("fgr"));
-        assertEquals("RFI2Q3pYa0JEZjhhbVZfNDh5WVg6eDNZcVVfcnFRd20tRVNya0V4Y25PZw==", infoNode.get("key"));
+        assertEquals("DR6CzXkBDf8amV_48yYX:x3YqU_rqQwm-ESrkExcnOg", infoNode.get("key"));
 
         final String tokenKibana = createEnrollmentToken.createNodeEnrollmentToken("elastic", new SecureString("elastic"));
 
@@ -137,7 +137,7 @@ public class CreateEnrollmentTokenTests extends ESTestCase {
         assertEquals("8.0.0", infoKibana.get("ver"));
         assertEquals("[192.168.0.1:9201, 172.16.254.1:9202, [2001:db8:0:1234:0:567:8:1]:9203]", infoKibana.get("adr"));
         assertEquals("598a35cd831ee6bb90e79aa80d6b073cda88b41d", infoKibana.get("fgr"));
-        assertEquals("RFI2Q3pYa0JEZjhhbVZfNDh5WVg6eDNZcVVfcnFRd20tRVNya0V4Y25PZw==", infoKibana.get("key"));
+        assertEquals("DR6CzXkBDf8amV_48yYX:x3YqU_rqQwm-ESrkExcnOg", infoKibana.get("key"));
     }
 
     public void testFailedCreateApiKey() throws Exception {


### PR DESCRIPTION
No need for base64 encode the API key before we put it as a value in the
 token, as the token itself will be Base64 encoded

A follow up PR for:
#73573