### PR TITLE
Update index names for endpoint Datastream permissions.

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStore.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStore.java
@@ -187,11 +187,11 @@ public class ReservedRolesStore implements BiConsumer<Set<String>, ActionListene
                                     .privileges("all").build(),
                                 // Endpoint / Fleet policy responses. Kibana requires read access to send telemetry
                                 RoleDescriptor.IndicesPrivileges.builder()
-                                    .indices("metrics-endpoint.policy-*")
+                                    .indices("metrics-endpoint.policy-default")
                                     .privileges("read").build(),
                                 // Endpoint metrics. Kibana requires read access to send telemetry
                                 RoleDescriptor.IndicesPrivileges.builder()
-                                    .indices("metrics-endpoint.metrics-*")
+                                    .indices("metrics-endpoint.metrics-default")
                                     .privileges("read").build()
                         },
                         null,

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStoreTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStoreTests.java
@@ -549,7 +549,7 @@ public class ReservedRolesStoreTests extends ESTestCase {
         });
 
         // read-only datastream for Endpoint policy responses
-        Arrays.asList("metrics-endpoint.policy-" + randomAlphaOfLength(randomIntBetween(0, 13))).forEach((index) -> {
+        Arrays.asList("metrics-endpoint.policy-default" + randomAlphaOfLength(randomIntBetween(0, 13))).forEach((index) -> {
             assertThat(kibanaRole.indices().allowedIndicesMatcher("indices:foo").test(mockIndexAbstraction(index)), is(false));
             assertThat(kibanaRole.indices().allowedIndicesMatcher("indices:bar").test(mockIndexAbstraction(index)), is(false));
             assertThat(kibanaRole.indices().allowedIndicesMatcher(DeleteIndexAction.NAME).test(mockIndexAbstraction(index)), is(false));
@@ -565,7 +565,7 @@ public class ReservedRolesStoreTests extends ESTestCase {
         });
 
         // read-only datastream for Endpoint metrics
-        Arrays.asList("metrics-endpoint.metrics-" + randomAlphaOfLength(randomIntBetween(0, 13))).forEach((index) -> {
+        Arrays.asList("metrics-endpoint.metrics-default" + randomAlphaOfLength(randomIntBetween(0, 13))).forEach((index) -> {
             assertThat(kibanaRole.indices().allowedIndicesMatcher("indices:foo").test(mockIndexAbstraction(index)), is(false));
             assertThat(kibanaRole.indices().allowedIndicesMatcher("indices:bar").test(mockIndexAbstraction(index)), is(false));
             assertThat(kibanaRole.indices().allowedIndicesMatcher(DeleteIndexAction.NAME).test(mockIndexAbstraction(index)), is(false));


### PR DESCRIPTION
<img width="1305" alt="Screenshot 2021-07-06 at 11 54 53" src="https://user-images.githubusercontent.com/8960296/124588700-00ad3280-de51-11eb-90e6-2cb284b5eaf7.png">

The Kibana System user can't read out of the `.ds-metrics-endpoint.policy-*` data streams to get the Endpoint metrics document + fleet policy responses. I'm wondering if this fixes it by referencing the data stream name directly. 