### PR TITLE
Remove support for configurable PKCS#11 keystores

### DIFF
--- a/docs/reference/settings/common-defs.asciidoc
+++ b/docs/reference/settings/common-defs.asciidoc
@@ -148,12 +148,6 @@ file name ends in ".p12", ".pfx" or "pkcs12", the default is `PKCS12`.
 Otherwise, it defaults to `jks`.
 end::ssl-truststore-type[]
 
-tag::ssl-truststore-type-pkcs11[]
-The format of the truststore file. For the Java keystore format, use `jks`. For
-PKCS#12 files, use `PKCS12`. For a PKCS#11 token, use `PKCS11`. The default is
-`jks`.
-end::ssl-truststore-type-pkcs11[]
-
 tag::ssl-verification-mode-values[]
 Controls the verification of certificates.
 +

--- a/docs/reference/settings/security-settings.asciidoc
+++ b/docs/reference/settings/security-settings.asciidoc
@@ -598,7 +598,7 @@ include::{es-repo-dir}/settings/common-defs.asciidoc[tag=ssl-truststore-secure-p
 
 `ssl.truststore.type`::
 (<<static-cluster-setting,Static>>)
-include::{es-repo-dir}/settings/common-defs.asciidoc[tag=ssl-truststore-type-pkcs11]
+include::{es-repo-dir}/settings/common-defs.asciidoc[tag=ssl-truststore-type]
 
 `ssl.verification_mode`::
 (<<static-cluster-setting,Static>>)
@@ -901,7 +901,7 @@ You cannot use this setting and `ssl.certificate_authorities` at the same time.
 
 `ssl.truststore.type`::
 (<<static-cluster-setting,Static>>)
-include::{es-repo-dir}/settings/common-defs.asciidoc[tag=ssl-truststore-type-pkcs11]
+include::{es-repo-dir}/settings/common-defs.asciidoc[tag=ssl-truststore-type]
 
 `ssl.verification_mode`::
 (<<static-cluster-setting,Static>>)

--- a/docs/reference/settings/ssl-settings.asciidoc
+++ b/docs/reference/settings/ssl-settings.asciidoc
@@ -150,7 +150,7 @@ include::{es-repo-dir}/settings/common-defs.asciidoc[tag=ssl-truststore-path]
 +{ssl-prefix}.ssl.truststore.type+::
 (<<static-cluster-setting,Static>>)
 Set this to `PKCS12` to indicate that the truststore is a PKCS#12 file.
-//TBD:Should this use the ssl-truststore-type-pkcs11 or ssl-truststore-type definition and default values?
+//TBD:Should this use the ssl-truststore-type definition and default values?
 
 +{ssl-prefix}.ssl.truststore.password+::
 (<<static-cluster-setting,Static>>)
@@ -160,30 +160,3 @@ include::{es-repo-dir}/settings/common-defs.asciidoc[tag=ssl-truststore-password
 (<<secure-settings,Secure>>)
 include::{es-repo-dir}/settings/common-defs.asciidoc[tag=ssl-truststore-secure-password]
 
-[#{ssl-context}-pkcs11-tokens]
-===== PKCS#11 tokens
-
-{es} can be configured to use a PKCS#11 token that contains the private key,
-certificate and certificates that should be trusted.
-
-PKCS#11 token require additional configuration on the JVM level and can be enabled
-via the following settings:
-
-+{ssl-prefix}.keystore.type+::
-(<<static-cluster-setting,Static>>)
-Set this to `PKCS11` to indicate that the PKCS#11 token should be used as a keystore.
-//TBD: Is the default value `jks`?
-
-+{ssl-prefix}.truststore.type+::
-(<<static-cluster-setting,Static>>)
-include::{es-repo-dir}/settings/common-defs.asciidoc[tag=ssl-truststore-type-pkcs11]
-
-[NOTE]
-When configuring the PKCS#11 token that your JVM is configured to use as
-a keystore or a truststore for Elasticsearch, the PIN for the token can be
-configured by setting the appropriate value to `ssl.truststore.password`
-or `ssl.truststore.secure_password` in the context that you are configuring.
-Since there can only be one PKCS#11 token configured, only one keystore and
-truststore will be usable for configuration in {es}. This in turn means
-that only one certificate can be used for TLS both in the transport and the
-http layer.

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ssl/CertParsingUtils.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ssl/CertParsingUtils.java
@@ -224,15 +224,21 @@ public class CertParsingUtils {
             return new PEMKeyConfig(keyPath, keyPassword, certPath);
         }
 
-        if (keyStorePath != null || keyStoreType.equalsIgnoreCase("pkcs11")) {
+        if (keyStorePath != null) {
             SecureString keyStorePassword = keyPair.keystorePassword.get(settings);
             String keyStoreAlgorithm = keyPair.keystoreAlgorithm.get(settings);
             SecureString keyStoreKeyPassword = keyPair.keystoreKeyPassword.get(settings);
             if (keyStoreKeyPassword.length() == 0) {
                 keyStoreKeyPassword = keyStorePassword;
             }
-            return new StoreKeyConfig(keyStorePath, keyStoreType, keyStorePassword, keyStoreKeyPassword, keyStoreAlgorithm,
-                trustStoreAlgorithm);
+            return new StoreKeyConfig(
+                keyStorePath,
+                keyStoreType,
+                keyStorePassword,
+                keyStoreKeyPassword,
+                keyStoreAlgorithm,
+                trustStoreAlgorithm
+            );
         }
         return null;
     }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ssl/SSLConfiguration.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ssl/SSLConfiguration.java
@@ -180,7 +180,7 @@ public final class SSLConfiguration {
             return TrustAllConfig.INSTANCE;
         } else if (caPaths != null) {
             return new PEMTrustConfig(caPaths);
-        } else if (trustStorePath != null || trustStoreType.equalsIgnoreCase("pkcs11")) {
+        } else if (trustStorePath != null) {
             String trustStoreAlgorithm = SETTINGS_PARSER.truststoreAlgorithm.get(settings);
             SecureString trustStorePassword = SETTINGS_PARSER.truststorePassword.get(settings);
             return new StoreTrustConfig(trustStorePath, trustStoreType, trustStorePassword, trustStoreAlgorithm);

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ssl/StoreKeyConfig.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ssl/StoreKeyConfig.java
@@ -52,7 +52,7 @@ public class StoreKeyConfig extends KeyConfig {
 
     /**
      * Creates a new configuration that can be used to load key and trust material from a {@link KeyStore}
-     * @param keyStorePath the path to the keystore file or null when keyStoreType is pkcs11
+     * @param keyStorePath the path to the keystore file
      * @param keyStoreType the type of the keystore file
      * @param keyStorePassword the password for the keystore
      * @param keyPassword the password for the private key in the keystore
@@ -61,7 +61,10 @@ public class StoreKeyConfig extends KeyConfig {
      */
     StoreKeyConfig(String keyStorePath, String keyStoreType, SecureString keyStorePassword, SecureString keyPassword,
                    String keyStoreAlgorithm, String trustStoreAlgorithm) {
-        this.keyStorePath = keyStorePath;
+        if (keyStoreType.equals("PKCS11")) {
+            throw new IllegalArgumentException("PKCS#11 keystores are no longer supported by Elasticsearch");
+        }
+        this.keyStorePath = Objects.requireNonNull(keyStorePath);
         this.keyStoreType = Objects.requireNonNull(keyStoreType, "keystore type must be specified");
         // since we support reloading the keystore, we must store the passphrase in memory for the life of the node, so we
         // clone the password and never close it during our uses below
@@ -73,7 +76,7 @@ public class StoreKeyConfig extends KeyConfig {
 
     @Override
     X509ExtendedKeyManager createKeyManager(@Nullable Environment environment) {
-        Path ksPath = keyStorePath == null ? null : CertParsingUtils.resolvePath(keyStorePath, environment);
+        Path ksPath = CertParsingUtils.resolvePath(keyStorePath, environment);
         try {
             KeyStore ks = getStore(ksPath, keyStoreType, keyStorePassword);
             checkKeyStore(ks);
@@ -146,9 +149,6 @@ public class StoreKeyConfig extends KeyConfig {
 
     @Override
     List<Path> filesToMonitor(@Nullable Environment environment) {
-        if (keyStorePath == null) {
-            return Collections.emptyList();
-        }
         return Collections.singletonList(CertParsingUtils.resolvePath(keyStorePath, environment));
     }
 
@@ -200,10 +200,7 @@ public class StoreKeyConfig extends KeyConfig {
                 return;
             }
         }
-        final String message = null != keyStorePath ?
-            "the keystore [" + keyStorePath + "] does not contain a private key entry" :
-            "the configured PKCS#11 token does not contain a private key entry";
-        throw new IllegalArgumentException(message);
+        throw new IllegalArgumentException("the keystore [" + keyStorePath + "] does not contain a private key entry");
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ssl/StoreKeyConfig.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ssl/StoreKeyConfig.java
@@ -61,7 +61,7 @@ public class StoreKeyConfig extends KeyConfig {
      */
     StoreKeyConfig(String keyStorePath, String keyStoreType, SecureString keyStorePassword, SecureString keyPassword,
                    String keyStoreAlgorithm, String trustStoreAlgorithm) {
-        if (keyStoreType.equals("PKCS11")) {
+        if (keyStoreType.equalsIgnoreCase("pkcs11")) {
             throw new IllegalArgumentException("PKCS#11 keystores are no longer supported by Elasticsearch");
         }
         this.keyStorePath = Objects.requireNonNull(keyStorePath);

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ssl/TrustConfig.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ssl/TrustConfig.java
@@ -78,11 +78,9 @@ abstract class TrustConfig {
 
     /**
      * Loads and returns the appropriate {@link KeyStore} for the given configuration. The KeyStore can be backed by a file
-     * in any format that the Security Provider might support, or a cryptographic software or hardware token in the case
-     * of a PKCS#11 Provider.
+     * in any format that the Security Provider might support.
      *
-     * @param storePath     the path to the {@link KeyStore} to load, or null if a PKCS11 token is configured as the keystore/truststore
-     *                      of the JVM
+     * @param storePath     the path to the {@link KeyStore} to load
      * @param storeType     the type of the {@link KeyStore}
      * @param storePassword the password to be used for decrypting the {@link KeyStore}
      * @return the loaded KeyStore to be used as a keystore or a truststore
@@ -92,18 +90,17 @@ abstract class TrustConfig {
      * @throws IOException              if there is an I/O issue with the KeyStore data or the password is incorrect
      */
     KeyStore getStore(Path storePath, String storeType, SecureString storePassword) throws IOException, GeneralSecurityException {
-        if (null != storePath) {
-            try (InputStream in = Files.newInputStream(storePath)) {
-                KeyStore ks = KeyStore.getInstance(storeType);
-                ks.load(in, storePassword.getChars());
-                return ks;
-            }
-        } else if (storeType.equalsIgnoreCase("pkcs11")) {
+        if (storeType.equalsIgnoreCase("pkcs11")) {
+            throw new IllegalArgumentException("PKCS#11 keystores are no longer supported by Elasticsearch");
+        }
+        if (storePath == null) {
+            throw new IllegalArgumentException("keystore.path or truststore.path cannot be empty");
+        }
+        try (InputStream in = Files.newInputStream(storePath)) {
             KeyStore ks = KeyStore.getInstance(storeType);
-            ks.load(null, storePassword.getChars());
+            ks.load(in, storePassword.getChars());
             return ks;
         }
-        throw new IllegalArgumentException("keystore.path or truststore.path can only be empty when using a PKCS#11 token");
     }
 
     /**


### PR DESCRIPTION
In theory, Elasticsearch supported configuring a PKCS#11 keystore
anywhere where a keystore/truststore could be used. For example:

    xpack.security.http.ssl.keystore.type: pkcs11

However, this support was poorly tested and broken.
This commit removes PKCS#11 support from any configurable SSL context.

It does not affect the ability to use a PKCS#11 keystore as the JRE's
system default keystore/truststore.