### PR TITLE
remove dependency on legacy geo code from test

### DIFF
--- a/server/src/test/java/org/elasticsearch/index/fielddata/AbstractGeoFieldDataTestCase.java
+++ b/server/src/test/java/org/elasticsearch/index/fielddata/AbstractGeoFieldDataTestCase.java
@@ -13,10 +13,11 @@ import org.apache.lucene.document.LatLonDocValuesField;
 import org.apache.lucene.document.StringField;
 import org.elasticsearch.common.geo.GeoPoint;
 import org.elasticsearch.common.geo.GeoUtils;
+import org.elasticsearch.geo.GeometryTestUtils;
+import org.elasticsearch.geometry.Point;
 
 import java.io.IOException;
 
-import static org.elasticsearch.test.geo.RandomShapeGenerator.randomPoint;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
@@ -26,8 +27,8 @@ public abstract class AbstractGeoFieldDataTestCase extends AbstractFieldDataImpl
     protected abstract String getFieldDataType();
 
     protected Field randomGeoPointField(String fieldName, Field.Store store) {
-        GeoPoint point = randomPoint(random());
-        return new LatLonDocValuesField(fieldName, point.lat(), point.lon());
+        Point point = GeometryTestUtils.randomPoint();
+        return new LatLonDocValuesField(fieldName, point.getLat(), point.getLon());
     }
 
     @Override

--- a/server/src/test/java/org/elasticsearch/index/query/GeoBoundingBoxQueryBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/GeoBoundingBoxQueryBuilderTests.java
@@ -16,13 +16,13 @@ import org.apache.lucene.search.Query;
 import org.elasticsearch.ElasticsearchParseException;
 import org.elasticsearch.common.geo.GeoPoint;
 import org.elasticsearch.common.geo.GeoUtils;
+import org.elasticsearch.geo.GeometryTestUtils;
+import org.elasticsearch.geometry.Rectangle;
+import org.elasticsearch.geometry.utils.Geohash;
 import org.elasticsearch.index.mapper.GeoPointFieldMapper;
 import org.elasticsearch.index.mapper.GeoShapeFieldMapper;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.test.AbstractQueryTestCase;
-import org.elasticsearch.test.geo.RandomShapeGenerator;
-import org.locationtech.spatial4j.io.GeohashUtils;
-import org.locationtech.spatial4j.shape.Rectangle;
 
 import java.io.IOException;
 
@@ -38,7 +38,8 @@ public class GeoBoundingBoxQueryBuilderTests extends AbstractQueryTestCase<GeoBo
     protected GeoBoundingBoxQueryBuilder doCreateTestQueryBuilder() {
         String fieldName = randomFrom(GEO_POINT_FIELD_NAME, GEO_POINT_ALIAS_FIELD_NAME, GEO_SHAPE_FIELD_NAME);
         GeoBoundingBoxQueryBuilder builder = new GeoBoundingBoxQueryBuilder(fieldName);
-        Rectangle box = RandomShapeGenerator.xRandomRectangle(random(), RandomShapeGenerator.xRandomPoint(random()));
+        // make sure that minX != maxX after geohash encoding
+        Rectangle box = randomValueOtherThanMany((r) -> Math.abs(r.getMaxX() - r.getMinX()) < 0.1, GeometryTestUtils::randomRectangle);
 
         if (randomBoolean()) {
             // check the top-left/bottom-right combination of setters
@@ -51,8 +52,8 @@ public class GeoBoundingBoxQueryBuilderTests extends AbstractQueryTestCase<GeoBo
                 break;
             case 1:
                 builder.setCorners(
-                        GeohashUtils.encodeLatLon(box.getMaxY(), box.getMinX()),
-                        GeohashUtils.encodeLatLon(box.getMinY(), box.getMaxX()));
+                        Geohash.stringEncode(box.getMinX(), box.getMaxY()),
+                        Geohash.stringEncode(box.getMaxX(), box.getMinY()));
                 break;
             default:
                 builder.setCorners(box.getMaxY(), box.getMinX(), box.getMinY(), box.getMaxX());
@@ -65,8 +66,8 @@ public class GeoBoundingBoxQueryBuilderTests extends AbstractQueryTestCase<GeoBo
                         new GeoPoint(box.getMaxY(), box.getMaxX()));
             } else {
                 builder.setCornersOGC(
-                        GeohashUtils.encodeLatLon(box.getMinY(), box.getMinX()),
-                        GeohashUtils.encodeLatLon(box.getMaxY(), box.getMaxX()));
+                        Geohash.stringEncode(box.getMinX(), box.getMinY()),
+                        Geohash.stringEncode(box.getMaxX(), box.getMaxY()));
             }
         }
 

