### PR TITLE
Release notes for v6.8.17

### DIFF
--- a/docs/reference/release-notes/6.8.asciidoc
+++ b/docs/reference/release-notes/6.8.asciidoc
@@ -5,6 +5,13 @@ Also see <<breaking-changes-6.8,Breaking changes in 6.8>>.
 
 coming::[6.8.17]
 
+[[bug-6.8.17]]
+[float]
+=== Bug fixes
+
+Features/Ingest::
+* Improve circular reference detection in grok processor {es-pull}74581[#74581]
+
 [[release-notes-6.8.16]]
 == {es} version 6.8.16
 

--- a/docs/reference/release-notes/6.8.asciidoc
+++ b/docs/reference/release-notes/6.8.asciidoc
@@ -3,8 +3,6 @@
 
 Also see <<breaking-changes-6.8,Breaking changes in 6.8>>.
 
-coming::[6.8.17]
-
 [[bug-6.8.17]]
 [float]
 === Bug fixes


### PR DESCRIPTION
Preview: https://elasticsearch_75071.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/6.8/release-notes-6.8.17.html