### PR TITLE
[7.x] Fix an NPE in TransportPutRollupJobAction

### DIFF
--- a/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/action/TransportPutRollupJobAction.java
+++ b/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/action/TransportPutRollupJobAction.java
@@ -183,7 +183,7 @@ public class TransportPutRollupJobAction extends AcknowledgedTransportMasterNode
 
         CheckedConsumer<GetMappingsResponse, Exception> getMappingResponseHandler = getMappingResponse -> {
             MappingMetadata mappings = getMappingResponse.getMappings().get(indexName).get(RollupField.TYPE_NAME);
-            Object m = mappings.getSourceAsMap().get("_meta");
+            Object m = mappings == null ? null : mappings.getSourceAsMap().get("_meta");
             if (m == null) {
                 String msg = "Rollup data cannot be added to existing indices that contain non-rollup data (expected " +
                     "to find _meta key in mapping of rollup index [" + indexName + "] but not found).";

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/rollup/put_job.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/rollup/put_job.yml
@@ -147,7 +147,7 @@ setup:
       indices.create:
         index: non-rollup
   - do:
-      catch: /foo/
+      catch: /Rollup data cannot be added to existing indices that contain non-rollup data/
       headers:
         Authorization: "Basic eF9wYWNrX3Jlc3RfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA==" # run as x_pack_rest_user, i.e. the test setup superuser
       rollup.put_job:


### PR DESCRIPTION
_Note: This issue only affects `7.x` -- `master` already works as intended._

We return an error either way, but this way we're returning the intended "you can't do that and here's why" error rather than something the user wouldn't grok. 

Kinda related to #32965, but I think this might go all the way back to when rollups were first introduced.

### Reproduction

```
PUT foo
{
  "mappings": {
    "properties": {
      "the_field": { "type": "date" },
     "value_field": { "type": "integer" }
    }
  }
}

PUT _rollup/job/foo-1
{
  "index_pattern": "foo",
  "rollup_index": "non-existent-index",
  "cron": "*/30 * * * * ?",
  "page_size" :10,
  "groups" : {
    "date_histogram": {
      "field": "the_field",
      "calendar_interval": "1h"
    }
  },
  "metrics": [
    {
      "field": "value_field",
      "metrics": ["min", "max", "sum"]
    }
  ]
}

PUT non-rollup

PUT _rollup/job/foo-2
{
  "index_pattern": "foo",
  "rollup_index": "non-rollup",
  "cron": "*/30 * * * * ?",
  "page_size" :10,
  "groups" : {
    "date_histogram": {
      "field": "the_field",
      "calendar_interval": "1h"
    }
  },
  "metrics": [
    {
      "field": "value_field",
      "metrics": ["min", "max", "sum"]
    }
  ]
}
```

### 7.x error without this change

```
{
  "error" : {
  "root_cause" : [
      {
        "type" : "runtime_exception",
        "reason" : "Could not update mappings for rollup job [foo-2]"
      }
    ],
    "type" : "runtime_exception",
    "reason" : "Could not update mappings for rollup job [foo-2]",
    "caused_by" : {
      "type" : "null_pointer_exception",
      "reason" : "Cannot invoke \"org.elasticsearch.cluster.metadata.MappingMetadata.getSourceAsMap()\" because \"mappings\" is null"
    }
  },
  "status" : 500
}
```

### master error without this change, 7.x error with this change

```
{
  "error" : {
    "root_cause" : [
      {
        "type" : "runtime_exception",
        "reason" : "Rollup data cannot be added to existing indices that contain non-rollup data (expected to find _meta key in mapping of rollup index [non-rollup] but not found)."
      }
    ],
    "type" : "runtime_exception",
    "reason" : "Rollup data cannot be added to existing indices that contain non-rollup data (expected to find _meta key in mapping of rollup index [non-rollup] but not found)."
  },
  "status" : 500
}
```