### PR TITLE
[DOCS] Update index template API docs for data stream aliases

### DIFF
--- a/docs/reference/indices/create-index.asciidoc
+++ b/docs/reference/indices/create-index.asciidoc
@@ -77,7 +77,7 @@ include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=timeoutparms]
 .Properties of `aliases` objects
 =======
 `<alias>`::
-(Required, object) The key is the alias name. Supports
+(Required, object) The key is the alias name. Index alias names support
 <<date-math-index-names,date math>>.
 +
 The object body contains options for the alias. Supports an empty object.

--- a/docs/reference/indices/put-component-template.asciidoc
+++ b/docs/reference/indices/put-component-template.asciidoc
@@ -132,8 +132,9 @@ This is the template to be applied, may optionally include a `mappings`,
 [%collapsible%open]
 ====
 `aliases`::
-(Optional, object of objects) Aliases for the index. If an index template
-includes `data_stream`, this parameter is not supported.
+(Optional, object of objects) Aliases to add.
++
+include::{es-repo-dir}/indices/put-index-template.asciidoc[tag=template-ds-alias]
 +
 include::{es-repo-dir}/indices/create-index.asciidoc[tag=aliases-props]
 

--- a/docs/reference/indices/put-index-template.asciidoc
+++ b/docs/reference/indices/put-index-template.asciidoc
@@ -137,8 +137,13 @@ Template to be applied. It may optionally include an `aliases`, `mappings`, or
 [%collapsible%open]
 ====
 `aliases`::
-(Optional, object of objects) Aliases for the index. If the index template
-includes `data_stream`, this parameter is not supported.
+(Optional, object of objects) Aliases to add.
++
+// tag::template-ds-alias[]
+If the index template includes a `data_stream` object, these are data stream
+aliases. Otherwise, these are index aliases. Data stream aliases ignore the
+`index_routing`, `routing`, and `search_routing` options.
+// end::template-ds-alias[]
 +
 include::{es-repo-dir}/indices/create-index.asciidoc[tag=aliases-props]
 


### PR DESCRIPTION
With #73867, you can use component and index templates to add data stream
aliases.  Relates to #75654.

### Previews
* Put index template: https://elasticsearch_75688.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/indices-put-template.html#put-index-template-api-request-body
* Put component template: https://elasticsearch_75688.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/indices-component-template.html#put-component-template-api-request-body