### PR TITLE
Fix RestGetSnapshotsCancellationIT Failures (#74827)

### DIFF
--- a/qa/smoke-test-http/src/test/java/org/elasticsearch/http/snapshots/RestGetSnapshotsCancellationIT.java
+++ b/qa/smoke-test-http/src/test/java/org/elasticsearch/http/snapshots/RestGetSnapshotsCancellationIT.java
@@ -14,6 +14,7 @@ import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.client.Cancellable;
 import org.elasticsearch.client.Request;
 import org.elasticsearch.client.Response;
+import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.snapshots.AbstractSnapshotIntegTestCase;
 import org.elasticsearch.snapshots.mockstore.MockRepository;
 
@@ -29,7 +30,10 @@ import static org.hamcrest.core.IsEqual.equalTo;
 public class RestGetSnapshotsCancellationIT extends AbstractSnapshotRestTestCase {
 
     public void testGetSnapshotsCancellation() throws Exception {
-        internalCluster().startMasterOnlyNode();
+        // use single threaded metadata fetching to make sure that once the snapshot meta thread is stuck on the blocked repo below, no
+        // other snapshot meta thread can concurrently finish the request/task
+        internalCluster().startMasterOnlyNode(
+            Settings.builder().put("thread_pool.snapshot_meta.core", 1).put("thread_pool.snapshot_meta.max", 1).build());
         internalCluster().startDataOnlyNode();
         ensureStableCluster(2);
 


### PR DESCRIPTION
Found this to be the easiest fix, the alternative would have been to actually
wait for all snapshot meta threads to become blocked but that's kind of hacky.

closes #74743

backport of #74827 