### PR TITLE
[DOCS] Adds peak_model_bytes and assignment_memory_basis to GET model snapshot API docs

### DIFF
--- a/docs/reference/ml/anomaly-detection/apis/get-snapshot.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/get-snapshot.asciidoc
@@ -98,9 +98,8 @@ properties:
 [%collapsible%open]
 ====
 `assignment_memory_basis`:::
-(string) Reports which memory calculation method is respected as the memory 
-requirement for the job to be assigned. Possible options are 
-`model_memory_limit` and `current_model_bytes`.
+(string)
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=assignment-memory-basis]
 
 `bucket_allocation_failures_count`:::
 (long) The number of buckets for which entities were not processed due to memory

--- a/docs/reference/ml/anomaly-detection/apis/get-snapshot.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/get-snapshot.asciidoc
@@ -169,7 +169,7 @@ reclaim space.
 (long) The upper limit for memory usage, checked on increasing values.
 
 `peak_model_bytes`:::
-(long) The maximum memory usage of the model.
+(long) The highest recorded value for the model memory usage.
 
 
 `rare_category_count`:::

--- a/docs/reference/ml/anomaly-detection/apis/get-snapshot.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/get-snapshot.asciidoc
@@ -97,6 +97,11 @@ properties:
 .Properties of `model_size_stats`
 [%collapsible%open]
 ====
+`assignment_memory_basis`:::
+(string) Reports which memory calculation method is respected as the memory 
+requirement for the job to be assigned. Possible options are 
+`model_memory_limit` and `current_model_bytes`.
+
 `bucket_allocation_failures_count`:::
 (long) The number of buckets for which entities were not processed due to memory
 limit constraints.
@@ -163,6 +168,10 @@ reclaim space.
 
 `model_bytes_memory_limit`:::
 (long) The upper limit for memory usage, checked on increasing values.
+
+`peak_model_bytes`:::
+(long) The maximum memory usage of the model.
+
 
 `rare_category_count`:::
 (long) The number of categories that match just one categorized document.


### PR DESCRIPTION
## Overview

This PR adds two properties to the `model.size.stats` object of the GET model snapshots API response body:
* `peak_model_bytes`
* `assignment_memory_basis`

Related PRs: https://github.com/elastic/elasticsearch/pull/65561 and https://github.com/elastic/elasticsearch/pull/59017.

### Preview

[Response body](https://elasticsearch_75413.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/ml-get-snapshot.html#ml-get-snapshot-results)