### PR TITLE
Remove legacy geo code from AbstractGeometryQueryBuilder classes (#74741)

### DIFF
--- a/modules/percolator/src/test/java/org/elasticsearch/percolator/PercolateQueryBuilderTests.java
+++ b/modules/percolator/src/test/java/org/elasticsearch/percolator/PercolateQueryBuilderTests.java
@@ -40,6 +40,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -187,10 +188,12 @@ public class PercolateQueryBuilderTests extends AbstractQueryTestCase<PercolateQ
     }
 
     @Override
-    protected Set<String> getObjectsHoldingArbitraryContent() {
+    protected Map<String, String> getObjectsHoldingArbitraryContent() {
         //document contains arbitrary content, no error expected when an object is added to it
-        return new HashSet<>(Arrays.asList(PercolateQueryBuilder.DOCUMENT_FIELD.getPreferredName(),
-                PercolateQueryBuilder.DOCUMENTS_FIELD.getPreferredName()));
+        final Map<String, String> objects = new HashMap<>();
+        objects.put(PercolateQueryBuilder.DOCUMENT_FIELD.getPreferredName(), null);
+        objects.put(PercolateQueryBuilder.DOCUMENTS_FIELD.getPreferredName(), null);
+        return objects;
     }
 
     public void testRequiredParameters() {

--- a/server/src/main/java/org/elasticsearch/index/query/AbstractGeometryQueryBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/AbstractGeometryQueryBuilder.java
@@ -22,7 +22,6 @@ import org.elasticsearch.common.geo.GeoJson;
 import org.elasticsearch.common.geo.GeometryIO;
 import org.elasticsearch.common.geo.GeometryParser;
 import org.elasticsearch.common.geo.ShapeRelation;
-import org.elasticsearch.common.geo.builders.ShapeBuilder;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.xcontent.LoggingDeprecationHandler;
@@ -76,21 +75,6 @@ public abstract class AbstractGeometryQueryBuilder<QB extends AbstractGeometryQu
     protected ShapeRelation relation = DEFAULT_SHAPE_RELATION;
 
     protected boolean ignoreUnmapped = DEFAULT_IGNORE_UNMAPPED;
-
-    /**
-     * Creates a new ShapeQueryBuilder whose Query will be against the given
-     * field name using the given Shape
-     *
-     * @param fieldName
-     *            Name of the field that will be queried
-     * @param shape
-     *            Shape used in the Query
-     * @deprecated use {@link #AbstractGeometryQueryBuilder(String, Geometry)} instead
-     */
-    @Deprecated
-    protected AbstractGeometryQueryBuilder(String fieldName, ShapeBuilder shape) {
-        this(fieldName, shape == null ? null : shape.buildGeometry(), null, null);
-    }
 
     /**
      * Creates a new AbstractGeometryQueryBuilder whose Query will be against the given
@@ -396,19 +380,19 @@ public abstract class AbstractGeometryQueryBuilder<QB extends AbstractGeometryQu
             try {
                 if (response.isExists() == false) {
                     throw new IllegalArgumentException("Shape with ID [" + getRequest.id() + "] in type [" + getRequest.type()
-                            + "] not found");
+                        + "] not found");
                 }
                 if (response.isSourceEmpty()) {
                     throw new IllegalArgumentException("Shape with ID [" + getRequest.id() + "] in type [" + getRequest.type() +
-                            "] source disabled");
+                        "] source disabled");
                 }
                 String[] pathElements = path.split("\\.");
                 int currentPathSlot = 0;
 
                 // It is safe to use EMPTY here because this never uses namedObject
                 try (XContentParser parser = XContentHelper
-                        .createParser(NamedXContentRegistry.EMPTY,
-                                LoggingDeprecationHandler.INSTANCE, response.getSourceAsBytesRef())) {
+                    .createParser(NamedXContentRegistry.EMPTY,
+                        LoggingDeprecationHandler.INSTANCE, response.getSourceAsBytesRef())) {
                     XContentParser.Token currentToken;
                     while ((currentToken = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
                         if (currentToken == XContentParser.Token.FIELD_NAME) {
@@ -520,7 +504,7 @@ public abstract class AbstractGeometryQueryBuilder<QB extends AbstractGeometryQu
     protected abstract static class ParsedGeometryQueryParams {
         public String fieldName;
         public ShapeRelation relation;
-        public ShapeBuilder shape;
+        public Geometry shape;
 
         public String id = null;
         public String type = null;

--- a/server/src/main/java/org/elasticsearch/index/query/GeoShapeQueryBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/GeoShapeQueryBuilder.java
@@ -10,13 +10,12 @@ package org.elasticsearch.index.query;
 
 import org.apache.lucene.search.ConstantScoreQuery;
 import org.apache.lucene.search.Query;
+import org.elasticsearch.common.geo.GeometryParser;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.common.xcontent.ParseField;
 import org.elasticsearch.common.ParsingException;
 import org.elasticsearch.common.geo.ShapeRelation;
 import org.elasticsearch.common.geo.SpatialStrategy;
-import org.elasticsearch.common.geo.builders.ShapeBuilder;
-import org.elasticsearch.common.geo.parsers.ShapeParser;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.logging.DeprecationCategory;
@@ -28,6 +27,7 @@ import org.elasticsearch.index.mapper.GeoShapeQueryable;
 import org.elasticsearch.index.mapper.MappedFieldType;
 
 import java.io.IOException;
+import java.text.ParseException;
 import java.util.Objects;
 import java.util.function.Supplier;
 
@@ -55,22 +55,6 @@ public class GeoShapeQueryBuilder extends AbstractGeometryQueryBuilder<GeoShapeQ
      *            Shape used in the Query
      */
     public GeoShapeQueryBuilder(String fieldName, Geometry shape) {
-        super(fieldName, shape);
-    }
-
-    /**
-     * Creates a new GeoShapeQueryBuilder whose Query will be against the given
-     * field name using the given Shape
-     *
-     * @param fieldName
-     *            Name of the field that will be queried
-     * @param shape
-     *            Shape used in the Query
-     *
-     * @deprecated use {@link #GeoShapeQueryBuilder(String, Geometry)} instead
-     */
-    @Deprecated
-    public GeoShapeQueryBuilder(String fieldName, ShapeBuilder shape) {
         super(fieldName, shape);
     }
 
@@ -216,12 +200,17 @@ public class GeoShapeQueryBuilder extends AbstractGeometryQueryBuilder<GeoShapeQ
 
     private static class ParsedGeoShapeQueryParams extends ParsedGeometryQueryParams {
         SpatialStrategy strategy;
+        private final GeometryParser geometryParser = new GeometryParser(true, true, true);
 
         @Override
         protected boolean parseXContentField(XContentParser parser) throws IOException {
             SpatialStrategy strategy;
             if (SHAPE_FIELD.match(parser.currentName(), parser.getDeprecationHandler())) {
-                this.shape = ShapeParser.parse(parser);
+                try {
+                    this.shape = geometryParser.parse(parser);
+                } catch (ParseException e) {
+                    throw new IOException(e);
+                }
                 return true;
             } else if (STRATEGY_FIELD.match(parser.currentName(), parser.getDeprecationHandler())) {
                 String strategyName = parser.text();

--- a/server/src/main/java/org/elasticsearch/index/query/QueryBuilders.java
+++ b/server/src/main/java/org/elasticsearch/index/query/QueryBuilders.java
@@ -679,7 +679,7 @@ public final class QueryBuilders {
      */
     @Deprecated
     public static GeoShapeQueryBuilder geoShapeQuery(String name, ShapeBuilder shape) throws IOException {
-        return new GeoShapeQueryBuilder(name, shape);
+        return new GeoShapeQueryBuilder(name, shape.buildGeometry());
     }
 
     public static GeoShapeQueryBuilder geoShapeQuery(String name, String indexedShapeId) {

--- a/server/src/test/java/org/elasticsearch/index/query/GeoShapeQueryBuilderGeoPointTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/GeoShapeQueryBuilderGeoPointTests.java
@@ -8,8 +8,8 @@
 package org.elasticsearch.index.query;
 
 import org.elasticsearch.common.geo.ShapeRelation;
-import org.elasticsearch.common.geo.builders.ShapeBuilder;
-import org.elasticsearch.test.geo.RandomShapeGenerator;
+import org.elasticsearch.geo.GeometryTestUtils;
+import org.elasticsearch.geometry.Geometry;
 
 public class GeoShapeQueryBuilderGeoPointTests extends GeoShapeQueryBuilderTests {
 
@@ -18,14 +18,13 @@ public class GeoShapeQueryBuilderGeoPointTests extends GeoShapeQueryBuilderTests
     }
 
     protected GeoShapeQueryBuilder doCreateTestQueryBuilder(boolean indexedShape) {
-        RandomShapeGenerator.ShapeType shapeType = RandomShapeGenerator.ShapeType.POLYGON;
-        ShapeBuilder<?, ?, ?> shape = RandomShapeGenerator.createShapeWithin(random(), null, shapeType);
+        Geometry geometry = GeometryTestUtils.randomPolygon(false);
         GeoShapeQueryBuilder builder;
         clearShapeFields();
         if (indexedShape == false) {
-            builder = new GeoShapeQueryBuilder(fieldName(), shape);
+            builder = new GeoShapeQueryBuilder(fieldName(), geometry);
         } else {
-            indexedShapeToReturn = shape;
+            indexedShapeToReturn = geometry;
             indexedShapeId = randomAlphaOfLengthBetween(3, 20);
             builder = new GeoShapeQueryBuilder(fieldName(), indexedShapeId);
             if (randomBoolean()) {

--- a/server/src/test/java/org/elasticsearch/index/query/GeoShapeQueryBuilderGeoShapeTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/GeoShapeQueryBuilderGeoShapeTests.java
@@ -9,8 +9,9 @@ package org.elasticsearch.index.query;
 
 import org.elasticsearch.Version;
 import org.elasticsearch.common.geo.ShapeRelation;
-import org.elasticsearch.common.geo.builders.ShapeBuilder;
-import org.elasticsearch.test.geo.RandomShapeGenerator;
+import org.elasticsearch.geo.GeometryTestUtils;
+import org.elasticsearch.geometry.Geometry;
+import org.elasticsearch.geometry.ShapeType;
 
 public class GeoShapeQueryBuilderGeoShapeTests extends GeoShapeQueryBuilderTests {
 
@@ -19,19 +20,19 @@ public class GeoShapeQueryBuilderGeoShapeTests extends GeoShapeQueryBuilderTests
     }
 
     protected GeoShapeQueryBuilder doCreateTestQueryBuilder(boolean indexedShape) {
-        RandomShapeGenerator.ShapeType shapeType = randomFrom(
-            RandomShapeGenerator.ShapeType.POINT,
-            RandomShapeGenerator.ShapeType.MULTIPOINT,
-            RandomShapeGenerator.ShapeType.LINESTRING,
-            RandomShapeGenerator.ShapeType.MULTILINESTRING,
-            RandomShapeGenerator.ShapeType.POLYGON);
-        ShapeBuilder<?, ?, ?> shape = RandomShapeGenerator.createShapeWithin(random(), null, shapeType);
+        ShapeType shapeType = randomFrom(
+            ShapeType.POINT,
+            ShapeType.MULTIPOINT,
+            ShapeType.LINESTRING,
+            ShapeType.MULTILINESTRING,
+            ShapeType.POLYGON);
+        Geometry geometry = GeometryTestUtils.randomGeometry(shapeType, false);
         GeoShapeQueryBuilder builder;
         clearShapeFields();
         if (indexedShape == false) {
-            builder = new GeoShapeQueryBuilder(fieldName(), shape);
+            builder = new GeoShapeQueryBuilder(fieldName(), geometry);
         } else {
-            indexedShapeToReturn = shape;
+            indexedShapeToReturn = geometry;
             indexedShapeId = randomAlphaOfLengthBetween(3, 20);
             builder = new GeoShapeQueryBuilder(fieldName(), indexedShapeId);
             if (randomBoolean()) {
@@ -50,14 +51,14 @@ public class GeoShapeQueryBuilderGeoShapeTests extends GeoShapeQueryBuilderTests
         if (randomBoolean()) {
             SearchExecutionContext context = createSearchExecutionContext();
             if (context.indexVersionCreated().onOrAfter(Version.V_7_5_0)) { // CONTAINS is only supported from version 7.5
-                if (shapeType == RandomShapeGenerator.ShapeType.LINESTRING || shapeType == RandomShapeGenerator.ShapeType.MULTILINESTRING) {
+                if (shapeType == ShapeType.LINESTRING || shapeType == ShapeType.MULTILINESTRING) {
                     builder.relation(randomFrom(ShapeRelation.DISJOINT, ShapeRelation.INTERSECTS, ShapeRelation.CONTAINS));
                 } else {
                     builder.relation(randomFrom(ShapeRelation.DISJOINT, ShapeRelation.INTERSECTS,
                         ShapeRelation.WITHIN, ShapeRelation.CONTAINS));
                 }
             } else {
-                if (shapeType == RandomShapeGenerator.ShapeType.LINESTRING || shapeType == RandomShapeGenerator.ShapeType.MULTILINESTRING) {
+                if (shapeType == ShapeType.LINESTRING || shapeType == ShapeType.MULTILINESTRING) {
                     builder.relation(randomFrom(ShapeRelation.DISJOINT, ShapeRelation.INTERSECTS));
                 } else {
                     builder.relation(randomFrom(ShapeRelation.DISJOINT, ShapeRelation.INTERSECTS, ShapeRelation.WITHIN));

--- a/server/src/test/java/org/elasticsearch/index/query/GeoShapeQueryBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/GeoShapeQueryBuilderTests.java
@@ -19,23 +19,25 @@ import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.geo.builders.EnvelopeBuilder;
-import org.elasticsearch.common.geo.builders.ShapeBuilder;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.json.JsonXContent;
+import org.elasticsearch.geo.GeometryTestUtils;
+import org.elasticsearch.geometry.Geometry;
+import org.elasticsearch.geometry.utils.WellKnownText;
 import org.elasticsearch.index.get.GetResult;
 import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.test.AbstractQueryTestCase;
 import org.elasticsearch.test.VersionUtils;
-import org.elasticsearch.test.geo.RandomShapeGenerator;
-import org.elasticsearch.test.geo.RandomShapeGenerator.ShapeType;
 import org.junit.After;
 import org.locationtech.jts.geom.Coordinate;
 
 import java.io.IOException;
+import java.util.Collections;
+import java.util.Map;
 
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.notNullValue;
@@ -50,7 +52,7 @@ public abstract class GeoShapeQueryBuilderTests extends AbstractQueryTestCase<Ge
     protected static String indexedShapePath;
     protected static String indexedShapeIndex;
     protected static String indexedShapeRouting;
-    protected static ShapeBuilder<?, ?, ?> indexedShapeToReturn;
+    protected static Geometry indexedShapeToReturn;
 
     protected abstract String fieldName();
 
@@ -59,9 +61,9 @@ public abstract class GeoShapeQueryBuilderTests extends AbstractQueryTestCase<Ge
         // force the new shape impl
         Version version = VersionUtils.randomVersionBetween(random(), Version.V_6_6_0, Version.CURRENT);
         return Settings.builder()
-                .put(super.createTestIndexSettings())
-                .put(IndexMetadata.SETTING_VERSION_CREATED, version)
-                .build();
+            .put(super.createTestIndexSettings())
+            .put(IndexMetadata.SETTING_VERSION_CREATED, version)
+            .build();
     }
 
     @Override
@@ -88,7 +90,7 @@ public abstract class GeoShapeQueryBuilderTests extends AbstractQueryTestCase<Ge
         try {
             XContentBuilder builder = XContentFactory.jsonBuilder().prettyPrint();
             builder.startObject();
-            builder.field(expectedShapePath, indexedShapeToReturn);
+            builder.field(expectedShapePath, WellKnownText.toWKT(indexedShapeToReturn));
             builder.field(randomAlphaOfLengthBetween(10, 20), "something");
             builder.endObject();
             json = Strings.toString(builder);
@@ -119,13 +121,13 @@ public abstract class GeoShapeQueryBuilderTests extends AbstractQueryTestCase<Ge
     }
 
     public void testNoFieldName() throws Exception {
-        ShapeBuilder<?, ?, ?> shape = RandomShapeGenerator.createShapeWithin(random(), null);
-        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> new GeoShapeQueryBuilder(null, shape));
+        Geometry geometry = GeometryTestUtils.randomGeometry(false);
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> new GeoShapeQueryBuilder(null, geometry));
         assertEquals("fieldName is required", e.getMessage());
     }
 
     public void testNoShape() throws IOException {
-        expectThrows(IllegalArgumentException.class, () -> new GeoShapeQueryBuilder(fieldName(), (ShapeBuilder) null));
+        expectThrows(IllegalArgumentException.class, () -> new GeoShapeQueryBuilder(fieldName(), (Geometry) null));
     }
 
     public void testNoIndexedShape() throws IOException {
@@ -135,7 +137,7 @@ public abstract class GeoShapeQueryBuilderTests extends AbstractQueryTestCase<Ge
     }
 
     public void testNoRelation() throws IOException {
-        ShapeBuilder<?, ?, ?> shape = RandomShapeGenerator.createShapeWithin(random(), null);
+        Geometry shape = GeometryTestUtils.randomGeometry(false);
         GeoShapeQueryBuilder builder = new GeoShapeQueryBuilder(fieldName(), shape);
         IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> builder.relation(null));
         assertEquals("No Shape Relation defined", e.getMessage());
@@ -180,7 +182,7 @@ public abstract class GeoShapeQueryBuilderTests extends AbstractQueryTestCase<Ge
         QueryBuilder rewrite = rewriteAndFetch(query, createSearchExecutionContext());
         GeoShapeQueryBuilder geoShapeQueryBuilder = randomBoolean() ?
             new GeoShapeQueryBuilder(fieldName(), indexedShapeToReturn) :
-            new GeoShapeQueryBuilder(fieldName(), indexedShapeToReturn.buildGeometry());
+            new GeoShapeQueryBuilder(fieldName(), indexedShapeToReturn);
         geoShapeQueryBuilder.strategy(query.strategy());
         geoShapeQueryBuilder.relation(query.relation());
         assertEquals(geoShapeQueryBuilder, rewrite);
@@ -196,7 +198,7 @@ public abstract class GeoShapeQueryBuilderTests extends AbstractQueryTestCase<Ge
 
         GeoShapeQueryBuilder expectedShape = randomBoolean() ?
             new GeoShapeQueryBuilder(fieldName(), indexedShapeToReturn) :
-            new GeoShapeQueryBuilder(fieldName(), indexedShapeToReturn.buildGeometry());
+            new GeoShapeQueryBuilder(fieldName(), indexedShapeToReturn);
         expectedShape.strategy(shape.strategy());
         expectedShape.relation(shape.relation());
         QueryBuilder expected = new BoolQueryBuilder()
@@ -206,30 +208,22 @@ public abstract class GeoShapeQueryBuilderTests extends AbstractQueryTestCase<Ge
     }
 
     public void testIgnoreUnmapped() throws IOException {
-        ShapeType shapeType = ShapeType.randomType(random());
-        ShapeBuilder<?, ?, ?> shape = RandomShapeGenerator.createShapeWithin(random(), null, shapeType);
-        final GeoShapeQueryBuilder queryBuilder = randomBoolean() ?
-            new GeoShapeQueryBuilder("unmapped", shape) :
-            new GeoShapeQueryBuilder("unmapped", shape.buildGeometry());
+        Geometry geometry = GeometryTestUtils.randomGeometry(false);
+        final GeoShapeQueryBuilder queryBuilder = new GeoShapeQueryBuilder("unmapped", geometry);
         queryBuilder.ignoreUnmapped(true);
         Query query = queryBuilder.toQuery(createSearchExecutionContext());
         assertThat(query, notNullValue());
         assertThat(query, instanceOf(MatchNoDocsQuery.class));
 
-        final GeoShapeQueryBuilder failingQueryBuilder = randomBoolean() ?
-            new GeoShapeQueryBuilder("unmapped", shape) :
-            new GeoShapeQueryBuilder("unmapped", shape.buildGeometry());
+        final GeoShapeQueryBuilder failingQueryBuilder = new GeoShapeQueryBuilder("unmapped", geometry);
         failingQueryBuilder.ignoreUnmapped(false);
         QueryShardException e = expectThrows(QueryShardException.class, () -> failingQueryBuilder.toQuery(createSearchExecutionContext()));
         assertThat(e.getMessage(), containsString("failed to find type for field [unmapped]"));
     }
 
     public void testWrongFieldType() throws IOException {
-        ShapeType shapeType = ShapeType.randomType(random());
-        ShapeBuilder<?, ?, ?> shape = RandomShapeGenerator.createShapeWithin(random(), null, shapeType);
-        final GeoShapeQueryBuilder queryBuilder = randomBoolean() ?
-            new GeoShapeQueryBuilder(TEXT_FIELD_NAME, shape) :
-            new GeoShapeQueryBuilder(TEXT_FIELD_NAME, shape.buildGeometry());
+        Geometry geometry = GeometryTestUtils.randomGeometry(false);
+        final GeoShapeQueryBuilder queryBuilder = new GeoShapeQueryBuilder(TEXT_FIELD_NAME, geometry);
         QueryShardException e = expectThrows(QueryShardException.class, () -> queryBuilder.toQuery(createSearchExecutionContext()));
         assertThat(e.getMessage(), containsString("Field [mapped_string] is of unsupported type [text] for [geo_shape] query"));
     }
@@ -253,5 +247,11 @@ public abstract class GeoShapeQueryBuilderTests extends AbstractQueryTestCase<Ge
             assertWarnings(GeoShapeQueryBuilder.TYPES_DEPRECATION_MESSAGE);
         }
         return query;
+    }
+
+    @Override
+    protected Map<String, String> getObjectsHoldingArbitraryContent() {
+        // shape field can accept any element but expects a type
+        return Collections.singletonMap("shape", "Required [type]");
     }
 }

--- a/server/src/test/java/org/elasticsearch/index/query/MoreLikeThisQueryBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/MoreLikeThisQueryBuilderTests.java
@@ -45,7 +45,6 @@ import java.util.Collections;
 import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Set;
 import java.util.stream.Stream;
 
 import static org.elasticsearch.index.query.QueryBuilders.moreLikeThisQuery;
@@ -215,9 +214,9 @@ public class MoreLikeThisQueryBuilderTests extends AbstractQueryTestCase<MoreLik
     }
 
     @Override
-    protected Set<String> getObjectsHoldingArbitraryContent() {
+    protected Map<String, String> getObjectsHoldingArbitraryContent() {
         //doc contains arbitrary content, anything can be added to it and no exception will be thrown
-        return Collections.singleton(MoreLikeThisQueryBuilder.DOC.getPreferredName());
+        return Collections.singletonMap(MoreLikeThisQueryBuilder.DOC.getPreferredName(), null);
     }
 
     @Override

--- a/server/src/test/java/org/elasticsearch/index/query/ScriptQueryBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/ScriptQueryBuilderTests.java
@@ -19,7 +19,6 @@ import org.elasticsearch.test.AbstractQueryTestCase;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.Map;
-import java.util.Set;
 
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.instanceOf;
@@ -103,10 +102,10 @@ public class ScriptQueryBuilderTests extends AbstractQueryTestCase<ScriptQueryBu
     }
 
     @Override
-    protected Set<String> getObjectsHoldingArbitraryContent() {
-        //script_score.script.params can contain arbitrary parameters. no error is expected when
-        //adding additional objects within the params object.
-        return Collections.singleton(Script.PARAMS_PARSE_FIELD.getPreferredName());
+    protected Map<String, String> getObjectsHoldingArbitraryContent() {
+        // script_score.script.params can contain arbitrary parameters. no error is expected when
+        // adding additional objects within the params object.
+        return Collections.singletonMap(Script.PARAMS_PARSE_FIELD.getPreferredName(), null);
     }
 
     /**

--- a/server/src/test/java/org/elasticsearch/index/query/functionscore/FunctionScoreQueryBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/functionscore/FunctionScoreQueryBuilderTests.java
@@ -61,10 +61,9 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashSet;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 import static java.util.Collections.singletonList;
 import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
@@ -116,11 +115,15 @@ public class FunctionScoreQueryBuilderTests extends AbstractQueryTestCase<Functi
     }
 
     @Override
-    protected Set<String> getObjectsHoldingArbitraryContent() {
+    protected Map<String, String> getObjectsHoldingArbitraryContent() {
         //script_score.script.params can contain arbitrary parameters. no error is expected when adding additional objects
         //within the params object. Score functions get parsed in the data nodes, so they are not validated in the coord node.
-        return new HashSet<>(Arrays.asList(Script.PARAMS_PARSE_FIELD.getPreferredName(), ExponentialDecayFunctionBuilder.NAME,
-                LinearDecayFunctionBuilder.NAME, GaussDecayFunctionBuilder.NAME));
+        final Map<String, String> objects = new HashMap<>();
+        objects.put(Script.PARAMS_PARSE_FIELD.getPreferredName(), null);
+        objects.put(ExponentialDecayFunctionBuilder.NAME, null);
+        objects.put(LinearDecayFunctionBuilder.NAME, null);
+        objects.put(GaussDecayFunctionBuilder.NAME, null);
+        return objects;
     }
 
     /**

--- a/test/framework/src/main/java/org/elasticsearch/geo/GeometryTestUtils.java
+++ b/test/framework/src/main/java/org/elasticsearch/geo/GeometryTestUtils.java
@@ -21,6 +21,7 @@ import org.elasticsearch.geometry.MultiPolygon;
 import org.elasticsearch.geometry.Point;
 import org.elasticsearch.geometry.Polygon;
 import org.elasticsearch.geometry.Rectangle;
+import org.elasticsearch.geometry.ShapeType;
 import org.elasticsearch.test.ESTestCase;
 
 import java.util.ArrayList;
@@ -187,6 +188,21 @@ public class GeometryTestUtils {
         return new GeometryCollection<>(shapes);
     }
 
+    public static Geometry randomGeometry(ShapeType type, boolean hasAlt) {
+       switch (type) {
+           case GEOMETRYCOLLECTION: return randomGeometryCollection(0, hasAlt);
+           case MULTILINESTRING: return randomMultiLine(hasAlt);
+           case ENVELOPE: return randomRectangle();
+           case LINESTRING: return randomLine(hasAlt);
+           case POLYGON: return randomPolygon(hasAlt);
+           case MULTIPOLYGON: return randomMultiPolygon(hasAlt);
+           case CIRCLE: return randomCircle(hasAlt);
+           case MULTIPOINT: return randomMultiPoint(hasAlt);
+           case POINT: return randomPoint(hasAlt);
+           default: throw new IllegalArgumentException("Ussuported shape type [" + type + "]");
+       }
+    }
+
     public static Geometry randomGeometry(boolean hasAlt) {
         return randomGeometry(0, hasAlt);
     }
@@ -216,7 +232,7 @@ public class GeometryTestUtils {
             GeometryTestUtils::randomMultiPolygon,
             hasAlt ? GeometryTestUtils::randomPoint : (b) -> randomRectangle(),
             level < 3 ? (b) ->
-                randomGeometryCollectionWithoutCircle(level + 1, hasAlt) : GeometryTestUtils::randomPoint // don't build too deep
+                randomGeometryWithoutCircleCollection(level + 1, hasAlt) : GeometryTestUtils::randomPoint // don't build too deep
         );
         return geometry.apply(hasAlt);
     }

--- a/test/framework/src/test/java/org/elasticsearch/test/AbstractQueryTestCaseTests.java
+++ b/test/framework/src/test/java/org/elasticsearch/test/AbstractQueryTestCaseTests.java
@@ -13,10 +13,10 @@ import org.elasticsearch.common.util.set.Sets;
 import org.hamcrest.Matcher;
 
 import java.io.IOException;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 import static java.util.Collections.singleton;
 import static org.elasticsearch.test.AbstractQueryTestCase.alterateQueries;
@@ -29,65 +29,76 @@ import static org.hamcrest.Matchers.notNullValue;
  */
 public class AbstractQueryTestCaseTests extends ESTestCase {
 
+    private final String STANDARD_ERROR = "unknown field [newField]";
+
     public void testAlterateQueries() throws IOException {
-        List<Tuple<String, Boolean>> alterations = alterateQueries(singleton("{\"field\": \"value\"}"), null);
-        assertAlterations(alterations, allOf(notNullValue(), hasEntry("{\"newField\":{\"field\":\"value\"}}", true)));
+        List<Tuple<String, String>> alterations = alterateQueries(singleton("{\"field\": \"value\"}"), null);
+        assertAlterations(alterations, allOf(notNullValue(), hasEntry("{\"newField\":{\"field\":\"value\"}}", STANDARD_ERROR)));
 
         alterations = alterateQueries(singleton("{\"term\":{\"field\": \"value\"}}"), null);
         assertAlterations(alterations, allOf(
-            hasEntry("{\"newField\":{\"term\":{\"field\":\"value\"}}}", true),
-            hasEntry("{\"term\":{\"newField\":{\"field\":\"value\"}}}", true))
+            hasEntry("{\"newField\":{\"term\":{\"field\":\"value\"}}}", STANDARD_ERROR),
+            hasEntry("{\"term\":{\"newField\":{\"field\":\"value\"}}}", STANDARD_ERROR))
         );
 
         alterations = alterateQueries(singleton("{\"bool\":{\"must\": [{\"match\":{\"field\":\"value\"}}]}}"), null);
         assertAlterations(alterations, allOf(
-                hasEntry("{\"newField\":{\"bool\":{\"must\":[{\"match\":{\"field\":\"value\"}}]}}}", true),
-                hasEntry("{\"bool\":{\"newField\":{\"must\":[{\"match\":{\"field\":\"value\"}}]}}}", true),
-                hasEntry("{\"bool\":{\"must\":[{\"newField\":{\"match\":{\"field\":\"value\"}}}]}}", true),
-                hasEntry("{\"bool\":{\"must\":[{\"match\":{\"newField\":{\"field\":\"value\"}}}]}}", true)
+                hasEntry("{\"newField\":{\"bool\":{\"must\":[{\"match\":{\"field\":\"value\"}}]}}}", STANDARD_ERROR),
+                hasEntry("{\"bool\":{\"newField\":{\"must\":[{\"match\":{\"field\":\"value\"}}]}}}", STANDARD_ERROR),
+                hasEntry("{\"bool\":{\"must\":[{\"newField\":{\"match\":{\"field\":\"value\"}}}]}}", STANDARD_ERROR),
+                hasEntry("{\"bool\":{\"must\":[{\"match\":{\"newField\":{\"field\":\"value\"}}}]}}", STANDARD_ERROR)
         ));
 
         alterations = alterateQueries(singleton("{\"function_score\":" +
                 "{\"query\": {\"term\":{\"foo\": \"bar\"}}, \"script_score\": {\"script\":\"a + 1\", \"params\": {\"a\":0}}}}"), null);
         assertAlterations(alterations, allOf(
                 hasEntry("{\"newField\":{\"function_score\":{\"query\":{\"term\":{\"foo\":\"bar\"}},\"script_score\":{\"script\":\"a + " +
-                        "1\",\"params\":{\"a\":0}}}}}", true),
+                        "1\",\"params\":{\"a\":0}}}}}", STANDARD_ERROR),
                 hasEntry("{\"function_score\":{\"newField\":{\"query\":{\"term\":{\"foo\":\"bar\"}},\"script_score\":{\"script\":\"a + " +
-                        "1\",\"params\":{\"a\":0}}}}}", true),
+                        "1\",\"params\":{\"a\":0}}}}}", STANDARD_ERROR),
                 hasEntry("{\"function_score\":{\"query\":{\"newField\":{\"term\":{\"foo\":\"bar\"}}},\"script_score\":{\"script\":\"a + " +
-                        "1\",\"params\":{\"a\":0}}}}", true),
+                        "1\",\"params\":{\"a\":0}}}}", STANDARD_ERROR),
                 hasEntry("{\"function_score\":{\"query\":{\"term\":{\"newField\":{\"foo\":\"bar\"}}},\"script_score\":{\"script\":\"a + " +
-                        "1\",\"params\":{\"a\":0}}}}", true),
+                        "1\",\"params\":{\"a\":0}}}}", STANDARD_ERROR),
                 hasEntry("{\"function_score\":{\"query\":{\"term\":{\"foo\":\"bar\"}},\"script_score\":{\"newField\":{\"script\":\"a + " +
-                        "1\",\"params\":{\"a\":0}}}}}", true),
+                        "1\",\"params\":{\"a\":0}}}}}", STANDARD_ERROR),
                 hasEntry("{\"function_score\":{\"query\":{\"term\":{\"foo\":\"bar\"}},\"script_score\":{\"script\":\"a + 1\"," +
-                        "\"params\":{\"newField\":{\"a\":0}}}}}", true)
+                        "\"params\":{\"newField\":{\"a\":0}}}}}", STANDARD_ERROR)
         ));
     }
 
     public void testAlterateQueriesWithArbitraryContent() throws IOException {
-        Set<String> arbitraryContentHolders = Sets.newHashSet("params", "doc");
+        Map<String, String> arbitraryContentHolders = new HashMap<>();
+        arbitraryContentHolders.put("params", null); // no exception expected
+        arbitraryContentHolders.put("doc", "my own error");
         Set<String> queries = Sets.newHashSet(
                 "{\"query\":{\"script\":\"test\",\"params\":{\"foo\":\"bar\"}}}",
                 "{\"query\":{\"more_like_this\":{\"fields\":[\"a\",\"b\"],\"like\":{\"doc\":{\"c\":\"d\"}}}}}"
         );
 
-        List<Tuple<String, Boolean>> alterations = alterateQueries(queries, arbitraryContentHolders);
+        List<Tuple<String, String>> alterations = alterateQueries(queries, arbitraryContentHolders);
         assertAlterations(alterations, allOf(
-            hasEntry("{\"newField\":{\"query\":{\"script\":\"test\",\"params\":{\"foo\":\"bar\"}}}}", true),
-            hasEntry("{\"query\":{\"newField\":{\"script\":\"test\",\"params\":{\"foo\":\"bar\"}}}}", true),
-            hasEntry("{\"query\":{\"script\":\"test\",\"params\":{\"newField\":{\"foo\":\"bar\"}}}}", false)
+            hasEntry("{\"newField\":{\"query\":{\"script\":\"test\",\"params\":{\"foo\":\"bar\"}}}}", STANDARD_ERROR),
+            hasEntry("{\"query\":{\"newField\":{\"script\":\"test\",\"params\":{\"foo\":\"bar\"}}}}", STANDARD_ERROR),
+            hasEntry("{\"query\":{\"script\":\"test\",\"params\":{\"newField\":{\"foo\":\"bar\"}}}}", null)
         ));
         assertAlterations(alterations, allOf(
-            hasEntry("{\"newField\":{\"query\":{\"more_like_this\":{\"fields\":[\"a\",\"b\"],\"like\":{\"doc\":{\"c\":\"d\"}}}}}}", true),
-            hasEntry("{\"query\":{\"newField\":{\"more_like_this\":{\"fields\":[\"a\",\"b\"],\"like\":{\"doc\":{\"c\":\"d\"}}}}}}", true),
-            hasEntry("{\"query\":{\"more_like_this\":{\"newField\":{\"fields\":[\"a\",\"b\"],\"like\":{\"doc\":{\"c\":\"d\"}}}}}}", true),
-            hasEntry("{\"query\":{\"more_like_this\":{\"fields\":[\"a\",\"b\"],\"like\":{\"newField\":{\"doc\":{\"c\":\"d\"}}}}}}", true),
-            hasEntry("{\"query\":{\"more_like_this\":{\"fields\":[\"a\",\"b\"],\"like\":{\"doc\":{\"newField\":{\"c\":\"d\"}}}}}}", false)
+            hasEntry("{\"newField\":{\"query\":{\"more_like_this\":{\"fields\":[\"a\",\"b\"],\"like\":{\"doc\":{\"c\":\"d\"}}}}}}",
+                STANDARD_ERROR),
+            hasEntry("{\"query\":{\"newField\":{\"more_like_this\":{\"fields\":[\"a\",\"b\"],\"like\":{\"doc\":{\"c\":\"d\"}}}}}}",
+                STANDARD_ERROR),
+            hasEntry("{\"query\":{\"more_like_this\":{\"newField\":{\"fields\":[\"a\",\"b\"],\"like\":{\"doc\":{\"c\":\"d\"}}}}}}",
+                STANDARD_ERROR),
+            hasEntry("{\"query\":{\"more_like_this\":{\"fields\":[\"a\",\"b\"],\"like\":{\"newField\":{\"doc\":{\"c\":\"d\"}}}}}}",
+                STANDARD_ERROR),
+            hasEntry("{\"query\":{\"more_like_this\":{\"fields\":[\"a\",\"b\"],\"like\":{\"doc\":{\"newField\":{\"c\":\"d\"}}}}}}",
+                "my own error")
         ));
     }
 
     private static <K, V> void assertAlterations(List<Tuple<K, V>> alterations, Matcher<Map<K, V>> matcher) {
-        assertThat(alterations.stream().collect(Collectors.toMap(Tuple::v1, Tuple::v2)), matcher);
+        Map<K, V> alterationsMap = new HashMap<>();
+        alterations.forEach(t -> alterationsMap.put(t.v1(), t.v2()));
+        assertThat(alterationsMap, matcher);
     }
 }

--- a/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/index/query/GeoShapeWithDocValuesQueryBuilderTests.java
+++ b/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/index/query/GeoShapeWithDocValuesQueryBuilderTests.java
@@ -26,6 +26,8 @@ import org.elasticsearch.xpack.spatial.LocalStateSpatialPlugin;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
 
 import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
 import static org.hamcrest.Matchers.equalTo;
@@ -68,5 +70,11 @@ public class GeoShapeWithDocValuesQueryBuilderTests extends AbstractQueryTestCas
         MappedFieldType fieldType = context.getFieldType("test");
         boolean IndexOrDocValuesQuery = fieldType.hasDocValues();
         assertThat(IndexOrDocValuesQuery, equalTo(geoShapeQuery instanceof IndexOrDocValuesQuery));
+    }
+
+    @Override
+    protected Map<String, String> getObjectsHoldingArbitraryContent() {
+        // shape field can accept any element but expects a type
+        return Collections.singletonMap("shape", "Required [type]");
     }
 }

--- a/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/index/query/ShapeQueryBuilderTests.java
+++ b/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/index/query/ShapeQueryBuilderTests.java
@@ -39,6 +39,8 @@ import org.junit.After;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
 
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.instanceOf;
@@ -277,5 +279,11 @@ public abstract class ShapeQueryBuilderTests extends AbstractQueryTestCase<Shape
         }
         return new GetResponse(new GetResult(indexedShapeIndex, indexedType, indexedShapeId, 0, 1, 0, true, new BytesArray(json),
             null, null));
+    }
+
+    @Override
+    protected Map<String, String> getObjectsHoldingArbitraryContent() {
+        // shape field can accept any element but expects a type
+        return Collections.singletonMap("shape", "Required [type]");
     }
 }


### PR DESCRIPTION

This PR removes references to Legacy ShapeParser and ShapeBuilder in AbstractGeometryQueryBuilder classes in favour to Geometry and GeometryParser.

One important difference is that ShapeParser and GeometryParser have a different behaviour when parsing GeoJson. Shape parser only accept type and coordinates fields, else it will throw an error if it finds any other element. On the other hand GeometryParser will ignore those elements.

This actually gives some problems in testing and I need to change hoe getObjectsHoldingArbitraryContent() behaves to take into account Objects that holds arbitrary comment but expect some specific content.

backport #74741