### PR TITLE
[doc] Document workaround for slow log levels

### DIFF
--- a/docs/reference/index-modules/slowlog.asciidoc
+++ b/docs/reference/index-modules/slowlog.asciidoc
@@ -129,3 +129,10 @@ the original document format is important, you can turn off reformatting by sett
 logged "as is" and can potentially span multiple log lines.
 
 The index slow log file is configured in the `log4j2.properties` file.
+
+[discrete]
+=== Slow log levels
+
+You can mimic the search or indexing slow log level by setting appropriate threshold preventing "more verbose" loggers to be turned off.
+If for instance we want to simulate index.indexing.slowlog.level = INFO then all we need to do is to set
+index.indexing.slowlog.threshold.index.debug and index.indexing.slowlog.threshold.index.trace to -1

--- a/docs/reference/index-modules/slowlog.asciidoc
+++ b/docs/reference/index-modules/slowlog.asciidoc
@@ -133,6 +133,8 @@ The index slow log file is configured in the `log4j2.properties` file.
 [discrete]
 === Slow log levels
 
-You can mimic the search or indexing slow log level by setting appropriate threshold preventing "more verbose" loggers to be turned off.
-If for instance we want to simulate index.indexing.slowlog.level = INFO then all we need to do is to set
+You can mimic the search or indexing slow log level by setting appropriate
+threshold making "more verbose" loggers to be switched off.
+If for instance we want to simulate index.indexing.slowlog.level = INFO
+then all we need to do is to set
 index.indexing.slowlog.threshold.index.debug and index.indexing.slowlog.threshold.index.trace to -1


### PR DESCRIPTION
settings for slow log levels are removed in v8. This commit adds a
documentation to how to mimic the behaviour
relates #57591
relates #73718