### PR TITLE
[TEST] Add logging when LDAP server starts/stops

### DIFF
--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/ldap/support/LdapTestCase.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/ldap/support/LdapTestCase.java
@@ -16,6 +16,7 @@ import com.unboundid.ldap.sdk.LDAPException;
 import com.unboundid.ldap.sdk.LDAPInterface;
 import com.unboundid.ldap.sdk.LDAPURL;
 import com.unboundid.ldap.sdk.SimpleBindRequest;
+
 import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.common.Strings;
@@ -57,7 +58,9 @@ import java.security.PrivilegedAction;
 import java.security.PrivilegedExceptionAction;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Objects;
+import java.util.stream.Collectors;
 
 import static org.elasticsearch.xpack.core.security.authc.RealmSettings.getFullSettingKey;
 import static org.elasticsearch.xpack.core.security.authc.ldap.support.SessionFactorySettings.HOSTNAME_VERIFICATION_SETTING;
@@ -107,6 +110,18 @@ public abstract class LdapTestCase extends ESTestCase {
                 ldapServer.startListening();
                 return null;
             });
+            String listenerConfig = listeners.stream()
+                .map(
+                    l -> String.format(
+                        Locale.ROOT,
+                        "(%s @ %s:%d)",
+                        l.getListenerName(),
+                        NetworkAddress.format(resolveListenAddress(l.getListenAddress())),
+                        ldapServer.getListenPort(l.getListenerName())
+                    )
+                )
+                .collect(Collectors.joining(","));
+            logger.info("Started in-memory LDAP server [#{}] with listeners: [{}]", i, listenerConfig);
             ldapServers[i] = ldapServer;
         }
     }
@@ -118,6 +133,7 @@ public abstract class LdapTestCase extends ESTestCase {
     @After
     public void stopLdap() {
         for (int i = 0; i < numberOfLdapServers; i++) {
+            logger.info("Shutting down in-memory LDAP server [#{}]", i);
             ldapServers[i].shutDown(true);
         }
     }
@@ -125,14 +141,19 @@ public abstract class LdapTestCase extends ESTestCase {
     protected String[] ldapUrls() throws LDAPException {
         List<String> urls = new ArrayList<>(numberOfLdapServers);
         for (int i = 0; i < numberOfLdapServers; i++) {
-            InetAddress listenAddress = ldapServers[i].getListenAddress();
-            if (listenAddress == null) {
-                listenAddress = InetAddress.getLoopbackAddress();
-            }
+            InetAddress listenAddress = resolveListenAddress(ldapServers[i].getListenAddress());
             LDAPURL url = new LDAPURL("ldap", NetworkAddress.format(listenAddress), ldapServers[i].getListenPort(), null, null, null, null);
             urls.add(url.toString());
         }
         return urls.toArray(Strings.EMPTY_ARRAY);
+    }
+
+    private InetAddress resolveListenAddress(InetAddress configuredAddress) {
+        InetAddress listenAddress = configuredAddress;
+        if (listenAddress != null) {
+            return listenAddress;
+        }
+        return InetAddress.getLoopbackAddress();
     }
 
     public static Settings buildLdapSettings(String ldapUrl, String userTemplate, String groupSearchBase, LdapSearchScope scope) {


### PR DESCRIPTION
This commit adds logging to the in memory LDAP server in LdapTestCase
that indicates when the server starts and stops and the addresses on
which it is listening.

Relates: #75176
