### PR TITLE
Simplify RuntimeField creation

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/mapper/AbstractScriptFieldType.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/AbstractScriptFieldType.java
@@ -210,16 +210,21 @@ abstract class AbstractScriptFieldType<LeafFactory> extends MappedFieldType {
             this.parseFromSourceFactory = parseFromSourceFactory;
         }
 
-        abstract RuntimeField newRuntimeField(Factory scriptFactory);
-
         @Override
         protected final RuntimeField createRuntimeField(MappingParserContext parserContext) {
             if (script.get() == null) {
-                return newRuntimeField(parseFromSourceFactory);
+                return createRuntimeField(parseFromSourceFactory);
             }
             Factory factory = parserContext.scriptCompiler().compile(script.getValue(), scriptContext);
-            return newRuntimeField(factory);
+            return createRuntimeField(factory);
         }
+
+        final RuntimeField createRuntimeField(Factory scriptFactory) {
+            AbstractScriptFieldType<?> fieldType = createFieldType(name, scriptFactory, getScript(), meta());
+            return new LeafRuntimeField(name, fieldType, this);
+        }
+
+        abstract AbstractScriptFieldType<?> createFieldType(String name, Factory factory, Script script, Map<String, String> meta);
 
         @Override
         protected List<FieldMapper.Parameter<?>> getParameters() {

--- a/server/src/main/java/org/elasticsearch/index/mapper/DoubleScriptFieldType.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DoubleScriptFieldType.java
@@ -14,7 +14,6 @@ import com.carrotsearch.hppc.LongSet;
 import org.apache.lucene.search.Query;
 import org.elasticsearch.common.lucene.search.Queries;
 import org.elasticsearch.common.time.DateMathParser;
-import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.index.fielddata.DoubleScriptFieldData;
 import org.elasticsearch.index.mapper.NumberFieldMapper.NumberType;
 import org.elasticsearch.index.query.SearchExecutionContext;
@@ -29,37 +28,29 @@ import org.elasticsearch.search.runtime.DoubleScriptFieldTermsQuery;
 
 import java.time.ZoneId;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.Map;
 import java.util.function.Supplier;
 
 public final class DoubleScriptFieldType extends AbstractScriptFieldType<DoubleFieldScript.LeafFactory> {
 
-    public static final RuntimeField.Parser PARSER = new RuntimeField.Parser(name ->
-        new Builder<>(name, DoubleFieldScript.CONTEXT, DoubleFieldScript.PARSE_FROM_SOURCE) {
-            @Override
-            RuntimeField newRuntimeField(DoubleFieldScript.Factory scriptFactory) {
-                return runtimeField(name, this, scriptFactory, getScript(), meta());
-            }
-        });
+    public static final RuntimeField.Parser PARSER = new RuntimeField.Parser(Builder::new);
 
-    private static RuntimeField runtimeField(
-        String name,
-        ToXContent toXContent,
-        DoubleFieldScript.Factory scriptFactory,
-        Script script,
-        Map<String, String> meta
-    ) {
-        return new LeafRuntimeField(name, new DoubleScriptFieldType(name, scriptFactory, script, meta), toXContent);
+    private static class Builder extends AbstractScriptFieldType.Builder<DoubleFieldScript.Factory> {
+        Builder(String name) {
+            super(name, DoubleFieldScript.CONTEXT, DoubleFieldScript.PARSE_FROM_SOURCE);
+        }
+
+        @Override
+        AbstractScriptFieldType<?> createFieldType(String name,
+                                                   DoubleFieldScript.Factory factory,
+                                                   Script script,
+                                                   Map<String, String> meta) {
+            return new DoubleScriptFieldType(name, factory, script, meta);
+        }
     }
 
     public static RuntimeField sourceOnly(String name) {
-        return runtimeField(
-            name,
-            (builder, params) -> builder,
-            DoubleFieldScript.PARSE_FROM_SOURCE,
-            DEFAULT_SCRIPT,
-            Collections.emptyMap());
+        return new Builder(name).createRuntimeField(DoubleFieldScript.PARSE_FROM_SOURCE);
     }
 
     DoubleScriptFieldType(

--- a/server/src/main/java/org/elasticsearch/index/mapper/GeoPointScriptFieldType.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/GeoPointScriptFieldType.java
@@ -38,8 +38,11 @@ public final class GeoPointScriptFieldType extends AbstractScriptFieldType<GeoPo
     public static final RuntimeField.Parser PARSER = new RuntimeField.Parser(name ->
         new Builder<>(name, GeoPointFieldScript.CONTEXT, GeoPointFieldScript.PARSE_FROM_SOURCE) {
             @Override
-            RuntimeField newRuntimeField(GeoPointFieldScript.Factory scriptFactory) {
-                return new LeafRuntimeField(name, new GeoPointScriptFieldType(name, scriptFactory, getScript(), meta()), this);
+            AbstractScriptFieldType<?> createFieldType(String name,
+                                                       GeoPointFieldScript.Factory factory,
+                                                       Script script,
+                                                       Map<String, String> meta) {
+                return new GeoPointScriptFieldType(name, factory, getScript(), meta());
             }
         });
 

--- a/server/src/main/java/org/elasticsearch/index/mapper/IpScriptFieldType.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/IpScriptFieldType.java
@@ -44,8 +44,11 @@ public final class IpScriptFieldType extends AbstractScriptFieldType<IpFieldScri
     public static final RuntimeField.Parser PARSER = new RuntimeField.Parser(name ->
         new Builder<>(name, IpFieldScript.CONTEXT, IpFieldScript.PARSE_FROM_SOURCE) {
             @Override
-            RuntimeField newRuntimeField(IpFieldScript.Factory scriptFactory) {
-                return new LeafRuntimeField(name, new IpScriptFieldType(name, scriptFactory, getScript(), meta()), this);
+            AbstractScriptFieldType<?> createFieldType(String name,
+                                                       IpFieldScript.Factory factory,
+                                                       Script script,
+                                                       Map<String, String> meta) {
+                return new IpScriptFieldType(name, factory, getScript(), meta());
             }
         });
 

--- a/server/src/main/java/org/elasticsearch/index/mapper/KeywordScriptFieldType.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/KeywordScriptFieldType.java
@@ -14,7 +14,6 @@ import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.lucene.BytesRefs;
 import org.elasticsearch.common.time.DateMathParser;
 import org.elasticsearch.common.unit.Fuzziness;
-import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.index.fielddata.StringScriptFieldData;
 import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.script.Script;
@@ -31,7 +30,6 @@ import org.elasticsearch.search.runtime.StringScriptFieldWildcardQuery;
 
 import java.time.ZoneId;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
@@ -41,31 +39,21 @@ import static java.util.stream.Collectors.toSet;
 
 public final class KeywordScriptFieldType extends AbstractScriptFieldType<StringFieldScript.LeafFactory> {
 
-    public static final RuntimeField.Parser PARSER = new RuntimeField.Parser(name ->
-        new Builder<>(name, StringFieldScript.CONTEXT, StringFieldScript.PARSE_FROM_SOURCE) {
-            @Override
-            RuntimeField newRuntimeField(StringFieldScript.Factory scriptFactory) {
-                return runtimeField(name, this, scriptFactory, getScript(), meta());
-            }
-        });
+    public static final RuntimeField.Parser PARSER = new RuntimeField.Parser(Builder::new);
 
-    private static RuntimeField runtimeField(
-        String name,
-        ToXContent toXContent,
-        StringFieldScript.Factory scriptFactory,
-        Script script,
-        Map<String, String> meta
-    ) {
-        return new LeafRuntimeField(name, new KeywordScriptFieldType(name, scriptFactory, script, meta), toXContent);
+    private static class Builder extends AbstractScriptFieldType.Builder<StringFieldScript.Factory> {
+        Builder(String name) {
+            super(name, StringFieldScript.CONTEXT, StringFieldScript.PARSE_FROM_SOURCE);
+        }
+
+        @Override
+        AbstractScriptFieldType<?> createFieldType(String name, StringFieldScript.Factory factory, Script script, Map<String, String> meta) {
+            return new KeywordScriptFieldType(name, factory, script, meta);
+        }
     }
 
     public static RuntimeField sourceOnly(String name) {
-        return runtimeField(
-            name,
-            (builder, params) -> builder,
-            StringFieldScript.PARSE_FROM_SOURCE,
-            DEFAULT_SCRIPT,
-            Collections.emptyMap());
+        return new Builder(name).createRuntimeField(StringFieldScript.PARSE_FROM_SOURCE);
     }
 
     public KeywordScriptFieldType(

--- a/server/src/main/java/org/elasticsearch/index/mapper/KeywordScriptFieldType.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/KeywordScriptFieldType.java
@@ -47,7 +47,10 @@ public final class KeywordScriptFieldType extends AbstractScriptFieldType<String
         }
 
         @Override
-        AbstractScriptFieldType<?> createFieldType(String name, StringFieldScript.Factory factory, Script script, Map<String, String> meta) {
+        AbstractScriptFieldType<?> createFieldType(String name,
+                                                   StringFieldScript.Factory factory,
+                                                   Script script,
+                                                   Map<String, String> meta) {
             return new KeywordScriptFieldType(name, factory, script, meta);
         }
     }

--- a/server/src/main/java/org/elasticsearch/index/mapper/LeafRuntimeField.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/LeafRuntimeField.java
@@ -20,12 +20,11 @@ import java.util.Collections;
  * a single MappedFieldType from {@link RuntimeField#asMappedFieldTypes()}
  */
 public final class LeafRuntimeField implements RuntimeField {
+    private final String name;
+    private final ToXContent toXContent;
+    private final AbstractScriptFieldType<?> mappedFieldType;
 
-    protected final String name;
-    protected final ToXContent toXContent;
-    protected final MappedFieldType mappedFieldType;
-
-    public LeafRuntimeField(String name, MappedFieldType mappedFieldType, ToXContent toXContent) {
+    public LeafRuntimeField(String name, AbstractScriptFieldType<?> mappedFieldType, ToXContent toXContent) {
         this.name = name;
         this.toXContent = toXContent;
         this.mappedFieldType = mappedFieldType;

--- a/server/src/main/java/org/elasticsearch/index/mapper/LeafRuntimeField.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/LeafRuntimeField.java
@@ -22,9 +22,9 @@ import java.util.Collections;
 public final class LeafRuntimeField implements RuntimeField {
     private final String name;
     private final ToXContent toXContent;
-    private final AbstractScriptFieldType<?> mappedFieldType;
+    private final MappedFieldType mappedFieldType;
 
-    public LeafRuntimeField(String name, AbstractScriptFieldType<?> mappedFieldType, ToXContent toXContent) {
+    public LeafRuntimeField(String name, MappedFieldType mappedFieldType, ToXContent toXContent) {
         this.name = name;
         this.toXContent = toXContent;
         this.mappedFieldType = mappedFieldType;

--- a/server/src/main/java/org/elasticsearch/index/mapper/LongScriptFieldType.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/LongScriptFieldType.java
@@ -14,7 +14,6 @@ import com.carrotsearch.hppc.LongSet;
 import org.apache.lucene.search.Query;
 import org.elasticsearch.common.lucene.search.Queries;
 import org.elasticsearch.common.time.DateMathParser;
-import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.index.fielddata.LongScriptFieldData;
 import org.elasticsearch.index.mapper.NumberFieldMapper.NumberType;
 import org.elasticsearch.index.query.SearchExecutionContext;
@@ -29,37 +28,26 @@ import org.elasticsearch.search.runtime.LongScriptFieldTermsQuery;
 
 import java.time.ZoneId;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.Map;
 import java.util.function.Supplier;
 
 public final class LongScriptFieldType extends AbstractScriptFieldType<LongFieldScript.LeafFactory> {
 
-    public static final RuntimeField.Parser PARSER = new RuntimeField.Parser(name ->
-        new Builder<>(name, LongFieldScript.CONTEXT, LongFieldScript.PARSE_FROM_SOURCE) {
-            @Override
-            RuntimeField newRuntimeField(LongFieldScript.Factory scriptFactory) {
-                return runtimeField(name, this, scriptFactory, getScript(), meta());
-            }
-        });
+    public static final RuntimeField.Parser PARSER = new RuntimeField.Parser(Builder::new);
 
-    private static RuntimeField runtimeField(
-        String name,
-        ToXContent toXContent,
-        LongFieldScript.Factory scriptFactory,
-        Script script,
-        Map<String, String> meta
-    ) {
-        return new LeafRuntimeField(name, new LongScriptFieldType(name, scriptFactory, script, meta), toXContent);
+    private static class Builder extends AbstractScriptFieldType.Builder<LongFieldScript.Factory> {
+        Builder(String name) {
+            super(name, LongFieldScript.CONTEXT, LongFieldScript.PARSE_FROM_SOURCE);
+        }
+
+        @Override
+        AbstractScriptFieldType<?> createFieldType(String name, LongFieldScript.Factory factory, Script script, Map<String, String> meta) {
+            return new LongScriptFieldType(name, factory, script, meta);
+        }
     }
 
     public static RuntimeField sourceOnly(String name) {
-        return runtimeField(
-            name,
-            (builder, params) -> builder,
-            LongFieldScript.PARSE_FROM_SOURCE,
-            DEFAULT_SCRIPT,
-            Collections.emptyMap());
+        return new Builder(name).createRuntimeField(LongFieldScript.PARSE_FROM_SOURCE);
     }
 
     public LongScriptFieldType(

--- a/server/src/test/java/org/elasticsearch/index/mapper/DocumentParserTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/DocumentParserTests.java
@@ -804,7 +804,7 @@ public class DocumentParserTests extends MapperServiceTestCase {
         ParsedDocument doc = mapper.parse(source(b -> b.startArray("foo").value(0).value(1).endArray()));
         assertEquals(0, doc.rootDoc().getFields("foo").length);
         RuntimeField foo = doc.dynamicMappingsUpdate().getRoot().getRuntimeField("foo");
-        assertEquals("long", foo.typeName());
+        assertEquals("{\"foo\":{\"type\":\"long\"}}", Strings.toString(foo));
     }
 
     public void testDynamicRuntimeDoubleArray() throws Exception {
@@ -812,7 +812,7 @@ public class DocumentParserTests extends MapperServiceTestCase {
         ParsedDocument doc = mapper.parse(source(b -> b.startArray("foo").value(0.25).value(1.43).endArray()));
         assertEquals(0, doc.rootDoc().getFields("foo").length);
         RuntimeField foo = doc.dynamicMappingsUpdate().getRoot().getRuntimeField("foo");
-        assertEquals("double", foo.typeName());
+        assertEquals("{\"foo\":{\"type\":\"double\"}}", Strings.toString(foo));
     }
 
     public void testDynamicRuntimeStringArray() throws Exception {
@@ -820,7 +820,7 @@ public class DocumentParserTests extends MapperServiceTestCase {
         ParsedDocument doc = mapper.parse(source(b -> b.startArray("foo").value("test1").value("test2").endArray()));
         assertEquals(0, doc.rootDoc().getFields("foo").length);
         RuntimeField foo = doc.dynamicMappingsUpdate().getRoot().getRuntimeField("foo");
-        assertEquals("keyword", foo.typeName());
+        assertEquals("{\"foo\":{\"type\":\"keyword\"}}", Strings.toString(foo));
     }
 
     public void testDynamicRuntimeBooleanArray() throws Exception {
@@ -828,7 +828,7 @@ public class DocumentParserTests extends MapperServiceTestCase {
         ParsedDocument doc = mapper.parse(source(b -> b.startArray("foo").value(true).value(false).endArray()));
         assertEquals(0, doc.rootDoc().getFields("foo").length);
         RuntimeField foo = doc.dynamicMappingsUpdate().getRoot().getRuntimeField("foo");
-        assertEquals("boolean", foo.typeName());
+        assertEquals("{\"foo\":{\"type\":\"boolean\"}}", Strings.toString(foo));
     }
 
     public void testDynamicRuntimeDateArray() throws Exception {
@@ -836,7 +836,7 @@ public class DocumentParserTests extends MapperServiceTestCase {
         ParsedDocument doc = mapper.parse(source(b -> b.startArray("foo").value("2020-12-15").value("2020-12-09").endArray()));
         assertEquals(0, doc.rootDoc().getFields("foo").length);
         RuntimeField foo = doc.dynamicMappingsUpdate().getRoot().getRuntimeField("foo");
-        assertEquals("date", foo.typeName());
+        assertEquals("{\"foo\":{\"type\":\"date\"}}", Strings.toString(foo));
     }
 
     public void testMappedGeoPointArray() throws Exception {

--- a/server/src/test/java/org/elasticsearch/index/mapper/FieldTypeLookupTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/FieldTypeLookupTests.java
@@ -65,7 +65,7 @@ public class FieldTypeLookupTests extends ESTestCase {
         FieldAliasMapper alias2 = new FieldAliasMapper("barometer", "barometer", "bar");
 
         TestRuntimeField runtimeField = new TestRuntimeField("baz", "type");
-        TestRuntimeField multi = new TestRuntimeField("flat", "multi",
+        TestRuntimeField multi = new TestRuntimeField("flat",
             List.of(new TestRuntimeField.TestRuntimeFieldType("flat.first", "first"),
                 new TestRuntimeField.TestRuntimeFieldType("flat.second", "second")));
 
@@ -138,7 +138,7 @@ public class FieldTypeLookupTests extends ESTestCase {
         MockFieldMapper concrete = new MockFieldMapper("concrete");
         TestRuntimeField runtimeLong = new TestRuntimeField("multi.outside", "date");
         TestRuntimeField runtime = new TestRuntimeField("string", "type");
-        TestRuntimeField multi = new TestRuntimeField("multi", "multi", List.of(
+        TestRuntimeField multi = new TestRuntimeField("multi", List.of(
             new TestRuntimeField.TestRuntimeFieldType("multi.string", "string"),
             new TestRuntimeField.TestRuntimeFieldType("multi.long", "long")));
 
@@ -162,7 +162,7 @@ public class FieldTypeLookupTests extends ESTestCase {
         MockFieldMapper subfield = new MockFieldMapper("object.subfield");
         MockFieldMapper concrete = new MockFieldMapper("concrete");
         TestRuntimeField fieldOverride = new TestRuntimeField("field", "string");
-        TestRuntimeField subfieldOverride = new TestRuntimeField("object", "multi",
+        TestRuntimeField subfieldOverride = new TestRuntimeField("object",
             Collections.singleton(new TestRuntimeField.TestRuntimeFieldType("object.subfield", "leaf")));
         TestRuntimeField runtime = new TestRuntimeField("runtime", "type");
         TestRuntimeField flattenedRuntime = new TestRuntimeField("flattened.runtime", "type");
@@ -320,7 +320,7 @@ public class FieldTypeLookupTests extends ESTestCase {
             assertEquals(iae.getMessage(), "Found two runtime fields with same name [field]");
         }
         {
-            TestRuntimeField multi = new TestRuntimeField("multi", "multi",
+            TestRuntimeField multi = new TestRuntimeField("multi",
                 Collections.singleton(new TestRuntimeField.TestRuntimeFieldType("multi.first", "leaf")));
             TestRuntimeField runtime = new TestRuntimeField("multi.first", "runtime");
             IllegalArgumentException iae = expectThrows(IllegalArgumentException.class, () -> new FieldTypeLookup(Collections.emptySet(),
@@ -328,7 +328,7 @@ public class FieldTypeLookupTests extends ESTestCase {
             assertEquals(iae.getMessage(), "Found two runtime fields with same name [multi.first]");
         }
         {
-            TestRuntimeField multi = new TestRuntimeField("multi", "multi",
+            TestRuntimeField multi = new TestRuntimeField("multi",
                 List.of(new TestRuntimeField.TestRuntimeFieldType("multi", "leaf"),
                     new TestRuntimeField.TestRuntimeFieldType("multi", "leaf")));
 
@@ -340,7 +340,7 @@ public class FieldTypeLookupTests extends ESTestCase {
 
     public void testRuntimeFieldNameOutsideContext() {
         {
-            TestRuntimeField multi = new TestRuntimeField("multi", "multi",
+            TestRuntimeField multi = new TestRuntimeField("multi",
                 List.of(new TestRuntimeField.TestRuntimeFieldType("first", "leaf"),
                     new TestRuntimeField.TestRuntimeFieldType("second", "leaf"),
                     new TestRuntimeField.TestRuntimeFieldType("multi.third", "leaf")));
@@ -350,7 +350,7 @@ public class FieldTypeLookupTests extends ESTestCase {
                 ise.getMessage());
         }
         {
-            TestRuntimeField multi = new TestRuntimeField("multi", "multi",
+            TestRuntimeField multi = new TestRuntimeField("multi",
                 List.of(new TestRuntimeField.TestRuntimeFieldType("multi.", "leaf"),
                     new TestRuntimeField.TestRuntimeFieldType("multi.f", "leaf")));
             IllegalStateException ise = expectThrows(IllegalStateException.class, () -> new FieldTypeLookup(Collections.emptySet(),

--- a/server/src/test/java/org/elasticsearch/index/mapper/TestRuntimeField.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/TestRuntimeField.java
@@ -12,21 +12,20 @@ import org.apache.lucene.search.Query;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.index.query.SearchExecutionContext;
 
+import java.io.IOException;
 import java.util.Collection;
 import java.util.Collections;
 
 public final class TestRuntimeField implements RuntimeField {
     private final String name;
-    private final String type;
     private final Collection<MappedFieldType> subfields;
 
     public TestRuntimeField(String name, String type) {
-        this(name, type, Collections.singleton(new TestRuntimeFieldType(name, type)));
+        this(name, Collections.singleton(new TestRuntimeFieldType(name, type)));
     }
 
-    public TestRuntimeField(String name, String type, Collection<MappedFieldType> subfields) {
+    public TestRuntimeField(String name, Collection<MappedFieldType> subfields) {
         this.name = name;
-        this.type = type;
         this.subfields = subfields;
     }
 
@@ -37,7 +36,7 @@ public final class TestRuntimeField implements RuntimeField {
 
     @Override
     public String typeName() {
-        return type;
+        throw new UnsupportedOperationException();
     }
 
     @Override
@@ -46,8 +45,13 @@ public final class TestRuntimeField implements RuntimeField {
     }
 
     @Override
-    public void doXContentBody(XContentBuilder builder, Params params) {
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        throw new UnsupportedOperationException();
+    }
 
+    @Override
+    public void doXContentBody(XContentBuilder builder, Params params) {
+        throw new UnsupportedOperationException();
     }
 
     public static class TestRuntimeFieldType extends MappedFieldType {

--- a/server/src/test/java/org/elasticsearch/index/query/SearchExecutionContextTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/SearchExecutionContextTests.java
@@ -555,7 +555,7 @@ public class SearchExecutionContextTests extends ESTestCase {
                 };
             }
         };
-        return new TestRuntimeField(name, null, Collections.singleton(fieldType));
+        return new TestRuntimeField(name, Collections.singleton(fieldType));
     }
 
     private static List<String> collect(String field, SearchExecutionContext searchExecutionContext) throws IOException {


### PR DESCRIPTION
Now that AbstractScriptFieldType and LeafRuntimeField are separate, we can further simplify the creation of runtime fields. Their builder always creates a new instance of the same class (LeafRuntimeField), which can be shared throughout all the builders. The only bit that changes is the MappedFieldType instance, which becomes the only required abstract method in the base builder.

Also, the dynamically created runtime field variant that parses its values from source can be created through a builder which makes sure that we reuse as much code as possible.
