### PR TITLE
[DOCS] Fixes links to machine learning concepts

### DIFF
--- a/docs/reference/cat/anomaly-detectors.asciidoc
+++ b/docs/reference/cat/anomaly-detectors.asciidoc
@@ -29,7 +29,7 @@ Returns configuration and usage information about {anomaly-jobs}.
 NOTE: This API returns a maximum of 10,000 jobs.
 
 For more information about {anomaly-detect}, see
-See {ml-docs}/ml-ad-finding-anomalies.html[Finding anomalies].
+{ml-docs}/ml-ad-finding-anomalies.html[Finding anomalies].
 
 [[cat-anomaly-detectors-path-params]]
 ==== {api-path-parms-title}

--- a/docs/reference/cat/anomaly-detectors.asciidoc
+++ b/docs/reference/cat/anomaly-detectors.asciidoc
@@ -26,7 +26,7 @@ Returns configuration and usage information about {anomaly-jobs}.
 [[cat-anomaly-detectors-desc]]
 ==== {api-description-title}
 
-See {ml-docs}/ml-jobs.html[{anomaly-jobs-cap}].
+See {ml-docs}/ml-ad-finding-anomalies.html#ml-ad-create-job[Create {anomaly-jobs}].
 
 NOTE: This API returns a maximum of 10,000 jobs.
 

--- a/docs/reference/cat/anomaly-detectors.asciidoc
+++ b/docs/reference/cat/anomaly-detectors.asciidoc
@@ -26,9 +26,10 @@ Returns configuration and usage information about {anomaly-jobs}.
 [[cat-anomaly-detectors-desc]]
 ==== {api-description-title}
 
-See {ml-docs}/ml-ad-finding-anomalies.html#ml-ad-create-job[Create {anomaly-jobs}].
-
 NOTE: This API returns a maximum of 10,000 jobs.
+
+For more information about {anomaly-detect}, see
+See {ml-docs}/ml-ad-finding-anomalies.html[Finding anomalies].
 
 [[cat-anomaly-detectors-path-params]]
 ==== {api-path-parms-title}

--- a/docs/reference/ml/anomaly-detection/apis/delete-filter.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/delete-filter.asciidoc
@@ -22,9 +22,10 @@ Requires the `manage_ml` cluster privilege. This privilege is included in the
 [[ml-delete-filter-desc]]
 == {api-description-title}
 
-This API deletes a {ml-docs}/ml-rules.html[filter]. 
-If a {ml} job references the filter, you cannot delete the filter. You must 
-update or delete the job before you can delete the filter.
+This API deletes a filter. If an {anomaly-job} references the filter, you cannot
+delete the filter. You must update or delete the job before you can delete the
+filter. For more information, see
+{ml-docs}/ml-ad-finding-anomalies.html#ml-ad-rules[Custom rules].
 
 [[ml-delete-filter-path-parms]]
 == {api-path-parms-title}

--- a/docs/reference/ml/anomaly-detection/apis/delete-forecast.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/delete-forecast.asciidoc
@@ -34,7 +34,7 @@ one or more forecasts before they expire.
 NOTE: When you delete a job, its associated forecasts are deleted.
 
 For more information, see
-{ml-docs}/ml-ad-overview.html#ml-forecasting[Forecasting the future].
+{ml-docs}/ml-ad-finding-anomalies.html#ml-ad-forecast[Forecasting the future].
 
 [[ml-delete-forecast-path-parms]]
 == {api-path-parms-title}

--- a/docs/reference/ml/anomaly-detection/apis/forecast.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/forecast.asciidoc
@@ -24,7 +24,8 @@ Requires the `manage_ml` cluster privilege. This privilege is included in the
 
 You can create a forecast job based on an {anomaly-job} to extrapolate future 
 behavior. Refer to
-{ml-docs}/ml-ad-overview.html#ml-forecasting[Forecasting the future] and 
+{ml-docs}/ml-ad-finding-anomalies.html#ml-ad-forecast[Forecasting the future]
+and 
 {ml-docs}/ml-limitations.html#ml-forecast-limitations[forecast limitations] to 
 learn more.
 

