### PR TITLE
[7.x] Make PUT shutdown API idempotent (#75161)

### DIFF
--- a/x-pack/plugin/shutdown/src/main/java/org/elasticsearch/xpack/shutdown/TransportPutShutdownNodeAction.java
+++ b/x-pack/plugin/shutdown/src/main/java/org/elasticsearch/xpack/shutdown/TransportPutShutdownNodeAction.java
@@ -24,13 +24,11 @@ import org.elasticsearch.cluster.metadata.NodesShutdownMetadata;
 import org.elasticsearch.cluster.metadata.SingleNodeShutdownMetadata;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.Priority;
-import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 
 import java.util.HashMap;
-import java.util.Objects;
 
 public class TransportPutShutdownNodeAction extends AcknowledgedTransportMasterNodeAction<PutShutdownNodeAction.Request> {
     private static final Logger logger = LogManager.getLogger(TransportPutShutdownNodeAction.class);
@@ -67,9 +65,16 @@ public class TransportPutShutdownNodeAction extends AcknowledgedTransportMasterN
                 }
 
                 // Verify that there's not already a shutdown metadata for this node
-                if (Objects.nonNull(currentShutdownMetadata.getAllNodeMetadataMap().get(request.getNodeId()))) {
-                    logger.error(Strings.toString(currentShutdownMetadata));
-                    throw new IllegalArgumentException("node [" + request.getNodeId() + "] is already shutting down");
+                SingleNodeShutdownMetadata existingRecord = currentShutdownMetadata.getAllNodeMetadataMap().get(request.getNodeId());
+                if (existingRecord != null) {
+                    logger.info(
+                        "updating existing shutdown record for node [{}] of type [{}] with reason [{}] with new type [{}] and reason [{}]",
+                        existingRecord.getNodeId(),
+                        existingRecord.getType(),
+                        existingRecord.getReason(),
+                        request.getType(),
+                        request.getReason()
+                    );
                 }
 
                 SingleNodeShutdownMetadata newNodeMetadata = SingleNodeShutdownMetadata.builder()


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Make PUT shutdown API idempotent (#75161)