### PR TITLE
Remove Repository Size Limit Default

### DIFF
--- a/docs/reference/snapshot-restore/apis/put-repo-api.asciidoc
+++ b/docs/reference/snapshot-restore/apis/put-repo-api.asciidoc
@@ -176,11 +176,8 @@ in snapshots. Data files are not compressed. Defaults to `true`.
 
 `max_number_of_snapshots`::
 (Optional, integer)
-Maximum number of snapshots the repository can contain. Defaults to `500`.
-+
-WARNING: We do not recommend increasing `max_number_of_snapshots`. Larger
-snapshot repositories may degrade master node performance and cause stability
-issues. Instead, delete older snapshots or use multiple repositories.
+Maximum number of snapshots the repository can contain.
+Defaults to `Integer.MAX_VALUE`, which is `2^31-1` or `2147483647`.
 
 `max_restore_bytes_per_sec`::
 (Optional, <<byte-units,byte value>>)

--- a/server/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
+++ b/server/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
@@ -237,7 +237,7 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
      */
     public static final Setting<Integer> MAX_SNAPSHOTS_SETTING = Setting.intSetting(
         "max_number_of_snapshots",
-        500,
+        Integer.MAX_VALUE,
         1,
         Setting.Property.NodeScope
     );


### PR DESCRIPTION
Now that we actively improve the scalability there is no point
of having a `500` limit in `master`.
