### PR TITLE
Override the `status()` method in `ReduceSearchPhaseException`

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/search/ReduceSearchPhaseException.java
+++ b/server/src/main/java/org/elasticsearch/action/search/ReduceSearchPhaseException.java
@@ -27,4 +27,15 @@ public class ReduceSearchPhaseException extends SearchPhaseExecutionException {
     public ReduceSearchPhaseException(StreamInput in) throws IOException {
         super(in);
     }
+
+    @Override
+    public RestStatus status() {
+        ShardSearchFailure[] shardFailures = super.shardFailures();
+        if (shardFailures.length == 0) {
+            // if no successful shards, the failure can be during reduce phase
+            // on coordinator node. so return an INTERNAL_SERVER_ERROR blindly
+            return RestStatus.INTERNAL_SERVER_ERROR;
+        }
+        return super.status();
+    }
 }

--- a/server/src/test/java/org/elasticsearch/action/search/ReduceSearchPhaseExceptionTest.java
+++ b/server/src/test/java/org/elasticsearch/action/search/ReduceSearchPhaseExceptionTest.java
@@ -1,0 +1,167 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.action.search;
+
+import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.action.OriginalIndices;
+import org.elasticsearch.action.TimestampParsingException;
+import org.elasticsearch.common.ParsingException;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.util.concurrent.EsRejectedExecutionException;
+import org.elasticsearch.common.xcontent.*;
+import org.elasticsearch.index.shard.IndexShardClosedException;
+import org.elasticsearch.index.shard.ShardId;
+import org.elasticsearch.indices.InvalidIndexTemplateException;
+import org.elasticsearch.rest.RestStatus;
+import org.elasticsearch.search.SearchShardTarget;
+import org.elasticsearch.test.ESTestCase;
+
+import java.io.IOException;
+
+import static org.hamcrest.CoreMatchers.hasItem;
+import static org.hamcrest.Matchers.hasSize;
+
+public class ReduceSearchPhaseExceptionTest extends ESTestCase {
+
+    public void testToXContent() throws IOException {
+        ReduceSearchPhaseException exception = new ReduceSearchPhaseException("test", "all shards failed", new RuntimeException(),
+            new ShardSearchFailure[]{
+                new ShardSearchFailure(new ParsingException(1, 2, "foobar", null),
+                    new SearchShardTarget("node_1", new ShardId("foo", "_na_", 0), null, OriginalIndices.NONE)),
+                new ShardSearchFailure(new IndexShardClosedException(new ShardId("foo", "_na_", 1)),
+                    new SearchShardTarget("node_2", new ShardId("foo", "_na_", 1), null, OriginalIndices.NONE)),
+                new ShardSearchFailure(new ParsingException(5, 7, "foobar", null),
+                    new SearchShardTarget("node_3", new ShardId("foo", "_na_", 2), null, OriginalIndices.NONE)),
+            });
+
+        // Failures are grouped (by default)
+        final String expectedJson = XContentHelper.stripWhitespace(
+            "{"
+                + "  \"type\": \"reduce_search_phase_exception\","
+                + "  \"reason\": \"[reduce] all shards failed\","
+                + "  \"phase\": \"test\","
+                + "  \"grouped\": true,"
+                + "  \"failed_shards\": ["
+                + "    {"
+                + "      \"shard\": 0,"
+                + "      \"index\": \"foo\","
+                + "      \"node\": \"node_1\","
+                + "      \"reason\": {"
+                + "        \"type\": \"parsing_exception\","
+                + "        \"reason\": \"foobar\","
+                + "        \"line\": 1,"
+                + "        \"col\": 2"
+                + "      }"
+                + "    },"
+                + "    {"
+                + "      \"shard\": 1,"
+                + "      \"index\": \"foo\","
+                + "      \"node\": \"node_2\","
+                + "      \"reason\": {"
+                + "        \"type\": \"index_shard_closed_exception\","
+                + "        \"reason\": \"CurrentState[CLOSED] Closed\","
+                + "        \"index_uuid\": \"_na_\","
+                + "        \"shard\": \"1\","
+                + "        \"index\": \"foo\""
+                + "      }"
+                + "    }"
+                + "  ],"
+                + "  \"caused_by\": {"
+                + "                    \"type\": \"runtime_exception\","
+                + "                    \"reason\": null"
+                + "                }"
+                + "}"
+        );
+        System.out.println(Strings.toString(exception));
+        assertEquals(expectedJson, Strings.toString(exception));
+    }
+
+    public void testToAndFromXContent() throws IOException {
+        final XContent xContent = randomFrom(XContentType.values()).xContent();
+
+        ShardSearchFailure[] shardSearchFailures = new ShardSearchFailure[randomIntBetween(1, 5)];
+        for (int i = 0; i < shardSearchFailures.length; i++) {
+            Exception cause = randomFrom(
+                new ParsingException(1, 2, "foobar", null),
+                new InvalidIndexTemplateException("foo", "bar"),
+                new TimestampParsingException("foo", null),
+                new NullPointerException()
+            );
+            shardSearchFailures[i] = new ShardSearchFailure(cause, new SearchShardTarget("node_" + i,
+                new ShardId("test", "_na_", i), null, OriginalIndices.NONE));
+        }
+
+        final String phase = randomFrom("reduce");
+        ReduceSearchPhaseException actual = new ReduceSearchPhaseException(phase, "unexpected failures", new RuntimeException(), shardSearchFailures);
+
+        BytesReference exceptionBytes = toShuffledXContent(actual, xContent.type(), ToXContent.EMPTY_PARAMS, randomBoolean());
+
+        ElasticsearchException parsedException;
+        try (XContentParser parser = createParser(xContent, exceptionBytes)) {
+            assertEquals(XContentParser.Token.START_OBJECT, parser.nextToken());
+            parsedException = ElasticsearchException.fromXContent(parser);
+            assertEquals(XContentParser.Token.END_OBJECT, parser.currentToken());
+            assertNull(parser.nextToken());
+        }
+
+        assertNotNull(parsedException);
+        assertThat(parsedException.getHeaderKeys(), hasSize(0));
+        assertThat(parsedException.getMetadataKeys(), hasSize(1));
+        assertThat(parsedException.getMetadata("es.phase"), hasItem(phase));
+        // SearchPhaseExecutionException has no cause field
+        assertNull(parsedException.getCause().getCause());
+    }
+
+    public void testPhaseFailureWithoutSearchShardFailure() {
+        final ShardSearchFailure[] searchShardFailures = ShardSearchFailure.EMPTY_ARRAY;
+        final String phase = randomFrom("fetch", "search", "other");
+        ReduceSearchPhaseException actual = new ReduceSearchPhaseException(phase, "unexpected failures",
+            new EsRejectedExecutionException("ES rejected execution of fetch phase"), searchShardFailures);
+
+        assertEquals(actual.status(), RestStatus.TOO_MANY_REQUESTS);
+    }
+
+    public void testPhaseFailureWithoutSearchShardFailureAndCause() {
+        final ShardSearchFailure[] searchShardFailures = ShardSearchFailure.EMPTY_ARRAY;
+        final String phase = randomFrom("reduce");
+        ReduceSearchPhaseException actual = new ReduceSearchPhaseException(phase, "unexpected failures", null, searchShardFailures);
+
+        assertEquals(actual.status(), RestStatus.INTERNAL_SERVER_ERROR);
+    }
+
+    public void testPhaseFailureWithSearchShardFailure() {
+        final ShardSearchFailure[] shardSearchFailures = new ShardSearchFailure[randomIntBetween(1, 5)];
+        for (int i = 0; i < shardSearchFailures.length; i++) {
+            Exception cause = randomFrom(
+                new ParsingException(1, 2, "foobar", null),
+                new InvalidIndexTemplateException("foo", "bar")
+            );
+            shardSearchFailures[i] = new ShardSearchFailure(cause, new SearchShardTarget("node_" + i,
+                new ShardId("test", "_na_", i), null, OriginalIndices.NONE));
+        }
+
+        final String phase = randomFrom("reduce");
+        ReduceSearchPhaseException actual = new ReduceSearchPhaseException(phase, "unexpected failures",
+            new EsRejectedExecutionException("ES rejected execution of reduce phase"), shardSearchFailures);
+
+        assertEquals(actual.status(), RestStatus.BAD_REQUEST);
+    }
+}


### PR DESCRIPTION
- Override the `status()` method in `ReduceSearchPhaseException`
- Implementation of Unit tests, similar from `SearchPhaseExecutionExceptionTests`
- Refers to issue #20004
