### PR TITLE
[7.x] [ML] Add datafeed_config field to anomaly detection job configs

### DIFF
--- a/docs/reference/ml/anomaly-detection/apis/get-job.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/get-job.asciidoc
@@ -22,7 +22,7 @@ Retrieves configuration information for {anomaly-jobs}.
 [[ml-get-job-prereqs]]
 == {api-prereq-title}
 
-Requires the `monitor_ml` cluster privilege. This privilege is included in the 
+Requires the `monitor_ml` cluster privilege. This privilege is included in the
 `machine_learning_user` built-in role.
 
 [[ml-get-job-desc]]
@@ -80,6 +80,69 @@ monitor progress.
 `create_time`::
 (string) The time the job was created. For example, `1491007356077`. This
 property is informational; you cannot change its value.
+
+`datafeed_config`::
+(object) The {dfeed} configured for the current {anomaly-job}.
++
+.Properties of `datafeed`
+[%collapsible%open]
+====
+`datafeed_id`:::
+(Optional, string)
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=datafeed-id]
+
+`aggregations`:::
+(Optional, object)
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=aggregations]
+
+`chunking_config`:::
+(Optional, object)
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=chunking-config]
+
+`delayed_data_check_config`:::
+(Optional, object)
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=delayed-data-check-config]
+
+`frequency`:::
+(Optional, <<time-units, time units>>)
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=frequency]
+
+`indices`:::
+(Required, array)
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=indices]
+
+`indices_options`:::
+(Optional, object)
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=indices-options]
+
+`job_id`::
+(Required, string)
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=job-id-anomaly-detection]
+
+`max_empty_searches`:::
+(Optional,integer)
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=max-empty-searches]
+
+`query`:::
+(Optional, object)
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=query]
+
+`query_delay`:::
+(Optional, <<time-units, time units>>)
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=query-delay]
+
+`runtime_mappings`:::
+(Optional, object)
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=runtime-mappings]
+
+`script_fields`:::
+(Optional, object)
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=script-fields]
+
+`scroll_size`:::
+(Optional, unsigned integer)
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=scroll-size]
+====
 
 `finished_time`::
 (string) If the job closed or failed, this is the time the job finished.

--- a/docs/reference/ml/anomaly-detection/apis/put-job.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/put-job.asciidoc
@@ -16,7 +16,7 @@ Instantiates an {anomaly-job}.
 [[ml-put-job-prereqs]]
 == {api-prereq-title}
 
-Requires the `manage_ml` cluster privilege. This privilege is included in the 
+Requires the `manage_ml` cluster privilege. This privilege is included in the
 `machine_learning_admin` built-in role.
 
 [[ml-put-job-desc]]
@@ -70,7 +70,7 @@ include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=categorization-filters]
 `detectors`:::
 (array) An array of detector configuration objects. Detector configuration
 objects specify which data fields a job analyzes. They also specify which
-analytical functions are used. You can specify multiple detectors for a job. 
+analytical functions are used. You can specify multiple detectors for a job.
 +
 NOTE: If the `detectors` array does not contain at least one detector,
 no analysis can occur and an error is returned.
@@ -222,7 +222,7 @@ include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=analysis-limits]
 include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=categorization-examples-limit]
 
 `model_memory_limit`:::
-(long or string) 
+(long or string)
 include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=model-memory-limit-ad]
 ====
 //End analysis_limits
@@ -234,6 +234,66 @@ include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=background-persist-interval]
 [[put-customsettings]]`custom_settings`::
 (Optional, object)
 include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=custom-settings]
+
+`datafeed_config`::
+(object) The {dfeed} configured for the current {anomaly-job}.
++
+.Properties of `datafeed`
+[%collapsible%open]
+====
+`datafeed_id`:::
+(Optional, string)
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=datafeed-id]
+Defaults to the same ID as the {anomaly-job}.
+
+`aggregations`:::
+(Optional, object)
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=aggregations]
+
+`chunking_config`:::
+(Optional, object)
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=chunking-config]
+
+`delayed_data_check_config`:::
+(Optional, object)
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=delayed-data-check-config]
+
+`frequency`:::
+(Optional, <<time-units, time units>>)
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=frequency]
+
+`indices`:::
+(Required, array)
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=indices]
+
+`indices_options`:::
+(Optional, object)
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=indices-options]
+
+`max_empty_searches`:::
+(Optional,integer)
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=max-empty-searches]
+
+`query`:::
+(Optional, object)
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=query]
+
+`query_delay`:::
+(Optional, <<time-units, time units>>)
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=query-delay]
+
+`runtime_mappings`:::
+(Optional, object)
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=runtime-mappings]
+
+`script_fields`:::
+(Optional, object)
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=script-fields]
+
+`scroll_size`:::
+(Optional, unsigned integer)
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=scroll-size]
+====
 
 //Begin data_description
 [[put-datadescription]]`data_description`::

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/ml.put_job.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/ml.put_job.json
@@ -26,6 +26,31 @@
         }
       ]
     },
