### PR TITLE
Simplify OutboundHandler (#72442)

### DIFF
--- a/server/src/main/java/org/elasticsearch/transport/OutboundHandler.java
+++ b/server/src/main/java/org/elasticsearch/transport/OutboundHandler.java
@@ -14,20 +14,17 @@ import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.apache.lucene.store.AlreadyClosedException;
 import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
-import org.elasticsearch.action.NotifyOnceListener;
 import org.elasticsearch.cluster.node.DiscoveryNode;
-import org.elasticsearch.common.CheckedSupplier;
 import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.io.stream.ReleasableBytesStreamOutput;
-import org.elasticsearch.core.Releasable;
-import org.elasticsearch.core.Releasables;
+import org.elasticsearch.core.Nullable;
 import org.elasticsearch.common.network.CloseableChannel;
 import org.elasticsearch.common.transport.NetworkExceptionHelper;
 import org.elasticsearch.common.transport.TransportAddress;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
-import org.elasticsearch.core.internal.io.IOUtils;
 import org.elasticsearch.threadpool.ThreadPool;
 
 import java.io.IOException;
@@ -63,13 +60,7 @@ final class OutboundHandler {
     }
 
     void sendBytes(TcpChannel channel, BytesReference bytes, ActionListener<Void> listener) {
-        SendContext sendContext = new SendContext(channel, () -> bytes, listener);
-        try {
-            internalSend(channel, sendContext);
-        } catch (IOException e) {
-            // This should not happen as the bytes are already serialized
-            throw new AssertionError(e);
-        }
+        internalSend(channel, bytes, null, listener);
     }
 
     /**
@@ -127,20 +118,59 @@ final class OutboundHandler {
     }
 
     private void sendMessage(TcpChannel channel, OutboundMessage networkMessage, ActionListener<Void> listener) throws IOException {
-        MessageSerializer serializer = new MessageSerializer(networkMessage, bigArrays);
-        SendContext sendContext = new SendContext(channel, serializer, listener, serializer);
-        internalSend(channel, sendContext);
+        final BytesStreamOutput bytesStreamOutput = new ReleasableBytesStreamOutput(bigArrays);
+        final ActionListener<Void> wrappedListener = ActionListener.runBefore(listener, bytesStreamOutput::close);
+        final BytesReference message;
+        try {
+            message = networkMessage.serialize(bytesStreamOutput);
+        } catch (Exception e) {
+            logger.warn(() -> new ParameterizedMessage("failed to serialize outbound message [{}]", networkMessage), e);
+            wrappedListener.onFailure(e);
+            throw e;
+        }
+        internalSend(channel, message, networkMessage, wrappedListener);
     }
 
-    private void internalSend(TcpChannel channel, SendContext sendContext) throws IOException {
-        channel.getChannelStats().markAccessed(threadPool.relativeTimeInMillis());
-        BytesReference reference = sendContext.get();
+    private void internalSend(TcpChannel channel, BytesReference reference, @Nullable OutboundMessage message,
+                              ActionListener<Void> listener) {
+        final long startTime = threadPool.relativeTimeInMillis();
+        channel.getChannelStats().markAccessed(startTime);
+        final long messageSize = reference.length();
+        TransportLogger.logOutboundMessage(channel, reference);
         // stash thread context so that channel event loop is not polluted by thread context
         try (ThreadContext.StoredContext existing = threadPool.getThreadContext().stashContext()) {
-            sendContext.startTime = threadPool.relativeTimeInMillis();
-            channel.sendMessage(reference, sendContext);
+            channel.sendMessage(reference, new ActionListener<Void>() {
+                @Override
+                public void onResponse(Void v) {
+                    statsTracker.markBytesWritten(messageSize);
+                    listener.onResponse(v);
+                    maybeLogSlowMessage(true);
+                }
+
+                @Override
+                public void onFailure(Exception e) {
+                    if (NetworkExceptionHelper.isCloseConnectionException(e)) {
+                        logger.debug(() -> new ParameterizedMessage("send message failed [channel: {}]", channel), e);
+                    } else {
+                        logger.warn(() -> new ParameterizedMessage("send message failed [channel: {}]", channel), e);
+                    }
+                    listener.onFailure(e);
+                    maybeLogSlowMessage(false);
+                }
+
+                private void maybeLogSlowMessage(boolean success) {
+                    final long logThreshold = slowLogThresholdMs;
+                    if (logThreshold > 0) {
+                        final long took = threadPool.relativeTimeInMillis() - startTime;
+                        if (took > logThreshold) {
+                            logger.warn("sending transport message [{}] of size [{}] on [{}] took [{}ms] which is above the warn " +
+                                    "threshold of [{}ms] with success [{}]", message, messageSize, channel, took, logThreshold, success);
+                        }
+                    }
+                }
+            });
         } catch (RuntimeException ex) {
-            sendContext.onFailure(ex);
+            listener.onFailure(ex);
             CloseableChannel.closeChannel(channel);
             throw ex;
         }
@@ -151,100 +181,6 @@ final class OutboundHandler {
             messageListener = listener;
         } else {
             throw new IllegalStateException("Cannot set message listener twice");
-        }
-    }
-
-    private static class MessageSerializer implements CheckedSupplier<BytesReference, IOException>, Releasable {
-
-        private final OutboundMessage message;
-        private final BigArrays bigArrays;
-        private volatile ReleasableBytesStreamOutput bytesStreamOutput;
-
-        private MessageSerializer(OutboundMessage message, BigArrays bigArrays) {
-            this.message = message;
-            this.bigArrays = bigArrays;
-        }
-
-        @Override
-        public BytesReference get() throws IOException {
-            bytesStreamOutput = new ReleasableBytesStreamOutput(bigArrays);
-            return message.serialize(bytesStreamOutput);
-        }
-
-        @Override
-        public void close() {
-            IOUtils.closeWhileHandlingException(bytesStreamOutput);
-        }
-
-        @Override
-        public String toString() {
-            return "MessageSerializer{" + message + "}";
-        }
-    }
-
-    private class SendContext extends NotifyOnceListener<Void> implements CheckedSupplier<BytesReference, IOException> {
-
-        private final TcpChannel channel;
-        private final CheckedSupplier<BytesReference, IOException> messageSupplier;
-        private final ActionListener<Void> listener;
-        private final Releasable optionalReleasable;
-        private long messageSize = -1;
-        private long startTime;
-
-        private SendContext(TcpChannel channel, CheckedSupplier<BytesReference, IOException> messageSupplier,
-                            ActionListener<Void> listener) {
-            this(channel, messageSupplier, listener, null);
-        }
-
-        private SendContext(TcpChannel channel, CheckedSupplier<BytesReference, IOException> messageSupplier,
-                            ActionListener<Void> listener, Releasable optionalReleasable) {
-            this.channel = channel;
-            this.messageSupplier = messageSupplier;
-            this.listener = listener;
-            this.optionalReleasable = optionalReleasable;
-        }
-
-        public BytesReference get() throws IOException {
-            BytesReference message;
-            try {
-                message = messageSupplier.get();
-                messageSize = message.length();
-                TransportLogger.logOutboundMessage(channel, message);
-                return message;
-            } catch (Exception e) {
-                onFailure(e);
-                throw e;
-            }
-        }
-
-        private void maybeLogSlowMessage() {
-            final long took = threadPool.relativeTimeInMillis() - startTime;
-            final long logThreshold = slowLogThresholdMs;
-            if (logThreshold > 0 && took > logThreshold) {
-                logger.warn("sending transport message [{}] of size [{}] on [{}] took [{}ms] which is above the warn threshold of [{}ms]",
-                        messageSupplier, messageSize, channel, took, logThreshold);
-            }
-        }
-
-        @Override
-        protected void innerOnResponse(Void v) {
-            assert messageSize != -1 : "If onResponse is being called, the message should have been serialized";
-            statsTracker.markBytesWritten(messageSize);
-            closeAndCallback(() -> listener.onResponse(v));
-        }
-
-        @Override
-        protected void innerOnFailure(Exception e) {
-            if (NetworkExceptionHelper.isCloseConnectionException(e)) {
-                logger.debug(() -> new ParameterizedMessage("send message failed [channel: {}]", channel), e);
-            } else {
-                logger.warn(() -> new ParameterizedMessage("send message failed [channel: {}]", channel), e);
-            }
-            closeAndCallback(() -> listener.onFailure(e));
-        }
-
-        private void closeAndCallback(Runnable runnable) {
-            Releasables.close(optionalReleasable, runnable::run, this::maybeLogSlowMessage);
         }
     }
 }


### PR DESCRIPTION
The whole serializer class adds nothing but complexity. Simplified it away
to make this code easier to read while saving some objects as well and making
the slow warning serialize slightly nicer.

backport of #72442 