### PR TITLE
Modifications for the new pipeline aggregation

### DIFF
--- a/server/src/main/java/org/elasticsearch/search/SearchModule.java
+++ b/server/src/main/java/org/elasticsearch/search/SearchModule.java
@@ -9,20 +9,17 @@
 package org.elasticsearch.search;
 
 import org.apache.lucene.search.BooleanQuery;
-import org.elasticsearch.common.CheckedBiConsumer;
 import org.elasticsearch.common.NamedRegistry;
 import org.elasticsearch.common.xcontent.ParseField;
 import org.elasticsearch.common.geo.GeoShapeType;
 import org.elasticsearch.common.geo.ShapesAvailability;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry.Entry;
-import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 import org.elasticsearch.common.xcontent.XContentParser;
-import org.elasticsearch.core.Nullable;
 import org.elasticsearch.index.query.BoolQueryBuilder;
 import org.elasticsearch.index.query.BoostingQueryBuilder;
 import org.elasticsearch.index.query.CombinedFieldsQueryBuilder;
@@ -226,7 +223,6 @@ import org.elasticsearch.search.fetch.subphase.highlight.HighlightPhase;
 import org.elasticsearch.search.fetch.subphase.highlight.Highlighter;
 import org.elasticsearch.search.fetch.subphase.highlight.PlainHighlighter;
 import org.elasticsearch.search.fetch.subphase.highlight.UnifiedHighlighter;
-import org.elasticsearch.search.internal.ShardSearchRequest;
 import org.elasticsearch.search.rescore.QueryRescorerBuilder;
 import org.elasticsearch.search.rescore.RescorerBuilder;
 import org.elasticsearch.search.sort.FieldSortBuilder;
