### PR TITLE
Check memory usage before decoding async response

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/async/AsyncTaskIndexService.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/async/AsyncTaskIndexService.java
@@ -8,6 +8,7 @@ package org.elasticsearch.xpack.core.async;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.elasticsearch.ElasticsearchParseException;
 import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.ResourceAlreadyExistsException;
 import org.elasticsearch.ResourceNotFoundException;
@@ -25,19 +26,25 @@ import org.elasticsearch.client.OriginSettingClient;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.TriFunction;
-import org.elasticsearch.common.io.stream.OutputStreamStreamOutput;
-import org.elasticsearch.common.io.stream.ReleasableBytesStreamOutput;
-import org.elasticsearch.common.util.BigArrays;
-import org.elasticsearch.common.xcontent.XContentFactory;
-import org.elasticsearch.core.Tuple;
-import org.elasticsearch.common.io.stream.ByteBufferStreamInput;
+import org.elasticsearch.common.breaker.CircuitBreaker;
+import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.io.stream.InputStreamStreamInput;
 import org.elasticsearch.common.io.stream.NamedWriteableAwareStreamInput;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
+import org.elasticsearch.common.io.stream.OutputStreamStreamOutput;
+import org.elasticsearch.common.io.stream.ReleasableBytesStreamOutput;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
+import org.elasticsearch.common.xcontent.DeprecationHandler;
+import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentFactory;
+import org.elasticsearch.common.xcontent.XContentHelper;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.common.xcontent.XContentParserUtils;
 import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.search.fetch.subphase.FetchSourceContext;
 import org.elasticsearch.tasks.Task;
@@ -49,15 +56,18 @@ import org.elasticsearch.xpack.core.security.authc.Authentication;
 import org.elasticsearch.xpack.core.security.authc.support.AuthenticationContextSerializer;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.OutputStream;
-import java.nio.ByteBuffer;
+import java.nio.CharBuffer;
 import java.util.Base64;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.function.Function;
 
 import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
+import static org.elasticsearch.common.xcontent.XContentParserUtils.ensureExpectedToken;
 import static org.elasticsearch.index.mapper.MapperService.SINGLE_MAPPING_NAME;
 import static org.elasticsearch.xpack.core.security.authc.AuthenticationField.AUTHENTICATION_KEY;
 
