### PR TITLE
Make LeafRuntimeField final

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/mapper/BooleanScriptFieldType.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/BooleanScriptFieldType.java
@@ -11,11 +11,11 @@ package org.elasticsearch.index.mapper;
 import org.apache.lucene.search.MatchNoDocsQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.util.BytesRef;
-import org.elasticsearch.core.Booleans;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.lucene.search.Queries;
 import org.elasticsearch.common.time.DateMathParser;
 import org.elasticsearch.common.xcontent.ToXContent;
+import org.elasticsearch.core.Booleans;
 import org.elasticsearch.index.fielddata.BooleanScriptFieldData;
 import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.script.BooleanFieldScript;
@@ -48,12 +48,7 @@ public final class BooleanScriptFieldType extends AbstractScriptFieldType<Boolea
         Script script,
         Map<String, String> meta
     ) {
-        return new LeafRuntimeField(name, new BooleanScriptFieldType(name, scriptFactory, script, meta), toXContent) {
-            @Override
-            public String typeName() {
-                return BooleanFieldMapper.CONTENT_TYPE;
-            }
-        };
+        return new LeafRuntimeField(name, new BooleanScriptFieldType(name, scriptFactory, script, meta), toXContent);
     }
 
     public static RuntimeField sourceOnly(String name) {

--- a/server/src/main/java/org/elasticsearch/index/mapper/DateScriptFieldType.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DateScriptFieldType.java
@@ -10,14 +10,15 @@ package org.elasticsearch.index.mapper;
 
 import com.carrotsearch.hppc.LongHashSet;
 import com.carrotsearch.hppc.LongSet;
+
 import org.apache.lucene.search.Query;
-import org.elasticsearch.core.Nullable;
 import org.elasticsearch.common.lucene.search.Queries;
 import org.elasticsearch.common.time.DateFormatter;
 import org.elasticsearch.common.time.DateMathParser;
-import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.common.util.LocaleUtils;
 import org.elasticsearch.common.xcontent.ToXContent;
+import org.elasticsearch.core.Nullable;
+import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.index.fielddata.DateScriptFieldData;
 import org.elasticsearch.index.mapper.DateFieldMapper.DateFieldType;
 import org.elasticsearch.index.mapper.DateFieldMapper.Resolution;
@@ -97,12 +98,7 @@ public class DateScriptFieldType extends AbstractScriptFieldType<DateFieldScript
         Script script,
         Map<String, String> meta
     ) {
-        return new LeafRuntimeField(name, new DateScriptFieldType(name, scriptFactory, dateFormatter, script, meta), toXContent) {
-            @Override
-            public String typeName() {
-                return DateFieldMapper.CONTENT_TYPE;
-            }
-        };
+        return new LeafRuntimeField(name, new DateScriptFieldType(name, scriptFactory, dateFormatter, script, meta), toXContent);
     }
 
     public static RuntimeField sourceOnly(String name, DateFormatter dateTimeFormatter) {

--- a/server/src/main/java/org/elasticsearch/index/mapper/DoubleScriptFieldType.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DoubleScriptFieldType.java
@@ -10,6 +10,7 @@ package org.elasticsearch.index.mapper;
 
 import com.carrotsearch.hppc.LongHashSet;
 import com.carrotsearch.hppc.LongSet;
+
 import org.apache.lucene.search.Query;
 import org.elasticsearch.common.lucene.search.Queries;
 import org.elasticsearch.common.time.DateMathParser;
@@ -49,12 +50,7 @@ public final class DoubleScriptFieldType extends AbstractScriptFieldType<DoubleF
         Script script,
         Map<String, String> meta
     ) {
-        return new LeafRuntimeField(name, new DoubleScriptFieldType(name, scriptFactory, script, meta), toXContent) {
-            @Override
-            public String typeName() {
-                return NumberType.DOUBLE.typeName();
-            }
-        };
+        return new LeafRuntimeField(name, new DoubleScriptFieldType(name, scriptFactory, script, meta), toXContent);
     }
 
     public static RuntimeField sourceOnly(String name) {

--- a/server/src/main/java/org/elasticsearch/index/mapper/GeoPointScriptFieldType.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/GeoPointScriptFieldType.java
@@ -39,12 +39,7 @@ public final class GeoPointScriptFieldType extends AbstractScriptFieldType<GeoPo
         new Builder<>(name, GeoPointFieldScript.CONTEXT, GeoPointFieldScript.PARSE_FROM_SOURCE) {
             @Override
             RuntimeField newRuntimeField(GeoPointFieldScript.Factory scriptFactory) {
-                return new LeafRuntimeField(name, new GeoPointScriptFieldType(name, scriptFactory, getScript(), meta()), this) {
-                    @Override
-                    public String typeName() {
-                        return GeoPointFieldMapper.CONTENT_TYPE;
-                    }
-                };
+                return new LeafRuntimeField(name, new GeoPointScriptFieldType(name, scriptFactory, getScript(), meta()), this);
             }
         });
 

