### PR TITLE
[DOCS] Move EQL APIs to separate page

### DIFF
--- a/docs/reference/eql/eql-apis.asciidoc
+++ b/docs/reference/eql/eql-apis.asciidoc
@@ -1,0 +1,19 @@
+[[eql-apis]]
+== EQL APIs
+
+Event Query Language (EQL) is a query language for event-based time series data,
+such as logs, metrics, and traces. For an overview of EQL and related tutorials,
+see <<eql>>.
+
+* <<eql-search-api>>
+* <<get-async-eql-search-api>>
+* <<get-async-eql-status-api>>
+* <<delete-async-eql-search-api>>
+
+include::delete-async-eql-search-api.asciidoc[]
+
+include::eql-search-api.asciidoc[]
+
+include::get-async-eql-search-api.asciidoc[]
+
+include::get-async-eql-status-api.asciidoc[]

--- a/docs/reference/rest-api/index.asciidoc
+++ b/docs/reference/rest-api/index.asciidoc
@@ -20,9 +20,10 @@ not be included yet.
 * <<data-stream-apis,Data stream APIs>>
 * <<docs, Document APIs>>
 * <<enrich-apis,Enrich APIs>>
-* <<graph-explore-api,Graph explore API>>
+* <<eql-apis,EQL search APIs>>
 * <<find-structure,Find structure API>>
 * <<fleet-apis,Fleet APIs>>
+* <<graph-explore-api,Graph explore API>>
 * <<indices, Index APIs>>
 * <<index-lifecycle-management-api,Index lifecycle management APIs>>
 * <<ingest-apis,Ingest APIs>>
@@ -55,6 +56,7 @@ include::{es-repo-dir}/ccr/apis/ccr-apis.asciidoc[]
 include::{es-repo-dir}/data-streams/data-stream-apis.asciidoc[]
 include::{es-repo-dir}/docs.asciidoc[]
 include::{es-repo-dir}/ingest/apis/enrich/index.asciidoc[]
+include::{es-repo-dir}/eql/eql-apis.asciidoc[]
 include::{es-repo-dir}/features/apis/features-apis.asciidoc[]
 include::{es-repo-dir}/fleet/index.asciidoc[]
 include::{es-repo-dir}/text-structure/apis/find-structure.asciidoc[leveloffset=+1]

--- a/docs/reference/search.asciidoc
+++ b/docs/reference/search.asciidoc
@@ -39,17 +39,6 @@ exception of the <<search-explain,explain API>>.
 * <<multi-search-template>>
 * <<render-search-template-api>>
 
-[discrete]
-[[eql-search-apis]]
-=== EQL search
-
-For an overview of EQL and related tutorials, see <<eql>>.
-
-* <<eql-search-api>>
-* <<get-async-eql-search-api>>
-* <<get-async-eql-status-api>>
-* <<delete-async-eql-search-api>>
-
 
 include::search/search.asciidoc[]
 
@@ -72,14 +61,6 @@ include::search/search-shards.asciidoc[]
 include::search/suggesters.asciidoc[]
 
 include::search/multi-search.asciidoc[]
-
-include::eql/eql-search-api.asciidoc[]
-
-include::eql/get-async-eql-search-api.asciidoc[]
-
-include::eql/get-async-eql-status-api.asciidoc[]
-
-include::eql/delete-async-eql-search-api.asciidoc[]
 
 include::search/count.asciidoc[]
 


### PR DESCRIPTION
In preparation for #74845, we need to create formal API reference documentation for our SQL APIs.

Due to the number of SQL APIs, we'll likely need to create a separate nested page for them. For parity, this PR moves
our EQL APIs to a separate page as well. Previously, they were listed under our search APIs.