### PR TITLE
Set max allowed size for stored async response

### DIFF
--- a/docs/reference/search/async-search.asciidoc
+++ b/docs/reference/search/async-search.asciidoc
@@ -3,13 +3,13 @@
 [[async-search]]
 === Async search
 
-The async search API let you asynchronously execute a search request, monitor 
+The async search API let you asynchronously execute a search request, monitor
 its progress, and retrieve partial results as they become available.
 
 [[submit-async-search]]
 ==== Submit async search API
 
-Executes a search request asynchronously. It accepts the same parameters and 
+Executes a search request asynchronously. It accepts the same parameters and
 request body as the <<search-search,search API>>.
 
 [source,console,id=submit-async-search-date-histogram-example]
@@ -32,9 +32,9 @@ POST /sales*/_async_search?size=0
 // TEST[setup:sales]
 // TEST[s/size=0/size=0&wait_for_completion_timeout=10s&keep_on_completion=true/]
 
-The response contains an identifier of the search being executed. You can use 
-this ID to later retrieve the search's final results. The currently available 
-search results are returned as part of the 
+The response contains an identifier of the search being executed. You can use
+this ID to later retrieve the search's final results. The currently available
+search results are returned as part of the
 <<search-api-response-body,`response`>> object.
 
 [source,console-result]
@@ -103,16 +103,16 @@ The `keep_on_completion` parameter, which defaults to `false`, can be set to
 `true` to request that results are stored for later retrieval also when the
 search completes within the `wait_for_completion_timeout`.
 
-You can also specify how long the async search needs to be available through the 
-`keep_alive` parameter, which defaults to `5d` (five days). Ongoing async 
+You can also specify how long the async search needs to be available through the
+`keep_alive` parameter, which defaults to `5d` (five days). Ongoing async
 searches and any saved search results are deleted after this period.
 
-NOTE: When the primary sort of the results is an indexed field, shards get 
-sorted based on minimum and maximum value that they hold for that field, hence 
+NOTE: When the primary sort of the results is an indexed field, shards get
+sorted based on minimum and maximum value that they hold for that field, hence
 partial results become available following the sort criteria that was requested.
 
-The submit async search API supports the same 
-<<search-search-api-query-params,parameters>> as the search API, though some 
+The submit async search API supports the same
+<<search-search-api-query-params,parameters>> as the search API, though some
 have different default values:
 
 * `batched_reduce_size` defaults to `5`: this affects how often partial results
@@ -129,14 +129,21 @@ supported value
 
 WARNING: Async search does not support <<scroll-search-results,scroll>>
 nor search requests that only include the <<search-suggesters,suggest section>>.
-{ccs-cap} is supported only with 
+{ccs-cap} is supported only with
 <<ccs-min-roundtrips,`ccs_minimize_roundtrips`>> set to `false`.
+
+NOTE: In 7.x {es}, by default,  doesn't limit the size of a stored async
+search response. Storing huge async responses can destabilize a cluster.
+If you want to set the limit for the maximum allowed size,
+change `search.max_async_search_response_size` cluster level setting.
+After that, an attempt to store an async response larger than this setting
+will result in an error.
 
 [[get-async-search]]
 ==== Get async search
 
-The get async search API retrieves the results of a previously submitted async 
-search request given its id. If the {es} {security-features} are enabled, the 
+The get async search API retrieves the results of a previously submitted async
+search request given its id. If the {es} {security-features} are enabled, the
 access to the results of a specific async search is restricted to
 <<can-access-resources-check,the user or API key that submitted it>>.
 
@@ -209,24 +216,24 @@ completed the execution of the query.
 The `wait_for_completion_timeout` parameter can also be provided when calling
 the Get Async Search API, in order to wait for the search to be completed up
 until the provided timeout. Final results will be returned if available before