@@ -248,7 +244,6 @@ import org.elasticsearch.search.suggest.phrase.StupidBackoff;
 import org.elasticsearch.search.suggest.term.TermSuggestion;
 import org.elasticsearch.search.suggest.term.TermSuggestionBuilder;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -276,7 +271,6 @@ public class SearchModule {
     private final List<NamedWriteableRegistry.Entry> namedWriteables = new ArrayList<>();
     private final List<NamedXContentRegistry.Entry> namedXContents = new ArrayList<>();
     private final ValuesSourceRegistry valuesSourceRegistry;
-    private final CheckedBiConsumer<ShardSearchRequest, StreamOutput, IOException> requestCacheKeyDifferentiator;
 
     /**
      * Constructs a new SearchModule object
@@ -302,7 +296,6 @@ public class SearchModule {
         registerSearchExts(plugins);
         registerShapes();
         registerIntervalsSourceProviders();
-        requestCacheKeyDifferentiator = registerRequestCacheKeyDifferentiator(plugins);
         namedWriteables.addAll(SortValue.namedWriteables());
     }
 
@@ -316,11 +309,6 @@ public class SearchModule {
 
     public ValuesSourceRegistry getValuesSourceRegistry() {
         return valuesSourceRegistry;
-    }
-
-    @Nullable
-    public CheckedBiConsumer<ShardSearchRequest, StreamOutput, IOException> getRequestCacheKeyDifferentiator() {
-        return requestCacheKeyDifferentiator;
     }
 
     /**
@@ -512,6 +500,12 @@ public class SearchModule {
     }
 
     private void registerPipelineAggregations(List<SearchPlugin> plugins) {
+        registerPipelineAggregation(new PipelineAggregationSpec(
+            PercentileRanksBucketPipelineAggregationBuilder.NAME,
+            PercentileRanksBucketPipelineAggregationBuilder::new,
+            PercentileRanksBucketPipelineAggregator::new,
+            PercentileRanksBucketPipelineAggregationBuilder.PARSER)
+            .addResultReader(InternalPercentileRanksBucket::new));
         registerPipelineAggregation(new PipelineAggregationSpec(
                 DerivativePipelineAggregationBuilder.NAME,
                 DerivativePipelineAggregationBuilder::new,
@@ -843,22 +837,6 @@ public class SearchModule {
 
     private void registerIntervalsSourceProviders() {
         namedWriteables.addAll(getIntervalsSourceProviderNamedWritables());
-    }
-
-    private CheckedBiConsumer<ShardSearchRequest, StreamOutput, IOException> registerRequestCacheKeyDifferentiator(
-        List<SearchPlugin> plugins) {
-        CheckedBiConsumer<ShardSearchRequest, StreamOutput, IOException> differentiator = null;
-        for (SearchPlugin plugin : plugins) {
-            final CheckedBiConsumer<ShardSearchRequest, StreamOutput, IOException> d = plugin.getRequestCacheKeyDifferentiator();
-            if (d != null) {
-                if (differentiator == null) {
-                    differentiator = d;
-                } else {
-                    throw new IllegalArgumentException("Cannot have more than one plugin providing a request cache key differentiator");
-                }
-            }
-        }
-        return differentiator;
     }
 
     public static List<NamedWriteableRegistry.Entry> getIntervalsSourceProviderNamedWritables() {

--- a/server/src/main/java/org/elasticsearch/search/aggregations/pipeline/InternalPercentileRanksBucket.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/pipeline/InternalPercentileRanksBucket.java
@@ -1,0 +1,204 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.search.aggregations.pipeline;
+
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.search.DocValueFormat;
+import org.elasticsearch.search.aggregations.InternalAggregation;
+import org.elasticsearch.search.aggregations.metrics.InternalNumericMetricsAggregation;
+import org.elasticsearch.search.aggregations.metrics.InternalMax;
+import org.elasticsearch.search.aggregations.metrics.PercentileRanks;
+
+import jdk.internal.jshell.tool.resources.version;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+public class InternalPercentileRanksBucket extends InternalNumericMetricsAggregation.MultiValue implements PercentileRanksBucket {
+    private double[] percentile_ranks;
+    private double[] values;
+    private boolean keyed = true;
+    private final transient Map<Double, Double> percentileLookups = new HashMap<>();
+
+    InternalPercentileRanksBucket(String name, double[] values, double[] PercentileRanks, boolean keyed,
+                                     DocValueFormat formatter, List<PipelineAggregator> pipelineAggregators,
+                                     Map<String, Object> metaData) {
+        super(name, pipelineAggregators, metaData);
+        if ((PercentileRanks.length == values.length) == false) {
+            throw new IllegalArgumentException("The number of provided values and PercentileRanks didn't match. values: "
+                    + Arrays.toString(values) + ", Percentile Ranks: " + Arrays.toString(PercentileRanks));
+        }
+        this.format = formatter;
+        this.percentile_ranks = percentile_ranks;
+        this.values = values;
+        this.keyed = keyed;
+        computeLookup();
+    }
+
+    private void computeLookup() {
+        for (int i = 0; i < values.length; i++) {
+            percentileLookups.put(values[i], percentile_ranks[i]);
+        }
+    }
+
+    /**
+     * Read from a stream.
+     */
+    public InternalPercentileRanksBucket(StreamInput in) throws IOException {
+        super(in);
+        format = in.readNamedWriteable(DocValueFormat.class);
+        percentile_ranks = in.readDoubleArray();
+        values = in.readDoubleArray();
+        keyed = in.readBoolean();
+
+        computeLookup();
+    }
+
+    @Override
+    protected void doWriteTo(StreamOutput out) throws IOException {
+        out.writeNamedWriteable(format);
+        out.writeDoubleArray(percentile_ranks);
+        out.writeDoubleArray(values);
+        out.writeBoolean(keyed);
+    }
+
+    @Override
+    public String getWriteableName() {
+        return PercentileRanksBucketPipelineAggregationBuilder.NAME;
+    }
+
+    @Override
+    public double percentile_rank(double value) throws IllegalArgumentException {
+        Double percentile_ranks = percentileLookups.get(value);
+        if (percentile_ranks == null) {
+            throw new IllegalArgumentException("value requested [" + String.valueOf(value) + "] was not" +
+                    " one of the computed percentile ranks.  Available keys are: " + Arrays.toString(values));
+        }
+        return percentile_ranks;
+    }
+
+    @Override
+    public String percentileRankAsString(double value) {
+        return format.format(percentile_rank(value)).toString();
+    }
+
+    DocValueFormat formatter() {
+        return format;
+    }
+
+    @Override
+    public Iterator<Percentile> iterator() {
+        return new Iter(values, percentile_ranks);
+    }
+
+    @Override
+    public double value(String name) {
+        return percentile_rank(Double.parseDouble(name));
+    }
+
+    @Override
+    public InternalMax doReduce(List<InternalAggregation> aggregations, ReduceContext reduceContext) {
+        throw new UnsupportedOperationException("Not supported");
+    }
+
+    @Override
+    public XContentBuilder doXContentBody(XContentBuilder builder, Params params) throws IOException {
+        if (keyed) {
+            builder.startObject("values");
+            for (double v : values) {
+                double value = percentile_rank(v);
+                boolean hasValue = (Double.isInfinite(value) == true || Double.isNaN(value) == true) == false;
+                String key = String.valueOf(v);
+                builder.field(key, hasValue ? value : null);
+                if (hasValue && format != DocValueFormat.RAW) {
+                    builder.field(key + "_as_string", percentileAsString(v));
+                }
+            }
+            builder.endObject();
+        } else {
+            builder.startArray("values");
+            for (double v : values) {
+                double value = percentile_rank(v);
+                boolean hasValue = !(Double.isInfinite(value) || Double.isNaN(value));
+                builder.startObject();
+                builder.field("key", v);
+                builder.field("value", hasValue ? value : null);
+                if (hasValue && format != DocValueFormat.RAW) {
+                    builder.field(String.valueOf(value) + "_as_string", percentileRankAsString(v));
+                }
+                builder.endObject();
+            }
+            builder.endArray();
+        }
+        return builder;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) return true;
+        if (obj == null || getClass() != obj.getClass()) return false;
+        if (super.equals(obj) == false) return false;
+
+        InternalPercentileRanksBucket that = (InternalPercentileRanksBucket) obj;
+        return Arrays.equals(values, that.values) && Arrays.equals(percentile_ranks, that.percentile_ranks);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), Arrays.hashCode(values), Arrays.hashCode(percentile_ranks));
+    }
+
+    public static class Iter implements Iterator<Percentile> {
+        
+        private final double[] values;
+        private final double[] percentile_ranks;
+        private int i;
+
+        public Iter(double[] values, double[] percentile_ranks) {
+            this.values = values;
+            this.percentile_ranks = percentile_ranks;
+            i = 0;
+        }
+
+        @Override
+        public boolean hasNext() {
+            return i < values.length;
+        }
+
+        @Override
+        public Percentile next() {
+            final Percentile next = new Percentile(percentile_ranks[i], values[i]);
+            ++i;
+            return next;
+        }
+
+        @Override
+        public final void remove() {
+            throw new UnsupportedOperationException();
+        }
+    }
+}