--- a/docs/reference/ml/anomaly-detection/apis/forecast.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/forecast.asciidoc
@@ -26,7 +26,7 @@ You can create a forecast job based on an {anomaly-job} to extrapolate future
 behavior. Refer to
 {ml-docs}/ml-ad-finding-anomalies.html#ml-ad-forecast[Forecasting the future]
 and 
-{ml-docs}/ml-limitations.html#ml-forecast-limitations[forecast limitations] to 
+{ml-docs}/ml-limitations.html#ml-forecast-limitations[Forecast limitations] to 
 learn more.
 
 You can delete a forecast by using the 

--- a/docs/reference/ml/anomaly-detection/apis/get-calendar-event.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/get-calendar-event.asciidoc
@@ -30,7 +30,7 @@ You can get scheduled event information for all calendars by using `_all`,
 by specifying `*` as the `<calendar_id>`, or by omitting the `<calendar_id>`.
 
 For more information, see
-{ml-docs}/ml-calendars.html[Calendars and scheduled events].
+{ml-docs}/ml-ad-finding-anomalies.html#ml-ad-calendars[Calendars and scheduled events].
 
 [[ml-get-calendar-event-path-parms]]
 == {api-path-parms-title}

--- a/docs/reference/ml/anomaly-detection/apis/get-calendar.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/get-calendar.asciidoc
@@ -30,7 +30,7 @@ information for all calendars by using `_all`, by specifying `*` as the
 `<calendar_id>`, or by omitting the `<calendar_id>`.
 
 For more information, see
-{ml-docs}/ml-calendars.html[Calendars and scheduled events].
+{ml-docs}/ml-ad-finding-anomalies.html#ml-ad-calendars[Calendars and scheduled events].
 
 [[ml-get-calendar-path-parms]]
 == {api-path-parms-title}

--- a/docs/reference/ml/anomaly-detection/apis/get-filter.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/get-filter.asciidoc
@@ -25,7 +25,7 @@ Requires the `manage_ml` cluster privilege. This privilege is included in the
 == {api-description-title}
 
 You can get a single filter or all filters. For more information, see 
-{ml-docs}/ml-rules.html[Machine learning custom rules].
+{ml-docs}/ml-ad-finding-anomalies.html#ml-ad-rules[Custom rules].
 
 [[ml-get-filter-path-parms]]
 == {api-path-parms-title}

--- a/docs/reference/ml/anomaly-detection/apis/post-calendar-event.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/post-calendar-event.asciidoc
@@ -22,7 +22,8 @@ Requires the `manage_ml` cluster privilege. This privilege is included in the
 [[ml-post-calendar-event-desc]]
 == {api-description-title}
 
-This API accepts a list of {ml-docs}/ml-calendars.html[scheduled events], each
+This API accepts a list of
+{ml-docs}/ml-ad-finding-anomalies.html#ml-ad-calendars[scheduled events], each
 of which must have a start time, end time, and description.
 
 [[ml-post-calendar-event-path-parms]]

--- a/docs/reference/ml/anomaly-detection/apis/put-calendar.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/put-calendar.asciidoc
@@ -23,7 +23,7 @@ Requires the `manage_ml` cluster privilege. This privilege is included in the
 == {api-description-title}
 
 For more information, see
-{ml-docs}/ml-calendars.html[Calendars and scheduled events].
+{ml-docs}/ml-ad-finding-anomalies.html#ml-ad-calendars[Calendars and scheduled events].
 
 [[ml-put-calendar-path-parms]]
 == {api-path-parms-title}

--- a/docs/reference/ml/anomaly-detection/apis/put-filter.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/put-filter.asciidoc
@@ -22,9 +22,10 @@ Requires the `manage_ml` cluster privilege. This privilege is included in the
 [[ml-put-filter-desc]]
 == {api-description-title}
 
-A {ml-docs}/ml-rules.html[filter] contains a list of strings. 
-It can be used by one or more jobs. Specifically, filters are referenced in 
-the `custom_rules` property of detector configuration objects. 
+A filter contains a list of strings. It can be used by one or more jobs.
+Specifically, filters are referenced in the `custom_rules` property of detector
+configuration objects. For more information, see
+{ml-docs}/ml-ad-finding-anomalies.html#ml-ad-rules[Custom rules].
 
 [[ml-put-filter-path-parms]]
 == {api-path-parms-title}

