### PR TITLE
[DOCS] Adds ml-cpp PRs to release notes

### DIFF
--- a/docs/reference/release-notes/8.0.0-alpha1.asciidoc
+++ b/docs/reference/release-notes/8.0.0-alpha1.asciidoc
@@ -32,3 +32,20 @@ all we need to do is to set `index.indexing.slowlog.threshold.index.debug` and
 Search::
 * Consistent treatment of numeric values for range query on date fields without `format` {es-pull}[#63692]
 
+[[enhancement-8.0.0-alpha1]]
+[float]
+=== Enhancements
+
+Machine learning::
+* The Windows build platform for the {ml} C++ code now uses Visual Studio 2019 {ml-pull}1352[#1352]
+* The macOS build platform for the {ml} C++ code is now Mojave running Xcode 11.3.1,
+  or Ubuntu 20.04 running clang 8 for cross compilation {ml-pull}1429[#1429]
+* The Linux build platform for the {ml} C++ code is now CentOS 7 running gcc 9.3 {ml-pull}1170[#1170]
+* Add a new application for evaluating PyTorch models. The app depends on LibTorch - the C++ front end to PyTorch and performs inference on models stored in the TorchScript format {ml-pull}1902[#1902]
+
+[[bug-8.0.0-alpha1]]
+[float]
+=== Bug Fixes
+
+Machine learning::
+* Ensure bucket `event_count` is calculated for jobs with 1 second bucket spans {ml-pull}1908[#1908]


### PR DESCRIPTION
This PR adds the content from https://raw.githubusercontent.com/elastic/ml-cpp/master/docs/CHANGELOG.asciidoc to the Elasticsearch release notes.