### PR TITLE
[7.14] Adjust skip version for data stream alias tests (#75585)

### DIFF
--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/data_stream/140_data_stream_aliases.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/data_stream/140_data_stream_aliases.yml
@@ -75,8 +75,8 @@
 ---
 "Create data stream aliases using wildcard expression":
   - skip:
-      version: " - 7.99.99"
-      reason: "bugfix has not yet backported to the 7.x branch"
+      version: " - 7.14.0"
+      reason: "bugfix fixed from 7.14.1 and later"
       features: allowed_warnings
 
   - do:


### PR DESCRIPTION
Backports the following commits to 7.14:
 - Adjust skip version for data stream alias tests (#75585)