### PR TITLE
Remote reindex stored fields since 5.0.0

### DIFF
--- a/modules/reindex/src/test/java/org/elasticsearch/index/reindex/remote/RemoteRequestBuildersTests.java
+++ b/modules/reindex/src/test/java/org/elasticsearch/index/reindex/remote/RemoteRequestBuildersTests.java
@@ -108,15 +108,16 @@ public class RemoteRequestBuildersTests extends ESTestCase {
         // Test stored_fields for versions that support it
         searchRequest = new SearchRequest().source(new SearchSourceBuilder());
         searchRequest.source().storedField("_source").storedField("_id");
-        // V_5_0_0_alpha4 => current
-        remoteVersion = Version.fromId(between(5000004, Version.CURRENT.id));
+        // V_5_0_0 (final) => current
+        int minStoredFieldsVersion = 5000099;
+        remoteVersion = Version.fromId(randomBoolean() ? minStoredFieldsVersion : between(minStoredFieldsVersion, Version.CURRENT.id));
         assertThat(initialSearch(searchRequest, query, remoteVersion).getParameters(), hasEntry("stored_fields", "_source,_id"));
 
         // Test fields for versions that support it
         searchRequest = new SearchRequest().source(new SearchSourceBuilder());
         searchRequest.source().storedField("_source").storedField("_id");
         // V_2_0_0 => V_5_0_0_alpha3
-        remoteVersion = Version.fromId(between(2000099, 5000003));
+        remoteVersion = Version.fromId(randomBoolean() ? minStoredFieldsVersion - 1 : between(2000099, minStoredFieldsVersion - 1));
         assertThat(initialSearch(searchRequest, query, remoteVersion).getParameters(), hasEntry("fields", "_source,_id"));
 
         // Test extra fields for versions that need it


### PR DESCRIPTION
Test would assume stored fields were available since 5.0.0.alpha4,
while production code only enables them after 5.0.0 (final, aka 99).

Closes #74131
