### PR TITLE
[7.x] Fix ExplainLifecycleIT.testExplainFilters (#74941)

### DIFF
--- a/x-pack/plugin/ilm/qa/multi-node/src/javaRestTest/java/org/elasticsearch/xpack/ilm/ExplainLifecycleIT.java
+++ b/x-pack/plugin/ilm/qa/multi-node/src/javaRestTest/java/org/elasticsearch/xpack/ilm/ExplainLifecycleIT.java
@@ -15,8 +15,8 @@ import org.elasticsearch.client.Request;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.test.rest.ESRestTestCase;
 import org.elasticsearch.xpack.core.ilm.DeleteAction;
 import org.elasticsearch.xpack.core.ilm.LifecycleAction;
@@ -61,7 +61,6 @@ public class ExplainLifecycleIT extends ESRestTestCase {
         alias = "alias-" + randomAlphaOfLength(5);
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/71010")
     public void testExplainFilters() throws Exception {
         String goodIndex = index + "-good-000001";
         String errorIndex = index + "-error";
@@ -115,7 +114,7 @@ public class ExplainLifecycleIT extends ESRestTestCase {
 
             Map<String, Map<String, Object>> onlyErrorsResponse = explain(client(), index + "*", true, true);
             assertNotNull(onlyErrorsResponse);
-            assertThat(onlyErrorsResponse, allOf(hasKey(errorIndex), hasKey(nonexistantPolicyIndex)));
+            assertThat(onlyErrorsResponse, hasKey(nonexistantPolicyIndex));
             assertThat(onlyErrorsResponse, allOf(not(hasKey(goodIndex)), not(hasKey(unmanagedIndex))));
         });
     }

--- a/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/ilm/action/TransportExplainLifecycleActionTests.java
+++ b/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/ilm/action/TransportExplainLifecycleActionTests.java
@@ -22,7 +22,6 @@ import org.elasticsearch.xpack.core.ilm.WaitForRolloverReadyStep;
 import org.elasticsearch.xpack.ilm.IndexLifecycleService;
 
 import java.io.IOException;
-import java.util.List;
 
 import static org.elasticsearch.xpack.core.ilm.LifecycleExecutionState.ILM_CUSTOM_METADATA_KEY;
 import static org.elasticsearch.xpack.ilm.action.TransportExplainLifecycleAction.getIndexLifecycleExplainResponse;

--- a/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/ilm/action/TransportExplainLifecycleActionTests.java
+++ b/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/ilm/action/TransportExplainLifecycleActionTests.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.ilm.action;
+
+import org.elasticsearch.Version;
+import org.elasticsearch.cluster.metadata.IndexMetadata;
+import org.elasticsearch.common.xcontent.NamedXContentRegistry;
+import org.elasticsearch.common.xcontent.ParseField;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.core.ilm.ErrorStep;
+import org.elasticsearch.xpack.core.ilm.IndexLifecycleExplainResponse;
+import org.elasticsearch.xpack.core.ilm.LifecycleAction;
+import org.elasticsearch.xpack.core.ilm.LifecycleExecutionState;
+import org.elasticsearch.xpack.core.ilm.LifecycleSettings;
+import org.elasticsearch.xpack.core.ilm.RolloverAction;
+import org.elasticsearch.xpack.core.ilm.WaitForRolloverReadyStep;
+import org.elasticsearch.xpack.ilm.IndexLifecycleService;
+
+import java.io.IOException;
+import java.util.List;
+
+import static org.elasticsearch.xpack.core.ilm.LifecycleExecutionState.ILM_CUSTOM_METADATA_KEY;
+import static org.elasticsearch.xpack.ilm.action.TransportExplainLifecycleAction.getIndexLifecycleExplainResponse;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class TransportExplainLifecycleActionTests extends ESTestCase {
+
+    public static final String PHASE_DEFINITION = "{\n" +
+        "        \"policy\" : \"my-policy\",\n" +
+        "        \"phase_definition\" : {\n" +
+        "          \"min_age\" : \"20m\",\n" +
+        "          \"actions\" : {\n" +
+        "            \"rollover\" : {\n" +
+        "              \"max_age\" : \"5s\"\n" +
+        "            }\n" +
+        "          }\n" +
+        "        },\n" +
+        "        \"version\" : 1,\n" +
+        "        \"modified_date_in_millis\" : 1578521007076\n" +
+        "      }";
+
+    private static final NamedXContentRegistry REGISTRY;
+
+    static {
+        REGISTRY = new NamedXContentRegistry(
+            org.elasticsearch.core.List.of(new NamedXContentRegistry.Entry(LifecycleAction.class, new ParseField(RolloverAction.NAME),
+                RolloverAction::parse))
+        );
+    }
+
+    public void testGetIndexLifecycleExplainResponse() throws IOException {
+        {
+            // only errors index
+            IndexLifecycleService indexLifecycleService = mock(IndexLifecycleService.class);
+            when(indexLifecycleService.policyExists("my-policy")).thenReturn(true);
+
+            LifecycleExecutionState.Builder errorStepState = LifecycleExecutionState.builder()
+                .setPhase("hot")
+                .setAction("rollover")
+                .setStep(ErrorStep.NAME)
+                .setPhaseDefinition(PHASE_DEFINITION);
+            String indexInErrorStep = "index_in_error";
+            IndexMetadata meta = IndexMetadata.builder(indexInErrorStep)
+                .settings(settings(Version.CURRENT).put(LifecycleSettings.LIFECYCLE_NAME, "my-policy"))
+                .numberOfShards(randomIntBetween(1, 5))
+                .numberOfReplicas(randomIntBetween(0, 5))
+                .putCustom(ILM_CUSTOM_METADATA_KEY, errorStepState.build().asMap())
+                .build();
+
+            IndexLifecycleExplainResponse onlyErrorsResponse = getIndexLifecycleExplainResponse(meta, true, true, indexLifecycleService,
+                REGISTRY);
+            assertThat(onlyErrorsResponse, notNullValue());
+            assertThat(onlyErrorsResponse.getIndex(), is(indexInErrorStep));
+            assertThat(onlyErrorsResponse.getStep(), is(ErrorStep.NAME));
+        }
+
+        {
+            // only managed index
+            IndexLifecycleService indexLifecycleService = mock(IndexLifecycleService.class);
+            when(indexLifecycleService.policyExists("my-policy")).thenReturn(true);
+
+            LifecycleExecutionState.Builder checkRolloverReadyStepState = LifecycleExecutionState.builder()
+                .setPhase("hot")
+                .setAction("rollover")
+                .setStep(WaitForRolloverReadyStep.NAME)
+                .setPhaseDefinition(PHASE_DEFINITION);
+
+            String indexInCheckRolloverStep = "index_in_check_rollover";
+            IndexMetadata meta = IndexMetadata.builder(indexInCheckRolloverStep)
+                .settings(settings(Version.CURRENT).put(LifecycleSettings.LIFECYCLE_NAME, "my-policy"))
+                .numberOfShards(randomIntBetween(1, 5))
+                .numberOfReplicas(randomIntBetween(0, 5))
+                .putCustom(ILM_CUSTOM_METADATA_KEY, checkRolloverReadyStepState.build().asMap())
+                .build();
+
+            IndexLifecycleExplainResponse onlyErrorsResponse = getIndexLifecycleExplainResponse(meta, true, true, indexLifecycleService,
+                REGISTRY);
+            assertThat(onlyErrorsResponse, nullValue());
+
+            IndexLifecycleExplainResponse allManagedResponse = getIndexLifecycleExplainResponse(meta, false, true, indexLifecycleService,
+                REGISTRY);
+            assertThat(allManagedResponse, notNullValue());
+            assertThat(allManagedResponse.getIndex(), is(indexInCheckRolloverStep));
+            assertThat(allManagedResponse.getStep(), is(WaitForRolloverReadyStep.NAME));
+        }
+
+        {
+            // index with missing policy
+            IndexLifecycleService indexLifecycleService = mock(IndexLifecycleService.class);
+            when(indexLifecycleService.policyExists("random-policy")).thenReturn(false);
+
+            String indexWithMissingPolicy = "index_with_missing_policy";
+            IndexMetadata meta = IndexMetadata.builder(indexWithMissingPolicy)
+                .settings(settings(Version.CURRENT).put(LifecycleSettings.LIFECYCLE_NAME, "random-policy"))
+                .numberOfShards(randomIntBetween(1, 5))
+                .numberOfReplicas(randomIntBetween(0, 5))
+                .build();
+
+            IndexLifecycleExplainResponse onlyErrorsResponse = getIndexLifecycleExplainResponse(meta, true, true, indexLifecycleService,
+                REGISTRY);
+            assertThat(onlyErrorsResponse, notNullValue());
+            assertThat(onlyErrorsResponse.getPolicyName(), is("random-policy"));
+        }
+
+        {
+            // not managed index
+            IndexLifecycleService indexLifecycleService = mock(IndexLifecycleService.class);
+            when(indexLifecycleService.policyExists(anyString())).thenReturn(true);
+
+            IndexMetadata meta = IndexMetadata.builder("index")
+                .settings(settings(Version.CURRENT))
+                .numberOfShards(randomIntBetween(1, 5))
+                .numberOfReplicas(randomIntBetween(0, 5))
+                .build();
+
+            IndexLifecycleExplainResponse onlyManaged = getIndexLifecycleExplainResponse(meta, false, true, indexLifecycleService,
+                REGISTRY);
+            assertThat(onlyManaged, nullValue());
+        }
+    }
+}


### PR DESCRIPTION
Explain `onlyErrors` is tricky to integration test as all the ILM steps
are now retryable (so the `explain` API might not catch a particular
failing step when it's in the `ERROR` state as when we retry we move it
back into the step that failed).

This adds an unit test for the "explain onlyErrors" case.

(cherry picked from commit 973610a0157af22e3e2588451d8554f6e7df37ec)
Signed-off-by: Andrei Dan <andrei.dan@elastic.co>

Backport of #74941 