### PR TITLE
Ensure replica requests are marked as index_data (#75008)

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/support/replication/TransportReplicationAction.java
+++ b/server/src/main/java/org/elasticsearch/action/support/replication/TransportReplicationAction.java
@@ -61,6 +61,7 @@ import org.elasticsearch.tasks.Task;
 import org.elasticsearch.tasks.TaskId;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.ConnectTransportException;
+import org.elasticsearch.transport.RawIndexingDataTransportRequest;
 import org.elasticsearch.transport.TransportChannel;
 import org.elasticsearch.transport.TransportException;
 import org.elasticsearch.transport.TransportRequest;
@@ -1098,7 +1099,8 @@ public abstract class TransportReplicationAction<
     }
 
     /** a wrapper class to encapsulate a request when being sent to a specific allocation id **/
-    public static class ConcreteShardRequest<R extends TransportRequest> extends TransportRequest {
+    public static class ConcreteShardRequest<R extends TransportRequest> extends TransportRequest
+        implements RawIndexingDataTransportRequest {
 
         /** {@link AllocationId#getId()} of the shard this request is sent to **/
         private final String targetAllocationID;
@@ -1187,6 +1189,14 @@ public abstract class TransportReplicationAction<
 
         public long getPrimaryTerm() {
             return primaryTerm;
+        }
+
+        @Override
+        public boolean isRawIndexingData() {
+            if (request instanceof RawIndexingDataTransportRequest) {
+                return ((RawIndexingDataTransportRequest) request).isRawIndexingData();
+            }
+            return false;
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/transport/RawIndexingDataTransportRequest.java
+++ b/server/src/main/java/org/elasticsearch/transport/RawIndexingDataTransportRequest.java
@@ -10,8 +10,12 @@ package org.elasticsearch.transport;
 
 /**
  * Requests that implement this interface will be compressed when {@link TransportSettings#TRANSPORT_COMPRESS}
- * is configured to {@link Compression.Enabled#INDEXING_DATA}. This is primary intended to be
- * requests/responses primarily composed of raw source data.
+ * is configured to {@link Compression.Enabled#INDEXING_DATA} and isRawIndexingData() returns true. This is
+ * intended to be requests/responses primarily composed of raw source data.
  */
 public interface RawIndexingDataTransportRequest {
+
+    default boolean isRawIndexingData() {
+        return true;
+    }
 }

--- a/server/src/main/java/org/elasticsearch/transport/TcpTransport.java
+++ b/server/src/main/java/org/elasticsearch/transport/TcpTransport.java
@@ -258,8 +258,13 @@ public abstract class TcpTransport extends AbstractLifecycleComponent implements
                 throw new NodeNotConnectedException(node, "connection already closed");
             }
             TcpChannel channel = channel(options.type());
+            // We compress if total transport compression is enabled or if indexing_data transport compression
+            // is enabled and the request is a RawIndexingDataTransportRequest which indicates it should be
+            // compressed.
             boolean shouldCompress = compress == Compression.Enabled.TRUE ||
-                (compress == Compression.Enabled.INDEXING_DATA && request instanceof RawIndexingDataTransportRequest);
+                (compress == Compression.Enabled.INDEXING_DATA
+                    && request instanceof RawIndexingDataTransportRequest
+                    && ((RawIndexingDataTransportRequest) request).isRawIndexingData());
             outboundHandler.sendRequest(node, channel, requestId, action, request, options, getVersion(), shouldCompress, false);
         }
 


### PR DESCRIPTION
This is related to #73497. Currently replica requests are wrapped in a
concrete replica shard request. This leads to the transport layer not
properly identifying them as replica index_data requests and not
compressing them properly. This commit resolves this bug.