### PR TITLE
Add threshold parameter to rare terms aggregation

### DIFF
--- a/docs/reference/aggregations/bucket/rare-terms-aggregation.asciidoc
+++ b/docs/reference/aggregations/bucket/rare-terms-aggregation.asciidoc
@@ -227,6 +227,15 @@ CuckooFilters are described in more detail in the paper:
 https://www.cs.cmu.edu/~dga/papers/cuckoo-conext2014.pdf[Fan, Bin, et al. "Cuckoo filter: Practically better than bloom."]
 Proceedings of the 10th ACM International on Conference on emerging Networking Experiments and Technologies. ACM, 2014.
 
+
+==== Threshold
+The `threshold` parameter defines the number of unique values that are collected using the naive approach and therefore
+doc counts are accurate. Above this value, cuckoo filters are used to collect the values and therefore doc counts might
+become a bit more fuzzy.
+
+The value of this parameter must be a positive integer with a maximum supported value of 500000.
+The default value is `10000`.
+
 ==== Precision
 
 Although the internal CuckooFilter is approximate in nature, the false-negative rate can be controlled with a

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.aggregation/285_rare_terms_low_threshold.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.aggregation/285_rare_terms_low_threshold.yml
@@ -1,7 +1,7 @@
 setup:
   - skip:
