### PR TITLE
[7.x] Skip Google Cloud Storage tests on JDK

### DIFF
--- a/plugins/repository-gcs/src/internalClusterTest/java/org/elasticsearch/repositories/gcs/GoogleCloudStorageThirdPartyTests.java
+++ b/plugins/repository-gcs/src/internalClusterTest/java/org/elasticsearch/repositories/gcs/GoogleCloudStorageThirdPartyTests.java
@@ -13,7 +13,6 @@ import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.settings.MockSecureSettings;
 import org.elasticsearch.common.settings.SecureSettings;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.jdk.JavaVersion;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.repositories.AbstractThirdPartyRepositoryTestCase;
 import org.junit.BeforeClass;

--- a/plugins/repository-gcs/src/internalClusterTest/java/org/elasticsearch/repositories/gcs/GoogleCloudStorageThirdPartyTests.java
+++ b/plugins/repository-gcs/src/internalClusterTest/java/org/elasticsearch/repositories/gcs/GoogleCloudStorageThirdPartyTests.java
@@ -13,8 +13,10 @@ import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.settings.MockSecureSettings;
 import org.elasticsearch.common.settings.SecureSettings;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.jdk.JavaVersion;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.repositories.AbstractThirdPartyRepositoryTestCase;
+import org.junit.BeforeClass;
 
 import java.util.Base64;
 import java.util.Collection;
@@ -24,6 +26,11 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.not;
 
 public class GoogleCloudStorageThirdPartyTests extends AbstractThirdPartyRepositoryTestCase {
+
+    @BeforeClass
+    public static void skipJava8() {
+        GoogleCloudStorageBlobStoreRepositoryTests.assumeNotJava8();
+    }
 
     @Override
     protected Collection<Class<? extends Plugin>> getPlugins() {

--- a/x-pack/plugin/repositories-metering-api/qa/gcs/src/test/java/org/elasticsearch/xpack/repositories/metering/gcs/GCSRepositoriesMeteringIT.java
+++ b/x-pack/plugin/repositories-metering-api/qa/gcs/src/test/java/org/elasticsearch/xpack/repositories/metering/gcs/GCSRepositoriesMeteringIT.java
@@ -7,12 +7,22 @@
 package org.elasticsearch.xpack.repositories.metering.gcs;
 
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.jdk.JavaVersion;
 import org.elasticsearch.xpack.repositories.metering.AbstractRepositoriesMeteringAPIRestTestCase;
+import org.junit.BeforeClass;
 
 import java.util.List;
 import java.util.Map;
 
 public class GCSRepositoriesMeteringIT extends AbstractRepositoriesMeteringAPIRestTestCase {
+
+    @BeforeClass
+    public static void skipJava8() {
+        assumeFalse("This test is flaky on jdk8 - we suspect a JDK bug to trigger some assertion in the HttpServer implementation used " +
+            "to emulate the server side logic of Google Cloud Storage. See https://bugs.openjdk.java.net/browse/JDK-8180754, " +
+            "https://github.com/elastic/elasticsearch/pull/51933 and https://github.com/elastic/elasticsearch/issues/52906 " +
+            "for more background on this issue.", JavaVersion.current().equals(JavaVersion.parse("8")));
+    }
 
     @Override
     protected String repositoryType() {

--- a/x-pack/plugin/searchable-snapshots/qa/gcs/src/test/java/org/elasticsearch/xpack/searchablesnapshots/GCSSearchableSnapshotsIT.java
+++ b/x-pack/plugin/searchable-snapshots/qa/gcs/src/test/java/org/elasticsearch/xpack/searchablesnapshots/GCSSearchableSnapshotsIT.java
@@ -8,11 +8,21 @@
 package org.elasticsearch.xpack.searchablesnapshots;
 
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.jdk.JavaVersion;
+import org.junit.BeforeClass;
 
 import static org.hamcrest.Matchers.blankOrNullString;
 import static org.hamcrest.Matchers.not;
 
 public class GCSSearchableSnapshotsIT extends AbstractSearchableSnapshotsRestTestCase {
+
+    @BeforeClass
+    public static void skipJava8() {
+        assumeFalse("This test is flaky on jdk8 - we suspect a JDK bug to trigger some assertion in the HttpServer implementation used " +
+            "to emulate the server side logic of Google Cloud Storage. See https://bugs.openjdk.java.net/browse/JDK-8180754, " +
+            "https://github.com/elastic/elasticsearch/pull/51933 and https://github.com/elastic/elasticsearch/issues/52906 " +
+            "for more background on this issue.", JavaVersion.current().equals(JavaVersion.parse("8")));
+    }
 
     @Override
     protected String writeRepositoryType() {


### PR DESCRIPTION
See #53119 for more context about why those tests are muted on JDK8.

They start failing more often recently now #74313 and #74620 have been merged, as reported in #74739.