### PR TITLE
Make some vector tile body parameters as query parameters (#75522)

### DIFF
--- a/x-pack/plugin/vector-tile/src/main/java/org/elasticsearch/xpack/vectortile/rest/RestVectorTileAction.java
+++ b/x-pack/plugin/vector-tile/src/main/java/org/elasticsearch/xpack/vectortile/rest/RestVectorTileAction.java
@@ -58,6 +58,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import static org.elasticsearch.rest.RestRequest.Method.GET;
+import static org.elasticsearch.rest.RestRequest.Method.POST;
 
 /**
  * Main class handling a call to the _mvt API.
@@ -81,7 +82,10 @@ public class RestVectorTileAction extends BaseRestHandler {
 
     @Override
     public List<Route> routes() {
-        return org.elasticsearch.core.List.of(new Route(GET, "{index}/_mvt/{field}/{z}/{x}/{y}"));
+        return org.elasticsearch.core.List.of(
+            new Route(GET, "{index}/_mvt/{field}/{z}/{x}/{y}"),
+            new Route(POST, "{index}/_mvt/{field}/{z}/{x}/{y}")
+        );
     }
 
     @Override

--- a/x-pack/plugin/vector-tile/src/main/java/org/elasticsearch/xpack/vectortile/rest/VectorTileRequest.java
+++ b/x-pack/plugin/vector-tile/src/main/java/org/elasticsearch/xpack/vectortile/rest/VectorTileRequest.java
@@ -141,6 +141,23 @@ class VectorTileRequest {
                 PARSER.parse(contentParser, request, restRequest);
             }
         }
+        // Following the same strategy of the _search API, some parameters can be defined in the body or as URL parameters.
+        // URL parameters takes precedence so we check them here.
+        if (restRequest.hasParam(SearchSourceBuilder.SIZE_FIELD.getPreferredName())) {
+            request.setSize(restRequest.paramAsInt(SearchSourceBuilder.SIZE_FIELD.getPreferredName(), Defaults.SIZE));
+        }
+        if (restRequest.hasParam(GRID_PRECISION_FIELD.getPreferredName())) {
+            request.setGridPrecision(restRequest.paramAsInt(GRID_PRECISION_FIELD.getPreferredName(), Defaults.GRID_PRECISION));
+        }
+        if (restRequest.hasParam(EXTENT_FIELD.getPreferredName())) {
+            request.setExtent(restRequest.paramAsInt(EXTENT_FIELD.getPreferredName(), Defaults.EXTENT));
+        }
+        if (restRequest.hasParam(GRID_TYPE_FIELD.getPreferredName())) {
+            request.setGridType(restRequest.param(GRID_TYPE_FIELD.getPreferredName(), Defaults.GRID_TYPE.name()));
+        }
+        if (restRequest.hasParam(EXACT_BOUNDS_FIELD.getPreferredName())) {
+            request.setExactBounds(restRequest.paramAsBoolean(EXACT_BOUNDS_FIELD.getPreferredName(), Defaults.EXACT_BOUNDS));
+        }
         return request;
     }
 


### PR DESCRIPTION
Following the same structure of the _search API, this changes makes possible to define some body parameters as query parameters (e.g. defined as URL parameters). As in the _search API, the URL parameters take precedence over the body parameters so if both parameters are specified, only the query parameter is used.

In particular those parameters are:

size
exact_bounds
grid_precision
grid_type
This PR adds as well support for POST in the API.

backport #75522