### PR TITLE
[7.14] Deprecate freeze and unfreeze indices endpoints in REST API specification (#75042)

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.freeze.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.freeze.json
@@ -21,6 +21,10 @@
               "type":"string",
               "description":"The name of the index to freeze"
             }
+          },
+          "deprecated":{
+            "version":"7.14.0",
+            "description":"Frozen indices are deprecated because they provide no benefit given improvements in heap memory utilization. They will be removed in a future release."
           }
         }
       ]

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.unfreeze.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.unfreeze.json
@@ -21,6 +21,10 @@
               "type":"string",
               "description":"The name of the index to unfreeze"
             }
+          },
+          "deprecated":{
+            "version":"7.14.0",
+            "description":"Frozen indices are deprecated because they provide no benefit given improvements in heap memory utilization. They will be removed in a future release."
           }
         }
       ]


### PR DESCRIPTION
Backports the following commits to 7.14:
 - Deprecate freeze and unfreeze indices endpoints in REST API specification (#75042)