### PR TITLE
[DOCS] Add tip for Kibana Fleet APIs

### DIFF
--- a/docs/reference/fleet/index.asciidoc
+++ b/docs/reference/fleet/index.asciidoc
@@ -1,5 +1,11 @@
 [role="xpack"]
 [[fleet-apis]]
+[TIP]
+====
+If you are looking for the {kib} {fleet} API Documentation, please see the 
+{ref}/fleet/{branch}/fleet-api-docs.html[`Fleet API Documentation`].
+====
+
 == Fleet APIs
 
 The following APIs support {fleet}'s use of {es} as a data store for internal

--- a/docs/reference/fleet/index.asciidoc
+++ b/docs/reference/fleet/index.asciidoc
@@ -1,10 +1,8 @@
 [role="xpack"]
 [[fleet-apis]]
-[TIP]
-====
-If you are looking for the {kib} {fleet} API Documentation, please see the 
-{ref}/fleet/{branch}/fleet-api-docs.html[`Fleet API Documentation`].
-====
+
+TIP: For the {kib} {fleet} APIs, see the
+{fleet-guide}/fleet-api-docs.html[`Fleet API Documentation`].
 
 == Fleet APIs
 
@@ -16,4 +14,3 @@ agent and action data. These APIs are experimental and for internal use by
 
 // top-level
 include::get-global-checkpoints.asciidoc[]
-


### PR DESCRIPTION
This is part of addressing https://github.com/elastic/observability-docs/issues/881

My main goal is to disambiguate between the Fleet-Server used ES API as noted here, an the Kibana side Fleet API docs, as noted here:
https://www.elastic.co/guide/en/fleet/master/fleet-api-docs.html

So, any change that accomplishes the main goal is fine by me.  Thanks in advance.

Also, I was uncertain how to test the linking from ES-Docs into the Fleet docs, if someone could confirm.  Happy to modify, feedback welcome.  