### PR TITLE
[DOCS] Add memory limit details in update job API

### DIFF
--- a/docs/reference/ml/anomaly-detection/apis/update-job.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/update-job.asciidoc
@@ -63,7 +63,7 @@ determine the current usage, refer to the `model_bytes` value in
 the <<ml-get-snapshot,get model snapshots>> or <<ml-get-job-stats,get job stats>> 
 APIs.
 * If the `memory_status` property in the
-<<ml-get-snapshot-results,`model_size_stats` object>> has a value of 
+<<modelsizestats,`model_size_stats` object>> has a value of 
 `hard_limit`, this means that it was unable to process some data. You might want 
 to re-run the job with an increased `model_memory_limit`.
 =======

--- a/docs/reference/ml/anomaly-detection/apis/update-job.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/update-job.asciidoc
@@ -46,6 +46,8 @@ close the job, then reopen the job and restart the {dfeed} for the changes to ta
 (Optional, object)
 include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=analysis-limits]
 +
+You can update the `analysis_limits` only while the job is closed.
++
 .Properties of `analysis_limits`
 [%collapsible%open]
 ====
@@ -54,14 +56,17 @@ include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=analysis-limits]
 include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=model-memory-limit-ad]
 +
 --
-NOTE: You can update the `analysis_limits` only while the job is closed. The 
-`model_memory_limit` property value cannot be decreased below the current usage.
- 
-TIP: If the `memory_status` property in the
+[NOTE]
+=======
+* You cannot decrease the `model_memory_limit` value below the current usage. To
+determine the current usage, refer to the `model_bytes_memory_limit` value in
+the <<ml-get-snapshot,get model snapshots>> or <<ml-get-job-stats,get job stats>> 
+APIs.
+* If the `memory_status` property in the
 <<ml-get-snapshot-results,`model_size_stats` object>> has a value of 
 `hard_limit`, this means that it was unable to process some data. You might want 
 to re-run the job with an increased `model_memory_limit`.
-
+=======
 --
 ====
 //End analysis_limits

--- a/docs/reference/ml/anomaly-detection/apis/update-job.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/update-job.asciidoc
@@ -59,7 +59,7 @@ include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=model-memory-limit-ad]
 [NOTE]
 =======
 * You cannot decrease the `model_memory_limit` value below the current usage. To
-determine the current usage, refer to the `model_bytes_memory_limit` value in
+determine the current usage, refer to the `model_bytes` value in
 the <<ml-get-snapshot,get model snapshots>> or <<ml-get-job-stats,get job stats>> 
 APIs.
 * If the `memory_status` property in the

--- a/docs/reference/ml/anomaly-detection/apis/update-job.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/update-job.asciidoc
@@ -60,8 +60,7 @@ include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=model-memory-limit-ad]
 =======
 * You cannot decrease the `model_memory_limit` value below the current usage. To
 determine the current usage, refer to the `model_bytes` value in
-the <<ml-get-snapshot,get model snapshots>> or <<ml-get-job-stats,get job stats>> 
-APIs.
+the <<ml-get-job-stats,get job stats>> API.
 * If the `memory_status` property in the
 <<modelsizestats,`model_size_stats` object>> has a value of 
 `hard_limit`, this means that it was unable to process some data. You might want 


### PR DESCRIPTION
This PR clarifies the "update anomaly detection job" API with respect to the model_memory_limit. In particular, you cannot not reduce that value below the size reported in the latest model size stats.

### Preview

https://elasticsearch_74517.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/ml-update-job.html#ml-update-job-request-body