### PR TITLE
[7.x] [DOCS] SQL: Add formal API docs (#75506)

### DIFF
--- a/docs/reference/redirects.asciidoc
+++ b/docs/reference/redirects.asciidoc
@@ -1584,3 +1584,9 @@ See the {glossary}/terms.html[Elastic glossary].
 === Field usage stats API
 
 See <<field-usage-stats>>.
+
+[role="exclude",id="sql-rest-fields"]
+=== Supported REST parameters for SQL search API
+
+See the <<sql-search-api-request-body,request body parameters>> for the
+<<sql-search-api,SQL search API>>.

--- a/docs/reference/sql/apis/clear-sql-cursor-api.asciidoc
+++ b/docs/reference/sql/apis/clear-sql-cursor-api.asciidoc
@@ -1,0 +1,48 @@
+[role="xpack"]
+[testenv="basic"]
+[[clear-sql-cursor-api]]
+=== Clear SQL cursor API
+++++
+<titleabbrev>Clear SQL cursor</titleabbrev>
+++++
+
+Clears an <<sql-pagination,SQL search cursor>>.
+
+////
+[source,console]
+----
+POST _sql
+{
+  "query": "SELECT * FROM library ORDER BY page_count DESC",
+  "fetch_size": 5
+}
+----
+// TEST[setup:library]
+////
+
+[source,console]
+----
+POST _sql/close
+{
+  "cursor": "sDXF1ZXJ5QW5kRmV0Y2gBAAAAAAAAAAEWYUpOYklQMHhRUEtld3RsNnFtYU1hQQ==:BAFmBGRhdGUBZgVsaWtlcwFzB21lc3NhZ2UBZgR1c2Vy9f///w8="
+}
+----
+// TEST[continued]
+// TEST[s/sDXF1ZXJ5QW5kRmV0Y2gBAAAAAAAAAAEWYUpOYklQMHhRUEtld3RsNnFtYU1hQQ==:BAFmBGRhdGUBZgVsaWtlcwFzB21lc3NhZ2UBZgR1c2Vy9f\/\/\/w8=/$body.cursor/]
+
+[[clear-sql-cursor-api-request]]
+==== {api-request-title}
+
+`POST _sql/close`
+
+[[clear-sql-cursor-api-limitations]]
+===== Limitations
+
+See <<sql-limitations>>.
+
+[role="child_attributes"]
+[[clear-sql-cursor-api-request-body]]
+==== {api-request-body-title}
+
+`cursor`::
+(Required, string) Cursor to clear.

--- a/docs/reference/sql/apis/get-async-sql-search-api.asciidoc
+++ b/docs/reference/sql/apis/get-async-sql-search-api.asciidoc
@@ -60,5 +60,5 @@ Defaults to no timeout, meaning the request waits for complete search results.
 [[get-async-sql-search-api-response-body]]
 ==== {api-response-body-title}
 
-The get async SQL search API returns the same response body as the SQL search
-API.
+The get async SQL search API returns the same response body as the
+<<sql-search-api-response-body,SQL search API>>.

--- a/docs/reference/sql/apis/sql-apis.asciidoc
+++ b/docs/reference/sql/apis/sql-apis.asciidoc
@@ -3,17 +3,24 @@
 [[sql-apis]]
 == SQL APIs
 
-NOTE: This list of SQL APIs is incomplete. We're working to add more.
-
 {es}'s SQL APIs let you run SQL queries on {es} indices and data streams.
 For an overview of {es}'s SQL features and related tutorials, see <<xpack-sql>>.
 
+* <<sql-search-api>>
+* <<clear-sql-cursor-api>>
 * <<get-async-sql-search-api>>
 * <<get-async-sql-search-status-api>>
 * <<delete-async-sql-search-api>>
+* <<sql-translate-api>>
+
+include::clear-sql-cursor-api.asciidoc[]
 
 include::delete-async-sql-search-api.asciidoc[]
 
 include::get-async-sql-search-api.asciidoc[]
 
 include::get-async-sql-search-status-api.asciidoc[]
+
+include::sql-search-api.asciidoc[]
+
+include::sql-translate-api.asciidoc[]

--- a/docs/reference/sql/apis/sql-search-api.asciidoc
+++ b/docs/reference/sql/apis/sql-search-api.asciidoc
@@ -1,0 +1,180 @@
+[role="xpack"]
+[testenv="basic"]
+[[sql-search-api]]
+=== SQL search API
+++++
+<titleabbrev>SQL search</titleabbrev>
+++++
+
+Returns results for an <<sql-rest-overview,SQL search>>.
+
+[source,console]
+----
+POST _sql?format=txt
+{
+  "query": "SELECT * FROM library ORDER BY page_count DESC LIMIT 5"
+}
+----
+// TEST[setup:library]
+
+[[sql-search-api-request]]
+==== {api-request-title}
+
+`GET _sql`
+
+`POST _sql`
+
+[[sql-search-api-prereqs]]
+==== {api-prereq-title}
+
+* If the {es} {security-features} are enabled, you must have the `read`
+<<privileges-list-indices,index privilege>> for the data stream, index,
+or alias you search.
+
+[[sql-search-api-limitations]]
+===== Limitations
+
+See <<sql-limitations>>.
+
+[[search-api-query-params]]
+==== {api-query-parms-title}
+
+`delimiter`::
+(Optional, string) Separator for CSV results. Defaults to `,`. The API only
+supports this parameter for CSV responses.
+
+`format`::
+(Optional, string) Format for the response. For valid values, see
+<<sql-rest-format>>.
++
+You can also specify a format using the `Accept` HTTP header. If you specify
+both this parameter and the `Accept` HTTP header, this parameter takes
+precedence.
+
+[role="child_attributes"]
+[[sql-search-api-request-body]]
+==== {api-request-body-title}
+
+`columnar`::
+(Optional, Boolean) If `true`, returns results in a columnar format. Defaults to
+`false`. The API only supports this parameter for CBOR, JSON, SMILE, and YAML
+responses. See <<sql-rest-columnar>>.
+
+`cursor`::
+(Optional, string) <<sql-pagination,Cursor>> used to retrieve a set of paginated
+results. If you specify a `cursor`, the API only uses the `columnar` and
+`time_zone` request body parameters. It ignores other request body parameters.
+
+[[sql-search-api-fetch-size]]
+`fetch_size`::
+(Optional, integer) Maximum number of rows to return in the response. Defaults
+to `1000`.
+
+[[sql-search-api-field-multi-value-leniency]]
+`field_multi_value_leniency`::
+(Optional, Boolean) If `false`, the API returns an error for fields containing
+<<array,array values>>. If `true`, the API returns the first value from the
+array with no guarantee of consistent results. Defaults to `false`.
+
+`filter`::
+(Optional, object) <<query-dsl,Query DSL>> used to filter documents for the SQL
+search. See <<sql-rest-filtering>>.
+
+`index_include_frozen`::
+(Optional, Boolean) If `true`, the search can run on frozen indices. Defaults to
+`false`.
+
+`keep_alive`::
+(Optional, <<time-units,time value>>) Retention period for an
+<<sql-async,async>> or <<sql-store-searches,saved synchronous search>>. Defaults
+to `5d` (five days).
+
+`keep_on_completion`::
+(Optional, Boolean) If `true`, {es} <<sql-store-searches,stores synchronous
+searches>> if you also specify the `wait_for_completion_timeout` parameter. If
+`false`, {es} only stores <<sql-async,async searches>> that don't finish before
+the `wait_for_completion_timeout`. Defaults to `false`.
+
+`page_timeout`::
+(Optional, <<time-units,time value>>) Timeout before a
+<<sql-pagination,pagination request>> fails. Defaults to `45s` (45 seconds).
+
+`params`::
+(Optional, array) Values for parameters in the `query`. For syntax, see
+<<sql-rest-params>>.
+
+`query`::
+(Required, object) SQL query to run. For syntax, see <<sql-spec>>.
+
+`request_timeout`::
+(Optional, <<time-units,time value>>) Timeout before the request fails. Defaults
+to `90s` (90 seconds).
+
+include::{es-repo-dir}/search/search.asciidoc[tag=runtime-mappings-def]
+
+[[sql-search-api-time-zone]]
+`time_zone`::
+(Optional, string) ISO-8601 time zone ID for the search. Several
+<<sql-functions-datetime,SQL date/time functions>> use this time zone. Defaults
+to `Z` (UTC).
+
+`wait_for_completion_timeout`::
+(Optional, <<time-units,time value>>) Period to wait for complete results.
+Defaults to no timeout, meaning the request waits for complete search results.
+If the search doesn’t finish within this period, the search becomes
+<<sql-async,async>>.
++
+To <<sql-store-searches,save a synchronous search>>, you must specify this
+parameter and the `keep_on_completion` parameter.
+
+[role="child_attributes"]
+[[sql-search-api-response-body]]
+==== {api-response-body-title}
+
+The SQL search API supports <<sql-rest-format,multiple response formats>>. Most
+response formats use a tabular layout. JSON responses contain the following
+properties:
+
+`id`::
+(string) Identifier for the search. This value is only returned for
+<<sql-async,async>> and <<sql-store-searches,saved synchronous searches>>. For
+CSV, TSV, and TXT responses, this value is returned in the `Async-ID` HTTP
+header.
+
+`is_running`::
+(Boolean) If `true`, the search is still running. If `false`, the search has
+finished. This value is only returned for <<sql-async,async>> and
+<<sql-store-searches,saved synchronous searches>>. For CSV, TSV, and TXT
+responses, this value is returned in the `Async-partial` HTTP header.
+
+`is_partial`::
+(Boolean) If `true`, the response does not contain complete search results. If
+`is_partial` is `true` and `is_running` is `true`, the search is still running.
+If `is_partial` is `true` but `is_running` is `false`, the results are partial
+due to a failure or timeout.
++
+This value is only returned for <<sql-async,async>> and
+<<sql-store-searches,saved synchronous searches>>. For CSV, TSV, and TXT
+responses, this value is returned in the `Async-partial` HTTP header.
+
+`rows`::
+(array of arrays)
+Values for the search results.
+
+`columns`::
+(array of objects)
+Column headings for the search results. Each object is a column.
++
+.Properties of `columns` objects
+[%collapsible%open]
+====
+`name`::
+(string) Name of the column.
+
+`type`::
+(string) Data type for the column.
+====
+
+`cursor`::
+(string) <<sql-pagination,Cursor>> for the next set of paginated results. For
+CSV, TSV, and TXT responses, this value is returned in the `Cursor` HTTP header.

--- a/docs/reference/sql/apis/sql-translate-api.asciidoc
+++ b/docs/reference/sql/apis/sql-translate-api.asciidoc
@@ -1,0 +1,53 @@
+[role="xpack"]
+[testenv="basic"]
+[[sql-translate-api]]
+=== SQL translate API
+++++
+<titleabbrev>SQL translate</titleabbrev>
+++++
+
+Translates an <<sql-search-api,SQL search>> into a <<search-search,search API>>
+request containing <<query-dsl,Query DSL>>. See <<sql-translate>>.
+
+[source,console]
+----
+POST _sql/translate
+{
+  "query": "SELECT * FROM library ORDER BY page_count DESC",
+  "fetch_size": 10
+}
+----
+// TEST[setup:library]
+
+[[sql-translate-api-request]]
+==== {api-request-title}
+
+`GET _sql/translate`
+
+`POST _sql/translate`
+
+[[sql-translate-api-prereqs]]
+==== {api-prereq-title}
+
+* If the {es} {security-features} are enabled, you must have the `read`
+<<privileges-list-indices,index privilege>> for the data stream, index,
+or alias you search.
+
+[[sql-translate-api-limitations]]
+===== Limitations
+
+See <<sql-limitations>>.
+
+[role="child_attributes"]
+[[sql-translate-api-request-body]]
+==== {api-request-body-title}
+
+The SQL translate API accepts the same request body parameters as the
+<<sql-search-api-request-body,SQL search API>>, excluding `cursor`.
+
+[role="child_attributes"]
+[[sql-translate-api-response-body]]
+==== {api-response-body-title}
+
+The SQL translate API returns the same response body as the
+<<search-search,search API>>.

--- a/docs/reference/sql/endpoints/odbc/configuration.asciidoc
+++ b/docs/reference/sql/endpoints/odbc/configuration.asciidoc
@@ -220,8 +220,9 @@ timeout.
 * Max page size (rows)
 +
 The maximum number of rows that {es-sql} server should send the driver for one
-page. This corresponds to {es-sql}'s request parameter `fetch_size` (see
-<<sql-rest-fields>>). The value 0 means server default.
+page. This corresponds to the SQL search API's
+<<sql-search-api-fetch-size,`fetch_size`>> parameter. A `0` value indicates a
+server default.
 +
 * Max page length (MB)
 +
