### PR TITLE
[ML] fixing 7.x serialization for correlation aggregation (#75224)

### DIFF
--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/MlAggregationsIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/MlAggregationsIT.java
@@ -21,10 +21,9 @@ import org.elasticsearch.search.aggregations.bucket.terms.Terms;
 import org.elasticsearch.search.aggregations.metrics.NumericMetricsAggregation;
 import org.elasticsearch.search.aggregations.metrics.Percentiles;
 import org.elasticsearch.search.aggregations.pipeline.MovingFunctions;
-import org.elasticsearch.xpack.ml.MlSingleNodeTestCase;
-import org.elasticsearch.xpack.ml.aggs.correlation.BucketCorrelationAggregationBuilder;
-import org.elasticsearch.xpack.ml.aggs.correlation.CountCorrelationIndicator;
 import org.elasticsearch.xpack.ml.aggs.correlation.CountCorrelationFunction;
+import org.elasticsearch.xpack.ml.aggs.correlation.CountCorrelationIndicator;
+import org.elasticsearch.xpack.ml.aggs.correlation.BucketCorrelationAggregationBuilder;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -33,7 +32,7 @@ import java.util.stream.Stream;
 
 import static org.hamcrest.Matchers.closeTo;
 
-public class BucketCorrelationAggregationIT extends MlSingleNodeTestCase {
+public class MlAggregationsIT extends MlNativeAutodetectIntegTestCase {
 
     public void testCountCorrelation() {
 
@@ -209,8 +208,5 @@ public class BucketCorrelationAggregationIT extends MlSingleNodeTestCase {
             fail("Bulk response contained " + failures + " failures");
         }
     }
-
-
-
 
 }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MachineLearning.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MachineLearning.java
@@ -1174,7 +1174,10 @@ public class MachineLearning extends Plugin implements SystemIndexPlugin,
 
     @Override
     public List<NamedWriteableRegistry.Entry> getNamedWriteables() {
-        return MlAutoscalingNamedWritableProvider.getNamedWriteables();
+        List<NamedWriteableRegistry.Entry> namedWriteables = new ArrayList<>();
+        namedWriteables.addAll(MlAutoscalingNamedWritableProvider.getNamedWriteables());
+        namedWriteables.addAll(new CorrelationNamedContentProvider().getNamedWriteables());
+        return namedWriteables;
     }
 
     @Override


### PR DESCRIPTION
NamedWriteable Serialization was not declared in the original implementation for 7.x.

This commit fixes this. Relates to: #72133

closes: elastic/kibana#105047