### PR TITLE
Indicate quorumness of discovered nodes earlier

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/coordination/ClusterFormationFailureHelper.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/ClusterFormationFailureHelper.java
@@ -187,14 +187,14 @@ public class ClusterFormationFailureHelper {
 
             final VoteCollection voteCollection = new VoteCollection();
             foundPeers.forEach(voteCollection::addVote);
-            final String isQuorumOrNot
+            final String haveDiscoveredQuorum
                 = electionStrategy.isElectionQuorum(clusterState.nodes().getLocalNode(), currentTerm, clusterState.term(),
                     clusterState.version(), clusterState.getLastCommittedConfiguration(), clusterState.getLastAcceptedConfiguration(),
-                    voteCollection) ? "is a quorum" : "is not a quorum";
+                    voteCollection) ? "have discovered possible quorum" : "have only discovered non-quorum";
 
             return String.format(Locale.ROOT,
-                "master not discovered or elected yet, an election requires %s, have discovered [%s] which %s; %s",
-                quorumDescription, foundPeersDescription, isQuorumOrNot, discoveryWillContinueDescription);
+                "master not discovered or elected yet, an election requires %s, %s [%s]; %s",
+                quorumDescription, haveDiscoveredQuorum, foundPeersDescription, discoveryWillContinueDescription);
         }
 
         private String describeQuorum(VotingConfiguration votingConfiguration) {

--- a/server/src/test/java/org/elasticsearch/cluster/coordination/ClusterFormationFailureHelperTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/ClusterFormationFailureHelperTests.java
@@ -288,7 +288,7 @@ public class ClusterFormationFailureHelperTests extends ESTestCase {
         assertThat(new ClusterFormationState(Settings.EMPTY, clusterState, emptyList(), emptyList(), 0L, electionStrategy,
                 new StatusInfo(HEALTHY, "healthy-info")).getDescription(),
             is("master not discovered or elected yet, an election requires a node with id [otherNode], " +
-                "have discovered [] which is not a quorum; " +
+                "have only discovered non-quorum []; " +
                 "discovery will continue using [] from hosts providers and [" + noAttr(localNode) +
                 "] from last-known cluster state; node term 0, last-accepted version 0 in term 0"));
 
@@ -296,7 +296,7 @@ public class ClusterFormationFailureHelperTests extends ESTestCase {
         assertThat(new ClusterFormationState(Settings.EMPTY, clusterState, singletonList(otherAddress), emptyList(), 0L, electionStrategy,
                 new StatusInfo(HEALTHY, "healthy-info")).getDescription(),
             is("master not discovered or elected yet, an election requires a node with id [otherNode], " +
-                "have discovered [] which is not a quorum; " +
+                "have only discovered non-quorum []; " +
                 "discovery will continue using [" + otherAddress + "] from hosts providers and [" + noAttr(localNode) +
                 "] from last-known cluster state; node term 0, last-accepted version 0 in term 0"));
 
@@ -304,7 +304,7 @@ public class ClusterFormationFailureHelperTests extends ESTestCase {
         assertThat(new ClusterFormationState(Settings.EMPTY, clusterState, emptyList(), singletonList(otherNode), 0L, electionStrategy,
                 new StatusInfo(HEALTHY, "healthy-info")).getDescription(),
             is("master not discovered or elected yet, an election requires a node with id [otherNode], " +
-                "have discovered [" + noAttr(otherNode) + "] which is a quorum; " +
+                "have discovered possible quorum [" + noAttr(otherNode) + "]; " +
                 "discovery will continue using [] from hosts providers and [" + noAttr(localNode) +
                 "] from last-known cluster state; node term 0, last-accepted version 0 in term 0"));
 
@@ -312,49 +312,49 @@ public class ClusterFormationFailureHelperTests extends ESTestCase {
         assertThat(new ClusterFormationState(Settings.EMPTY, clusterState, emptyList(), singletonList(yetAnotherNode), 0L, electionStrategy,
                 new StatusInfo(HEALTHY, "healthy-info")).getDescription(),
             is("master not discovered or elected yet, an election requires a node with id [otherNode], " +
-                "have discovered [" + noAttr(yetAnotherNode) + "] which is not a quorum; " +
+                "have only discovered non-quorum [" + noAttr(yetAnotherNode) + "]; " +
                 "discovery will continue using [] from hosts providers and [" + noAttr(localNode) +
                 "] from last-known cluster state; node term 0, last-accepted version 0 in term 0"));
 
         assertThat(new ClusterFormationState(Settings.EMPTY, state(localNode, "n1", "n2"), emptyList(), emptyList(), 0L, electionStrategy,
                 new StatusInfo(HEALTHY, "healthy-info")).getDescription(),
             is("master not discovered or elected yet, an election requires two nodes with ids [n1, n2], " +
-                "have discovered [] which is not a quorum; " +
+                "have only discovered non-quorum []; " +
                 "discovery will continue using [] from hosts providers and [" + noAttr(localNode) +
                 "] from last-known cluster state; node term 0, last-accepted version 0 in term 0"));
 
         assertThat(new ClusterFormationState(Settings.EMPTY, state(localNode, "n1", "n2", "n3"), emptyList(), emptyList(), 0L,
                 electionStrategy, new StatusInfo(HEALTHY, "healthy-info")).getDescription(),
             is("master not discovered or elected yet, an election requires at least 2 nodes with ids from [n1, n2, n3], " +
-                "have discovered [] which is not a quorum; " +
+                "have only discovered non-quorum []; " +
                 "discovery will continue using [] from hosts providers and [" + noAttr(localNode) +
                 "] from last-known cluster state; node term 0, last-accepted version 0 in term 0"));
 
         assertThat(new ClusterFormationState(Settings.EMPTY, state(localNode, "n1", "n2", BOOTSTRAP_PLACEHOLDER_PREFIX + "n3"),
                 emptyList(), emptyList(), 0L, electionStrategy, new StatusInfo(HEALTHY, "healthy-info")).getDescription(),
             is("master not discovered or elected yet, an election requires 2 nodes with ids [n1, n2], " +
-                "have discovered [] which is not a quorum; " +
+                "have only discovered non-quorum []; " +
                 "discovery will continue using [] from hosts providers and [" + noAttr(localNode) +
                 "] from last-known cluster state; node term 0, last-accepted version 0 in term 0"));
 
         assertThat(new ClusterFormationState(Settings.EMPTY, state(localNode, "n1", "n2", "n3", "n4"), emptyList(), emptyList(), 0L,
                 electionStrategy, new StatusInfo(HEALTHY, "healthy-info")).getDescription(),
             is("master not discovered or elected yet, an election requires at least 3 nodes with ids from [n1, n2, n3, n4], " +
-                "have discovered [] which is not a quorum; " +
+                "have only discovered non-quorum []; " +
                 "discovery will continue using [] from hosts providers and [" + noAttr(localNode) +
                 "] from last-known cluster state; node term 0, last-accepted version 0 in term 0"));
 
         assertThat(new ClusterFormationState(Settings.EMPTY, state(localNode, "n1", "n2", "n3", "n4", "n5"), emptyList(), emptyList(), 0L,
                 electionStrategy, new StatusInfo(HEALTHY, "healthy-info")).getDescription(),
             is("master not discovered or elected yet, an election requires at least 3 nodes with ids from [n1, n2, n3, n4, n5], " +
-                "have discovered [] which is not a quorum; " +
+                "have only discovered non-quorum []; " +
                 "discovery will continue using [] from hosts providers and [" + noAttr(localNode) +
                 "] from last-known cluster state; node term 0, last-accepted version 0 in term 0"));
 
         assertThat(new ClusterFormationState(Settings.EMPTY, state(localNode, "n1", "n2", "n3", "n4", BOOTSTRAP_PLACEHOLDER_PREFIX + "n5"),
                 emptyList(), emptyList(), 0L, electionStrategy, new StatusInfo(HEALTHY, "healthy-info")).getDescription(),
             is("master not discovered or elected yet, an election requires at least 3 nodes with ids from [n1, n2, n3, n4], " +
-                "have discovered [] which is not a quorum; " +
+                "have only discovered non-quorum []; " +
                 "discovery will continue using [] from hosts providers and [" + noAttr(localNode) +
                 "] from last-known cluster state; node term 0, last-accepted version 0 in term 0"));
 
@@ -362,28 +362,28 @@ public class ClusterFormationFailureHelperTests extends ESTestCase {
             BOOTSTRAP_PLACEHOLDER_PREFIX + "n4", BOOTSTRAP_PLACEHOLDER_PREFIX + "n5"), emptyList(), emptyList(), 0L, electionStrategy,
                 new StatusInfo(HEALTHY, "healthy-info")).getDescription(),
             is("master not discovered or elected yet, an election requires 3 nodes with ids [n1, n2, n3], " +
-                "have discovered [] which is not a quorum; " +
+                "have only discovered non-quorum []; " +
                 "discovery will continue using [] from hosts providers and [" + noAttr(localNode) +
                 "] from last-known cluster state; node term 0, last-accepted version 0 in term 0"));
 
         assertThat(new ClusterFormationState(Settings.EMPTY, state(localNode, new String[]{"n1"}, new String[]{"n1"}), emptyList(),
                 emptyList(), 0L, electionStrategy, new StatusInfo(HEALTHY, "healthy-info")).getDescription(),
             is("master not discovered or elected yet, an election requires a node with id [n1], " +
-                "have discovered [] which is not a quorum; " +
+                "have only discovered non-quorum []; " +
                 "discovery will continue using [] from hosts providers and [" + noAttr(localNode) +
                 "] from last-known cluster state; node term 0, last-accepted version 0 in term 0"));
 
         assertThat(new ClusterFormationState(Settings.EMPTY, state(localNode, new String[]{"n1"}, new String[]{"n2"}), emptyList(),
                 emptyList(), 0L, electionStrategy, new StatusInfo(HEALTHY, "healthy-info")).getDescription(),
             is("master not discovered or elected yet, an election requires a node with id [n1] and a node with id [n2], " +
-                "have discovered [] which is not a quorum; " +
+                "have only discovered non-quorum []; " +
                 "discovery will continue using [] from hosts providers and [" + noAttr(localNode) +
                 "] from last-known cluster state; node term 0, last-accepted version 0 in term 0"));
 
         assertThat(new ClusterFormationState(Settings.EMPTY, state(localNode, new String[]{"n1"}, new String[]{"n2", "n3"}), emptyList(),
                 emptyList(), 0L, electionStrategy, new StatusInfo(HEALTHY, "healthy-info")).getDescription(),
             is("master not discovered or elected yet, an election requires a node with id [n1] and two nodes with ids [n2, n3], " +
-                "have discovered [] which is not a quorum; " +
+                "have only discovered non-quorum []; " +
                 "discovery will continue using [] from hosts providers and [" + noAttr(localNode) +
                 "] from last-known cluster state; node term 0, last-accepted version 0 in term 0"));
 
@@ -391,7 +391,7 @@ public class ClusterFormationFailureHelperTests extends ESTestCase {
                 emptyList(), emptyList(), 0L, electionStrategy, new StatusInfo(HEALTHY, "healthy-info")).getDescription(),
             is("master not discovered or elected yet, an election requires a node with id [n1] and " +
                 "at least 2 nodes with ids from [n2, n3, n4], " +
-                "have discovered [] which is not a quorum; " +
+                "have only discovered non-quorum []; " +
                 "discovery will continue using [] from hosts providers and [" + noAttr(localNode) +
                 "] from last-known cluster state; node term 0, last-accepted version 0 in term 0"));
 
@@ -415,12 +415,12 @@ public class ClusterFormationFailureHelperTests extends ESTestCase {
             // nodes from last-known cluster state could be in either order
             is(oneOf(
                 "master not discovered or elected yet, an election requires two nodes with ids [n1, n2], " +
-                    "have discovered [] which is not a quorum; " +
+                    "have only discovered non-quorum []; " +
                     "discovery will continue using [] from hosts providers and [" + noAttr(localNode) + ", " + noAttr(otherMasterNode) +
                     "] from last-known cluster state; node term 0, last-accepted version 0 in term 0",
 
                 "master not discovered or elected yet, an election requires two nodes with ids [n1, n2], " +
-                    "have discovered [] which is not a quorum; " +
+                    "have only discovered non-quorum []; " +
                     "discovery will continue using [] from hosts providers and [" + noAttr(otherMasterNode) + ", " + noAttr(localNode) +
                     "] from last-known cluster state; node term 0, last-accepted version 0 in term 0")));
 
@@ -428,7 +428,7 @@ public class ClusterFormationFailureHelperTests extends ESTestCase {
                 emptyList(), 0L, electionStrategy, new StatusInfo(HEALTHY, "healthy-info")).getDescription(),
             is("master not discovered or elected yet, an election requires one or more nodes that have already participated as " +
                 "master-eligible nodes in the cluster but this node was not master-eligible the last time it joined the cluster, " +
-                "have discovered [] which is not a quorum; " +
+                "have only discovered non-quorum []; " +
                 "discovery will continue using [] from hosts providers and [" + noAttr(localNode) +
                 "] from last-known cluster state; node term 0, last-accepted version 0 in term 0"));
 

--- a/server/src/test/java/org/elasticsearch/cluster/coordination/CoordinatorTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/CoordinatorTests.java
@@ -1436,8 +1436,10 @@ public class CoordinatorTests extends AbstractCoordinatorTestCase {
                                     .equals(getNodeIdForLogContext(n.getLocalNode()))).collect(Collectors.toList());
                             assertThat(matchingNodes, hasSize(1));
 
-                            assertTrue(Regex.simpleMatch(
-                                "*have discovered *" + matchingNodes.get(0).toString() + "*discovery will continue*",
+                            assertTrue(
+                                message,
+                                Regex.simpleMatch(
+                                    "*have only discovered non-quorum *" + matchingNodes.get(0).toString() + "*discovery will continue*",
                                 message));
 
                             nodesLogged.add(matchingNodes.get(0).getLocalNode());


### PR DESCRIPTION
Today the `ClusterFormationFailureHelper` logs a message of the form
`have discovered [...] which is/is not a quorum`. The `[...]` describes
all the nodes that have been discovered, which obscures the important
fact about whether they're a quorum or not by pushing it a long way into
the message. Also it can be confusing to say that the discovered nodes
form a quorum when our local state is stale and they're not a quorum
according to a fresher state.

This commit reorders the message to put the quorumness before the list
of nodes, and weakens the wording to call it a `possible quorum` to
account for the local state possibly being stale.