### PR TITLE
Remove SET aliases from disk usage and field usage YML tests

### DIFF
--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.stats/50_disk_usage.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.stats/50_disk_usage.yml
@@ -45,68 +45,61 @@ setup:
 
   - gt: { testindex.store_size_in_bytes: 100 }
   # all_fields
-  - set: { testindex.all_fields: all }
-  - gt: { $all.total_in_bytes: 0 }
-  - gt: { $all.inverted_index.total_in_bytes: 0 }
-  - gt: { $all.stored_fields_in_bytes: 0 }
-  - gt: { $all.doc_values_in_bytes: 0 }
-  - gt: { $all.points_in_bytes: 0 }
-  - match: { $all.term_vectors_in_bytes: 0 }
+  - gt: { testindex.all_fields.total_in_bytes: 0 }
+  - gt: { testindex.all_fields.inverted_index.total_in_bytes: 0 }
+  - gt: { testindex.all_fields.stored_fields_in_bytes: 0 }
+  - gt: { testindex.all_fields.doc_values_in_bytes: 0 }
+  - gt: { testindex.all_fields.points_in_bytes: 0 }
+  - match: { testindex.all_fields.term_vectors_in_bytes: 0 }
 
   # genre
-  - set: { testindex.fields.genre: genre }
-  - gt: { $genre.total_in_bytes: 0 }
-  - gt: { $genre.inverted_index.total_in_bytes: 0 }
-  - match: { $genre.stored_fields_in_bytes: 0 }
-  - gt: { $genre.doc_values_in_bytes: 0 }
-  - match: { $genre.points_in_bytes: 0 }
-  - match: { $genre.norms_in_bytes: 0 }
-  - match: { $genre.term_vectors_in_bytes: 0 }
+  - gt: { testindex.fields.genre.total_in_bytes: 0 }
+  - gt: { testindex.fields.genre.inverted_index.total_in_bytes: 0 }
+  - match: { testindex.fields.genre.stored_fields_in_bytes: 0 }
+  - gt: { testindex.fields.genre.doc_values_in_bytes: 0 }
+  - match: { testindex.fields.genre.points_in_bytes: 0 }
+  - match: { testindex.fields.genre.norms_in_bytes: 0 }
+  - match: { testindex.fields.genre.term_vectors_in_bytes: 0 }
 
   # name
-  - set: { testindex.fields.name: name }
-  - gt: { $name.total_in_bytes: 0 }
-  - gt: { $name.inverted_index.total_in_bytes: 0 }
-  - match: { $name.stored_fields_in_bytes: 0 }
-  - match: { $name.doc_values_in_bytes: 0 }
-  - match: { $name.points_in_bytes: 0 }
-  - match: { $name.term_vectors_in_bytes: 0 }
+  - gt: { testindex.fields.name.total_in_bytes: 0 }
+  - gt: { testindex.fields.name.inverted_index.total_in_bytes: 0 }
+  - match: { testindex.fields.name.stored_fields_in_bytes: 0 }
+  - match: { testindex.fields.name.doc_values_in_bytes: 0 }
+  - match: { testindex.fields.name.points_in_bytes: 0 }
+  - match: { testindex.fields.name.term_vectors_in_bytes: 0 }
 
   # quantity
-  - set: { testindex.fields.quantity: quantity }
-  - gt: { $quantity.total_in_bytes: 0 }
-  - match: { $quantity.inverted_index.total_in_bytes: 0 }
-  - match: { $quantity.stored_fields_in_bytes: 0 }
-  - match: { $quantity.doc_values_in_bytes: 0 }
-  - gt: { $quantity.points_in_bytes: 0 }
-  - match: { $quantity.norms_in_bytes: 0 }
-  - match: { $quantity.term_vectors_in_bytes: 0 }
+  - gt: { testindex.fields.quantity.total_in_bytes: 0 }
+  - match: { testindex.fields.quantity.inverted_index.total_in_bytes: 0 }
+  - match: { testindex.fields.quantity.stored_fields_in_bytes: 0 }
+  - match: { testindex.fields.quantity.doc_values_in_bytes: 0 }
+  - gt: { testindex.fields.quantity.points_in_bytes: 0 }
+  - match: { testindex.fields.quantity.norms_in_bytes: 0 }
+  - match: { testindex.fields.quantity.term_vectors_in_bytes: 0 }
 
   # _source
