### PR TITLE
Remove IndicesOptions.fromOptions (#30663)

### DIFF
--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/eql/EqlSearchRequest.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/eql/EqlSearchRequest.java
@@ -28,7 +28,7 @@ import static java.util.Collections.emptyMap;
 public class EqlSearchRequest implements Validatable, ToXContentObject {
 
     private String[] indices;
-    private IndicesOptions indicesOptions = IndicesOptions.fromOptions(true, true, true, false);
+    private IndicesOptions indicesOptions = new IndicesOptions(true, true, true, false);
 
     private QueryBuilder filter = null;
     private String timestampField = "@timestamp";

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/graph/GraphExploreRequest.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/graph/GraphExploreRequest.java
@@ -35,7 +35,7 @@ public class GraphExploreRequest implements IndicesRequest.Replaceable, ToXConte
     public static final String NO_HOPS_ERROR_MESSAGE = "Graph explore request must have at least one hop";
     public static final String NO_VERTICES_ERROR_MESSAGE = "Graph explore hop must have at least one VertexRequest";
     private String[] indices = Strings.EMPTY_ARRAY;
-    private IndicesOptions indicesOptions = IndicesOptions.fromOptions(false, false, true, false);
+    private IndicesOptions indicesOptions = new IndicesOptions(false, false, true, false);
     private String routing;
     private TimeValue timeout;
 

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/indices/GetIndexRequest.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/indices/GetIndexRequest.java
@@ -29,7 +29,7 @@ public class GetIndexRequest extends TimedRequest {
     private transient boolean includeDefaults = false;
 
     private final String[] indices;
-    private IndicesOptions indicesOptions = IndicesOptions.fromOptions(false, false, true, true);
+    private IndicesOptions indicesOptions = new IndicesOptions(false, false, true, true);
     private boolean local = false;
 
     public GetIndexRequest(String... indices) {

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/indices/PutMappingRequest.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/indices/PutMappingRequest.java
@@ -32,7 +32,7 @@ import java.util.Map;
 public class PutMappingRequest extends TimedRequest implements IndicesRequest, ToXContentObject {
 
     private final String[] indices;
-    private IndicesOptions indicesOptions = IndicesOptions.fromOptions(false, false, true, true);
+    private IndicesOptions indicesOptions = new IndicesOptions(false, false, true, true);
 
     private BytesReference source;
     private XContentType xContentType;

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/RequestConvertersTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/RequestConvertersTests.java
@@ -1207,7 +1207,7 @@ public class RequestConvertersTests extends ESTestCase {
             // specified from msearch api, so unset other options:
             IndicesOptions randomlyGenerated = searchRequest.indicesOptions();
             IndicesOptions msearchDefault = new MultiSearchRequest().indicesOptions();
-            searchRequest.indicesOptions(IndicesOptions.fromOptions(randomlyGenerated.ignoreUnavailable(),
+            searchRequest.indicesOptions(new IndicesOptions(randomlyGenerated.ignoreUnavailable(),
                     randomlyGenerated.allowNoIndices(), randomlyGenerated.expandWildcardsOpen(), randomlyGenerated.expandWildcardsClosed(),
                     msearchDefault.expandWildcardsHidden(), msearchDefault.allowAliasesToMultipleIndices(),
                     msearchDefault.forbidClosedIndices(), msearchDefault.ignoreAliases(), msearchDefault.ignoreThrottled()));
@@ -1994,7 +1994,7 @@ public class RequestConvertersTests extends ESTestCase {
                                         Map<String, String> expectedParams) {
 
         if (randomBoolean()) {
-            setter.accept(IndicesOptions.fromOptions(randomBoolean(), randomBoolean(), randomBoolean(), randomBoolean(),
+            setter.accept(new IndicesOptions(randomBoolean(), randomBoolean(), randomBoolean(), randomBoolean(),
                 true, false, false, randomBoolean()));
         }
         expectedParams.put("ignore_unavailable", Boolean.toString(getter.get().ignoreUnavailable()));
@@ -2013,7 +2013,7 @@ public class RequestConvertersTests extends ESTestCase {
 
     static IndicesOptions setRandomIndicesOptions(IndicesOptions indicesOptions, Map<String, String> expectedParams) {
         if (randomBoolean()) {
-            indicesOptions = IndicesOptions.fromOptions(randomBoolean(), randomBoolean(), randomBoolean(), randomBoolean(),
+            indicesOptions = new IndicesOptions(randomBoolean(), randomBoolean(), randomBoolean(), randomBoolean(),
                 true, false, false, randomBoolean());
         }
         expectedParams.put("ignore_unavailable", Boolean.toString(indicesOptions.ignoreUnavailable()));

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/core/CountRequestTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/core/CountRequestTests.java
@@ -107,7 +107,7 @@ public class CountRequestTests extends AbstractRequestTestCase<CountRequest, Que
         List<Runnable> mutators = new ArrayList<>();
         mutators.add(() -> mutation.indices(ArrayUtils.concat(countRequest.indices(), new String[]{randomAlphaOfLength(10)})));
         mutators.add(() -> mutation.indicesOptions(randomValueOtherThan(countRequest.indicesOptions(),
-            () -> IndicesOptions.fromOptions(randomBoolean(), randomBoolean(), randomBoolean(), randomBoolean()))));
+            () -> new IndicesOptions(randomBoolean(), randomBoolean(), randomBoolean(), randomBoolean()))));
         mutators.add(() -> mutation.types(ArrayUtils.concat(countRequest.types(), new String[]{randomAlphaOfLength(10)})));
         mutators.add(() -> mutation.preference(randomValueOtherThan(countRequest.preference(), () -> randomAlphaOfLengthBetween(3, 10))));
         mutators.add(() -> mutation.routing(randomValueOtherThan(countRequest.routing(), () -> randomAlphaOfLengthBetween(3, 10))));

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/SnapshotClientDocumentationIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/SnapshotClientDocumentationIT.java
@@ -512,7 +512,7 @@ public class SnapshotClientDocumentationIT extends ESRestHighLevelClientTestCase
         request.indices("test-index0", "test-index1"); // <1>
         // end::create-snapshot-request-indices
         // tag::create-snapshot-request-indicesOptions
-        request.indicesOptions(IndicesOptions.fromOptions(false, false, true, true)); // <1>
+        request.indicesOptions(new IndicesOptions(false, false, true, true)); // <1>
         // end::create-snapshot-request-indicesOptions
         // tag::create-snapshot-request-partial
         request.partial(false); // <1>

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/ilm/ExplainLifecycleRequestTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/ilm/ExplainLifecycleRequestTests.java
@@ -30,7 +30,7 @@ public class ExplainLifecycleRequestTests extends ESTestCase {
     private ExplainLifecycleRequest createTestInstance() {
         ExplainLifecycleRequest request = new ExplainLifecycleRequest(generateRandomStringArray(20, 20, false, false));
         if (randomBoolean()) {
-            IndicesOptions indicesOptions = IndicesOptions.fromOptions(randomBoolean(), randomBoolean(), randomBoolean(), randomBoolean(),
+            IndicesOptions indicesOptions = new IndicesOptions(randomBoolean(), randomBoolean(), randomBoolean(), randomBoolean(),
                     randomBoolean(), randomBoolean(), randomBoolean(), randomBoolean());
             request.indicesOptions(indicesOptions);
         }
@@ -46,7 +46,7 @@ public class ExplainLifecycleRequestTests extends ESTestCase {
                     () -> generateRandomStringArray(20, 10, false, false));
             break;
         case 1:
-            indicesOptions = randomValueOtherThan(indicesOptions, () -> IndicesOptions.fromOptions(randomBoolean(), randomBoolean(),
+            indicesOptions = randomValueOtherThan(indicesOptions, () -> new IndicesOptions(randomBoolean(), randomBoolean(),
                     randomBoolean(), randomBoolean(), randomBoolean(), randomBoolean(), randomBoolean(), randomBoolean()));
             break;
         default:

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/ilm/RemoveIndexLifecyclePolicyRequestTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/ilm/RemoveIndexLifecyclePolicyRequestTests.java
@@ -34,7 +34,7 @@ public class RemoveIndexLifecyclePolicyRequestTests extends ESTestCase {
     protected RemoveIndexLifecyclePolicyRequest createInstance() {
         if (randomBoolean()) {
             return new RemoveIndexLifecyclePolicyRequest(Arrays.asList(generateRandomStringArray(20, 20, false)),
-                    IndicesOptions.fromOptions(randomBoolean(), randomBoolean(), randomBoolean(),
+                    new IndicesOptions(randomBoolean(), randomBoolean(), randomBoolean(),
                     randomBoolean(), randomBoolean(), randomBoolean(), randomBoolean(), randomBoolean()));
         } else {
             return new RemoveIndexLifecyclePolicyRequest(Arrays.asList(generateRandomStringArray(20, 20, false)));
@@ -42,7 +42,7 @@ public class RemoveIndexLifecyclePolicyRequestTests extends ESTestCase {
     }
 
     private RemoveIndexLifecyclePolicyRequest copyInstance(RemoveIndexLifecyclePolicyRequest req) {
-        return new RemoveIndexLifecyclePolicyRequest(new ArrayList<>(req.indices()), IndicesOptions.fromOptions(
+        return new RemoveIndexLifecyclePolicyRequest(new ArrayList<>(req.indices()), new IndicesOptions(
                 req.indicesOptions().ignoreUnavailable(), req.indicesOptions().allowNoIndices(),
                 req.indicesOptions().expandWildcardsOpen(), req.indicesOptions().expandWildcardsClosed(),
                 req.indicesOptions().allowAliasesToMultipleIndices(), req.indicesOptions().forbidClosedIndices(),
@@ -52,7 +52,7 @@ public class RemoveIndexLifecyclePolicyRequestTests extends ESTestCase {
     private RemoveIndexLifecyclePolicyRequest mutateInstance(RemoveIndexLifecyclePolicyRequest req) {
         if (randomBoolean()) {
             return new RemoveIndexLifecyclePolicyRequest(req.indices(),
-                    randomValueOtherThan(req.indicesOptions(), () -> IndicesOptions.fromOptions(randomBoolean(), randomBoolean(),
+                    randomValueOtherThan(req.indicesOptions(), () -> new IndicesOptions(randomBoolean(), randomBoolean(),
                     randomBoolean(), randomBoolean(), randomBoolean(), randomBoolean(), randomBoolean(), randomBoolean())));
         } else {
             return new RemoveIndexLifecyclePolicyRequest(

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/indices/CloseIndexRequestTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/indices/CloseIndexRequestTests.java
@@ -36,7 +36,7 @@ public class CloseIndexRequestTests extends ESTestCase {
     }
 
     public void testIndicesOptions() {
-        IndicesOptions indicesOptions = IndicesOptions.fromOptions(randomBoolean(), randomBoolean(), randomBoolean(), randomBoolean());
+        IndicesOptions indicesOptions = new IndicesOptions(randomBoolean(), randomBoolean(), randomBoolean(), randomBoolean());
         CloseIndexRequest request = new CloseIndexRequest().indicesOptions(indicesOptions);
         assertEquals(indicesOptions, request.indicesOptions());
     }

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/indices/GetIndexRequestTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/indices/GetIndexRequestTests.java
@@ -49,7 +49,7 @@ public class GetIndexRequestTests extends ESTestCase {
     }
 
     public void testIndicesOptions() {
-        IndicesOptions indicesOptions = IndicesOptions.fromOptions(randomBoolean(), randomBoolean(), randomBoolean(), randomBoolean());
+        IndicesOptions indicesOptions = new IndicesOptions(randomBoolean(), randomBoolean(), randomBoolean(), randomBoolean());
         GetIndexRequest request = new GetIndexRequest().indicesOptions(indicesOptions);
         assertEquals(indicesOptions, request.indicesOptions());
     }

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/ml/datafeed/DatafeedConfigTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/ml/datafeed/DatafeedConfigTests.java
@@ -102,7 +102,7 @@ public class DatafeedConfigTests extends AbstractXContentTestCase<DatafeedConfig
             builder.setMaxEmptySearches(randomIntBetween(10, 100));
         }
         if (randomBoolean()) {
-            builder.setIndicesOptions(IndicesOptions.fromOptions(randomBoolean(),
+            builder.setIndicesOptions(new IndicesOptions(randomBoolean(),
                 randomBoolean(),
                 randomBoolean(),
                 randomBoolean(),

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/ml/datafeed/DatafeedUpdateTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/ml/datafeed/DatafeedUpdateTests.java
@@ -76,7 +76,7 @@ public class DatafeedUpdateTests extends AbstractXContentTestCase<DatafeedUpdate
             builder.setMaxEmptySearches(randomIntBetween(10, 100));
         }
         if (randomBoolean()) {
-            builder.setIndicesOptions(IndicesOptions.fromOptions(randomBoolean(),
+            builder.setIndicesOptions(new IndicesOptions(randomBoolean(),
                 randomBoolean(),
                 randomBoolean(),
                 randomBoolean(),

--- a/modules/rank-eval/src/test/java/org/elasticsearch/index/rankeval/RankEvalRequestTests.java
+++ b/modules/rank-eval/src/test/java/org/elasticsearch/index/rankeval/RankEvalRequestTests.java
@@ -48,7 +48,7 @@ public class RankEvalRequestTests extends AbstractWireSerializingTestCase<RankEv
             indices[i] = randomAlphaOfLengthBetween(5, 10);
         }
         RankEvalRequest rankEvalRequest = new RankEvalRequest(RankEvalSpecTests.createTestItem(), indices);
-        IndicesOptions indicesOptions = IndicesOptions.fromOptions(
+        IndicesOptions indicesOptions = new IndicesOptions(
                 randomBoolean(), randomBoolean(), randomBoolean(), randomBoolean(), randomBoolean(), randomBoolean(), randomBoolean(),
             randomBoolean());
         rankEvalRequest.indicesOptions(indicesOptions);
@@ -67,7 +67,7 @@ public class RankEvalRequestTests extends AbstractWireSerializingTestCase<RankEv
         List<Runnable> mutators = new ArrayList<>();
         mutators.add(() -> mutation.indices(ArrayUtils.concat(instance.indices(), new String[] { randomAlphaOfLength(10) })));
         mutators.add(() -> mutation.indicesOptions(randomValueOtherThan(instance.indicesOptions(),
-                () -> IndicesOptions.fromOptions(randomBoolean(), randomBoolean(), randomBoolean(), randomBoolean()))));
+                () -> new IndicesOptions(randomBoolean(), randomBoolean(), randomBoolean(), randomBoolean()))));
         mutators.add(() -> {
             if (instance.searchType() == SearchType.DFS_QUERY_THEN_FETCH) {
                 mutation.searchType(SearchType.QUERY_THEN_FETCH);

--- a/modules/rank-eval/src/test/java/org/elasticsearch/index/rankeval/TransportRankEvalActionTests.java
+++ b/modules/rank-eval/src/test/java/org/elasticsearch/index/rankeval/TransportRankEvalActionTests.java
@@ -46,7 +46,7 @@ public class TransportRankEvalActionTests extends ESTestCase {
                 new String[] { indexName });
         SearchType expectedSearchType = randomFrom(SearchType.CURRENTLY_SUPPORTED);
         rankEvalRequest.searchType(expectedSearchType);
-        IndicesOptions expectedIndicesOptions = IndicesOptions.fromOptions(randomBoolean(), randomBoolean(), randomBoolean(),
+        IndicesOptions expectedIndicesOptions = new IndicesOptions(randomBoolean(), randomBoolean(), randomBoolean(),
                 randomBoolean(), randomBoolean(), randomBoolean(), randomBoolean(), randomBoolean());
         rankEvalRequest.indicesOptions(expectedIndicesOptions);
 

--- a/server/src/internalClusterTest/java/org/elasticsearch/action/search/TransportSearchIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/action/search/TransportSearchIT.java
@@ -173,7 +173,7 @@ public class TransportSearchIT extends ESIntegTestCase {
         }
         {
             SearchRequest searchRequest = new SearchRequest("<test-{now/d}>");
-            searchRequest.indicesOptions(IndicesOptions.fromOptions(true, true, true, true));
+            searchRequest.indicesOptions(new IndicesOptions(true, true, true, true));
             SearchResponse searchResponse = client().search(searchRequest).actionGet();
             assertEquals(0, searchResponse.getTotalShards());
         }

--- a/server/src/internalClusterTest/java/org/elasticsearch/aliases/IndexAliasesIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/aliases/IndexAliasesIT.java
@@ -1199,7 +1199,7 @@ public class IndexAliasesIT extends ESIntegTestCase {
         // And querying using a wildcard with indices options set to expand hidden
         searchResponse = client().prepareSearch("alias*")
             .setQuery(QueryBuilders.matchAllQuery())
-            .setIndicesOptions(IndicesOptions.fromOptions(false, false, true, false, true, true, true, false, false)).get();
+            .setIndicesOptions(new IndicesOptions(false, false, true, false, true, true, true, false, false)).get();
         assertHits(searchResponse.getHits(), "1", "2", "3");
 
         // And that querying the alias with a wildcard and no expand options fails

--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/ClusterHealthIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/ClusterHealthIT.java
@@ -139,7 +139,7 @@ public class ClusterHealthIT extends ESIntegTestCase {
         }
         {
             ClusterHealthResponse response = client().admin().cluster().prepareHealth("index-*")
-                .setIndicesOptions(IndicesOptions.fromOptions(true, true, false, true))
+                .setIndicesOptions(new IndicesOptions(true, true, false, true))
                 .get();
             assertThat(response.getStatus(), equalTo(ClusterHealthStatus.GREEN));
             assertThat(response.isTimedOut(), equalTo(false));
@@ -209,7 +209,7 @@ public class ClusterHealthIT extends ESIntegTestCase {
         }
         {
             ClusterHealthResponse response = client().admin().cluster().prepareHealth("index-*")
-                .setIndicesOptions(IndicesOptions.fromOptions(true, true, false, true))
+                .setIndicesOptions(new IndicesOptions(true, true, false, true))
                 .get();
             assertThat(response.getStatus(), equalTo(ClusterHealthStatus.YELLOW));
             assertThat(response.isTimedOut(), equalTo(false));

--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/SimpleClusterStateIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/SimpleClusterStateIT.java
@@ -258,21 +258,21 @@ public class SimpleClusterStateIT extends ESIntegTestCase {
         assertThat(clusterStateResponse.getState().metadata().index("foo").getState(), equalTo(IndexMetadata.State.OPEN));
 
         // expand_wildcards_closed should toggle return only closed index fuu
-        IndicesOptions expandCloseOptions = IndicesOptions.fromOptions(false, true, false, true);
+        IndicesOptions expandCloseOptions = new IndicesOptions(false, true, false, true);
         clusterStateResponse = client().admin().cluster().prepareState().clear().setMetadata(true).setIndices("f*")
                 .setIndicesOptions(expandCloseOptions).get();
         assertThat(clusterStateResponse.getState().metadata().indices().size(), is(1));
         assertThat(clusterStateResponse.getState().metadata().index("fuu").getState(), equalTo(IndexMetadata.State.CLOSE));
 
         // ignore_unavailable set to true should not raise exception on fzzbzz
-        IndicesOptions ignoreUnavailabe = IndicesOptions.fromOptions(true, true, true, false);
+        IndicesOptions ignoreUnavailabe = new IndicesOptions(true, true, true, false);
         clusterStateResponse = client().admin().cluster().prepareState().clear().setMetadata(true).setIndices("fzzbzz")
                 .setIndicesOptions(ignoreUnavailabe).get();
         assertThat(clusterStateResponse.getState().metadata().indices().isEmpty(), is(true));
 
         // empty wildcard expansion result should work when allowNoIndices is
         // turned on
-        IndicesOptions allowNoIndices = IndicesOptions.fromOptions(false, true, true, false);
+        IndicesOptions allowNoIndices = new IndicesOptions(false, true, true, false);
         clusterStateResponse = client().admin().cluster().prepareState().clear().setMetadata(true).setIndices("a*")
                 .setIndicesOptions(allowNoIndices).get();
         assertThat(clusterStateResponse.getState().metadata().indices().isEmpty(), is(true));
@@ -280,7 +280,7 @@ public class SimpleClusterStateIT extends ESIntegTestCase {
 
     public void testIndicesOptionsOnAllowNoIndicesFalse() throws Exception {
         // empty wildcard expansion throws exception when allowNoIndices is turned off
-        IndicesOptions allowNoIndices = IndicesOptions.fromOptions(false, false, true, false);
+        IndicesOptions allowNoIndices = new IndicesOptions(false, false, true, false);
         try {
             client().admin().cluster().prepareState().clear().setMetadata(true).setIndices("a*").setIndicesOptions(allowNoIndices).get();
             fail("Expected IndexNotFoundException");
@@ -291,7 +291,7 @@ public class SimpleClusterStateIT extends ESIntegTestCase {
 
     public void testIndicesIgnoreUnavailableFalse() throws Exception {
         // ignore_unavailable set to false throws exception when allowNoIndices is turned off
-        IndicesOptions allowNoIndices = IndicesOptions.fromOptions(false, true, true, false);
+        IndicesOptions allowNoIndices = new IndicesOptions(false, true, true, false);
         try {
             client().admin().cluster().prepareState().clear().setMetadata(true)
                 .setIndices("fzzbzz").setIndicesOptions(allowNoIndices).get();

--- a/server/src/internalClusterTest/java/org/elasticsearch/index/shard/IndexShardIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/index/shard/IndexShardIT.java
@@ -301,7 +301,7 @@ public class IndexShardIT extends ESSingleNodeTestCase {
         logger.info("--> updating data_path to [{}] for index [{}]", newIndexDataPath, index);
         assertAcked(client().admin().indices().prepareUpdateSettings(index)
             .setSettings(Settings.builder().put(IndexMetadata.SETTING_DATA_PATH, newIndexDataPath.toAbsolutePath().toString()).build())
-            .setIndicesOptions(IndicesOptions.fromOptions(true, false, true, true)));
+            .setIndicesOptions(new IndicesOptions(true, false, true, true)));
 
         logger.info("--> settings updated and files moved, re-opening index");
         assertAcked(client().admin().indices().prepareOpen(index));

--- a/server/src/internalClusterTest/java/org/elasticsearch/indices/IndicesOptionsIntegrationIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/indices/IndicesOptionsIntegrationIT.java
@@ -148,7 +148,7 @@ public class IndicesOptionsIntegrationIT extends ESIntegTestCase {
         verify(getMapping("test1").setIndicesOptions(options), true);
         verify(getSettings("test1").setIndicesOptions(options), true);
 
-        options = IndicesOptions.fromOptions(true, options.allowNoIndices(), options.expandWildcardsOpen(),
+        options = new IndicesOptions(true, options.allowNoIndices(), options.expandWildcardsOpen(),
             options.expandWildcardsClosed(), options);
         verify(search("test1").setIndicesOptions(options), false);
         verify(msearch(options, "test1"), false);
@@ -199,7 +199,7 @@ public class IndicesOptionsIntegrationIT extends ESIntegTestCase {
         verify(getMapping("test1").setIndicesOptions(options), true);
         verify(getSettings("test1").setIndicesOptions(options), true);
 
-        options = IndicesOptions.fromOptions(true, options.allowNoIndices(), options.expandWildcardsOpen(),
+        options = new IndicesOptions(true, options.allowNoIndices(), options.expandWildcardsOpen(),
             options.expandWildcardsClosed(), options);
         verify(search("test1").setIndicesOptions(options), false);
         verify(msearch(options, "test1"), false);
@@ -281,7 +281,7 @@ public class IndicesOptionsIntegrationIT extends ESIntegTestCase {
         verify(getSettings(indices), false);
 
         // Now force allow_no_indices=true
-        IndicesOptions options = IndicesOptions.fromOptions(false, true, true, false);
+        IndicesOptions options = new IndicesOptions(false, true, true, false);
         verify(search(indices).setIndicesOptions(options), false);
         verify(msearch(options, indices).setIndicesOptions(options), false);
         verify(clearCache(indices).setIndicesOptions(options), false);
@@ -332,7 +332,7 @@ public class IndicesOptionsIntegrationIT extends ESIntegTestCase {
         verify(getSettings(indices).setIndicesOptions(options), false);
 
         // Now force allow_no_indices=true
-        options = IndicesOptions.fromOptions(false, true, true, false);
+        options = new IndicesOptions(false, true, true, false);
         verify(search(indices).setIndicesOptions(options), false, 1);
         verify(msearch(options, indices).setIndicesOptions(options), false, 1);
         verify(clearCache(indices).setIndicesOptions(options), false);
@@ -358,7 +358,7 @@ public class IndicesOptionsIntegrationIT extends ESIntegTestCase {
         assertThat(putRepositoryResponse.isAcknowledged(), equalTo(true));
         client().admin().cluster().prepareCreateSnapshot("dummy-repo", "snap1").setWaitForCompletion(true).get();
 
-        IndicesOptions options = IndicesOptions.fromOptions(false, false, true, false);
+        IndicesOptions options = new IndicesOptions(false, false, true, false);
         verify(snapshot("snap2", "foo*", "bar*").setIndicesOptions(options), true);
         verify(restore("snap1", "foo*", "bar*").setIndicesOptions(options), true);
 
@@ -370,11 +370,11 @@ public class IndicesOptionsIntegrationIT extends ESIntegTestCase {
         //TODO: temporary work-around for #5531
         ensureGreen("barbaz");
         waitForRelocation();
-        options = IndicesOptions.fromOptions(false, false, true, false);
+        options = new IndicesOptions(false, false, true, false);
         verify(snapshot("snap3", "foo*", "bar*").setIndicesOptions(options), false);
         verify(restore("snap3", "foo*", "bar*").setIndicesOptions(options), false);
 
-        options = IndicesOptions.fromOptions(false, false, true, false);
+        options = new IndicesOptions(false, false, true, false);
         verify(snapshot("snap4", "foo*", "baz*").setIndicesOptions(options), true);
         verify(restore("snap3", "foo*", "baz*").setIndicesOptions(options), true);
     }
@@ -426,7 +426,7 @@ public class IndicesOptionsIntegrationIT extends ESIntegTestCase {
 
         verify(search("test1", "test2"), true);
 
-        IndicesOptions options = IndicesOptions.fromOptions(true, true, true, false, IndicesOptions.strictExpandOpenAndForbidClosed());
+        IndicesOptions options = new IndicesOptions(true, true, true, false, IndicesOptions.strictExpandOpenAndForbidClosed());
         verify(search("test1", "test2").setIndicesOptions(options), false);
 
         verify(search(), false);
@@ -451,8 +451,8 @@ public class IndicesOptionsIntegrationIT extends ESIntegTestCase {
         verify(client().admin().indices().prepareOpen("_all"), false);
 
         // if there are no indices to open/close throw an exception
-        IndicesOptions openIndicesOptions = IndicesOptions.fromOptions(false, false, false, true);
-        IndicesOptions closeIndicesOptions = IndicesOptions.fromOptions(false, false, true, false);
+        IndicesOptions openIndicesOptions = new IndicesOptions(false, false, false, true);
+        IndicesOptions closeIndicesOptions = new IndicesOptions(false, false, true, false);
 
         verify(client().admin().indices().prepareClose("bar*").setIndicesOptions(closeIndicesOptions), false);
         verify(client().admin().indices().prepareClose("bar*").setIndicesOptions(closeIndicesOptions), true);

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/alias/IndicesAliasesRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/alias/IndicesAliasesRequest.java
@@ -56,7 +56,7 @@ public class IndicesAliasesRequest extends AcknowledgedRequest<IndicesAliasesReq
     // indices options that require every specified index to exist, expand wildcards only to open
     // indices, don't allow that no indices are resolved from wildcard expressions and resolve the
     // expressions only against indices
-    private static final IndicesOptions INDICES_OPTIONS = IndicesOptions.fromOptions(false, false, true, false, true, false, true, false);
+    private static final IndicesOptions INDICES_OPTIONS = new IndicesOptions(false, false, true, false, true, false, true, false);
 
     public IndicesAliasesRequest(StreamInput in) throws IOException {
         super(in);

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/delete/DeleteIndexRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/delete/DeleteIndexRequest.java
@@ -27,7 +27,7 @@ public class DeleteIndexRequest extends AcknowledgedRequest<DeleteIndexRequest> 
 
     private String[] indices;
     // Delete index should work by default on both open and closed indices.
-    private IndicesOptions indicesOptions = IndicesOptions.fromOptions(false, true, true, true, false, false, true, false);
+    private IndicesOptions indicesOptions = new IndicesOptions(false, true, true, true, false, false, true, false);
 
     public DeleteIndexRequest(StreamInput in) throws IOException {
         super(in);

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/mapping/put/PutMappingRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/mapping/put/PutMappingRequest.java
@@ -57,7 +57,7 @@ public class PutMappingRequest extends AcknowledgedRequest<PutMappingRequest> im
 
     private String[] indices;
 
-    private IndicesOptions indicesOptions = IndicesOptions.fromOptions(false, false, true, true);
+    private IndicesOptions indicesOptions = new IndicesOptions(false, false, true, true);
 
     private String source;
     private String origin = "";

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/open/OpenIndexRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/open/OpenIndexRequest.java
@@ -27,7 +27,7 @@ import static org.elasticsearch.action.ValidateActions.addValidationError;
 public class OpenIndexRequest extends AcknowledgedRequest<OpenIndexRequest> implements IndicesRequest.Replaceable {
 
     private String[] indices;
-    private IndicesOptions indicesOptions = IndicesOptions.fromOptions(false, true, false, true);
+    private IndicesOptions indicesOptions = new IndicesOptions(false, true, false, true);
     private ActiveShardCount waitForActiveShards = ActiveShardCount.DEFAULT;
 
     public OpenIndexRequest(StreamInput in) throws IOException {

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/rollover/TransportRolloverAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/rollover/TransportRolloverAction.java
@@ -69,7 +69,7 @@ public class TransportRolloverAction extends TransportMasterNodeAction<RolloverR
 
     @Override
     protected ClusterBlockException checkBlock(RolloverRequest request, ClusterState state) {
-        IndicesOptions indicesOptions = IndicesOptions.fromOptions(true, true,
+        IndicesOptions indicesOptions = new IndicesOptions(true, true,
             request.indicesOptions().expandWildcardsOpen(), request.indicesOptions().expandWildcardsClosed());
 
         return state.blocks().indicesBlockedException(ClusterBlockLevel.METADATA_WRITE,
@@ -84,7 +84,7 @@ public class TransportRolloverAction extends TransportMasterNodeAction<RolloverR
 
         IndicesStatsRequest statsRequest = new IndicesStatsRequest().indices(rolloverRequest.getRolloverTarget())
             .clear()
-            .indicesOptions(IndicesOptions.fromOptions(true, false, true, true))
+            .indicesOptions(new IndicesOptions(true, false, true, true))
             .docs(true);
         statsRequest.setParentTask(clusterService.localNode().getId(), task.getId());
         // Rollover can sometimes happen concurrently, to handle these cases, we treat rollover in the same way we would treat a

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/settings/get/GetSettingsRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/settings/get/GetSettingsRequest.java
@@ -24,7 +24,7 @@ import java.util.Objects;
 public class GetSettingsRequest extends MasterNodeReadRequest<GetSettingsRequest> implements IndicesRequest.Replaceable {
 
     private String[] indices = Strings.EMPTY_ARRAY;
-    private IndicesOptions indicesOptions = IndicesOptions.fromOptions(false, true, true, true);
+    private IndicesOptions indicesOptions = new IndicesOptions(false, true, true, true);
     private String[] names = Strings.EMPTY_ARRAY;
     private boolean humanReadable = false;
     private boolean includeDefaults = false;

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/settings/put/UpdateSettingsRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/settings/put/UpdateSettingsRequest.java
@@ -40,7 +40,7 @@ public class UpdateSettingsRequest extends AcknowledgedRequest<UpdateSettingsReq
         implements IndicesRequest.Replaceable, ToXContentObject {
 
     private String[] indices;
-    private IndicesOptions indicesOptions = IndicesOptions.fromOptions(false, false, true, true);
+    private IndicesOptions indicesOptions = new IndicesOptions(false, false, true, true);
     private Settings settings = EMPTY_SETTINGS;
     private boolean preserveExisting = false;
     private String origin = "";

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/validate/query/ValidateQueryRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/validate/query/ValidateQueryRequest.java
@@ -65,7 +65,7 @@ public class ValidateQueryRequest extends BroadcastRequest<ValidateQueryRequest>
      */
     public ValidateQueryRequest(String... indices) {
         super(indices);
-        indicesOptions(IndicesOptions.fromOptions(false, false, true, false));
+        indicesOptions(new IndicesOptions(false, false, true, false));
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/IndexNameExpressionResolver.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/IndexNameExpressionResolver.java
@@ -438,7 +438,7 @@ public class IndexNameExpressionResolver {
      */
     public Index concreteWriteIndex(ClusterState state, IndicesOptions options, String index, boolean allowNoIndices,
                                     boolean includeDataStreams) {
-        IndicesOptions combinedOptions = IndicesOptions.fromOptions(options.ignoreUnavailable(), allowNoIndices,
+        IndicesOptions combinedOptions = new IndicesOptions(options.ignoreUnavailable(), allowNoIndices,
             options.expandWildcardsOpen(), options.expandWildcardsClosed(), options.expandWildcardsHidden(),
             options.allowAliasesToMultipleIndices(), options.forbidClosedIndices(), options.ignoreAliases(),
             options.ignoreThrottled());

--- a/server/src/main/java/org/elasticsearch/rest/action/search/RestSearchAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/search/RestSearchAction.java
@@ -323,7 +323,7 @@ public class RestSearchAction extends BaseRestHandler {
         ExceptionsHelper.reThrowIfNotNull(validationException);
 
         final IndicesOptions indicesOptions = request.indicesOptions();
-        final IndicesOptions stricterIndicesOptions = IndicesOptions.fromOptions(
+        final IndicesOptions stricterIndicesOptions = new IndicesOptions(
             indicesOptions.ignoreUnavailable(), indicesOptions.allowNoIndices(), false, false, false,
             true, true, indicesOptions.ignoreThrottled());
         request.indicesOptions(stricterIndicesOptions);

--- a/server/src/main/java/org/elasticsearch/snapshots/RestoreService.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/RestoreService.java
@@ -474,7 +474,7 @@ public class RestoreService implements ClusterStateApplier {
         List<String> requestedDataStreams = filterIndices(
             snapshotInfo.dataStreams(),
             requestIndices.toArray(String[]::new),
-            IndicesOptions.fromOptions(true, true, true, true)
+            new IndicesOptions(true, true, true, true)
         );
         if (requestedDataStreams.isEmpty()) {
             dataStreams = Map.of();

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/health/ClusterHealthRequestTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/health/ClusterHealthRequestTests.java
@@ -144,7 +144,7 @@ public class ClusterHealthRequestTests extends ESTestCase {
             request.indices(indices);
         }
         if (randomBoolean()) {
-            request.indicesOptions(IndicesOptions.fromOptions(randomBoolean(), randomBoolean(), randomBoolean(), randomBoolean()));
+            request.indicesOptions(new IndicesOptions(randomBoolean(), randomBoolean(), randomBoolean(), randomBoolean()));
         }
         return request;
     }

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/shards/ClusterSearchShardsRequestTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/shards/ClusterSearchShardsRequestTests.java
@@ -29,7 +29,7 @@ public class ClusterSearchShardsRequestTests extends ESTestCase {
         }
         if (randomBoolean()) {
             request.indicesOptions(
-                    IndicesOptions.fromOptions(randomBoolean(), randomBoolean(), randomBoolean(), randomBoolean(), randomBoolean()));
+                    new IndicesOptions(randomBoolean(), randomBoolean(), randomBoolean(), randomBoolean(), randomBoolean()));
         }
         if (randomBoolean()) {
             request.preference(randomAlphaOfLengthBetween(3, 10));

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/state/ClusterStateRequestTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/state/ClusterStateRequestTests.java
@@ -27,7 +27,7 @@ public class ClusterStateRequestTests extends ESTestCase {
         int iterations = randomIntBetween(5, 20);
         for (int i = 0; i < iterations; i++) {
 
-            IndicesOptions indicesOptions = IndicesOptions.fromOptions(randomBoolean(), randomBoolean(), randomBoolean(), randomBoolean());
+            IndicesOptions indicesOptions = new IndicesOptions(randomBoolean(), randomBoolean(), randomBoolean(), randomBoolean());
             ClusterStateRequest clusterStateRequest = new ClusterStateRequest().routingTable(randomBoolean()).metadata(randomBoolean())
                     .nodes(randomBoolean()).blocks(randomBoolean()).indices("testindex", "testindex2").indicesOptions(indicesOptions);
 

--- a/server/src/test/java/org/elasticsearch/action/admin/indices/close/CloseIndexRequestTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/close/CloseIndexRequestTests.java
@@ -110,7 +110,7 @@ public class CloseIndexRequestTests extends ESTestCase {
         request.indices(generateRandomStringArray(10, 5, false, false));
         if (randomBoolean()) {
             request.indicesOptions(
-                IndicesOptions.fromOptions(randomBoolean(), randomBoolean(), randomBoolean(), randomBoolean(), randomBoolean()));
+                new IndicesOptions(randomBoolean(), randomBoolean(), randomBoolean(), randomBoolean(), randomBoolean()));
         }
         if (randomBoolean()) {
             request.timeout(randomPositiveTimeValue());

--- a/server/src/test/java/org/elasticsearch/action/admin/indices/resolve/ResolveIndexRequestTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/resolve/ResolveIndexRequestTests.java
@@ -23,7 +23,7 @@ public class ResolveIndexRequestTests extends AbstractWireSerializingTestCase<Re
     @Override
     protected Request createTestInstance() {
         String[] names = generateRandomStringArray(1, 4, false);
-        IndicesOptions indicesOptions = IndicesOptions.fromOptions(
+        IndicesOptions indicesOptions = new IndicesOptions(
             randomBoolean(), randomBoolean(), randomBoolean(), randomBoolean(), randomBoolean(), randomBoolean(), randomBoolean(),
             randomBoolean(), randomBoolean());
         return new Request(names, indicesOptions);

--- a/server/src/test/java/org/elasticsearch/action/admin/indices/segments/IndicesSegmentsRequestTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/segments/IndicesSegmentsRequestTests.java
@@ -78,7 +78,7 @@ public class IndicesSegmentsRequestTests extends ESSingleNodeTestCase {
     public void testRequestOnClosedIndexIgnoreUnavailable() {
         client().admin().indices().prepareClose("test").get();
         IndicesOptions defaultOptions = new IndicesSegmentsRequest().indicesOptions();
-        IndicesOptions testOptions = IndicesOptions.fromOptions(true, true, true, false, defaultOptions);
+        IndicesOptions testOptions = new IndicesOptions(true, true, true, false, defaultOptions);
         IndicesSegmentResponse rsp = client().admin().indices().prepareSegments("test").setIndicesOptions(testOptions).get();
         assertEquals(0, rsp.getIndices().size());
     }

--- a/server/src/test/java/org/elasticsearch/action/admin/indices/settings/put/UpdateSettingsRequestSerializationTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/settings/put/UpdateSettingsRequestSerializationTests.java
@@ -38,7 +38,7 @@ public class UpdateSettingsRequestSerializationTests extends AbstractWireSeriali
         mutators.add(() -> mutation.settings(mutateSettings(request.settings())));
         mutators.add(() -> mutation.indices(mutateIndices(request.indices())));
         mutators.add(() -> mutation.indicesOptions(randomValueOtherThan(request.indicesOptions(),
-                () -> IndicesOptions.fromOptions(randomBoolean(), randomBoolean(), randomBoolean(), randomBoolean()))));
+                () -> new IndicesOptions(randomBoolean(), randomBoolean(), randomBoolean(), randomBoolean()))));
         mutators.add(() -> mutation.setPreserveExisting(request.isPreserveExisting() == false));
         randomFrom(mutators).run();
         return mutation;
@@ -60,7 +60,7 @@ public class UpdateSettingsRequestSerializationTests extends AbstractWireSeriali
                 : new UpdateSettingsRequest(randomSettings(0, 2), randomIndicesNames(0, 2));
         request.masterNodeTimeout(randomTimeValue());
         request.timeout(randomTimeValue());
-        request.indicesOptions(IndicesOptions.fromOptions(randomBoolean(), randomBoolean(), randomBoolean(), randomBoolean()));
+        request.indicesOptions(new IndicesOptions(randomBoolean(), randomBoolean(), randomBoolean(), randomBoolean()));
         request.setPreserveExisting(randomBoolean());
         return request;
     }

--- a/server/src/test/java/org/elasticsearch/action/fieldcaps/FieldCapabilitiesRequestTests.java
+++ b/server/src/test/java/org/elasticsearch/action/fieldcaps/FieldCapabilitiesRequestTests.java
@@ -92,7 +92,7 @@ public class FieldCapabilitiesRequestTests extends AbstractWireSerializingTestCa
         });
         mutators.add(request -> {
             IndicesOptions indicesOptions = randomValueOtherThan(request.indicesOptions(),
-                () -> IndicesOptions.fromOptions(randomBoolean(), randomBoolean(), randomBoolean(), randomBoolean()));
+                () -> new IndicesOptions(randomBoolean(), randomBoolean(), randomBoolean(), randomBoolean()));
             request.indicesOptions(indicesOptions);
         });
         mutators.add(request -> request.setMergeResults(request.isMergeResults() == false));

--- a/server/src/test/java/org/elasticsearch/action/search/MultiSearchRequestTests.java
+++ b/server/src/test/java/org/elasticsearch/action/search/MultiSearchRequestTests.java
@@ -55,23 +55,23 @@ public class MultiSearchRequestTests extends ESTestCase {
         assertThat(request.requests().get(0).indices()[0],
                 equalTo("test"));
         assertThat(request.requests().get(0).indicesOptions(),
-                equalTo(IndicesOptions.fromOptions(true, true, true, true, SearchRequest.DEFAULT_INDICES_OPTIONS)));
+                equalTo(new IndicesOptions(true, true, true, true, SearchRequest.DEFAULT_INDICES_OPTIONS)));
         assertThat(request.requests().get(1).indices()[0],
                 equalTo("test"));
         assertThat(request.requests().get(1).indicesOptions(),
-                equalTo(IndicesOptions.fromOptions(false, true, true, true, SearchRequest.DEFAULT_INDICES_OPTIONS)));
+                equalTo(new IndicesOptions(false, true, true, true, SearchRequest.DEFAULT_INDICES_OPTIONS)));
         assertThat(request.requests().get(2).indices()[0],
                 equalTo("test"));
         assertThat(request.requests().get(2).indicesOptions(),
-                equalTo(IndicesOptions.fromOptions(false, true, true, false, SearchRequest.DEFAULT_INDICES_OPTIONS)));
+                equalTo(new IndicesOptions(false, true, true, false, SearchRequest.DEFAULT_INDICES_OPTIONS)));
         assertThat(request.requests().get(3).indices()[0],
                 equalTo("test"));
         assertThat(request.requests().get(3).indicesOptions(),
-                equalTo(IndicesOptions.fromOptions(true, true, true, true, SearchRequest.DEFAULT_INDICES_OPTIONS)));
+                equalTo(new IndicesOptions(true, true, true, true, SearchRequest.DEFAULT_INDICES_OPTIONS)));
         assertThat(request.requests().get(4).indices()[0],
                 equalTo("test"));
         assertThat(request.requests().get(4).indicesOptions(),
-                equalTo(IndicesOptions.fromOptions(true, false, false, true, SearchRequest.DEFAULT_INDICES_OPTIONS)));
+                equalTo(new IndicesOptions(true, false, false, true, SearchRequest.DEFAULT_INDICES_OPTIONS)));
 
         assertThat(request.requests().get(5).indices(), is(Strings.EMPTY_ARRAY));
         assertThat(request.requests().get(6).indices(), is(Strings.EMPTY_ARRAY));
@@ -98,7 +98,7 @@ public class MultiSearchRequestTests extends ESTestCase {
         assertThat(request.requests().size(), equalTo(1));
         assertThat(request.requests().get(0).indices()[0], equalTo("test"));
         assertThat(request.requests().get(0).indicesOptions(),
-            equalTo(IndicesOptions.fromOptions(true, true, true, true, SearchRequest.DEFAULT_INDICES_OPTIONS)));
+            equalTo(new IndicesOptions(true, true, true, true, SearchRequest.DEFAULT_INDICES_OPTIONS)));
     }
 
     public void testDefaultIndicesOptions() throws IOException {
@@ -112,7 +112,7 @@ public class MultiSearchRequestTests extends ESTestCase {
         assertThat(request.requests().size(), equalTo(1));
         assertThat(request.requests().get(0).indices()[0], equalTo("test"));
         assertThat(request.requests().get(0).indicesOptions(),
-            equalTo(IndicesOptions.fromOptions(true, true, true, true, SearchRequest.DEFAULT_INDICES_OPTIONS)));
+            equalTo(new IndicesOptions(true, true, true, true, SearchRequest.DEFAULT_INDICES_OPTIONS)));
     }
 
     public void testSimpleAdd2() throws Exception {
@@ -253,21 +253,21 @@ public class MultiSearchRequestTests extends ESTestCase {
     }
 
     public void testWritingExpandWildcards() throws IOException {
-        assertExpandWildcardsValue(IndicesOptions.fromOptions(randomBoolean(), randomBoolean(), true, true, true, randomBoolean(),
+        assertExpandWildcardsValue(new IndicesOptions(randomBoolean(), randomBoolean(), true, true, true, randomBoolean(),
             randomBoolean(), randomBoolean(), randomBoolean()), "all");
-        assertExpandWildcardsValue(IndicesOptions.fromOptions(randomBoolean(), randomBoolean(), true, true, false, randomBoolean(),
+        assertExpandWildcardsValue(new IndicesOptions(randomBoolean(), randomBoolean(), true, true, false, randomBoolean(),
             randomBoolean(), randomBoolean(), randomBoolean()), "open,closed");
-        assertExpandWildcardsValue(IndicesOptions.fromOptions(randomBoolean(), randomBoolean(), true, false, true, randomBoolean(),
+        assertExpandWildcardsValue(new IndicesOptions(randomBoolean(), randomBoolean(), true, false, true, randomBoolean(),
             randomBoolean(), randomBoolean(), randomBoolean()), "open,hidden");
-        assertExpandWildcardsValue(IndicesOptions.fromOptions(randomBoolean(), randomBoolean(), true, false, false, randomBoolean(),
+        assertExpandWildcardsValue(new IndicesOptions(randomBoolean(), randomBoolean(), true, false, false, randomBoolean(),
             randomBoolean(), randomBoolean(), randomBoolean()), "open");
-        assertExpandWildcardsValue(IndicesOptions.fromOptions(randomBoolean(), randomBoolean(), false, true, true, randomBoolean(),
+        assertExpandWildcardsValue(new IndicesOptions(randomBoolean(), randomBoolean(), false, true, true, randomBoolean(),
             randomBoolean(), randomBoolean(), randomBoolean()), "closed,hidden");
-        assertExpandWildcardsValue(IndicesOptions.fromOptions(randomBoolean(), randomBoolean(), false, true, false, randomBoolean(),
+        assertExpandWildcardsValue(new IndicesOptions(randomBoolean(), randomBoolean(), false, true, false, randomBoolean(),
             randomBoolean(), randomBoolean(), randomBoolean()), "closed");
-        assertExpandWildcardsValue(IndicesOptions.fromOptions(randomBoolean(), randomBoolean(), false, false, true, randomBoolean(),
+        assertExpandWildcardsValue(new IndicesOptions(randomBoolean(), randomBoolean(), false, false, true, randomBoolean(),
             randomBoolean(), randomBoolean(), randomBoolean()), "hidden");
-        assertExpandWildcardsValue(IndicesOptions.fromOptions(randomBoolean(), randomBoolean(), false, false, false, randomBoolean(),
+        assertExpandWildcardsValue(new IndicesOptions(randomBoolean(), randomBoolean(), false, false, false, randomBoolean(),
             randomBoolean(), randomBoolean(), randomBoolean()), "none");
     }
 
@@ -295,7 +295,7 @@ public class MultiSearchRequestTests extends ESTestCase {
         MultiSearchRequest mutation = copyRequest(searchRequest);
         List<CheckedRunnable<IOException>> mutators = new ArrayList<>();
         mutators.add(() -> mutation.indicesOptions(randomValueOtherThan(searchRequest.indicesOptions(),
-                () -> IndicesOptions.fromOptions(randomBoolean(), randomBoolean(), randomBoolean(), randomBoolean()))));
+                () -> new IndicesOptions(randomBoolean(), randomBoolean(), randomBoolean(), randomBoolean()))));
         mutators.add(() -> mutation.maxConcurrentSearchRequests(randomIntBetween(1, 32)));
         mutators.add(() -> mutation.add(createSimpleSearchRequest()));
         randomFrom(mutators).run();
@@ -330,7 +330,7 @@ public class MultiSearchRequestTests extends ESTestCase {
             // only expand_wildcards, ignore_unavailable and allow_no_indices can be specified from msearch api, so unset other options:
             IndicesOptions randomlyGenerated = searchRequest.indicesOptions();
             IndicesOptions msearchDefault = SearchRequest.DEFAULT_INDICES_OPTIONS;
-            searchRequest.indicesOptions(IndicesOptions.fromOptions(
+            searchRequest.indicesOptions(new IndicesOptions(
                 randomlyGenerated.ignoreUnavailable(), randomlyGenerated.allowNoIndices(), randomlyGenerated.expandWildcardsOpen(),
                 randomlyGenerated.expandWildcardsClosed(), msearchDefault.expandWildcardsHidden(),
                 msearchDefault.allowAliasesToMultipleIndices(), msearchDefault.forbidClosedIndices(), msearchDefault.ignoreAliases(),

--- a/server/src/test/java/org/elasticsearch/action/search/SearchRequestTests.java
+++ b/server/src/test/java/org/elasticsearch/action/search/SearchRequestTests.java
@@ -214,7 +214,7 @@ public class SearchRequestTests extends AbstractSearchTestCase {
         List<Runnable> mutators = new ArrayList<>();
         mutators.add(() -> mutation.indices(ArrayUtils.concat(searchRequest.indices(), new String[] { randomAlphaOfLength(10) })));
         mutators.add(() -> mutation.indicesOptions(randomValueOtherThan(searchRequest.indicesOptions(),
-                () -> IndicesOptions.fromOptions(randomBoolean(), randomBoolean(), randomBoolean(), randomBoolean()))));
+                () -> new IndicesOptions(randomBoolean(), randomBoolean(), randomBoolean(), randomBoolean()))));
         mutators.add(() -> mutation.preference(randomValueOtherThan(searchRequest.preference(), () -> randomAlphaOfLengthBetween(3, 10))));
         mutators.add(() -> mutation.routing(randomValueOtherThan(searchRequest.routing(), () -> randomAlphaOfLengthBetween(3, 10))));
         mutators.add(() -> mutation.requestCache((randomValueOtherThan(searchRequest.requestCache(), ESTestCase::randomBoolean))));

--- a/server/src/test/java/org/elasticsearch/action/search/SearchShardIteratorTests.java
+++ b/server/src/test/java/org/elasticsearch/action/search/SearchShardIteratorTests.java
@@ -36,7 +36,7 @@ public class SearchShardIteratorTests extends ESTestCase {
     public void testGetOriginalIndices() {
         ShardId shardId = new ShardId(randomAlphaOfLengthBetween(5, 10), randomAlphaOfLength(10), randomInt());
         OriginalIndices originalIndices = new OriginalIndices(new String[]{randomAlphaOfLengthBetween(3, 10)},
-            IndicesOptions.fromOptions(randomBoolean(), randomBoolean(), randomBoolean(), randomBoolean()));
+            new IndicesOptions(randomBoolean(), randomBoolean(), randomBoolean(), randomBoolean()));
         SearchShardIterator searchShardIterator = new SearchShardIterator(null, shardId, Collections.emptyList(), originalIndices);
         assertSame(originalIndices, searchShardIterator.getOriginalIndices());
     }
@@ -53,7 +53,7 @@ public class SearchShardIteratorTests extends ESTestCase {
         String clusterAlias = randomBoolean() ? null : randomAlphaOfLengthBetween(5, 10);
         ShardId shardId = new ShardId(randomAlphaOfLengthBetween(5, 10), randomAlphaOfLength(10), randomInt());
         OriginalIndices originalIndices = new OriginalIndices(new String[]{randomAlphaOfLengthBetween(3, 10)},
-            IndicesOptions.fromOptions(randomBoolean(), randomBoolean(), randomBoolean(), randomBoolean()));
+            new IndicesOptions(randomBoolean(), randomBoolean(), randomBoolean(), randomBoolean()));
 
         String nodeId = randomAlphaOfLengthBetween(3, 10);
         SearchShardIterator searchShardIterator = new SearchShardIterator(clusterAlias, shardId,

--- a/server/src/test/java/org/elasticsearch/action/support/IndicesOptionsTests.java
+++ b/server/src/test/java/org/elasticsearch/action/support/IndicesOptionsTests.java
@@ -40,7 +40,7 @@ public class IndicesOptionsTests extends ESTestCase {
     public void testSerialization() throws Exception {
         int iterations = randomIntBetween(5, 20);
         for (int i = 0; i < iterations; i++) {
-            IndicesOptions indicesOptions = IndicesOptions.fromOptions(
+            IndicesOptions indicesOptions = new IndicesOptions(
                 randomBoolean(), randomBoolean(), randomBoolean(), randomBoolean(), randomBoolean(), randomBoolean(), randomBoolean(),
                 randomBoolean(), randomBoolean());
 
@@ -74,7 +74,7 @@ public class IndicesOptionsTests extends ESTestCase {
         final boolean ignoreAliases = randomBoolean();
         final boolean ignoreThrottled = randomBoolean();
 
-        IndicesOptions indicesOptions = IndicesOptions.fromOptions(ignoreUnavailable, allowNoIndices, expandToOpenIndices,
+        IndicesOptions indicesOptions = new IndicesOptions(ignoreUnavailable, allowNoIndices, expandToOpenIndices,
             expandToClosedIndices, expandToHiddenIndices, allowAliasesToMultipleIndices, forbidClosedIndices, ignoreAliases,
             ignoreThrottled);
 
@@ -96,10 +96,10 @@ public class IndicesOptionsTests extends ESTestCase {
         boolean expandToOpenIndices = randomBoolean();
         boolean expandToClosedIndices = randomBoolean();
 
-        IndicesOptions defaultOptions = IndicesOptions.fromOptions(randomBoolean(), randomBoolean(), randomBoolean(), randomBoolean(),
+        IndicesOptions defaultOptions = new IndicesOptions(randomBoolean(), randomBoolean(), randomBoolean(), randomBoolean(),
                 randomBoolean(), randomBoolean(), randomBoolean(), randomBoolean(), randomBoolean());
 
-        IndicesOptions indicesOptions = IndicesOptions.fromOptions(ignoreUnavailable, allowNoIndices, expandToOpenIndices,
+        IndicesOptions indicesOptions = new IndicesOptions(ignoreUnavailable, allowNoIndices, expandToOpenIndices,
                 expandToClosedIndices, defaultOptions);
 
         assertEquals(ignoreUnavailable, indicesOptions.ignoreUnavailable());
@@ -145,7 +145,7 @@ public class IndicesOptionsTests extends ESTestCase {
         boolean allowNoIndices = randomBoolean();
         String allowNoIndicesString = Boolean.toString(allowNoIndices);
 
-        IndicesOptions defaultOptions = IndicesOptions.fromOptions(randomBoolean(), randomBoolean(), randomBoolean(), randomBoolean(),
+        IndicesOptions defaultOptions = new IndicesOptions(randomBoolean(), randomBoolean(), randomBoolean(), randomBoolean(),
                 randomBoolean(), randomBoolean(), randomBoolean(), randomBoolean(), randomBoolean());
 
         IndicesOptions updatedOptions = IndicesOptions.fromParameters(expandWildcardsString, ignoreUnavailableString,
@@ -162,11 +162,11 @@ public class IndicesOptionsTests extends ESTestCase {
     }
 
     public void testEqualityAndHashCode() {
-        IndicesOptions indicesOptions = IndicesOptions.fromOptions(randomBoolean(), randomBoolean(), randomBoolean(), randomBoolean(),
+        IndicesOptions indicesOptions = new IndicesOptions(randomBoolean(), randomBoolean(), randomBoolean(), randomBoolean(),
             randomBoolean(), randomBoolean(), randomBoolean(), randomBoolean(), randomBoolean());
 
         EqualsHashCodeTestUtils.checkEqualsAndHashCode(indicesOptions, opts -> {
-            return IndicesOptions.fromOptions(opts.ignoreUnavailable(), opts.allowNoIndices(), opts.expandWildcardsOpen(),
+            return new IndicesOptions(opts.ignoreUnavailable(), opts.allowNoIndices(), opts.expandWildcardsOpen(),
                 opts.expandWildcardsClosed(), opts.expandWildcardsHidden(), opts.allowAliasesToMultipleIndices(),
                 opts.forbidClosedIndices(), opts.ignoreAliases(), opts.ignoreThrottled());
         }, opts -> {
@@ -218,7 +218,7 @@ public class IndicesOptionsTests extends ESTestCase {
                     mutated = true;
                 }
             }
-            return IndicesOptions.fromOptions(ignoreUnavailable, allowNoIndices, expandOpen, expandClosed, expandHidden,
+            return new IndicesOptions(ignoreUnavailable, allowNoIndices, expandOpen, expandClosed, expandHidden,
                 allowAliasesToMulti, forbidClosed, ignoreAliases, ignoreThrottled);
         });
     }

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/IndexNameExpressionResolverTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/IndexNameExpressionResolverTests.java
@@ -256,8 +256,8 @@ public class IndexNameExpressionResolverTests extends ESTestCase {
                 .put(indexBuilder("foofoo").putAlias(AliasMetadata.builder("barbaz")));
         ClusterState state = ClusterState.builder(new ClusterName("_name")).metadata(mdBuilder).build();
 
-        IndicesOptions expandOpen = IndicesOptions.fromOptions(true, false, true, false);
-        IndicesOptions expand = IndicesOptions.fromOptions(true, false, true, true);
+        IndicesOptions expandOpen = new IndicesOptions(true, false, true, false);
+        IndicesOptions expand = new IndicesOptions(true, false, true, true);
         IndicesOptions[] indicesOptions = new IndicesOptions[]{expandOpen, expand};
 
         for (IndicesOptions options : indicesOptions) {
@@ -306,7 +306,7 @@ public class IndexNameExpressionResolverTests extends ESTestCase {
         ClusterState state = ClusterState.builder(new ClusterName("_name")).metadata(mdBuilder).build();
 
         // Only closed
-        IndicesOptions options = IndicesOptions.fromOptions(false, true, false, true, false);
+        IndicesOptions options = new IndicesOptions(false, true, false, true, false);
         IndexNameExpressionResolver.Context context = new IndexNameExpressionResolver.Context(state, options, SystemIndexAccessLevel.NONE);
         String[] results = indexNameExpressionResolver.concreteIndexNames(context, Strings.EMPTY_ARRAY);
         assertEquals(1, results.length);
@@ -331,7 +331,7 @@ public class IndexNameExpressionResolverTests extends ESTestCase {
         assertThat(results, arrayContainingInAnyOrder(".hidden-closed"));
 
         // Only open
-        options = IndicesOptions.fromOptions(false, true, true, false, false);
+        options = new IndicesOptions(false, true, true, false, false);
         context = new IndexNameExpressionResolver.Context(state, options, SystemIndexAccessLevel.NONE);
         results = indexNameExpressionResolver.concreteIndexNames(context, Strings.EMPTY_ARRAY);
         assertEquals(2, results.length);
@@ -355,7 +355,7 @@ public class IndexNameExpressionResolverTests extends ESTestCase {
         assertThat(results, arrayContainingInAnyOrder(".hidden"));
 
         // Open and closed
-        options = IndicesOptions.fromOptions(false, true, true, true, false);
+        options = new IndicesOptions(false, true, true, true, false);
         context = new IndexNameExpressionResolver.Context(state, options, SystemIndexAccessLevel.NONE);
         results = indexNameExpressionResolver.concreteIndexNames(context, Strings.EMPTY_ARRAY);
         assertEquals(3, results.length);
@@ -394,7 +394,7 @@ public class IndexNameExpressionResolverTests extends ESTestCase {
         assertThat(results, arrayContainingInAnyOrder(".hidden", ".hidden-closed"));
 
         // open closed and hidden
-        options = IndicesOptions.fromOptions(false, true, true, true, true);
+        options = new IndicesOptions(false, true, true, true, true);
         context = new IndexNameExpressionResolver.Context(state, options, SystemIndexAccessLevel.NONE);
         results = indexNameExpressionResolver.concreteIndexNames(context, Strings.EMPTY_ARRAY);
         assertEquals(7, results.length);
@@ -436,7 +436,7 @@ public class IndexNameExpressionResolverTests extends ESTestCase {
         assertEquals(0, results.length);
 
         // open and hidden
-        options = IndicesOptions.fromOptions(false, true, true, false, true);
+        options = new IndicesOptions(false, true, true, false, true);
         context = new IndexNameExpressionResolver.Context(state, options, SystemIndexAccessLevel.NONE);
         results = indexNameExpressionResolver.concreteIndexNames(context, Strings.EMPTY_ARRAY);
         assertEquals(4, results.length);
@@ -455,7 +455,7 @@ public class IndexNameExpressionResolverTests extends ESTestCase {
         assertEquals("hidden", results[0]);
 
         // closed and hidden
-        options = IndicesOptions.fromOptions(false, true, false, true, true);
+        options = new IndicesOptions(false, true, false, true, true);
         context = new IndexNameExpressionResolver.Context(state, options, SystemIndexAccessLevel.NONE);
         results = indexNameExpressionResolver.concreteIndexNames(context, Strings.EMPTY_ARRAY);
         assertEquals(3, results.length);
@@ -474,7 +474,7 @@ public class IndexNameExpressionResolverTests extends ESTestCase {
         assertEquals("hidden-closed", results[0]);
 
         // only hidden
-        options = IndicesOptions.fromOptions(false, true, false, false, true);
+        options = new IndicesOptions(false, true, false, false, true);
         context = new IndexNameExpressionResolver.Context(state, options, SystemIndexAccessLevel.NONE);
         results = indexNameExpressionResolver.concreteIndexNames(context, Strings.EMPTY_ARRAY);
         assertThat(results, emptyArray());
@@ -488,7 +488,7 @@ public class IndexNameExpressionResolverTests extends ESTestCase {
         results = indexNameExpressionResolver.concreteIndexNames(context, "hidden-closed");
         assertThat(results, arrayContainingInAnyOrder("hidden-closed"));
 
-        options = IndicesOptions.fromOptions(false, false, true, true, true);
+        options = new IndicesOptions(false, false, true, true, true);
         IndexNameExpressionResolver.Context context2 = new IndexNameExpressionResolver.Context(state, options, SystemIndexAccessLevel.NONE);
         IndexNotFoundException infe = expectThrows(IndexNotFoundException.class,
                 () -> indexNameExpressionResolver.concreteIndexNames(context2, "-*"));
@@ -505,7 +505,7 @@ public class IndexNameExpressionResolverTests extends ESTestCase {
 
         //ignore unavailable and allow no indices
         {
-            IndicesOptions noExpandLenient = IndicesOptions.fromOptions(true, true, false, false, randomBoolean());
+            IndicesOptions noExpandLenient = new IndicesOptions(true, true, false, false, randomBoolean());
             IndexNameExpressionResolver.Context context =
                 new IndexNameExpressionResolver.Context(state, noExpandLenient, SystemIndexAccessLevel.NONE);
             String[] results = indexNameExpressionResolver.concreteIndexNames(context, "baz*");
@@ -528,7 +528,7 @@ public class IndexNameExpressionResolverTests extends ESTestCase {
 
         //ignore unavailable but don't allow no indices
         {
-            IndicesOptions noExpandDisallowEmpty = IndicesOptions.fromOptions(true, false, false, false, randomBoolean());
+            IndicesOptions noExpandDisallowEmpty = new IndicesOptions(true, false, false, false, randomBoolean());
             IndexNameExpressionResolver.Context context =
                 new IndexNameExpressionResolver.Context(state, noExpandDisallowEmpty, SystemIndexAccessLevel.NONE);
 
@@ -554,7 +554,7 @@ public class IndexNameExpressionResolverTests extends ESTestCase {
 
         //error on unavailable but allow no indices
         {
-            IndicesOptions noExpandErrorUnavailable = IndicesOptions.fromOptions(false, true, false, false, randomBoolean());
+            IndicesOptions noExpandErrorUnavailable = new IndicesOptions(false, true, false, false, randomBoolean());
             IndexNameExpressionResolver.Context context =
                 new IndexNameExpressionResolver.Context(state, noExpandErrorUnavailable, SystemIndexAccessLevel.NONE);
             {
@@ -581,7 +581,7 @@ public class IndexNameExpressionResolverTests extends ESTestCase {
 
         //error on both unavailable and no indices
         {
-            IndicesOptions noExpandStrict = IndicesOptions.fromOptions(false, false, false, false, randomBoolean());
+            IndicesOptions noExpandStrict = new IndicesOptions(false, false, false, false, randomBoolean());
             IndexNameExpressionResolver.Context context =
                 new IndexNameExpressionResolver.Context(state, noExpandStrict, SystemIndexAccessLevel.NONE);
             IndexNotFoundException infe = expectThrows(IndexNotFoundException.class,
@@ -693,7 +693,7 @@ public class IndexNameExpressionResolverTests extends ESTestCase {
         assertThat(results, emptyArray());
 
         final IndexNameExpressionResolver.Context context3 =
-            new IndexNameExpressionResolver.Context(state, IndicesOptions.fromOptions(true, false, true, false),
+            new IndexNameExpressionResolver.Context(state, new IndicesOptions(true, false, true, false),
                 SystemIndexAccessLevel.NONE);
         IndexNotFoundException infe = expectThrows(IndexNotFoundException.class,
                 () -> indexNameExpressionResolver.concreteIndexNames(context3, Strings.EMPTY_ARRAY));
@@ -766,7 +766,7 @@ public class IndexNameExpressionResolverTests extends ESTestCase {
         Metadata.Builder mdBuilder = Metadata.builder();
         ClusterState state = ClusterState.builder(new ClusterName("_name")).metadata(mdBuilder).build();
         IndexNameExpressionResolver.Context context = new IndexNameExpressionResolver.Context(state,
-            IndicesOptions.fromOptions(false, false, true, true), SystemIndexAccessLevel.NONE);
+            new IndicesOptions(false, false, true, true), SystemIndexAccessLevel.NONE);
         IndexNotFoundException infe = expectThrows(IndexNotFoundException.class,
                 () -> indexNameExpressionResolver.concreteIndices(context, new String[]{}));
         assertThat(infe.getMessage(), is("no such index [null] and no indices exist"));
@@ -776,7 +776,7 @@ public class IndexNameExpressionResolverTests extends ESTestCase {
         Metadata.Builder mdBuilder = Metadata.builder();
         ClusterState state = ClusterState.builder(new ClusterName("_name")).metadata(mdBuilder).build();
         IndexNameExpressionResolver.Context context = new IndexNameExpressionResolver.Context(state,
-            IndicesOptions.fromOptions(false, false, false, false), SystemIndexAccessLevel.NONE);
+            new IndicesOptions(false, false, false, false), SystemIndexAccessLevel.NONE);
         IndexNotFoundException infe = expectThrows(IndexNotFoundException.class,
                 () -> indexNameExpressionResolver.concreteIndices(context, new String[]{}));
         assertThat(infe.getMessage(), is("no such index [_all] and no indices exist"));
@@ -792,19 +792,19 @@ public class IndexNameExpressionResolverTests extends ESTestCase {
         ClusterState state = ClusterState.builder(new ClusterName("_name")).metadata(mdBuilder).build();
 
         IndexNameExpressionResolver.Context context =
-            new IndexNameExpressionResolver.Context(state, IndicesOptions.fromOptions(true, true, false, false),
+            new IndexNameExpressionResolver.Context(state, new IndicesOptions(true, true, false, false),
                 SystemIndexAccessLevel.NONE);
         assertThat(newHashSet(indexNameExpressionResolver.concreteIndexNames(context, "testX*")),
             equalTo(new HashSet<String>()));
-        context = new IndexNameExpressionResolver.Context(state, IndicesOptions.fromOptions(true, true, true, false),
+        context = new IndexNameExpressionResolver.Context(state, new IndicesOptions(true, true, true, false),
             SystemIndexAccessLevel.NONE);
         assertThat(newHashSet(indexNameExpressionResolver.concreteIndexNames(context, "testX*")),
             equalTo(newHashSet("testXXX", "testXXY")));
-        context = new IndexNameExpressionResolver.Context(state, IndicesOptions.fromOptions(true, true, false, true),
+        context = new IndexNameExpressionResolver.Context(state, new IndicesOptions(true, true, false, true),
             SystemIndexAccessLevel.NONE);
         assertThat(newHashSet(indexNameExpressionResolver.concreteIndexNames(context, "testX*")),
             equalTo(newHashSet("testXYY")));
-        context = new IndexNameExpressionResolver.Context(state, IndicesOptions.fromOptions(true, true, true, true),
+        context = new IndexNameExpressionResolver.Context(state, new IndicesOptions(true, true, true, true),
             SystemIndexAccessLevel.NONE);
         assertThat(newHashSet(indexNameExpressionResolver.concreteIndexNames(context, "testX*")),
             equalTo(newHashSet("testXXX", "testXXY", "testXYY")));
@@ -823,7 +823,7 @@ public class IndexNameExpressionResolverTests extends ESTestCase {
         ClusterState state = ClusterState.builder(new ClusterName("_name")).metadata(mdBuilder).build();
 
         IndexNameExpressionResolver.Context context = new IndexNameExpressionResolver.Context(state,
-                IndicesOptions.fromOptions(true, true, true, true), SystemIndexAccessLevel.NONE);
+                new IndicesOptions(true, true, true, true), SystemIndexAccessLevel.NONE);
         assertThat(newHashSet(indexNameExpressionResolver.concreteIndexNames(context, "testX*")),
                 equalTo(newHashSet("testXXX", "testXXY", "testXYY")));
 
@@ -876,7 +876,7 @@ public class IndexNameExpressionResolverTests extends ESTestCase {
 
         // when ignoreAliases option is set, concreteIndexNames resolves the provided expressions
         // only against the defined indices
-        IndicesOptions ignoreAliasesOptions = IndicesOptions.fromOptions(false, false, true, false, true, false, true, false);
+        IndicesOptions ignoreAliasesOptions = new IndicesOptions(false, false, true, false, true, false, true, false);
 
         String[] indexNamesIndexWildcard = indexNameExpressionResolver.concreteIndexNames(state, ignoreAliasesOptions, "foo*");
 
@@ -900,7 +900,7 @@ public class IndexNameExpressionResolverTests extends ESTestCase {
 
         // when ignoreAliases option is not set, concreteIndexNames resolves the provided
         // expressions against the defined indices and aliases
-        IndicesOptions indicesAndAliasesOptions = IndicesOptions.fromOptions(false, false, true, false, true, false, false, false);
+        IndicesOptions indicesAndAliasesOptions = new IndicesOptions(false, false, true, false, true, false, false, false);
 
         List<String> indexNames = Arrays.asList(indexNameExpressionResolver.concreteIndexNames(state, indicesAndAliasesOptions, "foo*"));
         assertEquals(2, indexNames.size());
@@ -931,8 +931,8 @@ public class IndexNameExpressionResolverTests extends ESTestCase {
         final String dottedHiddenAlias = ".hidden_alias";
         final String dottedHiddenIndex = ".hidden_index";
 
-        IndicesOptions excludeHiddenOptions = IndicesOptions.fromOptions(false, false, true, false, false, true, false, false, false);
-        IndicesOptions includeHiddenOptions = IndicesOptions.fromOptions(false, false, true, false, true, true, false, false, false);
+        IndicesOptions excludeHiddenOptions = new IndicesOptions(false, false, true, false, false, true, false, false, false);
+        IndicesOptions includeHiddenOptions = new IndicesOptions(false, false, true, false, true, true, false, false, false);
 
         {
             // A visible index with a visible alias and a hidden index with a hidden alias
@@ -1065,8 +1065,8 @@ public class IndexNameExpressionResolverTests extends ESTestCase {
         final String hiddenAlias = "my-hidden-alias";
         final String visibleAlias = "my-visible-alias";
 
-        IndicesOptions excludeHiddenOptions = IndicesOptions.fromOptions(false, true, true, false, false, true, false, false, false);
-        IndicesOptions includeHiddenOptions = IndicesOptions.fromOptions(false, true, true, false, true, true, false, false, false);
+        IndicesOptions excludeHiddenOptions = new IndicesOptions(false, true, true, false, false, true, false, false, false);
+        IndicesOptions includeHiddenOptions = new IndicesOptions(false, true, true, false, true, true, false, false, false);
 
         Metadata.Builder mdBuilder = Metadata.builder()
             .put(indexBuilder(hiddenIndex,  Settings.builder().put(INDEX_HIDDEN_SETTING.getKey(), true).build())
@@ -1106,7 +1106,7 @@ public class IndexNameExpressionResolverTests extends ESTestCase {
                 default:
                     throw new UnsupportedOperationException();
             }
-            final IndicesOptions indicesOptions = IndicesOptions.fromOptions(randomBoolean(), randomBoolean(),
+            final IndicesOptions indicesOptions = new IndicesOptions(randomBoolean(), randomBoolean(),
                     randomBoolean(), randomBoolean());
 
             {
@@ -1156,7 +1156,7 @@ public class IndexNameExpressionResolverTests extends ESTestCase {
      */
     public void testConcreteIndicesWildcardNoMatch() {
         for (int i = 0; i < 10; i++) {
-            IndicesOptions indicesOptions = IndicesOptions.fromOptions(randomBoolean(), randomBoolean(), randomBoolean(), randomBoolean());
+            IndicesOptions indicesOptions = new IndicesOptions(randomBoolean(), randomBoolean(), randomBoolean(), randomBoolean());
             Metadata.Builder mdBuilder = Metadata.builder()
                     .put(indexBuilder("aaa").state(State.OPEN).putAlias(AliasMetadata.builder("aaa_alias1")))
                     .put(indexBuilder("bbb").state(State.OPEN).putAlias(AliasMetadata.builder("bbb_alias1")))
@@ -1296,7 +1296,7 @@ public class IndexNameExpressionResolverTests extends ESTestCase {
         expectThrows(IndexClosedException.class, () -> indexNameExpressionResolver.concreteIndexNames(contextICE, "foo1-closed"));
         expectThrows(IndexClosedException.class, () -> indexNameExpressionResolver.concreteIndexNames(contextICE, "foobar1-closed"));
 
-        IndexNameExpressionResolver.Context context = new IndexNameExpressionResolver.Context(state, IndicesOptions.fromOptions(true,
+        IndexNameExpressionResolver.Context context = new IndexNameExpressionResolver.Context(state, new IndicesOptions(true,
                 contextICE.getOptions().allowNoIndices(), contextICE.getOptions().expandWildcardsOpen(),
             contextICE.getOptions().expandWildcardsClosed(), contextICE.getOptions()), SystemIndexAccessLevel.NONE);
         String[] results = indexNameExpressionResolver.concreteIndexNames(context, "foo1-closed");
@@ -1324,7 +1324,7 @@ public class IndexNameExpressionResolverTests extends ESTestCase {
             // expected
         }
 
-        context = new IndexNameExpressionResolver.Context(state, IndicesOptions.fromOptions(true,
+        context = new IndexNameExpressionResolver.Context(state, new IndicesOptions(true,
             context.getOptions().allowNoIndices(), context.getOptions().expandWildcardsOpen(),
             context.getOptions().expandWildcardsClosed(), context.getOptions()), SystemIndexAccessLevel.NONE);
         results = indexNameExpressionResolver.concreteIndexNames(context, "foobar2-closed");
@@ -1634,13 +1634,13 @@ public class IndexNameExpressionResolverTests extends ESTestCase {
         }
         {
             DeleteIndexRequest deleteIndexRequest = new DeleteIndexRequest("test-alias");
-            deleteIndexRequest.indicesOptions(IndicesOptions.fromOptions(true, true, true, true, false, false, true, false));
+            deleteIndexRequest.indicesOptions(new IndicesOptions(true, true, true, true, false, false, true, false));
             String[] indices = indexNameExpressionResolver.concreteIndexNames(state, deleteIndexRequest);
             assertEquals(0, indices.length);
         }
         {
             DeleteIndexRequest deleteIndexRequest = new DeleteIndexRequest("test-a*");
-            deleteIndexRequest.indicesOptions(IndicesOptions.fromOptions(randomBoolean(), false, true, true, false, false, true, false));
+            deleteIndexRequest.indicesOptions(new IndicesOptions(randomBoolean(), false, true, true, false, false, true, false));
             IndexNotFoundException infe = expectThrows(IndexNotFoundException.class,
                     () -> indexNameExpressionResolver.concreteIndexNames(state, deleteIndexRequest));
             assertEquals(infe.getIndex().getName(), "test-a*");

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/WildcardExpressionResolverTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/WildcardExpressionResolverTests.java
@@ -95,13 +95,13 @@ public class WildcardExpressionResolverTests extends ESTestCase {
         IndexNameExpressionResolver.WildcardExpressionResolver resolver = new IndexNameExpressionResolver.WildcardExpressionResolver();
 
         IndexNameExpressionResolver.Context context = new IndexNameExpressionResolver.Context(state,
-            IndicesOptions.fromOptions(true, true, true, true), SystemIndexAccessLevel.NONE);
+            new IndicesOptions(true, true, true, true), SystemIndexAccessLevel.NONE);
         assertThat(newHashSet(resolver.resolve(context, Collections.singletonList("testX*"))),
             equalTo(newHashSet("testXXX", "testXXY", "testXYY")));
-        context = new IndexNameExpressionResolver.Context(state, IndicesOptions.fromOptions(true, true, false, true),
+        context = new IndexNameExpressionResolver.Context(state, new IndicesOptions(true, true, false, true),
             SystemIndexAccessLevel.NONE);
         assertThat(newHashSet(resolver.resolve(context, Collections.singletonList("testX*"))), equalTo(newHashSet("testXYY")));
-        context = new IndexNameExpressionResolver.Context(state, IndicesOptions.fromOptions(true, true, true, false),
+        context = new IndexNameExpressionResolver.Context(state, new IndicesOptions(true, true, true, false),
             SystemIndexAccessLevel.NONE);
         assertThat(newHashSet(resolver.resolve(context, Collections.singletonList("testX*"))), equalTo(newHashSet("testXXX", "testXXY")));
     }
@@ -155,16 +155,16 @@ public class WildcardExpressionResolverTests extends ESTestCase {
         IndexNameExpressionResolver.WildcardExpressionResolver resolver = new IndexNameExpressionResolver.WildcardExpressionResolver();
         // when ignoreAliases option is not set, WildcardExpressionResolver resolves the provided
         // expressions against the defined indices and aliases
-        IndicesOptions indicesAndAliasesOptions = IndicesOptions.fromOptions(randomBoolean(), randomBoolean(), true, false, true, false,
+        IndicesOptions indicesAndAliasesOptions = new IndicesOptions(randomBoolean(), randomBoolean(), true, false, true, false,
             false, false);
         IndexNameExpressionResolver.Context indicesAndAliasesContext =
             new IndexNameExpressionResolver.Context(state, indicesAndAliasesOptions, SystemIndexAccessLevel.NONE);
         // ignoreAliases option is set, WildcardExpressionResolver throws error when
-        IndicesOptions skipAliasesIndicesOptions = IndicesOptions.fromOptions(true, true, true, false, true, false, true, false);
+        IndicesOptions skipAliasesIndicesOptions = new IndicesOptions(true, true, true, false, true, false, true, false);
         IndexNameExpressionResolver.Context skipAliasesLenientContext =
             new IndexNameExpressionResolver.Context(state, skipAliasesIndicesOptions, SystemIndexAccessLevel.NONE);
         // ignoreAliases option is set, WildcardExpressionResolver resolves the provided expressions only against the defined indices
-        IndicesOptions errorOnAliasIndicesOptions = IndicesOptions.fromOptions(false, false, true, false, true, false, true, false);
+        IndicesOptions errorOnAliasIndicesOptions = new IndicesOptions(false, false, true, false, true, false, true, false);
         IndexNameExpressionResolver.Context skipAliasesStrictContext =
             new IndexNameExpressionResolver.Context(state, errorOnAliasIndicesOptions, SystemIndexAccessLevel.NONE);
 
@@ -230,7 +230,7 @@ public class WildcardExpressionResolverTests extends ESTestCase {
         IndexNameExpressionResolver.WildcardExpressionResolver resolver = new IndexNameExpressionResolver.WildcardExpressionResolver();
 
         {
-            IndicesOptions indicesAndAliasesOptions = IndicesOptions.fromOptions(randomBoolean(), randomBoolean(), true, false, true, false,
+            IndicesOptions indicesAndAliasesOptions = new IndicesOptions(randomBoolean(), randomBoolean(), true, false, true, false,
                 false, false);
             IndexNameExpressionResolver.Context indicesAndAliasesContext =
                 new IndexNameExpressionResolver.Context(state, indicesAndAliasesOptions, SystemIndexAccessLevel.NONE);
@@ -245,7 +245,7 @@ public class WildcardExpressionResolverTests extends ESTestCase {
         }
 
         {
-            IndicesOptions indicesAndAliasesOptions = IndicesOptions.fromOptions(randomBoolean(), randomBoolean(), true, false, true, false,
+            IndicesOptions indicesAndAliasesOptions = new IndicesOptions(randomBoolean(), randomBoolean(), true, false, true, false,
                 false, false);
             IndexNameExpressionResolver.Context indicesAliasesAndDataStreamsContext = new IndexNameExpressionResolver.Context(state,
                 indicesAndAliasesOptions, false, false, true, SystemIndexAccessLevel.NONE, NONE, NONE);
@@ -264,7 +264,7 @@ public class WildcardExpressionResolverTests extends ESTestCase {
         }
 
         {
-            IndicesOptions indicesAliasesAndExpandHiddenOptions = IndicesOptions.fromOptions(randomBoolean(), randomBoolean(), true, false,
+            IndicesOptions indicesAliasesAndExpandHiddenOptions = new IndicesOptions(randomBoolean(), randomBoolean(), true, false,
                 true, true, false, false, false);
             IndexNameExpressionResolver.Context indicesAliasesDataStreamsAndHiddenIndices = new IndexNameExpressionResolver.Context(state,
                 indicesAliasesAndExpandHiddenOptions, false, false, true, SystemIndexAccessLevel.NONE, NONE, NONE);
@@ -293,13 +293,13 @@ public class WildcardExpressionResolverTests extends ESTestCase {
 
         // when ignoreAliases option is not set, WildcardExpressionResolver resolves the provided
         // expressions against the defined indices and aliases
-        IndicesOptions indicesAndAliasesOptions = IndicesOptions.fromOptions(false, false, true, false, true, false, false, false);
+        IndicesOptions indicesAndAliasesOptions = new IndicesOptions(false, false, true, false, true, false, false, false);
         IndexNameExpressionResolver.Context indicesAndAliasesContext =
             new IndexNameExpressionResolver.Context(state, indicesAndAliasesOptions, SystemIndexAccessLevel.NONE);
 
         // ignoreAliases option is set, WildcardExpressionResolver resolves the provided expressions
         // only against the defined indices
-        IndicesOptions onlyIndicesOptions = IndicesOptions.fromOptions(false, false, true, false, true, false, true, false);
+        IndicesOptions onlyIndicesOptions = new IndicesOptions(false, false, true, false, true, false, true, false);
         IndexNameExpressionResolver.Context onlyIndicesContext =
             new IndexNameExpressionResolver.Context(state, onlyIndicesOptions, SystemIndexAccessLevel.NONE);
 

--- a/server/src/test/java/org/elasticsearch/index/reindex/DeleteByQueryRequestTests.java
+++ b/server/src/test/java/org/elasticsearch/index/reindex/DeleteByQueryRequestTests.java
@@ -31,7 +31,7 @@ public class DeleteByQueryRequestTests extends AbstractBulkByScrollRequestTestCa
         }
 
         SearchRequest searchRequest = new SearchRequest(indices);
-        IndicesOptions indicesOptions = IndicesOptions.fromOptions(randomBoolean(), randomBoolean(), randomBoolean(), randomBoolean());
+        IndicesOptions indicesOptions = new IndicesOptions(randomBoolean(), randomBoolean(), randomBoolean(), randomBoolean());
         searchRequest.indicesOptions(indicesOptions);
 
         DeleteByQueryRequest request = new DeleteByQueryRequest(searchRequest);

--- a/server/src/test/java/org/elasticsearch/index/reindex/UpdateByQueryRequestTests.java
+++ b/server/src/test/java/org/elasticsearch/index/reindex/UpdateByQueryRequestTests.java
@@ -23,7 +23,7 @@ public class UpdateByQueryRequestTests extends AbstractBulkByScrollRequestTestCa
             indices[i] = randomSimpleString(random(), 1, 30);
         }
 
-        IndicesOptions indicesOptions = IndicesOptions.fromOptions(randomBoolean(), randomBoolean(), randomBoolean(), randomBoolean());
+        IndicesOptions indicesOptions = new IndicesOptions(randomBoolean(), randomBoolean(), randomBoolean(), randomBoolean());
 
         UpdateByQueryRequest request = new UpdateByQueryRequest();
         request.indices(indices);

--- a/server/src/test/java/org/elasticsearch/snapshots/SnapshotRequestsTests.java
+++ b/server/src/test/java/org/elasticsearch/snapshots/SnapshotRequestsTests.java
@@ -36,7 +36,7 @@ public class SnapshotRequestsTests extends ESTestCase {
             builder.endArray();
         }
 
-        IndicesOptions indicesOptions = IndicesOptions.fromOptions(randomBoolean(), randomBoolean(), randomBoolean(), randomBoolean());
+        IndicesOptions indicesOptions = new IndicesOptions(randomBoolean(), randomBoolean(), randomBoolean(), randomBoolean());
         if (indicesOptions.expandWildcardsClosed()) {
             if (indicesOptions.expandWildcardsOpen()) {
                 builder.field("expand_wildcards", "all");
@@ -101,7 +101,7 @@ public class SnapshotRequestsTests extends ESTestCase {
             builder.endArray();
         }
 
-        IndicesOptions indicesOptions = IndicesOptions.fromOptions(randomBoolean(), randomBoolean(), randomBoolean(), randomBoolean());
+        IndicesOptions indicesOptions = new IndicesOptions(randomBoolean(), randomBoolean(), randomBoolean(), randomBoolean());
         if (indicesOptions.expandWildcardsClosed()) {
             if (indicesOptions.expandWildcardsOpen()) {
                 builder.field("expand_wildcards", "all");

--- a/test/framework/src/main/java/org/elasticsearch/search/RandomSearchRequestGenerator.java
+++ b/test/framework/src/main/java/org/elasticsearch/search/RandomSearchRequestGenerator.java
@@ -84,7 +84,7 @@ public class RandomSearchRequestGenerator {
             searchRequest.indices(generateRandomStringArray(10, 10, false, false));
         }
         if (randomBoolean()) {
-            searchRequest.indicesOptions(IndicesOptions.fromOptions(randomBoolean(), randomBoolean(), randomBoolean(), randomBoolean()));
+            searchRequest.indicesOptions(new IndicesOptions(randomBoolean(), randomBoolean(), randomBoolean(), randomBoolean()));
         }
         if (randomBoolean()) {
             searchRequest.preference(randomAlphaOfLengthBetween(3, 10));

--- a/test/framework/src/main/java/org/elasticsearch/test/TestCluster.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/TestCluster.java
@@ -125,7 +125,7 @@ public abstract class TestCluster implements Closeable {
             try {
                 // include wiping hidden indices!
                 assertAcked(client().admin().indices().prepareDelete(indices)
-                    .setIndicesOptions(IndicesOptions.fromOptions(false, true, true, true, true, false, false, true, false)));
+                    .setIndicesOptions(new IndicesOptions(false, true, true, true, true, false, false, true, false)));
             } catch (IndexNotFoundException e) {
                 // ignore
             } catch (IllegalArgumentException e) {

--- a/x-pack/plugin/async-search/src/test/java/org/elasticsearch/xpack/search/SubmitAsyncSearchRequestTests.java
+++ b/x-pack/plugin/async-search/src/test/java/org/elasticsearch/xpack/search/SubmitAsyncSearchRequestTests.java
@@ -48,7 +48,7 @@ public class SubmitAsyncSearchRequestTests extends AbstractWireSerializingTransf
         }
         if (randomBoolean()) {
             searchRequest.getSearchRequest()
-                .indicesOptions(IndicesOptions.fromOptions(randomBoolean(), randomBoolean(), randomBoolean(), randomBoolean()));
+                .indicesOptions(new IndicesOptions(randomBoolean(), randomBoolean(), randomBoolean(), randomBoolean()));
         }
         if (randomBoolean()) {
             searchRequest.getSearchRequest()

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/protocol/xpack/graph/GraphExploreRequest.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/protocol/xpack/graph/GraphExploreRequest.java
@@ -37,7 +37,7 @@ public class GraphExploreRequest extends ActionRequest implements IndicesRequest
     public static final String NO_HOPS_ERROR_MESSAGE = "Graph explore request must have at least one hop";
     public static final String NO_VERTICES_ERROR_MESSAGE = "Graph explore hop must have at least one VertexRequest";
     private String[] indices = Strings.EMPTY_ARRAY;
-    private IndicesOptions indicesOptions = IndicesOptions.fromOptions(false, false, true, false);
+    private IndicesOptions indicesOptions = new IndicesOptions(false, false, true, false);
     private String routing;
     private TimeValue timeout;
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/action/AbstractTransportGetResourcesAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/action/AbstractTransportGetResourcesAction.java
@@ -83,7 +83,7 @@ public abstract class AbstractTransportGetResourcesAction<Resource extends ToXCo
 
         IndicesOptions indicesOptions = SearchRequest.DEFAULT_INDICES_OPTIONS;
         SearchRequest searchRequest = new SearchRequest(getIndices())
-            .indicesOptions(IndicesOptions.fromOptions(true,
+            .indicesOptions(new IndicesOptions(true,
                 indicesOptions.allowNoIndices(),
                 indicesOptions.expandWildcardsOpen(),
                 indicesOptions.expandWildcardsClosed(),

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/action/DataStreamsStatsAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/action/DataStreamsStatsAction.java
@@ -38,7 +38,7 @@ public class DataStreamsStatsAction extends ActionType<DataStreamsStatsAction.Re
         public Request() {
             // this doesn't really matter since data stream name resolution isn't affected by IndicesOptions and
             // a data stream's backing indices are retrieved from its metadata
-            super(null, IndicesOptions.fromOptions(false, true, true, true, true, false, true, false));
+            super(null, new IndicesOptions(false, true, true, true, true, false, true, false));
         }
 
         public Request(StreamInput in) throws IOException {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/action/DeleteDataStreamAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/action/DeleteDataStreamAction.java
@@ -43,7 +43,7 @@ public class DeleteDataStreamAction extends ActionType<AcknowledgedResponse> {
         // empty response can be returned in case wildcards were used or
         // 404 status code returned in case no wildcard were used.
         private final boolean wildcardExpressionsOriginallySpecified;
-        private IndicesOptions indicesOptions = IndicesOptions.fromOptions(false, true, true, true, false, false, true, false);
+        private IndicesOptions indicesOptions = new IndicesOptions(false, true, true, true, false, false, true, false);
 
         public Request(String[] names) {
             this.names = Objects.requireNonNull(names);

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/action/GetDataStreamAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/action/GetDataStreamAction.java
@@ -39,7 +39,7 @@ public class GetDataStreamAction extends ActionType<GetDataStreamAction.Response
     public static class Request extends MasterNodeReadRequest<Request> implements IndicesRequest.Replaceable {
 
         private String[] names;
-        private IndicesOptions indicesOptions = IndicesOptions.fromOptions(false, true, true, true, false, false, true, false);
+        private IndicesOptions indicesOptions = new IndicesOptions(false, true, true, true, false, false, true, false);
 
         public Request(String[] names) {
             this.names = names;

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/rollup/action/PutRollupJobAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/rollup/action/PutRollupJobAction.java
@@ -38,7 +38,7 @@ public class PutRollupJobAction extends ActionType<AcknowledgedResponse> {
     public static class Request extends AcknowledgedRequest<Request> implements IndicesRequest, ToXContentObject {
 
         private RollupJobConfig config;
-        private IndicesOptions indicesOptions = IndicesOptions.fromOptions(false, false, true, false);
+        private IndicesOptions indicesOptions = new IndicesOptions(false, false, true, false);
 
         public Request(RollupJobConfig config) {
             this.config = config;

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/termsenum/action/TermsEnumRequest.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/termsenum/action/TermsEnumRequest.java
@@ -47,7 +47,7 @@ public class TermsEnumRequest extends BroadcastRequest<TermsEnumRequest> impleme
      */
     public TermsEnumRequest(String... indices) {
         super(indices);
-        indicesOptions(IndicesOptions.fromOptions(false, false, true, false));
+        indicesOptions(new IndicesOptions(false, false, true, false));
         timeout(DEFAULT_TIMEOUT);
     }
 

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/ExplainLifecycleRequestTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/ExplainLifecycleRequestTests.java
@@ -23,7 +23,7 @@ public class ExplainLifecycleRequestTests extends AbstractWireSerializingTestCas
             request.indices(generateRandomStringArray(20, 20, false, false));
         }
         if (randomBoolean()) {
-            IndicesOptions indicesOptions = IndicesOptions.fromOptions(randomBoolean(), randomBoolean(), randomBoolean(), randomBoolean(),
+            IndicesOptions indicesOptions = new IndicesOptions(randomBoolean(), randomBoolean(), randomBoolean(), randomBoolean(),
                     randomBoolean(), randomBoolean(), randomBoolean(), randomBoolean());
             request.indicesOptions(indicesOptions);
         }
@@ -48,7 +48,7 @@ public class ExplainLifecycleRequestTests extends AbstractWireSerializingTestCas
                     () -> generateRandomStringArray(20, 10, false, false));
                 break;
             case 1:
-                indicesOptions = randomValueOtherThan(indicesOptions, () -> IndicesOptions.fromOptions(randomBoolean(), randomBoolean(),
+                indicesOptions = randomValueOtherThan(indicesOptions, () -> new IndicesOptions(randomBoolean(), randomBoolean(),
                     randomBoolean(), randomBoolean(), randomBoolean(), randomBoolean(), randomBoolean(), randomBoolean()));
                 break;
             case 2:

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/action/RemoveIndexLifecyclePolicyRequestTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/action/RemoveIndexLifecyclePolicyRequestTests.java
@@ -21,7 +21,7 @@ public class RemoveIndexLifecyclePolicyRequestTests extends AbstractWireSerializ
     protected Request createTestInstance() {
         Request request = new Request(generateRandomStringArray(20, 20, false));
         if (randomBoolean()) {
-            IndicesOptions indicesOptions = IndicesOptions.fromOptions(randomBoolean(), randomBoolean(), randomBoolean(), randomBoolean(),
+            IndicesOptions indicesOptions = new IndicesOptions(randomBoolean(), randomBoolean(), randomBoolean(), randomBoolean(),
                     randomBoolean(), randomBoolean(), randomBoolean(), randomBoolean());
             request.indicesOptions(indicesOptions);
         }
@@ -46,7 +46,7 @@ public class RemoveIndexLifecyclePolicyRequestTests extends AbstractWireSerializ
                     () -> generateRandomStringArray(20, 20, false));
             break;
         case 1:
-            indicesOptions = randomValueOtherThan(indicesOptions, () -> IndicesOptions.fromOptions(randomBoolean(), randomBoolean(),
+            indicesOptions = randomValueOtherThan(indicesOptions, () -> new IndicesOptions(randomBoolean(), randomBoolean(),
                     randomBoolean(), randomBoolean(), randomBoolean(), randomBoolean(), randomBoolean(), randomBoolean()));
             break;
         default:

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/action/RetryRequestTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/action/RetryRequestTests.java
@@ -24,7 +24,7 @@ public class RetryRequestTests extends AbstractWireSerializingTestCase<Request> 
             request.indices(generateRandomStringArray(20, 20, false));
         }
         if (randomBoolean()) {
-            IndicesOptions indicesOptions = IndicesOptions.fromOptions(randomBoolean(), randomBoolean(), randomBoolean(), randomBoolean(),
+            IndicesOptions indicesOptions = new IndicesOptions(randomBoolean(), randomBoolean(), randomBoolean(), randomBoolean(),
                 randomBoolean(), randomBoolean(), randomBoolean(), randomBoolean());
             request.indicesOptions(indicesOptions);
         }
@@ -46,7 +46,7 @@ public class RetryRequestTests extends AbstractWireSerializingTestCase<Request> 
                     () -> generateRandomStringArray(20, 10, false, true));
                 break;
             case 1:
-                indicesOptions = randomValueOtherThan(indicesOptions, () -> IndicesOptions.fromOptions(randomBoolean(), randomBoolean(),
+                indicesOptions = randomValueOtherThan(indicesOptions, () -> new IndicesOptions(randomBoolean(), randomBoolean(),
                     randomBoolean(), randomBoolean(), randomBoolean(), randomBoolean(), randomBoolean(), randomBoolean()));
                 break;
             default:

--- a/x-pack/plugin/data-streams/src/internalClusterTest/java/org/elasticsearch/datastreams/DataStreamMigrationIT.java
+++ b/x-pack/plugin/data-streams/src/internalClusterTest/java/org/elasticsearch/datastreams/DataStreamMigrationIT.java
@@ -82,7 +82,7 @@ public class DataStreamMigrationIT extends ESIntegTestCase {
 
         ResolveIndexAction.Request resolveRequest = new ResolveIndexAction.Request(
             new String[] { "*" },
-            IndicesOptions.fromOptions(true, true, true, true, true)
+            new IndicesOptions(true, true, true, true, true)
         );
         ResolveIndexAction.Response resolveResponse = admin().indices().resolveIndex(resolveRequest).get();
         assertThat(resolveResponse.getAliases().size(), equalTo(1));
@@ -121,7 +121,7 @@ public class DataStreamMigrationIT extends ESIntegTestCase {
 
         ResolveIndexAction.Request resolveRequest = new ResolveIndexAction.Request(
             new String[] { "*" },
-            IndicesOptions.fromOptions(true, true, true, true, true)
+            new IndicesOptions(true, true, true, true, true)
         );
         ResolveIndexAction.Response resolveResponse = admin().indices().resolveIndex(resolveRequest).get();
         assertThat(resolveResponse.getAliases().size(), equalTo(1));
@@ -153,7 +153,7 @@ public class DataStreamMigrationIT extends ESIntegTestCase {
 
         ResolveIndexAction.Request resolveRequest = new ResolveIndexAction.Request(
             new String[] { "*" },
-            IndicesOptions.fromOptions(true, true, true, true, true)
+            new IndicesOptions(true, true, true, true, true)
         );
         ResolveIndexAction.Response resolveResponse = admin().indices().resolveIndex(resolveRequest).get();
         assertThat(resolveResponse.getAliases().size(), equalTo(1));
@@ -188,7 +188,7 @@ public class DataStreamMigrationIT extends ESIntegTestCase {
 
         ResolveIndexAction.Request resolveRequest = new ResolveIndexAction.Request(
             new String[] { "*" },
-            IndicesOptions.fromOptions(true, true, true, true, true)
+            new IndicesOptions(true, true, true, true, true)
         );
         ResolveIndexAction.Response resolveResponse = admin().indices().resolveIndex(resolveRequest).get();
         assertThat(resolveResponse.getAliases().size(), equalTo(1));
@@ -223,7 +223,7 @@ public class DataStreamMigrationIT extends ESIntegTestCase {
 
         ResolveIndexAction.Request resolveRequest = new ResolveIndexAction.Request(
             new String[] { "*" },
-            IndicesOptions.fromOptions(true, true, true, true, true)
+            new IndicesOptions(true, true, true, true, true)
         );
         ResolveIndexAction.Response resolveResponse = admin().indices().resolveIndex(resolveRequest).get();
         assertThat(resolveResponse.getAliases().size(), equalTo(1));

--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/DeprecationInfoAction.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/DeprecationInfoAction.java
@@ -215,7 +215,7 @@ public class DeprecationInfoAction extends ActionType<DeprecationInfoAction.Resp
 
     public static class Request extends MasterNodeReadRequest<Request> implements IndicesRequest.Replaceable {
 
-        private static final IndicesOptions INDICES_OPTIONS = IndicesOptions.fromOptions(false, true, true, true);
+        private static final IndicesOptions INDICES_OPTIONS = new IndicesOptions(false, true, true, true);
         private String[] indices;
 
         public Request(String... indices) {

--- a/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/EnrichPolicyMaintenanceService.java
+++ b/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/EnrichPolicyMaintenanceService.java
@@ -41,7 +41,7 @@ public class EnrichPolicyMaintenanceService implements LocalNodeMasterListener {
     private static final Logger logger = LogManager.getLogger(EnrichPolicyMaintenanceService.class);
 
     private static final String MAPPING_POLICY_FIELD_PATH = "_meta." + EnrichPolicyRunner.ENRICH_POLICY_NAME_FIELD_NAME;
-    private static final IndicesOptions IGNORE_UNAVAILABLE = IndicesOptions.fromOptions(true, false, false, false);
+    private static final IndicesOptions IGNORE_UNAVAILABLE = new IndicesOptions(true, false, false, false);
 
     private final Settings settings;
     private final Client client;

--- a/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/action/TransportDeleteEnrichPolicyAction.java
+++ b/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/action/TransportDeleteEnrichPolicyAction.java
@@ -47,7 +47,7 @@ public class TransportDeleteEnrichPolicyAction extends AcknowledgedTransportMast
     private final Client client;
     // the most lenient we can get in order to not bomb out if no indices are found, which is a valid case
     // where a user creates and deletes a policy before running execute
-    private static final IndicesOptions LENIENT_OPTIONS = IndicesOptions.fromOptions(true, true, true, true);
+    private static final IndicesOptions LENIENT_OPTIONS = new IndicesOptions(true, true, true, true);
 
     @Inject
     public TransportDeleteEnrichPolicyAction(

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/action/EqlSearchRequest.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/action/EqlSearchRequest.java
@@ -48,7 +48,7 @@ public class EqlSearchRequest extends ActionRequest implements IndicesRequest.Re
     public static TimeValue DEFAULT_KEEP_ALIVE = TimeValue.timeValueDays(5);
 
     private String[] indices;
-    private IndicesOptions indicesOptions = IndicesOptions.fromOptions(true, true, true, false);
+    private IndicesOptions indicesOptions = new IndicesOptions(true, true, true, false);
 
     private QueryBuilder filter = null;
     private String timestampField = FIELD_TIMESTAMP;

--- a/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/EqlTestUtils.java
+++ b/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/EqlTestUtils.java
@@ -73,7 +73,7 @@ public final class EqlTestUtils {
     }
 
     public static IndicesOptions randomIndicesOptions() {
-        return IndicesOptions.fromOptions(randomBoolean(), randomBoolean(), randomBoolean(), randomBoolean(), randomBoolean(),
+        return new IndicesOptions(randomBoolean(), randomBoolean(), randomBoolean(), randomBoolean(), randomBoolean(),
             randomBoolean(), randomBoolean(), randomBoolean(), randomBoolean());
     }
 

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/persistence/TrainedModelProvider.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/persistence/TrainedModelProvider.java
@@ -797,7 +797,7 @@ public class TrainedModelProvider {
 
         IndicesOptions indicesOptions = SearchRequest.DEFAULT_INDICES_OPTIONS;
         SearchRequest searchRequest = new SearchRequest(InferenceIndexConstants.INDEX_PATTERN)
-            .indicesOptions(IndicesOptions.fromOptions(true,
+            .indicesOptions(new IndicesOptions(true,
                 indicesOptions.allowNoIndices(),
                 indicesOptions.expandWildcardsOpen(),
                 indicesOptions.expandWildcardsClosed(),

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/utils/MlIndicesUtils.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/utils/MlIndicesUtils.java
@@ -17,7 +17,7 @@ public final class MlIndicesUtils {
     }
 
     public static IndicesOptions addIgnoreUnavailable(IndicesOptions indicesOptions) {
-        return IndicesOptions.fromOptions(true, indicesOptions.allowNoIndices(), indicesOptions.expandWildcardsOpen(),
+        return new IndicesOptions(true, indicesOptions.allowNoIndices(), indicesOptions.expandWildcardsOpen(),
                 indicesOptions.expandWildcardsClosed(), indicesOptions);
     }
 }

--- a/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/cleaner/local/LocalIndicesCleanerTests.java
+++ b/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/cleaner/local/LocalIndicesCleanerTests.java
@@ -52,7 +52,7 @@ public class LocalIndicesCleanerTests extends AbstractIndicesCleanerTestCase {
             //so when es core gets the request with the explicit index name, it throws an index not found exception as that index
             //doesn't exist anymore. If we ignore unavailable instead no error will be thrown.
             GetSettingsResponse getSettingsResponse = client().admin().indices().prepareGetSettings()
-                    .setIndicesOptions(IndicesOptions.fromOptions(true, true, true, true, true)).get();
+                    .setIndicesOptions(new IndicesOptions(true, true, true, true, true)).get();
             assertThat(getSettingsResponse.getIndexToSettings().size(), equalTo(count));
         });
     }

--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/authz/ReadActionsTests.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/authz/ReadActionsTests.java
@@ -75,7 +75,7 @@ public class ReadActionsTests extends SecurityIntegTestCase {
         //wildcard doesn't match any authorized index
         createIndicesWithRandomAliases("test1", "test2", "index1", "index2");
         IndexNotFoundException e = expectThrows(IndexNotFoundException.class, () -> client().prepareSearch("index*")
-                .setIndicesOptions(IndicesOptions.fromOptions(randomBoolean(), false, true, randomBoolean())).get());
+                .setIndicesOptions(new IndicesOptions(randomBoolean(), false, true, randomBoolean())).get());
         assertEquals("no such index [index*]", e.getMessage());
     }
 
@@ -85,7 +85,7 @@ public class ReadActionsTests extends SecurityIntegTestCase {
 
     public void testEmptyClusterSearchForAllDisallowNoIndices() {
         IndexNotFoundException e = expectThrows(IndexNotFoundException.class, () -> client().prepareSearch()
-                .setIndicesOptions(IndicesOptions.fromOptions(randomBoolean(), false, true, randomBoolean())).get());
+                .setIndicesOptions(new IndicesOptions(randomBoolean(), false, true, randomBoolean())).get());
         assertEquals("no such index [[]]", e.getMessage());
     }
 
@@ -96,7 +96,7 @@ public class ReadActionsTests extends SecurityIntegTestCase {
 
     public void testEmptyClusterSearchForWildcardDisallowNoIndices() {
         IndexNotFoundException e = expectThrows(IndexNotFoundException.class, () -> client().prepareSearch("*")
-                .setIndicesOptions(IndicesOptions.fromOptions(randomBoolean(), false, true, randomBoolean())).get());
+                .setIndicesOptions(new IndicesOptions(randomBoolean(), false, true, randomBoolean())).get());
         assertEquals("no such index [*]", e.getMessage());
     }
 
@@ -108,7 +108,7 @@ public class ReadActionsTests extends SecurityIntegTestCase {
     public void testEmptyAuthorizedIndicesSearchForAllDisallowNoIndices() {
         createIndicesWithRandomAliases("index1", "index2");
         IndexNotFoundException e = expectThrows(IndexNotFoundException.class, () -> client().prepareSearch()
-                .setIndicesOptions(IndicesOptions.fromOptions(randomBoolean(), false, true, randomBoolean())).get());
+                .setIndicesOptions(new IndicesOptions(randomBoolean(), false, true, randomBoolean())).get());
         assertEquals("no such index [[]]", e.getMessage());
     }
 
@@ -120,7 +120,7 @@ public class ReadActionsTests extends SecurityIntegTestCase {
     public void testEmptyAuthorizedIndicesSearchForWildcardDisallowNoIndices() {
         createIndicesWithRandomAliases("index1", "index2");
         IndexNotFoundException e = expectThrows(IndexNotFoundException.class, () -> client().prepareSearch("*")
-                .setIndicesOptions(IndicesOptions.fromOptions(randomBoolean(), false, true, randomBoolean())).get());
+                .setIndicesOptions(new IndicesOptions(randomBoolean(), false, true, randomBoolean())).get());
         assertEquals("no such index [*]", e.getMessage());
     }
 
@@ -226,7 +226,7 @@ public class ReadActionsTests extends SecurityIntegTestCase {
             MultiSearchResponse multiSearchResponse = client().prepareMultiSearch()
                     .add(Requests.searchRequest())
                     .add(Requests.searchRequest("index1")
-                            .indicesOptions(IndicesOptions.fromOptions(true, true, true, randomBoolean()))).get();
+                            .indicesOptions(new IndicesOptions(true, true, true, randomBoolean()))).get();
             assertEquals(2, multiSearchResponse.getResponses().length);
             assertFalse(multiSearchResponse.getResponses()[0].isFailure());
             SearchResponse searchResponse = multiSearchResponse.getResponses()[0].getResponse();
@@ -257,7 +257,7 @@ public class ReadActionsTests extends SecurityIntegTestCase {
             MultiSearchResponse multiSearchResponse = client().prepareMultiSearch()
                     .add(Requests.searchRequest())
                     .add(Requests.searchRequest("missing")
-                            .indicesOptions(IndicesOptions.fromOptions(true, true, true, randomBoolean()))).get();
+                            .indicesOptions(new IndicesOptions(true, true, true, randomBoolean()))).get();
             assertEquals(2, multiSearchResponse.getResponses().length);
             assertFalse(multiSearchResponse.getResponses()[0].isFailure());
             SearchResponse searchResponse = multiSearchResponse.getResponses()[0].getResponse();
@@ -287,7 +287,7 @@ public class ReadActionsTests extends SecurityIntegTestCase {
             MultiSearchResponse multiSearchResponse = client().prepareMultiSearch()
                     .add(Requests.searchRequest())
                     .add(Requests.searchRequest("test4")
-                            .indicesOptions(IndicesOptions.fromOptions(true, true, true, randomBoolean()))).get();
+                            .indicesOptions(new IndicesOptions(true, true, true, randomBoolean()))).get();
             assertReturnedIndices(multiSearchResponse.getResponses()[0].getResponse(), "test1", "test2", "test3");
             assertNoSearchHits(multiSearchResponse.getResponses()[1].getResponse());
         }
@@ -308,7 +308,7 @@ public class ReadActionsTests extends SecurityIntegTestCase {
         {
             MultiSearchResponse multiSearchResponse = client().prepareMultiSearch().add(Requests.searchRequest())
                     .add(Requests.searchRequest("index*")
-                            .indicesOptions(IndicesOptions.fromOptions(randomBoolean(), false, true, randomBoolean()))).get();
+                            .indicesOptions(new IndicesOptions(randomBoolean(), false, true, randomBoolean()))).get();
             assertEquals(2, multiSearchResponse.getResponses().length);
             assertFalse(multiSearchResponse.getResponses()[0].isFailure());
             SearchResponse searchResponse = multiSearchResponse.getResponses()[0].getResponse();

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/action/filter/SecurityActionFilterTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/action/filter/SecurityActionFilterTests.java
@@ -201,7 +201,7 @@ public class SecurityActionFilterTests extends ESTestCase {
 
     public void testApplyDestructiveOperations() throws Exception {
         ActionRequest request = new MockIndicesRequest(
-                IndicesOptions.fromOptions(randomBoolean(), randomBoolean(), randomBoolean(), randomBoolean()),
+                new IndicesOptions(randomBoolean(), randomBoolean(), randomBoolean(), randomBoolean()),
                 randomFrom("*", "_all", "test*"));
         String action = randomFrom(CloseIndexAction.NAME, OpenIndexAction.NAME, DeleteIndexAction.NAME);
         ActionListener listener = mock(ActionListener.class);

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/AuthorizationServiceTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/AuthorizationServiceTests.java
@@ -787,7 +787,7 @@ public class AuthorizationServiceTests extends ESTestCase {
         {
             //ignore_unavailable set to false, user is not authorized for this index nor does it exist
             SearchRequest searchRequest = new SearchRequest("does_not_exist")
-                .indicesOptions(IndicesOptions.fromOptions(false, true,
+                .indicesOptions(new IndicesOptions(false, true,
                     true, false));
 
             assertThrowsAuthorizationException(
@@ -801,7 +801,7 @@ public class AuthorizationServiceTests extends ESTestCase {
         {
             //ignore_unavailable and allow_no_indices both set to true, user is not authorized for this index nor does it exist
             SearchRequest searchRequest = new SearchRequest("does_not_exist")
-                .indicesOptions(IndicesOptions.fromOptions(true, true, true, false));
+                .indicesOptions(new IndicesOptions(true, true, true, false));
             final ActionListener<Void> listener = ActionListener.wrap(ignore -> {
                 final IndicesAccessControl indicesAccessControl =
                     threadContext.getTransient(AuthorizationServiceField.INDICES_PERMISSIONS_KEY);
@@ -1138,7 +1138,7 @@ public class AuthorizationServiceTests extends ESTestCase {
     }
 
     public void testAuditTrailIsRecordedWhenIndexWildcardThrowsError() throws IOException {
-        IndicesOptions options = IndicesOptions.fromOptions(false, false, true, true);
+        IndicesOptions options = new IndicesOptions(false, false, true, true);
         TransportRequest request = new GetIndexRequest().indices("not-an-index-*").indicesOptions(options);
         ClusterState state = mockEmptyMetadata();
         RoleDescriptor role = new RoleDescriptor("a_all", null,

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/IndicesAndAliasesResolverTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/IndicesAndAliasesResolverTests.java
@@ -385,7 +385,7 @@ public class IndicesAndAliasesResolverTests extends ESTestCase {
 
     public void testDashIndicesNoExpandWildcard() {
         SearchRequest request = new SearchRequest("-index1*", "--index11");
-        request.indicesOptions(IndicesOptions.fromOptions(false, randomBoolean(), false, false));
+        request.indicesOptions(new IndicesOptions(false, randomBoolean(), false, false));
         List<String> indices =
                 resolveIndices(request, buildAuthorizedIndices(userDashIndices, SearchAction.NAME)).getLocal();
         String[] expectedIndices = new String[]{"-index1*", "--index11"};
@@ -397,7 +397,7 @@ public class IndicesAndAliasesResolverTests extends ESTestCase {
 
     public void testDashIndicesMinus() {
         SearchRequest request = new SearchRequest("-index10", "-index11", "--index11", "-index20");
-        request.indicesOptions(IndicesOptions.fromOptions(false, randomBoolean(), randomBoolean(), randomBoolean()));
+        request.indicesOptions(new IndicesOptions(false, randomBoolean(), randomBoolean(), randomBoolean()));
         List<String> indices =
                 resolveIndices(request, buildAuthorizedIndices(userDashIndices, SearchAction.NAME)).getLocal();
         String[] expectedIndices = new String[]{"-index10", "-index11", "--index11", "-index20"};
@@ -409,14 +409,14 @@ public class IndicesAndAliasesResolverTests extends ESTestCase {
 
     public void testDashIndicesPlus() {
         SearchRequest request = new SearchRequest("+bar");
-        request.indicesOptions(IndicesOptions.fromOptions(true, false, randomBoolean(), randomBoolean()));
+        request.indicesOptions(new IndicesOptions(true, false, randomBoolean(), randomBoolean()));
         expectThrows(IndexNotFoundException.class,
                 () -> resolveIndices(request, buildAuthorizedIndices(userDashIndices, SearchAction.NAME)));
     }
 
     public void testDashNotExistingIndex() {
         SearchRequest request = new SearchRequest("-does_not_exist");
-        request.indicesOptions(IndicesOptions.fromOptions(false, randomBoolean(), randomBoolean(), randomBoolean()));
+        request.indicesOptions(new IndicesOptions(false, randomBoolean(), randomBoolean(), randomBoolean()));
         List<String> indices = resolveIndices(request, buildAuthorizedIndices(userDashIndices, SearchAction.NAME)).getLocal();
         String[] expectedIndices = new String[]{"-does_not_exist"};
         assertThat(indices.size(), equalTo(expectedIndices.length));
@@ -427,7 +427,7 @@ public class IndicesAndAliasesResolverTests extends ESTestCase {
 
     public void testResolveEmptyIndicesExpandWilcardsOpenAndClosed() {
         SearchRequest request = new SearchRequest();
-        request.indicesOptions(IndicesOptions.fromOptions(randomBoolean(), randomBoolean(), true, true));
+        request.indicesOptions(new IndicesOptions(randomBoolean(), randomBoolean(), true, true));
         List<String> indices = resolveIndices(request, buildAuthorizedIndices(user, SearchAction.NAME)).getLocal();
         String[] replacedIndices = new String[]{"bar", "bar-closed", "foofoobar", "foobarfoo", "foofoo", "foofoo-closed"};
         assertThat(indices.size(), equalTo(replacedIndices.length));
@@ -438,7 +438,7 @@ public class IndicesAndAliasesResolverTests extends ESTestCase {
 
     public void testResolveEmptyIndicesExpandWilcardsOpen() {
         SearchRequest request = new SearchRequest();
-        request.indicesOptions(IndicesOptions.fromOptions(randomBoolean(), randomBoolean(), true, false));
+        request.indicesOptions(new IndicesOptions(randomBoolean(), randomBoolean(), true, false));
         List<String> indices = resolveIndices(request, buildAuthorizedIndices(user, SearchAction.NAME)).getLocal();
         String[] replacedIndices = new String[]{"bar", "foofoobar", "foobarfoo", "foofoo"};
         assertSameValues(indices, replacedIndices);
@@ -447,7 +447,7 @@ public class IndicesAndAliasesResolverTests extends ESTestCase {
 
     public void testResolveAllExpandWilcardsOpenAndClosed() {
         SearchRequest request = new SearchRequest("_all");
-        request.indicesOptions(IndicesOptions.fromOptions(randomBoolean(), randomBoolean(), true, true));
+        request.indicesOptions(new IndicesOptions(randomBoolean(), randomBoolean(), true, true));
         List<String> indices = resolveIndices(request, buildAuthorizedIndices(user, SearchAction.NAME)).getLocal();
         String[] replacedIndices = new String[]{"bar", "bar-closed", "foofoobar", "foobarfoo", "foofoo", "foofoo-closed"};
         assertThat(indices.size(), equalTo(replacedIndices.length));
@@ -458,7 +458,7 @@ public class IndicesAndAliasesResolverTests extends ESTestCase {
 
     public void testResolveAllExpandWilcardsOpen() {
         SearchRequest request = new SearchRequest("_all");
-        request.indicesOptions(IndicesOptions.fromOptions(randomBoolean(), randomBoolean(), true, false));
+        request.indicesOptions(new IndicesOptions(randomBoolean(), randomBoolean(), true, false));
         List<String> indices = resolveIndices(request, buildAuthorizedIndices(user, SearchAction.NAME)).getLocal();
         String[] replacedIndices = new String[]{"bar", "foofoobar", "foobarfoo", "foofoo"};
         assertThat(indices.size(), equalTo(replacedIndices.length));
@@ -469,7 +469,7 @@ public class IndicesAndAliasesResolverTests extends ESTestCase {
 
     public void testResolveWildcardsStrictExpand() {
         SearchRequest request = new SearchRequest("barbaz", "foofoo*");
-        request.indicesOptions(IndicesOptions.fromOptions(false, randomBoolean(), true, true));
+        request.indicesOptions(new IndicesOptions(false, randomBoolean(), true, true));
         List<String> indices = resolveIndices(request, buildAuthorizedIndices(user, SearchAction.NAME)).getLocal();
         String[] replacedIndices = new String[]{"barbaz", "foofoobar", "foofoo", "foofoo-closed"};
         assertThat(indices.size(), equalTo(replacedIndices.length));
@@ -480,7 +480,7 @@ public class IndicesAndAliasesResolverTests extends ESTestCase {
 
     public void testResolveWildcardsExpandOpenAndClosedIgnoreUnavailable() {
         SearchRequest request = new SearchRequest("barbaz", "foofoo*");
-        request.indicesOptions(IndicesOptions.fromOptions(true, randomBoolean(), true, true));
+        request.indicesOptions(new IndicesOptions(true, randomBoolean(), true, true));
         List<String> indices = resolveIndices(request, buildAuthorizedIndices(user, SearchAction.NAME)).getLocal();
         String[] replacedIndices = new String[]{"foofoobar", "foofoo", "foofoo-closed"};
         assertThat(indices.size(), equalTo(replacedIndices.length));
@@ -491,7 +491,7 @@ public class IndicesAndAliasesResolverTests extends ESTestCase {
 
     public void testResolveWildcardsStrictExpandOpen() {
         SearchRequest request = new SearchRequest("barbaz", "foofoo*");
-        request.indicesOptions(IndicesOptions.fromOptions(false, randomBoolean(), true, false));
+        request.indicesOptions(new IndicesOptions(false, randomBoolean(), true, false));
         List<String> indices = resolveIndices(request, buildAuthorizedIndices(user, SearchAction.NAME)).getLocal();
         String[] replacedIndices = new String[]{"barbaz", "foofoobar", "foofoo"};
         assertThat(indices.size(), equalTo(replacedIndices.length));
@@ -502,7 +502,7 @@ public class IndicesAndAliasesResolverTests extends ESTestCase {
 
     public void testResolveWildcardsLenientExpandOpen() {
         SearchRequest request = new SearchRequest("barbaz", "foofoo*");
-        request.indicesOptions(IndicesOptions.fromOptions(true, randomBoolean(), true, false));
+        request.indicesOptions(new IndicesOptions(true, randomBoolean(), true, false));
         List<String> indices = resolveIndices(request, buildAuthorizedIndices(user, SearchAction.NAME)).getLocal();
         String[] replacedIndices = new String[]{"foofoobar", "foofoo"};
         assertThat(indices.size(), equalTo(replacedIndices.length));
@@ -513,7 +513,7 @@ public class IndicesAndAliasesResolverTests extends ESTestCase {
 
     public void testResolveWildcardsMinusExpandWilcardsOpen() {
         SearchRequest request = new SearchRequest("*", "-foofoo*");
-        request.indicesOptions(IndicesOptions.fromOptions(randomBoolean(), randomBoolean(), true, false));
+        request.indicesOptions(new IndicesOptions(randomBoolean(), randomBoolean(), true, false));
         List<String> indices = resolveIndices(request, buildAuthorizedIndices(user, SearchAction.NAME)).getLocal();
         String[] replacedIndices = new String[]{"bar", "foobarfoo"};
         assertThat(indices.size(), equalTo(replacedIndices.length));
@@ -524,7 +524,7 @@ public class IndicesAndAliasesResolverTests extends ESTestCase {
 
     public void testResolveWildcardsMinusExpandWilcardsOpenAndClosed() {
         SearchRequest request = new SearchRequest("*", "-foofoo*");
-        request.indicesOptions(IndicesOptions.fromOptions(randomBoolean(), randomBoolean(), true, true));
+        request.indicesOptions(new IndicesOptions(randomBoolean(), randomBoolean(), true, true));
         List<String> indices = resolveIndices(request, buildAuthorizedIndices(user, SearchAction.NAME)).getLocal();
         String[] replacedIndices = new String[]{"bar", "foobarfoo", "bar-closed"};
         assertThat(indices.size(), equalTo(replacedIndices.length));
@@ -535,7 +535,7 @@ public class IndicesAndAliasesResolverTests extends ESTestCase {
 
     public void testResolveWildcardsExclusionsExpandWilcardsOpenStrict() {
         SearchRequest request = new SearchRequest("*", "-foofoo*", "barbaz", "foob*");
-        request.indicesOptions(IndicesOptions.fromOptions(false, true, true, false));
+        request.indicesOptions(new IndicesOptions(false, true, true, false));
         List<String> indices = resolveIndices(request, buildAuthorizedIndices(user, SearchAction.NAME)).getLocal();
         String[] replacedIndices = new String[]{"bar", "foobarfoo", "barbaz"};
         assertSameValues(indices, replacedIndices);
@@ -544,7 +544,7 @@ public class IndicesAndAliasesResolverTests extends ESTestCase {
 
     public void testResolveWildcardsPlusAndMinusExpandWilcardsOpenIgnoreUnavailable() {
         SearchRequest request = new SearchRequest("*", "-foofoo*", "+barbaz", "+foob*");
-        request.indicesOptions(IndicesOptions.fromOptions(true, true, true, false));
+        request.indicesOptions(new IndicesOptions(true, true, true, false));
         List<String> indices = resolveIndices(request, buildAuthorizedIndices(user, SearchAction.NAME)).getLocal();
         String[] replacedIndices = new String[]{"bar", "foobarfoo"};
         assertThat(indices.size(), equalTo(replacedIndices.length));
@@ -555,7 +555,7 @@ public class IndicesAndAliasesResolverTests extends ESTestCase {
 
     public void testResolveWildcardsExclusionExpandWilcardsOpenAndClosedStrict() {
         SearchRequest request = new SearchRequest("*", "-foofoo*", "barbaz");
-        request.indicesOptions(IndicesOptions.fromOptions(false, randomBoolean(), true, true));
+        request.indicesOptions(new IndicesOptions(false, randomBoolean(), true, true));
         List<String> indices = resolveIndices(request, buildAuthorizedIndices(user, SearchAction.NAME)).getLocal();
         String[] replacedIndices = new String[]{"bar", "bar-closed", "barbaz", "foobarfoo"};
         assertSameValues(indices, replacedIndices);
@@ -564,7 +564,7 @@ public class IndicesAndAliasesResolverTests extends ESTestCase {
 
     public void testResolveWildcardsExclusionExpandWilcardsOpenAndClosedIgnoreUnavailable() {
         SearchRequest request = new SearchRequest("*", "-foofoo*", "barbaz");
-        request.indicesOptions(IndicesOptions.fromOptions(true, randomBoolean(), true, true));
+        request.indicesOptions(new IndicesOptions(true, randomBoolean(), true, true));
         List<String> indices = resolveIndices(request, buildAuthorizedIndices(user, SearchAction.NAME)).getLocal();
         String[] replacedIndices = new String[]{"bar", "bar-closed", "foobarfoo"};
         assertThat(indices.size(), equalTo(replacedIndices.length));
@@ -574,13 +574,13 @@ public class IndicesAndAliasesResolverTests extends ESTestCase {
 
     public void testResolveNonMatchingIndicesAllowNoIndices() {
         SearchRequest request = new SearchRequest("missing*");
-        request.indicesOptions(IndicesOptions.fromOptions(randomBoolean(), true, true, randomBoolean()));
+        request.indicesOptions(new IndicesOptions(randomBoolean(), true, true, randomBoolean()));
         assertNoIndices(request, resolveIndices(request, buildAuthorizedIndices(user, SearchAction.NAME)));
     }
 
     public void testResolveNonMatchingIndicesDisallowNoIndices() {
         SearchRequest request = new SearchRequest("missing*");
-        request.indicesOptions(IndicesOptions.fromOptions(randomBoolean(), false, true, randomBoolean()));
+        request.indicesOptions(new IndicesOptions(randomBoolean(), false, true, randomBoolean()));
         IndexNotFoundException e = expectThrows(IndexNotFoundException.class,
                 () -> resolveIndices(request, buildAuthorizedIndices(user, SearchAction.NAME)));
         assertEquals("no such index [missing*]", e.getMessage());
@@ -588,7 +588,7 @@ public class IndicesAndAliasesResolverTests extends ESTestCase {
 
     public void testResolveExplicitIndicesStrict() {
         SearchRequest request = new SearchRequest("missing", "bar", "barbaz");
-        request.indicesOptions(IndicesOptions.fromOptions(false, randomBoolean(), randomBoolean(), randomBoolean()));
+        request.indicesOptions(new IndicesOptions(false, randomBoolean(), randomBoolean(), randomBoolean()));
         List<String> indices = resolveIndices(request, buildAuthorizedIndices(user, SearchAction.NAME)).getLocal();
         String[] replacedIndices = new String[]{"missing", "bar", "barbaz"};
         assertThat(indices.size(), equalTo(replacedIndices.length));
@@ -599,7 +599,7 @@ public class IndicesAndAliasesResolverTests extends ESTestCase {
 
     public void testResolveExplicitIndicesIgnoreUnavailable() {
         SearchRequest request = new SearchRequest("missing", "bar", "barbaz");
-        request.indicesOptions(IndicesOptions.fromOptions(true, randomBoolean(), randomBoolean(), randomBoolean()));
+        request.indicesOptions(new IndicesOptions(true, randomBoolean(), randomBoolean(), randomBoolean()));
         List<String> indices = resolveIndices(request, buildAuthorizedIndices(user, SearchAction.NAME)).getLocal();
         String[] replacedIndices = new String[]{"bar"};
         assertThat(indices.size(), equalTo(replacedIndices.length));
@@ -610,14 +610,14 @@ public class IndicesAndAliasesResolverTests extends ESTestCase {
 
     public void testResolveNoAuthorizedIndicesAllowNoIndices() {
         SearchRequest request = new SearchRequest();
-        request.indicesOptions(IndicesOptions.fromOptions(randomBoolean(), true, true, randomBoolean()));
+        request.indicesOptions(new IndicesOptions(randomBoolean(), true, true, randomBoolean()));
         assertNoIndices(request, resolveIndices(request,
                 buildAuthorizedIndices(userNoIndices, SearchAction.NAME)));
     }
 
     public void testResolveNoAuthorizedIndicesDisallowNoIndices() {
         SearchRequest request = new SearchRequest();
-        request.indicesOptions(IndicesOptions.fromOptions(randomBoolean(), false, true, randomBoolean()));
+        request.indicesOptions(new IndicesOptions(randomBoolean(), false, true, randomBoolean()));
         IndexNotFoundException e = expectThrows(IndexNotFoundException.class,
                 () -> resolveIndices(request, buildAuthorizedIndices(userNoIndices, SearchAction.NAME)));
         assertEquals("no such index [[]]", e.getMessage());
@@ -625,7 +625,7 @@ public class IndicesAndAliasesResolverTests extends ESTestCase {
 
     public void testResolveMissingIndexStrict() {
         SearchRequest request = new SearchRequest("bar*", "missing");
-        request.indicesOptions(IndicesOptions.fromOptions(false, true, true, false));
+        request.indicesOptions(new IndicesOptions(false, true, true, false));
         List<String> indices = resolveIndices(request, buildAuthorizedIndices(user, SearchAction.NAME)).getLocal();
         String[] expectedIndices = new String[]{"bar", "missing"};
         assertThat(indices.size(), equalTo(expectedIndices.length));
@@ -636,7 +636,7 @@ public class IndicesAndAliasesResolverTests extends ESTestCase {
 
     public void testResolveMissingIndexIgnoreUnavailable() {
         SearchRequest request = new SearchRequest("bar*", "missing");
-        request.indicesOptions(IndicesOptions.fromOptions(true, randomBoolean(), true, false));
+        request.indicesOptions(new IndicesOptions(true, randomBoolean(), true, false));
         List<String> indices = resolveIndices(request, buildAuthorizedIndices(user, SearchAction.NAME)).getLocal();
         String[] expectedIndices = new String[]{"bar"};
         assertThat(indices.size(), equalTo(expectedIndices.length));
@@ -647,7 +647,7 @@ public class IndicesAndAliasesResolverTests extends ESTestCase {
 
     public void testResolveNonMatchingIndicesAndExplicit() {
         SearchRequest request = new SearchRequest("missing*", "bar");
-        request.indicesOptions(IndicesOptions.fromOptions(randomBoolean(), true, true, randomBoolean()));
+        request.indicesOptions(new IndicesOptions(randomBoolean(), true, true, randomBoolean()));
         List<String> indices = resolveIndices(request, buildAuthorizedIndices(user, SearchAction.NAME)).getLocal();
         String[] expectedIndices = new String[]{"bar"};
         assertThat(indices.toArray(new String[indices.size()]), equalTo(expectedIndices));
@@ -656,7 +656,7 @@ public class IndicesAndAliasesResolverTests extends ESTestCase {
 
     public void testResolveNoExpandStrict() {
         SearchRequest request = new SearchRequest("missing*");
-        request.indicesOptions(IndicesOptions.fromOptions(false, randomBoolean(), false, false));
+        request.indicesOptions(new IndicesOptions(false, randomBoolean(), false, false));
         List<String> indices = resolveIndices(request, buildAuthorizedIndices(user, SearchAction.NAME)).getLocal();
         String[] expectedIndices = new String[]{"missing*"};
         assertThat(indices.toArray(new String[indices.size()]), equalTo(expectedIndices));
@@ -665,13 +665,13 @@ public class IndicesAndAliasesResolverTests extends ESTestCase {
 
     public void testResolveNoExpandIgnoreUnavailable() {
         SearchRequest request = new SearchRequest("missing*");
-        request.indicesOptions(IndicesOptions.fromOptions(true, true, false, false));
+        request.indicesOptions(new IndicesOptions(true, true, false, false));
         assertNoIndices(request, resolveIndices(request, buildAuthorizedIndices(user, SearchAction.NAME)));
     }
 
     public void testSearchWithRemoteIndex() {
         SearchRequest request = new SearchRequest("remote:indexName");
-        request.indicesOptions(IndicesOptions.fromOptions(randomBoolean(), randomBoolean(), randomBoolean(), randomBoolean()));
+        request.indicesOptions(new IndicesOptions(randomBoolean(), randomBoolean(), randomBoolean(), randomBoolean()));
         final ResolvedIndices resolved = resolveIndices(request, buildAuthorizedIndices(user, SearchAction.NAME));
         assertThat(resolved.getLocal(), emptyIterable());
         assertThat(resolved.getRemote(), containsInAnyOrder("remote:indexName"));
@@ -680,7 +680,7 @@ public class IndicesAndAliasesResolverTests extends ESTestCase {
 
     public void testSearchWithRemoteAndLocalIndices() {
         SearchRequest request = new SearchRequest("remote:indexName", "bar", "bar2");
-        request.indicesOptions(IndicesOptions.fromOptions(true, randomBoolean(), randomBoolean(), randomBoolean()));
+        request.indicesOptions(new IndicesOptions(true, randomBoolean(), randomBoolean(), randomBoolean()));
         final ResolvedIndices resolved = resolveIndices(request, buildAuthorizedIndices(user, SearchAction.NAME));
         assertThat(resolved.getLocal(), containsInAnyOrder("bar"));
         assertThat(resolved.getRemote(), containsInAnyOrder("remote:indexName"));
@@ -689,7 +689,7 @@ public class IndicesAndAliasesResolverTests extends ESTestCase {
 
     public void testSearchWithRemoteAndLocalWildcards() {
         SearchRequest request = new SearchRequest("*:foo", "r*:bar*", "remote:baz*", "bar*", "foofoo");
-        request.indicesOptions(IndicesOptions.fromOptions(randomBoolean(), randomBoolean(), true, false));
+        request.indicesOptions(new IndicesOptions(randomBoolean(), randomBoolean(), true, false));
         final Set<String> authorizedIndices = buildAuthorizedIndices(user, SearchAction.NAME);
         final ResolvedIndices resolved = resolveIndices(request, authorizedIndices);
         assertThat(resolved.getRemote(), containsInAnyOrder("remote:foo", "other_remote:foo", "remote:bar*", "remote:baz*"));
@@ -927,7 +927,7 @@ public class IndicesAndAliasesResolverTests extends ESTestCase {
 
     public void testResolveGetAliasesRequestStrict() {
         GetAliasesRequest request = new GetAliasesRequest("alias1").indices("foo", "foofoo");
-        request.indicesOptions(IndicesOptions.fromOptions(false, randomBoolean(), randomBoolean(), randomBoolean()));
+        request.indicesOptions(new IndicesOptions(false, randomBoolean(), randomBoolean(), randomBoolean()));
         final Set<String> authorizedIndices = buildAuthorizedIndices(user, GetAliasesAction.NAME);
         List<String> indices = resolveIndices(request, authorizedIndices).getLocal();
         //the union of all indices and aliases gets returned
@@ -940,7 +940,7 @@ public class IndicesAndAliasesResolverTests extends ESTestCase {
 
     public void testResolveGetAliasesRequestIgnoreUnavailable() {
         GetAliasesRequest request = new GetAliasesRequest("alias1").indices("foo", "foofoo");
-        request.indicesOptions(IndicesOptions.fromOptions(true, randomBoolean(), randomBoolean(), randomBoolean()));
+        request.indicesOptions(new IndicesOptions(true, randomBoolean(), randomBoolean(), randomBoolean()));
         final Set<String> authorizedIndices = buildAuthorizedIndices(user, GetAliasesAction.NAME);
         List<String> indices = resolveIndices(request, authorizedIndices).getLocal();
         String[] expectedIndices = new String[]{"alias1", "foofoo"};
@@ -952,7 +952,7 @@ public class IndicesAndAliasesResolverTests extends ESTestCase {
 
     public void testResolveGetAliasesRequestMissingIndexStrict() {
         GetAliasesRequest request = new GetAliasesRequest();
-        request.indicesOptions(IndicesOptions.fromOptions(false, randomBoolean(), true, randomBoolean()));
+        request.indicesOptions(new IndicesOptions(false, randomBoolean(), true, randomBoolean()));
         request.indices("missing");
         request.aliases("alias2");
         final Set<String> authorizedIndices = buildAuthorizedIndices(user, GetAliasesAction.NAME);
@@ -967,7 +967,7 @@ public class IndicesAndAliasesResolverTests extends ESTestCase {
 
     public void testGetAliasesRequestMissingIndexIgnoreUnavailableDisallowNoIndices() {
         GetAliasesRequest request = new GetAliasesRequest();
-        request.indicesOptions(IndicesOptions.fromOptions(true, false, randomBoolean(), randomBoolean()));
+        request.indicesOptions(new IndicesOptions(true, false, randomBoolean(), randomBoolean()));
         request.indices("missing");
         request.aliases("alias2");
         IndexNotFoundException exception = expectThrows(IndexNotFoundException.class,
@@ -977,7 +977,7 @@ public class IndicesAndAliasesResolverTests extends ESTestCase {
 
     public void testGetAliasesRequestMissingIndexIgnoreUnavailableAllowNoIndices() {
         GetAliasesRequest request = new GetAliasesRequest();
-        request.indicesOptions(IndicesOptions.fromOptions(true, true, randomBoolean(), randomBoolean()));
+        request.indicesOptions(new IndicesOptions(true, true, randomBoolean(), randomBoolean()));
         request.indices("missing");
         request.aliases("alias2");
         assertNoIndices(request, resolveIndices(request, buildAuthorizedIndices(user, GetAliasesAction.NAME)));
@@ -985,7 +985,7 @@ public class IndicesAndAliasesResolverTests extends ESTestCase {
 
     public void testGetAliasesRequestMissingIndexStrict() {
         GetAliasesRequest request = new GetAliasesRequest();
-        request.indicesOptions(IndicesOptions.fromOptions(false, randomBoolean(), randomBoolean(), randomBoolean()));
+        request.indicesOptions(new IndicesOptions(false, randomBoolean(), randomBoolean(), randomBoolean()));
         request.indices("missing");
         request.aliases("alias2");
         final Set<String> authorizedIndices = buildAuthorizedIndices(user, GetAliasesAction.NAME);
@@ -999,7 +999,7 @@ public class IndicesAndAliasesResolverTests extends ESTestCase {
 
     public void testResolveWildcardsGetAliasesRequestStrictExpand() {
         GetAliasesRequest request = new GetAliasesRequest();
-        request.indicesOptions(IndicesOptions.fromOptions(false, randomBoolean(), true, true));
+        request.indicesOptions(new IndicesOptions(false, randomBoolean(), true, true));
         request.aliases("alias1");
         request.indices("foo*");
         final Set<String> authorizedIndices = buildAuthorizedIndices(user, GetAliasesAction.NAME);
@@ -1015,7 +1015,7 @@ public class IndicesAndAliasesResolverTests extends ESTestCase {
 
     public void testResolveWildcardsGetAliasesRequestStrictExpandOpen() {
         GetAliasesRequest request = new GetAliasesRequest();
-        request.indicesOptions(IndicesOptions.fromOptions(false, randomBoolean(), true, false));
+        request.indicesOptions(new IndicesOptions(false, randomBoolean(), true, false));
         request.aliases("alias1");
         request.indices("foo*");
         final Set<String> authorizedIndices = buildAuthorizedIndices(user, GetAliasesAction.NAME);
@@ -1031,7 +1031,7 @@ public class IndicesAndAliasesResolverTests extends ESTestCase {
 
     public void testResolveWildcardsGetAliasesRequestLenientExpandOpen() {
         GetAliasesRequest request = new GetAliasesRequest();
-        request.indicesOptions(IndicesOptions.fromOptions(true, randomBoolean(), true, false));
+        request.indicesOptions(new IndicesOptions(true, randomBoolean(), true, false));
         request.aliases("alias1");
         request.indices("foo*", "bar", "missing");
         final Set<String> authorizedIndices = buildAuthorizedIndices(user, GetAliasesAction.NAME);
@@ -1047,7 +1047,7 @@ public class IndicesAndAliasesResolverTests extends ESTestCase {
 
     public void testWildcardsGetAliasesRequestNoMatchingIndicesDisallowNoIndices() {
         GetAliasesRequest request = new GetAliasesRequest();
-        request.indicesOptions(IndicesOptions.fromOptions(randomBoolean(), false, true, randomBoolean()));
+        request.indicesOptions(new IndicesOptions(randomBoolean(), false, true, randomBoolean()));
         request.aliases("alias3");
         request.indices("non_matching_*");
         IndexNotFoundException e = expectThrows(IndexNotFoundException.class,
@@ -1057,7 +1057,7 @@ public class IndicesAndAliasesResolverTests extends ESTestCase {
 
     public void testWildcardsGetAliasesRequestNoMatchingIndicesAllowNoIndices() {
         GetAliasesRequest request = new GetAliasesRequest();
-        request.indicesOptions(IndicesOptions.fromOptions(randomBoolean(), true, true, randomBoolean()));
+        request.indicesOptions(new IndicesOptions(randomBoolean(), true, true, randomBoolean()));
         request.aliases("alias3");
         request.indices("non_matching_*");
         assertNoIndices(request, resolveIndices(request, buildAuthorizedIndices(user, GetAliasesAction.NAME)));
@@ -1087,7 +1087,7 @@ public class IndicesAndAliasesResolverTests extends ESTestCase {
     public void testResolveAllGetAliasesRequestExpandWildcardsOpenOnly() {
         GetAliasesRequest request = new GetAliasesRequest();
         //set indices options to have wildcards resolved to open indices only (default is open and closed)
-        request.indicesOptions(IndicesOptions.fromOptions(true, false, true, false));
+        request.indicesOptions(new IndicesOptions(true, false, true, false));
         //even if not set, empty means _all
         if (randomBoolean()) {
             request.indices("_all");
@@ -1107,7 +1107,7 @@ public class IndicesAndAliasesResolverTests extends ESTestCase {
 
     public void testAllGetAliasesRequestNoAuthorizedIndicesAllowNoIndices() {
         GetAliasesRequest request = new GetAliasesRequest();
-        request.indicesOptions(IndicesOptions.fromOptions(randomBoolean(), true, true, randomBoolean()));
+        request.indicesOptions(new IndicesOptions(randomBoolean(), true, true, randomBoolean()));
         request.aliases("alias1");
         request.indices("_all");
         assertNoIndices(request, resolveIndices(request,
@@ -1116,7 +1116,7 @@ public class IndicesAndAliasesResolverTests extends ESTestCase {
 
     public void testAllGetAliasesRequestNoAuthorizedIndicesDisallowNoIndices() {
         GetAliasesRequest request = new GetAliasesRequest();
-        request.indicesOptions(IndicesOptions.fromOptions(randomBoolean(), false, true, randomBoolean()));
+        request.indicesOptions(new IndicesOptions(randomBoolean(), false, true, randomBoolean()));
         request.aliases("alias1");
         request.indices("_all");
         IndexNotFoundException e = expectThrows(IndexNotFoundException.class,
@@ -1128,14 +1128,14 @@ public class IndicesAndAliasesResolverTests extends ESTestCase {
         GetAliasesRequest request = new GetAliasesRequest();
         request.aliases("alias1");
         request.indices("foo*");
-        request.indicesOptions(IndicesOptions.fromOptions(randomBoolean(), true, true, randomBoolean()));
+        request.indicesOptions(new IndicesOptions(randomBoolean(), true, true, randomBoolean()));
         assertNoIndices(request, resolveIndices(request,
                 buildAuthorizedIndices(userNoIndices, GetAliasesAction.NAME)));
     }
 
     public void testWildcardsGetAliasesRequestNoAuthorizedIndicesDisallowNoIndices() {
         GetAliasesRequest request = new GetAliasesRequest();
-        request.indicesOptions(IndicesOptions.fromOptions(randomBoolean(), false, true, randomBoolean()));
+        request.indicesOptions(new IndicesOptions(randomBoolean(), false, true, randomBoolean()));
         request.aliases("alias1");
         request.indices("foo*");
         //current user is not authorized for any index, foo* resolves to no indices, the request fails
@@ -1261,7 +1261,7 @@ public class IndicesAndAliasesResolverTests extends ESTestCase {
      *  the resolver
      */
     public void testRemotableRequestsAllowRemoteIndices() {
-        IndicesOptions options = IndicesOptions.fromOptions(true, false, false, false);
+        IndicesOptions options = new IndicesOptions(true, false, false, false);
         Tuple<TransportRequest, String> tuple = randomFrom(
                 new Tuple<TransportRequest, String>(new SearchRequest("remote:foo").indicesOptions(options), SearchAction.NAME),
                 new Tuple<TransportRequest, String>(new FieldCapabilitiesRequest().indices("remote:foo").indicesOptions(options),
@@ -1280,7 +1280,7 @@ public class IndicesAndAliasesResolverTests extends ESTestCase {
      * Tests that request types that do not support remote indices will be resolved as if all index names are local.
      */
     public void testNonRemotableRequestDoesNotAllowRemoteIndices() {
-        IndicesOptions options = IndicesOptions.fromOptions(true, false, false, false);
+        IndicesOptions options = new IndicesOptions(true, false, false, false);
         Tuple<TransportRequest, String> tuple = randomFrom(
                 new Tuple<TransportRequest, String>(new CloseIndexRequest("remote:foo").indicesOptions(options), CloseIndexAction.NAME),
                 new Tuple<TransportRequest, String>(new DeleteIndexRequest("remote:foo").indicesOptions(options), DeleteIndexAction.NAME),
@@ -1292,7 +1292,7 @@ public class IndicesAndAliasesResolverTests extends ESTestCase {
     }
 
     public void testNonRemotableRequestDoesNotAllowRemoteWildcardIndices() {
-        IndicesOptions options = IndicesOptions.fromOptions(randomBoolean(), true, true, true);
+        IndicesOptions options = new IndicesOptions(randomBoolean(), true, true, true);
         Tuple<TransportRequest, String> tuple = randomFrom(
                 new Tuple<TransportRequest, String>(new CloseIndexRequest("*:*").indicesOptions(options), CloseIndexAction.NAME),
                 new Tuple<TransportRequest, String>(new DeleteIndexRequest("*:*").indicesOptions(options), DeleteIndexAction.NAME),
@@ -1375,13 +1375,13 @@ public class IndicesAndAliasesResolverTests extends ESTestCase {
 
     public void testUnauthorizedDateMathExpressionIgnoreUnavailable() {
         SearchRequest request = new SearchRequest("<datetime-{now/M}>");
-        request.indicesOptions(IndicesOptions.fromOptions(true, true, randomBoolean(), randomBoolean()));
+        request.indicesOptions(new IndicesOptions(true, true, randomBoolean(), randomBoolean()));
         assertNoIndices(request, resolveIndices(request, buildAuthorizedIndices(user, SearchAction.NAME)));
     }
 
     public void testUnauthorizedDateMathExpressionIgnoreUnavailableDisallowNoIndices() {
         SearchRequest request = new SearchRequest("<datetime-{now/M}>");
-        request.indicesOptions(IndicesOptions.fromOptions(true, false, randomBoolean(), randomBoolean()));
+        request.indicesOptions(new IndicesOptions(true, false, randomBoolean(), randomBoolean()));
         IndexNotFoundException e = expectThrows(IndexNotFoundException.class,
                 () -> resolveIndices(request, buildAuthorizedIndices(user, SearchAction.NAME)));
         assertEquals("no such index [[<datetime-{now/M}>]]" , e.getMessage());
@@ -1391,7 +1391,7 @@ public class IndicesAndAliasesResolverTests extends ESTestCase {
         String expectedIndex = "datetime-" + DateTimeFormat.forPattern("YYYY.MM.dd").print(
             new DateTime(DateTimeZone.UTC).monthOfYear().roundFloorCopy());
         SearchRequest request = new SearchRequest("<datetime-{now/M}>");
-        request.indicesOptions(IndicesOptions.fromOptions(false, randomBoolean(), randomBoolean(), randomBoolean()));
+        request.indicesOptions(new IndicesOptions(false, randomBoolean(), randomBoolean(), randomBoolean()));
         IndexNotFoundException e = expectThrows(IndexNotFoundException.class,
                 () -> resolveIndices(request, buildAuthorizedIndices(user, SearchAction.NAME)));
         assertEquals("no such index [" + expectedIndex + "]" , e.getMessage());
@@ -1408,7 +1408,7 @@ public class IndicesAndAliasesResolverTests extends ESTestCase {
         SearchRequest request = new SearchRequest(pattern);
         if (randomBoolean()) {
             final boolean expandIndicesOpen = Regex.isSimpleMatchPattern(pattern) ? true : randomBoolean();
-            request.indicesOptions(IndicesOptions.fromOptions(randomBoolean(), randomBoolean(), expandIndicesOpen, randomBoolean()));
+            request.indicesOptions(new IndicesOptions(randomBoolean(), randomBoolean(), expandIndicesOpen, randomBoolean()));
         }
         List<String> indices = resolveIndices(request, buildAuthorizedIndices(user, SearchAction.NAME)).getLocal();
         assertThat(indices.size(), equalTo(1));
@@ -1417,13 +1417,13 @@ public class IndicesAndAliasesResolverTests extends ESTestCase {
 
     public void testMissingDateMathExpressionIgnoreUnavailable() {
         SearchRequest request = new SearchRequest("<foobar-{now/M}>");
-        request.indicesOptions(IndicesOptions.fromOptions(true, true, randomBoolean(), randomBoolean()));
+        request.indicesOptions(new IndicesOptions(true, true, randomBoolean(), randomBoolean()));
         assertNoIndices(request, resolveIndices(request, buildAuthorizedIndices(user, SearchAction.NAME)));
     }
 
     public void testMissingDateMathExpressionIgnoreUnavailableDisallowNoIndices() {
         SearchRequest request = new SearchRequest("<foobar-{now/M}>");
-        request.indicesOptions(IndicesOptions.fromOptions(true, false, randomBoolean(), randomBoolean()));
+        request.indicesOptions(new IndicesOptions(true, false, randomBoolean(), randomBoolean()));
         IndexNotFoundException e = expectThrows(IndexNotFoundException.class,
                 () -> resolveIndices(request, buildAuthorizedIndices(user, SearchAction.NAME)));
         assertEquals("no such index [[<foobar-{now/M}>]]" , e.getMessage());
@@ -1433,7 +1433,7 @@ public class IndicesAndAliasesResolverTests extends ESTestCase {
         String expectedIndex = "foobar-" + DateTimeFormat.forPattern("YYYY.MM.dd").print(
             new DateTime(DateTimeZone.UTC).monthOfYear().roundFloorCopy());
         SearchRequest request = new SearchRequest("<foobar-{now/M}>");
-        request.indicesOptions(IndicesOptions.fromOptions(false, randomBoolean(), randomBoolean(), randomBoolean()));
+        request.indicesOptions(new IndicesOptions(false, randomBoolean(), randomBoolean(), randomBoolean()));
         IndexNotFoundException e = expectThrows(IndexNotFoundException.class,
                 () -> resolveIndices(request, buildAuthorizedIndices(user, SearchAction.NAME)));
         assertEquals("no such index [" + expectedIndex + "]" , e.getMessage());
@@ -1496,7 +1496,7 @@ public class IndicesAndAliasesResolverTests extends ESTestCase {
 
     public void testHiddenIndicesResolution() {
         SearchRequest searchRequest = new SearchRequest();
-        searchRequest.indicesOptions(IndicesOptions.fromOptions(false, false, true, true, true));
+        searchRequest.indicesOptions(new IndicesOptions(false, false, true, true, true));
         Set<String> authorizedIndices = buildAuthorizedIndices(user, SearchAction.NAME);
         ResolvedIndices resolvedIndices
             = defaultIndicesResolver.resolveIndicesAndAliases(SearchAction.NAME, searchRequest, metadata, authorizedIndices);
@@ -1507,7 +1507,7 @@ public class IndicesAndAliasesResolverTests extends ESTestCase {
 
         // open + hidden
         searchRequest = new SearchRequest();
-        searchRequest.indicesOptions(IndicesOptions.fromOptions(false, false, true, false, true));
+        searchRequest.indicesOptions(new IndicesOptions(false, false, true, false, true));
         resolvedIndices = defaultIndicesResolver.resolveIndicesAndAliases(SearchAction.NAME, searchRequest, metadata, authorizedIndices);
         assertThat(resolvedIndices.getLocal(),
             containsInAnyOrder("bar", "foofoobar", "foobarfoo", "foofoo", "hidden-open", ".hidden-open", "date-hidden-" + todaySuffix,
@@ -1516,7 +1516,7 @@ public class IndicesAndAliasesResolverTests extends ESTestCase {
 
         // open + implicit hidden for . indices
         searchRequest = new SearchRequest(randomFrom(".h*", ".hid*"));
-        searchRequest.indicesOptions(IndicesOptions.fromOptions(false, false, true, false, false));
+        searchRequest.indicesOptions(new IndicesOptions(false, false, true, false, false));
         authorizedIndices = buildAuthorizedIndices(user, SearchAction.NAME);
         resolvedIndices = defaultIndicesResolver.resolveIndicesAndAliases(SearchAction.NAME, searchRequest, metadata, authorizedIndices);
         assertThat(resolvedIndices.getLocal(), containsInAnyOrder(".hidden-open"));
@@ -1524,7 +1524,7 @@ public class IndicesAndAliasesResolverTests extends ESTestCase {
 
         // closed + hidden, ignore aliases
         searchRequest = new SearchRequest();
-        searchRequest.indicesOptions(IndicesOptions.fromOptions(false, false, false, true, true, true, false, true, false));
+        searchRequest.indicesOptions(new IndicesOptions(false, false, false, true, true, true, false, true, false));
         authorizedIndices = buildAuthorizedIndices(user, SearchAction.NAME);
         resolvedIndices = defaultIndicesResolver.resolveIndicesAndAliases(SearchAction.NAME, searchRequest, metadata, authorizedIndices);
         assertThat(resolvedIndices.getLocal(), containsInAnyOrder("bar-closed", "foofoo-closed", "hidden-closed", ".hidden-closed"));
@@ -1532,7 +1532,7 @@ public class IndicesAndAliasesResolverTests extends ESTestCase {
 
         // closed + implicit hidden for . indices
         searchRequest = new SearchRequest(randomFrom(".h*", ".hid*"));
-        searchRequest.indicesOptions(IndicesOptions.fromOptions(false, false, false, true, false));
+        searchRequest.indicesOptions(new IndicesOptions(false, false, false, true, false));
         authorizedIndices = buildAuthorizedIndices(user, SearchAction.NAME);
         resolvedIndices = defaultIndicesResolver.resolveIndicesAndAliases(SearchAction.NAME, searchRequest, metadata, authorizedIndices);
         assertThat(resolvedIndices.getLocal(), containsInAnyOrder(".hidden-closed"));
@@ -1540,7 +1540,7 @@ public class IndicesAndAliasesResolverTests extends ESTestCase {
 
         // allow no indices, do not expand to open or closed, expand hidden, ignore aliases
         searchRequest = new SearchRequest();
-        searchRequest.indicesOptions(IndicesOptions.fromOptions(false, true, false, false, false, true, false, true, false));
+        searchRequest.indicesOptions(new IndicesOptions(false, true, false, false, false, true, false, true, false));
         authorizedIndices = buildAuthorizedIndices(user, SearchAction.NAME);
         resolvedIndices = defaultIndicesResolver.resolveIndicesAndAliases(SearchAction.NAME, searchRequest, metadata, authorizedIndices);
         assertThat(resolvedIndices.getLocal(), contains("-*"));
@@ -1560,7 +1560,7 @@ public class IndicesAndAliasesResolverTests extends ESTestCase {
 
         // Visible only
         SearchRequest searchRequest = new SearchRequest();
-        searchRequest.indicesOptions(IndicesOptions.fromOptions(false, false, true, false, false));
+        searchRequest.indicesOptions(new IndicesOptions(false, false, true, false, false));
         ResolvedIndices resolvedIndices
             = defaultIndicesResolver.resolveIndicesAndAliases(SearchAction.NAME, searchRequest, metadata, authorizedIndices);
         assertThat(resolvedIndices.getLocal(), containsInAnyOrder("alias-visible", "alias-visible-mixed"));
@@ -1568,7 +1568,7 @@ public class IndicesAndAliasesResolverTests extends ESTestCase {
 
         // Include hidden explicitly
         searchRequest = new SearchRequest();
-        searchRequest.indicesOptions(IndicesOptions.fromOptions(false, false, true, false, true));
+        searchRequest.indicesOptions(new IndicesOptions(false, false, true, false, true));
         resolvedIndices = defaultIndicesResolver.resolveIndicesAndAliases(SearchAction.NAME, searchRequest, metadata, authorizedIndices);
         assertThat(resolvedIndices.getLocal(),
             containsInAnyOrder("alias-visible", "alias-visible-mixed", "alias-hidden", ".alias-hidden", "hidden-open"));
@@ -1576,28 +1576,28 @@ public class IndicesAndAliasesResolverTests extends ESTestCase {
 
         // Include hidden with a wildcard
         searchRequest = new SearchRequest("alias-h*");
-        searchRequest.indicesOptions(IndicesOptions.fromOptions(false, false, true, false, true));
+        searchRequest.indicesOptions(new IndicesOptions(false, false, true, false, true));
         resolvedIndices = defaultIndicesResolver.resolveIndicesAndAliases(SearchAction.NAME, searchRequest, metadata, authorizedIndices);
         assertThat(resolvedIndices.getLocal(), containsInAnyOrder("alias-hidden"));
         assertThat(resolvedIndices.getRemote(), emptyIterable());
 
         // Dot prefix, implicitly including hidden
         searchRequest = new SearchRequest(".a*");
-        searchRequest.indicesOptions(IndicesOptions.fromOptions(false, false, true, false, false));
+        searchRequest.indicesOptions(new IndicesOptions(false, false, true, false, false));
         resolvedIndices = defaultIndicesResolver.resolveIndicesAndAliases(SearchAction.NAME, searchRequest, metadata, authorizedIndices);
         assertThat(resolvedIndices.getLocal(), containsInAnyOrder(".alias-hidden"));
         assertThat(resolvedIndices.getRemote(), emptyIterable());
 
         // Make sure ignoring aliases works (visible only)
         searchRequest = new SearchRequest();
-        searchRequest.indicesOptions(IndicesOptions.fromOptions(false, true, true, false, false, true, false, true, false));
+        searchRequest.indicesOptions(new IndicesOptions(false, true, true, false, false, true, false, true, false));
         resolvedIndices = defaultIndicesResolver.resolveIndicesAndAliases(SearchAction.NAME, searchRequest, metadata, authorizedIndices);
         assertThat(resolvedIndices.getLocal(), contains("-*"));
         assertThat(resolvedIndices.getRemote(), emptyIterable());
 
         // Make sure ignoring aliases works (including hidden)
         searchRequest = new SearchRequest();
-        searchRequest.indicesOptions(IndicesOptions.fromOptions(false, false, true, false, true, true, false, true, false));
+        searchRequest.indicesOptions(new IndicesOptions(false, false, true, false, true, true, false, true, false));
         resolvedIndices = defaultIndicesResolver.resolveIndicesAndAliases(SearchAction.NAME, searchRequest, metadata, authorizedIndices);
         assertThat(resolvedIndices.getLocal(), containsInAnyOrder("hidden-open"));
         assertThat(resolvedIndices.getRemote(), emptyIterable());
@@ -1610,7 +1610,7 @@ public class IndicesAndAliasesResolverTests extends ESTestCase {
             // Resolve data streams:
             SearchRequest searchRequest = new SearchRequest();
             searchRequest.indices("logs-*");
-            searchRequest.indicesOptions(IndicesOptions.fromOptions(false, false, true, false, false, true, true, true, true));
+            searchRequest.indicesOptions(new IndicesOptions(false, false, true, false, false, true, true, true, true));
             final Set<String> authorizedIndices = buildAuthorizedIndices(user, SearchAction.NAME, searchRequest);
             ResolvedIndices resolvedIndices = defaultIndicesResolver.resolveIndicesAndAliases(
                 SearchAction.NAME,
@@ -1624,7 +1624,7 @@ public class IndicesAndAliasesResolverTests extends ESTestCase {
             // Data streams with allow no indices:
             searchRequest = new SearchRequest();
             searchRequest.indices("logs-*");
-            searchRequest.indicesOptions(IndicesOptions.fromOptions(false, true, true, false, false, true, true, true, true));
+            searchRequest.indicesOptions(new IndicesOptions(false, true, true, false, false, true, true, true, true));
             resolvedIndices = defaultIndicesResolver.resolveIndicesAndAliases(
                 SearchAction.NAME,
                 searchRequest,
@@ -1641,7 +1641,7 @@ public class IndicesAndAliasesResolverTests extends ESTestCase {
             // Resolve *all* data streams:
             SearchRequest searchRequest = new SearchRequest();
             searchRequest.indices("logs-*");
-            searchRequest.indicesOptions(IndicesOptions.fromOptions(false, false, true, false, false, true, true, true, true));
+            searchRequest.indicesOptions(new IndicesOptions(false, false, true, false, false, true, true, true, true));
             final Set<String> authorizedIndices = buildAuthorizedIndices(user, SearchAction.NAME, searchRequest);
             ResolvedIndices resolvedIndices = defaultIndicesResolver.resolveIndicesAndAliases(
                 SearchAction.NAME,

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/transport/ServerTransportFilterTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/transport/ServerTransportFilterTests.java
@@ -95,7 +95,7 @@ public class ServerTransportFilterTests extends ESTestCase {
     public void testInboundDestructiveOperations() throws Exception {
         String action = randomFrom(CloseIndexAction.NAME, OpenIndexAction.NAME, DeleteIndexAction.NAME);
         TransportRequest request = new MockIndicesRequest(
-                IndicesOptions.fromOptions(randomBoolean(), randomBoolean(), randomBoolean(), randomBoolean()),
+                new IndicesOptions(randomBoolean(), randomBoolean(), randomBoolean(), randomBoolean()),
                 randomFrom("*", "_all", "test*"));
         Authentication authentication = mock(Authentication.class);
         when(authentication.getVersion()).thenReturn(Version.CURRENT);

--- a/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/support/WatcherUtilsTests.java
+++ b/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/support/WatcherUtilsTests.java
@@ -92,7 +92,7 @@ public class WatcherUtilsTests extends ESTestCase {
 
     public void testSerializeSearchRequest() throws Exception {
         String[] expectedIndices = generateRandomStringArray(5, 5, true);
-        IndicesOptions expectedIndicesOptions = IndicesOptions.fromOptions(randomBoolean(), randomBoolean(), randomBoolean(),
+        IndicesOptions expectedIndicesOptions = new IndicesOptions(randomBoolean(), randomBoolean(), randomBoolean(),
             randomBoolean(), randomBoolean(), DEFAULT_INDICES_OPTIONS.allowAliasesToMultipleIndices(),
             DEFAULT_INDICES_OPTIONS.forbidClosedIndices(), DEFAULT_INDICES_OPTIONS.ignoreAliases(),
             DEFAULT_INDICES_OPTIONS.ignoreThrottled());
@@ -163,7 +163,7 @@ public class WatcherUtilsTests extends ESTestCase {
 
         IndicesOptions indicesOptions = DEFAULT_INDICES_OPTIONS;
         if (randomBoolean()) {
-            indicesOptions = IndicesOptions.fromOptions(randomBoolean(), randomBoolean(), randomBoolean(),
+            indicesOptions = new IndicesOptions(randomBoolean(), randomBoolean(), randomBoolean(),
                 randomBoolean(), randomBoolean(), indicesOptions.allowAliasesToMultipleIndices(),
                 indicesOptions.forbidClosedIndices(), indicesOptions.ignoreAliases(), indicesOptions.ignoreThrottled());
             builder.startObject("indices_options");


### PR DESCRIPTION
- Transform fromOptions() methods into constructors
- Refres to issue [Remove IndicesOptions.fromOptions #30663 ](https://github.com/elastic/elasticsearch/issues/30663)