### PR TITLE
[ML] Adding license key check arguments

### DIFF
--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/process/AnalyticsBuilder.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/process/AnalyticsBuilder.java
@@ -31,6 +31,7 @@ public class AnalyticsBuilder {
     private static final String LENGTH_ENCODED_INPUT_ARG = "--lengthEncodedInput";
     private static final String CONFIG_ARG = "--config=";
     private static final String MEMORY_USAGE_ESTIMATION_ONLY_ARG = "--memoryUsageEstimationOnly";
+    private static final String LICENSE_KEY_VALIDATED_ARG = "--validElasticLicenseKeyConfirmed=";
 
     private final Supplier<Path> tempDirPathSupplier;
     private final NativeController nativeController;
@@ -67,6 +68,8 @@ public class AnalyticsBuilder {
         if (performMemoryUsageEstimationOnly) {
             command.add(MEMORY_USAGE_ESTIMATION_ONLY_ARG);
         }
+        // License was validated when the data frame analytics job was started
+        command.add(LICENSE_KEY_VALIDATED_ARG + true);
         return command;
     }
 

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/process/autodetect/AutodetectBuilder.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/process/autodetect/AutodetectBuilder.java
@@ -56,6 +56,7 @@ public class AutodetectBuilder {
     public static final String LENGTH_ENCODED_INPUT_ARG = "--lengthEncodedInput";
     public static final String MODEL_CONFIG_ARG = "--modelconfig=";
     public static final String QUANTILES_STATE_PATH_ARG = "--quantilesState=";
+    public static final String LICENSE_KEY_VALIDATED_ARG = "--validElasticLicenseKeyConfirmed=";
 
     private static final String JSON_EXTENSION = ".json";
     private static final String CONFIG_ARG = "--config=";
@@ -166,6 +167,9 @@ public class AutodetectBuilder {
             String modelConfigFile = XPackPlugin.resolveConfigFile(env, ProcessBuilderUtils.ML_MODEL_CONF).toString();
             command.add(MODEL_CONFIG_ARG + modelConfigFile);
         }
+
+        // License has been created by the open job action
+        command.add(LICENSE_KEY_VALIDATED_ARG + true);
 
         return command;
     }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/process/normalizer/NormalizerBuilder.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/process/normalizer/NormalizerBuilder.java
@@ -62,6 +62,9 @@ public class NormalizerBuilder {
             command.add(AutodetectBuilder.MODEL_CONFIG_ARG + modelConfigFile);
         }
 
+        // License was validated when the corresponding job was opened
+        command.add(AutodetectBuilder.LICENSE_KEY_VALIDATED_ARG + true);
+
         return command;
     }
 }

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/dataframe/process/AnalyticsBuilderTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/dataframe/process/AnalyticsBuilderTests.java
@@ -54,6 +54,7 @@ public class AnalyticsBuilderTests extends ESTestCase {
 
         List<String> command = commandCaptor.getValue();
         assertThat(command, not(hasItem("--memoryUsageEstimationOnly")));
+        assertThat(command, hasItem("--validElasticLicenseKeyConfirmed=true"));
     }
 
     public void testBuild_MemoryUsageEstimation() throws Exception {
@@ -67,5 +68,6 @@ public class AnalyticsBuilderTests extends ESTestCase {
 
         List<String> command = commandCaptor.getValue();
         assertThat(command, hasItem("--memoryUsageEstimationOnly"));
+        assertThat(command, hasItem("--validElasticLicenseKeyConfirmed=true"));
     }
 }

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/process/autodetect/AutodetectBuilderTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/process/autodetect/AutodetectBuilderTests.java
@@ -89,8 +89,9 @@ public class AutodetectBuilderTests extends ESTestCase {
 
         assertTrue(command.contains(AutodetectBuilder.LENGTH_ENCODED_INPUT_ARG));
         assertTrue(command.contains(AutodetectBuilder.maxAnomalyRecordsArg(settings)));
+        assertTrue(command.contains(AutodetectBuilder.LICENSE_KEY_VALIDATED_ARG + true));
 
-        assertEquals(3, command.size());
+        assertEquals(4, command.size());
     }
 
     private AutodetectBuilder autodetectBuilder(Job job) {

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/process/normalizer/NormalizerBuilderTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/process/normalizer/NormalizerBuilderTests.java
@@ -23,9 +23,10 @@ public class NormalizerBuilderTests extends ESTestCase {
         String jobId = "unit-test-job";
 
         List<String> command = new NormalizerBuilder(env, jobId, null, 300).build();
-        assertEquals(3, command.size());
+        assertEquals(4, command.size());
         assertTrue(command.contains("./normalize"));
         assertTrue(command.contains(NormalizerBuilder.BUCKET_SPAN_ARG + "300"));
         assertTrue(command.contains(AutodetectBuilder.LENGTH_ENCODED_INPUT_ARG));
+        assertTrue(command.contains(AutodetectBuilder.LICENSE_KEY_VALIDATED_ARG + true));
     }
 }


### PR DESCRIPTION
From version 7.15 the ML native processes will have
a command line option to confirm that a valid Elastic
license key is installed when they are started.

This change adds the necessary argument for the autodetect,
normalize and data_frame_analyzer processes.