### PR TITLE
[7.x] [doc] Document workaround for slow log levels (#75438)

### DIFF
--- a/docs/reference/index-modules/slowlog.asciidoc
+++ b/docs/reference/index-modules/slowlog.asciidoc
@@ -95,7 +95,7 @@ The user ID is also included in JSON logs.
 === Index Slow log
 
 The indexing slow log, similar in functionality to the search slow
-log. The log file name ends with `_index_indexing_slowlog.json`. Log and
+log. The log file name ends with `_index_indexing_slowlog.log`. Log and
 the thresholds are configured in the same way as the search slowlog.
 Index slowlog sample:
 

--- a/docs/reference/index-modules/slowlog.asciidoc
+++ b/docs/reference/index-modules/slowlog.asciidoc
@@ -95,7 +95,7 @@ The user ID is also included in JSON logs.
 === Index Slow log
 
 The indexing slow log, similar in functionality to the search slow
-log. The log file name ends with `_index_indexing_slowlog.log`. Log and
+log. The log file name ends with `_index_indexing_slowlog.json`. Log and
 the thresholds are configured in the same way as the search slowlog.
 Index slowlog sample:
 
@@ -155,3 +155,12 @@ logger.index_indexing_slowlog.level = trace
 logger.index_indexing_slowlog.appenderRef.index_indexing_slowlog_rolling.ref = index_indexing_slowlog_rolling
 logger.index_indexing_slowlog.additivity = false
 --------------------------------------------------
+
+[discrete]
+=== Slow log levels
+
+You can mimic the search or indexing slow log level by setting appropriate
+threshold making "more verbose" loggers to be switched off.
+If for instance we want to simulate index.indexing.slowlog.level = INFO
+then all we need to do is to set
+index.indexing.slowlog.threshold.index.debug and index.indexing.slowlog.threshold.index.trace to -1


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [doc] Document workaround for slow log levels (#75438)