### PR TITLE
Fix test compression setting upgrade tests

### DIFF
--- a/qa/full-cluster-restart/src/test/java/org/elasticsearch/upgrades/FullClusterRestartIT.java
+++ b/qa/full-cluster-restart/src/test/java/org/elasticsearch/upgrades/FullClusterRestartIT.java
@@ -1593,6 +1593,9 @@ public class FullClusterRestartIT extends AbstractFullClusterRestartTestCase {
      * translated properly. This test can be removed in 9.0.
      */
     public void testTransportCompressionSetting() throws IOException {
+        assumeTrue("the old transport.compress setting existed before 7.14", getOldClusterVersion().before(Version.V_7_14_0));
+        assumeTrue("Early versions of 6.x do not have cluster.remote* prefixed settings",
+            getOldClusterVersion().onOrAfter(Version.V_7_14_0.minimumCompatibilityVersion()));
         if (isRunningAgainstOldCluster()) {
             final Request putSettingsRequest = new Request("PUT", "/_cluster/settings");
             try (XContentBuilder builder = jsonBuilder()) {


### PR DESCRIPTION
This is related to #74755. The test to check that compression settings
are compatible after upgrade uses the cluster.remote prefix for remote
cluster settings. These settings did not exist in early versions of 6.x.
This commit adds an assume true to ensure that the test is not run
against older versions.