### PR TITLE
Deprecate security implicitly disabled on trial/basic (#72339)

### DIFF
--- a/docs/reference/migration/migrate_7_14.asciidoc
+++ b/docs/reference/migration/migrate_7_14.asciidoc
@@ -117,6 +117,19 @@ Discontinue use of the `type` parameter in `geo_bounding_box` queries.
 [[breaking_714_security_changes]]
 ==== Security deprecations
 
+[discrete]
+[[implicitly-disabled-security]]
+.The default behavior of disabling security on basic and trial licenses is deprecated
+[%collapsible]
+====
+*Details* +
+Currently, security features are disabled when operating on a basic or trial
+license when `xpack.security.enabled` has not been explicitly set to `true`.
+This behavior is now deprecated. In version 8.0.0, security features will be
+enabled by default for all licenses, unless explicitly disabled (by setting
+`xpack.security.enabled` to `false`).
+====
+
 [[reserved-prefixed-realm-names]]
 .Configuring a realm name with a leading underscore is deprecated.
 [%collapsible]

--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/DeprecationChecks.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/DeprecationChecks.java
@@ -10,8 +10,8 @@ import org.elasticsearch.action.admin.cluster.node.info.PluginsAndModules;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.node.DiscoveryNode;
-import org.elasticsearch.common.TriFunction;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.license.XPackLicenseState;
 import org.elasticsearch.xpack.core.XPackSettings;
 
 import java.util.Arrays;
@@ -41,14 +41,15 @@ public class DeprecationChecks {
             ClusterDeprecationChecks::checkClusterRoutingAllocationIncludeRelocationsSetting
         ));
 
