### PR TITLE
[ML] Delete expired annotations

### DIFF
--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/ml/job/config/Job.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/ml/job/config/Job.java
@@ -55,7 +55,7 @@ public class Job implements ToXContentObject {
     public static final ParseField DAILY_MODEL_SNAPSHOT_RETENTION_AFTER_DAYS =
         new ParseField("daily_model_snapshot_retention_after_days");
     public static final ParseField RESULTS_RETENTION_DAYS = new ParseField("results_retention_days");
-    public static final ParseField ANNOTATIONS_RETENTION_DAYS = new ParseField("annotations_retention_days");
+    public static final ParseField SYSTEM_ANNOTATIONS_RETENTION_DAYS = new ParseField("system_system_annotations_retention_days");
     public static final ParseField MODEL_SNAPSHOT_ID = new ParseField("model_snapshot_id");
     public static final ParseField RESULTS_INDEX_NAME = new ParseField("results_index_name");
     public static final ParseField DELETING = new ParseField("deleting");
@@ -84,7 +84,7 @@ public class Job implements ToXContentObject {
         PARSER.declareString((builder, val) -> builder.setBackgroundPersistInterval(
             TimeValue.parseTimeValue(val, BACKGROUND_PERSIST_INTERVAL.getPreferredName())), BACKGROUND_PERSIST_INTERVAL);
         PARSER.declareLong(Builder::setResultsRetentionDays, RESULTS_RETENTION_DAYS);
-        PARSER.declareLong(Builder::setAnnotationsRetentionDays, ANNOTATIONS_RETENTION_DAYS);
+        PARSER.declareLong(Builder::setSystemAnnotationsRetentionDays, SYSTEM_ANNOTATIONS_RETENTION_DAYS);
         PARSER.declareLong(Builder::setModelSnapshotRetentionDays, MODEL_SNAPSHOT_RETENTION_DAYS);
         PARSER.declareLong(Builder::setDailyModelSnapshotRetentionAfterDays, DAILY_MODEL_SNAPSHOT_RETENTION_AFTER_DAYS);
         PARSER.declareField(Builder::setCustomSettings, (p, c) -> p.mapOrdered(), CUSTOM_SETTINGS, ValueType.OBJECT);
@@ -110,7 +110,7 @@ public class Job implements ToXContentObject {
     private final Long modelSnapshotRetentionDays;
     private final Long dailyModelSnapshotRetentionAfterDays;
     private final Long resultsRetentionDays;
-    private final Long annotationsRetentionDays;
+    private final Long systemAnnotationsRetentionDays;
     private final Map<String, Object> customSettings;
     private final String modelSnapshotId;
     private final String resultsIndexName;
@@ -122,7 +122,7 @@ public class Job implements ToXContentObject {
                 AnalysisConfig analysisConfig, AnalysisLimits analysisLimits, DataDescription dataDescription,
                 ModelPlotConfig modelPlotConfig, Long renormalizationWindowDays, TimeValue backgroundPersistInterval,
                 Long modelSnapshotRetentionDays, Long dailyModelSnapshotRetentionAfterDays, Long resultsRetentionDays,
-                Long annotationsRetentionDays, Map<String, Object> customSettings, String modelSnapshotId, String resultsIndexName,
+                Long systemAnnotationsRetentionDays, Map<String, Object> customSettings, String modelSnapshotId, String resultsIndexName,
                 Boolean deleting, Boolean allowLazyOpen) {
 
         this.jobId = jobId;
@@ -140,7 +140,7 @@ public class Job implements ToXContentObject {
         this.modelSnapshotRetentionDays = modelSnapshotRetentionDays;
         this.dailyModelSnapshotRetentionAfterDays = dailyModelSnapshotRetentionAfterDays;
         this.resultsRetentionDays = resultsRetentionDays;
-        this.annotationsRetentionDays = annotationsRetentionDays;
+        this.systemAnnotationsRetentionDays = systemAnnotationsRetentionDays;
         this.customSettings = customSettings == null ? null : Collections.unmodifiableMap(customSettings);
         this.modelSnapshotId = modelSnapshotId;
         this.resultsIndexName = resultsIndexName;
@@ -266,8 +266,8 @@ public class Job implements ToXContentObject {
         return resultsRetentionDays;
     }
 
-    public Long getAnnotationsRetentionDays() {
-        return annotationsRetentionDays;
+    public Long getSystemAnnotationsRetentionDays() {
+        return systemAnnotationsRetentionDays;
     }
 
     public Map<String, Object> getCustomSettings() {
@@ -332,8 +332,8 @@ public class Job implements ToXContentObject {
         if (resultsRetentionDays != null) {
             builder.field(RESULTS_RETENTION_DAYS.getPreferredName(), resultsRetentionDays);
         }
-        if (annotationsRetentionDays != null) {
-            builder.field(ANNOTATIONS_RETENTION_DAYS.getPreferredName(), annotationsRetentionDays);
+        if (systemAnnotationsRetentionDays != null) {
+            builder.field(SYSTEM_ANNOTATIONS_RETENTION_DAYS.getPreferredName(), systemAnnotationsRetentionDays);
         }
         if (customSettings != null) {
             builder.field(CUSTOM_SETTINGS.getPreferredName(), customSettings);
@@ -383,7 +383,7 @@ public class Job implements ToXContentObject {
             && Objects.equals(this.customSettings, that.customSettings)
             && Objects.equals(this.modelSnapshotId, that.modelSnapshotId)
             && Objects.equals(this.resultsIndexName, that.resultsIndexName)
-            && Objects.equals(this.annotationsRetentionDays, that.annotationsRetentionDays)
+            && Objects.equals(this.systemAnnotationsRetentionDays, that.systemAnnotationsRetentionDays)
             && Objects.equals(this.deleting, that.deleting)
             && Objects.equals(this.allowLazyOpen, that.allowLazyOpen);
     }
@@ -393,7 +393,7 @@ public class Job implements ToXContentObject {
         return Objects.hash(jobId, jobType, groups, description, createTime, finishedTime,
             analysisConfig, analysisLimits, dataDescription, modelPlotConfig, renormalizationWindowDays,
             backgroundPersistInterval, modelSnapshotRetentionDays, dailyModelSnapshotRetentionAfterDays, resultsRetentionDays,
-            annotationsRetentionDays, customSettings, modelSnapshotId, resultsIndexName, deleting, allowLazyOpen);
+            systemAnnotationsRetentionDays, customSettings, modelSnapshotId, resultsIndexName, deleting, allowLazyOpen);
     }
 
     @Override
@@ -422,7 +422,7 @@ public class Job implements ToXContentObject {
         private Long modelSnapshotRetentionDays;
         private Long dailyModelSnapshotRetentionAfterDays;
         private Long resultsRetentionDays;
-        private Long annotationsRetentionDays;
+        private Long systemAnnotationsRetentionDays;
         private Map<String, Object> customSettings;
         private String modelSnapshotId;
         private String resultsIndexName;
@@ -452,7 +452,7 @@ public class Job implements ToXContentObject {
             this.modelSnapshotRetentionDays = job.getModelSnapshotRetentionDays();
             this.dailyModelSnapshotRetentionAfterDays = job.getDailyModelSnapshotRetentionAfterDays();
             this.resultsRetentionDays = job.getResultsRetentionDays();
-            this.annotationsRetentionDays = job.getAnnotationsRetentionDays();
+            this.systemAnnotationsRetentionDays = job.getSystemAnnotationsRetentionDays();
             this.customSettings = job.getCustomSettings() == null ? null : new LinkedHashMap<>(job.getCustomSettings());
             this.modelSnapshotId = job.getModelSnapshotId();
             this.resultsIndexName = job.getResultsIndexNameNoPrefix();
@@ -544,8 +544,8 @@ public class Job implements ToXContentObject {
             return this;
         }
 
-        public Builder setAnnotationsRetentionDays(Long annotationsRetentionDays) {
-            this.annotationsRetentionDays = annotationsRetentionDays;
+        public Builder setSystemAnnotationsRetentionDays(Long systemAnnotationsRetentionDays) {
+            this.systemAnnotationsRetentionDays = systemAnnotationsRetentionDays;
             return this;
         }
 
@@ -581,7 +581,7 @@ public class Job implements ToXContentObject {
                 id, jobType, groups, description, createTime, finishedTime,
                 analysisConfig, analysisLimits, dataDescription, modelPlotConfig, renormalizationWindowDays,
                 backgroundPersistInterval, modelSnapshotRetentionDays, dailyModelSnapshotRetentionAfterDays, resultsRetentionDays,
-                annotationsRetentionDays, customSettings, modelSnapshotId, resultsIndexName, deleting, allowLazyOpen);
+                systemAnnotationsRetentionDays, customSettings, modelSnapshotId, resultsIndexName, deleting, allowLazyOpen);
         }
     }
 }

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/ml/job/config/Job.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/ml/job/config/Job.java
@@ -55,7 +55,7 @@ public class Job implements ToXContentObject {
     public static final ParseField DAILY_MODEL_SNAPSHOT_RETENTION_AFTER_DAYS =
         new ParseField("daily_model_snapshot_retention_after_days");
     public static final ParseField RESULTS_RETENTION_DAYS = new ParseField("results_retention_days");
-    public static final ParseField SYSTEM_ANNOTATIONS_RETENTION_DAYS = new ParseField("system_system_annotations_retention_days");
+    public static final ParseField SYSTEM_ANNOTATIONS_RETENTION_DAYS = new ParseField("system_annotations_retention_days");
     public static final ParseField MODEL_SNAPSHOT_ID = new ParseField("model_snapshot_id");
     public static final ParseField RESULTS_INDEX_NAME = new ParseField("results_index_name");
     public static final ParseField DELETING = new ParseField("deleting");

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/ml/job/config/Job.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/ml/job/config/Job.java
@@ -55,6 +55,7 @@ public class Job implements ToXContentObject {
     public static final ParseField DAILY_MODEL_SNAPSHOT_RETENTION_AFTER_DAYS =
         new ParseField("daily_model_snapshot_retention_after_days");
     public static final ParseField RESULTS_RETENTION_DAYS = new ParseField("results_retention_days");
+    public static final ParseField ANNOTATIONS_RETENTION_DAYS = new ParseField("annotations_retention_days");
     public static final ParseField MODEL_SNAPSHOT_ID = new ParseField("model_snapshot_id");
     public static final ParseField RESULTS_INDEX_NAME = new ParseField("results_index_name");
     public static final ParseField DELETING = new ParseField("deleting");
@@ -83,6 +84,7 @@ public class Job implements ToXContentObject {
         PARSER.declareString((builder, val) -> builder.setBackgroundPersistInterval(
             TimeValue.parseTimeValue(val, BACKGROUND_PERSIST_INTERVAL.getPreferredName())), BACKGROUND_PERSIST_INTERVAL);
         PARSER.declareLong(Builder::setResultsRetentionDays, RESULTS_RETENTION_DAYS);
+        PARSER.declareLong(Builder::setAnnotationsRetentionDays, ANNOTATIONS_RETENTION_DAYS);
         PARSER.declareLong(Builder::setModelSnapshotRetentionDays, MODEL_SNAPSHOT_RETENTION_DAYS);
         PARSER.declareLong(Builder::setDailyModelSnapshotRetentionAfterDays, DAILY_MODEL_SNAPSHOT_RETENTION_AFTER_DAYS);
         PARSER.declareField(Builder::setCustomSettings, (p, c) -> p.mapOrdered(), CUSTOM_SETTINGS, ValueType.OBJECT);
@@ -108,6 +110,7 @@ public class Job implements ToXContentObject {
     private final Long modelSnapshotRetentionDays;
     private final Long dailyModelSnapshotRetentionAfterDays;
     private final Long resultsRetentionDays;
+    private final Long annotationsRetentionDays;
     private final Map<String, Object> customSettings;
     private final String modelSnapshotId;
     private final String resultsIndexName;
@@ -119,8 +122,8 @@ public class Job implements ToXContentObject {
                 AnalysisConfig analysisConfig, AnalysisLimits analysisLimits, DataDescription dataDescription,
                 ModelPlotConfig modelPlotConfig, Long renormalizationWindowDays, TimeValue backgroundPersistInterval,
                 Long modelSnapshotRetentionDays, Long dailyModelSnapshotRetentionAfterDays, Long resultsRetentionDays,
-                Map<String, Object> customSettings, String modelSnapshotId, String resultsIndexName, Boolean deleting,
-                Boolean allowLazyOpen) {
+                Long annotationsRetentionDays, Map<String, Object> customSettings, String modelSnapshotId, String resultsIndexName,
+                Boolean deleting, Boolean allowLazyOpen) {
 
         this.jobId = jobId;
         this.jobType = jobType;
@@ -137,6 +140,7 @@ public class Job implements ToXContentObject {
         this.modelSnapshotRetentionDays = modelSnapshotRetentionDays;
         this.dailyModelSnapshotRetentionAfterDays = dailyModelSnapshotRetentionAfterDays;
         this.resultsRetentionDays = resultsRetentionDays;
+        this.annotationsRetentionDays = annotationsRetentionDays;
         this.customSettings = customSettings == null ? null : Collections.unmodifiableMap(customSettings);
         this.modelSnapshotId = modelSnapshotId;
         this.resultsIndexName = resultsIndexName;
@@ -262,6 +266,10 @@ public class Job implements ToXContentObject {
         return resultsRetentionDays;
     }
 
+    public Long getAnnotationsRetentionDays() {
+        return annotationsRetentionDays;
+    }
+
     public Map<String, Object> getCustomSettings() {
         return customSettings;
     }
@@ -324,6 +332,9 @@ public class Job implements ToXContentObject {
         if (resultsRetentionDays != null) {
             builder.field(RESULTS_RETENTION_DAYS.getPreferredName(), resultsRetentionDays);
         }
+        if (annotationsRetentionDays != null) {
+            builder.field(ANNOTATIONS_RETENTION_DAYS.getPreferredName(), annotationsRetentionDays);
+        }
         if (customSettings != null) {
             builder.field(CUSTOM_SETTINGS.getPreferredName(), customSettings);
         }
@@ -372,6 +383,7 @@ public class Job implements ToXContentObject {
             && Objects.equals(this.customSettings, that.customSettings)
             && Objects.equals(this.modelSnapshotId, that.modelSnapshotId)
             && Objects.equals(this.resultsIndexName, that.resultsIndexName)
+            && Objects.equals(this.annotationsRetentionDays, that.annotationsRetentionDays)
             && Objects.equals(this.deleting, that.deleting)
             && Objects.equals(this.allowLazyOpen, that.allowLazyOpen);
     }
@@ -381,7 +393,7 @@ public class Job implements ToXContentObject {
         return Objects.hash(jobId, jobType, groups, description, createTime, finishedTime,
             analysisConfig, analysisLimits, dataDescription, modelPlotConfig, renormalizationWindowDays,
             backgroundPersistInterval, modelSnapshotRetentionDays, dailyModelSnapshotRetentionAfterDays, resultsRetentionDays,
-            customSettings, modelSnapshotId, resultsIndexName, deleting, allowLazyOpen);
+            annotationsRetentionDays, customSettings, modelSnapshotId, resultsIndexName, deleting, allowLazyOpen);
     }
 
     @Override
@@ -410,6 +422,7 @@ public class Job implements ToXContentObject {
         private Long modelSnapshotRetentionDays;
         private Long dailyModelSnapshotRetentionAfterDays;
         private Long resultsRetentionDays;
+        private Long annotationsRetentionDays;
         private Map<String, Object> customSettings;
         private String modelSnapshotId;
         private String resultsIndexName;
@@ -439,6 +452,7 @@ public class Job implements ToXContentObject {
             this.modelSnapshotRetentionDays = job.getModelSnapshotRetentionDays();
             this.dailyModelSnapshotRetentionAfterDays = job.getDailyModelSnapshotRetentionAfterDays();
             this.resultsRetentionDays = job.getResultsRetentionDays();
+            this.annotationsRetentionDays = job.getAnnotationsRetentionDays();
             this.customSettings = job.getCustomSettings() == null ? null : new LinkedHashMap<>(job.getCustomSettings());
             this.modelSnapshotId = job.getModelSnapshotId();
             this.resultsIndexName = job.getResultsIndexNameNoPrefix();
@@ -530,6 +544,11 @@ public class Job implements ToXContentObject {
             return this;
         }
 
+        public Builder setAnnotationsRetentionDays(Long annotationsRetentionDays) {
+            this.annotationsRetentionDays = annotationsRetentionDays;
+            return this;
+        }
+
         public Builder setModelSnapshotId(String modelSnapshotId) {
             this.modelSnapshotId = modelSnapshotId;
             return this;
@@ -562,7 +581,7 @@ public class Job implements ToXContentObject {
                 id, jobType, groups, description, createTime, finishedTime,
                 analysisConfig, analysisLimits, dataDescription, modelPlotConfig, renormalizationWindowDays,
                 backgroundPersistInterval, modelSnapshotRetentionDays, dailyModelSnapshotRetentionAfterDays, resultsRetentionDays,
-                customSettings, modelSnapshotId, resultsIndexName, deleting, allowLazyOpen);
+                annotationsRetentionDays, customSettings, modelSnapshotId, resultsIndexName, deleting, allowLazyOpen);
         }
     }
 }

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/ml/job/config/JobUpdate.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/ml/job/config/JobUpdate.java
@@ -40,6 +40,7 @@ public class JobUpdate implements ToXContentObject {
                 TimeValue.parseTimeValue(val, Job.BACKGROUND_PERSIST_INTERVAL.getPreferredName())), Job.BACKGROUND_PERSIST_INTERVAL);
         PARSER.declareLong(Builder::setRenormalizationWindowDays, Job.RENORMALIZATION_WINDOW_DAYS);
         PARSER.declareLong(Builder::setResultsRetentionDays, Job.RESULTS_RETENTION_DAYS);
+        PARSER.declareLong(Builder::setAnnotationsRetentionDays, Job.ANNOTATIONS_RETENTION_DAYS);
         PARSER.declareLong(Builder::setModelSnapshotRetentionDays, Job.MODEL_SNAPSHOT_RETENTION_DAYS);
         PARSER.declareLong(Builder::setDailyModelSnapshotRetentionAfterDays, Job.DAILY_MODEL_SNAPSHOT_RETENTION_AFTER_DAYS);
         PARSER.declareStringArray(Builder::setCategorizationFilters, AnalysisConfig.CATEGORIZATION_FILTERS);
@@ -60,6 +61,7 @@ public class JobUpdate implements ToXContentObject {
     private final Long modelSnapshotRetentionDays;
     private final Long dailyModelSnapshotRetentionAfterDays;
     private final Long resultsRetentionDays;
+    private final Long annotationsRetentionDays;
     private final List<String> categorizationFilters;
     private final PerPartitionCategorizationConfig perPartitionCategorizationConfig;
     private final Map<String, Object> customSettings;
@@ -69,8 +71,8 @@ public class JobUpdate implements ToXContentObject {
                       @Nullable List<DetectorUpdate> detectorUpdates, @Nullable ModelPlotConfig modelPlotConfig,
                       @Nullable AnalysisLimits analysisLimits, @Nullable TimeValue backgroundPersistInterval,
                       @Nullable Long renormalizationWindowDays, @Nullable Long resultsRetentionDays,
-                      @Nullable Long modelSnapshotRetentionDays, @Nullable Long dailyModelSnapshotRetentionAfterDays,
-                      @Nullable List<String> categorizationFilters,
+                      @Nullable Long annotationsRetentionDays, @Nullable Long modelSnapshotRetentionDays,
+                      @Nullable Long dailyModelSnapshotRetentionAfterDays, @Nullable List<String> categorizationFilters,
                       @Nullable PerPartitionCategorizationConfig perPartitionCategorizationConfig,
                       @Nullable Map<String, Object> customSettings, @Nullable Boolean allowLazyOpen) {
         this.jobId = jobId;
@@ -84,6 +86,7 @@ public class JobUpdate implements ToXContentObject {
         this.modelSnapshotRetentionDays = modelSnapshotRetentionDays;
         this.dailyModelSnapshotRetentionAfterDays = dailyModelSnapshotRetentionAfterDays;
         this.resultsRetentionDays = resultsRetentionDays;
+        this.annotationsRetentionDays = annotationsRetentionDays;
         this.categorizationFilters = categorizationFilters;
         this.perPartitionCategorizationConfig = perPartitionCategorizationConfig;
         this.customSettings = customSettings;
@@ -128,6 +131,10 @@ public class JobUpdate implements ToXContentObject {
 
     public Long getResultsRetentionDays() {
         return resultsRetentionDays;
+    }
+
+    public Long getAnnotationsRetentionDays() {
+        return annotationsRetentionDays;
     }
 
     public List<String> getCategorizationFilters() {
@@ -180,6 +187,9 @@ public class JobUpdate implements ToXContentObject {
         if (resultsRetentionDays != null) {
             builder.field(Job.RESULTS_RETENTION_DAYS.getPreferredName(), resultsRetentionDays);
         }
+        if (annotationsRetentionDays != null) {
+            builder.field(Job.ANNOTATIONS_RETENTION_DAYS.getPreferredName(), annotationsRetentionDays);
+        }
         if (categorizationFilters != null) {
             builder.field(AnalysisConfig.CATEGORIZATION_FILTERS.getPreferredName(), categorizationFilters);
         }
@@ -219,6 +229,7 @@ public class JobUpdate implements ToXContentObject {
             && Objects.equals(this.modelSnapshotRetentionDays, that.modelSnapshotRetentionDays)
             && Objects.equals(this.dailyModelSnapshotRetentionAfterDays, that.dailyModelSnapshotRetentionAfterDays)
             && Objects.equals(this.resultsRetentionDays, that.resultsRetentionDays)
+            && Objects.equals(this.annotationsRetentionDays, that.annotationsRetentionDays)
             && Objects.equals(this.categorizationFilters, that.categorizationFilters)
             && Objects.equals(this.perPartitionCategorizationConfig, that.perPartitionCategorizationConfig)
             && Objects.equals(this.customSettings, that.customSettings)
@@ -229,7 +240,7 @@ public class JobUpdate implements ToXContentObject {
     public int hashCode() {
         return Objects.hash(jobId, groups, description, detectorUpdates, modelPlotConfig, analysisLimits, renormalizationWindowDays,
             backgroundPersistInterval, modelSnapshotRetentionDays, dailyModelSnapshotRetentionAfterDays, resultsRetentionDays,
-            categorizationFilters, perPartitionCategorizationConfig, customSettings, allowLazyOpen);
+            annotationsRetentionDays, categorizationFilters, perPartitionCategorizationConfig, customSettings, allowLazyOpen);
     }
 
     public static class DetectorUpdate implements ToXContentObject {
@@ -324,6 +335,7 @@ public class JobUpdate implements ToXContentObject {
         private Long modelSnapshotRetentionDays;
         private Long dailyModelSnapshotRetentionAfterDays;
         private Long resultsRetentionDays;
+        private Long annotationsRetentionDays;
         private List<String> categorizationFilters;
         private PerPartitionCategorizationConfig perPartitionCategorizationConfig;
         private Map<String, Object> customSettings;
@@ -459,6 +471,18 @@ public class JobUpdate implements ToXContentObject {
         }
 
         /**
+         * Advanced configuration option. The number of days for which job annotations are retained
+         *
+         * Updates the {@link Job#annotationsRetentionDays} setting
+         *
+         * @param annotationsRetentionDays number of days to keep results.
+         */
+        public Builder setAnnotationsRetentionDays(Long annotationsRetentionDays) {
+            this.annotationsRetentionDays = annotationsRetentionDays;
+            return this;
+        }
+
+        /**
          * Sets the categorization filters on the {@link Job}
          *
          * Updates the {@link AnalysisConfig#categorizationFilters} setting.
@@ -503,8 +527,9 @@ public class JobUpdate implements ToXContentObject {
 
         public JobUpdate build() {
             return new JobUpdate(jobId, groups, description, detectorUpdates, modelPlotConfig, analysisLimits, backgroundPersistInterval,
-                renormalizationWindowDays, resultsRetentionDays, modelSnapshotRetentionDays, dailyModelSnapshotRetentionAfterDays,
-                categorizationFilters, perPartitionCategorizationConfig, customSettings, allowLazyOpen);
+                renormalizationWindowDays, resultsRetentionDays, annotationsRetentionDays, modelSnapshotRetentionDays,
+                dailyModelSnapshotRetentionAfterDays, categorizationFilters, perPartitionCategorizationConfig, customSettings,
+                allowLazyOpen);
         }
     }
 }

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/ml/job/config/JobUpdate.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/ml/job/config/JobUpdate.java
@@ -40,7 +40,7 @@ public class JobUpdate implements ToXContentObject {
                 TimeValue.parseTimeValue(val, Job.BACKGROUND_PERSIST_INTERVAL.getPreferredName())), Job.BACKGROUND_PERSIST_INTERVAL);
         PARSER.declareLong(Builder::setRenormalizationWindowDays, Job.RENORMALIZATION_WINDOW_DAYS);
         PARSER.declareLong(Builder::setResultsRetentionDays, Job.RESULTS_RETENTION_DAYS);
-        PARSER.declareLong(Builder::setAnnotationsRetentionDays, Job.ANNOTATIONS_RETENTION_DAYS);
+        PARSER.declareLong(Builder::setSystemAnnotationsRetentionDays, Job.SYSTEM_ANNOTATIONS_RETENTION_DAYS);
         PARSER.declareLong(Builder::setModelSnapshotRetentionDays, Job.MODEL_SNAPSHOT_RETENTION_DAYS);
         PARSER.declareLong(Builder::setDailyModelSnapshotRetentionAfterDays, Job.DAILY_MODEL_SNAPSHOT_RETENTION_AFTER_DAYS);
         PARSER.declareStringArray(Builder::setCategorizationFilters, AnalysisConfig.CATEGORIZATION_FILTERS);
@@ -61,7 +61,7 @@ public class JobUpdate implements ToXContentObject {
     private final Long modelSnapshotRetentionDays;
     private final Long dailyModelSnapshotRetentionAfterDays;
     private final Long resultsRetentionDays;
-    private final Long annotationsRetentionDays;
+    private final Long systemAnnotationsRetentionDays;
     private final List<String> categorizationFilters;
     private final PerPartitionCategorizationConfig perPartitionCategorizationConfig;
     private final Map<String, Object> customSettings;
@@ -71,7 +71,7 @@ public class JobUpdate implements ToXContentObject {
                       @Nullable List<DetectorUpdate> detectorUpdates, @Nullable ModelPlotConfig modelPlotConfig,
                       @Nullable AnalysisLimits analysisLimits, @Nullable TimeValue backgroundPersistInterval,
                       @Nullable Long renormalizationWindowDays, @Nullable Long resultsRetentionDays,
-                      @Nullable Long annotationsRetentionDays, @Nullable Long modelSnapshotRetentionDays,
+                      @Nullable Long systemAnnotationsRetentionDays, @Nullable Long modelSnapshotRetentionDays,
                       @Nullable Long dailyModelSnapshotRetentionAfterDays, @Nullable List<String> categorizationFilters,
                       @Nullable PerPartitionCategorizationConfig perPartitionCategorizationConfig,
                       @Nullable Map<String, Object> customSettings, @Nullable Boolean allowLazyOpen) {
@@ -86,7 +86,7 @@ public class JobUpdate implements ToXContentObject {
         this.modelSnapshotRetentionDays = modelSnapshotRetentionDays;
         this.dailyModelSnapshotRetentionAfterDays = dailyModelSnapshotRetentionAfterDays;
         this.resultsRetentionDays = resultsRetentionDays;
-        this.annotationsRetentionDays = annotationsRetentionDays;
+        this.systemAnnotationsRetentionDays = systemAnnotationsRetentionDays;
         this.categorizationFilters = categorizationFilters;
         this.perPartitionCategorizationConfig = perPartitionCategorizationConfig;
         this.customSettings = customSettings;
@@ -133,8 +133,8 @@ public class JobUpdate implements ToXContentObject {
         return resultsRetentionDays;
     }
 
-    public Long getAnnotationsRetentionDays() {
-        return annotationsRetentionDays;
+    public Long getSystemAnnotationsRetentionDays() {
+        return systemAnnotationsRetentionDays;
     }
 
     public List<String> getCategorizationFilters() {
@@ -187,8 +187,8 @@ public class JobUpdate implements ToXContentObject {
         if (resultsRetentionDays != null) {
             builder.field(Job.RESULTS_RETENTION_DAYS.getPreferredName(), resultsRetentionDays);
         }
-        if (annotationsRetentionDays != null) {
-            builder.field(Job.ANNOTATIONS_RETENTION_DAYS.getPreferredName(), annotationsRetentionDays);
+        if (systemAnnotationsRetentionDays != null) {
+            builder.field(Job.SYSTEM_ANNOTATIONS_RETENTION_DAYS.getPreferredName(), systemAnnotationsRetentionDays);
         }
         if (categorizationFilters != null) {
             builder.field(AnalysisConfig.CATEGORIZATION_FILTERS.getPreferredName(), categorizationFilters);
@@ -229,7 +229,7 @@ public class JobUpdate implements ToXContentObject {
             && Objects.equals(this.modelSnapshotRetentionDays, that.modelSnapshotRetentionDays)
             && Objects.equals(this.dailyModelSnapshotRetentionAfterDays, that.dailyModelSnapshotRetentionAfterDays)
             && Objects.equals(this.resultsRetentionDays, that.resultsRetentionDays)
-            && Objects.equals(this.annotationsRetentionDays, that.annotationsRetentionDays)
+            && Objects.equals(this.systemAnnotationsRetentionDays, that.systemAnnotationsRetentionDays)
             && Objects.equals(this.categorizationFilters, that.categorizationFilters)
             && Objects.equals(this.perPartitionCategorizationConfig, that.perPartitionCategorizationConfig)
             && Objects.equals(this.customSettings, that.customSettings)
@@ -240,7 +240,7 @@ public class JobUpdate implements ToXContentObject {
     public int hashCode() {
         return Objects.hash(jobId, groups, description, detectorUpdates, modelPlotConfig, analysisLimits, renormalizationWindowDays,
             backgroundPersistInterval, modelSnapshotRetentionDays, dailyModelSnapshotRetentionAfterDays, resultsRetentionDays,
-            annotationsRetentionDays, categorizationFilters, perPartitionCategorizationConfig, customSettings, allowLazyOpen);
+            systemAnnotationsRetentionDays, categorizationFilters, perPartitionCategorizationConfig, customSettings, allowLazyOpen);
     }
 
     public static class DetectorUpdate implements ToXContentObject {
@@ -335,7 +335,7 @@ public class JobUpdate implements ToXContentObject {
         private Long modelSnapshotRetentionDays;
         private Long dailyModelSnapshotRetentionAfterDays;
         private Long resultsRetentionDays;
-        private Long annotationsRetentionDays;
+        private Long systemAnnotationsRetentionDays;
         private List<String> categorizationFilters;
         private PerPartitionCategorizationConfig perPartitionCategorizationConfig;
         private Map<String, Object> customSettings;
@@ -473,12 +473,12 @@ public class JobUpdate implements ToXContentObject {
         /**
          * Advanced configuration option. The number of days for which job annotations are retained
          *
-         * Updates the {@link Job#annotationsRetentionDays} setting
+         * Updates the {@link Job#systemAnnotationsRetentionDays} setting
          *
-         * @param annotationsRetentionDays number of days to keep results.
+         * @param systemAnnotationsRetentionDays number of days to keep results.
          */
-        public Builder setAnnotationsRetentionDays(Long annotationsRetentionDays) {
-            this.annotationsRetentionDays = annotationsRetentionDays;
+        public Builder setSystemAnnotationsRetentionDays(Long systemAnnotationsRetentionDays) {
+            this.systemAnnotationsRetentionDays = systemAnnotationsRetentionDays;
             return this;
         }
 
@@ -527,7 +527,7 @@ public class JobUpdate implements ToXContentObject {
 
         public JobUpdate build() {
             return new JobUpdate(jobId, groups, description, detectorUpdates, modelPlotConfig, analysisLimits, backgroundPersistInterval,
-                renormalizationWindowDays, resultsRetentionDays, annotationsRetentionDays, modelSnapshotRetentionDays,
+                renormalizationWindowDays, resultsRetentionDays, systemAnnotationsRetentionDays, modelSnapshotRetentionDays,
                 dailyModelSnapshotRetentionAfterDays, categorizationFilters, perPartitionCategorizationConfig, customSettings,
                 allowLazyOpen);
         }

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/ml/job/config/JobTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/ml/job/config/JobTests.java
@@ -146,7 +146,7 @@ public class JobTests extends AbstractXContentTestCase<Job> {
             builder.setResultsRetentionDays(randomNonNegativeLong());
         }
         if (randomBoolean()) {
-            builder.setAnnotationsRetentionDays(randomNonNegativeLong());
+            builder.setSystemAnnotationsRetentionDays(randomNonNegativeLong());
         }
         if (randomBoolean()) {
             builder.setCustomSettings(Collections.singletonMap(randomAlphaOfLength(10), randomAlphaOfLength(10)));

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/ml/job/config/JobTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/ml/job/config/JobTests.java
@@ -146,6 +146,9 @@ public class JobTests extends AbstractXContentTestCase<Job> {
             builder.setResultsRetentionDays(randomNonNegativeLong());
         }
         if (randomBoolean()) {
+            builder.setAnnotationsRetentionDays(randomNonNegativeLong());
+        }
+        if (randomBoolean()) {
             builder.setCustomSettings(Collections.singletonMap(randomAlphaOfLength(10), randomAlphaOfLength(10)));
         }
         if (randomBoolean()) {

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/ml/job/config/JobUpdateTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/ml/job/config/JobUpdateTests.java
@@ -66,6 +66,9 @@ public class JobUpdateTests extends AbstractXContentTestCase<JobUpdate> {
             update.setResultsRetentionDays(randomNonNegativeLong());
         }
         if (randomBoolean()) {
+            update.setAnnotationsRetentionDays(randomNonNegativeLong());
+        }
+        if (randomBoolean()) {
             update.setCategorizationFilters(Arrays.asList(generateRandomStringArray(10, 10, false)));
         }
         if (randomBoolean()) {

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/ml/job/config/JobUpdateTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/ml/job/config/JobUpdateTests.java
@@ -66,7 +66,7 @@ public class JobUpdateTests extends AbstractXContentTestCase<JobUpdate> {
             update.setResultsRetentionDays(randomNonNegativeLong());
         }
         if (randomBoolean()) {
-            update.setAnnotationsRetentionDays(randomNonNegativeLong());
+            update.setSystemAnnotationsRetentionDays(randomNonNegativeLong());
         }
         if (randomBoolean()) {
             update.setCategorizationFilters(Arrays.asList(generateRandomStringArray(10, 10, false)));

--- a/docs/reference/ml/anomaly-detection/apis/put-job.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/put-job.asciidoc
@@ -375,7 +375,7 @@ include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=results-index-name]
 (Optional, long)
 include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=results-retention-days]
 
-`system_system_annotations_retention_days`::
+`system_annotations_retention_days`::
 (Optional, long)
 include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=system-annotations-retention-days]
 

--- a/docs/reference/ml/anomaly-detection/apis/put-job.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/put-job.asciidoc
@@ -375,6 +375,10 @@ include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=results-index-name]
 (Optional, long)
 include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=results-retention-days]
 
+`annotations_retention_days`::
+(Optional, long)
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=annotations-retention-days]
+
 [[ml-put-job-example]]
 == {api-examples-title}
 

--- a/docs/reference/ml/anomaly-detection/apis/put-job.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/put-job.asciidoc
@@ -375,9 +375,9 @@ include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=results-index-name]
 (Optional, long)
 include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=results-retention-days]
 
-`annotations_retention_days`::
+`system_system_annotations_retention_days`::
 (Optional, long)
-include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=annotations-retention-days]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=system-annotations-retention-days]
 
 [[ml-put-job-example]]
 == {api-examples-title}

--- a/docs/reference/ml/anomaly-detection/apis/update-job.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/update-job.asciidoc
@@ -232,7 +232,7 @@ close the job, then reopen the job and restart the {dfeed} for the changes to ta
 (long)
 include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=results-retention-days]
 
-`system_system_annotations_retention_days`::
+`system_annotations_retention_days`::
 (long)
 include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=system-annotations-retention-days]
 
@@ -257,7 +257,7 @@ POST _ml/anomaly_detectors/low_request_rate/_update
   "background_persist_interval": "2h",
   "model_snapshot_retention_days": 7,
   "results_retention_days": 60,
-  "system_system_annotations_retention_days": 60
+  "system_annotations_retention_days": 60
 }
 --------------------------------------------------
 // TEST[skip:setup:Kibana sample data]

--- a/docs/reference/ml/anomaly-detection/apis/update-job.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/update-job.asciidoc
@@ -232,6 +232,10 @@ close the job, then reopen the job and restart the {dfeed} for the changes to ta
 (long)
 include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=results-retention-days]
 
+`annotations_retention_days`::
+(long)
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=annotations-retention-days]
+
 
 [[ml-update-job-example]]
 == {api-examples-title}
@@ -252,7 +256,8 @@ POST _ml/anomaly_detectors/low_request_rate/_update
   "renormalization_window_days": 30,
   "background_persist_interval": "2h",
   "model_snapshot_retention_days": 7,
-  "results_retention_days": 60
+  "results_retention_days": 60,
+  "annotations_retention_days": 60
 }
 --------------------------------------------------
 // TEST[skip:setup:Kibana sample data]

--- a/docs/reference/ml/anomaly-detection/apis/update-job.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/update-job.asciidoc
@@ -232,9 +232,9 @@ close the job, then reopen the job and restart the {dfeed} for the changes to ta
 (long)
 include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=results-retention-days]
 
-`annotations_retention_days`::
+`system_system_annotations_retention_days`::
 (long)
-include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=annotations-retention-days]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=system-annotations-retention-days]
 
 
 [[ml-update-job-example]]
@@ -257,7 +257,7 @@ POST _ml/anomaly_detectors/low_request_rate/_update
   "background_persist_interval": "2h",
   "model_snapshot_retention_days": 7,
   "results_retention_days": 60,
-  "annotations_retention_days": 60
+  "system_system_annotations_retention_days": 60
 }
 --------------------------------------------------
 // TEST[skip:setup:Kibana sample data]

--- a/docs/reference/ml/ml-shared.asciidoc
+++ b/docs/reference/ml/ml-shared.asciidoc
@@ -1427,6 +1427,15 @@ bucket result are deleted from {es}. The default value is null, which means all
 results are retained.
 end::results-retention-days[]
 
+tag::annotations-retention-days[]
+Advanced configuration option. The period of time (in days) that annotations are
+retained. Age is calculated relative to the timestamp of the latest bucket
+result. If this property has a non-null value, once per day at 00:30 (server
+time), annotations that are the specified number of days older than the latest
+bucket result are deleted from {es}. The default value is null, which means all
+annotations are retained.
+end::annotations-retention-days[]
+
 tag::retain[]
 If `true`, this snapshot will not be deleted during automatic cleanup of
 snapshots older than `model_snapshot_retention_days`. However, this snapshot

--- a/docs/reference/ml/ml-shared.asciidoc
+++ b/docs/reference/ml/ml-shared.asciidoc
@@ -1427,7 +1427,7 @@ bucket result are deleted from {es}. The default value is null, which means all
 results are retained.
 end::results-retention-days[]
 
-tag::annotations-retention-days[]
+tag::system-annotations-retention-days[]
 Advanced configuration option. The period of time (in days) that automatically
 created annotations are retained. Age is calculated relative to the timestamp of
 the latest bucket result. If this property has a non-null value, once per day at
@@ -1435,7 +1435,7 @@ the latest bucket result. If this property has a non-null value, once per day at
 than the latest bucket result are deleted from {es}. The default value is null,
 which means all annotations are retained.
 User created annotations are never deleted automatically.
-end::annotations-retention-days[]
+end::system-annotations-retention-days[]
 
 tag::retain[]
 If `true`, this snapshot will not be deleted during automatic cleanup of

--- a/docs/reference/ml/ml-shared.asciidoc
+++ b/docs/reference/ml/ml-shared.asciidoc
@@ -1428,12 +1428,13 @@ results are retained.
 end::results-retention-days[]
 
 tag::annotations-retention-days[]
-Advanced configuration option. The period of time (in days) that annotations are
-retained. Age is calculated relative to the timestamp of the latest bucket
-result. If this property has a non-null value, once per day at 00:30 (server
-time), annotations that are the specified number of days older than the latest
-bucket result are deleted from {es}. The default value is null, which means all
-annotations are retained.
+Advanced configuration option. The period of time (in days) that automatically
+created annotations are retained. Age is calculated relative to the timestamp of
+the latest bucket result. If this property has a non-null value, once per day at
+00:30 (server time), annotations that are the specified number of days older
+than the latest bucket result are deleted from {es}. The default value is null,
+which means all annotations are retained.
+User created annotations are never deleted automatically.
 end::annotations-retention-days[]
 
 tag::retain[]

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/config/Job.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/config/Job.java
@@ -83,7 +83,7 @@ public class Job extends AbstractDiffable<Job> implements Writeable, ToXContentO
     public static final ParseField DAILY_MODEL_SNAPSHOT_RETENTION_AFTER_DAYS =
         new ParseField("daily_model_snapshot_retention_after_days");
     public static final ParseField RESULTS_RETENTION_DAYS = new ParseField("results_retention_days");
-    public static final ParseField ANNOTATIONS_RETENTION_DAYS = new ParseField("annotations_retention_days");
+    public static final ParseField SYSTEM_ANNOTATIONS_RETENTION_DAYS = new ParseField("system_system_annotations_retention_days");
     public static final ParseField MODEL_SNAPSHOT_ID = new ParseField("model_snapshot_id");
     public static final ParseField MODEL_SNAPSHOT_MIN_VERSION = new ParseField("model_snapshot_min_version");
     public static final ParseField RESULTS_INDEX_NAME = new ParseField("results_index_name");
@@ -136,7 +136,7 @@ public class Job extends AbstractDiffable<Job> implements Writeable, ToXContentO
         parser.declareString((builder, val) -> builder.setBackgroundPersistInterval(
             TimeValue.parseTimeValue(val, BACKGROUND_PERSIST_INTERVAL.getPreferredName())), BACKGROUND_PERSIST_INTERVAL);
         parser.declareLong(Builder::setResultsRetentionDays, RESULTS_RETENTION_DAYS);
-        parser.declareLong(Builder::setAnnotationsRetentionDays, ANNOTATIONS_RETENTION_DAYS);
+        parser.declareLong(Builder::setSystemAnnotationsRetentionDays, SYSTEM_ANNOTATIONS_RETENTION_DAYS);
         parser.declareLong(Builder::setModelSnapshotRetentionDays, MODEL_SNAPSHOT_RETENTION_DAYS);
         parser.declareLong(Builder::setDailyModelSnapshotRetentionAfterDays, DAILY_MODEL_SNAPSHOT_RETENTION_AFTER_DAYS);
         parser.declareField(Builder::setCustomSettings, (p, c) -> p.mapOrdered(), CUSTOM_SETTINGS, ValueType.OBJECT);
@@ -176,7 +176,7 @@ public class Job extends AbstractDiffable<Job> implements Writeable, ToXContentO
     private final Long modelSnapshotRetentionDays;
     private final Long dailyModelSnapshotRetentionAfterDays;
     private final Long resultsRetentionDays;
-    private final Long annotationsRetentionDays;
+    private final Long systemAnnotationsRetentionDays;
     private final Map<String, Object> customSettings;
     private final String modelSnapshotId;
     private final Version modelSnapshotMinVersion;
@@ -191,8 +191,9 @@ public class Job extends AbstractDiffable<Job> implements Writeable, ToXContentO
                 AnalysisConfig analysisConfig, AnalysisLimits analysisLimits, DataDescription dataDescription,
                 ModelPlotConfig modelPlotConfig, Long renormalizationWindowDays, TimeValue backgroundPersistInterval,
                 Long modelSnapshotRetentionDays, Long dailyModelSnapshotRetentionAfterDays, Long resultsRetentionDays,
-                Long annotationsRetentionDays, Map<String, Object> customSettings, String modelSnapshotId, Version modelSnapshotMinVersion,
-                String resultsIndexName, boolean deleting, boolean allowLazyOpen, Blocked blocked, DatafeedConfig datafeedConfig) {
+                Long systemAnnotationsRetentionDays, Map<String, Object> customSettings, String modelSnapshotId,
+                Version modelSnapshotMinVersion, String resultsIndexName, boolean deleting, boolean allowLazyOpen, Blocked blocked,
+                DatafeedConfig datafeedConfig) {
         this.jobId = jobId;
         this.jobType = jobType;
         this.jobVersion = jobVersion;
@@ -209,7 +210,7 @@ public class Job extends AbstractDiffable<Job> implements Writeable, ToXContentO
         this.modelSnapshotRetentionDays = modelSnapshotRetentionDays;
         this.dailyModelSnapshotRetentionAfterDays = dailyModelSnapshotRetentionAfterDays;
         this.resultsRetentionDays = resultsRetentionDays;
-        this.annotationsRetentionDays = annotationsRetentionDays;
+        this.systemAnnotationsRetentionDays = systemAnnotationsRetentionDays;
         this.customSettings = customSettings == null ? null : Collections.unmodifiableMap(customSettings);
         this.modelSnapshotId = modelSnapshotId;
         this.modelSnapshotMinVersion = modelSnapshotMinVersion;
@@ -248,9 +249,9 @@ public class Job extends AbstractDiffable<Job> implements Writeable, ToXContentO
         dailyModelSnapshotRetentionAfterDays = in.readOptionalLong();
         resultsRetentionDays = in.readOptionalLong();
         if (in.getVersion().onOrAfter(Version.V_8_0_0)) {  // TODO: 7.15
-            annotationsRetentionDays = in.readOptionalLong();
+            systemAnnotationsRetentionDays = in.readOptionalLong();
         } else {
-            annotationsRetentionDays = null;
+            systemAnnotationsRetentionDays = null;
         }
         Map<String, Object> readCustomSettings = in.readMap();
         customSettings = readCustomSettings == null ? null : Collections.unmodifiableMap(readCustomSettings);
@@ -430,8 +431,8 @@ public class Job extends AbstractDiffable<Job> implements Writeable, ToXContentO
         return resultsRetentionDays;
     }
 
-    public Long getAnnotationsRetentionDays() {
-        return annotationsRetentionDays;
+    public Long getSystemAnnotationsRetentionDays() {
+        return systemAnnotationsRetentionDays;
     }
 
     public Map<String, Object> getCustomSettings() {
@@ -539,7 +540,7 @@ public class Job extends AbstractDiffable<Job> implements Writeable, ToXContentO
         out.writeOptionalLong(dailyModelSnapshotRetentionAfterDays);
         out.writeOptionalLong(resultsRetentionDays);
         if (out.getVersion().onOrAfter(Version.V_8_0_0)) {  // TODO: 7.15
-            out.writeOptionalLong(annotationsRetentionDays);
+            out.writeOptionalLong(systemAnnotationsRetentionDays);
         }
         out.writeMap(customSettings);
         out.writeOptionalString(modelSnapshotId);
@@ -633,8 +634,8 @@ public class Job extends AbstractDiffable<Job> implements Writeable, ToXContentO
         if (resultsRetentionDays != null) {
             builder.field(RESULTS_RETENTION_DAYS.getPreferredName(), resultsRetentionDays);
         }
-        if (annotationsRetentionDays != null) {
-            builder.field(ANNOTATIONS_RETENTION_DAYS.getPreferredName(), annotationsRetentionDays);
+        if (systemAnnotationsRetentionDays != null) {
+            builder.field(SYSTEM_ANNOTATIONS_RETENTION_DAYS.getPreferredName(), systemAnnotationsRetentionDays);
         }
         builder.field(RESULTS_INDEX_NAME.getPreferredName(), resultsIndexName);
         builder.field(ALLOW_LAZY_OPEN.getPreferredName(), allowLazyOpen);
@@ -671,7 +672,7 @@ public class Job extends AbstractDiffable<Job> implements Writeable, ToXContentO
                 && Objects.equals(this.modelSnapshotRetentionDays, that.modelSnapshotRetentionDays)
                 && Objects.equals(this.dailyModelSnapshotRetentionAfterDays, that.dailyModelSnapshotRetentionAfterDays)
                 && Objects.equals(this.resultsRetentionDays, that.resultsRetentionDays)
-                && Objects.equals(this.annotationsRetentionDays, that.annotationsRetentionDays)
+                && Objects.equals(this.systemAnnotationsRetentionDays, that.systemAnnotationsRetentionDays)
                 && Objects.equals(this.customSettings, that.customSettings)
                 && Objects.equals(this.modelSnapshotId, that.modelSnapshotId)
                 && Objects.equals(this.modelSnapshotMinVersion, that.modelSnapshotMinVersion)
@@ -687,8 +688,8 @@ public class Job extends AbstractDiffable<Job> implements Writeable, ToXContentO
         return Objects.hash(jobId, jobType, jobVersion, groups, description, createTime, finishedTime,
             analysisConfig, analysisLimits, dataDescription, modelPlotConfig, renormalizationWindowDays,
             backgroundPersistInterval, modelSnapshotRetentionDays, dailyModelSnapshotRetentionAfterDays, resultsRetentionDays,
-            annotationsRetentionDays, customSettings, modelSnapshotId, modelSnapshotMinVersion, resultsIndexName, deleting, allowLazyOpen,
-            blocked, datafeedConfig);
+            systemAnnotationsRetentionDays, customSettings, modelSnapshotId, modelSnapshotMinVersion, resultsIndexName, deleting,
+            allowLazyOpen, blocked, datafeedConfig);
     }
 
     // Class already extends from AbstractDiffable, so copied from ToXContentToBytes#toString()
@@ -732,7 +733,7 @@ public class Job extends AbstractDiffable<Job> implements Writeable, ToXContentO
         private Long modelSnapshotRetentionDays = DEFAULT_MODEL_SNAPSHOT_RETENTION_DAYS;
         private Long dailyModelSnapshotRetentionAfterDays;
         private Long resultsRetentionDays;
-        private Long annotationsRetentionDays;
+        private Long systemAnnotationsRetentionDays;
         private Map<String, Object> customSettings;
         private String modelSnapshotId;
         private Version modelSnapshotMinVersion;
@@ -766,7 +767,7 @@ public class Job extends AbstractDiffable<Job> implements Writeable, ToXContentO
             this.modelSnapshotRetentionDays = job.getModelSnapshotRetentionDays();
             this.dailyModelSnapshotRetentionAfterDays = job.getDailyModelSnapshotRetentionAfterDays();
             this.resultsRetentionDays = job.getResultsRetentionDays();
-            this.annotationsRetentionDays = job.getAnnotationsRetentionDays();
+            this.systemAnnotationsRetentionDays = job.getSystemAnnotationsRetentionDays();
             this.customSettings = job.getCustomSettings() == null ? null : new LinkedHashMap<>(job.getCustomSettings());
             this.modelSnapshotId = job.getModelSnapshotId();
             this.modelSnapshotMinVersion = job.getModelSnapshotMinVersion();
@@ -795,7 +796,7 @@ public class Job extends AbstractDiffable<Job> implements Writeable, ToXContentO
             dailyModelSnapshotRetentionAfterDays = in.readOptionalLong();
             resultsRetentionDays = in.readOptionalLong();
             if (in.getVersion().onOrAfter(Version.V_8_0_0)) {  // TODO: 7.15
-                annotationsRetentionDays = in.readOptionalLong();
+                systemAnnotationsRetentionDays = in.readOptionalLong();
             }
             customSettings = in.readMap();
             modelSnapshotId = in.readOptionalString();
@@ -913,8 +914,8 @@ public class Job extends AbstractDiffable<Job> implements Writeable, ToXContentO
             return this;
         }
 
-        public Builder setAnnotationsRetentionDays(Long annotationsRetentionDays) {
-            this.annotationsRetentionDays = annotationsRetentionDays;
+        public Builder setSystemAnnotationsRetentionDays(Long systemAnnotationsRetentionDays) {
+            this.systemAnnotationsRetentionDays = systemAnnotationsRetentionDays;
             return this;
         }
 
@@ -1030,7 +1031,7 @@ public class Job extends AbstractDiffable<Job> implements Writeable, ToXContentO
             out.writeOptionalLong(dailyModelSnapshotRetentionAfterDays);
             out.writeOptionalLong(resultsRetentionDays);
             if (out.getVersion().onOrAfter(Version.V_8_0_0)) {  // TODO: 7.15
-                out.writeOptionalLong(annotationsRetentionDays);
+                out.writeOptionalLong(systemAnnotationsRetentionDays);
             }
             out.writeMap(customSettings);
             out.writeOptionalString(modelSnapshotId);
@@ -1068,7 +1069,7 @@ public class Job extends AbstractDiffable<Job> implements Writeable, ToXContentO
                     && Objects.equals(this.modelSnapshotRetentionDays, that.modelSnapshotRetentionDays)
                     && Objects.equals(this.dailyModelSnapshotRetentionAfterDays, that.dailyModelSnapshotRetentionAfterDays)
                     && Objects.equals(this.resultsRetentionDays, that.resultsRetentionDays)
-                    && Objects.equals(this.annotationsRetentionDays, that.annotationsRetentionDays)
+                    && Objects.equals(this.systemAnnotationsRetentionDays, that.systemAnnotationsRetentionDays)
                     && Objects.equals(this.customSettings, that.customSettings)
                     && Objects.equals(this.modelSnapshotId, that.modelSnapshotId)
                     && Objects.equals(this.modelSnapshotMinVersion, that.modelSnapshotMinVersion)
@@ -1084,7 +1085,7 @@ public class Job extends AbstractDiffable<Job> implements Writeable, ToXContentO
             return Objects.hash(id, jobType, jobVersion, groups, description, analysisConfig, analysisLimits, dataDescription,
                     createTime, finishedTime, modelPlotConfig, renormalizationWindowDays,
                     backgroundPersistInterval, modelSnapshotRetentionDays, dailyModelSnapshotRetentionAfterDays, resultsRetentionDays,
-                    annotationsRetentionDays, customSettings, modelSnapshotId, modelSnapshotMinVersion, resultsIndexName, deleting,
+                    systemAnnotationsRetentionDays, customSettings, modelSnapshotId, modelSnapshotMinVersion, resultsIndexName, deleting,
                     allowLazyOpen, blocked, datafeedConfig);
         }
 
@@ -1107,7 +1108,7 @@ public class Job extends AbstractDiffable<Job> implements Writeable, ToXContentO
             checkValidBackgroundPersistInterval();
             checkValueNotLessThan(0, RENORMALIZATION_WINDOW_DAYS.getPreferredName(), renormalizationWindowDays);
             checkValueNotLessThan(0, RESULTS_RETENTION_DAYS.getPreferredName(), resultsRetentionDays);
-            checkValueNotLessThan(0, ANNOTATIONS_RETENTION_DAYS.getPreferredName(), annotationsRetentionDays);
+            checkValueNotLessThan(0, SYSTEM_ANNOTATIONS_RETENTION_DAYS.getPreferredName(), systemAnnotationsRetentionDays);
 
             if (MlStrings.isValidId(id) == false) {
                 throw new IllegalArgumentException(Messages.getMessage(Messages.INVALID_ID, ID.getPreferredName(), id));
@@ -1256,7 +1257,7 @@ public class Job extends AbstractDiffable<Job> implements Writeable, ToXContentO
                     id, jobType, jobVersion, groups, description, createTime, finishedTime,
                     analysisConfig, analysisLimits, dataDescription, modelPlotConfig, renormalizationWindowDays,
                     backgroundPersistInterval, modelSnapshotRetentionDays, dailyModelSnapshotRetentionAfterDays, resultsRetentionDays,
-                    annotationsRetentionDays, customSettings, modelSnapshotId, modelSnapshotMinVersion, resultsIndexName, deleting,
+                    systemAnnotationsRetentionDays, customSettings, modelSnapshotId, modelSnapshotMinVersion, resultsIndexName, deleting,
                     allowLazyOpen, blocked, Optional.ofNullable(datafeedConfig).map(DatafeedConfig.Builder::build).orElse(null));
         }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/config/Job.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/config/Job.java
@@ -247,7 +247,7 @@ public class Job extends AbstractDiffable<Job> implements Writeable, ToXContentO
         modelSnapshotRetentionDays = in.readOptionalLong();
         dailyModelSnapshotRetentionAfterDays = in.readOptionalLong();
         resultsRetentionDays = in.readOptionalLong();
-        if (in.getVersion().onOrAfter(Version.CURRENT)) {  // TODO: 7.15
+        if (in.getVersion().onOrAfter(Version.V_8_0_0)) {  // TODO: 7.15
             annotationsRetentionDays = in.readOptionalLong();
         } else {
             annotationsRetentionDays = null;
@@ -538,7 +538,7 @@ public class Job extends AbstractDiffable<Job> implements Writeable, ToXContentO
         out.writeOptionalLong(modelSnapshotRetentionDays);
         out.writeOptionalLong(dailyModelSnapshotRetentionAfterDays);
         out.writeOptionalLong(resultsRetentionDays);
-        if (out.getVersion().onOrAfter(Version.CURRENT)) {  // TODO: 7.15
+        if (out.getVersion().onOrAfter(Version.V_8_0_0)) {  // TODO: 7.15
             out.writeOptionalLong(annotationsRetentionDays);
         }
         out.writeMap(customSettings);
@@ -794,7 +794,7 @@ public class Job extends AbstractDiffable<Job> implements Writeable, ToXContentO
             modelSnapshotRetentionDays = in.readOptionalLong();
             dailyModelSnapshotRetentionAfterDays = in.readOptionalLong();
             resultsRetentionDays = in.readOptionalLong();
-            if (in.getVersion().onOrAfter(Version.CURRENT)) {  // TODO: 7.15
+            if (in.getVersion().onOrAfter(Version.V_8_0_0)) {  // TODO: 7.15
                 annotationsRetentionDays = in.readOptionalLong();
             }
             customSettings = in.readMap();
@@ -1029,7 +1029,7 @@ public class Job extends AbstractDiffable<Job> implements Writeable, ToXContentO
             out.writeOptionalLong(modelSnapshotRetentionDays);
             out.writeOptionalLong(dailyModelSnapshotRetentionAfterDays);
             out.writeOptionalLong(resultsRetentionDays);
-            if (out.getVersion().onOrAfter(Version.CURRENT)) {  // TODO: 7.15
+            if (out.getVersion().onOrAfter(Version.V_8_0_0)) {  // TODO: 7.15
                 out.writeOptionalLong(annotationsRetentionDays);
             }
             out.writeMap(customSettings);

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/config/Job.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/config/Job.java
@@ -83,7 +83,7 @@ public class Job extends AbstractDiffable<Job> implements Writeable, ToXContentO
     public static final ParseField DAILY_MODEL_SNAPSHOT_RETENTION_AFTER_DAYS =
         new ParseField("daily_model_snapshot_retention_after_days");
     public static final ParseField RESULTS_RETENTION_DAYS = new ParseField("results_retention_days");
-    public static final ParseField SYSTEM_ANNOTATIONS_RETENTION_DAYS = new ParseField("system_system_annotations_retention_days");
+    public static final ParseField SYSTEM_ANNOTATIONS_RETENTION_DAYS = new ParseField("system_annotations_retention_days");
     public static final ParseField MODEL_SNAPSHOT_ID = new ParseField("model_snapshot_id");
     public static final ParseField MODEL_SNAPSHOT_MIN_VERSION = new ParseField("model_snapshot_min_version");
     public static final ParseField RESULTS_INDEX_NAME = new ParseField("results_index_name");

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/config/Job.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/config/Job.java
@@ -83,6 +83,7 @@ public class Job extends AbstractDiffable<Job> implements Writeable, ToXContentO
     public static final ParseField DAILY_MODEL_SNAPSHOT_RETENTION_AFTER_DAYS =
         new ParseField("daily_model_snapshot_retention_after_days");
     public static final ParseField RESULTS_RETENTION_DAYS = new ParseField("results_retention_days");
+    public static final ParseField ANNOTATIONS_RETENTION_DAYS = new ParseField("annotations_retention_days");
     public static final ParseField MODEL_SNAPSHOT_ID = new ParseField("model_snapshot_id");
     public static final ParseField MODEL_SNAPSHOT_MIN_VERSION = new ParseField("model_snapshot_min_version");
     public static final ParseField RESULTS_INDEX_NAME = new ParseField("results_index_name");
@@ -135,6 +136,7 @@ public class Job extends AbstractDiffable<Job> implements Writeable, ToXContentO
         parser.declareString((builder, val) -> builder.setBackgroundPersistInterval(
             TimeValue.parseTimeValue(val, BACKGROUND_PERSIST_INTERVAL.getPreferredName())), BACKGROUND_PERSIST_INTERVAL);
         parser.declareLong(Builder::setResultsRetentionDays, RESULTS_RETENTION_DAYS);
+        parser.declareLong(Builder::setAnnotationsRetentionDays, ANNOTATIONS_RETENTION_DAYS);
         parser.declareLong(Builder::setModelSnapshotRetentionDays, MODEL_SNAPSHOT_RETENTION_DAYS);
         parser.declareLong(Builder::setDailyModelSnapshotRetentionAfterDays, DAILY_MODEL_SNAPSHOT_RETENTION_AFTER_DAYS);
         parser.declareField(Builder::setCustomSettings, (p, c) -> p.mapOrdered(), CUSTOM_SETTINGS, ValueType.OBJECT);
@@ -174,6 +176,7 @@ public class Job extends AbstractDiffable<Job> implements Writeable, ToXContentO
     private final Long modelSnapshotRetentionDays;
     private final Long dailyModelSnapshotRetentionAfterDays;
     private final Long resultsRetentionDays;
+    private final Long annotationsRetentionDays;
     private final Map<String, Object> customSettings;
     private final String modelSnapshotId;
     private final Version modelSnapshotMinVersion;
@@ -188,8 +191,8 @@ public class Job extends AbstractDiffable<Job> implements Writeable, ToXContentO
                 AnalysisConfig analysisConfig, AnalysisLimits analysisLimits, DataDescription dataDescription,
                 ModelPlotConfig modelPlotConfig, Long renormalizationWindowDays, TimeValue backgroundPersistInterval,
                 Long modelSnapshotRetentionDays, Long dailyModelSnapshotRetentionAfterDays, Long resultsRetentionDays,
-                Map<String, Object> customSettings, String modelSnapshotId, Version modelSnapshotMinVersion, String resultsIndexName,
-                boolean deleting, boolean allowLazyOpen, Blocked blocked, DatafeedConfig datafeedConfig) {
+                Long annotationsRetentionDays, Map<String, Object> customSettings, String modelSnapshotId, Version modelSnapshotMinVersion,
+                String resultsIndexName, boolean deleting, boolean allowLazyOpen, Blocked blocked, DatafeedConfig datafeedConfig) {
         this.jobId = jobId;
         this.jobType = jobType;
         this.jobVersion = jobVersion;
@@ -206,6 +209,7 @@ public class Job extends AbstractDiffable<Job> implements Writeable, ToXContentO
         this.modelSnapshotRetentionDays = modelSnapshotRetentionDays;
         this.dailyModelSnapshotRetentionAfterDays = dailyModelSnapshotRetentionAfterDays;
         this.resultsRetentionDays = resultsRetentionDays;
+        this.annotationsRetentionDays = annotationsRetentionDays;
         this.customSettings = customSettings == null ? null : Collections.unmodifiableMap(customSettings);
         this.modelSnapshotId = modelSnapshotId;
         this.modelSnapshotMinVersion = modelSnapshotMinVersion;
@@ -243,6 +247,11 @@ public class Job extends AbstractDiffable<Job> implements Writeable, ToXContentO
         modelSnapshotRetentionDays = in.readOptionalLong();
         dailyModelSnapshotRetentionAfterDays = in.readOptionalLong();
         resultsRetentionDays = in.readOptionalLong();
+        if (in.getVersion().onOrAfter(Version.CURRENT)) {  // TODO: 7.15
+            annotationsRetentionDays = in.readOptionalLong();
+        } else {
+            annotationsRetentionDays = null;
+        }
         Map<String, Object> readCustomSettings = in.readMap();
         customSettings = readCustomSettings == null ? null : Collections.unmodifiableMap(readCustomSettings);
         modelSnapshotId = in.readOptionalString();
@@ -421,6 +430,10 @@ public class Job extends AbstractDiffable<Job> implements Writeable, ToXContentO
         return resultsRetentionDays;
     }
 
+    public Long getAnnotationsRetentionDays() {
+        return annotationsRetentionDays;
+    }
+
     public Map<String, Object> getCustomSettings() {
         return customSettings;
     }
@@ -525,6 +538,9 @@ public class Job extends AbstractDiffable<Job> implements Writeable, ToXContentO
         out.writeOptionalLong(modelSnapshotRetentionDays);
         out.writeOptionalLong(dailyModelSnapshotRetentionAfterDays);
         out.writeOptionalLong(resultsRetentionDays);
+        if (out.getVersion().onOrAfter(Version.CURRENT)) {  // TODO: 7.15
+            out.writeOptionalLong(annotationsRetentionDays);
+        }
         out.writeMap(customSettings);
         out.writeOptionalString(modelSnapshotId);
         if (modelSnapshotMinVersion != null) {
@@ -617,6 +633,9 @@ public class Job extends AbstractDiffable<Job> implements Writeable, ToXContentO
         if (resultsRetentionDays != null) {
             builder.field(RESULTS_RETENTION_DAYS.getPreferredName(), resultsRetentionDays);
         }
+        if (annotationsRetentionDays != null) {
+            builder.field(ANNOTATIONS_RETENTION_DAYS.getPreferredName(), annotationsRetentionDays);
+        }
         builder.field(RESULTS_INDEX_NAME.getPreferredName(), resultsIndexName);
         builder.field(ALLOW_LAZY_OPEN.getPreferredName(), allowLazyOpen);
         if (blocked.getReason() != Blocked.Reason.NONE) {
@@ -652,6 +671,7 @@ public class Job extends AbstractDiffable<Job> implements Writeable, ToXContentO
                 && Objects.equals(this.modelSnapshotRetentionDays, that.modelSnapshotRetentionDays)
                 && Objects.equals(this.dailyModelSnapshotRetentionAfterDays, that.dailyModelSnapshotRetentionAfterDays)
                 && Objects.equals(this.resultsRetentionDays, that.resultsRetentionDays)
+                && Objects.equals(this.annotationsRetentionDays, that.annotationsRetentionDays)
                 && Objects.equals(this.customSettings, that.customSettings)
                 && Objects.equals(this.modelSnapshotId, that.modelSnapshotId)
                 && Objects.equals(this.modelSnapshotMinVersion, that.modelSnapshotMinVersion)
@@ -667,8 +687,8 @@ public class Job extends AbstractDiffable<Job> implements Writeable, ToXContentO
         return Objects.hash(jobId, jobType, jobVersion, groups, description, createTime, finishedTime,
             analysisConfig, analysisLimits, dataDescription, modelPlotConfig, renormalizationWindowDays,
             backgroundPersistInterval, modelSnapshotRetentionDays, dailyModelSnapshotRetentionAfterDays, resultsRetentionDays,
-            customSettings, modelSnapshotId, modelSnapshotMinVersion, resultsIndexName, deleting, allowLazyOpen, blocked,
-            datafeedConfig);
+            annotationsRetentionDays, customSettings, modelSnapshotId, modelSnapshotMinVersion, resultsIndexName, deleting, allowLazyOpen,
+            blocked, datafeedConfig);
     }
 
     // Class already extends from AbstractDiffable, so copied from ToXContentToBytes#toString()
@@ -712,6 +732,7 @@ public class Job extends AbstractDiffable<Job> implements Writeable, ToXContentO
         private Long modelSnapshotRetentionDays = DEFAULT_MODEL_SNAPSHOT_RETENTION_DAYS;
         private Long dailyModelSnapshotRetentionAfterDays;
         private Long resultsRetentionDays;
+        private Long annotationsRetentionDays;
         private Map<String, Object> customSettings;
         private String modelSnapshotId;
         private Version modelSnapshotMinVersion;
@@ -745,6 +766,7 @@ public class Job extends AbstractDiffable<Job> implements Writeable, ToXContentO
             this.modelSnapshotRetentionDays = job.getModelSnapshotRetentionDays();
             this.dailyModelSnapshotRetentionAfterDays = job.getDailyModelSnapshotRetentionAfterDays();
             this.resultsRetentionDays = job.getResultsRetentionDays();
+            this.annotationsRetentionDays = job.getAnnotationsRetentionDays();
             this.customSettings = job.getCustomSettings() == null ? null : new LinkedHashMap<>(job.getCustomSettings());
             this.modelSnapshotId = job.getModelSnapshotId();
             this.modelSnapshotMinVersion = job.getModelSnapshotMinVersion();
@@ -772,6 +794,9 @@ public class Job extends AbstractDiffable<Job> implements Writeable, ToXContentO
             modelSnapshotRetentionDays = in.readOptionalLong();
             dailyModelSnapshotRetentionAfterDays = in.readOptionalLong();
             resultsRetentionDays = in.readOptionalLong();
+            if (in.getVersion().onOrAfter(Version.CURRENT)) {  // TODO: 7.15
+                annotationsRetentionDays = in.readOptionalLong();
+            }
             customSettings = in.readMap();
             modelSnapshotId = in.readOptionalString();
             if (in.readBoolean()) {
@@ -888,6 +913,11 @@ public class Job extends AbstractDiffable<Job> implements Writeable, ToXContentO
             return this;
         }
 
+        public Builder setAnnotationsRetentionDays(Long annotationsRetentionDays) {
+            this.annotationsRetentionDays = annotationsRetentionDays;
+            return this;
+        }
+
         public Builder setModelSnapshotId(String modelSnapshotId) {
             this.modelSnapshotId = modelSnapshotId;
             return this;
@@ -999,6 +1029,9 @@ public class Job extends AbstractDiffable<Job> implements Writeable, ToXContentO
             out.writeOptionalLong(modelSnapshotRetentionDays);
             out.writeOptionalLong(dailyModelSnapshotRetentionAfterDays);
             out.writeOptionalLong(resultsRetentionDays);
+            if (out.getVersion().onOrAfter(Version.CURRENT)) {  // TODO: 7.15
+                out.writeOptionalLong(annotationsRetentionDays);
+            }
             out.writeMap(customSettings);
             out.writeOptionalString(modelSnapshotId);
             if (modelSnapshotMinVersion != null) {
@@ -1035,6 +1068,7 @@ public class Job extends AbstractDiffable<Job> implements Writeable, ToXContentO
                     && Objects.equals(this.modelSnapshotRetentionDays, that.modelSnapshotRetentionDays)
                     && Objects.equals(this.dailyModelSnapshotRetentionAfterDays, that.dailyModelSnapshotRetentionAfterDays)
                     && Objects.equals(this.resultsRetentionDays, that.resultsRetentionDays)
+                    && Objects.equals(this.annotationsRetentionDays, that.annotationsRetentionDays)
                     && Objects.equals(this.customSettings, that.customSettings)
                     && Objects.equals(this.modelSnapshotId, that.modelSnapshotId)
                     && Objects.equals(this.modelSnapshotMinVersion, that.modelSnapshotMinVersion)
@@ -1050,8 +1084,8 @@ public class Job extends AbstractDiffable<Job> implements Writeable, ToXContentO
             return Objects.hash(id, jobType, jobVersion, groups, description, analysisConfig, analysisLimits, dataDescription,
                     createTime, finishedTime, modelPlotConfig, renormalizationWindowDays,
                     backgroundPersistInterval, modelSnapshotRetentionDays, dailyModelSnapshotRetentionAfterDays, resultsRetentionDays,
-                    customSettings, modelSnapshotId, modelSnapshotMinVersion, resultsIndexName, deleting, allowLazyOpen, blocked,
-                datafeedConfig);
+                    annotationsRetentionDays, customSettings, modelSnapshotId, modelSnapshotMinVersion, resultsIndexName, deleting,
+                    allowLazyOpen, blocked, datafeedConfig);
         }
 
         /**
@@ -1073,6 +1107,7 @@ public class Job extends AbstractDiffable<Job> implements Writeable, ToXContentO
             checkValidBackgroundPersistInterval();
             checkValueNotLessThan(0, RENORMALIZATION_WINDOW_DAYS.getPreferredName(), renormalizationWindowDays);
             checkValueNotLessThan(0, RESULTS_RETENTION_DAYS.getPreferredName(), resultsRetentionDays);
+            checkValueNotLessThan(0, ANNOTATIONS_RETENTION_DAYS.getPreferredName(), annotationsRetentionDays);
 
             if (MlStrings.isValidId(id) == false) {
                 throw new IllegalArgumentException(Messages.getMessage(Messages.INVALID_ID, ID.getPreferredName(), id));
@@ -1221,8 +1256,8 @@ public class Job extends AbstractDiffable<Job> implements Writeable, ToXContentO
                     id, jobType, jobVersion, groups, description, createTime, finishedTime,
                     analysisConfig, analysisLimits, dataDescription, modelPlotConfig, renormalizationWindowDays,
                     backgroundPersistInterval, modelSnapshotRetentionDays, dailyModelSnapshotRetentionAfterDays, resultsRetentionDays,
-                    customSettings, modelSnapshotId, modelSnapshotMinVersion, resultsIndexName, deleting, allowLazyOpen, blocked,
-                Optional.ofNullable(datafeedConfig).map(DatafeedConfig.Builder::build).orElse(null));
+                    annotationsRetentionDays, customSettings, modelSnapshotId, modelSnapshotMinVersion, resultsIndexName, deleting,
+                    allowLazyOpen, blocked, Optional.ofNullable(datafeedConfig).map(DatafeedConfig.Builder::build).orElse(null));
         }
 
         private void checkValidBackgroundPersistInterval() {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/config/JobUpdate.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/config/JobUpdate.java
@@ -53,6 +53,7 @@ public class JobUpdate implements Writeable, ToXContentObject {
                     TimeValue.parseTimeValue(val, Job.BACKGROUND_PERSIST_INTERVAL.getPreferredName())), Job.BACKGROUND_PERSIST_INTERVAL);
             parser.declareLong(Builder::setRenormalizationWindowDays, Job.RENORMALIZATION_WINDOW_DAYS);
             parser.declareLong(Builder::setResultsRetentionDays, Job.RESULTS_RETENTION_DAYS);
+            parser.declareLong(Builder::setAnnotationsRetentionDays, Job.ANNOTATIONS_RETENTION_DAYS);
             parser.declareLong(Builder::setModelSnapshotRetentionDays, Job.MODEL_SNAPSHOT_RETENTION_DAYS);
             parser.declareLong(Builder::setDailyModelSnapshotRetentionAfterDays, Job.DAILY_MODEL_SNAPSHOT_RETENTION_AFTER_DAYS);
             parser.declareStringArray(Builder::setCategorizationFilters, AnalysisConfig.CATEGORIZATION_FILTERS);
@@ -80,6 +81,7 @@ public class JobUpdate implements Writeable, ToXContentObject {
     private final Long modelSnapshotRetentionDays;
     private final Long dailyModelSnapshotRetentionAfterDays;
     private final Long resultsRetentionDays;
+    private final Long annotationsRetentionDays;
     private final List<String> categorizationFilters;
     private final PerPartitionCategorizationConfig perPartitionCategorizationConfig;
     private final Map<String, Object> customSettings;
@@ -94,8 +96,8 @@ public class JobUpdate implements Writeable, ToXContentObject {
                       @Nullable List<DetectorUpdate> detectorUpdates, @Nullable ModelPlotConfig modelPlotConfig,
                       @Nullable AnalysisLimits analysisLimits, @Nullable TimeValue backgroundPersistInterval,
                       @Nullable Long renormalizationWindowDays, @Nullable Long resultsRetentionDays,
-                      @Nullable Long modelSnapshotRetentionDays, @Nullable Long dailyModelSnapshotRetentionAfterDays,
-                      @Nullable List<String> categorizationFilters,
+                      @Nullable Long annotationsRetentionDays, @Nullable Long modelSnapshotRetentionDays,
+                      @Nullable Long dailyModelSnapshotRetentionAfterDays, @Nullable List<String> categorizationFilters,
                       @Nullable PerPartitionCategorizationConfig perPartitionCategorizationConfig,
                       @Nullable Map<String, Object> customSettings, @Nullable String modelSnapshotId,
                       @Nullable Version modelSnapshotMinVersion, @Nullable Version jobVersion, @Nullable Boolean clearJobFinishTime,
@@ -111,6 +113,7 @@ public class JobUpdate implements Writeable, ToXContentObject {
         this.modelSnapshotRetentionDays = modelSnapshotRetentionDays;
         this.dailyModelSnapshotRetentionAfterDays = dailyModelSnapshotRetentionAfterDays;
         this.resultsRetentionDays = resultsRetentionDays;
+        this.annotationsRetentionDays = annotationsRetentionDays;
         this.categorizationFilters = categorizationFilters;
         this.perPartitionCategorizationConfig = perPartitionCategorizationConfig;
         this.customSettings = customSettings;
@@ -139,6 +142,11 @@ public class JobUpdate implements Writeable, ToXContentObject {
         modelSnapshotRetentionDays = in.readOptionalLong();
         dailyModelSnapshotRetentionAfterDays = in.readOptionalLong();
         resultsRetentionDays = in.readOptionalLong();
+        if (in.getVersion().onOrAfter(Version.CURRENT)) {  // TODO: 7.15
+            annotationsRetentionDays = in.readOptionalLong();
+        } else {
+            annotationsRetentionDays = null;
+        }
         if (in.readBoolean()) {
             categorizationFilters = in.readStringList();
         } else {
@@ -179,6 +187,9 @@ public class JobUpdate implements Writeable, ToXContentObject {
         out.writeOptionalLong(modelSnapshotRetentionDays);
         out.writeOptionalLong(dailyModelSnapshotRetentionAfterDays);
         out.writeOptionalLong(resultsRetentionDays);
+        if (out.getVersion().onOrAfter(Version.CURRENT)) {  // TODO: 7.15
+            out.writeOptionalLong(annotationsRetentionDays);
+        }
         out.writeBoolean(categorizationFilters != null);
         if (categorizationFilters != null) {
             out.writeStringCollection(categorizationFilters);
@@ -245,6 +256,10 @@ public class JobUpdate implements Writeable, ToXContentObject {
 
     public Long getResultsRetentionDays() {
         return resultsRetentionDays;
+    }
+
+    public Long getAnnotationsRetentionDays() {
+        return annotationsRetentionDays;
     }
 
     public List<String> getCategorizationFilters() {
@@ -321,6 +336,9 @@ public class JobUpdate implements Writeable, ToXContentObject {
         if (resultsRetentionDays != null) {
             builder.field(Job.RESULTS_RETENTION_DAYS.getPreferredName(), resultsRetentionDays);
         }
+        if (annotationsRetentionDays != null) {
+            builder.field(Job.ANNOTATIONS_RETENTION_DAYS.getPreferredName(), annotationsRetentionDays);
+        }
         if (categorizationFilters != null) {
             builder.field(AnalysisConfig.CATEGORIZATION_FILTERS.getPreferredName(), categorizationFilters);
         }
@@ -383,6 +401,9 @@ public class JobUpdate implements Writeable, ToXContentObject {
         }
         if (resultsRetentionDays != null) {
             updateFields.add(Job.RESULTS_RETENTION_DAYS.getPreferredName());
+        }
+        if (annotationsRetentionDays != null) {
+            updateFields.add(Job.ANNOTATIONS_RETENTION_DAYS.getPreferredName());
         }
         if (categorizationFilters != null) {
             updateFields.add(AnalysisConfig.CATEGORIZATION_FILTERS.getPreferredName());
@@ -468,6 +489,9 @@ public class JobUpdate implements Writeable, ToXContentObject {
         if (resultsRetentionDays != null) {
             builder.setResultsRetentionDays(resultsRetentionDays);
         }
+        if (annotationsRetentionDays != null) {
+            builder.setAnnotationsRetentionDays(annotationsRetentionDays);
+        }
         if (categorizationFilters != null) {
             newAnalysisConfig.setCategorizationFilters(categorizationFilters);
         }
@@ -517,6 +541,7 @@ public class JobUpdate implements Writeable, ToXContentObject {
                 && (dailyModelSnapshotRetentionAfterDays == null
                         || Objects.equals(dailyModelSnapshotRetentionAfterDays, job.getDailyModelSnapshotRetentionAfterDays()))
                 && (resultsRetentionDays == null || Objects.equals(resultsRetentionDays, job.getResultsRetentionDays()))
+                && (annotationsRetentionDays == null || Objects.equals(annotationsRetentionDays, job.getAnnotationsRetentionDays()))
                 && (categorizationFilters == null
                         || Objects.equals(categorizationFilters, job.getAnalysisConfig().getCategorizationFilters()))
                 && (perPartitionCategorizationConfig == null
@@ -571,6 +596,7 @@ public class JobUpdate implements Writeable, ToXContentObject {
                 && Objects.equals(this.modelSnapshotRetentionDays, that.modelSnapshotRetentionDays)
                 && Objects.equals(this.dailyModelSnapshotRetentionAfterDays, that.dailyModelSnapshotRetentionAfterDays)
                 && Objects.equals(this.resultsRetentionDays, that.resultsRetentionDays)
+                && Objects.equals(this.annotationsRetentionDays, that.annotationsRetentionDays)
                 && Objects.equals(this.categorizationFilters, that.categorizationFilters)
                 && Objects.equals(this.perPartitionCategorizationConfig, that.perPartitionCategorizationConfig)
                 && Objects.equals(this.customSettings, that.customSettings)
@@ -586,8 +612,8 @@ public class JobUpdate implements Writeable, ToXContentObject {
     public int hashCode() {
         return Objects.hash(jobId, groups, description, detectorUpdates, modelPlotConfig, analysisLimits, renormalizationWindowDays,
                 backgroundPersistInterval, modelSnapshotRetentionDays, dailyModelSnapshotRetentionAfterDays, resultsRetentionDays,
-                categorizationFilters, perPartitionCategorizationConfig, customSettings, modelSnapshotId, modelSnapshotMinVersion,
-                jobVersion, clearJobFinishTime, allowLazyOpen, blocked);
+                annotationsRetentionDays, categorizationFilters, perPartitionCategorizationConfig, customSettings, modelSnapshotId,
+                modelSnapshotMinVersion, jobVersion, clearJobFinishTime, allowLazyOpen, blocked);
     }
 
     public static class DetectorUpdate implements Writeable, ToXContentObject {
@@ -694,6 +720,7 @@ public class JobUpdate implements Writeable, ToXContentObject {
         private Long modelSnapshotRetentionDays;
         private Long dailyModelSnapshotRetentionAfterDays;
         private Long resultsRetentionDays;
+        private Long annotationsRetentionDays;
         private List<String> categorizationFilters;
         private PerPartitionCategorizationConfig perPartitionCategorizationConfig;
         private Map<String, Object> customSettings;
@@ -763,6 +790,11 @@ public class JobUpdate implements Writeable, ToXContentObject {
             return this;
         }
 
+        public Builder setAnnotationsRetentionDays(Long annotationsRetentionDays) {
+            this.annotationsRetentionDays = annotationsRetentionDays;
+            return this;
+        }
+
         public Builder setCategorizationFilters(List<String> categorizationFilters) {
             this.categorizationFilters = categorizationFilters;
             return this;
@@ -820,9 +852,9 @@ public class JobUpdate implements Writeable, ToXContentObject {
 
         public JobUpdate build() {
             return new JobUpdate(jobId, groups, description, detectorUpdates, modelPlotConfig, analysisLimits, backgroundPersistInterval,
-                    renormalizationWindowDays, resultsRetentionDays, modelSnapshotRetentionDays, dailyModelSnapshotRetentionAfterDays,
-                    categorizationFilters, perPartitionCategorizationConfig, customSettings, modelSnapshotId, modelSnapshotMinVersion,
-                    jobVersion, clearJobFinishTime, allowLazyOpen, blocked);
+                    renormalizationWindowDays, resultsRetentionDays, annotationsRetentionDays, modelSnapshotRetentionDays,
+                    dailyModelSnapshotRetentionAfterDays, categorizationFilters, perPartitionCategorizationConfig, customSettings,
+                    modelSnapshotId, modelSnapshotMinVersion, jobVersion, clearJobFinishTime, allowLazyOpen, blocked);
         }
     }
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/config/JobUpdate.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/config/JobUpdate.java
@@ -142,7 +142,7 @@ public class JobUpdate implements Writeable, ToXContentObject {
         modelSnapshotRetentionDays = in.readOptionalLong();
         dailyModelSnapshotRetentionAfterDays = in.readOptionalLong();
         resultsRetentionDays = in.readOptionalLong();
-        if (in.getVersion().onOrAfter(Version.CURRENT)) {  // TODO: 7.15
+        if (in.getVersion().onOrAfter(Version.V_8_0_0)) {  // TODO: 7.15
             annotationsRetentionDays = in.readOptionalLong();
         } else {
             annotationsRetentionDays = null;
@@ -187,7 +187,7 @@ public class JobUpdate implements Writeable, ToXContentObject {
         out.writeOptionalLong(modelSnapshotRetentionDays);
         out.writeOptionalLong(dailyModelSnapshotRetentionAfterDays);
         out.writeOptionalLong(resultsRetentionDays);
-        if (out.getVersion().onOrAfter(Version.CURRENT)) {  // TODO: 7.15
+        if (out.getVersion().onOrAfter(Version.V_8_0_0)) {  // TODO: 7.15
             out.writeOptionalLong(annotationsRetentionDays);
         }
         out.writeBoolean(categorizationFilters != null);

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/config/JobUpdate.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/config/JobUpdate.java
@@ -53,7 +53,7 @@ public class JobUpdate implements Writeable, ToXContentObject {
                     TimeValue.parseTimeValue(val, Job.BACKGROUND_PERSIST_INTERVAL.getPreferredName())), Job.BACKGROUND_PERSIST_INTERVAL);
             parser.declareLong(Builder::setRenormalizationWindowDays, Job.RENORMALIZATION_WINDOW_DAYS);
             parser.declareLong(Builder::setResultsRetentionDays, Job.RESULTS_RETENTION_DAYS);
-            parser.declareLong(Builder::setAnnotationsRetentionDays, Job.ANNOTATIONS_RETENTION_DAYS);
+            parser.declareLong(Builder::setSystemAnnotationsRetentionDays, Job.SYSTEM_ANNOTATIONS_RETENTION_DAYS);
             parser.declareLong(Builder::setModelSnapshotRetentionDays, Job.MODEL_SNAPSHOT_RETENTION_DAYS);
             parser.declareLong(Builder::setDailyModelSnapshotRetentionAfterDays, Job.DAILY_MODEL_SNAPSHOT_RETENTION_AFTER_DAYS);
             parser.declareStringArray(Builder::setCategorizationFilters, AnalysisConfig.CATEGORIZATION_FILTERS);
@@ -81,7 +81,7 @@ public class JobUpdate implements Writeable, ToXContentObject {
     private final Long modelSnapshotRetentionDays;
     private final Long dailyModelSnapshotRetentionAfterDays;
     private final Long resultsRetentionDays;
-    private final Long annotationsRetentionDays;
+    private final Long systemAnnotationsRetentionDays;
     private final List<String> categorizationFilters;
     private final PerPartitionCategorizationConfig perPartitionCategorizationConfig;
     private final Map<String, Object> customSettings;
@@ -96,7 +96,7 @@ public class JobUpdate implements Writeable, ToXContentObject {
                       @Nullable List<DetectorUpdate> detectorUpdates, @Nullable ModelPlotConfig modelPlotConfig,
                       @Nullable AnalysisLimits analysisLimits, @Nullable TimeValue backgroundPersistInterval,
                       @Nullable Long renormalizationWindowDays, @Nullable Long resultsRetentionDays,
-                      @Nullable Long annotationsRetentionDays, @Nullable Long modelSnapshotRetentionDays,
+                      @Nullable Long systemAnnotationsRetentionDays, @Nullable Long modelSnapshotRetentionDays,
                       @Nullable Long dailyModelSnapshotRetentionAfterDays, @Nullable List<String> categorizationFilters,
                       @Nullable PerPartitionCategorizationConfig perPartitionCategorizationConfig,
                       @Nullable Map<String, Object> customSettings, @Nullable String modelSnapshotId,
@@ -113,7 +113,7 @@ public class JobUpdate implements Writeable, ToXContentObject {
         this.modelSnapshotRetentionDays = modelSnapshotRetentionDays;
         this.dailyModelSnapshotRetentionAfterDays = dailyModelSnapshotRetentionAfterDays;
         this.resultsRetentionDays = resultsRetentionDays;
-        this.annotationsRetentionDays = annotationsRetentionDays;
+        this.systemAnnotationsRetentionDays = systemAnnotationsRetentionDays;
         this.categorizationFilters = categorizationFilters;
         this.perPartitionCategorizationConfig = perPartitionCategorizationConfig;
         this.customSettings = customSettings;
@@ -143,9 +143,9 @@ public class JobUpdate implements Writeable, ToXContentObject {
         dailyModelSnapshotRetentionAfterDays = in.readOptionalLong();
         resultsRetentionDays = in.readOptionalLong();
         if (in.getVersion().onOrAfter(Version.V_8_0_0)) {  // TODO: 7.15
-            annotationsRetentionDays = in.readOptionalLong();
+            systemAnnotationsRetentionDays = in.readOptionalLong();
         } else {
-            annotationsRetentionDays = null;
+            systemAnnotationsRetentionDays = null;
         }
         if (in.readBoolean()) {
             categorizationFilters = in.readStringList();
@@ -188,7 +188,7 @@ public class JobUpdate implements Writeable, ToXContentObject {
         out.writeOptionalLong(dailyModelSnapshotRetentionAfterDays);
         out.writeOptionalLong(resultsRetentionDays);
         if (out.getVersion().onOrAfter(Version.V_8_0_0)) {  // TODO: 7.15
-            out.writeOptionalLong(annotationsRetentionDays);
+            out.writeOptionalLong(systemAnnotationsRetentionDays);
         }
         out.writeBoolean(categorizationFilters != null);
         if (categorizationFilters != null) {
@@ -258,8 +258,8 @@ public class JobUpdate implements Writeable, ToXContentObject {
         return resultsRetentionDays;
     }
 
-    public Long getAnnotationsRetentionDays() {
-        return annotationsRetentionDays;
+    public Long getSystemAnnotationsRetentionDays() {
+        return systemAnnotationsRetentionDays;
     }
 
     public List<String> getCategorizationFilters() {
@@ -336,8 +336,8 @@ public class JobUpdate implements Writeable, ToXContentObject {
         if (resultsRetentionDays != null) {
             builder.field(Job.RESULTS_RETENTION_DAYS.getPreferredName(), resultsRetentionDays);
         }
-        if (annotationsRetentionDays != null) {
-            builder.field(Job.ANNOTATIONS_RETENTION_DAYS.getPreferredName(), annotationsRetentionDays);
+        if (systemAnnotationsRetentionDays != null) {
+            builder.field(Job.SYSTEM_ANNOTATIONS_RETENTION_DAYS.getPreferredName(), systemAnnotationsRetentionDays);
         }
         if (categorizationFilters != null) {
             builder.field(AnalysisConfig.CATEGORIZATION_FILTERS.getPreferredName(), categorizationFilters);
@@ -402,8 +402,8 @@ public class JobUpdate implements Writeable, ToXContentObject {
         if (resultsRetentionDays != null) {
             updateFields.add(Job.RESULTS_RETENTION_DAYS.getPreferredName());
         }
-        if (annotationsRetentionDays != null) {
-            updateFields.add(Job.ANNOTATIONS_RETENTION_DAYS.getPreferredName());
+        if (systemAnnotationsRetentionDays != null) {
+            updateFields.add(Job.SYSTEM_ANNOTATIONS_RETENTION_DAYS.getPreferredName());
         }
         if (categorizationFilters != null) {
             updateFields.add(AnalysisConfig.CATEGORIZATION_FILTERS.getPreferredName());
@@ -489,8 +489,8 @@ public class JobUpdate implements Writeable, ToXContentObject {
         if (resultsRetentionDays != null) {
             builder.setResultsRetentionDays(resultsRetentionDays);
         }
-        if (annotationsRetentionDays != null) {
-            builder.setAnnotationsRetentionDays(annotationsRetentionDays);
+        if (systemAnnotationsRetentionDays != null) {
+            builder.setSystemAnnotationsRetentionDays(systemAnnotationsRetentionDays);
         }
         if (categorizationFilters != null) {
             newAnalysisConfig.setCategorizationFilters(categorizationFilters);
@@ -541,7 +541,8 @@ public class JobUpdate implements Writeable, ToXContentObject {
                 && (dailyModelSnapshotRetentionAfterDays == null
                         || Objects.equals(dailyModelSnapshotRetentionAfterDays, job.getDailyModelSnapshotRetentionAfterDays()))
                 && (resultsRetentionDays == null || Objects.equals(resultsRetentionDays, job.getResultsRetentionDays()))
-                && (annotationsRetentionDays == null || Objects.equals(annotationsRetentionDays, job.getAnnotationsRetentionDays()))
+                && (systemAnnotationsRetentionDays == null
+                        || Objects.equals(systemAnnotationsRetentionDays, job.getSystemAnnotationsRetentionDays()))
                 && (categorizationFilters == null
                         || Objects.equals(categorizationFilters, job.getAnalysisConfig().getCategorizationFilters()))
                 && (perPartitionCategorizationConfig == null
@@ -596,7 +597,7 @@ public class JobUpdate implements Writeable, ToXContentObject {
                 && Objects.equals(this.modelSnapshotRetentionDays, that.modelSnapshotRetentionDays)
                 && Objects.equals(this.dailyModelSnapshotRetentionAfterDays, that.dailyModelSnapshotRetentionAfterDays)
                 && Objects.equals(this.resultsRetentionDays, that.resultsRetentionDays)
-                && Objects.equals(this.annotationsRetentionDays, that.annotationsRetentionDays)
+                && Objects.equals(this.systemAnnotationsRetentionDays, that.systemAnnotationsRetentionDays)
                 && Objects.equals(this.categorizationFilters, that.categorizationFilters)
                 && Objects.equals(this.perPartitionCategorizationConfig, that.perPartitionCategorizationConfig)
                 && Objects.equals(this.customSettings, that.customSettings)
@@ -612,7 +613,7 @@ public class JobUpdate implements Writeable, ToXContentObject {
     public int hashCode() {
         return Objects.hash(jobId, groups, description, detectorUpdates, modelPlotConfig, analysisLimits, renormalizationWindowDays,
                 backgroundPersistInterval, modelSnapshotRetentionDays, dailyModelSnapshotRetentionAfterDays, resultsRetentionDays,
-                annotationsRetentionDays, categorizationFilters, perPartitionCategorizationConfig, customSettings, modelSnapshotId,
+                systemAnnotationsRetentionDays, categorizationFilters, perPartitionCategorizationConfig, customSettings, modelSnapshotId,
                 modelSnapshotMinVersion, jobVersion, clearJobFinishTime, allowLazyOpen, blocked);
     }
 
@@ -720,7 +721,7 @@ public class JobUpdate implements Writeable, ToXContentObject {
         private Long modelSnapshotRetentionDays;
         private Long dailyModelSnapshotRetentionAfterDays;
         private Long resultsRetentionDays;
-        private Long annotationsRetentionDays;
+        private Long systemAnnotationsRetentionDays;
         private List<String> categorizationFilters;
         private PerPartitionCategorizationConfig perPartitionCategorizationConfig;
         private Map<String, Object> customSettings;
@@ -790,8 +791,8 @@ public class JobUpdate implements Writeable, ToXContentObject {
             return this;
         }
 
-        public Builder setAnnotationsRetentionDays(Long annotationsRetentionDays) {
-            this.annotationsRetentionDays = annotationsRetentionDays;
+        public Builder setSystemAnnotationsRetentionDays(Long systemAnnotationsRetentionDays) {
+            this.systemAnnotationsRetentionDays = systemAnnotationsRetentionDays;
             return this;
         }
 
@@ -852,7 +853,7 @@ public class JobUpdate implements Writeable, ToXContentObject {
 
         public JobUpdate build() {
             return new JobUpdate(jobId, groups, description, detectorUpdates, modelPlotConfig, analysisLimits, backgroundPersistInterval,
-                    renormalizationWindowDays, resultsRetentionDays, annotationsRetentionDays, modelSnapshotRetentionDays,
+                    renormalizationWindowDays, resultsRetentionDays, systemAnnotationsRetentionDays, modelSnapshotRetentionDays,
                     dailyModelSnapshotRetentionAfterDays, categorizationFilters, perPartitionCategorizationConfig, customSettings,
                     modelSnapshotId, modelSnapshotMinVersion, jobVersion, clearJobFinishTime, allowLazyOpen, blocked);
         }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/messages/Messages.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/messages/Messages.java
@@ -157,6 +157,7 @@ public final class Messages {
     public static final String JOB_AUDIT_DELETED = "Job deleted";
     public static final String JOB_AUDIT_KILLING = "Killing job";
     public static final String JOB_AUDIT_OLD_RESULTS_DELETED = "Deleted results prior to {0}";
+    public static final String JOB_AUDIT_OLD_ANNOTATIONS_DELETED = "Deleted annotations prior to {0}";
     public static final String JOB_AUDIT_SNAPSHOT_STORED = "Job model snapshot with id [{0}] stored";
     public static final String JOB_AUDIT_REVERTED = "Job model snapshot reverted to ''{0}''";
     public static final String JOB_AUDIT_SNAPSHOT_DELETED = "Model snapshot [{0}] with description ''{1}'' deleted";

--- a/x-pack/plugin/core/src/main/resources/org/elasticsearch/xpack/core/ml/config_index_mappings.json
+++ b/x-pack/plugin/core/src/main/resources/org/elasticsearch/xpack/core/ml/config_index_mappings.json
@@ -288,6 +288,9 @@
         "type" : "object",
         "enabled" : false
       },
+      "annotations_retention_days" : {
+        "type" : "long"
+      },
       "background_persist_interval" : {
         "type" : "keyword"
       },

--- a/x-pack/plugin/core/src/main/resources/org/elasticsearch/xpack/core/ml/config_index_mappings.json
+++ b/x-pack/plugin/core/src/main/resources/org/elasticsearch/xpack/core/ml/config_index_mappings.json
@@ -288,7 +288,7 @@
         "type" : "object",
         "enabled" : false
       },
-      "annotations_retention_days" : {
+      "system_system_annotations_retention_days" : {
         "type" : "long"
       },
       "background_persist_interval" : {

--- a/x-pack/plugin/core/src/main/resources/org/elasticsearch/xpack/core/ml/config_index_mappings.json
+++ b/x-pack/plugin/core/src/main/resources/org/elasticsearch/xpack/core/ml/config_index_mappings.json
@@ -288,7 +288,7 @@
         "type" : "object",
         "enabled" : false
       },
-      "system_system_annotations_retention_days" : {
+      "system_annotations_retention_days" : {
         "type" : "long"
       },
       "background_persist_interval" : {

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/job/config/JobTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/job/config/JobTests.java
@@ -142,7 +142,7 @@ public class JobTests extends AbstractSerializingTestCase<Job> {
         assertThat(job.getModelSnapshotRetentionDays(), equalTo(10L));
         assertNull(job.getDailyModelSnapshotRetentionAfterDays());
         assertNull(job.getResultsRetentionDays());
-        assertNull(job.getAnnotationsRetentionDays());
+        assertNull(job.getSystemAnnotationsRetentionDays());
         assertNotNull(job.allInputFields());
         assertFalse(job.allInputFields().isEmpty());
         assertFalse(job.allowLazyOpen());
@@ -266,16 +266,16 @@ public class JobTests extends AbstractSerializingTestCase<Job> {
         assertNotEquals(jobDetails1.build(), jobDetails2.build());
     }
 
-    public void testEquals_GivenDifferentAnnotationsRetentionDays() {
+    public void testEquals_GivenDifferentSystemAnnotationsRetentionDays() {
         Date date = new Date();
         Job.Builder jobDetails1 = new Job.Builder("foo");
         jobDetails1.setDataDescription(new DataDescription.Builder());
         jobDetails1.setAnalysisConfig(createAnalysisConfig());
         jobDetails1.setCreateTime(date);
-        jobDetails1.setAnnotationsRetentionDays(30L);
+        jobDetails1.setSystemAnnotationsRetentionDays(30L);
         Job.Builder jobDetails2 = new Job.Builder("foo");
         jobDetails2.setDataDescription(new DataDescription.Builder());
-        jobDetails2.setAnnotationsRetentionDays(4L);
+        jobDetails2.setSystemAnnotationsRetentionDays(4L);
         jobDetails2.setAnalysisConfig(createAnalysisConfig());
         jobDetails2.setCreateTime(date);
         assertNotEquals(jobDetails1.build(), jobDetails2.build());
@@ -487,10 +487,11 @@ public class JobTests extends AbstractSerializingTestCase<Job> {
         assertEquals(errorMessage, e.getMessage());
     }
 
-    public void testVerify_GivenNegativeAnnotationsRetentionDays() {
-        String errorMessage = Messages.getMessage(Messages.JOB_CONFIG_FIELD_VALUE_TOO_LOW, "annotations_retention_days", 0, -1);
+    public void testVerify_GivenNegativeSystemAnnotationsRetentionDays() {
+        String errorMessage =
+            Messages.getMessage(Messages.JOB_CONFIG_FIELD_VALUE_TOO_LOW, "system_system_annotations_retention_days", 0, -1);
         Job.Builder builder = buildJobBuilder("foo");
-        builder.setAnnotationsRetentionDays(-1L);
+        builder.setSystemAnnotationsRetentionDays(-1L);
         IllegalArgumentException e = expectThrows(IllegalArgumentException.class, builder::build);
         assertEquals(errorMessage, e.getMessage());
     }
@@ -767,7 +768,7 @@ public class JobTests extends AbstractSerializingTestCase<Job> {
             builder.setResultsRetentionDays(randomNonNegativeLong());
         }
         if (randomBoolean()) {
-            builder.setAnnotationsRetentionDays(randomNonNegativeLong());
+            builder.setSystemAnnotationsRetentionDays(randomNonNegativeLong());
         }
         if (randomBoolean()) {
             builder.setCustomSettings(Collections.singletonMap(randomAlphaOfLength(10), randomAlphaOfLength(10)));

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/job/config/JobTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/job/config/JobTests.java
@@ -489,7 +489,7 @@ public class JobTests extends AbstractSerializingTestCase<Job> {
 
     public void testVerify_GivenNegativeSystemAnnotationsRetentionDays() {
         String errorMessage =
-            Messages.getMessage(Messages.JOB_CONFIG_FIELD_VALUE_TOO_LOW, "system_system_annotations_retention_days", 0, -1);
+            Messages.getMessage(Messages.JOB_CONFIG_FIELD_VALUE_TOO_LOW, "system_annotations_retention_days", 0, -1);
         Job.Builder builder = buildJobBuilder("foo");
         builder.setSystemAnnotationsRetentionDays(-1L);
         IllegalArgumentException e = expectThrows(IllegalArgumentException.class, builder::build);

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/job/config/JobUpdateTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/job/config/JobUpdateTests.java
@@ -106,6 +106,9 @@ public class JobUpdateTests extends AbstractSerializingTestCase<JobUpdate> {
         if (randomBoolean()) {
             update.setResultsRetentionDays(randomNonNegativeLong());
         }
+        if (randomBoolean()) {
+            update.setAnnotationsRetentionDays(randomNonNegativeLong());
+        }
         if (randomBoolean() && jobSupportsCategorizationFilters(job)) {
             update.setCategorizationFilters(Arrays.asList(generateRandomStringArray(10, 10, false)));
         }
@@ -252,6 +255,7 @@ public class JobUpdateTests extends AbstractSerializingTestCase<JobUpdate> {
         updateBuilder.setAnalysisLimits(analysisLimits);
         updateBuilder.setBackgroundPersistInterval(TimeValue.timeValueHours(randomIntBetween(1, 24)));
         updateBuilder.setResultsRetentionDays(randomNonNegativeLong());
+        updateBuilder.setAnnotationsRetentionDays(randomNonNegativeLong());
         // The createRandom() method tests the complex interactions between these next two, so this test can always update both
         long newModelSnapshotRetentionDays = randomNonNegativeLong();
         updateBuilder.setModelSnapshotRetentionDays(newModelSnapshotRetentionDays);
@@ -289,6 +293,7 @@ public class JobUpdateTests extends AbstractSerializingTestCase<JobUpdate> {
         assertEquals(update.getBackgroundPersistInterval(), updatedJob.getBackgroundPersistInterval());
         assertEquals(update.getModelSnapshotRetentionDays(), updatedJob.getModelSnapshotRetentionDays());
         assertEquals(update.getResultsRetentionDays(), updatedJob.getResultsRetentionDays());
+        assertEquals(update.getAnnotationsRetentionDays(), updatedJob.getAnnotationsRetentionDays());
         assertEquals(update.getCategorizationFilters(), updatedJob.getAnalysisConfig().getCategorizationFilters());
         assertEquals(update.getPerPartitionCategorizationConfig().isEnabled(),
             updatedJob.getAnalysisConfig().getPerPartitionCategorizationConfig().isEnabled());

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/job/config/JobUpdateTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/job/config/JobUpdateTests.java
@@ -107,7 +107,7 @@ public class JobUpdateTests extends AbstractSerializingTestCase<JobUpdate> {
             update.setResultsRetentionDays(randomNonNegativeLong());
         }
         if (randomBoolean()) {
-            update.setAnnotationsRetentionDays(randomNonNegativeLong());
+            update.setSystemAnnotationsRetentionDays(randomNonNegativeLong());
         }
         if (randomBoolean() && jobSupportsCategorizationFilters(job)) {
             update.setCategorizationFilters(Arrays.asList(generateRandomStringArray(10, 10, false)));
@@ -255,7 +255,7 @@ public class JobUpdateTests extends AbstractSerializingTestCase<JobUpdate> {
         updateBuilder.setAnalysisLimits(analysisLimits);
         updateBuilder.setBackgroundPersistInterval(TimeValue.timeValueHours(randomIntBetween(1, 24)));
         updateBuilder.setResultsRetentionDays(randomNonNegativeLong());
-        updateBuilder.setAnnotationsRetentionDays(randomNonNegativeLong());
+        updateBuilder.setSystemAnnotationsRetentionDays(randomNonNegativeLong());
         // The createRandom() method tests the complex interactions between these next two, so this test can always update both
         long newModelSnapshotRetentionDays = randomNonNegativeLong();
         updateBuilder.setModelSnapshotRetentionDays(newModelSnapshotRetentionDays);
@@ -293,7 +293,7 @@ public class JobUpdateTests extends AbstractSerializingTestCase<JobUpdate> {
         assertEquals(update.getBackgroundPersistInterval(), updatedJob.getBackgroundPersistInterval());
         assertEquals(update.getModelSnapshotRetentionDays(), updatedJob.getModelSnapshotRetentionDays());
         assertEquals(update.getResultsRetentionDays(), updatedJob.getResultsRetentionDays());
-        assertEquals(update.getAnnotationsRetentionDays(), updatedJob.getAnnotationsRetentionDays());
+        assertEquals(update.getSystemAnnotationsRetentionDays(), updatedJob.getSystemAnnotationsRetentionDays());
         assertEquals(update.getCategorizationFilters(), updatedJob.getAnalysisConfig().getCategorizationFilters());
         assertEquals(update.getPerPartitionCategorizationConfig().isEnabled(),
             updatedJob.getAnalysisConfig().getPerPartitionCategorizationConfig().isEnabled());

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/DeleteExpiredDataIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/DeleteExpiredDataIT.java
@@ -361,7 +361,7 @@ public class DeleteExpiredDataIT extends MlNativeAutodetectIntegTestCase {
         Job.Builder job =
             new Job.Builder(jobId)
                 .setResultsRetentionDays(2L)
-                .setAnnotationsRetentionDays(1L)
+                .setSystemAnnotationsRetentionDays(1L)
                 .setAnalysisConfig(
                     new AnalysisConfig.Builder(Collections.singletonList(new Detector.Builder().setFunction("count").build()))
                         .setBucketSpan(TimeValue.timeValueHours(1)))

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/DeleteExpiredDataIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/DeleteExpiredDataIT.java
@@ -18,6 +18,9 @@ import org.elasticsearch.action.support.WriteRequest;
 import org.elasticsearch.action.update.UpdateAction;
 import org.elasticsearch.action.update.UpdateRequest;
 import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.xcontent.ToXContent;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.index.query.QueryBuilders;
@@ -25,6 +28,8 @@ import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.xpack.core.ml.action.DeleteExpiredDataAction;
 import org.elasticsearch.xpack.core.ml.action.UpdateModelSnapshotAction;
+import org.elasticsearch.xpack.core.ml.annotations.Annotation;
+import org.elasticsearch.xpack.core.ml.annotations.AnnotationIndex;
 import org.elasticsearch.xpack.core.ml.datafeed.DatafeedConfig;
 import org.elasticsearch.xpack.core.ml.job.config.AnalysisConfig;
 import org.elasticsearch.xpack.core.ml.job.config.DataDescription;
@@ -36,15 +41,21 @@ import org.elasticsearch.xpack.core.ml.job.process.autodetect.state.ModelSnapsho
 import org.elasticsearch.xpack.core.ml.job.results.Bucket;
 import org.elasticsearch.xpack.core.ml.job.results.ForecastRequestStats;
 import org.elasticsearch.xpack.core.ml.notifications.NotificationsIndex;
+import org.elasticsearch.xpack.core.security.user.XPackUser;
 import org.junit.After;
 import org.junit.Before;
 
+import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Date;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
+import static org.elasticsearch.xpack.core.ml.annotations.AnnotationTests.randomAnnotation;
 import static org.hamcrest.Matchers.arrayContaining;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
@@ -55,6 +66,8 @@ import static org.hamcrest.Matchers.lessThanOrEqualTo;
 public class DeleteExpiredDataIT extends MlNativeAutodetectIntegTestCase {
 
     private static final String DATA_INDEX = "delete-expired-data-test-data";
+    private static final String TIME_FIELD = "time";
+    private static final String USER_NAME = "some-user";
 
     @Before
     public void setUpData()  {
@@ -336,6 +349,74 @@ public class DeleteExpiredDataIT extends MlNativeAutodetectIntegTestCase {
         }
         assertThat("Documents for non_existing_job are still around; examples: " + nonExistingJobExampleIds,
             nonExistingJobDocsCount, equalTo(0));
+    }
+
+    public void testDeleteExpiresDataDeletesAnnotations() throws Exception {
+        String jobId = "delete-annotations-a";
+        String datafeedId = jobId + "-feed";
+
+        // No annotations so far
+        assertThatNumberOfAnnotationsIsEqualTo(0);
+
+        Job.Builder job =
+            new Job.Builder(jobId)
+                .setResultsRetentionDays(2L)
+                .setAnnotationsRetentionDays(1L)
+                .setAnalysisConfig(
+                    new AnalysisConfig.Builder(Collections.singletonList(new Detector.Builder().setFunction("count").build()))
+                        .setBucketSpan(TimeValue.timeValueHours(1)))
+                .setDataDescription(
+                    new DataDescription.Builder()
+                        .setTimeField(TIME_FIELD));
+
+        putJob(job);
+
+        DatafeedConfig datafeed =
+            new DatafeedConfig.Builder(datafeedId, jobId)
+                .setIndices(Collections.singletonList(DATA_INDEX))
+                .build();
+
+        putDatafeed(datafeed);
+
+        openJob(jobId);
+        // Run up to a day ago
+        Instant now = Instant.now();
+        startDatafeed(datafeedId, 0, now.minus(Duration.ofDays(1)).toEpochMilli());
+        waitUntilJobIsClosed(jobId);
+
+        assertThatNumberOfAnnotationsIsEqualTo(1);
+
+        // The following 4 annotations are created by the system and the 2 oldest ones *will* be deleted
+        client().index(randomAnnotationIndexRequest(jobId, now.minus(Duration.ofDays(1)), XPackUser.NAME)).actionGet();
+        client().index(randomAnnotationIndexRequest(jobId, now.minus(Duration.ofDays(2)), XPackUser.NAME)).actionGet();
+        client().index(randomAnnotationIndexRequest(jobId, now.minus(Duration.ofDays(3)), XPackUser.NAME)).actionGet();
+        client().index(randomAnnotationIndexRequest(jobId, now.minus(Duration.ofDays(4)), XPackUser.NAME)).actionGet();
+        // The following 4 annotations are created by the user and *will not* be deleted
+        client().index(randomAnnotationIndexRequest(jobId, now.minus(Duration.ofDays(1)), USER_NAME)).actionGet();
+        client().index(randomAnnotationIndexRequest(jobId, now.minus(Duration.ofDays(2)), USER_NAME)).actionGet();
+        client().index(randomAnnotationIndexRequest(jobId, now.minus(Duration.ofDays(3)), USER_NAME)).actionGet();
+        client().index(randomAnnotationIndexRequest(jobId, now.minus(Duration.ofDays(4)), USER_NAME)).actionGet();
+
+        assertThatNumberOfAnnotationsIsEqualTo(9);
+
+        client().execute(DeleteExpiredDataAction.INSTANCE, new DeleteExpiredDataAction.Request()).get();
+        refresh();
+
+        assertThatNumberOfAnnotationsIsEqualTo(7);
+    }
+
+    private static IndexRequest randomAnnotationIndexRequest(String jobId, Instant timestamp, String createUsername) throws IOException {
+        Annotation annotation =
+            new Annotation.Builder(randomAnnotation(jobId))
+                .setTimestamp(Date.from(timestamp))
+                .setCreateUsername(createUsername)
+                .build();
+        try (XContentBuilder xContentBuilder = annotation.toXContent(XContentFactory.jsonBuilder(), ToXContent.EMPTY_PARAMS)) {
+            return new IndexRequest(AnnotationIndex.WRITE_ALIAS_NAME)
+                .source(xContentBuilder)
+                .setRequireAlias(true)
+                .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE);
+        }
     }
 
     private static Job.Builder newJobBuilder(String id) {

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportDeleteExpiredDataAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportDeleteExpiredDataAction.java
@@ -32,6 +32,7 @@ import org.elasticsearch.xpack.ml.job.persistence.JobConfigProvider;
 import org.elasticsearch.xpack.ml.job.persistence.JobResultsProvider;
 import org.elasticsearch.xpack.ml.job.persistence.SearchAfterJobsIterator;
 import org.elasticsearch.xpack.ml.job.retention.EmptyStateIndexRemover;
+import org.elasticsearch.xpack.ml.job.retention.ExpiredAnnotationsRemover;
 import org.elasticsearch.xpack.ml.job.retention.ExpiredForecastsRemover;
 import org.elasticsearch.xpack.ml.job.retention.ExpiredModelSnapshotsRemover;
 import org.elasticsearch.xpack.ml.job.retention.ExpiredResultsRemover;
@@ -210,7 +211,10 @@ public class TransportDeleteExpiredDataAction extends HandledTransportAction<Del
                 new WrappedBatchedJobsIterator(new SearchAfterJobsIterator(client)), threadPool, parentTaskId, jobResultsProvider, auditor),
             new UnusedStateRemover(client, clusterService, parentTaskId),
             new EmptyStateIndexRemover(client, parentTaskId),
-            new UnusedStatsRemover(client, parentTaskId));
+            new UnusedStatsRemover(client, parentTaskId),
+            new ExpiredAnnotationsRemover(client,
+                new WrappedBatchedJobsIterator(new SearchAfterJobsIterator(client)), parentTaskId, auditor, threadPool)
+        );
     }
 
     private List<MlDataRemover> createDataRemovers(List<Job> jobs, TaskId parentTaskId, AnomalyDetectionAuditor auditor) {
@@ -224,7 +228,9 @@ public class TransportDeleteExpiredDataAction extends HandledTransportAction<Del
                 auditor),
             new UnusedStateRemover(client, clusterService, parentTaskId),
             new EmptyStateIndexRemover(client, parentTaskId),
-            new UnusedStatsRemover(client, parentTaskId));
+            new UnusedStatsRemover(client, parentTaskId),
+            new ExpiredAnnotationsRemover(client, new VolatileCursorIterator<>(jobs), parentTaskId, auditor, threadPool)
+        );
     }
 
 }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportRevertModelSnapshotAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportRevertModelSnapshotAction.java
@@ -254,7 +254,7 @@ public class TransportRevertModelSnapshotAction extends TransportMasterNodeActio
                     Annotation.Event.DELAYED_DATA.toString(),
                     // Because the model that changed is no longer in use as it has been rolled back to a time before those changes occurred
                     Annotation.Event.MODEL_CHANGE.toString());
-            dataDeleter.deleteAnnotationsFromTime(deleteAfter.getTime() + 1, eventsToDelete,
+            dataDeleter.deleteAnnotations(deleteAfter.getTime() + 1, null, eventsToDelete,
                     listener.delegateFailure((l, r) -> l.onResponse(response)));
         }, listener::onFailure);
     }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/retention/AbstractExpiredJobDataRemover.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/retention/AbstractExpiredJobDataRemover.java
@@ -8,11 +8,8 @@ package org.elasticsearch.xpack.ml.job.retention;
 
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.client.OriginSettingClient;
-import org.elasticsearch.index.query.BoolQueryBuilder;
-import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.tasks.TaskId;
 import org.elasticsearch.xpack.core.ml.job.config.Job;
-import org.elasticsearch.xpack.core.ml.job.results.Result;
 
 import java.util.Iterator;
 import java.util.Objects;
@@ -103,12 +100,6 @@ abstract class AbstractExpiredJobDataRemover implements MlDataRemover {
         long cutoffEpochMs,
         ActionListener<Boolean> listener
     );
-
-    static BoolQueryBuilder createQuery(String jobId, long cutoffEpochMs) {
-        return QueryBuilders.boolQuery()
-                .filter(QueryBuilders.termQuery(Job.ID.getPreferredName(), jobId))
-                .filter(QueryBuilders.rangeQuery(Result.TIMESTAMP.getPreferredName()).lt(cutoffEpochMs).format("epoch_millis"));
-    }
 
     /**
      * The latest time that cutoffs are measured from is not wall clock time,

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/retention/ExpiredAnnotationsRemover.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/retention/ExpiredAnnotationsRemover.java
@@ -63,7 +63,7 @@ public class ExpiredAnnotationsRemover extends AbstractExpiredJobDataRemover {
 
     @Override
     Long getRetentionDays(Job job) {
-        return job.getAnnotationsRetentionDays();
+        return job.getSystemAnnotationsRetentionDays();
     }
 
     @Override

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/retention/ExpiredAnnotationsRemover.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/retention/ExpiredAnnotationsRemover.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+package org.elasticsearch.xpack.ml.job.retention;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.support.ThreadedActionListener;
+import org.elasticsearch.client.OriginSettingClient;
+import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.index.query.QueryBuilder;
+import org.elasticsearch.index.query.QueryBuilders;
+import org.elasticsearch.index.reindex.AbstractBulkByScrollRequest;
+import org.elasticsearch.index.reindex.BulkByScrollResponse;
+import org.elasticsearch.index.reindex.DeleteByQueryAction;
+import org.elasticsearch.index.reindex.DeleteByQueryRequest;
+import org.elasticsearch.tasks.TaskId;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.xpack.core.ml.annotations.Annotation;
+import org.elasticsearch.xpack.core.ml.annotations.AnnotationIndex;
+import org.elasticsearch.xpack.core.ml.job.config.Job;
+import org.elasticsearch.xpack.core.ml.job.messages.Messages;
+import org.elasticsearch.xpack.core.ml.job.persistence.ElasticsearchMappings;
+import org.elasticsearch.xpack.core.security.user.XPackUser;
+import org.elasticsearch.xpack.ml.MachineLearning;
+import org.elasticsearch.xpack.ml.notifications.AnomalyDetectionAuditor;
+
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Iterator;
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
+
+import static org.elasticsearch.xpack.ml.job.retention.ExpiredResultsRemover.latestBucketTime;
+
+/**
+ * Removes all annotations that have expired the configured retention time
+ * of their respective job. An annotation is deleted if its timestamp is earlier
+ * than the start of the current day (local time-zone) minus the retention
+ * period.
+ *
+ * This is expected to be used by actions requiring admin rights. Thus,
+ * it is also expected that the provided client will be a client with the
+ * ML origin so that permissions to manage ML indices are met.
+ */
+public class ExpiredAnnotationsRemover extends AbstractExpiredJobDataRemover {
+
+    private static final Logger LOGGER = LogManager.getLogger(ExpiredAnnotationsRemover.class);
+
+    private final AnomalyDetectionAuditor auditor;
+    private final ThreadPool threadPool;
+
+    public ExpiredAnnotationsRemover(OriginSettingClient client, Iterator<Job> jobIterator, TaskId parentTaskId,
+                                     AnomalyDetectionAuditor auditor, ThreadPool threadPool) {
+        super(client, jobIterator, parentTaskId);
+        this.auditor = Objects.requireNonNull(auditor);
+        this.threadPool = Objects.requireNonNull(threadPool);
+    }
+
+    @Override
+    Long getRetentionDays(Job job) {
+        return job.getAnnotationsRetentionDays();
+    }
+
+    @Override
+    protected void removeDataBefore(
+        Job job,
+        float requestsPerSecond,
+        long latestTimeMs,
+        long cutoffEpochMs,
+        ActionListener<Boolean> listener
+    ) {
+        DeleteByQueryRequest request = createDBQRequest(job, requestsPerSecond, cutoffEpochMs);
+        request.setParentTask(getParentTaskId());
+
+        client.execute(DeleteByQueryAction.INSTANCE, request, new ActionListener<>() {
+            @Override
+            public void onResponse(BulkByScrollResponse bulkByScrollResponse) {
+                try {
+                    if (bulkByScrollResponse.getDeleted() > 0) {
+                        auditAnnotationsWereDeleted(job.getId(), cutoffEpochMs);
+                    }
+                    listener.onResponse(true);
+                } catch (Exception e) {
+                    onFailure(e);
+                }
+            }
+
+            @Override
+            public void onFailure(Exception e) {
+                listener.onFailure(new ElasticsearchException("Failed to remove expired annotations for job [" + job.getId() + "]", e));
+            }
+        });
+    }
+
+    private static DeleteByQueryRequest createDBQRequest(Job job, float requestsPerSec, long cutoffEpochMs) {
+        QueryBuilder query = QueryBuilders.boolQuery()
+            .filter(QueryBuilders.termQuery(Job.ID.getPreferredName(), job.getId()))
+            .filter(QueryBuilders.rangeQuery(Annotation.TIMESTAMP.getPreferredName()).lt(cutoffEpochMs).format("epoch_millis"))
+            .filter(QueryBuilders.termQuery(Annotation.CREATE_USERNAME.getPreferredName(), XPackUser.NAME));
+        DeleteByQueryRequest request = new DeleteByQueryRequest(AnnotationIndex.READ_ALIAS_NAME)
+            .setSlices(AbstractBulkByScrollRequest.AUTO_SLICES)
+            .setBatchSize(AbstractBulkByScrollRequest.DEFAULT_SCROLL_SIZE)
+            // We are deleting old data, we should simply proceed as a version conflict could mean that another deletion is taking place
+            .setAbortOnVersionConflict(false)
+            .setTimeout(DEFAULT_MAX_DURATION)
+            .setRequestsPerSecond(requestsPerSec)
+            .setQuery(query);
+
+        // _doc is the most efficient sort order and will also disable scoring
+        request.getSearchRequest().source().sort(ElasticsearchMappings.ES_DOC);
+        return request;
+    }
+
+    @Override
+    void calcCutoffEpochMs(String jobId, long retentionDays, ActionListener<CutoffDetails> listener) {
+        ThreadedActionListener<CutoffDetails> threadedActionListener = new ThreadedActionListener<>(LOGGER, threadPool,
+                MachineLearning.UTILITY_THREAD_POOL_NAME, listener, false);
+        latestBucketTime(client, getParentTaskId(), jobId, ActionListener.wrap(
+                latestTime -> {
+                    if (latestTime == null) {
+                        threadedActionListener.onResponse(null);
+                    } else {
+                        long cutoff = latestTime - new TimeValue(retentionDays, TimeUnit.DAYS).getMillis();
+                        threadedActionListener.onResponse(new CutoffDetails(latestTime, cutoff));
+                    }
+                },
+                listener::onFailure
+        ));
+    }
+
+    private void auditAnnotationsWereDeleted(String jobId, long cutoffEpochMs) {
+        Instant instant = Instant.ofEpochMilli(cutoffEpochMs);
+        ZonedDateTime zonedDateTime = ZonedDateTime.ofInstant(instant, ZoneOffset.systemDefault());
+        String formatted = DateTimeFormatter.ISO_OFFSET_DATE_TIME.format(zonedDateTime);
+        String msg = Messages.getMessage(Messages.JOB_AUDIT_OLD_ANNOTATIONS_DELETED, formatted);
+        LOGGER.debug("[{}] {}", jobId, msg);
+        auditor.info(jobId, msg);
+    }
+}

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/retention/ExpiredAnnotationsRemover.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/retention/ExpiredAnnotationsRemover.java
@@ -25,7 +25,6 @@ import org.elasticsearch.xpack.core.ml.annotations.Annotation;
 import org.elasticsearch.xpack.core.ml.annotations.AnnotationIndex;
 import org.elasticsearch.xpack.core.ml.job.config.Job;
 import org.elasticsearch.xpack.core.ml.job.messages.Messages;
-import org.elasticsearch.xpack.core.ml.job.persistence.ElasticsearchMappings;
 import org.elasticsearch.xpack.core.security.user.XPackUser;
 import org.elasticsearch.xpack.ml.MachineLearning;
 import org.elasticsearch.xpack.ml.notifications.AnomalyDetectionAuditor;
@@ -41,10 +40,8 @@ import java.util.concurrent.TimeUnit;
 import static org.elasticsearch.xpack.ml.job.retention.ExpiredResultsRemover.latestBucketTime;
 
 /**
- * Removes all annotations that have expired the configured retention time
- * of their respective job. An annotation is deleted if its timestamp is earlier
- * than the start of the current day (local time-zone) minus the retention
- * period.
+ * Removes all the automatically created annotations that have expired the configured retention time of their respective job.
+ * An annotation is deleted if its timestamp is earlier than the timestamp of the latest bucket minus the retention period.
  *
  * This is expected to be used by actions requiring admin rights. Thus,
  * it is also expected that the provided client will be a client with the
@@ -113,9 +110,6 @@ public class ExpiredAnnotationsRemover extends AbstractExpiredJobDataRemover {
             .setTimeout(DEFAULT_MAX_DURATION)
             .setRequestsPerSecond(requestsPerSec)
             .setQuery(query);
-
-        // _doc is the most efficient sort order and will also disable scoring
-        request.getSearchRequest().source().sort(ElasticsearchMappings.ES_DOC);
         return request;
     }
 

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/retention/ExpiredResultsRemover.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/retention/ExpiredResultsRemover.java
@@ -57,9 +57,8 @@ import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 
 /**
- * Removes all results that have expired the configured retention time
- * of their respective job. A result is deleted if its timestamp is earlier
- * than the timestamp of the latest bucket minus the retention period.
+ * Removes all results that have expired the configured retention time of their respective job.
+ * A result is deleted if its timestamp is earlier than the timestamp of the latest bucket minus the retention period.
  *
  * This is expected to be used by actions requiring admin rights. Thus,
  * it is also expected that the provided client will be a client with the

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/retention/ExpiredResultsRemover.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/retention/ExpiredResultsRemover.java
@@ -14,12 +14,12 @@ import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.support.ThreadedActionListener;
 import org.elasticsearch.client.OriginSettingClient;
-import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.common.xcontent.LoggingDeprecationHandler;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.XContentType;
+import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.index.reindex.AbstractBulkByScrollRequest;
@@ -59,8 +59,7 @@ import java.util.concurrent.TimeUnit;
 /**
  * Removes all results that have expired the configured retention time
  * of their respective job. A result is deleted if its timestamp is earlier
- * than the start of the current day (local time-zone) minus the retention
- * period.
+ * than the timestamp of the latest bucket minus the retention period.
  *
  * This is expected to be used by actions requiring admin rights. Thus,
  * it is also expected that the provided client will be a client with the
@@ -117,23 +116,25 @@ public class ExpiredResultsRemover extends AbstractExpiredJobDataRemover {
         });
     }
 
-    DeleteByQueryRequest createDBQRequest(Job job, float requestsPerSec, long cutoffEpochMs) {
-        DeleteByQueryRequest request = new DeleteByQueryRequest();
-        request.setSlices(AbstractBulkByScrollRequest.AUTO_SLICES);
-
-        request.setBatchSize(AbstractBulkByScrollRequest.DEFAULT_SCROLL_SIZE)
+    private DeleteByQueryRequest createDBQRequest(Job job, float requestsPerSec, long cutoffEpochMs) {
+        QueryBuilder excludeFilter = QueryBuilders.termsQuery(
+            Result.RESULT_TYPE.getPreferredName(),
+            ModelSizeStats.RESULT_TYPE_VALUE,
+            ForecastRequestStats.RESULT_TYPE_VALUE,
+            Forecast.RESULT_TYPE_VALUE);
+        QueryBuilder query = QueryBuilders.boolQuery()
+            .filter(QueryBuilders.termQuery(Job.ID.getPreferredName(), job.getId()))
+            .filter(QueryBuilders.rangeQuery(Result.TIMESTAMP.getPreferredName()).lt(cutoffEpochMs).format("epoch_millis"))
+            .filter(QueryBuilders.existsQuery(Result.RESULT_TYPE.getPreferredName()))
+            .mustNot(excludeFilter);
+        DeleteByQueryRequest request = new DeleteByQueryRequest(AnomalyDetectorsIndex.jobResultsAliasedName(job.getId()))
+            .setSlices(AbstractBulkByScrollRequest.AUTO_SLICES)
+            .setBatchSize(AbstractBulkByScrollRequest.DEFAULT_SCROLL_SIZE)
             // We are deleting old data, we should simply proceed as a version conflict could mean that another deletion is taking place
             .setAbortOnVersionConflict(false)
             .setTimeout(DEFAULT_MAX_DURATION)
-            .setRequestsPerSecond(requestsPerSec);
-
-        request.indices(AnomalyDetectorsIndex.jobResultsAliasedName(job.getId()));
-        QueryBuilder excludeFilter = QueryBuilders.termsQuery(Result.RESULT_TYPE.getPreferredName(),
-                ModelSizeStats.RESULT_TYPE_VALUE, ForecastRequestStats.RESULT_TYPE_VALUE, Forecast.RESULT_TYPE_VALUE);
-        QueryBuilder query = createQuery(job.getId(), cutoffEpochMs)
-                .filter(QueryBuilders.existsQuery(Result.RESULT_TYPE.getPreferredName()))
-                .mustNot(excludeFilter);
-        request.setQuery(query);
+            .setRequestsPerSecond(requestsPerSec)
+            .setQuery(query);
 
         // _doc is the most efficient sort order and will also disable scoring
         request.getSearchRequest().source().sort(ElasticsearchMappings.ES_DOC);
@@ -144,7 +145,7 @@ public class ExpiredResultsRemover extends AbstractExpiredJobDataRemover {
     void calcCutoffEpochMs(String jobId, long retentionDays, ActionListener<CutoffDetails> listener) {
         ThreadedActionListener<CutoffDetails> threadedActionListener = new ThreadedActionListener<>(LOGGER, threadPool,
                 MachineLearning.UTILITY_THREAD_POOL_NAME, listener, false);
-        latestBucketTime(jobId, ActionListener.wrap(
+        latestBucketTime(client, getParentTaskId(), jobId, ActionListener.wrap(
                 latestTime -> {
                     if (latestTime == null) {
                         threadedActionListener.onResponse(null);
@@ -157,7 +158,7 @@ public class ExpiredResultsRemover extends AbstractExpiredJobDataRemover {
         ));
     }
 
-    private void latestBucketTime(String jobId, ActionListener<Long> listener) {
+    static void latestBucketTime(OriginSettingClient client, TaskId parentTaskId, String jobId, ActionListener<Long> listener) {
         SortBuilder<?> sortBuilder = new FieldSortBuilder(Result.TIMESTAMP.getPreferredName()).order(SortOrder.DESC);
         QueryBuilder bucketType = QueryBuilders.termQuery(Result.RESULT_TYPE.getPreferredName(), Bucket.RESULT_TYPE_VALUE);
 
@@ -171,7 +172,7 @@ public class ExpiredResultsRemover extends AbstractExpiredJobDataRemover {
         SearchRequest searchRequest = new SearchRequest(indexName);
         searchRequest.source(searchSourceBuilder);
         searchRequest.indicesOptions(MlIndicesUtils.addIgnoreUnavailable(SearchRequest.DEFAULT_INDICES_OPTIONS));
-        searchRequest.setParentTask(getParentTaskId());
+        searchRequest.setParentTask(parentTaskId);
 
         client.search(searchRequest, ActionListener.wrap(
                 response -> {

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/config/JobBuilderTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/config/JobBuilderTests.java
@@ -65,7 +65,7 @@ public class JobBuilderTests extends AbstractWireSerializingTestCase<Job.Builder
             builder.setResultsRetentionDays(randomNonNegativeLong());
         }
         if (randomBoolean()) {
-            builder.setAnnotationsRetentionDays(randomNonNegativeLong());
+            builder.setSystemAnnotationsRetentionDays(randomNonNegativeLong());
         }
         if (randomBoolean()) {
             builder.setCustomSettings(Collections.singletonMap(randomAlphaOfLength(10),

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/config/JobBuilderTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/config/JobBuilderTests.java
@@ -65,6 +65,9 @@ public class JobBuilderTests extends AbstractWireSerializingTestCase<Job.Builder
             builder.setResultsRetentionDays(randomNonNegativeLong());
         }
         if (randomBoolean()) {
+            builder.setAnnotationsRetentionDays(randomNonNegativeLong());
+        }
+        if (randomBoolean()) {
             builder.setCustomSettings(Collections.singletonMap(randomAlphaOfLength(10),
                     randomAlphaOfLength(10)));
         }

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/persistence/JobDataDeleterTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/persistence/JobDataDeleterTests.java
@@ -11,6 +11,7 @@ import org.elasticsearch.client.Client;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
+import org.elasticsearch.core.Tuple;
 import org.elasticsearch.index.reindex.DeleteByQueryAction;
 import org.elasticsearch.index.reindex.DeleteByQueryRequest;
 import org.elasticsearch.test.ESTestCase;
@@ -23,6 +24,7 @@ import org.mockito.ArgumentCaptor;
 
 import java.util.Set;
 
+import static org.elasticsearch.core.Tuple.tuple;
 import static org.hamcrest.Matchers.arrayContaining;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
@@ -67,13 +69,19 @@ public class JobDataDeleterTests extends ESTestCase {
 
         DeleteByQueryRequest deleteRequest = deleteRequestCaptor.getValue();
         assertThat(deleteRequest.indices(), is(arrayContaining(AnnotationIndex.READ_ALIAS_NAME)));
-        assertThat(Strings.toString(deleteRequest), not(containsString("timestamp")));
-        assertThat(Strings.toString(deleteRequest), not(containsString("event")));
+        String dbqQueryString = Strings.toString(deleteRequest.getSearchRequest().source().query());
+        assertThat(dbqQueryString, not(containsString("timestamp")));
+        assertThat(dbqQueryString, not(containsString("event")));
     }
 
-    public void testDeleteAnnotationsFromTime_TimestampFiltering() {
+    public void testDeleteAnnotations_TimestampFiltering() {
         JobDataDeleter jobDataDeleter = new JobDataDeleter(client, JOB_ID);
-        jobDataDeleter.deleteAnnotationsFromTime(1_000_000_000L, null, ActionListener.wrap(
+        Tuple<Long, Long> range =
+            randomFrom(
+                tuple(1_000_000_000L, 2_000_000_000L),
+                tuple(1_000_000_000L, null),
+                tuple(null, 2_000_000_000L));
+        jobDataDeleter.deleteAnnotations(range.v1(), range.v2(), null, ActionListener.wrap(
             deleteResponse -> {},
             e -> fail(e.toString())
         ));
@@ -82,13 +90,14 @@ public class JobDataDeleterTests extends ESTestCase {
 
         DeleteByQueryRequest deleteRequest = deleteRequestCaptor.getValue();
         assertThat(deleteRequest.indices(), is(arrayContaining(AnnotationIndex.READ_ALIAS_NAME)));
-        assertThat(Strings.toString(deleteRequest), containsString("timestamp"));
-        assertThat(Strings.toString(deleteRequest), not(containsString("event")));
+        String dbqQueryString = Strings.toString(deleteRequest.getSearchRequest().source().query());
+        assertThat(dbqQueryString, containsString("timestamp"));
+        assertThat(dbqQueryString, not(containsString("event")));
     }
 
-    public void testDeleteAnnotationsFromTime_EventFiltering() {
+    public void testDeleteAnnotations_EventFiltering() {
         JobDataDeleter jobDataDeleter = new JobDataDeleter(client, JOB_ID);
-        jobDataDeleter.deleteAnnotationsFromTime(null, Set.of("dummy_event"), ActionListener.wrap(
+        jobDataDeleter.deleteAnnotations(null, null, Set.of("dummy_event"), ActionListener.wrap(
             deleteResponse -> {},
             e -> fail(e.toString())
         ));
@@ -97,8 +106,9 @@ public class JobDataDeleterTests extends ESTestCase {
 
         DeleteByQueryRequest deleteRequest = deleteRequestCaptor.getValue();
         assertThat(deleteRequest.indices(), is(arrayContaining(AnnotationIndex.READ_ALIAS_NAME)));
-        assertThat(Strings.toString(deleteRequest), not(containsString("timestamp")));
-        assertThat(Strings.toString(deleteRequest), containsString("event"));
+        String dbqQueryString = Strings.toString(deleteRequest.getSearchRequest().source().query());
+        assertThat(dbqQueryString, not(containsString("timestamp")));
+        assertThat(dbqQueryString, containsString("event"));
     }
 
     public void testDeleteDatafeedTimingStats() {

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/retention/ExpiredAnnotationsRemoverTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/retention/ExpiredAnnotationsRemoverTests.java
@@ -88,8 +88,8 @@ public class ExpiredAnnotationsRemoverTests extends ESTestCase {
 
         List<Job> jobs = Arrays.asList(
             JobTests.buildJobBuilder("none").build(),
-            JobTests.buildJobBuilder("annotations-1").setAnnotationsRetentionDays(10L).build(),
-            JobTests.buildJobBuilder("annotations-2").setAnnotationsRetentionDays(20L).build());
+            JobTests.buildJobBuilder("annotations-1").setSystemAnnotationsRetentionDays(10L).build(),
+            JobTests.buildJobBuilder("annotations-2").setSystemAnnotationsRetentionDays(20L).build());
 
         createExpiredAnnotationsRemover(jobs.iterator()).remove(1.0f, listener, () -> false);
 
@@ -106,8 +106,8 @@ public class ExpiredAnnotationsRemoverTests extends ESTestCase {
         givenBucket(new Bucket("id_not_important", new Date(), 60));
 
         List<Job> jobs = Arrays.asList(
-            JobTests.buildJobBuilder("annotations-1").setAnnotationsRetentionDays(10L).build(),
-            JobTests.buildJobBuilder("annotations-2").setAnnotationsRetentionDays(20L).build()
+            JobTests.buildJobBuilder("annotations-1").setSystemAnnotationsRetentionDays(10L).build(),
+            JobTests.buildJobBuilder("annotations-2").setSystemAnnotationsRetentionDays(20L).build()
         );
 
         final int timeoutAfter = randomIntBetween(0, 1);
@@ -125,8 +125,8 @@ public class ExpiredAnnotationsRemoverTests extends ESTestCase {
 
         List<Job> jobs = Arrays.asList(
             JobTests.buildJobBuilder("none").build(),
-            JobTests.buildJobBuilder("annotations-1").setAnnotationsRetentionDays(10L).build(),
-            JobTests.buildJobBuilder("annotations-2").setAnnotationsRetentionDays(20L).build());
+            JobTests.buildJobBuilder("annotations-1").setSystemAnnotationsRetentionDays(10L).build(),
+            JobTests.buildJobBuilder("annotations-2").setSystemAnnotationsRetentionDays(20L).build());
         createExpiredAnnotationsRemover(jobs.iterator()).remove(1.0f, listener, () -> false);
 
         assertThat(capturedDeleteByQueryRequests.size(), equalTo(1));
@@ -141,7 +141,7 @@ public class ExpiredAnnotationsRemoverTests extends ESTestCase {
         Date latest = new Date();
 
         givenBucket(new Bucket(jobId, latest, 60));
-        List<Job> jobs = Collections.singletonList(JobTests.buildJobBuilder(jobId).setAnnotationsRetentionDays(1L).build());
+        List<Job> jobs = Collections.singletonList(JobTests.buildJobBuilder(jobId).setSystemAnnotationsRetentionDays(1L).build());
 
         ActionListener<AbstractExpiredJobDataRemover.CutoffDetails> cutoffListener = mock(ActionListener.class);
         createExpiredAnnotationsRemover(jobs.iterator()).calcCutoffEpochMs(jobId, 1L, cutoffListener);

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/retention/ExpiredAnnotationsRemoverTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/retention/ExpiredAnnotationsRemoverTests.java
@@ -1,0 +1,206 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+package org.elasticsearch.xpack.ml.job.retention;
+
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.search.SearchAction;
+import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.client.Client;
+import org.elasticsearch.client.OriginSettingClient;
+import org.elasticsearch.index.reindex.BulkByScrollResponse;
+import org.elasticsearch.index.reindex.DeleteByQueryAction;
+import org.elasticsearch.index.reindex.DeleteByQueryRequest;
+import org.elasticsearch.tasks.TaskId;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.xpack.core.ClientHelper;
+import org.elasticsearch.xpack.core.ml.annotations.AnnotationIndex;
+import org.elasticsearch.xpack.core.ml.job.config.Job;
+import org.elasticsearch.xpack.core.ml.job.config.JobTests;
+import org.elasticsearch.xpack.core.ml.job.persistence.AnomalyDetectorsIndex;
+import org.elasticsearch.xpack.core.ml.job.results.Bucket;
+import org.elasticsearch.xpack.ml.MachineLearning;
+import org.elasticsearch.xpack.ml.notifications.AnomalyDetectionAuditor;
+import org.elasticsearch.xpack.ml.test.MockOriginSettingClient;
+import org.junit.Before;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Date;
+import java.util.Iterator;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Matchers.same;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class ExpiredAnnotationsRemoverTests extends ESTestCase {
+
+    private Client client;
+    private OriginSettingClient originSettingClient;
+    private List<DeleteByQueryRequest> capturedDeleteByQueryRequests;
+    private ActionListener<Boolean> listener;
+
+    @Before
+    @SuppressWarnings("unchecked")
+    public void setUpTests() {
+        capturedDeleteByQueryRequests = new ArrayList<>();
+
+        client = mock(Client.class);
+        originSettingClient = MockOriginSettingClient.mockOriginSettingClient(client, ClientHelper.ML_ORIGIN);
+        listener = mock(ActionListener.class);
+    }
+
+    public void testRemove_GivenNoJobs() {
+        givenDBQRequestsSucceed();
+
+        createExpiredAnnotationsRemover(Collections.emptyIterator()).remove(1.0f, listener, () -> false);
+
+        verify(listener).onResponse(true);
+    }
+
+    public void testRemove_GivenJobsWithoutRetentionPolicy() {
+        givenDBQRequestsSucceed();
+        List<Job> jobs = Arrays.asList(
+                JobTests.buildJobBuilder("foo").build(),
+                JobTests.buildJobBuilder("bar").build()
+        );
+
+        createExpiredAnnotationsRemover(jobs.iterator()).remove(1.0f, listener, () -> false);
+
+        verify(listener).onResponse(true);
+    }
+
+    public void testRemove_GivenJobsWithAndWithoutRetentionPolicy() {
+        givenDBQRequestsSucceed();
+        givenBucket(new Bucket("id_not_important", new Date(), 60));
+
+        List<Job> jobs = Arrays.asList(
+            JobTests.buildJobBuilder("none").build(),
+            JobTests.buildJobBuilder("annotations-1").setAnnotationsRetentionDays(10L).build(),
+            JobTests.buildJobBuilder("annotations-2").setAnnotationsRetentionDays(20L).build());
+
+        createExpiredAnnotationsRemover(jobs.iterator()).remove(1.0f, listener, () -> false);
+
+        assertThat(capturedDeleteByQueryRequests.size(), equalTo(2));
+        DeleteByQueryRequest dbqRequest = capturedDeleteByQueryRequests.get(0);
+        assertThat(dbqRequest.indices(), equalTo(new String[] {AnnotationIndex.READ_ALIAS_NAME}));
+        dbqRequest = capturedDeleteByQueryRequests.get(1);
+        assertThat(dbqRequest.indices(), equalTo(new String[] {AnnotationIndex.READ_ALIAS_NAME}));
+        verify(listener).onResponse(true);
+    }
+
+    public void testRemove_GivenTimeout() {
+        givenDBQRequestsSucceed();
+        givenBucket(new Bucket("id_not_important", new Date(), 60));
+
+        List<Job> jobs = Arrays.asList(
+            JobTests.buildJobBuilder("annotations-1").setAnnotationsRetentionDays(10L).build(),
+            JobTests.buildJobBuilder("annotations-2").setAnnotationsRetentionDays(20L).build()
+        );
+
+        final int timeoutAfter = randomIntBetween(0, 1);
+        AtomicInteger attemptsLeft = new AtomicInteger(timeoutAfter);
+
+        createExpiredAnnotationsRemover(jobs.iterator()).remove(1.0f, listener, () -> (attemptsLeft.getAndDecrement() <= 0));
+
+        assertThat(capturedDeleteByQueryRequests.size(), equalTo(timeoutAfter));
+        verify(listener).onResponse(false);
+    }
+
+    public void testRemove_GivenClientRequestsFailed() {
+        givenDBQRequestsFailed();
+        givenBucket(new Bucket("id_not_important", new Date(), 60));
+
+        List<Job> jobs = Arrays.asList(
+            JobTests.buildJobBuilder("none").build(),
+            JobTests.buildJobBuilder("annotations-1").setAnnotationsRetentionDays(10L).build(),
+            JobTests.buildJobBuilder("annotations-2").setAnnotationsRetentionDays(20L).build());
+        createExpiredAnnotationsRemover(jobs.iterator()).remove(1.0f, listener, () -> false);
+
+        assertThat(capturedDeleteByQueryRequests.size(), equalTo(1));
+        DeleteByQueryRequest dbqRequest = capturedDeleteByQueryRequests.get(0);
+        assertThat(dbqRequest.indices(), equalTo(new String[] {AnnotationIndex.READ_ALIAS_NAME}));
+        verify(listener).onFailure(any());
+    }
+
+    @SuppressWarnings("unchecked")
+    public void testCalcCutoffEpochMs() {
+        String jobId = "calc-cutoff";
+        Date latest = new Date();
+
+        givenBucket(new Bucket(jobId, latest, 60));
+        List<Job> jobs = Collections.singletonList(JobTests.buildJobBuilder(jobId).setAnnotationsRetentionDays(1L).build());
+
+        ActionListener<AbstractExpiredJobDataRemover.CutoffDetails> cutoffListener = mock(ActionListener.class);
+        createExpiredAnnotationsRemover(jobs.iterator()).calcCutoffEpochMs(jobId, 1L, cutoffListener);
+
+        long dayInMills = 60 * 60 * 24 * 1000;
+        long expectedCutoffTime = latest.getTime() - dayInMills;
+        verify(cutoffListener).onResponse(eq(new AbstractExpiredJobDataRemover.CutoffDetails(latest.getTime(), expectedCutoffTime)));
+    }
+
+    private void givenDBQRequestsSucceed() {
+        givenDBQRequest(true);
+    }
+
+    private void givenDBQRequestsFailed() {
+        givenDBQRequest(false);
+    }
+
+    @SuppressWarnings("unchecked")
+    private void givenDBQRequest(boolean shouldSucceed) {
+        doAnswer(invocationOnMock -> {
+                capturedDeleteByQueryRequests.add((DeleteByQueryRequest) invocationOnMock.getArguments()[1]);
+                ActionListener<BulkByScrollResponse> listener =
+                        (ActionListener<BulkByScrollResponse>) invocationOnMock.getArguments()[2];
+                if (shouldSucceed) {
+                    BulkByScrollResponse bulkByScrollResponse = mock(BulkByScrollResponse.class);
+                    when(bulkByScrollResponse.getDeleted()).thenReturn(42L);
+                    listener.onResponse(bulkByScrollResponse);
+                } else {
+                    listener.onFailure(new RuntimeException("failed"));
+                }
+                return null;
+            }
+        ).when(client).execute(same(DeleteByQueryAction.INSTANCE), any(), any());
+    }
+
+    @SuppressWarnings("unchecked")
+    private void givenBucket(Bucket bucket) {
+        doAnswer(invocationOnMock -> {
+            ActionListener<SearchResponse> listener = (ActionListener<SearchResponse>) invocationOnMock.getArguments()[2];
+            listener.onResponse(AbstractExpiredJobDataRemoverTests.createSearchResponse(Collections.singletonList(bucket)));
+            return null;
+        }).when(client).execute(eq(SearchAction.INSTANCE), any(), any());
+    }
+
+    private ExpiredAnnotationsRemover createExpiredAnnotationsRemover(Iterator<Job> jobIterator) {
+        ThreadPool threadPool = mock(ThreadPool.class);
+        ExecutorService executor = mock(ExecutorService.class);
+
+        when(threadPool.executor(eq(MachineLearning.UTILITY_THREAD_POOL_NAME))).thenReturn(executor);
+
+        doAnswer(invocationOnMock -> {
+                Runnable run = (Runnable) invocationOnMock.getArguments()[0];
+                run.run();
+                return null;
+            }
+        ).when(executor).execute(any());
+
+        return new ExpiredAnnotationsRemover(
+            originSettingClient, jobIterator, new TaskId("test", 0L), mock(AnomalyDetectionAuditor.class), threadPool);
+    }
+}

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/retention/ExpiredAnnotationsRemoverTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/retention/ExpiredAnnotationsRemoverTests.java
@@ -21,7 +21,6 @@ import org.elasticsearch.xpack.core.ClientHelper;
 import org.elasticsearch.xpack.core.ml.annotations.AnnotationIndex;
 import org.elasticsearch.xpack.core.ml.job.config.Job;
 import org.elasticsearch.xpack.core.ml.job.config.JobTests;
-import org.elasticsearch.xpack.core.ml.job.persistence.AnomalyDetectorsIndex;
 import org.elasticsearch.xpack.core.ml.job.results.Bucket;
 import org.elasticsearch.xpack.ml.MachineLearning;
 import org.elasticsearch.xpack.ml.notifications.AnomalyDetectionAuditor;

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/ml/delete_expired_data.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/ml/delete_expired_data.yml
@@ -18,7 +18,7 @@ setup:
                 "time_format":"yyyy-MM-dd HH:mm:ssX"
             },
             "results_retention_days" : 1,
-            "annotations_retention_days" : 1,
+            "system_system_annotations_retention_days" : 1,
             "model_snapshot_retention_days" : 1
           }
 
@@ -39,7 +39,7 @@ setup:
                 "time_format":"yyyy-MM-dd HH:mm:ssX"
             },
             "results_retention_days" : 1,
-            "annotations_retention_days" : 1,
+            "system_system_annotations_retention_days" : 1,
             "model_snapshot_retention_days" : 1
           }
 

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/ml/delete_expired_data.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/ml/delete_expired_data.yml
@@ -18,6 +18,7 @@ setup:
                 "time_format":"yyyy-MM-dd HH:mm:ssX"
             },
             "results_retention_days" : 1,
+            "annotations_retention_days" : 1,
             "model_snapshot_retention_days" : 1
           }
 
@@ -38,6 +39,7 @@ setup:
                 "time_format":"yyyy-MM-dd HH:mm:ssX"
             },
             "results_retention_days" : 1,
+            "annotations_retention_days" : 1,
             "model_snapshot_retention_days" : 1
           }
 

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/ml/delete_expired_data.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/ml/delete_expired_data.yml
@@ -18,7 +18,7 @@ setup:
                 "time_format":"yyyy-MM-dd HH:mm:ssX"
             },
             "results_retention_days" : 1,
-            "system_system_annotations_retention_days" : 1,
+            "system_annotations_retention_days" : 1,
             "model_snapshot_retention_days" : 1
           }
 
@@ -39,7 +39,7 @@ setup:
                 "time_format":"yyyy-MM-dd HH:mm:ssX"
             },
             "results_retention_days" : 1,
-            "system_system_annotations_retention_days" : 1,
+            "system_annotations_retention_days" : 1,
             "model_snapshot_retention_days" : 1
           }
 

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/ml/jobs_crud.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/ml/jobs_crud.yml
@@ -328,7 +328,7 @@
             "model_snapshot_retention_days": 3,
             "daily_model_snapshot_retention_after_days": 2,
             "results_retention_days": 4,
-            "system_system_annotations_retention_days": 5,
+            "system_annotations_retention_days": 5,
             "custom_settings": {
               "setting1": "custom1",
               "setting2": "custom2"
@@ -381,7 +381,7 @@
             "background_persist_interval": "3h",
             "model_snapshot_retention_days": 30,
             "results_retention_days": 40,
-            "system_system_annotations_retention_days": 50,
+            "system_annotations_retention_days": 50,
             "custom_settings": {
               "setting3": "custom3"
             }
@@ -402,7 +402,7 @@
   - match: { model_snapshot_retention_days: 30 }
   - match: { daily_model_snapshot_retention_after_days: 2 }
   - match: { results_retention_days: 40 }
-  - match: { system_system_annotations_retention_days: 50 }
+  - match: { system_annotations_retention_days: 50 }
 
   - do:
       catch: "/Cannot update analysis_limits while the job is open/"

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/ml/jobs_crud.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/ml/jobs_crud.yml
@@ -328,7 +328,7 @@
             "model_snapshot_retention_days": 3,
             "daily_model_snapshot_retention_after_days": 2,
             "results_retention_days": 4,
-            "annotations_retention_days": 5,
+            "system_system_annotations_retention_days": 5,
             "custom_settings": {
               "setting1": "custom1",
               "setting2": "custom2"
@@ -381,7 +381,7 @@
             "background_persist_interval": "3h",
             "model_snapshot_retention_days": 30,
             "results_retention_days": 40,
-            "annotations_retention_days": 50,
+            "system_system_annotations_retention_days": 50,
             "custom_settings": {
               "setting3": "custom3"
             }
@@ -402,7 +402,7 @@
   - match: { model_snapshot_retention_days: 30 }
   - match: { daily_model_snapshot_retention_after_days: 2 }
   - match: { results_retention_days: 40 }
-  - match: { annotations_retention_days: 50 }
+  - match: { system_system_annotations_retention_days: 50 }
 
   - do:
       catch: "/Cannot update analysis_limits while the job is open/"

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/ml/jobs_crud.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/ml/jobs_crud.yml
@@ -328,6 +328,7 @@
             "model_snapshot_retention_days": 3,
             "daily_model_snapshot_retention_after_days": 2,
             "results_retention_days": 4,
+            "annotations_retention_days": 5,
             "custom_settings": {
               "setting1": "custom1",
               "setting2": "custom2"
@@ -380,6 +381,7 @@
             "background_persist_interval": "3h",
             "model_snapshot_retention_days": 30,
             "results_retention_days": 40,
+            "annotations_retention_days": 50,
             "custom_settings": {
               "setting3": "custom3"
             }
@@ -400,6 +402,7 @@
   - match: { model_snapshot_retention_days: 30 }
   - match: { daily_model_snapshot_retention_after_days: 2 }
   - match: { results_retention_days: 40 }
+  - match: { annotations_retention_days: 50 }
 
   - do:
       catch: "/Cannot update analysis_limits while the job is open/"


### PR DESCRIPTION
This PR makes old system annotations (*not* user annotations) deleted during daily maintenance activity, similarly to how old results are deleted.
~The retention period is controlled by the new setting: `Job.system_annotations_retention_days`.~
The retention period is controlled by the existing setting: `Job.results_retention_days`.

Closes https://github.com/elastic/elasticsearch/issues/75572