### PR TITLE
Docs: Mention pipeline aggregations that work together with composite aggregations

### DIFF
--- a/docs/reference/aggregations/bucket/composite-aggregation.asciidoc
+++ b/docs/reference/aggregations/bucket/composite-aggregation.asciidoc
@@ -918,12 +918,14 @@ GET /_search
 // TESTRESPONSE[s/\.\.\.//]
 
 [[search-aggregations-bucket-composite-aggregation-pipeline-aggregations]]
+
 ==== Pipeline aggregations
 
-The composite agg is not currently compatible with pipeline aggregations, nor does it make sense in most cases.
-E.g. due to the paging nature of composite aggs, a single logical partition (one day for example) might be spread
-over multiple pages. Since pipeline aggregations are purely post-processing on the final list of buckets,
-running something like a derivative on a composite page could lead to inaccurate results as it is only taking into
-account a "partial" result on that page.
+The composite aggregation is currently not compatible with pipeline aggregations spanning more than one bucket, nor does
+it make sense in most cases. E.g. due to the paging nature of composite aggs, a single logical partition (one day for
+example) might be spread over multiple pages. Since pipeline aggregations are purely post-processing on the final list
+of buckets, running something like a derivative on a composite page could lead to inaccurate results as it is only
+taking into account a "partial" result on that page.
 
-Pipeline aggs that are self contained to a single bucket (such as `bucket_selector`) might be supported in the future.
+Pipeline aggregations operating on a single bucket (such as `bucket_selector` or `bucket_script`) are supported and can
+use buckets from composite aggregations.


### PR DESCRIPTION
I noticed that the limitation mentioned in https://www.elastic.co/guide/en/elasticsearch/reference/master/search-aggregations-bucket-composite-aggregation.html#search-aggregations-bucket-composite-aggregation-pipeline-aggregations is no longer accurate as some pipeline aggregations seem to be able to operate on composite aggregations.

See for example the following request generated from an SQL query:

```
{
  "size": 0,
  "_source": false,
  "aggregations": {
    "groupby": {
      "composite": {
        "size": 1000,
        "sources": [
          {
            "8a3bf544": {
              "terms": {
                "field": "gender",
                "missing_bucket": true,
                "order": "asc"
              }
            }
          }
        ]
      },
      "aggregations": {
        "ad4ab13a": {
          "stats": {
            "field": "languages"
          }
        },
        "having.having.ebea05f6_&_having.f143ef6a": {
          "bucket_selector": {
            "buckets_path": {
              "a0": "ad4ab13a.sum",
              "a1": "_count"
            },
            "script": {
              "source": "InternalQlScriptUtils.nullSafeFilter(InternalQlScriptUtils.and(InternalQlScriptUtils.nullSafeFilter(InternalQlScriptUtils.gt(InternalQlScriptUtils.nullSafeCastNumeric(params.a0,params.v0),params.v1)),InternalQlScriptUtils.nullSafeFilter(InternalQlScriptUtils.gt(params.a1,params.v2))))",
              "lang": "painless",
              "params": {
                "v0": "LONG",
                "v1": 0,
                "v2": 0
              }
            },
            "gap_policy": "skip"
          }
        }
      }
    }
  }
}
```

I couldn't find the PR that made this possible but I found the related issue https://github.com/elastic/elasticsearch/issues/36853.