### PR TITLE
Fix typo in deprecation log for size=-1

### DIFF
--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/asyncsearch/SubmitAsyncSearchRequest.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/asyncsearch/SubmitAsyncSearchRequest.java
@@ -31,7 +31,7 @@ public class SubmitAsyncSearchRequest implements Validatable {
     private Boolean keepOnCompletion;
     private TimeValue keepAlive;
     private final SearchRequest searchRequest;
-    // The following is optional and will only be sent down with the request if explicitely set by the user
+    // The following is optional and will only be sent down with the request if explicitly set by the user
     private Integer batchedReduceSize;
 
     /**

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search/260_parameter_validation.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search/260_parameter_validation.yml
@@ -26,8 +26,9 @@ setup:
       features: allowed_warnings
 
   - do:
-      allowed_warnings:
-        - "Using search size of -1 is deprecated and will be removed in future versions. Instead, don't use the `size` parameter if you don't want to set it explicitly."
+      allowed_warnings_regex:
+        #regex because of bwc and a typo existing in prev versions
+        - "Using search size of -1 is deprecated and will be removed in future versions. Instead, don't use the `size` parameter if you don't want to set it explicit[e]?ly."
       search:
         rest_total_hits_as_int: true
         index: index1

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search/260_parameter_validation.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search/260_parameter_validation.yml
@@ -27,7 +27,7 @@ setup:
 
   - do:
       allowed_warnings:
-        - "Using search size of -1 is deprecated and will be removed in future versions. Instead, don't use the `size` parameter if you don't want to set it explicitely."
+        - "Using search size of -1 is deprecated and will be removed in future versions. Instead, don't use the `size` parameter if you don't want to set it explicitly."
       search:
         rest_total_hits_as_int: true
         index: index1

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search/260_parameter_validation.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search/260_parameter_validation.yml
@@ -23,7 +23,7 @@ setup:
   - skip:
       version: " - 7.12.99"
       reason: deprecation added in 7.13
-      features: allowed_warnings
+      features: allowed_warnings_regex
 
   - do:
       allowed_warnings_regex:

--- a/server/src/main/java/org/elasticsearch/rest/action/search/RestSearchAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/search/RestSearchAction.java
@@ -217,7 +217,7 @@ public class RestSearchAction extends BaseRestHandler {
                     DeprecationCategory.API,
                     "search-api-size-1",
                     "Using search size of -1 is deprecated and will be removed in future versions. Instead, don't use the `size` parameter "
-                        + "if you don't want to set it explicitely."
+                        + "if you don't want to set it explicitly."
                 );
             }
         }
@@ -315,7 +315,7 @@ public class RestSearchAction extends BaseRestHandler {
         assert request.pointInTimeBuilder() != null;
         ActionRequestValidationException validationException = null;
         if (request.indices().length > 0) {
-            validationException = addValidationError("[indices] cannot be used with point in time. Do " + 
+            validationException = addValidationError("[indices] cannot be used with point in time. Do " +
                 "not specify any index with point in time.", validationException);
         }
         if (request.indicesOptions().equals(DEFAULT_INDICES_OPTIONS) == false) {

--- a/server/src/main/java/org/elasticsearch/search/builder/SearchSourceBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/builder/SearchSourceBuilder.java
@@ -1161,7 +1161,7 @@ public final class SearchSourceBuilder implements Writeable, ToXContentObject, R
                             DeprecationCategory.API,
                             "search-api-size-1",
                             "Using search size of -1 is deprecated and will be removed in future versions. "
-                            + "Instead, don't use the `size` parameter if you don't want to set it explicitely."
+                            + "Instead, don't use the `size` parameter if you don't want to set it explicitly."
                         );
                     }
 

--- a/server/src/test/java/org/elasticsearch/search/builder/SearchSourceBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/search/builder/SearchSourceBuilderTests.java
@@ -488,7 +488,7 @@ public class SearchSourceBuilderTests extends AbstractSearchTestCase {
             assertEquals(-1, searchSourceBuilder.size());
         }
         assertWarnings("Using search size of -1 is deprecated and will be removed in future versions. Instead, don't use the `size` "
-            + "parameter if you don't want to set it explicitely.");
+            + "parameter if you don't want to set it explicitly.");
 
         restContent = "{\"size\" : " + randomSize + "}";
         try (XContentParser parser = createParser(JsonXContent.jsonXContent, restContent)) {


### PR DESCRIPTION
explicitely -> explicitly