### PR TITLE
[DOCS] Comments out link that points to outlier detection example

### DIFF
--- a/docs/reference/ml/df-analytics/apis/get-dfanalytics-stats.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/get-dfanalytics-stats.asciidoc
@@ -528,7 +528,8 @@ values: `failed`, `started`, `starting`,`stopping`, `stopped`.
 == {api-examples-title}
 
 The following API retrieves usage information for the
-{ml-docs}/ml-dfa-finding-outliers.html#weblogs-outliers[{oldetection} {dfanalytics-job} example]:
+// {ml-docs}/ml-dfa-finding-outliers.html#weblogs-outliers[{oldetection} {dfanalytics-job} example]:
+{ml-docs}/ml-dfa-finding-outliers.html[{oldetection} {dfanalytics-job} example]:
 
 [source,console]
 --------------------------------------------------

--- a/docs/reference/ml/df-analytics/apis/get-dfanalytics-stats.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/get-dfanalytics-stats.asciidoc
@@ -528,11 +528,11 @@ values: `failed`, `started`, `starting`,`stopping`, `stopped`.
 == {api-examples-title}
 
 The following API retrieves usage information for the
-{ml-docs}/ml-dfa-finding-outliers.html#ecommerce-outliers[{oldetection} {dfanalytics-job} example]:
+{ml-docs}/ml-dfa-finding-outliers.html#weblogs-outliers[{oldetection} {dfanalytics-job} example]:
 
 [source,console]
 --------------------------------------------------
-GET _ml/data_frame/analytics/ecommerce/_stats
+GET _ml/data_frame/analytics/weblog-outliers/_stats
 --------------------------------------------------
 // TEST[skip:Kibana sample data]
 
@@ -542,7 +542,7 @@ GET _ml/data_frame/analytics/ecommerce/_stats
   "count" : 1,
   "data_frame_analytics" : [
     {
-      "id" : "ecommerce",
+      "id" : "weblog-outliers",
       "state" : "stopped",
       "progress" : [
         {
@@ -554,7 +554,7 @@ GET _ml/data_frame/analytics/ecommerce/_stats
           "progress_percent" : 100
         },
         {
-          "phase" : "analyzing",
+          "phase" : "computing_outliers",
           "progress_percent" : 100
         },
         {
@@ -563,17 +563,18 @@ GET _ml/data_frame/analytics/ecommerce/_stats
         }
       ],
       "data_counts" : {
-        "training_docs_count" : 3321,
+        "training_docs_count" : 1001,
         "test_docs_count" : 0,
         "skipped_docs_count" : 0
       },
       "memory_usage" : {
-        "timestamp" : 1586905058000,
-        "peak_usage_bytes" : 279484
+        "timestamp" : 1626264770206,
+        "peak_usage_bytes" : 328011,
+        "status" : "ok"
       },
       "analysis_stats" : {
         "outlier_detection_stats" : {
-          "timestamp" : 1586905058000,
+          "timestamp" : 1626264770206,
           "parameters" : {
             "n_neighbors" : 0,
             "method" : "ensemble",
@@ -583,7 +584,7 @@ GET _ml/data_frame/analytics/ecommerce/_stats
             "standardization_enabled" : true
           },
           "timing_stats" : {
-            "elapsed_time" : 245
+            "elapsed_time" : 32
           }
         }
       }


### PR DESCRIPTION
## Overview

This PR comments out a link that points to a section in the ML docs that is changed via https://github.com/elastic/stack-docs/pull/1758. Removing the links makes it possible for the docs check CI to pass.

Also changes the example response to be in line with the changes in the ML book.