### PR TITLE
[ML] Avoid 5s wait in AbstractNativeProcessTests

### DIFF
--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/process/AbstractNativeProcessTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/process/AbstractNativeProcessTests.java
@@ -87,17 +87,23 @@ public class AbstractNativeProcessTests extends ESTestCase {
     public void testStart_DoNotDetectCrashWhenNoInputPipeProvided() throws Exception {
         when(processPipes.getProcessInStream()).thenReturn(Optional.empty());
         try (AbstractNativeProcess process = new TestNativeProcess()) {
-            process.start(executorService);
-            mockNativeProcessLoggingStreamEnds.countDown();
-            // Not detecting a crash is confirmed in terminateExecutorService()
+            try {
+                process.start(executorService);
+            } finally {
+                mockNativeProcessLoggingStreamEnds.countDown();
+                // Not detecting a crash is confirmed in terminateExecutorService()
+            }
         }
     }
 
     public void testStart_DoNotDetectCrashWhenProcessIsBeingClosed() throws Exception {
         try (AbstractNativeProcess process = new TestNativeProcess()) {
-            process.start(executorService);
-            mockNativeProcessLoggingStreamEnds.countDown();
-            // Not detecting a crash is confirmed in terminateExecutorService()
+            try {
+                process.start(executorService);
+            } finally {
+                mockNativeProcessLoggingStreamEnds.countDown();
+                // Not detecting a crash is confirmed in terminateExecutorService()
+            }
         }
     }
 
@@ -140,58 +146,74 @@ public class AbstractNativeProcessTests extends ESTestCase {
 
     public void testWriteRecord() throws Exception {
         try (AbstractNativeProcess process = new TestNativeProcess()) {
-            process.start(executorService);
-            process.writeRecord(new String[] {"a", "b", "c"});
-            process.flushStream();
-
-            verify(inputStream).write(any(), anyInt(), anyInt());
-            mockNativeProcessLoggingStreamEnds.countDown();
+            try {
+                process.start(executorService);
+                process.writeRecord(new String[]{"a", "b", "c"});
+                process.flushStream();
+                verify(inputStream).write(any(), anyInt(), anyInt());
+            } finally {
+                mockNativeProcessLoggingStreamEnds.countDown();
+            }
         }
     }
 
     public void testWriteRecord_FailWhenNoInputPipeProvided() throws Exception {
         when(processPipes.getProcessInStream()).thenReturn(Optional.empty());
         try (AbstractNativeProcess process = new TestNativeProcess()) {
-            process.start(executorService);
-            expectThrows(NullPointerException.class, () -> process.writeRecord(new String[] {"a", "b", "c"}));
-            mockNativeProcessLoggingStreamEnds.countDown();
+            try {
+                process.start(executorService);
+                expectThrows(NullPointerException.class, () -> process.writeRecord(new String[]{"a", "b", "c"}));
+            } finally {
+                mockNativeProcessLoggingStreamEnds.countDown();
+            }
         }
     }
 
     public void testFlush() throws Exception {
         try (AbstractNativeProcess process = new TestNativeProcess()) {
-            process.start(executorService);
-            process.flushStream();
-
-            verify(inputStream).flush();
-            mockNativeProcessLoggingStreamEnds.countDown();
+            try {
+                process.start(executorService);
+                process.flushStream();
+                verify(inputStream).flush();
+            } finally {
+                mockNativeProcessLoggingStreamEnds.countDown();
+            }
         }
     }
 
     public void testFlush_FailWhenNoInputPipeProvided() throws Exception {
         when(processPipes.getProcessInStream()).thenReturn(Optional.empty());
         try (AbstractNativeProcess process = new TestNativeProcess()) {
-            process.start(executorService);
-            expectThrows(NullPointerException.class, process::flushStream);
-            mockNativeProcessLoggingStreamEnds.countDown();
+            try {
+                process.start(executorService);
+                expectThrows(NullPointerException.class, process::flushStream);
+            } finally {
+                mockNativeProcessLoggingStreamEnds.countDown();
+            }
         }
     }
 
     public void testIsReady() throws Exception {
         try (AbstractNativeProcess process = new TestNativeProcess()) {
-            process.start(executorService);
-            assertThat(process.isReady(), is(false));
-            process.setReady();
-            assertThat(process.isReady(), is(true));
-            mockNativeProcessLoggingStreamEnds.countDown();
+            try {
+                process.start(executorService);
+                assertThat(process.isReady(), is(false));
+                process.setReady();
+                assertThat(process.isReady(), is(true));
+            } finally {
+                mockNativeProcessLoggingStreamEnds.countDown();
+            }
         }
     }
 
     public void testConsumeAndCloseOutputStream_GivenNoOutputStream() throws Exception {
         when(processPipes.getProcessOutStream()).thenReturn(Optional.empty());
         try (AbstractNativeProcess process = new TestNativeProcess()) {
-            process.consumeAndCloseOutputStream();
-            mockNativeProcessLoggingStreamEnds.countDown();
+            try {
+                process.consumeAndCloseOutputStream();
+            } finally {
+                mockNativeProcessLoggingStreamEnds.countDown();
+            }
         }
     }
 

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/process/AbstractNativeProcessTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/process/AbstractNativeProcessTests.java
@@ -88,7 +88,6 @@ public class AbstractNativeProcessTests extends ESTestCase {
         when(processPipes.getProcessInStream()).thenReturn(Optional.empty());
         try (AbstractNativeProcess process = new TestNativeProcess()) {
             process.start(executorService);
-        } finally {
             mockNativeProcessLoggingStreamEnds.countDown();
             // Not detecting a crash is confirmed in terminateExecutorService()
         }
@@ -97,7 +96,6 @@ public class AbstractNativeProcessTests extends ESTestCase {
     public void testStart_DoNotDetectCrashWhenProcessIsBeingClosed() throws Exception {
         try (AbstractNativeProcess process = new TestNativeProcess()) {
             process.start(executorService);
-        } finally {
             mockNativeProcessLoggingStreamEnds.countDown();
             // Not detecting a crash is confirmed in terminateExecutorService()
         }
@@ -147,8 +145,6 @@ public class AbstractNativeProcessTests extends ESTestCase {
             process.flushStream();
 
             verify(inputStream).write(any(), anyInt(), anyInt());
-
-        } finally {
             mockNativeProcessLoggingStreamEnds.countDown();
         }
     }
@@ -158,7 +154,6 @@ public class AbstractNativeProcessTests extends ESTestCase {
         try (AbstractNativeProcess process = new TestNativeProcess()) {
             process.start(executorService);
             expectThrows(NullPointerException.class, () -> process.writeRecord(new String[] {"a", "b", "c"}));
-        } finally {
             mockNativeProcessLoggingStreamEnds.countDown();
         }
     }
@@ -169,7 +164,6 @@ public class AbstractNativeProcessTests extends ESTestCase {
             process.flushStream();
 
             verify(inputStream).flush();
-        } finally {
             mockNativeProcessLoggingStreamEnds.countDown();
         }
     }
@@ -179,7 +173,6 @@ public class AbstractNativeProcessTests extends ESTestCase {
         try (AbstractNativeProcess process = new TestNativeProcess()) {
             process.start(executorService);
             expectThrows(NullPointerException.class, process::flushStream);
-        } finally {
             mockNativeProcessLoggingStreamEnds.countDown();
         }
     }
@@ -190,7 +183,6 @@ public class AbstractNativeProcessTests extends ESTestCase {
             assertThat(process.isReady(), is(false));
             process.setReady();
             assertThat(process.isReady(), is(true));
-        } finally {
             mockNativeProcessLoggingStreamEnds.countDown();
         }
     }
@@ -199,7 +191,6 @@ public class AbstractNativeProcessTests extends ESTestCase {
         when(processPipes.getProcessOutStream()).thenReturn(Optional.empty());
         try (AbstractNativeProcess process = new TestNativeProcess()) {
             process.consumeAndCloseOutputStream();
-        } finally {
             mockNativeProcessLoggingStreamEnds.countDown();
         }
     }


### PR DESCRIPTION
Running the unit tests I've noticed `AbstractNativeProcessTests` often takes a long time to complete, individual methods either complete very quickly or take a little over 5 seconds suggesting something is timing out. 

Indeed the 5 second wait is in the `close()` method https://github.com/elastic/elasticsearch/blob/68817d7ca29c264b3ea3f766737d81e2ebb4028c/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/process/AbstractNativeProcess.java#L195

When used in a try-with-resource block `close()` is called before `mockNativeProcessLoggingStreamEnds.countDown()` so the call to wait for the log tail future to finish always times out as it is waiting on the `mockNativeProcessLoggingStreamEnds` latch to countdown.

Closes #37339