### PR TITLE
Fix fips tests for vanilla Test tasks

### DIFF
--- a/build-tools-internal/src/main/groovy/elasticsearch.fips.gradle
+++ b/build-tools-internal/src/main/groovy/elasticsearch.fips.gradle
@@ -76,6 +76,7 @@ if (BuildParams.inFipsJvm) {
         }
       }
       project.tasks.withType(Test).configureEach { Test task ->
+        dependsOn 'fipsResources'
         task.systemProperty('javax.net.ssl.trustStorePassword', 'password')
         task.systemProperty('javax.net.ssl.keyStorePassword', 'password')
         task.systemProperty('javax.net.ssl.trustStoreType', 'BCFKS')


### PR DESCRIPTION
This fixes a regression introduced with #74670.
Vanilla test tasks (of plain type Test) must also dependOn `fipsResources`
when build is run in FIPS mode. Otherwise we see the plain test task failing with

"SHA MessageDigest not available"

Fixes #74922