### PR TITLE
Mute enrollment tests in FIPS 140-2 mode

### DIFF
--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/action/enrollment/TransportKibanaEnrollmentActionTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/action/enrollment/TransportKibanaEnrollmentActionTests.java
@@ -30,6 +30,7 @@ import org.elasticsearch.xpack.core.security.action.user.ChangePasswordRequest;
 import org.elasticsearch.xpack.core.ssl.SSLConfiguration;
 import org.elasticsearch.xpack.core.ssl.SSLService;
 import org.junit.Before;
+import org.junit.BeforeClass;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -50,19 +51,23 @@ public class TransportKibanaEnrollmentActionTests extends ESTestCase {
     private List<ChangePasswordRequest> changePasswordRequests;
     private TransportKibanaEnrollmentAction action;
     private Client client;
-    private Path httpCaPath;
+
+    @BeforeClass
+    public static void muteInFips(){
+        assumeFalse("Enrollment is not supported in FIPS 140-2 as we are using PKCS#12 keystores", inFipsJvm());
+    }
 
     @Before @SuppressWarnings("unchecked") public void setup() throws Exception {
         changePasswordRequests = new ArrayList<>();
         final Environment env = mock(Environment.class);
         final Path tempDir = createTempDir();
-        httpCaPath = tempDir.resolve("httpCa.p12");
+        final Path httpCaPath = tempDir.resolve("httpCa.p12");
         Files.copy(getDataPath("/org/elasticsearch/xpack/security/action/enrollment/httpCa.p12"), httpCaPath);
         when(env.configFile()).thenReturn(tempDir);
         final MockSecureSettings secureSettings = new MockSecureSettings();
         secureSettings.setString("keystore.secure_password", "password");
         final Settings settings = Settings.builder()
-            .put("keystore.path", "httpCa.p12")
+            .put("keystore.path", httpCaPath)
             .setSecureSettings(secureSettings)
             .build();
         when(env.settings()).thenReturn(settings);

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/enrollment/CreateEnrollmentTokenTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/enrollment/CreateEnrollmentTokenTests.java
@@ -25,6 +25,7 @@ import org.elasticsearch.xpack.security.tool.CommandLineHttpClient;
 import org.elasticsearch.xpack.security.tool.HttpResponse;
 import org.hamcrest.Matchers;
 import org.junit.Before;
+import org.junit.BeforeClass;
 
 import java.io.IOException;
 import java.net.HttpURLConnection;
@@ -49,6 +50,11 @@ import static org.mockito.Mockito.when;
 
 public class CreateEnrollmentTokenTests extends ESTestCase {
     private Environment environment;
+
+    @BeforeClass
+    public static void muteInFips(){
+        assumeFalse("Enrollment is not supported in FIPS 140-2 as we are using PKCS#12 keystores", inFipsJvm());
+    }
 
     @Before
     public void setupMocks() throws Exception {


### PR DESCRIPTION
We don't support enrollment mode in FIPS 140-2 mode as we are
using PKCS#12 keystores. This change mutes related tests in FIPS
140-2 mode.

Resolves: #74526
