### PR TITLE
[DOCS] Remove beta label for most service accounts docs

### DIFF
--- a/docs/reference/commands/service-tokens-command.asciidoc
+++ b/docs/reference/commands/service-tokens-command.asciidoc
@@ -3,8 +3,6 @@
 [[service-tokens-command]]
 == elasticsearch-service-tokens
 
-beta::[]
-
 Use the `elasticsearch-service-tokens` command to create, list, and delete file-based service account tokens.
 
 [discrete]

--- a/x-pack/docs/en/rest-api/security/clear-service-token-caches.asciidoc
+++ b/x-pack/docs/en/rest-api/security/clear-service-token-caches.asciidoc
@@ -2,8 +2,6 @@
 [[security-api-clear-service-token-caches]]
 === Clear service account token caches API
 
-beta::[]
-
 ++++
 <titleabbrev>Clear service account token caches</titleabbrev>
 ++++

--- a/x-pack/docs/en/rest-api/security/create-service-token.asciidoc
+++ b/x-pack/docs/en/rest-api/security/create-service-token.asciidoc
@@ -1,9 +1,6 @@
 [role="xpack"]
 [[security-api-create-service-token]]
 === Create service account token API
-
-beta::[]
-
 ++++
 <titleabbrev>Create service account tokens</titleabbrev>
 ++++

--- a/x-pack/docs/en/rest-api/security/delete-service-token.asciidoc
+++ b/x-pack/docs/en/rest-api/security/delete-service-token.asciidoc
@@ -1,9 +1,6 @@
 [role="xpack"]
 [[security-api-delete-service-token]]
 === Delete service account tokens API
-
-beta::[]
-
 ++++
 <titleabbrev>Delete service account token</titleabbrev>
 ++++

--- a/x-pack/docs/en/rest-api/security/get-service-accounts.asciidoc
+++ b/x-pack/docs/en/rest-api/security/get-service-accounts.asciidoc
@@ -2,8 +2,6 @@
 [[security-api-get-service-accounts]]
 === Get service accounts API
 
-beta::[]
-
 ++++
 <titleabbrev>Get service accounts</titleabbrev>
 ++++

--- a/x-pack/docs/en/security/authentication/service-accounts.asciidoc
+++ b/x-pack/docs/en/security/authentication/service-accounts.asciidoc
@@ -2,8 +2,6 @@
 [[service-accounts]]
 === Service accounts
 
-beta::[]
-
 The {stack-security-features} provide _service accounts_ specifically for
 integration with external services that connect to {es}, such as {fleet} server.
 Service accounts have a fixed set of privileges and cannot authenticate

--- a/x-pack/docs/en/security/authentication/token-authentication-services.asciidoc
+++ b/x-pack/docs/en/security/authentication/token-authentication-services.asciidoc
@@ -16,8 +16,6 @@ _service-accounts_::
 +
 --
 
-beta::[]
-
 The <<service-accounts,service accounts>> use either the
 <<security-api-create-service-token,create service account token API>>
 or the <<service-tokens-command,elasticsearch-service-tokens>> CLI tool to

--- a/x-pack/docs/en/security/authorization/privileges.asciidoc
+++ b/x-pack/docs/en/security/authorization/privileges.asciidoc
@@ -112,11 +112,6 @@ All security-related operations on {es} service accounts including
 <<security-api-get-service-accounts>>,
 <<security-api-create-service-token>>, <<security-api-delete-service-token>>,
 and <<security-api-get-service-credentials>>.
-+
---
-beta::[]
-
---
 
 `manage_slm`::
 All {slm} ({slm-init}) actions, including creating and updating policies and


### PR DESCRIPTION
Removes the beta label for the following:

* Service accounts
* Create service account token API
* Delete service account token API
* Get service accounts
* Clear service token caches
* Service tokens command
* Token authentication service
* manage_service_account in privileges page