### PR TITLE
[7.x] EQL: Remove "yet" from unsupported pipe error message (#74850)

### DIFF
--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/parser/LogicalPlanBuilder.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/parser/LogicalPlanBuilder.java
@@ -60,9 +60,9 @@ import static org.elasticsearch.xpack.ql.tree.Source.synthetic;
 
 public abstract class LogicalPlanBuilder extends ExpressionBuilder {
 
-    private static final String FILTER_PIPE = "filter", HEAD_PIPE = "head", TAIL_PIPE = "tail";
+    static final String FILTER_PIPE = "filter", HEAD_PIPE = "head", TAIL_PIPE = "tail";
 
-    private static final Set<String> SUPPORTED_PIPES = Sets.newHashSet("count", FILTER_PIPE, HEAD_PIPE, "sort", TAIL_PIPE, "unique",
+    static final Set<String> SUPPORTED_PIPES = Sets.newHashSet("count", FILTER_PIPE, HEAD_PIPE, "sort", TAIL_PIPE, "unique",
             "unique_count");
 
     private final UnresolvedRelation RELATION = new UnresolvedRelation(synthetic("<relation>"), null, "", false, "");
@@ -348,7 +348,7 @@ public abstract class LogicalPlanBuilder extends ExpressionBuilder {
                 return new Tail(source(ctx), tailLimit, plan);
 
             default:
-                throw new ParsingException(source(ctx), "Pipe [{}] is not supported yet", name);
+                throw new ParsingException(source(ctx), "Pipe [{}] is not supported", name);
         }
     }
 

--- a/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/parser/ExpressionTests.java
+++ b/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/parser/ExpressionTests.java
@@ -34,7 +34,11 @@ import java.util.Arrays;
 import java.util.List;
 
 import static org.elasticsearch.xpack.eql.parser.AbstractBuilder.unquoteString;
+import static org.elasticsearch.xpack.eql.parser.LogicalPlanBuilder.HEAD_PIPE;
+import static org.elasticsearch.xpack.eql.parser.LogicalPlanBuilder.SUPPORTED_PIPES;
+import static org.elasticsearch.xpack.eql.parser.LogicalPlanBuilder.TAIL_PIPE;
 import static org.elasticsearch.xpack.ql.TestUtils.UTC;
+import static org.hamcrest.Matchers.endsWith;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
@@ -508,5 +512,12 @@ public class ExpressionTests extends ESTestCase {
             "' expecting {<EOF>, 'and', 'in', 'in~', 'like', 'like~', 'not', 'or', "
             + "'regex', 'regex~', ':', '+', '-', '*', '/', '%', '.', '['}",
             e.getMessage());
+    }
+
+    public void testUnsupportedPipes() {
+        String pipe = randomValueOtherThanMany(Arrays.asList(HEAD_PIPE, TAIL_PIPE)::contains, () -> randomFrom(SUPPORTED_PIPES));
+        ParsingException pe = expectThrows(ParsingException.class, "Expected parsing exception",
+            () -> parser.createStatement("process where foo == true | " + pipe));
+        assertThat(pe.getMessage(), endsWith("Pipe [" + pipe + "] is not supported"));
     }
 }


### PR DESCRIPTION
Backports the following commits to 7.x:
 - EQL: Remove "yet" from unsupported pipe error message (#74850)