### PR TITLE
[7.14] Adjust graph explore api to also support data streams. (#75541)

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/protocol/xpack/graph/GraphExploreRequest.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/protocol/xpack/graph/GraphExploreRequest.java
@@ -94,6 +94,11 @@ public class GraphExploreRequest extends ActionRequest implements IndicesRequest
         return indicesOptions;
     }
 
+    @Override
+    public boolean includeDataStreams() {
+        return true;
+    }
+
     public GraphExploreRequest indicesOptions(IndicesOptions indicesOptions) {
         if (indicesOptions == null) {
             throw new IllegalArgumentException("IndicesOptions must not be null");

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/data_stream/10_data_stream_resolvability.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/data_stream/10_data_stream_resolvability.yml
@@ -303,6 +303,13 @@
   - length: {vertices: 3}
 
   - do:
+      graph.explore:
+        index: simple*
+        body: { "query": { "match": { "keys": 1 } },"controls": { "use_significance": false },"vertices": [ { "field": "keys","min_doc_count": 1 } ] }
+  - length: { failures: 0 }
+  - length: { vertices: 3 }
+
+  - do:
       indices.delete_data_stream:
         name: simple-data-stream1
   - is_true: acknowledged


### PR DESCRIPTION
Backports the following commits to 7.14:
 - Adjust graph explore api to also support data streams. (#75541)