### PR TITLE
Cache vectors usage stats

### DIFF
--- a/x-pack/plugin/vectors/src/main/java/org/elasticsearch/xpack/vectors/VectorsUsageTransportAction.java
+++ b/x-pack/plugin/vectors/src/main/java/org/elasticsearch/xpack/vectors/VectorsUsageTransportAction.java
@@ -8,12 +8,15 @@ package org.elasticsearch.xpack.vectors;
 
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.ActionFilters;
+import org.elasticsearch.cluster.ClusterChangedEvent;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.metadata.MappingMetadata;
+import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.util.concurrent.ConcurrentCollections;
 import org.elasticsearch.protocol.xpack.XPackUsageRequest;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.threadpool.ThreadPool;
@@ -23,55 +26,164 @@ import org.elasticsearch.xpack.core.action.XPackUsageFeatureResponse;
 import org.elasticsearch.xpack.core.action.XPackUsageFeatureTransportAction;
 import org.elasticsearch.xpack.core.vectors.VectorsFeatureSetUsage;
 import org.elasticsearch.xpack.vectors.mapper.DenseVectorFieldMapper;
-import org.elasticsearch.xpack.vectors.mapper.SparseVectorFieldMapper;
 
 import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
 
 public class VectorsUsageTransportAction extends XPackUsageFeatureTransportAction {
 
+    private final Map<String, IndexVectorUsage> usageByIndexUuid = ConcurrentCollections.newConcurrentMap();
+
+    // updated & read on cluster applier thread only, just used to skip work when the cluster state update didn't change the metadata
+    private long lastMetadataVersion = Long.MIN_VALUE;
+
     @Inject
-    public VectorsUsageTransportAction(TransportService transportService, ClusterService clusterService, ThreadPool threadPool,
-                                       ActionFilters actionFilters, IndexNameExpressionResolver indexNameExpressionResolver) {
-        super(XPackUsageFeatureAction.VECTORS.name(), transportService, clusterService,
-            threadPool, actionFilters, indexNameExpressionResolver);
+    public VectorsUsageTransportAction(
+            TransportService transportService,
+            ClusterService clusterService,
+            ThreadPool threadPool,
+            ActionFilters actionFilters,
+            IndexNameExpressionResolver indexNameExpressionResolver) {
+        super(
+            XPackUsageFeatureAction.VECTORS.name(),
+            transportService,
+            clusterService,
+            threadPool,
+            actionFilters,
+            indexNameExpressionResolver);
+        clusterService.addListener(this::removeOldCacheEntries);
     }
 
     @Override
-    protected void masterOperation(Task task, XPackUsageRequest request, ClusterState state,
-                                   ActionListener<XPackUsageFeatureResponse> listener) {
+    protected void masterOperation(
+        Task task,
+        XPackUsageRequest request,
+        ClusterState state,
+        ActionListener<XPackUsageFeatureResponse> listener) {
+
         int numDenseVectorFields = 0;
-        int numSparseVectorFields = 0;
-        int avgDenseVectorDims = 0;
+        int numDenseVectorDims = 0;
 
         if (state != null) {
             for (IndexMetadata indexMetadata : state.metadata()) {
-                MappingMetadata mappingMetadata = indexMetadata.mapping();
-                if (mappingMetadata != null) {
-                    Map<String, Object> mappings = mappingMetadata.getSourceAsMap();
-                    if (mappings.containsKey("properties")) {
-                        @SuppressWarnings("unchecked") Map<String, Map<String, Object>> fieldMappings =
-                            (Map<String, Map<String, Object>>) mappings.get("properties");
-                        for (Map<String, Object> typeDefinition : fieldMappings.values()) {
-                            String fieldType = (String) typeDefinition.get("type");
-                            if (fieldType != null) {
-                                if (fieldType.equals(DenseVectorFieldMapper.CONTENT_TYPE)) {
-                                    numDenseVectorFields++;
-                                    int dims = (Integer) typeDefinition.get("dims");
-                                    avgDenseVectorDims += dims;
-                                } else if (fieldType.equals(SparseVectorFieldMapper.CONTENT_TYPE)) {
-                                    numSparseVectorFields++;
-                                }
-                            }
+
+                final IndexVectorUsage usage = getUsage(indexMetadata);
+
+                numDenseVectorFields += usage.getNumDenseVectorFields();
+                numDenseVectorDims += usage.getNumDenseVectorDims();
+
+                if (usage.isCached() == false) {
+                    // Update the cache. We're fairly loose with the precise details of the contents of the cache, allowing for a certain
+                    // amount of duplicated/discarded work in cases where there are a lot of mapping updates and concurrent calls to this
+                    // API, on the grounds that this API is normally not called concurrently and that mapping updates are mostly rare.
+                    usageByIndexUuid.compute(indexMetadata.getIndexUUID(), (indexUuid, currentUsage) -> {
+                        if (currentUsage != null && usage.getMappingVersion() <= currentUsage.getMappingVersion()) {
+                            return currentUsage;
+                        } else {
+                            return usage.forCache();
                         }
-                    }
+                    });
                 }
             }
-            if (numDenseVectorFields > 0) {
-                avgDenseVectorDims = avgDenseVectorDims / numDenseVectorFields;
+        }
+
+        final int avgDenseVectorDims;
+        if (numDenseVectorFields > 0) {
+            avgDenseVectorDims = numDenseVectorDims / numDenseVectorFields;
+        } else {
+            avgDenseVectorDims = 0;
+        }
+
+        listener.onResponse(new XPackUsageFeatureResponse(new VectorsFeatureSetUsage(true, numDenseVectorFields, avgDenseVectorDims)));
+    }
+
+    private IndexVectorUsage getUsage(IndexMetadata indexMetadata) {
+        final IndexVectorUsage cachedUsage = usageByIndexUuid.get(indexMetadata.getIndexUUID());
+        if (cachedUsage != null && cachedUsage.getMappingVersion() == indexMetadata.getMappingVersion()) {
+            assert cachedUsage.isCached();
+            return cachedUsage;
+        }
+
+        MappingMetadata mappingMetadata = indexMetadata.mapping();
+        if (mappingMetadata == null) {
+            return new IndexVectorUsage(indexMetadata.getMappingVersion(), 0, 0);
+        }
+
+        final Map<String, Object> mappings = mappingMetadata.getSourceAsMap();
+        if (mappings.containsKey("properties") == false) {
+            return new IndexVectorUsage(indexMetadata.getMappingVersion(), 0, 0);
+        }
+
+        int numDenseVectorFields = 0;
+        int numDenseVectorDims = 0;
+        @SuppressWarnings("unchecked") Map<String, Map<String, Object>> fieldMappings =
+            (Map<String, Map<String, Object>>) mappings.get("properties");
+        for (Map<String, Object> typeDefinition : fieldMappings.values()) {
+            String fieldType = (String) typeDefinition.get("type");
+            if (fieldType != null) {
+                if (fieldType.equals(DenseVectorFieldMapper.CONTENT_TYPE)) {
+                    numDenseVectorFields++;
+                    numDenseVectorDims += (int) typeDefinition.get("dims");
+                }
             }
         }
-        VectorsFeatureSetUsage usage =
-            new VectorsFeatureSetUsage(true, numDenseVectorFields, avgDenseVectorDims);
-        listener.onResponse(new XPackUsageFeatureResponse(usage));
+
+        return new IndexVectorUsage(indexMetadata.getMappingVersion(), numDenseVectorFields, numDenseVectorDims);
     }
+
+    private void removeOldCacheEntries(ClusterChangedEvent event) {
+        final Metadata metadata = event.state().metadata();
+        assert lastMetadataVersion <= metadata.version();
+        if (lastMetadataVersion < metadata.version()) {
+            lastMetadataVersion = metadata.version();
+            usageByIndexUuid.keySet().retainAll(StreamSupport.stream(metadata.indices().spliterator(), false)
+                .map(i -> i.value.getIndexUUID())
+                .collect(Collectors.toSet()));
+        }
+    }
+
+    // exposed for tests
+    int cacheSize() {
+        return usageByIndexUuid.size();
+    }
+
+    private static class IndexVectorUsage {
+        private final boolean cached;
+        private final long mappingVersion;
+        private final int numDenseVectorFields;
+        private final int numDenseVectorDims;
+
+        IndexVectorUsage(long mappingVersion, int numDenseVectorFields, int numDenseVectorDims) {
+            this(false, mappingVersion, numDenseVectorFields, numDenseVectorDims);
+        }
+
+        private IndexVectorUsage(boolean cached, long mappingVersion, int numDenseVectorFields, int numDenseVectorDims) {
+            this.cached = cached;
+            this.mappingVersion = mappingVersion;
+            this.numDenseVectorFields = numDenseVectorFields;
+            this.numDenseVectorDims = numDenseVectorDims;
+        }
+
+        boolean isCached() {
+            return cached;
+        }
+
+        long getMappingVersion() {
+            return mappingVersion;
+        }
+
+        int getNumDenseVectorFields() {
+            return numDenseVectorFields;
+        }
+
+        int getNumDenseVectorDims() {
+            return numDenseVectorDims;
+        }
+
+        IndexVectorUsage forCache() {
+            return new IndexVectorUsage(true, mappingVersion, numDenseVectorFields, numDenseVectorDims);
+        }
+    }
+
 }

--- a/x-pack/plugin/vectors/src/test/java/org/elasticsearch/xpack/vectors/VectorsInfoTransportActionTests.java
+++ b/x-pack/plugin/vectors/src/test/java/org/elasticsearch/xpack/vectors/VectorsInfoTransportActionTests.java
@@ -6,30 +6,52 @@
  */
 package org.elasticsearch.xpack.vectors;
 
+import org.elasticsearch.Version;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.PlainActionFuture;
+import org.elasticsearch.cluster.ClusterChangedEvent;
+import org.elasticsearch.cluster.ClusterName;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.ClusterStateListener;
+import org.elasticsearch.cluster.metadata.IndexMetadata;
+import org.elasticsearch.cluster.metadata.Metadata;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.UUIDs;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
+import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.xpack.core.XPackFeatureSet;
 import org.elasticsearch.xpack.core.action.XPackUsageFeatureResponse;
 import org.elasticsearch.xpack.core.vectors.VectorsFeatureSetUsage;
 
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.core.Is.is;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
 
 public class VectorsInfoTransportActionTests extends ESTestCase {
 
-    public void testAvailable() throws Exception {
-        VectorsInfoTransportAction featureSet = new VectorsInfoTransportAction(
-            mock(TransportService.class), mock(ActionFilters.class));
+    public void testAvailable() throws IOException {
+        VectorsInfoTransportAction featureSet = new VectorsInfoTransportAction(mock(TransportService.class), mock(ActionFilters.class));
         assertThat(featureSet.available(), is(true));
 
-        var usageAction = new VectorsUsageTransportAction(mock(TransportService.class), null, null,
-            mock(ActionFilters.class), null);
-        PlainActionFuture<XPackUsageFeatureResponse> future = new PlainActionFuture<>();
-        usageAction.masterOperation(null, null, null, future);
-        XPackFeatureSet.Usage usage = future.get().getUsage();
+        var usageAction = new VectorsUsageTransportAction(
+            mock(TransportService.class),
+            mock(ClusterService.class),
+            null,
+            mock(ActionFilters.class),
+            null);
+        XPackFeatureSet.Usage usage = executeUsageAction(usageAction, null);
         assertThat(usage.available(), is(true));
 
         BytesStreamOutput out = new BytesStreamOutput();
@@ -38,22 +60,128 @@ public class VectorsInfoTransportActionTests extends ESTestCase {
         assertThat(serializedUsage.available(), is(true));
     }
 
-    public void testAlwaysEnabled() throws Exception {
-        VectorsInfoTransportAction featureSet = new VectorsInfoTransportAction(
-mock(TransportService.class), mock(ActionFilters.class));
+    public void testAlwaysEnabled() throws IOException {
+        VectorsInfoTransportAction featureSet = new VectorsInfoTransportAction(mock(TransportService.class), mock(ActionFilters.class));
         assertThat(featureSet.enabled(), is(true));
 
-        VectorsUsageTransportAction usageAction = new VectorsUsageTransportAction(mock(TransportService.class),
-            null, null, mock(ActionFilters.class), null);
-        PlainActionFuture<XPackUsageFeatureResponse> future = new PlainActionFuture<>();
-        usageAction.masterOperation(null, null, null, future);
-        XPackFeatureSet.Usage usage = future.get().getUsage();
+        VectorsUsageTransportAction usageAction = new VectorsUsageTransportAction(
+            mock(TransportService.class),
+            mock(ClusterService.class),
+            null,
+            mock(ActionFilters.class),
+            null);
+        XPackFeatureSet.Usage usage = executeUsageAction(usageAction, null);
         assertThat(usage.enabled(), is(true));
 
         BytesStreamOutput out = new BytesStreamOutput();
         usage.writeTo(out);
         XPackFeatureSet.Usage serializedUsage = new VectorsFeatureSetUsage(out.bytes().streamInput());
         assertThat(serializedUsage.enabled(), is(true));
+    }
+
+    private VectorsFeatureSetUsage executeUsageAction(VectorsUsageTransportAction usageAction, ClusterState clusterState) {
+        PlainActionFuture<XPackUsageFeatureResponse> future = new PlainActionFuture<>();
+        usageAction.masterOperation(null, null, clusterState, future);
+        assert future.isDone();
+        return (VectorsFeatureSetUsage) future.actionGet(0, TimeUnit.SECONDS).getUsage();
+    }
+
+    public void testCaching() {
+        final ClusterService clusterService = mock(ClusterService.class);
+        final AtomicReference<ClusterStateListener> clusterStateListenerRef = new AtomicReference<>();
+        doAnswer(invocation -> {
+            clusterStateListenerRef.set((ClusterStateListener) invocation.getArguments()[0]);
+            return null;
+        }).when(clusterService).addListener(any());
+
+        final VectorsUsageTransportAction usageAction = new VectorsUsageTransportAction(
+            mock(TransportService.class),
+            clusterService,
+            null,
+            mock(ActionFilters.class),
+            null);
+
+        assertThat(clusterStateListenerRef, not(nullValue()));
+
+        final ClusterState emptyClusterState = ClusterState.builder(ClusterName.DEFAULT).build();
+        final VectorsFeatureSetUsage emptyUsage = executeUsageAction(usageAction, emptyClusterState);
+        assertTrue(emptyUsage.available());
+        assertTrue(emptyUsage.enabled());
+        assertThat(emptyUsage.numDenseVectorFields(), equalTo(0));
+        assertThat(emptyUsage.avgDenseVectorDims(), equalTo(0));
+        assertThat(usageAction.cacheSize(), equalTo(0));
+
+        final IndexMetadata indexMetadata = IndexMetadata.builder("test")
+            .settings(Settings.builder()
+                .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
+                .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0)
+                .put(IndexMetadata.SETTING_INDEX_UUID, UUIDs.randomBase64UUID())
+                .put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT))
+            .build();
+
+        final IndexMetadata indexMetadata1 = IndexMetadata.builder(indexMetadata)
+            .putMapping("{\"properties\":{\"my_dense_vector1\":{\"type\":\"dense_vector\",\"dims\":1}}}")
+            .mappingVersion(1)
+            .build();
+
+        final IndexMetadata indexMetadata2 = IndexMetadata.builder(indexMetadata)
+            .putMapping("{\"properties\":{\"my_dense_vector1\":{\"type\":\"dense_vector\",\"dims\":2}}}")
+            .mappingVersion(2)
+            .build();
+
+        final IndexMetadata indexMetadata2Cached = spy(indexMetadata2);
+        when(indexMetadata2Cached.mapping()).thenThrow(new AssertionError("should not get mapping"));
+
+        final IndexMetadata indexMetadata3 = IndexMetadata.builder(indexMetadata)
+            .putMapping("{\"properties\":{\"my_dense_vector1\":{\"type\":\"dense_vector\",\"dims\":3}}}")
+            .mappingVersion(3)
+            .build();
+
+        clusterStateListenerRef.get().clusterChanged(new ClusterChangedEvent("test", emptyClusterState, emptyClusterState));
+
+        final VectorsFeatureSetUsage usage2 = executeUsageAction(usageAction, ClusterState.builder(emptyClusterState)
+            .metadata(Metadata.builder(emptyClusterState.metadata()).put(indexMetadata2, true).build()).build());
+        assertTrue(usage2.available());
+        assertTrue(usage2.enabled());
+        assertThat(usage2.numDenseVectorFields(), equalTo(1));
+        assertThat(usage2.avgDenseVectorDims(), equalTo(2));
+        assertThat(usageAction.cacheSize(), equalTo(1));
+
+        final VectorsFeatureSetUsage usage2Cached = executeUsageAction(usageAction, ClusterState.builder(emptyClusterState)
+            .metadata(Metadata.builder(emptyClusterState.metadata()).put(indexMetadata2Cached, false).build()).build());
+        assertTrue(usage2Cached.available());
+        assertTrue(usage2Cached.enabled());
+        assertThat(usage2Cached.numDenseVectorFields(), equalTo(1));
+        assertThat(usage2Cached.avgDenseVectorDims(), equalTo(2));
+        assertThat(usageAction.cacheSize(), equalTo(1));
+
+        final VectorsFeatureSetUsage usage1 = executeUsageAction(usageAction, ClusterState.builder(emptyClusterState)
+            .metadata(Metadata.builder(emptyClusterState.metadata()).put(indexMetadata1, true).build()).build());
+        assertTrue(usage1.available());
+        assertTrue(usage1.enabled());
+        assertThat(usage1.numDenseVectorFields(), equalTo(1));
+        assertThat(usage1.avgDenseVectorDims(), equalTo(1));
+        assertThat(usageAction.cacheSize(), equalTo(1));
+
+        final VectorsFeatureSetUsage usage3 = executeUsageAction(usageAction, ClusterState.builder(emptyClusterState)
+            .metadata(Metadata.builder(emptyClusterState.metadata()).put(indexMetadata3, true).build()).build());
+        assertTrue(usage3.available());
+        assertTrue(usage3.enabled());
+        assertThat(usage3.numDenseVectorFields(), equalTo(1));
+        assertThat(usage3.avgDenseVectorDims(), equalTo(3));
+        assertThat(usageAction.cacheSize(), equalTo(1));
+
+        executeUsageAction(usageAction, emptyClusterState);
+        assertThat(usageAction.cacheSize(), equalTo(1)); // stale entries not cleared on execution
+
+        clusterStateListenerRef.get().clusterChanged(new ClusterChangedEvent("test", emptyClusterState, emptyClusterState));
+        assertThat(usageAction.cacheSize(), equalTo(1)); // stale entries not cleared if metadata version unchanged
+
+        clusterStateListenerRef.get().clusterChanged(new ClusterChangedEvent(
+            "test",
+            ClusterState.builder(emptyClusterState).metadata(Metadata.builder(emptyClusterState.metadata()).version(1)).build(),
+            emptyClusterState));
+        assertThat(usageAction.cacheSize(), equalTo(0));
     }
 
 }


### PR DESCRIPTION
Today `VectorsUsageTransportAction` is pretty heavyweight since it must
decompress and read the mappings for every index in the cluster. In
particular Metricbeat hits this action every 10s by default, and it runs
on the elected master, which causes nontrivial load in an otherwise
quiet cluster.

This commit introduces a cache for the usage stats, keyed by index,
avoiding recomputing these stats in the common case that the mapping
hasn't changed.