--- a/docs/reference/ml/anomaly-detection/ml-configuring-detector-custom-rules.asciidoc
+++ b/docs/reference/ml/anomaly-detection/ml-configuring-detector-custom-rules.asciidoc
@@ -2,7 +2,7 @@
 [[ml-configuring-detector-custom-rules]]
 = Customizing detectors with custom rules
 
-<<ml-rules,Custom rules>> – or _job rules_ as {kib} refers to them – enable you 
+<<ml-ad-rules,Custom rules>> – or _job rules_ as {kib} refers to them – enable you 
 to change the behavior of anomaly detectors based on domain-specific knowledge.
 
 Custom rules describe _when_ a detector should take a certain _action_ instead

--- a/docs/reference/ml/ml-shared.asciidoc
+++ b/docs/reference/ml/ml-shared.asciidoc
@@ -157,7 +157,7 @@ The size of the interval that the analysis is aggregated into, typically between
 `5m` and `1h`. The default value is `5m`. If the {anomaly-job} uses a {dfeed}
 with {ml-docs}/ml-configuring-aggregation.html[aggregations], this value must be
 divisible by the interval of the date histogram aggregation. For more
-information, see {ml-docs}/ml-buckets.html[Buckets].
+information, see {ml-docs}/ml-ad-finding-anomalies.html#ml-ad-bucket-span[Bucket span].
 end::bucket-span[]
 
 tag::bucket-span-results[]
@@ -411,7 +411,7 @@ of the most recent snapshot for this job. Valid values range from `0` to
 `model_snapshot_retention_days`. For new jobs, the default value is `1`. For
 jobs created before version 7.8.0, the default value matches
 `model_snapshot_retention_days`. For more information, refer to
-{ml-docs}/ml-model-snapshots.html[Model snapshots].
+{ml-docs}/ml-ad-finding-anomalies.html#ml-ad-model-snapshots[Model snapshots].
 end::daily-model-snapshot-retention-after-days[]
 
 tag::data-description[]
@@ -1254,7 +1254,7 @@ snapshots for this job. It specifies the maximum period of time (in days) that
 snapshots are retained. This period is relative to the timestamp of the most
 recent snapshot for this job. The default value is `10`, which means snapshots
 ten days older than the newest snapshot are deleted. For more information, refer
-to {ml-docs}/ml-model-snapshots.html[Model snapshots].
+to {ml-docs}/ml-ad-finding-anomalies.html#ml-ad-model-snapshots[Model snapshots].
 end::model-snapshot-retention-days[]
 
 tag::model-timestamp[]

--- a/docs/reference/redirects.asciidoc
+++ b/docs/reference/redirects.asciidoc
@@ -220,19 +220,19 @@ See <<commands>>.
 === Calendar resources
 
 See <<ml-get-calendar>> and
-{ml-docs}/ml-calendars.html[Calendars and scheduled events].
+{ml-docs}/ml-ad-finding-anomalies.html#ml-ad-calendars[Calendars and scheduled events].
 
 [role="exclude",id="ml-filter-resource"]
 === Filter resources
 
 See <<ml-get-filter>> and
-{ml-docs}/ml-rules.html[Machine learning custom rules].
+{ml-docs}/ml-ad-finding-anomalies.html#ml-ad-rules[Machine learning custom rules].
 
 [role="exclude",id="ml-event-resource"]
 === Scheduled event resources
 
 See <<ml-get-calendar-event>> and
-{ml-docs}/ml-calendars.html[Calendars and scheduled events].
+{ml-docs}/ml-ad-finding-anomalies.html#ml-ad-calendars[Calendars and scheduled events].
 
 [role="exclude",id="index-apis"]
 === Index APIs


### PR DESCRIPTION
Related to https://github.com/elastic/stack-docs/pull/1750

This PR updates links to the machine learning conceptual pages, which have moved within the Machine Learning guide.