### PR TITLE
[7.11] [DOC] Add ingest error metadata (#75653)

### DIFF
--- a/docs/reference/ingest.asciidoc
+++ b/docs/reference/ingest.asciidoc
@@ -531,6 +531,32 @@ PUT _ingest/pipeline/my-pipeline
 ----
 // TEST[s/\.\.\./{"lowercase": {"field":"my-keyword-field"}}/]
 
+Additional information about the pipeline failure may be available in the
+document metadata fields `on_failure_message`, `on_failure_processor_type`,
+`on_failure_processor_tag`, and `on_failure_pipeline`. These fields are
+accessible only from within an `on_failure` block.
+
+The following example uses the error metadata fields to provide additional
+information on the document about the failure.
+
+[source,console]
+----
+PUT _ingest/pipeline/my-pipeline
+{
+  "processors": [ ... ],
+  "on_failure": [
+    {
+      "set": {
+        "description": "Record error information",
+        "field": "error_information",
+        "value": "Processor {{ _ingest.on_failure_processor_type }} with tag {{ _ingest.on_failure_processor_tag }} in pipeline {{ _ingest.on_failure_pipeline }} failed with message {{ _ingest.on_failure_message }}"
+      }
+    }
+  ]
+}
+----
+// TEST[s/\.\.\./{"lowercase": {"field":"my-keyword-field"}}/]
+
 [discrete]
 [[conditionally-run-processor]]
 === Conditionally run a processor


### PR DESCRIPTION
Backports the following commits to 7.11:
 - [DOC] Add ingest error metadata (#75653)