### PR TITLE
[DOCS] Adds link that points to outlier detection example to GET DFA stats API docs

### DIFF
--- a/docs/reference/ml/df-analytics/apis/get-dfanalytics-stats.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/get-dfanalytics-stats.asciidoc
@@ -528,8 +528,7 @@ values: `failed`, `started`, `starting`,`stopping`, `stopped`.
 == {api-examples-title}
 
 The following API retrieves usage information for the
-// {ml-docs}/ml-dfa-finding-outliers.html#weblogs-outliers[{oldetection} {dfanalytics-job} example]:
-{ml-docs}/ml-dfa-finding-outliers.html[{oldetection} {dfanalytics-job} example]:
+{ml-docs}/ml-dfa-finding-outliers.html#weblogs-outliers[{oldetection} {dfanalytics-job} example]:
 
 [source,console]
 --------------------------------------------------


### PR DESCRIPTION
## Overview

This PR adds a link that points to the outlier detection example in the ML docs book to the GET STATS DFA API.

Related to https://github.com/elastic/stack-docs/pull/1758

**DO NOT MERGE BEFORE https://github.com/elastic/stack-docs/pull/1758**

### Preview

[GET DFA stats](https://elasticsearch_75689.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/get-dfanalytics-stats.html)