### PR TITLE
[DOCS] Document dimension mapping parameter

### DIFF
--- a/docs/reference/index-modules.asciidoc
+++ b/docs/reference/index-modules.asciidoc
@@ -329,6 +329,13 @@ Defaults to `*`, which matches all fields eligible for
     the default pipeline (if it exists). The special pipeline name `_none`
     indicates no ingest pipeline will run.
 
+[[index-mapping-dimension-fields-limit]]
+`index.mapping.dimension_fields.limit`::
+For internal use by {kib} only. Maximum number of time series dimensions for the
+index. Defaults to `16`.
++
+You can mark a field as a dimension using the `dimension` mapping parameter.
+
 [discrete]
 === Settings in other index modules
 

--- a/docs/reference/mapping/types/ip.asciidoc
+++ b/docs/reference/mapping/types/ip.asciidoc
@@ -45,6 +45,8 @@ The following parameters are accepted by `ip` fields:
 
 [horizontal]
 
+include::keyword.asciidoc[tag=dimension]
+
 <<doc-values,`doc_values`>>::
 
     Should the field be stored on disk in a column-stride fashion, so that it

--- a/docs/reference/mapping/types/keyword.asciidoc
+++ b/docs/reference/mapping/types/keyword.asciidoc
@@ -56,6 +56,22 @@ The following parameters are accepted by `keyword` fields:
 
 [horizontal]
 
+// tag::dimension[]
+`dimension`::
+For internal use by {kib} only. Marks the field as a time series dimension.
+Accepts `true` or `false` (default).
++
+The <<index-mapping-dimension-fields-limit,`index.mapping.dimension_fields.limit`>>
+index setting limits the number of dimensions in an index.
++
+Dimension fields have the following constraints:
++
+* The `doc_values` and `index` mapping parameters must be `true`.
+* Field values cannot be an <<array,array or multi-value>>.
+// end::dimension[]
+* Field values cannot be larger than 1024 bytes.
+* The field cannot use a <<normalizer,`normalizer`>>.
+
 <<doc-values,`doc_values`>>::
 
     Should the field be stored on disk in a column-stride fashion, so that it

--- a/docs/reference/mapping/types/numeric.asciidoc
+++ b/docs/reference/mapping/types/numeric.asciidoc
@@ -119,6 +119,11 @@ The following parameters are accepted by numeric types:
     Accepts `true` (default) and `false`. Not applicable for `unsigned_long`.
     Note that this cannot be set if the `script` parameter is used.
 
+include::keyword.asciidoc[tag=dimension]
++
+Of the numeric field types, only `byte`, `short`, `integer`, and `long` fields
+support this parameter.
+
 <<doc-values,`doc_values`>>::
 
     Should the field be stored on disk in a column-stride fashion, so that it


### PR DESCRIPTION
Changes:

* Documents the `dimension` mapping parameter for `ip`, `keyword`, and `numeric`
  fields.

* Documents the `index.mapping.dimension_fields.limit` index setting.

Relates to #74450 and #74939

### Previews

* `ip` field type: https://elasticsearch_75414.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/ip.html#ip-params
* `keyword` field type: https://elasticsearch_75414.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/keyword.html#keyword-params
* `numeric` field types: https://elasticsearch_75414.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/number.html#number-params
* Index settings: https://elasticsearch_75414.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/index-modules.html#index-mapping-dimension-fields-limit