### PR TITLE
[Transform][Rollup] remove unnecessary list indirection

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/indexing/AsyncTwoPhaseIndexer.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/indexing/AsyncTwoPhaseIndexer.java
@@ -12,14 +12,12 @@ import org.apache.logging.log4j.Logger;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.bulk.BulkRequest;
 import org.elasticsearch.action.bulk.BulkResponse;
-import org.elasticsearch.action.index.IndexRequest;
 import org.elasticsearch.action.search.SearchResponse;
-import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.common.util.concurrent.RunOnce;
+import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.threadpool.Scheduler;
 import org.elasticsearch.threadpool.ThreadPool;
 
-import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
@@ -487,13 +485,12 @@ public abstract class AsyncTwoPhaseIndexer<JobPosition, JobStats extends Indexer
                 return;
             }
 
-            final List<IndexRequest> docs = iterationResult.getToIndex();
+            final BulkRequest bulkRequest = new BulkRequest();
+            iterationResult.getToIndex().forEach(bulkRequest::add);
+            stats.markEndProcessing();
 
             // an iteration result might return an empty set of documents to be indexed
-            if (docs.isEmpty() == false) {
-                final BulkRequest bulkRequest = new BulkRequest();
-                docs.forEach(bulkRequest::add);
-                stats.markEndProcessing();
+            if (bulkRequest.numberOfActions() > 0) {
                 stats.markStartIndexing();
                 doNextBulk(bulkRequest, ActionListener.wrap(bulkResponse -> {
                     // TODO we should check items in the response and move after accordingly to
@@ -512,7 +509,6 @@ public abstract class AsyncTwoPhaseIndexer<JobPosition, JobStats extends Indexer
                     onBulkResponse(bulkResponse, newPosition);
                 }, this::finishWithIndexingFailure));
             } else {
-                stats.markEndProcessing();
                 // no documents need to be indexed, continue with search
                 try {
                     JobPosition newPosition = iterationResult.getPosition();

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/indexing/IterationResult.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/indexing/IterationResult.java
@@ -9,7 +9,7 @@ package org.elasticsearch.xpack.core.indexing;
 
 import org.elasticsearch.action.index.IndexRequest;
 
-import java.util.List;
+import java.util.stream.Stream;
 
 /**
  * Result object to hold the result of 1 iteration of iterative indexing.
@@ -19,18 +19,18 @@ public class IterationResult<JobPosition> {
 
     private final boolean isDone;
     private final JobPosition position;
-    private final List<IndexRequest> toIndex;
+    private final Stream<IndexRequest> toIndex;
 
     /**
      * Constructor for the result of 1 iteration.
      *
-     * @param toIndex the list of requests to be indexed
+     * @param toIndex the stream of requests to be indexed
      * @param position the extracted, persistable position of the job required for the search phase
      * @param isDone true if source is exhausted and job should go to sleep
      *
      * Note: toIndex.empty() != isDone due to possible filtering in the specific implementation
      */
-    public IterationResult(List<IndexRequest> toIndex, JobPosition position, boolean isDone) {
+    public IterationResult(Stream<IndexRequest> toIndex, JobPosition position, boolean isDone) {
         this.toIndex = toIndex;
         this.position = position;
         this.isDone = isDone;
@@ -53,11 +53,11 @@ public class IterationResult<JobPosition> {
     }
 
     /**
-     * List of requests to be passed to bulk indexing.
+     * Stream of requests to be passed to bulk indexing.
      *
-     * @return List of index requests.
+     * @return Stream of index requests.
      */
-    public List<IndexRequest> getToIndex() {
+    public Stream<IndexRequest> getToIndex() {
         return toIndex;
     }
 }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/indexing/AsyncTwoPhaseIndexerTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/indexing/AsyncTwoPhaseIndexerTests.java
@@ -17,8 +17,8 @@ import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.search.SearchResponseSections;
 import org.elasticsearch.action.search.ShardSearchFailure;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.search.SearchHits;
 import org.elasticsearch.test.ESTestCase;
@@ -36,6 +36,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Stream;
 
 import static org.hamcrest.Matchers.equalTo;
 
@@ -74,7 +75,7 @@ public class AsyncTwoPhaseIndexerTests extends ESTestCase {
             assertFalse("should not be called as stoppedBeforeFinished is false", stoppedBeforeFinished);
             assertThat(step, equalTo(2));
             ++step;
-            return new IterationResult<>(Collections.emptyList(), 3, true);
+            return new IterationResult<>(Stream.empty(), 3, true);
         }
 
         private void awaitForLatch() {
@@ -191,13 +192,13 @@ public class AsyncTwoPhaseIndexerTests extends ESTestCase {
 
             ++processOps;
             if (processOps == 5) {
-                return new IterationResult<>(Collections.singletonList(new IndexRequest()), processOps, true);
+                return new IterationResult<>(Collections.singletonList(new IndexRequest()).stream(), processOps, true);
             }
             else if (processOps % 2 == 0) {
-                return new IterationResult<>(Collections.emptyList(), processOps, false);
+                return new IterationResult<>(Stream.empty(), processOps, false);
             }
 
-            return new IterationResult<>(Collections.singletonList(new IndexRequest()), processOps, false);
+            return new IterationResult<>(Collections.singletonList(new IndexRequest()).stream(), processOps, false);
         }
 
         @Override

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/indexing/AsyncTwoPhaseIndexerTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/indexing/AsyncTwoPhaseIndexerTests.java
@@ -192,13 +192,13 @@ public class AsyncTwoPhaseIndexerTests extends ESTestCase {
 
             ++processOps;
             if (processOps == 5) {
-                return new IterationResult<>(Collections.singletonList(new IndexRequest()).stream(), processOps, true);
+                return new IterationResult<>(Stream.of(new IndexRequest()), processOps, true);
             }
             else if (processOps % 2 == 0) {
                 return new IterationResult<>(Stream.empty(), processOps, false);
             }
 
-            return new IterationResult<>(Collections.singletonList(new IndexRequest()).stream(), processOps, false);
+            return new IterationResult<>(Stream.of(new IndexRequest()), processOps, false);
         }
 
         @Override

--- a/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/job/IndexerUtils.java
+++ b/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/job/IndexerUtils.java
@@ -27,7 +27,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
-import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * These utilities are used to convert agg responses into a set of rollup documents.
@@ -45,9 +45,9 @@ class IndexerUtils {
      * @param stats            The stats accumulator for this job's task
      * @param groupConfig      The grouping configuration for the job
      * @param jobId            The ID for the job
-     * @return             A list of rolled documents derived from the response
+     * @return                 A stream of rolled documents derived from the response
      */
-    static List<IndexRequest> processBuckets(CompositeAggregation agg, String rollupIndex, RollupIndexerJobStats stats,
+    static Stream<IndexRequest> processBuckets(CompositeAggregation agg, String rollupIndex, RollupIndexerJobStats stats,
                                              GroupConfig groupConfig, String jobId) {
 
         logger.debug("Buckets: [" + agg.getBuckets().size() + "][" + jobId + "]");
@@ -72,7 +72,7 @@ class IndexerUtils {
             IndexRequest request = new IndexRequest(rollupIndex).id(idGenerator.getID());
             request.source(doc);
             return request;
-        }).collect(Collectors.toList());
+        });
     }
 
     private static void processKeys(Map<String, Object> keys, Map<String, Object> doc,

--- a/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/job/RollupIndexer.java
+++ b/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/job/RollupIndexer.java
@@ -51,6 +51,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Stream;
 
 import static org.elasticsearch.xpack.core.rollup.RollupField.formatFieldName;
 
@@ -130,7 +131,7 @@ public abstract class RollupIndexer extends AsyncTwoPhaseIndexer<Map<String, Obj
 
         if (response.getBuckets().isEmpty()) {
             // do not reset the position as we want to continue from where we stopped
-            return new IterationResult<>(Collections.emptyList(), getPosition(), true);
+            return new IterationResult<>(Stream.empty(), getPosition(), true);
         }
 
         return new IterationResult<>(

--- a/x-pack/plugin/rollup/src/test/java/org/elasticsearch/xpack/rollup/job/IndexerUtilsTests.java
+++ b/x-pack/plugin/rollup/src/test/java/org/elasticsearch/xpack/rollup/job/IndexerUtilsTests.java
@@ -55,6 +55,7 @@ import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import static java.util.Collections.singletonList;
 import static org.elasticsearch.xpack.core.rollup.ConfigTestHelpers.randomDateHistogramGroupConfig;
@@ -113,7 +114,7 @@ public class IndexerUtilsTests extends AggregatorTestCase {
         directory.close();
 
         final GroupConfig groupConfig = randomGroupConfig(random());
-        List<IndexRequest> docs = IndexerUtils.processBuckets(composite, indexName, stats, groupConfig, "foo");
+        List<IndexRequest> docs = IndexerUtils.processBuckets(composite, indexName, stats, groupConfig, "foo").collect(Collectors.toList());
 
         assertThat(docs.size(), equalTo(numDocs));
         for (IndexRequest doc : docs) {
@@ -174,7 +175,7 @@ public class IndexerUtilsTests extends AggregatorTestCase {
         directory.close();
 
         final GroupConfig groupConfig = randomGroupConfig(random());
-        List<IndexRequest> docs = IndexerUtils.processBuckets(composite, indexName, stats, groupConfig, "foo");
+        List<IndexRequest> docs = IndexerUtils.processBuckets(composite, indexName, stats, groupConfig, "foo").collect(Collectors.toList());
 
         assertThat(docs.size(), equalTo(numDocs));
         for (IndexRequest doc : docs) {
@@ -227,7 +228,7 @@ public class IndexerUtilsTests extends AggregatorTestCase {
         directory.close();
 
         final GroupConfig groupConfig = randomGroupConfig(random());
-        List<IndexRequest> docs = IndexerUtils.processBuckets(composite, indexName, stats, groupConfig, "foo");
+        List<IndexRequest> docs = IndexerUtils.processBuckets(composite, indexName, stats, groupConfig, "foo").collect(Collectors.toList());
 
         assertThat(docs.size(), equalTo(numDocs));
         for (IndexRequest doc : docs) {
@@ -287,7 +288,7 @@ public class IndexerUtilsTests extends AggregatorTestCase {
         directory.close();
 
         final GroupConfig groupConfig = randomGroupConfig(random());
-        List<IndexRequest> docs = IndexerUtils.processBuckets(composite, indexName, stats, groupConfig, "foo");
+        List<IndexRequest> docs = IndexerUtils.processBuckets(composite, indexName, stats, groupConfig, "foo").collect(Collectors.toList());
 
         assertThat(docs.size(), equalTo(numDocs));
         for (IndexRequest doc : docs) {
@@ -337,7 +338,8 @@ public class IndexerUtilsTests extends AggregatorTestCase {
         });
 
         GroupConfig groupConfig = new GroupConfig(randomDateHistogramGroupConfig(random()), new HistogramGroupConfig(1L, "abc"), null);
-        List<IndexRequest> docs = IndexerUtils.processBuckets(composite, "foo", new RollupIndexerJobStats(), groupConfig, "foo");
+        List<IndexRequest> docs = IndexerUtils.processBuckets(composite, "foo", new RollupIndexerJobStats(), groupConfig, "foo")
+            .collect(Collectors.toList());
         assertThat(docs.size(), equalTo(1));
         assertThat(docs.get(0).id(), equalTo("foo$c9LcrFqeFW92uN_Z7sv1hA"));
     }
@@ -387,7 +389,8 @@ public class IndexerUtilsTests extends AggregatorTestCase {
         });
 
         GroupConfig groupConfig = new GroupConfig(randomDateHistogramGroupConfig(random()), new HistogramGroupConfig(1, "abc"), null);
-        List<IndexRequest> docs = IndexerUtils.processBuckets(composite, "foo", new RollupIndexerJobStats(), groupConfig, "foo");
+        List<IndexRequest> docs = IndexerUtils.processBuckets(composite, "foo", new RollupIndexerJobStats(), groupConfig, "foo")
+            .collect(Collectors.toList());
         assertThat(docs.size(), equalTo(1));
         assertThat(docs.get(0).id(), equalTo("foo$VAFKZpyaEqYRPLyic57_qw"));
     }
@@ -414,7 +417,8 @@ public class IndexerUtilsTests extends AggregatorTestCase {
         });
 
         GroupConfig groupConfig = new GroupConfig(randomDateHistogramGroupConfig(random()), randomHistogramGroupConfig(random()), null);
-        List<IndexRequest> docs = IndexerUtils.processBuckets(composite, "foo", new RollupIndexerJobStats(), groupConfig, "foo");
+        List<IndexRequest> docs = IndexerUtils.processBuckets(composite, "foo", new RollupIndexerJobStats(), groupConfig, "foo")
+            .collect(Collectors.toList());
         assertThat(docs.size(), equalTo(1));
         assertFalse(Strings.isNullOrEmpty(docs.get(0).id()));
     }
@@ -471,7 +475,7 @@ public class IndexerUtilsTests extends AggregatorTestCase {
         directory.close();
 
         final GroupConfig groupConfig = randomGroupConfig(random());
-        List<IndexRequest> docs = IndexerUtils.processBuckets(composite, indexName, stats, groupConfig, "foo");
+        List<IndexRequest> docs = IndexerUtils.processBuckets(composite, indexName, stats, groupConfig, "foo").collect(Collectors.toList());
 
         assertThat(docs.size(), equalTo(6));
         for (IndexRequest doc : docs) {
@@ -542,7 +546,7 @@ public class IndexerUtilsTests extends AggregatorTestCase {
         directory.close();
 
         final GroupConfig groupConfig = randomGroupConfig(random());
-        List<IndexRequest> docs = IndexerUtils.processBuckets(composite, indexName, stats, groupConfig, "foo");
+        List<IndexRequest> docs = IndexerUtils.processBuckets(composite, indexName, stats, groupConfig, "foo").collect(Collectors.toList());
 
         assertThat(docs.size(), equalTo(2));
 

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/Function.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/Function.java
@@ -209,6 +209,7 @@ public interface Function {
      * @param destinationPipeline the destination pipeline
      * @param fieldMappings field mappings for the destination
      * @param stats a stats object to record/collect stats
+     * @param progress a progress object to record/collect progress information
      * @return a tuple with the stream of index requests and the cursor
      */
     Tuple<Stream<IndexRequest>, Map<String, Object>> processSearchResponse(
@@ -216,6 +217,7 @@ public interface Function {
         String destinationIndex,
         String destinationPipeline,
         Map<String, String> fieldMappings,
-        TransformIndexerStats stats
+        TransformIndexerStats stats,
+        TransformProgress progress
     );
 }

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/TransformIndexer.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/TransformIndexer.java
@@ -891,11 +891,7 @@ public abstract class TransformIndexer extends AsyncTwoPhaseIndexer<TransformInd
             runState = RunState.IDENTIFY_CHANGES;
 
             // advance the cursor for changed bucket detection
-            return new IterationResult<>(
-                Stream.empty(),
-                new TransformIndexerPosition(null, nextChangeCollectorBucketPosition),
-                false
-            );
+            return new IterationResult<>(Stream.empty(), new TransformIndexerPosition(null, nextChangeCollectorBucketPosition), false);
         }
 
         Stream<IndexRequest> indexRequestStream = indexRequestStreamAndCursor.v1();

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/common/AbstractCompositeAggFunction.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/common/AbstractCompositeAggFunction.java
@@ -86,8 +86,9 @@ public abstract class AbstractCompositeAggFunction implements Function {
                     }
                     final CompositeAggregation agg = aggregations.get(COMPOSITE_AGGREGATION_NAME);
                     TransformIndexerStats stats = new TransformIndexerStats();
+                    TransformProgress progress = new TransformProgress();
 
-                    List<Map<String, Object>> docs = extractResults(agg, fieldTypeMap, stats, null).map(
+                    List<Map<String, Object>> docs = extractResults(agg, fieldTypeMap, stats, progress).map(
                         this::documentTransformationFunction
                     ).collect(Collectors.toList());
 

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/common/AbstractCompositeAggFunction.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/common/AbstractCompositeAggFunction.java
@@ -80,15 +80,16 @@ public abstract class AbstractCompositeAggFunction implements Function {
                     final Aggregations aggregations = r.getAggregations();
                     if (aggregations == null) {
                         listener.onFailure(
-                            new ElasticsearchStatusException("Source indices have been deleted or closed.", RestStatus.BAD_REQUEST));
+                            new ElasticsearchStatusException("Source indices have been deleted or closed.", RestStatus.BAD_REQUEST)
+                        );
                         return;
                     }
                     final CompositeAggregation agg = aggregations.get(COMPOSITE_AGGREGATION_NAME);
                     TransformIndexerStats stats = new TransformIndexerStats();
 
-                    List<Map<String, Object>> docs = extractResults(agg, fieldTypeMap, stats, null)
-                        .map(this::documentTransformationFunction)
-                        .collect(Collectors.toList());
+                    List<Map<String, Object>> docs = extractResults(agg, fieldTypeMap, stats, null).map(
+                        this::documentTransformationFunction
+                    ).collect(Collectors.toList());
 
                     listener.onResponse(docs);
                 } catch (AggregationResultUtils.AggregationExtractionException extractionException) {
@@ -108,11 +109,10 @@ public abstract class AbstractCompositeAggFunction implements Function {
             }
             if (response.status() != RestStatus.OK) {
                 listener.onFailure(
-                    new ValidationException()
-                        .addValidationError(
-                            new ParameterizedMessage("Unexpected status from response of test query: {}", response.status())
-                                .getFormattedMessage()
-                        )
+                    new ValidationException().addValidationError(
+                        new ParameterizedMessage("Unexpected status from response of test query: {}", response.status())
+                            .getFormattedMessage()
+                    )
                 );
                 return;
             }
@@ -123,10 +123,9 @@ public abstract class AbstractCompositeAggFunction implements Function {
                 ? ((ElasticsearchException) unwrapped).status()
                 : RestStatus.SERVICE_UNAVAILABLE;
             listener.onFailure(
-                new ValidationException(unwrapped)
-                    .addValidationError(
-                        new ParameterizedMessage("Failed to test query, received status: {}", status).getFormattedMessage()
-                    )
+                new ValidationException(unwrapped).addValidationError(
+                    new ParameterizedMessage("Failed to test query, received status: {}", status).getFormattedMessage()
+                )
             );
         }));
     }
@@ -153,16 +152,15 @@ public abstract class AbstractCompositeAggFunction implements Function {
             return null;
         }
 
-        Stream<IndexRequest> indexRequestStream = extractResults(compositeAgg, fieldTypeMap, stats, progress)
-            .map(doc -> {
-                String docId = (String)doc.remove(TransformField.DOCUMENT_ID_FIELD);
-                return DocumentConversionUtils.convertDocumentToIndexRequest(
-                    docId,
-                    documentTransformationFunction(doc),
-                    destinationIndex,
-                    destinationPipeline
-                );
-            });
+        Stream<IndexRequest> indexRequestStream = extractResults(compositeAgg, fieldTypeMap, stats, progress).map(doc -> {
+            String docId = (String) doc.remove(TransformField.DOCUMENT_ID_FIELD);
+            return DocumentConversionUtils.convertDocumentToIndexRequest(
+                docId,
+                documentTransformationFunction(doc),
+                destinationIndex,
+                destinationPipeline
+            );
+        });
 
         return Tuple.tuple(indexRequestStream, compositeAgg.afterKey());
     }
@@ -177,13 +175,10 @@ public abstract class AbstractCompositeAggFunction implements Function {
     );
 
     private SearchRequest buildSearchRequest(SourceConfig sourceConfig, Map<String, Object> position, int pageSize) {
-        SearchSourceBuilder sourceBuilder = new SearchSourceBuilder()
-            .query(sourceConfig.getQueryConfig().getQuery())
+        SearchSourceBuilder sourceBuilder = new SearchSourceBuilder().query(sourceConfig.getQueryConfig().getQuery())
             .runtimeMappings(sourceConfig.getRuntimeMappings());
         buildSearchQuery(sourceBuilder, null, pageSize);
-        return new SearchRequest(sourceConfig.getIndex())
-            .source(sourceBuilder)
-            .indicesOptions(IndicesOptions.LENIENT_EXPAND_OPEN);
+        return new SearchRequest(sourceConfig.getIndex()).source(sourceBuilder).indicesOptions(IndicesOptions.LENIENT_EXPAND_OPEN);
     }
 
     @Override

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/common/AbstractCompositeAggFunction.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/common/AbstractCompositeAggFunction.java
@@ -86,7 +86,7 @@ public abstract class AbstractCompositeAggFunction implements Function {
                     final CompositeAggregation agg = aggregations.get(COMPOSITE_AGGREGATION_NAME);
                     TransformIndexerStats stats = new TransformIndexerStats();
 
-                    List<Map<String, Object>> docs = extractResults(agg, fieldTypeMap, stats)
+                    List<Map<String, Object>> docs = extractResults(agg, fieldTypeMap, stats, null)
                         .map(this::documentTransformationFunction)
                         .collect(Collectors.toList());
 
@@ -137,7 +137,8 @@ public abstract class AbstractCompositeAggFunction implements Function {
         String destinationIndex,
         String destinationPipeline,
         Map<String, String> fieldTypeMap,
-        TransformIndexerStats stats
+        TransformIndexerStats stats,
+        TransformProgress progress
     ) {
         Aggregations aggregations = searchResponse.getAggregations();
 
@@ -152,7 +153,7 @@ public abstract class AbstractCompositeAggFunction implements Function {
             return null;
         }
 
-        Stream<IndexRequest> indexRequestStream = extractResults(compositeAgg, fieldTypeMap, stats)
+        Stream<IndexRequest> indexRequestStream = extractResults(compositeAgg, fieldTypeMap, stats, progress)
             .map(doc -> {
                 String docId = (String)doc.remove(TransformField.DOCUMENT_ID_FIELD);
                 return DocumentConversionUtils.convertDocumentToIndexRequest(
@@ -171,7 +172,8 @@ public abstract class AbstractCompositeAggFunction implements Function {
     protected abstract Stream<Map<String, Object>> extractResults(
         CompositeAggregation agg,
         Map<String, String> fieldTypeMap,
-        TransformIndexerStats transformIndexerStats
+        TransformIndexerStats transformIndexerStats,
+        TransformProgress progress
     );
 
     private SearchRequest buildSearchRequest(SourceConfig sourceConfig, Map<String, Object> position, int pageSize) {

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/latest/Latest.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/latest/Latest.java
@@ -80,10 +80,8 @@ public class Latest extends AbstractCompositeAggFunction {
         TransformProgress progress
     ) {
         transformIndexerStats.incrementNumDocuments(bucket.getDocCount());
-        if (progress != null) {
-            progress.incrementDocsProcessed(bucket.getDocCount());
-            progress.incrementDocsIndexed(1L);
-        }
+        progress.incrementDocsProcessed(bucket.getDocCount());
+        progress.incrementDocsIndexed(1L);
 
         TopHits topHits = bucket.getAggregations().get(TOP_HITS_AGGREGATION_NAME);
         if (topHits.getHits().getHits().length != 1) {

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/latest/Latest.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/latest/Latest.java
@@ -53,14 +53,13 @@ public class Latest extends AbstractCompositeAggFunction {
     }
 
     private static CompositeAggregationBuilder createCompositeAggregation(LatestConfig config) {
-        List<CompositeValuesSourceBuilder<?>> sources =
-            config.getUniqueKey().stream()
-                .map(field -> new TermsValuesSourceBuilder(field).field(field).missingBucket(true))
-                .collect(toList());
-        TopHitsAggregationBuilder topHitsAgg =
-            AggregationBuilders.topHits(TOP_HITS_AGGREGATION_NAME)
-                .size(1)  // we are only interested in the top-1
-                .sorts(config.getSorts());  // we copy the sort config directly from the function config
+        List<CompositeValuesSourceBuilder<?>> sources = config.getUniqueKey()
+            .stream()
+            .map(field -> new TermsValuesSourceBuilder(field).field(field).missingBucket(true))
+            .collect(toList());
+        TopHitsAggregationBuilder topHitsAgg = AggregationBuilders.topHits(TOP_HITS_AGGREGATION_NAME)
+            .size(1)  // we are only interested in the top-1
+            .sorts(config.getSorts());  // we copy the sort config directly from the function config
         return AggregationBuilders.composite(COMPOSITE_AGGREGATION_NAME, sources).subAggregation(topHitsAgg);
     }
 
@@ -74,10 +73,12 @@ public class Latest extends AbstractCompositeAggFunction {
         return new LatestChangeCollector(synchronizationField);
     }
 
-    private static Map<String, Object> convertBucketToDocument(CompositeAggregation.Bucket bucket,
-                                                               LatestConfig config,
-                                                               TransformIndexerStats transformIndexerStats,
-                                                               TransformProgress progress) {
+    private static Map<String, Object> convertBucketToDocument(
+        CompositeAggregation.Bucket bucket,
+        LatestConfig config,
+        TransformIndexerStats transformIndexerStats,
+        TransformProgress progress
+    ) {
         transformIndexerStats.incrementNumDocuments(bucket.getDocCount());
         if (progress != null) {
             progress.incrementDocsProcessed(bucket.getDocCount());
@@ -87,7 +88,9 @@ public class Latest extends AbstractCompositeAggFunction {
         TopHits topHits = bucket.getAggregations().get(TOP_HITS_AGGREGATION_NAME);
         if (topHits.getHits().getHits().length != 1) {
             throw new ElasticsearchException(
-                "Unexpected number of hits in the top_hits aggregation result. Wanted: 1, was: {}", topHits.getHits().getHits().length);
+                "Unexpected number of hits in the top_hits aggregation result. Wanted: 1, was: {}",
+                topHits.getHits().getHits().length
+            );
         }
         Map<String, Object> document = topHits.getHits().getHits()[0].getSourceAsMap();
 

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/pivot/AggregationResultUtils.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/pivot/AggregationResultUtils.java
@@ -104,10 +104,8 @@ public final class AggregationResultUtils {
     ) {
         return agg.getBuckets().stream().map(bucket -> {
             stats.incrementNumDocuments(bucket.getDocCount());
-            if (progress != null) {
-                progress.incrementDocsProcessed(bucket.getDocCount());
-                progress.incrementDocsIndexed(1L);
-            }
+            progress.incrementDocsProcessed(bucket.getDocCount());
+            progress.incrementDocsIndexed(1L);
 
             Map<String, Object> document = new HashMap<>();
             // generator to create unique but deterministic document ids, so we

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/pivot/AggregationResultUtils.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/pivot/AggregationResultUtils.java
@@ -457,11 +457,8 @@ public final class AggregationResultUtils {
 
         @Override
         public Object value(Aggregation aggregation, Map<String, String> fieldTypeMap, String lookupFieldPrefix) {
-            assert aggregation instanceof GeoShapeMetricAggregation : "Unexpected type ["
-                + aggregation.getClass().getName()
-                + "] for aggregation ["
-                + aggregation.getName()
-                + "]";
+            assert aggregation instanceof GeoShapeMetricAggregation
+                : "Unexpected type [" + aggregation.getClass().getName() + "] for aggregation [" + aggregation.getName() + "]";
             return ((GeoShapeMetricAggregation) aggregation).geoJSONGeometry();
         }
     }

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/pivot/AggregationResultUtils.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/pivot/AggregationResultUtils.java
@@ -34,6 +34,7 @@ import org.elasticsearch.search.aggregations.metrics.ScriptedMetric;
 import org.elasticsearch.xpack.core.spatial.search.aggregations.GeoShapeMetricAggregation;
 import org.elasticsearch.xpack.core.transform.TransformField;
 import org.elasticsearch.xpack.core.transform.transforms.TransformIndexerStats;
+import org.elasticsearch.xpack.core.transform.transforms.TransformProgress;
 import org.elasticsearch.xpack.core.transform.transforms.pivot.GeoTileGroupSource;
 import org.elasticsearch.xpack.core.transform.transforms.pivot.GroupConfig;
 import org.elasticsearch.xpack.core.transform.transforms.pivot.SingleGroupSource;
@@ -98,10 +99,16 @@ public final class AggregationResultUtils {
         Collection<PipelineAggregationBuilder> pipelineAggs,
         Map<String, String> fieldTypeMap,
         TransformIndexerStats stats,
+        TransformProgress progress,
         boolean datesAsEpoch
     ) {
         return agg.getBuckets().stream().map(bucket -> {
             stats.incrementNumDocuments(bucket.getDocCount());
+            if (progress != null) {
+                progress.incrementDocsProcessed(bucket.getDocCount());
+                progress.incrementDocsIndexed(1L);
+            }
+
             Map<String, Object> document = new HashMap<>();
             // generator to create unique but deterministic document ids, so we
             // - do not create duplicates if we re-run after failure

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/pivot/Pivot.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/pivot/Pivot.java
@@ -29,6 +29,7 @@ import org.elasticsearch.xpack.core.transform.TransformMessages;
 import org.elasticsearch.xpack.core.transform.transforms.SettingsConfig;
 import org.elasticsearch.xpack.core.transform.transforms.SourceConfig;
 import org.elasticsearch.xpack.core.transform.transforms.TransformIndexerStats;
+import org.elasticsearch.xpack.core.transform.transforms.TransformProgress;
 import org.elasticsearch.xpack.core.transform.transforms.pivot.PivotConfig;
 import org.elasticsearch.xpack.core.transform.transforms.pivot.SingleGroupSource;
 import org.elasticsearch.xpack.transform.Transform;
@@ -127,7 +128,8 @@ public class Pivot extends AbstractCompositeAggFunction {
     protected Stream<Map<String, Object>> extractResults(
         CompositeAggregation agg,
         Map<String, String> fieldTypeMap,
-        TransformIndexerStats transformIndexerStats
+        TransformIndexerStats transformIndexerStats,
+        TransformProgress transformProgress
     ) {
         // defines how dates are written, if not specified in settings
         // < 7.11 as epoch millis
@@ -144,6 +146,7 @@ public class Pivot extends AbstractCompositeAggFunction {
             config.getAggregationConfig().getPipelineAggregatorFactories(),
             fieldTypeMap,
             transformIndexerStats,
+            transformProgress,
             datesAsEpoch
         );
     }

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/TransformIndexerFailureHandlingTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/TransformIndexerFailureHandlingTests.java
@@ -66,6 +66,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 
 import static java.util.Collections.singletonList;
 import static org.elasticsearch.xpack.core.transform.transforms.DestConfigTests.randomDestConfig;
@@ -415,7 +416,7 @@ public class TransformIndexerFailureHandlingTests extends ESTestCase {
         );
 
         IterationResult<TransformIndexerPosition> newPosition = indexer.doProcess(searchResponse);
-        assertThat(newPosition.getToIndex(), is(empty()));
+        assertThat(newPosition.getToIndex().collect(Collectors.toList()), is(empty()));
         assertThat(newPosition.getPosition(), is(nullValue()));
         assertThat(newPosition.isDone(), is(true));
     }

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/TransformIndexerStateTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/TransformIndexerStateTests.java
@@ -232,7 +232,11 @@ public class TransformIndexerStateTests extends ESTestCase {
         protected IterationResult<TransformIndexerPosition> doProcess(SearchResponse searchResponse) {
             // pretend that we processed 10k documents for each call
             getStats().incrementNumDocuments(10_000);
-            return new IterationResult<>(Collections.singletonList(new IndexRequest()), new TransformIndexerPosition(null, null), false);
+            return new IterationResult<>(
+                Collections.singletonList(new IndexRequest()).stream(),
+                new TransformIndexerPosition(null, null),
+                false
+            );
         }
 
         public boolean waitingForNextSearch() {

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/TransformIndexerStateTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/TransformIndexerStateTests.java
@@ -63,6 +63,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
+import java.util.stream.Stream;
 
 import static org.elasticsearch.xpack.core.transform.transforms.DestConfigTests.randomDestConfig;
 import static org.elasticsearch.xpack.core.transform.transforms.SourceConfigTests.randomSourceConfig;
@@ -233,7 +234,7 @@ public class TransformIndexerStateTests extends ESTestCase {
             // pretend that we processed 10k documents for each call
             getStats().incrementNumDocuments(10_000);
             return new IterationResult<>(
-                Collections.singletonList(new IndexRequest()).stream(),
+                Stream.of(new IndexRequest()),
                 new TransformIndexerPosition(null, null),
                 false
             );

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/TransformIndexerTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/TransformIndexerTests.java
@@ -247,7 +247,7 @@ public class TransformIndexerTests extends ESTestCase {
             // pretend that we processed 10k documents for each call
             getStats().incrementNumDocuments(10_000);
             return new IterationResult<>(
-                Collections.singletonList(new IndexRequest()),
+                Collections.singletonList(new IndexRequest()).stream(),
                 new TransformIndexerPosition(null, null),
                 numberOfLoops == 0
             );

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/TransformIndexerTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/TransformIndexerTests.java
@@ -60,6 +60,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
+import java.util.stream.Stream;
 
 import static org.elasticsearch.xpack.core.transform.transforms.DestConfigTests.randomDestConfig;
 import static org.elasticsearch.xpack.core.transform.transforms.SourceConfigTests.randomSourceConfig;
@@ -247,7 +248,7 @@ public class TransformIndexerTests extends ESTestCase {
             // pretend that we processed 10k documents for each call
             getStats().incrementNumDocuments(10_000);
             return new IterationResult<>(
-                Collections.singletonList(new IndexRequest()).stream(),
+                Stream.of(new IndexRequest()),
                 new TransformIndexerPosition(null, null),
                 numberOfLoops == 0
             );

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/pivot/AggregationResultUtilsTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/pivot/AggregationResultUtilsTests.java
@@ -1100,6 +1100,7 @@ public class AggregationResultUtilsTests extends ESTestCase {
                 pipelineAggregationBuilders,
                 fieldTypeMap,
                 stats,
+                null,
                 true
             ).collect(Collectors.toList());
         }

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/pivot/AggregationResultUtilsTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/pivot/AggregationResultUtilsTests.java
@@ -7,12 +7,12 @@
 
 package org.elasticsearch.xpack.transform.transforms.pivot;
 
-import org.elasticsearch.common.xcontent.ParseField;
 import org.elasticsearch.common.geo.GeoPoint;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.xcontent.ContextParser;
 import org.elasticsearch.common.xcontent.DeprecationHandler;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
+import org.elasticsearch.common.xcontent.ParseField;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.common.xcontent.XContentParser;

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/pivot/AggregationResultUtilsTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/pivot/AggregationResultUtilsTests.java
@@ -66,6 +66,7 @@ import org.elasticsearch.search.aggregations.pipeline.StatsBucketPipelineAggrega
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.core.transform.TransformField;
 import org.elasticsearch.xpack.core.transform.transforms.TransformIndexerStats;
+import org.elasticsearch.xpack.core.transform.transforms.TransformProgress;
 import org.elasticsearch.xpack.core.transform.transforms.pivot.GroupConfig;
 import org.elasticsearch.xpack.transform.transforms.pivot.AggregationResultUtils.BucketKeyExtractor;
 
@@ -647,6 +648,7 @@ public class AggregationResultUtilsTests extends ESTestCase {
             )
         );
         TransformIndexerStats stats = new TransformIndexerStats();
+        TransformProgress progress = new TransformProgress();
 
         Map<String, String> fieldTypeMap = asStringMap(aggName, "double", targetField, "keyword", targetField2, "keyword");
 
@@ -656,7 +658,8 @@ public class AggregationResultUtilsTests extends ESTestCase {
             Collections.emptyList(),
             inputFirstRun,
             fieldTypeMap,
-            stats
+            stats,
+            progress
         );
         List<Map<String, Object>> resultSecondRun = runExtraction(
             groupBy,
@@ -664,7 +667,8 @@ public class AggregationResultUtilsTests extends ESTestCase {
             Collections.emptyList(),
             inputSecondRun,
             fieldTypeMap,
-            stats
+            stats,
+            progress
         );
 
         assertNotEquals(resultFirstRun, resultSecondRun);
@@ -1057,6 +1061,7 @@ public class AggregationResultUtilsTests extends ESTestCase {
         long expectedDocCounts
     ) throws IOException {
         TransformIndexerStats stats = new TransformIndexerStats();
+        TransformProgress progress = new TransformProgress();
         XContentBuilder builder = XContentFactory.contentBuilder(randomFrom(XContentType.values()));
         builder.map(input);
 
@@ -1066,7 +1071,8 @@ public class AggregationResultUtilsTests extends ESTestCase {
             pipelineAggregationBuilders,
             input,
             fieldTypeMap,
-            stats
+            stats,
+            progress
         );
 
         // remove the document ids and test uniqueness
@@ -1085,7 +1091,8 @@ public class AggregationResultUtilsTests extends ESTestCase {
         Collection<PipelineAggregationBuilder> pipelineAggregationBuilders,
         Map<String, Object> input,
         Map<String, String> fieldTypeMap,
-        TransformIndexerStats stats
+        TransformIndexerStats stats,
+        TransformProgress progress
     ) throws IOException {
 
         XContentBuilder builder = XContentFactory.contentBuilder(randomFrom(XContentType.values()));
@@ -1100,7 +1107,7 @@ public class AggregationResultUtilsTests extends ESTestCase {
                 pipelineAggregationBuilders,
                 fieldTypeMap,
                 stats,
-                null,
+                progress,
                 true
             ).collect(Collectors.toList());
         }


### PR DESCRIPTION
Remove an unnecessary indirection and refactor progress tracking. Both rollup and transform process documents as stream, however in the `AsyncTwoPhaseIndexer` takes a `List` of index requests. This change removes the unnecessary temporary container. This simplification makes upcoming transform enhancements easier.

Main changes are in https://github.com/elastic/elasticsearch/commit/15afd31d3b4cd3375f5b02743202a56f822fb4ef
The 2nd commit only applies spotless formatting to files belonging to the transform codebase.