### PR TITLE
Fix Default Restore not Restoring Indices when DS are Restored (#75266)

### DIFF
--- a/server/src/main/java/org/elasticsearch/snapshots/RestoreService.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/RestoreService.java
@@ -77,7 +77,6 @@ import org.elasticsearch.repositories.blobstore.BlobStoreRepository;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -309,7 +308,14 @@ public class RestoreService implements ClusterStateApplier {
             metadataBuilder = Metadata.builder();
         }
 
-        List<String> requestIndices = new ArrayList<>(Arrays.asList(request.indices()));
+        final String[] indicesInRequest = request.indices();
+        List<String> requestIndices = new ArrayList<>(indicesInRequest.length);
+        if (indicesInRequest.length == 0) {
+            // no specific indices request means restore everything
+            requestIndices.add("*");
+        } else {
+            Collections.addAll(requestIndices, indicesInRequest);
+        }
 
         // Get data stream metadata for requested data streams
         Tuple<Map<String, DataStream>, Map<String, DataStreamAlias>> result = getDataStreamsToRestore(

--- a/x-pack/plugin/data-streams/src/internalClusterTest/java/org/elasticsearch/datastreams/DataStreamsSnapshotsIT.java
+++ b/x-pack/plugin/data-streams/src/internalClusterTest/java/org/elasticsearch/datastreams/DataStreamsSnapshotsIT.java
@@ -1002,4 +1002,25 @@ public class DataStreamsSnapshotsIT extends AbstractSnapshotIntegTestCase {
         assertThat(restoreInfo.failedShards(), is(0));
         assertThat(restoreInfo.successfulShards(), is(1));
     }
+
+    public void testRestoreSnapshotFully() throws Exception {
+        final String snapshotName = "test-snapshot";
+        final String indexName = "test-idx";
+        createIndexWithContent(indexName);
+        createFullSnapshot(REPO, snapshotName);
+
+        assertAcked(client.execute(DeleteDataStreamAction.INSTANCE, new DeleteDataStreamAction.Request(new String[] { "*" })).get());
+        assertAcked(client.admin().indices().prepareDelete("*").setIndicesOptions(IndicesOptions.lenientExpandOpenHidden()).get());
+
+        RestoreSnapshotResponse restoreSnapshotResponse = client.admin()
+            .cluster()
+            .prepareRestoreSnapshot(REPO, snapshotName)
+            .setWaitForCompletion(true)
+            .get();
+        assertEquals(RestStatus.OK, restoreSnapshotResponse.status());
+
+        GetDataStreamAction.Request getRequest = new GetDataStreamAction.Request(new String[] { "*" });
+        assertThat(client.execute(GetDataStreamAction.INSTANCE, getRequest).get().getDataStreams(), hasSize(2));
+        assertNotNull(client.admin().indices().prepareGetIndex().setIndices(indexName).get());
+    }
 }


### PR DESCRIPTION
There was a simple bug that caused the default to `*` or `_all` on the request to not work anymore
when resolving what indices to restore because we would add datastream indices to the restore array,
thus causing the indices filtering to think we only wanted those specific indices.

closes #75192

backport of #75266 