### PR TITLE
Avoid creating unused test tasks

### DIFF
--- a/build-tools-internal/src/main/groovy/elasticsearch.bwc-test.gradle
+++ b/build-tools-internal/src/main/groovy/elasticsearch.bwc-test.gradle
@@ -34,5 +34,4 @@ tasks.withType(Test).configureEach {
 }
 
 tasks.matching { it.name.equals("check") }.configureEach {dependsOn(bwcTestSnapshots) }
-
 tasks.matching { it.name.equals("test") }.configureEach {enabled = false}

--- a/qa/ccs-rolling-upgrade-remote-cluster/build.gradle
+++ b/qa/ccs-rolling-upgrade-remote-cluster/build.gradle
@@ -11,7 +11,7 @@ import org.elasticsearch.gradle.internal.info.BuildParams
 import org.elasticsearch.gradle.testclusters.StandaloneRestIntegTestTask
 
 apply plugin: 'elasticsearch.internal-testclusters'
-apply plugin: 'elasticsearch.standalone-test'
+apply plugin: 'elasticsearch.standalone-rest-test'
 apply plugin: 'elasticsearch.bwc-test'
 apply plugin: 'elasticsearch.rest-resources'
 

--- a/qa/full-cluster-restart/build.gradle
+++ b/qa/full-cluster-restart/build.gradle
@@ -12,7 +12,7 @@ import org.elasticsearch.gradle.internal.info.BuildParams
 import org.elasticsearch.gradle.testclusters.StandaloneRestIntegTestTask
 
 apply plugin: 'elasticsearch.internal-testclusters'
-apply plugin: 'elasticsearch.standalone-test'
+apply plugin: 'elasticsearch.standalone-rest-test'
 apply plugin: 'elasticsearch.internal-test-artifact'
 apply plugin: 'elasticsearch.bwc-test'
 

--- a/qa/mixed-cluster/build.gradle
+++ b/qa/mixed-cluster/build.gradle
@@ -12,7 +12,7 @@ import org.elasticsearch.gradle.internal.info.BuildParams
 import org.elasticsearch.gradle.testclusters.StandaloneRestIntegTestTask
 
 apply plugin: 'elasticsearch.internal-testclusters'
-apply plugin: 'elasticsearch.standalone-test'
+apply plugin: 'elasticsearch.standalone-rest-test'
 apply plugin: 'elasticsearch.bwc-test'
 apply plugin: 'elasticsearch.rest-resources'
 

--- a/qa/multi-cluster-search/build.gradle
+++ b/qa/multi-cluster-search/build.gradle
@@ -9,7 +9,7 @@
 import org.elasticsearch.gradle.internal.test.RestIntegTestTask
 
 apply plugin: 'elasticsearch.internal-testclusters'
