### PR TITLE
Snapshot clones do not conflict with index deletes

### DIFF
--- a/server/src/main/java/org/elasticsearch/snapshots/SnapshotsService.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/SnapshotsService.java
@@ -2699,7 +2699,7 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
 
         final Set<Index> indices = new HashSet<>();
         for (final SnapshotsInProgress.Entry entry : snapshots.entries()) {
-            if (entry.partial() == false) {
+            if (entry.partial() == false && entry.isClone() == false) {
                 for (String indexName : entry.indices().keySet()) {
                     IndexMetadata indexMetadata = currentState.metadata().index(indexName);
                     if (indexMetadata != null && indicesToCheck.contains(indexMetadata.getIndex())) {

--- a/server/src/test/java/org/elasticsearch/snapshots/SnapshotsServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/snapshots/SnapshotsServiceTests.java
@@ -389,11 +389,14 @@ public class SnapshotsServiceTests extends ESTestCase {
     public void testSnapshottingIndicesExcludesClones() {
         final String repoName = "test-repo";
         final String indexName = "index";
-        final ClusterState clusterState = stateWithSnapshots(stateWithUnassignedIndices(indexName), cloneEntry(
-            snapshot(repoName, "target-snapshot"),
-            snapshot(repoName, "source-snapshot").getSnapshotId(),
-            clonesMap(new RepositoryShardId(indexId(indexName), 0), initShardStatus(uuid()))
-        ));
+        final ClusterState clusterState = stateWithSnapshots(
+            stateWithUnassignedIndices(indexName),
+            cloneEntry(
+                snapshot(repoName, "target-snapshot"),
+                snapshot(repoName, "source-snapshot").getSnapshotId(),
+                clonesMap(new RepositoryShardId(indexId(indexName), 0), initShardStatus(uuid()))
+            )
+        );
 
         assertThat(
             SnapshotsService.snapshottingIndices(clusterState, singleton(clusterState.metadata().index(indexName).getIndex())),

--- a/server/src/test/java/org/elasticsearch/snapshots/SnapshotsServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/snapshots/SnapshotsServiceTests.java
@@ -37,7 +37,9 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
+import static java.util.Collections.singleton;
 import static org.elasticsearch.cluster.metadata.IndexMetadata.SETTING_VERSION_CREATED;
+import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.is;
 
 public class SnapshotsServiceTests extends ESTestCase {
@@ -382,6 +384,21 @@ public class SnapshotsServiceTests extends ESTestCase {
         assertThat(startedSnapshot.state(), is(SnapshotsInProgress.State.STARTED));
         assertThat(startedSnapshot.clones().get(shardId1).state(), is(SnapshotsInProgress.ShardState.INIT));
         assertIsNoop(updatedClusterState, completeShardClone);
+    }
+
+    public void testSnapshottingIndicesExcludesClones() {
+        final String repoName = "test-repo";
+        final String indexName = "index";
+        final ClusterState clusterState = stateWithSnapshots(stateWithUnassignedIndices(indexName), cloneEntry(
+            snapshot(repoName, "target-snapshot"),
+            snapshot(repoName, "source-snapshot").getSnapshotId(),
+            clonesMap(new RepositoryShardId(indexId(indexName), 0), initShardStatus(uuid()))
+        ));
+
+        assertThat(
+            SnapshotsService.snapshottingIndices(clusterState, singleton(clusterState.metadata().index(indexName).getIndex())),
+            empty()
+        );
     }
 
     private static DiscoveryNodes discoveryNodes(String localNodeId) {


### PR DESCRIPTION
Today we refuse to delete an index if it is the subject of an ongoing
non-partial snapshot, but we also consider the indices targetted by
ongoing clones. This commit ignores clones in the conflict detection
logic.