### PR TITLE
Determine upgrades correctly for deb packages

### DIFF
--- a/distribution/packages/src/common/scripts/postinst
+++ b/distribution/packages/src/common/scripts/postinst
@@ -23,7 +23,7 @@ case "$1" in
     configure)
 
         # If $1=configure and $2 is set, this is an upgrade
-        if [ -n $2 ]; then
+        if [ -n "$2" ]; then
             IS_UPGRADE=true
         fi
         PACKAGE=deb


### PR DESCRIPTION
We are using the `-n` bash operator to determine whether a second
argument is passed to the `postinst` script during installation of
our DEB packages. The reasoning is that we want to differentiate
between installations and upgrades and a second argument to
`postinst` is only passed when this is an upgrade ( the identifier
of the version the package is upgraded to ).
The problem is that we use `-n` without quoting the $2 and this is
unsafe practice as it might yield unexpected results for `-n` and
`-z` operators used within test brackets. Testing with bash
5.0-6ubuntu1.1 `[ -n $2 ]` returns false both for upgrades and
installations, while `[ -n "$2" ]` behaves as expected.

References:
https://tldp.org/LDP/abs/html/comparison-ops.html
https://wiki.debian.org/MaintainerScripts