### PR TITLE
EQL: Add CircuitBreaker for sequence queries (#74381)

### DIFF
--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/execution/PlanExecutor.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/execution/PlanExecutor.java
@@ -9,7 +9,7 @@ package org.elasticsearch.xpack.eql.execution;
 
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.client.Client;
-import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
+import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.xpack.eql.analysis.PostAnalyzer;
 import org.elasticsearch.xpack.eql.analysis.PreAnalyzer;
 import org.elasticsearch.xpack.eql.analysis.Verifier;
@@ -29,7 +29,6 @@ import static org.elasticsearch.action.ActionListener.wrap;
 
 public class PlanExecutor {
     private final Client client;
-    private final NamedWriteableRegistry writableRegistry;
 
     private final IndexResolver indexResolver;
     private final FunctionRegistry functionRegistry;
@@ -39,15 +38,16 @@ public class PlanExecutor {
     private final Verifier verifier;
     private final Optimizer optimizer;
     private final Planner planner;
+    private final CircuitBreaker circuitBreaker;
 
     private final Metrics metrics;
 
 
-    public PlanExecutor(Client client, IndexResolver indexResolver, NamedWriteableRegistry writeableRegistry) {
+    public PlanExecutor(Client client, IndexResolver indexResolver, CircuitBreaker circuitBreaker) {
         this.client = client;
-        this.writableRegistry = writeableRegistry;
-
         this.indexResolver = indexResolver;
+        this.circuitBreaker = circuitBreaker;
+
         this.functionRegistry = new EqlFunctionRegistry();
 
         this.metrics = new Metrics();
@@ -60,7 +60,18 @@ public class PlanExecutor {
     }
 
     private EqlSession newSession(EqlConfiguration cfg) {
-        return new EqlSession(client, cfg, indexResolver, preAnalyzer, postAnalyzer, functionRegistry, verifier, optimizer, planner, this);
+        return new EqlSession(
+            client,
+            cfg,
+            indexResolver,
+            preAnalyzer,
+            postAnalyzer,
+            functionRegistry,
+            verifier,
+            optimizer,
+            planner,
+            circuitBreaker
+        );
     }
 
     public void eql(EqlConfiguration cfg, String eql, ParserParams parserParams, ActionListener<Results> listener) {

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/execution/assembler/ExecutionManager.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/execution/assembler/ExecutionManager.java
@@ -109,7 +109,7 @@ public class ExecutionManager {
         }
 
         int completionStage = criteria.size() - 1;
-        SequenceMatcher matcher = new SequenceMatcher(completionStage, descending, maxSpan, limit);
+        SequenceMatcher matcher = new SequenceMatcher(completionStage, descending, maxSpan, limit, session.circuitBreaker());
 
         TumblingWindow w = new TumblingWindow(new PITAwareQueryClient(session),
                 criteria.subList(0, completionStage),

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/execution/search/HitReference.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/execution/search/HitReference.java
@@ -7,13 +7,17 @@
 
 package org.elasticsearch.xpack.eql.execution.search;
 
+import org.apache.lucene.util.Accountable;
+import org.apache.lucene.util.RamUsageEstimator;
 import org.elasticsearch.search.SearchHit;
 
 import java.util.Objects;
 
 import static org.elasticsearch.xpack.eql.util.SearchHitUtils.qualifiedIndex;
 
-public class HitReference {
+public class HitReference implements Accountable {
+
+    private static final long SHALLOW_SIZE = RamUsageEstimator.shallowSizeOfInstance(HitReference.class);
 
     private final String index;
     private final String id;
@@ -33,6 +37,12 @@ public class HitReference {
 
     public String id() {
         return id;
+    }
+
+    @Override
+    public long ramBytesUsed() {
+        // index string is cached in TumblingWindow and there is no need of accounting for it
+        return SHALLOW_SIZE + RamUsageEstimator.sizeOf(id);
     }
 
     @Override

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/execution/search/Ordinal.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/execution/search/Ordinal.java
@@ -7,9 +7,13 @@
 
 package org.elasticsearch.xpack.eql.execution.search;
 
+import org.apache.lucene.util.Accountable;
+import org.apache.lucene.util.RamUsageEstimator;
 import java.util.Objects;
 
-public class Ordinal implements Comparable<Ordinal> {
+public class Ordinal implements Comparable<Ordinal>, Accountable {
+
+    private static final long SHALLOW_SIZE = RamUsageEstimator.shallowSizeOfInstance(Ordinal.class);
 
     private final long timestamp;
     private final Comparable<Object> tiebreaker;
@@ -31,6 +35,11 @@ public class Ordinal implements Comparable<Ordinal> {
 
     public long implicitTiebreaker() {
         return implicitTiebreaker;
+    }
+
+    @Override
+    public long ramBytesUsed() {
+        return SHALLOW_SIZE;
     }
 
     @Override

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/execution/sequence/Match.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/execution/sequence/Match.java
@@ -7,6 +7,8 @@
 
 package org.elasticsearch.xpack.eql.execution.sequence;
 
+import org.apache.lucene.util.Accountable;
+import org.apache.lucene.util.RamUsageEstimator;
 import org.elasticsearch.xpack.eql.execution.search.HitReference;
 import org.elasticsearch.xpack.eql.execution.search.Ordinal;
 
@@ -15,7 +17,9 @@ import java.util.Objects;
 /**
  * A match within a sequence, holding the result and occurrence time.
  */
-class Match {
+class Match implements Accountable {
+
+    private static final long SHALLOW_SIZE = RamUsageEstimator.shallowSizeOfInstance(Match.class);
 
     private final Ordinal ordinal;
     private final HitReference hit;
@@ -31,6 +35,11 @@ class Match {
 
     HitReference hit() {
         return hit;
+    }
+
+    @Override
+    public long ramBytesUsed() {
+        return SHALLOW_SIZE + RamUsageEstimator.sizeOf(ordinal) + RamUsageEstimator.sizeOf(hit);
     }
 
     @Override

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/execution/sequence/OrdinalGroup.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/execution/sequence/OrdinalGroup.java
@@ -7,6 +7,8 @@
 
 package org.elasticsearch.xpack.eql.execution.sequence;
 
+import org.apache.lucene.util.Accountable;
+import org.apache.lucene.util.RamUsageEstimator;
 import org.elasticsearch.core.Tuple;
 import org.elasticsearch.xpack.eql.execution.search.Ordinal;
 
@@ -21,7 +23,9 @@ import static org.elasticsearch.common.logging.LoggerMessageFormat.format;
  * List of in-flight ordinals for a given key. For fast lookup, typically associated with a stage.
  * this class expects the insertion to be ordered
  */
-abstract class OrdinalGroup<E> implements Iterable<Ordinal> {
+abstract class OrdinalGroup<E> implements Iterable<Ordinal>, Accountable {
+
+    private static final long SHALLOW_SIZE = RamUsageEstimator.shallowSizeOfInstance(OrdinalGroup.class);
 
     private final Function<E, Ordinal> extractor;
 
@@ -129,6 +133,11 @@ abstract class OrdinalGroup<E> implements Iterable<Ordinal> {
                 return extractor.apply(iter.next());
             }
         };
+    }
+
+    @Override
+    public long ramBytesUsed() {
+        return SHALLOW_SIZE + RamUsageEstimator.sizeOfCollection(elements);
     }
 
     @Override

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/execution/sequence/Sequence.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/execution/sequence/Sequence.java
@@ -7,6 +7,8 @@
 
 package org.elasticsearch.xpack.eql.execution.sequence;
 
+import org.apache.lucene.util.Accountable;
+import org.apache.lucene.util.RamUsageEstimator;
 import org.elasticsearch.xpack.eql.EqlIllegalArgumentException;
 import org.elasticsearch.xpack.eql.execution.search.HitReference;
 import org.elasticsearch.xpack.eql.execution.search.Ordinal;
@@ -25,7 +27,9 @@ import static org.elasticsearch.common.logging.LoggerMessageFormat.format;
  * Defined by its key and stage.
  * This class is NOT immutable (to optimize memory) which means its associations need to be managed.
  */
-public class Sequence implements Comparable<Sequence> {
+public class Sequence implements Comparable<Sequence>, Accountable {
+
+    private static final long SHALLOW_SIZE = RamUsageEstimator.shallowSizeOfInstance(Sequence.class);
 
     private final SequenceKey key;
     private final int stages;
@@ -68,6 +72,11 @@ public class Sequence implements Comparable<Sequence> {
             hits.add(m.hit());
         }
         return hits;
+    }
+
+    @Override
+    public long ramBytesUsed() {
+        return SHALLOW_SIZE + RamUsageEstimator.sizeOf(key) + RamUsageEstimator.sizeOf(matches);
     }
 
     @Override

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/execution/sequence/SequenceKey.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/execution/sequence/SequenceKey.java
@@ -7,6 +7,8 @@
 
 package org.elasticsearch.xpack.eql.execution.sequence;
 
+import org.apache.lucene.util.Accountable;
+import org.apache.lucene.util.RamUsageEstimator;
 import org.elasticsearch.common.util.CollectionUtils;
 
 import java.util.Arrays;
@@ -15,7 +17,9 @@ import java.util.Objects;
 
 import static java.util.Collections.emptyList;
 
-public class SequenceKey {
+public class SequenceKey implements Accountable {
+
+    private static final long SHALLOW_SIZE = RamUsageEstimator.shallowSizeOfInstance(SequenceKey.class);
 
     public static final SequenceKey NONE = new SequenceKey();
 
@@ -29,6 +33,11 @@ public class SequenceKey {
 
     public List<Object> asList() {
         return keys == null ? emptyList() : Arrays.asList(keys);
+    }
+
+    @Override
+    public long ramBytesUsed() {
+        return SHALLOW_SIZE + RamUsageEstimator.sizeOfObject(keys);
     }
 
     @Override

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/execution/sequence/SequenceMatcher.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/execution/sequence/SequenceMatcher.java
@@ -9,9 +9,11 @@ package org.elasticsearch.xpack.eql.execution.sequence;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.elasticsearch.core.Tuple;
+import org.apache.lucene.util.RamUsageEstimator;
+import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.common.logging.LoggerMessageFormat;
 import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.core.Tuple;
 import org.elasticsearch.xpack.eql.execution.search.HitReference;
 import org.elasticsearch.xpack.eql.execution.search.Limit;
 import org.elasticsearch.xpack.eql.execution.search.Ordinal;
@@ -26,9 +28,13 @@ import java.util.TreeSet;
  */
 public class SequenceMatcher {
 
+    private static final String CB_INFLIGHT_LABEL = "sequence_inflight";
+    private static final String CB_COMPLETED_LABEL = "sequence_completed";
+
     private final Logger log = LogManager.getLogger(SequenceMatcher.class);
 
     static class Stats {
+
         long seen = 0;
         long ignored = 0;
         long rejectionMaxspan = 0;
@@ -68,12 +74,15 @@ public class SequenceMatcher {
     private final boolean descending;
 
     private final Limit limit;
-    private boolean headLimit = false;
+    private final CircuitBreaker circuitBreaker;
 
     private final Stats stats = new Stats();
 
+    private boolean headLimit = false;
+    private long totalRamBytesUsed = 0;
+
     @SuppressWarnings("rawtypes")
-    public SequenceMatcher(int stages, boolean descending, TimeValue maxSpan, Limit limit) {
+    public SequenceMatcher(int stages, boolean descending, TimeValue maxSpan, Limit limit, CircuitBreaker circuitBreaker) {
         this.numberOfStages = stages;
         this.completionStage = stages - 1;
 
@@ -84,8 +93,8 @@ public class SequenceMatcher {
 
         this.maxSpanInMillis = maxSpan.millis();
 
-        // limit
         this.limit = limit;
+        this.circuitBreaker = circuitBreaker;
     }
 
     private void trackSequence(Sequence sequence) {
@@ -102,6 +111,9 @@ public class SequenceMatcher {
      * Returns false if the process needs to be stopped.
      */
     boolean match(int stage, Iterable<Tuple<KeyAndOrdinal, HitReference>> hits) {
+        long ramBytesUsedInFlight = ramBytesUsedInFlight();
+        long ramBytesUsedCompleted = ramBytesUsedCompleted();
+
         for (Tuple<KeyAndOrdinal, HitReference> tuple : hits) {
             KeyAndOrdinal ko = tuple.v1();
             HitReference hit = tuple.v2();
@@ -121,13 +133,17 @@ public class SequenceMatcher {
             }
         }
 
+        boolean matched;
         // check tail limit
         if (tailLimitReached()) {
             log.trace("(Tail) Limit reached {}", stats);
-            return false;
+            matched = false;
+        } else {
+            log.trace("{}", stats);
+            matched = true;
         }
-        log.trace("{}", stats);
-        return true;
+        trackMemory(ramBytesUsedInFlight, ramBytesUsedCompleted);
+        return matched;
     }
 
     private boolean tailLimitReached() {
@@ -283,6 +299,37 @@ public class SequenceMatcher {
         keyToSequences.clear();
         stageToKeys.clear();
         completed.clear();
+        clearCircuitBreaker();
+    }
+
+    private long ramBytesUsedInFlight() {
+        return RamUsageEstimator.sizeOf(keyToSequences) + RamUsageEstimator.sizeOf(stageToKeys);
+    }
+
+    private long ramBytesUsedCompleted() {
+        return RamUsageEstimator.sizeOfCollection(completed);
+    }
+
+    private void addMemory(long bytes, String label) {
+        totalRamBytesUsed += bytes;
+        circuitBreaker.addEstimateBytesAndMaybeBreak(bytes, label);
+    }
+
+    private void clearCircuitBreaker() {
+        circuitBreaker.addWithoutBreaking(-totalRamBytesUsed);
+        totalRamBytesUsed = 0;
+    }
+
+    // The method is called at the end of match() which is called for every sub query in the sequence query
+    // and for each subquery every "fetch_size" docs. Doing RAM accounting on object creation is
+    // expensive, so we just calculate the difference in bytes of the total memory that the matcher's
+    // structure occupy for the in-flight tracking of sequences, as well as for the list of completed
+    // sequences.
+    private void trackMemory(long prevRamBytesUsedInflight, long prevRamBytesUsedCompleted) {
+        long bytesDiff = ramBytesUsedInFlight() - prevRamBytesUsedInflight;
+        addMemory(bytesDiff, CB_INFLIGHT_LABEL);
+        bytesDiff = ramBytesUsedCompleted() - prevRamBytesUsedCompleted;
+        addMemory(bytesDiff, CB_COMPLETED_LABEL);
     }
 
     @Override

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/execution/sequence/StageToKeys.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/execution/sequence/StageToKeys.java
@@ -7,6 +7,8 @@
 
 package org.elasticsearch.xpack.eql.execution.sequence;
 
+import org.apache.lucene.util.Accountable;
+import org.apache.lucene.util.RamUsageEstimator;
 import org.elasticsearch.xpack.ql.util.CollectionUtils;
 
 import java.util.Arrays;
@@ -18,7 +20,7 @@ import java.util.StringJoiner;
 import static java.util.Collections.emptySet;
 
 /** Dedicated collection for mapping a stage (represented by the index collection) to a set of keys */
-class StageToKeys {
+class StageToKeys implements Accountable {
 
     private final List<Set<SequenceKey>> stageToKey;
 
@@ -71,6 +73,11 @@ class StageToKeys {
                 set.clear();
             }
         }
+    }
+
+    @Override
+    public long ramBytesUsed() {
+        return RamUsageEstimator.sizeOfCollection(stageToKey);
     }
 
     @Override

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/plugin/EqlPlugin.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/plugin/EqlPlugin.java
@@ -6,6 +6,7 @@
  */
 package org.elasticsearch.xpack.eql.plugin;
 
+import org.apache.lucene.util.SetOnce;
 import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.client.Client;
@@ -13,6 +14,7 @@ import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.inject.Module;
+import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.settings.ClusterSettings;
 import org.elasticsearch.common.settings.IndexScopedSettings;
@@ -22,8 +24,11 @@ import org.elasticsearch.common.settings.SettingsFilter;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 import org.elasticsearch.env.Environment;
 import org.elasticsearch.env.NodeEnvironment;
+import org.elasticsearch.indices.breaker.BreakerSettings;
 import org.elasticsearch.license.XPackLicenseState;
+import org.elasticsearch.monitor.jvm.JvmInfo;
 import org.elasticsearch.plugins.ActionPlugin;
+import org.elasticsearch.plugins.CircuitBreakerPlugin;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.repositories.RepositoriesService;
 import org.elasticsearch.rest.RestController;
@@ -45,7 +50,12 @@ import java.util.Collections;
 import java.util.List;
 import java.util.function.Supplier;
 
-public class EqlPlugin extends Plugin implements ActionPlugin {
+public class EqlPlugin extends Plugin implements ActionPlugin, CircuitBreakerPlugin {
+
+    private static final String CIRCUIT_BREAKER_NAME = "eql_sequence";
+    private static final long CIRCUIT_BREAKER_LIMIT = (long)((0.50) * JvmInfo.jvmInfo().getMem().getHeapMax().getBytes());
+    private static final double CIRCUIT_BREAKER_OVERHEAD = 1.0D;
+    private final SetOnce<CircuitBreaker> circuitBreaker = new SetOnce<>();
 
     public static final Setting<Boolean> EQL_ENABLED_SETTING = Setting.boolSetting(
         "xpack.eql.enabled",
@@ -62,13 +72,13 @@ public class EqlPlugin extends Plugin implements ActionPlugin {
             ResourceWatcherService resourceWatcherService, ScriptService scriptService, NamedXContentRegistry xContentRegistry,
             Environment environment, NodeEnvironment nodeEnvironment, NamedWriteableRegistry namedWriteableRegistry,
             IndexNameExpressionResolver expressionResolver, Supplier<RepositoriesService> repositoriesServiceSupplier) {
-        return createComponents(client, clusterService.getClusterName().value(), namedWriteableRegistry);
+        return createComponents(client, clusterService.getClusterName().value());
     }
 
-    private Collection<Object> createComponents(Client client, String clusterName, NamedWriteableRegistry namedWriteableRegistry) {
+    private Collection<Object> createComponents(Client client, String clusterName) {
         IndexResolver indexResolver = new IndexResolver(client, clusterName, DefaultDataTypeRegistry.INSTANCE);
-        PlanExecutor planExecutor = new PlanExecutor(client, indexResolver, namedWriteableRegistry);
-        return Arrays.asList(planExecutor);
+        PlanExecutor planExecutor = new PlanExecutor(client, indexResolver, circuitBreaker.get());
+        return Collections.singletonList(planExecutor);
     }
 
     @Override
@@ -119,5 +129,24 @@ public class EqlPlugin extends Plugin implements ActionPlugin {
     // overridable by tests
     protected XPackLicenseState getLicenseState() {
         return XPackPlugin.getSharedLicenseState();
+    }
+
+    @Override
+    public BreakerSettings getCircuitBreaker(Settings settings) {
+        return BreakerSettings.updateFromSettings(
+                new BreakerSettings(
+                        CIRCUIT_BREAKER_NAME,
+                        CIRCUIT_BREAKER_LIMIT,
+                        CIRCUIT_BREAKER_OVERHEAD,
+                        CircuitBreaker.Type.MEMORY,
+                        CircuitBreaker.Durability.TRANSIENT
+                ),
+                settings);
+    }
+
+    @Override
+    public void setCircuitBreaker(CircuitBreaker circuitBreaker) {
+        assert circuitBreaker.getName().equals(CIRCUIT_BREAKER_NAME);
+        this.circuitBreaker.set(circuitBreaker);
     }
 }

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/session/EqlSession.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/session/EqlSession.java
@@ -10,12 +10,12 @@ package org.elasticsearch.xpack.eql.session;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.client.ParentTaskAssigningClient;
+import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.tasks.TaskCancelledException;
 import org.elasticsearch.xpack.eql.analysis.Analyzer;
 import org.elasticsearch.xpack.eql.analysis.PostAnalyzer;
 import org.elasticsearch.xpack.eql.analysis.PreAnalyzer;
 import org.elasticsearch.xpack.eql.analysis.Verifier;
-import org.elasticsearch.xpack.eql.execution.PlanExecutor;
 import org.elasticsearch.xpack.eql.optimizer.Optimizer;
 import org.elasticsearch.xpack.eql.parser.EqlParser;
 import org.elasticsearch.xpack.eql.parser.ParserParams;
@@ -39,10 +39,11 @@ public class EqlSession {
     private final Analyzer analyzer;
     private final Optimizer optimizer;
     private final Planner planner;
+    private final CircuitBreaker circuitBreaker;
 
     public EqlSession(Client client, EqlConfiguration cfg, IndexResolver indexResolver, PreAnalyzer preAnalyzer, PostAnalyzer postAnalyzer,
                       FunctionRegistry functionRegistry, Verifier verifier, Optimizer optimizer, Planner planner,
-                      PlanExecutor planExecutor) {
+                      CircuitBreaker circuitBreaker) {
 
         this.client = new ParentTaskAssigningClient(client, cfg.getTaskId());
         this.configuration = cfg;
@@ -52,6 +53,7 @@ public class EqlSession {
         this.analyzer = new Analyzer(cfg, functionRegistry, verifier);
         this.optimizer = optimizer;
         this.planner = planner;
+        this.circuitBreaker = circuitBreaker;
     }
 
     public Client client() {
@@ -64,6 +66,10 @@ public class EqlSession {
 
     public EqlConfiguration configuration() {
         return configuration;
+    }
+
+    public CircuitBreaker circuitBreaker() {
+        return circuitBreaker;
     }
 
     public void eql(String eql, ParserParams params, ActionListener<Results> listener) {

--- a/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/execution/assembler/ImplicitTiebreakerTests.java
+++ b/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/execution/assembler/ImplicitTiebreakerTests.java
@@ -15,6 +15,7 @@ import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.search.SearchResponse.Clusters;
 import org.elasticsearch.action.search.SearchResponseSections;
 import org.elasticsearch.common.text.Text;
+import org.elasticsearch.common.breaker.NoopCircuitBreaker;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.SearchHit;
@@ -39,6 +40,8 @@ import static org.elasticsearch.action.ActionListener.wrap;
 import static org.elasticsearch.index.query.QueryBuilders.matchAllQuery;
 
 public class ImplicitTiebreakerTests extends ESTestCase {
+
+    private static final NoopCircuitBreaker NOOP_CIRCUIT_BREAKER = new NoopCircuitBreaker("ImplicitTiebreakerTests");
 
     private final List<HitExtractor> keyExtractors = emptyList();
     private final HitExtractor tsExtractor = TimestampExtractor.INSTANCE;
@@ -115,7 +118,7 @@ public class ImplicitTiebreakerTests extends ESTestCase {
             }
         }
 
-        SequenceMatcher matcher = new SequenceMatcher(stages, descending, TimeValue.MINUS_ONE, null);
+        SequenceMatcher matcher = new SequenceMatcher(stages, descending, TimeValue.MINUS_ONE, null, NOOP_CIRCUIT_BREAKER);
         TumblingWindow window = new TumblingWindow(client, criteria, null, matcher);
         window.execute(wrap(p -> {}, ex -> {
             throw ExceptionsHelper.convertToRuntime(ex);

--- a/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/execution/assembler/SequenceSpecTests.java
+++ b/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/execution/assembler/SequenceSpecTests.java
@@ -27,6 +27,7 @@ import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.search.SearchResponse.Clusters;
 import org.elasticsearch.action.search.SearchResponseSections;
+import org.elasticsearch.common.breaker.NoopCircuitBreaker;
 import org.elasticsearch.core.Tuple;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.core.TimeValue;
@@ -48,6 +49,8 @@ import org.elasticsearch.xpack.ql.execution.search.extractor.HitExtractor;
 import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
 
 public class SequenceSpecTests extends ESTestCase {
+
+    private static final NoopCircuitBreaker NOOP_CIRCUIT_BREAKER = new NoopCircuitBreaker("SequenceSpecTests");
 
     private static final String PARAM_FORMATTING = "%1$s";
     private static final String QUERIES_FILENAME = "sequences.series-spec";
@@ -240,7 +243,7 @@ public class SequenceSpecTests extends ESTestCase {
         }
 
         // convert the results through a test specific payload
-        SequenceMatcher matcher = new SequenceMatcher(stages, false, TimeValue.MINUS_ONE, null);
+        SequenceMatcher matcher = new SequenceMatcher(stages, false, TimeValue.MINUS_ONE, null, NOOP_CIRCUIT_BREAKER);
 
         QueryClient testClient = new TestQueryClient();
         TumblingWindow window = new TumblingWindow(testClient, criteria, null, matcher);

--- a/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/execution/sequence/CircuitBreakerTests.java
+++ b/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/execution/sequence/CircuitBreakerTests.java
@@ -1,0 +1,192 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.eql.execution.sequence;
+
+import org.apache.lucene.search.TotalHits;
+import org.apache.lucene.search.TotalHits.Relation;
+import org.elasticsearch.ExceptionsHelper;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.action.search.SearchResponse.Clusters;
+import org.elasticsearch.action.search.SearchResponseSections;
+import org.elasticsearch.common.breaker.CircuitBreakingException;
+import org.elasticsearch.common.breaker.NoopCircuitBreaker;
+import org.elasticsearch.common.breaker.TestCircuitBreaker;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.core.Tuple;
+import org.elasticsearch.search.DocValueFormat;
+import org.elasticsearch.search.SearchHit;
+import org.elasticsearch.search.SearchHits;
+import org.elasticsearch.search.SearchSortValues;
+import org.elasticsearch.search.builder.SearchSourceBuilder;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.eql.execution.assembler.BoxedQueryRequest;
+import org.elasticsearch.xpack.eql.execution.assembler.Criterion;
+import org.elasticsearch.xpack.eql.execution.search.HitReference;
+import org.elasticsearch.xpack.eql.execution.search.Ordinal;
+import org.elasticsearch.xpack.eql.execution.search.QueryClient;
+import org.elasticsearch.xpack.eql.execution.search.QueryRequest;
+import org.elasticsearch.xpack.eql.execution.search.extractor.ImplicitTiebreakerHitExtractor;
+import org.elasticsearch.xpack.ql.execution.search.extractor.HitExtractor;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import static java.util.Collections.emptyList;
+import static org.elasticsearch.action.ActionListener.wrap;
+import static org.elasticsearch.index.query.QueryBuilders.matchAllQuery;
+
+public class CircuitBreakerTests extends ESTestCase {
+
+    private static final TestCircuitBreaker CIRCUIT_BREAKER = new TestCircuitBreaker();
+
+    private final List<HitExtractor> keyExtractors = emptyList();
+    private final HitExtractor tsExtractor = TimestampExtractor.INSTANCE;
+    private final HitExtractor implicitTbExtractor = ImplicitTiebreakerHitExtractor.INSTANCE;
+    private final int stages = randomIntBetween(3, 10);
+
+    static class TestQueryClient implements QueryClient {
+
+        @Override
+        public void query(QueryRequest r, ActionListener<SearchResponse> l) {
+            int ordinal = r.searchSource().terminateAfter();
+            SearchHit searchHit = new SearchHit(ordinal, String.valueOf(ordinal), null, null);
+            searchHit.sortValues(new SearchSortValues(
+                    new Long[] { (long) ordinal, 1L },
+                    new DocValueFormat[] { DocValueFormat.RAW, DocValueFormat.RAW }));
+            SearchHits searchHits = new SearchHits(new SearchHit[] { searchHit }, new TotalHits(1, Relation.EQUAL_TO), 0.0f);
+            SearchResponseSections internal = new SearchResponseSections(searchHits, null, null, false, false, null, 0);
+            SearchResponse s = new SearchResponse(internal, null, 0, 1, 0, 0, null, Clusters.EMPTY);
+            l.onResponse(s);
+        }
+
+        @Override
+        public void fetchHits(Iterable<List<HitReference>> refs, ActionListener<List<List<SearchHit>>> listener) {
+            List<List<SearchHit>> searchHits = new ArrayList<>();
+            for (List<HitReference> ref : refs) {
+                List<SearchHit> hits = new ArrayList<>(ref.size());
+                for (HitReference hitRef : ref) {
+                    hits.add(new SearchHit(-1, hitRef.id(), null, null));
+                }
+                searchHits.add(hits);
+            }
+            listener.onResponse(searchHits);
+        }
+    }
+
+    public void testCircuitBreakerTumblingWindow() {
+        QueryClient client = new TestQueryClient();
+        List<Criterion<BoxedQueryRequest>> criteria = new ArrayList<>(stages);
+
+        for (int i = 0; i < stages; i++) {
+            final int j = i;
+            criteria.add(new Criterion<>(i,
+                    new BoxedQueryRequest(() -> SearchSourceBuilder.searchSource()
+                            .size(10)
+                            .query(matchAllQuery())
+                            .terminateAfter(j), "@timestamp", emptyList()),
+                    keyExtractors,
+                    tsExtractor,
+                    null,
+                    implicitTbExtractor,
+                    false));
+        }
+
+        SequenceMatcher matcher = new SequenceMatcher(stages, false, TimeValue.MINUS_ONE, null, CIRCUIT_BREAKER);
+        TumblingWindow window = new TumblingWindow(client, criteria, null, matcher);
+        window.execute(wrap(p -> {}, ex -> {
+            throw ExceptionsHelper.convertToRuntime(ex);
+        }));
+
+        CIRCUIT_BREAKER.startBreaking();
+        RuntimeException e = expectThrows(
+                RuntimeException.class,
+                () -> window.execute(wrap(p -> {}, ex -> { throw new RuntimeException(ex); }))
+        );
+        assertEquals(CircuitBreakingException.class, e.getCause().getClass());
+
+        CIRCUIT_BREAKER.stopBreaking();
+        window.execute(wrap(p -> {}, ex -> {
+            throw ExceptionsHelper.convertToRuntime(ex);
+        }));
+    }
+
+    public void testCircuitBreakerSequnceMatcher() {
+        List<Tuple<KeyAndOrdinal, HitReference>> hits = new ArrayList<>();
+        for (int i = 0; i < 10; i++) {
+            hits.add(new Tuple<>(new KeyAndOrdinal(new SequenceKey(i), new Ordinal(i, o -> 1, 0)), new HitReference("index", i + "")));
+        }
+
+        // Break on first iteration
+        SequenceMatcher matcher1 = new SequenceMatcher(stages, false, TimeValue.MINUS_ONE, null, new EqlTestCircuitBreaker(10000));
+        CircuitBreakingException e = expectThrows(CircuitBreakingException.class, () -> matcher1.match(0, hits));
+        assertEquals("sequence_inflight", e.getMessage());
+
+        // Break on second iteration
+        SequenceMatcher matcher2 = new SequenceMatcher(stages, false, TimeValue.MINUS_ONE, null, new EqlTestCircuitBreaker(15000));
+        matcher2.match(0, hits);
+        e = expectThrows(CircuitBreakingException.class, () -> matcher2.match(0, hits));
+        assertEquals("sequence_inflight", e.getMessage());
+
+        // Break on 3rd iteration with clear() called in between
+        SequenceMatcher matcher3 = new SequenceMatcher(stages, false, TimeValue.MINUS_ONE, null, new EqlTestCircuitBreaker(15000));
+        matcher3.match(0, hits);
+        matcher3.clear();
+        matcher3.match(0, hits);
+        e = expectThrows(CircuitBreakingException.class, () -> matcher3.match(0, hits));
+        assertEquals("sequence_inflight", e.getMessage());
+    }
+
+    private static class EqlTestCircuitBreaker extends NoopCircuitBreaker {
+
+        private final long limitInBytes;
+        private long ramBytesUsed = 0;
+
+        private EqlTestCircuitBreaker(long limitInBytes) {
+            super("eql_test");
+            this.limitInBytes = limitInBytes;
+        }
+
+        @Override
+        public void addEstimateBytesAndMaybeBreak(long bytes, String label) throws CircuitBreakingException {
+            ramBytesUsed += bytes;
+            if (ramBytesUsed > limitInBytes) {
+                throw new CircuitBreakingException(label, getDurability());
+            }
+        }
+
+        @Override
+        public void addWithoutBreaking(long bytes) {
+            ramBytesUsed += bytes;
+        }
+    }
+
+    private static class TimestampExtractor implements HitExtractor {
+
+        static final TimestampExtractor INSTANCE = new TimestampExtractor();
+
+        @Override
+        public String getWriteableName() {
+            return null;
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {}
+
+        @Override
+        public String hitName() {
+            return null;
+        }
+
+        @Override
+        public Long extract(SearchHit hit) {
+            return (long) hit.docId();
+        }
+    }
+}

--- a/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/execution/sequence/CircuitBreakerTests.java
+++ b/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/execution/sequence/CircuitBreakerTests.java
@@ -18,6 +18,7 @@ import org.elasticsearch.common.breaker.CircuitBreakingException;
 import org.elasticsearch.common.breaker.NoopCircuitBreaker;
 import org.elasticsearch.common.breaker.TestCircuitBreaker;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.text.Text;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.core.Tuple;
 import org.elasticsearch.search.DocValueFormat;
@@ -56,7 +57,7 @@ public class CircuitBreakerTests extends ESTestCase {
         @Override
         public void query(QueryRequest r, ActionListener<SearchResponse> l) {
             int ordinal = r.searchSource().terminateAfter();
-            SearchHit searchHit = new SearchHit(ordinal, String.valueOf(ordinal), null, null);
+            SearchHit searchHit = new SearchHit(ordinal, String.valueOf(ordinal), new Text("_doc"), null, null);
             searchHit.sortValues(new SearchSortValues(
                     new Long[] { (long) ordinal, 1L },
                     new DocValueFormat[] { DocValueFormat.RAW, DocValueFormat.RAW }));
@@ -72,7 +73,7 @@ public class CircuitBreakerTests extends ESTestCase {
             for (List<HitReference> ref : refs) {
                 List<SearchHit> hits = new ArrayList<>(ref.size());
                 for (HitReference hitRef : ref) {
-                    hits.add(new SearchHit(-1, hitRef.id(), null, null));
+                    hits.add(new SearchHit(-1, hitRef.id(), new Text("_doc"), null, null));
                 }
                 searchHits.add(hits);
             }


### PR DESCRIPTION
The sequence matching algorithm holds some structures to keep track of
the matched and potentially matching sequences of events. When large
amount of events, sequence stages needs to be processed but also when
the requested size of the query (number of sequences to return) is large,
those structure can potentially increase the memory footprint.

Add a CircuitBreaker which can be configured through cluster settings,
which accounts for the memory used during the execution of a sequence
query. The memory accounting takes place every fetch_size number
of processed events (docs), to avoid significant performance overhead.

(cherry picked from commit c6f0fb8899fd14c5689511b38868bfc081f0c6da)
