### PR TITLE
EQL: [Docs] Add documentation for the CircuitBreaker

### DIFF
--- a/docs/reference/eql/eql-search-api.asciidoc
+++ b/docs/reference/eql/eql-search-api.asciidoc
@@ -293,6 +293,7 @@ change the sort order of hits in the response.
 
 include::{es-repo-dir}/search/search.asciidoc[tag=runtime-mappings-def]
 
+[[eql-search-api-params-size]]
 `size`::
 (Optional, integer or float)
 For <<eql-basic-syntax,basic queries>>, the maximum number of matching events to

--- a/docs/reference/eql/eql.asciidoc
+++ b/docs/reference/eql/eql.asciidoc
@@ -819,9 +819,8 @@ defined as a percentage of the JVM heap. Defaults to `50%`. If the
 this setting uses that value as its default instead.
 
 `breaker.eql_sequence.overhead`::
-(<<cluster-update-settings,Dynamic>>) A constant which all computed memory required
-for the execution of an EQL query is multiplied by to determine a final estimation.
-See <<circuit-breaker>>. Defaults to `1`.
+(<<cluster-update-settings,Dynamic>>) A constant that sequence query memory
+estimates are multiplied by to determine a final estimate. Defaults to `1`.
 
 `breaker.eql_sequence.type`::
 (<<static-cluster-setting,Static>>) Circuit breaker type. Valid values are:

--- a/docs/reference/eql/eql.asciidoc
+++ b/docs/reference/eql/eql.asciidoc
@@ -796,6 +796,21 @@ You can also manually delete saved synchronous searches using the
 [[eql-circuit-breaker]]
 === EQL circuit breaker settings
 
+When a <<eql-sequences, sequence>> query is executed, the node handling the query,
+needs to keep some structures in memory which are needed by the algorithm which
+implements the sequence matching. When large amounts of data need to be processed,
+and/or a large amount of matched sequences is requested by the user (by setting the
+<<eql-search-api-params-size, size>> query param), the memory occupied by those
+structures could potentially exceed the available memory in the JVM. This would cause
+and `OutOfMemory` exception which would bring down the node.
+
+To prevent this from happening, a special <<circuit-breaker, circuit breaker>> is used,
+which limits the memory allocation during the execution of a <<eql-sequences, sequence>>
+query, so instead of an `OutOfMemory` exception, a `org.elasticsearch.common.breaker.CircuitBreakingException`
+is thrown, and a descriptive error message is returned to the user.
+
+This <<circuit-breaker, circuit breaker>> can be configured using the following settings:
+
 `breaker.eql_sequence.limit`::
 (<<cluster-update-settings,Dynamic>>) The limit for circuit breaker used to restrict
 the memory utilisation during the execution of an EQL sequence query. This value is

--- a/docs/reference/eql/eql.asciidoc
+++ b/docs/reference/eql/eql.asciidoc
@@ -796,19 +796,19 @@ You can also manually delete saved synchronous searches using the
 [[eql-circuit-breaker]]
 === EQL circuit breaker settings
 
-`breaker.eql.limit`::
+`breaker.eql_sequence.limit`::
 (<<cluster-update-settings,Dynamic>>) The limit for circuit breaker used to restrict
 the memory utilisation during the execution of an EQL sequence query. This value is
 defined as a percentage of the JVM heap. Defaults to `50%`. If the
 <<parent-circuit-breaker,parent circuit breaker>> is set to a value less than `50%`,
 this setting uses that value as its default instead.
 
-`breaker.eql.overhead`::
+`breaker.eql_sequence.overhead`::
 (<<cluster-update-settings,Dynamic>>) A constant which all computed memory required
 for the execution of an EQL query is multiplied by to determine a final estimation.
 See <<circuit-breaker>>. Defaults to `1`.
 
-`breaker.eql.type`::
+`breaker.eql_sequence.type`::
 (<<static-cluster-setting,Static>>) The underlying type of the circuit breaker.
 There are two valid options: `noop` and `memory`. `noop` means the circuit
 breaker does nothing to prevent too much memory usage. `memory` means the

--- a/docs/reference/eql/eql.asciidoc
+++ b/docs/reference/eql/eql.asciidoc
@@ -824,11 +824,13 @@ for the execution of an EQL query is multiplied by to determine a final estimati
 See <<circuit-breaker>>. Defaults to `1`.
 
 `breaker.eql_sequence.type`::
-(<<static-cluster-setting,Static>>) The underlying type of the circuit breaker.
-There are two valid options: `noop` and `memory`. `noop` means the circuit
-breaker does nothing to prevent too much memory usage. `memory` means the
-circuit breaker tracks the memory used by sequence queries and can potentially
-break and prevent `OutOfMemory` errors. The default value is `memory`.
+(<<static-cluster-setting,Static>>) Circuit breaker type. Valid values are:
+
+`memory` (Default):::
+The breaker limits memory usage for EQL sequence queries.
+
+`noop`:::
+Disables the breaker.
 
 include::syntax.asciidoc[]
 include::functions.asciidoc[]

