### PR TITLE
Update HLRC's minimal Java version

### DIFF
--- a/docs/java-rest/high-level/getting-started.asciidoc
+++ b/docs/java-rest/high-level/getting-started.asciidoc
@@ -6,7 +6,7 @@ getting the artifact to using it in an application.
 
 [[java-rest-high-compatibility]]
 === Compatibility
-The Java High Level REST Client requires at least Java 1.8 and depends on the Elasticsearch
+The Java High Level REST Client requires at least Java 11 as it depends on the Elasticsearch
 core project. The client version is the same as the Elasticsearch version that the
 client was developed for. It accepts the same request arguments as the `TransportClient`
 and returns the same response objects. See the <<java-rest-high-level-migration>>
@@ -41,7 +41,7 @@ The javadoc for the REST high level client can be found at {rest-high-level-clie
 
 The high-level Java REST client is hosted on
 https://search.maven.org/search?q=g:org.elasticsearch.client[Maven
-Central]. The minimum Java version required is `1.8`.
+Central]. The minimum Java version required is `11`.
 
 The High Level REST Client is subject to the same release cycle as
 Elasticsearch. Replace the version with the desired client version.


### PR DESCRIPTION
HLRC docs state that it requires Java 8 or more. While this constraint should apply to LLRC, it cannot apply to the high level client since it depends on Elasticsearch server code that requires at least Java 11.

Fixes #74289