### PR TITLE
[DOCS] Fix tags and xrefs for 8.0 breaking changes

### DIFF
--- a/docs/reference/migration/migrate_8_0/aggregations.asciidoc
+++ b/docs/reference/migration/migrate_8_0/aggregations.asciidoc
@@ -38,5 +38,4 @@ the `date_histogram` composite source will now generate an error.  Instead
 please use the more specific `fixed_interval` or `calendar_interval`
 parameters.
 ====
-
 // end::notable-breaking-changes[]

--- a/docs/reference/migration/migrate_8_0/allocation.asciidoc
+++ b/docs/reference/migration/migrate_8_0/allocation.asciidoc
@@ -6,9 +6,6 @@
 //Installation and Upgrade Guide
 
 //tag::notable-breaking-changes[]
-
-// end::notable-breaking-changes[]
-
 [[breaking_80_allocation_change_flood_stage_block_always_removed]]
 .The automatic removal of flood-stage blocks is no longer optional.
 [%collapsible]
@@ -46,3 +43,4 @@ Discontinue use of the `cluster.routing.allocation.disk.include_relocations`
 setting. Specifying this setting in `elasticsearch.yml` will result in an error
 on startup.
 ====
+// end::notable-breaking-changes[]

--- a/docs/reference/migration/migrate_8_0/analysis.asciidoc
+++ b/docs/reference/migration/migrate_8_0/analysis.asciidoc
@@ -6,9 +6,6 @@
 //Installation and Upgrade Guide
 
 //tag::notable-breaking-changes[]
-
-// end::notable-breaking-changes[]
-
 [[ngram-edgengram-filter-names-removed]]
 .The `nGram` and `edgeNGram` token filter names have been removed.
 [%collapsible]
@@ -37,3 +34,4 @@ emit a deprecation warning. The tokenizer name should be changed to the fully eq
 Use the `ngram` and `edge_ngram` tokenizers. Requests to create new indices
 using the `nGram` and `edgeNGram` tokenizer names will return an error.
 ====
+// end::notable-breaking-changes[]

--- a/docs/reference/migration/migrate_8_0/api.asciidoc
+++ b/docs/reference/migration/migrate_8_0/api.asciidoc
@@ -4,10 +4,8 @@
 
 //NOTE: The notable-breaking-changes tagged regions are re-used in the
 //Installation and Upgrade Guide
+
 //tag::notable-breaking-changes[]
-
-// end::notable-breaking-changes[]
-
 .The cat node API's `local` query parameter has been removed.
 [%collapsible]
 ====
@@ -74,10 +72,10 @@ include this parameter will return an error.
 [%collapsible]
 ====
 *Details* +
-The {ml} <<ml-post-data,post data to jobs API>> is deprecated starting in 7.11.0
+The {ml} {ref}/ml-post-data.html[post data to jobs API] is deprecated starting in 7.11.0
 and will be removed in a future major version.
 
 *Impact* +
-Use <<ml-api-datafeed-endpoint,{dfeeds}>> instead.
-
+Use {ref}/ml-apis.html#ml-api-datafeed-endpoint[{dfeeds}] instead.
 ====
+// end::notable-breaking-changes[]

--- a/docs/reference/migration/migrate_8_0/breaker.asciidoc
+++ b/docs/reference/migration/migrate_8_0/breaker.asciidoc
@@ -2,6 +2,9 @@
 [[breaking_80_breaker_changes]]
 ==== Circuit breaker changes
 
+//NOTE: The notable-breaking-changes tagged regions are re-used in the
+//Installation and Upgrade Guide
+
 //tag::notable-breaking-changes[]
 .The `in_flight_requests` stat has been renamed `inflight_requests` in logs and diagnostic APIs.
 [%collapsible]

--- a/docs/reference/migration/migrate_8_0/ccr.asciidoc
+++ b/docs/reference/migration/migrate_8_0/ccr.asciidoc
@@ -6,17 +6,15 @@
 //Installation and Upgrade Guide
 
 //tag::notable-breaking-changes[]
