### PR TITLE
Loosen checks in REST test for PIT slicing

### DIFF
--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search/350_point_in_time.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search/350_point_in_time.yml
@@ -136,8 +136,8 @@ setup:
 ---
 "point-in-time with slicing":
   - skip:
-      version: "all"
-      reason: "https://github.com/elastic/elasticsearch/issues/75212"
+      version: " - 7.14.99"
+      reason: "support for slicing was added in 7.15"
   - do:
       open_point_in_time:
         index: test
@@ -157,9 +157,6 @@ setup:
           sort: [{ age: desc }, { id: desc }]
           pit:
             id: "$point_in_time_id"
-
-  - match: {hits.total.value: 2 }
-  - length: {hits.hits: 1 }
 
   - do:
       close_point_in_time:


### PR DESCRIPTION
Since the index may have more than one shard, we can't always predict how many
documents will fall in each slice. This PR simply removes the checks, since we
already test the slicing logic extensively in an integration test. The REST test
is now just a sanity check for the API.

Fixes #75212.