### PR TITLE
[ML] Memory based trained model task allocation

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/MlTasks.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/MlTasks.java
@@ -15,6 +15,8 @@ import org.elasticsearch.persistent.PersistentTasksCustomMetadata;
 import org.elasticsearch.xpack.core.ml.datafeed.DatafeedState;
 import org.elasticsearch.xpack.core.ml.dataframe.DataFrameAnalyticsState;
 import org.elasticsearch.xpack.core.ml.dataframe.DataFrameAnalyticsTaskState;
+import org.elasticsearch.xpack.core.ml.inference.deployment.TrainedModelDeploymentState;
+import org.elasticsearch.xpack.core.ml.inference.deployment.TrainedModelDeploymentTaskState;
 import org.elasticsearch.xpack.core.ml.job.config.JobState;
 import org.elasticsearch.xpack.core.ml.job.config.JobTaskState;
 import org.elasticsearch.xpack.core.ml.job.snapshot.upgrade.SnapshotUpgradeState;
@@ -223,6 +225,30 @@ public final class MlTasks {
         return state;
     }
 
+    public static TrainedModelDeploymentState getTrainedModelDeploymentState(PersistentTasksCustomMetadata.PersistentTask<?> task) {
+        if (task == null) {
+            return TrainedModelDeploymentState.STOPPED;
+        }
+        TrainedModelDeploymentTaskState taskState = (TrainedModelDeploymentTaskState) task.getState();
+        if (taskState == null) {
+            return TrainedModelDeploymentState.STARTING;
+        }
+
+        TrainedModelDeploymentState state = taskState.getState();
+        if (taskState.isStatusStale(task)) {
+            if (state == TrainedModelDeploymentState.STOPPING) {
+                // previous executor node failed while the job was stopping - it won't
+                // be restarted on another node, so consider it STOPPED for reassignment purposes
+                return TrainedModelDeploymentState.STOPPED;
+            }
+            if (state != TrainedModelDeploymentState.FAILED) {
+                // we are relocating at the moment
+                return TrainedModelDeploymentState.STARTING;
+            }
+        }
+        return state;
+    }
+
     /**
      * The job Ids of anomaly detector job tasks.
      * All anomaly detector jobs are returned regardless of the status of the
@@ -345,6 +371,8 @@ public final class MlTasks {
                 return taskState == null ? SnapshotUpgradeState.LOADING_OLD_STATE : taskState.getState();
             case DATA_FRAME_ANALYTICS_TASK_NAME:
                 return getDataFrameAnalyticsState(task);
+            case TRAINED_MODEL_DEPLOYMENT_TASK_NAME:
+                return getTrainedModelDeploymentState(task);
             default:
                 throw new IllegalStateException("unexpected task type [" + task.getTaskName() + "]");
         }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/MlTasks.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/MlTasks.java
@@ -243,6 +243,7 @@ public final class MlTasks {
             }
             if (state != TrainedModelDeploymentState.FAILED) {
                 // we are relocating at the moment
+                // TODO Revisit this in the new allocation framework as there won't necessarily be a concept of relocation.
                 return TrainedModelDeploymentState.STARTING;
             }
         }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/StartTrainedModelDeploymentAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/StartTrainedModelDeploymentAction.java
@@ -139,6 +139,9 @@ public class StartTrainedModelDeploymentAction extends ActionType<NodeAcknowledg
             this.modelId = Objects.requireNonNull(modelId);
             this.index = Objects.requireNonNull(index);
             this.modelBytes = modelBytes;
+            if (modelBytes < 0) {
+                throw new IllegalArgumentException("modelBytes must be non-negative");
+            }
         }
 
         public TaskParams(StreamInput in) throws IOException {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/StartTrainedModelDeploymentAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/StartTrainedModelDeploymentAction.java
@@ -124,6 +124,10 @@ public class StartTrainedModelDeploymentAction extends ActionType<NodeAcknowledg
 
         private static final ParseField MODEL_BYTES = new ParseField("model_bytes");
 
+        /**
+         * This has been found to be approximately 300MB on linux by manual testing.
+         * TODO Check if it is substantially different in other platforms.
+         */
         private static final ByteSizeValue MEMORY_OVERHEAD = ByteSizeValue.ofMb(300);
 
         private final String modelId;

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/StartTrainedModelDeploymentAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/StartTrainedModelDeploymentAction.java
@@ -11,6 +11,7 @@ import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.ActionType;
 import org.elasticsearch.action.support.master.MasterNodeRequest;
