### PR TITLE
Mute BWC tests for backport of persistent task local abort changes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -144,9 +144,9 @@ tasks.register("verifyVersions") {
  * after the backport of the backcompat code is complete.
  */
 
-boolean bwc_tests_enabled = true
+boolean bwc_tests_enabled = false
 // place a PR link here when committing bwc changes:
-String bwc_tests_disabled_issue = ""
+String bwc_tests_disabled_issue = "https://github.com/elastic/elasticsearch/pull/75067"
 /*
  * FIPS 140-2 behavior was fixed in 7.11.0. Before that there is no way to run elasticsearch in a
  * JVM that is properly configured to be in fips mode with BCFIPS. For now we need to disable


### PR DESCRIPTION
Temporarily muting BWC tests to allow #75002 to be merged.
Once this is merged to 7.x the BWC tests on master will be
reenabled in #75067.

Relates #74115