### PR TITLE
[7.x] Add missing X-Pack repositories REST specs (#65548)

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/nodes.clear_metering_archive.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/nodes.clear_metering_archive.json
@@ -1,0 +1,33 @@
+{
+  "nodes.clear_metering_archive":{
+    "documentation":{
+      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/clear-repositories-metering-archive-api.html",
+      "description":"Removes the archived repositories metering information present in the cluster."
+    },
+    "stability":"experimental",
+    "visibility":"public",
+    "headers":{
+      "accept": [ "application/json"]
+    },
+    "url":{
+      "paths":[
+        {
+          "path":"/_nodes/{node_id}/_repositories_metering/{max_archive_version}",
+          "methods":[
+            "DELETE"
+          ],
+          "parts":{
+            "node_id":{
+              "type":"list",
+              "description":"Comma-separated list of node IDs or names used to limit returned information."
+            },
+            "max_archive_version":{
+              "type":"long",
+              "description":"Specifies the maximum archive_version to be cleared from the archive."
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/nodes.get_metering_info.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/nodes.get_metering_info.json
@@ -1,0 +1,29 @@
+{
+  "nodes.get_metering_info":{
+    "documentation":{
+      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/get-repositories-metering-api.html",
+      "description":"Returns cluster repositories metering information."
+    },
+    "stability":"experimental",
+    "visibility":"public",
+    "headers":{
+      "accept": [ "application/json"]
+    },
+    "url":{
+      "paths":[
+        {
+          "path":"/_nodes/{node_id}/_repositories_metering",
+          "methods":[
+            "GET"
+          ],
+          "parts":{
+            "node_id":{
+              "type":"list",
+              "description":"A comma-separated list of node IDs or names to limit the returned information."
+            }
+          }
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Add missing X-Pack repositories REST specs (#65548)