### PR TITLE
[7.x] [DOCS] Remove 7.13.4 coming tag (#75486)

### DIFF
--- a/docs/reference/release-notes/7.13.asciidoc
+++ b/docs/reference/release-notes/7.13.asciidoc
@@ -3,8 +3,6 @@
 
 Also see <<breaking-changes-7.13,Breaking changes in 7.13>>.
 
-coming::[7.13.4]
-
 [[bug-7.13.4]]
 [float]
 === Bug fixes


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [DOCS] Remove 7.13.4 coming tag (#75486)