--- a/server/src/main/java/org/elasticsearch/index/mapper/IpScriptFieldType.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/IpScriptFieldType.java
@@ -45,12 +45,7 @@ public final class IpScriptFieldType extends AbstractScriptFieldType<IpFieldScri
         new Builder<>(name, IpFieldScript.CONTEXT, IpFieldScript.PARSE_FROM_SOURCE) {
             @Override
             RuntimeField newRuntimeField(IpFieldScript.Factory scriptFactory) {
-                return new LeafRuntimeField(name, new IpScriptFieldType(name, scriptFactory, getScript(), meta()), this) {
-                    @Override
-                    public String typeName() {
-                        return IpFieldMapper.CONTENT_TYPE;
-                    }
-                };
+                return new LeafRuntimeField(name, new IpScriptFieldType(name, scriptFactory, getScript(), meta()), this);
             }
         });
 

--- a/server/src/main/java/org/elasticsearch/index/mapper/KeywordScriptFieldType.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/KeywordScriptFieldType.java
@@ -56,12 +56,7 @@ public final class KeywordScriptFieldType extends AbstractScriptFieldType<String
         Script script,
         Map<String, String> meta
     ) {
-        return new LeafRuntimeField(name, new KeywordScriptFieldType(name, scriptFactory, script, meta), toXContent) {
-            @Override
-            public String typeName() {
-                return KeywordFieldMapper.CONTENT_TYPE;
-            }
-        };
+        return new LeafRuntimeField(name, new KeywordScriptFieldType(name, scriptFactory, script, meta), toXContent);
     }
 
     public static RuntimeField sourceOnly(String name) {

--- a/server/src/main/java/org/elasticsearch/index/mapper/LeafRuntimeField.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/LeafRuntimeField.java
@@ -19,7 +19,7 @@ import java.util.Collections;
  * RuntimeField base class for leaf fields that will only ever return
  * a single MappedFieldType from {@link RuntimeField#asMappedFieldTypes()}
  */
-public abstract class LeafRuntimeField implements RuntimeField {
+public final class LeafRuntimeField implements RuntimeField {
 
     protected final String name;
     protected final ToXContent toXContent;
@@ -37,12 +37,17 @@ public abstract class LeafRuntimeField implements RuntimeField {
     }
 
     @Override
-    public final Collection<MappedFieldType> asMappedFieldTypes() {
+    public String typeName() {
+        return mappedFieldType.typeName();
+    }
+
+    @Override
+    public Collection<MappedFieldType> asMappedFieldTypes() {
         return Collections.singleton(mappedFieldType);
     }
 
     @Override
-    public final void doXContentBody(XContentBuilder builder, Params params) throws IOException {
+    public void doXContentBody(XContentBuilder builder, Params params) throws IOException {
         toXContent.toXContent(builder, params);
     }
 }

--- a/server/src/main/java/org/elasticsearch/index/mapper/LongScriptFieldType.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/LongScriptFieldType.java
@@ -10,6 +10,7 @@ package org.elasticsearch.index.mapper;
 
 import com.carrotsearch.hppc.LongHashSet;
 import com.carrotsearch.hppc.LongSet;
+
 import org.apache.lucene.search.Query;
 import org.elasticsearch.common.lucene.search.Queries;
 import org.elasticsearch.common.time.DateMathParser;
@@ -49,12 +50,7 @@ public final class LongScriptFieldType extends AbstractScriptFieldType<LongField
         Script script,
         Map<String, String> meta
     ) {
-        return new LeafRuntimeField(name, new LongScriptFieldType(name, scriptFactory, script, meta), toXContent) {
-            @Override
-            public String typeName() {
-                return NumberType.LONG.typeName();
-            }
-        };
+        return new LeafRuntimeField(name, new LongScriptFieldType(name, scriptFactory, script, meta), toXContent);
     }
 
     public static RuntimeField sourceOnly(String name) {


### PR DESCRIPTION
LeafRuntimeField requires subclasses to define its type name, but it is already known from the MappedFieldType that is provided as constructor argument, as it can be made a final class.
