### PR TITLE
[DOCS] EQL: Document cross-cluster search support

### DIFF
--- a/docs/reference/eql/eql-search-api.asciidoc
+++ b/docs/reference/eql/eql-search-api.asciidoc
@@ -48,6 +48,9 @@ or alias.
 
 * See <<eql-required-fields>>.
 
+* experimental:[] For cross-cluster search, the local and remote clusters must
+use the same {es} version. For security, see <<cross-cluster-configuring>>.
+
 [[eql-search-api-limitations]]
 ===== Limitations
 
@@ -60,6 +63,9 @@ See <<eql-syntax-limitations,EQL limitations>>.
 (Required, string) Comma-separated list of data streams, indices, or aliases
 used to limit the request. Supports wildcards (`*`). To search all data streams
 and indices, use `*` or `_all`.
++
+experimental:[] To search a remote cluster, use the `<cluster>:<target>` syntax.
+See <<run-eql-search-across-clusters>>.
 
 [[eql-search-api-query-params]]
 ==== {api-query-parms-title}

--- a/docs/reference/eql/eql.asciidoc
+++ b/docs/reference/eql/eql.asciidoc
@@ -792,6 +792,60 @@ results by using <<get-async-eql-status-api,get async EQL status API>>.
 You can also manually delete saved synchronous searches using the
 <<delete-async-eql-search-api,delete async EQL search API>>.
 
+[discrete]
+[[run-eql-search-across-clusters]]
+=== Run an EQL search across clusters
+
+experimental::[]
+
+The EQL search API supports <<modules-cross-cluster-search,cross-cluster
+search>>. However, the local and <<modules-remote-clusters,remote clusters>>
+must use the same {es} version.
+
+The following <<cluster-update-settings,update cluster settings>> request
+adds two remote clusters: `cluster_one` and `cluster_two`.
+
+[source,console]
+----
+PUT /_cluster/settings
+{
+  "persistent": {
+    "cluster": {
+      "remote": {
+        "cluster_one": {
+          "seeds": [
+            "127.0.0.1:9300"
+          ]
+        },
+        "cluster_two": {
+          "seeds": [
+            "127.0.0.1:9301"
+          ]
+        }
+      }
+    }
+  }
+}
+----
+// TEST[setup:host]
+// TEST[s/127.0.0.1:930\d+/\${transport_host}/]
+
+To target a data stream or index on a remote cluster, use the
+`<cluster>:<target>` syntax.
+
+[source,console]
+----
+GET /cluster_one:my-data-stream,cluster_two:my-data-stream/_eql/search
+{
+  "query": """
+    process where process.name == "regsvr32.exe"
+  """
+}
+----
+// TEST[continued]
+// TEST[setup:sec_logs]
+// TEST[teardown:data_stream_cleanup]
+
 include::syntax.asciidoc[]
 include::functions.asciidoc[]
 include::pipes.asciidoc[]

--- a/docs/reference/eql/eql.asciidoc
+++ b/docs/reference/eql/eql.asciidoc
@@ -845,6 +845,7 @@ GET /cluster_one:my-data-stream,cluster_two:my-data-stream/_eql/search
 // TEST[continued]
 // TEST[setup:sec_logs]
 // TEST[teardown:data_stream_cleanup]
+
 [[eql-circuit-breaker]]
 === EQL circuit breaker settings
 

--- a/docs/reference/eql/eql.asciidoc
+++ b/docs/reference/eql/eql.asciidoc
@@ -846,6 +846,7 @@ GET /cluster_one:my-data-stream,cluster_two:my-data-stream/_eql/search
 // TEST[setup:sec_logs]
 // TEST[teardown:data_stream_cleanup]
 
+[discrete]
 [[eql-circuit-breaker]]
 === EQL circuit breaker settings
 

--- a/docs/reference/eql/syntax.asciidoc
+++ b/docs/reference/eql/syntax.asciidoc
@@ -836,13 +836,6 @@ sub-fields of a `nested` field. However, data streams and indices containing
 `nested` field mappings are otherwise supported.
 
 [discrete]
