### PR TITLE
unsigned longs should be compatible with index sorting (#75599)

### DIFF
--- a/x-pack/plugin/mapper-unsigned-long/src/main/java/org/elasticsearch/xpack/unsignedlong/UnsignedLongIndexFieldData.java
+++ b/x-pack/plugin/mapper-unsigned-long/src/main/java/org/elasticsearch/xpack/unsignedlong/UnsignedLongIndexFieldData.java
@@ -41,7 +41,7 @@ public class UnsignedLongIndexFieldData extends IndexNumericFieldData {
 
     @Override
     protected boolean sortRequiresCustomComparator() {
-        return true;
+        return false;
     }
 
     @Override

--- a/x-pack/plugin/mapper-unsigned-long/src/test/java/org/elasticsearch/xpack/unsignedlong/UnsignedLongTests.java
+++ b/x-pack/plugin/mapper-unsigned-long/src/test/java/org/elasticsearch/xpack/unsignedlong/UnsignedLongTests.java
@@ -78,10 +78,12 @@ public class UnsignedLongTests extends ESIntegTestCase {
         prepareCreate("idx-sort").addMapping("_doc", "ul_field", "type=unsigned_long").setSettings(sortSettings).get();
         List<IndexRequestBuilder> builders = new ArrayList<>();
         for (int i = 0; i < numDocs; i++) {
-            builders.add(client().prepareIndex("idx", "_doc")
-                .setSource(jsonBuilder().startObject().field("ul_field", values[i]).endObject()));
-            builders.add(client().prepareIndex("idx-sort", "_doc")
-                .setSource(jsonBuilder().startObject().field("ul_field", values[i]).endObject()));
+            builders.add(
+                client().prepareIndex("idx", "_doc").setSource(jsonBuilder().startObject().field("ul_field", values[i]).endObject())
+            );
+            builders.add(
+                client().prepareIndex("idx-sort", "_doc").setSource(jsonBuilder().startObject().field("ul_field", values[i]).endObject())
+            );
         }
         indexRandom(true, builders);
 


### PR DESCRIPTION
This change allows the type `unsigned_long` to be used in the index sort specification. 
The internal representation uses plain longs so we can rely on the existing support for that type.