@@ -314,8 +315,9 @@ multi-value field is queried. In case this is set and the server encounters
 such a field, it will pick a value in the set - without any guarantees of what
 that will be, but typically the first in natural ascending order - and return
 it as the value for the column. If not set, the server will return an error.
-This corresponds to {es-sql}'s request parameter `field_multi_value_leniency`
-(see <<sql-rest-fields>>).
+This corresponds to the SQL search API's
+<<sql-search-api-field-multi-value-leniency,`field_multi_value_leniency`>>
+parameter.
 +
 * Include frozen indices
 +

--- a/docs/reference/sql/endpoints/rest.asciidoc
+++ b/docs/reference/sql/endpoints/rest.asciidoc
@@ -11,14 +11,12 @@
 * <<sql-rest-params>>
 * <<sql-runtime-fields>>
 * <<sql-async>>
-* <<sql-rest-fields>>
 
 [[sql-rest-overview]]
 === Overview
 
-The SQL REST API accepts SQL in a JSON document, executes it,
-and returns the results.
-For example:
+The <<sql-search-api,SQL search API>> accepts SQL in a JSON document, executes
+it, and returns the results. For example:
 
 [source,console]
 --------------------------------------------------
@@ -344,7 +342,7 @@ SQL may keep state in Elasticsearch to support the cursor. Unlike
 scroll, receiving the last page is enough to guarantee that the
 Elasticsearch state is cleared.
 
