### PR TITLE
[7.x] Add `dry_run` support to the migrate to data tiers API (#74639)

### DIFF
--- a/docs/reference/ilm/apis/migrate-to-data-tiers.asciidoc
+++ b/docs/reference/ilm/apis/migrate-to-data-tiers.asciidoc
@@ -41,6 +41,16 @@ Defaults to `data`.
 to stop {ilm-init} and <<ilm-get-status-request, get status API>> to wait until the
 reported operation mode is `STOPPED`.
 
+[[ilm-migrate-to-data-tiers-query-params]]
+==== {api-query-parms-title}
+
+`dry_run`::
+(Optional, Boolean)
+If `true`, simulates the migration from node attributes based allocation filters to data tiers, but does
+not perform the migration. This provides a way to retrieve the indices and ILM policies that need to be
+migrated.
+Defaults to `false`.
+
 [[ilm-migrate-to-data-tiers-example]]
 ==== {api-examples-title}
 
@@ -118,6 +128,7 @@ If the request succeeds, a response like the following will be received:
 [source,console-result]
 ------------------------------------------------------------------------------
 {
+  "dry_run": false,
   "removed_legacy_template":"global-template", <1>
   "migrated_ilm_policies":["policy_with_allocate_action"], <2>
   "migrated_indices":["warm-index-to-migrate-000001"] <3>

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/ilm.migrate_to_data_tiers.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/ilm.migrate_to_data_tiers.json
@@ -20,7 +20,12 @@
         }
       ]
     },
-    "params":{},
+    "params": {
+      "dry_run": {
+        "type": "boolean",
+        "description": "If set to true it will simulate the migration, providing a way to retrieve the ILM policies and indices that need to be migrated. The default is false"
+      }
+    },
     "body":{
       "description":"Optionally specify a legacy index template name to delete and optionally specify a node attribute name used for index shard routing (defaults to \"data\")",
       "required":false

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/cluster/action/MigrateToDataTiersRequest.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/cluster/action/MigrateToDataTiersRequest.java
@@ -45,6 +45,7 @@ public class MigrateToDataTiersRequest extends AcknowledgedRequest<MigrateToData
      */
     @Nullable
     private final String legacyTemplateToDelete;
+    private boolean dryRun = false;
 
     public static MigrateToDataTiersRequest parse(XContentParser parser) throws IOException {
         return PARSER.parse(parser, null);
@@ -61,6 +62,7 @@ public class MigrateToDataTiersRequest extends AcknowledgedRequest<MigrateToData
 
     public MigrateToDataTiersRequest(StreamInput in) throws IOException {
         super(in);
+        dryRun = in.readBoolean();
         legacyTemplateToDelete = in.readOptionalString();
         nodeAttributeName = in.readOptionalString();
     }
@@ -73,8 +75,13 @@ public class MigrateToDataTiersRequest extends AcknowledgedRequest<MigrateToData
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
+        out.writeBoolean(dryRun);
         out.writeOptionalString(legacyTemplateToDelete);
         out.writeOptionalString(nodeAttributeName);
+    }
+
+    public void setDryRun(boolean dryRun) {
+        this.dryRun = dryRun;
     }
 
     public String getNodeAttributeName() {
@@ -83,6 +90,10 @@ public class MigrateToDataTiersRequest extends AcknowledgedRequest<MigrateToData
 
     public String getLegacyTemplateToDelete() {
         return legacyTemplateToDelete;
+    }
+
+    public boolean isDryRun() {
+        return dryRun;
     }
 
     @Override
@@ -94,20 +105,13 @@ public class MigrateToDataTiersRequest extends AcknowledgedRequest<MigrateToData
             return false;
         }
         MigrateToDataTiersRequest that = (MigrateToDataTiersRequest) o;
-        return Objects.equals(nodeAttributeName, that.nodeAttributeName) && Objects.equals(legacyTemplateToDelete,
-            that.legacyTemplateToDelete);
+        return dryRun == that.dryRun &&
+            Objects.equals(nodeAttributeName, that.nodeAttributeName) &&
+            Objects.equals(legacyTemplateToDelete, that.legacyTemplateToDelete);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(nodeAttributeName, legacyTemplateToDelete);
-    }
-
-    @Override
-    public String toString() {
-        return "MigrateToDataTiersRequest{" +
-            "nodeAttributeName='" + nodeAttributeName + '\'' +
-            ", legacyTemplateToDelete='" + legacyTemplateToDelete + '\'' +
-            '}';
+        return Objects.hash(nodeAttributeName, legacyTemplateToDelete, dryRun);
     }
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/cluster/action/MigrateToDataTiersResponse.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/cluster/action/MigrateToDataTiersResponse.java
@@ -17,23 +17,27 @@ import org.elasticsearch.core.Nullable;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Objects;
 
 public class MigrateToDataTiersResponse extends ActionResponse implements ToXContentObject {
 
     public static final ParseField REMOVED_LEGACY_TEMPLATE = new ParseField("removed_legacy_template");
     public static final ParseField MIGRATED_INDICES = new ParseField("migrated_indices");
     public static final ParseField MIGRATED_ILM_POLICIES = new ParseField("migrated_ilm_policies");
+    private static final ParseField DRY_RUN = new ParseField("dry_run");
 
     @Nullable
     private final String removedIndexTemplateName;
     private final List<String> migratedPolicies;
     private final List<String> migratedIndices;
+    private final boolean dryRun;
 
     public MigrateToDataTiersResponse(@Nullable String removedIndexTemplateName, List<String> migratedPolicies,
-                                      List<String> migratedIndices) {
+                                      List<String> migratedIndices, boolean dryRun) {
         this.removedIndexTemplateName = removedIndexTemplateName;
         this.migratedPolicies = migratedPolicies;
         this.migratedIndices = migratedIndices;
+        this.dryRun = dryRun;
     }
 
     public MigrateToDataTiersResponse(StreamInput in) throws IOException {
@@ -41,11 +45,13 @@ public class MigrateToDataTiersResponse extends ActionResponse implements ToXCon
         removedIndexTemplateName = in.readOptionalString();
         migratedPolicies = in.readStringList();
         migratedIndices = in.readStringList();
+        dryRun = in.readBoolean();
     }
 
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startObject();
+        builder.field(DRY_RUN.getPreferredName(), dryRun);
         if (this.removedIndexTemplateName != null) {
             builder.field(REMOVED_LEGACY_TEMPLATE.getPreferredName(), this.removedIndexTemplateName);
         }
@@ -67,10 +73,45 @@ public class MigrateToDataTiersResponse extends ActionResponse implements ToXCon
         return builder;
     }
 
