### PR TITLE
Fix broken test for dimension keywords

### DIFF
--- a/server/src/test/java/org/elasticsearch/index/mapper/KeywordFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/KeywordFieldMapperTests.java
@@ -375,7 +375,7 @@ public class KeywordFieldMapperTests extends MapperTestCase {
         }));
 
         Exception e = expectThrows(MapperParsingException.class,
-            () -> mapper.parse(source(b -> b.field("field", randomAlphaOfLengthBetween(1024, 2048)))));
+            () -> mapper.parse(source(b -> b.field("field", randomAlphaOfLengthBetween(1025, 2048)))));
         assertThat(e.getCause().getMessage(),
             containsString("Dimension field [field] cannot be more than [1024] bytes long."));
     }


### PR DESCRIPTION
Test was failing because it was testing 1024 bytes long keyword and assertion was failing. 

Closes #75225

