### PR TITLE
[7.x] Allow remove alias actions to target both data streams and regular indices

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/admin/indices/alias/TransportIndicesAliasesAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/alias/TransportIndicesAliasesAction.java
@@ -97,23 +97,6 @@ public class TransportIndicesAliasesAction extends AcknowledgedTransportMasterNo
             List<String> concreteDataStreams =
                 indexNameExpressionResolver.dataStreamNames(state, request.indicesOptions(), action.indices());
             if (concreteDataStreams.size() != 0) {
-                // Fail if parameters are used that data streams don't support:
-                if (action.filter() != null) {
-                    throw new IllegalArgumentException("aliases that point to data streams don't support filters");
-                }
-                if (action.routing() != null) {
-                    throw new IllegalArgumentException("aliases that point to data streams don't support routing");
-                }
-                if (action.indexRouting() != null) {
-                    throw new IllegalArgumentException("aliases that point to data streams don't support index_routing");
-                }
-                if (action.searchRouting() != null) {
-                    throw new IllegalArgumentException("aliases that point to data streams don't support search_routing");
-                }
-                if (action.isHidden() != null) {
-                    throw new IllegalArgumentException("aliases that point to data streams don't support is_hidden");
-                }
-                // Fail if expressions match both data streams and regular indices:
                 String[] concreteIndices =
                     indexNameExpressionResolver.concreteIndexNames(state, request.indicesOptions(), true, action.indices());
                 List<String> nonBackingIndices = Arrays.stream(concreteIndices)
@@ -121,19 +104,35 @@ public class TransportIndicesAliasesAction extends AcknowledgedTransportMasterNo
                     .filter(ia -> ia.getParentDataStream() == null)
                     .map(IndexAbstraction::getName)
                     .collect(Collectors.toList());
-                if (nonBackingIndices.isEmpty() == false) {
-                    throw new IllegalArgumentException("expressions " + Arrays.toString(action.indices()) +
-                        " that match with both data streams and regular indices are disallowed");
-                }
-
                 switch (action.actionType()) {
                     case ADD:
+                        // Fail if parameters are used that data stream aliases don't support:
+                        if (action.filter() != null) {
+                            throw new IllegalArgumentException("aliases that point to data streams don't support filters");
+                        }
+                        if (action.routing() != null) {
+                            throw new IllegalArgumentException("aliases that point to data streams don't support routing");
+                        }
+                        if (action.indexRouting() != null) {
+                            throw new IllegalArgumentException("aliases that point to data streams don't support index_routing");
+                        }
+                        if (action.searchRouting() != null) {
+                            throw new IllegalArgumentException("aliases that point to data streams don't support search_routing");
+                        }
+                        if (action.isHidden() != null) {
+                            throw new IllegalArgumentException("aliases that point to data streams don't support is_hidden");
+                        }
+                        // Fail if expressions match both data streams and regular indices:
+                        if (nonBackingIndices.isEmpty() == false) {
+                            throw new IllegalArgumentException("expressions " + Arrays.toString(action.indices()) +
+                                " that match with both data streams and regular indices are disallowed");
+                        }
                         for (String dataStreamName : concreteDataStreams) {
                             for (String alias : concreteDataStreamAliases(action, state.metadata(), dataStreamName)) {
                                 finalActions.add(new AliasAction.AddDataStreamAlias(alias, dataStreamName, action.writeIndex()));
                             }
                         }
-                        break;
+                        continue;
                     case REMOVE:
                         for (String dataStreamName : concreteDataStreams) {
                             for (String alias : concreteDataStreamAliases(action, state.metadata(), dataStreamName)) {
@@ -141,11 +140,16 @@ public class TransportIndicesAliasesAction extends AcknowledgedTransportMasterNo
                                     new AliasAction.RemoveDataStreamAlias(alias, dataStreamName, action.mustExist()));
                             }
                         }
-                        break;
+                        if (nonBackingIndices.isEmpty() == false) {
+                            // Regular aliases/indices match as well with the provided expression.
+                            // (Only when adding new aliases, matching both data streams and indices is disallowed)
+                            break;
+                        } else {
+                            continue;
+                        }
                     default:
                         throw new IllegalArgumentException("Unsupported action [" + action.actionType() + "]");
                 }
