### PR TITLE
[DOCS] Fixes nesting of datafeed config in APIs

### DIFF
--- a/docs/reference/ml/anomaly-detection/apis/get-job.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/get-job.asciidoc
@@ -139,7 +139,7 @@ include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=indices]
 (Optional, object)
 include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=indices-options]
 
-`job_id`::
+`job_id`:::
 (Required, string)
 include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=job-id-anomaly-detection]
 

--- a/docs/reference/ml/anomaly-detection/apis/get-job.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/get-job.asciidoc
@@ -84,7 +84,7 @@ property is informational; you cannot change its value.
 `datafeed_config`::
 (object) The {dfeed} configured for the current {anomaly-job}.
 +
-.Properties of `datafeed`
+.Properties of `datafeed_config`
 [%collapsible%open]
 ====
 `datafeed_id`:::
@@ -98,10 +98,34 @@ include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=aggregations]
 `chunking_config`:::
 (Optional, object)
 include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=chunking-config]
++
+.Properties of `chunking_config`
+[%collapsible%open]
+=====
+`mode`:::
+(string)
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=mode]
+
+`time_span`:::
+(<<time-units,time units>>)
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=time-span]
+=====
 
 `delayed_data_check_config`:::
 (Optional, object)
 include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=delayed-data-check-config]
++
+.Properties of `delayed_data_check_config`
+[%collapsible%open]
+=====
+`check_window`::
+(<<time-units,time units>>)
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=delayed-data-check-config-check-window]
+
+`enabled`::
+(Boolean)
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=delayed-data-check-config-enabled]
+=====
 
 `frequency`:::
 (Optional, <<time-units, time units>>)

--- a/docs/reference/ml/anomaly-detection/apis/put-datafeed.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/put-datafeed.asciidoc
@@ -65,10 +65,34 @@ include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=aggregations]
 `chunking_config`::
 (Optional, object)
 include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=chunking-config]
++
+.Properties of `chunking_config`
+[%collapsible%open]
+====
+`mode`:::
+(string)
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=mode]
+
+`time_span`:::
+(<<time-units,time units>>)
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=time-span]
+====
 
 `delayed_data_check_config`::
 (Optional, object)
 include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=delayed-data-check-config]
++
+.Properties of `delayed_data_check_config`
+[%collapsible%open]
+====
+`check_window`::
+(<<time-units,time units>>)
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=delayed-data-check-config-check-window]
+
+`enabled`::
+(Boolean)
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=delayed-data-check-config-enabled]
+====
 
 `frequency`::
 (Optional, <<time-units, time units>>)

--- a/docs/reference/ml/anomaly-detection/apis/put-job.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/put-job.asciidoc
@@ -251,12 +251,6 @@ include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=data-description]
 .Properties of `datafeed`
 [%collapsible%open]
 ====
-`datafeed_id`:::
-(Optional, string)
-include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=datafeed-id]
-+
-Defaults to the same ID as the {anomaly-job}.
-
 `aggregations`:::
 (Optional, object)
 include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=aggregations]
@@ -276,6 +270,12 @@ include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=mode]
 (<<time-units,time units>>)
 include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=time-span]
 =====
+
+`datafeed_id`:::
+(Optional, string)
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=datafeed-id]
++
+Defaults to the same ID as the {anomaly-job}.
 
 `delayed_data_check_config`:::
 (Optional, object)

--- a/docs/reference/ml/anomaly-detection/apis/put-job.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/put-job.asciidoc
@@ -235,6 +235,16 @@ include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=background-persist-interval]
 (Optional, object)
 include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=custom-settings]
 
+`daily_model_snapshot_retention_after_days`::
+(Optional, long)
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=daily-model-snapshot-retention-after-days]
+
+//Begin data_description
+[[put-datadescription]]`data_description`::
+(Required, object)
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=data-description]
+//End data_description
+
 `datafeed_config`::
 (object) The {dfeed} configured for the current {anomaly-job}.
 +
@@ -319,16 +329,6 @@ include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=script-fields]
 (Optional, unsigned integer)
 include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=scroll-size]
 ====
-
-//Begin data_description
-[[put-datadescription]]`data_description`::
-(Required, object)
-include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=data-description]
-//End data_description
-
-`daily_model_snapshot_retention_after_days`::
-(Optional, long)
-include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=daily-model-snapshot-retention-after-days]
 
 `description`::
   (Optional, string) A description of the job.

--- a/docs/reference/ml/anomaly-detection/apis/put-job.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/put-job.asciidoc
@@ -244,6 +244,7 @@ include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=custom-settings]
 `datafeed_id`:::
 (Optional, string)
 include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=datafeed-id]
