### PR TITLE
Disable testing conventions task in ilm-qa in FIPS

### DIFF
--- a/x-pack/plugin/ilm/qa/multi-cluster/build.gradle
+++ b/x-pack/plugin/ilm/qa/multi-cluster/build.gradle
@@ -60,4 +60,6 @@ tasks.named("check").configure { dependsOn 'follow-cluster' }
 tasks.withType(Test).configureEach {
   enabled = BuildParams.inFipsJvm == false
 }
-
+tasks.named("testingConventions").configure {
+  enabled = BuildParams.inFipsJvm == false 
+}


### PR DESCRIPTION
We disable all these tests in FIPS mode in this QA project so
Testing conventions task fails with
Testing conventions [Test classes are not included in any enabled task ():
org.elasticsearch.xpack.ilm.CCRIndexLifecycleIT] are not honored

This change disables Testing Conventions check in FIPS mode for
the specific QA project