### PR TITLE
Disable BWC tests for LZ4 compression backport

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -117,9 +117,9 @@ tasks.register("verifyVersions") {
  * after the backport of the backcompat code is complete.
  */
 
-boolean bwc_tests_enabled = true
+boolean bwc_tests_enabled = false
 // place a PR link here when committing bwc changes:
-String bwc_tests_disabled_issue = ""
+String bwc_tests_disabled_issue = "https://github.com/elastic/elasticsearch/pull/74719"
 /*
  * FIPS 140-2 behavior was fixed in 7.11.0. Before that there is no way to run elasticsearch in a
  * JVM that is properly configured to be in fips mode with BCFIPS. For now we need to disable
@@ -207,7 +207,7 @@ allprojects {
       }
     }
   }
-  
+
   tasks.register('resolveAllDependencies', ResolveAllDependencies) {
     configs = project.configurations
     if (project.path.contains("fixture")) {

--- a/server/src/main/java/org/elasticsearch/transport/Compression.java
+++ b/server/src/main/java/org/elasticsearch/transport/Compression.java
@@ -21,9 +21,8 @@ public class Compression {
     public enum Scheme {
         LZ4,
         DEFLATE;
-
-        // TODO: Change after backport
-        static final Version LZ4_VERSION = Version.V_8_0_0;
+        
+        static final Version LZ4_VERSION = Version.V_7_14_0;
         static final int HEADER_LENGTH = 4;
         private static final byte[] DEFLATE_HEADER = new byte[]{'D', 'F', 'L', '\0'};
         private static final byte[] LZ4_HEADER = new byte[]{'L', 'Z', '4', '\0'};


### PR DESCRIPTION
This commit updates the version constant and disables BWC tests for the
LZ4 compression backport.