### PR TITLE
Fix failure on attempt to overwrite multi fields

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/mapper/DocumentParser.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DocumentParser.java
@@ -880,9 +880,11 @@ public final class DocumentParser {
         String fieldPath = context.path().pathAsText(fieldName);
         MappedFieldType fieldType = context.mappingLookup().getFieldType(fieldPath);
         if (fieldType != null) {
-            //we haven't found a mapper with this name above, which means if a field type is found it is for sure a runtime field.
-            assert fieldType.hasDocValues() == false && fieldType.isAggregatable() && fieldType.isSearchable();
-            return new NoOpFieldMapper(subfields[subfields.length - 1], fieldType.name());
+            RuntimeField runtimeField = context.root().getRuntimeField(fieldPath);
+            if (runtimeField != null) {
+                assert fieldType.hasDocValues() == false && fieldType.isAggregatable() && fieldType.isSearchable();
+                return new NoOpFieldMapper(subfields[subfields.length - 1], fieldType.name());
+            }
         }
         return null;
     }

--- a/server/src/test/java/org/elasticsearch/index/mapper/DocumentParserTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/DocumentParserTests.java
@@ -1878,6 +1878,31 @@ public class DocumentParserTests extends MapperServiceTestCase {
             + "Existing mapping for [alias-field] must be of type object but found [alias].", exception.getMessage());
     }
 
+    public void testMultifieldOverwriteFails() throws Exception {
+        DocumentMapper mapper = createDocumentMapper(mapping(b -> {
+            b.startObject("message");
+            {
+                b.field("type", "keyword");
+                b.startObject("fields");
+                {
+                    b.startObject("text");
+                    {
+                        b.field("type", "text");
+                    }
+                    b.endObject();
+                }
+                b.endObject();
+            }
+            b.endObject();
+        }));
+
+        MapperParsingException exception = expectThrows(MapperParsingException.class,
+            () -> mapper.parse(source(b -> b.field("message", "original").field("message.text", "overwrite"))));
+
+        assertEquals("Could not dynamically add mapping for field [message.text]. "
+            + "Existing mapping for [message] must be of type object but found [keyword].", exception.getMessage());
+    }
+
     public void testTypeless() throws IOException {
         String mapping = Strings.toString(XContentFactory.jsonBuilder()
                 .startObject().startObject("type").startObject("properties")


### PR DESCRIPTION
We used to throw a parsing exception when trying to overwrite a multi field on
indexing a document. These errors got lost on some recent changes in
DocumentParser around runtime fields and not detected in tests. This PR adds a
test for this case and restores parts of the logic in
DocumentParser#getLeafMapper to prevent this kind of overwrite from happening.

Fixes #75343