### PR TITLE
[DOCS] Clarify usage of the enroll Kibana API

### DIFF
--- a/x-pack/docs/en/rest-api/security/enroll-kibana.asciidoc
+++ b/x-pack/docs/en/rest-api/security/enroll-kibana.asciidoc
@@ -16,12 +16,8 @@ NOTE: This API is currently intended for internal use only by {kib}.
 [[security-api-kibana-enrollment-desc]]
 ==== {api-description-title}
 
-Use this API to enable a {kib} instance to configure itself for communications
-with an {es} cluster that already has security features enabled.
-
-When you first start {es}, the installation process generates an enrollment token for
-{kib}. You enter this enrollment token when starting {kib} for the first time, and
-{kib} calls the enroll {kib} API to verify the fingerprint of the enrollment token.
+{kib} uses this API internally to configure itself for communications with an
+{es} cluster that already has security features enabled.
 
 [[security-api-client-enrollment-examples]]
 ==== {api-examples-title}

--- a/x-pack/docs/en/rest-api/security/enroll-kibana.asciidoc
+++ b/x-pack/docs/en/rest-api/security/enroll-kibana.asciidoc
@@ -6,6 +6,8 @@
 
 Enables a {kib} instance to configure itself for communication with a secured {es} cluster.
 
+NOTE: This API is currently intended for internal use only by {kib}.
+
 [[security-api-kibana-enrollment-request]]
 ==== {api-request-title}
 
@@ -16,6 +18,10 @@ Enables a {kib} instance to configure itself for communication with a secured {e
 
 Use this API to enable a {kib} instance to configure itself for communications
 with an {es} cluster that already has security features enabled.
+
+When you first start {es}, the installation process generates an enrollment token for
+{kib}. You enter this enrollment token when starting {kib} for the first time, and
+{kib} calls the enroll {kib} API to verify the fingerprint of the enrollment token.
 
 [[security-api-client-enrollment-examples]]
 ==== {api-examples-title}


### PR DESCRIPTION
I had a discussion with @bytebilly about whether users will call the enroll Kibana API on their own, or if it's only intended for internal use. It seems that only Kibana uses this API to verify the enrollment token from Elasticsearch, so I'm adding a note to indicate this usage, along with some explanatory information about when Kibana calls this API.