### PR TITLE
[ML] Fix race in AbstractNativeProcessTests

### DIFF
--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/process/AbstractNativeProcess.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/process/AbstractNativeProcess.java
@@ -182,6 +182,7 @@ public abstract class AbstractNativeProcess implements NativeProcess {
             if (processInStream() != null) {
                 processInStream().close();
             }
+            afterProcessInStreamClose();
             // wait for the process to exit by waiting for end-of-file on the named pipe connected
             // to the state processor - it may take a long time for all the model state to be
             // indexed
@@ -209,6 +210,14 @@ public abstract class AbstractNativeProcess implements NativeProcess {
         } finally {
             deleteAssociatedFiles();
         }
+    }
+
+    /**
+     * Implementations can override this if they need to perform extra processing
+     * immediately after the native process's input stream is closed.
+     */
+    protected void afterProcessInStreamClose() {
+        // no-op by default
     }
 
     @Override

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/process/logging/CppLogMessageHandler.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/process/logging/CppLogMessageHandler.java
@@ -170,7 +170,7 @@ public class CppLogMessageHandler implements Closeable {
     /**
      * Get the process ID of the C++ process if available.
      *
-     * In contrast to {@link getPid} this version will not wait/block.
+     * In contrast to {@link #getPid} this version will not wait/block.
      *
      * @return the pid or -1 if the pid is unknown
      */

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/process/AbstractNativeProcessTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/process/AbstractNativeProcessTests.java
@@ -87,44 +87,37 @@ public class AbstractNativeProcessTests extends ESTestCase {
     public void testStart_DoNotDetectCrashWhenNoInputPipeProvided() throws Exception {
         when(processPipes.getProcessInStream()).thenReturn(Optional.empty());
         try (AbstractNativeProcess process = new TestNativeProcess()) {
-            try {
-                process.start(executorService);
-            } finally {
-                mockNativeProcessLoggingStreamEnds.countDown();
-                // Not detecting a crash is confirmed in terminateExecutorService()
-            }
+            process.start(executorService);
         }
+        // Not detecting a crash during the close sequence is confirmed in terminateExecutorService()
     }
 
     public void testStart_DoNotDetectCrashWhenProcessIsBeingClosed() throws Exception {
         try (AbstractNativeProcess process = new TestNativeProcess()) {
-            try {
-                process.start(executorService);
-            } finally {
-                mockNativeProcessLoggingStreamEnds.countDown();
-                // Not detecting a crash is confirmed in terminateExecutorService()
-            }
+            process.start(executorService);
         }
+        // Not detecting a crash during the close sequence is confirmed in terminateExecutorService()
     }
 
     public void testStart_DoNotDetectCrashWhenProcessIsBeingKilled() throws Exception {
-        AbstractNativeProcess process = new TestNativeProcess();
-        try {
-            process.start(executorService);
-            process.kill(randomBoolean());
-        } finally {
-            // It is critical that this comes after kill() but before close(), otherwise we
-            // would not be accurately simulating a kill().  This is why try-with-resources
-            // is not used in this case.
-            mockNativeProcessLoggingStreamEnds.countDown();
-            // Not detecting a crash is confirmed in terminateExecutorService()
-            process.close();
-        }
-    }
-
-    public void testStart_DetectCrashWhenInputPipeExists() throws Exception {
         try (AbstractNativeProcess process = new TestNativeProcess()) {
             process.start(executorService);
+            process.kill(randomBoolean());
+            // This ends the logging stream immediately after the kill() instead of part
+            // way through the close sequence.  It is critical that this is done, otherwise
+            // we would not be accurately simulating what happens with the order streams
+            // receive end-of-file after a kill() of a real process.  The latch is counted
+            // down again during the close() call, but that is harmless.
+            mockNativeProcessLoggingStreamEnds.countDown();
+        }
+        // Not detecting a crash during the close sequence is confirmed in terminateExecutorService()
+    }
+
+    public void testStart_DetectCrashBeforeFirstLogMessage() throws Exception {
+        try (AbstractNativeProcess process = new TestNativeProcess()) {
+            process.start(executorService);
+            // Even though we are simulating no log messages (by not mocking a PID via cppLogHandler.tryGetPid())
+            // we need to simulate disconnection of the logging stream.
             mockNativeProcessLoggingStreamEnds.countDown();
             ThreadPool.terminate(executorService, 10, TimeUnit.SECONDS);
 
@@ -137,6 +130,8 @@ public class AbstractNativeProcessTests extends ESTestCase {
         when(cppLogHandler.getErrors()).thenReturn("Failed to find the answer");
         try (AbstractNativeProcess process = new TestNativeProcess()) {
             process.start(executorService);
+            // Losing the logging stream before the input stream is closed is how we
+            // detect crashes.
             mockNativeProcessLoggingStreamEnds.countDown();
             ThreadPool.terminate(executorService, 10, TimeUnit.SECONDS);
 
@@ -146,74 +141,50 @@ public class AbstractNativeProcessTests extends ESTestCase {
 
     public void testWriteRecord() throws Exception {
         try (AbstractNativeProcess process = new TestNativeProcess()) {
-            try {
-                process.start(executorService);
-                process.writeRecord(new String[]{"a", "b", "c"});
-                process.flushStream();
-                verify(inputStream).write(any(), anyInt(), anyInt());
-            } finally {
-                mockNativeProcessLoggingStreamEnds.countDown();
-            }
+            process.start(executorService);
+            process.writeRecord(new String[]{"a", "b", "c"});
+            process.flushStream();
+            verify(inputStream).write(any(), anyInt(), anyInt());
         }
     }
 
     public void testWriteRecord_FailWhenNoInputPipeProvided() throws Exception {
         when(processPipes.getProcessInStream()).thenReturn(Optional.empty());
         try (AbstractNativeProcess process = new TestNativeProcess()) {
-            try {
-                process.start(executorService);
-                expectThrows(NullPointerException.class, () -> process.writeRecord(new String[]{"a", "b", "c"}));
-            } finally {
-                mockNativeProcessLoggingStreamEnds.countDown();
-            }
+            process.start(executorService);
+            expectThrows(NullPointerException.class, () -> process.writeRecord(new String[]{"a", "b", "c"}));
         }
     }
 
     public void testFlush() throws Exception {
         try (AbstractNativeProcess process = new TestNativeProcess()) {
-            try {
-                process.start(executorService);
-                process.flushStream();
-                verify(inputStream).flush();
-            } finally {
-                mockNativeProcessLoggingStreamEnds.countDown();
-            }
+            process.start(executorService);
+            process.flushStream();
+            verify(inputStream).flush();
         }
     }
 
     public void testFlush_FailWhenNoInputPipeProvided() throws Exception {
         when(processPipes.getProcessInStream()).thenReturn(Optional.empty());
         try (AbstractNativeProcess process = new TestNativeProcess()) {
-            try {
-                process.start(executorService);
-                expectThrows(NullPointerException.class, process::flushStream);
-            } finally {
-                mockNativeProcessLoggingStreamEnds.countDown();
-            }
+            process.start(executorService);
+            expectThrows(NullPointerException.class, process::flushStream);
         }
     }
 
     public void testIsReady() throws Exception {
         try (AbstractNativeProcess process = new TestNativeProcess()) {
-            try {
-                process.start(executorService);
-                assertThat(process.isReady(), is(false));
-                process.setReady();
-                assertThat(process.isReady(), is(true));
-            } finally {
-                mockNativeProcessLoggingStreamEnds.countDown();
-            }
+            process.start(executorService);
+            assertThat(process.isReady(), is(false));
+            process.setReady();
+            assertThat(process.isReady(), is(true));
         }
     }
 
     public void testConsumeAndCloseOutputStream_GivenNoOutputStream() throws Exception {
         when(processPipes.getProcessOutStream()).thenReturn(Optional.empty());
         try (AbstractNativeProcess process = new TestNativeProcess()) {
-            try {
-                process.consumeAndCloseOutputStream();
-            } finally {
-                mockNativeProcessLoggingStreamEnds.countDown();
-            }
+            process.consumeAndCloseOutputStream();
         }
     }
 
@@ -237,6 +208,12 @@ public class AbstractNativeProcessTests extends ESTestCase {
 
         @Override
         public void persistState(long snapshotTimestamp, String snapshotId, String snapshotDescription) {
+        }
+
+        @Override
+        protected void afterProcessInStreamClose() {
+            // This simulates the process's log stream disconnecting shortly after its input stream is closed
+            mockNativeProcessLoggingStreamEnds.countDown();
         }
     }
 }


### PR DESCRIPTION
The order of closure of the process input stream and
logging stream is extremely important to whether the
process is considered to have crashed or exited
gracefully.

Previously it was not possible to simulate this from
the unit test code alone, so this change introduces a
protected function into the AbstractNativeProcess class
that the unit test code can override to control the
point at which the log stream is considered to have
disconnected.

Fixes #75027