### PR TITLE
[DOCS] Fix `expand_wildcards` default for snapshots in 7.x

### DIFF
--- a/docs/reference/snapshot-restore/take-snapshot.asciidoc
+++ b/docs/reference/snapshot-restore/take-snapshot.asciidoc
@@ -140,7 +140,7 @@ templates required for a data stream.
 
 By default, the entire snapshot will fail if one or more indices participating in the snapshot do not have
 all primary shards available. You can change this behaviour by setting `partial` to `true`. The `expand_wildcards`
-option can be used to control whether hidden and closed indices will be included in the snapshot, and defaults to `all`.
+option can be used to control whether hidden and closed indices will be included in the snapshot, and defaults to `open,hidden`.
 
 Use the `metadata` field to attach arbitrary metadata to the snapshot,
 such as who took the snapshot,


### PR DESCRIPTION
In 7.x, the create snapshot API's `expand_wildcards` option defaults to `open,hidden`.

This default was changed in #57325. This fixes a docs bug introduced in #59730.

Closes #66585.

CC @stefnestor 

### Preview
https://elasticsearch_75432.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/7.x/snapshots-take-snapshot.html#create-snapshot-options