-      version: " - 7.2.99"
-      reason: RareTerms added in 7.3.0
+      version: " - 7.99.99"
+      reason: RareTerms threshfold added in 8.0
   - do:
       indices.create:
           index: test_1

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.aggregation/285_rare_terms_low_threshold.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.aggregation/285_rare_terms_low_threshold.yml
@@ -1,0 +1,424 @@
+setup:
+  - skip:
+      version: " - 7.2.99"
+      reason: RareTerms added in 7.3.0
+  - do:
+      indices.create:
+          index: test_1
+          body:
+            settings:
+              number_of_replicas: 0
+            mappings:
+              properties:
+                str:
+                   type: keyword
+                ip:
+                   type: ip
+                boolean:
+                   type: boolean
+                integer:
+                  type: long
+                number:
+                  type: long
+                date:
+                  type: date
+
+
+  - do:
+      cluster.health:
+        wait_for_status: green
+
+---
+"Basic test":
+  - do:
+      index:
+        index: test_1
+        id: 1
+        body: { "str" : "abc" }
+
+  - do:
+      index:
+        index: test_1
+        id: 2
+        body: { "str": "abc" }
+
+  - do:
+      index:
+        index: test_1
+        id: 3
+        body: { "str": "bcd" }
+
+  - do:
+      indices.refresh: {}
+
+  - do:
+      search:
+        body: { "size" : 0, "aggs" : { "str_terms" : { "rare_terms" : { "field" : "str", "max_doc_count" : 1, "threshold" : 1 } } } }
+
+  - match: { hits.total.value: 3 }
+  - length: { aggregations.str_terms.buckets: 1 }
+  - match: { aggregations.str_terms.buckets.0.key: "bcd" }
+  - is_false: aggregations.str_terms.buckets.0.key_as_string
+  - match: { aggregations.str_terms.buckets.0.doc_count: 1 }
+
+---
+"IP test":
+  - do:
+      index:
+        index: test_1
+        id: 1
+        body: { "ip": "::1" }
+
+  - do:
+      index:
+        index: test_1
+        id: 2
+        body: { "ip": "127.0.0.1" }
+
+  - do:
+      index:
+        index: test_1
+        id: 3
+        body: { "ip": "::1" }
+
+  - do:
+      indices.refresh: {}
+
+  - do:
+      search:
+        body: { "size" : 0, "aggs" : { "ip_terms" : { "rare_terms" : { "field" : "ip", "threshold" : 1 } } } }
+
+  - match: { hits.total.value: 3 }
+  - length: { aggregations.ip_terms.buckets: 1 }
+  - match: { aggregations.ip_terms.buckets.0.key: "127.0.0.1" }
+  - is_false: aggregations.ip_terms.buckets.0.key_as_string
+  - match: { aggregations.ip_terms.buckets.0.doc_count: 1 }
+
+  - do:
+      search:
+        body: { "size" : 0, "aggs" : { "ip_terms" : { "rare_terms" : { "field" : "ip", "include" : [ "127.0.0.1" ], "threshold" : 1 } } } }
+
+  - match: { hits.total.value: 3 }
+  - length: { aggregations.ip_terms.buckets: 1 }
+  - match: { aggregations.ip_terms.buckets.0.key: "127.0.0.1" }
+  - is_false: aggregations.ip_terms.buckets.0.key_as_string
+  - match: { aggregations.ip_terms.buckets.0.doc_count: 1 }
+
+  - do:
+      search:
+        body: { "size" : 0, "aggs" : { "ip_terms" : { "rare_terms" : { "field" : "ip", "exclude" : [ "127.0.0.1" ], "threshold" : 1 } } } }
+
+  - match: { hits.total.value: 3 }
+  - length: { aggregations.ip_terms.buckets: 0 }
+
+  - do:
+      catch: /Aggregation \[ip_terms\] cannot support regular expression style include\/exclude settings as they can only be applied to string fields\. Use an array of values for include\/exclude clauses/
+      search:
+        index: test_1
+        body: { "size" : 0, "aggs" : { "ip_terms" : { "rare_terms" : { "field" : "ip", "exclude" :  "127.*", "threshold" : 1  } } } }
+
+
+
+---
+"Boolean test":
+  - do:
+      index:
+        index: test_1
+        id: 1
+        body: { "boolean": true }
+
+  - do:
+      index:
+        index: test_1
+        id: 2
+        body: { "boolean": false }
+
+  - do:
+      index:
+        index: test_1
+        id: 3
+        body: { "boolean": true }
+
+  - do:
+      indices.refresh: {}
+
+  - do:
+      search:
+        body: { "size" : 0, "aggs" : { "boolean_terms" : { "rare_terms" : { "field" : "boolean", "threshold" : 1 } } } }
+
+  - match: { hits.total.value: 3 }
+  - length: { aggregations.boolean_terms.buckets: 1 }
+  - match: { aggregations.boolean_terms.buckets.0.key: 0 }
+  - match: { aggregations.boolean_terms.buckets.0.key_as_string: "false" }
+  - match: { aggregations.boolean_terms.buckets.0.doc_count: 1 }
+
+---
+"Integer test":
+  - do:
+      index:
+        index: test_1
+        id: 1
+        body: { "integer": 1234 }
+
+  - do:
+      index:
+        index: test_1
+        id: 2
+        body: { "integer": 5678 }
+
+  - do:
+      index:
+        index: test_1
+        id: 3
+        body: { "integer": 1234 }
+
+  - do:
+      indices.refresh: {}
+
+  - do:
+      search:
+        body: { "size" : 0, "aggs" : { "integer_terms" : { "rare_terms" : { "field" : "integer", "threshold" : 1 } } } }
+
+  - match: { hits.total.value: 3 }
+
+  - length: { aggregations.integer_terms.buckets: 1 }
+
+  - match: { aggregations.integer_terms.buckets.0.key: 5678 }
+  - is_false: aggregations.integer_terms.buckets.0.key_as_string
+  - match: { aggregations.integer_terms.buckets.0.doc_count: 1 }
+
+---
+"Date test":
+  - do:
+      index:
+        index: test_1
+        id: 1
+        body: { "date": "2016-05-03" }
+
+  - do:
+      index:
+        index: test_1
+        id: 2
+        body: { "date": "2014-09-01" }
+
+  - do:
+      index:
+        index: test_1
+        id: 3
+        body: { "date": "2016-05-03" }
+
+  - do:
+      indices.refresh: {}
+
+  - do:
+      search:
+        body: { "size" : 0, "aggs" : { "date_terms" : { "rare_terms" : { "field" : "date", "threshold" : 1 } } } }
+
+  - match: { hits.total.value: 3 }
+
+  - length: { aggregations.date_terms.buckets: 1 }
+  - match: { aggregations.date_terms.buckets.0.key: 1409529600000 }
+  - match: { aggregations.date_terms.buckets.0.key_as_string: "2014-09-01T00:00:00.000Z" }
+  - match: { aggregations.date_terms.buckets.0.doc_count: 1 }
+
+  - do:
+      search:
+        body: { "size" : 0, "aggs" : { "date_terms" : { "rare_terms" : { "field" : "date", "include" : [ "2014-09-01" ], "threshold" : 1 } } } }
+
+  - match: { hits.total.value: 3 }
+  - length: { aggregations.date_terms.buckets: 1 }
+  - match: { aggregations.date_terms.buckets.0.key_as_string: "2014-09-01T00:00:00.000Z" }
+  - match: { aggregations.date_terms.buckets.0.doc_count: 1 }
+
+  - do:
+      search:
+        body: { "size" : 0, "aggs" : { "date_terms" : { "rare_terms" : { "field" : "date", "exclude" : [ "2014-09-01" ] , "threshold" : 1} } } }
+
+  - match: { hits.total.value: 3 }
+  - length: { aggregations.date_terms.buckets: 0 }
+
+---
+"Unmapped strings":
+
+  - do:
+      index:
+        index: test_1
+        id: 1
+        body: {}
+
+  - do:
+      indices.refresh: {}
+
+  - do:
+      search:
+        body: { "size" : 0, "aggs" : { "string_terms" : { "rare_terms" : { "field" : "unmapped_string", "threshold" : 1} } } }
+
+  - match: { hits.total.value: 1 }
+  - length: { aggregations.string_terms.buckets: 0 }
+
+---
+"Unmapped booleans":
+
+  - do:
+      index:
+        index: test_1
+        id: 1
+        body: {}
+
+  - do:
+      indices.refresh: {}
+
+  - do:
+      search:
+        body: { "size" : 0, "aggs" : { "boolean_terms" : { "rare_terms" : { "field" : "unmapped_boolean", "threshold" : 1 } } } }
+
+  - match: { hits.total.value: 1 }
+  - length: { aggregations.boolean_terms.buckets: 0 }
+
+---
+"Unmapped dates":
+
+  - do:
+      index:
+        index: test_1
+        id: 1
+        body: {}
+
+  - do:
+      indices.refresh: {}
+
+  - do:
+      search:
+        body: { "size" : 0, "aggs" : { "date_terms" : { "rare_terms" : { "field" : "unmapped_date", "threshold" : 1} } } }
+
+  - match: { hits.total.value: 1 }
+  - length: { aggregations.date_terms.buckets: 0 }
+
+---
+"Unmapped longs":
+
+  - do:
+      index:
+        index: test_1
+        id: 1
+        body: {}
+
+  - do:
+      indices.refresh: {}
+
+  - do:
+      search:
+        body: { "size" : 0, "aggs" : { "long_terms" : { "rare_terms" : { "field" : "unmapped_long", "value_type" : "long", "threshold" : 1 } } } }
+
+  - match: { hits.total.value: 1 }
+  - length: { aggregations.long_terms.buckets: 0 }
+
+---
+"sub aggs":
+  - skip:
+      version: " - 7.6.1"
+      reason: Sub aggs fixed in 7.6.1
+
+  - do:
+      index:
+        refresh: true
+        index: test_1
+        id: 1
+        body: { "str" : "abc", "number": 1 }
+
+  - do:
+      index:
+        refresh: true
+        index: test_1
+        id: 2
+        body: { "str": "abc", "number": 2 }
+
+  - do:
+      index:
+        refresh: true
+        index: test_1
+        id: 3
+        body: { "str": "bcd", "number": 3 }
+
+  - do:
+      search:
+        body:
+          size: 0
+          aggs:
+            str_terms:
+              rare_terms:
+                field: str
+                max_doc_count: 1
+                threshold: 1
+              aggs:
+                max_n:
+                  max:
+                    field: number
+
+  - match: { hits.total.value: 3 }
+  - length: { aggregations.str_terms.buckets: 1 }
+  - match: { aggregations.str_terms.buckets.0.key: "bcd" }
+  - is_false: aggregations.str_terms.buckets.0.key_as_string
+  - match: { aggregations.str_terms.buckets.0.doc_count: 1 }
+  - match: { aggregations.str_terms.buckets.0.max_n.value: 3.0 }
+
+---
+"avg_bucket":
+  - skip:
+      version: " - 7.7.99"
+      reason: Fixed in 7.8.0
+  - do:
+      indices.create:
+          index: test
+          body:
+            settings:
+              number_of_replicas: 0
+            mappings:
+              properties:
+                str:
+                   type: keyword
+  - do:
+      bulk:
+        index: test
+        refresh: true
+        body:
+          - '{"index": {}}'
+          - '{"str": "foo", "v": 1}'
+          - '{"index": {}}'
+          - '{"str": "foo", "v": 2}'
+          - '{"index": {}}'
+          - '{"str": "foo", "v": 3}'
+          - '{"index": {}}'
+          - '{"str": "bar", "v": 4}'
+          - '{"index": {}}'
+          - '{"str": "bar", "v": 5}'
+          - '{"index": {}}'
+          - '{"str": "baz", "v": 6}'
+
+  - do:
+      search:
+        index: test
+        body:
+          size: 0
+          aggs:
+            str_terms:
+              rare_terms:
+                field: str
+                max_doc_count: 2
+              aggs:
+                v:
+                  sum:
+                    field: v
+            str_terms_avg_v:
+              avg_bucket:
+                buckets_path: str_terms.v
+
+  - match: { hits.total.value: 6 }
+  - length: { aggregations.str_terms.buckets: 2 }
+  - match: { aggregations.str_terms.buckets.0.key: baz }
+  - match: { aggregations.str_terms.buckets.0.doc_count: 1 }
+  - match: { aggregations.str_terms.buckets.0.v.value: 6 }
+  - match: { aggregations.str_terms.buckets.1.key: bar }
+  - match: { aggregations.str_terms.buckets.1.doc_count: 2 }
+  - match: { aggregations.str_terms.buckets.1.v.value: 9 }
+  - match: { aggregations.str_terms_avg_v.value: 7.5 }

