### PR TITLE
[ML] ensure the `fractions` and bucket doc count have the same lengths in `bucket_count_ks_test`

### DIFF
--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/aggs/kstest/BucketCountKSTestAggregator.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/aggs/kstest/BucketCountKSTestAggregator.java
@@ -255,7 +255,9 @@ public class BucketCountKSTestAggregator extends SiblingPipelineAggregator {
                     .limit(bucketsValue.getDocCounts().length - 1)
                     .mapToDouble(Double::valueOf)
             ).toArray()
-            : this.fractions;
+            // We prepend zero to the fractions as we prepend 0 to the doc counts and we want them to be the same length when
+            // we create the monotonically increasing values for distribution comparison.
+            : DoubleStream.concat(DoubleStream.of(0.0), Arrays.stream(this.fractions)).toArray();
         return new InternalKSTestAggregation(name(), metadata(), ksTest(fractions, bucketsValue, alternatives, samplingMethod));
     }
 }

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/ml/bucket_count_ks_test_agg.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/ml/bucket_count_ks_test_agg.yml
@@ -120,6 +120,46 @@ setup:
   - is_false: aggregations.good.buckets.2.bucket_ks.two_sided
 
 ---
+"Test bucket count ks test bucket agg simple with fractions":
+
+  - do:
+      search:
+        index: store
+        body: >
+          {
+            "size": 0,
+            "aggs": {
+              "good": {
+                "terms": {
+                  "field": "product",
+                  "size": 10
+                },
+                "aggs": {
+                  "ranged_cost": {
+                    "range": {
+                      "field": "cost",
+                      "ranges": [
+                        {"from": 200},
+                        {"from": 200, "to": 250},
+                        {"from": 250, "to": 300},
+                        {"from": 300}
+                      ]
+                    }
+                  },
+                  "bucket_ks": {
+                    "bucket_count_ks_test": {
+                      "buckets_path": "ranged_cost>_count",
+                      "fractions": [0.25, 0.25, 0.25, 0.25]
+                    }
+                  }
+                }
+              }
+            }
+          }
+  - is_true: aggregations.good.buckets.0.bucket_ks.less
+  - is_true: aggregations.good.buckets.1.bucket_ks.greater
+  - is_true: aggregations.good.buckets.2.bucket_ks.two_sided
+---
 "Test bucket count ks test with missing buckets_path":
 
   - do:


### PR DESCRIPTION
Originally, there was the thought that the `fractions` provided to the `bucket_count_ks_test` would need some special handling to ensure appropriate perturbation of the values. This way the KS-test would provide good information.

But, this requirement was removed as the calculation was improved. 

Consequently, remnants of this requirement (like requiring the caller to provide appropriately perturbed fractions) are no longer necessary. 

This commit allows the `fractions` parameter provided in the `bucket_count_ks_test` to simply be the expected fraction of documents per bucket. Previously the caller would have to append `0` to the fractions parameter (undocumented, and thus troublesome). 

