### PR TITLE
Increase wait time in GeoIpDownloaderIT to stabilise test

### DIFF
--- a/modules/ingest-geoip/src/internalClusterTest/java/org/elasticsearch/ingest/geoip/GeoIpDownloaderIT.java
+++ b/modules/ingest-geoip/src/internalClusterTest/java/org/elasticsearch/ingest/geoip/GeoIpDownloaderIT.java
@@ -111,7 +111,7 @@ public class GeoIpDownloaderIT extends AbstractGeoIpIT {
                     assertThat(names, not(hasItem("GeoLite2-Country.mmdb")));
                 }
             }
-        });
+        }, 30, TimeUnit.SECONDS);
     }
 
     public void testInvalidTimestamp() throws Exception {


### PR DESCRIPTION
`GeoIpDownloaderIT.testInvalidTimestamp` has failed a few times this week, and I believe this
is because a cleanup step is taking longer than the test is prepared to wait. Increase the wait
time from 10s to 30s, which will hopefully stabilise the test.