### PR TITLE
Remove usage of deprecated JavaPluginConvention

### DIFF
--- a/build-conventions/src/main/java/org/elasticsearch/gradle/internal/conventions/precommit/LicenseHeadersPrecommitPlugin.java
+++ b/build-conventions/src/main/java/org/elasticsearch/gradle/internal/conventions/precommit/LicenseHeadersPrecommitPlugin.java
@@ -11,7 +11,7 @@ package org.elasticsearch.gradle.internal.conventions.precommit;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
 import org.gradle.api.plugins.JavaBasePlugin;
-import org.gradle.api.plugins.JavaPluginConvention;
+import org.gradle.api.plugins.JavaPluginExtension;
 import org.gradle.api.provider.ProviderFactory;
 import org.gradle.api.tasks.SourceSetContainer;
 import org.gradle.api.tasks.TaskProvider;
@@ -29,7 +29,7 @@ public class LicenseHeadersPrecommitPlugin extends PrecommitPlugin {
     public TaskProvider<? extends Task> createTask(Project project) {
         return project.getTasks().register("licenseHeaders", LicenseHeadersTask.class, licenseHeadersTask -> {
             project.getPlugins().withType(JavaBasePlugin.class, javaBasePlugin -> {
-                final SourceSetContainer sourceSets = project.getConvention().getPlugin(JavaPluginConvention.class).getSourceSets();
+                final SourceSetContainer sourceSets = project.getExtensions().getByType(JavaPluginExtension.class).getSourceSets();
                 licenseHeadersTask.getSourceFolders()
                     .addAll(providerFactory.provider(() -> sourceSets.stream().map(s -> s.getAllJava()).collect(Collectors.toList())));
             });

--- a/build-conventions/src/main/java/org/elasticsearch/gradle/internal/conventions/precommit/PrecommitPlugin.java
+++ b/build-conventions/src/main/java/org/elasticsearch/gradle/internal/conventions/precommit/PrecommitPlugin.java
@@ -11,7 +11,7 @@ package org.elasticsearch.gradle.internal.conventions.precommit;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
-import org.gradle.api.plugins.JavaPluginConvention;
+import org.gradle.api.plugins.JavaPluginExtension;
 import org.gradle.api.tasks.TaskProvider;
 
 /**
@@ -29,7 +29,7 @@ public abstract class PrecommitPlugin implements Plugin<Project> {
         precommit.configure(t -> t.dependsOn(task));
         project.getPluginManager().withPlugin("java", p -> {
             // We want to get any compilation error before running the pre-commit checks.
-            project.getConvention().getPlugin(JavaPluginConvention.class).getSourceSets().all(sourceSet ->
+            project.getExtensions().getByType(JavaPluginExtension.class).getSourceSets().all(sourceSet ->
                     task.configure(t -> t.shouldRunAfter(sourceSet.getClassesTaskName()))
             );
         });

--- a/build-conventions/src/main/java/org/elasticsearch/gradle/internal/conventions/util/Util.java
+++ b/build-conventions/src/main/java/org/elasticsearch/gradle/internal/conventions/util/Util.java
@@ -12,14 +12,12 @@ import org.gradle.api.Action;
 import org.gradle.api.GradleException;
 import org.gradle.api.Project;
 import org.gradle.api.file.FileTree;
-import org.gradle.api.plugins.JavaPluginConvention;
+import org.gradle.api.plugins.JavaPluginExtension;
 import org.gradle.api.tasks.SourceSet;
 import org.gradle.api.tasks.SourceSetContainer;
 import org.gradle.api.tasks.util.PatternFilterable;
 
 import javax.annotation.Nullable;
-import java.net.URI;
-import java.net.URISyntaxException;
 import java.util.Optional;
 import java.util.function.Supplier;
 
@@ -85,7 +83,7 @@ public class Util {
      * @return An Optional that contains the Java test SourceSet if it exists.
      */
     public static Optional<SourceSet> getJavaTestSourceSet(Project project) {
-        return project.getConvention().findPlugin(JavaPluginConvention.class) == null
+        return project.getExtensions().findByName("java") == null
             ? Optional.empty()
             : Optional.ofNullable(getJavaSourceSets(project).findByName(SourceSet.TEST_SOURCE_SET_NAME));
     }
@@ -95,9 +93,13 @@ public class Util {
      * @return An Optional that contains the Java main SourceSet if it exists.
      */
     public static Optional<SourceSet> getJavaMainSourceSet(Project project) {
-        return project.getConvention().findPlugin(JavaPluginConvention.class) == null
+        return isJavaExtensionAvailable(project)
             ? Optional.empty()
             : Optional.ofNullable(getJavaSourceSets(project).findByName(SourceSet.MAIN_SOURCE_SET_NAME));
+    }
+
+    private static boolean isJavaExtensionAvailable(Project project) {
+        return project.getExtensions().getByType(JavaPluginExtension.class) == null;
     }
 
 
@@ -111,7 +113,7 @@ public class Util {
     }
 
     public static SourceSetContainer getJavaSourceSets(Project project) {
-        return project.getConvention().getPlugin(JavaPluginConvention.class).getSourceSets();
+        return project.getExtensions().getByType(JavaPluginExtension.class).getSourceSets();
     }
 
 }

--- a/build-tools/src/main/java/org/elasticsearch/gradle/util/GradleUtils.java
+++ b/build-tools/src/main/java/org/elasticsearch/gradle/util/GradleUtils.java
@@ -19,6 +19,7 @@ import org.gradle.api.artifacts.ProjectDependency;
 import org.gradle.api.plugins.JavaBasePlugin;
 import org.gradle.api.plugins.JavaPlugin;
 import org.gradle.api.plugins.JavaPluginConvention;
+import org.gradle.api.plugins.JavaPluginExtension;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.services.BuildService;
 import org.gradle.api.services.BuildServiceRegistration;
@@ -46,7 +47,7 @@ public abstract class GradleUtils {
     }
 
     public static SourceSetContainer getJavaSourceSets(Project project) {
-        return project.getConvention().getPlugin(JavaPluginConvention.class).getSourceSets();
+        return project.getExtensions().getByType(JavaPluginExtension.class).getSourceSets();
     }
 
     public static void maybeConfigure(TaskContainer tasks, String name, Action<? super Task> config) {


### PR DESCRIPTION
this has been deprecated and will be removed in Gradle 8.0. We use
JavaPluginExtension instead from now on.