### PR TITLE
[DOCS] Fix stability and doc URL for rollup V2 JSON spec

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/rollup.rollup.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/rollup.rollup.json
@@ -1,10 +1,10 @@
 {
   "rollup.rollup":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/rollup-api.html",
+      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/xpack-rollup.html",
       "description":"Rollup an index"
     },
-    "stability":"stable",
+    "stability":"experimental",
     "visibility":"public",
     "headers":{
       "accept": [ "application/json"],


### PR DESCRIPTION
Changes:
* Removes an outdated docs link. These docs were removed with #70885.
* Correctly marks the rollup V2 API as `experimental`.

It's likely this API will be removed or significantly changed before release.

CC @stevejgordon 