--- a/docs/reference/eql/eql.asciidoc
+++ b/docs/reference/eql/eql.asciidoc
@@ -797,17 +797,17 @@ You can also manually delete saved synchronous searches using the
 === EQL circuit breaker settings
 
 When a <<eql-sequences, sequence>> query is executed, the node handling the query,
-needs to keep some structures in memory which are needed by the algorithm which
-implements the sequence matching. When large amounts of data need to be processed,
+needs to keep some structures in memory which are needed by the algorithm
+implementing the sequence matching. When large amounts of data need to be processed,
 and/or a large amount of matched sequences is requested by the user (by setting the
 <<eql-search-api-params-size, size>> query param), the memory occupied by those
-structures could potentially exceed the available memory in the JVM. This would cause
+structures could potentially exceed the available memory of the JVM. This would cause
 and `OutOfMemory` exception which would bring down the node.
 
 To prevent this from happening, a special <<circuit-breaker, circuit breaker>> is used,
 which limits the memory allocation during the execution of a <<eql-sequences, sequence>>
-query, so instead of an `OutOfMemory` exception, a `org.elasticsearch.common.breaker.CircuitBreakingException`
-is thrown, and a descriptive error message is returned to the user.
+query. When the breaker is triggered, an `org.elasticsearch.common.breaker.CircuitBreakingException`
+is thrown and a descriptive error message is returned to the user.
 
 This <<circuit-breaker, circuit breaker>> can be configured using the following settings:
 

--- a/docs/reference/eql/eql.asciidoc
+++ b/docs/reference/eql/eql.asciidoc
@@ -796,8 +796,8 @@ You can also manually delete saved synchronous searches using the
 [[eql-circuit-breaker]]
 === EQL circuit breaker settings
 
-When a <<eql-sequences, sequence>> query is executed, the node handling the query,
-needs to keep some structures in memory which are needed by the algorithm
+When a <<eql-sequences, sequence>> query is executed, the node handling the query
+needs to keep some structures in memory, which are needed by the algorithm
 implementing the sequence matching. When large amounts of data need to be processed,
 and/or a large amount of matched sequences is requested by the user (by setting the
 <<eql-search-api-params-size, size>> query param), the memory occupied by those
@@ -827,7 +827,7 @@ See <<circuit-breaker>>. Defaults to `1`.
 (<<static-cluster-setting,Static>>) The underlying type of the circuit breaker.
 There are two valid options: `noop` and `memory`. `noop` means the circuit
 breaker does nothing to prevent too much memory usage. `memory` means the
-circuit breaker tracks the memory used by trained models and can potentially
+circuit breaker tracks the memory used by sequence queries and can potentially
 break and prevent `OutOfMemory` errors. The default value is `memory`.
 
 include::syntax.asciidoc[]

--- a/docs/reference/eql/eql.asciidoc
+++ b/docs/reference/eql/eql.asciidoc
@@ -792,6 +792,29 @@ results by using <<get-async-eql-status-api,get async EQL status API>>.
 You can also manually delete saved synchronous searches using the
 <<delete-async-eql-search-api,delete async EQL search API>>.
 
+[discrete]
+[[eql-circuit-breaker]]
+=== EQL circuit breaker settings
+
+`breaker.eql.limit`::
+(<<cluster-update-settings,Dynamic>>) The limit for circuit breaker used to restrict
+the memory utilisation during the execution of an EQL sequence query. This value is
+defined as a percentage of the JVM heap. Defaults to `50%`. If the
+<<parent-circuit-breaker,parent circuit breaker>> is set to a value less than `50%`,
+this setting uses that value as its default instead.
+
+`breaker.eql.overhead`::
+(<<cluster-update-settings,Dynamic>>) A constant which all computed memory required
+for the execution of an EQL query is multiplied by to determine a final estimation.
+See <<circuit-breaker>>. Defaults to `1`.
+
+`breaker.eql.type`::
+(<<static-cluster-setting,Static>>) The underlying type of the circuit breaker.
+There are two valid options: `noop` and `memory`. `noop` means the circuit
+breaker does nothing to prevent too much memory usage. `memory` means the
+circuit breaker tracks the memory used by trained models and can potentially
+break and prevent `OutOfMemory` errors. The default value is `memory`.
+
 include::syntax.asciidoc[]
 include::functions.asciidoc[]
 include::pipes.asciidoc[]

--- a/docs/reference/eql/eql.asciidoc
+++ b/docs/reference/eql/eql.asciidoc
@@ -802,7 +802,7 @@ implementing the sequence matching. When large amounts of data need to be proces
 and/or a large amount of matched sequences is requested by the user (by setting the
 <<eql-search-api-params-size, size>> query param), the memory occupied by those
 structures could potentially exceed the available memory of the JVM. This would cause
-and `OutOfMemory` exception which would bring down the node.
+an `OutOfMemory` exception which would bring down the node.
 
 To prevent this from happening, a special <<circuit-breaker, circuit breaker>> is used,
 which limits the memory allocation during the execution of a <<eql-sequences, sequence>>


### PR DESCRIPTION
Add documentation for the newly introduced CircuitBreaker, which is
used to restrict the memory usage for an EQL sequence query to avoid
OutOfMemory exceptions.

Follows: #74381
