### PR TITLE
Trigger FIPS checks on all security team PRs

### DIFF
--- a/.ci/jobs.t/elastic+elasticsearch+pull-request+part-1-fips.yml
+++ b/.ci/jobs.t/elastic+elasticsearch+pull-request+part-1-fips.yml
@@ -24,7 +24,7 @@
           excluded-regions:
             - ^docs/.*
           white-list-labels:
-            - ':Security/FIPS'
+            - 'Team:Security'
           black-list-labels:
             - '>test-mute'
     builders:

--- a/.ci/jobs.t/elastic+elasticsearch+pull-request+part-2-fips.yml
+++ b/.ci/jobs.t/elastic+elasticsearch+pull-request+part-2-fips.yml
@@ -24,7 +24,7 @@
           excluded-regions:
             - ^docs/.*
           white-list-labels:
-            - ':Security/FIPS'
+            - 'Team:Security'
           black-list-labels:
             - '>test-mute'
     builders:


### PR DESCRIPTION
We originally opted to running FIPS CI checks when PRs have a
specific label in hope that we will be adding this label when
our code changes might have an impact or be affected by our
FIPS 140-2 setup/support.
In practice, we omit to add the label in many cases and this
still leads to the problem of having CI failures that we fail to
catch in PR checks.
This change makes it so that the FIPS CI checks will run in all
the PRs that have one of the ES Security team labels.