### PR TITLE
OnChange listener now only runs when there is actual change

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/license/OperationModeFileWatcher.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/license/OperationModeFileWatcher.java
@@ -91,6 +91,7 @@ public final class OperationModeFileWatcher implements FileChangesListener {
 
     private synchronized void onChange(Path file) {
         if (file.equals(licenseModePath)) {
+            final OperationMode savedOperationMode = this.currentOperationMode;
             OperationMode newOperationMode = defaultOperationMode;
             try {
                 if (Files.exists(licenseModePath)
@@ -116,11 +117,13 @@ public final class OperationModeFileWatcher implements FileChangesListener {
                     }
                 }
             } finally {
-                // set this after the fact to prevent that we are jumping back and forth first setting to defautl and then reading the
+                // set this after the fact to prevent that we are jumping back and forth first setting to default and then reading the
                 // actual op mode resetting it.
                 this.currentOperationMode = newOperationMode;
             }
-            onChange.run();
+            if (savedOperationMode != newOperationMode) {
+                onChange.run();
+            }
         }
     }
 }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/license/OperationModeFileWatcherTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/license/OperationModeFileWatcherTests.java
@@ -51,7 +51,7 @@ public class OperationModeFileWatcherTests extends ESTestCase {
     }
 
     public void testInit() throws Exception {
-        onChangeCounter.set(new CountDownLatch(2));
+        onChangeCounter.set(new CountDownLatch(1));
         writeMode("gold");
         assertThat(operationModeFileWatcher.getCurrentOperationMode(), equalTo(License.OperationMode.PLATINUM));
         operationModeFileWatcher.init();


### PR DESCRIPTION
OperationModeFileWatcher#onChange maybe called when the file content
remains the same. When this happens, the newOperationMode will be the
same as the currentOperationMode and the onChange listener should not
run.

This PR checks whether the value actually changes before invoking the
listener.

Resolves: #44701
