### PR TITLE
[DOCS] Removes link to classification and regression

### DIFF
--- a/docs/reference/ingest/processors/inference.asciidoc
+++ b/docs/reference/ingest/processors/inference.asciidoc
@@ -125,7 +125,8 @@ classes to the `probabilities` field. Both fields are contained in the
 `target_field` results object.
 
 Refer to the 
-{ml-docs}/ml-lang-ident.html#ml-lang-ident-example[language identification] 
+// {ml-docs}/ml-dfa-lang-ident.html#ml-lang-ident-example[language identification] 
+language identification
 trained model documentation for a full example.
 
 

--- a/docs/reference/ml/df-analytics/apis/get-trained-models.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/get-trained-models.asciidoc
@@ -225,9 +225,8 @@ List of the available hyperparameters optimized during the
 `absolute_importance`::::
 (double)
 A positive number showing how much the parameter influences the variation of the 
-{ml-docs}/dfa-regression.html#dfa-regression-lossfunction[loss function]. For 
-hyperparameters with values that are not specified by the user but tuned during 
-hyperparameter optimization. 
+loss function. For hyperparameters with values that are not specified by the 
+user but tuned during hyperparameter optimization. 
 
 `max_trees`::::
 (integer)

--- a/docs/reference/ml/df-analytics/apis/put-dfanalytics.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/put-dfanalytics.asciidoc
@@ -81,8 +81,8 @@ one of the following types of analysis: {classification}, {oldetection}, or
 //Begin classification
 `classification`:::
 (Required^*^, object)
-The configuration information necessary to perform
-{ml-docs}/dfa-classification.html[{classification}].
+The configuration information necessary to perform {classification}:
+// {ml-docs}/ml-dfa-classification.html[{classification}].
 +
 TIP: Advanced parameters are for fine-tuning {classanalysis}. They are set
 automatically by hyperparameter optimization to give the minimum validation
@@ -263,9 +263,8 @@ a large number of categories, there could be a significant effect on the size of
 +
 --
 NOTE: To use the
-{ml-docs}/ml-dfanalytics-evaluate.html#ml-dfanalytics-class-aucroc[AUC ROC evaluation method],
-`num_top_classes` must be set to `-1` or a value greater than or equal to the
-total number of categories.
+AUC ROC evaluation method, `num_top_classes` must be set to `-1` or a value 
+greater than or equal to the total number of categories.
 
 --
 
@@ -333,8 +332,8 @@ include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=standardization-enabled]
 //Begin regression
 `regression`:::
 (Required^*^, object)
-The configuration information necessary to perform
-{ml-docs}/dfa-regression.html[{regression}].
+The configuration information necessary to perform {regression:}
+// {ml-docs}/ml-dfa-regression.html[{regression}].
 +
 TIP: Advanced parameters are for fine-tuning {reganalysis}. They are set
 automatically by hyperparameter optimization to give the minimum validation
@@ -391,9 +390,10 @@ include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=lambda]
 (Optional, string)
 The loss function used during {regression}. Available options are `mse` (mean
 squared error), `msle` (mean squared logarithmic error),  `huber` (Pseudo-Huber
-loss). Defaults to `mse`. Refer to
-{ml-docs}/dfa-regression.html#dfa-regression-lossfunction[Loss functions for {regression} analyses]
-to learn more.
+loss). Defaults to `mse`.
+// Refer to
+// {ml-docs}/ml-dfa-regression.html#dfa-regression-lossfunction[Loss functions for {regression} analyses]
+// to learn more.
 
 `loss_function_parameter`::::
 (Optional, double)


### PR DESCRIPTION
## Overview

Related to https://github.com/elastic/stack-docs/pull/1736 and https://github.com/elastic/stack-docs/issues/1725

This PR comments out links that point to classification and regression-related docs. Due to the ML book reorg, these links would break the docs build after merging https://github.com/elastic/stack-docs/pull/1736.