### PR TITLE
[6.8] Backport: Add a system property to ignore awareness attributes

### DIFF
--- a/docs/reference/modules/cluster/allocation_awareness.asciidoc
+++ b/docs/reference/modules/cluster/allocation_awareness.asciidoc
@@ -56,6 +56,11 @@ Elasticsearch will prefer using local shards -- shards in the same awareness
 group -- to execute the request. This is usually faster than crossing between
 racks or across zone boundaries.
 
+Note that shard awareness routing takes precedence over the custom string
+preference parameter used in the search requests. The shard awareness
+behavior can be disabled by specifying
+`export ES_JAVA_OPTS="$ES_JAVA_OPTS -Des.search.ignore_awareness_attributes=true"`
+
 *********************************************
 
 Multiple awareness attributes can be specified, in which case each attribute

--- a/qa/evil-tests/src/test/java/org/elasticsearch/cluster/routing/EvilSystemPropertyTests.java
+++ b/qa/evil-tests/src/test/java/org/elasticsearch/cluster/routing/EvilSystemPropertyTests.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.cluster.routing;
+
+import org.elasticsearch.common.SuppressForbidden;
+import org.elasticsearch.common.settings.ClusterSettings;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.test.ESTestCase;
+
+import static org.hamcrest.Matchers.equalTo;
+
+public class EvilSystemPropertyTests extends ESTestCase {
+
+    @SuppressForbidden(reason = "manipulates system properties for testing")
+    public void testDisableSearchAllocationAwareness() {
+        Settings indexSettings = Settings.builder()
+            .put("cluster.routing.allocation.awareness.attributes", "test")
+            .build();
+        OperationRouting routing = new OperationRouting(indexSettings,
+            new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS));
+        assertThat(routing.getAwarenessAttributes().size(), equalTo(1));
+        assertThat(routing.getAwarenessAttributes().get(0), equalTo("test"));
+        System.setProperty("es.search.ignore_awareness_attributes", "true");
+        try {
+            routing = new OperationRouting(indexSettings,
+                new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS));
+            assertTrue(routing.getAwarenessAttributes().isEmpty());
+        } finally {
+            System.clearProperty("es.search.ignore_awareness_attributes");
+        }
+
+    }
+}

--- a/server/src/main/java/org/elasticsearch/cluster/routing/OperationRouting.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/OperationRouting.java
@@ -46,6 +46,8 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import static org.elasticsearch.common.Booleans.parseBoolean;
+
 public class OperationRouting {
     private static final Logger logger = LogManager.getLogger(OperationRouting.class);
     private static final DeprecationLogger deprecationLogger = new DeprecationLogger(logger);
@@ -58,15 +60,26 @@ public class OperationRouting {
     private boolean useAdaptiveReplicaSelection;
 
     public OperationRouting(Settings settings, ClusterSettings clusterSettings) {
-        this.awarenessAttributes = AwarenessAllocationDecider.CLUSTER_ROUTING_ALLOCATION_AWARENESS_ATTRIBUTE_SETTING.get(settings);
+        // whether to ignore awareness attributes when routing requests
+        boolean ignoreAwarenessAttr = parseBoolean(System.getProperty("es.search.ignore_awareness_attributes"), false);
+        if (ignoreAwarenessAttr == false) {
+            awarenessAttributes = AwarenessAllocationDecider.CLUSTER_ROUTING_ALLOCATION_AWARENESS_ATTRIBUTE_SETTING.get(settings);
+            clusterSettings.addSettingsUpdateConsumer(AwarenessAllocationDecider.CLUSTER_ROUTING_ALLOCATION_AWARENESS_ATTRIBUTE_SETTING,
+                this::setAwarenessAttributes);
+        } else {
+            awarenessAttributes = Collections.emptyList();
+        }
+
         this.useAdaptiveReplicaSelection = USE_ADAPTIVE_REPLICA_SELECTION_SETTING.get(settings);
-        clusterSettings.addSettingsUpdateConsumer(AwarenessAllocationDecider.CLUSTER_ROUTING_ALLOCATION_AWARENESS_ATTRIBUTE_SETTING,
-            this::setAwarenessAttributes);
         clusterSettings.addSettingsUpdateConsumer(USE_ADAPTIVE_REPLICA_SELECTION_SETTING, this::setUseAdaptiveReplicaSelection);
     }
 
     void setUseAdaptiveReplicaSelection(boolean useAdaptiveReplicaSelection) {
         this.useAdaptiveReplicaSelection = useAdaptiveReplicaSelection;
+    }
+
+    List<String> getAwarenessAttributes() {
+        return awarenessAttributes;
     }
 
     private void setAwarenessAttributes(List<String> awarenessAttributes) {


### PR DESCRIPTION
Fixes https://github.com/elastic/elasticsearch/issues/53054 for ES6 in order to be able to use a custom preference string.

The code was initially written for ES7 in https://github.com/elastic/elasticsearch/pull/46375.