### PR TITLE
Fix _terms_enum default indices options

### DIFF
--- a/x-pack/plugin/core/src/internalClusterTest/java/org/elasticsearch/xpack/core/termsenum/CCSTermsEnumIT.java
+++ b/x-pack/plugin/core/src/internalClusterTest/java/org/elasticsearch/xpack/core/termsenum/CCSTermsEnumIT.java
@@ -58,6 +58,9 @@ public class CCSTermsEnumIT extends AbstractMultiClustersTestCase {
             .field("foo.keyword");
         TermsEnumResponse response = client().execute(TermsEnumAction.INSTANCE, req).actionGet();
         assertTrue(response.isComplete());
+        assertThat(response.getTotalShards(), equalTo(1));
+        assertThat(response.getSuccessfulShards(), equalTo(1));
+        assertThat(response.getFailedShards(), equalTo(0));
         assertThat(response.getTerms().size(), equalTo(3));
         assertThat(response.getTerms().get(0), equalTo("bar"));
         assertThat(response.getTerms().get(1), equalTo("foobar"));
@@ -68,6 +71,9 @@ public class CCSTermsEnumIT extends AbstractMultiClustersTestCase {
             .field("foo.keyword");
         response = client().execute(TermsEnumAction.INSTANCE, req).actionGet();
         assertTrue(response.isComplete());
+        assertThat(response.getTotalShards(), equalTo(2));
+        assertThat(response.getSuccessfulShards(), equalTo(2));
+        assertThat(response.getFailedShards(), equalTo(0));
         assertThat(response.getTerms().size(), equalTo(4));
         assertThat(response.getTerms().get(0), equalTo("bar"));
         assertThat(response.getTerms().get(1), equalTo("foo"));
@@ -79,6 +85,9 @@ public class CCSTermsEnumIT extends AbstractMultiClustersTestCase {
             .searchAfter("foobar");
         response = client().execute(TermsEnumAction.INSTANCE, req).actionGet();
         assertTrue(response.isComplete());
+        assertThat(response.getTotalShards(), equalTo(2));
+        assertThat(response.getSuccessfulShards(), equalTo(2));
+        assertThat(response.getFailedShards(), equalTo(0));
         assertThat(response.getTerms().size(), equalTo(1));
         assertThat(response.getTerms().get(0), equalTo("zar"));
 
@@ -87,6 +96,9 @@ public class CCSTermsEnumIT extends AbstractMultiClustersTestCase {
             .searchAfter("bar");
         response = client().execute(TermsEnumAction.INSTANCE, req).actionGet();
         assertTrue(response.isComplete());
+        assertThat(response.getTotalShards(), equalTo(2));
+        assertThat(response.getSuccessfulShards(), equalTo(2));
+        assertThat(response.getFailedShards(), equalTo(0));
         assertThat(response.getTerms().size(), equalTo(3));
         assertThat(response.getTerms().get(0), equalTo("foo"));
         assertThat(response.getTerms().get(1), equalTo("foobar"));

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/termsenum/action/TermsEnumAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/termsenum/action/TermsEnumAction.java
@@ -45,6 +45,6 @@ public class TermsEnumAction extends ActionType<TermsEnumResponse> {
         PARSER.declareField(TermsEnumRequest::timeout,
             (p, c) -> TimeValue.parseTimeValue(p.text(), TIMEOUT.getPreferredName()),
             TIMEOUT, ObjectParser.ValueType.STRING);
-        PARSER.declareObject(TermsEnumRequest::indexFilter, (p, context) -> parseInnerQueryBuilder(p),INDEX_FILTER);
+        PARSER.declareObject(TermsEnumRequest::indexFilter, (p, context) -> parseInnerQueryBuilder(p), INDEX_FILTER);
     }
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/termsenum/action/TermsEnumRequest.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/termsenum/action/TermsEnumRequest.java
@@ -8,6 +8,7 @@ package org.elasticsearch.xpack.core.termsenum.action;
 
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.ValidateActions;
+import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.action.support.broadcast.BroadcastRequest;
 import org.elasticsearch.common.Strings;
@@ -21,12 +22,15 @@ import org.elasticsearch.index.query.QueryBuilder;
 
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.Objects;
+
 
 /**
  * A request to gather terms for a given field matching a string prefix
  */
 public class TermsEnumRequest extends BroadcastRequest<TermsEnumRequest> implements ToXContentObject {
 
+    public static final IndicesOptions DEFAULT_INDICES_OPTIONS = SearchRequest.DEFAULT_INDICES_OPTIONS;
     public static int DEFAULT_SIZE = 10;
     public static TimeValue DEFAULT_TIMEOUT = new TimeValue(1000);
 
@@ -47,7 +51,7 @@ public class TermsEnumRequest extends BroadcastRequest<TermsEnumRequest> impleme
      */
     public TermsEnumRequest(String... indices) {
         super(indices);
-        indicesOptions(IndicesOptions.fromOptions(false, false, true, false));
+        indicesOptions(DEFAULT_INDICES_OPTIONS);
         timeout(DEFAULT_TIMEOUT);
     }
 
@@ -83,6 +87,25 @@ public class TermsEnumRequest extends BroadcastRequest<TermsEnumRequest> impleme
         out.writeBoolean(caseInsensitive);
         out.writeVInt(size);
         out.writeOptionalNamedWriteable(indexFilter);
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.startObject();
+        builder.field("field", field);
+        if (string != null) {
+            builder.field("string", string);
+        }
+        if (searchAfter != null) {
+            builder.field("search_after", searchAfter);
+        }
+        builder.field("size", size);
+        builder.field("timeout", timeout());
+        builder.field("case_insensitive", caseInsensitive);
+        if (indexFilter != null) {
+            builder.field("index_filter", indexFilter);
+        }
+        return builder.endObject();
     }
 
     @Override
@@ -200,21 +223,26 @@ public class TermsEnumRequest extends BroadcastRequest<TermsEnumRequest> impleme
     }
 
     @Override
-    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
-        builder.startObject();
-        builder.field("field", field);
-        if (string != null) {
-            builder.field("string", string);
-        }
-        if (searchAfter != null) {
-            builder.field("search_after", searchAfter);
-        }
-        builder.field("size", size);
-        builder.field("timeout", timeout().getMillis());
-        builder.field("case_insensitive", caseInsensitive);
-        if (indexFilter != null) {
-            builder.field("index_filter", indexFilter);
-        }
-        return builder.endObject();
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        TermsEnumRequest that = (TermsEnumRequest) o;
+        return size == that.size
+            && caseInsensitive == that.caseInsensitive
+            && Objects.equals(field, that.field)
+            && Objects.equals(string, that.string)
+            && Objects.equals(searchAfter, that.searchAfter)
+            && Objects.equals(indexFilter, that.indexFilter)
+            && Arrays.equals(indices, that.indices)
+            && Objects.equals(indicesOptions(), that.indicesOptions())
+            && Objects.equals(timeout(), that.timeout());
+    }
+
+    @Override
+    public int hashCode() {
+        int result = Objects.hash(field, string, searchAfter, size, caseInsensitive,
+            indexFilter, indicesOptions(), timeout());
+        result = 31 * result + Arrays.hashCode(indices);
+        return result;
     }
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/termsenum/action/TransportTermsEnumAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/termsenum/action/TransportTermsEnumAction.java
@@ -247,8 +247,8 @@ public class TransportTermsEnumAction extends HandledTransportAction<TermsEnumRe
                 if (rc.resp.isComplete() == false || rc.resp.getFailedShards() > 0) {
                     complete = false;
                 }
-                successfulShards = rc.resp.getSuccessfulShards();
-                failedShards = rc.resp.getFailedShards();
+                successfulShards += rc.resp.getSuccessfulShards();
+                failedShards += rc.resp.getFailedShards();
                 for (DefaultShardOperationFailedException exc : rc.resp.getShardFailures()) {
                     shardFailures.add(new DefaultShardOperationFailedException(rc.clusterAlias + ":" + exc.index(),
                         exc.shardId(), exc.getCause()));

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/termsenum/TermsEnumRequestTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/termsenum/TermsEnumRequestTests.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.core.termsenum;
+
+import org.elasticsearch.action.support.IndicesOptions;
+import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
+import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.ArrayUtils;
+import org.elasticsearch.common.xcontent.NamedXContentRegistry;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.common.xcontent.XContentType;
+import org.elasticsearch.index.query.QueryBuilders;
+import org.elasticsearch.indices.IndicesModule;
+import org.elasticsearch.search.SearchModule;
+import org.elasticsearch.test.AbstractSerializingTestCase;
+import org.elasticsearch.xpack.core.termsenum.action.TermsEnumAction;
+import org.elasticsearch.xpack.core.termsenum.action.TermsEnumRequest;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.function.Consumer;
+
+public class TermsEnumRequestTests extends AbstractSerializingTestCase<TermsEnumRequest> {
+    private NamedXContentRegistry xContentRegistry;
+    private NamedWriteableRegistry namedWriteableRegistry;
+
+    public void setUp() throws Exception {
+        super.setUp();
+        SearchModule searchModule = new SearchModule(Settings.EMPTY, Collections.emptyList());
+        List<NamedWriteableRegistry.Entry> entries = new ArrayList<>();
+        entries.addAll(IndicesModule.getNamedWriteables());
+        entries.addAll(searchModule.getNamedWriteables());
+        namedWriteableRegistry = new NamedWriteableRegistry(entries);
+        xContentRegistry = new NamedXContentRegistry(searchModule.getNamedXContents());
+    }
+
+    @Override
+    protected TermsEnumRequest createTestInstance() {
+        TermsEnumRequest request =  new TermsEnumRequest();
+        request.size(randomIntBetween(1, 20));
+        request.field(randomAlphaOfLengthBetween(3, 10));
+        request.caseInsensitive(randomBoolean());
+        if (randomBoolean()) {
+            request.indexFilter(QueryBuilders.termQuery("field", randomAlphaOfLength(5)));
+        }
+        String[] randomIndices = new String[randomIntBetween(1, 5)];
+        for (int i = 0; i < randomIndices.length; i++) {
+            randomIndices[i] = randomAlphaOfLengthBetween(5, 10);
+        }
+        request.indices(randomIndices);
+        if (randomBoolean()) {
+            request.indicesOptions(randomBoolean() ? IndicesOptions.strictExpand() : IndicesOptions.lenientExpandOpen());
+        }
+        return request;
+    }
+
+    @Override
+    protected TermsEnumRequest createXContextTestInstance(XContentType xContentType) {
+        return createTestInstance()
+            // these options are outside of the xcontent
+            .indices("test")
+            .indicesOptions(TermsEnumRequest.DEFAULT_INDICES_OPTIONS);
+    }
+
+    @Override
+    protected NamedWriteableRegistry getNamedWriteableRegistry() {
+        return namedWriteableRegistry;
+    }
+
+    @Override
+    protected NamedXContentRegistry xContentRegistry() {
+        return xContentRegistry;
+    }
+
+    @Override
+    protected Writeable.Reader<TermsEnumRequest> instanceReader() {
+        return TermsEnumRequest::new;
+    }
+
+    @Override
+    protected TermsEnumRequest doParseInstance(XContentParser parser) throws IOException {
+        return TermsEnumAction.fromXContent(parser, "test");
+    }
+
+    @Override
+    protected TermsEnumRequest mutateInstance(TermsEnumRequest instance) throws IOException {
+        List<Consumer<TermsEnumRequest>> mutators = new ArrayList<>();
+        mutators.add(request -> {
+            request.field(randomAlphaOfLengthBetween(3, 10));
+        });
+        mutators.add(request -> {
+            String[] indices = ArrayUtils.concat(instance.indices(), generateRandomStringArray(5, 10, false, false));
+            request.indices(indices);
+        });
+        mutators.add(request -> {
+            IndicesOptions indicesOptions = randomValueOtherThan(request.indicesOptions(),
+                () -> IndicesOptions.fromOptions(randomBoolean(), randomBoolean(), randomBoolean(), randomBoolean()));
+            request.indicesOptions(indicesOptions);
+        });
+        mutators.add(
+            request -> request.indexFilter(request.indexFilter() != null ? request.indexFilter().boost(2) : QueryBuilders.matchAllQuery())
+        );
+        TermsEnumRequest mutatedInstance = copyInstance(instance);
+        Consumer<TermsEnumRequest> mutator = randomFrom(mutators);
+        mutator.accept(mutatedInstance);
+        return mutatedInstance;
+    }
+}


### PR DESCRIPTION
This commit changes the default indices options of the new terms enum API
to be consistent with _search.
This change also fixes the shards statistics in the response when ccs is involved.

Closes #75155 