### PR TITLE
[7.x] Clean up Node Shutdown API responses (#74523)

### DIFF
--- a/x-pack/plugin/shutdown/src/main/java/org/elasticsearch/xpack/shutdown/TransportDeleteShutdownNodeAction.java
+++ b/x-pack/plugin/shutdown/src/main/java/org/elasticsearch/xpack/shutdown/TransportDeleteShutdownNodeAction.java
@@ -10,6 +10,7 @@ package org.elasticsearch.xpack.shutdown;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.message.ParameterizedMessage;
+import org.elasticsearch.ResourceNotFoundException;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.master.AcknowledgedResponse;
@@ -58,8 +59,8 @@ public class TransportDeleteShutdownNodeAction extends AcknowledgedTransportMast
     ) throws Exception {
         { // This block solely to ensure this NodesShutdownMetadata isn't accidentally used in the cluster state update task below
             NodesShutdownMetadata nodesShutdownMetadata = state.metadata().custom(NodesShutdownMetadata.TYPE);
-            if (nodesShutdownMetadata.getAllNodeMetadataMap().get(request.getNodeId()) == null) {
-                throw new IllegalArgumentException("node [" + request.getNodeId() + "] is not currently shutting down");
+            if (nodesShutdownMetadata == null || nodesShutdownMetadata.getAllNodeMetadataMap().get(request.getNodeId()) == null) {
+                throw new ResourceNotFoundException("node [" + request.getNodeId() + "] is not currently shutting down");
             }
         }
 

--- a/x-pack/plugin/shutdown/src/main/java/org/elasticsearch/xpack/shutdown/TransportGetShutdownStatusAction.java
+++ b/x-pack/plugin/shutdown/src/main/java/org/elasticsearch/xpack/shutdown/TransportGetShutdownStatusAction.java
@@ -170,6 +170,15 @@ public class TransportGetShutdownStatusAction extends TransportMasterNodeAction<
             );
         }
 
+        if (currentState.getRoutingNodes().node(nodeId) == null) {
+            // We don't know about that node
+            return new ShutdownShardMigrationStatus(
+                SingleNodeShutdownMetadata.Status.NOT_STARTED,
+                0,
+                "node is not currently part of the cluster"
+            );
+        }
+
         // First, check if there are any shards currently on this node, and if there are any relocating shards
         int startedShards = currentState.getRoutingNodes().node(nodeId).numberOfShardsWithState(ShardRoutingState.STARTED);
         int relocatingShards = currentState.getRoutingNodes().node(nodeId).numberOfShardsWithState(ShardRoutingState.RELOCATING);
@@ -242,7 +251,7 @@ public class TransportGetShutdownStatusAction extends TransportMasterNodeAction<
                 SingleNodeShutdownMetadata.Status.STALLED,
                 totalRemainingShards,
                 new ParameterizedMessage(
-                    "shard [{}] [{}] of index [{}] cannot move, see Cluster Allocation Explain API for details",
+                    "shard [{}] [{}] of index [{}] cannot move, use the Cluster Allocation Explain API on this shard for details",
                     shardRouting.shardId().getId(),
                     shardRouting.primary() ? "primary" : "replica",
                     shardRouting.index().getName()

--- a/x-pack/plugin/shutdown/src/test/java/org/elasticsearch/xpack/shutdown/TransportGetShutdownStatusActionTests.java
+++ b/x-pack/plugin/shutdown/src/test/java/org/elasticsearch/xpack/shutdown/TransportGetShutdownStatusActionTests.java
@@ -394,6 +394,76 @@ public class TransportGetShutdownStatusActionTests extends ESTestCase {
         );
     }
 
+    public void testNodeNotInCluster() {
+        String bogusNodeId = randomAlphaOfLength(10);
+        ImmutableOpenMap.Builder<String, IndexMetadata> indicesTable = ImmutableOpenMap.<String, IndexMetadata>builder();
+        RoutingTable.Builder routingTable = RoutingTable.builder();
+
+        ClusterState state = ClusterState.builder(ClusterState.EMPTY_STATE)
+            .metadata(
+                Metadata.builder()
+                    .indices(indicesTable.build())
+                    .putCustom(
+                        NodesShutdownMetadata.TYPE,
+                        new NodesShutdownMetadata(
+                            Collections.singletonMap(
+                                bogusNodeId,
+                                SingleNodeShutdownMetadata.builder()
+                                    .setType(SingleNodeShutdownMetadata.Type.REMOVE)
+                                    .setStartedAtMillis(randomNonNegativeLong())
+                                    .setReason(this.getTestName())
+                                    .setNodeId(bogusNodeId)
+                                    .build()
+                            )
+                        )
+                    )
+            )
+            .nodes(
+                DiscoveryNodes.builder()
+                    .add(
+                        DiscoveryNode.createLocal(
+                            Settings.builder()
+                                .put(Settings.builder().build())
+                                .put(Node.NODE_NAME_SETTING.getKey(), SHUTTING_DOWN_NODE_ID)
+                                .build(),
+                            new TransportAddress(TransportAddress.META_ADDRESS, 9200),
+                            SHUTTING_DOWN_NODE_ID
+                        )
+                    )
+                    .add(
+                        DiscoveryNode.createLocal(
+                            Settings.builder().put(Settings.builder().build()).put(Node.NODE_NAME_SETTING.getKey(), LIVE_NODE_ID).build(),
+                            new TransportAddress(TransportAddress.META_ADDRESS, 9201),
+                            LIVE_NODE_ID
+                        )
+                    )
+                    .add(
+                        DiscoveryNode.createLocal(
+                            Settings.builder()
+                                .put(Settings.builder().build())
+                                .put(Node.NODE_NAME_SETTING.getKey(), OTHER_LIVE_NODE_ID)
+                                .build(),
+                            new TransportAddress(TransportAddress.META_ADDRESS, 9202),
+                            OTHER_LIVE_NODE_ID
+                        )
+                    )
+            )
+            .routingTable(routingTable.build())
+            .build();
+
+        ShutdownShardMigrationStatus status = TransportGetShutdownStatusAction.shardMigrationStatus(
+            state,
+            bogusNodeId,
+            SingleNodeShutdownMetadata.Type.REMOVE,
+            allocationDeciders,
+            clusterInfoService,
+            snapshotsInfoService,
+            allocationService
+        );
+
+        assertShardMigration(status, SingleNodeShutdownMetadata.Status.NOT_STARTED, 0, is("node is not currently part of the cluster"));
+    }
+
     private IndexMetadata generateIndexMetadata(Index index, int numberOfShards, int numberOfReplicas) {
         return IndexMetadata.builder(index.getName())
             .settings(


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Clean up Node Shutdown API responses (#74523)