-                continue;
             }
 
             final Index[] concreteIndices = indexNameExpressionResolver.concreteIndices(state, request.indicesOptions(), false,

--- a/x-pack/plugin/data-streams/src/internalClusterTest/java/org/elasticsearch/datastreams/DataStreamIT.java
+++ b/x-pack/plugin/data-streams/src/internalClusterTest/java/org/elasticsearch/datastreams/DataStreamIT.java
@@ -43,6 +43,7 @@ import org.elasticsearch.action.support.master.AcknowledgedResponse;
 import org.elasticsearch.action.update.UpdateRequest;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.health.ClusterHealthStatus;
+import org.elasticsearch.cluster.metadata.AliasMetadata;
 import org.elasticsearch.cluster.metadata.ComposableIndexTemplate;
 import org.elasticsearch.cluster.metadata.DataStream;
 import org.elasticsearch.cluster.metadata.DataStreamAlias;
@@ -752,6 +753,38 @@ public class DataStreamIT extends ESIntegTestCase {
         aliasesAddRequest.addAliasAction(addAction);
         Exception e = expectThrows(IllegalArgumentException.class, () -> client().admin().indices().aliases(aliasesAddRequest).actionGet());
         assertThat(e.getMessage(), equalTo("expressions [metrics-*] that match with both data streams and regular indices are disallowed"));
+    }
+
+    public void testRemoveDataStreamAliasesMixedExpression() throws Exception {
+        createIndex("metrics-myindex");
+        putComposableIndexTemplate("id1", List.of("metrics-*"));
+        String dataStreamName = "metrics-foo";
+        CreateDataStreamAction.Request createDataStreamRequest = new CreateDataStreamAction.Request(dataStreamName);
+        client().execute(CreateDataStreamAction.INSTANCE, createDataStreamRequest).get();
+
+        IndicesAliasesRequest aliasesAddRequest = new IndicesAliasesRequest();
+        aliasesAddRequest.addAliasAction(new AliasActions(AliasActions.Type.ADD).index("metrics-foo").aliases("my-alias1"));
+        aliasesAddRequest.addAliasAction(new AliasActions(AliasActions.Type.ADD).index("metrics-myindex").aliases("my-alias2"));
+        assertAcked(client().admin().indices().aliases(aliasesAddRequest).actionGet());
+        GetAliasesResponse response = client().admin().indices().getAliases(new GetAliasesRequest()).actionGet();
+        assertThat(
+            response.getDataStreamAliases(),
+            equalTo(Map.of("metrics-foo", List.of(new DataStreamAlias("my-alias1", List.of("metrics-foo"), null))))
+        );
+        assertThat(response.getAliases().get("metrics-myindex"), equalTo(List.of(new AliasMetadata.Builder("my-alias2").build())));
+
+        aliasesAddRequest = new IndicesAliasesRequest();
+        if (randomBoolean()) {
+            aliasesAddRequest.addAliasAction(new AliasActions(AliasActions.Type.REMOVE).index("_all").aliases("my-alias1"));
+            aliasesAddRequest.addAliasAction(new AliasActions(AliasActions.Type.REMOVE).index("_all").aliases("my-alias2"));
+        } else {
+            aliasesAddRequest.addAliasAction(new AliasActions(AliasActions.Type.REMOVE).index("_all").aliases("my-*"));
+        }
+        assertAcked(client().admin().indices().aliases(aliasesAddRequest).actionGet());
+        response = client().admin().indices().getAliases(new GetAliasesRequest()).actionGet();
+        assertThat(response.getDataStreamAliases(), anEmptyMap());
+        assertThat(response.getAliases().get("metrics-myindex").size(), equalTo(0));
+        assertThat(response.getAliases().size(), equalTo(1));
     }
 
     public void testUpdateDataStreamsWithWildcards() throws Exception {


### PR DESCRIPTION
backporting #74403 to 7.x branch.

When removing aliases allow that an alias action's index expression can match
both data streams and regular indices.

This allows api calls like `DELETE /_all/_alias/my-alias`, which can common
in tear down / cleanup logic. In this case `my-alias` just points to regular
indices, but `_all` can be expanded to data streams too if exist. This can
then trigger validation logic that prevents adding aliases that refer to both
indices and data streams. However this api call never adds any alias, only
removes it. So failing with this validation error doesn't make much sense.

This change adjusts the validation logic so that: 'match with both data streams and
regular indices are disallowed' validation is only executed for alias actions
that add aliases.

Relates to #66163