+import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.xcontent.ParseField;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -24,6 +25,7 @@ import org.elasticsearch.xpack.core.ml.MlTasks;
 import org.elasticsearch.xpack.core.ml.inference.TrainedModelConfig;
 import org.elasticsearch.xpack.core.ml.inference.trainedmodel.IndexLocation;
 import org.elasticsearch.xpack.core.ml.utils.ExceptionsHelper;
+import org.elasticsearch.xpack.core.ml.utils.MlTaskParams;
 
 import java.io.IOException;
 import java.util.Objects;
@@ -116,21 +118,28 @@ public class StartTrainedModelDeploymentAction extends ActionType<NodeAcknowledg
         }
     }
 
-    public static class TaskParams implements PersistentTaskParams {
+    public static class TaskParams implements PersistentTaskParams, MlTaskParams {
 
         public static final Version VERSION_INTRODUCED = Version.V_8_0_0;
 
+        private static final ParseField MODEL_BYTES = new ParseField("model_bytes");
+
+        private static final ByteSizeValue MEMORY_OVERHEAD = ByteSizeValue.ofMb(300);
+
         private final String modelId;
         private final String index;
+        private final long modelBytes;
 
-        public TaskParams(String modelId, String index) {
+        public TaskParams(String modelId, String index, long modelBytes) {
             this.modelId = Objects.requireNonNull(modelId);
             this.index = Objects.requireNonNull(index);
+            this.modelBytes = modelBytes;
         }
 
         public TaskParams(StreamInput in) throws IOException {
             this.modelId = in.readString();
             this.index = in.readString();
+            this.modelBytes = in.readVLong();
         }
 
         public String getModelId() {
@@ -139,6 +148,11 @@ public class StartTrainedModelDeploymentAction extends ActionType<NodeAcknowledg
 
         public String getIndex() {
             return index;
+        }
+
+        public long estimateMemoryUsageBytes() {
+            // While loading the model in the process we need twice the model size
+            return MEMORY_OVERHEAD.getBytes() + 2 * modelBytes;
         }
 
         @Override
@@ -155,6 +169,7 @@ public class StartTrainedModelDeploymentAction extends ActionType<NodeAcknowledg
         public void writeTo(StreamOutput out) throws IOException {
             out.writeString(modelId);
             out.writeString(index);
+            out.writeVLong(modelBytes);
         }
 
         @Override
@@ -162,13 +177,14 @@ public class StartTrainedModelDeploymentAction extends ActionType<NodeAcknowledg
             builder.startObject();
             builder.field(TrainedModelConfig.MODEL_ID.getPreferredName(), modelId);
             builder.field(IndexLocation.INDEX.getPreferredName(), index);
+            builder.field(MODEL_BYTES.getPreferredName(), modelBytes);
             builder.endObject();
             return builder;
         }
 
         @Override
         public int hashCode() {
-            return Objects.hash(modelId);
+            return Objects.hash(modelId, index, modelBytes);
         }
 
         @Override
@@ -177,7 +193,14 @@ public class StartTrainedModelDeploymentAction extends ActionType<NodeAcknowledg
             if (o == null || getClass() != o.getClass()) return false;
 
             TaskParams other = (TaskParams) o;
-            return Objects.equals(modelId, other.modelId);
+            return Objects.equals(modelId, other.modelId)
+                && Objects.equals(index, other.index)
+                && modelBytes == other.modelBytes;
+        }
+
+        @Override
+        public String getMlId() {
+            return modelId;
         }
     }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/StartTrainedModelDeploymentAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/StartTrainedModelDeploymentAction.java
@@ -126,9 +126,10 @@ public class StartTrainedModelDeploymentAction extends ActionType<NodeAcknowledg
 
         /**
          * This has been found to be approximately 300MB on linux by manual testing.
+         * We also subtract 30MB that we always add as overhead (see MachineLearning.NATIVE_EXECUTABLE_CODE_OVERHEAD).
          * TODO Check if it is substantially different in other platforms.
          */
-        private static final ByteSizeValue MEMORY_OVERHEAD = ByteSizeValue.ofMb(300);
+        private static final ByteSizeValue MEMORY_OVERHEAD = ByteSizeValue.ofMb(270);
 
         private final String modelId;
         private final String index;
@@ -155,7 +156,7 @@ public class StartTrainedModelDeploymentAction extends ActionType<NodeAcknowledg
         }
 
         public long estimateMemoryUsageBytes() {
-            // While loading the model in the process we need twice the model size
+            // While loading the model in the process we need twice the model size.
             return MEMORY_OVERHEAD.getBytes() + 2 * modelBytes;
         }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/deployment/TrainedModelDeploymentState.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/deployment/TrainedModelDeploymentState.java