-  - set: { testindex.fields._source: source }
-  - gt: { $source.total_in_bytes: 0 }
-  - match: { $source.inverted_index.total_in_bytes: 0 }
-  - gt: { $source.stored_fields_in_bytes: 0 }
-  - match: { $source.doc_values_in_bytes: 0 }
-  - match: { $source.points_in_bytes: 0 }
-  - match: { $source.norms_in_bytes: 0 }
-  - match: { $source.term_vectors_in_bytes: 0 }
+  - gt: { testindex.fields._source.total_in_bytes: 0 }
+  - match: { testindex.fields._source.inverted_index.total_in_bytes: 0 }
+  - gt: { testindex.fields._source.stored_fields_in_bytes: 0 }
+  - match: { testindex.fields._source.doc_values_in_bytes: 0 }
+  - match: { testindex.fields._source.points_in_bytes: 0 }
+  - match: { testindex.fields._source.norms_in_bytes: 0 }
+  - match: { testindex.fields._source.term_vectors_in_bytes: 0 }
 
   # _id
-  - set: { testindex.fields._id: id }
-  - gt: { $id.total_in_bytes: 0 }
-  - gt: { $id.inverted_index.total_in_bytes: 0 }
-  - gt: { $id.stored_fields_in_bytes: 0 }
-  - match: { $id.doc_values_in_bytes: 0 }
-  - match: { $id.points_in_bytes: 0 }
-  - match: { $id.norms_in_bytes: 0 }
-  - match: { $id.term_vectors_in_bytes: 0 }
+  - gt: { testindex.fields._id.total_in_bytes: 0 }
+  - gt: { testindex.fields._id.inverted_index.total_in_bytes: 0 }
+  - gt: { testindex.fields._id.stored_fields_in_bytes: 0 }
+  - match: { testindex.fields._id.doc_values_in_bytes: 0 }
+  - match: { testindex.fields._id.points_in_bytes: 0 }
+  - match: { testindex.fields._id.norms_in_bytes: 0 }
+  - match: { testindex.fields._id.term_vectors_in_bytes: 0 }
 
   # _seq_no
-  - set: { testindex.fields._seq_no: seqno }
-  - gt: { $seqno.total_in_bytes: 0 }
-  - match: { $seqno.inverted_index.total_in_bytes: 0 }
-  - match: { $seqno.stored_fields_in_bytes: 0 }
-  - gt: { $seqno.points_in_bytes: 0 }
-  - match: { $seqno.norms_in_bytes: 0 }
-  - match: { $seqno.term_vectors_in_bytes: 0 }
+  - gt: { testindex.fields._seq_no.total_in_bytes: 0 }
+  - match: { testindex.fields._seq_no.inverted_index.total_in_bytes: 0 }
+  - match: { testindex.fields._seq_no.stored_fields_in_bytes: 0 }
+  - gt: { testindex.fields._seq_no.points_in_bytes: 0 }
+  - match: { testindex.fields._seq_no.norms_in_bytes: 0 }
+  - match: { testindex.fields._seq_no.term_vectors_in_bytes: 0 }

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.stats/60_field_usage.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.stats/60_field_usage.yml
@@ -79,100 +79,94 @@ setup:
   - is_true: testindex.shards.0.stats
 
   # all_fields
