### PR TITLE
Clean up Node Shutdown API responses

### DIFF
--- a/x-pack/plugin/shutdown/qa/multi-node/src/javaRestTest/java/org/elasticsearch/xpack/shutdown/NodeShutdownIT.java
+++ b/x-pack/plugin/shutdown/qa/multi-node/src/javaRestTest/java/org/elasticsearch/xpack/shutdown/NodeShutdownIT.java
@@ -7,9 +7,12 @@
 
 package org.elasticsearch.xpack.shutdown;
 
+import org.apache.http.util.EntityUtils;
 import org.elasticsearch.Build;
+import org.elasticsearch.ResourceNotFoundException;
 import org.elasticsearch.client.Request;
 import org.elasticsearch.client.Response;
+import org.elasticsearch.client.ResponseException;
 import org.elasticsearch.common.settings.SecureString;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
@@ -236,6 +239,15 @@ public class NodeShutdownIT extends ESRestTestCase {
             assertThat(ObjectPath.eval("nodes.0.shard_migration.shard_migrations_remaining", status), equalTo(0));
                         assertThat(ObjectPath.eval("nodes.0.shard_migration.explanation", status), nullValue());
         });
+    }
+
+    /**
+     * Ensures that attempting to delete the status of a node that is not registered for shutdown gives a 404 response code.
+     */
+    public void testDeleteNodeNotRegisteredForShutdown() throws Exception {
+        Request deleteReq = new Request("DELETE", "_nodes/this-node-doesnt-exist/shutdown");
+        ResponseException ex = expectThrows(ResponseException.class, () -> client().performRequest(deleteReq));
+        assertThat(ex.getResponse().getStatusLine().getStatusCode(), is(404));
     }
 
     @SuppressWarnings("unchecked")