-
-// end::notable-breaking-changes[]
-
 .Remote system indices are not followed automatically if they match an auto-follow pattern.
 [%collapsible]
 ====
 *Details* +
-Remote system indices matching an <<ccr-auto-follow,auto-follow pattern>>
-won't be configured as a follower index automatically.
+Remote system indices matching an {ref}/ccr-auto-follow.html[auto-follow
+pattern] won't be configured as a follower index automatically.
 
 *Impact* +
-Explicitly <<ccr-put-follow,create a follower index>> to follow a remote system
-index if that's the wanted behaviour.
+Explicitly {ref}/ccr-put-follow.html[create a follower index] to follow a remote
+system index if that's the wanted behaviour.
 ====
+// end::notable-breaking-changes[]

--- a/docs/reference/migration/migrate_8_0/cluster.asciidoc
+++ b/docs/reference/migration/migrate_8_0/cluster.asciidoc
@@ -6,9 +6,6 @@
 //Installation and Upgrade Guide
 
 //tag::notable-breaking-changes[]
-
-// end::notable-breaking-changes[]
-
 .The voting configuration exclusions API endpoint has changed.
 [%collapsible]
 ====
@@ -35,3 +32,4 @@ time out.
 *Impact* +
 Do not set `cluster.join.timeout` in your `elasticsearch.yml` file.
 ====
+// end::notable-breaking-changes[]

--- a/docs/reference/migration/migrate_8_0/discovery.asciidoc
+++ b/docs/reference/migration/migrate_8_0/discovery.asciidoc
@@ -6,10 +6,6 @@
 //Installation and Upgrade Guide
 
 //tag::notable-breaking-changes[]
-
-// end::notable-breaking-changes[]
-
-
 .`discovery.zen` settings have been removed.
 [%collapsible]
 ====
@@ -46,3 +42,4 @@ are no longer supported. In particular, this includes:
 Discontinue use of the `discovery.zen` settings. Specifying these settings in
 `elasticsearch.yml` will result in an error on startup.
 ====
+// end::notable-breaking-changes[]

--- a/docs/reference/migration/migrate_8_0/eql.asciidoc
+++ b/docs/reference/migration/migrate_8_0/eql.asciidoc
@@ -2,6 +2,9 @@
 [[breaking_80_eql_changes]]
 ==== EQL changes
 
+//NOTE: The notable-breaking-changes tagged regions are re-used in the
+//Installation and Upgrade Guide
+
 //tag::notable-breaking-changes[]
 .The `wildcard` function has been removed.
 [%collapsible]

--- a/docs/reference/migration/migrate_8_0/http.asciidoc
+++ b/docs/reference/migration/migrate_8_0/http.asciidoc
@@ -4,10 +4,8 @@
 
 //NOTE: The notable-breaking-changes tagged regions are re-used in the
 //Installation and Upgrade Guide
+
 //tag::notable-breaking-changes[]
-
-// end::notable-breaking-changes[]
-
 .The `http.content_type.required` setting has been removed.
 [%collapsible]
 ====
@@ -51,3 +49,4 @@ Update your workflow and applications to assume `+` in a URL is encoded as
 Specifying this property in `elasticsearch.yml` will result in an error on
 startup.
 ====
+// end::notable-breaking-changes[]

--- a/docs/reference/migration/migrate_8_0/ilm.asciidoc
+++ b/docs/reference/migration/migrate_8_0/ilm.asciidoc
@@ -6,9 +6,6 @@
 //Installation and Upgrade Guide
 
 //tag::notable-breaking-changes[]
-
-// end::notable-breaking-changes[]
-
 [[ilm-poll-interval-limit]]
 .The `indices.lifecycle.poll_interval` setting must be greater than `1s`.
 [%collapsible]
@@ -41,3 +38,4 @@ renamed to `ilm` to match the package rename inside the {es} code.
 Update your workflow and applications to use the `ilm` package in place of
 `indexlifecycle`.
 ====
+// end::notable-breaking-changes[]

