### PR TITLE
[7.x] Fix test compression setting upgrade tests (#74790)

### DIFF
--- a/qa/full-cluster-restart/src/test/java/org/elasticsearch/upgrades/FullClusterRestartIT.java
+++ b/qa/full-cluster-restart/src/test/java/org/elasticsearch/upgrades/FullClusterRestartIT.java
@@ -1675,6 +1675,9 @@ public class FullClusterRestartIT extends AbstractFullClusterRestartTestCase {
      * translated properly. This test can be removed in 9.0.
      */
     public void testTransportCompressionSetting() throws IOException {
+        assumeTrue("the old transport.compress setting existed before 7.14", getOldClusterVersion().before(Version.V_7_14_0));
+        assumeTrue("Early versions of 6.x do not have cluster.remote* prefixed settings",
+            getOldClusterVersion().onOrAfter(Version.V_7_14_0.minimumCompatibilityVersion()));
         if (isRunningAgainstOldCluster()) {
             final Request putSettingsRequest = new Request("PUT", "/_cluster/settings");
             try (XContentBuilder builder = jsonBuilder()) {


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Fix test compression setting upgrade tests (#74790)