### PR TITLE
[7.x] OnChange listener now only runs when there is actual change (#75207)

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/license/OperationModeFileWatcher.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/license/OperationModeFileWatcher.java
@@ -91,6 +91,7 @@ public final class OperationModeFileWatcher implements FileChangesListener {
 
     private synchronized void onChange(Path file) {
         if (file.equals(licenseModePath)) {
+            final OperationMode savedOperationMode = this.currentOperationMode;
             OperationMode newOperationMode = defaultOperationMode;
             try {
                 if (Files.exists(licenseModePath)
@@ -116,11 +117,13 @@ public final class OperationModeFileWatcher implements FileChangesListener {
                     }
                 }
             } finally {
-                // set this after the fact to prevent that we are jumping back and forth first setting to defautl and then reading the
+                // set this after the fact to prevent that we are jumping back and forth first setting to default and then reading the
                 // actual op mode resetting it.
                 this.currentOperationMode = newOperationMode;
             }
-            onChange.run();
+            if (savedOperationMode != newOperationMode) {
+                onChange.run();
+            }
         }
     }
 }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/license/OperationModeFileWatcherTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/license/OperationModeFileWatcherTests.java
@@ -51,7 +51,7 @@ public class OperationModeFileWatcherTests extends ESTestCase {
     }
 
     public void testInit() throws Exception {
-        onChangeCounter.set(new CountDownLatch(2));
+        onChangeCounter.set(new CountDownLatch(1));
         writeMode("gold");
         assertThat(operationModeFileWatcher.getCurrentOperationMode(), equalTo(License.OperationMode.PLATINUM));
         operationModeFileWatcher.init();


### PR DESCRIPTION
Backports the following commits to 7.x:
 - OnChange listener now only runs when there is actual change (#75207)