### PR TITLE
[7.x] Improve error message when minimum compiler version is not met (#74512)

### DIFF
--- a/build-tools-internal/build.gradle
+++ b/build-tools-internal/build.gradle
@@ -158,12 +158,13 @@ gradlePlugin {
  *         Java version                                                      *
  *****************************************************************************/
 
-if (JavaVersion.current() < JavaVersion.VERSION_11) {
-  throw new GradleException('At least Java 11 is required to build elasticsearch gradle tools')
-}
+def minCompilerJava = JavaVersion.toVersion(file('src/main/resources/minimumCompilerVersion').text)
+targetCompatibility = minCompilerJava
+sourceCompatibility = minCompilerJava
 
-targetCompatibility = 11
-sourceCompatibility = 11
+if (JavaVersion.current() < JavaVersion.toVersion(minCompilerJava)) {
+  throw new GradleException("Java ${minCompilerJava} is required to build Elasticsearch but current Java is version ${JavaVersion.current()}.")
+}
 
 sourceSets {
   integTest {


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Improve error message when minimum compiler version is not met (#74512)