### PR TITLE
[7.x] Expose Community ID processor in Painless (#73963)

### DIFF
--- a/modules/ingest-common/src/main/java/org/elasticsearch/ingest/common/Processors.java
+++ b/modules/ingest-common/src/main/java/org/elasticsearch/ingest/common/Processors.java
@@ -85,4 +85,73 @@ public final class Processors {
         return URLDecodeProcessor.apply(value);
     }
 
+    /**
+     * Uses {@link CommunityIdProcessor} to compute community ID for network flow data.
+     *
+     * @param sourceIpAddrString source IP address
+     * @param destIpAddrString destination IP address
+     * @param ianaNumber IANA number
+     * @param transport transport protocol
+     * @param sourcePort source port
+     * @param destinationPort destination port
+     * @param icmpType ICMP type
+     * @param icmpCode ICMP code
+     * @param seed hash seed (must be between 0 and 65535)
+     * @return Community ID
+     */
+    public static String communityId(
+        String sourceIpAddrString,
+        String destIpAddrString,
+        Object ianaNumber,
+        Object transport,
+        Object sourcePort,
+        Object destinationPort,
+        Object icmpType,
+        Object icmpCode,
+        int seed) {
+        return CommunityIdProcessor.apply(
+            sourceIpAddrString,
+            destIpAddrString,
+            ianaNumber,
+            transport,
+            sourcePort,
+            destinationPort,
+            icmpType,
+            icmpCode,
+            seed
+        );
+    }
+
+    /**
+     * Uses {@link CommunityIdProcessor} to compute community ID for network flow data.
+     *
+     * @param sourceIpAddrString source IP address
+     * @param destIpAddrString destination IP address
+     * @param ianaNumber IANA number
+     * @param transport transport protocol
+     * @param sourcePort source port
+     * @param destinationPort destination port
+     * @param icmpType ICMP type
+     * @param icmpCode ICMP code
+     * @return Community ID
+     */
+    public static String communityId(
+        String sourceIpAddrString,
+        String destIpAddrString,
+        Object ianaNumber,
+        Object transport,
+        Object sourcePort,
+        Object destinationPort,
+        Object icmpType,
+        Object icmpCode) {
+        return CommunityIdProcessor.apply(sourceIpAddrString,
+            destIpAddrString,
+            ianaNumber,
+            transport,
+            sourcePort,
+            destinationPort,
+            icmpType,
+            icmpCode);
+    }
+
 }

--- a/modules/ingest-common/src/main/resources/org/elasticsearch/ingest/common/processors_whitelist.txt
+++ b/modules/ingest-common/src/main/resources/org/elasticsearch/ingest/common/processors_whitelist.txt
@@ -15,4 +15,6 @@ class org.elasticsearch.ingest.common.Processors {
   Object json(Object)
   void json(Map, String)
   String urlDecode(String)
+  String communityId(String, String, Object, Object, Object, Object, Object, Object, int)
+  String communityId(String, String, Object, Object, Object, Object, Object, Object)
 }

--- a/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/CommunityIdProcessorTests.java
+++ b/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/CommunityIdProcessorTests.java
@@ -12,8 +12,6 @@ import org.elasticsearch.ingest.IngestDocument;
 import org.elasticsearch.test.ESTestCase;
 import org.junit.Before;
 
-import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -38,17 +36,9 @@ public class CommunityIdProcessorTests extends ESTestCase {
     // https://github.com/elastic/beats/blob/master/libbeat/processors/communityid/communityid_test.go
 
     private Map<String, Object> event;
-    private ThreadLocal<MessageDigest> messageDigest;
 
     @Before
     public void setup() throws Exception {
-        messageDigest = ThreadLocal.withInitial(() -> {
-            try {
-                return MessageDigest.getInstance("SHA-1");
-            } catch (NoSuchAlgorithmException e) {
-                throw new IllegalStateException("unable to obtain SHA-1 hasher", e);
-            }
-        });
         event = buildEvent();
     }
 
@@ -323,6 +313,19 @@ public class CommunityIdProcessorTests extends ESTestCase {
         testCommunityIdProcessor(event, 0, null, true);
     }
 
+    public void testIgnoreMissingIsFalse() throws Exception {
+        @SuppressWarnings("unchecked")
+        var source = (Map<String, Object>) event.get("source");
+        source.remove("ip");
+
+        IllegalArgumentException e = expectThrows(
+            IllegalArgumentException.class,
+            () -> testCommunityIdProcessor(event, 0, null, false)
+        );
+
+        assertThat(e.getMessage(), containsString("field [ip] not present as part of path [source.ip]"));
+    }
+
     private void testCommunityIdProcessor(Map<String, Object> source, String expectedHash) throws Exception {
         testCommunityIdProcessor(source, 0, expectedHash);
     }
@@ -346,7 +349,6 @@ public class CommunityIdProcessorTests extends ESTestCase {
             DEFAULT_ICMP_TYPE,
             DEFAULT_ICMP_CODE,
             DEFAULT_TARGET,
-            messageDigest,
             CommunityIdProcessor.toUint16(seed),
             ignoreMissing
         );

--- a/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/CommunityIdProcessorTests.java
+++ b/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/CommunityIdProcessorTests.java
@@ -315,7 +315,7 @@ public class CommunityIdProcessorTests extends ESTestCase {
 
     public void testIgnoreMissingIsFalse() throws Exception {
         @SuppressWarnings("unchecked")
-        var source = (Map<String, Object>) event.get("source");
+        Map<String, Object> source = (Map<String, Object>) event.get("source");
         source.remove("ip");
 
         IllegalArgumentException e = expectThrows(

--- a/modules/ingest-common/src/yamlRestTest/resources/rest-api-spec/test/ingest/190_script_processor.yml
+++ b/modules/ingest-common/src/yamlRestTest/resources/rest-api-spec/test/ingest/190_script_processor.yml
@@ -202,3 +202,43 @@ teardown:
         id: 1
   - match: { _source.source_field: "foo%20bar" }
   - match: { _source.target_field: "foo bar" }
+
+---
+"Test invoke community_id processor":
+  - do:
+      ingest.put_pipeline:
+        id: "my_pipeline"
+        body:  >
+          {
+            "description": "_description",
+            "processors": [
+              {
+                "script" : {
+                  "lang": "painless",
+                  "source" : "ctx.target_field1 = Processors.communityId('128.232.110.120', '66.35.250.204', null, 'TCP', 34855, 80, null, null, 123);"
+                }
+              },
+              {
+                "script" : {
+                  "lang": "painless",
+                  "source" : "ctx.target_field2 = Processors.communityId('128.232.110.120', '66.35.250.204', null, 'TCP', 34855, 80, null, null);"
+                }
+              }
+            ]
+          }
+  - match: { acknowledged: true }
+
+  - do:
+      index:
+        index: test
+        id: 1
+        pipeline: "my_pipeline"
+        body: {source_field: "foo"}
+
+  - do:
+      get:
+        index: test
+        id: 1
+  - match: { _source.source_field: "foo" }
+  - match: { _source.target_field1: "1:hTSGlFQnR58UCk+NfKRZzA32dPg=" }
+  - match: { _source.target_field2: "1:LQU9qZlK+B5F3KDmev6m5PMibrg=" }


### PR DESCRIPTION
Adds two `Processors.communityId()` methods to Painless that exposes the functionality of the community ID processor.

Relates to #73346

Backport of #73963
