### PR TITLE
Fix aggs test failures (again)

### DIFF
--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/filter/FiltersAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/filter/FiltersAggregatorTests.java
@@ -460,7 +460,7 @@ public class FiltersAggregatorTests extends AggregatorTestCase {
                                 matchesList().item(
                                     matchesMap().entry("query", "*:*")
                                         .entry("specialized_for", "match_all")
-                                        .entry("results_from_metadata", 1)
+                                        .entry("results_from_metadata", greaterThanOrEqualTo(1))
                                 )
                             )
                     )


### PR DESCRIPTION
The tests for the debugging information in the filters aggregation where
too specific for the kind of randomization we run with. We mostly fixed
them in #74750 by replacing `equalTo(1)` with `greaterThanOrEqualTo(1)`.
But we missed a spot. In all fairness, we ran the test a couple thousand
times and it didn't fail. But letting the ES build chew on it gets many
many many thousands of executions over a month. So it found the spot.
This performs one additional `equalTo(1)` to `greaterThanOrEqualTo(1)`
replacement.

Closes #74936
