### PR TITLE
[7.x] [DOCS] Fix broken doc url values in JSON API spec (#75385)

### DIFF
--- a/docs/reference/indices.asciidoc
+++ b/docs/reference/indices.asciidoc
@@ -72,6 +72,7 @@ For more information, see <<index-templates, Index Templates>>.
 [[monitoring]]
 === Monitoring:
 * <<indices-stats>>
+* <<field-usage-stats>>
 * <<indices-segments>>
 * <<indices-recovery>>
 * <<indices-shards-stores>>
@@ -111,6 +112,7 @@ include::indices/delete-index.asciidoc[]
 include::indices/delete-index-template.asciidoc[]
 include::indices/delete-index-template-v1.asciidoc[]
 include::indices/indices-exists.asciidoc[]
+include::indices/field-usage-stats.asciidoc[]
 include::indices/flush.asciidoc[]
 include::indices/forcemerge.asciidoc[]
 include::indices/apis/freeze.asciidoc[]

--- a/docs/reference/redirects.asciidoc
+++ b/docs/reference/redirects.asciidoc
@@ -1579,3 +1579,8 @@ include::redirects.asciidoc[tag=frozen-index-redirect]
 === Glossary
 
 See the {glossary}/terms.html[Elastic glossary].
+
+[role="exclude",id="indices-field-usage-stats"]
+=== Field usage stats API
+
+See <<field-usage-stats>>.

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.field_usage_stats.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.field_usage_stats.json
@@ -1,7 +1,7 @@
 {
   "indices.field_usage_stats": {
     "documentation": {
-      "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-field-usage-stats.html",
+      "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/field-usage-stats.html",
       "description": "Returns the field usage stats for each field of an index"
     },
     "stability": "experimental",


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [DOCS] Fix broken doc url values in JSON API spec (#75385)