### PR TITLE
[7.x] Json processor: allow duplicate keys (#74956)

### DIFF
--- a/docs/reference/ingest/processors/json.asciidoc
+++ b/docs/reference/ingest/processors/json.asciidoc
@@ -10,10 +10,12 @@ Converts a JSON string into a structured JSON object.
 .Json Options
 [options="header"]
 |======
-| Name           | Required  | Default  | Description
-| `field`        | yes       | -        | The field to be parsed.
-| `target_field` | no        | `field`  | The field that the converted structured object will be written into. Any existing content in this field will be overwritten.
-| `add_to_root`  | no        | false    | Flag that forces the serialized json to be injected into the top level of the document. `target_field` must not be set when this option is chosen.
+| Name                         | Required  | Default  | Description
+| `field`                      | yes       | -        | The field to be parsed.
+| `target_field`               | no        | `field`  | The field that the converted structured object will be written into. Any existing content in this field will be overwritten.
+| `add_to_root`                | no        | false    | Flag that forces the serialized json to be injected into the top level of the document. `target_field` must not be set when this option is chosen.
+| `allow_duplicate_keys`       | no        | false    | When set to `true`, the JSON parser will not fail if the JSON contains duplicate keys.
+                                                        Instead, the latest value wins. Allowing duplicate keys also improves execution time.
 include::common-options.asciidoc[]
 |======
 

--- a/libs/x-content/src/main/java/org/elasticsearch/common/xcontent/FilterXContentParser.java
+++ b/libs/x-content/src/main/java/org/elasticsearch/common/xcontent/FilterXContentParser.java
@@ -33,6 +33,11 @@ public abstract class FilterXContentParser implements XContentParser {
     }
 
     @Override
+    public void allowDuplicateKeys(boolean allowDuplicateKeys) {
+        in.allowDuplicateKeys(allowDuplicateKeys);
+    }
+
+    @Override
     public Token nextToken() throws IOException {
         return in.nextToken();
     }

--- a/libs/x-content/src/main/java/org/elasticsearch/common/xcontent/XContentParser.java
+++ b/libs/x-content/src/main/java/org/elasticsearch/common/xcontent/XContentParser.java
@@ -111,6 +111,8 @@ public interface XContentParser extends Closeable {
 
     XContentType contentType();
 
+    void allowDuplicateKeys(boolean allowDuplicateKeys);
+
     Token nextToken() throws IOException;
 
     void skipChildren() throws IOException;

--- a/libs/x-content/src/main/java/org/elasticsearch/common/xcontent/XContentSubParser.java
+++ b/libs/x-content/src/main/java/org/elasticsearch/common/xcontent/XContentSubParser.java
@@ -43,6 +43,11 @@ public class XContentSubParser implements XContentParser {
     }
 
     @Override
+    public void allowDuplicateKeys(boolean allowDuplicateKeys) {
+        parser.allowDuplicateKeys(allowDuplicateKeys);
+    }
+
+    @Override
     public Token nextToken() throws IOException {
         if (level > 0) {
             Token token = parser.nextToken();

--- a/libs/x-content/src/main/java/org/elasticsearch/common/xcontent/cbor/CborXContentParser.java
+++ b/libs/x-content/src/main/java/org/elasticsearch/common/xcontent/cbor/CborXContentParser.java
@@ -25,4 +25,9 @@ public class CborXContentParser extends JsonXContentParser {
     public XContentType contentType() {
         return XContentType.CBOR;
     }
+
+    @Override
+    public void allowDuplicateKeys(boolean allowDuplicateKeys) {
+        throw new UnsupportedOperationException("Allowing duplicate keys after the parser has been created is not possible for CBOR");
+    }
 }

--- a/libs/x-content/src/main/java/org/elasticsearch/common/xcontent/json/JsonXContentParser.java
+++ b/libs/x-content/src/main/java/org/elasticsearch/common/xcontent/json/JsonXContentParser.java
@@ -37,6 +37,11 @@ public class JsonXContentParser extends AbstractXContentParser {
     }
 
     @Override
+    public void allowDuplicateKeys(boolean allowDuplicateKeys) {
+        parser.configure(JsonParser.Feature.STRICT_DUPLICATE_DETECTION, allowDuplicateKeys == false);
+    }
+
+    @Override
     public Token nextToken() throws IOException {
         return convertToken(parser.nextToken());
     }

--- a/libs/x-content/src/main/java/org/elasticsearch/common/xcontent/smile/SmileXContentParser.java
+++ b/libs/x-content/src/main/java/org/elasticsearch/common/xcontent/smile/SmileXContentParser.java
@@ -25,4 +25,9 @@ public class SmileXContentParser extends JsonXContentParser {
     public XContentType contentType() {
         return XContentType.SMILE;
     }
+
+    @Override
+    public void allowDuplicateKeys(boolean allowDuplicateKeys) {
+        throw new UnsupportedOperationException("Allowing duplicate keys after the parser has been created is not possible for Smile");
+    }
 }

--- a/libs/x-content/src/main/java/org/elasticsearch/common/xcontent/support/MapXContentParser.java
+++ b/libs/x-content/src/main/java/org/elasticsearch/common/xcontent/support/MapXContentParser.java
@@ -91,6 +91,11 @@ public class MapXContentParser extends AbstractXContentParser {
     }
 
     @Override
+    public void allowDuplicateKeys(boolean allowDuplicateKeys) {
+        throw new UnsupportedOperationException("Allowing duplicate keys is not possible for maps");
+    }
+
+    @Override
     public Token nextToken() throws IOException {
         if (iterator == null) {
             return null;

--- a/modules/ingest-common/src/main/java/org/elasticsearch/ingest/common/JsonProcessor.java
+++ b/modules/ingest-common/src/main/java/org/elasticsearch/ingest/common/JsonProcessor.java
@@ -36,12 +36,14 @@ public final class JsonProcessor extends AbstractProcessor {
     private final String field;
     private final String targetField;
     private final boolean addToRoot;
+    private final boolean allowDuplicateKeys;
 
-    JsonProcessor(String tag, String description, String field, String targetField, boolean addToRoot) {
+    JsonProcessor(String tag, String description, String field, String targetField, boolean addToRoot, boolean allowDuplicateKeys) {
         super(tag, description);
         this.field = field;
         this.targetField = targetField;
         this.addToRoot = addToRoot;
+        this.allowDuplicateKeys = allowDuplicateKeys;
     }
 
     public String getField() {
@@ -56,11 +58,12 @@ public final class JsonProcessor extends AbstractProcessor {
         return addToRoot;
     }
 
-    public static Object apply(Object fieldValue) {
+    public static Object apply(Object fieldValue, boolean allowDuplicateKeys) {
         BytesReference bytesRef = fieldValue == null ? new BytesArray("null") : new BytesArray(fieldValue.toString());
         try (InputStream stream = bytesRef.streamInput();
              XContentParser parser = JsonXContent.jsonXContent
                  .createParser(NamedXContentRegistry.EMPTY, DeprecationHandler.THROW_UNSUPPORTED_OPERATION, stream)) {
+            parser.allowDuplicateKeys(allowDuplicateKeys);
             XContentParser.Token token = parser.nextToken();
             Object value = null;
             if (token == XContentParser.Token.VALUE_NULL) {
@@ -84,12 +87,12 @@ public final class JsonProcessor extends AbstractProcessor {
         }
     }
 
-    public static void apply(Map<String, Object> ctx, String fieldName) {
-        Object value = apply(ctx.get(fieldName));
+    public static void apply(Map<String, Object> ctx, String fieldName, boolean allowDuplicateKeys) {
+        Object value = apply(ctx.get(fieldName), allowDuplicateKeys);
         if (value instanceof Map) {
             @SuppressWarnings("unchecked")
                 Map<String, Object> map = (Map<String, Object>) value;
-                ctx.putAll(map);
+            ctx.putAll(map);
         } else {
             throw new IllegalArgumentException("cannot add non-map fields to root of document");
         }
@@ -98,9 +101,9 @@ public final class JsonProcessor extends AbstractProcessor {
     @Override
     public IngestDocument execute(IngestDocument document) throws Exception {
         if (addToRoot) {
-           apply(document.getSourceAndMetadata(), field);
+            apply(document.getSourceAndMetadata(), field, allowDuplicateKeys);
         } else {
-            document.setFieldValue(targetField, apply(document.getFieldValue(field, Object.class)));
+            document.setFieldValue(targetField, apply(document.getFieldValue(field, Object.class), allowDuplicateKeys));
         }
         return document;
     }
@@ -117,6 +120,7 @@ public final class JsonProcessor extends AbstractProcessor {
             String field = ConfigurationUtils.readStringProperty(TYPE, processorTag, config, "field");
             String targetField = ConfigurationUtils.readOptionalStringProperty(TYPE, processorTag, config, "target_field");
             boolean addToRoot = ConfigurationUtils.readBooleanProperty(TYPE, processorTag, config, "add_to_root", false);
+            boolean allowDuplicateKeys = ConfigurationUtils.readBooleanProperty(TYPE, processorTag, config, "allow_duplicate_keys", false);
 
             if (addToRoot && targetField != null) {
                 throw newConfigurationException(TYPE, processorTag, "target_field",
@@ -127,7 +131,7 @@ public final class JsonProcessor extends AbstractProcessor {
                 targetField = field;
             }
 
-            return new JsonProcessor(processorTag, description, field, targetField, addToRoot);
+            return new JsonProcessor(processorTag, description, field, targetField, addToRoot, allowDuplicateKeys);
         }
     }
 }

--- a/modules/ingest-common/src/main/java/org/elasticsearch/ingest/common/Processors.java
+++ b/modules/ingest-common/src/main/java/org/elasticsearch/ingest/common/Processors.java
@@ -59,7 +59,7 @@ public final class Processors {
      * @return structured JSON object
      */
     public static Object json(Object fieldValue) {
-        return JsonProcessor.apply(fieldValue);
+        return JsonProcessor.apply(fieldValue, false);
     }
 
     /**
@@ -72,7 +72,7 @@ public final class Processors {
      *             contains the JSON string
      */
     public static void json(Map<String, Object> map, String field) {
-        JsonProcessor.apply(map, field);
+        JsonProcessor.apply(map, field, false);
     }
 
     /**

--- a/modules/ingest-common/src/yamlRestTest/resources/rest-api-spec/test/ingest/140_json.yml
+++ b/modules/ingest-common/src/yamlRestTest/resources/rest-api-spec/test/ingest/140_json.yml
@@ -4,6 +4,10 @@ teardown:
       ingest.delete_pipeline:
         id: "1"
         ignore: 404
+  - do:
+      ingest.delete_pipeline:
+        id: "2"
+        ignore: 404
 
 ---
 "Test JSON Processor":
@@ -71,3 +75,36 @@ teardown:
   - match: { _source.foo_number: 3 }
   - is_true:  _source.foo_boolean
   - is_false: _source.foo_null
+
+---
+"Test JSON Processor duplicate keys":
+  - do:
+      ingest.put_pipeline:
+        id: "2"
+        body: {
+            "processors": [
+              {
+                "json" : {
+                  "field" : "json",
+                  "add_to_root": true,
+                  "allow_duplicate_keys": true
+                }
+              }
+            ]
+          }
+  - match: { acknowledged: true }
+
+  - do:
+      index:
+        index: test
+        id: 2
+        pipeline: "2"
+        body: {
+          json: "{\"dupe\": 1, \"dupe\": 2}",
+        }
+
+  - do:
+      get:
+        index: test
+        id: 2
+  - match: { _source.dupe: 2 }

--- a/server/src/test/java/org/elasticsearch/common/xcontent/BaseXContentTestCase.java
+++ b/server/src/test/java/org/elasticsearch/common/xcontent/BaseXContentTestCase.java
@@ -1157,7 +1157,7 @@ public abstract class BaseXContentTestCase extends ESTestCase {
                 .endObject();
         try (XContentParser xParser = createParser(builder)) {
             xParser.allowDuplicateKeys(true);
-            assertThat(xParser.map(), equalTo(Map.of("key", 2)));
+            assertThat(xParser.map(), equalTo(Collections.singletonMap("key", 2)));
         }
     }
 

--- a/server/src/test/java/org/elasticsearch/common/xcontent/BaseXContentTestCase.java
+++ b/server/src/test/java/org/elasticsearch/common/xcontent/BaseXContentTestCase.java
@@ -80,7 +80,7 @@ public abstract class BaseXContentTestCase extends ESTestCase {
 
     protected abstract XContentType xcontentType();
 
-    private XContentBuilder builder() throws IOException {
+    protected XContentBuilder builder() throws IOException {
         return XContentBuilder.builder(xcontentType().xContent());
     }
 
@@ -1146,6 +1146,18 @@ public abstract class BaseXContentTestCase extends ESTestCase {
         try (XContentParser xParser = createParser(builder)) {
             JsonParseException pex = expectThrows(JsonParseException.class, () -> xParser.map());
             assertThat(pex.getMessage(), startsWith("Duplicate field 'key'"));
+        }
+    }
+
+    public void testAllowsDuplicates() throws Exception {
+        XContentBuilder builder = builder()
+                .startObject()
+                    .field("key", 1)
+                    .field("key", 2)
+                .endObject();
+        try (XContentParser xParser = createParser(builder)) {
+            xParser.allowDuplicateKeys(true);
+            assertThat(xParser.map(), equalTo(Map.of("key", 2)));
         }
     }
 

--- a/server/src/test/java/org/elasticsearch/common/xcontent/cbor/CborXContentTests.java
+++ b/server/src/test/java/org/elasticsearch/common/xcontent/cbor/CborXContentTests.java
@@ -12,6 +12,7 @@ import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.dataformat.cbor.CBORFactory;
 
 import org.elasticsearch.common.xcontent.BaseXContentTestCase;
+import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.XContentType;
 
 import java.io.ByteArrayOutputStream;
@@ -27,5 +28,11 @@ public class CborXContentTests extends BaseXContentTestCase {
         ByteArrayOutputStream os = new ByteArrayOutputStream();
         JsonGenerator generator = new CBORFactory().createGenerator(os);
         doTestBigInteger(generator, os);
+    }
+
+    public void testAllowsDuplicates() throws Exception {
+        try (XContentParser xParser = createParser(builder().startObject().endObject())) {
+            expectThrows(UnsupportedOperationException.class, () -> xParser.allowDuplicateKeys(true));
+        }
     }
 }

--- a/server/src/test/java/org/elasticsearch/common/xcontent/smile/SmileXContentTests.java
+++ b/server/src/test/java/org/elasticsearch/common/xcontent/smile/SmileXContentTests.java
@@ -12,6 +12,7 @@ import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.dataformat.smile.SmileFactory;
 
 import org.elasticsearch.common.xcontent.BaseXContentTestCase;
+import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.XContentType;
 
 import java.io.ByteArrayOutputStream;
@@ -27,5 +28,11 @@ public class SmileXContentTests extends BaseXContentTestCase {
         ByteArrayOutputStream os = new ByteArrayOutputStream();
         JsonGenerator generator = new SmileFactory().createGenerator(os);
         doTestBigInteger(generator, os);
+    }
+
+    public void testAllowsDuplicates() throws Exception {
+        try (XContentParser xParser = createParser(builder().startObject().endObject())) {
+            expectThrows(UnsupportedOperationException.class, () -> xParser.allowDuplicateKeys(true));
+        }
     }
 }


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Json processor: allow duplicate keys (#74956)