### PR TITLE
[ML] Adds missing properties to create anomaly detection job API spec

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/ml.put_job.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/ml.put_job.json
@@ -26,33 +26,44 @@
         }
       ]
     },
-    "params":{
+    "params":{},
+    "body":{
+      "description":"The job",
+      "required":true,
       "allow_lazy_open":{
         "type":"boolean",
-        "required":false
+        "required":false,
+        "default":false,
+        "description":"Advanced configuration option. Specifies whether this job can open when there is insufficient machine learning node capacity for it to be immediately assigned to a node. By default, a machine learning node with capacity to run the job cannot immediately be found, the open anomaly detection jobs API returns an error. However, this is also subject to the cluster-wide `xpack.ml.max_lazy_ml_nodes` setting. If this option is set to `true`, the open anomaly detection jobs API does not return an error and the job waits in the opening state until sufficient machine learning node capacity is available.",
       },
       "analysis_config":{
         "type":"object",
+        "description":"The analysis configuration, which specifies how to analyze the data. After you create a job, you cannot change the analysis configuration; all the properties are informational.",
         "required":true
       },
       "analysis_limits":{
         "type":"object",
+        "description":"Limits can be applied for the resources required to hold the mathematical models in memory. These limits are approximate and can be set per job. They do not control the memory used by other processes, for example the Elasticsearch Java processes.",
         "required":false
       },
       "background_persist_interval":{
         "type":"time",
+        "description":"Advanced configuration option. The time between each periodic persistence of the model. The default value is a randomized value between 3 to 4 hours, which avoids all jobs persisting at exactly the same time. The smallest allowed value is 1 hour.",
         "required":false
       },
       "custom_settings":{
         "type":"object",
+        "description":"Advanced configuration option. Contains custom meta data about the job.",
         "required":false
       },
       "daily_model_snapshot_retention_after_days":{
         "type":"long",
+        "description":"Advanced configuration option, which affects the automatic removal of old model snapshots for this job. It specifies a period of time (in days) after which only the first snapshot per day is retained. This period is relative to the timestamp of the most recent snapshot for this job. Valid values range from 0 to `model_snapshot_retention_days`. For new jobs, the default value is `1`. For jobs created before version 7.8.0, the default value matches `model_snapshot_retention_days`.",
         "required":false
       },
       "data_description":{
         "type":"object",
+        "description":"The data description defines the format of the input data when you send data to the job by using the post data API. Note that when configure a datafeed, these properties are automatically set. When data is received via the post data API, it is not stored in Elasticsearch. Only the results for anomaly detection are retained.",
         "required":true
       },
       "datafeed_config":{
@@ -60,33 +71,41 @@
         "required":false,
         "aggregations":{
           "type":"object",
+          "description":"If set, the datafeed performs aggregation searches. Support for aggregations is limited and should be used only with low cardinality data.",
           "required":false
         },
         "chunking_config":{
           "type":"object",
+          "description":"Datafeeds might be required to search over long time periods, for several months or years. This search is split into time chunks in order to ensure the load on Elasticsearch is managed. Chunking configuration controls how the size of these time chunks are calculated and is an advanced configuration option.",
           "required":false
         },
         "datafeed_id":{
           "type":"string",
+          "description":"A numerical character string that uniquely identifies the datafeed. This identifier can contain lowercase alphanumeric characters (a-z and 0-9), hyphens, and underscores. It must start and end with alphanumeric characters.",
           "required":false
         },
         "delayed_data_check_config":{
           "type":"object",
+          "description":"Specifies whether the datafeed checks for missing data and the size of the window. The datafeed can optionally search over indices that have already been read in an effort to determine whether any data has subsequently been added to the index. If missing data is found, it is a good indication that the query_delay option is set too low and the data is being indexed after the datafeed has passed that moment in time. This check runs only on real-time datafeeds.",
           "required":false
         },
         "frequency":{
           "type":"time",
-          "required":false
+          "required":false,
+          "description":"The interval at which scheduled queries are made while the datafeed runs in real time. The default value is either the bucket span for short bucket spans, or, for longer bucket spans, a sensible fraction of the bucket span. For example: 150s. When frequency is shorter than the bucket span, interim results for the last (partial) bucket are written then eventually overwritten by the full bucket results. If the datafeed uses aggregations, this value must be divisible by the interval of the date histogram aggregation."
         },
         "indices":{
           "type":"array",
+          "description":"An array of index names. Wildcards are supported.",
           "required":false
         }, 
         "indices_options" : {
           "type":"object",
           "required":false,
+          "description":"Specifies index expansion options that are used during search.",
           "allow_no_indices":{
             "type":"boolean",
+            "description":"",
             "description":"Ignore if the source indices expressions resolves to no concrete indices (default: true). Only set if datafeed_config is provided."
           },
           "expand_wildcards":{
@@ -109,50 +128,74 @@
             "description":"Ignore unavailable indexes (default: false). Only set if datafeed_config is provided."
           }
         },
+        "max_empty_searches":
+        {
+          "type":"integer",
+          "required":false,
+          "description":"If a real-time datafeed has never seen any data (including during any initial training period) then it will automatically stop itself and close its associated job after this many real-time searches that return no documents. In other words, it will stop after frequency times `max_empty_searches` of real-time operation. If not set then a datafeed with no end time that sees no data will remain started until it is explicitly stopped. By default, this setting is not set."
+        },
         "query":{
           "type":"object",
+          "description":"The Elasticsearch query domain-specific language (DSL). This value corresponds to the query object in an Elasticsearch search POST body. All the options that are supported by Elasticsearch can be used, as this object is passed verbatim to Elasticsearch. By default, this property has the following value: `{"match_all": {"boost": 1}}`.",
           "required":false 
         },
         "query_delay":{
           "type":"time",
+          "description":"The number of seconds behind real time that data is queried. For example, if data from 10:04 a.m. might not be searchable in Elasticsearch until 10:06 a.m., set this property to 120 seconds. The default value is randomly selected between 60s and 120s. This randomness improves the query performance when there are multiple jobs running on the same node.",
           "required":false
         },
         "runtime_mappings":{
           "type":"object",
+          "description":"Specifies runtime fields for the datafeed search.",
           "required":false
         },
         "script_fields":{
           "type":"object",
+          "description":"Specifies scripts that evaluate custom expressions and returns script fields to the datafeed. The detector configuration objects in a job can contain functions that use these script fields.",
           "required":false
         },
-        "scroll_size":{} 
+        "scroll_size":{
+          "type":"unsigned integer",
+          "required":false,
+          "default":"1000",
+          "description":"The size parameter that is used in Elasticsearch searches when the datafeed does not use aggregations. The maximum value is the value of `index.max_result_window` which is 10,000 by default."
+        } 
       },
       "description":{
         "type":"string",
+        "description":"A description of the job.",
         "required":false
       },
       "groups":{
         "type":"array of strings",
+        "description":"A list of job groups. A job can belong to no groups or many.",
         "required":false
       },
       "model_plot_config":{
         "type":"object",
+        "description":"This advanced configuration option stores model information along with the results. It provides a more detailed view into anomaly detection. If you enable model plot it can add considerable overhead to the performance of the system; it is not feasible for jobs with many entities. Model plot provides a simplified and indicative view of the model and its bounds. It does not display complex features such as multivariate correlations or multimodal data. As such, anomalies may occasionally be reported which cannot be seen in the model plot. Model plot config can be configured when the job is created or updated later. It must be disabled if performance issues are experienced.",
         "required":false
       },
       "model_snapshot_retention_days":{
         "type":"long",
+        "default":"10",
+        "description":"Advanced configuration option, which affects the automatic removal of old model snapshots for this job. It specifies the maximum period of time (in days) that snapshots are retained. This period is relative to the timestamp of the most recent snapshot for this job. By default, snapshots ten days older than the newest snapshot are deleted.",
         "required":false
       },
       "renormalization_window_days":{
         "type":"long",
+        "description":"Advanced configuration option. The period over which adjustments to the score are applied, as new data is seen. The default value is the longer of 30 days or 100 bucket spans.",
         "required":false
       },
       "results_index_name":{
         "type":"string",
+        "default":"shared",
+        "description":"A text string that affects the name of the machine learning results index. By default, it generates an index named .ml-anomalies-shared.",
         "required":false
       },
       "results_retention_days":{
         "type":"long",
+        "description":"Advanced configuration option. The period of time (in days) that results are retained. Age is calculated relative to the timestamp of the latest bucket result. If this property has a non-null value, once per day at 00:30 (server time), results that are the specified number of days older than the latest bucket result are deleted from Elasticsearch. The default value is null, which means all results are retained.",
         "required":false
       }
     }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/ml.put_job.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/ml.put_job.json
@@ -20,40 +20,141 @@
           "parts":{
             "job_id":{
               "type":"string",
-              "description":"The ID of the job to create"
+              "description":"Identifier for the anomaly detection job. This identifier can contain lowercase alphanumeric characters (a-z and 0-9), hyphens, and underscores. It must start and end with alphanumeric characters."
             }
           }
         }
       ]
     },
     "params":{
-      "ignore_unavailable":{
+      "allow_lazy_open":{
         "type":"boolean",
-        "description":"Ignore unavailable indexes (default: false). Only set if datafeed_config is provided."
+        "required":false
       },
-      "allow_no_indices":{
-        "type":"boolean",
-        "description":"Ignore if the source indices expressions resolves to no concrete indices (default: true). Only set if datafeed_config is provided."
+      "analysis_config":{
+        "type":"object",
+        "required":true
       },
-      "ignore_throttled":{
-        "type":"boolean",
-        "description":"Ignore indices that are marked as throttled (default: true). Only set if datafeed_config is provided."
+      "analysis_limits":{
+        "type":"object",
+        "required":false
       },
-      "expand_wildcards":{
-        "type":"enum",
-        "options":[
-          "open",
-          "closed",
-          "hidden",
-          "none",
-          "all"
-        ],
-        "description":"Whether source index expressions should get expanded to open or closed indices (default: open). Only set if datafeed_config is provided."
+      "background_persist_interval":{
+        "type":"time",
+        "required":false
+      },
+      "custom_settings":{
+        "type":"object",
+        "required":false
+      },
+      "daily_model_snapshot_retention_after_days":{
+        "type":"long",
+        "required":false
+      },
+      "data_description":{
+        "type":"object",
+        "required":true
+      },
+      "datafeed_config":{
+        "type":"object",
+        "required":false,
+        "aggregations":{
+          "type":"object",
+          "required":false
+        },
+        "chunking_config":{
+          "type":"object",
+          "required":false
+        },
+        "datafeed_id":{
+          "type":"string",
+          "required":false
+        },
+        "delayed_data_check_config":{
+          "type":"object",
+          "required":false
+        },
+        "frequency":{
+          "type":"time",
+          "required":false
+        },
+        "indices":{
+          "type":"array",
+          "required":false
+        }, 
+        "indices_options" : {
+          "type":"object",
+          "required":false,
+          "allow_no_indices":{
+            "type":"boolean",
+            "description":"Ignore if the source indices expressions resolves to no concrete indices (default: true). Only set if datafeed_config is provided."
+          },
+          "expand_wildcards":{
+            "type":"enum",
+            "options":[
+              "open",
+              "closed",
+              "hidden",
+              "none",
+              "all"
+            ],
+            "description":"Whether source index expressions should get expanded to open or closed indices (default: open). Only set if datafeed_config is provided."
+          },
+          "ignore_throttled":{
+            "type":"boolean",
+            "description":"Ignore indices that are marked as throttled (default: true). Only set if datafeed_config is provided."
+          },
+          "ignore_unavailable":{
+            "type":"boolean",
+            "description":"Ignore unavailable indexes (default: false). Only set if datafeed_config is provided."
+          }
+        },
+        "query":{
+          "type":"object",
+          "required":false 
+        },
+        "query_delay":{
+          "type":"time",
+          "required":false
+        },
+        "runtime_mappings":{
+          "type":"object",
+          "required":false
+        },
+        "script_fields":{
+          "type":"object",
+          "required":false
+        },
+        "scroll_size":{} 
+      },
+      "description":{
+        "type":"string",
+        "required":false
+      },
+      "groups":{
+        "type":"array of strings",
+        "required":false
+      },
+      "model_plot_config":{
+        "type":"object",
+        "required":false
+      },
+      "model_snapshot_retention_days":{
+        "type":"long",
+        "required":false
+      },
+      "renormalization_window_days":{
+        "type":"long",
+        "required":false
+      },
+      "results_index_name":{
+        "type":"string",
+        "required":false
+      },
+      "results_retention_days":{
+        "type":"long",
+        "required":false
       }
-    },
-    "body":{
-      "description":"The job",
-      "required":true
     }
   }
 }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/ml.put_job.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/ml.put_job.json
@@ -26,10 +26,7 @@
         }
       ]
     },
