### PR TITLE
[7.x] Rework AutoFollowIT.testAutoFollowSearchableSnapshotsFails

### DIFF
--- a/x-pack/plugin/ccr/qa/multi-cluster/src/test/java/org/elasticsearch/xpack/ccr/AutoFollowIT.java
+++ b/x-pack/plugin/ccr/qa/multi-cluster/src/test/java/org/elasticsearch/xpack/ccr/AutoFollowIT.java
@@ -14,7 +14,6 @@ import org.elasticsearch.client.Request;
 import org.elasticsearch.client.Response;
 import org.elasticsearch.client.ResponseException;
 import org.elasticsearch.client.RestClient;
-import org.elasticsearch.core.CheckedRunnable;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.settings.SecureString;
 import org.elasticsearch.common.settings.Settings;
@@ -22,6 +21,7 @@ import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.common.xcontent.ObjectPath;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.json.JsonXContent;
+import org.elasticsearch.core.CheckedRunnable;
 import org.elasticsearch.rest.RestStatus;
 
 import java.io.IOException;
@@ -39,7 +39,7 @@ import static org.elasticsearch.common.xcontent.ObjectPath.eval;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.emptyOrNullString;
 import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.hasEntry;
 import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.hasSize;
@@ -777,14 +777,44 @@ public class AutoFollowIT extends ESCCRRestTestCase {
         }
 
         final String testPrefix = getTestName().toLowerCase(Locale.ROOT);
-        int initialNumberOfSuccessfulFollowedIndicesInFollowCluster = getNumberOfSuccessfulFollowedIndices();
+        final String repository = testPrefix + "-repository";
+        final String snapshot = testPrefix + "-snapshot";
+
+
+        // Create a repository and a snapshot of a 5 docs index on leader
+        final String indexName = testPrefix + "-index";
+        try {
+            try (RestClient leaderClient = buildLeaderClient()) {
+                final String systemPropertyRepoPath = System.getProperty("tests.leader_cluster_repository_path");
+                assertThat("Missing system property [tests.leader_cluster_repository_path]",
+                    systemPropertyRepoPath, not(emptyOrNullString()));
+                final String repositoryPath = systemPropertyRepoPath + '/' + testPrefix;
+
+                registerRepository(leaderClient, repository, "fs", true, Settings.builder().put("location", repositoryPath).build());
+
+                for (int i = 0; i < 5; i++) {
+                    Request indexRequest = new Request("POST", "/" + indexName + "/_doc");
+                    indexRequest.addParameter("refresh", "true");
+                    indexRequest.setJsonEntity("{\"value\":" + i + "}");
+                    assertOK(leaderClient.performRequest(indexRequest));
+                }
+                verifyDocuments(leaderClient, indexName, 5);
+
+                deleteSnapshot(leaderClient, repository, snapshot, true);
+                createSnapshot(leaderClient, repository, snapshot, true);
+            }
+        } finally {
+            cleanUpLeader(singletonList(indexName), emptyList(), emptyList());
+        }
 
         final String autoFollowPattern = "pattern-" + testPrefix;
-        createAutoFollowPattern(client(), autoFollowPattern, testPrefix + "-*", "leader_cluster");
-
-        // Create a regular index on leader
         final String regularIndex = testPrefix + "-regular";
