### PR TITLE
Script: User funcs are script instance methods (#74268)

### DIFF
--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/FunctionRef.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/FunctionRef.java
@@ -14,6 +14,7 @@ import org.elasticsearch.painless.lookup.PainlessLookupUtility;
 import org.elasticsearch.painless.lookup.PainlessMethod;
 import org.elasticsearch.painless.symbol.FunctionTable;
 import org.elasticsearch.painless.symbol.FunctionTable.LocalFunction;
+import org.objectweb.asm.Type;
 
 import java.lang.invoke.MethodType;
 import java.lang.reflect.Modifier;
@@ -21,6 +22,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.stream.Collectors;
 
 import static org.elasticsearch.painless.WriterConstants.CLASS_NAME;
 import static org.objectweb.asm.Opcodes.H_INVOKEINTERFACE;
@@ -44,9 +46,11 @@ public class FunctionRef {
      * @param methodName the right hand side of a method reference expression
      * @param numberOfCaptures number of captured arguments
      * @param constants constants used for injection when necessary
+     * @param needsScriptInstance uses an instance method and so receiver must be captured.
      */
     public static FunctionRef create(PainlessLookup painlessLookup, FunctionTable functionTable, Location location,
-            Class<?> targetClass, String typeName, String methodName, int numberOfCaptures, Map<String, Object> constants) {
+            Class<?> targetClass, String typeName, String methodName, int numberOfCaptures, Map<String, Object> constants,
+            boolean needsScriptInstance) {
 
         Objects.requireNonNull(painlessLookup);
         Objects.requireNonNull(targetClass);
@@ -98,8 +102,8 @@ public class FunctionRef {
                 delegateClassName = CLASS_NAME;
                 isDelegateInterface = false;
                 isDelegateAugmented = false;
-                delegateInvokeType = H_INVOKESTATIC;
-                delegateMethodName = localFunction.getFunctionName();
+                delegateInvokeType = needsScriptInstance ? H_INVOKEVIRTUAL : H_INVOKESTATIC;
+                delegateMethodName = localFunction.getMangledName();
                 delegateMethodType = localFunction.getMethodType();
                 delegateInjections = new Object[0];
 
@@ -178,7 +182,7 @@ public class FunctionRef {
                     if (painlessMethod.methodType.parameterType(0) != Object.class) {
                         throw new IllegalStateException("internal error");
                     }
-                    
+
                     delegateMethodType = delegateMethodType.changeParameterType(0, painlessMethod.javaMethod.getDeclaringClass());
                 }
 
@@ -213,7 +217,7 @@ public class FunctionRef {
             return new FunctionRef(interfaceMethodName, interfaceMethodType,
                     delegateClassName, isDelegateInterface, isDelegateAugmented,
                     delegateInvokeType, delegateMethodName, delegateMethodType, delegateInjections,
-                    factoryMethodType
+                    factoryMethodType, needsScriptInstance ? WriterConstants.CLASS_TYPE : null
             );
         } catch (IllegalArgumentException iae) {
             if (location != null) {
@@ -243,13 +247,15 @@ public class FunctionRef {
     /** injected constants */
     public final Object[] delegateInjections;
     /** factory (CallSite) method signature */
-    public final MethodType factoryMethodType;
+    private final MethodType factoryMethodType;
+    /** factory (CallSite) method receiver, this modifies the method descriptor for the factory method */
+    public final Type factoryMethodReceiver;
 
     private FunctionRef(
             String interfaceMethodName, MethodType interfaceMethodType,
             String delegateClassName, boolean isDelegateInterface, boolean isDelegateAugmented,
             int delegateInvokeType, String delegateMethodName, MethodType delegateMethodType, Object[] delegateInjections,
-            MethodType factoryMethodType) {
+            MethodType factoryMethodType, Type factoryMethodReceiver) {
 
         this.interfaceMethodName = interfaceMethodName;
         this.interfaceMethodType = interfaceMethodType;
@@ -261,5 +267,27 @@ public class FunctionRef {
         this.delegateMethodType = delegateMethodType;
         this.delegateInjections = delegateInjections;
         this.factoryMethodType = factoryMethodType;
+        this.factoryMethodReceiver = factoryMethodReceiver;
+    }
+
+    /** Get the factory method type, with updated receiver if {@code factoryMethodReceiver} is set */
+    public String getFactoryMethodDescriptor() {
+        if (factoryMethodReceiver == null) {
+            return factoryMethodType.toMethodDescriptorString();
+        }
+        List<Type> arguments = factoryMethodType.parameterList().stream().map(Type::getType).collect(Collectors.toList());
+        arguments.add(0, factoryMethodReceiver);
+        Type[] argArray = new Type[arguments.size()];
+        arguments.toArray(argArray);
+        return Type.getMethodDescriptor(Type.getType(factoryMethodType.returnType()), argArray);
+    }
+
+    /** Get the factory method type, updating the receiver if {@code factoryMethodReceiverClass} is non-null */
+    public Class<?>[] factoryMethodParameters(Class<?> factoryMethodReceiverClass) {
+        List<Class<?>> parameters = new ArrayList<>(factoryMethodType.parameterList());
+        if (factoryMethodReceiverClass != null) {
+            parameters.add(0, factoryMethodReceiverClass);
+        }
+        return parameters.toArray(new Class<?>[0]);
     }
 }

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/MethodWriter.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/MethodWriter.java
@@ -514,11 +514,6 @@ public final class MethodWriter extends GeneratorAdapter {
         args[6] = functionRef.isDelegateAugmented ? 1 : 0;
         System.arraycopy(functionRef.delegateInjections, 0, args, 7, functionRef.delegateInjections.length);
 
-        invokeDynamic(
-                functionRef.interfaceMethodName,
-                functionRef.factoryMethodType.toMethodDescriptorString(),
-                LAMBDA_BOOTSTRAP_HANDLE,
-                args
-        );
+        invokeDynamic(functionRef.interfaceMethodName, functionRef.getFactoryMethodDescriptor(), LAMBDA_BOOTSTRAP_HANDLE, args);
     }
 }

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/antlr/Walker.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/antlr/Walker.java
@@ -273,7 +273,7 @@ public final class Walker extends PainlessParserBaseVisitor<ANode> {
         }
 
         return new SFunction(nextIdentifier(), location(ctx),
-                rtnType, name, paramTypes, paramNames, new SBlock(nextIdentifier(), location(ctx), statements), false, true, false, false);
+                rtnType, name, paramTypes, paramNames, new SBlock(nextIdentifier(), location(ctx), statements), false, false, false, false);
     }
 
     @Override

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/phase/DefaultUserTreeToIRTreePhase.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/phase/DefaultUserTreeToIRTreePhase.java
@@ -8,6 +8,7 @@
 
 package org.elasticsearch.painless.phase;
 
+import org.elasticsearch.painless.Def;
 import org.elasticsearch.painless.DefBootstrap;
 import org.elasticsearch.painless.FunctionRef;
 import org.elasticsearch.painless.Location;
@@ -158,6 +159,8 @@ import org.elasticsearch.painless.symbol.Decorations.Explicit;
 import org.elasticsearch.painless.symbol.Decorations.ExpressionPainlessCast;
 import org.elasticsearch.painless.symbol.Decorations.GetterPainlessMethod;
 import org.elasticsearch.painless.symbol.Decorations.IRNodeDecoration;
+import org.elasticsearch.painless.symbol.Decorations.InstanceCapturingLambda;
+import org.elasticsearch.painless.symbol.Decorations.InstanceCapturingFunctionRef;
 import org.elasticsearch.painless.symbol.Decorations.InstanceType;
 import org.elasticsearch.painless.symbol.Decorations.IterablePainlessMethod;
 import org.elasticsearch.painless.symbol.Decorations.ListShortcut;
@@ -193,6 +196,7 @@ import org.elasticsearch.painless.symbol.IRDecorations.IRCAllEscape;
 import org.elasticsearch.painless.symbol.IRDecorations.IRCCaptureBox;
 import org.elasticsearch.painless.symbol.IRDecorations.IRCContinuous;
 import org.elasticsearch.painless.symbol.IRDecorations.IRCInitialize;
+import org.elasticsearch.painless.symbol.IRDecorations.IRCInstanceCapture;
 import org.elasticsearch.painless.symbol.IRDecorations.IRCRead;
 import org.elasticsearch.painless.symbol.IRDecorations.IRCStatic;
 import org.elasticsearch.painless.symbol.IRDecorations.IRCSynthetic;
@@ -1352,7 +1356,12 @@ public class DefaultUserTreeToIRTreePhase implements UserTreeVisitor<ScriptScope
                 new ArrayList<>(scriptScope.getDecoration(userLambdaNode, TypeParameters.class).getTypeParameters())));
         irFunctionNode.attachDecoration(new IRDParameterNames(
                 new ArrayList<>(scriptScope.getDecoration(userLambdaNode, ParameterNames.class).getParameterNames())));
-        irFunctionNode.attachCondition(IRCStatic.class);
+        if (scriptScope.getCondition(userLambdaNode, InstanceCapturingLambda.class)) {
+            irFunctionNode.attachCondition(IRCInstanceCapture.class);
+            irExpressionNode.attachCondition(IRCInstanceCapture.class);
+        } else {
+            irFunctionNode.attachCondition(IRCStatic.class);
+        }
         irFunctionNode.attachCondition(IRCSynthetic.class);
         irFunctionNode.attachDecoration(new IRDMaxLoopCounter(scriptScope.getCompilerSettings().getMaxLoopCounter()));
         irClassNode.addFunctionNode(irFunctionNode);
@@ -1382,9 +1391,12 @@ public class DefaultUserTreeToIRTreePhase implements UserTreeVisitor<ScriptScope
         CapturesDecoration capturesDecoration = scriptScope.getDecoration(userFunctionRefNode, CapturesDecoration.class);
 
         if (targetType == null) {
-            String encoding = scriptScope.getDecoration(userFunctionRefNode, EncodingDecoration.class).getEncoding();
+            Def.Encoding encoding = scriptScope.getDecoration(userFunctionRefNode, EncodingDecoration.class).getEncoding();
             DefInterfaceReferenceNode defInterfaceReferenceNode = new DefInterfaceReferenceNode(userFunctionRefNode.getLocation());
             defInterfaceReferenceNode.attachDecoration(new IRDDefReferenceEncoding(encoding));
+            if (scriptScope.getCondition(userFunctionRefNode, InstanceCapturingFunctionRef.class)) {
+                defInterfaceReferenceNode.attachCondition(IRCInstanceCapture.class);
+            }
             irReferenceNode = defInterfaceReferenceNode;
         } else if (capturesDecoration != null && capturesDecoration.getCaptures().get(0).getType() == def.class) {
             TypedCaptureReferenceNode typedCaptureReferenceNode = new TypedCaptureReferenceNode(userFunctionRefNode.getLocation());
@@ -1394,6 +1406,9 @@ public class DefaultUserTreeToIRTreePhase implements UserTreeVisitor<ScriptScope
             FunctionRef reference = scriptScope.getDecoration(userFunctionRefNode, ReferenceDecoration.class).getReference();
             TypedInterfaceReferenceNode typedInterfaceReferenceNode = new TypedInterfaceReferenceNode(userFunctionRefNode.getLocation());
             typedInterfaceReferenceNode.attachDecoration(new IRDReference(reference));
+            if (scriptScope.getCondition(userFunctionRefNode, InstanceCapturingFunctionRef.class)) {
+                typedInterfaceReferenceNode.attachCondition(IRCInstanceCapture.class);
+            }
             irReferenceNode = typedInterfaceReferenceNode;
         }
 
@@ -1423,7 +1438,7 @@ public class DefaultUserTreeToIRTreePhase implements UserTreeVisitor<ScriptScope
             typedInterfaceReferenceNode.attachDecoration(new IRDReference(reference));
             irReferenceNode = typedInterfaceReferenceNode;
         } else {
-            String encoding = scriptScope.getDecoration(userNewArrayFunctionRefNode, EncodingDecoration.class).getEncoding();
+            Def.Encoding encoding = scriptScope.getDecoration(userNewArrayFunctionRefNode, EncodingDecoration.class).getEncoding();
             DefInterfaceReferenceNode defInterfaceReferenceNode = new DefInterfaceReferenceNode(userNewArrayFunctionRefNode.getLocation());
             defInterfaceReferenceNode.attachDecoration(new IRDDefReferenceEncoding(encoding));
             irReferenceNode = defInterfaceReferenceNode;

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/symbol/Decorations.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/symbol/Decorations.java
@@ -8,6 +8,7 @@
 
 package org.elasticsearch.painless.symbol;
 
+import org.elasticsearch.painless.Def;
 import org.elasticsearch.painless.FunctionRef;
 import org.elasticsearch.painless.ir.IRNode;
 import org.elasticsearch.painless.lookup.PainlessCast;
@@ -513,13 +514,13 @@ public class Decorations {
 
     public static class EncodingDecoration implements Decoration {
 
-        private final String encoding;
+        private final Def.Encoding encoding;
 
-        public EncodingDecoration(String encoding) {
-            this.encoding = Objects.requireNonNull(encoding);
+        public EncodingDecoration(boolean isStatic, boolean needsInstance, String symbol, String methodName, int captures) {
+            this.encoding = new Def.Encoding(isStatic, needsInstance, symbol, methodName, captures);
         }
 
-        public String getEncoding() {
+        public Def.Encoding getEncoding() {
             return encoding;
         }
     }
@@ -608,6 +609,16 @@ public class Decorations {
     // collect additional information about where doc is used
 
     public interface IsDocument extends Condition {
+
+    }
+
+    // Does the lambda need to capture the enclosing instance?
+    public interface InstanceCapturingLambda extends Condition {
+
+    }
+
+    // Does the function reference need to capture the enclosing instance?
+    public interface InstanceCapturingFunctionRef extends Condition {
 
     }
 }

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/symbol/IRDecorations.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/symbol/IRDecorations.java
@@ -8,6 +8,7 @@
 
 package org.elasticsearch.painless.symbol;
 
+import org.elasticsearch.painless.Def;
 import org.elasticsearch.painless.FunctionRef;
 import org.elasticsearch.painless.Operation;
 import org.elasticsearch.painless.ir.IRNode.IRCondition;
@@ -165,9 +166,9 @@ public class IRDecorations {
     }
 
     /** describes an encoding used to resolve references and lambdas at runtime */
-    public static class IRDDefReferenceEncoding extends IRDecoration<String> {
+    public static class IRDDefReferenceEncoding extends IRDecoration<Def.Encoding> {
 
-        public IRDDefReferenceEncoding(String value) {
+        public IRDDefReferenceEncoding(Def.Encoding value) {
             super(value);
         }
     }
@@ -333,6 +334,14 @@ public class IRDecorations {
     public static class IRCSynthetic implements IRCondition {
 
         private IRCSynthetic() {
+
+        }
+    }
+
+    /** describes if a method needs to capture the script "this" */
+    public static class IRCInstanceCapture implements IRCondition {
+
+        private IRCInstanceCapture() {
 
         }
     }

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/symbol/SemanticScope.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/symbol/SemanticScope.java
@@ -137,6 +137,7 @@ public abstract class SemanticScope {
         protected final SemanticScope parent;
         protected final Class<?> returnType;
         protected final Set<Variable> captures = new HashSet<>();
+        protected boolean usesInstanceMethod = false;
 
         protected LambdaScope(SemanticScope parent, Class<?> returnType) {
             super(parent.scriptScope, parent.usedVariables);
@@ -189,6 +190,19 @@ public abstract class SemanticScope {
 
         public Set<Variable> getCaptures() {
             return Collections.unmodifiableSet(captures);
+        }
+
+        @Override
+        public void setUsesInstanceMethod() {
+            if (usesInstanceMethod) {
+                return;
+            }
+            usesInstanceMethod = true;
+        }
+
+        @Override
+        public boolean usesInstanceMethod() {
+            return usesInstanceMethod;
         }
     }
 
@@ -339,6 +353,13 @@ public abstract class SemanticScope {
 
     public abstract boolean isVariableDefined(String name);
     public abstract Variable getVariable(Location location, String name);
+
+    // We only want to track instance method use inside of lambdas for "this" injection.  It's a noop for other scopes.
+    public void setUsesInstanceMethod() {}
+
+    public boolean usesInstanceMethod() {
+        return false;
+    }
 
     public Variable defineInternalVariable(Location location, Class<?> type, String name, boolean isReadOnly) {
         return defineVariable(location, type, "#" + name, isReadOnly);

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/toxcontent/DecorationToXContent.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/toxcontent/DecorationToXContent.java
@@ -291,8 +291,8 @@ public class DecorationToXContent {
             builder.endArray();
         }
 
-        builder.field("factoryMethodType");
-        ToXContent(ref.factoryMethodType, builder);
+        builder.field("factoryMethodDescriptor", ref.getFactoryMethodDescriptor());
+
         builder.endObject();
     }
 

--- a/modules/lang-painless/src/test/java/org/elasticsearch/painless/EmitTests.java
+++ b/modules/lang-painless/src/test/java/org/elasticsearch/painless/EmitTests.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.painless;
+
+import org.elasticsearch.painless.spi.Whitelist;
+import org.elasticsearch.painless.spi.WhitelistLoader;
+import org.elasticsearch.script.ScriptContext;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class EmitTests extends ScriptTestCase {
+    @Override
+    protected Map<ScriptContext<?>, List<Whitelist>> scriptContexts() {
+        Map<ScriptContext<?>, List<Whitelist>> contexts = new HashMap<>();
+        List<Whitelist> whitelists = new ArrayList<>(Whitelist.BASE_WHITELISTS);
+        whitelists.add(WhitelistLoader.loadFromResourceFiles(Whitelist.class, "org.elasticsearch.painless.test"));
+        contexts.put(TestFieldScript.CONTEXT, whitelists);
+        return contexts;
+    }
+
+    @Override
+    public TestFieldScript exec(String script) {
+        TestFieldScript.Factory factory = scriptEngine.compile(null, script, TestFieldScript.CONTEXT, new HashMap<>());
+        TestFieldScript testScript = factory.newInstance();
+        testScript.execute();
+        return testScript;
+    }
+
+    public void testEmit() {
+        TestFieldScript script = exec("emit(1L)");
+        assertNotNull(script);
+        assertArrayEquals(new long[]{1L}, script.fetchValues());
+    }
+
+    public void testEmitFromUserFunction() {
+        TestFieldScript script = exec("void doEmit(long l) { emit(l) } doEmit(1L); doEmit(100L)");
+        assertNotNull(script);
+        assertArrayEquals(new long[]{1L, 100L}, script.fetchValues());
+    }
+}

--- a/modules/lang-painless/src/test/java/org/elasticsearch/painless/FunctionRefTests.java
+++ b/modules/lang-painless/src/test/java/org/elasticsearch/painless/FunctionRefTests.java
@@ -150,12 +150,12 @@ public class FunctionRefTests extends ScriptTestCase {
                 "return test.twoFunctionsOfX(x::concat, y::substring);"));
     }
 
-    public void testOwnStaticMethodReference() {
+    public void testOwnMethodReference() {
         assertEquals(2, exec("int mycompare(int i, int j) { j - i } " +
                              "List l = new ArrayList(); l.add(2); l.add(1); l.sort(this::mycompare); return l.get(0);"));
     }
 
-    public void testOwnStaticMethodReferenceDef() {
+    public void testOwnMethodReferenceDef() {
         assertEquals(2, exec("int mycompare(int i, int j) { j - i } " +
                              "def l = new ArrayList(); l.add(2); l.add(1); l.sort(this::mycompare); return l.get(0);"));
     }

--- a/modules/lang-painless/src/test/java/org/elasticsearch/painless/TestFieldScript.java
+++ b/modules/lang-painless/src/test/java/org/elasticsearch/painless/TestFieldScript.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.painless;
+
+import org.elasticsearch.script.ScriptContext;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public abstract class TestFieldScript {
+    private final List<Long> values = new ArrayList<>();
+
+    @SuppressWarnings("unused")
+    public static final String[] PARAMETERS = {};
+    public interface Factory {
+        TestFieldScript newInstance();
+    }
+
+    public static final ScriptContext<TestFieldScript.Factory> CONTEXT =
+            new ScriptContext<>("painless_test_fieldscript", TestFieldScript.Factory.class);
+
+    public static class Emit {
+        private final TestFieldScript script;
+
+        public Emit(TestFieldScript script) {
+            this.script = script;
+        }
+
+        public void emit(long v) {
+            script.emit(v);
+        }
+    }
+
+    public abstract void execute();
+
+    public final void emit(long v) {
+        values.add(v);
+    }
+
+    public long[] fetchValues() {
+        return values.stream().mapToLong(i->i).toArray();
+    }
+}

--- a/modules/lang-painless/src/test/java/org/elasticsearch/painless/ToXContentTests.java
+++ b/modules/lang-painless/src/test/java/org/elasticsearch/painless/ToXContentTests.java
@@ -25,7 +25,7 @@ public class ToXContentTests extends ScriptTestCase {
     public void testUserFunction() {
         Map<?,?> func = getFunction("def twofive(int i) { return 25 + i; } int j = 23; twofive(j)", "twofive");
         assertFalse((Boolean)func.get("isInternal"));
-        assertTrue((Boolean)func.get("isStatic"));
+        assertFalse((Boolean)func.get("isStatic"));
         assertEquals("SFunction", func.get("node"));
         assertEquals("def", func.get("returns"));
         assertEquals(org.elasticsearch.core.List.of("int"), func.get("parameterTypes"));

--- a/modules/lang-painless/src/test/java/org/elasticsearch/painless/UserFunctionTests.java
+++ b/modules/lang-painless/src/test/java/org/elasticsearch/painless/UserFunctionTests.java
@@ -8,9 +8,147 @@
 
 package org.elasticsearch.painless;
 
+import java.util.List;
+import java.util.Map;
+
 public class UserFunctionTests extends ScriptTestCase {
     public void testZeroArgumentUserFunction() {
         String source = "def twofive() { return 25; } twofive()";
         assertEquals(25, exec(source));
+    }
+
+    public void testUserFunctionDefCallRef() {
+        String source =
+            "String getSource() { 'source'; }\n" +
+            "int myCompare(int a, int b) { getMulti() * Integer.compare(a, b) }\n" +
+                "int getMulti() { return -1 }\n" +
+                "def l = [1, 100, -100];\n" +
+                "if (myCompare(10, 50) > 0) { l.add(50 + getMulti()) }\n" +
+                "l.sort(this::myCompare);\n" +
+                "if (l[0] == 100) { l.remove(l.size() - 1) ; l.sort((a, b) -> -1 * myCompare(a, b)) } \n"+
+                "if (getSource().startsWith('sour')) { l.add(255); }\n" +
+                "return l;";
+        assertEquals(List.of(1, 49, 100, 255), exec(source));
+        assertBytecodeExists(source, "public &getSource()Ljava/lang/String");
+        assertBytecodeExists(source, "public &getMulti()I");
+        assertBytecodeExists(source, "INVOKEVIRTUAL org/elasticsearch/painless/PainlessScript$Script.&getMulti ()I");
+        assertBytecodeExists(source, "public &myCompare(II)I");
+        assertBytecodeExists(source, "INVOKEVIRTUAL org/elasticsearch/painless/PainlessScript$Script.&myCompare (II)I");
+    }
+
+    public void testChainedUserMethods() {
+        String source = "int myCompare(int a, int b) { getMulti() * (a - b) }\n" +
+                        "int getMulti() { -1 }\n" +
+                        "List l = [1, 100, -100];\n" +
+                        "l.sort(this::myCompare);\n" +
+                        "l;\n";
+        assertEquals(List.of(100, 1, -100), exec(source, Map.of("a", 1), false));
+    }
+
+
+    public void testChainedUserMethodsLambda() {
+        String source = "int myCompare(int a, int b) { getMulti() * (a - b) }\n" +
+                        "int getMulti() { -1 }\n" +
+                        "List l = [1, 100, -100];\n" +
+                        "l.sort((a, b) -> myCompare(a, b));\n" +
+                        "l;\n";
+        assertEquals(List.of(100, 1, -100), exec(source, Map.of("a", 1), false));
+    }
+
+    public void testChainedUserMethodsDef() {
+        String source = "int myCompare(int a, int b) { getMulti() * (a - b) }\n" +
+                        "int getMulti() { -1 }\n" +
+                        "def l = [1, 100, -100];\n" +
+                        "l.sort(this::myCompare);\n" +
+                        "l;\n";
+        assertEquals(List.of(100, 1, -100), exec(source, Map.of("a", 1), false));
+    }
+
+
+    public void testChainedUserMethodsLambdaDef() {
+        String source = "int myCompare(int a, int b) { getMulti() * (a - b) }\n" +
+                        "int getMulti() { -1 }\n" +
+                        "def l = [1, 100, -100];\n" +
+                        "l.sort((a, b) -> myCompare(a, b));\n" +
+                        "l;\n";
+        assertEquals(List.of(100, 1, -100), exec(source, Map.of("a", 1), false));
+    }
+
+    public void testChainedUserMethodsLambdaCaptureDef() {
+        String source = "int myCompare(int a, int b, int x, int m) { getMulti(m) * (a - b + x) }\n" +
+                        "int getMulti(int m) { -1 * m }\n" +
+                        "def l = [1, 100, -100];\n" +
+                        "int cx = 100;\n" +
+                        "int cm = 1;\n" +
+                        "l.sort((a, b) -> myCompare(a, b, cx, cm));\n" +
+                        "l;\n";
+        assertEquals(List.of(100, 1, -100), exec(source, Map.of("a", 1), false));
+    }
+
+    public void testMethodReferenceInUserFunction() {
+        String source = "int myCompare(int a, int b, String s) { " +
+                        "   Map m = ['f': 5];" +
+                        "   a - b + m.computeIfAbsent(s, this::getLength) " +
+                        "}\n" +
+                        "int getLength(String s) { s.length() }\n" +
+                        "def l = [1, 0, -2];\n" +
+                        "String s = 'g';\n" +
+                        "l.sort((a, b) -> myCompare(a, b, s));\n" +
+                        "l;\n";
+        assertEquals(List.of(-2, 1, 0), exec(source, Map.of("a", 1), false));
+    }
+
+    public void testUserFunctionVirtual() {
+        String source = "int myCompare(int x, int y) { return -1 * (x - y)  }\n" +
+                        "return myCompare(100, 90);";
+        assertEquals(-10, exec(source, Map.of("a", 1), false));
+        assertBytecodeExists(source, "INVOKEVIRTUAL org/elasticsearch/painless/PainlessScript$Script.&myCompare (II)I");
+    }
+
+    public void testUserFunctionRef() {
+        String source = "int myCompare(int x, int y) { return -1 * x - y  }\n" +
+                        "List l = [1, 100, -100];\n" +
+                        "l.sort(this::myCompare);\n" +
+                        "return l;";
+        assertEquals(List.of(100, 1, -100), exec(source, Map.of("a", 1), false));
+        assertBytecodeExists(source, "public &myCompare(II)I");
+    }
+
+    public void testUserFunctionRefEmpty() {
+        String source = "int myCompare(int x, int y) { return -1 * x - y  }\n" +
+                        "[].sort((a, b) -> myCompare(a, b));\n";
+        assertNull(exec(source, Map.of("a", 1), false));
+        assertBytecodeExists(source, "public &myCompare(II)I");
+        assertBytecodeExists(source, "INVOKEVIRTUAL org/elasticsearch/painless/PainlessScript$Script.&myCompare (II)I");
+    }
+
+    public void testUserFunctionCallInLambda() {
+        String source = "int myCompare(int x, int y) { -1 * ( x - y ) }\n" +
+                        "List l = [1, 100, -100];\n" +
+                        "l.sort((a, b) -> myCompare(a, b));\n" +
+                        "return l;";
+        assertEquals(List.of(100, 1, -100), exec(source, Map.of("a", 1), false));
+        assertBytecodeExists(source, "public &myCompare(II)I");
+        assertBytecodeExists(source, "INVOKEVIRTUAL org/elasticsearch/painless/PainlessScript$Script.&myCompare (II)I");
+    }
+
+    public void testUserFunctionLambdaCapture() {
+        String source = "int myCompare(Object o, int x, int y) { return o != null ? -1 * ( x - y ) : ( x - y ) }\n" +
+                        "List l = [1, 100, -100];\n" +
+                        "Object q = '';\n" +
+                        "l.sort((a, b) -> myCompare(q, a, b));\n" +
+                        "return l;";
+        assertEquals(List.of(100, 1, -100), exec(source, Map.of("a", 1), false));
+        assertBytecodeExists(source, "public &myCompare(Ljava/lang/Object;II)I");
+        assertBytecodeExists(source, "INVOKEVIRTUAL org/elasticsearch/painless/PainlessScript$Script.&myCompare (Ljava/lang/Object;II)I");
+    }
+
+    public void testLambdaCapture() {
+        String source = "List l = [1, 100, -100];\n" +
+                        "int q = -1;\n" +
+                        "l.sort((a, b) -> q * ( a - b ));\n" +
+                        "return l;";
+        assertEquals(List.of(100, 1, -100), exec(source, Map.of("a", 1), false));
+        assertBytecodeExists(source, "public static synthetic lambda$synthetic$0(ILjava/lang/Object;Ljava/lang/Object;)I");
     }
 }

--- a/modules/lang-painless/src/test/resources/org/elasticsearch/painless/spi/org.elasticsearch.painless.test
+++ b/modules/lang-painless/src/test/resources/org/elasticsearch/painless/spi/org.elasticsearch.painless.test
@@ -15,6 +15,13 @@ class org.elasticsearch.painless.api.Json {
 class org.elasticsearch.painless.BindingsTests$BindingsTestScript {
 }
 
+# Runtime-field-like test objects
+class org.elasticsearch.painless.TestFieldScript @no_import {
+}
+class org.elasticsearch.painless.TestFieldScript$Factory @no_import {
+}
+
+
 class org.elasticsearch.painless.FeatureTestObject @no_import {
   int z
   ()
@@ -55,4 +62,5 @@ static_import {
   int classMul(int, int) from_class org.elasticsearch.painless.BindingsTests @compile_time_only
   int compileTimeBlowUp(int, int) from_class org.elasticsearch.painless.BindingsTests @compile_time_only
   List fancyConstant(String, String) from_class org.elasticsearch.painless.BindingsTests @compile_time_only
+  void emit(org.elasticsearch.painless.TestFieldScript, long) bound_to org.elasticsearch.painless.TestFieldScript$Emit
 }


### PR DESCRIPTION
User defined functions are instance methods on the Script class.

Update lambdas and method references to capture the script `this`
reference.

Def method encoding string takes an extra char at index 1, whether
to capture the script reference.

For runtime fields, this means emit, which is an script instance
method already, now works in user defined functions.

Fixes: #69742
Refs: #68235
Backport: e26fa4e

