### PR TITLE
[DOCS] Troubleshooting SIGSEGV on SELinux when elasticsearch home directory is missing

### DIFF
--- a/docs/reference/setup/sysconfig/executable-jna-tmpdir.asciidoc
+++ b/docs/reference/setup/sysconfig/executable-jna-tmpdir.asciidoc
@@ -23,3 +23,7 @@ of Elasticsearch that rely on execution of native code via JNA will fail with
 messages indicating that it is `because JNA is not available`. If you are seeing
 such error messages, you must remount the temporary directory used for JNA to
 not be mounted with `noexec`.
+
+If Elasticsearch still fails to startup after setting the above temporary
+directories, make sure that the user account that Elasticsearch is running under
+has a home directory.


### PR DESCRIPTION
This PR updates docs to guide users who run into this bug: https://github.com/elastic/elasticsearch/issues/73309

(The issue is that in some hardened environments, Java tries to write a small file called `.oracle_jre_usage` to the user's home directory, but if the user has no home directory, there's a very cryptic error.)