### PR TITLE
Set processor: Allow copy_from into root object

### DIFF
--- a/docs/reference/ingest/processors/set.asciidoc
+++ b/docs/reference/ingest/processors/set.asciidoc
@@ -12,7 +12,7 @@ its value will be replaced with the provided one.
 [options="header"]
 |======
 | Name        | Required | Default | Description
-| `field`     | yes      | -       | The field to insert, upsert, or update. Supports <<template-snippets,template snippets>>.
+| `field`     | yes      | -       | The field to insert, upsert, or update.  Supports <<template-snippets,template snippets>>. Using `.` as field will copy everything into the root object, but requires a map as its source.
 | `value`     | yes*     | -       | The value to be set for the field. Supports <<template-snippets,template snippets>>. May specify only one of `value` or `copy_from`.
 | `copy_from` | no       | -       | The origin field which will be copied to `field`, cannot set `value` simultaneously. Supported data types are `boolean`, `number`, `array`, `object`, `string`, `date`, etc.
 | `override`  | no       | `true`  | If processor will update fields with pre-existing non-null-valued field. When set to `false`, such fields will not be touched.

--- a/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/SetProcessorTests.java
+++ b/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/SetProcessorTests.java
@@ -18,6 +18,7 @@ import org.elasticsearch.test.ESTestCase;
 import org.hamcrest.Matchers;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -29,6 +30,7 @@ import java.util.stream.IntStream;
 
 import static org.hamcrest.Matchers.arrayContainingInAnyOrder;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasEntry;
 
 public class SetProcessorTests extends ESTestCase {
 
@@ -176,6 +178,19 @@ public class SetProcessorTests extends ESTestCase {
         } else {
             assertThat(copiedValue, equalTo(fieldValue));
         }
+    }
+
+    public void testCopyFromToRoot() throws Exception {
+        Map<String, Object> document = new HashMap<>();
+        document.put("field", "value");
+        document.put("data", Collections.singletonMap("key", "value"));
+        IngestDocument ingestDocument = new IngestDocument(document, Collections.emptyMap());
+
+        Processor processor = createSetProcessor(".", null, "data", true, false);
+        processor.execute(ingestDocument);
+
+        assertThat(ingestDocument.getSourceAndMetadata(), hasEntry("field", "value"));
+        assertThat(ingestDocument.getSourceAndMetadata(), hasEntry("key", "value"));
     }
 
     private static void assertMapEquals(Object actual, Object expected) {

--- a/server/src/main/java/org/elasticsearch/ingest/IngestDocument.java
+++ b/server/src/main/java/org/elasticsearch/ingest/IngestDocument.java
@@ -508,6 +508,16 @@ public final class IngestDocument {
     }
 
     private void setFieldValue(String path, Object value, boolean append, boolean allowDuplicates) {
+        // put everything under the root element
+        if (".".equals(path)) {
+            if (value instanceof Map == false) {
+                throw new IllegalArgumentException("if \".\" is specified as path, a map is needed");
+            }
+            Map fields = (Map) value;
+            fields.forEach((k, v) -> setFieldValue((String) k, v, append, allowDuplicates));
+            return;
+        }
+
         FieldPath fieldPath = new FieldPath(path);
         Object context = fieldPath.initialContext;
         for (int i = 0; i < fieldPath.pathElements.length - 1; i++) {

--- a/server/src/test/java/org/elasticsearch/ingest/IngestDocumentTests.java
+++ b/server/src/test/java/org/elasticsearch/ingest/IngestDocumentTests.java
@@ -24,9 +24,12 @@ import java.util.Map;
 
 import static org.elasticsearch.ingest.IngestDocumentMatcher.assertIngestDocument;
 import static org.hamcrest.Matchers.both;
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.hasEntry;
+import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
 import static org.hamcrest.Matchers.not;
@@ -1046,4 +1049,17 @@ public class IngestDocumentTests extends ESTestCase {
         }
     }
 
+    public void testSetFieldValueRootField() throws Exception {
+        Map<String, Object> sourceAndMetadata = new HashMap<>();
+        sourceAndMetadata.put("field", "content");
+
+        IngestDocument original = new IngestDocument(sourceAndMetadata, new HashMap<>());
+        Map<String, Object> appendMap = new HashMap<>();
+        appendMap.put("key", "value");
+        original.setFieldValue(".", appendMap);
+
+        assertThat(original.getSourceAndMetadata().keySet(), containsInAnyOrder("field", "key"));
+        assertThat(original.getSourceAndMetadata(), hasEntry("field", "content"));
+        assertThat(original.getSourceAndMetadata(), hasEntry("key", "value"));
+    }
 }

--- a/server/src/test/java/org/elasticsearch/ingest/IngestDocumentTests.java
+++ b/server/src/test/java/org/elasticsearch/ingest/IngestDocumentTests.java
@@ -29,7 +29,6 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.hasEntry;
-import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
 import static org.hamcrest.Matchers.not;


### PR DESCRIPTION
This is up for discussion and can also be closed if it is deemed a bad idea. While this can be done using a script processor, I think there is no reason, that this works for everything except the root object. 

My use case is, that many documents arrive in the format of

```json
{
  "data: {
    "first": "value",
    "second": "value"
  }
}
```

It's quite tedious to use `rename` to move everything into the top-level object from the `data`, if there are dozens of fields and leads to a very unreadable pipeline. So this would be a shortcut.