### PR TITLE
[DOCS] Added note about GET requests with bodies to API conventions

### DIFF
--- a/docs/reference/api-conventions.asciidoc
+++ b/docs/reference/api-conventions.asciidoc
@@ -3,8 +3,13 @@
 
 The {es} REST APIs are exposed over HTTP.
 
-The conventions listed in this chapter can be applied throughout the REST
-API, unless otherwise specified.
+A number of {es} GET APIs--most notably the search API--support a request body. 
+While the GET action makes sense in the context of retrieving information, 
+GET requests with a body are not supported by all HTTP libraries.
+All {es} GET APIs that require a body can also be submitted as POST requests.
+Alternatively, you can pass the request body as the 
+<<api-request-body-query-string, `source` query string parameter>>
+when using GET.
 
 * <<multi-index>>
 * <<date-math-index-names>>

--- a/docs/reference/api-conventions.asciidoc
+++ b/docs/reference/api-conventions.asciidoc
@@ -677,6 +677,7 @@ The response looks like:
 // TESTRESPONSE[s/"stack_trace": "java.lang.Number.+\.\.\."/"stack_trace": $body.error.caused_by.stack_trace/]
 
 [discrete]
+[[api-request-body-query-string]]
 ==== Request body in query string
 
 For libraries that don't accept a request body for non-POST requests,


### PR DESCRIPTION
Adds the info from https://github.com/elastic/elasticsearch/pull/74529 without moving things around. 