### PR TITLE
Fix GCS Keystore Handling in FIPS Mode

### DIFF
--- a/plugins/repository-gcs/src/main/java/org/elasticsearch/repositories/gcs/GoogleCloudStorageService.java
+++ b/plugins/repository-gcs/src/main/java/org/elasticsearch/repositories/gcs/GoogleCloudStorageService.java
@@ -12,6 +12,7 @@ import com.google.api.client.googleapis.GoogleUtils;
 import com.google.api.client.http.HttpRequestInitializer;
 import com.google.api.client.http.HttpTransport;
 import com.google.api.client.http.javanet.NetHttpTransport;
+import com.google.api.client.util.SecurityUtils;
 import com.google.auth.oauth2.GoogleCredentials;
 import com.google.auth.oauth2.ServiceAccountCredentials;
 import com.google.cloud.ServiceOptions;
@@ -34,6 +35,7 @@ import java.io.InputStreamReader;
 import java.net.HttpURLConnection;
 import java.net.URI;
 import java.net.URL;
+import java.security.KeyStore;
 import java.util.Map;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
@@ -126,7 +128,11 @@ public class GoogleCloudStorageService {
             final NetHttpTransport.Builder builder = new NetHttpTransport.Builder();
             // requires java.lang.RuntimePermission "setFactory"
             // Pin the TLS trust certificates.
-            builder.trustCertificates(GoogleUtils.getCertificateTrustStore());
+            final KeyStore certTrustStore = SecurityUtils.getJavaKeyStore();
+            try (InputStream keyStoreStream = GoogleUtils.class.getResourceAsStream("google.jks")) {
+                SecurityUtils.loadKeyStore(certTrustStore, keyStoreStream, "notasecret");
+            }
+            builder.trustCertificates(certTrustStore);
             return builder.build();
         });
 

--- a/plugins/repository-gcs/src/main/java/org/elasticsearch/repositories/gcs/GoogleCloudStorageService.java
+++ b/plugins/repository-gcs/src/main/java/org/elasticsearch/repositories/gcs/GoogleCloudStorageService.java
@@ -128,6 +128,8 @@ public class GoogleCloudStorageService {
             final NetHttpTransport.Builder builder = new NetHttpTransport.Builder();
             // requires java.lang.RuntimePermission "setFactory"
             // Pin the TLS trust certificates.
+            // We manually load the key store from jks instead of using GoogleUtils.getCertificateTrustStore() because that uses a .p12
+            // store format not compatible with FIPS mode.
             final KeyStore certTrustStore = SecurityUtils.getJavaKeyStore();
             try (InputStream keyStoreStream = GoogleUtils.class.getResourceAsStream("google.jks")) {
                 SecurityUtils.loadKeyStore(certTrustStore, keyStoreStream, "notasecret");

--- a/plugins/repository-gcs/src/main/java/org/elasticsearch/repositories/gcs/SocketAccess.java
+++ b/plugins/repository-gcs/src/main/java/org/elasticsearch/repositories/gcs/SocketAccess.java
@@ -32,7 +32,7 @@ final class SocketAccess {
         try {
             return AccessController.doPrivileged(operation);
         } catch (PrivilegedActionException e) {
-            throw (IOException) e.getCause();
+            throw causeAsIOException(e);
         }
     }
 
@@ -44,7 +44,18 @@ final class SocketAccess {
                 return null;
             });
         } catch (PrivilegedActionException e) {
-            throw (IOException) e.getCause();
+            throw causeAsIOException(e);
         }
+    }
+
+    private static IOException causeAsIOException(PrivilegedActionException e) {
+        final Throwable cause = e.getCause();
+        if (cause instanceof IOException) {
+            return (IOException) cause;
+        }
+        if (cause instanceof RuntimeException) {
+            throw (RuntimeException) cause;
+        }
+        throw new RuntimeException(cause);
     }
 }


### PR DESCRIPTION
Fallout from upgrading the GCS dep. in #74938

In FIPS mode loading the `.p12` keystore used by the new SDK version is not supported
because of "PBE AlgorithmParameters not available". Fortunately, the SDK still includes
the old jks trust store so we can just manually load it the same way it was loaded by
the previous version to fix things.
Also, fixed `SocketAccess` to properly rethrow this kind of exception and not run into
a class cast issue.

Closes #75023

Relates googleapis/google-api-java-client#1738

non-issue as this hasn't been released yet