### PR TITLE
Introduce GitHub action workflow to automate backporting

### DIFF
--- a/.backportrc.json
+++ b/.backportrc.json
@@ -1,0 +1,15 @@
+{
+  "upstream": "elastic/elasticsearch",
+  "targetBranchChoices": [
+    { "name": "master", "checked": true },
+    { "name": "7.x", "checked": true },
+    "7.13",
+    "6.8"
+  ],
+  "targetPRLabels": ["backport"],
+  "branchLabelMapping": {
+    "^v8.0.0$": "master",
+    "^v7.14.0$": "7.x",
+    "^v(\\d+).(\\d+).\\d+$": "$1.$2"
+  }
+}

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -1,0 +1,38 @@
+on:
+  pull_request_target:
+    branches:
+      - master
+    types:
+      - labeled
+      - closed
+
+jobs:
+  backport:
+    name: Backport PR
+    if: |
+      github.event.pull_request.merged == true
+      && contains(github.event.pull_request.labels.*.name, 'auto-backport')
+      && (
+        (github.event.action == 'labeled' && github.event.label.name == 'auto-backport')
+        || (github.event.action == 'closed')
+      )
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Actions
+        uses: actions/checkout@v2
+        with:
+          repository: 'elastic/kibana-github-actions'
+          ref: main
+          path: ./actions
+
+      - name: Install Actions
+        run: npm install --production --prefix ./actions
+
+      - name: Run Backport
+        uses: ./actions/backport
+        with:
+          github_token: ${{secrets.ELASTICSEARCHMACHINE_TOKEN}}
+          commit_user: elasticsearchmachine
+          commit_email: elasticsarchmachine@users.noreply.github.com
+          auto_merge: 'false'
+          manual_backport_command_template: 'backport --pr %pullNumber%'

--- a/build.gradle
+++ b/build.gradle
@@ -7,11 +7,14 @@
  */
 
 import com.avast.gradle.dockercompose.tasks.ComposePull
+import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.databind.ObjectMapper
 import com.github.jengelman.gradle.plugins.shadow.ShadowPlugin
 import de.thetaphi.forbiddenapis.gradle.ForbiddenApisPlugin
 import org.elasticsearch.gradle.internal.BuildPlugin
 import org.elasticsearch.gradle.Version
 import org.elasticsearch.gradle.VersionProperties
+import org.elasticsearch.gradle.internal.BwcVersions
 import org.elasticsearch.gradle.internal.info.BuildParams
 import org.elasticsearch.gradle.plugin.PluginBuildPlugin
 import org.gradle.plugins.ide.eclipse.model.AccessRule
@@ -106,6 +109,28 @@ tasks.register("verifyVersions") {
       if (ciYml.contains("\"$it\"\n") == false) {
         throw new Exception(".ci/bwcVersions is outdated, run `./gradlew updateCIBwcVersions` and check in the results");
       }
+    }
+
+    // Make sure backport bot config file is up to date
+    JsonNode backportConfig = new ObjectMapper().readTree(file(".backportrc.json"))
+    List<BwcVersions.UnreleasedVersionInfo> unreleased = BuildParams.bwcVersions.unreleased.collect { BuildParams.bwcVersions.unreleasedInfo(it) }
+    unreleased.each { unreleasedVersion ->
+      boolean valid = backportConfig.get("targetBranchChoices").elements().any { branchChoice ->
+        if (branchChoice.isObject()) {
+          return branchChoice.get("name").textValue() == unreleasedVersion.branch
+        } else {
+          return branchChoice.textValue() == unreleasedVersion.branch
+        }
+      }
+      if (valid == false) {
+        throw new GradleException("No branch choice exists for development branch ${unreleasedVersion.branch} in .backportrc.json.")
+      }
+    }
+    BwcVersions.UnreleasedVersionInfo nextMinor = unreleased.find { it.branch.endsWith("x") }
+    String versionMapping = backportConfig.get("branchLabelMapping").fields().find { it.value.textValue() == nextMinor.branch }.key
+    if (versionMapping != "^v${nextMinor.version}\$") {
+      throw new GradleException("Backport label mapping for branch ${nextMinor.branch} is '${versionMapping}' but should be " +
+        "'^v${nextMinor.version}\$'. Update .backportrc.json.")
     }
   }
 }
@@ -207,7 +232,7 @@ allprojects {
       }
     }
   }
-  
+
   tasks.register('resolveAllDependencies', ResolveAllDependencies) {
     configs = project.configurations
     if (project.path.contains("fixture")) {


### PR DESCRIPTION
This pull request introduces a new GitHub action workflow leveraging the [Kibana action](https://github.com/elastic/kibana-github-actions/tree/main/backport) which in turn is based on https://github.com/sqren/backport-github-action. This GitHub action is effectively an extension of the https://github.com/sqren/backport CLI tool and uses the same configuration, which should make for better consistency with manually created backports.

The GitHub action works off of pull request labels. If a pull request is labeled with `auto-backport`, the workflow will trigger when that PR is merged. When merged it will create backport PRs based on the version labels as-per the `branchLabelMapping` in `.backportrc.json`. If the PR can be cleanly cherry-picked a comment will be made on the original PR indicating success. If not the comment will indicate the backport failed and will have to be done manually to address conflicts.

Additionally, in order to ensure that the backport config is kept up to date with new releases, feature freezes, etc, the `verifyVersions` Gradle task has been updated to fail in case newly added versions aren't reflected in the backport configuration.