-        {
+        final String mountedIndex = testPrefix + "-mounted";
+
+        try {
+            createAutoFollowPattern(client(), autoFollowPattern, testPrefix + "-*", "leader_cluster");
+
+            // Create a regular index on leader
             try (RestClient leaderClient = buildLeaderClient()) {
                 for (int i = 0; i < 10; i++) {
                     Request indexRequest = new Request("POST", "/" + regularIndex + "/_doc");
@@ -794,56 +824,32 @@ public class AutoFollowIT extends ESCCRRestTestCase {
                 }
                 verifyDocuments(leaderClient, regularIndex, 10);
             }
-        }
 
-        // Create a snapshot backed index on leader
-        final String mountedIndex = testPrefix + "-mounted";
-        {
+            // Mount the snapshot on leader
             try (RestClient leaderClient = buildLeaderClient()) {
-                final String systemPropertyRepoPath = System.getProperty("tests.leader_cluster_repository_path");
-                assertThat("Missing system property [tests.leader_cluster_repository_path]",
-                    systemPropertyRepoPath, not(emptyOrNullString()));
-                final String repositoryPath = systemPropertyRepoPath + '/' + testPrefix;
-
-                final String repository = testPrefix + "-repository";
-                registerRepository(leaderClient, repository, "fs", true, Settings.builder().put("location", repositoryPath).build());
-
-                final String indexName = testPrefix + "-index";
-                for (int i = 0; i < 5; i++) {
-                    Request indexRequest = new Request("POST", "/" + indexName + "/_doc");
-                    indexRequest.addParameter("refresh", "true");
-                    indexRequest.setJsonEntity("{\"value\":" + i + "}");
-                    assertOK(leaderClient.performRequest(indexRequest));
-                }
-                verifyDocuments(leaderClient, indexName, 5);
-
-                final String snapshot = testPrefix + "-snapshot";
-                deleteSnapshot(leaderClient, repository, snapshot, true);
-                createSnapshot(leaderClient, repository, snapshot, true);
-                deleteIndex(leaderClient, indexName);
-
                 final Request mountRequest = new Request(HttpPost.METHOD_NAME, "/_snapshot/" + repository + '/' + snapshot + "/_mount");
                 mountRequest.setJsonEntity("{\"index\": \"" + indexName + "\",\"renamed_index\": \"" + mountedIndex + "\"}");
                 final Response mountResponse = leaderClient.performRequest(mountRequest);
                 assertThat(mountResponse.getStatusLine().getStatusCode(), equalTo(RestStatus.OK.getStatus()));
                 ensureYellow(mountedIndex, leaderClient);
             }
+
+            assertLongBusy(() -> {
+                Map<?, ?> response = toMap(getAutoFollowStats());
+                assertThat(eval("auto_follow_stats.number_of_failed_follow_indices", response),
+                    greaterThanOrEqualTo(1));
+                assertThat(eval("auto_follow_stats.recent_auto_follow_errors", response),
+                    hasSize(greaterThanOrEqualTo(1)));
+                assertThat(eval("auto_follow_stats.recent_auto_follow_errors.0.auto_follow_exception.reason", response),
+                    containsString("index to follow [" + mountedIndex + "] is a searchable snapshot index and cannot be used " +
+                        "for cross-cluster replication purpose"));
+                ensureYellow(regularIndex);
+                verifyDocuments(client(), regularIndex, 10);
+            });
+        } finally {
+            cleanUpLeader(asList(regularIndex, mountedIndex), emptyList(), emptyList());
+            cleanUpFollower(singletonList(regularIndex), emptyList(), singletonList(autoFollowPattern));
         }
-
-        assertLongBusy(() -> {
-            Map<?, ?> response = toMap(getAutoFollowStats());
-            assertThat(eval("auto_follow_stats.number_of_successful_follow_indices", response),
-                equalTo(initialNumberOfSuccessfulFollowedIndicesInFollowCluster + 2));
-            assertThat(eval("auto_follow_stats.recent_auto_follow_errors", response),
-                hasSize(greaterThan(0)));
-            assertThat(eval("auto_follow_stats.recent_auto_follow_errors.0.auto_follow_exception.reason", response),
-                containsString("index to follow [" + mountedIndex + "] is a searchable snapshot index and cannot be used " +
-                    "for cross-cluster replication purpose"));
-            ensureYellow(regularIndex);
-            verifyDocuments(client(), regularIndex, 10);
-        });
-
-        deleteAutoFollowPattern(client(), autoFollowPattern);
     }
 
     private int getNumberOfSuccessfulFollowedIndices() throws IOException {


### PR DESCRIPTION
The test AutoFollowIT.testAutoFollowSearchableSnapshotsFails was
added in #70580 in order to test that mounted indices of a leader
cluster are not auto-followed in a follower cluster using CCR.

This test sometimes fails because it expects 2 indices to be
followed (the -regular and the -index indices) but not the mounted
one. This looks wrong as the -index index is deleted soon after it
is snapshotted, and this index only exist to create a snapshot that
can be later mounted as an index in the leader cluster.

This commit changes the test so that the -index index, the
repository and the snapshot are created at the beginning of the
test. Then the test creates the mounted index and the regular
one and can now asserts that only the regular one was
auto-followed.

Backport of #74498
Closes #74486