### PR TITLE
[7.14] [DOCS] Fix <index> param def for delete index API (#74674)

### DIFF
--- a/docs/reference/indices/delete-index.asciidoc
+++ b/docs/reference/indices/delete-index.asciidoc
@@ -30,17 +30,14 @@ or `manage` <<privileges-list-indices,index privilege>> for the target index.
 `<index>`::
 +
 --
-(Request, string) Comma-separated list or wildcard expression of indices to
-delete.
+(Required, string) Comma-separated list of indices to delete. You cannot specify
+<<alias,index aliases>>.
 
-In this parameter, wildcard expressions match only open, concrete indices. You
-cannot delete an index using an <<alias,alias>>.
-
-To delete all indices, use `_all` or `*` . To disallow the deletion of indices
-with `_all` or wildcard expressions, change the
-`action.destructive_requires_name` cluster setting to `true`. You can update
-this setting in the `elasticsearch.yml` file or using the
-<<cluster-update-settings,cluster update settings>> API.
+By default, this parameter does not support wildcards (`*`) or `_all`. To use
+wildcards or `_all`, change the `action.destructive_requires_name` setting to
+`false`. You can update this setting in the `elasticsearch.yml` file or using
+the <<cluster-update-settings,cluster update settings>> API. Wildcard patterns
+only match open, concrete indices.
 
 NOTE: You cannot delete the current write index of a data stream. To delete the
 index, you must <<data-streams-rollover,roll over>> the data stream so a new


### PR DESCRIPTION
Backports the following commits to 7.14:
 - [DOCS] Fix <index> param def for delete index API (#74674)