### PR TITLE
SearchModuleTests uses wrong check for deprecated query names

### DIFF
--- a/server/src/test/java/org/elasticsearch/search/SearchModuleTests.java
+++ b/server/src/test/java/org/elasticsearch/search/SearchModuleTests.java
@@ -241,7 +241,7 @@ public class SearchModuleTests extends ESTestCase {
 
         Set<String> registeredNonDeprecated = module.getNamedXContents().stream()
                 .filter(e -> e.categoryClass.equals(QueryBuilder.class))
-                .filter(e -> e.name.getDeprecatedNames().length == 0)
+                .filter(e -> e.name.getAllReplacedWith() == null)
                 .map(e -> e.name.getPreferredName())
                 .collect(toSet());
         Set<String> registeredAll = module.getNamedXContents().stream()


### PR DESCRIPTION
SearchModuleTests checks through a list of queries that it expects to be 
registered, and separately checks a through a list of queries that have
not been deprecated.  This second check filters out non-deprecated
queries by seeing if they have deprecated names; but this will miss queries
that have been renamed (for example, we plan to rename `field_masking_span`
to `span_field_masking`, and this query will be perfectly valid but have a
deprecated name).  This commit changes the filter to check that there are
any undeprecated names instead.