### PR TITLE
Remove remote cluster compression_scheme setting

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/settings/ClusterSettings.java
+++ b/server/src/main/java/org/elasticsearch/common/settings/ClusterSettings.java
@@ -332,7 +332,6 @@ public final class ClusterSettings extends AbstractScopedSettings {
             RemoteClusterService.SEARCH_ENABLE_REMOTE_CLUSTERS,
             RemoteClusterService.REMOTE_CLUSTER_PING_SCHEDULE,
             RemoteClusterService.REMOTE_CLUSTER_COMPRESS,
-            RemoteClusterService.REMOTE_CLUSTER_COMPRESSION_SCHEME,
             RemoteConnectionStrategy.REMOTE_CONNECTION_MODE,
             ProxyConnectionStrategy.PROXY_ADDRESS,
             ProxyConnectionStrategy.REMOTE_SOCKET_CONNECTIONS,

--- a/server/src/main/java/org/elasticsearch/transport/RemoteClusterService.java
+++ b/server/src/main/java/org/elasticsearch/transport/RemoteClusterService.java
@@ -156,12 +156,6 @@ public final class RemoteClusterService extends RemoteClusterAware implements Cl
         (ns, key) -> enumSetting(Compression.Enabled.class, key, TransportSettings.TRANSPORT_COMPRESS,
             new RemoteConnectionEnabled<>(ns, key), Setting.Property.Dynamic, Setting.Property.NodeScope));
 
-    public static final Setting.AffixSetting<Compression.Scheme> REMOTE_CLUSTER_COMPRESSION_SCHEME = Setting.affixKeySetting(
-        "cluster.remote.",
-        "transport.compression_scheme",
-        (ns, key) -> enumSetting(Compression.Scheme.class, key, TransportSettings.TRANSPORT_COMPRESSION_SCHEME,
-            new RemoteConnectionEnabled<>(ns, key), Setting.Property.Dynamic, Setting.Property.NodeScope));
-
     private final boolean enabled;
 
     public boolean isEnabled() {

--- a/server/src/main/java/org/elasticsearch/transport/RemoteConnectionStrategy.java
+++ b/server/src/main/java/org/elasticsearch/transport/RemoteConnectionStrategy.java
@@ -125,8 +125,6 @@ public abstract class RemoteConnectionStrategy implements TransportConnectionLis
             .setConnectTimeout(TransportSettings.CONNECT_TIMEOUT.get(settings))
             .setHandshakeTimeout(TransportSettings.CONNECT_TIMEOUT.get(settings))
             .setCompressionEnabled(RemoteClusterService.REMOTE_CLUSTER_COMPRESS.getConcreteSettingForNamespace(clusterAlias).get(settings))
-            .setCompressionScheme(RemoteClusterService.REMOTE_CLUSTER_COMPRESSION_SCHEME
-                .getConcreteSettingForNamespace(clusterAlias).get(settings))
             .setPingInterval(RemoteClusterService.REMOTE_CLUSTER_PING_SCHEDULE.getConcreteSettingForNamespace(clusterAlias).get(settings))
             .addConnections(0, TransportRequestOptions.Type.BULK, TransportRequestOptions.Type.STATE,
                 TransportRequestOptions.Type.RECOVERY, TransportRequestOptions.Type.PING)
@@ -281,9 +279,7 @@ public abstract class RemoteConnectionStrategy implements TransportConnectionLis
             Compression.Enabled compressionEnabled = RemoteClusterService.REMOTE_CLUSTER_COMPRESS
                 .getConcreteSettingForNamespace(clusterAlias)
                 .get(newSettings);
-            Compression.Scheme compressionScheme = RemoteClusterService.REMOTE_CLUSTER_COMPRESSION_SCHEME
-                .getConcreteSettingForNamespace(clusterAlias)
-                .get(newSettings);
+            Compression.Scheme compressionScheme = TransportSettings.TRANSPORT_COMPRESSION_SCHEME.get(newSettings);
             TimeValue pingSchedule = RemoteClusterService.REMOTE_CLUSTER_PING_SCHEDULE
                 .getConcreteSettingForNamespace(clusterAlias)
                 .get(newSettings);

--- a/server/src/main/java/org/elasticsearch/transport/RemoteConnectionStrategy.java
+++ b/server/src/main/java/org/elasticsearch/transport/RemoteConnectionStrategy.java
@@ -125,6 +125,7 @@ public abstract class RemoteConnectionStrategy implements TransportConnectionLis
             .setConnectTimeout(TransportSettings.CONNECT_TIMEOUT.get(settings))
             .setHandshakeTimeout(TransportSettings.CONNECT_TIMEOUT.get(settings))
             .setCompressionEnabled(RemoteClusterService.REMOTE_CLUSTER_COMPRESS.getConcreteSettingForNamespace(clusterAlias).get(settings))
+            .setCompressionScheme(TransportSettings.TRANSPORT_COMPRESSION_SCHEME.get(settings))
             .setPingInterval(RemoteClusterService.REMOTE_CLUSTER_PING_SCHEDULE.getConcreteSettingForNamespace(clusterAlias).get(settings))
             .addConnections(0, TransportRequestOptions.Type.BULK, TransportRequestOptions.Type.STATE,
                 TransportRequestOptions.Type.RECOVERY, TransportRequestOptions.Type.PING)

--- a/server/src/test/java/org/elasticsearch/transport/RemoteClusterServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/RemoteClusterServiceTests.java
@@ -360,13 +360,8 @@ public class RemoteClusterServiceTests extends ESTestCase {
                     Settings.Builder settingsChange = Settings.builder();
                     TimeValue pingSchedule = TimeValue.timeValueSeconds(randomIntBetween(6, 8));
                     settingsChange.put("cluster.remote.cluster_1.transport.ping_schedule", pingSchedule);
-                    boolean compressionScheme = randomBoolean();
                     Compression.Enabled enabled = randomFrom(Compression.Enabled.TRUE, Compression.Enabled.INDEXING_DATA);
-                    if (compressionScheme) {
-                        settingsChange.put("cluster.remote.cluster_1.transport.compression_scheme", Compression.Scheme.LZ4);
-                    } else {
-                        settingsChange.put("cluster.remote.cluster_1.transport.compress", enabled);
-                    }
+                    settingsChange.put("cluster.remote.cluster_1.transport.compress", enabled);
                     settingsChange.putList("cluster.remote.cluster_1.seeds", cluster1Seed.getAddress().toString());
                     service.validateAndUpdateRemoteCluster("cluster_1", settingsChange.build());
                     assertBusy(remoteClusterConnection::isClosed);
@@ -374,13 +369,8 @@ public class RemoteClusterServiceTests extends ESTestCase {
                     remoteClusterConnection = service.getRemoteClusterConnection("cluster_1");
                     ConnectionProfile connectionProfile = remoteClusterConnection.getConnectionManager().getConnectionProfile();
                     assertEquals(pingSchedule, connectionProfile.getPingInterval());
-                    if (compressionScheme) {
-                        assertEquals(Compression.Enabled.FALSE, connectionProfile.getCompressionEnabled());
-                        assertEquals(Compression.Scheme.LZ4, connectionProfile.getCompressionScheme());
-                    } else {
-                        assertEquals(enabled, connectionProfile.getCompressionEnabled());
-                        assertEquals(Compression.Scheme.DEFLATE, connectionProfile.getCompressionScheme());
-                    }
+                    assertEquals(enabled, connectionProfile.getCompressionEnabled());
+                    assertEquals(Compression.Scheme.DEFLATE, connectionProfile.getCompressionScheme());
                 }
             }
         }