--- a/docs/reference/migration/migrate_8_0/indices.asciidoc
+++ b/docs/reference/migration/migrate_8_0/indices.asciidoc
@@ -6,8 +6,6 @@
 //Installation and Upgrade Guide
 
 //tag::notable-breaking-changes[]
-//end::notable-breaking-changes[]
-
 .The deprecated `_upgrade` API has been removed.
 [%collapsible]
 ====
@@ -110,10 +108,12 @@ include these settings will return an error.
 When closing an index in earlier versions, by default {es} would not wait for
 the shards of the closed index to be properly assigned before returning. From
 version 8.0 onwards the default behaviour is to wait for shards to be assigned
-according to the <<index-wait-for-active-shards,index setting
-`index.write.wait_for_active_shards`>>.
+according to the
+{ref}/docs-index_.html#index-wait-for-active-shards[`index.write.wait_for_active_shards`
+index setting].
 
 *Impact* +
 Accept the new behaviour, or specify `?wait_for_active_shards=0` to preserve
 the old behaviour if needed.
 ====
+//end::notable-breaking-changes[]

--- a/docs/reference/migration/migrate_8_0/java.asciidoc
+++ b/docs/reference/migration/migrate_8_0/java.asciidoc
@@ -6,9 +6,6 @@
 //Installation and Upgrade Guide
 
 //tag::notable-breaking-changes[]
-
-// end::notable-breaking-changes[]
-
 .Changes to `Fuzziness`.
 [%collapsible]
 ====
@@ -42,3 +39,4 @@ testability.
 *Impact* +
 No action needed.
 ====
+// end::notable-breaking-changes[]

--- a/docs/reference/migration/migrate_8_0/mappings.asciidoc
+++ b/docs/reference/migration/migrate_8_0/mappings.asciidoc
@@ -6,10 +6,6 @@
 //Installation and Upgrade Guide
 
 //tag::notable-breaking-changes[]
-
-// end::notable-breaking-changes[]
-
-
 .The maximum number of completion contexts per field is now 10.
 [%collapsible]
 ====
@@ -79,7 +75,6 @@ The `boost` setting should be removed from templates and mappings. Use boosts
 directly on queries instead.
 ====
 
-//tag::notable-breaking-changes[]
 .Java-time date formats replace joda-time formats.
 [%collapsible]
 ====

--- a/docs/reference/migration/migrate_8_0/network.asciidoc
+++ b/docs/reference/migration/migrate_8_0/network.asciidoc
@@ -4,10 +4,8 @@
 
 //NOTE: The notable-breaking-changes tagged regions are re-used in the
 //Installation and Upgrade Guide
+
 //tag::notable-breaking-changes[]
-
-// end::notable-breaking-changes[]
-
 .The `network.tcp.connect_timeout` setting has been removed.
 [%collapsible]
 ====
@@ -22,3 +20,4 @@ timeout for client connections. Discontinue use of the
 `network.tcp.connect_timeout` setting in `elasticsearch.yml` will result in an
 error on startup.
 ====
+// end::notable-breaking-changes[]

--- a/docs/reference/migration/migrate_8_0/node.asciidoc
+++ b/docs/reference/migration/migrate_8_0/node.asciidoc
@@ -4,10 +4,8 @@
 
 //NOTE: The notable-breaking-changes tagged regions are re-used in the
 //Installation and Upgrade Guide
+
 //tag::notable-breaking-changes[]
-
-// end::notable-breaking-changes[]
-
 .The `node.max_local_storage_nodes` setting has been removed.
 [%collapsible]
 ====
@@ -158,3 +156,4 @@ open or closed, at startup time.
 Reindex closed indices created in {es} 6.x or before with {es} 7.x if they need
 to be carried forward to {es} 8.x.
 ====
+// end::notable-breaking-changes[]

--- a/docs/reference/migration/migrate_8_0/packaging.asciidoc
+++ b/docs/reference/migration/migrate_8_0/packaging.asciidoc
@@ -2,6 +2,9 @@
 [[breaking_80_packaging_changes]]
 ==== Packaging changes
 
