### PR TITLE
[7.14] [DOCS] HTTP client stats (#70512)

### DIFF
--- a/docs/reference/cluster/nodes-stats.asciidoc
+++ b/docs/reference/cluster/nodes-stats.asciidoc
@@ -1891,6 +1891,65 @@ Current number of open HTTP connections for the node.
 `total_opened`::
 (integer)
 Total number of HTTP connections opened for the node.
+
+`clients`::
+(array of objects)
+Information on current and recently-closed HTTP client connections.
++
+.Properties of `clients`
+[%collapsible%open]
+=======
+`id`::
+(integer)
+Unique ID for the HTTP client.
+
+`agent`::
+(string)
+Reported agent for the HTTP client. If unavailable, this property is not
+included in the response.
+
+`local_address`::
+(string)
+Local address for the HTTP client.
+
+`remote_address`::
+(string)
+Remote address for the HTTP client.
+
+`last_uri`::
+(string)
+The URI of the client's most recent request.
+
+`x_forwarded_for`::
+(string)
+Value from the client's `x-forwarded-for` HTTP header. If unavailable, this
+property is not included in the response.
+
+`x_opaque_id`::
+(string)
+Value from the client's `x-opaque-id` HTTP header. If unavailable, this property
+is not included in the response.
+
+`opened_time_millis`::
+(integer)
+Time at which the client opened the connection.
+
+`closed_time_millis`::
+(integer)
+Time at which the client closed the connection if the connection is closed.
+
+`last_request_time_millis`::
+(integer)
+Time of the most recent request from this client.
+
+`request_count`::
+(integer)
+Number of requests from this client.
+
+`request_size_bytes`::
+(integer)
+Cumulative size in bytes of all requests from this client.
+=======
 ======
 
 [[cluster-nodes-stats-api-response-body-breakers]]


### PR DESCRIPTION
Adds documentation for the stats added in #64561.

Backport of #70512
