### PR TITLE
EQL: Increase client timeout on CCS tests

### DIFF
--- a/x-pack/plugin/eql/qa/common/src/main/java/org/elasticsearch/test/eql/RemoteClusterAwareEqlRestTestCase.java
+++ b/x-pack/plugin/eql/qa/common/src/main/java/org/elasticsearch/test/eql/RemoteClusterAwareEqlRestTestCase.java
@@ -30,6 +30,8 @@ import static org.elasticsearch.common.Strings.hasText;
 
 public abstract class RemoteClusterAwareEqlRestTestCase extends ESRestTestCase {
 
+    private static final long CLIENT_TIMEOUT = 40L; // upped from 10s to accomodate for max measured throughput decline
+
     // client used for loading data on a remote cluster only.
     private static RestClient remoteClient;
 
@@ -82,7 +84,7 @@ public abstract class RemoteClusterAwareEqlRestTestCase extends ESRestTestCase {
     }
 
     protected static TimeValue timeout() {
-        return TimeValue.timeValueSeconds(10);
+        return TimeValue.timeValueSeconds(CLIENT_TIMEOUT);
     }
 
     // returned client is used to load the test data, either in the local cluster (for rest/javaRestTests) or a remote one (for


### PR DESCRIPTION
Increase the client timeout for CCS tests that are occasionally
timing out.

Closes #74685.