+    public String getRemovedIndexTemplateName() {
+        return removedIndexTemplateName;
+    }
+
+    public List<String> getMigratedPolicies() {
+        return migratedPolicies;
+    }
+
+    public List<String> getMigratedIndices() {
+        return migratedIndices;
+    }
+
+    public boolean isDryRun() {
+        return dryRun;
+    }
+
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         out.writeOptionalString(removedIndexTemplateName);
         out.writeStringCollection(migratedPolicies);
         out.writeStringCollection(migratedIndices);
+        out.writeBoolean(dryRun);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        MigrateToDataTiersResponse that = (MigrateToDataTiersResponse) o;
+        return dryRun == that.dryRun && Objects.equals(removedIndexTemplateName, that.removedIndexTemplateName) &&
+            Objects.equals(migratedPolicies, that.migratedPolicies) && Objects.equals(migratedIndices, that.migratedIndices);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(removedIndexTemplateName, migratedPolicies, migratedIndices, dryRun);
     }
 }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/cluster/action/MigrateToDataTiersResponseTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/cluster/action/MigrateToDataTiersResponseTests.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.cluster.action;
+
+import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.test.AbstractWireSerializingTestCase;
+
+import java.io.IOException;
+
+public class MigrateToDataTiersResponseTests extends AbstractWireSerializingTestCase<MigrateToDataTiersResponse> {
+
+    @Override
+    protected Writeable.Reader<MigrateToDataTiersResponse> instanceReader() {
+        return MigrateToDataTiersResponse::new;
+    }
+
+    @Override
+    protected MigrateToDataTiersResponse createTestInstance() {
+        boolean dryRun = randomBoolean();
+        return new MigrateToDataTiersResponse(randomAlphaOfLength(10), randomList(1, 5, () -> randomAlphaOfLengthBetween(5, 50)),
+            randomList(1, 5, () -> randomAlphaOfLengthBetween(5, 50)), dryRun);
+    }
+
+    @Override
+    protected MigrateToDataTiersResponse mutateInstance(MigrateToDataTiersResponse instance) throws IOException {
+        int i = randomIntBetween(0, 3);
+        switch (i) {
+            case 0:
+                return new MigrateToDataTiersResponse(randomValueOtherThan(instance.getRemovedIndexTemplateName(),
+                    () -> randomAlphaOfLengthBetween(5, 15)), instance.getMigratedPolicies(), instance.getMigratedIndices(),
+                    instance.isDryRun());
+            case 1:
+                return new MigrateToDataTiersResponse(instance.getRemovedIndexTemplateName(),
+                    randomList(6, 10, () -> randomAlphaOfLengthBetween(5, 50)), instance.getMigratedIndices(), instance.isDryRun());
+            case 2:
+                return new MigrateToDataTiersResponse(instance.getRemovedIndexTemplateName(), instance.getMigratedPolicies(),
+                    randomList(6, 10, () -> randomAlphaOfLengthBetween(5, 50)), instance.isDryRun());
+            case 3:
+                return new MigrateToDataTiersResponse(instance.getRemovedIndexTemplateName(), instance.getMigratedPolicies(),
+                    instance.getMigratedIndices(), instance.isDryRun() ? false : true);
+            default:
+                throw new UnsupportedOperationException();
+        }
+    }
+}

