### PR TITLE
Fix Potential Memory Leak in SecurityServerTransportInterceptor (#75669)

### DIFF
--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/transport/SecurityServerTransportInterceptor.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/transport/SecurityServerTransportInterceptor.java
@@ -12,7 +12,6 @@ import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.DestructiveOperations;
 import org.elasticsearch.cluster.service.ClusterService;
-import org.elasticsearch.core.CheckedConsumer;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Setting.Property;
 import org.elasticsearch.common.settings.Settings;
@@ -47,7 +46,6 @@ import org.elasticsearch.xpack.security.authz.AuthorizationUtils;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.concurrent.Executor;
 import java.util.function.Function;
 
 import static org.elasticsearch.xpack.core.security.SecurityField.setting;
@@ -294,35 +292,61 @@ public class SecurityServerTransportInterceptor implements TransportInterceptor 
                         }
                     }
                     assert filter != null;
-                    final Thread executingThread = Thread.currentThread();
 
                     final AbstractRunnable receiveMessage = getReceiveRunnable(request, channel, task);
-                    CheckedConsumer<Void, Exception> consumer = (x) -> {
-                        final Executor executor;
-                        if (executingThread == Thread.currentThread()) {
-                            // only fork off if we get called on another thread this means we moved to
-                            // an async execution and in this case we need to go back to the thread pool
-                            // that was actually executing it. it's also possible that the
-                            // thread-pool we are supposed to execute on is `SAME` in that case
-                            // the handler is OK with executing on a network thread and we can just continue even if
-                            // we are on another thread due to async operations
-                            executor = threadPool.executor(ThreadPool.Names.SAME);
-                        } else {
-                            executor = threadPool.executor(executorName);
-                        }
-
-                        try {
-                            executor.execute(receiveMessage);
-                        } catch (Exception e) {
-                            receiveMessage.onFailure(e);
-                        }
-
-                    };
-                    ActionListener<Void> filterListener = ActionListener.wrap(consumer, receiveMessage::onFailure);
+                    final ActionListener<Void> filterListener;
+                    if (ThreadPool.Names.SAME.equals(executorName)) {
+                        filterListener = new AbstractFilterListener(receiveMessage) {
+                            @Override
+                            public void onResponse(Void unused) {
+                                receiveMessage.run();
+                            }
+                        };
+                    } else {
+                        final Thread executingThread = Thread.currentThread();
+                        filterListener = new AbstractFilterListener(receiveMessage) {
+                            @Override
+                            public void onResponse(Void unused) {
+                                if (executingThread == Thread.currentThread()) {
+                                    // only fork off if we get called on another thread this means we moved to
+                                    // an async execution and in this case we need to go back to the thread pool
+                                    // that was actually executing it. it's also possible that the
+                                    // thread-pool we are supposed to execute on is `SAME` in that case
+                                    // the handler is OK with executing on a network thread and we can just continue even if
+                                    // we are on another thread due to async operations
+                                    receiveMessage.run();
+                                } else {
+                                    try {
+                                        threadPool.executor(executorName).execute(receiveMessage);
+                                    } catch (Exception e) {
+                                        onFailure(e);
+                                    }
+                                }
+                            }
+                        };
+                    }
                     filter.inbound(action, request, channel, filterListener);
                 } else {
                     getReceiveRunnable(request, channel, task).run();
                 }
+            }
+        }
+    }
+
+    private abstract static class AbstractFilterListener implements ActionListener<Void> {
+
+        protected final AbstractRunnable receiveMessage;
+
+        protected AbstractFilterListener(AbstractRunnable receiveMessage) {
+            this.receiveMessage = receiveMessage;
+        }
+
+        @Override
+        public void onFailure(Exception e) {
+            try {
+                receiveMessage.onFailure(e);
+            } finally {
+                receiveMessage.onAfter();
             }
         }
     }


### PR DESCRIPTION
Calling `onFailure` on an `AbstractRunnable` would not trigger the `onAfter` hook.
If a request that actually needed the ref counting would run into an auth failure
we'd leak it. This currently isn't an issue I think since we only use the ref counting
with recovery and cluster state requests but would cause a memory leak if auth started
to actually fail here.

backport of #75669 