### PR TITLE
[7.x] Update test assertion library for better errors (#74863)

### DIFF
--- a/test/framework/build.gradle
+++ b/test/framework/build.gradle
@@ -26,7 +26,7 @@ dependencies {
   api "commons-codec:commons-codec:${versions.commonscodec}"
   api "org.elasticsearch:securemock:${versions.securemock}"
   api "org.elasticsearch:mocksocket:${versions.mocksocket}"
-  api "io.github.nik9000:mapmatcher:0.0.2"
+  api "io.github.nik9000:mapmatcher:0.0.3"
 
   // json schema validation dependencies
   api "com.fasterxml.jackson.core:jackson-core:${versions.jackson}"


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Update test assertion library for better errors (#74863)