### PR TITLE
Improved UI error messages when the parameter must be a constant

### DIFF
--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/phase/DefaultConstantFoldingOptimizationPhase.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/phase/DefaultConstantFoldingOptimizationPhase.java
@@ -834,14 +834,9 @@ public class DefaultConstantFoldingOptimizationPhase extends IRTreeBaseVisitor<C
 
     private String convertIntToOrdinal(int i) {
         String[] suffixes = new String[] { "th", "st", "nd", "rd", "th", "th", "th", "th", "th", "th" };
-        switch (i % 100) {
-            case 11:
-            case 12:
-            case 13:
-                return i + "th";
-            default:
-                return i + suffixes[i % 10];
-        }
+        int aux = i % 100;
+        if(aux == 11 || aux == 12 || aux == 13) return i + "th";
+        return i + suffixes[i % 10];
     }
 
     private void replaceCallWithConstant(

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/phase/DefaultConstantFoldingOptimizationPhase.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/phase/DefaultConstantFoldingOptimizationPhase.java
@@ -832,6 +832,18 @@ public class DefaultConstantFoldingOptimizationPhase extends IRTreeBaseVisitor<C
         }
     }
 
+    private String convertIntToOrdinal(int i) {
+        String[] suffixes = new String[] { "th", "st", "nd", "rd", "th", "th", "th", "th", "th", "th" };
+        switch (i % 100) {
+            case 11:
+            case 12:
+            case 13:
+                return i + "th";
+            default:
+                return i + suffixes[i % 10];
+        }
+    }
+
     private void replaceCallWithConstant(
         InvokeCallMemberNode irInvokeCallMemberNode,
         Consumer<ExpressionNode> scope,
@@ -846,8 +858,8 @@ public class DefaultConstantFoldingOptimizationPhase extends IRTreeBaseVisitor<C
                 throw irInvokeCallMemberNode.getLocation()
                     .createError(
                         new IllegalArgumentException(
-                            "The [" + javaMethod.getName() + "] method is sad because it needs constant arguments to work properly. " +
-                                "Please provide a constant to the [" + (i + 1) + "] argument"
+                            "The [" + javaMethod.getName() + "] method needs constant arguments to work properly. " +
+                                "Please provide a constant to the [" + convertIntToOrdinal(i + 1) + "] argument"
                         )
                     );
             }

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/phase/DefaultConstantFoldingOptimizationPhase.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/phase/DefaultConstantFoldingOptimizationPhase.java
@@ -843,11 +843,11 @@ public class DefaultConstantFoldingOptimizationPhase extends IRTreeBaseVisitor<C
             ExpressionNode argNode = irInvokeCallMemberNode.getArgumentNodes().get(i);
             IRDConstant constantDecoration = argNode.getDecoration(IRDConstant.class);
             if (constantDecoration == null) {
-                // TODO find a better string to output
                 throw irInvokeCallMemberNode.getLocation()
                     .createError(
                         new IllegalArgumentException(
-                            "all arguments to [" + javaMethod.getName() + "] must be constant but the [" + (i + 1) + "] argument isn't"
+                            "The [" + javaMethod.getName() + "] method is sad because it needs constant arguments to work properly. " +
+                                "Please provide a constant to the [" + (i + 1) + "] argument"
                         )
                     );
             }

--- a/modules/lang-painless/src/test/java/org/elasticsearch/painless/BindingsTests.java
+++ b/modules/lang-painless/src/test/java/org/elasticsearch/painless/BindingsTests.java
@@ -211,7 +211,8 @@ public class BindingsTests extends ScriptTestCase {
             IllegalArgumentException.class,
             () -> scriptEngine.compile(null, "def a = 2; classMul(2, a)", BindingsTestScript.CONTEXT, Collections.emptyMap())
         );
