### PR TITLE
[7.14] [DOCS] Update security prereqs for delete async EQL API (#75091)

### DIFF
--- a/docs/reference/eql/delete-async-eql-search-api.asciidoc
+++ b/docs/reference/eql/delete-async-eql-search-api.asciidoc
@@ -25,8 +25,11 @@ DELETE /_eql/search/FkpMRkJGS1gzVDRlM3g4ZzMyRGlLbkEaTXlJZHdNT09TU2VTZVBoNDM3cFZM
 [[delete-async-eql-search-api-prereqs]]
 ==== {api-prereq-title}
 
-* If the {es} {security-features} are enabled, only the user who first submitted
-the EQL search can delete the search using this API.
+* If the {es} {security-features} are enabled, only the following users can
+use this API to delete a search:
+
+** Users with the `cancel_task` <<privileges-list-cluster,cluster privilege>>
+** The user who first submitted the search
 
 * See <<eql-required-fields>>.
 


### PR DESCRIPTION
Backports the following commits to 7.14:
 - [DOCS] Update security prereqs for delete async EQL API (#75091)