### PR TITLE
[DOCS] Adds outlier detection links to DFA API docs

### DIFF
--- a/docs/reference/ml/df-analytics/apis/get-dfanalytics-stats.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/get-dfanalytics-stats.asciidoc
@@ -527,8 +527,8 @@ values: `failed`, `started`, `starting`,`stopping`, `stopped`.
 [[ml-get-dfanalytics-stats-example]]
 == {api-examples-title}
 
-// The following API retrieves usage information for the
-// {ml-docs}//ml-dfa-finding-outliers.html#ecommerce-outliers[{oldetection} {dfanalytics-job} example]:
+The following API retrieves usage information for the
+{ml-docs}//ml-dfa-finding-outliers.html#ecommerce-outliers[{oldetection} {dfanalytics-job} example]:
 
 [source,console]
 --------------------------------------------------

--- a/docs/reference/ml/df-analytics/apis/get-dfanalytics-stats.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/get-dfanalytics-stats.asciidoc
@@ -528,7 +528,7 @@ values: `failed`, `started`, `starting`,`stopping`, `stopped`.
 == {api-examples-title}
 
 The following API retrieves usage information for the
-{ml-docs}//ml-dfa-finding-outliers.html#ecommerce-outliers[{oldetection} {dfanalytics-job} example]:
+{ml-docs}/ml-dfa-finding-outliers.html#ecommerce-outliers[{oldetection} {dfanalytics-job} example]:
 
 [source,console]
 --------------------------------------------------

--- a/docs/reference/ml/df-analytics/apis/put-dfanalytics.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/put-dfanalytics.asciidoc
@@ -299,8 +299,8 @@ include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=training-percent]
 //Begin outlier_detection
 `outlier_detection`:::
 (Required^*^, object)
-The configuration information necessary to perform {oldetection}:
-// {ml-docs}/ml-dfa-finding-outliers.html#dfa-outlier-detection[{oldetection}]:
+The configuration information necessary to perform
+{ml-docs}/ml-dfa-finding-outliers.html#dfa-outlier-detection[{oldetection}]:
 +
 .Properties of `outlier_detection`
 [%collapsible%open]


### PR DESCRIPTION
## Overview

Puts back the outlier detection-related docs links to the DFA API pages that were commented out in https://github.com/elastic/elasticsearch/pull/74745.

## Note

**Do not merge this PR before https://github.com/elastic/stack-docs/pull/1732**