### PR TITLE
[7.x] Fix ActionConfigStatsTests.testEqualsAndHashcode (#74907)

### DIFF
--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/ActionConfigStatsTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/ActionConfigStatsTests.java
@@ -68,13 +68,16 @@ public class ActionConfigStatsTests extends AbstractWireSerializingTestCase<Acti
         ActionConfigStats.Builder builder = ActionConfigStats.builder(instance);
         switch (between(0, 8)) {
             case 0:
-                builder.setAllocateNumberOfReplicas(randomIntBetween(0, 10000));
+                int numberOfReplicas = randomValueOtherThan(instance.getAllocateNumberOfReplicas(), () -> randomIntBetween(0, 10000));
+                builder.setAllocateNumberOfReplicas(numberOfReplicas);
                 break;
             case 1:
-                builder.setForceMergeMaxNumberOfSegments(randomIntBetween(0, 10000));
+                int numberOfSegments = randomValueOtherThan(instance.getForceMergeMaxNumberOfSegments(), () -> randomIntBetween(0, 10000));
+                builder.setForceMergeMaxNumberOfSegments(numberOfSegments);
                 break;
             case 2:
-                TimeValue randomAge = TimeValue.parseTimeValue(randomTimeValue(), "action_config_stats_tests");
+                TimeValue randomAge = randomValueOtherThan(instance.getRolloverMaxAge(),
+                    () -> TimeValue.parseTimeValue(randomTimeValue(), "action_config_stats_tests"));
                 builder.setRolloverMaxAge(randomAge);
                 break;
             case 3:
@@ -89,7 +92,7 @@ public class ActionConfigStatsTests extends AbstractWireSerializingTestCase<Acti
                 builder.setRolloverMaxSize(randomMaxByteSize);
                 break;
             case 6:
-                builder.setPriority(randomIntBetween(0, 50));
+                builder.setPriority(randomValueOtherThan(instance.getSetPriorityPriority(), () -> randomIntBetween(0, 50)));
                 break;
             case 7:
                 ByteSizeValue randomPrimaryByteSize = ByteSizeValue.ofBytes(randomLongBetween(0, 1024L*1024L*1024L*50L));


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Fix ActionConfigStatsTests.testEqualsAndHashcode (#74907)