### PR TITLE
Fix unit test classpath when testing shadow jar projects

### DIFF
--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/ElasticsearchTestBasePlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/ElasticsearchTestBasePlugin.java
@@ -22,6 +22,7 @@ import org.gradle.api.Project;
 import org.gradle.api.Task;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.file.FileCollection;
+import org.gradle.api.plugins.JavaPlugin;
 import org.gradle.api.tasks.SourceSet;
 import org.gradle.api.tasks.SourceSetContainer;
 import org.gradle.api.tasks.testing.Test;
@@ -187,17 +188,17 @@ public class ElasticsearchTestBasePlugin implements Plugin<Project> {
              *  compiled class output and dependency jars. This better emulates the runtime environment of consumers.
              */
             project.getPluginManager().withPlugin("com.github.johnrengelman.shadow", p -> {
-                // Remove output class files and any other dependencies from the test classpath, since the shadow JAR includes these
-                FileCollection mainRuntime = project.getExtensions()
-                    .getByType(SourceSetContainer.class)
-                    .getByName(SourceSet.MAIN_SOURCE_SET_NAME)
-                    .getRuntimeClasspath();
-                // Add any "shadow" dependencies. These are dependencies that are *not* bundled into the shadow JAR
-                Configuration shadowConfig = project.getConfigurations().getByName(ShadowBasePlugin.getCONFIGURATION_NAME());
-                // Add the shadow JAR artifact itself
-                FileCollection shadowJar = project.files(project.getTasks().named("shadowJar"));
-
-                test.setClasspath(test.getClasspath().minus(mainRuntime).plus(shadowConfig).plus(shadowJar));
+                if (test.getName().equals(JavaPlugin.TEST_TASK_NAME)) {
+                    // Remove output class files and any other dependencies from the test classpath, since the shadow JAR includes these
+                    SourceSetContainer sourceSets = project.getExtensions().getByType(SourceSetContainer.class);
+                    FileCollection mainRuntime = sourceSets.getByName(SourceSet.MAIN_SOURCE_SET_NAME).getRuntimeClasspath();
+                    // Add any "shadow" dependencies. These are dependencies that are *not* bundled into the shadow JAR
+                    Configuration shadowConfig = project.getConfigurations().getByName(ShadowBasePlugin.getCONFIGURATION_NAME());
+                    // Add the shadow JAR artifact itself
+                    FileCollection shadowJar = project.files(project.getTasks().named("shadowJar"));
+                    FileCollection testRuntime = sourceSets.getByName(SourceSet.TEST_SOURCE_SET_NAME).getRuntimeClasspath();
+                    test.setClasspath(testRuntime.minus(mainRuntime).plus(shadowConfig).plus(shadowJar));
+                }
             });
         });
     }


### PR DESCRIPTION
The pull request sorts out a configuration ordering issue when modifying unit test task classpaths to test against a shadow jar instead of the normal classes directory. Instead of trying to mutate the existing task's classpath, we use the test sourceset runtime classpath isntead. We also limit this to only apply to unit test (i.e. the `test` task).