### PR TITLE
Test fix: adjusting expected error message in test

### DIFF
--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/enrollment/CreateEnrollmentTokenTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/enrollment/CreateEnrollmentTokenTests.java
@@ -373,7 +373,7 @@ public class CreateEnrollmentTokenTests extends ESTestCase {
 
         final List<String> invalid_addresses = Arrays.asList("nldfnbndflbnl");
         UnknownHostException ex = expectThrows(UnknownHostException.class, () -> getFilteredAddresses(invalid_addresses));
-        assertThat(ex.getMessage(), Matchers.containsString("nldfnbndflbnl:"));
+        assertThat(ex.getMessage(), Matchers.containsString("nldfnbndflbnl"));
     }
 
     private Map<String, String> getDecoded(String token) throws IOException {


### PR DESCRIPTION
Test fix: Unknown host error message is different on Windows, adjusting 
the expected message accordingly