--- a/server/src/main/java/org/elasticsearch/search/aggregations/pipeline/PercentileRanksBucketPipelineAggregationBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/pipeline/PercentileRanksBucketPipelineAggregationBuilder.java
@@ -1,0 +1,182 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.search.aggregations.pipeline;
+
+import com.carrotsearch.hppc.DoubleArrayList;
+import org.elasticsearch.common.ParseField;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.search.aggregations.AggregationBuilder;
+import org.elasticsearch.search.aggregations.AggregatorFactory;
+import org.elasticsearch.search.aggregations.PipelineAggregationBuilder;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Map;
+import java.util.Objects;
+
+public class PercentileRanksBucketPipelineAggregationBuilder
+    extends BucketMetricsPipelineAggregationBuilder<PercentileRanksBucketPipelineAggregationBuilder> {
+    public static final String NAME = "percentile_ranks_bucket";
+    static final ParseField VALUES_FIELD = new ParseField("values");
+    static final ParseField KEYED_FIELD = new ParseField("keyed");
+
+    private double[] values;
+    private boolean keyed = true;
+
+    public PercentileRanksBucketPipelineAggregationBuilder(String name, String bucketsPath, double[] values) {
+        super(name, NAME, new String[] { bucketsPath });
+    }
+
+    /**
+     * Read from a stream.
+     */
+    public PercentileRanksBucketPipelineAggregationBuilder(StreamInput in)
+        throws IOException {
+        super(in, NAME);
+        values = in.readDoubleArray();
+        keyed = in.readBoolean();
+    }
+
+    @Override
+    protected void innerWriteTo(StreamOutput out) throws IOException {
+        out.writeDoubleArray(values);
+        out.writeBoolean(keyed);
+    }
+
+    /**
+     * Get the percentages to calculate percentiles ranks for in this aggregation
+     */
+    public double[] getValues() {
+        return values;
+    }
+
+    /**
+     * Set the percentages to calculate percentiles ranks for in this aggregation
+     */
+    public PercentileRanksBucketPipelineAggregationBuilder setPercents(double[] values) {
+        if (values.length == 0) {
+            throw new IllegalArgumentException("[values] must not be null: [" + name + "]");
+        }
+
+        this.values = values;
+        return this;
+    }
+
+    /**
+     * Set whether the XContent should be keyed
+     */
+    public PercentileRanksBucketPipelineAggregationBuilder setKeyed(boolean keyed) {
+        this.keyed = keyed;
+        return this;
+    }
+
+    /**
+     * Get whether the XContent should be keyed
+     */
+    public boolean getKeyed() {
+        return keyed;
+    }
+
+    @Override
+    protected PipelineAggregator createInternal(Map<String, Object> metaData) {
+        return new PercentileRanksBucketPipelineAggregator(name, values, keyed, bucketsPaths, gapPolicy(), formatter(), metaData);
+    }
+
+    @Override
+    public void doValidate(AggregatorFactory<?> parent, Collection<AggregationBuilder> aggFactories,
+                           Collection<PipelineAggregationBuilder> pipelineAggregatorFactories) {
+        super.doValidate(parent, aggFactories, pipelineAggregatorFactories);
+
+    }
+
+    @Override
+    protected XContentBuilder doXContentBody(XContentBuilder builder, Params params) throws IOException {
+        if (values != null) {
+            builder.array(VALUES_FIELD.getPreferredName(), values);
+        }
+        builder.field(KEYED_FIELD.getPreferredName(), keyed);
+        return builder;
+    }
+
+    public static final PipelineAggregator.Parser PARSER = new BucketMetricsParser() {
+
+        @Override
+        protected PercentileRanksBucketPipelineAggregationBuilder buildFactory(String pipelineAggregatorName,
+                                                                           String bucketsPath, Map<String, Object> params) {
+
+            PercentileRanksBucketPipelineAggregationBuilder factory = new
+                PercentileRanksBucketPipelineAggregationBuilder(pipelineAggregatorName, bucketsPath);
+
+            double[] values = (double[]) params.get(VALUES_FIELD.getPreferredName());
+            if (values != null) {
+                factory.setValues(values);
+            }
+            Boolean keyed = (Boolean) params.get(KEYED_FIELD.getPreferredName());
+            if (keyed != null) {
+                factory.setKeyed(keyed);
+            }
+
+            return factory;
+        }
+
+        @Override
+        protected boolean token(XContentParser parser, String field, XContentParser.Token token, Map<String, Object> params)
+            throws IOException {
+            if (VALUES_FIELD.match(field, parser.getDeprecationHandler()) && token == XContentParser.Token.START_ARRAY) {
+                DoubleArrayList values = new DoubleArrayList(10);
+                while (parser.nextToken() != XContentParser.Token.END_ARRAY) {
+                    values.add(parser.doubleValue());
+                }
+                params.put(VALUES_FIELD.getPreferredName(), values.toArray());
+                return true;
+                
+            } else if (KEYED_FIELD.match(field, parser.getDeprecationHandler()) && token == XContentParser.Token.VALUE_BOOLEAN){
+                params.put(KEYED_FIELD.getPreferredName(), parser.booleanValue());
+                return true;
+            }
+            return false;
+        }
+
+    };
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), Arrays.hashCode(values), keyed);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) return true;
+        if (obj == null || getClass() != obj.getClass()) return false;
+        if (super.equals(obj) == false) return false;
+        PercentileRanksBucketPipelineAggregationBuilder other = (PercentileRanksBucketPipelineAggregationBuilder) obj;
+        return Objects.deepEquals(values, other.values)
+            && Objects.equals(keyed, other.keyed);
+    }
+
+    @Override
+    public String getWriteableName() {
+        return NAME;
+    }
+}

