### PR TITLE
Make fixRedundantIncludes internal to RootObjectMapper

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/mapper/DocumentParser.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DocumentParser.java
@@ -258,7 +258,6 @@ public final class DocumentParser {
         RootObjectMapper root;
         if (dynamicMappers.isEmpty() == false) {
             root = createDynamicUpdate(mappingLookup, dynamicMappers);
-            root.fixRedundantIncludes();
         } else {
             root = mappingLookup.getMapping().getRoot().copyAndReset();
         }

--- a/server/src/main/java/org/elasticsearch/index/mapper/MapperService.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/MapperService.java
@@ -285,7 +285,6 @@ public class MapperService extends AbstractIndexComponent implements Closeable {
 
     private DocumentMapper newDocumentMapper(Mapping mapping, MergeReason reason) {
         DocumentMapper newMapper = new DocumentMapper(documentParser, mapping);
-        newMapper.mapping().getRoot().fixRedundantIncludes();
         newMapper.validate(indexSettings, reason != MergeReason.MAPPING_RECOVERY);
         return newMapper;
     }

--- a/server/src/main/java/org/elasticsearch/index/mapper/RootObjectMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/RootObjectMapper.java
@@ -96,7 +96,9 @@ public class RootObjectMapper extends ObjectMapper {
 
         @Override
         public RootObjectMapper build(ContentPath contentPath) {
-            return (RootObjectMapper) super.build(contentPath);
+            RootObjectMapper root = (RootObjectMapper) super.build(contentPath);
+            root.fixRedundantIncludes();
+            return root;
         }
 
         @Override
@@ -118,7 +120,7 @@ public class RootObjectMapper extends ObjectMapper {
      * {@code true} or which is transitively included in root by a chain of nodes with
      * {@code isIncludeInParent} returning {@code true}.
      */
-    public void fixRedundantIncludes() {
+    private void fixRedundantIncludes() {
        fixRedundantIncludes(this, true);
     }
 
@@ -294,7 +296,9 @@ public class RootObjectMapper extends ObjectMapper {
 
     @Override
     public RootObjectMapper merge(Mapper mergeWith, MergeReason reason) {
-        return (RootObjectMapper) super.merge(mergeWith, reason);
+        RootObjectMapper merged = (RootObjectMapper) super.merge(mergeWith, reason);
+        merged.fixRedundantIncludes();
+        return merged;
     }
 
     @Override


### PR DESCRIPTION
When we create a new root object mapper, we have to remember to also 
call `fixRedundantIncludes()` to remove some parameters on grandchild
nested mappers.  This is easy to miss, and is also done in callsites that are
distant from the initial object creation making it hard to reason about.

This commit makes the method private, and calls it instead from the 
Builder.build() and object merge() methods; RootObjectMapper itself
is responsible for it, and callers do not need to worry about it.