-the timeout expires, otherwise the currently available results will be returned 
-once the timeout expires. By default no timeout is set meaning that the 
+the timeout expires, otherwise the currently available results will be returned
+once the timeout expires. By default no timeout is set meaning that the
 currently available results will be returned without any additional wait.
 
 The `keep_alive` parameter specifies how long the async search should be
 available in the cluster. When not specified, the `keep_alive` set with the
 corresponding submit async request will be used. Otherwise, it is possible to
 override such value and extend the validity of the request. When this period
-expires, the search, if still running, is cancelled. If the search is completed, 
+expires, the search, if still running, is cancelled. If the search is completed,
 its saved results are deleted.
 
 
 [[get-async-search-status]]
 ==== Get async search status
 
-The get async search status API, without retrieving search results, shows only 
-the status of a previously submitted async search request given its `id`. If the 
-{es} {security-features} are enabled, the access to the get async search status 
+The get async search status API, without retrieving search results, shows only
+the status of a previously submitted async search request given its `id`. If the
+{es} {security-features} are enabled, the access to the get async search status
 API is restricted to the <<built-in-roles, monitoring_user role>>.
 
 [source,console,id=get-async-search-status-example]
@@ -255,8 +262,8 @@ GET /_async_search/status/FmRldE8zREVEUzA2ZVpUeGs2ejJFUFEaMkZ5QTVrSTZSaVN3WlNFVm
 
 <1> Indicates how many shards have executed the query so far.
 
-For an async search that has been completed, the status response has an 
-additional `completion_status` field that shows the status code of the completed 
+For an async search that has been completed, the status response has an
+additional `completion_status` field that shows the status code of the completed
 async search.
 
 [source,console-result]
@@ -306,8 +313,8 @@ async search.
 [[delete-async-search]]
 ==== Delete async search
 
-You can use the delete async search API to manually delete an async search by 
-ID. If the search is still running, the search request will be cancelled. 
+You can use the delete async search API to manually delete an async search by
+ID. If the search is still running, the search request will be cancelled.
 Otherwise, the saved search results are deleted.
 
 [source,console,id=delete-async-search-date-histogram-example]

--- a/server/src/main/java/org/elasticsearch/common/io/stream/BytesStreamOutput.java
+++ b/server/src/main/java/org/elasticsearch/common/io/stream/BytesStreamOutput.java
@@ -170,7 +170,7 @@ public class BytesStreamOutput extends BytesStream {
         return bytes.ramBytesUsed();
     }
 