-    static final List<TriFunction<Settings, PluginsAndModules, ClusterState, DeprecationIssue>> NODE_SETTINGS_CHECKS;
+    static final List<NodeDeprecationCheck<Settings, PluginsAndModules, ClusterState, XPackLicenseState, DeprecationIssue>>
+        NODE_SETTINGS_CHECKS;
 
         static {
-            final Stream<TriFunction<Settings, PluginsAndModules, ClusterState, DeprecationIssue>> legacyRoleSettings =
-                DiscoveryNode.getPossibleRoles()
-                .stream()
+            final Stream<NodeDeprecationCheck<Settings, PluginsAndModules, ClusterState, XPackLicenseState, DeprecationIssue>>
+                legacyRoleSettings =
+                DiscoveryNode.getPossibleRoles().stream()
                 .filter(r -> r.legacySetting() != null)
-                .map(r -> (s, p, cs) -> NodeDeprecationChecks.checkLegacyRoleSettings(r.legacySetting(), s, p));
+                .map(r -> (s, p, t, c) -> NodeDeprecationChecks.checkLegacyRoleSettings(r.legacySetting(), s, p));
             NODE_SETTINGS_CHECKS = Stream.concat(
                 legacyRoleSettings,
                 Stream.of(
@@ -59,36 +60,40 @@ public class DeprecationChecks {
                     NodeDeprecationChecks::checkUniqueRealmOrders,
                     NodeDeprecationChecks::checkImplicitlyDisabledBasicRealms,
                     NodeDeprecationChecks::checkReservedPrefixedRealmNames,
-                    (settings, pluginsAndModules, cs) -> NodeDeprecationChecks.checkThreadPoolListenerQueueSize(settings),
-                    (settings, pluginsAndModules, cs) -> NodeDeprecationChecks.checkThreadPoolListenerSize(settings),
+                    (settings, pluginsAndModules, clusterState, licenseState) ->
+                        NodeDeprecationChecks.checkThreadPoolListenerQueueSize(settings),
+                    (settings, pluginsAndModules, clusterState, licenseState) ->
+                        NodeDeprecationChecks.checkThreadPoolListenerSize(settings),
                     NodeDeprecationChecks::checkClusterRemoteConnectSetting,
                     NodeDeprecationChecks::checkNodeLocalStorageSetting,
                     NodeDeprecationChecks::checkGeneralScriptSizeSetting,
                     NodeDeprecationChecks::checkGeneralScriptExpireSetting,
                     NodeDeprecationChecks::checkGeneralScriptCompileSettings,
-                    (settings, pluginsAndModules, cs) -> NodeDeprecationChecks.checkNodeBasicLicenseFeatureEnabledSetting(settings,
-                        XPackSettings.ENRICH_ENABLED_SETTING),
-                    (settings, pluginsAndModules, cs) -> NodeDeprecationChecks.checkNodeBasicLicenseFeatureEnabledSetting(settings,
-                        XPackSettings.FLATTENED_ENABLED),
-                    (settings, pluginsAndModules, cs) -> NodeDeprecationChecks.checkNodeBasicLicenseFeatureEnabledSetting(settings,
-                        XPackSettings.INDEX_LIFECYCLE_ENABLED),
-                    (settings, pluginsAndModules, cs) -> NodeDeprecationChecks.checkNodeBasicLicenseFeatureEnabledSetting(settings,
-                        XPackSettings.MONITORING_ENABLED),
-                    (settings, pluginsAndModules, cs) -> NodeDeprecationChecks.checkNodeBasicLicenseFeatureEnabledSetting(settings,
-                        XPackSettings.ROLLUP_ENABLED),
-                    (settings, pluginsAndModules, cs) -> NodeDeprecationChecks.checkNodeBasicLicenseFeatureEnabledSetting(settings,
-                        XPackSettings.SNAPSHOT_LIFECYCLE_ENABLED),
-                    (settings, pluginsAndModules, cs) -> NodeDeprecationChecks.checkNodeBasicLicenseFeatureEnabledSetting(settings,
-                        XPackSettings.SQL_ENABLED),
-                    (settings, pluginsAndModules, cs) -> NodeDeprecationChecks.checkNodeBasicLicenseFeatureEnabledSetting(settings,
-                        XPackSettings.TRANSFORM_ENABLED),
-                    (settings, pluginsAndModules, cs) -> NodeDeprecationChecks.checkNodeBasicLicenseFeatureEnabledSetting(settings,
-                        XPackSettings.VECTORS_ENABLED),
+                    (settings, pluginsAndModules, clusterState, licenseState) ->
+                        NodeDeprecationChecks.checkNodeBasicLicenseFeatureEnabledSetting(settings, XPackSettings.ENRICH_ENABLED_SETTING),
+                    (settings, pluginsAndModules, clusterState, licenseState) ->
+                        NodeDeprecationChecks.checkNodeBasicLicenseFeatureEnabledSetting(settings, XPackSettings.FLATTENED_ENABLED),
+                    (settings, pluginsAndModules, clusterState, licenseState) ->
+                        NodeDeprecationChecks.checkNodeBasicLicenseFeatureEnabledSetting(settings, XPackSettings.INDEX_LIFECYCLE_ENABLED),
+                    (settings, pluginsAndModules, clusterState, licenseState) ->
+                        NodeDeprecationChecks.checkNodeBasicLicenseFeatureEnabledSetting(settings, XPackSettings.MONITORING_ENABLED),
+                    (settings, pluginsAndModules, clusterState, licenseState) ->
+                        NodeDeprecationChecks.checkNodeBasicLicenseFeatureEnabledSetting(settings, XPackSettings.ROLLUP_ENABLED),
+                    (settings, pluginsAndModules, clusterState, licenseState) ->
+                        NodeDeprecationChecks.checkNodeBasicLicenseFeatureEnabledSetting(settings,
+                            XPackSettings.SNAPSHOT_LIFECYCLE_ENABLED),
+                    (settings, pluginsAndModules, clusterState, licenseState) ->
+                        NodeDeprecationChecks.checkNodeBasicLicenseFeatureEnabledSetting(settings, XPackSettings.SQL_ENABLED),
+                    (settings, pluginsAndModules, clusterState, licenseState) ->
+                        NodeDeprecationChecks.checkNodeBasicLicenseFeatureEnabledSetting(settings, XPackSettings.TRANSFORM_ENABLED),
+                    (settings, pluginsAndModules, clusterState, licenseState) ->
+                        NodeDeprecationChecks.checkNodeBasicLicenseFeatureEnabledSetting(settings, XPackSettings.VECTORS_ENABLED),
                     NodeDeprecationChecks::checkMultipleDataPaths,
                     NodeDeprecationChecks::checkDataPathsList,
                     NodeDeprecationChecks::checkBootstrapSystemCallFilterSetting,
                     NodeDeprecationChecks::checkSharedDataPathSetting,
                     NodeDeprecationChecks::checkSingleDataNodeWatermarkSetting,
+                    NodeDeprecationChecks::checkImplicitlyDisabledSecurityOnBasicAndTrial,
                     NodeDeprecationChecks::checkMonitoringExporterPassword,
                     NodeDeprecationChecks::checkClusterRoutingAllocationIncludeRelocationsSetting
                 )
@@ -113,11 +118,15 @@ public class DeprecationChecks {
      *
      * @param checks The functional checks to execute using the mapper function
      * @param mapper The function that executes the lambda check with the appropriate arguments
-     * @param <T> The signature of the check (BiFunction, Function, including the appropriate arguments)
+     * @param <T> The signature of the check (TriFunction, BiFunction, Function, including the appropriate arguments)
      * @return The list of {@link DeprecationIssue} that were found in the cluster
      */
     static <T> List<DeprecationIssue> filterChecks(List<T> checks, Function<T, DeprecationIssue> mapper) {
         return checks.stream().map(mapper).filter(Objects::nonNull).collect(Collectors.toList());
     }
 
+    @FunctionalInterface
+    public interface NodeDeprecationCheck<A, B, C, D, R> {
+        R apply(A first, B second, C third, D fourth);
+    }
 }

--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/TransportNodeDeprecationCheckAction.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/TransportNodeDeprecationCheckAction.java
@@ -14,6 +14,7 @@ import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.license.XPackLicenseState;
 import org.elasticsearch.plugins.PluginsService;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
@@ -27,10 +28,11 @@ public class TransportNodeDeprecationCheckAction extends TransportNodesAction<No
     NodesDeprecationCheckAction.NodeResponse> {
 
     private final Settings settings;
+    private final XPackLicenseState licenseState;
     private final PluginsService pluginsService;
 
     @Inject
-    public TransportNodeDeprecationCheckAction(Settings settings, ThreadPool threadPool,
+    public TransportNodeDeprecationCheckAction(Settings settings, ThreadPool threadPool, XPackLicenseState licenseState,
                                                ClusterService clusterService, TransportService transportService,
                                                PluginsService pluginsService, ActionFilters actionFilters) {
         super(NodesDeprecationCheckAction.NAME, threadPool, clusterService, transportService, actionFilters,
@@ -40,6 +42,7 @@ public class TransportNodeDeprecationCheckAction extends TransportNodesAction<No
             NodesDeprecationCheckAction.NodeResponse.class);
         this.settings = settings;
         this.pluginsService = pluginsService;
+        this.licenseState = licenseState;
     }
 
     @Override
@@ -62,7 +65,7 @@ public class TransportNodeDeprecationCheckAction extends TransportNodesAction<No
     @Override
     protected NodesDeprecationCheckAction.NodeResponse nodeOperation(NodesDeprecationCheckAction.NodeRequest request) {
         List<DeprecationIssue> issues = DeprecationInfoAction.filterChecks(DeprecationChecks.NODE_SETTINGS_CHECKS,
-            (c) -> c.apply(settings, pluginsService.info(), clusterService.state()));
+            (c) -> c.apply(settings, pluginsService.info(), clusterService.state(), licenseState));
 
         return new NodesDeprecationCheckAction.NodeResponse(transportService.getLocalNode(), issues);
     }

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/support/SecurityStatusChangeListener.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/support/SecurityStatusChangeListener.java
@@ -10,6 +10,9 @@ package org.elasticsearch.xpack.security.support;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.Version;
+import org.elasticsearch.common.logging.DeprecationCategory;
+import org.elasticsearch.common.logging.DeprecationLogger;
+import org.elasticsearch.license.License;
 import org.elasticsearch.license.LicenseStateListener;
 import org.elasticsearch.license.XPackLicenseState;
 
@@ -22,11 +25,13 @@ import java.util.Objects;
 public class SecurityStatusChangeListener implements LicenseStateListener {
 
     private final Logger logger;
+    private final DeprecationLogger deprecationLogger;
     private final XPackLicenseState licenseState;
     private Boolean securityEnabled;
 
     public SecurityStatusChangeListener(XPackLicenseState licenseState) {
         this.logger = LogManager.getLogger(getClass());
+        this.deprecationLogger = DeprecationLogger.getLogger(getClass());
         this.licenseState = licenseState;
         this.securityEnabled = null;
     }
@@ -45,6 +50,16 @@ public class SecurityStatusChangeListener implements LicenseStateListener {
                 logger.warn("Elasticsearch built-in security features are not enabled. Without authentication, your cluster could be " +
                     "accessible to anyone. See https://www.elastic.co/guide/en/elasticsearch/reference/" + Version.CURRENT.major + "." +
                     Version.CURRENT.minor + "/security-minimal-setup.html to enable security.");
+                if (licenseState.getOperationMode().equals(License.OperationMode.BASIC)
+                    || licenseState.getOperationMode().equals(License.OperationMode.TRIAL)) {
+                    deprecationLogger.deprecate(DeprecationCategory.SECURITY, "security_implicitly_disabled",
+                        "The default behavior of disabling security on " + licenseState.getOperationMode().description()
+                            + " licenses is deprecated. In a later version of Elasticsearch, the value of [xpack.security.enabled] will "
+                            + "default to \"true\" , regardless of the license level. "
+                            + "See https://www.elastic.co/guide/en/elasticsearch/reference/" + Version.CURRENT.major + "."
+                            + Version.CURRENT.minor + "/security-minimal-setup.html to enable security, or explicitly disable security by "
+                            + "setting [xpack.security.enabled] to false in elasticsearch.yml");
+                }
             }
             this.securityEnabled = newState;
         }

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/support/SecurityStatusChangeListenerTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/support/SecurityStatusChangeListenerTests.java
@@ -81,6 +81,11 @@ public class SecurityStatusChangeListenerTests extends ESTestCase {
             "Active license is now [BASIC]; Security is disabled"
         ));
         listener.licenseStateChanged();
+        assertWarnings("The default behavior of disabling security on basic"
+            + " licenses is deprecated. In a later version of Elasticsearch, the value of [xpack.security.enabled] will "
+            + "default to \"true\" , regardless of the license level. "
+            + "See https://www.elastic.co/guide/en/elasticsearch/reference/7.15/security-minimal-setup.html to enable security, "
+            + "or explicitly disable security by setting [xpack.security.enabled] to false in elasticsearch.yml");
 
         logAppender.assertAllExpectationsMatched();
     }
@@ -104,6 +109,11 @@ public class SecurityStatusChangeListenerTests extends ESTestCase {
                 Version.CURRENT.minor + "/security-minimal-setup.html to enable security."
         ));
         listener.licenseStateChanged();
+        assertWarnings("The default behavior of disabling security on trial"
+            + " licenses is deprecated. In a later version of Elasticsearch, the value of [xpack.security.enabled] will "
+            + "default to \"true\" , regardless of the license level. "
+            + "See https://www.elastic.co/guide/en/elasticsearch/reference/7.15/security-minimal-setup.html to enable security, "
+            + "or explicitly disable security by setting [xpack.security.enabled] to false in elasticsearch.yml");
 
         when(licenseState.getOperationMode()).thenReturn(License.OperationMode.BASIC);
         logAppender.addExpectation(new MockLogAppender.UnseenEventExpectation(
@@ -124,6 +134,17 @@ public class SecurityStatusChangeListenerTests extends ESTestCase {
         listener.licenseStateChanged();
 
         logAppender.assertAllExpectationsMatched();
+    }
+
+    public void testWarningForImplicitlyDisabledSecurity() {
+        when(licenseState.isSecurityEnabled()).thenReturn(false);
+        when(licenseState.getOperationMode()).thenReturn(License.OperationMode.TRIAL);
+        listener.licenseStateChanged();
+        assertWarnings("The default behavior of disabling security on trial"
+            + " licenses is deprecated. In a later version of Elasticsearch, the value of [xpack.security.enabled] will "
+            + "default to \"true\" , regardless of the license level. "
+            + "See https://www.elastic.co/guide/en/elasticsearch/reference/7.15/security-minimal-setup.html to enable security, "
+            + "or explicitly disable security by setting [xpack.security.enabled] to false in elasticsearch.yml");
     }
 
 }

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/support/SecurityStatusChangeListenerTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/support/SecurityStatusChangeListenerTests.java
@@ -84,7 +84,7 @@ public class SecurityStatusChangeListenerTests extends ESTestCase {
         assertWarnings("The default behavior of disabling security on basic"
             + " licenses is deprecated. In a later version of Elasticsearch, the value of [xpack.security.enabled] will "
             + "default to \"true\" , regardless of the license level. "
-            + "See https://www.elastic.co/guide/en/elasticsearch/reference/7.15/security-minimal-setup.html to enable security, "
+            + "See https://www.elastic.co/guide/en/elasticsearch/reference/7.14/security-minimal-setup.html to enable security, "
             + "or explicitly disable security by setting [xpack.security.enabled] to false in elasticsearch.yml");
 
         logAppender.assertAllExpectationsMatched();
@@ -112,7 +112,7 @@ public class SecurityStatusChangeListenerTests extends ESTestCase {
         assertWarnings("The default behavior of disabling security on trial"
             + " licenses is deprecated. In a later version of Elasticsearch, the value of [xpack.security.enabled] will "
             + "default to \"true\" , regardless of the license level. "
-            + "See https://www.elastic.co/guide/en/elasticsearch/reference/7.15/security-minimal-setup.html to enable security, "
+            + "See https://www.elastic.co/guide/en/elasticsearch/reference/7.14/security-minimal-setup.html to enable security, "
             + "or explicitly disable security by setting [xpack.security.enabled] to false in elasticsearch.yml");
 
         when(licenseState.getOperationMode()).thenReturn(License.OperationMode.BASIC);
@@ -143,7 +143,7 @@ public class SecurityStatusChangeListenerTests extends ESTestCase {
         assertWarnings("The default behavior of disabling security on trial"
             + " licenses is deprecated. In a later version of Elasticsearch, the value of [xpack.security.enabled] will "
             + "default to \"true\" , regardless of the license level. "
-            + "See https://www.elastic.co/guide/en/elasticsearch/reference/7.15/security-minimal-setup.html to enable security, "
+            + "See https://www.elastic.co/guide/en/elasticsearch/reference/7.14/security-minimal-setup.html to enable security, "
             + "or explicitly disable security by setting [xpack.security.enabled] to false in elasticsearch.yml");
     }
 


### PR DESCRIPTION
This change deprecates the behavior where security features are
disabled implicitly when the license is basic or trial and the
xpack.security.enabled setting is not explicitly set. The
recommendation is to be explicit in the configuration and either
enable or disable security in elasticsearch.yml.
