### PR TITLE
[7.x] Wait for ES to finish startup during password tests (#75420)

### DIFF
--- a/qa/os/src/test/java/org/elasticsearch/packaging/test/PasswordToolsTests.java
+++ b/qa/os/src/test/java/org/elasticsearch/packaging/test/PasswordToolsTests.java
@@ -52,6 +52,7 @@ public class PasswordToolsTests extends PackagingTestCase {
 
     public void test20GeneratePasswords() throws Exception {
         assertWhileRunning(() -> {
+            ServerUtils.waitForElasticsearch(installation);
             Shell.Result result = installation.executables().setupPasswordsTool.run("auto --batch", null);
             Map<String, String> userpasses = parseUsersAndPasswords(result.stdout);
             for (Map.Entry<String, String> userpass : userpasses.entrySet()) {


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Wait for ES to finish startup during password tests (#75420)