### PR TITLE
Ensure tests that leverage Mockito can be run from the IDE

### DIFF
--- a/build-tools-internal/src/main/groovy/elasticsearch.ide.gradle
+++ b/build-tools-internal/src/main/groovy/elasticsearch.ide.gradle
@@ -128,7 +128,8 @@ if (System.getProperty('idea.active') == 'true') {
               '--add-opens=java.base/java.net=ALL-UNNAMED',
               '--add-opens=java.base/javax.net.ssl=ALL-UNNAMED',
               '--add-opens=java.base/java.nio.file=ALL-UNNAMED',
-              '--add-opens=java.base/java.time=ALL-UNNAMED'
+              '--add-opens=java.base/java.time=ALL-UNNAMED',
+              '--add-opens=java.base/java.lang=ALL-UNNAMED'
             ].join(' ')
           }
         }


### PR DESCRIPTION
Add the same JVM arguments necessary for module access to IDE configuration as we do for normal Gradle test execution. This ensures that test suites that leverage Mockito can continue to be run from the IDE.

Closes #74232