### PR TITLE
Fix ByteSizeValue parse exceptions

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/unit/ByteSizeValue.java
+++ b/server/src/main/java/org/elasticsearch/common/unit/ByteSizeValue.java
@@ -224,7 +224,7 @@ public class ByteSizeValue implements Writeable, Comparable<ByteSizeValue>, ToXC
         } else if (lowerSValue.endsWith("pb")) {
             return parse(sValue, lowerSValue, "pb", ByteSizeUnit.PB, settingName);
         } else if (lowerSValue.endsWith("b")) {
-            return new ByteSizeValue(Long.parseLong(lowerSValue.substring(0, lowerSValue.length() - 1).trim()), ByteSizeUnit.BYTES);
+            return parseBytes(lowerSValue, settingName, sValue);
         } else if (lowerSValue.equals("-1")) {
             // Allow this special value to be unit-less:
             return new ByteSizeValue(-1, ByteSizeUnit.BYTES);
@@ -236,6 +236,18 @@ public class ByteSizeValue implements Writeable, Comparable<ByteSizeValue>, ToXC
             throw new ElasticsearchParseException(
                     "failed to parse setting [{}] with value [{}] as a size in bytes: unit is missing or unrecognized", settingName,
                     sValue);
+        }
+    }
+
+    private static ByteSizeValue parseBytes(String lowerSValue, String settingName, String initialInput) {
+        String s = lowerSValue.substring(0, lowerSValue.length() - 1).trim();
+        try {
+            return new ByteSizeValue(Long.parseLong(s), ByteSizeUnit.BYTES);
+        } catch (NumberFormatException e) {
+            throw new ElasticsearchParseException("failed to parse setting [{}] with value [{}]", e, settingName, initialInput);
+        } catch (IllegalArgumentException e) {
+            throw new ElasticsearchParseException("failed to parse setting [{}] with value [{}] as a size in bytes", e, settingName,
+                initialInput);
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/common/unit/RelativeByteSizeValue.java
+++ b/server/src/main/java/org/elasticsearch/common/unit/RelativeByteSizeValue.java
@@ -84,8 +84,7 @@ public class RelativeByteSizeValue {
         }
         try {
             return new RelativeByteSizeValue(ByteSizeValue.parseBytesSizeValue(value, settingName));
-            // todo: fix NumberFormatException case in ByteSizeValue.
-        } catch (NumberFormatException | ElasticsearchParseException e) {
+        } catch (ElasticsearchParseException e) {
             throw new ElasticsearchParseException("unable to parse [{}={}] as either percentage or bytes", e,
                 settingName, value);
         }

--- a/server/src/test/java/org/elasticsearch/common/unit/ByteSizeValueTests.java
+++ b/server/src/test/java/org/elasticsearch/common/unit/ByteSizeValueTests.java
@@ -262,9 +262,10 @@ public class ByteSizeValueTests extends AbstractWireSerializingTestCase<ByteSize
     }
 
     public void testParseInvalidValue() {
+        String unitSuffix = (randomBoolean() ? " " : "") + randomFrom(ByteSizeUnit.values()).getSuffix();
         ElasticsearchParseException exception = expectThrows(ElasticsearchParseException.class,
-                () -> ByteSizeValue.parseBytesSizeValue("-6mb", "test_setting"));
-        assertEquals("failed to parse setting [test_setting] with value [-6mb] as a size in bytes", exception.getMessage());
+                () -> ByteSizeValue.parseBytesSizeValue("-6" + unitSuffix, "test_setting"));
+        assertEquals("failed to parse setting [test_setting] with value [-6" + unitSuffix + "] as a size in bytes", exception.getMessage());
         assertNotNull(exception.getCause());
         assertEquals(IllegalArgumentException.class, exception.getCause().getClass());
     }
@@ -290,8 +291,10 @@ public class ByteSizeValueTests extends AbstractWireSerializingTestCase<ByteSize
         assertEquals("failed to parse setting [test] with value [notANumber] as a size in bytes: unit is missing or unrecognized",
                 exception.getMessage());
 
-        exception = expectThrows(ElasticsearchParseException.class, () -> ByteSizeValue.parseBytesSizeValue("notANumberMB", "test"));
-        assertEquals("failed to parse setting [test] with value [notANumberMB]", exception.getMessage());
+        String unitSuffix = (randomBoolean() ? " " : "") + randomFrom(ByteSizeUnit.values()).getSuffix();
+        exception = expectThrows(ElasticsearchParseException.class,
+            () -> ByteSizeValue.parseBytesSizeValue("notANumber" + unitSuffix, "test"));
+        assertEquals("failed to parse setting [test] with value [notANumber" + unitSuffix + "]", exception.getMessage());
     }
 
     public void testParseFractionalNumber() throws IOException {


### PR DESCRIPTION
ByteSizeValue.parseBytesSizeValue would in some cases throw an
IllegalArgumentException or NumberFormatException. Now always throws
ElasticsearchParseException.

Relates #71855
