### PR TITLE
Limit JDK versions for FIPS 140-2 matrix jobs

### DIFF
--- a/.ci/matrix-runtime-javas-fips.yml
+++ b/.ci/matrix-runtime-javas-fips.yml
@@ -1,15 +1,12 @@
 # This file is used as part of a matrix build in Jenkins where the
 # values below are included as an axis of the matrix.
 
-# This axis of the build matrix represents the versions of Java on
-# which Elasticsearch will be tested.  Valid Java versions are 'java'
-# or 'openjdk' followed by the major release number.
+# java11 should always be included as we only support Oracle Java 11 in
+# FIPS 140-2 mode.
+# We also want to test with the bundled JDK so that we proactively find
+# issues that might later be backported to JDK11. Current bundled JDK is
+# openjdk16
 
 ES_RUNTIME_JAVA:
   - java11
   - openjdk16
-  - zulu8
-  - zulu11
-  - corretto11
-  - corretto8
-  - adoptopenjdk11


### PR DESCRIPTION
We _only_ support Oracle JDK11 for FIPS 140-2 mode so there is no
need to run tests in FIPS 140-2 mode with all JDKs we otherwise
support. This change limits the versions for our matrix fips jobs
to JDK11 and openjdk16 which is the current bundled JDK. We want to
use the latter as a canary for changes that might break the
FIPS 140-2 mode, that might get introduced in JDK16 and later
backported to JDK11

backport of #74564
