### PR TITLE
Address recent percolator failures.

### DIFF
--- a/modules/percolator/src/test/java/org/elasticsearch/percolator/CandidateQueryTests.java
+++ b/modules/percolator/src/test/java/org/elasticsearch/percolator/CandidateQueryTests.java
@@ -868,10 +868,13 @@ public class CandidateQueryTests extends ESSingleNodeTestCase {
         }
 
         // This will trigger using the TermsQuery instead of individual term query clauses in the CoveringQuery:
+        int origMaxClauseCount = BooleanQuery.getMaxClauseCount();
         try (Directory directory = new ByteBuffersDirectory()) {
+            final int maxClauseCount = 100;
+            BooleanQuery.setMaxClauseCount(maxClauseCount);
             try (IndexWriter iw = new IndexWriter(directory, newIndexWriterConfig())) {
                 Document document = new Document();
-                for (int i = 0; i < 4096; i++) {
+                for (int i = 0; i < maxClauseCount; i++) {
                     int fieldNumber = 2 + i;
                     document.add(new StringField("field", "value" + fieldNumber, Field.Store.NO));
                 }
@@ -897,6 +900,8 @@ public class CandidateQueryTests extends ESSingleNodeTestCase {
                 assertEquals(1, topDocs.scoreDocs[0].doc);
                 assertEquals(2, topDocs.scoreDocs[1].doc);
             }
+        } finally {
+            BooleanQuery.setMaxClauseCount(origMaxClauseCount);
         }
     }
 

--- a/modules/percolator/src/test/java/org/elasticsearch/percolator/CandidateQueryTests.java
+++ b/modules/percolator/src/test/java/org/elasticsearch/percolator/CandidateQueryTests.java
@@ -807,7 +807,6 @@ public class CandidateQueryTests extends ESSingleNodeTestCase {
         assertEquals(2, topDocs.scoreDocs[1].doc);
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/75592")
     public void testPercolateSmallAndLargeDocument() throws Exception {
         List<LuceneDocument> docs = new ArrayList<>();
         BooleanQuery.Builder builder = new BooleanQuery.Builder();
@@ -872,7 +871,7 @@ public class CandidateQueryTests extends ESSingleNodeTestCase {
         try (Directory directory = new ByteBuffersDirectory()) {
             try (IndexWriter iw = new IndexWriter(directory, newIndexWriterConfig())) {
                 Document document = new Document();
-                for (int i = 0; i < 1024; i++) {
+                for (int i = 0; i < 4096; i++) {
                     int fieldNumber = 2 + i;
                     document.add(new StringField("field", "value" + fieldNumber, Field.Store.NO));
                 }

--- a/modules/percolator/src/test/java/org/elasticsearch/percolator/PercolatorFieldMapperTests.java
+++ b/modules/percolator/src/test/java/org/elasticsearch/percolator/PercolatorFieldMapperTests.java
@@ -337,33 +337,40 @@ public class PercolatorFieldMapperTests extends ESSingleNodeTestCase {
 
 
     public void testCreateCandidateQuery() throws Exception {
-        addQueryFieldMappings();
+        int origMaxClauseCount = BooleanQuery.getMaxClauseCount();
+        try {
+            final int maxClauseCount = 100;
+            BooleanQuery.setMaxClauseCount(maxClauseCount);
+            addQueryFieldMappings();
 
-        MemoryIndex memoryIndex = new MemoryIndex(false);
-        StringBuilder text = new StringBuilder();
-        for (int i = 0; i < 4094; i++) {
-            text.append(i).append(' ');
+            MemoryIndex memoryIndex = new MemoryIndex(false);
+            StringBuilder text = new StringBuilder();
+            for (int i = 0; i < maxClauseCount - 2; i++) {
+                text.append(i).append(' ');
+            }
+            memoryIndex.addField("field1", text.toString(), new WhitespaceAnalyzer());
+            memoryIndex.addField(new LongPoint("field2", 10L), new WhitespaceAnalyzer());
+            IndexReader indexReader = memoryIndex.createSearcher().getIndexReader();
+
+            Tuple<BooleanQuery, Boolean> t = fieldType.createCandidateQuery(indexReader, Version.CURRENT);
+            assertTrue(t.v2());
+            assertEquals(2, t.v1().clauses().size());
+            assertThat(t.v1().clauses().get(0).getQuery(), instanceOf(CoveringQuery.class));
+            assertThat(t.v1().clauses().get(1).getQuery(), instanceOf(TermQuery.class));
+
+            // Now push it over the edge, so that it falls back using TermInSetQuery
+            memoryIndex.addField("field2", "value", new WhitespaceAnalyzer());
+            indexReader = memoryIndex.createSearcher().getIndexReader();
+            t = fieldType.createCandidateQuery(indexReader, Version.CURRENT);
+            assertFalse(t.v2());
+            assertEquals(3, t.v1().clauses().size());
+            TermInSetQuery terms = (TermInSetQuery) t.v1().clauses().get(0).getQuery();
+            assertEquals(maxClauseCount - 1, terms.getTermData().size());
+            assertThat(t.v1().clauses().get(1).getQuery().toString(), containsString(fieldName + ".range_field:<ranges:"));
+            assertThat(t.v1().clauses().get(2).getQuery().toString(), containsString(fieldName + ".extraction_result:failed"));
+        } finally {
+            BooleanQuery.setMaxClauseCount(origMaxClauseCount);
         }
-        memoryIndex.addField("field1", text.toString(), new WhitespaceAnalyzer());
-        memoryIndex.addField(new LongPoint("field2", 10L), new WhitespaceAnalyzer());
-        IndexReader indexReader = memoryIndex.createSearcher().getIndexReader();
-
-        Tuple<BooleanQuery, Boolean> t = fieldType.createCandidateQuery(indexReader, Version.CURRENT);
-        assertTrue(t.v2());
-        assertEquals(2, t.v1().clauses().size());
-        assertThat(t.v1().clauses().get(0).getQuery(), instanceOf(CoveringQuery.class));
-        assertThat(t.v1().clauses().get(1).getQuery(), instanceOf(TermQuery.class));
-
-        // Now push it over the edge, so that it falls back using TermInSetQuery
-        memoryIndex.addField("field2", "value", new WhitespaceAnalyzer());
-        indexReader = memoryIndex.createSearcher().getIndexReader();
-        t = fieldType.createCandidateQuery(indexReader, Version.CURRENT);
-        assertFalse(t.v2());
-        assertEquals(3, t.v1().clauses().size());
-        TermInSetQuery terms = (TermInSetQuery) t.v1().clauses().get(0).getQuery();
-        assertEquals(4095, terms.getTermData().size());
-        assertThat(t.v1().clauses().get(1).getQuery().toString(), containsString(fieldName + ".range_field:<ranges:"));
-        assertThat(t.v1().clauses().get(2).getQuery().toString(), containsString(fieldName + ".extraction_result:failed"));
     }
 
     public void testExtractTermsAndRanges_numberFields() throws Exception {

--- a/modules/percolator/src/test/java/org/elasticsearch/percolator/PercolatorFieldMapperTests.java
+++ b/modules/percolator/src/test/java/org/elasticsearch/percolator/PercolatorFieldMapperTests.java
@@ -341,7 +341,7 @@ public class PercolatorFieldMapperTests extends ESSingleNodeTestCase {
 
         MemoryIndex memoryIndex = new MemoryIndex(false);
         StringBuilder text = new StringBuilder();
-        for (int i = 0; i < 1022; i++) {
+        for (int i = 0; i < 4094; i++) {
             text.append(i).append(' ');
         }
         memoryIndex.addField("field1", text.toString(), new WhitespaceAnalyzer());
@@ -361,7 +361,7 @@ public class PercolatorFieldMapperTests extends ESSingleNodeTestCase {
         assertFalse(t.v2());
         assertEquals(3, t.v1().clauses().size());
         TermInSetQuery terms = (TermInSetQuery) t.v1().clauses().get(0).getQuery();
-        assertEquals(1023, terms.getTermData().size());
+        assertEquals(4095, terms.getTermData().size());
         assertThat(t.v1().clauses().get(1).getQuery().toString(), containsString(fieldName + ".range_field:<ranges:"));
         assertThat(t.v1().clauses().get(2).getQuery().toString(), containsString(fieldName + ".extraction_result:failed"));
     }


### PR DESCRIPTION
They are due to changes to `indices.query.bool.max_clause_count` that got pushed
in #75297.

Closes #75591
Closes #75592
