### PR TITLE
Drop ReceiveTimeoutTransportException stack trace

### DIFF
--- a/server/src/main/java/org/elasticsearch/transport/ReceiveTimeoutTransportException.java
+++ b/server/src/main/java/org/elasticsearch/transport/ReceiveTimeoutTransportException.java
@@ -23,4 +23,9 @@ public class ReceiveTimeoutTransportException extends ActionTransportException {
         super(in);
     }
 
+    @Override
+    public synchronized Throwable fillInStackTrace() {
+        // stack trace is uninformative
+        return this;
+    }
 }

--- a/test/framework/src/main/java/org/elasticsearch/transport/AbstractSimpleTransportTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/transport/AbstractSimpleTransportTestCase.java
@@ -933,6 +933,7 @@ public abstract class AbstractSimpleTransportTestCase extends ESTestCase {
                 @Override
                 public void handleException(TransportException exp) {
                     assertThat(exp, instanceOf(ReceiveTimeoutTransportException.class));
+                    assertThat(exp.getStackTrace().length, equalTo(0));
                 }
             });
 
@@ -992,6 +993,7 @@ public abstract class AbstractSimpleTransportTestCase extends ESTestCase {
                 public void handleException(TransportException exp) {
                     latch.countDown();
                     assertThat(exp, instanceOf(ReceiveTimeoutTransportException.class));
+                    assertThat(exp.getStackTrace().length, equalTo(0));
                 }
             });
 
@@ -1580,6 +1582,7 @@ public abstract class AbstractSimpleTransportTestCase extends ESTestCase {
                 @Override
                 public void handleException(TransportException exp) {
                     assertThat(exp, instanceOf(ReceiveTimeoutTransportException.class));
+                    assertThat(exp.getStackTrace().length, equalTo(0));
                 }
             });
 


### PR DESCRIPTION
We only create a `ReceiveTimeoutTransportException` in one place, the
timeout handler for the corresponding transport request, so the stack
trace contains no useful information and just adds noise if ever it is
logged. With this commit we drop the stack trace from these exceptions.