### PR TITLE
[7.14] Fix unit test classpath when testing shadow jar projects (#74783)

### DIFF
--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/ElasticsearchTestBasePlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/ElasticsearchTestBasePlugin.java
@@ -23,6 +23,7 @@ import org.gradle.api.Project;
 import org.gradle.api.Task;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.file.FileCollection;
+import org.gradle.api.plugins.JavaPlugin;
 import org.gradle.api.tasks.SourceSet;
 import org.gradle.api.tasks.SourceSetContainer;
 import org.gradle.api.tasks.testing.Test;
@@ -194,17 +195,17 @@ public class ElasticsearchTestBasePlugin implements Plugin<Project> {
              *  compiled class output and dependency jars. This better emulates the runtime environment of consumers.
              */
             project.getPluginManager().withPlugin("com.github.johnrengelman.shadow", p -> {
-                // Remove output class files and any other dependencies from the test classpath, since the shadow JAR includes these
-                FileCollection mainRuntime = project.getExtensions()
-                    .getByType(SourceSetContainer.class)
-                    .getByName(SourceSet.MAIN_SOURCE_SET_NAME)
-                    .getRuntimeClasspath();
-                // Add any "shadow" dependencies. These are dependencies that are *not* bundled into the shadow JAR
-                Configuration shadowConfig = project.getConfigurations().getByName(ShadowBasePlugin.getCONFIGURATION_NAME());
-                // Add the shadow JAR artifact itself
-                FileCollection shadowJar = project.files(project.getTasks().named("shadowJar"));
-
-                test.setClasspath(test.getClasspath().minus(mainRuntime).plus(shadowConfig).plus(shadowJar));
+                if (test.getName().equals(JavaPlugin.TEST_TASK_NAME)) {
+                    // Remove output class files and any other dependencies from the test classpath, since the shadow JAR includes these
+                    SourceSetContainer sourceSets = project.getExtensions().getByType(SourceSetContainer.class);
+                    FileCollection mainRuntime = sourceSets.getByName(SourceSet.MAIN_SOURCE_SET_NAME).getRuntimeClasspath();
+                    // Add any "shadow" dependencies. These are dependencies that are *not* bundled into the shadow JAR
+                    Configuration shadowConfig = project.getConfigurations().getByName(ShadowBasePlugin.getCONFIGURATION_NAME());
+                    // Add the shadow JAR artifact itself
+                    FileCollection shadowJar = project.files(project.getTasks().named("shadowJar"));
+                    FileCollection testRuntime = sourceSets.getByName(SourceSet.TEST_SOURCE_SET_NAME).getRuntimeClasspath();
+                    test.setClasspath(testRuntime.minus(mainRuntime).plus(shadowConfig).plus(shadowJar));
+                }
             });
         });
     }


### PR DESCRIPTION
Backports the following commits to 7.14:
 - Fix unit test classpath when testing shadow jar projects (#74783)