### PR TITLE
Fix error getting all aliases when net-new system indices exist

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/admin/indices/alias/get/TransportGetAliasesAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/alias/get/TransportGetAliasesAction.java
@@ -94,8 +94,13 @@ public class TransportGetAliasesAction extends TransportMasterNodeReadAction<Get
             }
 
             if (aliases.get(index) == null && noAliasesSpecified) {
-                List<AliasMetadata> previous = mapBuilder.put(index, Collections.emptyList());
-                assert previous == null;
+                if (systemIndices.isNetNewSystemIndex(ia.getName()) == false) {
+                    List<AliasMetadata> previous = mapBuilder.put(index, Collections.emptyList());
+                    assert previous == null;
+                } else {
+                    // This is a net-new system index, it didn't resolve any aliases, no aliases were specified, just drop it.
+                    continue;
+                }
             }
         }
         final ImmutableOpenMap<String, List<AliasMetadata>> finalResponse = mapBuilder.build();

--- a/server/src/test/java/org/elasticsearch/action/admin/indices/alias/get/TransportGetAliasesActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/alias/get/TransportGetAliasesActionTests.java
@@ -15,9 +15,9 @@ import org.elasticsearch.cluster.metadata.DataStreamTestHelper;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.common.collect.ImmutableOpenMap;
-import org.elasticsearch.core.Tuple;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
+import org.elasticsearch.core.Tuple;
 import org.elasticsearch.indices.EmptySystemIndices;
 import org.elasticsearch.indices.SystemIndexDescriptor;
 import org.elasticsearch.indices.SystemIndices;
@@ -219,6 +219,43 @@ public class TransportGetAliasesActionTests extends ESTestCase {
         result = TransportGetAliasesAction.postProcess(resolver, getAliasesRequest, clusterState);
         assertThat(result.keySet(), containsInAnyOrder("logs-foo"));
         assertThat(result.get("logs-foo"), contains(new DataStreamAlias("logs", List.of("logs-bar", "logs-foo"), null)));
+    }
+
+    public void testNetNetSystemIndicesDontErrorWhenNotRequested() {
+        GetAliasesRequest aliasesRequest = new GetAliasesRequest();
+        // `.b` will be the "net new" system index this test case
+        ClusterState clusterState = systemIndexTestClusterState();
+        String[] concreteIndices = new String[] { ".b" };
+
+        SystemIndexDescriptor netNewDescriptor = SystemIndexDescriptor.builder()
+            .setIndexPattern(".b")
+            .setAliasName(".y")
+            .setPrimaryIndex(".b")
+            .setDescription(this.getTestName())
+            .setMappings("{\"_meta\":  {\"version\":  \"1.0.0\"}}")
+            .setSettings(Settings.EMPTY)
+            .setVersionMetaKey("version")
+            .setOrigin(this.getTestName())
+            .setNetNew()
+            .build();
+        SystemIndices systemIndices = new SystemIndices(Collections.singletonMap(
+            this.getTestName(),
+            new SystemIndices.Feature(this.getTestName(), "test feature",
+                Collections.singletonList(netNewDescriptor))));
+
+        ImmutableOpenMap<String, List<AliasMetadata>> initialAliases = ImmutableOpenMap.<String, List<AliasMetadata>>builder().build();
+        ImmutableOpenMap<String, List<AliasMetadata>> finalResponse = TransportGetAliasesAction.postProcess(
+            aliasesRequest,
+            concreteIndices,
+            initialAliases,
+            clusterState,
+            SystemIndexAccessLevel.RESTRICTED,
+            new ThreadContext(Settings.EMPTY),
+            systemIndices
+        );
+
+        // The real assertion is that the above `postProcess` call doesn't throw
+        assertFalse(finalResponse.containsKey(".b"));
     }
 
     public ClusterState systemIndexTestClusterState() {


### PR DESCRIPTION
This PR drops net-new system indices from the Get Aliases API response IF no aliases were requested AND the net-new system indices do not have any aliases.

This approach is a little hacky, but the only other options I can think of to address this are much more invasive (e.g. adding a whole new system index access level and plumbing it all through `IndexNameExpressionResolver` just for this one case).

Relates https://github.com/elastic/elasticsearch/issues/74687