+    "params":{
+      "ignore_unavailable":{
+        "type":"boolean",
+        "description":"Ignore unavailable indexes (default: false). Only set if datafeed_config is provided."
+      },
+      "allow_no_indices":{
+        "type":"boolean",
+        "description":"Ignore if the source indices expressions resolves to no concrete indices (default: true). Only set if datafeed_config is provided."
+      },
+      "ignore_throttled":{
+        "type":"boolean",
+        "description":"Ignore indices that are marked as throttled (default: true). Only set if datafeed_config is provided."
+      },
+      "expand_wildcards":{
+        "type":"enum",
+        "options":[
+          "open",
+          "closed",
+          "hidden",
+          "none",
+          "all"
+        ],
+        "description":"Whether source index expressions should get expanded to open or closed indices (default: open). Only set if datafeed_config is provided."
+      }
+    },
     "body":{
       "description":"The job",
       "required":true

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/MlMetadata.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/MlMetadata.java
@@ -42,6 +42,8 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.SortedMap;
 import java.util.TreeMap;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 import static org.elasticsearch.xpack.core.ClientHelper.filterSecurityHeaders;
 
@@ -102,6 +104,13 @@ public class MlMetadata implements XPackPlugin.XPackMetadataCustom {
 
     public Optional<DatafeedConfig> getDatafeedByJobId(String jobId) {
         return datafeeds.values().stream().filter(s -> s.getJobId().equals(jobId)).findFirst();
+    }
+
+    public Map<String, DatafeedConfig> getDatafeedsByJobIds(Set<String> jobIds) {
+        return datafeeds.values()
+            .stream()
+            .filter(df -> jobIds.contains(df.getJobId()))
+            .collect(Collectors.toMap(DatafeedConfig::getJobId, Function.identity()));
     }
 
     public Set<String> expandDatafeedIds(String expression, boolean allowNoMatch) {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/PutJobAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/PutJobAction.java
@@ -10,6 +10,7 @@ import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.action.ActionType;
+import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.action.support.master.AcknowledgedRequest;
 import org.elasticsearch.action.support.master.MasterNodeOperationRequestBuilder;
 import org.elasticsearch.client.ElasticsearchClient;
@@ -37,7 +38,7 @@ public class PutJobAction extends ActionType<PutJobAction.Response> {
 
     public static class Request extends AcknowledgedRequest<Request> {
 
-        public static Request parseRequest(String jobId, XContentParser parser) {
+        public static Request parseRequest(String jobId, XContentParser parser, IndicesOptions indicesOptions) {
             Job.Builder jobBuilder = Job.STRICT_PARSER.apply(parser, null);
             if (jobBuilder.getId() == null) {
                 jobBuilder.setId(jobId);
@@ -46,7 +47,7 @@ public class PutJobAction extends ActionType<PutJobAction.Response> {
                 throw new IllegalArgumentException(Messages.getMessage(Messages.INCONSISTENT_ID, Job.ID.getPreferredName(),
                         jobBuilder.getId(), jobId));
             }
-
+            jobBuilder.setDatafeedIndicesOptionsIfRequired(indicesOptions);
             return new Request(jobBuilder);
         }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/datafeed/DatafeedConfig.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/datafeed/DatafeedConfig.java
@@ -13,6 +13,7 @@ import org.elasticsearch.Version;
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.cluster.AbstractDiffable;
+import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.common.xcontent.ParseField;
 import org.elasticsearch.common.Strings;
@@ -37,7 +38,6 @@ import org.elasticsearch.search.builder.SearchSourceBuilder;
 import org.elasticsearch.search.sort.SortOrder;
 import org.elasticsearch.xpack.core.common.time.TimeUtils;
 import org.elasticsearch.xpack.core.ml.datafeed.extractor.ExtractorUtils;
-import org.elasticsearch.xpack.core.ml.job.config.Job;
 import org.elasticsearch.xpack.core.ml.utils.ExceptionsHelper;
 import org.elasticsearch.xpack.core.ml.utils.MlStrings;
 import org.elasticsearch.xpack.core.ml.utils.QueryProvider;
@@ -109,6 +109,8 @@ public class DatafeedConfig extends AbstractDiffable<DatafeedConfig> implements 
      */
     public static final String DOC_COUNT = "doc_count";
 
+    // Accessing `Job.ID` here causes an NPE in tests as a DatafeedConfig parser is referenced in the Job parser
+    public static final ParseField JOB_ID = new ParseField("job_id");
     public static final ParseField ID = new ParseField("datafeed_id");
     public static final ParseField CONFIG_TYPE = new ParseField("config_type");
     public static final ParseField QUERY_DELAY = new ParseField("query_delay");
@@ -158,7 +160,7 @@ public class DatafeedConfig extends AbstractDiffable<DatafeedConfig> implements 
 
         parser.declareString(Builder::setId, ID);
         parser.declareString((c, s) -> {}, CONFIG_TYPE);
-        parser.declareString(Builder::setJobId, Job.ID);
+        parser.declareString(Builder::setJobId, JOB_ID);
         parser.declareStringArray(Builder::setIndices, INDEXES);
         parser.declareStringArray(Builder::setIndices, INDICES);
         parser.declareString((builder, val) ->
@@ -556,7 +558,7 @@ public class DatafeedConfig extends AbstractDiffable<DatafeedConfig> implements 
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startObject();
         builder.field(ID.getPreferredName(), id);
-        builder.field(Job.ID.getPreferredName(), jobId);
+        builder.field(JOB_ID.getPreferredName(), jobId);
         if (params.paramAsBoolean(EXCLUDE_GENERATED, false) == false) {
             if (params.paramAsBoolean(ToXContentParams.FOR_INTERNAL_STORAGE, false)) {
                 builder.field(CONFIG_TYPE.getPreferredName(), TYPE);
@@ -731,7 +733,7 @@ public class DatafeedConfig extends AbstractDiffable<DatafeedConfig> implements 
         return TimeValue.timeValueHours(1);
     }
 
-    public static class Builder {
+    public static class Builder implements Writeable {
 
         private String id;
         private String jobId;
@@ -754,7 +756,7 @@ public class DatafeedConfig extends AbstractDiffable<DatafeedConfig> implements 
         public Builder(String id, String jobId) {
             this();
             this.id = ExceptionsHelper.requireNonNull(id, ID.getPreferredName());
-            this.jobId = ExceptionsHelper.requireNonNull(jobId, Job.ID.getPreferredName());
+            this.jobId = ExceptionsHelper.requireNonNull(jobId, JOB_ID.getPreferredName());
         }
 
         public Builder(DatafeedConfig config) {
@@ -775,6 +777,116 @@ public class DatafeedConfig extends AbstractDiffable<DatafeedConfig> implements 
             this.runtimeMappings = new HashMap<>(config.runtimeMappings);
         }
 
+        public Builder(StreamInput in) throws IOException {
+            this.id = in.readOptionalString();
+            this.jobId = in.readOptionalString();
+            this.queryDelay = in.readOptionalTimeValue();
+            this.frequency = in.readOptionalTimeValue();
+            if (in.readBoolean()) {
+                this.indices = Collections.unmodifiableList(in.readStringList());
+            } else {
+                this.indices = null;
+            }
+            // each of these writables are version aware
+            this.queryProvider = QueryProvider.fromStream(in);
+            // This reads a boolean from the stream, if true, it sends the stream to the `fromStream` method
+            this.aggProvider = in.readOptionalWriteable(AggProvider::fromStream);
+
+            if (in.readBoolean()) {
+                this.scriptFields = Collections.unmodifiableList(in.readList(SearchSourceBuilder.ScriptField::new));
+            } else {
+                this.scriptFields = null;
+            }
+            this.scrollSize = in.readOptionalVInt();
+            this.chunkingConfig = in.readOptionalWriteable(ChunkingConfig::new);
+            this.headers = Collections.unmodifiableMap(in.readMap(StreamInput::readString, StreamInput::readString));
+            delayedDataCheckConfig = in.readOptionalWriteable(DelayedDataCheckConfig::new);
+            maxEmptySearches = in.readOptionalVInt();
+            if (in.readBoolean()) {
+                indicesOptions = IndicesOptions.readIndicesOptions(in);
+            }
+            runtimeMappings = in.readMap();
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            out.writeOptionalString(id);
+            out.writeOptionalString(jobId);
+            out.writeOptionalTimeValue(queryDelay);
+            out.writeOptionalTimeValue(frequency);
+            if (indices != null) {
+                out.writeBoolean(true);
+                out.writeStringCollection(indices);
+            } else {
+                out.writeBoolean(false);
+            }
+
+            // Each of these writables are version aware
+            queryProvider.writeTo(out); // never null
+            // This writes a boolean to the stream, if true, it sends the stream to the `writeTo` method
+            out.writeOptionalWriteable(aggProvider);
+
+            if (scriptFields != null) {
+                out.writeBoolean(true);
+                out.writeList(scriptFields);
+            } else {
+                out.writeBoolean(false);
+            }
+            out.writeOptionalVInt(scrollSize);
+            out.writeOptionalWriteable(chunkingConfig);
+            out.writeMap(headers, StreamOutput::writeString, StreamOutput::writeString);
+            out.writeOptionalWriteable(delayedDataCheckConfig);
+            out.writeOptionalVInt(maxEmptySearches);
+            out.writeBoolean(indicesOptions != null);
+            if (indicesOptions != null) {
+                indicesOptions.writeIndicesOptions(out);
+            }
+            out.writeMap(runtimeMappings);
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            Builder builder = (Builder) o;
+            return Objects.equals(id, builder.id)
+                && Objects.equals(jobId, builder.jobId)
+                && Objects.equals(queryDelay, builder.queryDelay)
+                && Objects.equals(frequency, builder.frequency)
+                && Objects.equals(indices, builder.indices)
+                && Objects.equals(queryProvider, builder.queryProvider)
+                && Objects.equals(aggProvider, builder.aggProvider)
+                && Objects.equals(scriptFields, builder.scriptFields)
+                && Objects.equals(scrollSize, builder.scrollSize)
+                && Objects.equals(chunkingConfig, builder.chunkingConfig)
+                && Objects.equals(headers, builder.headers)
+                && Objects.equals(delayedDataCheckConfig, builder.delayedDataCheckConfig)
+                && Objects.equals(maxEmptySearches, builder.maxEmptySearches)
+                && Objects.equals(indicesOptions, builder.indicesOptions)
+                && Objects.equals(runtimeMappings, builder.runtimeMappings);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(
+                id,
+                jobId,
+                queryDelay,
+                frequency,
+                indices,
+                queryProvider,
+                aggProvider,
+                scriptFields,
+                scrollSize,
+                chunkingConfig,
+                headers,
+                delayedDataCheckConfig,
+                maxEmptySearches,
+                indicesOptions,
+                runtimeMappings
+            );
+        }
+
         public Builder setId(String datafeedId) {
             id = ExceptionsHelper.requireNonNull(datafeedId, ID.getPreferredName());
             return this;
@@ -785,7 +897,7 @@ public class DatafeedConfig extends AbstractDiffable<DatafeedConfig> implements 
         }
 
         public Builder setJobId(String jobId) {
-            this.jobId = ExceptionsHelper.requireNonNull(jobId, Job.ID.getPreferredName());
+            this.jobId = ExceptionsHelper.requireNonNull(jobId, JOB_ID.getPreferredName());
             return this;
         }
 
@@ -914,7 +1026,7 @@ public class DatafeedConfig extends AbstractDiffable<DatafeedConfig> implements 
 
         public DatafeedConfig build() {
             ExceptionsHelper.requireNonNull(id, ID.getPreferredName());
-            ExceptionsHelper.requireNonNull(jobId, Job.ID.getPreferredName());
+            ExceptionsHelper.requireNonNull(jobId, JOB_ID.getPreferredName());
             if (MlStrings.isValidId(id) == false) {
                 throw ExceptionsHelper.badRequestException(getMessage(INVALID_ID, ID.getPreferredName(), id));
             }
@@ -1053,6 +1165,7 @@ public class DatafeedConfig extends AbstractDiffable<DatafeedConfig> implements 
                 checkNoMoreCompositeAggregations(agg.getSubAggregations());
             }
         }
+
         private void setDefaultChunkingConfig() {
             if (chunkingConfig == null) {
                 chunkingConfig = defaultChunkingConfig(aggProvider);

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/config/Job.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/config/Job.java
@@ -8,6 +8,7 @@ package org.elasticsearch.xpack.core.ml.job.config;
 
 import org.elasticsearch.ResourceAlreadyExistsException;
 import org.elasticsearch.Version;
+import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.cluster.AbstractDiffable;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.common.xcontent.ParseField;
@@ -21,12 +22,14 @@ import org.elasticsearch.common.xcontent.ObjectParser;
 import org.elasticsearch.common.xcontent.ObjectParser.ValueType;
 import org.elasticsearch.common.xcontent.ToXContentObject;
 import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.xpack.core.ml.datafeed.DatafeedConfig;
 import org.elasticsearch.xpack.core.ml.job.messages.Messages;
 import org.elasticsearch.xpack.core.ml.job.persistence.AnomalyDetectorsIndexFields;
 import org.elasticsearch.xpack.core.ml.job.process.autodetect.state.DataCounts;
 import org.elasticsearch.xpack.core.ml.utils.ExceptionsHelper;
 import org.elasticsearch.xpack.core.ml.utils.MlStrings;
 import org.elasticsearch.xpack.core.common.time.TimeUtils;
+import org.elasticsearch.xpack.core.ml.utils.ToXContentParams;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -39,10 +42,12 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.concurrent.TimeUnit;
 
+import static org.elasticsearch.xpack.core.ml.job.messages.Messages.JOB_CONFIG_DATAFEED_CONFIG_JOB_ID_MISMATCH;
 import static org.elasticsearch.xpack.core.ml.utils.ToXContentParams.EXCLUDE_GENERATED;
 
 /**
@@ -84,6 +89,7 @@ public class Job extends AbstractDiffable<Job> implements Writeable, ToXContentO
     public static final ParseField DELETING = new ParseField("deleting");
     public static final ParseField ALLOW_LAZY_OPEN = new ParseField("allow_lazy_open");
     public static final ParseField BLOCKED = new ParseField("blocked");
+    public static final ParseField DATAFEED_CONFIG = new ParseField("datafeed_config");
 
     // Used for QueryPage
     public static final ParseField RESULTS_FIELD = new ParseField("jobs");
@@ -138,7 +144,9 @@ public class Job extends AbstractDiffable<Job> implements Writeable, ToXContentO
         parser.declareBoolean(Builder::setDeleting, DELETING);
         parser.declareBoolean(Builder::setAllowLazyOpen, ALLOW_LAZY_OPEN);
         parser.declareObject(Builder::setBlocked, ignoreUnknownFields ? Blocked.LENIENT_PARSER : Blocked.STRICT_PARSER, BLOCKED);
-
+        parser.declareObject(Builder::setDatafeed,
+            ignoreUnknownFields ? DatafeedConfig.LENIENT_PARSER : DatafeedConfig.STRICT_PARSER,
+            DATAFEED_CONFIG);
         return parser;
     }
 
@@ -173,6 +181,7 @@ public class Job extends AbstractDiffable<Job> implements Writeable, ToXContentO
     private final boolean deleting;
     private final boolean allowLazyOpen;
     private final Blocked blocked;
+    private final DatafeedConfig datafeedConfig;
 
     private Job(String jobId, String jobType, Version jobVersion, List<String> groups, String description,
                 Date createTime, Date finishedTime,
@@ -180,8 +189,7 @@ public class Job extends AbstractDiffable<Job> implements Writeable, ToXContentO
                 ModelPlotConfig modelPlotConfig, Long renormalizationWindowDays, TimeValue backgroundPersistInterval,
                 Long modelSnapshotRetentionDays, Long dailyModelSnapshotRetentionAfterDays, Long resultsRetentionDays,
                 Map<String, Object> customSettings, String modelSnapshotId, Version modelSnapshotMinVersion, String resultsIndexName,
-                boolean deleting, boolean allowLazyOpen, Blocked blocked) {
-
+                boolean deleting, boolean allowLazyOpen, Blocked blocked, DatafeedConfig datafeedConfig) {
         this.jobId = jobId;
         this.jobType = jobType;
         this.jobVersion = jobVersion;
@@ -215,6 +223,7 @@ public class Job extends AbstractDiffable<Job> implements Writeable, ToXContentO
         } else {
             this.blocked = blocked;
         }
+        this.datafeedConfig = datafeedConfig;
     }
 
     public Job(StreamInput in) throws IOException {
@@ -271,6 +280,11 @@ public class Job extends AbstractDiffable<Job> implements Writeable, ToXContentO
             blocked = new Blocked(in);
         } else {
             blocked = deleting ? new Blocked(Blocked.Reason.DELETE, null) : Blocked.none();
+        }
+        if (in.getVersion().onOrAfter(Version.V_7_15_0)) {
+            this.datafeedConfig = in.readOptionalWriteable(DatafeedConfig::new);
+        } else {
+            this.datafeedConfig = null;
         }
     }
 
@@ -509,6 +523,10 @@ public class Job extends AbstractDiffable<Job> implements Writeable, ToXContentO
         return currentTime;
     }
 
+    public Optional<DatafeedConfig> getDatafeedConfig() {
+        return Optional.ofNullable(datafeedConfig);
+    }
+
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         out.writeString(jobId);
@@ -567,6 +585,9 @@ public class Job extends AbstractDiffable<Job> implements Writeable, ToXContentO
         if (out.getVersion().onOrAfter(Version.V_7_14_0)) {
             blocked.writeTo(out);
         }
+        if (out.getVersion().onOrAfter(Version.V_7_15_0)) {
+            out.writeOptionalWriteable(datafeedConfig);
+        }
     }
 
     @Override
@@ -601,6 +622,12 @@ public class Job extends AbstractDiffable<Job> implements Writeable, ToXContentO
             }
             if (customSettings != null) {
                 builder.field(CUSTOM_SETTINGS.getPreferredName(), customSettings);
+            }
+            //TODO in v8.0.0 move this out so that it will be included when `exclude_generated` is `true`
+            if (params.paramAsBoolean(ToXContentParams.FOR_INTERNAL_STORAGE, false) == false) {
+                if (datafeedConfig != null) {
+                    builder.field(DATAFEED_CONFIG.getPreferredName(), datafeedConfig, params);
+                }
             }
         } else {
             if (customSettings != null) {
@@ -681,15 +708,17 @@ public class Job extends AbstractDiffable<Job> implements Writeable, ToXContentO
                 && Objects.equals(this.resultsIndexName, that.resultsIndexName)
                 && Objects.equals(this.deleting, that.deleting)
                 && Objects.equals(this.allowLazyOpen, that.allowLazyOpen)
-                && Objects.equals(this.blocked, that.blocked);
+                && Objects.equals(this.blocked, that.blocked)
+                && Objects.equals(this.datafeedConfig, that.datafeedConfig);
     }
 
     @Override
     public int hashCode() {
         return Objects.hash(jobId, jobType, jobVersion, groups, description, createTime, finishedTime,
-                analysisConfig, analysisLimits, dataDescription, modelPlotConfig, renormalizationWindowDays,
-                backgroundPersistInterval, modelSnapshotRetentionDays, dailyModelSnapshotRetentionAfterDays, resultsRetentionDays,
-                customSettings, modelSnapshotId, modelSnapshotMinVersion, resultsIndexName, deleting, allowLazyOpen, blocked);
+            analysisConfig, analysisLimits, dataDescription, modelPlotConfig, renormalizationWindowDays,
+            backgroundPersistInterval, modelSnapshotRetentionDays, dailyModelSnapshotRetentionAfterDays, resultsRetentionDays,
+            customSettings, modelSnapshotId, modelSnapshotMinVersion, resultsIndexName, deleting, allowLazyOpen, blocked,
+            datafeedConfig);
     }
 
     // Class already extends from AbstractDiffable, so copied from ToXContentToBytes#toString()
@@ -740,6 +769,7 @@ public class Job extends AbstractDiffable<Job> implements Writeable, ToXContentO
         private boolean deleting;
         private boolean allowLazyOpen;
         private Blocked blocked = Blocked.none();
+        private DatafeedConfig.Builder datafeedConfig;
 
         public Builder() {
         }
@@ -772,6 +802,7 @@ public class Job extends AbstractDiffable<Job> implements Writeable, ToXContentO
             this.deleting = job.isDeleting();
             this.allowLazyOpen = job.allowLazyOpen();
             this.blocked = job.getBlocked();
+            this.datafeedConfig = job.getDatafeedConfig().isPresent() ? new DatafeedConfig.Builder(job.datafeedConfig) : null;
         }
 
         public Builder(StreamInput in) throws IOException {
@@ -823,6 +854,9 @@ public class Job extends AbstractDiffable<Job> implements Writeable, ToXContentO
                 blocked = new Blocked(in);
             } else {
                 blocked = Blocked.none();
+            }
+            if (in.getVersion().onOrAfter(Version.V_7_15_0)) {
+                datafeedConfig = in.readOptionalWriteable(DatafeedConfig.Builder::new);
             }
         }
 
@@ -963,6 +997,24 @@ public class Job extends AbstractDiffable<Job> implements Writeable, ToXContentO
             return this;
         }
 
+        public Builder setDatafeed(DatafeedConfig.Builder datafeed) {
+            this.datafeedConfig = datafeed;
+            return this;
+        }
+
+        /**
+         * This is used for parsing. If the datafeed_config exists AND its indices options are `null`, we set them to these options
+         *
+         * @param indicesOptions To set if the datafeed indices options are null
+         * @return The job builder.
+         */
+        public Builder setDatafeedIndicesOptionsIfRequired(IndicesOptions indicesOptions) {
+            if (this.datafeedConfig != null && this.datafeedConfig.getIndicesOptions() == null) {
+                this.datafeedConfig.setIndicesOptions(indicesOptions);
+            }
+            return this;
+        }
+
         /**
          * Return the list of fields that have been set and are invalid to
          * be set when the job is created e.g. model snapshot Id should not
@@ -1046,6 +1098,9 @@ public class Job extends AbstractDiffable<Job> implements Writeable, ToXContentO
             if (out.getVersion().onOrAfter(Version.V_7_14_0)) {
                 blocked.writeTo(out);
             }
+            if (out.getVersion().onOrAfter(Version.V_7_15_0)) {
+                out.writeOptionalWriteable(datafeedConfig);
+            }
         }
 
         public boolean equals(Object o) {
@@ -1075,7 +1130,8 @@ public class Job extends AbstractDiffable<Job> implements Writeable, ToXContentO
                     && Objects.equals(this.resultsIndexName, that.resultsIndexName)
                     && Objects.equals(this.deleting, that.deleting)
                     && Objects.equals(this.allowLazyOpen, that.allowLazyOpen)
-                    && Objects.equals(this.blocked, that.blocked);
+                    && Objects.equals(this.blocked, that.blocked)
+                    && Objects.equals(this.datafeedConfig, that.datafeedConfig);
         }
 
         @Override
@@ -1083,7 +1139,8 @@ public class Job extends AbstractDiffable<Job> implements Writeable, ToXContentO
             return Objects.hash(id, jobType, jobVersion, groups, description, analysisConfig, analysisLimits, dataDescription,
                     createTime, finishedTime, modelPlotConfig, renormalizationWindowDays,
                     backgroundPersistInterval, modelSnapshotRetentionDays, dailyModelSnapshotRetentionAfterDays, resultsRetentionDays,
-                    customSettings, modelSnapshotId, modelSnapshotMinVersion, resultsIndexName, deleting, allowLazyOpen, blocked);
+                    customSettings, modelSnapshotId, modelSnapshotMinVersion, resultsIndexName, deleting, allowLazyOpen, blocked,
+                datafeedConfig);
         }
 
         /**
@@ -1237,12 +1294,24 @@ public class Job extends AbstractDiffable<Job> implements Writeable, ToXContentO
                         ? resultsIndexName
                         : "custom-" + resultsIndexName;
             }
+            if (datafeedConfig != null) {
+                if (datafeedConfig.getId() == null) {
+                    datafeedConfig.setId(id);
+                }
+                if (datafeedConfig.getJobId() != null && datafeedConfig.getJobId().equals(id) == false) {
+                    throw new IllegalArgumentException(
+                        Messages.getMessage(JOB_CONFIG_DATAFEED_CONFIG_JOB_ID_MISMATCH, datafeedConfig.getJobId(), id)
+                    );
+                }
+                datafeedConfig.setJobId(id);
+            }
 
             return new Job(
                     id, jobType, jobVersion, groups, description, createTime, finishedTime,
                     analysisConfig, analysisLimits, dataDescription, modelPlotConfig, renormalizationWindowDays,
                     backgroundPersistInterval, modelSnapshotRetentionDays, dailyModelSnapshotRetentionAfterDays, resultsRetentionDays,
-                    customSettings, modelSnapshotId, modelSnapshotMinVersion, resultsIndexName, deleting, allowLazyOpen, blocked);
+                    customSettings, modelSnapshotId, modelSnapshotMinVersion, resultsIndexName, deleting, allowLazyOpen, blocked,
+                Optional.ofNullable(datafeedConfig).map(DatafeedConfig.Builder::build).orElse(null));
         }
 
         private void checkValidBackgroundPersistInterval() {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/messages/Messages.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/messages/Messages.java
@@ -245,6 +245,8 @@ public final class Messages {
     public static final String JOB_CONFIG_MODEL_SNAPSHOT_RETENTION_SETTINGS_INCONSISTENT =
             "The value of '" + Job.DAILY_MODEL_SNAPSHOT_RETENTION_AFTER_DAYS + "' [{0}] cannot be greater than '" +
                 Job.MODEL_SNAPSHOT_RETENTION_DAYS + "' [{1}]";
+    public static final String JOB_CONFIG_DATAFEED_CONFIG_JOB_ID_MISMATCH =
+        "datafeed job_id [{0}] does not equal job id [{1}}";
 
     public static final String JOB_AND_GROUP_NAMES_MUST_BE_UNIQUE =
             "job and group names must be unique but job [{0}] and group [{0}] have the same name";

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/datafeed/DatafeedConfigBuilderTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/datafeed/DatafeedConfigBuilderTests.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+package org.elasticsearch.xpack.core.ml.datafeed;
+
+import org.elasticsearch.action.search.SearchRequest;
+import org.elasticsearch.action.support.IndicesOptions;
+import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
+import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.search.SearchModule;
+import org.elasticsearch.search.aggregations.AggregationBuilder;
+import org.elasticsearch.search.aggregations.AggregationBuilders;
+import org.elasticsearch.search.aggregations.AggregatorFactories;
+import org.elasticsearch.search.aggregations.bucket.composite.DateHistogramValuesSourceBuilder;
+import org.elasticsearch.search.aggregations.bucket.histogram.DateHistogramInterval;
+import org.elasticsearch.search.aggregations.metrics.MaxAggregationBuilder;
+import org.elasticsearch.search.builder.SearchSourceBuilder;
+import org.elasticsearch.test.AbstractWireSerializingTestCase;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+import static org.elasticsearch.xpack.core.ml.datafeed.DatafeedConfigTests.randomStringList;
+import static org.elasticsearch.xpack.core.ml.utils.QueryProviderTests.createRandomValidQueryProvider;
+
+public class DatafeedConfigBuilderTests extends AbstractWireSerializingTestCase<DatafeedConfig.Builder> {
+
+    static DatafeedConfig.Builder createRandomizedDatafeedConfigBuilder(String jobId, String datafeedId, long bucketSpanMillis) {
+        DatafeedConfig.Builder builder = new DatafeedConfig.Builder();
+        if (jobId != null) {
+            builder.setJobId(jobId);
+        }
+        if (datafeedId != null) {
+            builder.setId(datafeedId);
+        }
+        builder.setIndices(randomStringList(1, 10));
+        if (randomBoolean()) {
+            builder.setQueryProvider(createRandomValidQueryProvider(randomAlphaOfLengthBetween(1, 10), randomAlphaOfLengthBetween(1, 10)));
+        }
+        boolean addScriptFields = randomBoolean();
+        if (addScriptFields) {
+            int scriptsSize = randomInt(3);
+            List<SearchSourceBuilder.ScriptField> scriptFields = new ArrayList<>(scriptsSize);
+            for (int scriptIndex = 0; scriptIndex < scriptsSize; scriptIndex++) {
+                scriptFields.add(new SearchSourceBuilder.ScriptField(randomAlphaOfLength(10), mockScript(randomAlphaOfLength(10)),
+                    randomBoolean()));
+            }
+            builder.setScriptFields(scriptFields);
+        }
+        Long aggHistogramInterval = null;
+        if (randomBoolean() && addScriptFields == false) {
+            // can only test with a single agg as the xcontent order gets randomized by test base class and then
+            // the actual xcontent isn't the same and test fail.
+            // Testing with a single agg is ok as we don't have special list writeable / xcontent logic
+            AggregatorFactories.Builder aggs = new AggregatorFactories.Builder();
+            aggHistogramInterval = randomNonNegativeLong();
+            aggHistogramInterval = aggHistogramInterval> bucketSpanMillis ? bucketSpanMillis : aggHistogramInterval;
+            aggHistogramInterval = aggHistogramInterval <= 0 ? 1 : aggHistogramInterval;
+            MaxAggregationBuilder maxTime = AggregationBuilders.max("time").field("time");
+            AggregationBuilder topAgg = randomBoolean() ?
+                AggregationBuilders.dateHistogram("buckets")
+                    .field("time")
+                    .fixedInterval(new DateHistogramInterval(aggHistogramInterval + "ms")) :
+                AggregationBuilders.composite(
+                    "buckets",
+                    Collections.singletonList(
+                        new DateHistogramValuesSourceBuilder("time")
+                            .field("time")
+                            .fixedInterval(new DateHistogramInterval(aggHistogramInterval + "ms"))
+                    )
+                );
+            aggs.addAggregator(topAgg.subAggregation(maxTime));
+            builder.setParsedAggregations(aggs);
+        }
+        if (randomBoolean()) {
+            builder.setScrollSize(randomIntBetween(0, Integer.MAX_VALUE));
+        }
+        if (randomBoolean()) {
+            if (aggHistogramInterval == null) {
+                builder.setFrequency(TimeValue.timeValueSeconds(randomIntBetween(1, 1_000_000)));
+            } else {
+                builder.setFrequency(TimeValue.timeValueSeconds(randomIntBetween(1, 5) * aggHistogramInterval));
+            }
+        }
+        if (randomBoolean()) {
+            builder.setQueryDelay(TimeValue.timeValueMillis(randomIntBetween(1, 1_000_000)));
+        }
+        if (randomBoolean()) {
+            builder.setChunkingConfig(ChunkingConfigTests.createRandomizedChunk());
+        }
+        if (randomBoolean()) {
+            builder.setDelayedDataCheckConfig(DelayedDataCheckConfigTests.createRandomizedConfig(bucketSpanMillis));
+        }
+        if (randomBoolean()) {
+            builder.setMaxEmptySearches(randomIntBetween(10, 100));
+        }
+        builder.setIndicesOptions(IndicesOptions.fromParameters(
+            randomFrom(IndicesOptions.WildcardStates.values()).name().toLowerCase(Locale.ROOT),
+            Boolean.toString(randomBoolean()),
+            Boolean.toString(randomBoolean()),
+            Boolean.toString(randomBoolean()),
+            SearchRequest.DEFAULT_INDICES_OPTIONS));
+        if (randomBoolean()) {
+            Map<String, Object> settings = new HashMap<>();
+            settings.put("type", "keyword");
+            settings.put("script", "");
+            Map<String, Object> field = new HashMap<>();
+            field.put("runtime_field_foo", settings);
+            builder.setRuntimeMappings(field);
+        }
+        return builder;
+    }
+
+    @Override
+    protected DatafeedConfig.Builder createTestInstance() {
+        return createRandomizedDatafeedConfigBuilder(
+            randomBoolean() ? null : randomAlphaOfLength(10),
+            randomBoolean() ? null : randomAlphaOfLength(10),
+            3600000
+        );
+    }
+
+    @Override
+    protected NamedWriteableRegistry getNamedWriteableRegistry() {
+        SearchModule searchModule = new SearchModule(Settings.EMPTY, false, Collections.emptyList());
+        return new NamedWriteableRegistry(searchModule.getNamedWriteables());
+    }
+
+    @Override
+    protected Writeable.Reader<DatafeedConfig.Builder> instanceReader() {
+        return DatafeedConfig.Builder::new;
+    }
+
+}

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/datafeed/DatafeedConfigTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/datafeed/DatafeedConfigTests.java
@@ -35,7 +35,6 @@ import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.index.query.TermQueryBuilder;
 import org.elasticsearch.script.Script;
 import org.elasticsearch.search.SearchModule;
-import org.elasticsearch.search.aggregations.AggregationBuilder;
 import org.elasticsearch.search.aggregations.AggregationBuilders;
 import org.elasticsearch.search.aggregations.AggregatorFactories;
 import org.elasticsearch.search.aggregations.PipelineAggregatorBuilders;
@@ -69,6 +68,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 
+import static org.elasticsearch.xpack.core.ml.datafeed.DatafeedConfigBuilderTests.createRandomizedDatafeedConfigBuilder;
 import static org.elasticsearch.xpack.core.ml.job.messages.Messages.DATAFEED_AGGREGATIONS_INTERVAL_MUST_BE_GREATER_THAN_ZERO;
 import static org.elasticsearch.xpack.core.ml.utils.QueryProviderTests.createRandomValidQueryProvider;
 import static org.hamcrest.Matchers.containsString;
@@ -76,7 +76,6 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.hasEntry;
 import static org.hamcrest.Matchers.hasSize;
-import static org.hamcrest.Matchers.in;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.lessThan;
 import static org.hamcrest.Matchers.not;
@@ -115,86 +114,6 @@ public class DatafeedConfigTests extends AbstractSerializingTestCase<DatafeedCon
 
     public static DatafeedConfig createRandomizedDatafeedConfig(String jobId, String datafeedId, long bucketSpanMillis) {
         return createRandomizedDatafeedConfigBuilder(jobId, datafeedId, bucketSpanMillis).build();
-    }
-
-    private static DatafeedConfig.Builder createRandomizedDatafeedConfigBuilder(String jobId, String datafeedId, long bucketSpanMillis) {
-        DatafeedConfig.Builder builder = new DatafeedConfig.Builder(datafeedId, jobId);
-        builder.setIndices(randomStringList(1, 10));
-        if (randomBoolean()) {
-            builder.setQueryProvider(createRandomValidQueryProvider(randomAlphaOfLengthBetween(1, 10), randomAlphaOfLengthBetween(1, 10)));
-        }
-        boolean addScriptFields = randomBoolean();
-        if (addScriptFields) {
-            int scriptsSize = randomInt(3);
-            List<SearchSourceBuilder.ScriptField> scriptFields = new ArrayList<>(scriptsSize);
-            for (int scriptIndex = 0; scriptIndex < scriptsSize; scriptIndex++) {
-                scriptFields.add(new SearchSourceBuilder.ScriptField(randomAlphaOfLength(10), mockScript(randomAlphaOfLength(10)),
-                        randomBoolean()));
-            }
-            builder.setScriptFields(scriptFields);
-        }
-        Long aggHistogramInterval = null;
-        if (randomBoolean() && addScriptFields == false) {
-            // can only test with a single agg as the xcontent order gets randomized by test base class and then
-            // the actual xcontent isn't the same and test fail.
-            // Testing with a single agg is ok as we don't have special list writeable / xcontent logic
-            AggregatorFactories.Builder aggs = new AggregatorFactories.Builder();
-            aggHistogramInterval = randomNonNegativeLong();
-            aggHistogramInterval = aggHistogramInterval> bucketSpanMillis ? bucketSpanMillis : aggHistogramInterval;
-            aggHistogramInterval = aggHistogramInterval <= 0 ? 1 : aggHistogramInterval;
-            MaxAggregationBuilder maxTime = AggregationBuilders.max("time").field("time");
-            AggregationBuilder topAgg = randomBoolean() ?
-                AggregationBuilders.dateHistogram("buckets")
-                    .field("time")
-                    .fixedInterval(new DateHistogramInterval(aggHistogramInterval + "ms")) :
-                AggregationBuilders.composite(
-                    "buckets",
-                    Collections.singletonList(
-                        new DateHistogramValuesSourceBuilder("time")
-                            .field("time")
-                            .fixedInterval(new DateHistogramInterval(aggHistogramInterval + "ms"))
-                    )
-                );
-            aggs.addAggregator(topAgg.subAggregation(maxTime));
-            builder.setParsedAggregations(aggs);
-        }
-        if (randomBoolean()) {
-            builder.setScrollSize(randomIntBetween(0, Integer.MAX_VALUE));
-        }
-        if (randomBoolean()) {
-            if (aggHistogramInterval == null) {
-                builder.setFrequency(TimeValue.timeValueSeconds(randomIntBetween(1, 1_000_000)));
-            } else {
-                builder.setFrequency(TimeValue.timeValueSeconds(randomIntBetween(1, 5) * aggHistogramInterval));
-            }
-        }
-        if (randomBoolean()) {
-            builder.setQueryDelay(TimeValue.timeValueMillis(randomIntBetween(1, 1_000_000)));
-        }
-        if (randomBoolean()) {
-            builder.setChunkingConfig(ChunkingConfigTests.createRandomizedChunk());
-        }
-        if (randomBoolean()) {
-            builder.setDelayedDataCheckConfig(DelayedDataCheckConfigTests.createRandomizedConfig(bucketSpanMillis));
-        }
-        if (randomBoolean()) {
-            builder.setMaxEmptySearches(randomIntBetween(10, 100));
-        }
-        builder.setIndicesOptions(IndicesOptions.fromParameters(
-            randomFrom(IndicesOptions.WildcardStates.values()).name().toLowerCase(Locale.ROOT),
-            Boolean.toString(randomBoolean()),
-            Boolean.toString(randomBoolean()),
-            Boolean.toString(randomBoolean()),
-            SearchRequest.DEFAULT_INDICES_OPTIONS));
-        if (randomBoolean()) {
-            Map<String, Object> settings = new HashMap<>();
-            settings.put("type", "keyword");
-            settings.put("script", "");
-            Map<String, Object> field = new HashMap<>();
-            field.put("runtime_field_foo", settings);
-            builder.setRuntimeMappings(field);
-        }
-        return builder;
     }
 
     @Override

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/job/config/JobTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/job/config/JobTests.java
@@ -11,9 +11,13 @@ import org.elasticsearch.ElasticsearchStatusException;
 import org.elasticsearch.ResourceAlreadyExistsException;
 import org.elasticsearch.Version;
 import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.ByteSizeUnit;
 import org.elasticsearch.common.unit.ByteSizeValue;
+import org.elasticsearch.common.xcontent.LoggingDeprecationHandler;
+import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.common.xcontent.DeprecationHandler;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
@@ -23,12 +27,15 @@ import org.elasticsearch.common.xcontent.XContentParseException;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.common.xcontent.json.JsonXContent;
+import org.elasticsearch.search.SearchModule;
 import org.elasticsearch.test.AbstractSerializingTestCase;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.core.ml.MachineLearningField;
+import org.elasticsearch.xpack.core.ml.datafeed.DatafeedConfig;
 import org.elasticsearch.xpack.core.ml.job.messages.Messages;
 import org.elasticsearch.xpack.core.ml.job.persistence.AnomalyDetectorsIndexFields;
 import org.elasticsearch.xpack.core.ml.job.process.autodetect.state.DataCounts;
+import org.elasticsearch.xpack.core.ml.utils.ToXContentParams;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -65,7 +72,19 @@ public class JobTests extends AbstractSerializingTestCase<Job> {
 
     @Override
     protected Job createTestInstance() {
-        return createRandomizedJob();
+        return createRandomizedJob(new DatafeedConfig.Builder().setIndices(Arrays.asList("airline_data")));
+    }
+
+    @Override
+    protected NamedWriteableRegistry getNamedWriteableRegistry() {
+        SearchModule searchModule = new SearchModule(Settings.EMPTY, false, Collections.emptyList());
+        return new NamedWriteableRegistry(searchModule.getNamedWriteables());
+    }
+
+    @Override
+    protected NamedXContentRegistry xContentRegistry() {
+        SearchModule searchModule = new SearchModule(Settings.EMPTY, false, Collections.emptyList());
+        return new NamedXContentRegistry(searchModule.getNamedXContents());
     }
 
     @Override
@@ -76,6 +95,19 @@ public class JobTests extends AbstractSerializingTestCase<Job> {
     @Override
     protected Job doParseInstance(XContentParser parser) {
         return Job.STRICT_PARSER.apply(parser, null).build();
+    }
+
+    public void testToXContentForInternalStorage() throws IOException {
+        Job config = createRandomizedJob(new DatafeedConfig.Builder().setIndices(Arrays.asList("airline_data")));
+        ToXContent.MapParams params = new ToXContent.MapParams(Collections.singletonMap(ToXContentParams.FOR_INTERNAL_STORAGE, "true"));
+
+        BytesReference serializedJob = XContentHelper.toXContent(config, XContentType.JSON, params, false);
+        XContentParser parser = XContentFactory.xContent(XContentType.JSON)
+            .createParser(xContentRegistry(), LoggingDeprecationHandler.INSTANCE, serializedJob.streamInput());
+
+        Job parsedConfig = Job.LENIENT_PARSER.apply(parser, null).build();
+        // When we are writing for internal storage, we do not include the datafeed config
+        assertThat(parsedConfig.getDatafeedConfig().isPresent(), is(false));
     }
 
     public void testFutureConfigParse() throws IOException {
@@ -658,6 +690,10 @@ public class JobTests extends AbstractSerializingTestCase<Job> {
     }
 
     public static Job createRandomizedJob() {
+        return createRandomizedJob(null);
+    }
+
+    public static Job createRandomizedJob(DatafeedConfig.Builder datafeedBuilder) {
         String jobId = randomValidJobId();
         Job.Builder builder = new Job.Builder(jobId);
         if (randomBoolean()) {
@@ -725,6 +761,9 @@ public class JobTests extends AbstractSerializingTestCase<Job> {
         }
         if (randomBoolean()) {
             builder.setBlocked(BlockedTests.createRandom());
+        }
+        if (datafeedBuilder != null) {
+            builder.setDatafeed(datafeedBuilder);
         }
         return builder.build();
     }

--- a/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/DatafeedConfigProviderIT.java
+++ b/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/DatafeedConfigProviderIT.java
@@ -38,11 +38,14 @@ import java.util.function.BiConsumer;
 import java.util.stream.Collectors;
 
 import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.anEmptyMap;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.nullValue;
@@ -326,7 +329,7 @@ public class DatafeedConfigProviderIT extends MlSingleNodeTestCase {
         assertThat(exceptionHolder.get().getMessage(), containsString("No datafeed with id [foo-1*] exists"));
     }
 
-    public void testFindDatafeedsForJobIds() throws Exception {
+    public void testFindDatafeedIdsForJobIds() throws Exception {
         putDatafeedConfig(createDatafeedConfig("foo-1", "j1"), Collections.emptyMap());
         putDatafeedConfig(createDatafeedConfig("foo-2", "j2"), Collections.emptyMap());
         putDatafeedConfig(createDatafeedConfig("bar-1", "j3"), Collections.emptyMap());
@@ -336,17 +339,55 @@ public class DatafeedConfigProviderIT extends MlSingleNodeTestCase {
         AtomicReference<Set<String>> datafeedIdsHolder = new AtomicReference<>();
         AtomicReference<Exception> exceptionHolder = new AtomicReference<>();
 
-        blockingCall(actionListener -> datafeedConfigProvider.findDatafeedsForJobIds(Collections.singletonList("new-job"), actionListener),
-                datafeedIdsHolder, exceptionHolder);
+        blockingCall(
+            actionListener -> datafeedConfigProvider.findDatafeedIdsForJobIds(
+                Collections.singletonList("new-job"),
+                actionListener
+            ),
+            datafeedIdsHolder,
+            exceptionHolder
+        );
         assertThat(datafeedIdsHolder.get(), empty());
 
-        blockingCall(actionListener -> datafeedConfigProvider.findDatafeedsForJobIds(Collections.singletonList("j2"), actionListener),
+        blockingCall(actionListener -> datafeedConfigProvider.findDatafeedIdsForJobIds(Collections.singletonList("j2"), actionListener),
                 datafeedIdsHolder, exceptionHolder);
         assertThat(datafeedIdsHolder.get(), contains("foo-2"));
 
-        blockingCall(actionListener -> datafeedConfigProvider.findDatafeedsForJobIds(Arrays.asList("j3", "j1"), actionListener),
+        blockingCall(actionListener -> datafeedConfigProvider.findDatafeedIdsForJobIds(Arrays.asList("j3", "j1"), actionListener),
                 datafeedIdsHolder, exceptionHolder);
         assertThat(datafeedIdsHolder.get(), contains("bar-1", "foo-1"));
+    }
+
+    public void testFindDatafeedsForJobIds() throws Exception {
+        putDatafeedConfig(createDatafeedConfig("foo-1", "j1"), Collections.emptyMap());
+        putDatafeedConfig(createDatafeedConfig("foo-2", "j2"), Collections.emptyMap());
+        putDatafeedConfig(createDatafeedConfig("bar-1", "j3"), Collections.emptyMap());
+
+        client().admin().indices().prepareRefresh(MlConfigIndex.indexName()).get();
+
+        AtomicReference<Map<String, DatafeedConfig.Builder>> datafeedMapHolder = new AtomicReference<>();
+        AtomicReference<Exception> exceptionHolder = new AtomicReference<>();
+
+        blockingCall(
+            actionListener -> datafeedConfigProvider.findDatafeedsByJobIds(
+                Collections.singletonList("new-job"),
+                actionListener
+            ),
+            datafeedMapHolder,
+            exceptionHolder
+        );
+        assertThat(datafeedMapHolder.get(), anEmptyMap());
+
+        blockingCall(actionListener -> datafeedConfigProvider.findDatafeedsByJobIds(Collections.singletonList("j2"), actionListener),
+            datafeedMapHolder, exceptionHolder);
+        assertThat(datafeedMapHolder.get(), hasKey("j2"));
+        assertThat(datafeedMapHolder.get().get("j2").getId(), equalTo("foo-2"));
+
+        blockingCall(actionListener -> datafeedConfigProvider.findDatafeedsByJobIds(Arrays.asList("j3", "j1"), actionListener),
+            datafeedMapHolder, exceptionHolder);
+        assertThat(datafeedMapHolder.get(), allOf(hasKey("j3"), hasKey("j1")));
+        assertThat(datafeedMapHolder.get().get("j3").getId(), equalTo("bar-1"));
+        assertThat(datafeedMapHolder.get().get("j1").getId(), equalTo("foo-1"));
     }
 
     public void testHeadersAreOverwritten() throws Exception {

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportCloseJobAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportCloseJobAction.java
@@ -242,7 +242,7 @@ public class TransportCloseJobAction extends TransportTasksAction<JobTask, Close
 
     void stopDatafeedsIfNecessary(OpenAndClosingIds jobIds, boolean isForce, TimeValue timeout, PersistentTasksCustomMetadata tasksMetadata,
                                   ActionListener<Boolean> listener) {
-        datafeedConfigProvider.findDatafeedsForJobIds(jobIds.openJobIds, ActionListener.wrap(
+        datafeedConfigProvider.findDatafeedIdsForJobIds(jobIds.openJobIds, ActionListener.wrap(
                 datafeedIds -> {
                     List<String> runningDatafeedIds = datafeedIds
                         .stream()

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportDeleteJobAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportDeleteJobAction.java
@@ -214,7 +214,6 @@ public class TransportDeleteJobAction extends AcknowledgedTransportMasterNodeAct
 
         // We clean up the memory tracker on delete rather than close as close is not a master node action
         memoryTracker.removeAnomalyDetectorJob(jobId);
-
         jobManager.deleteJob(request, parentTaskClient, state, listener);
     }
 
@@ -296,7 +295,7 @@ public class TransportDeleteJobAction extends AcknowledgedTransportMasterNodeAct
 
     private void markJobAsDeletingIfNotUsed(String jobId, TaskId taskId, ActionListener<PutJobAction.Response> listener) {
 
-        datafeedConfigProvider.findDatafeedsForJobIds(Collections.singletonList(jobId), ActionListener.wrap(
+        datafeedConfigProvider.findDatafeedIdsForJobIds(Collections.singletonList(jobId), ActionListener.wrap(
                 datafeedIds -> {
                     if (datafeedIds.isEmpty() == false) {
                         listener.onFailure(ExceptionsHelper.conflictStatusException("Cannot delete job [" + jobId + "] because datafeed ["

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetJobsAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetJobsAction.java
@@ -19,33 +19,55 @@ import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
+import org.elasticsearch.xpack.core.action.util.QueryPage;
 import org.elasticsearch.xpack.core.ml.action.GetJobsAction;
+import org.elasticsearch.xpack.core.ml.job.config.Job;
+import org.elasticsearch.xpack.ml.datafeed.DatafeedManager;
 import org.elasticsearch.xpack.ml.job.JobManager;
+
+import java.util.Optional;
+import java.util.stream.Collectors;
 
 public class TransportGetJobsAction extends TransportMasterNodeReadAction<GetJobsAction.Request, GetJobsAction.Response> {
 
     private static final Logger logger = LogManager.getLogger(TransportGetJobsAction.class);
 
     private final JobManager jobManager;
+    private final DatafeedManager datafeedManager;
 
     @Inject
     public TransportGetJobsAction(TransportService transportService, ClusterService clusterService,
                                   ThreadPool threadPool, ActionFilters actionFilters,
                                   IndexNameExpressionResolver indexNameExpressionResolver,
-                                  JobManager jobManager) {
+                                  JobManager jobManager, DatafeedManager datafeedManager) {
         super(GetJobsAction.NAME, transportService, clusterService, threadPool, actionFilters,
             GetJobsAction.Request::new, indexNameExpressionResolver, GetJobsAction.Response::new, ThreadPool.Names.SAME);
         this.jobManager = jobManager;
+        this.datafeedManager = datafeedManager;
     }
 
     @Override
     protected void masterOperation(GetJobsAction.Request request, ClusterState state,
                                    ActionListener<GetJobsAction.Response> listener) {
         logger.debug("Get job '{}'", request.getJobId());
-        jobManager.expandJobs(request.getJobId(), request.allowNoMatch(), ActionListener.wrap(
-                jobs -> {
-                    listener.onResponse(new GetJobsAction.Response(jobs));
-                },
+        jobManager.expandJobBuilders(request.getJobId(), request.allowNoMatch(), ActionListener.wrap(
+                jobs -> datafeedManager.getDatafeedsByJobIds(
+                        jobs.stream().map(Job.Builder::getId).collect(Collectors.toSet()),
+                        state,
+                        ActionListener.wrap(
+                            dfsByJobId ->
+                                listener.onResponse(new GetJobsAction.Response(
+                                    new QueryPage<>(
+                                        jobs.stream().map(jb -> {
+                                            Optional.ofNullable(dfsByJobId.get(jb.getId())).ifPresent(jb::setDatafeed);
+                                            return jb.build();
+                                        }).collect(Collectors.toList()),
+                                        jobs.size(),
+                                        Job.RESULTS_FIELD
+                                    )
+                                )),
+                            listener::onFailure
+                        )),
                 listener::onFailure
         ));
     }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportPutJobAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportPutJobAction.java
@@ -6,6 +6,10 @@
  */
 package org.elasticsearch.xpack.ml.action;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.message.ParameterizedMessage;
+import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.master.TransportMasterNodeAction;
@@ -15,6 +19,7 @@ import org.elasticsearch.cluster.block.ClusterBlockLevel;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.analysis.AnalysisRegistry;
 import org.elasticsearch.license.LicenseUtils;
 import org.elasticsearch.license.XPackLicenseState;
@@ -22,31 +27,82 @@ import org.elasticsearch.tasks.Task;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.xpack.core.XPackField;
+import org.elasticsearch.xpack.core.XPackSettings;
+import org.elasticsearch.xpack.core.ml.action.DeleteJobAction;
+import org.elasticsearch.xpack.core.ml.action.PutDatafeedAction;
 import org.elasticsearch.xpack.core.ml.action.PutJobAction;
+import org.elasticsearch.xpack.core.security.SecurityContext;
+import org.elasticsearch.xpack.ml.datafeed.DatafeedManager;
 import org.elasticsearch.xpack.ml.job.JobManager;
 
 public class TransportPutJobAction extends TransportMasterNodeAction<PutJobAction.Request, PutJobAction.Response> {
 
+    private static final Logger logger = LogManager.getLogger(TransportPutJobAction.class);
     private final JobManager jobManager;
+    private final DatafeedManager datafeedManager;
     private final XPackLicenseState licenseState;
     private final AnalysisRegistry analysisRegistry;
+    private final SecurityContext securityContext;
+
 
     @Inject
-    public TransportPutJobAction(TransportService transportService, ClusterService clusterService,
+    public TransportPutJobAction(Settings settings, TransportService transportService, ClusterService clusterService,
                                  ThreadPool threadPool, XPackLicenseState licenseState, ActionFilters actionFilters,
                                  IndexNameExpressionResolver indexNameExpressionResolver, JobManager jobManager,
-                                 AnalysisRegistry analysisRegistry) {
+                                 DatafeedManager datafeedManager, AnalysisRegistry analysisRegistry) {
         super(PutJobAction.NAME, transportService, clusterService, threadPool, actionFilters, PutJobAction.Request::new,
             indexNameExpressionResolver, PutJobAction.Response::new, ThreadPool.Names.SAME);
         this.licenseState = licenseState;
         this.jobManager = jobManager;
         this.analysisRegistry = analysisRegistry;
+        this.datafeedManager = datafeedManager;
+        this.securityContext = XPackSettings.SECURITY_ENABLED.get(settings) ?
+            new SecurityContext(settings, threadPool.getThreadContext()) : null;
     }
 
     @Override
     protected void masterOperation(PutJobAction.Request request, ClusterState state,
                                    ActionListener<PutJobAction.Response> listener) throws Exception {
-        jobManager.putJob(request, analysisRegistry, state, listener);
+        jobManager.putJob(request, analysisRegistry, state, ActionListener.wrap(
+            jobCreated -> {
+                if (jobCreated.getResponse().getDatafeedConfig().isPresent() == false) {
+                    listener.onResponse(jobCreated);
+                    return;
+                }
+                datafeedManager.putDatafeed(
+                    new PutDatafeedAction.Request(jobCreated.getResponse().getDatafeedConfig().get()),
+                    // Use newer state from cluster service as the job creation may have created shared indexes
+                    clusterService.state(),
+                    licenseState,
+                    securityContext,
+                    threadPool,
+                    ActionListener.wrap(
+                        createdDatafeed -> listener.onResponse(jobCreated),
+                        failed -> jobManager.deleteJob(
+                            new DeleteJobAction.Request(request.getJobBuilder().getId()),
+                            state,
+                            ActionListener.wrap(
+                                deleted -> listener.onFailure(failed),
+                                deleteFailed -> {
+                                    logger.warn(
+                                        () -> new ParameterizedMessage(
+                                            "[{}] failed to cleanup job after datafeed creation failure",
+                                            request.getJobBuilder().getId()
+                                        ),
+                                        deleteFailed);
+                                    ElasticsearchException ex = new ElasticsearchException(
+                                        "failed to cleanup job after datafeed creation failure",
+                                        failed
+                                    );
+                                    ex.addSuppressed(deleteFailed);
+                                    listener.onFailure(ex);
+                                }
+                            )
+                        )
+                    ));
+            },
+            listener::onFailure
+        ));
     }
 
     @Override

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/DatafeedManager.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/DatafeedManager.java
@@ -472,7 +472,7 @@ public final class DatafeedManager {
     }
 
     private void checkJobDoesNotHaveADifferentDatafeed(String jobId, String datafeedId, ActionListener<Boolean> listener) {
-        datafeedConfigProvider.findDatafeedsForJobIds(Collections.singletonList(jobId), ActionListener.wrap(
+        datafeedConfigProvider.findDatafeedIdsForJobIds(Collections.singletonList(jobId), ActionListener.wrap(
             datafeedIds -> {
                 if (datafeedIds.isEmpty()) {
                     // Ok the job does not have a datafeed

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/DatafeedManager.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/DatafeedManager.java
@@ -198,6 +198,41 @@ public final class DatafeedManager {
         ));
     }
 
+    public void getDatafeedsByJobIds(Set<String> jobIds, ClusterState state, ActionListener<Map<String, DatafeedConfig.Builder>> listener) {
+        datafeedConfigProvider.findDatafeedsByJobIds(jobIds, ActionListener.wrap(
+            datafeeds -> {
+                Map<String, DatafeedConfig.Builder> response = new HashMap<>(datafeeds);
+                Map<String, DatafeedConfig> fromState = MlMetadata.getMlMetadata(state).getDatafeedsByJobIds(jobIds);
+                for (Map.Entry<String, DatafeedConfig> datafeedConfigEntry : fromState.entrySet()) {
+                    DatafeedConfig.Builder alreadyExistingDatafeed = response.get(datafeedConfigEntry.getKey());
+                    if (alreadyExistingDatafeed != null) {
+                        if (alreadyExistingDatafeed.getId().equals(datafeedConfigEntry.getValue().getId())) {
+                            listener.onFailure(new IllegalStateException(
+                                "Datafeed ["
+                                    + alreadyExistingDatafeed.getId()
+                                    + "] configuration "
+                                    + "exists in both clusterstate and index"));
+                            return;
+                        }
+                        listener.onFailure(new IllegalStateException(
+                            "datafeed ["
+                                + datafeedConfigEntry.getValue().getId()
+                                + "] configuration in cluster state and ["
+                                + alreadyExistingDatafeed.getId()
+                                + "] in the configuration index both refer to job ["
+                                + datafeedConfigEntry.getKey()
+                                + "]"
+                        ));
+                        return;
+                    }
+                    response.put(datafeedConfigEntry.getKey(), new DatafeedConfig.Builder(datafeedConfigEntry.getValue()));
+                }
+                listener.onResponse(response);
+            },
+            listener::onFailure
+        ));
+    }
+
     public void updateDatafeed(
         UpdateDatafeedAction.Request request,
         ClusterState state,
@@ -423,7 +458,7 @@ public final class DatafeedManager {
     }
 
     private void checkJobDoesNotHaveADatafeed(String jobId, ActionListener<Boolean> listener) {
-        datafeedConfigProvider.findDatafeedsForJobIds(Collections.singletonList(jobId), ActionListener.wrap(
+        datafeedConfigProvider.findDatafeedIdsForJobIds(Collections.singletonList(jobId), ActionListener.wrap(
             datafeedIds -> {
                 if (datafeedIds.isEmpty()) {
                     listener.onResponse(Boolean.TRUE);

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/persistence/DatafeedConfigProvider.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/persistence/DatafeedConfigProvider.java
@@ -55,13 +55,13 @@ import org.elasticsearch.xpack.core.ml.job.config.Job;
 import org.elasticsearch.xpack.core.ml.utils.ExceptionsHelper;
 import org.elasticsearch.xpack.core.ml.utils.MlStrings;
 import org.elasticsearch.xpack.core.ml.utils.ToXContentParams;
-import org.elasticsearch.xpack.core.action.util.ExpandedIdsMatcher;
 
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -185,7 +185,7 @@ public class DatafeedConfigProvider {
      * @param jobIds    The jobs to find the datafeeds of
      * @param listener  Datafeed Id listener
      */
-    public void findDatafeedsForJobIds(Collection<String> jobIds, ActionListener<Set<String>> listener) {
+    public void findDatafeedIdsForJobIds(Collection<String> jobIds, ActionListener<Set<String>> listener) {
         SearchSourceBuilder sourceBuilder = new SearchSourceBuilder().query(buildDatafeedJobIdsQuery(jobIds));
         sourceBuilder.fetchSource(false);
         sourceBuilder.docValueField(DatafeedConfig.ID.getPreferredName(), null);
@@ -211,6 +211,31 @@ public class DatafeedConfigProvider {
                         },
                         listener::onFailure)
                 , client::search);
+    }
+
+    public void findDatafeedsByJobIds(Collection<String> jobIds, ActionListener<Map<String, DatafeedConfig.Builder>> listener) {
+        SearchRequest searchRequest = client.prepareSearch(MlConfigIndex.indexName())
+            .setIndicesOptions(IndicesOptions.lenientExpandOpen())
+            .setSize(jobIds.size())
+            .setSource(new SearchSourceBuilder().query(buildDatafeedJobIdsQuery(jobIds))).request();
+
+        executeAsyncWithOrigin(client.threadPool().getThreadContext(), ML_ORIGIN, searchRequest,
+            ActionListener.<SearchResponse>wrap(
+                response -> {
+                    Map<String, DatafeedConfig.Builder> datafeedsByJobId = new HashMap<>();
+                    // There cannot be more than one datafeed per job
+                    assert response.getHits().getTotalHits().value <= jobIds.size();
+                    SearchHit[] hits = response.getHits().getHits();
+                    for (SearchHit hit : hits) {
+                        DatafeedConfig.Builder builder = parseLenientlyFromSource(hit.getSourceRef());
+                        datafeedsByJobId.put(builder.getJobId(), builder);
+                    }
+                    listener.onResponse(datafeedsByJobId);
+                },
+                listener::onFailure)
+            ,
+            client::search
+        );
     }
 
     /**

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/JobManager.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/JobManager.java
@@ -43,6 +43,7 @@ import org.elasticsearch.xpack.core.ml.action.DeleteJobAction;
 import org.elasticsearch.xpack.core.ml.action.PutJobAction;
 import org.elasticsearch.xpack.core.ml.action.RevertModelSnapshotAction;
 import org.elasticsearch.xpack.core.ml.action.UpdateJobAction;
+import org.elasticsearch.xpack.core.ml.datafeed.DatafeedJobValidator;
 import org.elasticsearch.xpack.core.ml.job.config.AnalysisConfig;
 import org.elasticsearch.xpack.core.ml.job.config.AnalysisLimits;
 import org.elasticsearch.xpack.core.ml.job.config.Blocked;
@@ -80,6 +81,7 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 /**
  * Allows interactions with jobs. The managed interactions include:
@@ -106,6 +108,7 @@ public class JobManager {
     private final UpdateJobProcessNotifier updateJobProcessNotifier;
     private final JobConfigProvider jobConfigProvider;
     private final MlConfigMigrationEligibilityCheck migrationEligibilityCheck;
+    private final NamedXContentRegistry xContentRegistry;
     private final IndexNameExpressionResolver indexNameExpressionResolver;
 
     private volatile ByteSizeValue maxModelMemoryLimit;
@@ -113,10 +116,19 @@ public class JobManager {
     /**
      * Create a JobManager
      */
-    public JobManager(Environment environment, Settings settings, JobResultsProvider jobResultsProvider,
-                      JobResultsPersister jobResultsPersister, ClusterService clusterService, AnomalyDetectionAuditor auditor,
-                      ThreadPool threadPool, Client client, UpdateJobProcessNotifier updateJobProcessNotifier,
-                      NamedXContentRegistry xContentRegistry, IndexNameExpressionResolver indexNameExpressionResolver) {
+    public JobManager(
+        Environment environment,
+        Settings settings,
+        JobResultsProvider jobResultsProvider,
+        JobResultsPersister jobResultsPersister,
+        ClusterService clusterService,
+        AnomalyDetectionAuditor auditor,
+        ThreadPool threadPool,
+        Client client,
+        UpdateJobProcessNotifier updateJobProcessNotifier,
+        NamedXContentRegistry xContentRegistry,
+        IndexNameExpressionResolver indexNameExpressionResolver
+        ) {
         this.jobResultsProvider = Objects.requireNonNull(jobResultsProvider);
         this.jobResultsPersister = Objects.requireNonNull(jobResultsPersister);
         this.clusterService = Objects.requireNonNull(clusterService);
@@ -125,9 +137,9 @@ public class JobManager {
         this.threadPool = Objects.requireNonNull(threadPool);
         this.updateJobProcessNotifier = updateJobProcessNotifier;
         this.jobConfigProvider = new JobConfigProvider(client, xContentRegistry);
+        this.xContentRegistry = xContentRegistry;
         this.migrationEligibilityCheck = new MlConfigMigrationEligibilityCheck(settings, clusterService);
-        this.indexNameExpressionResolver = indexNameExpressionResolver;
-
+        this.indexNameExpressionResolver = Objects.requireNonNull(indexNameExpressionResolver);
         maxModelMemoryLimit = MachineLearningField.MAX_MODEL_MEMORY_LIMIT.get(settings);
         clusterService.getClusterSettings()
                 .addSettingsUpdateConsumer(MachineLearningField.MAX_MODEL_MEMORY_LIMIT, this::setMaxModelMemoryLimit);
@@ -180,6 +192,36 @@ public class JobManager {
     }
 
     /**
+     * Get the jobs as builder objects that match the given {@code expression}.
+     * Note that when the {@code jobId} is {@link Metadata#ALL} all jobs are returned.
+     *
+     * @param expression   the jobId or an expression matching jobIds
+     * @param allowNoMatch if {@code false}, an error is thrown when no job matches the {@code jobId}
+     * @param jobsListener The jobs listener
+     */
+    public void expandJobBuilders(String expression, boolean allowNoMatch, ActionListener<List<Job.Builder>> jobsListener) {
+        Map<String, Job> clusterStateJobs = expandJobsFromClusterState(expression, allowNoMatch, clusterService.state());
+        jobConfigProvider.expandJobs(expression, allowNoMatch, false, ActionListener.wrap(
+            jobBuilders -> {
+                // Check for duplicate jobs
+                for (Job.Builder jb : jobBuilders) {
+                    if (clusterStateJobs.containsKey(jb.getId())) {
+                        jobsListener.onFailure(new IllegalStateException("Job [" + jb.getId() + "] configuration " +
+                            "exists in both clusterstate and index"));
+                        return;
+                    }
+                }
+                // Merge cluster state and index jobs
+                List<Job.Builder> jobs = new ArrayList<>(jobBuilders);
+                jobs.addAll(clusterStateJobs.values().stream().map(Job.Builder::new).collect(Collectors.toList()));
+                jobs.sort(Comparator.comparing(Job.Builder::getId));
+                jobsListener.onResponse(jobs);
+            },
+            jobsListener::onFailure
+        ));
+    }
+
+    /**
      * Get the jobs that match the given {@code expression}.
      * Note that when the {@code jobId} is {@link Metadata#ALL} all jobs are returned.
      *
@@ -188,30 +230,15 @@ public class JobManager {
      * @param jobsListener The jobs listener
      */
     public void expandJobs(String expression, boolean allowNoMatch, ActionListener<QueryPage<Job>> jobsListener) {
-        Map<String, Job> clusterStateJobs = expandJobsFromClusterState(expression, allowNoMatch, clusterService.state());
-
-        jobConfigProvider.expandJobs(expression, allowNoMatch, false, ActionListener.wrap(
-                jobBuilders -> {
-                    // Check for duplicate jobs
-                    for (Job.Builder jb : jobBuilders) {
-                        if (clusterStateJobs.containsKey(jb.getId())) {
-                            jobsListener.onFailure(new IllegalStateException("Job [" + jb.getId() + "] configuration " +
-                                    "exists in both clusterstate and index"));
-                            return;
-                        }
-                    }
-
-                    // Merge cluster state and index jobs
-                    List<Job> jobs = new ArrayList<>();
-                    for (Job.Builder jb : jobBuilders) {
-                        jobs.add(jb.build());
-                    }
-
-                    jobs.addAll(clusterStateJobs.values());
-                    Collections.sort(jobs, Comparator.comparing(Job::getId));
-                    jobsListener.onResponse(new QueryPage<>(jobs, jobs.size(), Job.RESULTS_FIELD));
-                },
-                jobsListener::onFailure
+        expandJobBuilders(expression, allowNoMatch, ActionListener.wrap(
+            jobBuilders -> jobsListener.onResponse(
+                new QueryPage<>(
+                    jobBuilders.stream().map(Job.Builder::build).collect(Collectors.toList()),
+                    jobBuilders.size(),
+                    Job.RESULTS_FIELD
+                )
+            ),
+            jobsListener::onFailure
         ));
     }
 
@@ -331,6 +358,14 @@ public class JobManager {
         ActionListener<List<String>> checkForLeftOverDocs = ActionListener.wrap(
                 matchedIds -> {
                     if (matchedIds.isEmpty()) {
+                        if (job.getDatafeedConfig().isPresent()) {
+                            try {
+                                DatafeedJobValidator.validate(job.getDatafeedConfig().get(), job, xContentRegistry);
+                            } catch (Exception e) {
+                                actionListener.onFailure(e);
+                                return;
+                            }
+                        }
                         jobResultsProvider.createJobResultIndex(job, state, addDocMappingsListener);
                     } else {
                         // A job has the same Id as one of the group names
@@ -443,7 +478,9 @@ public class JobManager {
         // Step 3. When the physical storage has been deleted, delete the job config document
         // -------
         // Don't report an error if the document has already been deleted
-        CheckedConsumer<Boolean, Exception> deleteJobStateHandler = response -> jobConfigProvider.deleteJob(jobId, false,
+        CheckedConsumer<Boolean, Exception> deleteJobStateHandler = response -> jobConfigProvider.deleteJob(
+            jobId,
+            false,
             ActionListener.wrap(
                 deleteResponse -> apiResponseHandler.accept(Boolean.TRUE),
                 listener::onFailure
@@ -451,8 +488,10 @@ public class JobManager {
         );
 
         // Step 2. Remove the job from any calendars
-        CheckedConsumer<Boolean, Exception> removeFromCalendarsHandler = response -> jobResultsProvider.removeJobFromCalendars(jobId,
-            ActionListener.wrap(deleteJobStateHandler, listener::onFailure));
+        CheckedConsumer<Boolean, Exception> removeFromCalendarsHandler = response -> jobResultsProvider.removeJobFromCalendars(
+            jobId,
+            ActionListener.wrap(deleteJobStateHandler, listener::onFailure)
+        );
 
 
         // Step 1. Delete the physical storage

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/task/OpenJobPersistentTasksExecutor.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/task/OpenJobPersistentTasksExecutor.java
@@ -278,7 +278,7 @@ public class OpenJobPersistentTasksExecutor extends AbstractJobPersistentTasksEx
             listener::onFailure
         );
 
-        datafeedConfigProvider.findDatafeedsForJobIds(Collections.singleton(jobId), datafeedListener);
+        datafeedConfigProvider.findDatafeedIdsForJobIds(Collections.singleton(jobId), datafeedListener);
     }
 
     private void revertToCurrentSnapshot(String jobId, ActionListener<Boolean> listener) {

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/rest/job/RestPutJobAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/rest/job/RestPutJobAction.java
@@ -6,6 +6,8 @@
  */
 package org.elasticsearch.xpack.ml.rest.job;
 
+import org.elasticsearch.action.search.SearchRequest;
+import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.client.node.NodeClient;
 import org.elasticsearch.core.RestApiVersion;
 import org.elasticsearch.common.xcontent.XContentParser;
@@ -41,7 +43,8 @@ public class RestPutJobAction extends BaseRestHandler {
     protected RestChannelConsumer prepareRequest(RestRequest restRequest, NodeClient client) throws IOException {
         String jobId = restRequest.param(Job.ID.getPreferredName());
         XContentParser parser = restRequest.contentParser();
-        PutJobAction.Request putJobRequest = PutJobAction.Request.parseRequest(jobId, parser);
+        IndicesOptions indicesOptions = IndicesOptions.fromRequest(restRequest, SearchRequest.DEFAULT_INDICES_OPTIONS);
+        PutJobAction.Request putJobRequest = PutJobAction.Request.parseRequest(jobId, parser, indicesOptions);
         putJobRequest.timeout(restRequest.paramAsTime("timeout", putJobRequest.timeout()));
         putJobRequest.masterNodeTimeout(restRequest.paramAsTime("master_timeout", putJobRequest.masterNodeTimeout()));
 

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/MlMetadataTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/MlMetadataTests.java
@@ -26,7 +26,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 import static org.elasticsearch.xpack.core.ml.job.config.JobTests.buildJobBuilder;
 import static org.elasticsearch.xpack.ml.datafeed.DatafeedRunnerTests.createDatafeedConfig;
@@ -156,7 +155,9 @@ public class MlMetadataTests extends AbstractSerializingTestCase<MlMetadata> {
         mlMetadataBuilder.putDatafeeds(datafeeds);
         MlMetadata mlMetadata = mlMetadataBuilder.build();
 
-        Map<String, DatafeedConfig> datafeedsByJobIds = mlMetadata.getDatafeedsByJobIds(Set.of("bar-1", "foo-1", "foo-2"));
+        Map<String, DatafeedConfig> datafeedsByJobIds = mlMetadata.getDatafeedsByJobIds(
+            org.elasticsearch.core.Set.of("bar-1", "foo-1", "foo-2")
+        );
         assertThat(datafeedsByJobIds, allOf(hasKey("bar-1"), hasKey("foo-1"), hasKey("foo-2")));
         assertThat(datafeedsByJobIds.get("bar-1").getId(), equalTo("bar-1-feed"));
         assertThat(datafeedsByJobIds.get("foo-1").getId(), equalTo("foo-1-feed"));

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/action/TransportCloseJobActionTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/action/TransportCloseJobActionTests.java
@@ -336,7 +336,7 @@ public class TransportCloseJobActionTests extends ESTestCase {
             listener.onResponse(datafeedIds);
 
             return null;
-        }).when(datafeedConfigProvider).findDatafeedsForJobIds(any(), any(ActionListener.class));
+        }).when(datafeedConfigProvider).findDatafeedIdsForJobIds(any(), any(ActionListener.class));
     }
 
     @SuppressWarnings("unchecked")

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/ml/jobs_crud.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/ml/jobs_crud.yml
@@ -992,6 +992,113 @@
                 "time_field": "@timestamp"
             }
           }
+---
+"Test put job with datafeed":
+  - do:
+      ml.put_job:
+        job_id: jobs-crud-put-with-datafeed
+        body: >
+          {
+            "description":"Analysis of response time by airline",
+            "analysis_config" : {
+                "detectors" :[{"function":"count"}]
+            },
+            "analysis_limits" : {
+                "model_memory_limit": "20mb"
+            },
+            "data_description" : {
+                "format":"xcontent"
+            },
+            "datafeed_config": {
+              "indexes":["index-foo"]
+            }
+          }
+  - match: { job_id: "jobs-crud-put-with-datafeed" }
+  - is_true: datafeed_config
+  - match: { datafeed_config.job_id: "jobs-crud-put-with-datafeed" }
+  - match: { datafeed_config.datafeed_id: "jobs-crud-put-with-datafeed" }
+
+  - do:
+      ml.get_datafeeds:
+        datafeed_id: "jobs-crud-put-with-datafeed"
+
+  - match: { count: 1 }
+  - match: { datafeeds.0.job_id: "jobs-crud-put-with-datafeed" }
+  - match: { datafeeds.0.datafeed_id: "jobs-crud-put-with-datafeed" }
+---
+"Test get job with datafeed":
+  - do:
+      ml.put_job:
+        job_id: jobs-crud-get-with-datafeed
+        body: >
+          {
+            "description":"Analysis of response time by airline",
+            "analysis_config" : {
+                "detectors" :[{"function":"count"}]
+            },
+            "analysis_limits" : {
+                "model_memory_limit": "20mb"
+            },
+            "data_description" : {
+                "format":"xcontent"
+            }
+          }
+  - match: { job_id: "jobs-crud-get-with-datafeed" }
+  - do:
+      ml.put_datafeed:
+        datafeed_id: jobs-crud-get-with-datafeed
+        body: >
+          {
+            "job_id":"jobs-crud-get-with-datafeed",
+            "indexes":["index-foo"]
+          }
+  - match: { datafeed_id: "jobs-crud-get-with-datafeed" }
+  - do:
+      ml.get_jobs:
+        job_id: jobs-crud-get-with-datafeed
+  - match: { count: 1 }
+  - match: { jobs.0.job_id: "jobs-crud-get-with-datafeed" }
+  - match: { jobs.0.datafeed_config.datafeed_id: "jobs-crud-get-with-datafeed" }
+
+# TODO in v8.0.0 adjust this test to handle exclude_generated behavior
+  - do:
+      ml.get_jobs:
+        job_id: jobs-crud-get-with-datafeed
+        exclude_generated: true
+  - match: { count: 1 }
+  - match: { jobs.0.job_id: "jobs-crud-get-with-datafeed" }
+  - is_false: jobs.0.datafeed_config
+---
+"Test put job with datafeed with indices options in params":
+  - do:
+      ml.put_job:
+        job_id: jobs-crud-put-with-datafeed-with-indices-options
+        ignore_throttled: false
+        body: >
+          {
+            "description":"Analysis of response time by airline",
+            "analysis_config" : {
+                "detectors" :[{"function":"count"}]
+            },
+            "analysis_limits" : {
+                "model_memory_limit": "20mb"
+            },
+            "data_description" : {
+                "format":"xcontent"
+            },
+            "datafeed_config": {
+              "indexes":["index-foo"]
+            }
+          }
+  - match: { job_id: "jobs-crud-put-with-datafeed-with-indices-options" }
+  - match: { datafeed_config.datafeed_id: "jobs-crud-put-with-datafeed-with-indices-options" }
+  - match: { datafeed_config.indices_options.ignore_throttled: false }
+
+  - do:
+      ml.get_datafeeds:
+        datafeed_id: jobs-crud-put-with-datafeed-with-indices-options
+
+  - match: { datafeeds.0.indices_options.ignore_throttled: false }
 
 ---
 "Test max model memory limit":


### PR DESCRIPTION
This is a quality of life improvement for typical users. Almost all anomaly detection jobs receive their input data through a datafeed.

The datafeed config can now be supplied and is available in the datafeed_config field in the job config for creation and getting jobs.

backport of: https://github.com/elastic/elasticsearch/pull/74265