### PR TITLE
[7.x] Disable testing conventions task in ilm-qa in FIPS (#75072)

### DIFF
--- a/x-pack/plugin/ilm/qa/multi-cluster/build.gradle
+++ b/x-pack/plugin/ilm/qa/multi-cluster/build.gradle
@@ -60,3 +60,6 @@ tasks.named("check").configure { dependsOn 'follow-cluster' }
 tasks.withType(Test).configureEach {
   enabled = BuildParams.inFipsJvm == false
 }
+tasks.named("testingConventions").configure {
+  enabled = BuildParams.inFipsJvm == false
+} 


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Disable testing conventions task in ilm-qa in FIPS (#75072)