### PR TITLE
Align XCombinedFieldQuery with latest Lucene changes

### DIFF
--- a/server/src/main/java/org/apache/lucene/search/XCombinedFieldQuery.java
+++ b/server/src/main/java/org/apache/lucene/search/XCombinedFieldQuery.java
@@ -18,6 +18,8 @@
  */
 package org.apache.lucene.search;
 
+import org.apache.lucene.index.FieldInfo;
+import org.apache.lucene.index.FieldInfos;
 import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.PostingsEnum;
@@ -68,6 +70,9 @@ import java.util.TreeMap;
  * be encoded using {@link SmallFloat#intToByte4}. These requirements hold for all similarities that
  * compute norms the same way as {@link SimilarityBase#computeNorm}, which includes {@link
  * BM25Similarity} and {@link DFRSimilarity}. Per-field similarities are not supported.
+ *
+ * <p>The query also requires that either all fields or no fields have norms enabled. Having only
+ * some fields with norms enabled can result in errors.
  *
  * <p>The scoring is based on BM25F's simple formula described in:
  * http://www.staff.city.ac.uk/~sb317/papers/foundations_bm25_review.pdf. This query implements the
@@ -264,12 +269,36 @@ public final class XCombinedFieldQuery extends Query implements Accountable {
   @Override
   public Weight createWeight(IndexSearcher searcher, ScoreMode scoreMode, float boost)
       throws IOException {
+    validateConsistentNorms(searcher.getIndexReader());
     if (scoreMode.needsScores()) {
       return new CombinedFieldWeight(this, searcher, scoreMode, boost);
     } else {
       // rewrite to a simple disjunction if the score is not needed.
       Query bq = rewriteToBoolean();
       return searcher.rewrite(bq).createWeight(searcher, ScoreMode.COMPLETE_NO_SCORES, boost);
+    }
+  }
+
+   private void validateConsistentNorms(IndexReader reader) {
+    boolean allFieldsHaveNorms = true;
+    boolean noFieldsHaveNorms = true;
+
+    for (LeafReaderContext context : reader.leaves()) {
+      FieldInfos fieldInfos = context.reader().getFieldInfos();
+      for (String field : fieldAndWeights.keySet()) {
+        FieldInfo fieldInfo = fieldInfos.fieldInfo(field);
+        if (fieldInfo != null) {
+          allFieldsHaveNorms &= fieldInfo.hasNorms();
+          noFieldsHaveNorms &= fieldInfo.omitsNorms();
+        }
+      }
+    }
+
+    if (allFieldsHaveNorms == false && noFieldsHaveNorms == false) {
+      throw new IllegalArgumentException(
+          getClass().getSimpleName()
+              + " requires norms to be consistent across fields: some fields cannot "
+              + " have norms enabled, while others have norms disabled");
     }
   }
 

--- a/server/src/main/java/org/apache/lucene/search/XMultiNormsLeafSimScorer.java
+++ b/server/src/main/java/org/apache/lucene/search/XMultiNormsLeafSimScorer.java
@@ -34,8 +34,9 @@ import java.util.Objects;
  * Copy of {@link MultiNormsLeafSimScorer} that contains a fix for LUCENE-9999.
  * TODO: remove once LUCENE-9999 is fixed and integrated
  *
- * <p>This scorer requires that either all fields or no fields have norms enabled. It will throw an
- * error if some fields have norms enabled, while others have norms disabled.
+ * <p>For all fields, norms must be encoded using {@link SmallFloat#intToByte4}. This scorer also
+ * requires that either all fields or no fields have norms enabled. Having only some fields with
+ * norms enabled can result in errors or undefined behavior.
  */
 final class XMultiNormsLeafSimScorer {
   /** Cache of decoded norms. */
@@ -67,13 +68,6 @@ final class XMultiNormsLeafSimScorer {
           normsList.add(norms);
           weightList.add(field.weight);
         }
-      }
-
-      if (normsList.isEmpty() == false && normsList.size() != normFields.size()) {
-        throw new IllegalArgumentException(
-            getClass().getSimpleName()
-                + " requires norms to be consistent across fields: some fields cannot"
-                + " have norms enabled, while others have norms disabled");
       }
 
       if (normsList.isEmpty()) {


### PR DESCRIPTION
In #74678 we released an early fix for a Lucene bug around `combined_fields`
queries with missing fields. This PR brings our fix up-to-date with what was
actually committed to Lucene.