### PR TITLE
Data Tier correlation for searchable_snapshot mount location

### DIFF
--- a/docs/reference/ilm/actions/ilm-searchable-snapshot.asciidoc
+++ b/docs/reference/ilm/actions/ilm-searchable-snapshot.asciidoc
@@ -5,6 +5,7 @@
 Phases allowed: hot, cold, frozen.
 
 Takes a snapshot of the managed index in the configured repository and mounts it
+<<<<<<< Updated upstream
 as a <<searchable-snapshots,{search-snap}>>.
 
 In the frozen phase, the action mounts a <<partially-mounted,partially mounted
@@ -12,6 +13,16 @@ index>> to the frozen data tier. In other phases, the action mounts a
 <<fully-mounted,fully mounted index>> to the corresponding data tier. If the 
 original index is part of a <<data-streams, data stream>>, the mounted index 
 replaces the original index in the data stream.
+=======
+as a <<searchable-snapshots,{search-snap}>>. If the original index is part of a
+<<data-streams, data stream>>, the mounted index replaces the original index in
+the data stream.
+>>>>>>> Stashed changes
+
+The `searchable_snapshot` action requires <<data-tiers,data tiers>>. In the
+frozen phase, the action mounts a <<partially-mounted,partially mounted index>>
+to the frozen tier. In other phases, the action mounts a <<fully-mounted,fully
+mounted index>> to the corresponding data tier.
 
 IMPORTANT: If the `searchable_snapshot` action is used in the hot phase the
 subsequent phases cannot include the `shrink`, `forcemerge`, or `freeze`

--- a/docs/reference/ilm/actions/ilm-searchable-snapshot.asciidoc
+++ b/docs/reference/ilm/actions/ilm-searchable-snapshot.asciidoc
@@ -9,10 +9,13 @@ as a <<searchable-snapshots,{search-snap}>>. If the index is part of a
 <<data-streams, data stream>>, the mounted index replaces the original index in
 the stream.
 
-The `searchable_snapshot` action requires <<data-tiers,data tiers>>. In the
-frozen phase, the action mounts a <<partially-mounted,partially mounted index>>
-to the frozen tier. In other phases, the action mounts a <<fully-mounted,fully
-mounted index>> to the corresponding data tier.
+The `searchable_snapshot` action requires <<data-tiers,data tiers>>. The actions
+uses the
+<<tier-preference-allocation-filter,`index.routing.allocation.include._tier_preference`>>
+setting to mount the index directly to the phase's data tier. In the frozen
+phase, the action mounts a <<partially-mounted,partially mounted index>> to the
+frozen tier. In other phases, the action mounts a <<fully-mounted,fully mounted
+index>> to the corresponding data tier.
 
 IMPORTANT: If the `searchable_snapshot` action is used in the hot phase the
 subsequent phases cannot include the `shrink`, `forcemerge`, or `freeze`

--- a/docs/reference/ilm/actions/ilm-searchable-snapshot.asciidoc
+++ b/docs/reference/ilm/actions/ilm-searchable-snapshot.asciidoc
@@ -5,19 +5,9 @@
 Phases allowed: hot, cold, frozen.
 
 Takes a snapshot of the managed index in the configured repository and mounts it
-<<<<<<< Updated upstream
-as a <<searchable-snapshots,{search-snap}>>.
-
-In the frozen phase, the action mounts a <<partially-mounted,partially mounted
-index>> to the frozen data tier. In other phases, the action mounts a 
-<<fully-mounted,fully mounted index>> to the corresponding data tier. If the 
-original index is part of a <<data-streams, data stream>>, the mounted index 
-replaces the original index in the data stream.
-=======
 as a <<searchable-snapshots,{search-snap}>>. If the original index is part of a
 <<data-streams, data stream>>, the mounted index replaces the original index in
 the data stream.
->>>>>>> Stashed changes
 
 The `searchable_snapshot` action requires <<data-tiers,data tiers>>. In the
 frozen phase, the action mounts a <<partially-mounted,partially mounted index>>

