### PR TITLE
[7.11] [DOCS] Note ILM `searchable_snapshot` action requires data tiers (#74706)

### DIFF
--- a/docs/reference/ilm/actions/ilm-searchable-snapshot.asciidoc
+++ b/docs/reference/ilm/actions/ilm-searchable-snapshot.asciidoc
@@ -13,7 +13,7 @@ The `searchable_snapshot` action requires <<data-tiers,data tiers>>. The action
 uses the
 <<tier-preference-allocation-filter,`index.routing.allocation.include._tier_preference`>>
 setting to mount the index directly to the phase's corresponding data tier. For
-example, in the cold phase, the action mounts a searchable snapshot index in the
+example, in the cold phase, the action mounts a searchable snapshot index to the
 cold data tier.
 
 IMPORTANT: If the `searchable_snapshot` action is used in the `hot` phase the

--- a/docs/reference/ilm/actions/ilm-searchable-snapshot.asciidoc
+++ b/docs/reference/ilm/actions/ilm-searchable-snapshot.asciidoc
@@ -4,14 +4,17 @@
 
 Phases allowed: hot, cold.
 
-Takes a snapshot of the managed index in the configured repository
-and mounts it as a searchable snapshot.
-If the managed index is part of a <<data-streams, data stream>>,
-the mounted index replaces the original index in the data stream.
+Takes a snapshot of the managed index in the configured repository and mounts it
+as a <<searchable-snapshots,{search-snap}>>. If the index is part of a
+<<data-streams, data stream>>, the mounted index replaces the original index in
+the stream.
 
-To use the `searchable_snapshot` action in the `hot` phase, the `rollover`
-action *must* be present. If no rollover action is configured, {ilm-init}
-will reject the policy.
+The `searchable_snapshot` action requires <<data-tiers,data tiers>>. The action
+uses the
+<<tier-preference-allocation-filter,`index.routing.allocation.include._tier_preference`>>
+setting to mount the index directly to the phase's corresponding data tier. For
+example, in the cold phase, the action mounts a searchable snapshot index in the
+cold data tier.
 
 IMPORTANT: If the `searchable_snapshot` action is used in the `hot` phase the
 subsequent phases cannot define any of the `shrink`, `forcemerge`, `freeze` or


### PR DESCRIPTION
Backports the following commits to 7.11:
 - [DOCS] Note ILM `searchable_snapshot` action requires data tiers (#74706)