-  - set: { testindex.shards.0.stats.all_fields: stat }
-  - gt: { $stat.any: 0 }
-  - gt: { $stat.inverted_index.terms: 0 }
-  - gt: { $stat.inverted_index.postings: 0 }
-  - gt: { $stat.inverted_index.proximity: 0 }
-  - gt: { $stat.stored_fields: 0 }
-  - gt: { $stat.doc_values: 0 }
-  - gt: { $stat.points: 0 }
-  - match: { $stat.norms: 0 }
-  - match: { $stat.term_vectors: 0 }
-  - gt: { $stat.inverted_index.term_frequencies: 0 }
-  - gt: { $stat.inverted_index.positions: 0 }
-  - match: { $stat.inverted_index.offsets: 0 }
-  - match: { $stat.inverted_index.payloads: 0 }
+  - gt: { testindex.shards.0.stats.all_fields.any: 0 }
+  - gt: { testindex.shards.0.stats.all_fields.inverted_index.terms: 0 }
+  - gt: { testindex.shards.0.stats.all_fields.inverted_index.postings: 0 }
+  - gt: { testindex.shards.0.stats.all_fields.inverted_index.proximity: 0 }
+  - gt: { testindex.shards.0.stats.all_fields.stored_fields: 0 }
+  - gt: { testindex.shards.0.stats.all_fields.doc_values: 0 }
+  - gt: { testindex.shards.0.stats.all_fields.points: 0 }
+  - match: { testindex.shards.0.stats.all_fields.norms: 0 }
+  - match: { testindex.shards.0.stats.all_fields.term_vectors: 0 }
+  - gt: { testindex.shards.0.stats.all_fields.inverted_index.term_frequencies: 0 }
+  - gt: { testindex.shards.0.stats.all_fields.inverted_index.positions: 0 }
+  - match: { testindex.shards.0.stats.all_fields.inverted_index.offsets: 0 }
+  - match: { testindex.shards.0.stats.all_fields.inverted_index.payloads: 0 }
 
   # name
-  - set: { testindex.shards.0.stats.fields.name: stat }
-  - gt: { $stat.any: 0 }
-  - gt: { $stat.inverted_index.terms: 0 }
-  - gt: { $stat.inverted_index.postings: 0 }
-  - gt: { $stat.inverted_index.proximity: 0 }
-  - match: { $stat.stored_fields: 0 }
-  - match: { $stat.doc_values: 0 }
-  - match: { $stat.points: 0 }
-  - match: { $stat.norms: 0 }
-  - match: { $stat.term_vectors: 0 }
-  - gt: { $stat.inverted_index.term_frequencies: 0 }
-  - gt: { $stat.inverted_index.positions: 0 }
-  - match: { $stat.inverted_index.offsets: 0 }
-  - match: { $stat.inverted_index.payloads: 0 }
+  - gt: { testindex.shards.0.stats.fields.name.any: 0 }
+  - gt: { testindex.shards.0.stats.fields.name.inverted_index.terms: 0 }
+  - gt: { testindex.shards.0.stats.fields.name.inverted_index.postings: 0 }
+  - gt: { testindex.shards.0.stats.fields.name.inverted_index.proximity: 0 }
+  - match: { testindex.shards.0.stats.fields.name.stored_fields: 0 }
+  - match: { testindex.shards.0.stats.fields.name.doc_values: 0 }
+  - match: { testindex.shards.0.stats.fields.name.points: 0 }
+  - match: { testindex.shards.0.stats.fields.name.norms: 0 }
+  - match: { testindex.shards.0.stats.fields.name.term_vectors: 0 }
+  - gt: { testindex.shards.0.stats.fields.name.inverted_index.term_frequencies: 0 }
+  - gt: { testindex.shards.0.stats.fields.name.inverted_index.positions: 0 }
+  - match: { testindex.shards.0.stats.fields.name.inverted_index.offsets: 0 }
+  - match: { testindex.shards.0.stats.fields.name.inverted_index.payloads: 0 }
 
   # price