--- a/server/src/main/java/org/elasticsearch/common/util/SetBackedScalingCuckooFilter.java
+++ b/server/src/main/java/org/elasticsearch/common/util/SetBackedScalingCuckooFilter.java
@@ -88,10 +88,8 @@ public class SetBackedScalingCuckooFilter implements Writeable {
             throw new IllegalArgumentException("[threshold] must be a positive integer");
         }
 
-        // We have to ensure that, in the worst case, two full sets can be converted into
-        // one cuckoo filter without overflowing.  This keeps merging logic simpler
-        if (threshold * 2 > FILTER_CAPACITY) {
-            throw new IllegalArgumentException("[threshold] must be smaller than [" + (FILTER_CAPACITY / 2) + "]");
+        if (threshold > maxThreshold()) {
+            throw new IllegalArgumentException("[threshold] must be smaller than [" + maxThreshold() + "]");
         }
         if (fpp < 0) {
             throw new IllegalArgumentException("[fpp] must be a positive double");
@@ -101,6 +99,12 @@ public class SetBackedScalingCuckooFilter implements Writeable {
         this.rng = rng;
         this.capacity = FILTER_CAPACITY;
         this.fpp = fpp;
+    }
+
+    public static int maxThreshold() {
+        // We have to ensure that, in the worst case, two full sets can be converted into
+        // one cuckoo filter without overflowing.  This keeps merging logic simpler
+        return FILTER_CAPACITY / 2;
     }
 
     public SetBackedScalingCuckooFilter(SetBackedScalingCuckooFilter other) {

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/AbstractRareTermsAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/AbstractRareTermsAggregator.java
@@ -29,6 +29,7 @@ public abstract class AbstractRareTermsAggregator extends DeferableBucketAggrega
     private final double precision;
     protected final DocValueFormat format;
     private final int filterSeed;
+    private final int threshold;
 
     AbstractRareTermsAggregator(
         String name,
@@ -38,7 +39,8 @@ public abstract class AbstractRareTermsAggregator extends DeferableBucketAggrega
         Map<String, Object> metadata,
         long maxDocCount,
         double precision,
-        DocValueFormat format
+        DocValueFormat format,
+        int threshold
     ) throws IOException {
         super(name, factories, context, parent, metadata);
 
@@ -46,6 +48,7 @@ public abstract class AbstractRareTermsAggregator extends DeferableBucketAggrega
         this.precision = precision;
         this.format = format;
         this.filterSeed = context.shardRandomSeed();
+        this.threshold = threshold;
         String scoringAgg = subAggsNeedScore();
         String nestedAgg = descendsFromNestedAggregator(parent);
         if (scoringAgg != null && nestedAgg != null) {
@@ -64,7 +67,7 @@ public abstract class AbstractRareTermsAggregator extends DeferableBucketAggrega
     }
 
     protected SetBackedScalingCuckooFilter newFilter() {
-        SetBackedScalingCuckooFilter filter = new SetBackedScalingCuckooFilter(10000, new Random(filterSeed), precision);
+        SetBackedScalingCuckooFilter filter = new SetBackedScalingCuckooFilter(threshold, new Random(filterSeed), precision);
         filter.registerBreaker(this::addRequestCircuitBreakerBytes);
         return filter;
     }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/LongRareTermsAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/LongRareTermsAggregator.java
@@ -51,7 +51,8 @@ public class LongRareTermsAggregator extends AbstractRareTermsAggregator {
         int maxDocCount,
         double precision,
         CardinalityUpperBound cardinality,
-        Map<String, Object> metadata
+        Map<String, Object> metadata,
+        int threshold
     ) throws IOException {
         super(
             name,
@@ -61,7 +62,8 @@ public class LongRareTermsAggregator extends AbstractRareTermsAggregator {
             metadata,
             maxDocCount,
             precision,
-            format
+            format,
+            threshold
         );
         this.valuesSource = valuesSource;
         this.filter = filter;

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/RareTermsAggregationBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/RareTermsAggregationBuilder.java
@@ -8,6 +8,7 @@
 package org.elasticsearch.search.aggregations.bucket.terms;
 
 import org.elasticsearch.Version;
+import org.elasticsearch.common.util.SetBackedScalingCuckooFilter;
 import org.elasticsearch.common.xcontent.ParseField;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -35,8 +36,10 @@ public class RareTermsAggregationBuilder extends ValuesSourceAggregationBuilder<
 
     private static final ParseField MAX_DOC_COUNT_FIELD_NAME = new ParseField("max_doc_count");
     private static final ParseField PRECISION = new ParseField("precision");
+    private static final ParseField THRESHOLD = new ParseField("threshold");
 
     private static final int MAX_MAX_DOC_COUNT = 100;
+    private static final int DEFAULT_THRESHOLD = 1000;
     public static final ObjectParser<RareTermsAggregationBuilder, String> PARSER =
             ObjectParser.fromBuilder(NAME, RareTermsAggregationBuilder::new);
     static {
@@ -50,6 +53,8 @@ public class RareTermsAggregationBuilder extends ValuesSourceAggregationBuilder<
             IncludeExclude::parseExclude, IncludeExclude.EXCLUDE_FIELD, ObjectParser.ValueType.STRING_ARRAY);
 
         PARSER.declareDouble(RareTermsAggregationBuilder::setPrecision, PRECISION);
+
+        PARSER.declareInt(RareTermsAggregationBuilder::setThreshold, THRESHOLD);
     }
 
     public static void registerAggregators(ValuesSourceRegistry.Builder builder) {
@@ -59,6 +64,7 @@ public class RareTermsAggregationBuilder extends ValuesSourceAggregationBuilder<
     private IncludeExclude includeExclude = null;
     private int maxDocCount = 1;
     private double precision = 0.001;
+    private int threshold = DEFAULT_THRESHOLD;
 
     public RareTermsAggregationBuilder(String name) {
         super(name);
@@ -88,6 +94,9 @@ public class RareTermsAggregationBuilder extends ValuesSourceAggregationBuilder<
         super(in);
         includeExclude = in.readOptionalWriteable(IncludeExclude::new);
         maxDocCount = in.readVInt();
+        if (in.getVersion().onOrAfter(Version.V_8_0_0)) {
+            threshold = in.readVInt();
+        }
     }
 
     @Override
@@ -99,6 +108,9 @@ public class RareTermsAggregationBuilder extends ValuesSourceAggregationBuilder<
     protected void innerWriteTo(StreamOutput out) throws IOException {
         out.writeOptionalWriteable(includeExclude);
         out.writeVInt(maxDocCount);
+        if (out.getVersion().onOrAfter(Version.V_8_0_0)) {
+            out.writeVInt(threshold);
+        }
     }
 
     /**
@@ -150,11 +162,28 @@ public class RareTermsAggregationBuilder extends ValuesSourceAggregationBuilder<
      * This value does, however, affect the overall space usage of the filter.  Coarser precisions provide
      * more compact filters.  The default is 0.01
      */
-    public void setPrecision(double precision) {
+    public RareTermsAggregationBuilder setPrecision(double precision) {
         if (precision < 0.00001) {
             throw new IllegalArgumentException("[precision] must be greater than 0.00001");
         }
         this.precision = precision;
+        return this;
+    }
+
+    public double getThreshold() {
+        return threshold;
+    }
+
+    public RareTermsAggregationBuilder setThreshold(int threshold) {
+        if (threshold < 0) {
+            throw new IllegalArgumentException("[threshold] must be a positive integer");
+        }
+        if (threshold > SetBackedScalingCuckooFilter.maxThreshold()) {
+            throw new IllegalArgumentException(
+                "[threshold] must be smaller than [" + (SetBackedScalingCuckooFilter.maxThreshold()) + "]");
+        }
+        this.threshold = threshold;
+        return this;
     }
 
     @Override
@@ -172,7 +201,7 @@ public class RareTermsAggregationBuilder extends ValuesSourceAggregationBuilder<
             context.getValuesSourceRegistry().getAggregator(REGISTRY_KEY, config);
 
         return new RareTermsAggregatorFactory(name, config, includeExclude,
-            context, parent, subFactoriesBuilder, metadata, maxDocCount, precision, aggregatorSupplier);
+            context, parent, subFactoriesBuilder, metadata, maxDocCount, precision, aggregatorSupplier, threshold);
     }
 
     @Override
@@ -182,12 +211,13 @@ public class RareTermsAggregationBuilder extends ValuesSourceAggregationBuilder<
         }
         builder.field(MAX_DOC_COUNT_FIELD_NAME.getPreferredName(), maxDocCount);
         builder.field(PRECISION.getPreferredName(), precision);
+        builder.field(THRESHOLD.getPreferredName(), threshold);
         return builder;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(super.hashCode(), includeExclude, maxDocCount, precision);
+        return Objects.hash(super.hashCode(), includeExclude, maxDocCount, precision, threshold);
     }
 
     @Override
@@ -198,7 +228,8 @@ public class RareTermsAggregationBuilder extends ValuesSourceAggregationBuilder<
         RareTermsAggregationBuilder other = (RareTermsAggregationBuilder) obj;
         return Objects.equals(includeExclude, other.includeExclude)
             && Objects.equals(maxDocCount, other.maxDocCount)
-            && Objects.equals(precision, other.precision);
+            && Objects.equals(precision, other.precision)
+            && Objects.equals(threshold, other.threshold);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/RareTermsAggregatorFactory.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/RareTermsAggregatorFactory.java
@@ -34,6 +34,7 @@ public class RareTermsAggregatorFactory extends ValuesSourceAggregatorFactory {
     private final IncludeExclude includeExclude;
     private final int maxDocCount;
     private final double precision;
+    private final int threshold;
 
     static void registerAggregators(ValuesSourceRegistry.Builder builder) {
         builder.register(RareTermsAggregationBuilder.REGISTRY_KEY,
@@ -62,7 +63,8 @@ public class RareTermsAggregatorFactory extends ValuesSourceAggregatorFactory {
                                     AggregationContext context,
                                     Aggregator parent,
                                     CardinalityUpperBound cardinality,
-                                    Map<String, Object> metadata) throws IOException {
+                                    Map<String, Object> metadata,
+                                    int threshold) throws IOException {
 
                 ExecutionMode execution = ExecutionMode.MAP; //TODO global ords not implemented yet, only supports "map"
 
@@ -83,7 +85,8 @@ public class RareTermsAggregatorFactory extends ValuesSourceAggregatorFactory {
                     metadata,
                     maxDocCount,
                     precision,
-                    cardinality
+                    cardinality,
+                    threshold
                 );
 
             }
@@ -107,7 +110,8 @@ public class RareTermsAggregatorFactory extends ValuesSourceAggregatorFactory {
                                     AggregationContext context,
                                     Aggregator parent,
                                     CardinalityUpperBound cardinality,
-                                    Map<String, Object> metadata) throws IOException {
+                                    Map<String, Object> metadata,
+                                    int threshold) throws IOException {
 
                 if ((includeExclude != null) && (includeExclude.isRegexBased())) {
                     throw new IllegalArgumentException("Aggregation [" + name + "] cannot support regular expression " +
@@ -133,7 +137,8 @@ public class RareTermsAggregatorFactory extends ValuesSourceAggregatorFactory {
                     maxDocCount,
                     precision,
                     cardinality,
-                    metadata
+                    metadata,
+                    threshold
                 );
             }
         };
@@ -144,13 +149,14 @@ public class RareTermsAggregatorFactory extends ValuesSourceAggregatorFactory {
                                       AggregationContext context,
                                       AggregatorFactory parent, AggregatorFactories.Builder subFactoriesBuilder,
                                       Map<String, Object> metadata, int maxDocCount, double precision,
-                                      RareTermsAggregatorSupplier aggregatorSupplier) throws IOException {
+                                      RareTermsAggregatorSupplier aggregatorSupplier, int threshold) throws IOException {
         super(name, config, context, parent, subFactoriesBuilder, metadata);
 
         this.aggregatorSupplier = aggregatorSupplier;
         this.includeExclude = includeExclude;
         this.maxDocCount = maxDocCount;
         this.precision = precision;
+        this.threshold = threshold;
     }
 
     @Override
@@ -182,7 +188,8 @@ public class RareTermsAggregatorFactory extends ValuesSourceAggregatorFactory {
                 context,
                 parent,
                 cardinality,
-                metadata
+                metadata,
+                threshold
             );
     }
 
@@ -202,7 +209,8 @@ public class RareTermsAggregatorFactory extends ValuesSourceAggregatorFactory {
                 Map<String, Object> metadata,
                 long maxDocCount,
                 double precision,
-                CardinalityUpperBound cardinality
+                CardinalityUpperBound cardinality,
+                int threshold
             ) throws IOException {
                 final IncludeExclude.StringFilter filter = includeExclude == null ? null : includeExclude.convertToStringFilter(format);
                 return new StringRareTermsAggregator(
@@ -216,7 +224,8 @@ public class RareTermsAggregatorFactory extends ValuesSourceAggregatorFactory {
                     metadata,
                     maxDocCount,
                     precision,
-                    cardinality
+                    cardinality,
+                    threshold
                 );
             }
 
@@ -253,7 +262,8 @@ public class RareTermsAggregatorFactory extends ValuesSourceAggregatorFactory {
             Map<String, Object> metadata,
             long maxDocCount,
             double precision,
-            CardinalityUpperBound cardinality
+            CardinalityUpperBound cardinality,
+            int threshold
         ) throws IOException;
 
         abstract boolean needsGlobalOrdinals();

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/RareTermsAggregatorSupplier.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/RareTermsAggregatorSupplier.java
@@ -28,5 +28,6 @@ interface RareTermsAggregatorSupplier {
                      AggregationContext context,
                      Aggregator parent,
                      CardinalityUpperBound carinality,
-                     Map<String, Object> metadata) throws IOException;
+                     Map<String, Object> metadata,
+                     int threshold) throws IOException;
 }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/StringRareTermsAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/StringRareTermsAggregator.java
@@ -53,7 +53,8 @@ public class StringRareTermsAggregator extends AbstractRareTermsAggregator {
         Map<String, Object> metadata,
         long maxDocCount,
         double precision,
-        CardinalityUpperBound cardinality
+        CardinalityUpperBound cardinality,
+        int threshold
     ) throws IOException {
         super(
             name,
@@ -63,7 +64,8 @@ public class StringRareTermsAggregator extends AbstractRareTermsAggregator {
             metadata,
             maxDocCount,
             precision,
-            format
+            format,
+            threshold
         );
         this.valuesSource = valuesSource;
         this.filter = filter;

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/terms/InternalRareTermsTestCase.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/terms/InternalRareTermsTestCase.java
@@ -22,7 +22,7 @@ import java.util.stream.Stream;
 public abstract class InternalRareTermsTestCase extends InternalMultiBucketAggregationTestCase<InternalRareTerms<?, ?>> {
 
     private long maxDocCount;
-    private int threshold;
+    private int threshold = 1;
 
     @Before
     public void init() {

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/terms/InternalRareTermsTestCase.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/terms/InternalRareTermsTestCase.java
@@ -8,6 +8,7 @@
 
 package org.elasticsearch.search.aggregations.bucket.terms;
 
+import org.elasticsearch.common.util.SetBackedScalingCuckooFilter;
 import org.elasticsearch.search.aggregations.InternalAggregations;
 import org.elasticsearch.test.InternalMultiBucketAggregationTestCase;
 import org.junit.Before;
@@ -21,23 +22,26 @@ import java.util.stream.Stream;
 public abstract class InternalRareTermsTestCase extends InternalMultiBucketAggregationTestCase<InternalRareTerms<?, ?>> {
 
     private long maxDocCount;
+    private int threshold;
 
     @Before
     public void init() {
         maxDocCount = randomIntBetween(1, 5);
+        threshold = randomIntBetween(1, SetBackedScalingCuckooFilter.maxThreshold());
     }
 
     @Override
     protected final InternalRareTerms<?, ?> createTestInstance(String name,
                                                                Map<String, Object> metadata,
                                                                InternalAggregations aggregations) {
-        return createTestInstance(name, metadata, aggregations, maxDocCount);
+        return createTestInstance(name, metadata, aggregations, maxDocCount, threshold);
     }
 
     protected abstract InternalRareTerms<?, ?> createTestInstance(String name,
                                                                   Map<String, Object> metadata,
                                                                   InternalAggregations aggregations,
-                                                                  long maxDocCount);
+                                                                  long maxDocCount,
+                                                                  int threshold);
 
     @Override
     protected InternalRareTerms<?, ?> createUnmappedInstance(String name, Map<String, Object> metadata) {

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/terms/LongRareTermsTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/terms/LongRareTermsTests.java
@@ -25,7 +25,8 @@ public class LongRareTermsTests extends InternalRareTermsTestCase {
     protected InternalRareTerms<?, ?> createTestInstance(String name,
                                                          Map<String, Object> metadata,
                                                          InternalAggregations aggregations,
-                                                         long maxDocCount) {
+                                                         long maxDocCount,
+                                                         int threshold) {
         BucketOrder order = BucketOrder.count(false);
         DocValueFormat format = randomNumericDocValueFormat();
         List<LongRareTerms.Bucket> buckets = new ArrayList<>();
@@ -35,7 +36,7 @@ public class LongRareTermsTests extends InternalRareTermsTestCase {
             int docCount = randomIntBetween(1, 100);
             buckets.add(new LongRareTerms.Bucket(term, docCount, aggregations, format));
         }
-        SetBackedScalingCuckooFilter filter = new SetBackedScalingCuckooFilter(1000, Randomness.get(), 0.01);
+        SetBackedScalingCuckooFilter filter = new SetBackedScalingCuckooFilter(threshold, Randomness.get(), 0.01);
         return new LongRareTerms(name, order, metadata, format, buckets, maxDocCount, filter);
     }
 

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/terms/StringRareTermsTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/terms/StringRareTermsTests.java
@@ -28,7 +28,8 @@ public class StringRareTermsTests extends InternalRareTermsTestCase {
     protected InternalRareTerms<?, ?> createTestInstance(String name,
                                                          Map<String, Object> metadata,
                                                          InternalAggregations aggregations,
-                                                         long maxDocCount) {
+                                                         long maxDocCount,
+                                                         int threshold) {
         BucketOrder order = BucketOrder.count(false);
         DocValueFormat format = DocValueFormat.RAW;
         List<StringRareTerms.Bucket> buckets = new ArrayList<>();
@@ -39,7 +40,7 @@ public class StringRareTermsTests extends InternalRareTermsTestCase {
             int docCount = randomIntBetween(1, 100);
             buckets.add(new StringRareTerms.Bucket(term, docCount, aggregations, format));
         }
-        SetBackedScalingCuckooFilter filter = new SetBackedScalingCuckooFilter(1000, Randomness.get(), 0.01);
+        SetBackedScalingCuckooFilter filter = new SetBackedScalingCuckooFilter(threshold, Randomness.get(), 0.01);
         return new StringRareTerms(name, order, metadata, format, buckets, maxDocCount, filter);
     }
 


### PR DESCRIPTION
The algorithm behind the rare terms aggregation uses a naive approach (hence exact) backed by a HashSet to collect up to 10k different values. After that, it switches to list of cuckoo filters to collect values (hence approximated). Currently the number of distinct values, called threshold,  is hardcoded and cannot be changed.

This PR exposes the threshold as a parameter of the aggregation.  One motivation for this change is to make it easy to test cuckoo filters as part of the aggregation but it might be useful for low cardinality data still bigger than 10K.