### PR TITLE
[7.14] Docs: Fix node selector documentation (#75217)

### DIFF
--- a/docs/java-rest/low-level/configuration.asciidoc
+++ b/docs/java-rest/low-level/configuration.asciidoc
@@ -166,7 +166,7 @@ security policy].
 The client sends each request to one of the configured nodes in round-robin
 fashion. Nodes can optionally be filtered through a node selector that needs
 to be provided when initializing the client. This is useful when sniffing is
-enabled, in case only dedicated master nodes should be hit by HTTP requests.
+enabled, in case no dedicated master nodes should be hit by HTTP requests.
 For each request the client will run the eventually configured node selector
 to filter the node candidates, then select the next one in the list out of the
 remaining ones.


### PR DESCRIPTION
Backports the following commits to 7.14:
 - Docs: Fix node selector documentation (#75217)