--- a/x-pack/plugin/shutdown/qa/multi-node/src/javaRestTest/java/org/elasticsearch/xpack/shutdown/NodeShutdownIT.java
+++ b/x-pack/plugin/shutdown/qa/multi-node/src/javaRestTest/java/org/elasticsearch/xpack/shutdown/NodeShutdownIT.java
@@ -245,6 +245,7 @@ public class NodeShutdownIT extends ESRestTestCase {
      * Ensures that attempting to delete the status of a node that is not registered for shutdown gives a 404 response code.
      */
     public void testDeleteNodeNotRegisteredForShutdown() throws Exception {
+        assumeTrue("must be on a snapshot build of ES to run in order for the feature flag to be set", Build.CURRENT.isSnapshot());
         Request deleteReq = new Request("DELETE", "_nodes/this-node-doesnt-exist/shutdown");
         ResponseException ex = expectThrows(ResponseException.class, () -> client().performRequest(deleteReq));
         assertThat(ex.getResponse().getStatusLine().getStatusCode(), is(404));

--- a/x-pack/plugin/shutdown/qa/multi-node/src/javaRestTest/java/org/elasticsearch/xpack/shutdown/NodeShutdownIT.java
+++ b/x-pack/plugin/shutdown/qa/multi-node/src/javaRestTest/java/org/elasticsearch/xpack/shutdown/NodeShutdownIT.java
@@ -216,7 +216,10 @@ public class NodeShutdownIT extends ESRestTestCase {
             assertThat(ObjectPath.eval("nodes.0.shard_migration.shard_migrations_remaining", status), equalTo(numberOfShards));
             assertThat(
                 ObjectPath.eval("nodes.0.shard_migration.explanation", status),
-                allOf(containsString(indexName), containsString("cannot move, see Cluster Allocation Explain API for details"))
+                allOf(
+                    containsString(indexName),
+                    containsString("cannot move, use the Cluster Allocation Explain API on this shard for details")
+                )
             );
         }
 

--- a/x-pack/plugin/shutdown/src/main/java/org/elasticsearch/xpack/shutdown/TransportDeleteShutdownNodeAction.java
+++ b/x-pack/plugin/shutdown/src/main/java/org/elasticsearch/xpack/shutdown/TransportDeleteShutdownNodeAction.java
@@ -10,6 +10,7 @@ package org.elasticsearch.xpack.shutdown;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.message.ParameterizedMessage;
+import org.elasticsearch.ResourceNotFoundException;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.master.AcknowledgedResponse;
@@ -60,8 +61,8 @@ public class TransportDeleteShutdownNodeAction extends AcknowledgedTransportMast
     ) throws Exception {
         { // This block solely to ensure this NodesShutdownMetadata isn't accidentally used in the cluster state update task below
             NodesShutdownMetadata nodesShutdownMetadata = state.metadata().custom(NodesShutdownMetadata.TYPE);
-            if (nodesShutdownMetadata.getAllNodeMetadataMap().get(request.getNodeId()) == null) {
-                throw new IllegalArgumentException("node [" + request.getNodeId() + "] is not currently shutting down");
+            if (nodesShutdownMetadata == null || nodesShutdownMetadata.getAllNodeMetadataMap().get(request.getNodeId()) == null) {
+                throw new ResourceNotFoundException("node [" + request.getNodeId() + "] is not currently shutting down");
             }
         }
 

--- a/x-pack/plugin/shutdown/src/main/java/org/elasticsearch/xpack/shutdown/TransportGetShutdownStatusAction.java
+++ b/x-pack/plugin/shutdown/src/main/java/org/elasticsearch/xpack/shutdown/TransportGetShutdownStatusAction.java
@@ -251,7 +251,7 @@ public class TransportGetShutdownStatusAction extends TransportMasterNodeAction<
                 SingleNodeShutdownMetadata.Status.STALLED,
                 totalRemainingShards,
                 new ParameterizedMessage(
-                    "shard [{}] [{}] of index [{}] cannot move, see Cluster Allocation Explain API for details",
+                    "shard [{}] [{}] of index [{}] cannot move, use the Cluster Allocation Explain API on this shard for details",
                     shardRouting.shardId().getId(),
                     shardRouting.primary() ? "primary" : "replica",
                     shardRouting.index().getName()

--- a/x-pack/plugin/shutdown/src/main/java/org/elasticsearch/xpack/shutdown/TransportGetShutdownStatusAction.java
+++ b/x-pack/plugin/shutdown/src/main/java/org/elasticsearch/xpack/shutdown/TransportGetShutdownStatusAction.java
@@ -174,9 +174,11 @@ public class TransportGetShutdownStatusAction extends TransportMasterNodeAction<
 
         if (currentState.getRoutingNodes().node(nodeId) == null) {
             // We don't know about that node
-            return new ShutdownShardMigrationStatus(SingleNodeShutdownMetadata.Status.NOT_STARTED,
+            return new ShutdownShardMigrationStatus(
+                SingleNodeShutdownMetadata.Status.NOT_STARTED,
                 0,
-                "node is not currently part of the cluster");
+                "node is not currently part of the cluster"
+            );
         }
 
         // First, check if there are any shards currently on this node, and if there are any relocating shards

--- a/x-pack/plugin/shutdown/src/main/java/org/elasticsearch/xpack/shutdown/TransportGetShutdownStatusAction.java
+++ b/x-pack/plugin/shutdown/src/main/java/org/elasticsearch/xpack/shutdown/TransportGetShutdownStatusAction.java
@@ -172,6 +172,13 @@ public class TransportGetShutdownStatusAction extends TransportMasterNodeAction<
             );
         }
 
+        if (currentState.getRoutingNodes().node(nodeId) == null) {
+            // We don't know about that node
+            return new ShutdownShardMigrationStatus(SingleNodeShutdownMetadata.Status.NOT_STARTED,
+                0,
+                "node is not currently part of the cluster");
+        }
+
         // First, check if there are any shards currently on this node, and if there are any relocating shards
         int startedShards = currentState.getRoutingNodes().node(nodeId).numberOfShardsWithState(ShardRoutingState.STARTED);
         int relocatingShards = currentState.getRoutingNodes().node(nodeId).numberOfShardsWithState(ShardRoutingState.RELOCATING);


### PR DESCRIPTION
This PR cleans up a few issues with the Node Shutdown API, specifically:
- GET'ing the status of a node that's registered for shutdown, but not in the cluster, now produces a useful response instead of an NPE.
- The explanation of the `STALLED` status now calls out that the Allocation Explain API should be used on the given shard in particular. We may handle this differently soon, but this improves things for now.
- DELETE'ing a non-existent shutdown request now returns HTTP code 404 instead of 400.