### PR TITLE
Fix Tripped Assertion on Failed Snapshot Clone Cleanup

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/snapshots/CloneSnapshotIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/snapshots/CloneSnapshotIT.java
@@ -495,6 +495,75 @@ public class CloneSnapshotIT extends AbstractSnapshotIntegTestCase {
         );
     }
 
+    public void testSnapshotQueuedAfterCloneFromBrokenSourceSnapshot() throws Exception {
+        internalCluster().startMasterOnlyNode();
+        final String dataNode = internalCluster().startDataOnlyNode();
+        final String repoName = "test-repo";
+        createRepository(repoName, "mock");
+        final String testIndex = "index-test";
+        createIndexWithContent(testIndex);
+
+        final String sourceSnapshot = "source-snapshot";
+        blockDataNode(repoName, dataNode);
+        final Client masterClient = internalCluster().masterClient();
+        final ActionFuture<CreateSnapshotResponse> sourceSnapshotFuture = masterClient.admin()
+            .cluster()
+            .prepareCreateSnapshot(repoName, sourceSnapshot)
+            .setWaitForCompletion(true)
+            .execute();
+        awaitNumberOfSnapshotsInProgress(1);
+        waitForBlock(dataNode, repoName);
+        internalCluster().restartNode(dataNode);
+        ensureGreen();
+        assertThat(sourceSnapshotFuture.get().getSnapshotInfo().state(), is(SnapshotState.PARTIAL));
+        final String sourceSnapshotHealthy = "source-snapshot-healthy";
+        createFullSnapshot(repoName, "source-snapshot-healthy");
+
+        final ActionFuture<CreateSnapshotResponse> sn1 = startFullSnapshot(repoName, "concurrent-snapshot-1");
+        final ActionFuture<AcknowledgedResponse> clone1 = startClone(
+            masterClient,
+            repoName,
+            sourceSnapshotHealthy,
+            "target-snapshot-1",
+            testIndex
+        );
+        final ActionFuture<CreateSnapshotResponse> sn2 = startFullSnapshot(repoName, "concurrent-snapshot-2");
+        final ActionFuture<AcknowledgedResponse> clone2 = startClone(
+            masterClient,
+            repoName,
+            sourceSnapshotHealthy,
+            "target-snapshot-2",
+            testIndex
+        );
+        final ActionFuture<CreateSnapshotResponse> sn3 = startFullSnapshot(repoName, "concurrent-snapshot-3");
+        final ActionFuture<AcknowledgedResponse> clone3 = startClone(
+            masterClient,
+            repoName,
+            sourceSnapshotHealthy,
+            "target-snapshot-3",
+            testIndex
+        );
+        final SnapshotException sne = expectThrows(
+            SnapshotException.class,
+            () -> startClone(masterClient, repoName, sourceSnapshot, "target-snapshot", testIndex).actionGet(
+                TimeValue.timeValueSeconds(30L)
+            )
+        );
+        assertThat(
+            sne.getMessage(),
+            containsString(
+                "Can't clone index [" + getRepositoryData(repoName).resolveIndexId(testIndex) + "] because its snapshot was not successful."
+            )
+        );
+
+        assertSuccessful(sn1);
+        assertSuccessful(sn2);
+        assertSuccessful(sn3);
+        assertAcked(clone1.get());
+        assertAcked(clone2.get());
+        assertAcked(clone3.get());
+    }
+
     public void testStartSnapshotWithSuccessfulShardClonePendingFinalization() throws Exception {
         final String masterName = internalCluster().startMasterOnlyNode(LARGE_SNAPSHOT_POOL_SETTINGS);
         final String dataNode = internalCluster().startDataOnlyNode();

--- a/server/src/main/java/org/elasticsearch/snapshots/SnapshotsService.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/SnapshotsService.java
@@ -573,6 +573,7 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
         final Executor executor = threadPool.executor(ThreadPool.Names.SNAPSHOT);
         // Exception handler for IO exceptions with loading index and repo metadata
         final Consumer<Exception> onFailure = e -> {
+            endingSnapshots.add(targetSnapshot);
             initializingClones.remove(targetSnapshot);
             logger.info(() -> new ParameterizedMessage("Failed to start snapshot clone [{}]", cloneEntry), e);
             removeFailedSnapshotFromClusterState(targetSnapshot, e, null);
@@ -1921,6 +1922,8 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
             @Override
             public ClusterState execute(ClusterState currentState) {
                 final ClusterState updatedState = stateWithoutFailedSnapshot(currentState, snapshot);
+                assert updatedState == currentState || endingSnapshots.contains(snapshot)
+                    : "did not track [" + snapshot + "] in ending snapshots while removing it from the cluster state";
                 // now check if there are any delete operations that refer to the just failed snapshot and remove the snapshot from them
                 return updateWithSnapshots(
                     updatedState,


### PR DESCRIPTION
We have to put the entry into `endingSnapshots`, otherwise we trip
an assertion about listener consistency with the cluster state if
there's other concurrent operations.

=> added another more specific assertion for this
=> added test that triggers this situation in almost 100% of cases

... not marking as bug even though it touches prod code as this doesn't have production impact as far as I can see