### PR TITLE
Simplify ParseContext

### DIFF
--- a/modules/percolator/src/test/java/org/elasticsearch/percolator/CandidateQueryTests.java
+++ b/modules/percolator/src/test/java/org/elasticsearch/percolator/CandidateQueryTests.java
@@ -74,16 +74,14 @@ import org.elasticsearch.common.geo.ShapeRelation;
 import org.elasticsearch.common.lucene.search.function.FunctionScoreQuery;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.XContentFactory;
-import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.core.CheckedFunction;
 import org.elasticsearch.index.IndexService;
-import org.elasticsearch.index.mapper.ContentPath;
-import org.elasticsearch.index.mapper.DocumentMapper;
 import org.elasticsearch.index.mapper.LuceneDocument;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.mapper.NumberFieldMapper;
 import org.elasticsearch.index.mapper.ParseContext;
+import org.elasticsearch.index.mapper.TestParseContext;
 import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.test.ESSingleNodeTestCase;
@@ -112,7 +110,6 @@ public class CandidateQueryTests extends ESSingleNodeTestCase {
 
     private Directory directory;
     private IndexWriter indexWriter;
-    private DocumentMapper documentMapper;
     private DirectoryReader directoryReader;
     private IndexService indexService;
     private MapperService mapperService;
@@ -149,7 +146,7 @@ public class CandidateQueryTests extends ESSingleNodeTestCase {
                 .startObject("ip_field").field("type", "ip").endObject()
                 .startObject("field").field("type", "keyword").endObject()
                 .endObject().endObject().endObject());
-        documentMapper = mapperService.merge("type", new CompressedXContent(mapper), MapperService.MergeReason.MAPPING_UPDATE);
+        mapperService.merge("type", new CompressedXContent(mapper), MapperService.MergeReason.MAPPING_UPDATE);
 
         String queryField = "query_field";
         String percolatorMapper = Strings.toString(XContentFactory.jsonBuilder().startObject().startObject("type")
@@ -1105,41 +1102,7 @@ public class CandidateQueryTests extends ESSingleNodeTestCase {
     }
 
     private void addQuery(Query query, List<LuceneDocument> docs) {
-        ParseContext parseContext = new ParseContext(documentMapper.mappers(), indexService.getIndexSettings(),
-            indexService.getIndexAnalyzers(), null, null) {
-
-            private final LuceneDocument document = new LuceneDocument();
-
-            @Override
-            public Iterable<LuceneDocument> nonRootDocuments() {
-                throw new UnsupportedOperationException();
-            }
-
-            @Override
-            public ContentPath path() {
-                throw new UnsupportedOperationException();
-            }
-
-            @Override
-            public XContentParser parser() {
-                throw new UnsupportedOperationException();
-            }
-
-            @Override
-            public LuceneDocument rootDoc() {
-                throw new UnsupportedOperationException();
-            }
-
-            @Override
-            public LuceneDocument doc() {
-                return document;
-            }
-
-            @Override
-            protected void addDoc(LuceneDocument doc) {
-                throw new UnsupportedOperationException();
-            }
-        };
+        ParseContext parseContext = new TestParseContext();
         fieldMapper.processQuery(query, parseContext);
         LuceneDocument queryDocument = parseContext.doc();
         // Add to string representation of the query to make debugging easier:

--- a/modules/percolator/src/test/java/org/elasticsearch/percolator/CandidateQueryTests.java
+++ b/modules/percolator/src/test/java/org/elasticsearch/percolator/CandidateQueryTests.java
@@ -74,8 +74,10 @@ import org.elasticsearch.common.geo.ShapeRelation;
 import org.elasticsearch.common.lucene.search.function.FunctionScoreQuery;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.XContentFactory;
+import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.core.CheckedFunction;
 import org.elasticsearch.index.IndexService;
+import org.elasticsearch.index.mapper.ContentPath;
 import org.elasticsearch.index.mapper.DocumentMapper;
 import org.elasticsearch.index.mapper.LuceneDocument;
 import org.elasticsearch.index.mapper.MappedFieldType;
@@ -1103,8 +1105,41 @@ public class CandidateQueryTests extends ESSingleNodeTestCase {
     }
 
     private void addQuery(Query query, List<LuceneDocument> docs) {
-        ParseContext.InternalParseContext parseContext = new ParseContext.InternalParseContext(
-            documentMapper.mappers(), indexService.getIndexSettings(), indexService.getIndexAnalyzers(), null, null, null);
+        ParseContext parseContext = new ParseContext(documentMapper.mappers(), indexService.getIndexSettings(),
+            indexService.getIndexAnalyzers(), null, null) {
+
+            private final LuceneDocument document = new LuceneDocument();
+
+            @Override
+            public Iterable<LuceneDocument> nonRootDocuments() {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public ContentPath path() {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public XContentParser parser() {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public LuceneDocument rootDoc() {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public LuceneDocument doc() {
+                return document;
+            }
+
+            @Override
+            protected void addDoc(LuceneDocument doc) {
+                throw new UnsupportedOperationException();
+            }
+        };
         fieldMapper.processQuery(query, parseContext);
         LuceneDocument queryDocument = parseContext.doc();
         // Add to string representation of the query to make debugging easier:

--- a/modules/percolator/src/test/java/org/elasticsearch/percolator/PercolatorFieldMapperTests.java
+++ b/modules/percolator/src/test/java/org/elasticsearch/percolator/PercolatorFieldMapperTests.java
@@ -44,13 +44,18 @@ import org.elasticsearch.common.network.InetAddresses;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentFactory;
+import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.core.Tuple;
 import org.elasticsearch.index.IndexService;
+import org.elasticsearch.index.IndexSettings;
+import org.elasticsearch.index.analysis.IndexAnalyzers;
+import org.elasticsearch.index.mapper.ContentPath;
 import org.elasticsearch.index.mapper.DocumentMapper;
 import org.elasticsearch.index.mapper.LuceneDocument;
 import org.elasticsearch.index.mapper.MapperParsingException;
 import org.elasticsearch.index.mapper.MapperService;
+import org.elasticsearch.index.mapper.MappingLookup;
 import org.elasticsearch.index.mapper.ParseContext;
 import org.elasticsearch.index.mapper.ParsedDocument;
 import org.elasticsearch.index.mapper.SourceToParse;
@@ -171,8 +176,7 @@ public class PercolatorFieldMapperTests extends ESSingleNodeTestCase {
 
         DocumentMapper documentMapper = mapperService.documentMapper();
         PercolatorFieldMapper fieldMapper = (PercolatorFieldMapper) documentMapper.mappers().getMapper(fieldName);
-        ParseContext.InternalParseContext parseContext = new ParseContext.InternalParseContext(documentMapper.mappers(),
-            mapperService.getIndexSettings(), null, null, null, null);
+        ParseContext parseContext = new TestParseContext(documentMapper.mappers(), mapperService.getIndexSettings(), null);
         fieldMapper.processQuery(bq.build(), parseContext);
         LuceneDocument document = parseContext.doc();
 
@@ -193,8 +197,7 @@ public class PercolatorFieldMapperTests extends ESSingleNodeTestCase {
         bq.add(termQuery1, Occur.MUST);
         bq.add(termQuery2, Occur.MUST);
 
-        parseContext = new ParseContext.InternalParseContext(documentMapper.mappers(), mapperService.getIndexSettings(),
-            null, null, null, null);
+        parseContext = new TestParseContext(documentMapper.mappers(), mapperService.getIndexSettings(), null);
         fieldMapper.processQuery(bq.build(), parseContext);
         document = parseContext.doc();
 
@@ -223,8 +226,7 @@ public class PercolatorFieldMapperTests extends ESSingleNodeTestCase {
 
         DocumentMapper documentMapper = mapperService.documentMapper();
         PercolatorFieldMapper fieldMapper = (PercolatorFieldMapper) documentMapper.mappers().getMapper(fieldName);
-        ParseContext.InternalParseContext parseContext = new ParseContext.InternalParseContext(documentMapper.mappers(),
-            mapperService.getIndexSettings(), null, null, null, null);
+        ParseContext parseContext = new TestParseContext(documentMapper.mappers(), mapperService.getIndexSettings(), null);
         fieldMapper.processQuery(bq.build(), parseContext);
         LuceneDocument document = parseContext.doc();
 
@@ -249,8 +251,7 @@ public class PercolatorFieldMapperTests extends ESSingleNodeTestCase {
             .rangeQuery(15, 20, true, true, null, null, null, context);
         bq.add(rangeQuery2, Occur.MUST);
 
-        parseContext = new ParseContext.InternalParseContext(documentMapper.mappers(), mapperService.getIndexSettings(),
-            null, null, null, null);
+        parseContext = new TestParseContext(documentMapper.mappers(), mapperService.getIndexSettings(), null);
         fieldMapper.processQuery(bq.build(), parseContext);
         document = parseContext.doc();
 
@@ -273,8 +274,7 @@ public class PercolatorFieldMapperTests extends ESSingleNodeTestCase {
         TermRangeQuery query = new TermRangeQuery("field1", new BytesRef("a"), new BytesRef("z"), true, true);
         DocumentMapper documentMapper = mapperService.documentMapper();
         PercolatorFieldMapper fieldMapper = (PercolatorFieldMapper) documentMapper.mappers().getMapper(fieldName);
-        ParseContext.InternalParseContext parseContext = new ParseContext.InternalParseContext(documentMapper.mappers(),
-            mapperService.getIndexSettings(), null, null, null, null);
+        ParseContext parseContext = new TestParseContext(documentMapper.mappers(), mapperService.getIndexSettings(), null);
         fieldMapper.processQuery(query, parseContext);
         LuceneDocument document = parseContext.doc();
 
@@ -288,8 +288,7 @@ public class PercolatorFieldMapperTests extends ESSingleNodeTestCase {
         PhraseQuery phraseQuery = new PhraseQuery("field", "term");
         DocumentMapper documentMapper = mapperService.documentMapper();
         PercolatorFieldMapper fieldMapper = (PercolatorFieldMapper) documentMapper.mappers().getMapper(fieldName);
-        ParseContext.InternalParseContext parseContext = new ParseContext.InternalParseContext(documentMapper.mappers(),
-            mapperService.getIndexSettings(), null, null, null, null);
+        ParseContext parseContext = new TestParseContext(documentMapper.mappers(), mapperService.getIndexSettings(), null);
         fieldMapper.processQuery(phraseQuery, parseContext);
         LuceneDocument document = parseContext.doc();
 
@@ -928,4 +927,42 @@ public class PercolatorFieldMapperTests extends ESSingleNodeTestCase {
         }
     }
 
+    private static class TestParseContext extends ParseContext {
+        private final ContentPath contentPath = new ContentPath(0);
+        private final LuceneDocument document = new LuceneDocument();
+
+        protected TestParseContext(MappingLookup mappingLookup, IndexSettings indexSettings, IndexAnalyzers indexAnalyzers) {
+            super(mappingLookup, indexSettings, indexAnalyzers, null, null);
+        }
+
+        @Override
+        public Iterable<LuceneDocument> nonRootDocuments() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public ContentPath path() {
+            return contentPath;
+        }
+
+        @Override
+        public XContentParser parser() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public LuceneDocument rootDoc() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public LuceneDocument doc() {
+            return document;
+        }
+
+        @Override
+        protected void addDoc(LuceneDocument doc) {
+            throw new UnsupportedOperationException();
+        }
+    }
 }

--- a/modules/percolator/src/test/java/org/elasticsearch/percolator/PercolatorFieldMapperTests.java
+++ b/modules/percolator/src/test/java/org/elasticsearch/percolator/PercolatorFieldMapperTests.java
@@ -44,21 +44,17 @@ import org.elasticsearch.common.network.InetAddresses;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentFactory;
-import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.core.Tuple;
 import org.elasticsearch.index.IndexService;
-import org.elasticsearch.index.IndexSettings;
-import org.elasticsearch.index.analysis.IndexAnalyzers;
-import org.elasticsearch.index.mapper.ContentPath;
 import org.elasticsearch.index.mapper.DocumentMapper;
 import org.elasticsearch.index.mapper.LuceneDocument;
 import org.elasticsearch.index.mapper.MapperParsingException;
 import org.elasticsearch.index.mapper.MapperService;
-import org.elasticsearch.index.mapper.MappingLookup;
 import org.elasticsearch.index.mapper.ParseContext;
 import org.elasticsearch.index.mapper.ParsedDocument;
 import org.elasticsearch.index.mapper.SourceToParse;
+import org.elasticsearch.index.mapper.TestParseContext;
 import org.elasticsearch.index.query.BoolQueryBuilder;
 import org.elasticsearch.index.query.BoostingQueryBuilder;
 import org.elasticsearch.index.query.ConstantScoreQueryBuilder;
@@ -176,7 +172,7 @@ public class PercolatorFieldMapperTests extends ESSingleNodeTestCase {
 
         DocumentMapper documentMapper = mapperService.documentMapper();
         PercolatorFieldMapper fieldMapper = (PercolatorFieldMapper) documentMapper.mappers().getMapper(fieldName);
-        ParseContext parseContext = new TestParseContext(documentMapper.mappers(), mapperService.getIndexSettings(), null);
+        ParseContext parseContext = new TestParseContext();
         fieldMapper.processQuery(bq.build(), parseContext);
         LuceneDocument document = parseContext.doc();
 
@@ -197,7 +193,7 @@ public class PercolatorFieldMapperTests extends ESSingleNodeTestCase {
         bq.add(termQuery1, Occur.MUST);
         bq.add(termQuery2, Occur.MUST);
 
-        parseContext = new TestParseContext(documentMapper.mappers(), mapperService.getIndexSettings(), null);
+        parseContext = new TestParseContext();
         fieldMapper.processQuery(bq.build(), parseContext);
         document = parseContext.doc();
 
@@ -226,7 +222,7 @@ public class PercolatorFieldMapperTests extends ESSingleNodeTestCase {
 
         DocumentMapper documentMapper = mapperService.documentMapper();
         PercolatorFieldMapper fieldMapper = (PercolatorFieldMapper) documentMapper.mappers().getMapper(fieldName);
-        ParseContext parseContext = new TestParseContext(documentMapper.mappers(), mapperService.getIndexSettings(), null);
+        ParseContext parseContext = new TestParseContext();
         fieldMapper.processQuery(bq.build(), parseContext);
         LuceneDocument document = parseContext.doc();
 
@@ -251,7 +247,7 @@ public class PercolatorFieldMapperTests extends ESSingleNodeTestCase {
             .rangeQuery(15, 20, true, true, null, null, null, context);
         bq.add(rangeQuery2, Occur.MUST);
 
-        parseContext = new TestParseContext(documentMapper.mappers(), mapperService.getIndexSettings(), null);
+        parseContext = new TestParseContext();
         fieldMapper.processQuery(bq.build(), parseContext);
         document = parseContext.doc();
 
@@ -274,7 +270,7 @@ public class PercolatorFieldMapperTests extends ESSingleNodeTestCase {
         TermRangeQuery query = new TermRangeQuery("field1", new BytesRef("a"), new BytesRef("z"), true, true);
         DocumentMapper documentMapper = mapperService.documentMapper();
         PercolatorFieldMapper fieldMapper = (PercolatorFieldMapper) documentMapper.mappers().getMapper(fieldName);
-        ParseContext parseContext = new TestParseContext(documentMapper.mappers(), mapperService.getIndexSettings(), null);
+        ParseContext parseContext = new TestParseContext();
         fieldMapper.processQuery(query, parseContext);
         LuceneDocument document = parseContext.doc();
 
@@ -288,7 +284,7 @@ public class PercolatorFieldMapperTests extends ESSingleNodeTestCase {
         PhraseQuery phraseQuery = new PhraseQuery("field", "term");
         DocumentMapper documentMapper = mapperService.documentMapper();
         PercolatorFieldMapper fieldMapper = (PercolatorFieldMapper) documentMapper.mappers().getMapper(fieldName);
-        ParseContext parseContext = new TestParseContext(documentMapper.mappers(), mapperService.getIndexSettings(), null);
+        ParseContext parseContext = new TestParseContext();
         fieldMapper.processQuery(phraseQuery, parseContext);
         LuceneDocument document = parseContext.doc();
 
@@ -924,45 +920,6 @@ public class PercolatorFieldMapperTests extends ESSingleNodeTestCase {
         @Override
         public String pluginScriptLang() {
             return Script.DEFAULT_SCRIPT_LANG;
-        }
-    }
-
-    private static class TestParseContext extends ParseContext {
-        private final ContentPath contentPath = new ContentPath(0);
-        private final LuceneDocument document = new LuceneDocument();
-
-        protected TestParseContext(MappingLookup mappingLookup, IndexSettings indexSettings, IndexAnalyzers indexAnalyzers) {
-            super(mappingLookup, indexSettings, indexAnalyzers, null, null);
-        }
-
-        @Override
-        public Iterable<LuceneDocument> nonRootDocuments() {
-            throw new UnsupportedOperationException();
-        }
-
-        @Override
-        public ContentPath path() {
-            return contentPath;
-        }
-
-        @Override
-        public XContentParser parser() {
-            throw new UnsupportedOperationException();
-        }
-
-        @Override
-        public LuceneDocument rootDoc() {
-            throw new UnsupportedOperationException();
-        }
-
-        @Override
-        public LuceneDocument doc() {
-            return document;
-        }
-
-        @Override
-        protected void addDoc(LuceneDocument doc) {
-            throw new UnsupportedOperationException();
         }
     }
 }

--- a/modules/percolator/src/test/java/org/elasticsearch/percolator/QueryBuilderStoreTests.java
+++ b/modules/percolator/src/test/java/org/elasticsearch/percolator/QueryBuilderStoreTests.java
@@ -18,10 +18,10 @@ import org.apache.lucene.search.Query;
 import org.apache.lucene.search.TermQuery;
 import org.apache.lucene.store.Directory;
 import org.elasticsearch.Version;
-import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
+import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.core.CheckedFunction;
 import org.elasticsearch.index.fielddata.plain.BytesBinaryIndexFieldData;
 import org.elasticsearch.index.mapper.BinaryFieldMapper;
@@ -61,19 +61,47 @@ public class QueryBuilderStoreTests extends ESTestCase {
             TermQueryBuilder[] queryBuilders = new TermQueryBuilder[randomIntBetween(1, 16)];
             IndexWriterConfig config = new IndexWriterConfig(new WhitespaceAnalyzer());
             config.setMergePolicy(NoMergePolicy.INSTANCE);
-            Settings settings = Settings.builder().put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT).build();
             BinaryFieldMapper fieldMapper = PercolatorFieldMapper.Builder.createQueryBuilderFieldBuilder(new ContentPath(0));
 
             Version version = Version.CURRENT;
             try (IndexWriter indexWriter = new IndexWriter(directory, config)) {
                 for (int i = 0; i < queryBuilders.length; i++) {
                     queryBuilders[i] = new TermQueryBuilder(randomAlphaOfLength(4), randomAlphaOfLength(8));
-                    ParseContext parseContext = mock(ParseContext.class);
-                    LuceneDocument document = new LuceneDocument();
-                    when(parseContext.doc()).thenReturn(document);
+                    LuceneDocument doc = new LuceneDocument();
+                    ParseContext parseContext = new ParseContext(null, null, null, null, null) {
+                        @Override
+                        public Iterable<LuceneDocument> nonRootDocuments() {
+                            throw new UnsupportedOperationException();
+                        }
+
+                        @Override
+                        public ContentPath path() {
+                            throw new UnsupportedOperationException();
+                        }
+
+                        @Override
+                        public XContentParser parser() {
+                            throw new UnsupportedOperationException();
+                        }
+
+                        @Override
+                        public LuceneDocument rootDoc() {
+                            throw new UnsupportedOperationException();
+                        }
+
+                        @Override
+                        public LuceneDocument doc() {
+                            return doc;
+                        }
+
+                        @Override
+                        protected void addDoc(LuceneDocument doc) {
+                            throw new UnsupportedOperationException();
+                        }
+                    };
                     PercolatorFieldMapper.createQueryBuilderField(version,
                         fieldMapper, queryBuilders[i], parseContext);
-                    indexWriter.addDocument(document);
+                    indexWriter.addDocument(doc);
                 }
             }
 

--- a/modules/percolator/src/test/java/org/elasticsearch/percolator/QueryBuilderStoreTests.java
+++ b/modules/percolator/src/test/java/org/elasticsearch/percolator/QueryBuilderStoreTests.java
@@ -26,7 +26,6 @@ import org.elasticsearch.index.fielddata.plain.BytesBinaryIndexFieldData;
 import org.elasticsearch.index.mapper.BinaryFieldMapper;
 import org.elasticsearch.index.mapper.ContentPath;
 import org.elasticsearch.index.mapper.KeywordFieldMapper;
-import org.elasticsearch.index.mapper.LuceneDocument;
 import org.elasticsearch.index.mapper.ParseContext;
 import org.elasticsearch.index.mapper.TestParseContext;
 import org.elasticsearch.index.query.SearchExecutionContext;
@@ -67,11 +66,10 @@ public class QueryBuilderStoreTests extends ESTestCase {
             try (IndexWriter indexWriter = new IndexWriter(directory, config)) {
                 for (int i = 0; i < queryBuilders.length; i++) {
                     queryBuilders[i] = new TermQueryBuilder(randomAlphaOfLength(4), randomAlphaOfLength(8));
-                    LuceneDocument doc = new LuceneDocument();
                     ParseContext parseContext = new TestParseContext();
                     PercolatorFieldMapper.createQueryBuilderField(version,
                         fieldMapper, queryBuilders[i], parseContext);
-                    indexWriter.addDocument(doc);
+                    indexWriter.addDocument(parseContext.doc());
                 }
             }
 
@@ -99,5 +97,4 @@ public class QueryBuilderStoreTests extends ESTestCase {
             }
         }
     }
-
 }

--- a/modules/percolator/src/test/java/org/elasticsearch/percolator/QueryBuilderStoreTests.java
+++ b/modules/percolator/src/test/java/org/elasticsearch/percolator/QueryBuilderStoreTests.java
@@ -21,7 +21,6 @@ import org.elasticsearch.Version;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
-import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.core.CheckedFunction;
 import org.elasticsearch.index.fielddata.plain.BytesBinaryIndexFieldData;
 import org.elasticsearch.index.mapper.BinaryFieldMapper;
@@ -29,6 +28,7 @@ import org.elasticsearch.index.mapper.ContentPath;
 import org.elasticsearch.index.mapper.KeywordFieldMapper;
 import org.elasticsearch.index.mapper.LuceneDocument;
 import org.elasticsearch.index.mapper.ParseContext;
+import org.elasticsearch.index.mapper.TestParseContext;
 import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.index.query.TermQueryBuilder;
 import org.elasticsearch.mock.orig.Mockito;
@@ -68,37 +68,7 @@ public class QueryBuilderStoreTests extends ESTestCase {
                 for (int i = 0; i < queryBuilders.length; i++) {
                     queryBuilders[i] = new TermQueryBuilder(randomAlphaOfLength(4), randomAlphaOfLength(8));
                     LuceneDocument doc = new LuceneDocument();
-                    ParseContext parseContext = new ParseContext(null, null, null, null, null) {
-                        @Override
-                        public Iterable<LuceneDocument> nonRootDocuments() {
-                            throw new UnsupportedOperationException();
-                        }
-
-                        @Override
-                        public ContentPath path() {
-                            throw new UnsupportedOperationException();
-                        }
-
-                        @Override
-                        public XContentParser parser() {
-                            throw new UnsupportedOperationException();
-                        }
-
-                        @Override
-                        public LuceneDocument rootDoc() {
-                            throw new UnsupportedOperationException();
-                        }
-
-                        @Override
-                        public LuceneDocument doc() {
-                            return doc;
-                        }
-
-                        @Override
-                        protected void addDoc(LuceneDocument doc) {
-                            throw new UnsupportedOperationException();
-                        }
-                    };
+                    ParseContext parseContext = new TestParseContext();
                     PercolatorFieldMapper.createQueryBuilderField(version,
                         fieldMapper, queryBuilders[i], parseContext);
                     indexWriter.addDocument(doc);

--- a/server/src/main/java/org/elasticsearch/index/mapper/ParseContext.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/ParseContext.java
@@ -19,7 +19,6 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -32,22 +31,13 @@ public abstract class ParseContext {
         private final ParseContext in;
 
         private FilterParseContext(ParseContext in) {
+            super(in);
             this.in = in;
-        }
-
-        @Override
-        public ObjectMapper getObjectMapper(String name) {
-            return in.getObjectMapper(name);
         }
 
         @Override
         public Iterable<LuceneDocument> nonRootDocuments() {
             return in.nonRootDocuments();
-        }
-
-        @Override
-        public MappingParserContext dynamicTemplateParserContext(DateFormatter dateFormatter) {
-            return in.dynamicTemplateParserContext(dateFormatter);
         }
 
         @Override
@@ -58,16 +48,6 @@ public abstract class ParseContext {
         @Override
         public boolean isWithinMultiFields() {
             return in.isWithinMultiFields();
-        }
-
-        @Override
-        public IndexSettings indexSettings() {
-            return in.indexSettings();
-        }
-
-        @Override
-        public SourceToParse sourceToParse() {
-            return in.sourceToParse();
         }
 
         @Override
@@ -94,328 +74,97 @@ public abstract class ParseContext {
         protected void addDoc(LuceneDocument doc) {
             in.addDoc(doc);
         }
-
-        @Override
-        public RootObjectMapper root() {
-            return in.root();
-        }
-
-        @Override
-        public MappingLookup mappingLookup() {
-            return in.mappingLookup();
-        }
-
-        @Override
-        public MetadataFieldMapper getMetadataMapper(String mapperName) {
-            return in.getMetadataMapper(mapperName);
-        }
-
-        @Override
-        public IndexAnalyzers indexAnalyzers() {
-            return in.indexAnalyzers();
-        }
-
-        @Override
-        public Field version() {
-            return in.version();
-        }
-
-        @Override
-        public void version(Field version) {
-            in.version(version);
-        }
-
-        @Override
-        public SeqNoFieldMapper.SequenceIDFields seqID() {
-            return in.seqID();
-        }
-
-        @Override
-        public void seqID(SeqNoFieldMapper.SequenceIDFields seqID) {
-            in.seqID(seqID);
-        }
-
-        @Override
-        public void addDynamicMapper(Mapper update) {
-            in.addDynamicMapper(update);
-        }
-
-        @Override
-        public List<Mapper> getDynamicMappers() {
-            return in.getDynamicMappers();
-        }
-
-        @Override
-        public void addDynamicRuntimeField(RuntimeField runtimeField) {
-            in.addDynamicRuntimeField(runtimeField);
-        }
-
-        @Override
-        public List<RuntimeField> getDynamicRuntimeFields() {
-            return in.getDynamicRuntimeFields();
-        }
-
-        @Override
-        public void addIgnoredField(String field) {
-            in.addIgnoredField(field);
-        }
-
-        @Override
-        public Collection<String> getIgnoredFields() {
-            return in.getIgnoredFields();
-        }
-
-        @Override
-        public void addToFieldNames(String field) {
-            in.addToFieldNames(field);
-        }
-
-        @Override
-        public Collection<String> getFieldNames() {
-            return in.getFieldNames();
-        }
     }
 
-    public static class InternalParseContext extends ParseContext {
-        private final MappingLookup mappingLookup;
-        private final IndexSettings indexSettings;
-        private final IndexAnalyzers indexAnalyzers;
-        private final Function<DateFormatter, MappingParserContext> parserContextFunction;
-        private final ContentPath path = new ContentPath(0);
-        private final XContentParser parser;
-        private final LuceneDocument document;
-        private final List<LuceneDocument> documents = new ArrayList<>();
-        private final SourceToParse sourceToParse;
-        private final long maxAllowedNumNestedDocs;
-        private final List<Mapper> dynamicMappers = new ArrayList<>();
-        private final Set<String> newFieldsSeen = new HashSet<>();
-        private final Map<String, ObjectMapper> dynamicObjectMappers = new HashMap<>();
-        private final List<RuntimeField> dynamicRuntimeFields = new ArrayList<>();
-        private final Set<String> ignoredFields = new HashSet<>();
-        private final Set<String> fieldNameFields = new HashSet<>();
-        private Field version;
-        private SeqNoFieldMapper.SequenceIDFields seqID;
-        private long numNestedDocs;
-        private boolean docsReversed = false;
+    private final IndexSettings indexSettings;
+    private final IndexAnalyzers indexAnalyzers;
+    private final MappingLookup mappingLookup;
+    private final Function<DateFormatter, MappingParserContext> parserContextFunction;
+    private final SourceToParse sourceToParse;
+    private final Set<String> ignoredFields;
+    private final Set<String> fieldNameFields;
+    private final List<Mapper> dynamicMappers;
+    private final Set<String> newFieldsSeen;
+    private final Map<String, ObjectMapper> dynamicObjectMappers;
+    private final List<RuntimeField> dynamicRuntimeFields;
+    private Field version;
+    private SeqNoFieldMapper.SequenceIDFields seqID;
 
-        public InternalParseContext(MappingLookup mappingLookup,
-                                    IndexSettings indexSettings,
-                                    IndexAnalyzers indexAnalyzers,
-                                    Function<DateFormatter, MappingParserContext> parserContext,
-                                    SourceToParse source,
-                                    XContentParser parser) {
-            this.mappingLookup = mappingLookup;
-            this.indexSettings = indexSettings;
-            this.indexAnalyzers = indexAnalyzers;
-            this.parserContextFunction = parserContext;
-            this.parser = parser;
-            this.document = new LuceneDocument();
-            this.documents.add(document);
-            this.version = null;
-            this.sourceToParse = source;
-            this.maxAllowedNumNestedDocs = indexSettings().getMappingNestedDocsLimit();
-            this.numNestedDocs = 0L;
-        }
-
-        @Override
-        public MappingParserContext dynamicTemplateParserContext(DateFormatter dateFormatter) {
-            return parserContextFunction.apply(dateFormatter);
-        }
-
-        @Override
-        public IndexSettings indexSettings() {
-            return this.indexSettings;
-        }
-
-        @Override
-        public SourceToParse sourceToParse() {
-            return this.sourceToParse;
-        }
-
-        @Override
-        public ContentPath path() {
-            return this.path;
-        }
-
-        @Override
-        public XContentParser parser() {
-            return this.parser;
-        }
-
-        @Override
-        public LuceneDocument rootDoc() {
-            return documents.get(0);
-        }
-
-        List<LuceneDocument> docs() {
-            return this.documents;
-        }
-
-        @Override
-        public LuceneDocument doc() {
-            return this.document;
-        }
-
-        @Override
-        protected void addDoc(LuceneDocument doc) {
-            numNestedDocs ++;
-            if (numNestedDocs > maxAllowedNumNestedDocs) {
-                throw new MapperParsingException(
-                    "The number of nested documents has exceeded the allowed limit of [" + maxAllowedNumNestedDocs + "]."
-                        + " This limit can be set by changing the [" + MapperService.INDEX_MAPPING_NESTED_DOCS_LIMIT_SETTING.getKey()
-                        + "] index level setting.");
-            }
-            this.documents.add(doc);
-        }
-
-        @Override
-        public RootObjectMapper root() {
-            return this.mappingLookup.getMapping().getRoot();
-        }
-
-        @Override
-        public MappingLookup mappingLookup() {
-            return mappingLookup;
-        }
-
-        @Override
-        public MetadataFieldMapper getMetadataMapper(String mapperName) {
-            return mappingLookup.getMapping().getMetadataMapperByName(mapperName);
-        }
-
-        @Override
-        public IndexAnalyzers indexAnalyzers() {
-            return this.indexAnalyzers;
-        }
-
-        @Override
-        public Field version() {
-            return this.version;
-        }
-
-        @Override
-        public void version(Field version) {
-            this.version = version;
-        }
-
-        @Override
-        public SeqNoFieldMapper.SequenceIDFields seqID() {
-            return this.seqID;
-        }
-
-        @Override
-        public void seqID(SeqNoFieldMapper.SequenceIDFields seqID) {
-            this.seqID = seqID;
-        }
-
-        @Override
-        public void addDynamicMapper(Mapper mapper) {
-            // eagerly check field name limit here to avoid OOM errors
-            // only check fields that are not already mapped or tracked in order to avoid hitting field limit too early via double-counting
-            // note that existing fields can also receive dynamic mapping updates (e.g. constant_keyword to fix the value)
-            if (mappingLookup.getMapper(mapper.name()) == null &&
-                mappingLookup.objectMappers().containsKey(mapper.name()) == false &&
-                newFieldsSeen.add(mapper.name())) {
-                mappingLookup.checkFieldLimit(indexSettings.getMappingTotalFieldsLimit(), newFieldsSeen.size());
-            }
-            if (mapper instanceof ObjectMapper) {
-                dynamicObjectMappers.put(mapper.name(), (ObjectMapper)mapper);
-            }
-            dynamicMappers.add(mapper);
-        }
-
-        @Override
-        public List<Mapper> getDynamicMappers() {
-            return dynamicMappers;
-        }
-
-        @Override
-        public ObjectMapper getObjectMapper(String name) {
-            return dynamicObjectMappers.get(name);
-        }
-
-        @Override
-        public void addDynamicRuntimeField(RuntimeField runtimeField) {
-            dynamicRuntimeFields.add(runtimeField);
-        }
-
-        @Override
-        public List<RuntimeField> getDynamicRuntimeFields() {
-            return Collections.unmodifiableList(dynamicRuntimeFields);
-        }
-
-        @Override
-        public Iterable<LuceneDocument> nonRootDocuments() {
-            if (docsReversed) {
-                throw new IllegalStateException("documents are already reversed");
-            }
-            return documents.subList(1, documents.size());
-        }
-
-        void postParse() {
-            if (documents.size() > 1) {
-                docsReversed = true;
-                // We preserve the order of the children while ensuring that parents appear after them.
-                List<LuceneDocument> newDocs = reorderParent(documents);
-                documents.clear();
-                documents.addAll(newDocs);
-            }
-        }
-
-        /**
-         * Returns a copy of the provided {@link List} where parent documents appear
-         * after their children.
-         */
-        private List<LuceneDocument> reorderParent(List<LuceneDocument> docs) {
-            List<LuceneDocument> newDocs = new ArrayList<>(docs.size());
-            LinkedList<LuceneDocument> parents = new LinkedList<>();
-            for (LuceneDocument doc : docs) {
-                while (parents.peek() != doc.getParent()){
-                    newDocs.add(parents.poll());
-                }
-                parents.add(0, doc);
-            }
-            newDocs.addAll(parents);
-            return newDocs;
-        }
-
-        @Override
-        public void addIgnoredField(String field) {
-            ignoredFields.add(field);
-        }
-
-        @Override
-        public Collection<String> getIgnoredFields() {
-            return Collections.unmodifiableCollection(ignoredFields);
-        }
-
-        @Override
-        public void addToFieldNames(String field) {
-            fieldNameFields.add(field);
-        }
-
-        @Override
-        public Collection<String> getFieldNames() {
-            return Collections.unmodifiableCollection(fieldNameFields);
-        }
+    protected ParseContext(ParseContext in) {
+        this.mappingLookup = in.mappingLookup;
+        this.indexSettings = in.indexSettings;
+        this.indexAnalyzers = in.indexAnalyzers;
+        this.parserContextFunction = in.parserContextFunction;
+        this.sourceToParse = in.sourceToParse;
+        this.ignoredFields = in.ignoredFields;
+        this.fieldNameFields = in.fieldNameFields;
+        this.dynamicMappers = in.dynamicMappers;
+        this.newFieldsSeen = in.newFieldsSeen;
+        this.dynamicObjectMappers = in.dynamicObjectMappers;
+        this.dynamicRuntimeFields = in.dynamicRuntimeFields;
+        this.version = in.version;
+        this.seqID = in.seqID;
     }
 
-    /**
-     * Returns an Iterable over all non-root documents. If there are no non-root documents
-     * the iterable will return an empty iterator.
-     */
-    public abstract Iterable<LuceneDocument> nonRootDocuments();
+    protected ParseContext(MappingLookup mappingLookup,
+                           IndexSettings indexSettings,
+                           IndexAnalyzers indexAnalyzers,
+                           Function<DateFormatter, MappingParserContext> parserContextFunction,
+                           SourceToParse source) {
+        this.mappingLookup = mappingLookup;
+        this.indexSettings = indexSettings;
+        this.indexAnalyzers = indexAnalyzers;
+        this.parserContextFunction = parserContextFunction;
+        this.sourceToParse = source;
+        this.ignoredFields = new HashSet<>();
+        this.fieldNameFields = new HashSet<>();
+        this.dynamicMappers = new ArrayList<>();
+        this.newFieldsSeen = new HashSet<>();
+        this.dynamicObjectMappers = new HashMap<>();
+        this.dynamicRuntimeFields = new ArrayList<>();
+    }
 
+    public final IndexSettings indexSettings() {
+        return indexSettings;
+    }
+
+    public final IndexAnalyzers indexAnalyzers() {
+        return indexAnalyzers;
+    }
+
+    public final RootObjectMapper root() {
+        return this.mappingLookup.getMapping().getRoot();
+    }
+
+    public final MappingLookup mappingLookup() {
+        return mappingLookup;
+    }
+
+    public final MetadataFieldMapper getMetadataMapper(String mapperName) {
+        return mappingLookup.getMapping().getMetadataMapperByName(mapperName);
+    }
+
+    public final MappingParserContext dynamicTemplateParserContext(DateFormatter dateFormatter) {
+        return parserContextFunction.apply(dateFormatter);
+    }
+
+    public final SourceToParse sourceToParse() {
+        return this.sourceToParse;
+    }
 
     /**
      * Add the given {@code field} to the set of ignored fields.
      */
-    public abstract void addIgnoredField(String field);
+    public final void addIgnoredField(String field) {
+        ignoredFields.add(field);
+    }
 
     /**
      * Return the collection of fields that have been ignored so far.
      */
-    public abstract Collection<String> getIgnoredFields();
+    public final Collection<String> getIgnoredFields() {
+        return Collections.unmodifiableCollection(ignoredFields);
+    }
 
     /**
      * Add the given {@code field} to the _field_names field
@@ -423,14 +172,81 @@ public abstract class ParseContext {
      * Use this if an exists query run against the field cannot use docvalues
      * or norms.
      */
-    public abstract void addToFieldNames(String field);
+    public final void addToFieldNames(String field) {
+        fieldNameFields.add(field);
+    }
 
     /**
      * Return the collection of fields to be added to the _field_names field
      */
-    public abstract Collection<String> getFieldNames();
+    public final Collection<String> getFieldNames() {
+        return Collections.unmodifiableCollection(fieldNameFields);
+    }
 
-    public abstract MappingParserContext dynamicTemplateParserContext(DateFormatter dateFormatter);
+    public final Field version() {
+        return this.version;
+    }
+
+    public final void version(Field version) {
+        this.version = version;
+    }
+
+    public final SeqNoFieldMapper.SequenceIDFields seqID() {
+        return this.seqID;
+    }
+
+    public final void seqID(SeqNoFieldMapper.SequenceIDFields seqID) {
+        this.seqID = seqID;
+    }
+
+    /**
+     * Add a new mapper dynamically created while parsing.
+     */
+    public final void addDynamicMapper(Mapper mapper) {
+        // eagerly check field name limit here to avoid OOM errors
+        // only check fields that are not already mapped or tracked in order to avoid hitting field limit too early via double-counting
+        // note that existing fields can also receive dynamic mapping updates (e.g. constant_keyword to fix the value)
+        if (mappingLookup.getMapper(mapper.name()) == null &&
+            mappingLookup.objectMappers().containsKey(mapper.name()) == false &&
+            newFieldsSeen.add(mapper.name())) {
+            mappingLookup.checkFieldLimit(indexSettings().getMappingTotalFieldsLimit(), newFieldsSeen.size());
+        }
+        if (mapper instanceof ObjectMapper) {
+            dynamicObjectMappers.put(mapper.name(), (ObjectMapper)mapper);
+        }
+        dynamicMappers.add(mapper);
+    }
+
+    /**
+     * Get dynamic mappers created while parsing.
+     */
+    public final List<Mapper> getDynamicMappers() {
+        return dynamicMappers;
+    }
+
+    public final ObjectMapper getObjectMapper(String name) {
+        return dynamicObjectMappers.get(name);
+    }
+
+    /**
+     * Add a new runtime field dynamically created while parsing.
+     */
+    public final void addDynamicRuntimeField(RuntimeField runtimeField) {
+        dynamicRuntimeFields.add(runtimeField);
+    }
+
+    /**
+     * Get dynamic runtime fields created while parsing.
+     */
+    public final List<RuntimeField> getDynamicRuntimeFields() {
+        return Collections.unmodifiableList(dynamicRuntimeFields);
+    }
+
+    /**
+     * Returns an Iterable over all non-root documents. If there are no non-root documents
+     * the iterable will return an empty iterator.
+     */
+    public abstract Iterable<LuceneDocument> nonRootDocuments();
 
     /**
      * Return a new context that will be within a copy-to operation.
@@ -458,6 +274,10 @@ public abstract class ParseContext {
                 return true;
             }
         };
+    }
+
+    public boolean isWithinMultiFields() {
+        return false;
     }
 
     /**
@@ -507,14 +327,6 @@ public abstract class ParseContext {
         };
     }
 
-    public boolean isWithinMultiFields() {
-        return false;
-    }
-
-    public abstract IndexSettings indexSettings();
-
-    public abstract SourceToParse sourceToParse();
-
     public abstract ContentPath path();
 
     public abstract XContentParser parser();
@@ -524,44 +336,6 @@ public abstract class ParseContext {
     public abstract LuceneDocument doc();
 
     protected abstract void addDoc(LuceneDocument doc);
-
-    public abstract RootObjectMapper root();
-
-    public abstract MappingLookup mappingLookup();
-
-    public abstract MetadataFieldMapper getMetadataMapper(String mapperName);
-
-    public abstract IndexAnalyzers indexAnalyzers();
-
-    public abstract Field version();
-
-    public abstract void version(Field version);
-
-    public abstract SeqNoFieldMapper.SequenceIDFields seqID();
-
-    public abstract void seqID(SeqNoFieldMapper.SequenceIDFields seqID);
-
-    /**
-     * Add a new mapper dynamically created while parsing.
-     */
-    public abstract void addDynamicMapper(Mapper update);
-
-    public abstract ObjectMapper getObjectMapper(String name);
-
-    /**
-     * Get dynamic mappers created while parsing.
-     */
-    public abstract List<Mapper> getDynamicMappers();
-
-    /**
-     * Add a new runtime field dynamically created while parsing.
-     */
-    public abstract void addDynamicRuntimeField(RuntimeField runtimeField);
-
-    /**
-     * Get dynamic runtime fields created while parsing.
-     */
-    public abstract List<RuntimeField> getDynamicRuntimeFields();
 
     /**
      * Find a dynamic mapping template for the given field and its matching type

--- a/server/src/main/java/org/elasticsearch/index/mapper/ParseContext.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/ParseContext.java
@@ -24,10 +24,16 @@ import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
 
+/**
+ * Context used when parsing incoming documents. Holds everything that is needed to parse a document as well as
+ * the lucene data structures and mappings to be dynamically created as the outcome of parsing a document.
+ */
 public abstract class ParseContext {
 
+    /**
+     * Wraps a given context while allowing to override some of its behaviour by re-implementing some of the non final methods
+     */
     private static class FilterParseContext extends ParseContext {
-
         private final ParseContext in;
 
         private FilterParseContext(ParseContext in) {
@@ -90,7 +96,7 @@ public abstract class ParseContext {
     private Field version;
     private SeqNoFieldMapper.SequenceIDFields seqID;
 
-    protected ParseContext(ParseContext in) {
+    private ParseContext(ParseContext in) {
         this.mappingLookup = in.mappingLookup;
         this.indexSettings = in.indexSettings;
         this.indexAnalyzers = in.indexAnalyzers;

--- a/server/src/test/java/org/elasticsearch/index/mapper/BooleanScriptFieldTypeTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/BooleanScriptFieldTypeTests.java
@@ -310,35 +310,10 @@ public class BooleanScriptFieldTypeTests extends AbstractNonTextScriptFieldTypeT
             SourceToParse sourceToParse = new SourceToParse("test", "test", new BytesArray(source), XContentType.JSON);
             LuceneDocument doc = new LuceneDocument();
             doc.add(new StoredField("_source", new BytesRef(source)));
-            ParseContext ctx = new ParseContext(null, null, null, null, sourceToParse) {
-                @Override
-                public Iterable<LuceneDocument> nonRootDocuments() {
-                    throw new UnsupportedOperationException();
-                }
-
-                @Override
-                public ContentPath path() {
-                    throw new UnsupportedOperationException();
-                }
-
+            ParseContext ctx = new TestParseContext(null, null, null, null, sourceToParse) {
                 @Override
                 public XContentParser parser() {
                     return parser;
-                }
-
-                @Override
-                public LuceneDocument rootDoc() {
-                    throw new UnsupportedOperationException();
-                }
-
-                @Override
-                public LuceneDocument doc() {
-                    return doc;
-                }
-
-                @Override
-                protected void addDoc(LuceneDocument doc) {
-                    throw new UnsupportedOperationException();
                 }
             };
 

--- a/server/src/test/java/org/elasticsearch/index/mapper/BooleanScriptFieldTypeTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/BooleanScriptFieldTypeTests.java
@@ -29,6 +29,7 @@ import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.Version;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.lucene.search.function.ScriptScoreQuery;
+import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.XContentParser.Token;
 import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.common.xcontent.json.JsonXContent;
@@ -52,8 +53,6 @@ import static java.util.Collections.emptyMap;
 import static java.util.Collections.singletonList;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 public class BooleanScriptFieldTypeTests extends AbstractNonTextScriptFieldTypeTestCase {
 
@@ -307,12 +306,42 @@ public class BooleanScriptFieldTypeTests extends AbstractNonTextScriptFieldTypeT
         try (Directory directory = newDirectory(); RandomIndexWriter iw = new RandomIndexWriter(random(), directory)) {
             List<Boolean> values = randomList(0, 2, ESTestCase::randomBoolean);
             String source = "{\"foo\": " + values + "}";
-            ParseContext ctx = mock(ParseContext.class);
-            when(ctx.parser()).thenReturn(createParser(JsonXContent.jsonXContent, source));
+            XContentParser parser = createParser(JsonXContent.jsonXContent, source);
+            SourceToParse sourceToParse = new SourceToParse("test", "test", new BytesArray(source), XContentType.JSON);
             LuceneDocument doc = new LuceneDocument();
-            when(ctx.doc()).thenReturn(doc);
-            when(ctx.sourceToParse()).thenReturn(new SourceToParse("test", "test", new BytesArray(source), XContentType.JSON));
             doc.add(new StoredField("_source", new BytesRef(source)));
+            ParseContext ctx = new ParseContext(null, null, null, null, sourceToParse) {
+                @Override
+                public Iterable<LuceneDocument> nonRootDocuments() {
+                    throw new UnsupportedOperationException();
+                }
+
+                @Override
+                public ContentPath path() {
+                    throw new UnsupportedOperationException();
+                }
+
+                @Override
+                public XContentParser parser() {
+                    return parser;
+                }
+
+                @Override
+                public LuceneDocument rootDoc() {
+                    throw new UnsupportedOperationException();
+                }
+
+                @Override
+                public LuceneDocument doc() {
+                    return doc;
+                }
+
+                @Override
+                protected void addDoc(LuceneDocument doc) {
+                    throw new UnsupportedOperationException();
+                }
+            };
+
             ctx.parser().nextToken();
             ctx.parser().nextToken();
             ctx.parser().nextToken();

--- a/server/src/test/java/org/elasticsearch/index/mapper/DocumentParserTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/DocumentParserTests.java
@@ -607,41 +607,8 @@ public class DocumentParserTests extends MapperServiceTestCase {
     }
 
     // creates an object mapper, which is about 100x harder than it should be....
-    ObjectMapper createObjectMapper(MapperService mapperService, String name) {
-        DocumentMapper docMapper = mapperService.documentMapper();
-        ParseContext context = new ParseContext(docMapper.mappers(), mapperService.getIndexSettings(), null, null, null) {
-            private final ContentPath contentPath = new ContentPath(0);
-
-            @Override
-            public Iterable<LuceneDocument> nonRootDocuments() {
-                throw new UnsupportedOperationException();
-            }
-
-            @Override
-            public ContentPath path() {
-                return contentPath;
-            }
-
-            @Override
-            public XContentParser parser() {
-                throw new UnsupportedOperationException();
-            }
-
-            @Override
-            public LuceneDocument rootDoc() {
-                throw new UnsupportedOperationException();
-            }
-
-            @Override
-            public LuceneDocument doc() {
-                throw new UnsupportedOperationException();
-            }
-
-            @Override
-            protected void addDoc(LuceneDocument doc) {
-                throw new UnsupportedOperationException();
-            }
-        };
+    private static ObjectMapper createObjectMapper(String name) {
+        ParseContext context = new TestParseContext();
         String[] nameParts = name.split("\\.");
         for (int i = 0; i < nameParts.length - 1; ++i) {
             context.path().add(nameParts[i]);
@@ -743,8 +710,8 @@ public class DocumentParserTests extends MapperServiceTestCase {
         MapperService mapperService = createMapperService();
         DocumentMapper docMapper = mapperService.documentMapper();
         List<Mapper> updates = new ArrayList<>();
-        updates.add(createObjectMapper(mapperService, "foo"));
-        updates.add(createObjectMapper(mapperService, "foo.bar"));
+        updates.add(createObjectMapper("foo"));
+        updates.add(createObjectMapper("foo.bar"));
         updates.add(new MockFieldMapper("foo.bar.baz"));
         updates.add(new MockFieldMapper("foo.field"));
         Mapping mapping = DocumentParser.createDynamicUpdate(docMapper.mappers(), updates, Collections.emptyList());

--- a/server/src/test/java/org/elasticsearch/index/mapper/DocumentParserTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/DocumentParserTests.java
@@ -608,13 +608,12 @@ public class DocumentParserTests extends MapperServiceTestCase {
 
     // creates an object mapper, which is about 100x harder than it should be....
     private static ObjectMapper createObjectMapper(String name) {
-        ParseContext context = new TestParseContext();
+        ContentPath path = new ContentPath(0);
         String[] nameParts = name.split("\\.");
         for (int i = 0; i < nameParts.length - 1; ++i) {
-            context.path().add(nameParts[i]);
+            path.add(nameParts[i]);
         }
-        Mapper.Builder builder = new ObjectMapper.Builder(nameParts[nameParts.length - 1], Version.CURRENT).enabled(true);
-        return (ObjectMapper)builder.build(context.path());
+        return new ObjectMapper.Builder(nameParts[nameParts.length - 1], Version.CURRENT).enabled(true).build(path);
     }
 
     public void testEmptyMappingUpdate() throws Exception {

--- a/server/src/test/java/org/elasticsearch/index/mapper/DocumentParserTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/DocumentParserTests.java
@@ -609,8 +609,39 @@ public class DocumentParserTests extends MapperServiceTestCase {
     // creates an object mapper, which is about 100x harder than it should be....
     ObjectMapper createObjectMapper(MapperService mapperService, String name) {
         DocumentMapper docMapper = mapperService.documentMapper();
-        ParseContext context = new ParseContext.InternalParseContext(docMapper.mappers(), mapperService.getIndexSettings(), null,
-            null, null, null);
+        ParseContext context = new ParseContext(docMapper.mappers(), mapperService.getIndexSettings(), null, null, null) {
+            private final ContentPath contentPath = new ContentPath(0);
+
+            @Override
+            public Iterable<LuceneDocument> nonRootDocuments() {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public ContentPath path() {
+                return contentPath;
+            }
+
+            @Override
+            public XContentParser parser() {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public LuceneDocument rootDoc() {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public LuceneDocument doc() {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            protected void addDoc(LuceneDocument doc) {
+                throw new UnsupportedOperationException();
+            }
+        };
         String[] nameParts = name.split("\\.");
         for (int i = 0; i < nameParts.length - 1; ++i) {
             context.path().add(nameParts[i]);

--- a/test/framework/src/main/java/org/elasticsearch/index/mapper/TestParseContext.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/mapper/TestParseContext.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.index.mapper;
+
+import org.elasticsearch.common.time.DateFormatter;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.index.IndexSettings;
+import org.elasticsearch.index.analysis.IndexAnalyzers;
+
+import java.util.function.Function;
+
+/**
+ * Simplified version of {@link ParseContext} to be used in tests.
+ * Every non final method throws {@link UnsupportedOperationException} and can be implemented as needed.
+ * {@link #doc()} and {@link #path()} are defined and final, as their behaviour is standard and they
+ * are both needed in almost every situation.
+ * The methods defined final in {@link ParseContext} depend on the provided constructor arguments.
+ */
+public class TestParseContext extends ParseContext {
+    private final LuceneDocument document = new LuceneDocument();
+    private final ContentPath contentPath = new ContentPath(0);
+
+    /**
+     * The shortest and easiest way to create a context, to be used when none of the constructor arguments are needed.
+     * Use with caution as it can cause {@link NullPointerException}s down the line.
+     */
+    public TestParseContext() {
+        super(null, null, null, null, null);
+    }
+
+    /**
+     * More verbose way to create a context, to be used when one or more constructor arguments are needed as final methods
+     * that depend on them are called while executing tests.
+     */
+    public TestParseContext(MappingLookup mappingLookup,
+                            IndexSettings indexSettings,
+                            IndexAnalyzers indexAnalyzers,
+                            Function<DateFormatter, MappingParserContext> parserContextFunction,
+                            SourceToParse source) {
+        super(mappingLookup, indexSettings, indexAnalyzers, parserContextFunction, source);
+    }
+
+    @Override
+    public final LuceneDocument doc() {
+        return document;
+    }
+
+    @Override
+    public final ContentPath path() {
+        return contentPath;
+    }
+
+    @Override
+    public Iterable<LuceneDocument> nonRootDocuments() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public XContentParser parser() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public LuceneDocument rootDoc() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    protected void addDoc(LuceneDocument doc) {
+        throw new UnsupportedOperationException();
+    }
+}


### PR DESCRIPTION
We currently have one ParseContext class, which is used to parse incoming documents, not to be confused with the former ParserContext (now renamed to MappingParserContext) which is instead used to parse mappings.

There are a few implementations of ParseContext, but mostly the InternalParseContext one is used. There is also a FilterParseContext that allows to delegate to a given context for all methods besides the one explicitly overridden by it.

This commit attempts to simplify ParseContext by extracting its InternalParseContext implementation and moving it where it's used, within DocumentParser and making it privatae, so that the super-class can be used. This allows to hide some implementation details that only InternalParseContext knows about on nested documents and the way they are stored in lucene.

Also, we are introducing separate test implementations in place of reusing InternalParseContext in tests too.

Additionally FilterParseContext can be greatly simplified by relying on a copy constructor, that makes it so that it does not have to override every single method to delegate to the provided context.