--- a/server/src/main/java/org/elasticsearch/search/aggregations/pipeline/PercentileRanksBucketPipelineAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/pipeline/PercentileRanksBucketPipelineAggregator.java
@@ -1,0 +1,108 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.search.aggregations.pipeline;
+
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.search.DocValueFormat;
+import org.elasticsearch.search.aggregations.InternalAggregation;
+import org.elasticsearch.search.aggregations.pipeline.BucketHelpers.GapPolicy;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+public class PercentileRanksBucketPipelineAggregator extends BucketMetricsPipelineAggregator {
+
+    private final double[] values;
+    private boolean keyed = true;
+    private List<Double> data;
+
+    PercentileRanksBucketPipelineAggregator(String name, double[] values, boolean keyed, String[] bucketsPaths,
+                                        GapPolicy gapPolicy, DocValueFormat formatter, Map<String, Object> metaData) {
+        super(name, bucketsPaths, gapPolicy, formatter, metaData);
+        this.values = values;
+        this.keyed = keyed;
+    }
+
+    /**
+     * Read from a stream.
+     */
+    public PercentileRanksBucketPipelineAggregator(StreamInput in) throws IOException {
+        super(in);
+        values = in.readDoubleArray();
+        keyed = in.readBoolean();
+    }
+
+    @Override
+    public void innerWriteTo(StreamOutput out) throws IOException {
+        out.writeDoubleArray(values);
+        out.writeBoolean(keyed);
+    }
+
+    @Override
+    public String getWriteableName() {
+        return PercentileRanksBucketPipelineAggregationBuilder.NAME;
+    }
+
+    @Override
+    protected void preCollection() {
+       data = new ArrayList<>(1024);
+    }
+
+    @Override
+    protected void collectBucketValue(String bucketKey, Double bucketValue) {
+        data.add(bucketValue);
+    }
+
+    @Override
+    protected InternalAggregation buildAggregation(List<PipelineAggregator> pipelineAggregators, Map<String, Object> metadata) {
+
+        // Perform the sorting and percentile rank collection now that all the data
+        // has been collected.
+        Collections.sort(data);
+        int n = data.size();
+        double[] percentileRanks = new double[values.length];
+
+        if (data.size() == 0) {
+            for (int i = 0; i < values.length; i++) {
+                percentileRanks[i] = Double.NaN;
+            }
+        } else {
+            for (int i = 0; i < values.length; i++) {
+                int index = Collections.binarySearch(data, values[i]);
+                if (index < 0) {
+                    // index < 0 means value is not present in data set. Java returns
+                    // -(insertion_point) - 1 as result in this case.
+                    // derive insertion_point which shows # of values smaller than value of interest.
+                    index = -index-1;
+                }
+                double percentile_rank = (double) index / n;
+                percentileRanks[i] = percentile_rank * 100;
+        }
+    }
+
+        // todo need postCollection() to clean up temp sorted data?
+
+        return new InternalPercentileRanksBucket(name(), values, PercentileRanks, keyed, format, pipelineAggregators, metadata);
+    }
+}


### PR DESCRIPTION
- Implementation of `InternalPercentileRanksBucket`, `PercentileRanksBucketPipelineAggregationBuilder `and `PercentileRanksBucketPipelineAggregator `classes
- Modification on `SearchModule `to register the new pipeline aggregation
- Refers to issue [#19546](https://github.com/elastic/elasticsearch/issues/19546)

