### PR TITLE
[DOCS] Fix allowed `refresh` args for several doc APIs

### DIFF
--- a/docs/reference/docs/delete-by-query.asciidoc
+++ b/docs/reference/docs/delete-by-query.asciidoc
@@ -209,7 +209,9 @@ include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=search-q]
 
 include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=request_cache]
 
-include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=refresh]
+`refresh`::
+(Optional, Boolean) If `true`, the request refreshes all shards involved in the
+query. Defaults to `false`.
 
 include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=requests_per_second]
 

--- a/docs/reference/docs/delete-by-query.asciidoc
+++ b/docs/reference/docs/delete-by-query.asciidoc
@@ -211,7 +211,7 @@ include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=request_cache]
 
 `refresh`::
 (Optional, Boolean) If `true`, {es} refreshes all shards involved in the
-query after the request completes. Defaults to `false`.
+delete by query after the request completes. Defaults to `false`.
 
 include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=requests_per_second]
 

--- a/docs/reference/docs/delete-by-query.asciidoc
+++ b/docs/reference/docs/delete-by-query.asciidoc
@@ -210,8 +210,8 @@ include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=search-q]
 include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=request_cache]
 
 `refresh`::
-(Optional, Boolean) If `true`, the request refreshes all shards involved in the
-query. Defaults to `false`.
+(Optional, Boolean) If `true`, {es} refreshes all shards involved in the
+query after the request completes. Defaults to `false`.
 
 include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=requests_per_second]
 

--- a/docs/reference/docs/get.asciidoc
+++ b/docs/reference/docs/get.asciidoc
@@ -167,9 +167,8 @@ include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=preference]
 include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=realtime]
 
 `refresh`::
-(Optional, Boolean)
-If `true`, {es} refreshes the affected shards to make this operation visible to
-search. If `false`, do nothing with refreshes. Defaults to `false`.
+(Optional, Boolean) If `true`, the request refreshes the relevant shard before
+retrieving the document. Defaults to `false`.
 
 include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=routing]
 

--- a/docs/reference/docs/multi-get.asciidoc
+++ b/docs/reference/docs/multi-get.asciidoc
@@ -68,7 +68,9 @@ include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=preference]
 
 include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=realtime]
 
-include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=refresh]
+`refresh`::
+(Optional, Boolean) If `true`, the request refreshes relevant shards before
+retrieving documents. Defaults to `false`.
 
 include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=routing]
 

--- a/docs/reference/docs/reindex.asciidoc
+++ b/docs/reference/docs/reindex.asciidoc
@@ -466,7 +466,9 @@ POST _reindex
 [[docs-reindex-api-query-params]]
 ==== {api-query-parms-title}
 
-include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=refresh]
+`refresh`::
+(Optional, Boolean) If `true`, the request refreshes affected shards to make
+this operation visible to search. Defaults to `false`.
 
 `timeout`::
 +


### PR DESCRIPTION
We incorrectly list `wait_for` as a valid `refresh` argument for the
following APIs:

* Delete by query
* Multi get
* Reindex

This fixes that error. It also updates the get API docs for consistency.

Closes #65031