### PR TITLE
[7.x] [DOCS] Document  dimension mapping parameter (#75414)

### DIFF
--- a/docs/reference/index-modules.asciidoc
+++ b/docs/reference/index-modules.asciidoc
@@ -329,6 +329,13 @@ Defaults to `*`, which matches all fields eligible for
     the default pipeline (if it exists). The special pipeline name `_none`
     indicates no ingest pipeline will run.
 
+[[index-mapping-dimension-fields-limit]]
+`index.mapping.dimension_fields.limit`::
+For internal use by {kib} only. Maximum number of time series dimensions for the
+index. Defaults to `16`.
++
+You can mark a field as a dimension using the `dimension` mapping parameter.
+
 [discrete]
 === Settings in other index modules
 

--- a/docs/reference/mapping/types/ip.asciidoc
+++ b/docs/reference/mapping/types/ip.asciidoc
@@ -50,6 +50,8 @@ The following parameters are accepted by `ip` fields:
     Mapping field-level query time boosting. Accepts a floating point number, defaults
     to `1.0`.
 
+include::keyword.asciidoc[tag=dimension]
+
 <<doc-values,`doc_values`>>::
 
     Should the field be stored on disk in a column-stride fashion, so that it

--- a/docs/reference/mapping/types/keyword.asciidoc
+++ b/docs/reference/mapping/types/keyword.asciidoc
@@ -61,6 +61,22 @@ The following parameters are accepted by `keyword` fields:
     Mapping field-level query time boosting. Accepts a floating point number, defaults
     to `1.0`.
 
+// tag::dimension[]
+`dimension`::
+For internal use by {kib} only. Marks the field as a time series dimension.
+Accepts `true` or `false` (default).
++
+The <<index-mapping-dimension-fields-limit,`index.mapping.dimension_fields.limit`>>
+index setting limits the number of dimensions in an index.
++
+Dimension fields have the following constraints:
++
+* The `doc_values` and `index` mapping parameters must be `true`.
+* Field values cannot be an <<array,array or multi-value>>.
+// end::dimension[]
+* Field values cannot be larger than 1024 bytes.
+* The field cannot use a <<normalizer,`normalizer`>>.
+
 <<doc-values,`doc_values`>>::
 
     Should the field be stored on disk in a column-stride fashion, so that it

--- a/docs/reference/mapping/types/numeric.asciidoc
+++ b/docs/reference/mapping/types/numeric.asciidoc
@@ -124,6 +124,11 @@ The following parameters are accepted by numeric types:
     Mapping field-level query time boosting. Accepts a floating point number, defaults
     to `1.0`.
 
+include::keyword.asciidoc[tag=dimension]
++
+Of the numeric field types, only `byte`, `short`, `integer`, and `long` fields
+support this parameter.
+
 <<doc-values,`doc_values`>>::
 
     Should the field be stored on disk in a column-stride fashion, so that it


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [DOCS] Document time series dimension mapping parameters (#75414)