### PR TITLE
Fix computation of max cells for bounded geohash grid aggregation

### DIFF
--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/search/aggregations/bucket/geogrid/BoundedGeoHashGridTiler.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/search/aggregations/bucket/geogrid/BoundedGeoHashGridTiler.java
@@ -23,12 +23,14 @@ public class BoundedGeoHashGridTiler extends AbstractGeoHashGridTiler {
         super(precision);
         this.bbox = bbox;
         this.crossesDateline = bbox.right() < bbox.left();
-        final long hashesY = (long)((bbox.top() - bbox.bottom()) / Geohash.latHeightInDegrees(precision)) + 1;
+        final long hashesY = (long) Math.ceil(((bbox.top() - bbox.bottom()) / Geohash.latHeightInDegrees(precision)) + 1);
         final long hashesX;
         if (crossesDateline) {
-            hashesX = (long)((360 - bbox.left() + bbox.right()) / Geohash.lonWidthInDegrees(precision)) + 1;
+            final long hashesLeft = (long) Math.ceil(((180 - bbox.left()) / Geohash.lonWidthInDegrees(precision)) + 1);
+            final long hashesRight = (long) Math.ceil(((bbox.right() + 180) / Geohash.lonWidthInDegrees(precision)) + 1);
+            hashesX = hashesLeft + hashesRight;
         } else {
-            hashesX = (long)((bbox.right() - bbox.left()) / Geohash.lonWidthInDegrees(precision)) + 1;
+            hashesX = (long) Math.ceil(((bbox.right() - bbox.left()) / Geohash.lonWidthInDegrees(precision)) + 1);
         }
         this.maxHashes = hashesX * hashesY;
     }


### PR DESCRIPTION
In order not to allocate too many cells for a bounded aggregation, implementations need to compute the maximum number of cells they can match. In the case of geohash this computation is actually underestimated as we are not rounding properly the results. This PR makes sure we rounded up this values.

PR set as non-issue as this code has not been released.

closes https://github.com/elastic/elasticsearch/issues/74537



