### PR TITLE
[DOCS] Move ML functions to appendix

### DIFF
--- a/docs/reference/ml/anomaly-detection/functions/ml-count-functions.asciidoc
+++ b/docs/reference/ml/anomaly-detection/functions/ml-count-functions.asciidoc
@@ -1,5 +1,4 @@
-[role="xpack"]
-[[ml-count-functions]]
+["appendix",role="exclude",id="ml-count-functions"]
 = Count functions
 
 Count functions detect anomalies when the number of events in a bucket is

--- a/docs/reference/ml/anomaly-detection/functions/ml-functions.asciidoc
+++ b/docs/reference/ml/anomaly-detection/functions/ml-functions.asciidoc
@@ -35,10 +35,10 @@ functions are strongly affected by empty buckets. For this reason, there are
 `non_null_sum` and `non_zero_count` functions, which are tolerant to sparse data.
 These functions effectively ignore empty buckets.
 
-* <<ml-count-functions>>
-* <<ml-geo-functions>>
-* <<ml-info-functions>>
-* <<ml-metric-functions>>
-* <<ml-rare-functions>>
-* <<ml-sum-functions>>
-* <<ml-time-functions>>
+* <<ml-count-functions,Count functions>>
+* <<ml-geo-functions,Geographic functions>>
+* <<ml-info-functions,Information content functions>>
+* <<ml-metric-functions,Metric functions>>
+* <<ml-rare-functions,Rare functions>>
+* <<ml-sum-functions,Sum functions>>
+* <<ml-time-functions,Time functions>>

--- a/docs/reference/ml/anomaly-detection/functions/ml-geo-functions.asciidoc
+++ b/docs/reference/ml/anomaly-detection/functions/ml-geo-functions.asciidoc
@@ -1,5 +1,4 @@
-[role="xpack"]
-[[ml-geo-functions]]
+["appendix",role="exclude",id="ml-geo-functions"]
 = Geographic functions
 
 The geographic functions detect anomalies in the geographic location of the

--- a/docs/reference/ml/anomaly-detection/functions/ml-info-functions.asciidoc
+++ b/docs/reference/ml/anomaly-detection/functions/ml-info-functions.asciidoc
@@ -1,5 +1,5 @@
-[[ml-info-functions]]
-= Information Content Functions
+["appendix",role="exclude",id="ml-info-functions"]
+= Information content functions
 
 The information content functions detect anomalies in the amount of information
 that is contained in strings within a bucket. These functions can be used as

--- a/docs/reference/ml/anomaly-detection/functions/ml-metric-functions.asciidoc
+++ b/docs/reference/ml/anomaly-detection/functions/ml-metric-functions.asciidoc
@@ -1,5 +1,4 @@
-[role="xpack"]
-[[ml-metric-functions]]
+["appendix",role="exclude",id="ml-metric-functions"]
 = Metric functions
 
 The metric functions include functions such as mean, min and max. These values

--- a/docs/reference/ml/anomaly-detection/functions/ml-rare-functions.asciidoc
+++ b/docs/reference/ml/anomaly-detection/functions/ml-rare-functions.asciidoc
@@ -1,5 +1,4 @@
-[role="xpack"]
-[[ml-rare-functions]]
+["appendix",role="exclude",id="ml-rare-functions"]
 = Rare functions
 
 The rare functions detect values that occur rarely in time or rarely for a

--- a/docs/reference/ml/anomaly-detection/functions/ml-sum-functions.asciidoc
+++ b/docs/reference/ml/anomaly-detection/functions/ml-sum-functions.asciidoc
@@ -1,5 +1,4 @@
-[role="xpack"]
-[[ml-sum-functions]]
+["appendix",role="exclude",id="ml-sum-functions"]
 = Sum functions
 
 The sum functions detect anomalies when the sum of a field in a bucket is

--- a/docs/reference/ml/anomaly-detection/functions/ml-time-functions.asciidoc
+++ b/docs/reference/ml/anomaly-detection/functions/ml-time-functions.asciidoc
@@ -1,5 +1,4 @@
-[role="xpack"]
-[[ml-time-functions]]
+["appendix",role="exclude",id="ml-time-functions"]
 = Time functions
 
 The time functions detect events that happen at unusual times, either of the day


### PR DESCRIPTION
Related to https://github.com/elastic/stack-docs/pull/1731

This PR moves the machine learning function reference to appendices.