### PR TITLE
Fix task dependency wiring for multi node test clusters

### DIFF
--- a/build-tools/src/main/java/org/elasticsearch/gradle/testclusters/TestClustersAware.java
+++ b/build-tools/src/main/java/org/elasticsearch/gradle/testclusters/TestClustersAware.java
@@ -7,6 +7,7 @@
  */
 package org.elasticsearch.gradle.testclusters;
 
+import org.gradle.api.Action;
 import org.gradle.api.Task;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.tasks.Nested;
@@ -24,11 +25,10 @@ public interface TestClustersAware extends Task {
             throw new TestClustersException("Task " + getPath() + " can't use test cluster from" + " another project " + cluster);
         }
 
-        cluster.getNodes()
-            .stream()
-            .flatMap(node -> node.getDistributions().stream())
-            .forEach(distro -> dependsOn(getProject().provider(() -> distro.maybeFreeze())));
-        cluster.getNodes().forEach(node -> dependsOn((Callable<Collection<Configuration>>) node::getPluginAndModuleConfigurations));
+        cluster.getNodes().all(node -> node.getDistributions().stream()
+                .forEach(distro -> dependsOn(getProject().provider(() -> distro.maybeFreeze()))));
+        cluster.getNodes().all(node -> dependsOn((Callable<Collection<Configuration>>) node::getPluginAndModuleConfigurations));
+        cluster.getNodes().all(node -> dependsOn((Callable<Collection<Configuration>>) node::getPluginAndModuleConfigurations));
         getClusters().add(cluster);
     }
 

--- a/build-tools/src/main/java/org/elasticsearch/gradle/testclusters/TestClustersAware.java
+++ b/build-tools/src/main/java/org/elasticsearch/gradle/testclusters/TestClustersAware.java
@@ -28,7 +28,6 @@ public interface TestClustersAware extends Task {
         cluster.getNodes().all(node -> node.getDistributions().stream()
                 .forEach(distro -> dependsOn(getProject().provider(() -> distro.maybeFreeze()))));
         cluster.getNodes().all(node -> dependsOn((Callable<Collection<Configuration>>) node::getPluginAndModuleConfigurations));
-        cluster.getNodes().all(node -> dependsOn((Callable<Collection<Configuration>>) node::getPluginAndModuleConfigurations));
         getClusters().add(cluster);
     }
 


### PR DESCRIPTION
for multi node test cluster configurations we accidentally miss calculating the proper
task dependencies in TestClusterAware. This moves the task dependency declaration
in TestClusterAware to use the live collection method nodes#all instead of nodes.forEach
which will also take nodes into account that are added later to the cluster _after_
this configuration block is triggered.

This should fix the configuration issues we see when running test cluster tests in fips mode.