### PR TITLE
Persistent banner to ./bin/elasticsearch on the terminal 

### DIFF
--- a/distribution/src/bin/elasticsearch
+++ b/distribution/src/bin/elasticsearch
@@ -17,6 +17,7 @@ source "`dirname "$0"`"/elasticsearch-env
 
 CHECK_KEYSTORE=true
 DAEMONIZE=false
+QUIET=false
 for option in "$@"; do
   case "$option" in
     -h|--help|-V|--version)
@@ -24,6 +25,9 @@ for option in "$@"; do
       ;;
     -d|--daemonize)
       DAEMONIZE=true
+      ;;
+    -q|--quiet)
+      QUIET=true
       ;;
   esac
 done
@@ -56,6 +60,12 @@ ES_JAVA_OPTS=`export ES_TMPDIR; "$JAVA" "$XSHARE" -cp "$ES_CLASSPATH" org.elasti
 
 # manual parsing to find out, if process should be detached
 if [[ $DAEMONIZE = false ]]; then
+  if [[ "$QUIET" = false ]]; then
+    exec > >("$JAVA" "$XSHARE" -cp "$ES_CLASSPATH" org.elasticsearch.tools.launchers.OutputBottomBanner <(echo -ne "TEST BANNER\nTEST BANNER2"))
+    #exec > >(while read line; do
+    #  printf "%s\nTEST BOTTOM BANNER\r" "$line"
+    #  done)
+  fi
   exec \
     "$JAVA" \
     "$XSHARE" \

--- a/distribution/src/bin/elasticsearch
+++ b/distribution/src/bin/elasticsearch
@@ -61,6 +61,8 @@ ES_JAVA_OPTS=`export ES_TMPDIR; "$JAVA" "$XSHARE" -cp "$ES_CLASSPATH" org.elasti
 # manual parsing to find out, if process should be detached
 if [[ $DAEMONIZE = false ]]; then
   if [[ "$QUIET" = false ]]; then
