### PR TITLE
[DOCS] Fix broken links in JSON API spec

### DIFF
--- a/docs/reference/indices.asciidoc
+++ b/docs/reference/indices.asciidoc
@@ -71,6 +71,7 @@ For more information, see <<index-templates, Index Templates>>.
 [[monitoring]]
 === Monitoring:
 * <<indices-stats>>
+* <<field-usage-stats>>
 * <<indices-segments>>
 * <<indices-recovery>>
 * <<indices-shards-stores>>
@@ -109,6 +110,7 @@ include::indices/delete-index.asciidoc[]
 include::indices/delete-index-template.asciidoc[]
 include::indices/delete-index-template-v1.asciidoc[]
 include::indices/indices-exists.asciidoc[]
+include::indices/field-usage-stats.asciidoc[]
 include::indices/flush.asciidoc[]
 include::indices/forcemerge.asciidoc[]
 include::indices/apis/freeze.asciidoc[]

--- a/docs/reference/redirects.asciidoc
+++ b/docs/reference/redirects.asciidoc
@@ -1623,3 +1623,13 @@ See <<api-cron-expressions>>.
 === URL-based access control
 
 See <<api-url-access-control>>.
+
+[role="exclude",id="indices-field-usage-stats"]
+=== Field usage stats API
+
+See <<field-usage-stats>>.
+
+[role="exclude",id="security-api-enroll-kibana"]
+=== Enroll {kib} API
+
+See <<security-api-kibana-enrollment>>.

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.field_usage_stats.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.field_usage_stats.json
@@ -1,7 +1,7 @@
 {
   "indices.field_usage_stats": {
     "documentation": {
-      "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-field-usage-stats.html",
+      "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/field-usage-stats.html",
       "description": "Returns the field usage stats for each field of an index"
     },
     "stability": "experimental",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/security.enroll_kibana.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/security.enroll_kibana.json
@@ -1,7 +1,7 @@
 {
   "security.enroll_kibana":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-enroll-kibana.html",
+      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-kibana-enrollment.html",
       "description":"Allows a kibana instance to configure itself to communicate with a secured elasticsearch cluster."
     },
     "stability":"stable",


### PR DESCRIPTION
Fixes broken `documentation.url` links in the following API's JSON specs:

* Field usage stats API
* Enroll Kibana API

Also adds a missing include for the field usage stats API.

These broken links caused the build for the JS client docs to fail.