### PR TITLE
[7.x] Fix ActionConfigStatsTests.testEqualsAndHashcode (#74849)

### DIFF
--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/ActionConfigStatsTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/ActionConfigStatsTests.java
@@ -96,7 +96,7 @@ public class ActionConfigStatsTests extends AbstractWireSerializingTestCase<Acti
                 builder.setShrinkMaxPrimaryShardSize(randomPrimaryByteSize);
                 break;
             case 8:
-                builder.setShrinkNumberOfShards(randomIntBetween(0, 50));
+                builder.setShrinkNumberOfShards(randomValueOtherThan(instance.getShrinkNumberOfShards(), () -> randomIntBetween(0, 50)));
                 break;
             default:
                 throw new IllegalStateException("Illegal randomization branch");


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Fix ActionConfigStatsTests.testEqualsAndHashcode (#74849)