### PR TITLE
[master] [DOCS] EQL: Document cross-cluster search support (#74995)

### DIFF
--- a/docs/reference/eql/eql-search-api.asciidoc
+++ b/docs/reference/eql/eql-search-api.asciidoc
@@ -48,6 +48,9 @@ or alias.
 
 * See <<eql-required-fields>>.
 
+* experimental:[] For cross-cluster search, the local and remote clusters must
+use the same {es} version. For security, see <<cross-cluster-configuring>>.
+
 [[eql-search-api-limitations]]
 ===== Limitations
 
@@ -60,6 +63,9 @@ See <<eql-syntax-limitations,EQL limitations>>.
 (Required, string) Comma-separated list of data streams, indices, or aliases
 used to limit the request. Supports wildcards (`*`). To search all data streams
 and indices, use `*` or `_all`.
++
+experimental:[] To search a remote cluster, use the `<cluster>:<target>` syntax.
+See <<run-eql-search-across-clusters>>.
 
 [[eql-search-api-query-params]]
 ==== {api-query-parms-title}

--- a/docs/reference/eql/eql.asciidoc
+++ b/docs/reference/eql/eql.asciidoc
@@ -793,6 +793,60 @@ You can also manually delete saved synchronous searches using the
 <<delete-async-eql-search-api,delete async EQL search API>>.
 
 [discrete]
+[[run-eql-search-across-clusters]]
+=== Run an EQL search across clusters
+
+experimental::[]
+
+The EQL search API supports <<modules-cross-cluster-search,cross-cluster
+search>>. However, the local and <<modules-remote-clusters,remote clusters>>
+must use the same {es} version.
+
+The following <<cluster-update-settings,update cluster settings>> request
+adds two remote clusters: `cluster_one` and `cluster_two`.
+
+[source,console]
+----
+PUT /_cluster/settings
+{
+  "persistent": {
+    "cluster": {
+      "remote": {
+        "cluster_one": {
+          "seeds": [
+            "127.0.0.1:9300"
+          ]
+        },
+        "cluster_two": {
+          "seeds": [
+            "127.0.0.1:9301"
+          ]
+        }
+      }
+    }
+  }
+}
+----
+// TEST[setup:host]
+// TEST[s/127.0.0.1:930\d+/\${transport_host}/]
+
+To target a data stream or index on a remote cluster, use the
+`<cluster>:<target>` syntax.
+
+[source,console]
+----
+GET /cluster_one:my-data-stream,cluster_two:my-data-stream/_eql/search
+{
+  "query": """
+    process where process.name == "regsvr32.exe"
+  """
+}
+----
+// TEST[continued]
+// TEST[setup:sec_logs]
+// TEST[teardown:data_stream_cleanup]
+
+[discrete]
 [[eql-circuit-breaker]]
 === EQL circuit breaker settings
 

--- a/docs/reference/eql/syntax.asciidoc
+++ b/docs/reference/eql/syntax.asciidoc
@@ -836,13 +836,6 @@ sub-fields of a `nested` field. However, data streams and indices containing
 `nested` field mappings are otherwise supported.
 
 [discrete]
-[[eql-ccs-support]]
-==== {ccs-cap} is not supported
-
-EQL search APIs do not support <<modules-cross-cluster-search,{ccs}
-({ccs-init})>>.
-
-[discrete]
 [[eql-unsupported-syntax]]
 ==== Differences from Endgame EQL syntax
 

--- a/docs/reference/search/search-your-data/search-across-clusters.asciidoc
+++ b/docs/reference/search/search-your-data/search-across-clusters.asciidoc
@@ -19,6 +19,7 @@ The following APIs support {ccs}:
 * <<search-template,Search template>>
 * <<multi-search-template,Multi search template>>
 * <<search-field-caps,Field capabilities>>
+* experimental:[] <<eql-search-api,EQL search>>
 
 [discrete]
 [[ccs-example]]
@@ -409,9 +410,14 @@ image:images/ccs/ccs-min-roundtrip-client-response.svg[]
 [[ccs-supported-configurations]]
 === Supported configurations
 
-Generally, <<gateway-nodes-selection, cross cluster search>> can search remote
+Generally, <<gateway-nodes-selection,cross-cluster search>> can search remote
 clusters that are one major version ahead or behind the coordinating node's
-version. Cross cluster search can also search remote clusters that are being
+version.
+
+IMPORTANT: For the <<eql-search-api,EQL search API>>, the local and remote
+clusters must use the same {es} version.
+
+Cross-cluster search can also search remote clusters that are being
 <<rolling-upgrades, upgraded>> so long as both the "upgrade from" and
 "upgrade to" version are compatible with the gateway node.
 


### PR DESCRIPTION
Backports the following commits to master:
 - [DOCS] EQL: Document cross-cluster search support (#74995)