### PR TITLE
Mute PersistentTasksNodeServiceTests.testTaskLocalAbort

### DIFF
--- a/server/src/test/java/org/elasticsearch/persistent/PersistentTasksNodeServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/persistent/PersistentTasksNodeServiceTests.java
@@ -318,6 +318,7 @@ public class PersistentTasksNodeServiceTests extends ESTestCase {
         assertThat(taskManager.getTasks().values(), empty());
     }
 
+    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/75004")
     public void testTaskLocalAbort() {
         AtomicReference<String> capturedTaskId = new AtomicReference<>();
         AtomicReference<ActionListener<PersistentTask<?>>> capturedListener = new AtomicReference<>();


### PR DESCRIPTION
Due to https://github.com/elastic/elasticsearch/issues/75004