### PR TITLE
[ML] Parse time from inference result

### DIFF
--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/PyTorchModelIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/PyTorchModelIT.java
@@ -19,6 +19,8 @@ import org.elasticsearch.xpack.core.security.authc.support.UsernamePasswordToken
 import java.io.IOException;
 import java.util.Base64;
 
+import static org.hamcrest.Matchers.equalTo;
+
 /**
  * This test uses a tiny hardcoded base64 encoded PyTorch TorchScript model.
  * The model was created with the following python script and returns a
@@ -41,8 +43,6 @@ import java.util.Base64;
  * torch.jit.save(traced_model, "simplemodel.pt")
  * ## End Python
  */
-import static org.hamcrest.Matchers.equalTo;
-
 public class PyTorchModelIT extends ESRestTestCase {
 
     private static final String BASIC_AUTH_VALUE_SUPER_USER =
@@ -83,7 +83,6 @@ public class PyTorchModelIT extends ESRestTestCase {
         RAW_MODEL_SIZE = Base64.getDecoder().decode(BASE_64_ENCODED_MODEL).length;
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/73769")
     public void testEvaluate() throws IOException {
         createModelStoreIndex();
         putTaskConfig();

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/deployment/PyTorchResultTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/deployment/PyTorchResultTests.java
@@ -29,7 +29,7 @@ public class PyTorchResultTests extends AbstractSerializingTestCase<PyTorchResul
         boolean createError = randomBoolean();
         String id = randomAlphaOfLength(6);
         if (createError) {
-            return new PyTorchResult(id, null, "This is an error message");
+            return new PyTorchResult(id, null, null, "This is an error message");
         } else {
             int rows = randomIntBetween(1, 10);
             int columns = randomIntBetween(1, 10);
@@ -39,7 +39,7 @@ public class PyTorchResultTests extends AbstractSerializingTestCase<PyTorchResul
                     arr[i][j] = randomDouble();
                 }
             }
-            return new PyTorchResult(id, arr, null);
+            return new PyTorchResult(id, arr, randomLong(), null);
         }
     }
 }

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/nlp/FillMaskProcessorTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/nlp/FillMaskProcessorTests.java
@@ -46,7 +46,7 @@ public class FillMaskProcessorTests extends ESTestCase {
             tokenIds, tokenMap);
 
         FillMaskProcessor processor = new FillMaskProcessor(mock(BertTokenizer.class), mock(NlpTaskConfig.class));
-        FillMaskResults result = (FillMaskResults) processor.processResult(tokenization, new PyTorchResult("1", scores, null));
+        FillMaskResults result = (FillMaskResults) processor.processResult(tokenization, new PyTorchResult("1", scores, 0L, null));
         assertThat(result.getPredictions(), hasSize(5));
         FillMaskResults.Prediction prediction = result.getPredictions().get(0);
         assertEquals("France", prediction.getToken());
@@ -67,7 +67,7 @@ public class FillMaskProcessorTests extends ESTestCase {
             new int[] {}, new int[] {});
 
         FillMaskProcessor processor = new FillMaskProcessor(mock(BertTokenizer.class), mock(NlpTaskConfig.class));
-        PyTorchResult pyTorchResult = new PyTorchResult("1", new double[][]{{}}, null);
+        PyTorchResult pyTorchResult = new PyTorchResult("1", new double[][]{{}}, 0L, null);
         FillMaskResults result = (FillMaskResults) processor.processResult(tokenization, pyTorchResult);
         assertThat(result.getPredictions(), empty());
     }

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/nlp/NerProcessorTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/nlp/NerProcessorTests.java
@@ -79,7 +79,7 @@ public class NerProcessorTests extends ESTestCase {
 
     public void testProcessResults_GivenNoTokens() {
         NerProcessor.NerResultProcessor processor = createProcessor(Collections.emptyList(), "");
-        NerResults result = (NerResults) processor.processResult(new PyTorchResult("test", null, null));
+        NerResults result = (NerResults) processor.processResult(new PyTorchResult("test", null, 0L, null));
         assertThat(result.getEntityGroups(), is(empty()));
     }
 
@@ -95,7 +95,7 @@ public class NerProcessorTests extends ESTestCase {
             { 0, 0, 0, 0, 0, 0, 0, 0, 0}, // in
             { 0, 0, 0, 0, 0, 0, 0, 6, 0} // london
         };
-        NerResults result = (NerResults) processor.processResult(new PyTorchResult("1", scores, null));
+        NerResults result = (NerResults) processor.processResult(new PyTorchResult("1", scores, 1L, null));
 
         assertThat(result.getEntityGroups().size(), equalTo(2));
         assertThat(result.getEntityGroups().get(0).getWord(), equalTo("elasticsearch"));
@@ -131,7 +131,7 @@ public class NerProcessorTests extends ESTestCase {
             { 0, 0, 0, 0, 0, 0, 0, 0, 5}, // in
             { 6, 0, 0, 0, 0, 0, 0, 0, 0} // london
         };
-        NerResults result = (NerResults) processor.processResult(new PyTorchResult("1", scores, null));
+        NerResults result = (NerResults) processor.processResult(new PyTorchResult("1", scores, 1L, null));
 
         assertThat(result.getEntityGroups().size(), equalTo(2));
         assertThat(result.getEntityGroups().get(0).getWord(), equalTo("elasticsearch"));

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/nlp/SentimentAnalysisProcessorTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/nlp/SentimentAnalysisProcessorTests.java
@@ -32,14 +32,14 @@ public class SentimentAnalysisProcessorTests extends ESTestCase {
     public void testInvalidResult() {
         SentimentAnalysisProcessor processor = new SentimentAnalysisProcessor(mock(BertTokenizer.class), NlpTaskConfig.builder().build());
         {
-            PyTorchResult torchResult = new PyTorchResult("foo", new double[][]{}, null);
+            PyTorchResult torchResult = new PyTorchResult("foo", new double[][]{}, 0L, null);
             InferenceResults inferenceResults = processor.processResult(torchResult);
             assertThat(inferenceResults, instanceOf(WarningInferenceResults.class));
             assertEquals("Sentiment analysis result has no data",
                 ((WarningInferenceResults) inferenceResults).getWarning());
         }
         {
-            PyTorchResult torchResult = new PyTorchResult("foo", new double[][]{{1.0}}, null);
+            PyTorchResult torchResult = new PyTorchResult("foo", new double[][]{{1.0}}, 0L, null);
             InferenceResults inferenceResults = processor.processResult(torchResult);
             assertThat(inferenceResults, instanceOf(WarningInferenceResults.class));
             assertEquals("Expected 2 values in sentiment analysis result",


### PR DESCRIPTION
Parse the `time_ms` field written by the native libtorch process. 

This code first appeared in the GET deployments Stats API PR #75268 but because of ongoing discussions about the response format it is not likely to be merged soon. Merging the the time parsing code in this PR means the integration test can be re-enabled.

Eventually the inference time will be reported as a stat but for now this change is about getting the tests running again