### PR TITLE
[7.x] Expose URI parts processor in Painless (#73634)

### DIFF
--- a/modules/ingest-common/src/main/java/org/elasticsearch/ingest/common/Processors.java
+++ b/modules/ingest-common/src/main/java/org/elasticsearch/ingest/common/Processors.java
@@ -154,4 +154,14 @@ public final class Processors {
             icmpCode);
     }
 
+    /**
+     * Uses {@link UriPartsProcessor} to decompose an URI into its constituent parts.
+     *
+     * @param uri string to decode
+     * @return Map containing URI components
+     */
+    public static Map<String, Object> uriParts(String uri) {
+        return UriPartsProcessor.apply(uri);
+    }
+
 }

--- a/modules/ingest-common/src/main/resources/org/elasticsearch/ingest/common/processors_whitelist.txt
+++ b/modules/ingest-common/src/main/resources/org/elasticsearch/ingest/common/processors_whitelist.txt
@@ -17,4 +17,5 @@ class org.elasticsearch.ingest.common.Processors {
   String urlDecode(String)
   String communityId(String, String, Object, Object, Object, Object, Object, Object, int)
   String communityId(String, String, Object, Object, Object, Object, Object, Object)
+  Map uriParts(String)
 }

--- a/modules/ingest-common/src/yamlRestTest/resources/rest-api-spec/test/ingest/190_script_processor.yml
+++ b/modules/ingest-common/src/yamlRestTest/resources/rest-api-spec/test/ingest/190_script_processor.yml
@@ -242,3 +242,38 @@ teardown:
   - match: { _source.source_field: "foo" }
   - match: { _source.target_field1: "1:hTSGlFQnR58UCk+NfKRZzA32dPg=" }
   - match: { _source.target_field2: "1:LQU9qZlK+B5F3KDmev6m5PMibrg=" }
+
+---
+"Test invoke uri_parts processor":
+  - do:
+      ingest.put_pipeline:
+        id: "my_pipeline"
+        body:  >
+          {
+            "description": "_description",
+            "processors": [
+              {
+                "script" : {
+                  "lang": "painless",
+                  "source" : "ctx.target_field = Processors.uriParts(ctx.source_field)"
+                }
+              }
+            ]
+          }
+  - match: { acknowledged: true }
+
+  - do:
+      index:
+        index: test
+        id: 1
+        pipeline: "my_pipeline"
+        body: {source_field: "http://www.example.com/index.html"}
+
+  - do:
+      get:
+        index: test
+        id: 1
+  - match: { _source.source_field: "http://www.example.com/index.html" }
+  - match: { _source.target_field.scheme: "http" }
+  - match: { _source.target_field.domain: "www.example.com" }
+  - match: { _source.target_field.path: "/index.html" }


### PR DESCRIPTION
Adds a new `Processors.uriParts(String)` method to Painless that exposes the functionality of the URI parts processor.

Relates to https://github.com/elastic/elasticsearch/issues/73346

Backport of #73634 