### PR TITLE
[7.x] Ensure tests that leverage Mockito can be run from the IDE (#74794)

### DIFF
--- a/build-tools-internal/src/main/groovy/elasticsearch.ide.gradle
+++ b/build-tools-internal/src/main/groovy/elasticsearch.ide.gradle
@@ -118,7 +118,19 @@ if (System.getProperty('idea.active') == 'true') {
         }
         runConfigurations {
           defaults(JUnit) {
-            vmParameters = '-ea -Djava.locale.providers=SPI,COMPAT'
+            vmParameters = [
+              '-ea',
+              '-Djava.locale.providers=SPI,COMPAT',
+              "--illegal-access=deny",
+              // TODO: only open these for mockito when it is modularized
+              '--add-opens=java.base/java.security.cert=ALL-UNNAMED',
+              '--add-opens=java.base/java.nio.channels=ALL-UNNAMED',
+              '--add-opens=java.base/java.net=ALL-UNNAMED',
+              '--add-opens=java.base/javax.net.ssl=ALL-UNNAMED',
+              '--add-opens=java.base/java.nio.file=ALL-UNNAMED',
+              '--add-opens=java.base/java.time=ALL-UNNAMED',
+              '--add-opens=java.base/java.lang=ALL-UNNAMED'
+            ].join(' ')
           }
         }
         copyright {


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Ensure tests that leverage Mockito can be run from the IDE (#74794)