-apply plugin: 'elasticsearch.standalone-test'
+apply plugin: 'elasticsearch.standalone-rest-test'
 apply plugin: 'elasticsearch.rest-resources'
 
 dependencies {
@@ -45,7 +45,5 @@ testClusters.matching { it.name == "mixedClusterTest"}.configureEach {
 tasks.register("integTest") {
   dependsOn "mixedClusterTest"
 }
-
-tasks.named("test").configure { enabled = false }// no unit tests for multi-cluster-search, only integration tests
 
 tasks.named("check").configure { dependsOn("integTest") }

--- a/qa/repository-multi-version/build.gradle
+++ b/qa/repository-multi-version/build.gradle
@@ -11,7 +11,7 @@ import org.elasticsearch.gradle.internal.info.BuildParams
 import org.elasticsearch.gradle.testclusters.StandaloneRestIntegTestTask
 
 apply plugin: 'elasticsearch.internal-testclusters'
-apply plugin: 'elasticsearch.standalone-test'
+apply plugin: 'elasticsearch.standalone-rest-test'
 apply plugin: 'elasticsearch.internal-test-artifact'
 
 apply plugin: 'elasticsearch.bwc-test'

--- a/qa/rolling-upgrade/build.gradle
+++ b/qa/rolling-upgrade/build.gradle
@@ -11,7 +11,7 @@ import org.elasticsearch.gradle.internal.info.BuildParams
 import org.elasticsearch.gradle.testclusters.StandaloneRestIntegTestTask
 
 apply plugin: 'elasticsearch.internal-testclusters'
-apply plugin: 'elasticsearch.standalone-test'
+apply plugin: 'elasticsearch.standalone-rest-test'
 apply plugin: 'elasticsearch.bwc-test'
 apply plugin: 'elasticsearch.rest-resources'
 

--- a/qa/verify-version-constants/build.gradle
+++ b/qa/verify-version-constants/build.gradle
@@ -12,7 +12,7 @@ import org.elasticsearch.gradle.internal.info.BuildParams
 import org.elasticsearch.gradle.testclusters.StandaloneRestIntegTestTask
 
 apply plugin: 'elasticsearch.internal-testclusters'
-apply plugin: 'elasticsearch.standalone-test'
+apply plugin: 'elasticsearch.standalone-rest-test'
 apply plugin: 'elasticsearch.bwc-test'
 
 for (Version bwcVersion : BuildParams.bwcVersions.indexCompatible) {

--- a/x-pack/plugin/ccr/qa/downgrade-to-basic-license/build.gradle
+++ b/x-pack/plugin/ccr/qa/downgrade-to-basic-license/build.gradle
@@ -2,7 +2,7 @@ import org.elasticsearch.gradle.internal.info.BuildParams
 import org.elasticsearch.gradle.internal.test.RestIntegTestTask
 
 apply plugin: 'elasticsearch.internal-testclusters'
-apply plugin: 'elasticsearch.standalone-test'
+apply plugin: 'elasticsearch.standalone-rest-test'
 
 dependencies {
   testImplementation(testArtifact(project(xpackModule('core'))))
@@ -61,8 +61,6 @@ tasks.register("follow-cluster", RestIntegTestTask) {
 }
 
 tasks.named("check").configure { dependsOn "follow-cluster" }
-// no unit tests for multi-cluster-search, only the rest integration test
-tasks.named("test").configure { enabled = false }
 
 // We can't run in FIPS mode with a basic license
 tasks.withType(Test).configureEach {

--- a/x-pack/plugin/ccr/qa/multi-cluster/build.gradle
+++ b/x-pack/plugin/ccr/qa/multi-cluster/build.gradle
@@ -1,7 +1,7 @@
 import org.elasticsearch.gradle.internal.test.RestIntegTestTask
 
 apply plugin: 'elasticsearch.internal-testclusters'
-apply plugin: 'elasticsearch.standalone-test'
+apply plugin: 'elasticsearch.standalone-rest-test'
 
 dependencies {
   testImplementation(testArtifact(project(xpackModule('core'))))
@@ -68,4 +68,3 @@ testClusters.matching { it.name == "follow-cluster" }.configureEach {
 }
 
 tasks.named("check").configure { dependsOn "follow-cluster" }
-tasks.named("test").configure { enabled = false } // no unit tests for multi-cluster-search, only the rest integration test

--- a/x-pack/plugin/ccr/qa/non-compliant-license/build.gradle
+++ b/x-pack/plugin/ccr/qa/non-compliant-license/build.gradle
@@ -1,7 +1,7 @@
 import org.elasticsearch.gradle.internal.test.RestIntegTestTask
 
 apply plugin: 'elasticsearch.internal-testclusters'
-apply plugin: 'elasticsearch.standalone-test'
+apply plugin: 'elasticsearch.standalone-rest-test'
 
 dependencies {
   testImplementation(testArtifact(project(xpackModule('core'))))
@@ -40,4 +40,3 @@ tasks.register('follow-cluster', RestIntegTestTask) {
 }
 
 tasks.named("check").configure { dependsOn "follow-cluster" }
-tasks.named("test").configure { enabled = false }

--- a/x-pack/plugin/ccr/qa/restart/build.gradle
+++ b/x-pack/plugin/ccr/qa/restart/build.gradle
@@ -2,7 +2,7 @@ import org.elasticsearch.gradle.internal.test.RestIntegTestTask
 import org.elasticsearch.gradle.testclusters.StandaloneRestIntegTestTask
 
 apply plugin: 'elasticsearch.internal-testclusters'
-apply plugin: 'elasticsearch.standalone-test'
+apply plugin: 'elasticsearch.standalone-rest-test'
 
 dependencies {
   testImplementation project(':x-pack:plugin:ccr:qa')
@@ -56,4 +56,4 @@ tasks.register("followClusterRestartTest", StandaloneRestIntegTestTask) {
 }
 
 tasks.named("check").configure { dependsOn "followClusterRestartTest" }
-tasks.named("test").configure { enabled = false }
+//tasks.named("test").configure { enabled = false }

--- a/x-pack/plugin/ccr/qa/restart/build.gradle
+++ b/x-pack/plugin/ccr/qa/restart/build.gradle
@@ -56,4 +56,3 @@ tasks.register("followClusterRestartTest", StandaloneRestIntegTestTask) {
 }
 
 tasks.named("check").configure { dependsOn "followClusterRestartTest" }
-//tasks.named("test").configure { enabled = false }

--- a/x-pack/plugin/ccr/qa/security/build.gradle
+++ b/x-pack/plugin/ccr/qa/security/build.gradle
@@ -1,7 +1,7 @@
 import org.elasticsearch.gradle.internal.test.RestIntegTestTask
 
 apply plugin: 'elasticsearch.internal-testclusters'
-apply plugin: 'elasticsearch.standalone-test'
+apply plugin: 'elasticsearch.standalone-rest-test'
 
 dependencies {
   testImplementation(testArtifact(project(xpackModule('core'))))
@@ -55,5 +55,3 @@ tasks.register('follow-cluster', RestIntegTestTask) {
 }
 
 tasks.named("check").configure { dependsOn('follow-cluster') }
-// no unit tests for multi-cluster-search, only the rest integration test
-tasks.named("test").configure { enabled = false }

--- a/x-pack/plugin/ilm/qa/multi-cluster/build.gradle
+++ b/x-pack/plugin/ilm/qa/multi-cluster/build.gradle
@@ -2,7 +2,7 @@ import org.elasticsearch.gradle.internal.test.RestIntegTestTask
 import org.elasticsearch.gradle.internal.info.BuildParams
 
 apply plugin: 'elasticsearch.internal-testclusters'
-apply plugin: 'elasticsearch.standalone-test'
+apply plugin: 'elasticsearch.standalone-rest-test'
 
 dependencies {
   testImplementation project(':x-pack:plugin:ccr:qa')
@@ -56,10 +56,8 @@ testClusters.matching{ it.name == 'follow-cluster' }.configureEach {
 }
 
 tasks.named("check").configure { dependsOn 'follow-cluster' }
-// no unit tests for this module, only the rest integration test
-tasks.named("test").configure { enabled = false }
 // Security is explicitly disabled for follow-cluster and leader-cluster, do not run these in FIPS mode
 tasks.withType(Test).configureEach {
-  onlyIf { BuildParams.inFipsJvm == false}
+  enabled = BuildParams.inFipsJvm == false
 }
 

--- a/x-pack/plugin/transform/qa/multi-cluster-tests-with-security/build.gradle
+++ b/x-pack/plugin/transform/qa/multi-cluster-tests-with-security/build.gradle
@@ -1,7 +1,7 @@
 import org.elasticsearch.gradle.internal.test.RestIntegTestTask
 
 apply plugin: 'elasticsearch.internal-testclusters'
-apply plugin: 'elasticsearch.standalone-test'
+apply plugin: 'elasticsearch.standalone-rest-test'
 apply plugin: 'elasticsearch.rest-resources'
 
 dependencies {
@@ -63,5 +63,4 @@ tasks.register("integTest") {
   dependsOn 'mixed-cluster'
 }
 
-tasks.named("test").configure { enabled = false } // no unit tests for multi-cluster-search, only the rest integration test
 tasks.named("check").configure { dependsOn("integTest") }

--- a/x-pack/qa/full-cluster-restart/build.gradle
+++ b/x-pack/qa/full-cluster-restart/build.gradle
@@ -3,7 +3,7 @@ import org.elasticsearch.gradle.internal.info.BuildParams
 import org.elasticsearch.gradle.testclusters.StandaloneRestIntegTestTask
 
 apply plugin: 'elasticsearch.internal-testclusters'
-apply plugin: 'elasticsearch.standalone-test'
+apply plugin: 'elasticsearch.standalone-rest-test'
 apply plugin: 'elasticsearch.bwc-test'
 
 dependencies {
@@ -74,7 +74,6 @@ for (Version bwcVersion : BuildParams.bwcVersions.indexCompatible) {
     exclude 'org/elasticsearch/upgrades/FullClusterRestartSettingsUpgradeIT.class'
     exclude 'org/elasticsearch/upgrades/QueryBuilderBWCIT.class'
   }
-
 
   tasks.register("${baseName}#upgradedClusterTest", StandaloneRestIntegTestTask) {
     mustRunAfter("precommit")

--- a/x-pack/qa/multi-cluster-search-security/build.gradle
+++ b/x-pack/qa/multi-cluster-search-security/build.gradle
@@ -2,7 +2,7 @@ import org.elasticsearch.gradle.internal.info.BuildParams
 import org.elasticsearch.gradle.internal.test.RestIntegTestTask
 
 apply plugin: 'elasticsearch.internal-testclusters'
-apply plugin: 'elasticsearch.standalone-test'
+apply plugin: 'elasticsearch.standalone-rest-test'
 apply plugin: 'elasticsearch.rest-resources'
 
 dependencies {
@@ -77,5 +77,4 @@ tasks.register("integTest") {
   dependsOn 'mixed-cluster'
 }
 
-tasks.named("test").configure { enabled = false } // no unit tests for multi-cluster-search, only the rest integration test
 tasks.named("check").configure { dependsOn("integTest") }

--- a/x-pack/qa/rolling-upgrade-basic/build.gradle
+++ b/x-pack/qa/rolling-upgrade-basic/build.gradle
@@ -3,15 +3,11 @@ import org.elasticsearch.gradle.internal.info.BuildParams
 import org.elasticsearch.gradle.testclusters.StandaloneRestIntegTestTask
 
 apply plugin: 'elasticsearch.internal-testclusters'
-apply plugin: 'elasticsearch.standalone-test'
+apply plugin: 'elasticsearch.standalone-rest-test'
 apply plugin: 'elasticsearch.bwc-test'
 
 dependencies {
   testImplementation project(':x-pack:qa')
-}
-if (BuildParams.inFipsJvm){
-  // This test is testing rolling upgrades with a BASIC license and FIPS 140 mode is not available in BASIC
-  tasks.withType(Test).configureEach{ enabled = false }
 }
 
 for (Version bwcVersion : BuildParams.bwcVersions.wireCompatible) {
@@ -87,8 +83,9 @@ for (Version bwcVersion : BuildParams.bwcVersions.wireCompatible) {
 
 // Security is explicitly disabled, do not run tests in FIPS mode
 tasks.withType(Test).configureEach {
-  onlyIf { BuildParams.inFipsJvm == false}
+  enabled ==  BuildParams.inFipsJvm == false
 }
+
 tasks.named("testingConventions").configure {
-  onlyIf { BuildParams.inFipsJvm == false }
+  enabled ==  BuildParams.inFipsJvm == false
 }

--- a/x-pack/qa/rolling-upgrade-basic/build.gradle
+++ b/x-pack/qa/rolling-upgrade-basic/build.gradle
@@ -87,5 +87,5 @@ tasks.withType(Test).configureEach {
 }
 
 tasks.named("testingConventions").configure {
-  enabled ==  BuildParams.inFipsJvm == false
+  enabled = BuildParams.inFipsJvm == false
 }

--- a/x-pack/qa/rolling-upgrade-basic/build.gradle
+++ b/x-pack/qa/rolling-upgrade-basic/build.gradle
@@ -83,7 +83,7 @@ for (Version bwcVersion : BuildParams.bwcVersions.wireCompatible) {
 
 // Security is explicitly disabled, do not run tests in FIPS mode
 tasks.withType(Test).configureEach {
-  enabled ==  BuildParams.inFipsJvm == false
+  enabled = BuildParams.inFipsJvm == false
 }
 
 tasks.named("testingConventions").configure {

--- a/x-pack/qa/rolling-upgrade-multi-cluster/build.gradle
+++ b/x-pack/qa/rolling-upgrade-multi-cluster/build.gradle
@@ -3,7 +3,7 @@ import org.elasticsearch.gradle.internal.info.BuildParams
 import org.elasticsearch.gradle.testclusters.StandaloneRestIntegTestTask
 
 apply plugin: 'elasticsearch.internal-testclusters'
-apply plugin: 'elasticsearch.standalone-test'
+apply plugin: 'elasticsearch.standalone-rest-test'
 apply plugin: 'elasticsearch.bwc-test'
 
 dependencies {

--- a/x-pack/qa/rolling-upgrade/build.gradle
+++ b/x-pack/qa/rolling-upgrade/build.gradle
@@ -3,7 +3,7 @@ import org.elasticsearch.gradle.internal.info.BuildParams
 import org.elasticsearch.gradle.testclusters.StandaloneRestIntegTestTask
 
 apply plugin: 'elasticsearch.internal-testclusters'
-apply plugin: 'elasticsearch.standalone-test'
+apply plugin: 'elasticsearch.standalone-rest-test'
 apply plugin: 'elasticsearch.bwc-test'
 apply plugin: 'elasticsearch.rest-resources'
 


### PR DESCRIPTION
With the overall theme of trying to configure and add less to the build instead of just disabling it later, 
we're replacing standalone-test by standalone-rest tasks avoids creating the
unused test tasks.

Standalone rest test plugin and the other rest test plugins behave a little bit different in the sense how source sets and test tasks are wired.

The standalone rest test plugin assumes that all RestTestTasks are using the same sourceSet (`test`). The `yaml, java Rest test plugins` use one dedicated sourceSet per test task. 

In the long run we probably will migrate standalone-rest-test usages to one of the other plugins and deprecate `standalone-rest-test`