--- a/docs/reference/ilm/actions/ilm-searchable-snapshot.asciidoc
+++ b/docs/reference/ilm/actions/ilm-searchable-snapshot.asciidoc
@@ -8,10 +8,10 @@ Takes a snapshot of the managed index in the configured repository and mounts it
 as a <<searchable-snapshots,{search-snap}>>.
 
 In the frozen phase, the action mounts a <<partially-mounted,partially mounted
-index>>. In other phases, the action mounts a <<fully-mounted,fully mounted
-index>>. If the original index is part of a
-<<data-streams, data stream>>, the mounted index replaces the original index in
-the data stream.
+index>> to the frozen data tier. In other phases, the action mounts a 
+<<fully-mounted,fully mounted index>> to the corresponding data tier. If the 
+original index is part of a <<data-streams, data stream>>, the mounted index 
+replaces the original index in the data stream.
 
 IMPORTANT: If the `searchable_snapshot` action is used in the hot phase the
 subsequent phases cannot include the `shrink`, `forcemerge`, or `freeze`

--- a/docs/reference/ilm/actions/ilm-searchable-snapshot.asciidoc
+++ b/docs/reference/ilm/actions/ilm-searchable-snapshot.asciidoc
@@ -12,10 +12,10 @@ the stream.
 The `searchable_snapshot` action requires <<data-tiers,data tiers>>. The action
 uses the
 <<tier-preference-allocation-filter,`index.routing.allocation.include._tier_preference`>>
-setting to mount the index directly to the phase's data tier. In the frozen
-phase, the action mounts a <<partially-mounted,partially mounted index>> to the
-frozen tier. In other phases, the action mounts a <<fully-mounted,fully mounted
-index>> to the corresponding data tier.
+setting to mount the index directly to the phase's corresponding data tier. In
+the frozen phase, the action mounts a <<partially-mounted,partially mounted
+index>> to the frozen tier. In other phases, the action mounts a
+<<fully-mounted,fully mounted index>> to the corresponding data tier.
 
 IMPORTANT: If the `searchable_snapshot` action is used in the hot phase the
 subsequent phases cannot include the `shrink`, `forcemerge`, or `freeze`

--- a/docs/reference/ilm/actions/ilm-searchable-snapshot.asciidoc
+++ b/docs/reference/ilm/actions/ilm-searchable-snapshot.asciidoc
@@ -9,7 +9,7 @@ as a <<searchable-snapshots,{search-snap}>>. If the index is part of a
 <<data-streams, data stream>>, the mounted index replaces the original index in
 the stream.
 
-The `searchable_snapshot` action requires <<data-tiers,data tiers>>. The actions
+The `searchable_snapshot` action requires <<data-tiers,data tiers>>. The action
 uses the
 <<tier-preference-allocation-filter,`index.routing.allocation.include._tier_preference`>>
 setting to mount the index directly to the phase's data tier. In the frozen

--- a/docs/reference/ilm/actions/ilm-searchable-snapshot.asciidoc
+++ b/docs/reference/ilm/actions/ilm-searchable-snapshot.asciidoc
@@ -5,9 +5,9 @@
 Phases allowed: hot, cold, frozen.
 
 Takes a snapshot of the managed index in the configured repository and mounts it
-as a <<searchable-snapshots,{search-snap}>>. If the original index is part of a
+as a <<searchable-snapshots,{search-snap}>>. If the index is part of a
 <<data-streams, data stream>>, the mounted index replaces the original index in
-the data stream.
+the stream.
 
 The `searchable_snapshot` action requires <<data-tiers,data tiers>>. In the
 frozen phase, the action mounts a <<partially-mounted,partially mounted index>>


### PR DESCRIPTION
Per @andreidan wisdom:

> searchable snapshots are mounted directly on the corresponding data tiers (namely, fully mounted indices on the `hot`, `cold` or `frozen` tiers (depending on the ILM phase where the searchable_action is defined) while the partially mounted indices are mounted on the `frozen` tier).

This points out the prerequisite of the corresponding data tier for the searchable_snapshot phase.