--- a/server/src/test/java/org/elasticsearch/transport/RemoteConnectionStrategyTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/RemoteConnectionStrategyTests.java
@@ -56,19 +56,13 @@ public class RemoteConnectionStrategyTests extends ESTestCase {
         newBuilder.put(ProxyConnectionStrategy.PROXY_ADDRESS.getConcreteSettingForNamespace("cluster-alias").getKey(), "127.0.0.1:9300");
         String ping = "ping";
         String compress = "compress";
-        String compressionScheme = "compression_scheme";
-        String change = randomFrom(ping, compress, compressionScheme);
+        String change = randomFrom(ping, compress);
         if (change.equals(ping)) {
             newBuilder.put(RemoteClusterService.REMOTE_CLUSTER_PING_SCHEDULE.getConcreteSettingForNamespace("cluster-alias").getKey(),
                 TimeValue.timeValueSeconds(5));
         } else if (change.equals(compress)) {
             newBuilder.put(RemoteClusterService.REMOTE_CLUSTER_COMPRESS.getConcreteSettingForNamespace("cluster-alias").getKey(),
                 randomFrom(Compression.Enabled.INDEXING_DATA, Compression.Enabled.TRUE));
-        } else if (change.equals(compressionScheme)) {
-            newBuilder.put(
-                RemoteClusterService.REMOTE_CLUSTER_COMPRESSION_SCHEME.getConcreteSettingForNamespace("cluster-alias").getKey(),
-                Compression.Scheme.LZ4
-            );
         } else {
             throw new AssertionError("Unexpected option: " + change);
         }


### PR DESCRIPTION
The `cluster.remote.*.transport.compression_scheme` setting is currently
broken. All connections fall back to the `transport.compression_scheme`
setting. This commit removes this setting for 7.14 until we can fix it
in a future version.