### PR TITLE
[7.x] [DOCS] Fix stability and doc URL for rollup V2 JSON spec (#74992)

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/rollup.rollup.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/rollup.rollup.json
@@ -1,10 +1,10 @@
 {
   "rollup.rollup":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/rollup-api.html",
+      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/xpack-rollup.html",
       "description":"Rollup an index"
     },
-    "stability":"stable",
+    "stability":"experimental",
     "visibility":"public",
     "headers":{
       "accept": [ "application/json"],


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [DOCS] Fix stability and doc URL for rollup V2 JSON spec (#74992)