-To clear the state earlier, you can use the clear cursor command:
+To clear the state earlier, use the <<clear-sql-cursor-api,clear cursor API>>:
 
 [source,console]
 --------------------------------------------------
@@ -734,96 +732,3 @@ Saved synchronous searches are still subject to the `keep_alive` retention
 period. When this period ends, {es} deletes the search results. You can also
 delete saved searches using the <<delete-async-sql-search-api,delete async SQL
 search API>>.
-
-[[sql-rest-fields]]
-=== Supported REST parameters
-
-In addition to the `query` and `fetch_size`, a request a number of user-defined fields for specifying
-the request time-outs or localization information (such as timezone).
-
-The table below lists the supported parameters:
-
-[cols="<m,<m,<5"]
-
-|===
-
-s|name
-s|Default value
-s|Description
-
-|query
-|Mandatory
-|SQL query to execute
-
-|fetch_size
-|1000
-|The maximum number of rows (or entries) to return in one response
-
-|filter
-|none
-|Optional {es} Query DSL for additional <<sql-rest-filtering, filtering>>.
-
-|request_timeout
-|90s
-|The timeout before the request fails.
-
-|page_timeout
-|45s
-|The timeout before a pagination request fails.
-
-|[[sql-rest-fields-timezone]]time_zone
-|`Z` (or `UTC`)
-|Time-zone in ISO 8601 used for executing the query on the server.
-More information available https://docs.oracle.com/javase/8/docs/api/java/time/ZoneId.html[here].
-
-|columnar
-|false
-|Return the results in a columnar fashion, rather than row-based fashion. Valid for `json`, `yaml`, `cbor` and `smile`.
-
-|field_multi_value_leniency
-|false
-|Throw an exception when encountering multiple values for a field (default) or be lenient and return the first value from the list (without any guarantees of what that will be - typically the first in natural ascending order).
-
-|index_include_frozen
-|false
-|Whether to include <<freeze-index-api, frozen-indices>> in the query execution or not (default).
-
-|params
-|none
-|Optional list of parameters to replace question mark (`?`) placeholders inside the query.
-
-|runtime_mappings
-|none
-|Defines one or more <<runtime-search-request,runtime fields>> in the search
-request. These fields take precedence over mapped fields with the same name.
-
-|keep_alive
-|`5d`
-a|Period {es} stores the search and its results. Must be greater than `1m` (one
-minute).
-
-When this period end, {es} deletes the search and its results, even if the
-search is still running.
-
-If `keep_on_completion` is `false`, {es} only stores searches that don't finish
-within the `wait_for_completion_timeout`, regardless of this value.
-
-|keep_on_completion
-|`false`
-|If `true`, {es} stores the search and its results. If `false`, {es} stores the
-search and its results only if it doesn't finish before the
-`wait_for_completion_timeout`.
-
-|wait_for_completion_timeout
-|None
-a|Duration to wait for the search to finish. Defaults to no timeout, meaning the
-request waits for complete results.
-
-If you specify this parameter and the search finishes during the timeout, the
-request returns complete results. If the search doesn't finish during this
-period, the search becomes async. See <<sql-async>>.
-
-|===
-
-Do note that most parameters (outside the timeout and `columnar` ones) make sense only during the initial query - any follow-up pagination request only requires the `cursor` parameter as explained in the <<sql-pagination, pagination>> chapter.
-That's because the query has already been executed and the calls are simply about returning the found results - thus the parameters are simply ignored.