++
 Defaults to the same ID as the {anomaly-job}.
 
 `aggregations`:::
@@ -253,10 +254,34 @@ include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=aggregations]
 `chunking_config`:::
 (Optional, object)
 include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=chunking-config]
++
+.Properties of `chunking_config`
+[%collapsible%open]
+=====
+`mode`:::
+(string)
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=mode]
+
+`time_span`:::
+(<<time-units,time units>>)
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=time-span]
+=====
 
 `delayed_data_check_config`:::
 (Optional, object)
 include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=delayed-data-check-config]
++
+.Properties of `delayed_data_check_config`
+[%collapsible%open]
+=====
+`check_window`::
+(<<time-units,time units>>)
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=delayed-data-check-config-check-window]
+
+`enabled`::
+(Boolean)
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=delayed-data-check-config-enabled]
+=====
 
 `frequency`:::
 (Optional, <<time-units, time units>>)

--- a/docs/reference/ml/anomaly-detection/apis/update-datafeed.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/update-datafeed.asciidoc
@@ -55,10 +55,34 @@ include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=aggregations]
 `chunking_config`::
 (Optional, object)
 include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=chunking-config]
++
+.Properties of `chunking_config`
+[%collapsible%open]
+====
+`mode`:::
+(string)
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=mode]
+
+`time_span`:::
+(<<time-units,time units>>)
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=time-span]
+====
 
 `delayed_data_check_config`::
 (Optional, object)
 include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=delayed-data-check-config]
++
+.Properties of `delayed_data_check_config`
+[%collapsible%open]
+====
+`check_window`::
+(<<time-units,time units>>)
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=delayed-data-check-config-check-window]
+
+`enabled`::
+(Boolean)
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=delayed-data-check-config-enabled]
+====
 
 `frequency`::
 (Optional, <<time-units, time units>>)

--- a/docs/reference/ml/ml-shared.asciidoc
+++ b/docs/reference/ml/ml-shared.asciidoc
@@ -296,18 +296,6 @@ tag::chunking-config[]
 months or years. This search is split into time chunks in order to ensure the
 load on {es} is managed. Chunking configuration controls how the size of these
 time chunks are calculated and is an advanced configuration option.
-+
-.Properties of `chunking_config`
-[%collapsible%open]
-====
-`mode`:::
-(string)
-include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=mode]
-
-`time_span`:::
-(<<time-units,time units>>)
-include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=time-span]
-====
 end::chunking-config[]
 
 tag::class-assignment-objective[]
@@ -468,22 +456,20 @@ that moment in time. See
 {ml-docs}/ml-delayed-data-detection.html[Working with delayed data].
 +
 This check runs only on real-time {dfeeds}.
-+
-.Properties of `delayed_data_check_config`
-[%collapsible%open]
-====
-`check_window`::
-(<<time-units,time units>>) The window of time that is searched for late data.
-This window of time ends with the latest finalized bucket. It defaults to
-`null`, which causes an appropriate `check_window` to be calculated when the
-real-time {dfeed} runs. In particular, the default `check_window` span
-calculation is based on the maximum of `2h` or `8 * bucket_span`.
-
-`enabled`::
-(Boolean) Specifies whether the {dfeed} periodically checks for delayed data.
-Defaults to `true`.
-====
 end::delayed-data-check-config[]
+
+tag::delayed-data-check-config-check-window[]
+The window of time that is searched for late data. This window of time ends with
+the latest finalized bucket. It defaults to `null`, which causes an appropriate
+`check_window` to be calculated when the real-time {dfeed} runs. In particular,
+the default `check_window` span calculation is based on the maximum of `2h` or
+`8 * bucket_span`.
+end::delayed-data-check-config-check-window[]
+
+tag::delayed-data-check-config-enabled[]
+Specifies whether the {dfeed} periodically checks for delayed data. Defaults to
+`true`.
+end::delayed-data-check-config-enabled[]
 
 tag::dependent-variable[]
 Defines which field of the document is to be predicted.


### PR DESCRIPTION
Related to https://github.com/elastic/elasticsearch/pull/74265
This PR fixes some problems with the nesting of datafeed configuration objects in the anomaly detection job APIs.

### Preview

https://elasticsearch_75502.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/ml-put-job.html

### Screenshots

#### Before

![image](https://user-images.githubusercontent.com/26471269/126233937-384c1be7-dc44-48d0-91f0-528ba710b013.png)

#### After

![image](https://user-images.githubusercontent.com/26471269/126237833-b3ea8f78-d40b-4071-be95-3110df7f491c.png)
