### PR TITLE
[7.x] SQL: More information when printing Alias and LocalRelation nodes (#74847)

### DIFF
--- a/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/expression/Alias.java
+++ b/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/expression/Alias.java
@@ -97,4 +97,9 @@ public class Alias extends NamedExpression {
     public String toString() {
         return child + " AS " + name() + "#" + id();
     }
+
+    @Override
+    public String nodeString() {
+        return child.nodeString() + " AS " + name();
+    }
 }

--- a/x-pack/plugin/sql/qa/server/single-node/src/test/java/org/elasticsearch/xpack/sql/qa/single_node/CliExplainIT.java
+++ b/x-pack/plugin/sql/qa/server/single-node/src/test/java/org/elasticsearch/xpack/sql/qa/single_node/CliExplainIT.java
@@ -130,13 +130,13 @@ public class CliExplainIT extends CliIntegrationTestCase {
 
         assertThat(command("EXPLAIN " + (randomBoolean() ? "" : "(PLAN ANALYZED) ") + "SELECT COUNT(*) FROM test"), containsString("plan"));
         assertThat(readLine(), startsWith("----------"));
-        assertThat(readLine(), startsWith("Aggregate[[],[COUNT(*)"));
+        assertThat(readLine(), startsWith("Aggregate[[],[COUNT(1[INTEGER]) AS COUNT(*)"));
         assertThat(readLine(), startsWith("\\_EsRelation[test][i{f}#"));
         assertEquals("", readLine());
 
         assertThat(command("EXPLAIN (PLAN OPTIMIZED) SELECT COUNT(*) FROM test"), containsString("plan"));
         assertThat(readLine(), startsWith("----------"));
-        assertThat(readLine(), startsWith("Aggregate[[],[COUNT(*)"));
+        assertThat(readLine(), startsWith("Aggregate[[],[COUNT(1[INTEGER]) AS COUNT(*)"));
         assertThat(readLine(), startsWith("\\_EsRelation[test][i{f}#"));
         assertEquals("", readLine());
 

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/plan/logical/LocalRelation.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/plan/logical/LocalRelation.java
@@ -10,7 +10,6 @@ import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.xpack.ql.expression.Attribute;
 import org.elasticsearch.xpack.ql.plan.logical.LeafPlan;
 import org.elasticsearch.xpack.ql.tree.NodeInfo;
-import org.elasticsearch.xpack.ql.tree.NodeUtils;
 import org.elasticsearch.xpack.ql.tree.Source;
 import org.elasticsearch.xpack.sql.session.Cursor.Page;
 import org.elasticsearch.xpack.sql.session.Executable;
@@ -71,8 +70,4 @@ public class LocalRelation extends LeafPlan implements Executable {
         return Objects.equals(executable, other.executable);
     }
 
-    @Override
-    public String nodeString() {
-        return nodeName() + NodeUtils.limitedToString(output());
-    }
 }

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/session/EmptyExecutable.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/session/EmptyExecutable.java
@@ -8,6 +8,7 @@ package org.elasticsearch.xpack.sql.session;
 
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.xpack.ql.expression.Attribute;
+import org.elasticsearch.xpack.ql.tree.NodeUtils;
 import org.elasticsearch.xpack.sql.session.Cursor.Page;
 
 import java.util.List;
@@ -52,6 +53,6 @@ public class EmptyExecutable implements SqlExecutable {
 
     @Override
     public String toString() {
-        return output.toString();
+        return NodeUtils.limitedToString(output());
     }
 }

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/session/SingletonExecutable.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/session/SingletonExecutable.java
@@ -8,6 +8,7 @@ package org.elasticsearch.xpack.sql.session;
 
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.xpack.ql.expression.Attribute;
+import org.elasticsearch.xpack.ql.tree.NodeUtils;
 import org.elasticsearch.xpack.sql.session.Cursor.Page;
 import org.elasticsearch.xpack.sql.util.Check;
 
@@ -42,12 +43,6 @@ public class SingletonExecutable implements Executable {
 
     @Override
     public String toString() {
-        StringBuilder sb = new StringBuilder();
-        for (int i = 0; i < values.length; i++) {
-            sb.append(output.get(i));
-            sb.append("=");
-            sb.append(values[i]);
-        }
-        return sb.toString();
+        return NodeUtils.limitedToString(output) + "," + NodeUtils.limitedToString(List.of(values));
     }
 }

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/session/SingletonExecutable.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/session/SingletonExecutable.java
@@ -12,6 +12,7 @@ import org.elasticsearch.xpack.ql.tree.NodeUtils;
 import org.elasticsearch.xpack.sql.session.Cursor.Page;
 import org.elasticsearch.xpack.sql.util.Check;
 
+import java.util.Arrays;
 import java.util.List;
 
 import static java.util.Collections.emptyList;
@@ -43,6 +44,6 @@ public class SingletonExecutable implements Executable {
 
     @Override
     public String toString() {
-        return NodeUtils.limitedToString(output) + "," + NodeUtils.limitedToString(List.of(values));
+        return NodeUtils.limitedToString(output) + "," + NodeUtils.limitedToString(Arrays.asList(values));
     }
 }


### PR DESCRIPTION
Backports the following commits to 7.x:
 - SQL: More information when printing Alias and LocalRelation nodes (#74847)