-    void ensureCapacity(long offset) {
+    protected void ensureCapacity(long offset) {
         if (offset > Integer.MAX_VALUE) {
             throw new IllegalArgumentException(getClass().getSimpleName() + " cannot hold more than 2GB of data");
         }

--- a/server/src/main/java/org/elasticsearch/common/settings/ClusterSettings.java
+++ b/server/src/main/java/org/elasticsearch/common/settings/ClusterSettings.java
@@ -472,6 +472,7 @@ public final class ClusterSettings extends AbstractScopedSettings {
             SearchService.LOW_LEVEL_CANCELLATION_SETTING,
             SearchService.MAX_OPEN_SCROLL_CONTEXT,
             SearchService.ENABLE_REWRITE_AGGS_TO_FILTER_BY_FILTER,
+            SearchService.MAX_ASYNC_SEARCH_RESPONSE_SIZE_SETTING,
             Node.WRITE_PORTS_FILE_SETTING,
             Node.NODE_NAME_SETTING,
             Node.NODE_ATTRIBUTES,

--- a/server/src/main/java/org/elasticsearch/search/SearchService.java
+++ b/server/src/main/java/org/elasticsearch/search/SearchService.java
@@ -32,6 +32,7 @@ import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.common.component.AbstractLifecycleComponent;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.core.Releasable;
 import org.elasticsearch.core.Releasables;
 import org.elasticsearch.common.lucene.Lucene;
@@ -168,6 +169,13 @@ public class SearchService extends AbstractLifecycleComponent implements IndexEv
     public static final Setting<Boolean> ENABLE_REWRITE_AGGS_TO_FILTER_BY_FILTER = Setting.boolSetting(
         "search.aggs.rewrite_to_filter_by_filter",
         true,
+        Property.Dynamic,
+        Property.NodeScope
+    );
+
+    public static final Setting<ByteSizeValue> MAX_ASYNC_SEARCH_RESPONSE_SIZE_SETTING = Setting.byteSizeSetting(
+        "search.max_async_search_response_size",
+        new ByteSizeValue(-1),
         Property.Dynamic,
         Property.NodeScope
     );

--- a/x-pack/plugin/async-search/src/internalClusterTest/java/org/elasticsearch/xpack/search/AsyncSearchActionIT.java
+++ b/x-pack/plugin/async-search/src/internalClusterTest/java/org/elasticsearch/xpack/search/AsyncSearchActionIT.java
@@ -9,9 +9,11 @@ package org.elasticsearch.xpack.search;
 
 import org.apache.lucene.store.AlreadyClosedException;
 import org.elasticsearch.ExceptionsHelper;
+import org.elasticsearch.action.admin.cluster.settings.ClusterUpdateSettingsRequest;
 import org.elasticsearch.action.index.IndexRequestBuilder;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.index.query.MatchAllQueryBuilder;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.search.aggregations.AggregationBuilders;
 import org.elasticsearch.search.aggregations.bucket.terms.InternalTerms;
@@ -21,8 +23,10 @@ import org.elasticsearch.search.aggregations.metrics.InternalMin;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
 import org.elasticsearch.test.ESIntegTestCase.SuiteScopeTestCase;
 import org.elasticsearch.xpack.core.XPackPlugin;
+import org.elasticsearch.xpack.core.async.GetAsyncResultRequest;
 import org.elasticsearch.xpack.core.search.action.AsyncSearchResponse;
 import org.elasticsearch.xpack.core.search.action.AsyncStatusResponse;
+import org.elasticsearch.xpack.core.search.action.GetAsyncSearchAction;
 import org.elasticsearch.xpack.core.search.action.SubmitAsyncSearchRequest;
 
 import java.util.ArrayList;
@@ -34,6 +38,8 @@ import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import static org.elasticsearch.search.SearchService.MAX_ASYNC_SEARCH_RESPONSE_SIZE_SETTING;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
@@ -60,7 +66,7 @@ public class AsyncSearchActionIT extends AsyncSearchIntegTestCase {
         createIndex(indexName, Settings.builder()
             .put("index.number_of_shards", numShards)
             .build());
-        numKeywords = randomIntBetween(1, 100);
+        numKeywords = randomIntBetween(50, 100);
         keywordFreqs = new HashMap<>();
         Set<String> keywordSet = new HashSet<>();
         for (int i = 0; i < numKeywords; i++) {
@@ -455,5 +461,45 @@ public class AsyncSearchActionIT extends AsyncSearchIntegTestCase {
         assertThat(response.status(), equalTo(RestStatus.SERVICE_UNAVAILABLE));
         assertNotNull(response.getFailure());
         ensureTaskNotRunning(response.getId());
+    }
+
+    public void testFinalResponseLargerMaxSize() throws Exception {
+        SearchSourceBuilder source = new SearchSourceBuilder()
+            .query(new MatchAllQueryBuilder())
+            .aggregation(AggregationBuilders.terms("terms").field("terms.keyword").size(numKeywords));
+
+        int limit = 1000; // should be enough to store initial response, but not enough for final response
+        ClusterUpdateSettingsRequest updateSettingsRequest = new ClusterUpdateSettingsRequest();
+        updateSettingsRequest.transientSettings(Settings.builder().put("search.max_async_search_response_size", limit + "b"));
+        assertAcked(client().admin().cluster().updateSettings(updateSettingsRequest).actionGet());
+
+        final SubmitAsyncSearchRequest request = new SubmitAsyncSearchRequest(source, indexName);
+        request.setWaitForCompletionTimeout(TimeValue.timeValueMillis(0));
+
+        // initial response – ok
+        final AsyncSearchResponse initialResponse = submitAsyncSearch(request);
+        assertTrue(initialResponse.isRunning());
+        assertNull(initialResponse.getFailure());
+
+        // final response – with failure; test that stored async search response is updated with this failure
+        assertBusy(() -> {
+            final AsyncSearchResponse finalResponse = client().execute(GetAsyncSearchAction.INSTANCE,
+                new GetAsyncResultRequest(initialResponse.getId())
+                    .setWaitForCompletionTimeout(TimeValue.timeValueMillis(300))).get();
+            assertNotNull(finalResponse.getFailure());
+            assertFalse(finalResponse.isRunning());
+            if (finalResponse.getFailure() != null) {
+                assertEquals("Can't store an async search response larger than [" + limit + "] bytes. " +
+                        "This limit can be set by changing the [" + MAX_ASYNC_SEARCH_RESPONSE_SIZE_SETTING.getKey() + "] setting.",
+                    finalResponse.getFailure().getMessage());
+            }
+        });
+
+        updateSettingsRequest = new ClusterUpdateSettingsRequest();
+        updateSettingsRequest.transientSettings(Settings.builder().put("search.max_async_search_response_size", (String) null));
+        assertAcked(client().admin().cluster().updateSettings(updateSettingsRequest).actionGet());
+
+        deleteAsyncSearch(initialResponse.getId());
+        ensureTaskRemoval(initialResponse.getId());
     }
 }

--- a/x-pack/plugin/async-search/src/main/java/org/elasticsearch/xpack/search/TransportSubmitAsyncSearchAction.java
+++ b/x-pack/plugin/async-search/src/main/java/org/elasticsearch/xpack/search/TransportSubmitAsyncSearchAction.java
@@ -6,15 +6,10 @@
  */
 package org.elasticsearch.xpack.search;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.message.ParameterizedMessage;
-import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.index.IndexResponse;
 import org.elasticsearch.action.search.SearchAction;
 import org.elasticsearch.action.search.SearchRequest;
-import org.elasticsearch.action.search.SearchTask;
 import org.elasticsearch.action.search.TransportSearchAction;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.HandledTransportAction;
@@ -27,8 +22,6 @@ import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
-import org.elasticsearch.index.engine.DocumentMissingException;
-import org.elasticsearch.index.engine.VersionConflictEngineException;
 import org.elasticsearch.search.SearchService;
 import org.elasticsearch.search.aggregations.InternalAggregation;
 import org.elasticsearch.tasks.Task;
@@ -49,8 +42,6 @@ import java.util.function.Supplier;
 import static org.elasticsearch.xpack.core.ClientHelper.ASYNC_SEARCH_ORIGIN;
 
 public class TransportSubmitAsyncSearchAction extends HandledTransportAction<SubmitAsyncSearchRequest, AsyncSearchResponse> {
-    private static final Logger logger = LogManager.getLogger(TransportSubmitAsyncSearchAction.class);
-
     private final NodeClient nodeClient;
     private final Function<SearchRequest, InternalAggregation.ReduceContext> requestToAggReduceContextBuilder;
     private final TransportSearchAction searchAction;
@@ -177,21 +168,14 @@ public class TransportSubmitAsyncSearchAction extends HandledTransportAction<Sub
     private void onFinalResponse(AsyncSearchTask searchTask,
                                  AsyncSearchResponse response,
                                  Runnable nextAction) {
-        store.updateResponse(searchTask.getExecutionId().getDocId(), threadContext.getResponseHeaders(),response,
-            ActionListener.wrap(resp -> unregisterTaskAndMoveOn(searchTask, nextAction),
-                exc -> {
-                    Throwable cause = ExceptionsHelper.unwrapCause(exc);
-                    if (cause instanceof DocumentMissingException == false &&
-                            cause instanceof VersionConflictEngineException == false) {
-                        logger.error(() -> new ParameterizedMessage("failed to store async-search [{}]",
-                            searchTask.getExecutionId().getEncoded()), exc);
-                    }
-                    unregisterTaskAndMoveOn(searchTask, nextAction);
-                }));
+        store.updateResponse(searchTask.getExecutionId().getDocId(),
+            threadContext.getResponseHeaders(),
+            response,
+            ActionListener.wrap(() ->  {
+                taskManager.unregister(searchTask);
+                nextAction.run();
+            })
+        );
     }
 
-    private void unregisterTaskAndMoveOn(SearchTask searchTask, Runnable nextAction) {
-        taskManager.unregister(searchTask);
-        nextAction.run();
-    }
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/async/AsyncResponse.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/async/AsyncResponse.java
@@ -20,4 +20,11 @@ public interface AsyncResponse<T extends AsyncResponse<?>> extends Writeable {
      */
     T withExpirationTime(long expirationTimeMillis);
 
+    /**
+     * Convert this AsyncResponse to a new AsyncResponse with a given failure
+     * @return a new AsyncResponse that stores a failure with a provided exception
+     */
+    default T convertToFailure(Exception exc) {
+        return null;
+    }
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/search/action/AsyncSearchResponse.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/search/action/AsyncSearchResponse.java
@@ -206,4 +206,18 @@ public class AsyncSearchResponse extends ActionResponse implements StatusToXCont
         builder.endObject();
         return builder;
     }
+
+    @Override
+    public AsyncSearchResponse convertToFailure(Exception exc) {
+        exc.setStackTrace(new StackTraceElement[0]); // we don't need to store stack traces
+        return new AsyncSearchResponse(
+            id,
+            null,
+            exc,
+            isPartial,
+            false,
+            startTimeMillis,
+            expirationTimeMillis
+        );
+    }
 }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/async/AsyncSearchIndexServiceTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/async/AsyncSearchIndexServiceTests.java
@@ -7,6 +7,7 @@
 package org.elasticsearch.xpack.core.async;
 
 import org.elasticsearch.action.DocWriteResponse;
+import org.elasticsearch.action.admin.cluster.settings.ClusterUpdateSettingsRequest;
 import org.elasticsearch.action.index.IndexResponse;
 import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.action.update.UpdateResponse;
@@ -16,6 +17,7 @@ import org.elasticsearch.common.breaker.CircuitBreakingException;
 import org.elasticsearch.common.breaker.NoopCircuitBreaker;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.indices.breaker.AllCircuitBreakerStats;
 import org.elasticsearch.indices.breaker.CircuitBreakerService;
@@ -29,6 +31,8 @@ import java.io.IOException;
 import java.util.Collections;
 import java.util.Objects;
 
+import static org.elasticsearch.search.SearchService.MAX_ASYNC_SEARCH_RESPONSE_SIZE_SETTING;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.elasticsearch.xpack.core.ClientHelper.ASYNC_SEARCH_ORIGIN;
 import static org.hamcrest.Matchers.equalTo;
 
@@ -39,15 +43,23 @@ public class AsyncSearchIndexServiceTests extends ESSingleNodeTestCase {
     public static class TestAsyncResponse implements AsyncResponse<TestAsyncResponse> {
         public final String test;
         public final long expirationTimeMillis;
+        public String failure;
 
         public TestAsyncResponse(String test, long expirationTimeMillis) {
             this.test = test;
             this.expirationTimeMillis = expirationTimeMillis;
         }
 
+        public TestAsyncResponse(String test, long expirationTimeMillis, String failure) {
+            this.test = test;
+            this.expirationTimeMillis = expirationTimeMillis;
+            this.failure = failure;
+        }
+
         public TestAsyncResponse(StreamInput input) throws IOException {
             test = input.readOptionalString();
             this.expirationTimeMillis = input.readLong();
+            failure = input.readOptionalString();
         }
 
         @Override
@@ -57,13 +69,14 @@ public class AsyncSearchIndexServiceTests extends ESSingleNodeTestCase {
 
         @Override
         public TestAsyncResponse withExpirationTime(long expirationTime) {
-            return new TestAsyncResponse(test, expirationTime);
+            return new TestAsyncResponse(test, expirationTime, failure);
         }
 
         @Override
         public void writeTo(StreamOutput out) throws IOException {
             out.writeOptionalString(test);
             out.writeLong(expirationTimeMillis);
+            out.writeOptionalString(failure);
         }
 
         @Override
@@ -72,20 +85,26 @@ public class AsyncSearchIndexServiceTests extends ESSingleNodeTestCase {
             if (o == null || getClass() != o.getClass()) return false;
             TestAsyncResponse that = (TestAsyncResponse) o;
             return expirationTimeMillis == that.expirationTimeMillis &&
-                Objects.equals(test, that.test);
+                Objects.equals(test, that.test) && Objects.equals(failure, that.failure);
         }
 
         @Override
         public int hashCode() {
-            return Objects.hash(test, expirationTimeMillis);
+            return Objects.hash(test, expirationTimeMillis, failure);
         }
 
         @Override
         public String toString() {
             return "TestAsyncResponse{" +
                 "test='" + test + '\'' +
+                "failure='" + failure + '\'' +
                 ", expirationTimeMillis=" + expirationTimeMillis +
                 '}';
+        }
+
+        @Override
+        public TestAsyncResponse convertToFailure(Exception exc) {
+            return new TestAsyncResponse(test, expirationTimeMillis, exc.getMessage());
         }
     }
 
@@ -221,7 +240,8 @@ public class AsyncSearchIndexServiceTests extends ESSingleNodeTestCase {
             TestAsyncResponse initialResponse = new TestAsyncResponse(testMessage, expirationTime);
             PlainActionFuture<IndexResponse> createFuture = new PlainActionFuture<>();
             indexService.createResponse(executionId.getDocId(), Collections.emptyMap(), initialResponse, createFuture);
-            expectThrows(CircuitBreakingException.class, createFuture::actionGet);
+            CircuitBreakingException e = expectThrows(CircuitBreakingException.class, createFuture::actionGet);
+            assertEquals(0, e.getSuppressed().length); // no other suppressed exceptions
             assertThat(circuitBreaker.getUsed(), equalTo(0L));
         }
         {
@@ -261,7 +281,8 @@ public class AsyncSearchIndexServiceTests extends ESSingleNodeTestCase {
                 PlainActionFuture<UpdateResponse> updateFuture = new PlainActionFuture<>();
                 TestAsyncResponse updateResponse = new TestAsyncResponse(randomAlphaOfLength(100), randomLong());
                 indexService.updateResponse(executionId.getDocId(), Collections.emptyMap(), updateResponse, updateFuture);
-                expectThrows(CircuitBreakingException.class, updateFuture::actionGet);
+                CircuitBreakingException e = expectThrows(CircuitBreakingException.class, updateFuture::actionGet);
+                assertEquals(0, e.getSuppressed().length); // no other suppressed exceptions
                 assertThat(circuitBreaker.getUsed(), equalTo(0L));
             }
             if (randomBoolean()) {
@@ -280,5 +301,50 @@ public class AsyncSearchIndexServiceTests extends ESSingleNodeTestCase {
                 assertBusy(() -> assertThat(circuitBreaker.getUsed(), equalTo(0L)));
             }
         }
+    }
+
+    public void testMaxAsyncSearchResponseSize() throws Exception {
+        // successfully create an initial response
+        AsyncExecutionId executionId1 = new AsyncExecutionId(Long.toString(randomNonNegativeLong()),
+            new TaskId(randomAlphaOfLength(10), randomNonNegativeLong()));
+        TestAsyncResponse initialResponse = new TestAsyncResponse(randomAlphaOfLength(130), randomLong());
+        PlainActionFuture<IndexResponse> createFuture1 = new PlainActionFuture<>();
+        indexService.createResponse(executionId1.getDocId(), Collections.emptyMap(), initialResponse, createFuture1);
+        createFuture1.actionGet();
+
+        // setting very small limit for the max size of async search response
+        int limit = randomIntBetween(1, 125);
+        ClusterUpdateSettingsRequest updateSettingsRequest = new ClusterUpdateSettingsRequest();
+        updateSettingsRequest.transientSettings(Settings.builder().put("search.max_async_search_response_size", limit + "b"));
+        assertAcked(client().admin().cluster().updateSettings(updateSettingsRequest).actionGet());
+        String expectedErrMsg = "Can't store an async search response larger than ["+ limit + "] bytes. " +
+            "This limit can be set by changing the [" + MAX_ASYNC_SEARCH_RESPONSE_SIZE_SETTING.getKey() + "] setting.";
+
+        // test that an update operation of the initial response fails
+        PlainActionFuture<UpdateResponse> updateFuture = new PlainActionFuture<>();
+        TestAsyncResponse updateResponse = new TestAsyncResponse(randomAlphaOfLength(130), randomLong());
+        indexService.updateResponse(executionId1.getDocId(), Collections.emptyMap(), updateResponse, updateFuture);
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, updateFuture::actionGet);
+        assertEquals(expectedErrMsg, e.getMessage());
+        assertEquals(0, e.getSuppressed().length); // no other suppressed exceptions
+        // test that the inital response is overwritten with a failure
+        PlainActionFuture<TestAsyncResponse> getFuture = new PlainActionFuture<>();
+        indexService.getResponse(executionId1, randomBoolean(), getFuture);
+        assertEquals(expectedErrMsg, getFuture.actionGet().failure);
+
+        // test that a create operation fails
+        AsyncExecutionId executionId2 = new AsyncExecutionId(Long.toString(randomNonNegativeLong()),
+            new TaskId(randomAlphaOfLength(10), randomNonNegativeLong()));
+        PlainActionFuture<IndexResponse> createFuture = new PlainActionFuture<>();
+        TestAsyncResponse initialResponse2 = new TestAsyncResponse(randomAlphaOfLength(130), randomLong());
+        indexService.createResponse(executionId2.getDocId(), Collections.emptyMap(), initialResponse2, createFuture);
+        IllegalArgumentException e2 = expectThrows(IllegalArgumentException.class, createFuture::actionGet);
+        assertEquals(expectedErrMsg, e2.getMessage());
+        assertEquals(0, e2.getSuppressed().length); // no other suppressed exceptions
+
+        // restoring limit
+        updateSettingsRequest = new ClusterUpdateSettingsRequest();
+        updateSettingsRequest.transientSettings(Settings.builder().put("search.max_async_search_response_size", (String) null));
+        assertAcked(client().admin().cluster().updateSettings(updateSettingsRequest).actionGet());
     }
 }

--- a/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/async/AsyncTaskManagementService.java
+++ b/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/async/AsyncTaskManagementService.java
@@ -199,7 +199,7 @@ public class AsyncTaskManagementService<Request extends TaskAwareRequest, Respon
 
     private void storeResults(T searchTask, StoredAsyncResponse<Response> storedResponse, ActionListener<Void> finalListener) {
         try {
-            asyncTaskIndexService.createResponse(searchTask.getExecutionId().getDocId(),
+            asyncTaskIndexService.createResponseForEQL(searchTask.getExecutionId().getDocId(),
                 searchTask.getOriginHeaders(), storedResponse, ActionListener.wrap(
                     // We should only unregister after the result is saved
                     resp -> {


### PR DESCRIPTION
Add a dynamic transient cluster setting search.max_async_search_response_size
that controls the maximum allowed size for a stored async search
response. The default max size is not set for 7.x. If explicitly set by a user,
an attempt to store an async search response larger than the set size 
will result in error.

Backport for #74455
Relates to #67594