### PR TITLE
Simplify Stacktrace in GCS Streaming Upload Logic

### DIFF
--- a/plugins/repository-gcs/src/main/java/org/elasticsearch/repositories/gcs/GoogleCloudStorageBlobStore.java
+++ b/plugins/repository-gcs/src/main/java/org/elasticsearch/repositories/gcs/GoogleCloudStorageBlobStore.java
@@ -277,7 +277,7 @@ class GoogleCloudStorageBlobStore implements BlobStore {
         for (int retry = 0; retry < 3; ++retry) {
             try {
                 final WriteChannel writeChannel = SocketAccess.doPrivilegedIOException(() -> client().writer(blobInfo, writeOptions));
-                try (OutputStream out = new FilterOutputStream(Channels.newOutputStream(new WritableBlobChannel(writeChannel))) {
+                writer.accept(new FilterOutputStream(Channels.newOutputStream(new WritableBlobChannel(writeChannel))) {
                     @Override
                     public void write(byte[] b, int off, int len) throws IOException {
                         int written = 0;
@@ -289,10 +289,8 @@ class GoogleCloudStorageBlobStore implements BlobStore {
                             written += toWrite;
                         }
                     }
-                }) {
-                    writer.accept(out);
-                    SocketAccess.doPrivilegedVoidIOException(writeChannel::close);
-                }
+                });
+                SocketAccess.doPrivilegedVoidIOException(writeChannel::close);
                 stats.trackPutOperation();
                 return;
             } catch (final StorageException se) {


### PR DESCRIPTION
Aside from simplifying the code (the close is unnecessary since it's a noop on `WritableBlobChannel` anyway ) this change fixes access control checks breaking on Java 8 in 7.x. (see seemingly inexplicable test failure https://gradle-enterprise.elastic.co/s/tu563yn6doobg/console-log/raw for an example)

* non-issue as this hasn't been released yet