### PR TITLE
Fix the use of wildcard expressions for data streams in update aliases api

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/admin/indices/alias/IndicesAliasesRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/alias/IndicesAliasesRequest.java
@@ -12,6 +12,7 @@ import org.elasticsearch.ElasticsearchGenerationException;
 import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.AliasesRequest;
+import org.elasticsearch.action.IndicesRequest;
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.action.support.master.AcknowledgedRequest;
 import org.elasticsearch.cluster.metadata.AliasAction;
@@ -49,7 +50,7 @@ import static org.elasticsearch.common.xcontent.ObjectParser.fromList;
 /**
  * A request to add/remove aliases for one or more indices.
  */
-public class IndicesAliasesRequest extends AcknowledgedRequest<IndicesAliasesRequest> implements ToXContentObject {
+public class IndicesAliasesRequest extends AcknowledgedRequest<IndicesAliasesRequest> implements IndicesRequest, ToXContentObject {
 
     private List<AliasActions> allAliasActions = new ArrayList<>();
     private String origin = "";
@@ -506,6 +507,11 @@ public class IndicesAliasesRequest extends AcknowledgedRequest<IndicesAliasesReq
         }
 
         @Override
+        public boolean includeDataStreams() {
+            return true;
+        }
+
+        @Override
         public IndicesOptions indicesOptions() {
             return INDICES_OPTIONS;
         }
@@ -641,6 +647,18 @@ public class IndicesAliasesRequest extends AcknowledgedRequest<IndicesAliasesReq
 
     public IndicesOptions indicesOptions() {
         return INDICES_OPTIONS;
+    }
+
+    @Override
+    public String[] indices() {
+        return allAliasActions.stream()
+            .flatMap(aliasActions -> Arrays.stream(aliasActions.indices()))
+            .toArray(String[]::new);
+    }
+
+    @Override
+    public boolean includeDataStreams() {
+        return true;
     }
 
     @Override

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/IndexNameExpressionResolverTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/IndexNameExpressionResolverTests.java
@@ -1757,24 +1757,21 @@ public class IndexNameExpressionResolverTests extends ESTestCase {
 
         {
             IndicesAliasesRequest.AliasActions aliasActions = IndicesAliasesRequest.AliasActions.add().index(dataStreamName);
-            IndexNotFoundException iae = expectThrows(IndexNotFoundException.class,
-                () -> indexNameExpressionResolver.concreteIndexNames(state, aliasActions));
-            assertEquals("no such index [" + dataStreamName + "]", iae.getMessage());
+            assertThat(indexNameExpressionResolver.concreteIndexNames(state, aliasActions),
+                arrayContaining(backingIndexEqualTo(dataStreamName, 1)));
         }
 
         {
             IndicesAliasesRequest.AliasActions aliasActions = IndicesAliasesRequest.AliasActions.add().index("my-data-*").alias("my-data");
-            IndexNotFoundException iae = expectThrows(IndexNotFoundException.class,
-                () -> indexNameExpressionResolver.concreteIndexNames(state, aliasActions));
-            assertEquals("no such index [my-data-*]", iae.getMessage());
+            assertThat(indexNameExpressionResolver.concreteIndexNames(state, aliasActions),
+                arrayContaining(backingIndexEqualTo(dataStreamName, 1)));
         }
 
         {
             IndicesAliasesRequest.AliasActions aliasActions = IndicesAliasesRequest.AliasActions.add().index(dataStreamName)
                 .alias("my-data");
-            IndexNotFoundException iae = expectThrows(IndexNotFoundException.class,
-                () -> indexNameExpressionResolver.concreteIndexNames(state, aliasActions));
-            assertEquals("no such index [" + dataStreamName + "]", iae.getMessage());
+            assertThat(indexNameExpressionResolver.concreteIndexNames(state, aliasActions),
+                arrayContaining(backingIndexEqualTo(dataStreamName, 1)));
         }
     }
 

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/data_stream/140_data_stream_aliases.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/data_stream/140_data_stream_aliases.yml
@@ -71,3 +71,45 @@
         index: events
         body: { query: { match_all: {} } }
   - length:   { hits.hits: 2  }
+
+---
+"Create data stream aliases using wildcard expression":
+  - skip:
+      version: " - 7.99.99"
+      reason: "bugfix has not yet backported to the 7.x branch"
+      features: allowed_warnings
+
+  - do:
+      allowed_warnings:
+        - "index template [my-template] has index patterns [log-*] matching patterns from existing older templates [global] with patterns (global => [*]); this template [my-template] will take precedence during new index creation"
+      indices.put_index_template:
+        name: my-template
+        body:
+          index_patterns: [ log-* ]
+          template:
+            settings:
+              index.number_of_replicas: 0
+          data_stream: { }
+
+  - do:
+      indices.create_data_stream:
+        name: log-foobar
+  - is_true: acknowledged
+
+  - do:
+      indices.update_aliases:
+        body:
+          actions:
+            - add:
+                index: log-*
+                alias: my-alias
+  - is_true: acknowledged
+
+  - do:
+      indices.get_data_stream:
+        name: "*"
+  - match: { data_streams.0.name: log-foobar }
+
+  - do:
+      indices.get_alias: {}
+  - match: {log-foobar.aliases.my-alias: {}}


### PR DESCRIPTION
Backporting #75526 to 7.14 branch.

Prior to this change, supplying a wildcard expression in the `indices` field
of an alias action would always result in a 404, despite data streams existing
that could match with the provided wildcard expression.

Closes #75456