### PR TITLE
[DOCS] Fix <index> param def for delete index API

### DIFF
--- a/docs/reference/indices/delete-index.asciidoc
+++ b/docs/reference/indices/delete-index.asciidoc
@@ -30,7 +30,7 @@ or `manage` <<privileges-list-indices,index privilege>> for the target index.
 `<index>`::
 +
 --
-(Required, string) Comma-separated list indices to delete. You cannot specify
+(Required, string) Comma-separated list of indices to delete. You cannot specify
 <<alias,index aliases>>.
 
 To use wildcards (`*`) or `_all`, change the `action.destructive_requires_name`

--- a/docs/reference/indices/delete-index.asciidoc
+++ b/docs/reference/indices/delete-index.asciidoc
@@ -33,10 +33,11 @@ or `manage` <<privileges-list-indices,index privilege>> for the target index.
 (Required, string) Comma-separated list of indices to delete. You cannot specify
 <<alias,index aliases>>.
 
-To use wildcards (`*`) or `_all`, change the `action.destructive_requires_name`
-setting to `false`. You can update this setting in the `elasticsearch.yml` file
-or using the <<cluster-update-settings,cluster update settings>> API. Wildcard
-patterns only match open, concrete indices.
+By default, this parameter does not support wildcards (`*`) or `_all`. To use
+wildcards or `_all`, change the `action.destructive_requires_name` setting to
+`false`. You can update this setting in the `elasticsearch.yml` file or using
+the <<cluster-update-settings,cluster update settings>> API. Wildcard patterns
+only match open, concrete indices.
 
 NOTE: You cannot delete the current write index of a data stream. To delete the
 index, you must <<data-streams-rollover,roll over>> the data stream so a new

--- a/docs/reference/indices/delete-index.asciidoc
+++ b/docs/reference/indices/delete-index.asciidoc
@@ -34,7 +34,7 @@ or `manage` <<privileges-list-indices,index privilege>> for the target index.
 delete.
 
 In this parameter, wildcard expressions match only open, concrete indices. You
-cannot delete an index using an <<alias,alias>>.
+cannot delete an index through any associated <<alias,aliases>>.
 
 By default, you must explicitly name the indices you are deleting.
 To specify indices to delete with `_all`, `*`, or other wildcard

--- a/docs/reference/indices/delete-index.asciidoc
+++ b/docs/reference/indices/delete-index.asciidoc
@@ -30,17 +30,13 @@ or `manage` <<privileges-list-indices,index privilege>> for the target index.
 `<index>`::
 +
 --
-(Request, string) Comma-separated list or wildcard expression of indices to
-delete.
+(Required, string) Comma-separated list indices to delete. You cannot specify
+<<alias,index aliases>>.
 
-In this parameter, wildcard expressions match only open, concrete indices. You
-cannot delete an index through any associated <<alias,aliases>>.
-
-By default, you must explicitly name the indices you are deleting.
-To specify indices to delete with `_all`, `*`, or other wildcard
-expressions, change the `action.destructive_requires_name` setting to `false`.
-You can update this setting in the `elasticsearch.yml` file or using the
-<<cluster-update-settings,cluster update settings>> API.
+To use wildcards (`*`) or `_all`, change the `action.destructive_requires_name`
+setting to `false`. You can update this setting in the `elasticsearch.yml` file
+or using the <<cluster-update-settings,cluster update settings>> API. Wildcard
+patterns only match open, concrete indices.
 
 NOTE: You cannot delete the current write index of a data stream. To delete the
 index, you must <<data-streams-rollover,roll over>> the data stream so a new


### PR DESCRIPTION
The current documentation leads to assume that you cannot delete an index if there is an alias that exists and links to it. This appears not to be the case and what it means is that it cannot be deleted through the alias name.