### PR TITLE
[DOCS] Update forecasting links in ML APIs

### DIFF
--- a/docs/reference/ml/anomaly-detection/apis/delete-forecast.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/delete-forecast.asciidoc
@@ -34,7 +34,7 @@ one or more forecasts before they expire.
 NOTE: When you delete a job, its associated forecasts are deleted.
 
 For more information, see
-{ml-docs}/ml-overview.html#ml-forecasting[Forecasting the future].
+{ml-docs}/ml-overview.html[Forecasting the future].
 
 [[ml-delete-forecast-path-parms]]
 == {api-path-parms-title}

--- a/docs/reference/ml/anomaly-detection/apis/forecast.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/forecast.asciidoc
@@ -24,7 +24,7 @@ Requires the `manage_ml` cluster privilege. This privilege is included in the
 
 You can create a forecast job based on an {anomaly-job} to extrapolate future 
 behavior. Refer to
-{ml-docs}/ml-overview.html#ml-forecasting[Forecasting the future] and 
+{ml-docs}/ml-overview.html#[Forecasting the future] and 
 {ml-docs}/ml-limitations.html#ml-forecast-limitations[forecast limitations] to 
 learn more.
 


### PR DESCRIPTION
This PR addresses links that will break in https://github.com/elastic/stack-docs/pull/1731