### PR TITLE
[7.13] [DOCS]: allow multiple searchable_snapshot actions in the same policy (#74679)

### DIFF
--- a/docs/reference/ilm/actions/ilm-searchable-snapshot.asciidoc
+++ b/docs/reference/ilm/actions/ilm-searchable-snapshot.asciidoc
@@ -14,8 +14,8 @@ index>>. If the original index is part of a
 the data stream.
 
 IMPORTANT: If the `searchable_snapshot` action is used in the hot phase the
-subsequent phases cannot define any of the `shrink`, `forcemerge`, `freeze` or
-`searchable_snapshot` (also available in the cold and frozen phases) actions.
+subsequent phases cannot include the `shrink`, `forcemerge`, or `freeze`
+actions.
 
 [NOTE]
 This action cannot be performed on a data stream's write index. Attempts to do


### PR DESCRIPTION
Since `7.12` we allow multiple searchable_snapshot actions in the same
policy. This updates the docs to reflect this.

(cherry picked from commit 5e9405a513322e86f07efed3277d514bb6c43e63)
Signed-off-by: Andrei Dan <andrei.dan@elastic.co>

Backport of #74679
