### PR TITLE
Remove Outdated GetSnapshots BwC Handling in Rest Tests

### DIFF
--- a/qa/full-cluster-restart/src/test/java/org/elasticsearch/upgrades/FullClusterRestartIT.java
+++ b/qa/full-cluster-restart/src/test/java/org/elasticsearch/upgrades/FullClusterRestartIT.java
@@ -1052,13 +1052,7 @@ public class FullClusterRestartIT extends AbstractFullClusterRestartTestCase {
     private void checkSnapshot(final String snapshotName, final int count, final Version tookOnVersion) throws IOException {
         // Check the snapshot metadata, especially the version
         Request listSnapshotRequest = new Request("GET", "/_snapshot/repo/" + snapshotName);
-        Map<String, Object> responseMap = entityAsMap(client().performRequest(listSnapshotRequest));
-        Map<String, Object> snapResponse;
-        if (responseMap.get("responses") != null) {
-            snapResponse = (Map<String, Object>) ((List<Object>) responseMap.get("responses")).get(0);
-        } else {
-            snapResponse = responseMap;
-        }
+        Map<String, Object> snapResponse = entityAsMap(client().performRequest(listSnapshotRequest));
 
         assertEquals(singletonList(snapshotName), XContentMapValues.extractValue("snapshots.snapshot", snapResponse));
         assertEquals(singletonList("SUCCESS"), XContentMapValues.extractValue("snapshots.state", snapResponse));

--- a/qa/repository-multi-version/src/test/java/org/elasticsearch/upgrades/MultiVersionRepositoryAccessIT.java
+++ b/qa/repository-multi-version/src/test/java/org/elasticsearch/upgrades/MultiVersionRepositoryAccessIT.java
@@ -261,13 +261,7 @@ public class MultiVersionRepositoryAccessIT extends ESRestTestCase {
             new Request("GET", "/_snapshot/" + repoName + "/_all")).getEntity().getContent();
              XContentParser parser = JsonXContent.jsonXContent.createParser(
                  xContentRegistry(), DeprecationHandler.THROW_UNSUPPORTED_OPERATION, entity)) {
-            final Map<String, Object> raw = parser.map();
-            // Bwc lookup since the format of the snapshots response changed between versions
-            if (raw.containsKey("snapshots")) {
-                return (List<Map<String, Object>>) raw.get("snapshots");
-            } else {
-                return (List<Map<String, Object>>) ((List<Map<?, ?>>) raw.get("responses")).get(0).get("snapshots");
-            }
+            return (List<Map<String, Object>>) parser.map().get("snapshots");
         }
     }
 

--- a/test/framework/src/main/java/org/elasticsearch/test/rest/ESRestTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/ESRestTestCase.java
@@ -840,15 +840,7 @@ public abstract class ESRestTestCase extends ESTestCase {
                 Request listRequest = new Request("GET", "/_snapshot/" + repoName + "/_all");
                 listRequest.addParameter("ignore_unavailable", "true");
 
-                Map<?, ?> response = entityAsMap(adminClient.performRequest(listRequest));
-                Map<?, ?> oneRepoResponse;
-                if (response.containsKey("responses")) {
-                    oneRepoResponse = ((Map<?,?>)((List<?>) response.get("responses")).get(0));
-                } else {
-                    oneRepoResponse = response;
-                }
-
-                List<?> snapshots = (List<?>) oneRepoResponse.get("snapshots");
+                List<?> snapshots = (List<?>) entityAsMap(adminClient.performRequest(listRequest)).get("snapshots");
                 for (Object snapshot : snapshots) {
                     Map<?, ?> snapshotInfo = (Map<?, ?>) snapshot;
                     String name = (String) snapshotInfo.get("snapshot");


### PR DESCRIPTION
The group-by-repository response format is gone as a result of #74451
=> cleaning up its last remnants from REST tests.