+    # redirects the stdout of the following `exec` to the stdin of this special sort-of `cat` with a bottom banner
+    # the banner contents sit in a file (this uses bash process substitution), and are not available initially
     exec > >("$JAVA" "$XSHARE" -cp "$ES_CLASSPATH" org.elasticsearch.tools.launchers.OutputBottomBanner "EOF"\
       <(sleep 15; echo -ne "DEMO BANNER\n"\
 "SECURITY HAS BEEN AUTO-CONFIGURED\n"\

--- a/distribution/src/bin/elasticsearch
+++ b/distribution/src/bin/elasticsearch
@@ -61,7 +61,7 @@ ES_JAVA_OPTS=`export ES_TMPDIR; "$JAVA" "$XSHARE" -cp "$ES_CLASSPATH" org.elasti
 # manual parsing to find out, if process should be detached
 if [[ $DAEMONIZE = false ]]; then
   if [[ "$QUIET" = false ]]; then
-    exec > >("$JAVA" "$XSHARE" -cp "$ES_CLASSPATH" org.elasticsearch.tools.launchers.OutputBottomBanner <(echo -ne "TEST BANNER\nTEST BANNER2"))
+    exec > >("$JAVA" "$XSHARE" -cp "$ES_CLASSPATH" org.elasticsearch.tools.launchers.OutputBottomBanner <(echo -ne "TEST BANNER\nTEST BANNER2\nEOF"))
     #exec > >(while read line; do
     #  printf "%s\nTEST BOTTOM BANNER\r" "$line"
     #  done)

--- a/distribution/src/bin/elasticsearch
+++ b/distribution/src/bin/elasticsearch
@@ -61,10 +61,13 @@ ES_JAVA_OPTS=`export ES_TMPDIR; "$JAVA" "$XSHARE" -cp "$ES_CLASSPATH" org.elasti
 # manual parsing to find out, if process should be detached
 if [[ $DAEMONIZE = false ]]; then
   if [[ "$QUIET" = false ]]; then
-    exec > >("$JAVA" "$XSHARE" -cp "$ES_CLASSPATH" org.elasticsearch.tools.launchers.OutputBottomBanner <(echo -ne "TEST BANNER\nTEST BANNER2\nEOF"))
-    #exec > >(while read line; do
-    #  printf "%s\nTEST BOTTOM BANNER\r" "$line"
-    #  done)
+    exec > >("$JAVA" "$XSHARE" -cp "$ES_CLASSPATH" org.elasticsearch.tools.launchers.OutputBottomBanner "EOF"\
+      <(sleep 15; echo -ne "DEMO BANNER\n"\
+"SECURITY HAS BEEN AUTO-CONFIGURED\n"\
+"\"elastic\" user password: *******\n"\
+"ES node enrollment token (expires in 30 mins): *******\n"\
+"Kibana enrollment token (expires in 30 mins): *******\n"\
+"EOF"))
   fi
   exec \
     "$JAVA" \

--- a/distribution/tools/launchers/src/main/java/org/elasticsearch/tools/launchers/OutputBottomBanner.java
+++ b/distribution/tools/launchers/src/main/java/org/elasticsearch/tools/launchers/OutputBottomBanner.java
@@ -21,7 +21,14 @@ import java.util.Locale;
 import java.util.concurrent.atomic.AtomicReference;
 
 /**
- * Prints lines at the tail of the console output
+ * Prints the text lines, that are coming through the standard input, to the standard output
+ * (like the no-arg `cat` command), but followed by a multi-line text "banner" that persists as the last text
+ * that is printed to the terminal.
+ * The "banner" persists because it is printed out after every line of text, and is then cleared
+ * before the next line is printed. Clearing and moving the cursor only works if the output is a terminal
+ * (this redirection should not be used otherwise).
+ * The banner is read from an input file, and mustn't necessarily be available before the stdin input is.
+ * Once the content of the banner becomes available it cannot be changed.
  */
 final class OutputBottomBanner {
 

--- a/distribution/tools/launchers/src/main/java/org/elasticsearch/tools/launchers/OutputBottomBanner.java
+++ b/distribution/tools/launchers/src/main/java/org/elasticsearch/tools/launchers/OutputBottomBanner.java
@@ -8,27 +8,16 @@
 
 package org.elasticsearch.tools.launchers;
 
+import org.elasticsearch.tools.java_version_checker.SuppressForbidden;
+
 import java.io.BufferedReader;
-import java.io.File;
-import java.io.FileDescriptor;
-import java.io.FileInputStream;
-import java.io.FileNotFoundException;
 import java.io.FileReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.UncheckedIOException;
-import java.nio.channels.AsynchronousFileChannel;
-import java.nio.channels.FileChannel;
-import java.nio.channels.Selector;
 import java.nio.charset.Charset;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.List;
-import java.util.Random;
-import java.util.concurrent.atomic.AtomicInteger;
+import java.util.Locale;
 import java.util.concurrent.atomic.AtomicReference;
 
 /**
@@ -36,6 +25,7 @@ import java.util.concurrent.atomic.AtomicReference;
  */
 final class OutputBottomBanner {
 
+    @SuppressForbidden(reason = "System#out")
     public static void main(final String[] args) throws IOException {
         if (args.length != 2) {
             throw new IllegalArgumentException("expected two arguments, but provided " + Arrays.toString(args));
@@ -49,7 +39,7 @@ final class OutputBottomBanner {
             StringBuilder bannerBuilder = new StringBuilder();
             int lineCount = 0;
             // read banner from file using platform's charset
-            try (BufferedReader reader = new BufferedReader(new FileReader(bannerFileName))) {
+            try (BufferedReader reader = new BufferedReader(new FileReader(bannerFileName, Charset.defaultCharset()))) {
                 while (true) {
                     String bannerLine;
                     while ((bannerLine = reader.readLine()) != null) {
@@ -90,7 +80,7 @@ final class OutputBottomBanner {
                     // this is reasonable because the assumption is that the input is a stream of lines
                     // so it only blocks for a short while
                     line = reader.readLine();
-                    System.out.printf("%s%n", line);
+                    System.out.printf(Locale.ROOT, "%s%n", line);
                 } else {
                     // avoid busy looping when no input lines and no banner
                     Thread.sleep(1000);
@@ -98,15 +88,15 @@ final class OutputBottomBanner {
             }
             Banner banner = bannerReference.get();
             // print banner
-            System.out.printf("%s%n", banner.banner);
+            System.out.printf(Locale.ROOT, "%s%n", banner.banner);
             // we can block indefinitely for input lines since the banner has already been printed
             while ((line = reader.readLine()) != null) {
                 // clear banner
-                System.out.printf("\u001b[%dF\u001b[J", banner.lineCount);
+                System.out.printf(Locale.ROOT, "\u001b[%dF\u001b[J", banner.lineCount);
                 // line overwrites banner
-                System.out.printf("%s%n", line);
+                System.out.printf(Locale.ROOT, "%s%n", line);
                 // append another banner
-                System.out.printf("%s%n", banner.banner);
+                System.out.printf(Locale.ROOT, "%s%n", banner.banner);
             }
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();

--- a/distribution/tools/launchers/src/main/java/org/elasticsearch/tools/launchers/OutputBottomBanner.java
+++ b/distribution/tools/launchers/src/main/java/org/elasticsearch/tools/launchers/OutputBottomBanner.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.tools.launchers;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileDescriptor;
+import java.io.FileInputStream;
+import java.io.FileReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.channels.AsynchronousFileChannel;
+import java.nio.channels.FileChannel;
+import java.nio.channels.Selector;
+import java.nio.charset.Charset;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+final class OutputBottomBanner {
+
+    public static void main(final String[] args) throws IOException {
+        if (args.length != 1) {
+            throw new IllegalArgumentException("expected single argument but was " + Arrays.toString(args));
+        }
+        StringBuilder bannerBuilder = new StringBuilder();
+//        try (FileInputStream fis = new FileInputStream(new File(args[0]))) {
+//            banner.append(new String(fis.readAllBytes(), Charset.defaultCharset()));
+//        }
+        int bannerLineCount = 0;
+        try (BufferedReader reader = new BufferedReader(new FileReader(args[0]))) {
+            String bannerLine;
+            while ((bannerLine = reader.readLine()) != null) {
+                if (bannerLineCount != 0) {
+                    bannerBuilder.append(System.lineSeparator());
+                }
+                bannerBuilder.append(bannerLine);
+                bannerLineCount++;
+            }
+        }
+        String banner = bannerBuilder.toString();
+        System.out.println("THIS IS BANNER");
+        System.out.println(banner);
+        System.out.println("THAT WAS BANNER " + bannerLineCount);
+//        String banner = bannerLines.stream().reduce()
+        // strip trailing line ends
+//        while (banner.length() > 0 && (banner.charAt(banner.length() - 1) == '\r' ||
+//                banner.charAt(banner.length() - 1) == '\n')) {
+//            banner = banner.substring(0, banner.length() - 1);
+//        }
+        // TODO check charset and console
+        try (BufferedReader reader = new BufferedReader(new InputStreamReader(System.in, Charset.defaultCharset()))) {
+            String line;
+            while ((line = reader.readLine()) != null) {
+                if (bannerLineCount == 0) {
+                    System.out.printf("%s%n", line);
+                } else if (bannerLineCount == 1) {
+                    System.out.printf("\u001b[J%s%n%s\r", line, banner);
+                } else {
+                    System.out.printf("\u001b[J%s%n%s\u001b[%dF", line, banner, bannerLineCount - 1);
+                }
+//                System.out.printf("%s%n", line);
+//                System.out.printf("\u001b[s"); // save cursor position
+//                for (String bannerLine : bannerLines) {
+//                    System.out.printf("%s%n", bannerLine);
+//                }
+//                System.out.printf("\u001b[u"); // restore cursor position
+//                System.out.printf("\u001b[" + (bannerLines.size() + 1) + "A");
+            }
+        }
+    }
+
+}

--- a/docs/changelog/74516.yaml
+++ b/docs/changelog/74516.yaml
@@ -1,0 +1,5 @@
+pr: 74516
+summary: Persistent banner to ./bin/elasticsearch on the terminal
+area: Infra/CLI
+type: feature
+issues: []


### PR DESCRIPTION
As part of the "Security ON by default" project we ought to do some security auto-configuration when a v8 ES node is started for the first time, and from the terminal (the idea is that `./bin/elasticsearch` starts a node with Security enabled without you looking into the yml file at all).

The output of the auto-configuration can be displayed using a yet-to-be-implemented cmd line utility, but also, as a convenience to the user, when the node first starts, as part of the node's usual output (which are the logs). This PR addresses this latter requirement, by showing the auto-configuration information (only a static mock for now, but will be generated) as the last output to the terminal (following the logs), in a persistent, banner-like fashion.
In this way, the information is clearly visible, irrespective of the log output stream, and without breaking any of the log lines.

In order to achieve the cursor movement, the PR uses [ANSI VT 100 escape sequences](http://www.cse.psu.edu/~kxc104/class/cmpen472/11f/hw/hw7/vt100ansi.htm), which **should** be recognized by all terminal emulators (I have tested with `terminal` and `iTerm2` on MacOS, but I have qualms on Windows).

Here is a [short video](https://user-images.githubusercontent.com/4568420/123162530-62e15d00-d479-11eb-9f52-f53dccc85d27.mov) I made of the `./bin/elasticsearch` output.

@elastic/es-core-infra I would appreciate if someone can help us validate this approach (we must also validate on windows, etc). If everything looks reasonable to you, I will proceed to polish this PR to have a static banner, that we will then later make dynamically generated.

CC @jkakavas @BigPandaToo 