### PR TITLE
Improve error message when minimum compiler version is not met

### DIFF
--- a/build-tools-internal/build.gradle
+++ b/build-tools-internal/build.gradle
@@ -165,13 +165,13 @@ gradlePlugin {
  *         Java version                                                      *
  *****************************************************************************/
 
-if (JavaVersion.current() < JavaVersion.VERSION_11) {
-  throw new GradleException('At least Java 11 is required to build elasticsearch gradle tools')
-}
-
 def minCompilerJava = JavaVersion.toVersion(file('src/main/resources/minimumCompilerVersion').text)
 targetCompatibility = minCompilerJava
 sourceCompatibility = minCompilerJava
+
+if (JavaVersion.current() < JavaVersion.toVersion(minCompilerJava)) {
+  throw new GradleException("Java ${minCompilerJava} is required to build Elasticsearch but current Java is version ${JavaVersion.current()}.")
+}
 
 sourceSets {
   integTest {


### PR DESCRIPTION
When we refactored `buildSrc` into a composite build it had the odd side-effect of returning a very strange message if you weren't using the required JAVA_HOME.

```
A problem occurred configuring root project 'elasticsearch'.
> Could not resolve all artifacts for configuration ':classpath'.
   > Could not resolve project :build-tools-internal.
     Required by:
         project :
      > No matching variant of project :build-tools-internal was found. The consumer was configured to find a runtime of a library compatible with Java 15, packaged as a jar, and its dependencies declared externally, as well as attribute 'org.gradle.plugin.api-version' with value '7.1' but:
          - Variant 'apiElements' capability org.elasticsearch.gradle:build-tools-internal:8.0.0-SNAPSHOT declares a library, packaged as a jar, and its dependencies declared externally:
              - Incompatible because this component declares an API of a component compatible with Java 16 and the consumer needed a runtime of a component compatible with Java 15
              - Other compatible attribute:
                  - Doesn't say anything about org.gradle.plugin.api-version (required '7.1')
          - Variant 'runtimeElements' capability org.elasticsearch.gradle:build-tools-internal:8.0.0-SNAPSHOT declares a runtime of a library, packaged as a jar, and its dependencies declared externally:
              - Incompatible because this component declares a component compatible with Java 16 and the consumer needed a component compatible with Java 15
              - Other compatible attribute:
                  - Doesn't say anything about org.gradle.plugin.api-version (required '7.1')
```

Instead of this confusing mess about dependency constraints, this PR fixes the original message so that we blow up early with a message like this:

```
* What went wrong:
A problem occurred evaluating project ':build-tools-internal'.
> Java 16 is required to build Elasticsearch but current Java is version 15.
```