### PR TITLE
[DOCS]: allow multiple searchable_snapshot actions in the same policy

### DIFF
--- a/docs/reference/ilm/actions/ilm-searchable-snapshot.asciidoc
+++ b/docs/reference/ilm/actions/ilm-searchable-snapshot.asciidoc
@@ -14,8 +14,8 @@ index>>. If the original index is part of a
 the data stream.
 
 IMPORTANT: If the `searchable_snapshot` action is used in the hot phase the
-subsequent phases cannot define any of the `shrink`, `forcemerge`, `freeze` or
-`searchable_snapshot` (also available in the cold and frozen phases) actions.
+subsequent phases cannot define any of the `shrink`, `forcemerge` or `freeze`
+actions.
 
 [NOTE]
 This action cannot be performed on a data stream's write index. Attempts to do

--- a/docs/reference/ilm/actions/ilm-searchable-snapshot.asciidoc
+++ b/docs/reference/ilm/actions/ilm-searchable-snapshot.asciidoc
@@ -14,7 +14,7 @@ index>>. If the original index is part of a
 the data stream.
 
 IMPORTANT: If the `searchable_snapshot` action is used in the hot phase the
-subsequent phases cannot define any of the `shrink`, `forcemerge` or `freeze`
+subsequent phases cannot include the `shrink`, `forcemerge`, or `freeze`
 actions.
 
 [NOTE]


### PR DESCRIPTION
Since `7.12` we allow multiple searchable_snapshot actions in the same
policy. This updates the docs to reflect this.