### PR TITLE
[DOCS] Tidying for the enroll Kibana API

### DIFF
--- a/x-pack/docs/en/rest-api/security.asciidoc
+++ b/x-pack/docs/en/rest-api/security.asciidoc
@@ -125,8 +125,8 @@ realm when using a custom web application other than Kibana
 === Enrollment
 
 Use the following APIs to enable new nodes to join an existing cluster with
-security enabled, or to enable a client to configure itself to communicate with
-a secured {es} cluster.
+security enabled, or to enable a {kib} instance to configure itself to
+communicate with a secured {es} cluster.
 
 * <<security-api-node-enrollment, Enroll a new node>>
 * <<security-api-kibana-enrollment, Enroll a new {kib} instance>>

--- a/x-pack/docs/en/rest-api/security.asciidoc
+++ b/x-pack/docs/en/rest-api/security.asciidoc
@@ -4,7 +4,7 @@
 To use the security APIs, you must set `xpack.security.enabled` to `true` in
 the `elasticsearch.yml` file.
 
-You can use the following APIs to perform security activities.
+Use the following APIs to perform security activities.
 
 * <<security-api-authenticate>>
 * <<security-api-clear-cache>>
@@ -18,7 +18,7 @@ You can use the following APIs to perform security activities.
 [[security-api-app-privileges]]
 === Application privileges
 
-You can use the following APIs to add, update, retrieve, and remove application
+Use the following APIs to add, update, retrieve, and remove application
 privileges:
 
 * <<security-api-put-privileges,Create or update privileges>>
@@ -30,7 +30,7 @@ privileges:
 [[security-role-mapping-apis]]
 === Role mappings
 
-You can use the following APIs to add, remove, update, and retrieve role mappings:
+Use the following APIs to add, remove, update, and retrieve role mappings:
 
 * <<security-api-put-role-mapping,Create or update role mappings>>
 * <<security-api-delete-role-mapping,Delete role mappings>>
@@ -40,7 +40,7 @@ You can use the following APIs to add, remove, update, and retrieve role mapping
 [[security-role-apis]]
 === Roles
 
-You can use the following APIs to add, remove, update, and retrieve roles in the native realm:
+Use the following APIs to add, remove, update, and retrieve roles in the native realm:
 
 * <<security-api-put-role,Create or update roles>>
 * <<security-api-clear-role-cache,Clear roles cache>>
@@ -51,7 +51,7 @@ You can use the following APIs to add, remove, update, and retrieve roles in the
 [[security-token-apis]]
 === Tokens
 
-You can use the following APIs to create and invalidate bearer tokens for access
+Use the following APIs to create and invalidate bearer tokens for access
 without requiring basic authentication:
 
 * <<security-api-get-token,Get token>>
@@ -61,7 +61,7 @@ without requiring basic authentication:
 [[security-api-keys]]
 === API Keys
 
-You can use the following APIs to create, retrieve and invalidate API keys for access
+Use the following APIs to create, retrieve and invalidate API keys for access
 without requiring basic authentication:
 
 * <<security-api-create-api-key,Create API key>>
@@ -74,7 +74,7 @@ without requiring basic authentication:
 [[security-user-apis]]
 === Users
 
-You can use the following APIs to add, remove, update, or retrieve users in the
+Use the following APIs to add, remove, update, or retrieve users in the
 native realm:
 
 * <<security-api-put-user,Create or update users>>
@@ -88,7 +88,7 @@ native realm:
 [[security-service-account-apis]]
 === Service Accounts
 
-You can use the following APIs to list service accounts and manage the service tokens:
+Use the following APIs to list service accounts and manage the service tokens:
 
 * <<security-api-get-service-accounts>>
 * <<security-api-create-service-token>>
@@ -99,7 +99,7 @@ You can use the following APIs to list service accounts and manage the service t
 [[security-openid-apis]]
 === OpenID Connect
 
-You can use the following APIs to authenticate users against an OpenID Connect
+Use the following APIs to authenticate users against an OpenID Connect
 authentication realm when using a custom web application other than Kibana
 
 * <<security-api-oidc-prepare-authentication, Prepare an authentication request>>
@@ -110,7 +110,7 @@ authentication realm when using a custom web application other than Kibana
 [[security-saml-apis]]
 === SAML
 
-You can use the following APIs to authenticate users against a SAML authentication
+Use the following APIs to authenticate users against a SAML authentication
 realm when using a custom web application other than Kibana
 
 * <<security-api-saml-prepare-authentication, Prepare an authentication request>>
@@ -124,12 +124,12 @@ realm when using a custom web application other than Kibana
 [[security-enrollment-apis]]
 === Enrollment
 
-You can use the following APIs to allow new nodes to join an existing cluster with
-security enabled or to allow a client to configure itself to communicate with
-a secured {es} cluster
+Use the following APIs to enable new nodes to join an existing cluster with
+security enabled, or to enable a client to configure itself to communicate with
+a secured {es} cluster.
 
 * <<security-api-node-enrollment, Enroll a new node>>
-* <<security-api-kibana-enrollment, Enroll a new kibana instance>>
+* <<security-api-kibana-enrollment, Enroll a new {kib} instance>>
 
 
 include::security/authenticate.asciidoc[]

--- a/x-pack/docs/en/rest-api/security/enroll-kibana.asciidoc
+++ b/x-pack/docs/en/rest-api/security/enroll-kibana.asciidoc
@@ -11,16 +11,11 @@ Enables a {kib} instance to configure itself for communication with a secured {e
 
 `GET /_security/enroll/kibana`
 
-[[security-api-kibana-enrollment-prereqs]]
-==== {api-prereq-title}
-
-
 [[security-api-kibana-enrollment-desc]]
 ==== {api-description-title}
 
-The purpose of the enroll kibana API is to allow a kibana instance to configure itself to
-communicate with an {es} cluster that is already configured with security features
-enabled.
+Use this API to enable a {kib} instance to configure itself for communications
+with an {es} cluster that already has security features enabled.
 
 [[security-api-client-enrollment-examples]]
 ==== {api-examples-title}
@@ -44,4 +39,4 @@ The API returns the following response:
 ----
 <1> The password for the `kibana_system` user.
 <2> The CA certificate used to sign the node certificates that {es} uses for TLS on the HTTP layer.
-The certificate is returned as a Base64 encoded string of the ASN.1 DER encoding of the certificate
+The certificate is returned as a Base64 encoded string of the ASN.1 DER encoding of the certificate.


### PR DESCRIPTION
Removes the empty *Prerequisites* section for the enroll Kibana API and fixes a few typos.