### PR TITLE
[7.14] [DOCS] Add object subfield example for update API (#75460)

### DIFF
--- a/docs/reference/docs/update.asciidoc
+++ b/docs/reference/docs/update.asciidoc
@@ -102,19 +102,20 @@ include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=wait_for_active_shards
 First, let's index a simple doc:
 
 [source,console]
---------------------------------------------------
+----
 PUT test/_doc/1
 {
   "counter" : 1,
   "tags" : ["red"]
 }
---------------------------------------------------
+----
+// TESTSETUP
 
 To increment the counter, you can submit an update request with the
 following script:
 
 [source,console]
---------------------------------------------------
+----
 POST test/_update/1
 {
   "script" : {
@@ -125,14 +126,13 @@ POST test/_update/1
     }
   }
 }
---------------------------------------------------
-// TEST[continued]
+----
 
 Similarly, you could use and update script to add a tag to the list of tags
 (this is just a list, so the tag is added even it exists):
 
 [source,console]
---------------------------------------------------
+----
 POST test/_update/1
 {
   "script": {
@@ -143,8 +143,7 @@ POST test/_update/1
     }
   }
 }
---------------------------------------------------
-// TEST[continued]
+----
 
 You could also remove a tag from the list of tags. The Painless
 function to `remove` a tag takes the array index of the element
@@ -153,7 +152,7 @@ make sure the tag exists. If the list contains duplicates of the tag, this
 script just removes one occurrence.
 
 [source,console]
---------------------------------------------------
+----
 POST test/_update/1
 {
   "script": {
@@ -164,30 +163,51 @@ POST test/_update/1
     }
   }
 }
---------------------------------------------------
-// TEST[continued]
+----
 
 You can also add and remove fields from a document. For example, this script
 adds the field `new_field`:
 
 [source,console]
---------------------------------------------------
+----
 POST test/_update/1
 {
   "script" : "ctx._source.new_field = 'value_of_new_field'"
 }
---------------------------------------------------
-// TEST[continued]
+----
 
 Conversely, this script removes the field `new_field`:
 
 [source,console]
---------------------------------------------------
+----
 POST test/_update/1
 {
   "script" : "ctx._source.remove('new_field')"
 }
---------------------------------------------------
+----
+// TEST[continued]
+
+The following script removes a subfield from an object field:
+
+////
+[source,console]
+----
+PUT test/_doc/1?refresh
+{
+  "my-object": {
+    "my-subfield": true
+  }
+}
+----
+////
+
+[source,console]
+----
+POST test/_update/1
+{
+  "script": "ctx._source['my-object'].remove('my-subfield')"
+}
+----
 // TEST[continued]
 
 Instead of updating the document, you can also change the operation that is
@@ -195,7 +215,7 @@ executed from within the script. For example, this request deletes the doc if
 the `tags` field contains `green`, otherwise it does nothing (`noop`):
 
 [source,console]
---------------------------------------------------
+----
 POST test/_update/1
 {
   "script": {
@@ -206,8 +226,7 @@ POST test/_update/1
     }
   }
 }
---------------------------------------------------
-// TEST[continued]
+----
 
 [discrete]
 ===== Update part of a document
@@ -216,15 +235,14 @@ The following partial update adds a new field to the
 existing document:
 
 [source,console]
---------------------------------------------------
+----
 POST test/_update/1
 {
   "doc": {
     "name": "new_name"
   }
 }
---------------------------------------------------
-// TEST[continued]
+----
 
 If both `doc` and `script` are specified, then `doc` is ignored. If you
 specify a scripted update, include the fields you want to update in the script.
@@ -236,21 +254,21 @@ By default updates that don't change anything detect that they don't change
 anything and return `"result": "noop"`:
 
 [source,console]
---------------------------------------------------
+----
 POST test/_update/1
 {
   "doc": {
     "name": "new_name"
   }
 }
---------------------------------------------------
+----
 // TEST[continued]
 
 If the value of `name` is already `new_name`, the update
 request is ignored and the `result` element in the response returns `noop`:
 
 [source,console-result]
---------------------------------------------------
+----
 {
    "_shards": {
         "total": 0,
@@ -260,17 +278,17 @@ request is ignored and the `result` element in the response returns `noop`:
    "_index": "test",
    "_type": "_doc",
    "_id": "1",
-   "_version": 7,
+   "_version": 2,
    "_primary_term": 1,
-   "_seq_no": 6,
+   "_seq_no": 1,
    "result": "noop"
 }
---------------------------------------------------
+----
 
 You can disable this behavior by setting `"detect_noop": false`:
 
 [source,console]
---------------------------------------------------
+----
 POST test/_update/1
 {
   "doc": {
@@ -278,8 +296,7 @@ POST test/_update/1
   },
   "detect_noop": false
 }
---------------------------------------------------
-// TEST[continued]
+----
 
 [[upserts]]
 [discrete]
@@ -290,7 +307,7 @@ are inserted as a new document. If the document exists, the
 `script` is executed:
 
 [source,console]
---------------------------------------------------
+----
 POST test/_update/1
 {
   "script": {
@@ -304,8 +321,7 @@ POST test/_update/1
     "counter": 1
   }
 }
---------------------------------------------------
-// TEST[continued]
+----
 
 [discrete]
 [[scripted_upsert]]
@@ -315,7 +331,7 @@ To run the script whether or not the document exists, set `scripted_upsert` to
 `true`:
 
 [source,console]
---------------------------------------------------
+----
 POST sessions/_update/dh3sgudg8gsrgl
 {
   "scripted_upsert": true,
@@ -331,9 +347,8 @@ POST sessions/_update/dh3sgudg8gsrgl
   },
   "upsert": {}
 }
---------------------------------------------------
+----
 // TEST[s/"id": "my_web_session_summariser"/"source": "ctx._source.page_view_event = params.pageViewEvent"/]
-// TEST[continued]
 
 [discrete]
 [[doc_as_upsert]]
@@ -344,7 +359,7 @@ Instead of sending a partial `doc` plus an `upsert` doc, you can set
 value:
 
 [source,console]
---------------------------------------------------
+----
 POST test/_update/1
 {
   "doc": {
@@ -352,8 +367,8 @@ POST test/_update/1
   },
   "doc_as_upsert": true
 }
---------------------------------------------------
-// TEST[continued]
+----
+
 [NOTE]
 ====
 Using <<ingest,ingest pipelines>> with `doc_as_upsert` is not supported.


### PR DESCRIPTION
Backports the following commits to 7.14:
 - [DOCS] Add object subfield example for update API (#75460)