--- a/server/src/test/java/org/elasticsearch/index/query/GeoDistanceQueryBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/GeoDistanceQueryBuilderTests.java
@@ -17,12 +17,11 @@ import org.elasticsearch.common.ParsingException;
 import org.elasticsearch.common.geo.GeoDistance;
 import org.elasticsearch.common.geo.GeoPoint;
 import org.elasticsearch.common.unit.DistanceUnit;
+import org.elasticsearch.geo.GeometryTestUtils;
 import org.elasticsearch.index.mapper.GeoPointFieldMapper;
 import org.elasticsearch.index.mapper.GeoShapeFieldMapper;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.test.AbstractQueryTestCase;
-import org.elasticsearch.test.geo.RandomShapeGenerator;
-import org.locationtech.spatial4j.shape.Point;
 
 import java.io.IOException;
 
@@ -54,8 +53,7 @@ public class GeoDistanceQueryBuilderTests extends AbstractQueryTestCase<GeoDista
                 break;
         }
 
-        Point p = RandomShapeGenerator.xRandomPoint(random());
-        qb.point(new GeoPoint(p.getY(), p.getX()));
+        qb.point(new GeoPoint(GeometryTestUtils.randomLat(), GeometryTestUtils.randomLon()));
 
         if (randomBoolean()) {
             qb.setValidationMethod(randomFrom(GeoValidationMethod.values()));

--- a/server/src/test/java/org/elasticsearch/index/query/GeoPolygonQueryBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/GeoPolygonQueryBuilderTests.java
@@ -15,13 +15,10 @@ import org.apache.lucene.search.MatchNoDocsQuery;
 import org.apache.lucene.search.Query;
 import org.elasticsearch.common.ParsingException;
 import org.elasticsearch.common.geo.GeoPoint;
-import org.elasticsearch.common.geo.builders.ShapeBuilder;
+import org.elasticsearch.geo.GeometryTestUtils;
+import org.elasticsearch.geometry.LinearRing;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.test.AbstractQueryTestCase;
-import org.elasticsearch.test.geo.RandomShapeGenerator;
-import org.elasticsearch.test.geo.RandomShapeGenerator.ShapeType;
-import org.locationtech.jts.geom.Coordinate;
-import org.locationtech.spatial4j.shape.jts.JtsGeometry;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -102,18 +99,10 @@ public class GeoPolygonQueryBuilderTests extends AbstractQueryTestCase<GeoPolygo
     }
 
     private static List<GeoPoint> randomPolygon() {
-        ShapeBuilder<?, ?, ?> shapeBuilder = null;
-        // This is a temporary fix because sometimes the RandomShapeGenerator
-        // returns null. This is if there is an error generating the polygon. So
-        // in this case keep trying until we successfully generate one
-        while (shapeBuilder == null) {
-            shapeBuilder = RandomShapeGenerator.createShapeWithin(random(), null, ShapeType.POLYGON);
-        }
-        JtsGeometry shape = (JtsGeometry) shapeBuilder.buildS4J();
-        Coordinate[] coordinates = shape.getGeom().getCoordinates();
-        ArrayList<GeoPoint> polygonPoints = new ArrayList<>();
-        for (Coordinate coord : coordinates) {
-            polygonPoints.add(new GeoPoint(coord.y, coord.x));
+        LinearRing linearRing = GeometryTestUtils.randomPolygon(false).getPolygon();
+        List<GeoPoint> polygonPoints = new ArrayList<>(linearRing.length());
+        for (int i = 0; i < linearRing.length(); i++) {
+            polygonPoints.add(new GeoPoint(linearRing.getLat(i), linearRing.getLon(i)));
         }
         return polygonPoints;
     }

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/GeoDistanceRangeTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/GeoDistanceRangeTests.java
@@ -14,10 +14,11 @@ import org.elasticsearch.common.unit.DistanceUnit;
 import org.elasticsearch.common.xcontent.XContentParseException;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.json.JsonXContent;
+import org.elasticsearch.geo.GeometryTestUtils;
+import org.elasticsearch.geometry.Point;
 import org.elasticsearch.search.aggregations.BaseAggregationTestCase;
 import org.elasticsearch.search.aggregations.bucket.range.GeoDistanceAggregationBuilder;
 import org.elasticsearch.search.aggregations.bucket.range.GeoDistanceAggregationBuilder.Range;
-import org.elasticsearch.test.geo.RandomShapeGenerator;
 
 import java.io.IOException;
 
@@ -29,8 +30,9 @@ public class GeoDistanceRangeTests extends BaseAggregationTestCase<GeoDistanceAg
     @Override
     protected GeoDistanceAggregationBuilder createTestAggregatorBuilder() {
         int numRanges = randomIntBetween(1, 10);
-        GeoPoint origin = RandomShapeGenerator.randomPoint(random());
-        GeoDistanceAggregationBuilder factory = new GeoDistanceAggregationBuilder(randomAlphaOfLengthBetween(3, 10), origin);
+        Point origin = GeometryTestUtils.randomPoint();
+        GeoDistanceAggregationBuilder factory =
+            new GeoDistanceAggregationBuilder(randomAlphaOfLengthBetween(3, 10), new GeoPoint(origin.getLat(), origin.getLon()));
         for (int i = 0; i < numRanges; i++) {
             String key = null;
             if (randomBoolean()) {

--- a/test/framework/src/main/java/org/elasticsearch/geo/GeometryTestUtils.java
+++ b/test/framework/src/main/java/org/elasticsearch/geo/GeometryTestUtils.java
@@ -165,11 +165,24 @@ public class GeometryTestUtils {
         return randomGeometryCollection(0, hasAlt);
     }
 
+    public static GeometryCollection<Geometry> randomGeometryCollectionWithoutCircle(boolean hasAlt) {
+        return randomGeometryCollectionWithoutCircle(0, hasAlt);
+    }
+
     private static GeometryCollection<Geometry> randomGeometryCollection(int level, boolean hasAlt) {
         int size = ESTestCase.randomIntBetween(1, 10);
         List<Geometry> shapes = new ArrayList<>();
         for (int i = 0; i < size; i++) {
             shapes.add(randomGeometry(level, hasAlt));
+        }
+        return new GeometryCollection<>(shapes);
+    }
+
+    private static GeometryCollection<Geometry> randomGeometryCollectionWithoutCircle(int level, boolean hasAlt) {
+        int size = ESTestCase.randomIntBetween(1, 10);
+        List<Geometry> shapes = new ArrayList<>();
+        for (int i = 0; i < size; i++) {
+            shapes.add(randomGeometryWithoutCircle(level, hasAlt));
         }
         return new GeometryCollection<>(shapes);
     }
@@ -203,7 +216,7 @@ public class GeometryTestUtils {
             GeometryTestUtils::randomMultiPolygon,
             hasAlt ? GeometryTestUtils::randomPoint : (b) -> randomRectangle(),
             level < 3 ? (b) ->
-                randomGeometryWithoutCircleCollection(level + 1, hasAlt) : GeometryTestUtils::randomPoint // don't build too deep
+                randomGeometryCollectionWithoutCircle(level + 1, hasAlt) : GeometryTestUtils::randomPoint // don't build too deep
         );
         return geometry.apply(hasAlt);
     }


### PR DESCRIPTION
Following the effort of removing dependency on legacy geo code, this PR removes this dependency for some of the geo test. ShapeBuilders are moved to use Geometry classes.