### PR TITLE
Deprecate SimpleFS and replace it with NIOFS (#75156)

### DIFF
--- a/docs/plugins/store-smb.asciidoc
+++ b/docs/plugins/store-smb.asciidoc
@@ -27,8 +27,12 @@ The Store SMB plugin provides two storage types optimized for SMB:
 
 `smb_simple_fs`::
 
+    deprecated::[7.15,"smb_simple_fs is deprecated and will be removed in 8.0. Use smb_nio_fs or other file systems instead."]
+
+`smb_nio_fs`::
+
     a SMB specific implementation of the default
-    {ref}/index-modules-store.html#simplefs[simple fs]
+    {ref}/index-modules-store.html#niofs[nio fs]
 
 To use one of these specific storage types, you need to install the Store SMB plugin and restart the node.
 Then configure Elasticsearch to set the storage type you want.
@@ -37,7 +41,7 @@ This can be configured for all indices by adding this to the `elasticsearch.yml`
 
 [source,yaml]
 ----
-index.store.type: smb_simple_fs
+index.store.type: smb_nio_fs
 ----
 
 Note that setting will be applied for newly created indices.

--- a/docs/reference/index-modules/store.asciidoc
+++ b/docs/reference/index-modules/store.asciidoc
@@ -48,6 +48,8 @@ supported systems but is subject to change.
 
 [[simplefs]]`simplefs`::
 
+deprecated::[7.15,"simplefs is deprecated and will be removed in 8.0. Use niofs or other file systems instead. Elasticsearch 7.15 or later uses niofs for the simplefs store type as it offers superior or equivalent performance to simplefs."]
+
 The Simple FS type is a straightforward implementation of file system
 storage (maps to Lucene `SimpleFsDirectory`) using a random access file.
 This implementation has poor concurrent performance (multiple threads

--- a/plugins/store-smb/src/internalClusterTest/java/org/elasticsearch/index/store/smb/SmbNIOFSTests.java
+++ b/plugins/store-smb/src/internalClusterTest/java/org/elasticsearch/index/store/smb/SmbNIOFSTests.java
@@ -11,12 +11,12 @@ package org.elasticsearch.index.store.smb;
 import org.elasticsearch.common.settings.Settings;
 
 
-public class SmbSimpleFsTests extends AbstractAzureFsTestCase {
+public class SmbNIOFSTests extends AbstractAzureFsTestCase {
     @Override
     public Settings indexSettings() {
         return Settings.builder()
                 .put(super.indexSettings())
-                .put("index.store.type", "smb_simple_fs")
+                .put("index.store.type", randomFrom("smb_simple_fs", "smb_nio_fs"))
                 .build();
     }
 }

--- a/plugins/store-smb/src/main/java/org/elasticsearch/index/store/smb/SmbNIOFSDirectoryFactory.java
+++ b/plugins/store-smb/src/main/java/org/elasticsearch/index/store/smb/SmbNIOFSDirectoryFactory.java
@@ -10,17 +10,17 @@ package org.elasticsearch.index.store.smb;
 
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.store.LockFactory;
-import org.apache.lucene.store.SimpleFSDirectory;
+import org.apache.lucene.store.NIOFSDirectory;
 import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.store.FsDirectoryFactory;
 
 import java.io.IOException;
 import java.nio.file.Path;
 
-public final class SmbSimpleFsDirectoryFactory extends FsDirectoryFactory {
+public final class SmbNIOFSDirectoryFactory extends FsDirectoryFactory {
 
     @Override
     protected Directory newFSDirectory(Path location, LockFactory lockFactory, IndexSettings indexSettings) throws IOException {
-        return new SmbDirectoryWrapper(new SimpleFSDirectory(location, lockFactory));
+        return new SmbDirectoryWrapper(new NIOFSDirectory(location, lockFactory));
     }
 }

--- a/plugins/store-smb/src/main/java/org/elasticsearch/plugin/store/smb/SMBStorePlugin.java
+++ b/plugins/store-smb/src/main/java/org/elasticsearch/plugin/store/smb/SMBStorePlugin.java
@@ -9,7 +9,7 @@
 package org.elasticsearch.plugin.store.smb;
 
 import org.elasticsearch.index.store.smb.SmbMmapFsDirectoryFactory;
-import org.elasticsearch.index.store.smb.SmbSimpleFsDirectoryFactory;
+import org.elasticsearch.index.store.smb.SmbNIOFSDirectoryFactory;
 import org.elasticsearch.plugins.IndexStorePlugin;
 import org.elasticsearch.plugins.Plugin;
 
@@ -21,7 +21,9 @@ public class SMBStorePlugin extends Plugin implements IndexStorePlugin {
     public Map<String, DirectoryFactory> getDirectoryFactories() {
         return Map.of(
                 "smb_mmap_fs", new SmbMmapFsDirectoryFactory(),
-                "smb_simple_fs", new SmbSimpleFsDirectoryFactory());
+                "smb_simple_fs", new SmbNIOFSDirectoryFactory(),
+                "smb_nio_fs", new SmbNIOFSDirectoryFactory()
+            );
     }
 
 }

--- a/plugins/store-smb/src/test/java/org/elasticsearch/index/store/smb/SmbNIOFSDirectoryTests.java
+++ b/plugins/store-smb/src/test/java/org/elasticsearch/index/store/smb/SmbNIOFSDirectoryTests.java
@@ -11,14 +11,14 @@ package org.elasticsearch.index.store.smb;
 import java.io.IOException;
 import java.nio.file.Path;
 import org.apache.lucene.store.Directory;
-import org.apache.lucene.store.SimpleFSDirectory;
+import org.apache.lucene.store.NIOFSDirectory;
 import org.elasticsearch.index.store.EsBaseDirectoryTestCase;
 
-public class SmbSimpleFSDirectoryTests extends EsBaseDirectoryTestCase {
+public class SmbNIOFSDirectoryTests extends EsBaseDirectoryTestCase {
 
     @Override
     protected Directory getDirectory(Path file) throws IOException {
-        return new SmbDirectoryWrapper(new SimpleFSDirectory(file));
+        return new SmbDirectoryWrapper(new NIOFSDirectory(file));
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataUpdateSettingsService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataUpdateSettingsService.java
@@ -208,7 +208,9 @@ public class MetadataUpdateSettingsService {
                 if (IndexSettings.INDEX_TRANSLOG_RETENTION_AGE_SETTING.exists(normalizedSettings) ||
                     IndexSettings.INDEX_TRANSLOG_RETENTION_SIZE_SETTING.exists(normalizedSettings)) {
                     for (String index : actualIndices) {
-                        MetadataCreateIndexService.validateTranslogRetentionSettings(metadataBuilder.get(index).getSettings());
+                        final Settings settings = metadataBuilder.get(index).getSettings();
+                        MetadataCreateIndexService.validateTranslogRetentionSettings(settings);
+                        MetadataCreateIndexService.validateStoreTypeSetting(settings);
                     }
                 }
                 boolean changed = false;

--- a/server/src/main/java/org/elasticsearch/index/IndexModule.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexModule.java
@@ -380,8 +380,6 @@ public final class IndexModule {
     public static Type defaultStoreType(final boolean allowMmap) {
         if (allowMmap && Constants.JRE_IS_64BIT && MMapDirectory.UNMAP_SUPPORTED) {
             return Type.HYBRIDFS;
-        } else if (Constants.WINDOWS) {
-            return Type.SIMPLEFS;
         } else {
             return Type.NIOFS;
         }

--- a/server/src/main/java/org/elasticsearch/index/store/FsDirectoryFactory.java
+++ b/server/src/main/java/org/elasticsearch/index/store/FsDirectoryFactory.java
@@ -18,7 +18,6 @@ import org.apache.lucene.store.LockFactory;
 import org.apache.lucene.store.MMapDirectory;
 import org.apache.lucene.store.NIOFSDirectory;
 import org.apache.lucene.store.NativeFSLockFactory;
-import org.apache.lucene.store.SimpleFSDirectory;
 import org.apache.lucene.store.SimpleFSLockFactory;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Setting.Property;
@@ -80,7 +79,6 @@ public class FsDirectoryFactory implements IndexStorePlugin.DirectoryFactory {
             case MMAPFS:
                 return setPreload(new MMapDirectory(location, lockFactory), lockFactory, preLoadExtensions);
             case SIMPLEFS:
-                return new SimpleFSDirectory(location, lockFactory);
             case NIOFS:
                 return new NIOFSDirectory(location, lockFactory);
             default:

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataCreateIndexServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataCreateIndexServiceTests.java
@@ -39,6 +39,7 @@ import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.index.Index;
+import org.elasticsearch.index.IndexModule;
 import org.elasticsearch.index.IndexNotFoundException;
 import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.mapper.MapperService;
@@ -964,6 +965,20 @@ public class MetadataCreateIndexServiceTests extends ESTestCase {
             Collections.emptySet());
         assertWarnings("Translog retention settings [index.translog.retention.age] "
             + "and [index.translog.retention.size] are deprecated and effectively ignored. They will be removed in a future version.");
+    }
+
+    public void testDeprecateSimpleFS() {
+        request = new CreateIndexClusterStateUpdateRequest("create index", "test", "test");
+        final Settings.Builder settings = Settings.builder();
+        settings.put(IndexModule.INDEX_STORE_TYPE_SETTING.getKey(), IndexModule.Type.SIMPLEFS.getSettingsKey());
+
+        request.settings(settings.build());
+        aggregateIndexSettings(ClusterState.EMPTY_STATE, request, Settings.EMPTY,
+            null, Settings.EMPTY, IndexScopedSettings.DEFAULT_SCOPED_SETTINGS, randomShardLimitService(),
+            Collections.emptySet());
+        assertWarnings("[simplefs] is deprecated and will be removed in 8.0. Use [niofs] or other file systems instead. " +
+            "Elasticsearch 7.15 or later uses [niofs] for the [simplefs] store type " +
+            "as it offers superior or equivalent performance to [simplefs].");
     }
 
     private IndexTemplateMetadata addMatchingTemplate(Consumer<IndexTemplateMetadata.Builder> configurator) {

--- a/server/src/test/java/org/elasticsearch/index/store/FsDirectoryFactoryTests.java
+++ b/server/src/test/java/org/elasticsearch/index/store/FsDirectoryFactoryTests.java
@@ -13,7 +13,6 @@ import org.apache.lucene.store.IOContext;
 import org.apache.lucene.store.MMapDirectory;
 import org.apache.lucene.store.NIOFSDirectory;
 import org.apache.lucene.store.NoLockFactory;
-import org.apache.lucene.store.SimpleFSDirectory;
 import org.apache.lucene.store.SleepingLockWrapper;
 import org.apache.lucene.util.Constants;
 import org.elasticsearch.Version;
@@ -131,20 +130,16 @@ public class FsDirectoryFactoryTests extends ESTestCase {
                 case HYBRIDFS:
                     assertTrue(FsDirectoryFactory.isHybridFs(directory));
                     break;
+                case SIMPLEFS:
                 case NIOFS:
                     assertTrue(type + " " + directory.toString(), directory instanceof NIOFSDirectory);
                     break;
                 case MMAPFS:
                     assertTrue(type + " " + directory.toString(), directory instanceof MMapDirectory);
                     break;
-                case SIMPLEFS:
-                    assertTrue(type + " " + directory.toString(), directory instanceof SimpleFSDirectory);
-                    break;
                 case FS:
                     if (Constants.JRE_IS_64BIT && MMapDirectory.UNMAP_SUPPORTED) {
                         assertTrue(FsDirectoryFactory.isHybridFs(directory));
-                    } else if (Constants.WINDOWS) {
-                        assertTrue(directory.toString(), directory instanceof SimpleFSDirectory);
                     } else {
                         assertTrue(directory.toString(), directory instanceof NIOFSDirectory);
                     }

--- a/server/src/test/java/org/elasticsearch/plugins/PluginsServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/plugins/PluginsServiceTests.java
@@ -82,14 +82,14 @@ public class PluginsServiceTests extends ESTestCase {
         Settings settings = Settings.builder()
             .put(Environment.PATH_HOME_SETTING.getKey(), createTempDir())
             .put("my.setting", "test")
-            .put(IndexModule.INDEX_STORE_TYPE_SETTING.getKey(), IndexModule.Type.SIMPLEFS.getSettingsKey()).build();
+            .put(IndexModule.INDEX_STORE_TYPE_SETTING.getKey(), IndexModule.Type.NIOFS.getSettingsKey()).build();
         PluginsService service = newPluginsService(settings, AdditionalSettingsPlugin1.class);
         Settings newSettings = service.updatedSettings();
         assertEquals("test", newSettings.get("my.setting")); // previous settings still exist
         assertEquals("1", newSettings.get("foo.bar")); // added setting exists
         // does not override pre existing settings
         assertEquals(
-            IndexModule.Type.SIMPLEFS.getSettingsKey(),
+            IndexModule.Type.NIOFS.getSettingsKey(),
             newSettings.get(IndexModule.INDEX_STORE_TYPE_SETTING.getKey())
         );
     }
@@ -121,7 +121,7 @@ public class PluginsServiceTests extends ESTestCase {
         Settings settings = Settings.builder()
             .put(Environment.PATH_HOME_SETTING.getKey(), createTempDir())
             .put("my.setting", "test")
-            .put(IndexModule.INDEX_STORE_TYPE_SETTING.getKey(), IndexModule.Type.SIMPLEFS.getSettingsKey()).build();
+            .put(IndexModule.INDEX_STORE_TYPE_SETTING.getKey(), IndexModule.Type.NIOFS.getSettingsKey()).build();
         PluginsService service = newPluginsService(settings, AdditionalSettingsPlugin1.class, FilterablePlugin.class);
         List<ScriptPlugin> scriptPlugins = service.filterPlugins(ScriptPlugin.class);
         assertEquals(1, scriptPlugins.size());

--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/DeprecationChecks.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/DeprecationChecks.java
@@ -39,8 +39,9 @@ public class DeprecationChecks {
     static List<Function<IndexMetadata, DeprecationIssue>> INDEX_SETTINGS_CHECKS = List.of(
         IndexDeprecationChecks::oldIndicesCheck,
         IndexDeprecationChecks::translogRetentionSettingCheck,
-        IndexDeprecationChecks::checkIndexDataPath
-        );
+        IndexDeprecationChecks::checkIndexDataPath,
+        IndexDeprecationChecks::storeTypeSettingCheck
+    );
 
     /**
      * helper utility function to reduce repeat of running a specific {@link List} of checks.

--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/IndexDeprecationChecks.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/IndexDeprecationChecks.java
@@ -9,6 +9,7 @@ package org.elasticsearch.xpack.deprecation;
 
 import org.elasticsearch.Version;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
+import org.elasticsearch.index.IndexModule;
 import org.elasticsearch.index.IndexSettings;
 
 import java.util.Locale;
@@ -53,6 +54,19 @@ public class IndexDeprecationChecks {
                 "breaking-changes-7.13.html#deprecate-shared-data-path-setting";
             final String details = "Found index data path configured. Discontinue use of this setting.";
             return new DeprecationIssue(DeprecationIssue.Level.CRITICAL, message, url, details, null);
+        }
+        return null;
+    }
+
+    static DeprecationIssue storeTypeSettingCheck(IndexMetadata indexMetadata) {
+        final String storeType = IndexModule.INDEX_STORE_TYPE_SETTING.get(indexMetadata.getSettings());
+        if (IndexModule.Type.SIMPLEFS.match(storeType)) {
+            return new DeprecationIssue(DeprecationIssue.Level.WARNING,
+                "[simplefs] is deprecated and will be removed in future versions",
+                "https://www.elastic.co/guide/en/elasticsearch/reference/current/index-modules-store.html",
+                "[simplefs] is deprecated and will be removed in 8.0. Use [niofs] or other file systems instead. " +
+                    "Elasticsearch 7.15 or later uses [niofs] for the [simplefs] store type " +
+                    "as it offers superior or equivalent performance to [simplefs].", null);
         }
         return null;
     }


### PR DESCRIPTION
SimpleFS is deprecated and will be removed in Lucene 9. This commit
deprecates SimpleFS in 7.x and uses NIOFS for SimpleFS in Elasticsearch
7.15 or later as it offers superior or equivalent performance to
SimpleFS.

Backport of #75156