### PR TITLE
Update docs that composite agg no longer uses global ords

### DIFF
--- a/docs/reference/mapping/params/eager-global-ordinals.asciidoc
+++ b/docs/reference/mapping/params/eager-global-ordinals.asciidoc
@@ -27,8 +27,8 @@ ordinal for each segment.
 Global ordinals are used if a search contains any of the following components:
 
 * Certain bucket aggregations on `keyword`, `ip`, and `flattened` fields. This
-includes `terms` aggregations as mentioned above, as well as `composite`,
-`diversified_sampler`, and `significant_terms`.
+includes `terms` aggregations as mentioned above, as well as
+`diversified_sampler` and `significant_terms`.
 * Bucket aggregations on `text` fields that require <<fielddata, `fielddata`>>
 to be enabled.
 * Operations on parent and child documents from a `join` field, including


### PR DESCRIPTION
Follow-up to https://github.com/elastic/elasticsearch/pull/74559