-    "params":{},
     "body":{
-      "description":"The job",
-      "required":true,
       "allow_lazy_open":{
         "type":"boolean",
         "required":false,
@@ -39,12 +36,186 @@
       "analysis_config":{
         "type":"object",
         "description":"The analysis configuration, which specifies how to analyze the data. After you create a job, you cannot change the analysis configuration; all the properties are informational.",
-        "required":true
+        "required":true,
+        "bucket_span":{
+          "type":"time",
+          "default":"5m",
+          "description":"The size of the interval that the analysis is aggregated into, typically between `5m` and `1h`. If the anomaly detection job uses a datafeed with aggregations, this value must be divisible by the interval of the date histogram aggregation."
+        },
+        "categorization_analyzer":{
+          "type":"object or string",
+          "description":"If `categorization_field_name` is specified, you can also define the analyzer that is used to interpret the categorization field. This property cannot be used at the same time as `categorization_filters`. The categorization analyzer specifies how the `categorization_field` is interpreted by the categorization process. The `categorization_analyzer` field can be specified either as a string or as an object. If it is a string it must refer to a built-in analyzer or one added by another plugin.",
+          "char_filter":{
+            "type":"array of strings or objects",
+            "required":false,
+            "description":"One or more character filters. In addition to the built-in character filters, other plugins can provide more character filters. If it is not specified, no character filters are applied prior to categorization. If you are customizing some other aspect of the analyzer and you need to achieve the equivalent of   `categorization_filters` (which are not permitted when some other aspect of the analyzer is customized), add them here as pattern replace character filters."
+          },
+          "tokenizer":{
+            "type":"string or object",
+            "description":"The name or definition of the tokenizer to use after character filters are applied. This property is compulsory if `categorization_analyzer` is specified as an object. Machine learning provides a tokenizer called `ml_standard` that tokenizes in a way that has been determined to produce good categorization results on a variety of log file formats for logs in English. If you want to use that tokenizer but change the character or token filters, specify `tokenizer: ml_standard` in your `categorization_analyzer`. Additionally, the `ml_classic` tokenizer is available, which tokenizes in the same way as the non-customizable tokenizer in old versions of the product (before 6.2). `ml_classic` was the default categorization tokenizer in versions 6.2 to 7.13, so if you need categorization identical to the default for jobs created in these versions, specify `tokenizer: ml_classic` in your categorization_analyzer."
+          },
+          "filter":{
+            "type":"array of strings or objects",
+            "required":false,
+            "description":"One or more token filters. In addition to the built-in token filters, other plugins can provide more token filters. If it is not specified, no token filters are applied prior to categorization."
+          }
+        },
+        "categorization_field_name":{
+          "type":"string",
+          "description":"If this property is specified, the values of the specified field will be categorized. The resulting categories must be used in a detector by setting `by_field_name`, `over_field_name`, or `partition_field_name` to the keyword `mlcategory`. "
+        },
+        "categorization_filters":{
+          "type":"array of strings",
+          "description":"If `categorization_field_name` is specified, you can also define optional filters. This property expects an array of regular expressions. The expressions are used to filter out matching sequences from the categorization field values. You can use this functionality to fine tune the categorization by excluding sequences from consideration when categories are defined. For example, you can exclude SQL statements that appear in your log files. This property cannot be used at the same time as `categorization_analyzer`. If you only want to define simple regular expression filters that are applied prior to tokenization, setting this property is the easiest method. If you also want to customize the tokenizer or post-tokenization filtering, use the `categorization_analyzer` property instead and include the filters as `pattern_replace` character filters. The effect is exactly the same."
+        },
+        "detectors":{
+          "type":"array",
+          "description":"An array of detector configuration objects. Detector configuration objects specify which data fields a job analyzes. They also specify which analytical functions are used. You can specify multiple detectors for a job. If the detectors array does not contain at least one detector, no analysis can occur and an error is returned.",
+          "by_field_name":{
+            "type":"string",
+            "description":"The field used to split the data. In particular, this property is used for analyzing the splits with respect to their own history. It is used for finding unusual values in the context of the split."
+          },
+          "custom_rules":{
+            "type":"array",
+            "description":"An array of custom rule objects, which enable you to customize the way detectors operate. For example, a rule may dictate to the detector conditions under which results should be skipped. Kibana refers to custom rules as job rules.",
+            "actions":{
+              "description":"The set of actions to be triggered when the rule applies. If more than one action is specified the effects of all actions are combined.",
+              "default":"skip_result",
+              "type":"enum",
+              "options":[
+                "skip_result",
+                "skip_model_update"
+              ],
+            },
+            "conditions":{
+              "description":"An optional array of numeric conditions when the rule applies. A rule must either have a non-empty scope or at least one condition. Multiple conditions are combined together with a logical AND.",
+              "applies_to":{
+                "description":"Specifies the result property to which the condition applies. If your detector uses lat_long, metric, rare, or freq_rare functions, you can only specify conditions that apply to time.",
+                "type":"enum",
+                "options":[
+                  "actual",
+                  "typical",
+                  "diff_from_typical",
+                  "time"
+                ]
+              },
+              "operator":{
+                "description":"Specifies the condition operator.  The available options are gt (greater than), gte (greater than or equals), lt (less than) and lte (less than or equals).",
+                "type":"enum",
+                "options":[
+                  "gt",
+                  "gte",
+                  "lt",
+                  "lte"
+                ]
+              },
+              "value":{
+                "type":"double",
+                "description":"The value that is compared against the `applies_to` field using the `operator`."
+              }
+            },
+            "scope":{
+              "type":"object",
+              "description":"An optional scope of series where the rule applies. A rule must either have a non-empty scope or at least one condition. By default, the scope includes all series. Scoping is allowed for any of the fields that are also specified in `by_field_name`, `over_field_name`, or `partition_field_name`.",
+              "filter_id":{
+                "type":"string",
+                "description":"The identifier of the filter."
+              },
+              "filter_type":{
+                "description":"If set to `include`, the rule applies for values in the filter. If set to `exclude`,the rule applies for values not in the filter.",
+                "default":"include",
+                "type":"enum",
+                "options":[
+                  "include",
+                  "exclude"
+                ]
+              }
+            }
+          },
+          "detector_description":{
+            "type":"string",
+            "description":"A description of the detector. "
+          },
+          "detector_index":{
+            "type":"integer",
+            "description":"A unique identifier for the detector. This identifier is based on the order of the detectors in the `analysis_config`, starting at zero. If you specify a value for this property, it is ignored."
+          },
+          "exclude_frequent":{
+            "description":"If set, frequent entities are excluded from influencing the anomaly results. Entities can be considered frequent over time or frequent in a population. If you are working with both over and by fields, then you can set `exclude_frequent` to `all` for both fields, or to `by` or `over` for those specific fields.",
+            "type":"enum",
+            "options":[
+               "all",
+               "none",
+                "by",
+                "over"
+              ]
+          },
+          "field_name":{
+            "type":"string",
+            "description":"The field that the detector uses in the function. If you use an event rate function such as count or rare, do not specify this field. The field_name cannot contain double quotes or backslashes."
+          },
+          "function":{
+            "type":"string",
+            "description":"The analysis function that is used."
+          },
+          "over_field_name":{
+            "type":"string",
+            "desription":"The field used to split the data. In particular, this property is used for analyzing the splits with respect to the history of all splits. It is used for finding unusual values in the population of all splits. "
+          },
+          "partition_field_name":{
+            "type":"string",
+            "description":"The field used to segment the analysis. When you use this property, you have completely independent baselines for each value of this field."
+          },
+          "use_null":{
+            "type":"boolean",
+            "default":false,
+            "description":"Defines whether a new series is used as the null series when there is no value for the by or partition fields."
+          }
+        },
+        "influencers":{
+          "type":"array of strings",
+          "description":"A comma separated list of influencer field names. Typically these can be the by, over, or partition fields that are used in the detector configuration. You might also want to use a field name that is not specifically named in a detector, but is available as part of the input data. When you use multiple detectors, the use of influencers is recommended as it aggregates results for each influencer entity."
+        },
+        "latency":{
+          "type":"time",
+          "default":"0",
+          "description":"The size of the window in which to expect data that is out of time order. If you specify a non-zero value, it must be greater than or equal to one second. Latency is only applicable when you send data by using the post data API."
+        },
+        "multivariate_by_fields":{
+          "type":"boolean",
+          "description":"This functionality is reserved for internal use. It is not supported for use in customer environments and is not subject to the support SLA of official GA features. If set to true, the analysis will automatically find correlations between metrics for a given by field value and report anomalies when those correlations cease to hold. For example, suppose CPU and memory usage on host A is usually highly correlated with the same metrics on host B. Perhaps this correlation occurs because they are running a load-balanced application. If you enable this property, then anomalies will be reported when, for example, CPU usage on host A is high and the value of CPU usage on host B is low. That is to say, you’ll see an anomaly when the CPU of host A is unusual given the CPU of host B. To use the multivariate_by_fields property, you must also specify `by_field_name` in your detector."
+        },
+        "per_partition_categorization":{
+          "type":"object",
+          "required":false,
+          "description":"Settings related to how categorization interacts with partition fields.",
+          "enabled":{
+            "type":"boolean",
+            "description":"To enable this setting, you must also set the `partition_field_name` property to the same value in every detector that uses the keyword `mlcategory`. Otherwise, job creation fails."
+          },
+          "stop_on_warn":{
+            "type":"boolean",
+            "description":"This setting can be set to true only if per-partition categorization is enabled. If true, both categorization and subsequent anomaly detection stops for partitions where the categorization status changes to warn. This setting makes it viable to have a job where it is expected that categorization works well for some partitions but not others; you do not pay the cost of bad categorization forever in the partitions where it works badly."
+          }
+        },
+        "summary_count_field_name":{
+          "type":"string",
+          "description":"If this property is specified, the data that is fed to the job is expected to be pre-summarized. This property value is the name of the field that contains the count of raw data points that have been summarized. The same `summary_count_field_name` applies to all detectors in the job. NOTE: The `summary_count_field_name` property cannot be used with the metric function."
+        }
       },
       "analysis_limits":{
         "type":"object",
         "description":"Limits can be applied for the resources required to hold the mathematical models in memory. These limits are approximate and can be set per job. They do not control the memory used by other processes, for example the Elasticsearch Java processes.",
-        "required":false
+        "required":false,
+        "categorization_examples_limit":{
+          "type":"long",
+          "default":"4",
+          "description":"The maximum number of examples stored per category in memory and in the results data store. If you increase this value, more examples are available, however it requires that you have more storage available. If you set this value to 0, no examples are stored. The categorization_examples_limit only applies to analysis that uses categorization."
+        },
+        "model_memory_limit":{
+          "type":"long or string",
+          "description":"The approximate maximum amount of memory resources that are required for analytical processing. Once this limit is approached, data pruning becomes more aggressive. Upon exceeding this limit, new entities are not modeled. The default value for jobs created in version 6.1 and later is `1024mb`. If the `xpack.ml.max_model_memory_limit` setting has a value greater than `0` and less than `1024mb`, however, that value is used instead. The default value is relatively small to ensure that high resource usage is a conscious decision. If you have jobs that are expected to analyze high cardinality fields, you will likely need to use a higher value. If you specify a number instead of a string, the units are assumed to be MiB. Specifying a string is recommended for clarity. If you specify a byte size unit of `b` or `kb` and the number does not equate to a discrete number of megabytes, it is rounded down to the closest MiB. The minimum valid value is 1 MiB. If you specify a value less than 1 MiB, an error occurs. If you specify a value for the `xpack.ml.max_model_memory_limit` setting, an error occurs when you try to create jobs that have `model_memory_limit` values greater than that setting value."
+        }
       },
       "background_persist_interval":{
         "type":"time",
@@ -64,7 +235,21 @@
       "data_description":{
         "type":"object",
         "description":"The data description defines the format of the input data when you send data to the job by using the post data API. Note that when configure a datafeed, these properties are automatically set. When data is received via the post data API, it is not stored in Elasticsearch. Only the results for anomaly detection are retained.",
-        "required":true
+        "required":true,
+        "format":{
+          "type":"string",
+          "description":"Only JSON format is supported at this time."
+        },
+        "time_field":{
+          "type":"string",
+          "default":"time",
+          "description":"The name of the field that contains the timestamp."
+        },
+        "time_format":{
+          "type":"string",
+          "default":"epoch",
+          "description":"The time format, which can be `epoch`, `epoch_ms`, or a custom pattern. The value `epoch` refers to UNIX or Epoch time (the number of seconds since 1 Jan 1970). The value `epoch_ms` indicates that time is measured in milliseconds since the epoch. The `epoch` and `epoch_ms` time formats accept either integer or real values. Custom patterns must conform to the Java DateTimeFormatter class. When you use date-time formatting patterns, it is recommended that you provide the full date, time and time zone. For example: `yyyy-MM-dd'T'HH:mm:ssX`. If the pattern that you specify is not sufficient to produce a complete timestamp, job creation fails."
+        }
       },
       "datafeed_config":{
         "type":"object",
@@ -77,7 +262,21 @@
         "chunking_config":{
           "type":"object",
           "description":"Datafeeds might be required to search over long time periods, for several months or years. This search is split into time chunks in order to ensure the load on Elasticsearch is managed. Chunking configuration controls how the size of these time chunks are calculated and is an advanced configuration option.",
-          "required":false
+          "required":false,
+          "mode":{
+            "default":"auto",
+            "description":"If set to `auto`, the chunk size is dynamically calculated; this is the recommended value when the datafeed does not use aggregations. If set to `manual`, chunking is applied according to the specified `time_span`; use this mode when the datafeed uses aggregations. If set to `off`, no chunking is applied.",
+            "type":"enum",
+            "options":[
+              "auto",
+              "manual",
+              "off"
+            ]
+          },
+          "time_span":{
+            "type":"time",
+            "description":"The time span that each search will be querying. This setting is only applicable when the `mode` is set to `manual`. For example: `3h`."
+          }
         },
         "datafeed_id":{
           "type":"string",
@@ -86,18 +285,27 @@
         },
         "delayed_data_check_config":{
           "type":"object",
-          "description":"Specifies whether the datafeed checks for missing data and the size of the window. The datafeed can optionally search over indices that have already been read in an effort to determine whether any data has subsequently been added to the index. If missing data is found, it is a good indication that the query_delay option is set too low and the data is being indexed after the datafeed has passed that moment in time. This check runs only on real-time datafeeds.",
-          "required":false
+          "description":"Specifies whether the datafeed checks for missing data and the size of the window. The datafeed can optionally search over indices that have already been read in an effort to determine whether any data has subsequently been added to the index. If missing data is found, it is a good indication that the `query_delay` option is set too low and the data is being indexed after the datafeed has passed that moment in time. This check runs only on real-time datafeeds.",
+          "required":false,
+          "check_window":{
+            "type":"time",
+            "description":"The window of time that is searched for late data. This window of time ends with the latest finalized bucket. It defaults to null, which causes an appropriate `check_window` to be calculated when the real-time datafeed runs. In particular, the default `check_window` span calculation is based on the maximum of `2h` or `8 * bucket_span`."
+          },
+          "enabled":{
+            "type":"boolean",
+            "default":true,
+            "description":"Specifies whether the datafeed periodically checks for delayed data."
+          }
         },
         "frequency":{
           "type":"time",
           "required":false,
-          "description":"The interval at which scheduled queries are made while the datafeed runs in real time. The default value is either the bucket span for short bucket spans, or, for longer bucket spans, a sensible fraction of the bucket span. For example: 150s. When frequency is shorter than the bucket span, interim results for the last (partial) bucket are written then eventually overwritten by the full bucket results. If the datafeed uses aggregations, this value must be divisible by the interval of the date histogram aggregation."
+          "description":"The interval at which scheduled queries are made while the datafeed runs in real time. The default value is either the bucket span for short bucket spans, or, for longer bucket spans, a sensible fraction of the bucket span. For example: `150s`. When frequency is shorter than the bucket span, interim results for the last (partial) bucket are written then eventually overwritten by the full bucket results. If the datafeed uses aggregations, this value must be divisible by the interval of the date histogram aggregation."
         },
         "indices":{
           "type":"array",
           "description":"An array of index names. Wildcards are supported.",
-          "required":false
+          "required":true
         }, 
         "indices_options" : {
           "type":"object",
@@ -105,7 +313,6 @@
           "description":"Specifies index expansion options that are used during search.",
           "allow_no_indices":{
             "type":"boolean",
-            "description":"",
             "description":"Ignore if the source indices expressions resolves to no concrete indices (default: true). Only set if datafeed_config is provided."
           },
           "expand_wildcards":{
@@ -132,11 +339,11 @@
         {
           "type":"integer",
           "required":false,
-          "description":"If a real-time datafeed has never seen any data (including during any initial training period) then it will automatically stop itself and close its associated job after this many real-time searches that return no documents. In other words, it will stop after frequency times `max_empty_searches` of real-time operation. If not set then a datafeed with no end time that sees no data will remain started until it is explicitly stopped. By default, this setting is not set."
+          "description":"If a real-time datafeed has never seen any data (including during any initial training period) then it will automatically stop itself and close its associated job after this many real-time searches that return no documents. In other words, it will stop after frequency times `max_empty_searches` of real-time operation. If not set then a datafeed with no end time that sees no data will remain started until it is explicitly stopped. By default, it is not set."
         },
         "query":{
           "type":"object",
-          "description":"The Elasticsearch query domain-specific language (DSL). This value corresponds to the query object in an Elasticsearch search POST body. All the options that are supported by Elasticsearch can be used, as this object is passed verbatim to Elasticsearch. By default, this property has the following value: `{"match_all": {"boost": 1}}`.",
+          "description":"The Elasticsearch query domain-specific language (DSL). This value corresponds to the query object in an Elasticsearch search POST body. All the options that are supported by Elasticsearch can be used, as this object is passed verbatim to Elasticsearch. By default, this property has the following value: `{\"match_all\": {\"boost\": 1}}`.",
           "required":false 
         },
         "query_delay":{
@@ -174,7 +381,21 @@
       "model_plot_config":{
         "type":"object",
         "description":"This advanced configuration option stores model information along with the results. It provides a more detailed view into anomaly detection. If you enable model plot it can add considerable overhead to the performance of the system; it is not feasible for jobs with many entities. Model plot provides a simplified and indicative view of the model and its bounds. It does not display complex features such as multivariate correlations or multimodal data. As such, anomalies may occasionally be reported which cannot be seen in the model plot. Model plot config can be configured when the job is created or updated later. It must be disabled if performance issues are experienced.",
-        "required":false
+        "required":false,
+        "annotations_enabled":{
+          "type":"boolean",
+          "default":true,
+          "description":"If true, enables calculation and storage of the model change annotations for each entity that is being analyzed."
+        },
+        "enabled":{
+          "type":"boolean",
+          "default":"false",
+          "description":"If true, enables calculation and storage of the model bounds for each entity that is being analyzed."
+        },
+        "terms":{
+          "type":"string",
+          "description":" Limits data collection to this comma separated list of partition or by field values. If terms are not specified or it is an empty string, no filtering is applied. For example, \"CPU,NetworkIn,DiskWrites\". Wildcards are not supported. Only the specified terms can be viewed when using the Single Metric Viewer."
+        }
       },
       "model_snapshot_retention_days":{
         "type":"long",


### PR DESCRIPTION
This PR updates the API spec in https://github.com/elastic/elasticsearch/blob/master/rest-api-spec/src/main/resources/rest-api-spec/api/ml.put_job.json to properly nest the indices options and to add other missing properties.