### PR TITLE
Print suggestion to view log on fatal error

### DIFF
--- a/server/src/main/java/org/elasticsearch/bootstrap/Elasticsearch.java
+++ b/server/src/main/java/org/elasticsearch/bootstrap/Elasticsearch.java
@@ -80,18 +80,26 @@ class Elasticsearch extends EnvironmentAwareCommand {
         final Elasticsearch elasticsearch = new Elasticsearch();
         int status = main(args, elasticsearch, Terminal.DEFAULT);
         if (status != ExitCodes.OK) {
-            final String basePath = System.getProperty("es.logs.base_path");
-            // It's possible to fail before logging has been configured, in which case there's no point
-            // suggesting that the user look in the log file.
-            if (basePath != null) {
-                Terminal.DEFAULT.errorPrintln(
-                    "ERROR: Elasticsearch did not exit normally - check the logs at "
-                        + basePath
-                        + System.getProperty("file.separator")
-                        + System.getProperty("es.logs.cluster_name") + ".log"
-                );
-            }
+            printLogsSuggestion();
             exit(status);
+        }
+    }
+
+    /**
+     * Prints a message directing the user to look at the logs. A message is only printed if
+     * logging has been configured.
+     */
+    static void printLogsSuggestion() {
+        final String basePath = System.getProperty("es.logs.base_path");
+        // It's possible to fail before logging has been configured, in which case there's no point
+        // suggesting that the user look in the log file.
+        if (basePath != null) {
+            Terminal.DEFAULT.errorPrintln(
+                "ERROR: Elasticsearch did not exit normally - check the logs at "
+                    + basePath
+                    + System.getProperty("file.separator")
+                    + System.getProperty("es.logs.cluster_name") + ".log"
+            );
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/bootstrap/ElasticsearchUncaughtExceptionHandler.java
+++ b/server/src/main/java/org/elasticsearch/bootstrap/ElasticsearchUncaughtExceptionHandler.java
@@ -58,6 +58,8 @@ class ElasticsearchUncaughtExceptionHandler implements Thread.UncaughtExceptionH
         t.printStackTrace(Terminal.DEFAULT.getErrorWriter());
         // Without a final flush, the stacktrace may not be shown before ES exits
         Terminal.DEFAULT.flush();
+
+        Elasticsearch.printLogsSuggestion();
     }
 
     void onNonFatalUncaught(final String threadName, final Throwable t) {


### PR DESCRIPTION
Closes #61767.

When Elasticsearch fails to start up, it tries to print a message to
suggest to the user that they consult the log for more information.
However, if a fatal error is encounted, Elasticsearch exits directly and
no such message is printed.

Improve this situation by printing the same message when Elasticsearch
is about to exit due to a fatal unexpected error.