--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/action/RestMigrateToDataTiersAction.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/action/RestMigrateToDataTiersAction.java
@@ -35,6 +35,7 @@ public class RestMigrateToDataTiersAction extends BaseRestHandler {
     protected RestChannelConsumer prepareRequest(RestRequest request, NodeClient client) throws IOException {
         MigrateToDataTiersRequest migrateRequest = request.hasContent() ?
             MigrateToDataTiersRequest.parse(request.contentParser()) : new MigrateToDataTiersRequest();
+        migrateRequest.setDryRun(request.paramAsBoolean("dry_run", false));
         return channel -> client.execute(MigrateToDataTiersAction.INSTANCE, migrateRequest, new RestToXContentListener<>(channel));
     }
 }

--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/action/TransportMigrateToDataTiersAction.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/action/TransportMigrateToDataTiersAction.java
@@ -61,6 +61,17 @@ public class TransportMigrateToDataTiersAction extends TransportMasterNodeAction
                 currentMetadata.getOperationMode() + "]"));
             return;
         }
+
+        if (request.isDryRun()) {
+            MigratedEntities entities =
+                migrateToDataTiersRouting(state, request.getNodeAttributeName(), request.getLegacyTemplateToDelete(),
+                    xContentRegistry, client, licenseState).v2();
+            listener.onResponse(
+                new MigrateToDataTiersResponse(entities.removedIndexTemplateName, entities.migratedPolicies, entities.migratedIndices, true)
+            );
+            return;
+        }
+
         final SetOnce<MigratedEntities> migratedEntities = new SetOnce<>();
         clusterService.submitStateUpdateTask("migrate-to-data-tiers []", new ClusterStateUpdateTask(Priority.HIGH) {
             @Override
@@ -82,8 +93,8 @@ public class TransportMigrateToDataTiersAction extends TransportMasterNodeAction
             public void clusterStateProcessed(String source, ClusterState oldState, ClusterState newState) {
                 super.clusterStateProcessed(source, oldState, newState);
                 MigratedEntities entities = migratedEntities.get();
-                listener.onResponse(
-                    new MigrateToDataTiersResponse(entities.removedIndexTemplateName, entities.migratedPolicies, entities.migratedIndices)
+                listener.onResponse(new MigrateToDataTiersResponse(entities.removedIndexTemplateName, entities.migratedPolicies,
+                    entities.migratedIndices, false)
                 );
             }
         });


### PR DESCRIPTION
This adds support for a `dry_run` parameter for the
`_ilm/migrate_to_data_tiers` API. This defaults to `false`, but when
configured to `true` it will simulate the migration of elasticsearch
entities to data tiers based routing, returning the entites that need to
be updated (indices, ILM policies and the legacy index template that'd
be deleted, if any was configured in the request).

(cherry picked from commit 5ca240eabd6fac846caf3f98d6cf5e003cfddad9)
Signed-off-by: Andrei Dan <andrei.dan@elastic.co>

Backport of #74639 