### PR TITLE
Lock test to single shard index (backport of #74627)

### DIFF
--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.aggregation/22_terms_disable_opt.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.aggregation/22_terms_disable_opt.yml
@@ -1,4 +1,17 @@
 setup:
+  # Lock to one shard so the tests don't sometimes try to collect from an empty
+  # index. If they do they'll use the GlobalOrdinals collector regardless of the
+  # optimization setting. That's fine - but it causes the test to fail so we
+  # need to dodge that case.
+  - do:
+      indices.create:
+        index: test
+        body:
+          settings:
+            index:
+              number_of_shards: 1
+              number_of_replicas: 0
+
   - do:
       cluster.put_settings:
         body:


### PR DESCRIPTION
The filter by filter terms aggregation optimization only kicks in when
its targeting a non-empty shard. An empty shard is fast to collect no
matter what so there isn't really any need to do anything complex.
Anyway, this locks the test to a single sharded index so there isn't a
chance of the debugging data coming back from an empty shard. Which
would cause the test to fail because its expecting the optimization to
run.

Closes #74612