-  - set: { testindex.shards.0.stats.fields.price: stat }
-  - gt: { $stat.any: 0 }
-  - match: { $stat.inverted_index.terms: 0 }
-  - match: { $stat.inverted_index.postings: 0 }
-  - match: { $stat.inverted_index.proximity: 0 }
-  - match: { $stat.stored_fields: 0 }
-  - gt: { $stat.doc_values: 0 }
-  - match: { $stat.points: 0 }
-  - match: { $stat.norms: 0 }
-  - match: { $stat.term_vectors: 0 }
-  - match: { $stat.inverted_index.term_frequencies: 0 }
-  - match: { $stat.inverted_index.positions: 0 }
-  - match: { $stat.inverted_index.offsets: 0 }
-  - match: { $stat.inverted_index.payloads: 0 }
+  - gt: { testindex.shards.0.stats.fields.price.any: 0 }
+  - match: { testindex.shards.0.stats.fields.price.inverted_index.terms: 0 }
+  - match: { testindex.shards.0.stats.fields.price.inverted_index.postings: 0 }
+  - match: { testindex.shards.0.stats.fields.price.inverted_index.proximity: 0 }
+  - match: { testindex.shards.0.stats.fields.price.stored_fields: 0 }
+  - gt: { testindex.shards.0.stats.fields.price.doc_values: 0 }
+  - match: { testindex.shards.0.stats.fields.price.points: 0 }
+  - match: { testindex.shards.0.stats.fields.price.norms: 0 }
+  - match: { testindex.shards.0.stats.fields.price.term_vectors: 0 }
+  - match: { testindex.shards.0.stats.fields.price.inverted_index.term_frequencies: 0 }
+  - match: { testindex.shards.0.stats.fields.price.inverted_index.positions: 0 }
+  - match: { testindex.shards.0.stats.fields.price.inverted_index.offsets: 0 }
+  - match: { testindex.shards.0.stats.fields.price.inverted_index.payloads: 0 }
 
   # day
-  - set: { testindex.shards.0.stats.fields.day: stat }
-  - gt: { $stat.any: 0 }
-  - match: { $stat.inverted_index.terms: 0 }
-  - match: { $stat.inverted_index.postings: 0 }
-  - match: { $stat.inverted_index.proximity: 0 }
-  - match: { $stat.stored_fields: 0 }
-  - gt: { $stat.doc_values: 0 }
-  - gt: { $stat.points: 0 }
-  - match: { $stat.norms: 0 }
-  - match: { $stat.term_vectors: 0 }
-  - match: { $stat.inverted_index.term_frequencies: 0 }
-  - match: { $stat.inverted_index.positions: 0 }
-  - match: { $stat.inverted_index.offsets: 0 }
-  - match: { $stat.inverted_index.payloads: 0 }
+  - gt: { testindex.shards.0.stats.fields.day.any: 0 }
+  - match: { testindex.shards.0.stats.fields.day.inverted_index.terms: 0 }
+  - match: { testindex.shards.0.stats.fields.day.inverted_index.postings: 0 }
+  - match: { testindex.shards.0.stats.fields.day.inverted_index.proximity: 0 }
+  - match: { testindex.shards.0.stats.fields.day.stored_fields: 0 }
+  - gt: { testindex.shards.0.stats.fields.day.doc_values: 0 }
+  - gt: { testindex.shards.0.stats.fields.day.points: 0 }
+  - match: { testindex.shards.0.stats.fields.day.norms: 0 }
+  - match: { testindex.shards.0.stats.fields.day.term_vectors: 0 }
+  - match: { testindex.shards.0.stats.fields.day.inverted_index.term_frequencies: 0 }
+  - match: { testindex.shards.0.stats.fields.day.inverted_index.positions: 0 }
+  - match: { testindex.shards.0.stats.fields.day.inverted_index.offsets: 0 }
+  - match: { testindex.shards.0.stats.fields.day.inverted_index.payloads: 0 }
 
   # _source
-  - set: { testindex.shards.0.stats.fields._source: stat }
-  - gt: { $stat.any: 0 }
-  - match: { $stat.inverted_index.terms: 0 }
-  - match: { $stat.inverted_index.postings: 0 }
-  - match: { $stat.inverted_index.proximity: 0 }
-  - gt: { $stat.stored_fields: 0 }
-  - match: { $stat.doc_values: 0 }
-  - match: { $stat.points: 0 }
-  - match: { $stat.norms: 0 }
-  - match: { $stat.term_vectors: 0 }
-  - match: { $stat.inverted_index.term_frequencies: 0 }
-  - match: { $stat.inverted_index.positions: 0 }
-  - match: { $stat.inverted_index.offsets: 0 }
-  - match: { $stat.inverted_index.payloads: 0 }
+  - gt: { testindex.shards.0.stats.fields._source.any: 0 }
+  - match: { testindex.shards.0.stats.fields._source.inverted_index.terms: 0 }
+  - match: { testindex.shards.0.stats.fields._source.inverted_index.postings: 0 }
+  - match: { testindex.shards.0.stats.fields._source.inverted_index.proximity: 0 }
+  - gt: { testindex.shards.0.stats.fields._source.stored_fields: 0 }
+  - match: { testindex.shards.0.stats.fields._source.doc_values: 0 }
+  - match: { testindex.shards.0.stats.fields._source.points: 0 }
+  - match: { testindex.shards.0.stats.fields._source.norms: 0 }
+  - match: { testindex.shards.0.stats.fields._source.term_vectors: 0 }
+  - match: { testindex.shards.0.stats.fields._source.inverted_index.term_frequencies: 0 }
+  - match: { testindex.shards.0.stats.fields._source.inverted_index.positions: 0 }
+  - match: { testindex.shards.0.stats.fields._source.inverted_index.offsets: 0 }
+  - match: { testindex.shards.0.stats.fields._source.inverted_index.payloads: 0 }
 
   # _id
