### PR TITLE
[DOCS] Fixes link in EQL breaking changes

### DIFF
--- a/docs/reference/migration/migrate_8_0/eql.asciidoc
+++ b/docs/reference/migration/migrate_8_0/eql.asciidoc
@@ -10,7 +10,6 @@
 The `wildcard` function was deprecated in {es} 7.13.0 and has been removed.
 
 *Impact* +
-Use the <<eql-syntax-pattern-comparison-keywords,`like`>> or
-<<eql-syntax-pattern-comparison-keywords,`regex`>> keyword instead.
+Use the `like` or `regex` {ref}/eql-syntax.html#eql-syntax-pattern-comparison-keywords[keywords] instead.
 ====
 // end::notable-breaking-changes[]


### PR DESCRIPTION
This PR fixes a link in the EQL breaking changes so that it works when that content is re-used in the Installation and Upgrade Guide.

Related to https://github.com/elastic/stack-docs/pull/1768