### PR TITLE
Clean up build tools dependencies and fix maven coordinates

### DIFF
--- a/build-tools-internal/build.gradle
+++ b/build-tools-internal/build.gradle
@@ -205,7 +205,7 @@ dependencies {
   api gradleApi()
 
   api "org.elasticsearch:build-conventions:$version"
-  api "org.elasticsearch:build-tools:$version"
+  api "org.elasticsearch.gradle:build-tools:$version"
 
   api 'commons-codec:commons-codec:1.12'
   api 'org.apache.commons:commons-compress:1.19'

--- a/build-tools-internal/build.gradle
+++ b/build-tools-internal/build.gradle
@@ -228,6 +228,7 @@ dependencies {
   api "org.apache.httpcomponents:httpclient:${props.getProperty('httpclient')}"
   api "org.apache.httpcomponents:httpcore:${props.getProperty('httpcore')}"
   compileOnly "com.puppycrawl.tools:checkstyle:${props.getProperty('checkstyle')}"
+  runtimeOnly "org.elasticsearch.gradle:reaper:$version"
   testImplementation "com.puppycrawl.tools:checkstyle:${props.getProperty('checkstyle')}"
   testImplementation "junit:junit:${props.getProperty('junit')}"
   testImplementation 'com.github.tomakehurst:wiremock-jre8-standalone:2.23.2'

--- a/build-tools-internal/build.gradle
+++ b/build-tools-internal/build.gradle
@@ -234,7 +234,7 @@ dependencies {
   testImplementation 'org.mockito:mockito-core:1.9.5'
   testImplementation "org.hamcrest:hamcrest:${props.getProperty('hamcrest')}"
 
-  testImplementation testFixtures("org.elasticsearch:build-tools:$version")
+  testImplementation testFixtures("org.elasticsearch.gradle:build-tools:$version")
 
   integTestImplementation(platform("org.junit:junit-bom:${props.getProperty('junit5')}"))
   integTestImplementation("org.junit.jupiter:junit-jupiter") {

--- a/build-tools/build.gradle
+++ b/build-tools/build.gradle
@@ -24,7 +24,7 @@ Properties props = VersionPropertiesLoader.loadBuildSrcVersion(project.file('../
 def minRuntimeJava = JavaVersion.toVersion(file('../build-tools-internal/src/main/resources/minimumRuntimeVersion').text)
 
 allprojects {
-    group = "org.elasticsearch"
+    group = "org.elasticsearch.gradle"
     version = props.getProperty("elasticsearch")
 
     apply plugin: 'java'
@@ -65,7 +65,6 @@ def generateVersionProperties = tasks.register("generateVersionProperties", Writ
 
 tasks.named("processResources").configure {
     from(generateVersionProperties)
-    exclude 'buildSrc.marker'
     into('META-INF') {
         from configurations.reaper
     }
@@ -106,9 +105,6 @@ dependencies {
     api 'org.apache.commons:commons-compress:1.19'
     api 'org.apache.ant:ant:1.10.8'
     api 'commons-io:commons-io:2.2'
-    api 'gradle.plugin.com.github.jengelman.gradle.plugins:shadow:7.0.0'
-
-    runtimeOnly project(":reaper")
 
     testFixturesApi "junit:junit:${props.getProperty('junit')}"
     testFixturesApi "com.carrotsearch.randomizedtesting:randomizedtesting-runner:${props.getProperty('randomizedrunner')}"

--- a/build-tools/src/main/java/org/elasticsearch/gradle/plugin/PluginBuildPlugin.java
+++ b/build-tools/src/main/java/org/elasticsearch/gradle/plugin/PluginBuildPlugin.java
@@ -8,8 +8,8 @@
 
 package org.elasticsearch.gradle.plugin;
 
-import com.github.jengelman.gradle.plugins.shadow.ShadowPlugin;
 import groovy.lang.Closure;
+
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.elasticsearch.gradle.Version;
@@ -208,7 +208,7 @@ public class PluginBuildPlugin implements Plugin<Project> {
              */
             zip.from(new Closure<Object>(null, null) {
                 public Object doCall(Object it) {
-                    return project.getPlugins().hasPlugin(ShadowPlugin.class)
+                    return project.getPluginManager().hasPlugin("com.github.johnrengelman.shadow")
                         ? project.getTasks().named("shadowJar")
                         : project.getTasks().named("jar");
                 }


### PR DESCRIPTION
This pull request fixes some fallout form the `buildSrc` refactoring. A few things:

1. Fix the Maven coordinates for the `build-tools` project so it's published under the `org.elasticsearch.gradle` group as intended.
2. Remove the `:build-tools:reaper` runtime dependency so it's not included in the published POM. We embed this dependency in the build tools JAR so there's no need to bring it in transitively. Also, we don't publish it, so that would fail.
3. Remove the compile time dependency on the Shadow plugin. We only reference it for determining what artifact to bundle in the plugin bundle. We can reference this by plugin id vs by class.
4. Remove the `buildSrc.marker` file it's no longer needed as a result of #74329 