@@ -119,6 +129,7 @@ public final class AsyncTaskIndexService<R extends AsyncResponse<R>> {
     private final NamedWriteableRegistry registry;
     private final Writeable.Reader<R> reader;
     private final BigArrays bigArrays;
+    private final CircuitBreaker circuitBreaker;
 
     public AsyncTaskIndexService(String index,
                                  ClusterService clusterService,
@@ -136,6 +147,7 @@ public final class AsyncTaskIndexService<R extends AsyncResponse<R>> {
         this.registry = registry;
         this.reader = reader;
         this.bigArrays = bigArrays;
+        this.circuitBreaker = bigArrays.breakerService().getBreaker(CircuitBreaker.REQUEST);
     }
 
     /**
@@ -325,44 +337,6 @@ public final class AsyncTaskIndexService<R extends AsyncResponse<R>> {
         return asyncTask;
     }
 
-    private void getEncodedResponse(AsyncExecutionId asyncExecutionId,
-                                    boolean restoreResponseHeaders,
-                                    ActionListener<Tuple<String, Long>> listener) {
-        GetRequest internalGet = new GetRequest(index)
-            .preference(asyncExecutionId.getEncoded())
-            .id(asyncExecutionId.getDocId());
-        clientWithOrigin.get(internalGet, ActionListener.wrap(
-            get -> {
-                if (get.isExists() == false) {
-                    listener.onFailure(new ResourceNotFoundException(asyncExecutionId.getEncoded()));
-                    return;
-                }
-
-                // check the authentication of the current user against the user that initiated the async task
-                @SuppressWarnings("unchecked")
-                Map<String, String> headers = (Map<String, String>) get.getSource().get(HEADERS_FIELD);
-                if (ensureAuthenticatedUserIsSame(headers, securityContext.getAuthentication()) == false) {
-                    listener.onFailure(new ResourceNotFoundException(asyncExecutionId.getEncoded()));
-                    return;
-                }
-
-                if (restoreResponseHeaders && get.getSource().containsKey(RESPONSE_HEADERS_FIELD)) {
-                    @SuppressWarnings("unchecked")
-                    Map<String, List<String>> responseHeaders = (Map<String, List<String>>) get.getSource().get(RESPONSE_HEADERS_FIELD);
-                    restoreResponseHeadersContext(securityContext.getThreadContext(), responseHeaders);
-                }
-
-                long expirationTime = (long) get.getSource().get(EXPIRATION_TIME_FIELD);
-                String encoded = (String) get.getSource().get(RESULT_FIELD);
-                if (encoded != null) {
-                    listener.onResponse(new Tuple<>(encoded, expirationTime));
-                } else {
-                    listener.onResponse(null);
-                }
-            },
-            listener::onFailure
-        ));
-    }
 
     /**
      * Gets the response from the index if present, or delegate a {@link ResourceNotFoundException}
@@ -373,78 +347,116 @@ public final class AsyncTaskIndexService<R extends AsyncResponse<R>> {
     public void getResponse(AsyncExecutionId asyncExecutionId,
                             boolean restoreResponseHeaders,
                             ActionListener<R> listener) {
-        getEncodedResponse(asyncExecutionId, restoreResponseHeaders, ActionListener.wrap(
-            (t) -> listener.onResponse(decodeResponse(t.v1()).withExpirationTime(t.v2())),
-            listener::onFailure
-        ));
+        getResponseFromIndex(asyncExecutionId, restoreResponseHeaders, true, listener);
+    }
+
+    private void getResponseFromIndex(AsyncExecutionId asyncExecutionId,
+                                      boolean restoreResponseHeaders,
+                                      boolean checkAuthentication,
+                                      ActionListener<R> outerListener) {
+        final GetRequest getRequest = new GetRequest(index)
+            .preference(asyncExecutionId.getEncoded())
+            .id(asyncExecutionId.getDocId())
+            .realtime(true);
+        clientWithOrigin.get(getRequest, outerListener.delegateFailure((listener, getResponse) -> {
+            if (getResponse.isExists() == false) {
+                listener.onFailure(new ResourceNotFoundException(asyncExecutionId.getEncoded()));
+                return;
+            }
+            final R resp;
+            try {
+                final BytesReference source = getResponse.getSourceInternal();
+                // reserve twice memory of the source length: one for the internal XContent parser and one for the response
+                final int reservedBytes = source.length() * 2;
+                circuitBreaker.addEstimateBytesAndMaybeBreak(source.length() * 2L, "decode async response");
+                listener = ActionListener.runAfter(listener, () -> circuitBreaker.addWithoutBreaking(-reservedBytes));
+                resp = parseResponseFromIndex(asyncExecutionId, source, restoreResponseHeaders, checkAuthentication);
+            } catch (Exception e) {
+                listener.onFailure(e);
+                return;
+            }
+            listener.onResponse(resp);
+        }));
+    }
+
+    private R parseResponseFromIndex(AsyncExecutionId asyncExecutionId, BytesReference source,
+                                     boolean restoreResponseHeaders, boolean checkAuthentication) {
+        try (XContentParser parser = XContentHelper.createParser(NamedXContentRegistry.EMPTY,
+            DeprecationHandler.THROW_UNSUPPORTED_OPERATION, source, XContentType.JSON)) {
+            ensureExpectedToken(parser.nextToken(), XContentParser.Token.START_OBJECT, parser);
+            R resp = null;
+            Long expirationTime = null;
+            while (parser.nextToken() != XContentParser.Token.END_OBJECT) {
+                ensureExpectedToken(XContentParser.Token.FIELD_NAME, parser.currentToken(), parser);
+                parser.nextToken();
+                switch (parser.currentName()) {
+                    case RESULT_FIELD:
+                        resp = decodeResponse(parser.charBuffer());
+                        break;
+                    case EXPIRATION_TIME_FIELD:
+                        expirationTime = (long) parser.numberValue();
+                        break;
+                    case HEADERS_FIELD:
+                        @SuppressWarnings("unchecked") final Map<String, String> headers =
+                            (Map<String, String>) XContentParserUtils.parseFieldsValue(parser);
+                        // check the authentication of the current user against the user that initiated the async task
+                        if (checkAuthentication &&
+                            ensureAuthenticatedUserIsSame(headers, securityContext.getAuthentication()) == false) {
+                            throw new ResourceNotFoundException(asyncExecutionId.getEncoded());
+                        }
+                        break;
+                    case RESPONSE_HEADERS_FIELD:
+                        @SuppressWarnings("unchecked") final Map<String, List<String>> responseHeaders =
+                            (Map<String, List<String>>) XContentParserUtils.parseFieldsValue(parser);
+                        if (restoreResponseHeaders) {
+                            restoreResponseHeadersContext(securityContext.getThreadContext(), responseHeaders);
+                        }
+                        break;
+                    default:
+                        XContentParserUtils.parseFieldsValue(parser); // consume and discard unknown fields
+                        break;
+                }
+            }
+            Objects.requireNonNull(resp, "Get result doesn't include [" + RESULT_FIELD + "] field");
+            Objects.requireNonNull(expirationTime, "Get result doesn't include [" + EXPIRATION_TIME_FIELD + "] field");
+            return resp.withExpirationTime(expirationTime);
+        } catch (IOException e) {
+            throw new ElasticsearchParseException("Failed to parse the get result", e);
+        }
     }
 
     /**
      * Retrieve the status of the async search or async or stored eql search.
      * Retrieve from the task if the task is still available or from the index.
      */
-     public <T extends AsyncTask, SR extends SearchStatusResponse> void retrieveStatus(
-            GetAsyncStatusRequest request,
-            TaskManager taskManager,
-            Class<T> tClass,
-            Function<T, SR> statusProducerFromTask,
-            TriFunction<R, Long, String, SR> statusProducerFromIndex,
-            ActionListener<SR> listener) {
+    public <T extends AsyncTask, SR extends SearchStatusResponse> void retrieveStatus(
+        GetAsyncStatusRequest request,
+        TaskManager taskManager,
+        Class<T> tClass,
+        Function<T, SR> statusProducerFromTask,
+        TriFunction<R, Long, String, SR> statusProducerFromIndex,
+        ActionListener<SR> outerListener) {
+        // check if the result has expired
+        outerListener = outerListener.delegateFailure((listener, resp) -> {
+            if (resp.getExpirationTime() < System.currentTimeMillis()) {
+                listener.onFailure(new ResourceNotFoundException(request.getId()));
+            } else {
+                listener.onResponse(resp);
+            }
+        });
         AsyncExecutionId asyncExecutionId = AsyncExecutionId.decode(request.getId());
         try {
             T asyncTask = getTask(taskManager, asyncExecutionId, tClass);
             if (asyncTask != null) { // get status response from task
                 SR response = statusProducerFromTask.apply(asyncTask);
-                sendFinalStatusResponse(request, response, listener);
-            } else { // get status response from index
-                getStatusResponseFromIndex(asyncExecutionId, statusProducerFromIndex, listener.delegateFailure(
-                        (l, searchStatusResponse) -> sendFinalStatusResponse(request, searchStatusResponse, l)));
+                outerListener.onResponse(response);
+            } else {
+                // get status response from index
+                getResponseFromIndex(asyncExecutionId, false, false, outerListener.delegateFailure((listener, resp) ->
+                    listener.onResponse(statusProducerFromIndex.apply(resp, resp.getExpirationTime(), asyncExecutionId.getEncoded()))));
             }
         } catch (Exception exc) {
-            listener.onFailure(exc);
-        }
-    }
-
-    /**
-     * Gets the status response of the stored search from the index
-     * @param asyncExecutionId – id of the stored search (async search or stored eql search)
-     * @param statusProducer – a producer of a status from the stored search, expirationTime and async search id
-     * @param listener – listener to report result to
-     */
-    private <SR extends SearchStatusResponse> void getStatusResponseFromIndex(
-        AsyncExecutionId asyncExecutionId,
-        TriFunction<R, Long, String, SR> statusProducer,
-        ActionListener<SR> listener) {
-        String asyncId = asyncExecutionId.getEncoded();
-        GetRequest internalGet = new GetRequest(index)
-            .preference(asyncId)
-            .id(asyncExecutionId.getDocId());
-        clientWithOrigin.get(internalGet, ActionListener.wrap(
-            get -> {
-                if (get.isExists() == false) {
-                    listener.onFailure(new ResourceNotFoundException(asyncExecutionId.getEncoded()));
-                    return;
-                }
-                String encoded = (String) get.getSource().get(RESULT_FIELD);
-                if (encoded != null) {
-                    Long expirationTime = (Long) get.getSource().get(EXPIRATION_TIME_FIELD);
-                    listener.onResponse(statusProducer.apply(decodeResponse(encoded), expirationTime, asyncId));
-                } else {
-                    listener.onResponse(null);
-                }
-            },
-            listener::onFailure
-        ));
-    }
-
-    private static <SR extends SearchStatusResponse> void sendFinalStatusResponse(
-        GetAsyncStatusRequest request,
-        SR response,
-        ActionListener<SR> listener) {
-        if (response.getExpirationTime() < System.currentTimeMillis()) { // check if the result has expired
-            listener.onFailure(new ResourceNotFoundException(request.getId()));
-        } else {
-            listener.onResponse(response);
+            outerListener.onFailure(exc);
         }
     }
 
@@ -505,15 +517,22 @@ public final class AsyncTaskIndexService<R extends AsyncResponse<R>> {
     /**
      * Decode the provided base-64 bytes into a {@link AsyncSearchResponse}.
      */
-    R decodeResponse(String value) throws IOException {
-        // TODO: Integrate with the circuit breaker
-        try (ByteBufferStreamInput buf = new ByteBufferStreamInput(ByteBuffer.wrap(Base64.getDecoder().decode(value)))) {
-            try (StreamInput in = new NamedWriteableAwareStreamInput(buf, registry)) {
-                final Version version = Version.readVersion(in);
-                assert version.onOrBefore(Version.CURRENT) : version + " >= " + Version.CURRENT;
-                in.setVersion(version);
-                return reader.read(in);
+    private R decodeResponse(CharBuffer encodedBuffer) throws IOException {
+        final InputStream encodedIn = Base64.getDecoder().wrap(new InputStream() {
+            @Override
+            public int read() {
+                if (encodedBuffer.hasRemaining()) {
+                    return encodedBuffer.get();
+                } else {
+                    return -1; // end of stream
+                }
             }
+        });
+        try (StreamInput in = new NamedWriteableAwareStreamInput(new InputStreamStreamInput(encodedIn), registry)) {
+            final Version version = Version.readVersion(in);
+            assert version.onOrBefore(Version.CURRENT) : version + " >= " + Version.CURRENT;
+            in.setVersion(version);
+            return reader.read(in);
         }
     }
 


### PR DESCRIPTION
Backport of #74594 to 7.14

This change makes sure the system has enough memory before decoding an
async search response as a large response can lead to OOM.
