### PR TITLE
Simplify RuntimeField toXContent implementation

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/mapper/AbstractScriptFieldType.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/AbstractScriptFieldType.java
@@ -221,7 +221,7 @@ abstract class AbstractScriptFieldType<LeafFactory> extends MappedFieldType {
 
         final RuntimeField createRuntimeField(Factory scriptFactory) {
             AbstractScriptFieldType<?> fieldType = createFieldType(name, scriptFactory, getScript(), meta());
-            return new LeafRuntimeField(name, fieldType, this);
+            return new LeafRuntimeField(name, fieldType, getParameters());
         }
 
         abstract AbstractScriptFieldType<?> createFieldType(String name, Factory factory, Script script, Map<String, String> meta);

--- a/server/src/main/java/org/elasticsearch/index/mapper/RuntimeField.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/RuntimeField.java
@@ -8,12 +8,9 @@
 
 package org.elasticsearch.index.mapper;
 
-import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.ToXContentFragment;
-import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.index.mapper.FieldMapper.Parameter;
 
-import java.io.IOException;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -28,20 +25,6 @@ import java.util.stream.Collectors;
  */
 public interface RuntimeField extends ToXContentFragment {
 
-    @Override
-    default XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
-        builder.startObject(name());
-        builder.field("type", typeName());
-        doXContentBody(builder, params);
-        builder.endObject();
-        return builder;
-    }
-
-    /**
-     * Prints out the parameters that subclasses expose
-     */
-    void doXContentBody(XContentBuilder builder, Params params) throws IOException;
-
     /**
      * Exposes the name of the runtime field
      * @return name of the field
@@ -49,18 +32,12 @@ public interface RuntimeField extends ToXContentFragment {
     String name();
 
     /**
-     * Exposes the type of the runtime field
-     * @return type of the field
-     */
-    String typeName();
-
-    /**
      * Exposes the {@link MappedFieldType}s backing this runtime field, used to execute queries, run aggs etc.
      * @return the {@link MappedFieldType}s backing this runtime field
      */
     Collection<MappedFieldType> asMappedFieldTypes();
 
-    abstract class Builder implements ToXContent {
+    abstract class Builder {
         final String name;
         final Parameter<Map<String, String>> meta = Parameter.metaParam();
 
@@ -77,15 +54,6 @@ public interface RuntimeField extends ToXContentFragment {
         }
 
         protected abstract RuntimeField createRuntimeField(MappingParserContext parserContext);
-
-        @Override
-        public final XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
-            boolean includeDefaults = params.paramAsBoolean("include_defaults", false);
-            for (Parameter<?> parameter : getParameters()) {
-                parameter.toXContent(builder, includeDefaults);
-            }
-            return builder;
-        }
 
         public final void parse(String name, MappingParserContext parserContext, Map<String, Object> fieldNode) {
             Map<String, Parameter<?>> paramsMap = new HashMap<>();

--- a/server/src/test/java/org/elasticsearch/index/mapper/TestRuntimeField.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/TestRuntimeField.java
@@ -35,22 +35,12 @@ public final class TestRuntimeField implements RuntimeField {
     }
 
     @Override
-    public String typeName() {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
     public Collection<MappedFieldType> asMappedFieldTypes() {
         return subfields;
     }
 
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public void doXContentBody(XContentBuilder builder, Params params) {
         throw new UnsupportedOperationException();
     }
 


### PR DESCRIPTION
RuntimeField has a default toXContent method that prints out the outer part of the field's definition, while LeafRuntimeField holds a ToXContent instance variable that prints out the inner part, which RuntimeField.Builder implements and leans on Parameter's serialization.

We can greatly simplify this now that LeafRuntimeField is introduced, by having one full implementation as part of LeafRuntimeField, that prints out the full content. Instead of taking a ToXContent constructor argument, LeafRuntimeField takes a list of parameters, each one implementing ToXContent. This way RuntimeField.Builder does not have to implement ToXContent.
