### PR TITLE
[7.x] Reduce memory usage in SimpleClusterStateIT#testLargeClusterStatePublishing

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/SimpleClusterStateIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/SimpleClusterStateIT.java
@@ -215,7 +215,7 @@ public class SimpleClusterStateIT extends ESIntegTestCase {
         int counter = 0;
         int numberOfFields = 0;
         while (true) {
-            mapping.startObject(UUIDs.randomBase64UUID()).field("type", "text").endObject();
+            mapping.startObject(UUIDs.randomBase64UUID()).field("type", "boolean").endObject();
             counter += 10; // each field is about 10 bytes, assuming compression in place
             numberOfFields++;
             if (counter > estimatedBytesSize) {


### PR DESCRIPTION
In order to produce a large cluster state this test was creating 1000s
of text fields for index mappings. The in memory representation for
these mappings can consume all the heap causing OOMs. This commit
changes the mapping type for a boolean that's more lightweight.

Closes #73050
Backport of #73773