### PR TITLE
[7.x] Fix comparison of identical values leads to a bug of non-effective value (#74040)

### DIFF
--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/ml/StartDatafeedResponse.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/ml/StartDatafeedResponse.java
@@ -79,8 +79,7 @@ public class StartDatafeedResponse implements ToXContentObject {
         }
 
         StartDatafeedResponse that = (StartDatafeedResponse) other;
-        return started == started
-            && Objects.equals(node, that.node);
+        return started == that.started && Objects.equals(node, that.node);
     }
 
     @Override


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Fix comparison of identical values leads to a bug of non-effective value (#74040)