-[[eql-ccs-support]]
-==== {ccs-cap} is not supported
-
-EQL search APIs do not support <<modules-cross-cluster-search,{ccs}
-({ccs-init})>>.
-
-[discrete]
 [[eql-unsupported-syntax]]
 ==== Differences from Endgame EQL syntax
 

--- a/docs/reference/release-notes/highlights.asciidoc
+++ b/docs/reference/release-notes/highlights.asciidoc
@@ -26,14 +26,12 @@ Other versions:
 // Use the notable-highlights tag to mark entries that
 // should be featured in the Stack Installation and Upgrade Guide:
 // tag::notable-highlights[]
-// [discrete]
-// === Heading
-//
-// Description.
-// end::notable-highlights[]
+[discrete]
+[[cross-cluster-eql-search]]
+=== Cross-cluster EQL search
 
-// Omit the notable highlights tag for entries that only need to appear in the ES ref:
-// [discrete]
-// === Heading
-//
-// Description.
+In 7.14, we added cross-cluster search support to EQL. Cross-cluster search lets
+you run a single EQL search across one or more remote clusters. See
+{ref}/eql.html#run-eql-search-across-clusters[Run an EQL search across
+clusters].
+// end::notable-highlights[]

--- a/docs/reference/release-notes/highlights.asciidoc
+++ b/docs/reference/release-notes/highlights.asciidoc
@@ -32,6 +32,7 @@ In 7.14, we added cross-cluster search support to EQL. Cross-cluster search lets
 you run a single EQL search across one or more remote clusters. See
 {ref}/eql.html#run-eql-search-across-clusters[Run an EQL search across
 clusters].
+
 [[async-sql-search]]
 === Async SQL search
 

--- a/docs/reference/release-notes/highlights.asciidoc
+++ b/docs/reference/release-notes/highlights.asciidoc
@@ -33,6 +33,7 @@ you run a single EQL search across one or more remote clusters. See
 {ref}/eql.html#run-eql-search-across-clusters[Run an EQL search across
 clusters].
 
+[discrete]
 [[async-sql-search]]
 === Async SQL search
 

--- a/docs/reference/search/search-your-data/search-across-clusters.asciidoc
+++ b/docs/reference/search/search-your-data/search-across-clusters.asciidoc
@@ -19,6 +19,7 @@ The following APIs support {ccs}:
 * <<search-template,Search template>>
 * <<multi-search-template,Multi search template>>
 * <<search-field-caps,Field capabilities>>
+* experimental:[] <<eql-search-api,EQL search>>
 
 [discrete]
 [[ccs-example]]
@@ -413,9 +414,14 @@ image:images/ccs/ccs-min-roundtrip-client-response.svg[]
 [[ccs-supported-configurations]]
 === Supported configurations
 
-Generally, <<gateway-nodes-selection, cross cluster search>> can search remote
+Generally, <<gateway-nodes-selection,cross-cluster search>> can search remote
 clusters that are one major version ahead or behind the coordinating node's
-version. Cross cluster search can also search remote clusters that are being
+version.
+
+IMPORTANT: For the <<eql-search-api,EQL search API>>, the local and remote
+clusters must use the same {es} version.
+
+Cross-cluster search can also search remote clusters that are being
 <<rolling-upgrades, upgraded>> so long as both the "upgrade from" and
 "upgrade to" version are compatible with the gateway node.
 


### PR DESCRIPTION
Closes #74842.

### Previews
* Run an EQL search across clusters: https://elasticsearch_74995.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/7.14/eql.html#run-eql-search-across-clusters
* EQL search API: https://elasticsearch_74995.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/7.14/eql-search-api.html
* Search across clusters: https://elasticsearch_74995.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/7.14/modules-cross-cluster-search.html
* Release highlight: https://elasticsearch_74995.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/7.14/release-highlights.html#cross-cluster-eql-search