### PR TITLE
Fix contents of license tools zip file

### DIFF
--- a/x-pack/license-tools/build.gradle
+++ b/x-pack/license-tools/build.gradle
@@ -14,7 +14,7 @@ tasks.named("dependencyLicenses").configure { enabled = false }
 
 tasks.register("buildZip", Zip) {
   dependsOn "jar"
-  String parentDir = "license-tools-${archiveVersion}"
+  String parentDir = "license-tools-${project.version}"
   into(parentDir + '/lib') {
     from jar
     from configurations.runtimeClasspath


### PR DESCRIPTION
Use of `${archiveVersion}` would produce zip files with the parent
directory incorrectly set, and contents like:

   license-tools-task ':x-pack:license-tools:buildZip' property 'archiveVersion'/lib/elasticsearch-core-8.0.0-SNAPSHOT.jar

This replaces archiveVersion with the project version instead.
