### PR TITLE
Wait for ES to finish startup during password tests

### DIFF
--- a/qa/os/src/test/java/org/elasticsearch/packaging/test/PasswordToolsTests.java
+++ b/qa/os/src/test/java/org/elasticsearch/packaging/test/PasswordToolsTests.java
@@ -50,6 +50,7 @@ public class PasswordToolsTests extends PackagingTestCase {
 
     public void test20GeneratePasswords() throws Exception {
         assertWhileRunning(() -> {
+            ServerUtils.waitForElasticsearch(installation);
             Shell.Result result = installation.executables().setupPasswordsTool.run("auto --batch", null);
             Map<String, String> userpasses = parseUsersAndPasswords(result.stdout);
             for (Map.Entry<String, String> userpass : userpasses.entrySet()) {


### PR DESCRIPTION
Closes #74063.

Before trying to run `elasticsearch-setup-passwords` in `PasswordToolsTests`, ensure the cluster is up and green.