### PR TITLE
[7.x] [DOCS] EQL: Fix delete async EQL search snippet (#75093)

### DIFF
--- a/docs/reference/eql/eql.asciidoc
+++ b/docs/reference/eql/eql.asciidoc
@@ -732,7 +732,7 @@ search is still ongoing, {es} cancels the search request.
 
 [source,console]
 ----
-DELETE /_eql/search/FmNJRUZ1YWZCU3dHY1BIOUhaenVSRkEaaXFlZ3h4c1RTWFNocDdnY2FSaERnUTozNDE=?keep_alive=5d
+DELETE /_eql/search/FmNJRUZ1YWZCU3dHY1BIOUhaenVSRkEaaXFlZ3h4c1RTWFNocDdnY2FSaERnUTozNDE=
 ----
 // TEST[skip: no access to search ID]
 


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [DOCS] EQL: Fix delete async EQL search snippet (#75093)