### PR TITLE
Make test cluster tasks depend on fipsResources when fips enabled

### DIFF
--- a/build-tools-internal/src/main/groovy/elasticsearch.fips.gradle
+++ b/build-tools-internal/src/main/groovy/elasticsearch.fips.gradle
@@ -9,6 +9,7 @@
 import org.elasticsearch.gradle.internal.ExportElasticsearchBuildResourcesTask
 import org.elasticsearch.gradle.internal.info.BuildParams
 import org.elasticsearch.gradle.testclusters.TestDistribution
+import org.elasticsearch.gradle.testclusters.TestClustersAware
 
 // Common config when running with a FIPS-140 runtime JVM
 if (BuildParams.inFipsJvm) {
@@ -51,6 +52,9 @@ if (BuildParams.inFipsJvm) {
             }
           }
         }
+        tasks.withType(TestClustersAware) {
+          dependsOn 'fipsResources'
+        }
         testClusters.all {
           setTestDistribution(TestDistribution.DEFAULT)
           extraConfigFile "fips_java.security", fipsSecurity
@@ -72,7 +76,6 @@ if (BuildParams.inFipsJvm) {
         }
       }
       project.tasks.withType(Test).configureEach { Test task ->
-        task.dependsOn('fipsResources')
         task.systemProperty('javax.net.ssl.trustStorePassword', 'password')
         task.systemProperty('javax.net.ssl.keyStorePassword', 'password')
         task.systemProperty('javax.net.ssl.trustStoreType', 'BCFKS')


### PR DESCRIPTION
The fips specific cluster specification depends on files that are declared
as output of the fips-resources task. So far there has not been an explicit
dependency of all TestClustersAware tasks (so far only for Test tasks) to this
resources task in our build and.

implicit usage of task outputs without any explicit task dependency has been
deprecated in Gradle as the build tool detects that these file are outputs of
this task and urges users to have this  explicit dependency declared in a build.

RestIntegTestTask had this dependencies explicitly declared by us having defined a dependency
by declaring

`tasks.withType(Test) { dependsOn 'fipsResources'}`.

This has be replaced by with this PR by

`tasks.withType(TestClustersAware) { dependsOn 'fipsResources'}`

which also covers usages of `DefaultTestClustersTask` as used in the
`:x-pack:plugin:eql:qa:multi-cluster-with-security` project which
fails in #74664

fixes #74664