### PR TITLE
[ML] Fix forecasts deletion action when there are many forecast documents.

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/reindex/DeleteByQueryRequest.java
+++ b/server/src/main/java/org/elasticsearch/index/reindex/DeleteByQueryRequest.java
@@ -151,7 +151,7 @@ public class DeleteByQueryRequest extends AbstractBulkByScrollRequest<DeleteByQu
     //delete by query deletes all documents that match a query. The indices and indices options that affect how
     //indices are resolved depend entirely on the inner search request. That's why the following methods delegate to it.
     @Override
-    public IndicesRequest indices(String... indices) {
+    public DeleteByQueryRequest indices(String... indices) {
         assert getSearchRequest() != null;
         getSearchRequest().indices(indices);
         return this;

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/action/TransportDeleteForecastActionTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/action/TransportDeleteForecastActionTests.java
@@ -7,10 +7,15 @@
 package org.elasticsearch.xpack.ml.action;
 
 import org.elasticsearch.ElasticsearchStatusException;
+import org.elasticsearch.common.document.DocumentField;
+import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.core.ml.job.config.JobState;
 import org.elasticsearch.xpack.core.ml.job.results.ForecastRequestStats;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -21,8 +26,8 @@ public class TransportDeleteForecastActionTests extends ESTestCase {
 
     public void testValidateForecastStateWithAllFailedFinished() {
         for (int i = 0; i < TEST_RUNS; ++i) {
-            List<ForecastRequestStats> forecastRequestStats = Stream.generate(
-                () -> createForecastStats(randomFrom(
+            List<SearchHit> forecastRequestStatsHits = Stream.generate(
+                () -> createForecastStatsHit(randomFrom(
                     ForecastRequestStats.ForecastRequestStatus.FAILED,
                     ForecastRequestStats.ForecastRequestStatus.FINISHED
                 )))
@@ -30,8 +35,8 @@ public class TransportDeleteForecastActionTests extends ESTestCase {
                 .collect(Collectors.toList());
 
             // This should not throw.
-            TransportDeleteForecastAction.validateForecastState(
-                forecastRequestStats,
+            TransportDeleteForecastAction.extractForecastIds(
+                forecastRequestStatsHits.toArray(new SearchHit[0]),
                 randomFrom(JobState.values()),
                 randomAlphaOfLength(10));
         }
@@ -39,19 +44,22 @@ public class TransportDeleteForecastActionTests extends ESTestCase {
 
     public void testValidateForecastStateWithSomeFailedFinished() {
         for (int i = 0; i < TEST_RUNS; ++i) {
-            List<ForecastRequestStats> forecastRequestStats = Stream.generate(
-                () -> createForecastStats(randomFrom(
+            List<SearchHit> forecastRequestStatsHits = Stream.generate(
+                () -> createForecastStatsHit(randomFrom(
                     ForecastRequestStats.ForecastRequestStatus.values()
                 )))
                 .limit(randomInt(10))
                 .collect(Collectors.toList());
 
-            forecastRequestStats.add(createForecastStats(ForecastRequestStats.ForecastRequestStatus.STARTED));
+            forecastRequestStatsHits.add(createForecastStatsHit(ForecastRequestStats.ForecastRequestStatus.STARTED));
 
             {
                 JobState jobState = randomFrom(JobState.CLOSED, JobState.CLOSING, JobState.FAILED);
                 try {
-                    TransportDeleteForecastAction.validateForecastState(forecastRequestStats, jobState, randomAlphaOfLength(10));
+                    TransportDeleteForecastAction.extractForecastIds(
+                        forecastRequestStatsHits.toArray(new SearchHit[0]),
+                        jobState,
+                        randomAlphaOfLength(10));
                 } catch (Exception ex) {
                     fail("Should not have thrown: " + ex.getMessage());
                 }
@@ -60,17 +68,24 @@ public class TransportDeleteForecastActionTests extends ESTestCase {
                 JobState jobState = JobState.OPENED;
                 expectThrows(
                     ElasticsearchStatusException.class,
-                    () -> TransportDeleteForecastAction.validateForecastState(forecastRequestStats, jobState, randomAlphaOfLength(10))
+                    () -> TransportDeleteForecastAction.extractForecastIds(
+                        forecastRequestStatsHits.toArray(new SearchHit[0]),
+                        jobState,
+                        randomAlphaOfLength(10))
                 );
             }
         }
     }
 
 
-    private static ForecastRequestStats createForecastStats(ForecastRequestStats.ForecastRequestStatus status) {
-        ForecastRequestStats forecastRequestStats = new ForecastRequestStats(randomAlphaOfLength(10), randomAlphaOfLength(10));
-        forecastRequestStats.setStatus(status);
-        return forecastRequestStats;
+    private static SearchHit createForecastStatsHit(ForecastRequestStats.ForecastRequestStatus status) {
+        Map<String, DocumentField> documentFields = new HashMap<>(2);
+        documentFields.put(
+            ForecastRequestStats.FORECAST_ID.getPreferredName(),
+            new DocumentField(ForecastRequestStats.FORECAST_ID.getPreferredName(), Collections.singletonList("")));
+        documentFields.put(
+            ForecastRequestStats.STATUS.getPreferredName(),
+            new DocumentField(ForecastRequestStats.STATUS.getPreferredName(), Collections.singletonList(status.toString())));
+        return new SearchHit(0, "", documentFields, Collections.emptyMap());
     }
-
 }

--- a/x-pack/qa/reindex-tests-with-security/src/test/java/org/elasticsearch/xpack/security/ReindexWithSecurityIT.java
+++ b/x-pack/qa/reindex-tests-with-security/src/test/java/org/elasticsearch/xpack/security/ReindexWithSecurityIT.java
@@ -79,18 +79,18 @@ public class ReindexWithSecurityIT extends ESRestTestCase {
         createIndicesWithRandomAliases("test1", "test2", "test3");
 
         RestHighLevelClient restClient = new TestRestHighLevelClient();
-        BulkByScrollResponse response = restClient.deleteByQuery((DeleteByQueryRequest) new DeleteByQueryRequest()
+        BulkByScrollResponse response = restClient.deleteByQuery(new DeleteByQueryRequest()
             .setQuery(QueryBuilders.matchAllQuery())
             .indices("test1", "test2"), RequestOptions.DEFAULT);
         assertNotNull(response);
 
-        response = restClient.deleteByQuery((DeleteByQueryRequest) new DeleteByQueryRequest()
+        response = restClient.deleteByQuery(new DeleteByQueryRequest()
             .setQuery(QueryBuilders.matchAllQuery())
             .indices("test*"), RequestOptions.DEFAULT);
         assertNotNull(response);
 
         ElasticsearchStatusException e = expectThrows(ElasticsearchStatusException.class,
-                () -> restClient.deleteByQuery((DeleteByQueryRequest) new DeleteByQueryRequest()
+                () -> restClient.deleteByQuery(new DeleteByQueryRequest()
                     .setQuery(QueryBuilders.matchAllQuery())
                     .indices("test1", "index1"), RequestOptions.DEFAULT));
         assertThat(e.getMessage(), containsString("no such index [index1]"));


### PR DESCRIPTION
The request:
```
DELETE _ml/anomaly_detectors/my_job/_forecast/_all
```
might not delete all the forecasts.
It can happen in two situations:
1. There are more than 10 forecasts.
We rely on the default value (`10`) of search request source size. The search will just not return those outstanding forecasts.
2. There are more than 10000 forecast documents total.
When there is a partition field with a high cardinality, there are many documents created for each forecast in the results index.
We restrict DBQ `max_docs` to `10000` so DBQ will not delete those outstanding documents.

This PR fixes both problems.

Fixes https://github.com/elastic/elasticsearch/issues/74989