+//NOTE: The notable-breaking-changes tagged regions are re-used in the
+//Installation and Upgrade Guide
+
 //tag::notable-breaking-changes[]
 .Java 11 is required.
 [%collapsible]
@@ -14,9 +17,7 @@ line tools.
 Use Java 11 or higher. Attempts to run {es} 8.0 using earlier Java versions will
 fail.
 ====
-//end::notable-breaking-changes[]
 
-//tag::notable-breaking-changes[]
 .JAVA_HOME is no longer supported.
 [%collapsible]
 ====

--- a/docs/reference/migration/migrate_8_0/reindex.asciidoc
+++ b/docs/reference/migration/migrate_8_0/reindex.asciidoc
@@ -6,8 +6,6 @@
 //Installation and Upgrade Guide
 
 //tag::notable-breaking-changes[]
-//end::notable-breaking-changes[]
-
 .Reindex from remote now re-encodes URL-encoded index names.
 [%collapsible]
 ====
@@ -52,3 +50,4 @@ Similarly, the `size` parameter has been renamed to `max_docs` for
 Use the replacement parameters. Requests containing the `size` parameter will
 return an error.
 ====
+//end::notable-breaking-changes[]

--- a/docs/reference/migration/migrate_8_0/rollup.asciidoc
+++ b/docs/reference/migration/migrate_8_0/rollup.asciidoc
@@ -6,9 +6,6 @@
 //Installation and Upgrade Guide
 
 //tag::notable-breaking-changes[]
-
-// end::notable-breaking-changes[]
-
 .The StartRollupJob endpoint now returns a success status if a job has already started.
 [%collapsible]
 ====
@@ -26,3 +23,4 @@ attempting to start a rollup job means the job is in an actively started state.
 The request itself may have started the job, or it was previously running and so
 the request had no effect.
 ====
+// end::notable-breaking-changes[]

--- a/docs/reference/migration/migrate_8_0/search.asciidoc
+++ b/docs/reference/migration/migrate_8_0/search.asciidoc
@@ -36,7 +36,6 @@ Queries with many clauses should be avoided whenever possible. If you had bumped
 this setting already in order to accomodate for some heavy queries, you might
 need to bump it further so that these heavy queries keep working.
 ====
-//end::notable-breaking-changes[]
 
 .Search-related REST API endpoints containing mapping types have been removed.
 [%collapsible]
@@ -202,3 +201,4 @@ been removed in 8.0.0. This parameter is a no-op and has no effect on the query.
 Discontinue use of the `type` parameter. `geo_bounding_box` queries that include
 this parameter will return an error.
 ====
+//end::notable-breaking-changes[]

--- a/docs/reference/migration/migrate_8_0/security.asciidoc
+++ b/docs/reference/migration/migrate_8_0/security.asciidoc
@@ -51,7 +51,6 @@ to use the new names and to possibly account for gzip archives instead of plaint
 The Docker build of Elasticsearch is not affected since it logs on stdout where
 rollover is not performed.
 ====
-// end::notable-breaking-changes[]
 
 [[accept-default-password-removed]]
 .The `accept_default_password` setting has been removed.
@@ -282,3 +281,4 @@ renamed to better reflect its intended use.
 Assign users with the `kibana_user` role to the `kibana_admin` role.
 Discontinue use of the `kibana_user` role.
 ====
+// end::notable-breaking-changes[]

--- a/docs/reference/migration/migrate_8_0/settings.asciidoc
+++ b/docs/reference/migration/migrate_8_0/settings.asciidoc
@@ -197,8 +197,8 @@ operation explicitly name the indices it intends to modify.
 
 *Impact* +
 If you would like to use wildcard patterns for destructive actions, set
-`action.destructive_requires_name` to `false` using the <<cluster-update-settings,
-cluster settings>> API.
+`action.destructive_requires_name` to `false` using the
+{ref}/cluster-update-settings.html[] cluster settings API].
 ====
 
 .Legacy role settings have been removed.
@@ -249,9 +249,10 @@ configuration will result in an error on startup.
 ====
 *Details* +
 The cluster and index level settings ending in `._tier` used for filtering the allocation of a shard
