### PR TITLE
Make test cluster tasks depend on fipsResources when fips enabled (7.x backport)

### DIFF
--- a/build-tools-internal/src/main/groovy/elasticsearch.fips.gradle
+++ b/build-tools-internal/src/main/groovy/elasticsearch.fips.gradle
@@ -9,7 +9,7 @@
 import org.elasticsearch.gradle.internal.ExportElasticsearchBuildResourcesTask
 import org.elasticsearch.gradle.internal.info.BuildParams
 import org.elasticsearch.gradle.testclusters.TestDistribution
-import org.elasticsearch.gradle.testclusters.ElasticsearchCluster
+import org.elasticsearch.gradle.testclusters.TestClustersAware
 
 // Common config when running with a FIPS-140 runtime JVM
 if (BuildParams.inFipsJvm) {
@@ -67,6 +67,9 @@ if (BuildParams.inFipsJvm) {
             }
           }
         }
+        tasks.withType(TestClustersAware) {
+          dependsOn 'fipsResources'
+        }
         testClusters.all {
           setTestDistribution(TestDistribution.DEFAULT)
           extraConfigFile "fips_java.security", fipsSecurity
@@ -89,7 +92,6 @@ if (BuildParams.inFipsJvm) {
         }
       }
       project.tasks.withType(Test).configureEach { Test task ->
-        task.dependsOn('fipsResources')
         task.systemProperty('javax.net.ssl.trustStorePassword', 'password')
         task.systemProperty('javax.net.ssl.keyStorePassword', 'password')
         task.systemProperty('javax.net.ssl.trustStoreType', 'BCFKS')


### PR DESCRIPTION
backports #74670 to 7.x branch