### PR TITLE
Fix reported branch in build scans for pull request CI jobs

### DIFF
--- a/build-tools-internal/src/main/groovy/elasticsearch.build-scan.gradle
+++ b/build-tools-internal/src/main/groovy/elasticsearch.build-scan.gradle
@@ -22,7 +22,7 @@ buildScan {
     String buildUrl = System.getenv('BUILD_URL')
     String jobName = System.getenv('JOB_NAME')
     String nodeName = System.getenv('NODE_NAME')
-    String jobBranch = System.getenv('JOB_BRANCH')
+    String jobBranch = System.getenv('ghprbTargetBranch') ?: System.getenv('JOB_BRANCH')
 
     tag OS.current().name()
     tag Architecture.current().name()


### PR DESCRIPTION
Pull request jobs should use the pull request target branch as the reported branch, as provided by the `ghprbTargetBranch` created by the Jenkins GitHub Pull Request Builder plugin.