### PR TITLE
[Rest Api Compatibility] Do not return _doc for empty mappings in template

### DIFF
--- a/rest-api-spec/build.gradle
+++ b/rest-api-spec/build.gradle
@@ -78,8 +78,9 @@ def v7compatibilityNotSupportedTests = {
 
           'indices.create/10_basic/Create index without soft deletes', //Make soft-deletes mandatory in 8.0 #51122 - settings changes are note supported in Rest Api compatibility
 
-
           'field_caps/30_filter/Field caps with index filter', //behaviour change after #63692 4digits dates are parsed as epoch and in quotes as year
+
+          'indices.forcemerge/10_basic/Check deprecation warning when incompatible only_expunge_deletes and max_num_segments values are both set', //#44761 bug fix
   ]
 }
 tasks.named("yamlRestCompatTest").configure {
@@ -91,12 +92,7 @@ tasks.named("yamlRestCompatTest").configure {
     'cluster.voting_config_exclusions/10_basic/Throw exception when adding voting config exclusion and specifying both node_ids and node_names',
     'cluster.voting_config_exclusions/10_basic/Throw exception when adding voting config exclusion without specifying nodes',
     'indices.flush/10_basic/Index synced flush rest test',
-    'indices.forcemerge/10_basic/Check deprecation warning when incompatible only_expunge_deletes and max_num_segments values are both set',
-    // not fixing this in #70966
-    'indices.put_template/11_basic_with_types/Put template with empty mappings',
     'search.aggregation/200_top_hits_metric/top_hits aggregation with sequence numbers',
-    'search.aggregation/51_filter_with_types/Filter aggs with terms lookup and ensure it\'s cached',
-    'search/150_rewrite_on_coordinator/Ensure that we fetch the document only once', //terms_lookup
     'search/310_match_bool_prefix/multi_match multiple fields with cutoff_frequency throws exception', //cutoff_frequency
     'search/340_type_query/type query', // type_query - probably should behave like match_all
   ] + v7compatibilityNotSupportedTests())

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/IndexTemplateMetadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/IndexTemplateMetadata.java
@@ -27,6 +27,7 @@ import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.json.JsonXContent;
+import org.elasticsearch.index.mapper.MapperService;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
@@ -391,6 +392,8 @@ public class IndexTemplateMetadata extends AbstractDiffable<IndexTemplateMetadat
                 Map<String, Object> documentMapping = XContentHelper.convertToMap(m.uncompressed(), true).v2();
                 if (includeTypeName == false) {
                     documentMapping = reduceMapping(documentMapping);
+                } else {
+                    documentMapping = reduceEmptyMapping(documentMapping);
                 }
                 builder.field("mappings");
                 builder.map(documentMapping);
@@ -403,6 +406,16 @@ public class IndexTemplateMetadata extends AbstractDiffable<IndexTemplateMetadat
                 AliasMetadata.Builder.toXContent(cursor.value, builder, params);
             }
             builder.endObject();
+        }
+
+        @SuppressWarnings("unchecked")
+        private static Map<String, Object> reduceEmptyMapping(Map<String, Object> mapping) {
+            if(mapping.keySet().size() == 1 && mapping.containsKey(MapperService.SINGLE_MAPPING_NAME) &&
+                ((Map<String, Object>)mapping.get(MapperService.SINGLE_MAPPING_NAME)).size() == 0){
+                return (Map<String, Object>) mapping.values().iterator().next();
+            } else {
+                return mapping;
+            }
         }
 
         @SuppressWarnings("unchecked")


### PR DESCRIPTION
Previously the compatibility layer was always returning an _doc in mappings for get
template.
This commit does not return _doc in empty mappings.
Returning just {} empty object (v7 and v8 behaviour)

also moving term lookups tests which are already fixed (relates #74544)

relates #70966
relates main meta issue #51816
relates types removal meta #54160

<!--
Thank you for your interest in and contributing to Elasticsearch! There
are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.
-->

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/elasticsearch/blob/master/CONTRIBUTING.md)?
- If submitting code, have you built your formula locally prior to submission with `gradle check`?
- If submitting code, is your pull request against master? Unless there is a good reason otherwise, we prefer pull requests against master and will backport as needed.
- If submitting code, have you checked that your submission is for an [OS and architecture that we support](https://www.elastic.co/support/matrix#show_os)?
- If you are submitting this code for a class then read our [policy](https://github.com/elastic/elasticsearch/blob/master/CONTRIBUTING.md#contributing-as-part-of-a-class) for that.
