### PR TITLE
Prevent searchable snapshots indices to be shrunk/split

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataCreateIndexService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataCreateIndexService.java
@@ -100,6 +100,7 @@ import static org.elasticsearch.cluster.metadata.IndexMetadata.SETTING_NUMBER_OF
 import static org.elasticsearch.cluster.metadata.IndexMetadata.SETTING_NUMBER_OF_SHARDS;
 import static org.elasticsearch.cluster.metadata.MetadataCreateDataStreamService.validateTimestampFieldMapping;
 import static org.elasticsearch.cluster.metadata.MetadataIndexTemplateService.resolveSettings;
+import static org.elasticsearch.index.IndexModule.INDEX_STORE_TYPE_SETTING;
 
 /**
  * Service responsible for submitting create index requests
@@ -1132,7 +1133,9 @@ public class MetadataCreateIndexService {
             throw new IllegalArgumentException(String.format(Locale.ROOT, "cannot resize the write index [%s] for data stream [%s]",
                 sourceIndex, source.getParentDataStream().getName()));
         }
-
+        if ("snapshot".equals(INDEX_STORE_TYPE_SETTING.get(sourceMetadata.getSettings()))) {
+            throw new IllegalArgumentException("searchable snapshot index [" + sourceIndex + "] cannot be resized");
+        }
         // ensure index is read-only
         if (state.blocks().indexBlocked(ClusterBlockLevel.WRITE, sourceIndex) == false) {
             throw new IllegalStateException("index " + sourceIndex + " must be read-only to resize index. use \"index.blocks.write=true\"");

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataCreateIndexService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataCreateIndexService.java
@@ -72,6 +72,7 @@ import java.io.UnsupportedEncodingException;
 import java.nio.file.Path;
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -100,6 +101,7 @@ import static org.elasticsearch.cluster.metadata.IndexMetadata.SETTING_NUMBER_OF
 import static org.elasticsearch.cluster.metadata.IndexMetadata.SETTING_NUMBER_OF_SHARDS;
 import static org.elasticsearch.cluster.metadata.MetadataCreateDataStreamService.validateTimestampFieldMapping;
 import static org.elasticsearch.cluster.metadata.MetadataIndexTemplateService.resolveSettings;
+import static org.elasticsearch.index.IndexModule.INDEX_RECOVERY_TYPE_SETTING;
 import static org.elasticsearch.index.IndexModule.INDEX_STORE_TYPE_SETTING;
 
 /**
@@ -1078,6 +1080,9 @@ public class MetadataCreateIndexService {
      */
     static List<String> validateShrinkIndex(ClusterState state, String sourceIndex, String targetIndexName, Settings targetIndexSettings) {
         IndexMetadata sourceMetadata = validateResize(state, sourceIndex, targetIndexName, targetIndexSettings);
+        if ("snapshot".equals(INDEX_STORE_TYPE_SETTING.get(sourceMetadata.getSettings()))) {
+            throw new IllegalArgumentException("can't shrink searchable snapshot index [" + sourceIndex + ']');
+        }
         assert INDEX_NUMBER_OF_SHARDS_SETTING.exists(targetIndexSettings);
         IndexMetadata.selectShrinkShards(0, sourceMetadata, INDEX_NUMBER_OF_SHARDS_SETTING.get(targetIndexSettings));
 
@@ -1109,11 +1114,23 @@ public class MetadataCreateIndexService {
 
     static void validateSplitIndex(ClusterState state, String sourceIndex, String targetIndexName, Settings targetIndexSettings) {
         IndexMetadata sourceMetadata = validateResize(state, sourceIndex, targetIndexName, targetIndexSettings);
+        if ("snapshot".equals(INDEX_STORE_TYPE_SETTING.get(sourceMetadata.getSettings()))) {
+            throw new IllegalArgumentException("can't split searchable snapshot index [" + sourceIndex + ']');
+        }
         IndexMetadata.selectSplitShard(0, sourceMetadata, INDEX_NUMBER_OF_SHARDS_SETTING.get(targetIndexSettings));
     }
 
     static void validateCloneIndex(ClusterState state, String sourceIndex, String targetIndexName, Settings targetIndexSettings) {
         IndexMetadata sourceMetadata = validateResize(state, sourceIndex, targetIndexName, targetIndexSettings);
+        if ("snapshot".equals(INDEX_STORE_TYPE_SETTING.get(sourceMetadata.getSettings()))) {
+            for (Setting<?> nonCloneableSetting : List.of(INDEX_STORE_TYPE_SETTING, INDEX_RECOVERY_TYPE_SETTING)) {
+                if (nonCloneableSetting.exists(targetIndexSettings) == false) {
+                    throw new IllegalArgumentException("can't clone searchable snapshot index [" + sourceIndex + "]; setting ["
+                        + nonCloneableSetting.getKey()
+                        + "] should be overridden");
+                }
+            }
+        }
         IndexMetadata.selectCloneShard(0, sourceMetadata, INDEX_NUMBER_OF_SHARDS_SETTING.get(targetIndexSettings));
     }
 
@@ -1132,9 +1149,6 @@ public class MetadataCreateIndexService {
             source.getParentDataStream().getWriteIndex().getIndex().equals(sourceMetadata.getIndex())) {
             throw new IllegalArgumentException(String.format(Locale.ROOT, "cannot resize the write index [%s] for data stream [%s]",
                 sourceIndex, source.getParentDataStream().getName()));
-        }
-        if ("snapshot".equals(INDEX_STORE_TYPE_SETTING.get(sourceMetadata.getSettings()))) {
-            throw new IllegalArgumentException("searchable snapshot index [" + sourceIndex + "] cannot be resized");
         }
         // ensure index is read-only
         if (state.blocks().indexBlocked(ClusterBlockLevel.WRITE, sourceIndex) == false) {

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataCreateIndexService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataCreateIndexService.java
@@ -72,7 +72,6 @@ import java.io.UnsupportedEncodingException;
 import java.nio.file.Path;
 import java.time.Instant;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataCreateIndexService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataCreateIndexService.java
@@ -72,6 +72,7 @@ import java.io.UnsupportedEncodingException;
 import java.nio.file.Path;
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -1122,7 +1123,7 @@ public class MetadataCreateIndexService {
     static void validateCloneIndex(ClusterState state, String sourceIndex, String targetIndexName, Settings targetIndexSettings) {
         IndexMetadata sourceMetadata = validateResize(state, sourceIndex, targetIndexName, targetIndexSettings);
         if ("snapshot".equals(INDEX_STORE_TYPE_SETTING.get(sourceMetadata.getSettings()))) {
-            for (Setting<?> nonCloneableSetting : List.of(INDEX_STORE_TYPE_SETTING, INDEX_RECOVERY_TYPE_SETTING)) {
+            for (Setting<?> nonCloneableSetting : Arrays.asList(INDEX_STORE_TYPE_SETTING, INDEX_RECOVERY_TYPE_SETTING)) {
                 if (nonCloneableSetting.exists(targetIndexSettings) == false) {
                     throw new IllegalArgumentException("can't clone searchable snapshot index [" + sourceIndex + "]; setting ["
                         + nonCloneableSetting.getKey()

--- a/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/SearchableSnapshotsResizeIntegTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/SearchableSnapshotsResizeIntegTests.java
@@ -68,12 +68,7 @@ public class SearchableSnapshotsResizeIntegTests extends BaseFrozenSearchableSna
                 .indices()
                 .prepareResizeIndex("mounted-index", "shrunk-index")
                 .setResizeType(ResizeType.SHRINK)
-                .setSettings(
-                    Settings.builder()
-                        .put(INDEX_NUMBER_OF_REPLICAS_SETTING.getKey(), 0)
-                        .put(INDEX_NUMBER_OF_SHARDS_SETTING.getKey(), 1)
-                        .build()
-                )
+                .setSettings(indexSettingsNoReplicas(1).build())
                 .get()
         );
         assertThat(exception.getMessage(), equalTo("can't shrink searchable snapshot index [mounted-index]"));
@@ -86,12 +81,7 @@ public class SearchableSnapshotsResizeIntegTests extends BaseFrozenSearchableSna
                 .indices()
                 .prepareResizeIndex("mounted-index", "split-index")
                 .setResizeType(ResizeType.SPLIT)
-                .setSettings(
-                    Settings.builder()
-                        .put(INDEX_NUMBER_OF_REPLICAS_SETTING.getKey(), 0)
-                        .put(INDEX_NUMBER_OF_SHARDS_SETTING.getKey(), 4)
-                        .build()
-                )
+                .setSettings(indexSettingsNoReplicas(4).build())
                 .get()
         );
         assertThat(exception.getMessage(), equalTo("can't split searchable snapshot index [mounted-index]"));

--- a/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/SearchableSnapshotsResizeIntegTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/SearchableSnapshotsResizeIntegTests.java
@@ -45,6 +45,7 @@ public class SearchableSnapshotsResizeIntegTests extends BaseFrozenSearchableSna
                     .put(INDEX_SOFT_DELETES_SETTING.getKey(), true)
             )
         );
+        indexRandomDocs("index", scaledRandomIntBetween(0, 1_000));
         createSnapshot("repository", "snapshot", List.of("index"));
         assertAcked(client().admin().indices().prepareDelete("index"));
         mountSnapshot("repository", "snapshot", "index", "mounted-index", Settings.EMPTY, randomFrom(Storage.values()));

--- a/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/SearchableSnapshotsResizeIntegTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/SearchableSnapshotsResizeIntegTests.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.searchablesnapshots;
+
+import org.elasticsearch.action.admin.indices.shrink.ResizeType;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.repositories.fs.FsRepository;
+import org.elasticsearch.test.ESIntegTestCase;
+import org.junit.After;
+import org.junit.Before;
+
+import java.util.List;
+
+import static org.elasticsearch.cluster.metadata.IndexMetadata.INDEX_NUMBER_OF_REPLICAS_SETTING;
+import static org.elasticsearch.cluster.metadata.IndexMetadata.INDEX_NUMBER_OF_ROUTING_SHARDS_SETTING;
+import static org.elasticsearch.cluster.metadata.IndexMetadata.INDEX_NUMBER_OF_SHARDS_SETTING;
+import static org.elasticsearch.index.IndexSettings.INDEX_SOFT_DELETES_SETTING;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
+import static org.elasticsearch.xpack.core.searchablesnapshots.MountSearchableSnapshotRequest.Storage;
+import static org.hamcrest.Matchers.equalTo;
+
+@ESIntegTestCase.ClusterScope(numDataNodes = 1)
+public class SearchableSnapshotsResizeIntegTests extends BaseFrozenSearchableSnapshotsIntegTestCase {
+
+    @Before
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        createRepository("repository", FsRepository.TYPE);
+        assertAcked(
+            prepareCreate(
+                "index",
+                Settings.builder()
+                    .put(INDEX_NUMBER_OF_REPLICAS_SETTING.getKey(), 0)
+                    .put(INDEX_NUMBER_OF_SHARDS_SETTING.getKey(), 2)
+                    .put(INDEX_NUMBER_OF_ROUTING_SHARDS_SETTING.getKey(), 4)
+                    .put(INDEX_SOFT_DELETES_SETTING.getKey(), true)
+            )
+        );
+        createSnapshot("repository", "snapshot", List.of("index"));
+        assertAcked(client().admin().indices().prepareDelete("index"));
+        mountSnapshot("repository", "snapshot", "index", "mounted-index", Settings.EMPTY, randomFrom(Storage.values()));
+        ensureGreen("mounted-index");
+    }
+
+    @After
+    @Override
+    public void tearDown() throws Exception {
+        assertAcked(client().admin().indices().prepareDelete("mounted-*"));
+        assertAcked(client().admin().cluster().prepareDeleteSnapshot("repository", "snapshot").get());
+        assertAcked(client().admin().cluster().prepareDeleteRepository("repository"));
+        super.tearDown();
+    }
+
+    private void assertCannotResize(ThrowingRunnable runnable) {
+        final IllegalArgumentException exception = expectThrows(IllegalArgumentException.class, runnable);
+        assertThat(exception.getMessage(), equalTo("searchable snapshot index [mounted-index] cannot be resized"));
+    }
+
+    public void testShrinkSearchableSnapshotIndex() {
+        assertCannotResize(
+            () -> client().admin()
+                .indices()
+                .prepareResizeIndex("mounted-index", "shrunk-index")
+                .setResizeType(ResizeType.SHRINK)
+                .setSettings(
+                    Settings.builder()
+                        .put(INDEX_NUMBER_OF_REPLICAS_SETTING.getKey(), 0)
+                        .put(INDEX_NUMBER_OF_SHARDS_SETTING.getKey(), 1)
+                        .build()
+                )
+                .get()
+        );
+    }
+
+    public void testSplitSearchableSnapshotIndex() {
+        assertCannotResize(
+            () -> client().admin()
+                .indices()
+                .prepareResizeIndex("mounted-index", "split-index")
+                .setResizeType(ResizeType.SPLIT)
+                .setSettings(
+                    Settings.builder()
+                        .put(INDEX_NUMBER_OF_REPLICAS_SETTING.getKey(), 0)
+                        .put(INDEX_NUMBER_OF_SHARDS_SETTING.getKey(), 4)
+                        .build()
+                )
+                .get()
+        );
+    }
+
+    public void testCloneSearchableSnapshotIndex() {
+        assertCannotResize(
+            () -> client().admin().indices().prepareResizeIndex("mounted-index", "cloned-index").setResizeType(ResizeType.CLONE).get()
+        );
+    }
+}


### PR DESCRIPTION
Today if we try to shrink or to split a searchable snapshot index using the Resize API a new index will be created but can't be assigned, and even if it was assigned it won't work as the number of shards can't be changed and must always match the number of shards from the snapshot.

This pull request adds some verification to prevent a snapshot backed indices to be resized and if an attempt is made, throw a better error message.

Note that cloning is supported since #56595 and in this pull request we make sure that it is only used to convert the searchable snapshot index back to a regular index.

Relates https://github.com/elastic/elasticsearch/pull/74977#discussion_r666291537