### PR TITLE
Improve efficiency of BoundedBreakIteratorScanner fragmentation algorithm (the 2nd)

### DIFF
--- a/server/src/main/java/org/elasticsearch/lucene/search/uhighlight/BoundedBreakIteratorScanner.java
+++ b/server/src/main/java/org/elasticsearch/lucene/search/uhighlight/BoundedBreakIteratorScanner.java
@@ -94,7 +94,12 @@ public class BoundedBreakIteratorScanner extends BreakIterator {
             final int targetEndOffset = offset + Math.max(0, maxLen - (offset - innerStart));
             final int textEndIndex = getText().getEndIndex();
 
-            innerEnd = mainBreak.preceding(Math.min(targetEndOffset + 1, textEndIndex));
+            if (targetEndOffset + 1 > textEndIndex) {
+                innerEnd = textEndIndex;
+            } else {
+                innerEnd = mainBreak.preceding(targetEndOffset + 1);
+            }
+
             assert innerEnd != DONE && innerEnd >= innerStart;
 
             // in case no break was found up to maxLen, find one afterwards.

--- a/server/src/main/java/org/elasticsearch/lucene/search/uhighlight/BoundedBreakIteratorScanner.java
+++ b/server/src/main/java/org/elasticsearch/lucene/search/uhighlight/BoundedBreakIteratorScanner.java
@@ -91,20 +91,20 @@ public class BoundedBreakIteratorScanner extends BreakIterator {
         } else {
             innerStart = Math.max(mainBreak.preceding(offset), 0);
 
-            final int targetEndOffset = offset + Math.max(0, maxLen - (offset - innerStart));
+            final long targetEndOffset = (long)offset + Math.max(0, maxLen - (offset - innerStart));
             final int textEndIndex = getText().getEndIndex();
 
             if (targetEndOffset + 1 > textEndIndex) {
                 innerEnd = textEndIndex;
             } else {
-                innerEnd = mainBreak.preceding(targetEndOffset + 1);
+                innerEnd = mainBreak.preceding((int)targetEndOffset + 1);
             }
 
             assert innerEnd != DONE && innerEnd >= innerStart;
 
             // in case no break was found up to maxLen, find one afterwards.
             if (innerStart == innerEnd) {
-                innerEnd = mainBreak.following(targetEndOffset);
+                innerEnd = mainBreak.following((int)targetEndOffset);
                 assert innerEnd - innerStart > maxLen;
             } else {
                 assert innerEnd - innerStart <= maxLen;

--- a/server/src/main/java/org/elasticsearch/lucene/search/uhighlight/BoundedBreakIteratorScanner.java
+++ b/server/src/main/java/org/elasticsearch/lucene/search/uhighlight/BoundedBreakIteratorScanner.java
@@ -89,16 +89,28 @@ public class BoundedBreakIteratorScanner extends BreakIterator {
             innerStart = innerEnd;
             innerEnd = windowEnd;
         } else {
-            windowStart = innerStart = mainBreak.preceding(offset);
-            windowEnd = innerEnd = mainBreak.following(offset - 1);
-            // expand to next break until we reach maxLen
-            while (innerEnd - innerStart < maxLen) {
-                int newEnd = mainBreak.following(innerEnd);
-                if (newEnd == DONE || (newEnd - innerStart) > maxLen) {
-                    break;
+            innerStart = Math.max(mainBreak.preceding(offset), 0);
+
+            final int targetEndOffset = offset + Math.max(0, maxLen - (offset - innerStart));
+            final int textEndIndex = getText().getEndIndex();
+
+            innerEnd = mainBreak.preceding(Math.min(targetEndOffset + 1, textEndIndex));
+            assert innerEnd != DONE && innerEnd >= innerStart;
+
+            // in case no break was found up to maxLen, find one afterwards.
+            if (innerStart == innerEnd) {
+                if (targetEndOffset >= textEndIndex) {
+                    innerEnd = textEndIndex;
+                } else {
+                    innerEnd = mainBreak.following(targetEndOffset);
+                    assert innerEnd - innerStart > maxLen;
                 }
-                windowEnd = innerEnd = newEnd;
+            } else {
+                assert innerEnd - innerStart <= maxLen;
             }
+
+            windowStart = innerStart;
+            windowEnd = innerEnd;
         }
 
         if (innerEnd - innerStart > maxLen) {

--- a/server/src/main/java/org/elasticsearch/lucene/search/uhighlight/BoundedBreakIteratorScanner.java
+++ b/server/src/main/java/org/elasticsearch/lucene/search/uhighlight/BoundedBreakIteratorScanner.java
@@ -104,12 +104,8 @@ public class BoundedBreakIteratorScanner extends BreakIterator {
 
             // in case no break was found up to maxLen, find one afterwards.
             if (innerStart == innerEnd) {
-                if (targetEndOffset >= textEndIndex) {
-                    innerEnd = textEndIndex;
-                } else {
-                    innerEnd = mainBreak.following(targetEndOffset);
-                    assert innerEnd - innerStart > maxLen;
-                }
+                innerEnd = mainBreak.following(targetEndOffset);
+                assert innerEnd - innerStart > maxLen;
             } else {
                 assert innerEnd - innerStart <= maxLen;
             }

--- a/server/src/main/java/org/elasticsearch/lucene/search/uhighlight/BoundedBreakIteratorScanner.java
+++ b/server/src/main/java/org/elasticsearch/lucene/search/uhighlight/BoundedBreakIteratorScanner.java
@@ -91,20 +91,20 @@ public class BoundedBreakIteratorScanner extends BreakIterator {
         } else {
             innerStart = Math.max(mainBreak.preceding(offset), 0);
 
-            final long targetEndOffset = (long)offset + Math.max(0, maxLen - (offset - innerStart));
+            final long targetEndOffset = (long) offset + Math.max(0, maxLen - (offset - innerStart));
             final int textEndIndex = getText().getEndIndex();
 
             if (targetEndOffset + 1 > textEndIndex) {
                 innerEnd = textEndIndex;
             } else {
-                innerEnd = mainBreak.preceding((int)targetEndOffset + 1);
+                innerEnd = mainBreak.preceding((int) targetEndOffset + 1);
             }
 
             assert innerEnd != DONE && innerEnd >= innerStart;
 
             // in case no break was found up to maxLen, find one afterwards.
             if (innerStart == innerEnd) {
-                innerEnd = mainBreak.following((int)targetEndOffset);
+                innerEnd = mainBreak.following((int) targetEndOffset);
                 assert innerEnd - innerStart > maxLen;
             } else {
                 assert innerEnd - innerStart <= maxLen;

--- a/server/src/test/java/org/elasticsearch/lucene/search/uhighlight/BoundedBreakIteratorScannerTests.java
+++ b/server/src/test/java/org/elasticsearch/lucene/search/uhighlight/BoundedBreakIteratorScannerTests.java
@@ -117,4 +117,20 @@ public class BoundedBreakIteratorScannerTests extends ESTestCase {
             testRandomAsciiTextCase(BoundedBreakIteratorScanner.getSentence(Locale.ROOT, maxLen), maxLen);
         }
     }
+
+    public void testTextThatEndsBeforeMaxLen() {
+        BreakIterator bi = BoundedBreakIteratorScanner.getSentence(Locale.ROOT, 1000);
+
+        final String text = "This is the first test sentence. Here is the second one.";
+
+        int offset = text.indexOf("first");
+        bi.setText(text);
+        assertEquals(0, bi.preceding(offset));
+        assertEquals(text.length(), bi.following(offset - 1));
+
+        offset = text.indexOf("second");
+        bi.setText(text);
+        assertEquals(33, bi.preceding(offset));
+        assertEquals(text.length(), bi.following(offset - 1));
+    }
 }

--- a/server/src/test/java/org/elasticsearch/lucene/search/uhighlight/BoundedBreakIteratorScannerTests.java
+++ b/server/src/test/java/org/elasticsearch/lucene/search/uhighlight/BoundedBreakIteratorScannerTests.java
@@ -133,4 +133,16 @@ public class BoundedBreakIteratorScannerTests extends ESTestCase {
         assertEquals(33, bi.preceding(offset));
         assertEquals(text.length(), bi.following(offset - 1));
     }
+
+    public void testFragmentSizeThatIsTooBig() {
+        final int fragmentSize = Integer.MAX_VALUE;
+        BreakIterator bi = BoundedBreakIteratorScanner.getSentence(Locale.ROOT, fragmentSize);
+
+        final String text = "Any sentence";
+        final int offset = 0; // find at beggining of text
+
+        bi.setText(text);
+        assertEquals(0, bi.preceding(offset));
+        assertEquals(text.length(), bi.following(offset - 1));
+    }
 }


### PR DESCRIPTION
See #73569 for the issue this tries to solve. See PR #73785 for an explanation of the algorithm.

The previous PR had to be reverted due to it causing tests to fail in Kibana (see elastic/kibana#104466).

One of such failures was caused by `targetEndOffset` being a `int` but having a possibility of storing something bigger than that (more precisely for the Kibana tests, `if (targetEndOffset + 1 > textEndIndex)` overflowed). Commit e2635198d023fa0ef4b4c7132909d4da19e45574 in this PR fixes that.

There were still some failing tests after that. Needs investigation.