### PR TITLE
Fix round-robin load balancing of requests

### DIFF
--- a/client/rest/src/main/java/org/elasticsearch/client/RestClient.java
+++ b/client/rest/src/main/java/org/elasticsearch/client/RestClient.java
@@ -111,7 +111,7 @@ public class RestClient implements Closeable {
     // These are package private for tests.
     final List<Header> defaultHeaders;
     private final String pathPrefix;
-    private final AtomicInteger lastNodeIndex = new AtomicInteger(0);
+    private static final AtomicInteger lastNodeIndex = new AtomicInteger(0);
     private final ConcurrentMap<HttpHost, DeadHostState> blacklist = new ConcurrentHashMap<>();
     private final FailureListener failureListener;
     private final NodeSelector nodeSelector;


### PR DESCRIPTION
#75692-on-multiple-nodes-cluster-requests-are-not-following-round-robin-load-balancing

on multiple nodes cluster, requests are not following round-robin load balancing
all requests are served by the first host configured in the RestHighLevelClient
    
    Git issue link
    https://github.com/elastic/elasticsearch/issues/75692



PR Checks: Done

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)? YES
- Have you followed the [contributor guidelines](https://github.com/elastic/elasticsearch/blob/master/CONTRIBUTING.md)? YES
- If submitting code, have you built your formula locally prior to submission with `gradle check`? YES
- If submitting code, is your pull request against master? Unless there is a good reason otherwise, we prefer pull requests against master and will backport as needed. YES
- If submitting code, have you checked that your submission is for an [OS and architecture that we support](https://www.elastic.co/support/matrix#show_os)? YES
- If you are submitting this code for a class then read our [policy] YES (https://github.com/elastic/elasticsearch/blob/master/CONTRIBUTING.md#contributing-as-part-of-a-class) for that.
