### PR TITLE
[7.x] Add REST API specification for SAML APIs (#72839)

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/security.saml_authenticate.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/security.saml_authenticate.json
@@ -1,0 +1,28 @@
+{
+  "security.saml_authenticate":{
+    "documentation":{
+      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-saml-authenticate.html",
+      "description":"Exchanges a SAML Response message for an Elasticsearch access token and refresh token pair"
+    },
+    "stability":"stable",
+    "visibility":"public",
+    "headers":{
+      "accept": [ "application/json"],
+      "content_type": ["application/json"]
+    },
+    "url":{
+      "paths":[
+        {
+          "path":"/_security/saml/authenticate",
+          "methods":[
+            "POST"
+          ]
+        }
+      ]
+    },
+    "body":{
+      "description":"The SAML response to authenticate",
+      "required":true
+    }
+  }
+}

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/security.saml_invalidate.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/security.saml_invalidate.json
@@ -1,0 +1,28 @@
+{
+  "security.saml_invalidate":{
+    "documentation":{
+      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-saml-invalidate.html",
+      "description":"Consumes a SAML LogoutRequest"
+    },
+    "stability":"stable",
+    "visibility":"public",
+    "headers":{
+      "accept": [ "application/json"],
+      "content_type": ["application/json"]
+    },
+    "url":{
+      "paths":[
+        {
+          "path":"/_security/saml/invalidate",
+          "methods":[
+            "POST"
+          ]
+        }
+      ]
+    },
+    "body":{
+      "description":"The LogoutRequest message",
+      "required":true
+    }
+  }
+}

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/security.saml_logout.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/security.saml_logout.json
@@ -1,0 +1,28 @@
+{
+  "security.saml_logout":{
+    "documentation":{
+      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-saml-logout.html",
+      "description":"Invalidates an access token and a refresh token that were generated via the SAML Authenticate API"
+    },
+    "stability":"stable",
+    "visibility":"public",
+    "headers":{
+      "accept": [ "application/json"],
+      "content_type": ["application/json"]
+    },
+    "url":{
+      "paths":[
+        {
+          "path":"/_security/saml/logout",
+          "methods":[
+            "POST"
+          ]
+        }
+      ]
+    },
+    "body":{
+      "description":"The tokens to invalidate",
+      "required":true
+    }
+  }
+}

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/security.saml_prepare_authentication.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/security.saml_prepare_authentication.json
@@ -1,0 +1,28 @@
+{
+  "security.saml_prepare_authentication":{
+    "documentation":{
+      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-saml-prepare-authentication.html",
+      "description":"Creates a SAML authentication request"
+    },
+    "stability":"stable",
+    "visibility":"public",
+    "headers":{
+      "accept": [ "application/json"],
+      "content_type": ["application/json"]
+    },
+    "url":{
+      "paths":[
+        {
+          "path":"/_security/saml/prepare",
+          "methods":[
+            "POST"
+          ]
+        }
+      ]
+    },
+    "body":{
+      "description":"The realm for which to create the authentication request, identified by either its name or the ACS URL",
+      "required":true
+    }
+  }
+}

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/security.saml_service_provider_metadata.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/security.saml_service_provider_metadata.json
@@ -1,0 +1,30 @@
+{
+  "security.saml_service_provider_metadata":{
+    "documentation":{
+      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-saml-sp-metadata.html",
+      "description":"Generates SAML metadata for the Elastic stack SAML 2.0 Service Provider"
+    },
+    "stability":"stable",
+    "visibility":"public",
+    "headers":{
+      "accept": [ "application/json"],
+      "content_type": ["application/json"]
+    },
+    "url":{
+      "paths":[
+        {
+          "path":"/_security/saml/metadata/{realm_name}",
+          "methods":[
+            "GET"
+          ],
+          "parts":{
+            "realm_name":{
+              "type":"string",
+              "description":"The name of the SAML realm to get the metadata for"
+            }
+          }
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Add REST API specification for SAML APIs (#72839)