### PR TITLE
Update collapse-search-results.asciidoc

### DIFF
--- a/docs/reference/search/search-your-data/collapse-search-results.asciidoc
+++ b/docs/reference/search/search-your-data/collapse-search-results.asciidoc
@@ -92,12 +92,12 @@ GET /my-index-000001/_search
       {
         "name": "largest_responses",         <2>
         "size": 3,
-        "sort": [ "http.response.bytes" ]
+        "sort": [ "http.response.bytes":"desc" ]
       },
       {
         "name": "most_recent",               <3>
         "size": 3,
-        "sort": [ { "@timestamp": "asc" } ]
+        "sort": [ { "@timestamp": "desc" } ]
       }
     ]
   },

--- a/docs/reference/search/search-your-data/collapse-search-results.asciidoc
+++ b/docs/reference/search/search-your-data/collapse-search-results.asciidoc
@@ -92,7 +92,7 @@ GET /my-index-000001/_search
       {
         "name": "largest_responses",         <2>
         "size": 3,
-        "sort": [ "http.response.bytes":"desc" ]
+        "sort": [ {"http.response.bytes":"desc"} ]
       },
       {
         "name": "most_recent",               <3>


### PR DESCRIPTION
I found that the sample usage in the current version is also wrong, they should use desc

@lockewritesdocs 