-        assertThat(e.getMessage(), equalTo("all arguments to [classMul] must be constant but the [2] argument isn't"));
+        assertThat(e.getMessage(), equalTo("The [classMul] method is sad because it needs constant arguments to work properly. " +
+            "Please provide a constant to the [2] argument"));
     }
 
     public void testClassMethodCompileTimeOnlyThrows() {
@@ -240,7 +241,8 @@ public class BindingsTests extends ScriptTestCase {
             IllegalArgumentException.class,
             () -> scriptEngine.compile(null, "def a = 2; instanceMul(a, 2)", BindingsTestScript.CONTEXT, Collections.emptyMap())
         );
-        assertThat(e.getMessage(), equalTo("all arguments to [instanceMul] must be constant but the [1] argument isn't"));
+        assertThat(e.getMessage(), equalTo("The [instanceMul] method is sad because it needs constant arguments to work properly. " +
+            "Please provide a constant to the [1] argument"));
     }
 
     public void testCompileTimeOnlyParameterFoldedToConstant() {

--- a/modules/lang-painless/src/test/java/org/elasticsearch/painless/BindingsTests.java
+++ b/modules/lang-painless/src/test/java/org/elasticsearch/painless/BindingsTests.java
@@ -211,8 +211,8 @@ public class BindingsTests extends ScriptTestCase {
             IllegalArgumentException.class,
             () -> scriptEngine.compile(null, "def a = 2; classMul(2, a)", BindingsTestScript.CONTEXT, Collections.emptyMap())
         );
-        assertThat(e.getMessage(), equalTo("The [classMul] method is sad because it needs constant arguments to work properly. " +
-            "Please provide a constant to the [2] argument"));
+        assertThat(e.getMessage(), equalTo("The [classMul] method needs constant arguments to work properly. " +
+            "Please provide a constant to the second argument"));
     }
 
     public void testClassMethodCompileTimeOnlyThrows() {
@@ -241,8 +241,8 @@ public class BindingsTests extends ScriptTestCase {
             IllegalArgumentException.class,
             () -> scriptEngine.compile(null, "def a = 2; instanceMul(a, 2)", BindingsTestScript.CONTEXT, Collections.emptyMap())
         );
-        assertThat(e.getMessage(), equalTo("The [instanceMul] method is sad because it needs constant arguments to work properly. " +
-            "Please provide a constant to the [1] argument"));
+        assertThat(e.getMessage(), equalTo("The [instanceMul] method needs constant arguments to work properly. " +
+            "Please provide a constant to the first argument"));
     }
 
     public void testCompileTimeOnlyParameterFoldedToConstant() {

--- a/modules/runtime-fields-common/src/yamlRestTest/resources/rest-api-spec/test/runtime_fields/250_grok.yml
+++ b/modules/runtime-fields-common/src/yamlRestTest/resources/rest-api-spec/test/runtime_fields/250_grok.yml
@@ -80,7 +80,7 @@ fetch:
 ---
 mutable pattern:
   - do:
-      catch: /all arguments to \[grok\] must be constant but the \[1\] argument isn't/
+      catch: /The \[grok\] method is sad because it needs constant arguments to work properly. Please provide a constant to the \[1\] argument/
       search:
         index: http_logs
         body:

--- a/modules/runtime-fields-common/src/yamlRestTest/resources/rest-api-spec/test/runtime_fields/250_grok.yml
+++ b/modules/runtime-fields-common/src/yamlRestTest/resources/rest-api-spec/test/runtime_fields/250_grok.yml
@@ -80,7 +80,7 @@ fetch:
 ---
 mutable pattern:
   - do:
-      catch: /The \[grok\] method is sad because it needs constant arguments to work properly. Please provide a constant to the \[1\] argument/
+      catch: /The \[grok\] method needs constant arguments to work properly. Please provide a constant to the first argument/
       search:
         index: http_logs
         body:


### PR DESCRIPTION
Closes #68324.

Improved UI error messages when the parameter must be a constant. In order to propose a new message, i've looked into Elasticsearch UI errors Guidelines and then, did some research and analysed the UX Guidelines to write effective error messages.

This change improves usability, since a good error message has three parts: Problem identification, cause details if helpful, and a solution if possible. I would appreciate if someone could give me some feedback.