### PR TITLE
Unmute RareTermsIT

### DIFF
--- a/qa/mixed-cluster/src/test/java/org/elasticsearch/backwards/RareTermsIT.java
+++ b/qa/mixed-cluster/src/test/java/org/elasticsearch/backwards/RareTermsIT.java
@@ -38,7 +38,6 @@ public class RareTermsIT extends ESRestTestCase {
         return id;
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/74985")
     public void testSingleValuedString() throws Exception {
         final Settings.Builder settings = Settings.builder()
             .put(IndexMetadata.INDEX_NUMBER_OF_SHARDS_SETTING.getKey(), 2)


### PR DESCRIPTION
This test was muted due to a bug that has been fixed in https://github.com/elastic/elasticsearch/pull/75111. Now that the fix has been backported we can unmute this test again.

closes https://github.com/elastic/elasticsearch/issues/74985