### PR TITLE
[7.14] Fix GeoIpProcessor when there's no updated db (#74944)

### DIFF
--- a/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/GeoIpProcessor.java
+++ b/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/GeoIpProcessor.java
@@ -436,7 +436,9 @@ public final class GeoIpProcessor extends AbstractProcessor {
                     return true;
                 }
                 GeoIpTaskState state = (GeoIpTaskState) task.getState();
-                return state.getDatabases().get(databaseFile).isValid(currentState.metadata().settings());
+                GeoIpTaskState.Metadata metadata = state.getDatabases().get(databaseFile);
+                // we never remove metadata from cluster state, if metadata is null we deal with built-in database, which is always valid
+                return metadata == null || metadata.isValid(currentState.metadata().settings());
             };
             return new GeoIpProcessor(processorTag, description, ipField, supplier, isValid, targetField, properties, ignoreMissing,
                 firstOnly);

--- a/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/IngestGeoIpPlugin.java
+++ b/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/IngestGeoIpPlugin.java
@@ -64,6 +64,7 @@ import java.util.function.Supplier;
 
 import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
 import static org.elasticsearch.index.mapper.MapperService.SINGLE_MAPPING_NAME;
+import static org.elasticsearch.ingest.IngestService.INGEST_ORIGIN;
 import static org.elasticsearch.ingest.geoip.GeoIpDownloader.DATABASES_INDEX;
 import static org.elasticsearch.ingest.geoip.GeoIpDownloader.GEOIP_DOWNLOADER;
 
@@ -169,7 +170,7 @@ public class IngestGeoIpPlugin extends Plugin implements IngestPlugin, SystemInd
                 .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0)
                 .put(IndexMetadata.SETTING_AUTO_EXPAND_REPLICAS, "0-1")
                 .build())
-            .setOrigin("geoip")
+            .setOrigin(INGEST_ORIGIN)
             .setVersionMetaKey("version")
             .setPrimaryIndex(DATABASES_INDEX)
             .setNetNew()

--- a/modules/ingest-geoip/src/test/java/org/elasticsearch/ingest/geoip/GeoIpProcessorFactoryTests.java
+++ b/modules/ingest-geoip/src/test/java/org/elasticsearch/ingest/geoip/GeoIpProcessorFactoryTests.java
@@ -387,7 +387,7 @@ public class GeoIpProcessorFactoryTests extends ESTestCase {
 
         GeoIpProcessor processor = factory.create(null, processorTag, null, config);
 
-        processor.execute(RandomDocumentPicks.randomIngestDocument(random(), Map.of("_field", "89.160.20.128")));
+        processor.execute(RandomDocumentPicks.randomIngestDocument(random(), org.elasticsearch.core.Map.of("_field", "89.160.20.128")));
     }
 
     public void testFallbackUsingDefaultDatabasesWhileIngesting() throws Exception {


### PR DESCRIPTION
Backports the following commits to 7.14:
 - Fix GeoIpProcessor when there's no updated db (#74944)