### PR TITLE
[ML] adding datafeed_config to job in high level rest client

### DIFF
--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/ml/datafeed/DatafeedConfig.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/ml/datafeed/DatafeedConfig.java
@@ -8,7 +8,6 @@
 package org.elasticsearch.client.ml.datafeed;
 
 import org.elasticsearch.action.support.IndicesOptions;
-import org.elasticsearch.client.ml.job.config.Job;
 import org.elasticsearch.common.xcontent.ParseField;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.bytes.BytesReference;
@@ -43,6 +42,7 @@ import java.util.Objects;
 public class DatafeedConfig implements ToXContentObject {
 
     public static final ParseField ID = new ParseField("datafeed_id");
+    public static final ParseField JOB_ID = new ParseField("job_id");
     public static final ParseField QUERY_DELAY = new ParseField("query_delay");
     public static final ParseField FREQUENCY = new ParseField("frequency");
     public static final ParseField INDEXES = new ParseField("indexes");
@@ -61,7 +61,7 @@ public class DatafeedConfig implements ToXContentObject {
 
     static {
         PARSER.declareString(ConstructingObjectParser.constructorArg(), ID);
-        PARSER.declareString(ConstructingObjectParser.constructorArg(), Job.ID);
+        PARSER.declareString(ConstructingObjectParser.constructorArg(), JOB_ID);
 
         PARSER.declareStringArray(Builder::setIndices, INDEXES);
         PARSER.declareStringArray(Builder::setIndices, INDICES);
@@ -189,7 +189,7 @@ public class DatafeedConfig implements ToXContentObject {
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startObject();
         builder.field(ID.getPreferredName(), id);
-        builder.field(Job.ID.getPreferredName(), jobId);
+        builder.field(JOB_ID.getPreferredName(), jobId);
         if (queryDelay != null) {
             builder.field(QUERY_DELAY.getPreferredName(), queryDelay.getStringRep());
         }
@@ -312,7 +312,7 @@ public class DatafeedConfig implements ToXContentObject {
 
         public Builder(String id, String jobId) {
             this.id = Objects.requireNonNull(id, ID.getPreferredName());
-            this.jobId = Objects.requireNonNull(jobId, Job.ID.getPreferredName());
+            this.jobId = Objects.requireNonNull(jobId, JOB_ID.getPreferredName());
         }
 
         public Builder(DatafeedConfig config) {

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/ml/datafeed/DatafeedConfigTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/ml/datafeed/DatafeedConfigTests.java
@@ -40,9 +40,9 @@ public class DatafeedConfigTests extends AbstractXContentTestCase<DatafeedConfig
         return createRandomBuilder().build();
     }
 
-    public static DatafeedConfig.Builder createRandomBuilder() {
+    public static DatafeedConfig.Builder createRandomBuilder(String datafeedId, String jobId) {
         long bucketSpanMillis = 3600000;
-        DatafeedConfig.Builder builder = constructBuilder();
+        DatafeedConfig.Builder builder = constructBuilder(datafeedId, jobId);
         builder.setIndices(randomStringList(1, 10));
         if (randomBoolean()) {
             try {
@@ -119,6 +119,10 @@ public class DatafeedConfigTests extends AbstractXContentTestCase<DatafeedConfig
         return builder;
     }
 
+    public static DatafeedConfig.Builder createRandomBuilder() {
+        return createRandomBuilder(randomValidDatafeedId(), randomAlphaOfLength(10));
+    }
+
     public static List<String> randomStringList(int min, int max) {
         int size = scaledRandomIntBetween(min, max);
         List<String> list = new ArrayList<>();
@@ -175,8 +179,8 @@ public class DatafeedConfigTests extends AbstractXContentTestCase<DatafeedConfig
         return generator.ofCodePointsLength(random(), 10, 10);
     }
 
-    private static DatafeedConfig.Builder constructBuilder() {
-        return new DatafeedConfig.Builder(randomValidDatafeedId(), randomAlphaOfLength(10));
+    private static DatafeedConfig.Builder constructBuilder(String datafeedId, String jobId) {
+        return new DatafeedConfig.Builder(datafeedId, jobId);
     }
 
 }

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/ml/job/config/JobTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/ml/job/config/JobTests.java
@@ -8,6 +8,8 @@
 package org.elasticsearch.client.ml.job.config;
 
 import com.carrotsearch.randomizedtesting.generators.CodepointSetGenerator;
+
+import org.elasticsearch.client.ml.datafeed.DatafeedConfigTests;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.common.xcontent.DeprecationHandler;
@@ -162,6 +164,9 @@ public class JobTests extends AbstractXContentTestCase<Job> {
         }
         if (randomBoolean()) {
             builder.setBlocked(BlockedTests.createRandom());
+        }
+        if (randomBoolean()) {
+            builder.setDatafeed(DatafeedConfigTests.createRandomBuilder(jobId, jobId));
         }
         return builder;
     }


### PR DESCRIPTION
adds datafeed_config field to high level rest client. 

Realtes to: https://github.com/elastic/elasticsearch/pull/74265