### PR TITLE
Fix toXContent of PointInTimeBuilder (#75476)

### DIFF
--- a/server/src/main/java/org/elasticsearch/search/builder/PointInTimeBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/builder/PointInTimeBuilder.java
@@ -17,7 +17,7 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.xcontent.ObjectParser;
-import org.elasticsearch.common.xcontent.ToXContentObject;
+import org.elasticsearch.common.xcontent.ToXContentFragment;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
 
@@ -28,7 +28,7 @@ import java.util.Objects;
  * A search request with a point in time will execute using the reader contexts associated with that point time
  * instead of the latest reader contexts.
  */
-public final class PointInTimeBuilder implements Writeable, ToXContentObject {
+public final class PointInTimeBuilder implements Writeable, ToXContentFragment {
     private static final ParseField ID_FIELD = new ParseField("id");
     private static final ParseField KEEP_ALIVE_FIELD = new ParseField("keep_alive");
     private static final ObjectParser<XContentParams, Void> PARSER;
@@ -67,12 +67,10 @@ public final class PointInTimeBuilder implements Writeable, ToXContentObject {
 
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
-        builder.startObject(SearchSourceBuilder.POINT_IN_TIME.getPreferredName());
         builder.field(ID_FIELD.getPreferredName(), encodedId);
         if (keepAlive != null) {
-            builder.field(KEEP_ALIVE_FIELD.getPreferredName(), keepAlive);
+            builder.field(KEEP_ALIVE_FIELD.getPreferredName(), keepAlive.getStringRep());
         }
-        builder.endObject();
         return builder;
     }
 

--- a/server/src/main/java/org/elasticsearch/search/builder/SearchSourceBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/builder/SearchSourceBuilder.java
@@ -1465,7 +1465,9 @@ public final class SearchSourceBuilder implements Writeable, ToXContentObject, R
             builder.field(COLLAPSE.getPreferredName(), collapse);
         }
         if (pointInTimeBuilder != null) {
+            builder.startObject(POINT_IN_TIME.getPreferredName());
             pointInTimeBuilder.toXContent(builder, params);
+            builder.endObject();
         }
         if (false == runtimeMappings.isEmpty()) {
             builder.field(RUNTIME_MAPPINGS_FIELD.getPreferredName(), runtimeMappings);

--- a/server/src/test/java/org/elasticsearch/search/builder/PointInTimeBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/search/builder/PointInTimeBuilderTests.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.search.builder;
+
+import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.common.unit.TimeValue;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.test.AbstractSerializingTestCase;
+
+import java.io.IOException;
+
+public class PointInTimeBuilderTests extends AbstractSerializingTestCase<PointInTimeBuilder> {
+    @Override
+    protected PointInTimeBuilder doParseInstance(XContentParser parser) throws IOException {
+        return PointInTimeBuilder.fromXContent(parser);
+    }
+
+    @Override
+    protected Writeable.Reader<PointInTimeBuilder> instanceReader() {
+        return PointInTimeBuilder::new;
+    }
+
+    @Override
+    protected PointInTimeBuilder createTestInstance() {
+        final PointInTimeBuilder pointInTime = new PointInTimeBuilder(randomAlphaOfLength(20));
+        if (randomBoolean()) {
+            pointInTime.setKeepAlive(TimeValue.parseTimeValue(randomTimeValue(), "test"));
+        }
+        return pointInTime;
+    }
+}


### PR DESCRIPTION
We should use getStringRep instead of toString to avoid serializing the
keep_alive of a point in time in fractional format; otherwise, we won't
be able to parse it.

Fixes #75446