### PR TITLE
Increase default API key auth cache size to 25K. (#74388)

### DIFF
--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/ApiKeyService.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/ApiKeyService.java
@@ -34,6 +34,8 @@ import org.elasticsearch.action.update.UpdateRequest;
 import org.elasticsearch.action.update.UpdateResponse;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.cache.RemovalListener;
+import org.elasticsearch.common.cache.RemovalNotification.RemovalReason;
 import org.elasticsearch.core.CharArrays;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.common.xcontent.ParseField;
@@ -117,6 +119,8 @@ import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.LongAdder;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -174,7 +178,7 @@ public class ApiKeyService {
     public static final Setting<TimeValue> CACHE_TTL_SETTING = Setting.timeSetting("xpack.security.authc.api_key.cache.ttl",
         TimeValue.timeValueHours(24L), Property.NodeScope);
     public static final Setting<Integer> CACHE_MAX_KEYS_SETTING = Setting.intSetting("xpack.security.authc.api_key.cache.max_keys",
-        10000, Property.NodeScope);
+        25000, Property.NodeScope);
     public static final Setting<TimeValue> DOC_CACHE_TTL_SETTING = Setting.timeSetting("xpack.security.authc.api_key.doc_cache.ttl",
         TimeValue.timeValueMinutes(5), TimeValue.timeValueMinutes(0), TimeValue.timeValueMinutes(15), Property.NodeScope);
 
@@ -195,6 +199,12 @@ public class ApiKeyService {
 
     private volatile long lastExpirationRunMs;
 
+    private static final long EVICTION_MONITOR_INTERVAL_SECONDS = 300L; // 5 minutes
+    private static final long EVICTION_MONITOR_INTERVAL_NANOS = EVICTION_MONITOR_INTERVAL_SECONDS * 1_000_000_000L;
+    private static final long EVICTION_WARNING_THRESHOLD = 15L * EVICTION_MONITOR_INTERVAL_SECONDS; // 15 eviction per sec = 4500 in 5 min
+    private final AtomicLong lastEvictionCheckedAt = new AtomicLong(0);
+    private final LongAdder evictionCounter = new LongAdder();
+
     public ApiKeyService(Settings settings, Clock clock, Client client, XPackLicenseState licenseState, SecurityIndexManager securityIndex,
                          ClusterService clusterService, CacheInvalidatorRegistry cacheInvalidatorRegistry, ThreadPool threadPool) {
         this.clock = clock;
@@ -210,11 +220,12 @@ public class ApiKeyService {
         this.threadPool = threadPool;
         this.cacheHasher = Hasher.resolve(CACHE_HASH_ALGO_SETTING.get(settings));
         final TimeValue ttl = CACHE_TTL_SETTING.get(settings);
-        final Integer maximumWeight = CACHE_MAX_KEYS_SETTING.get(settings);
+        final int maximumWeight = CACHE_MAX_KEYS_SETTING.get(settings);
         if (ttl.getNanos() > 0) {
             this.apiKeyAuthCache = CacheBuilder.<String, ListenableFuture<CachedApiKeyHashResult>>builder()
                 .setExpireAfterAccess(ttl)
                 .setMaximumWeight(maximumWeight)
+                .removalListener(getAuthCacheRemovalListener(maximumWeight))
                 .build();
             final TimeValue doc_ttl = DOC_CACHE_TTL_SETTING.get(settings);
             this.apiKeyDocCache = doc_ttl.getNanos() == 0 ? null : new ApiKeyDocCache(doc_ttl, maximumWeight);
@@ -1139,6 +1150,32 @@ public class ApiKeyService {
             }, listener::onFailure));
     }
 
+    private RemovalListener<String, ListenableFuture<CachedApiKeyHashResult>> getAuthCacheRemovalListener(int maximumWeight) {
+        return notification -> {
+            if (RemovalReason.EVICTED == notification.getRemovalReason() && getApiKeyAuthCache().count() >= maximumWeight) {
+                evictionCounter.increment();
+                logger.trace("API key with ID [{}] was evicted from the authentication cache, "
+                        + "possibly due to cache size limit", notification.getKey());
+                final long last = lastEvictionCheckedAt.get();
+                final long now = System.nanoTime();
+                if (now - last >= EVICTION_MONITOR_INTERVAL_NANOS && lastEvictionCheckedAt.compareAndSet(last, now)) {
+                    final long sum = evictionCounter.sum();
+                    evictionCounter.add(-sum); // reset by decrease
+                    if (sum >= EVICTION_WARNING_THRESHOLD) {
+                        logger.warn("Possible thrashing for API key authentication cache, "
+                                + "[{}] eviction due to cache size within last [{}] seconds",
+                            sum, EVICTION_MONITOR_INTERVAL_SECONDS);
+                    }
+                }
+            }
+        };
+    }
+
+    // package private for test
+    LongAdder getEvictionCounter() {
+        return evictionCounter;
+    }
+
     /**
      * Returns realm name for the authenticated user.
      * If the user is authenticated by realm type {@value API_KEY_REALM_TYPE}
@@ -1359,7 +1396,7 @@ public class ApiKeyService {
             // multiple API keys, so we cache for longer and rely on the weight to manage the cache size.
             this.roleDescriptorsBytesCache = CacheBuilder.<String, BytesReference>builder()
                 .setExpireAfterAccess(TimeValue.timeValueHours(1))
-                .setMaximumWeight(maximumWeight * 2)
+                .setMaximumWeight(maximumWeight * 2L)
                 .build();
             this.lockingAtomicCounter = new LockingAtomicCounter();
         }

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/ApiKeyServiceTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/ApiKeyServiceTests.java
@@ -793,7 +793,7 @@ public class ApiKeyServiceTests extends ESTestCase {
         }
     }
 
-    public void testApiKeyAuthCacheWillLogWarningOnPossibleThrashing() throws IllegalAccessException {
+    public void testApiKeyAuthCacheWillLogWarningOnPossibleThrashing() throws Exception {
         ApiKeyService service = createApiKeyService(
             Settings.builder().put("xpack.security.authc.api_key.cache.max_keys", 1).build());
         final Cache<String, ListenableFuture<CachedApiKeyHashResult>> apiKeyAuthCache = service.getApiKeyAuthCache();
@@ -810,6 +810,8 @@ public class ApiKeyServiceTests extends ESTestCase {
         try {
             // Prepare the warning logging to trigger
             service.getEvictionCounter().add(4500);
+            // Ensure the counter is updated
+            assertBusy(() -> assertThat(service.getEvictionCounter().longValue() >= 4500, is(true)));
             appender.addExpectation(new MockLogAppender.SeenEventExpectation(
                 "thrashing", ApiKeyService.class.getName(), Level.WARN,
                 "Possible thrashing for API key authentication cache,*"

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/ApiKeyServiceTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/ApiKeyServiceTests.java
@@ -7,6 +7,9 @@
 
 package org.elasticsearch.xpack.security.authc;
 
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
@@ -25,6 +28,7 @@ import org.elasticsearch.client.Client;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.cache.Cache;
+import org.elasticsearch.common.logging.Loggers;
 import org.elasticsearch.common.util.concurrent.ListenableFuture;
 import org.elasticsearch.core.Tuple;
 import org.elasticsearch.common.settings.SecureString;
@@ -45,6 +49,7 @@ import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.license.XPackLicenseState;
 import org.elasticsearch.test.ClusterServiceUtils;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.MockLogAppender;
 import org.elasticsearch.test.VersionUtils;
 import org.elasticsearch.test.XContentTestUtils;
 import org.elasticsearch.threadpool.FixedExecutorBuilder;
@@ -98,6 +103,7 @@ import java.util.concurrent.Semaphore;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 import static org.elasticsearch.index.mapper.MapperService.SINGLE_MAPPING_NAME;
 import static org.elasticsearch.index.seqno.SequenceNumbers.UNASSIGNED_PRIMARY_TERM;
@@ -702,6 +708,127 @@ public class ApiKeyServiceTests extends ESTestCase {
         assertThat(result.isAuthenticated(), is(true));
         assertThat(service.getFromCache(creds.getId()), not(sameInstance(cachedApiKeyHashResult)));
         assertThat(service.getFromCache(creds.getId()).success, is(true));
+    }
+
+    public void testApiKeyAuthCacheWillTraceLogOnEvictionDueToCacheSize() throws IllegalAccessException {
+        final int cacheSize = randomIntBetween(2, 8);
+        ApiKeyService service = createApiKeyService(
+            Settings.builder().put("xpack.security.authc.api_key.cache.max_keys", cacheSize).build());
+        final Cache<String, ListenableFuture<CachedApiKeyHashResult>> apiKeyAuthCache = service.getApiKeyAuthCache();
+
+        // Fill the cache
+        final String idPrefix = randomAlphaOfLength(20);
+        final AtomicInteger count = new AtomicInteger(0);
+        IntStream.range(0, cacheSize).forEach(i -> apiKeyAuthCache.put(idPrefix + count.incrementAndGet(), new ListenableFuture<>()));
+        final Logger logger = LogManager.getLogger(ApiKeyService.class);
+        Loggers.setLevel(logger, Level.TRACE);
+        final MockLogAppender appender = new MockLogAppender();
+        Loggers.addAppender(logger, appender);
+        appender.start();
+
+        try {
+            appender.addExpectation(new MockLogAppender.PatternSeenEventExpectation(
+                "evict", ApiKeyService.class.getName(), Level.TRACE,
+                "API key with ID \\[" + idPrefix + "[0-9]+\\] was evicted from the authentication cache.*"
+            ));
+            appender.addExpectation(new MockLogAppender.UnseenEventExpectation(
+                "no-thrashing", ApiKeyService.class.getName(), Level.WARN,
+                "Possible thrashing for API key authentication cache,*"
+            ));
+            apiKeyAuthCache.put(idPrefix + count.incrementAndGet(), new ListenableFuture<>());
+            appender.assertAllExpectationsMatched();
+
+            appender.addExpectation(new MockLogAppender.UnseenEventExpectation(
+                "replace", ApiKeyService.class.getName(), Level.TRACE,
+                "API key with ID [" + idPrefix + "*] was evicted from the authentication cache*"
+            ));
+            apiKeyAuthCache.put(idPrefix + count.get(), new ListenableFuture<>());
+            appender.assertAllExpectationsMatched();
+
+            appender.addExpectation(new MockLogAppender.UnseenEventExpectation(
+                "invalidate", ApiKeyService.class.getName(), Level.TRACE,
+                "API key with ID [" + idPrefix + "*] was evicted from the authentication cache*"
+            ));
+            apiKeyAuthCache.invalidate(idPrefix + count.get(), new ListenableFuture<>());
+            apiKeyAuthCache.invalidateAll();
+            appender.assertAllExpectationsMatched();
+        } finally {
+            appender.stop();
+            Loggers.setLevel(logger, Level.INFO);
+            Loggers.removeAppender(logger, appender);
+        }
+    }
+
+    public void testApiKeyCacheWillNotTraceLogOnEvictionDueToCacheTtl() throws IllegalAccessException, InterruptedException {
+        ApiKeyService service = createApiKeyService(Settings.builder()
+            .put("xpack.security.authc.api_key.cache.max_keys", 2)
+            .put("xpack.security.authc.api_key.cache.ttl", TimeValue.timeValueMillis(100))
+            .build());
+        final Cache<String, ListenableFuture<CachedApiKeyHashResult>> apiKeyAuthCache = service.getApiKeyAuthCache();
+        final String apiKeyId = randomAlphaOfLength(22);
+
+        final Logger logger = LogManager.getLogger(ApiKeyService.class);
+        Loggers.setLevel(logger, Level.TRACE);
+        final MockLogAppender appender = new MockLogAppender();
+        Loggers.addAppender(logger, appender);
+        appender.start();
+
+        try {
+            appender.addExpectation(new MockLogAppender.UnseenEventExpectation(
+                "evict", ApiKeyService.class.getName(), Level.TRACE,
+                "API key with ID [" + apiKeyId + "] was evicted from the authentication cache*"
+            ));
+            apiKeyAuthCache.put(apiKeyId, new ListenableFuture<>());
+            // Wait for the entry to expire
+            Thread.sleep(200);
+            assertNull(apiKeyAuthCache.get(apiKeyId));
+            // Cache a new entry
+            apiKeyAuthCache.put(randomValueOtherThan(apiKeyId, () -> randomAlphaOfLength(22)), new ListenableFuture<>());
+            assertEquals(1, apiKeyAuthCache.count());
+            appender.assertAllExpectationsMatched();
+        } finally {
+            appender.stop();
+            Loggers.setLevel(logger, Level.INFO);
+            Loggers.removeAppender(logger, appender);
+        }
+    }
+
+    public void testApiKeyAuthCacheWillLogWarningOnPossibleThrashing() throws IllegalAccessException {
+        ApiKeyService service = createApiKeyService(
+            Settings.builder().put("xpack.security.authc.api_key.cache.max_keys", 1).build());
+        final Cache<String, ListenableFuture<CachedApiKeyHashResult>> apiKeyAuthCache = service.getApiKeyAuthCache();
+
+        // Fill the cache
+        final String apiKeyId = randomAlphaOfLength(22);
+        apiKeyAuthCache.put(apiKeyId, new ListenableFuture<>());
+        final Logger logger = LogManager.getLogger(ApiKeyService.class);
+        Loggers.setLevel(logger, Level.WARN);
+        final MockLogAppender appender = new MockLogAppender();
+        Loggers.addAppender(logger, appender);
+        appender.start();
+
+        try {
+            // Prepare the warning logging to trigger
+            service.getEvictionCounter().add(4500);
+            appender.addExpectation(new MockLogAppender.SeenEventExpectation(
+                "thrashing", ApiKeyService.class.getName(), Level.WARN,
+                "Possible thrashing for API key authentication cache,*"
+            ));
+            apiKeyAuthCache.put(randomAlphaOfLength(23), new ListenableFuture<>());
+            appender.assertAllExpectationsMatched();
+
+            // Will not log warning again for the next eviction because of throttling
+            appender.addExpectation(new MockLogAppender.UnseenEventExpectation(
+                "throttling", ApiKeyService.class.getName(), Level.WARN,
+                "Possible thrashing for API key authentication cache,*"
+            ));
+            apiKeyAuthCache.put(randomAlphaOfLength(24), new ListenableFuture<>());
+            appender.assertAllExpectationsMatched();
+        } finally {
+            appender.stop();
+            Loggers.setLevel(logger, Level.INFO);
+            Loggers.removeAppender(logger, appender);
+        }
     }
 
     public void testAuthenticateWhileCacheBeingPopulated() throws Exception {


### PR DESCRIPTION
This PR increases default size of the API key auth cache from 10K to 25K
to cover the majority of expected deployment sizes. Also add trace and warning
loggings on eviction for the API key auth cache to help identify potential cache 
thrashing issues.
