### PR TITLE
[7.x] Adjust versioning for a data stream aliases yaml test. (#74924)

### DIFF
--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/data_stream/140_data_stream_aliases.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/data_stream/140_data_stream_aliases.yml
@@ -1,8 +1,8 @@
 ---
 "Create data stream alias":
   - skip:
-      version: " - 7.99.99"
-      reason: "data streams alias not yet backported to the 7.x branch"
+      version: " - 7.13.99"
+      reason: "data streams aliases are available from 7.14.0"
       features: allowed_warnings
 
   - do:


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Adjust versioning for a data stream aliases yaml test. (#74924)