### PR TITLE
Fix ccs wildcard pattern in _terms_enum API

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/termsenum/action/TermsEnumRequest.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/termsenum/action/TermsEnumRequest.java
@@ -125,6 +125,11 @@ public class TermsEnumRequest extends BroadcastRequest<TermsEnumRequest> impleme
         return validationException;
     }
 
+    @Override
+    public boolean allowsRemoteIndices() {
+        return true;
+    }
+
     /**
      * The field to look inside for values
      */

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/termsenum/action/TermsEnumRequest.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/termsenum/action/TermsEnumRequest.java
@@ -130,6 +130,11 @@ public class TermsEnumRequest extends BroadcastRequest<TermsEnumRequest> impleme
         return true;
     }
 
+    @Override
+    public boolean includeDataStreams() {
+        return true;
+    }
+
     /**
      * The field to look inside for values
      */

--- a/x-pack/qa/multi-cluster-search-security/src/test/resources/rest-api-spec/test/multi_cluster/120_terms_enum.yml
+++ b/x-pack/qa/multi-cluster-search-security/src/test/resources/rest-api-spec/test/multi_cluster/120_terms_enum.yml
@@ -117,7 +117,7 @@ teardown:
   - do:
       headers: { Authorization: "Basic am9lX2FsbDpzM2tyaXQtcGFzc3dvcmQ=" } # joe_all sees all docs
       terms_enum:
-        index: my_remote_cluster:terms_enum_index
+        index: my_remote_cluster:terms_enum_*
         body: { "field": "foo", "search_after": "foobar" }
   - length: { terms:          1 }
   - match: { terms.0:     "zar" }
@@ -126,13 +126,13 @@ teardown:
   - do:
       headers: { Authorization: "Basic am9lX25vbmU6czNrcml0LXBhc3N3b3Jk" } # joe_none can't see docs
       terms_enum:
-        index:  my_remote_cluster:terms_enum_index
+        index:  my_remote_cluster:terms_enum_*
         body:  {"field": "foo"}
   - length: {terms: 0}
 
   - do:
       headers: { Authorization: "Basic am9lX2ZsczpzM2tyaXQtcGFzc3dvcmQ=" } # joe_fls can't see field
       terms_enum:
-        index:  my_remote_cluster:terms_enum_index
+        index:  my_remote_*:terms_enum_index
         body:  {"field": "foo"}
   - length: {terms: 0}


### PR DESCRIPTION
This change adds the support in the _terms_enum API for wildcard index
pattern that targets remote cluster with security enabled.

Closes #75152