### PR TITLE
Unmute RareTermsIT (#75169)

### DIFF
--- a/qa/mixed-cluster/src/test/java/org/elasticsearch/backwards/RareTermsIT.java
+++ b/qa/mixed-cluster/src/test/java/org/elasticsearch/backwards/RareTermsIT.java
@@ -46,7 +46,6 @@ public class RareTermsIT extends ESRestTestCase {
         return id;
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/74985")
     public void testSingleValuedString() throws Exception {
         IndexingIT.Nodes nodes = IndexingIT.buildNodeAndVersions(client());
         Version version = nodes.getBWCVersion();


### PR DESCRIPTION
This test was muted due to a bug that has been fixed in #75111. Now that the fix has been backported we can unmute this test again.

backport #75169