### PR TITLE
[7.x] Migrate to data tiers fix for phase with deactivated migrate action (#75102)

### DIFF
--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/cluster/metadata/MetadataMigrateToDataTiersRoutingService.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/cluster/metadata/MetadataMigrateToDataTiersRoutingService.java
@@ -334,6 +334,17 @@ public final class MetadataMigrateToDataTiersRoutingService {
                         phase.getName());
                 }
 
+                // we removed the allocate action allocation rules (or the action completely) so let's check if there is an
+                // explicit migrate action that's disabled, and remove it so ILM can inject an enabled one
+                if (actionMap.containsKey(MigrateAction.NAME)) {
+                    MigrateAction migrateAction = (MigrateAction) actionMap.get(MigrateAction.NAME);
+                    if (migrateAction.isEnabled() == false) {
+                        actionMap.remove(MigrateAction.NAME);
+                        logger.debug("ILM policy [{}], phase [{}]: removed the deactivated migrate action", lifecyclePolicy.getName(),
+                            phase.getName());
+                    }
+                }
+
                 Phase updatedPhase = new Phase(phase.getName(), phase.getMinimumAge(), actionMap);
                 Map<String, Phase> updatedPhases =
                     new HashMap<>(newLifecyclePolicy == null ? lifecyclePolicy.getPhases() : newLifecyclePolicy.getPhases());

--- a/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/cluster/metadata/MetadataMigrateToDataTiersRoutingServiceTests.java
+++ b/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/cluster/metadata/MetadataMigrateToDataTiersRoutingServiceTests.java
@@ -32,6 +32,7 @@ import org.elasticsearch.xpack.core.ilm.LifecycleExecutionState;
 import org.elasticsearch.xpack.core.ilm.LifecyclePolicy;
 import org.elasticsearch.xpack.core.ilm.LifecyclePolicyMetadata;
 import org.elasticsearch.xpack.core.ilm.LifecycleSettings;
+import org.elasticsearch.xpack.core.ilm.MigrateAction;
 import org.elasticsearch.xpack.core.ilm.OperationMode;
 import org.elasticsearch.xpack.core.ilm.Phase;
 import org.elasticsearch.xpack.core.ilm.SetPriorityAction;
@@ -121,6 +122,40 @@ public class MetadataMigrateToDataTiersRoutingServiceTests extends ESTestCase {
         AllocateAction migratedColdAllocateAction = (AllocateAction) coldActions.get(coldAllocateAction.getWriteableName());
         assertThat(migratedColdAllocateAction.getNumberOfReplicas(), is(0));
         assertThat(migratedColdAllocateAction.getRequire().size(), is(0));
+    }
+
+    public void testMigrateIlmPolicyFOrPhaseWithDeactivatedMigrateAction() {
+        ShrinkAction shrinkAction = new ShrinkAction(2, null);
+        AllocateAction warmAllocateAction = new AllocateAction(null, Map.of("data", "warm"), null, Map.of("rack", "rack1"));
+        MigrateAction deactivatedMigrateAction = new MigrateAction(false);
+
+        LifecyclePolicy policy = new LifecyclePolicy(lifecycleName,
+            Map.of("warm",
+                new Phase("warm", TimeValue.ZERO, Map.of(shrinkAction.getWriteableName(), shrinkAction,
+                    warmAllocateAction.getWriteableName(), warmAllocateAction, deactivatedMigrateAction.getWriteableName(),
+                    deactivatedMigrateAction))
+            ));
+        LifecyclePolicyMetadata policyMetadata = new LifecyclePolicyMetadata(policy, Collections.emptyMap(),
+            randomNonNegativeLong(), randomNonNegativeLong());
+
+        ClusterState state = ClusterState.builder(ClusterName.DEFAULT).metadata(Metadata.builder()
+            .putCustom(IndexLifecycleMetadata.TYPE, new IndexLifecycleMetadata(
+                Collections.singletonMap(policyMetadata.getName(), policyMetadata), OperationMode.STOPPED))
+            .put(IndexMetadata.builder(indexName).settings(getBaseIndexSettings())).build())
+            .build();
+
+        Metadata.Builder newMetadata = Metadata.builder(state.metadata());
+        List<String> migratedPolicies = migrateIlmPolicies(newMetadata, state, "data", REGISTRY, client, null);
+        assertThat(migratedPolicies.size(), is(1));
+        assertThat(migratedPolicies.get(0), is(lifecycleName));
+
+        ClusterState newState = ClusterState.builder(state).metadata(newMetadata).build();
+        IndexLifecycleMetadata updatedLifecycleMetadata = newState.metadata().custom(IndexLifecycleMetadata.TYPE);
+        LifecyclePolicy lifecyclePolicy = updatedLifecycleMetadata.getPolicies().get(lifecycleName);
+        Map<String, LifecycleAction> warmActions = lifecyclePolicy.getPhases().get("warm").getActions();
+        assertThat("allocate action in the warm phase didn't specify any number of replicas so it must be removed, together with the " +
+                "deactivated migrate action", warmActions.size(), is(1));
+        assertThat(warmActions.get(shrinkAction.getWriteableName()), is(shrinkAction));
     }
 
     @SuppressWarnings("unchecked")

--- a/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/cluster/metadata/MetadataMigrateToDataTiersRoutingServiceTests.java
+++ b/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/cluster/metadata/MetadataMigrateToDataTiersRoutingServiceTests.java
@@ -126,12 +126,13 @@ public class MetadataMigrateToDataTiersRoutingServiceTests extends ESTestCase {
 
     public void testMigrateIlmPolicyFOrPhaseWithDeactivatedMigrateAction() {
         ShrinkAction shrinkAction = new ShrinkAction(2, null);
-        AllocateAction warmAllocateAction = new AllocateAction(null, Map.of("data", "warm"), null, Map.of("rack", "rack1"));
+        AllocateAction warmAllocateAction = new AllocateAction(null, org.elasticsearch.core.Map.of("data", "warm"), null,
+            org.elasticsearch.core.Map.of("rack", "rack1"));
         MigrateAction deactivatedMigrateAction = new MigrateAction(false);
 
         LifecyclePolicy policy = new LifecyclePolicy(lifecycleName,
-            Map.of("warm",
-                new Phase("warm", TimeValue.ZERO, Map.of(shrinkAction.getWriteableName(), shrinkAction,
+            org.elasticsearch.core.Map.of("warm",
+                new Phase("warm", TimeValue.ZERO, org.elasticsearch.core.Map.of(shrinkAction.getWriteableName(), shrinkAction,
                     warmAllocateAction.getWriteableName(), warmAllocateAction, deactivatedMigrateAction.getWriteableName(),
                     deactivatedMigrateAction))
             ));


### PR DESCRIPTION
This fixes the migration to also take into account explicitly deactivated
migrate actions. A phase with both an allocate action (which we update
to not contain routing rules anymore) and a deactivated migrate action
will not configure any allocation routing rules.


Backport of #75102