--- a/docs/reference/sql/endpoints/translate.asciidoc
+++ b/docs/reference/sql/endpoints/translate.asciidoc
@@ -55,5 +55,5 @@ In this case, SQL will use the <<scroll-search-results,scroll>>
 API. If the result contained an aggregation then SQL would use
 the normal <<search-request-body,search>> API.
 
-The request body accepts all of the <<sql-rest-fields,fields>> that
-the <<sql-rest,SQL REST API>> accepts except `cursor`.
+The request body accepts the same <<sql-search-api-request-body,parameters>> as
+the <<sql-search-api,SQL search API>>, excluding `cursor`.

--- a/docs/reference/sql/functions/date-time.asciidoc
+++ b/docs/reference/sql/functions/date-time.asciidoc
@@ -442,7 +442,7 @@ include-tagged::{sql-specs}/docs/docs.csv-spec[dateParse1]
 [NOTE]
 ====
 The resulting `date` will have the time zone specified by the user through the 
-<<sql-rest-fields-timezone,`time_zone`>>/<<jdbc-cfg-timezone,`timezone`>> REST/driver parameters
+<<sql-search-api-time-zone,`time_zone`>>/<<jdbc-cfg-timezone,`timezone`>> REST/driver parameters
 with no conversion applied.
 
 [source, sql]
