### PR TITLE
[DOCS] Comments out links to outlier detection

### DIFF
--- a/docs/reference/ml/df-analytics/apis/get-dfanalytics-stats.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/get-dfanalytics-stats.asciidoc
@@ -527,8 +527,8 @@ values: `failed`, `started`, `starting`,`stopping`, `stopped`.
 [[ml-get-dfanalytics-stats-example]]
 == {api-examples-title}
 
-The following API retrieves usage information for the
-{ml-docs}/ecommerce-outliers.html[{oldetection} {dfanalytics-job} example]:
+// The following API retrieves usage information for the
+// {ml-docs}//ml-dfa-finding-outliers.html#ecommerce-outliers[{oldetection} {dfanalytics-job} example]:
 
 [source,console]
 --------------------------------------------------

--- a/docs/reference/ml/df-analytics/apis/put-dfanalytics.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/put-dfanalytics.asciidoc
@@ -299,8 +299,8 @@ include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=training-percent]
 //Begin outlier_detection
 `outlier_detection`:::
 (Required^*^, object)
-The configuration information necessary to perform
-{ml-docs}/dfa-outlier-detection.html[{oldetection}]:
+The configuration information necessary to perform {oldetection}:
+// {ml-docs}/ml-dfa-finding-outliers.html#dfa-outlier-detection[{oldetection}]:
 +
 .Properties of `outlier_detection`
 [%collapsible%open]


### PR DESCRIPTION
## Overview

Related to https://github.com/elastic/stack-docs/pull/1732 and https://github.com/elastic/stack-docs/issues/1725

This PR comments out two links that point to outlier detection-related docs. Due to the ML book reorg, these links would break the docs build after merging https://github.com/elastic/stack-docs/pull/1732. The PR also changes the URLs to point to the new pages. After the changes in [1732](https://github.com/elastic/stack-docs/pull/1732) are applied, it's enough to delete the `//` to make the links work.