### PR TITLE
Fix SQL Blocking IntegTests

### DIFF
--- a/x-pack/plugin/sql/src/internalClusterTest/java/org/elasticsearch/xpack/sql/action/AbstractSqlBlockingIntegTestCase.java
+++ b/x-pack/plugin/sql/src/internalClusterTest/java/org/elasticsearch/xpack/sql/action/AbstractSqlBlockingIntegTestCase.java
@@ -227,18 +227,8 @@ public abstract class AbstractSqlBlockingIntegTestCase extends ESIntegTestCase {
                             }
                             logger.trace("unblocking field caps on " + nodeId);
                         };
-                        final Thread originalThread = Thread.currentThread();
                         chain.proceed(task, action, request,
-                            ActionListener.wrap(
-                                resp -> {
-                                    if (originalThread == Thread.currentThread()) {
-                                        // async if we never exited the original thread
-                                        executorService.execute(() -> actionWrapper.accept(resp));
-                                    } else {
-                                        actionWrapper.accept(resp);
-                                    }
-                                },
-                                listener::onFailure)
+                            ActionListener.wrap(resp -> executorService.execute(() -> actionWrapper.accept(resp)), listener::onFailure)
                         );
                     } else {
                         chain.proceed(task, action, request, listener);


### PR DESCRIPTION
We have a number of failures in these tests due to #75022
which makes the field caps transport action fork to the management pool.
-> we have to always fork in this test now to not block the management pool.

Example failure https://gradle-enterprise.elastic.co/s/knxednfbfn67m/tests/:x-pack:plugin:eql:internalClusterTest/org.elasticsearch.xpack.eql.action.RestEqlCancellationIT/testRestCancellation?top-execution=1