@@ -533,7 +533,7 @@ include-tagged::{sql-specs}/docs/docs.csv-spec[dateTimeParse2]
 [NOTE]
 ====
 If timezone is not specified in the datetime string expression and the parsing pattern, the resulting `datetime` will have the
-time zone specified by the user through the <<sql-rest-fields-timezone,`time_zone`>>/<<jdbc-cfg-timezone,`timezone`>> REST/driver parameters
+time zone specified by the user through the <<sql-search-api-time-zone,`time_zone`>>/<<jdbc-cfg-timezone,`timezone`>> REST/driver parameters
 with no conversion applied.
 
 [source, sql]
@@ -583,7 +583,7 @@ include-tagged::{sql-specs}/docs/docs.csv-spec[timeParse2]
 ====
 If timezone is not specified in the time string expression and the parsing pattern,
 the resulting `time` will have the offset of the time zone specified by the user through the
- <<sql-rest-fields-timezone,`time_zone`>>/<<jdbc-cfg-timezone,`timezone`>> REST/driver
+ <<sql-search-api-time-zone,`time_zone`>>/<<jdbc-cfg-timezone,`timezone`>> REST/driver
 parameters at the Unix epoch date (`1970-01-01`) with no conversion applied.
 
 [source, sql]

--- a/docs/reference/sql/getting-started.asciidoc
+++ b/docs/reference/sql/getting-started.asciidoc
@@ -17,7 +17,7 @@ PUT /library/book/_bulk?refresh
 {"name": "Dune", "author": "Frank Herbert", "release_date": "1965-06-01", "page_count": 604}
 --------------------------------------------------
 
-And now you can execute SQL using the <<sql-rest>> right away:
+And now you can execute SQL using the <<sql-search-api,SQL search API>>:
 
 [source,console]
 --------------------------------------------------

--- a/docs/reference/sql/language/indices.asciidoc
+++ b/docs/reference/sql/language/indices.asciidoc
@@ -92,7 +92,7 @@ By default, {es-sql} doesn't search <<freeze-index-api,frozen indices>>. To
 search frozen indices, use one of the following features:
 
 dedicated configuration parameter::
-Set to `true` properties `index_include_frozen` in the <<sql-rest>> or `index.include.frozen` in the drivers to include frozen indices.
+Set to `true` properties `index_include_frozen` in the <<sql-search-api,SQL search API>> or `index.include.frozen` in the drivers to include frozen indices.
 
 dedicated keyword::
 Explicitly perform the inclusion through the dedicated `FROZEN` keyword in the `FROM` clause or `INCLUDE FROZEN` in the `SHOW` commands:

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/sql.clear_cursor.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/sql.clear_cursor.json
@@ -1,7 +1,7 @@
 {
   "sql.clear_cursor":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/sql-pagination.html",
+      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/clear-sql-cursor-api.html",
       "description":"Clears the SQL cursor"
     },
     "stability":"stable",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/sql.query.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/sql.query.json
@@ -1,7 +1,7 @@
 {
   "sql.query":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/sql-rest-overview.html",
+      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/sql-search-api.html",
       "description":"Executes a SQL request"
     },
     "stability":"stable",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/sql.translate.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/sql.translate.json
@@ -1,7 +1,7 @@
 {
   "sql.translate":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/sql-translate.html",
+      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/sql-translate-api.html",
       "description":"Translates SQL into Elasticsearch queries"
     },
     "stability":"stable",


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [DOCS] SQL: Add formal API docs (#75506)