### PR TITLE
Permit more temp files in data path

### DIFF
--- a/server/src/main/java/org/elasticsearch/env/NodeEnvironment.java
+++ b/server/src/main/java/org/elasticsearch/env/NodeEnvironment.java
@@ -365,6 +365,13 @@ public final class NodeEnvironment  implements Closeable {
                 SNAPSHOT_CACHE_FOLDER
             ));
 
+            final Set<String> ignoredFileNames = new HashSet<>(Arrays.asList(
+                NODE_LOCK_FILENAME,
+                TEMP_FILE_NAME,
+                TEMP_FILE_NAME + ".tmp",
+                TEMP_FILE_NAME + ".final"
+            ));
+
             try (DirectoryStream<Path> stream = Files.newDirectoryStream(legacyNodePath.path)) {
                 for (Path subFolderPath : stream) {
                     final String fileName = subFolderPath.getFileName().toString();
@@ -381,8 +388,7 @@ public final class NodeEnvironment  implements Closeable {
                                 targetSubFolderPath);
                         }
                         folderNames.add(fileName);
-                    } else if (fileName.equals(NODE_LOCK_FILENAME) == false &&
-                               fileName.equals(TEMP_FILE_NAME) == false) {
+                    } else if (ignoredFileNames.contains(fileName) == false) {
                         throw new IllegalStateException("unexpected file/folder encountered during data folder upgrade: " +
                             subFolderPath);
                     }


### PR DESCRIPTION
When a node starts up it creates, then immediately deletes, files called
`.es_temp_file.tmp` and `.es_temp_file.final`. If the node is killed at
exactly the wrong moment then we may leave one of these files on disk.

When upgrading from 7.x to 8.0 we reorganise the contents of the data
path, but bail out if we encounter anything unexpected to avoid causing
damage in unexpected situations. However we don't consider the temporary
files mentioned above as expected, so their existence will cause an
upgrade to fail.

This commit adjusts the logic to permit these files to exist during the
ugprade.

Closes #74908