### PR TITLE
[7.x] Fix ignore_missing takes no effect in Rename Ingest Processor (#74248)

### DIFF
--- a/modules/ingest-common/src/main/java/org/elasticsearch/ingest/common/RenameProcessor.java
+++ b/modules/ingest-common/src/main/java/org/elasticsearch/ingest/common/RenameProcessor.java
@@ -51,7 +51,7 @@ public final class RenameProcessor extends AbstractProcessor {
     @Override
     public IngestDocument execute(IngestDocument document) {
         String path = document.renderTemplate(field);
-        if (document.hasField(path, true) == false) {
+        if (path.isEmpty() || document.hasField(path, true) == false) {
             if (ignoreMissing) {
                 return document;
             } else {

--- a/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/RenameProcessorTests.java
+++ b/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/RenameProcessorTests.java
@@ -99,6 +99,11 @@ public class RenameProcessorTests extends ESTestCase {
             RandomDocumentPicks.randomFieldName(random()), true);
         processor.execute(ingestDocument);
         assertIngestDocument(originalIngestDocument, ingestDocument);
+
+        Processor processor1 = createRenameProcessor("",
+            RandomDocumentPicks.randomFieldName(random()), true);
+        processor1.execute(ingestDocument);
+        assertIngestDocument(originalIngestDocument, ingestDocument);
     }
 
     public void testRenameNewFieldAlreadyExists() throws Exception {

--- a/modules/ingest-common/src/yamlRestTest/resources/rest-api-spec/test/ingest/280_rename.yml
+++ b/modules/ingest-common/src/yamlRestTest/resources/rest-api-spec/test/ingest/280_rename.yml
@@ -1,0 +1,40 @@
+---
+teardown:
+  - do:
+      ingest.delete_pipeline:
+        id: "1"
+        ignore: 404
+
+---
+"Test Rename Processor with template snippets and ignore_missing":
+  - do:
+      ingest.put_pipeline:
+        id: "1"
+        body:  >
+          {
+            "processors": [
+              {
+                "rename" : {
+                  "field" : "{{foo}}",
+                  "target_field": "bar",
+                  "ignore_missing": true
+                }
+              }
+            ]
+          }
+  - match: { acknowledged: true }
+
+  - do:
+      index:
+        index: test
+        id: 1
+        pipeline: "1"
+        body: {
+          message: "test"
+        }
+
+  - do:
+      get:
+        index: test
+        id: 1
+  - match: { _source.message: "test" }


### PR DESCRIPTION
Relates to #74241.

The changes are:
1. Fix the bug, when rendered field of the `template snippets` does not exist and `ignore_missing` is `true`, rename processor should exit quietly.
2. Add some tests for the code change.

Backport of #74248
