### PR TITLE
[7.8] [DOCS] Fix `expand_wildcards` default for snapshots (#75432)

### DIFF
--- a/docs/reference/snapshot-restore/take-snapshot.asciidoc
+++ b/docs/reference/snapshot-restore/take-snapshot.asciidoc
@@ -94,7 +94,7 @@ the snapshot.
 
 By default, the entire snapshot will fail if one or more indices participating in the snapshot do not have
 all primary shards available. You can change this behaviour by setting `partial` to `true`. The `expand_wildcards`
-option can be used to control whether hidden and closed indices will be included in the snapshot, and defaults to `all`.
+option can be used to control whether hidden and closed indices will be included in the snapshot, and defaults to `open,hidden`.
 
 Use the `metadata` field to attach arbitrary metadata to the snapshot,
 such as who took the snapshot,


### PR DESCRIPTION
Backports the following commits to 7.8:
 - [DOCS] Fix `expand_wildcards` default for snapshots (#75432)