### PR TITLE
Adding shard count to node stats api

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/admin/indices/stats/CommonStatsFlags.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/stats/CommonStatsFlags.java
@@ -217,7 +217,8 @@ public class CommonStatsFlags implements Writeable, Cloneable {
         // 14 was previously used for Suggest
         RequestCache("request_cache", 15),
         Recovery("recovery", 16),
-        Bulk("bulk", 17);
+        Bulk("bulk", 17),
+        Shards("shards", 9);
 
         private final String restName;
         private final int index;

--- a/server/src/main/java/org/elasticsearch/index/shard/SimpleShardStats.java
+++ b/server/src/main/java/org/elasticsearch/index/shard/SimpleShardStats.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.index.shard;
+
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.common.xcontent.ToXContentFragment;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+
+import java.io.IOException;
+
+public class SimpleShardStats  implements Writeable, ToXContentFragment {
+
+    private long count = 0;
+
+    public SimpleShardStats() {
+
+    }
+
+    public SimpleShardStats(StreamInput in) throws IOException {
+        count = in.readVLong();
+    }
+
+    public SimpleShardStats(long count) {
+        this.count = count;
+    }
+
+    public long getCount() {
+        return this.count;
+    }
+
+    public SimpleShardStats add(SimpleShardStats other) {
+        return new SimpleShardStats(this.count + (other == null ? 0 : other.count));
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.startObject(Fields.SHARDS);
+        builder.field(Fields.COUNT, count);
+        builder.endObject();
+        return builder;
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeVLong(count);
+    }
+
+    static final class Fields {
+        static final String SHARDS = "shards";
+        static final String COUNT = "count";
+    }
+}

--- a/server/src/test/java/org/elasticsearch/index/shard/SimpleShardStatsTest.java
+++ b/server/src/test/java/org/elasticsearch/index/shard/SimpleShardStatsTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.index.shard;
+
+import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.io.stream.BytesStreamOutput;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.test.ESTestCase;
+import org.junit.Assert;
+
+import static org.hamcrest.Matchers.equalTo;
+
+class SimpleShardStatsTest extends ESTestCase {
+
+    public void testAdd() {
+        SimpleShardStats shardStats1 = new SimpleShardStats(5);
+        SimpleShardStats shardStats2 = new SimpleShardStats(8);
+        SimpleShardStats combinedShardStats = shardStats1.add(shardStats2);
+        Assert.assertEquals(13, combinedShardStats.getCount());
+        Assert.assertEquals(5, shardStats1.getCount());
+        Assert.assertEquals(8, shardStats2.getCount());
+        SimpleShardStats noCountGiven = new SimpleShardStats();
+        Assert.assertEquals(0, noCountGiven.getCount());
+        Assert.assertEquals(8, shardStats2.add(null).getCount());
+        Assert.assertEquals(8, shardStats2.getCount());
+    }
+
+    public void testSerialize() throws Exception {
+        SimpleShardStats originalStats = new SimpleShardStats(5);
+        try (BytesStreamOutput out = new BytesStreamOutput()) {
+            originalStats.writeTo(out);
+            BytesReference bytes = out.bytes();
+            try (StreamInput in = bytes.streamInput()) {
+                SimpleShardStats cloneStats = new SimpleShardStats(in);
+                assertThat(cloneStats.getCount(), equalTo(originalStats.getCount()));
+            }
+        }
+    }
+}


### PR DESCRIPTION
Added a shards section to each node returned by the _node/stats api. Currently it only contains a count of shards
