### PR TITLE
[7.13] [DOCS] Query strings are normalized for fuzzy (`~`) operator (#73921)

### DIFF
--- a/docs/reference/query-dsl/query-string-query.asciidoc
+++ b/docs/reference/query-dsl/query-string-query.asciidoc
@@ -142,8 +142,8 @@ You can use this parameter query to search across multiple fields. See
 --
 
 `fuzziness`::
-(Optional, string) Maximum edit distance allowed for matching. See <<fuzziness>>
-for valid values and more information.
+(Optional, string) Maximum edit distance allowed for fuzzy matching. For fuzzy
+syntax, see <<query-string-fuzziness>>.
 
 `fuzzy_max_expansions`::
 (Optional, integer) Maximum number of terms to which the query expands for fuzzy

--- a/docs/reference/query-dsl/query-string-syntax.asciidoc
+++ b/docs/reference/query-dsl/query-string-syntax.asciidoc
@@ -116,13 +116,15 @@ Use with caution!
 [[query-string-fuzziness]]
 ====== Fuzziness
 
-We can search for terms that are
-similar to, but not exactly like our search terms, using the ``fuzzy''
-operator:
+You can run <<query-dsl-fuzzy-query,`fuzzy` queries>> using the `~` operator:
 
     quikc~ brwn~ foks~
 
-This uses the
+For these queries, the query string is <<analysis-normalizers,normalized>>. If
+present, only certain filters from the analyzer are applied. For a list of
+applicable filters, see <<analysis-normalizers>>.
+
+The query uses the
 {wikipedia}/Damerau-Levenshtein_distance[Damerau-Levenshtein distance]
 to find all terms with a maximum of
 two changes, where a change is the insertion, deletion


### PR DESCRIPTION
Backports the following commits to 7.13:
 - [DOCS] Query strings are normalized for fuzzy (`~`) operator (#73921)