### PR TITLE
[DOCS] [7.x] Update monitoring cluster node name (#74500)

### DIFF
--- a/docs/reference/monitoring/collecting-monitoring-data.asciidoc
+++ b/docs/reference/monitoring/collecting-monitoring-data.asciidoc
@@ -125,7 +125,7 @@ HTTP exporter in the `xpack.monitoring.exporters` settings in the
 xpack.monitoring.exporters:
   id1:
     type: http
-    host: ["http://es-mon-1:9200", "http://es-mon2:9200"]
+    host: ["http://es-mon-1:9200", "http://es-mon-2:9200"]
 --------------------------------------------------
 --
 
@@ -148,7 +148,7 @@ For example:
 xpack.monitoring.exporters:
   id1:
     type: http
-    host: ["http://es-mon-1:9200", "http://es-mon2:9200"]
+    host: ["http://es-mon-1:9200", "http://es-mon-2:9200"]
     auth.username: remote_monitoring_user
     auth.password: YOUR_PASSWORD
 --------------------------------------------------
@@ -169,7 +169,7 @@ specify the location of the PEM encoded certificate with the
 xpack.monitoring.exporters:
   id1:
     type: http
-    host: ["https://es-mon1:9200", "https://es-mon2:9200"]
+    host: ["https://es-mon1:9200", "https://es-mon-2:9200"]
     auth:
       username: remote_monitoring_user
       password: YOUR_PASSWORD
@@ -187,7 +187,7 @@ xpack.monitoring.exporters:
 xpack.monitoring.exporters:
   id1:
     type: http
-    host: ["https://es-mon1:9200", "https://es-mon2:9200"]
+    host: ["https://es-mon1:9200", "https://es-mon-2:9200"]
     auth:
       username: remote_monitoring_user
       password: YOUR_PASSWORD

--- a/docs/reference/monitoring/configuring-filebeat.asciidoc
+++ b/docs/reference/monitoring/configuring-filebeat.asciidoc
@@ -66,7 +66,7 @@ the {filebeat} configuration file (`filebeat.yml`):
 ----------------------------------
 output.elasticsearch:
   # Array of hosts to connect to.
-  hosts: ["http://es-mon-1:9200", "http://es-mon2:9200"] <1>
+  hosts: ["http://es-mon-1:9200", "http://es-mon-2:9200"] <1>
 
   # Optional protocol and basic auth credentials.
   #protocol: "https"

--- a/docs/reference/monitoring/configuring-metricbeat.asciidoc
+++ b/docs/reference/monitoring/configuring-metricbeat.asciidoc
@@ -148,7 +148,7 @@ configuration file (`metricbeat.yml`):
 ----------------------------------
 output.elasticsearch:
   # Array of hosts to connect to.
-  hosts: ["http://es-mon-1:9200", "http://es-mon2:9200"] <1>
+  hosts: ["http://es-mon-1:9200", "http://es-mon-2:9200"] <1>
   
   # Optional protocol and basic auth credentials.
   #protocol: "https"


### PR DESCRIPTION
Backports the following commits to 7.x:
 - update monitoring cluster node name (#74500)