### PR TITLE
[7.14] Determine upgrades correctly for deb packages (#75010)

### DIFF
--- a/distribution/packages/src/common/scripts/postinst
+++ b/distribution/packages/src/common/scripts/postinst
@@ -23,7 +23,7 @@ case "$1" in
     configure)
 
         # If $1=configure and $2 is set, this is an upgrade
-        if [ -n $2 ]; then
+        if [ -n "$2" ]; then
             IS_UPGRADE=true
         fi
         PACKAGE=deb


### PR DESCRIPTION
Backports the following commits to 7.14:
 - Determine upgrades correctly for deb packages (#75010)