### PR TITLE
[7.x][ML] Ensure progress is complete by the time DFA job stops (#74506)

### DIFF
--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/DataFrameAnalyticsTask.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/DataFrameAnalyticsTask.java
@@ -9,6 +9,7 @@ package org.elasticsearch.xpack.ml.dataframe;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.message.ParameterizedMessage;
+import org.apache.lucene.util.SetOnce;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.index.IndexAction;
 import org.elasticsearch.action.index.IndexRequest;
@@ -187,20 +188,22 @@ public class DataFrameAnalyticsTask extends AllocatedPersistentTask implements S
         });
     }
 
-    public void persistProgress() {
-        persistProgress(client, taskParams.getId(), () -> {});
+    public void persistProgress(Runnable runnable) {
+        persistProgress(client, taskParams.getId(), runnable);
     }
 
     // Visible for testing
     void persistProgress(Client client, String jobId, Runnable runnable) {
         LOGGER.debug("[{}] Persisting progress", jobId);
 
+        SetOnce<StoredProgress> storedProgress = new SetOnce<>();
+
         String progressDocId = StoredProgress.documentId(jobId);
 
         // Step 4: Run the runnable provided as the argument
         ActionListener<IndexResponse> indexProgressDocListener = ActionListener.wrap(
             indexResponse -> {
-                LOGGER.debug("[{}] Successfully indexed progress document", jobId);
+                LOGGER.debug("[{}] Successfully indexed progress document: {}", jobId, storedProgress.get().get());
                 runnable.run();
             },
             indexError -> {
@@ -227,10 +230,11 @@ public class DataFrameAnalyticsTask extends AllocatedPersistentTask implements S
                 }
 
                 List<PhaseProgress> progress = statsHolder.getProgressTracker().report();
-                final StoredProgress progressToStore = new StoredProgress(progress);
-                if (progressToStore.equals(previous)) {
+                storedProgress.set(new StoredProgress(progress));
+                if (storedProgress.get().equals(previous)) {
                     LOGGER.debug(() -> new ParameterizedMessage(
-                        "[{}] new progress is the same as previously persisted progress. Skipping storage.", jobId));
+                        "[{}] new progress is the same as previously persisted progress. Skipping storage of progress: {}",
+                        jobId, progress));
                     runnable.run();
                     return;
                 }
@@ -241,7 +245,7 @@ public class DataFrameAnalyticsTask extends AllocatedPersistentTask implements S
                     .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE);
                 try (XContentBuilder jsonBuilder = JsonXContent.contentBuilder()) {
                     LOGGER.debug(() -> new ParameterizedMessage("[{}] Persisting progress is: {}", jobId, progress));
-                    progressToStore.toXContent(jsonBuilder, Payload.XContent.EMPTY_PARAMS);
+                    storedProgress.get().toXContent(jsonBuilder, Payload.XContent.EMPTY_PARAMS);
                     indexRequest.source(jsonBuilder);
                 }
                 executeAsyncWithOrigin(client, ML_ORIGIN, IndexAction.INSTANCE, indexRequest, indexProgressDocListener);

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/steps/AbstractDataFrameAnalyticsStep.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/steps/AbstractDataFrameAnalyticsStep.java
@@ -63,11 +63,14 @@ abstract class AbstractDataFrameAnalyticsStep implements DataFrameAnalyticsStep 
             listener.onResponse(new StepResponse(true));
             return;
         }
-        doExecute(listener);
-
-        // We persist progress at the end of each step to ensure we do not have
-        // to repeat the step in case the node goes down without getting a chance to persist progress.
-        task.persistProgress();
+        doExecute(ActionListener.wrap(
+            stepResponse -> {
+                // We persist progress at the end of each step to ensure we do not have
+                // to repeat the step in case the node goes down without getting a chance to persist progress.
+                task.persistProgress(() -> listener.onResponse(stepResponse));
+            },
+            listener::onFailure
+        ));
     }
 
     protected abstract void doExecute(ActionListener<StepResponse> listener);


### PR DESCRIPTION
Test failures in #74342 have shown that it is possible for a
data frame analytics job to complete and yet for its progress
to appear incomplete.

The reason this may happen is that we persist progress asynchronously
except for when we're marking the task complete. When we mark the task
complete, we make another try to persist complete progress. However,
we skip persistence if the existing progress document is the same.
Those previous fire-and-forget index requests may end up processed
in a different order resulting into overwriting a latter progress
document.

This commit fixes this by making the progress persist calls at
the end of each step wait for the index request to complete.

Closes #74342

Backport of #74506