-to a particular set of nodes have been removed. Instead, the <<tier-preference-allocation-filter,
-tier preference setting>>, `index.routing.allocation.include._tier_preference` should be used. The
-removed settings are:
+to a particular set of nodes have been removed. Instead, the
+{ref}/data-tier-shard-filtering.html#tier-preference-allocation-filter[tier
+preference setting], `index.routing.allocation.include._tier_preference` should
+be used. The removed settings are:
 
 Cluster level settings:
 - `cluster.routing.allocation.include._tier`

--- a/docs/reference/migration/migrate_8_0/snapshots.asciidoc
+++ b/docs/reference/migration/migrate_8_0/snapshots.asciidoc
@@ -6,9 +6,6 @@
 //Installation and Upgrade Guide
 
 //tag::notable-breaking-changes[]
-
-// end::notable-breaking-changes[]
-
 .The `repositories.fs.compress` node-level setting has been removed.
 [%collapsible]
 ====
@@ -19,7 +16,8 @@ The `repositories.fs.compress` setting has been removed.
 
 *Impact* +
 Use the repository specific `compress` setting to enable compression. See
-<<modules-snapshots>> for information on the `compress` setting.
+{ref}/snapshots-register-repository.html[Register a snapshot repository] for
+information on the `compress` setting.
 
 Discontinue use of the `repositories.fs.compress` node-level setting.
 ====
@@ -33,7 +31,8 @@ Previously, the default value for `compress` was `false`. The default has been c
 This change will affect both newly created repositories and existing repositories where `compress=false` has not been
 explicitly specified.
 
-For more information on the compress option, see <<modules-snapshots>>
+For more information on the compress option, see
+{ref}/snapshots-register-repository.html[Register a snapshot repository].
 
 *Impact* +
 Update your workflow and applications to assume a default value of `true` for
@@ -81,5 +80,7 @@ The repository stats API has been removed. We deprecated this experimental API
 in 7.10.0. 
 
 *Impact* +
-Use the <<repositories-metering-apis,repositories metering APIs>> instead.
+Use the {ref}/repositories-metering-apis.html[repositories metering APIs]
+instead.
 ====
+// end::notable-breaking-changes[]

--- a/docs/reference/migration/migrate_8_0/threadpool.asciidoc
+++ b/docs/reference/migration/migrate_8_0/threadpool.asciidoc
@@ -6,8 +6,6 @@
 //Installation and Upgrade Guide
 
 //tag::notable-breaking-changes[]
-//end::notable-breaking-changes[]
-
 .The `fixed_auto_queue_size` thread pool type has been removed.
 [%collapsible]
 ====
@@ -19,3 +17,4 @@ The `search` and `search_throttled` thread pools have the `fixed` type now.
 *Impact* +
 No action needed.
 ====
+//end::notable-breaking-changes[]

--- a/docs/reference/migration/migrate_8_0/transport.asciidoc
+++ b/docs/reference/migration/migrate_8_0/transport.asciidoc
@@ -2,6 +2,9 @@
 [[breaking_80_transport_changes]]
 ==== Transport changes
 
+//NOTE: The notable-breaking-changes tagged regions are re-used in the
+//Installation and Upgrade Guide
+
 //tag::notable-breaking-changes[]
 .Several `transport` settings have been replaced.
 [%collapsible]
@@ -26,8 +29,6 @@ Specifying the removed settings in `elasticsearch.yml` will result in an error
 on startup.
 ====
 
-// end::notable-breaking-changes[]
-
 .The `es.unsafely_permit_handshake_from_incompatible_builds` system property has been removed.
 [%collapsible]
 ====
@@ -45,3 +46,4 @@ system property, and ensure that all nodes of the same version are running
 exactly the same build. Setting this system property will result in an error
 on startup.
 ====
+// end::notable-breaking-changes[]


### PR DESCRIPTION
A tag is required to reuse Elasticsearch breaking changes in the Stack
Guide. To display properly, the breaking changes must use external
links rather than xrefs.

This PR correctly places those tags for reuse. It also replaces
several xrefs with external links for reuse.