### PR TITLE
[DOCS] Clean up xpack.ml.enabled details

### DIFF
--- a/docs/reference/modules/node.asciidoc
+++ b/docs/reference/modules/node.asciidoc
@@ -75,10 +75,9 @@ as a remote client.
 
 <<ml-node,Machine learning node>>::
 
-A node that has `xpack.ml.enabled` and the `ml` role. If you want to use
-{ml-features}, there must be at least one {ml} node in your cluster. For more
-information about {ml-features}, see {ml-docs}/index.html[Machine learning in
-the {stack}].
+A node that has the `ml` role. If you want to use {ml-features}, there must be
+at least one {ml} node in your cluster. For more information, see
+<<ml-settings>> and {ml-docs}/index.html[Machine learning in the {stack}].
 
 <<transform-node,{transform-cap} node>>::
 
@@ -343,31 +342,20 @@ node.roles: [ remote_cluster_client ]
 [[ml-node]]
 ==== [xpack]#Machine learning node#
 
-The {ml-features} provide {ml} nodes, which run jobs and handle {ml} API
-requests. If `xpack.ml.enabled` is set to `true` and the node does not have the
-`ml` role, the node can service API requests but it cannot run jobs.
-
-If you want to use {ml-features} in your cluster, you must enable {ml}
-(set `xpack.ml.enabled` to `true`) on all master-eligible nodes. If you want to
-use {ml-features} in clients (including {kib}), it must also be enabled on all
-coordinating nodes.
-
-For more information about these settings, see <<ml-settings>>.
+{ml-cap} nodes run jobs and handle {ml} API requests. For more information, see
+<<ml-settings>>.
 
 To create a dedicated {ml} node, set:
 
 [source,yaml]
 ----
-node.roles: [ ml, remote_cluster_client] <1>
-xpack.ml.enabled: true <2>
+node.roles: [ ml, remote_cluster_client]
 ----
-<1> The `remote_cluster_client` role is optional but strongly recommended.
-Otherwise, {ccs} fails when used in {ml} jobs or {dfeeds}. See <<remote-node>>.
-<2> The `xpack.ml.enabled` setting is enabled by default.
 
-NOTE: If you use {ccs} in your {anomaly-jobs}, the `remote_cluster_client` role 
-is also required on all master-eligible nodes. Otherwise, the {dfeed} cannot 
-start.
+The `remote_cluster_client` role is optional but strongly recommended.
+Otherwise, {ccs} fails when used in {ml} jobs or {dfeeds}. If you use {ccs} in
+your {anomaly-jobs}, the `remote_cluster_client` role is also required on all
+master-eligible nodes. Otherwise, the {dfeed} cannot start. See <<remote-node>>.
 
 [[transform-node]]
 ==== [xpack]#{transform-cap} node#
@@ -379,9 +367,10 @@ To create a dedicated {transform} node, set:
 
 [source,yaml]
 ----
-node.roles: [ transform, remote_cluster_client ] <1>
+node.roles: [ transform, remote_cluster_client ]
 ----
-<1> The `remote_cluster_client` role is optional but strongly recommended.
+
+The `remote_cluster_client` role is optional but strongly recommended.
 Otherwise, {ccs} fails when used in {transforms}. See <<remote-node>>.
 
 [[change-node-role]]

--- a/docs/reference/settings/ml-settings.asciidoc
+++ b/docs/reference/settings/ml-settings.asciidoc
@@ -32,25 +32,21 @@ the node. To learn more, refer to <<modules-node>>.
 ====
 * On dedicated coordinating nodes or dedicated master nodes, do not set
 the `ml` role.
-* It is strongly recommended that dedicated {ml} nodes also have the `remote_cluster_client` role; otherwise, {ccs} fails when used in {ml} jobs or {dfeeds}. See <<remote-node>>.
+* It is strongly recommended that dedicated {ml} nodes also have the
+`remote_cluster_client` role; otherwise, {ccs} fails when used in {ml} jobs or
+{dfeeds}. See <<remote-node>>.
 ====
 
 `xpack.ml.enabled`::
-(<<static-cluster-setting,Static>>) Set to `true` (default) to enable {ml} APIs
+(<<static-cluster-setting,Static>>) The default value (`true`) enables {ml} APIs
 on the node.
 +
-If set to `false`, the {ml} APIs are disabled on the node. Therefore the node
-cannot open jobs, start {dfeeds}, or receive transport (internal) communication
-requests related to {ml} APIs. If the node is a coordinating node, {ml} requests
-from clients (including {kib}) also fail. For more information about disabling
-{ml} in specific {kib} instances, see
-{kibana-ref}/ml-settings-kb.html[{kib} {ml} settings].
-+
 IMPORTANT: If you want to use {ml-features} in your cluster, it is recommended
-that you set `xpack.ml.enabled` to `true` on all nodes. This is the default
-behavior. At a minimum, it must be enabled on all master-eligible nodes. If you
-want to use {ml-features} in clients or {kib}, it must also be enabled on all
-coordinating nodes.
+that you use the default value for this setting on all nodes.
++
+If set to `false`, the {ml} APIs are disabled on the node. For example, the node
+cannot open jobs, start {dfeeds}, receive transport (internal) communication
+requests, or requests from clients (including {kib}) related to {ml} APIs.
 
 `xpack.ml.inference_model.cache_size`::
 (<<static-cluster-setting,Static>>) The maximum inference cache size allowed.


### PR DESCRIPTION
This PR simplifies the description of machine learning nodes and xpack.ml.enabled settings to avoid confusion about the default behaviour and the impact on coordinating nodes.

### Preview

* https://elasticsearch_74573.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/ml-settings.html
* https://elasticsearch_74573.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/modules-node.html#ml-node