-  - set: { testindex.shards.0.stats.fields._id: stat }
-  - gt: { $stat.any: 0 }
-  - match: { $stat.inverted_index.terms: 0 }
-  - match: { $stat.inverted_index.postings: 0 }
-  - match: { $stat.inverted_index.proximity: 0 }
-  - gt: { $stat.stored_fields: 0 }
-  - match: { $stat.doc_values: 0 }
-  - match: { $stat.points: 0 }
-  - match: { $stat.norms: 0 }
-  - match: { $stat.term_vectors: 0 }
-  - match: { $stat.inverted_index.term_frequencies: 0 }
-  - match: { $stat.inverted_index.positions: 0 }
-  - match: { $stat.inverted_index.offsets: 0 }
-  - match: { $stat.inverted_index.payloads: 0 }
+  - gt: { testindex.shards.0.stats.fields._id.any: 0 }
+  - match: { testindex.shards.0.stats.fields._id.inverted_index.terms: 0 }
+  - match: { testindex.shards.0.stats.fields._id.inverted_index.postings: 0 }
+  - match: { testindex.shards.0.stats.fields._id.inverted_index.proximity: 0 }
+  - gt: { testindex.shards.0.stats.fields._id.stored_fields: 0 }
+  - match: { testindex.shards.0.stats.fields._id.doc_values: 0 }
+  - match: { testindex.shards.0.stats.fields._id.points: 0 }
+  - match: { testindex.shards.0.stats.fields._id.norms: 0 }
+  - match: { testindex.shards.0.stats.fields._id.term_vectors: 0 }
+  - match: { testindex.shards.0.stats.fields._id.inverted_index.term_frequencies: 0 }
+  - match: { testindex.shards.0.stats.fields._id.inverted_index.positions: 0 }
+  - match: { testindex.shards.0.stats.fields._id.inverted_index.offsets: 0 }
+  - match: { testindex.shards.0.stats.fields._id.inverted_index.payloads: 0 }
 
   - do:
       termvectors:
@@ -185,8 +179,7 @@ setup:
       indices.field_usage_stats: { index: testindex }
 
   # name
-  - set: { testindex.shards.0.stats.fields.name: stat }
-  - gt: { $stat.term_vectors: 0 }
+  - gt: { testindex.shards.0.stats.fields.name.term_vectors: 0 }
 
   - do:
       search:
@@ -200,8 +193,7 @@ setup:
       indices.field_usage_stats: { index: testindex }
 
   # name
-  - set: { testindex.shards.0.stats.fields.name: stat }
-  - gt: { $stat.norms: 0 }
+  - gt: { testindex.shards.0.stats.fields.name.norms: 0 }
 
   - do:
       search:
@@ -213,5 +205,4 @@ setup:
       indices.field_usage_stats: { index: testindex }
 
   # name
-  - set: { testindex.shards.0.stats.fields.name: stat }
-  - gt: { $stat.inverted_index.offsets: 0 }
+  - gt: { testindex.shards.0.stats.fields.name.inverted_index.offsets: 0 }


### PR DESCRIPTION
As discussed with @dnhatn, the clients team have YAML test runners for each client which exercise that client using the main Elasticsearch YML tests. The disk usage and field usage tests use an alias approach to simplify asserting on nested object values in the JSON. The client runners are unable to handle this use of the set operation and fail the tests.

This PR removes the use of aliases such that the tests should succeed in the client team tests.