@@ -10,11 +10,13 @@ package org.elasticsearch.xpack.core.ml.inference.deployment;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.xpack.core.ml.utils.MemoryTrackedTaskState;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.Locale;
 
-public enum TrainedModelDeploymentState implements Writeable {
+public enum TrainedModelDeploymentState implements Writeable, MemoryTrackedTaskState {
 
     STARTING, STARTED, STOPPING, STOPPED, FAILED;
 
@@ -34,5 +36,17 @@ public enum TrainedModelDeploymentState implements Writeable {
     @Override
     public String toString() {
         return name().toLowerCase(Locale.ROOT);
+    }
+
+    /**
+     * @return {@code true} if state matches none of the given {@code candidates}
+     */
+    public boolean isNoneOf(TrainedModelDeploymentState... candidates) {
+        return Arrays.stream(candidates).noneMatch(candidate -> this == candidate);
+    }
+
+    @Override
+    public boolean consumesMemory() {
+        return isNoneOf(FAILED, STOPPED);
     }
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/deployment/TrainedModelDeploymentTaskState.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/deployment/TrainedModelDeploymentTaskState.java
@@ -15,6 +15,7 @@ import org.elasticsearch.common.xcontent.ConstructingObjectParser;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.persistent.PersistentTaskState;
+import org.elasticsearch.persistent.PersistentTasksCustomMetadata;
 import org.elasticsearch.xpack.core.ml.MlTasks;
 import org.elasticsearch.xpack.core.ml.dataframe.DataFrameAnalyticsState;
 
@@ -108,5 +109,9 @@ public class TrainedModelDeploymentTaskState implements PersistentTaskState {
     @Override
     public int hashCode() {
         return Objects.hash(state, allocationId, reason);
+    }
+
+    public boolean isStatusStale(PersistentTasksCustomMetadata.PersistentTask<?> task) {
+        return allocationId != task.getAllocationId();
     }
 }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/MlTasksTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/MlTasksTests.java
@@ -16,13 +16,17 @@ import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.core.ml.action.OpenJobAction;
 import org.elasticsearch.xpack.core.ml.action.StartDataFrameAnalyticsAction;
 import org.elasticsearch.xpack.core.ml.action.StartDatafeedAction;
+import org.elasticsearch.xpack.core.ml.action.StartTrainedModelDeploymentAction;
 import org.elasticsearch.xpack.core.ml.datafeed.DatafeedState;
 import org.elasticsearch.xpack.core.ml.dataframe.DataFrameAnalyticsState;
 import org.elasticsearch.xpack.core.ml.dataframe.DataFrameAnalyticsTaskState;
+import org.elasticsearch.xpack.core.ml.inference.deployment.TrainedModelDeploymentState;
+import org.elasticsearch.xpack.core.ml.inference.deployment.TrainedModelDeploymentTaskState;
 import org.elasticsearch.xpack.core.ml.job.config.JobState;
 import org.elasticsearch.xpack.core.ml.job.config.JobTaskState;
 
 import java.net.InetAddress;
+import java.util.Arrays;
 
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.empty;
@@ -243,6 +247,41 @@ public class MlTasksTests extends ESTestCase {
         assertThat(state, equalTo(DataFrameAnalyticsState.FAILED));
     }
 
+    public void testGetTrainedModelDeploymentState_GivenNull() {
+        assertThat(MlTasks.getTrainedModelDeploymentState(null), equalTo(TrainedModelDeploymentState.STOPPED));
+    }
+
+    public void testGetTrainedModelDeploymentState_GivenTaskStateIsNull() {
+        PersistentTasksCustomMetadata.PersistentTask<?> task = createTrainedModelTask(null, false);
+        assertThat(MlTasks.getTrainedModelDeploymentState(task), equalTo(TrainedModelDeploymentState.STARTING));
+    }
+
+    public void testGetTrainedModelDeploymentState_GivenTaskStateIsNotNullAndNotStale() {
+        TrainedModelDeploymentState state = randomFrom(TrainedModelDeploymentState.values());
+        PersistentTasksCustomMetadata.PersistentTask<?> task = createTrainedModelTask(state, false);
+        assertThat(MlTasks.getTrainedModelDeploymentState(task), equalTo(state));
+    }
+
+    public void testGetTrainedModelDeploymentState_GivenTaskStateIsStaleAndStopping() {
+        PersistentTasksCustomMetadata.PersistentTask<?> task = createTrainedModelTask(TrainedModelDeploymentState.STOPPING, true);
+        assertThat(MlTasks.getTrainedModelDeploymentState(task), equalTo(TrainedModelDeploymentState.STOPPED));
+    }
+
+    public void testGetTrainedModelDeploymentState_GivenTaskStateIsStaleAndFailed() {
+        PersistentTasksCustomMetadata.PersistentTask<?> task = createTrainedModelTask(TrainedModelDeploymentState.FAILED, true);
+        assertThat(MlTasks.getTrainedModelDeploymentState(task), equalTo(TrainedModelDeploymentState.FAILED));
+    }
+
+    public void testGetTrainedModelDeploymentState_GivenTaskStateIsStaleAndNotFailedNorStopping() {
+        TrainedModelDeploymentState state = randomFrom(
+            Arrays.stream(TrainedModelDeploymentState.values())
+                .filter(s -> s != TrainedModelDeploymentState.FAILED && s != TrainedModelDeploymentState.STOPPING)
+                .toArray(TrainedModelDeploymentState[]::new)
+        );
+        PersistentTasksCustomMetadata.PersistentTask<?> task = createTrainedModelTask(state, true);
+        assertThat(MlTasks.getTrainedModelDeploymentState(task), equalTo(TrainedModelDeploymentState.STARTING));
+    }
+
     private static PersistentTasksCustomMetadata.PersistentTask<?> createDataFrameAnalyticsTask(String jobId, String nodeId,
                                                                                                 DataFrameAnalyticsState state,
                                                                                                 boolean isStale) {
@@ -256,5 +295,20 @@ public class MlTasksTests extends ESTestCase {
         }
         PersistentTasksCustomMetadata tasks = builder.build();
         return tasks.getTask(MlTasks.dataFrameAnalyticsTaskId(jobId));
+    }
+
+    private static PersistentTasksCustomMetadata.PersistentTask<?> createTrainedModelTask(TrainedModelDeploymentState state,
+                                                                                          boolean isStale) {
+        String id = randomAlphaOfLength(10);
+        PersistentTasksCustomMetadata.Builder builder = PersistentTasksCustomMetadata.builder();
+        builder.addTask(MlTasks.trainedModelDeploymentTaskId(id), MlTasks.TRAINED_MODEL_DEPLOYMENT_TASK_NAME,
+            new StartTrainedModelDeploymentAction.TaskParams(id, randomAlphaOfLength(10), randomNonNegativeLong()),
+            new PersistentTasksCustomMetadata.Assignment(randomAlphaOfLength(10), "test assignment"));
+        if (state != null) {
+            builder.updateTaskState(MlTasks.trainedModelDeploymentTaskId(id),
+                new TrainedModelDeploymentTaskState(state, builder.getLastAllocationId() - (isStale ? 1 : 0), null));
+        }
+        PersistentTasksCustomMetadata tasks = builder.build();
+        return tasks.getTask(MlTasks.trainedModelDeploymentTaskId(id));
     }
 }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportStartTrainedModelDeploymentAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportStartTrainedModelDeploymentAction.java
@@ -147,8 +147,9 @@ public class TransportStartTrainedModelDeploymentAction
                             trainedModelConfig.getLocation().getResourceName(),
                             modelBytes
                         );
-                        memoryTracker.addTrainedModelMemoryAndRefreshAllOthers(taskParams.getMlId(), taskParams.estimateMemoryUsageBytes(),
-                            ActionListener.wrap(
+                        PersistentTasksCustomMetadata persistentTasks = clusterService.state().getMetadata().custom(
+                            PersistentTasksCustomMetadata.TYPE);
+                        memoryTracker.refresh(persistentTasks, ActionListener.wrap(
                                 aVoid -> persistentTasksService.sendStartRequest(
                                     MlTasks.trainedModelDeploymentTaskId(request.getModelId()),
                                     MlTasks.TRAINED_MODEL_DEPLOYMENT_TASK_NAME,
@@ -333,6 +334,7 @@ public class TransportStartTrainedModelDeploymentAction
                 );
 
             PersistentTasksCustomMetadata.Assignment assignment = jobNodeSelector.selectNode(
+                params.estimateMemoryUsageBytes(),
                 maxOpenJobs,
                 Integer.MAX_VALUE,
                 maxMachineMemoryPercent,

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportStartTrainedModelDeploymentAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportStartTrainedModelDeploymentAction.java
@@ -22,9 +22,9 @@ import org.elasticsearch.cluster.block.ClusterBlockLevel;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.service.ClusterService;
-import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.license.LicenseUtils;
 import org.elasticsearch.license.XPackLicenseState;
@@ -53,16 +53,15 @@ import org.elasticsearch.xpack.core.ml.utils.ExceptionsHelper;
 import org.elasticsearch.xpack.ml.MachineLearning;
 import org.elasticsearch.xpack.ml.inference.deployment.DeploymentManager;
 import org.elasticsearch.xpack.ml.inference.deployment.TrainedModelDeploymentTask;
+import org.elasticsearch.xpack.ml.inference.persistence.ChunkedTrainedModelRestorer;
 import org.elasticsearch.xpack.ml.job.JobNodeSelector;
 import org.elasticsearch.xpack.ml.process.MlMemoryTracker;
 import org.elasticsearch.xpack.ml.task.AbstractJobPersistentTasksExecutor;
 
 import java.util.Collection;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.function.Predicate;
 
 public class TransportStartTrainedModelDeploymentAction
@@ -73,18 +72,23 @@ public class TransportStartTrainedModelDeploymentAction
     private final XPackLicenseState licenseState;
     private final Client client;
     private final PersistentTasksService persistentTasksService;
+    private final NamedXContentRegistry xContentRegistry;
+    private final MlMemoryTracker memoryTracker;
 
     @Inject
     public TransportStartTrainedModelDeploymentAction(TransportService transportService, Client client, ClusterService clusterService,
                                                       ThreadPool threadPool, ActionFilters actionFilters, XPackLicenseState licenseState,
                                                       IndexNameExpressionResolver indexNameExpressionResolver,
-                                                      PersistentTasksService persistentTasksService) {
+                                                      PersistentTasksService persistentTasksService,
+                                                      NamedXContentRegistry xContentRegistry, MlMemoryTracker memoryTracker) {
         super(StartTrainedModelDeploymentAction.NAME, transportService, clusterService, threadPool, actionFilters,
             StartTrainedModelDeploymentAction.Request::new, indexNameExpressionResolver, NodeAcknowledgedResponse::new,
             ThreadPool.Names.SAME);
         this.licenseState = Objects.requireNonNull(licenseState);
         this.client = Objects.requireNonNull(client);
         this.persistentTasksService = Objects.requireNonNull(persistentTasksService);
+        this.xContentRegistry = Objects.requireNonNull(xContentRegistry);
+        this.memoryTracker = Objects.requireNonNull(memoryTracker);
     }
 
     @Override
@@ -136,18 +140,49 @@ public class TransportStartTrainedModelDeploymentAction
                     return;
                 }
 
-                persistentTasksService.sendStartRequest(
-                    MlTasks.trainedModelDeploymentTaskId(request.getModelId()),
-                    MlTasks.TRAINED_MODEL_DEPLOYMENT_TASK_NAME,
-                    new TaskParams(trainedModelConfig.getLocation().getModelId(), trainedModelConfig.getLocation().getResourceName()),
-                    waitForDeploymentToStart
-                );
+                getModelBytes(trainedModelConfig, ActionListener.wrap(
+                    modelBytes -> {
+                        TaskParams taskParams = new TaskParams(
+                            trainedModelConfig.getLocation().getModelId(),
+                            trainedModelConfig.getLocation().getResourceName(),
+                            modelBytes
+                        );
+                        memoryTracker.addTrainedModelMemoryAndRefreshAllOthers(taskParams.getMlId(), taskParams.estimateMemoryUsageBytes(),
+                            ActionListener.wrap(
+                                aVoid -> persistentTasksService.sendStartRequest(
+                                    MlTasks.trainedModelDeploymentTaskId(request.getModelId()),
+                                    MlTasks.TRAINED_MODEL_DEPLOYMENT_TASK_NAME,
+                                    taskParams,
+                                    waitForDeploymentToStart
+                                ),
+                                listener::onFailure
+                            )
+                        );
+                    },
+                    listener::onFailure
+                ));
             },
             listener::onFailure
         );
 
         GetTrainedModelsAction.Request getModelRequest = new GetTrainedModelsAction.Request(request.getModelId());
         client.execute(GetTrainedModelsAction.INSTANCE, getModelRequest, getModelListener);
+    }
+
+    private void getModelBytes(TrainedModelConfig trainedModelConfig, ActionListener<Long> listener) {
+        ChunkedTrainedModelRestorer restorer = new ChunkedTrainedModelRestorer(trainedModelConfig.getLocation().getModelId(),
+            client, threadPool.executor(MachineLearning.UTILITY_THREAD_POOL_NAME), xContentRegistry);
+        restorer.setSearchIndex(trainedModelConfig.getLocation().getResourceName());
+        restorer.setSearchSize(1);
+        restorer.restoreModelDefinition(
+            doc -> {
+                listener.onResponse(doc.getTotalDefinitionLength());
+                // Return false to stop the restorer as we only need the first doc
+                return false;
+            },
+            success -> { /* nothing to do */ },
+            listener::onFailure
+        );
     }
 
     private void waitForDeploymentStarted(PersistentTasksCustomMetadata.PersistentTask<TaskParams> task,
@@ -273,53 +308,33 @@ public class TransportStartTrainedModelDeploymentAction
                                                                       Collection<DiscoveryNode> candidateNodes,
                                                                       ClusterState clusterState) {
 
-            // This procedure chooses the first available ml node
-            // that is a high enough version.
-            // TODO assign models by memory this a a blocker on releasing the feature
-            // NORELEASE assign pytorch models to nodes by memory
-            DiscoveryNode chosenOne = null;
-            List<String> reasons = new LinkedList<>();
-            for (DiscoveryNode node : candidateNodes) {
-                if (MachineLearning.isMlNode(node) == false) {
-                    reasons.add(createReason(params.getModelId(), nodeNameOrId(node), "This node isn't a machine learning node."));
-                    continue;
-                }
-
-                String filter = nodeFilter(node, params);
-                if (filter != null) {
-                    reasons.add(filter);
-                    continue;
-                }
-
-                chosenOne = node;
-                break;
+            boolean isMemoryTrackerRecentlyRefreshed = memoryTracker.isRecentlyRefreshed();
+            Optional<PersistentTasksCustomMetadata.Assignment> optionalAssignment =
+                getPotentialAssignment(params, clusterState, isMemoryTrackerRecentlyRefreshed);
+            // NOTE: this will return here if isMemoryTrackerRecentlyRefreshed is false, we don't allow assignment with stale memory
+            if (optionalAssignment.isPresent()) {
+                return optionalAssignment.get();
             }
 
-            if (chosenOne == null) {
-                String explanation = "No suitable node found to deploy model [" + params.getModelId() + "]. Reasons: " +
-                    String.join("|", reasons);
-                logger.info(explanation);
-                return new PersistentTasksCustomMetadata.Assignment(null, explanation);
-            }
+            JobNodeSelector jobNodeSelector =
+                new JobNodeSelector(
+                    clusterState,
+                    candidateNodes,
+                    params.getModelId(),
+                    MlTasks.TRAINED_MODEL_DEPLOYMENT_TASK_NAME,
+                    memoryTracker,
+                    maxLazyMLNodes,
+                    node -> nodeFilter(node, params)
+                );
 
-            return new PersistentTasksCustomMetadata.Assignment(chosenOne.getId(), "");
-        }
-
-        private static String createReason(String job, String node, String msg, Object... params) {
-            String preamble =  String.format(
-                Locale.ROOT,
-                "Not opening job [%s] on node [%s]. Reason: ",
-                job,
-                node);
-            return preamble + ParameterizedMessage.format(msg, params);
-        }
-
-        private static String nodeNameOrId(DiscoveryNode node) {
-            String nodeNameOrID = node.getName();
-            if (Strings.isNullOrEmpty(nodeNameOrID)) {
-                nodeNameOrID = node.getId();
-            }
-            return nodeNameOrID;
+            PersistentTasksCustomMetadata.Assignment assignment = jobNodeSelector.selectNode(
+                maxOpenJobs,
+                Integer.MAX_VALUE,
+                maxMachineMemoryPercent,
+                maxNodeMemory,
+                useAutoMemoryPercentage
+            );
+            return assignment;
         }
 
         public static String nodeFilter(DiscoveryNode node, TaskParams params) {

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportStartTrainedModelDeploymentAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportStartTrainedModelDeploymentAction.java
@@ -176,7 +176,12 @@ public class TransportStartTrainedModelDeploymentAction
         restorer.setSearchSize(1);
         restorer.restoreModelDefinition(
             doc -> {
+                // The in-memory size of the model was found to be approximately equal
+                // to the size of the model on disk in experiments for BERT models. However,
+                // this might not always be the case.
+                // TODO Improve heuristic for in-memory model size.
                 listener.onResponse(doc.getTotalDefinitionLength());
+
                 // Return false to stop the restorer as we only need the first doc
                 return false;
             },

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/deployment/TrainedModelDeploymentTask.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/deployment/TrainedModelDeploymentTask.java
@@ -41,6 +41,10 @@ public class TrainedModelDeploymentTask extends AllocatedPersistentTask implemen
         return params.getIndex();
     }
 
+    public long estimateMemoryUsageBytes() {
+        return params.estimateMemoryUsageBytes();
+    }
+
     public void stop(String reason) {
         logger.debug("[{}] Stopping due to reason [{}]", getModelId(), reason);
 

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/JobNodeSelector.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/JobNodeSelector.java
@@ -134,6 +134,22 @@ public class JobNodeSelector {
                                                                long maxNodeSize,
                                                                boolean useAutoMemoryPercentage) {
         final Long estimatedMemoryFootprint = memoryTracker.getJobMemoryRequirement(taskName, jobId);
+        return selectNode(
+            estimatedMemoryFootprint,
+            dynamicMaxOpenJobs,
+            maxConcurrentJobAllocations,
+            maxMachineMemoryPercent,
+            maxNodeSize,
+            useAutoMemoryPercentage
+        );
+    }
+
+    public PersistentTasksCustomMetadata.Assignment selectNode(Long estimatedMemoryFootprint,
+                                                               int dynamicMaxOpenJobs,
+                                                               int maxConcurrentJobAllocations,
+                                                               int maxMachineMemoryPercent,
+                                                               long maxNodeSize,
+                                                               boolean useAutoMemoryPercentage) {
         if (estimatedMemoryFootprint == null) {
             memoryTracker.asyncRefresh();
             String reason = "Not opening job [" + jobId + "] because job memory requirements are stale - refresh requested";
@@ -143,6 +159,7 @@ public class JobNodeSelector {
         List<String> reasons = new LinkedList<>();
         long maxAvailableMemory = Long.MIN_VALUE;
         DiscoveryNode minLoadedNodeByMemory = null;
+        long requiredMemoryForJob = estimatedMemoryFootprint;
         for (DiscoveryNode node : candidateNodes) {
 
             // First check conditions that would rule out the node regardless of what other tasks are assigned to it
@@ -211,7 +228,6 @@ public class JobNodeSelector {
                 continue;
             }
 
-            long requiredMemoryForJob = estimatedMemoryFootprint;
             // If this will be the first job assigned to the node then it will need to
             // load the native code shared libraries, so add the overhead for this
             if (currentLoad.getNumAssignedJobs() == 0) {
@@ -242,6 +258,7 @@ public class JobNodeSelector {
         }
 
         return createAssignment(
+            estimatedMemoryFootprint,
             minLoadedNodeByMemory,
             reasons,
             maxNodeSize > 0L ?
@@ -249,7 +266,8 @@ public class JobNodeSelector {
                 Long.MAX_VALUE);
     }
 
-    PersistentTasksCustomMetadata.Assignment createAssignment(DiscoveryNode minLoadedNode,
+    PersistentTasksCustomMetadata.Assignment createAssignment(long estimatedMemoryUsage,
+                                                              DiscoveryNode minLoadedNode,
                                                               List<String> reasons,
                                                               long biggestPossibleJob) {
         if (minLoadedNode == null) {
@@ -257,9 +275,7 @@ public class JobNodeSelector {
             PersistentTasksCustomMetadata.Assignment currentAssignment =
                 new PersistentTasksCustomMetadata.Assignment(null, explanation);
             logger.debug("no node selected for job [{}], reasons [{}]", jobId, explanation);
-            Long estimatedMemoryUsage = memoryTracker.getJobMemoryRequirement(taskName, jobId);
-            if (estimatedMemoryUsage != null
-                && (MachineLearning.NATIVE_EXECUTABLE_CODE_OVERHEAD.getBytes() + estimatedMemoryUsage) > biggestPossibleJob) {
+            if ((MachineLearning.NATIVE_EXECUTABLE_CODE_OVERHEAD.getBytes() + estimatedMemoryUsage) > biggestPossibleJob) {
                 ParameterizedMessage message = new ParameterizedMessage(
                     "[{}] not waiting for node assignment as estimated job size [{}] is greater than largest possible job size [{}]",
                     jobId,

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/NodeLoadDetector.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/NodeLoadDetector.java
@@ -109,7 +109,8 @@ public class NodeLoadDetector {
     private static boolean isMemoryTrackedTask(PersistentTasksCustomMetadata.PersistentTask<?> task) {
         return MlTasks.JOB_TASK_NAME.equals(task.getTaskName())
             || MlTasks.JOB_SNAPSHOT_UPGRADE_TASK_NAME.equals(task.getTaskName())
-            || MlTasks.DATA_FRAME_ANALYTICS_TASK_NAME.equals(task.getTaskName());
+            || MlTasks.DATA_FRAME_ANALYTICS_TASK_NAME.equals(task.getTaskName())
+            || MlTasks.TRAINED_MODEL_DEPLOYMENT_TASK_NAME.equals(task.getTaskName());
     }
 
 }

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/ml/3rd_party_deployment.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/ml/3rd_party_deployment.yml
@@ -25,6 +25,6 @@
           }
 
   - do:
-      catch: /\[distilbert-finetuned-sst\] creating NLP task from configuration failed with error/
+      catch: /Could not find trained model definition \[distilbert-finetuned-sst\]/
       ml.start_trained_model_deployment:
         model_id: distilbert-finetuned-sst


### PR DESCRIPTION
This commit adds memory tracking to trained model tasks.
When a trained model deployment is started, we now
choose a node that has enough free memory to accommodate
the native process that loads the model.

The memory usage is calculated as twice the model size
plus some overhead. The reason we require twice the model size
is that during the loading of the model we store the model once
and then another time for the inflated object that represents
the model. After that, the process does return the memory needed
for storing the model back to the OS. However, if we lowered
the memory usage after the loading phase it would cause flopping
with the autoscaling service. For this reason, and as an initial
implementation, we require twice the model size. In the future,
we can avoid this waste by writing the model to disk and inflating
it from there instead.
