### PR TITLE
[DOCS] Fix formatting for several 8.0 breaking changes

### DIFF
--- a/docs/reference/migration/migrate_8_0.asciidoc
+++ b/docs/reference/migration/migrate_8_0.asciidoc
@@ -16,6 +16,7 @@ coming[8.0.0]
 * <<breaking_80_analysis_changes>>
 * <<breaking_80_breaker_changes>>
 * <<breaking_80_cluster_changes>>
+* <<breaking_80_ccr_changes>>
 * <<breaking_80_discovery_changes>>
 * <<breaking_80_eql_changes>>
 * <<breaking_80_http_changes>>
@@ -90,8 +91,8 @@ include::migrate_8_0/aggregations.asciidoc[]
 include::migrate_8_0/allocation.asciidoc[]
 include::migrate_8_0/analysis.asciidoc[]
 include::migrate_8_0/breaker.asciidoc[]
-include::migrate_8_0/ccr.asciidoc[]
 include::migrate_8_0/cluster.asciidoc[]
+include::migrate_8_0/ccr.asciidoc[]
 include::migrate_8_0/discovery.asciidoc[]
 include::migrate_8_0/eql.asciidoc[]
 include::migrate_8_0/http.asciidoc[]

--- a/docs/reference/migration/migrate_8_0/ccr.asciidoc
+++ b/docs/reference/migration/migrate_8_0/ccr.asciidoc
@@ -1,6 +1,6 @@
 [discrete]
 [[breaking_80_ccr_changes]]
-==== Cross Cluster Replication changes
+==== {ccr-cap} ({ccr-init}) changes
 
 //NOTE: The notable-breaking-changes tagged regions are re-used in the
 //Installation and Upgrade Guide

--- a/docs/reference/migration/migrate_8_0/ilm.asciidoc
+++ b/docs/reference/migration/migrate_8_0/ilm.asciidoc
@@ -1,6 +1,6 @@
 [discrete]
 [[breaking_80_ilm_changes]]
-==== {ilm-cap} changes
+==== {ilm-cap} ({ilm-init}) changes
 
 //NOTE: The notable-breaking-changes tagged regions are re-used in the
 //Installation and Upgrade Guide

--- a/docs/reference/migration/migrate_8_0/search.asciidoc
+++ b/docs/reference/migration/migrate_8_0/search.asciidoc
@@ -1,6 +1,6 @@
 [discrete]
 [[breaking_80_search_changes]]
-==== Search Changes
+==== Search changes
 
 //NOTE: The notable-breaking-changes tagged regions are re-used in the
 //Installation and Upgrade Guide

--- a/docs/reference/migration/migrate_8_0/security.asciidoc
+++ b/docs/reference/migration/migrate_8_0/security.asciidoc
@@ -114,7 +114,7 @@ result in an error on startup.
 
 [discrete]
 [[ssl-validation-changes]]
-==== SSL/TLS configuration validation
+===== SSL/TLS configuration validation
 
 .The `xpack.security.transport.ssl.enabled` setting is now required to configure `xpack.security.transport.ssl` settings.
 [%collapsible]
@@ -234,7 +234,7 @@ on startup.
 
 [discrete]
 [[builtin-users-changes]]
-==== Changes to built-in users
+===== Changes to built-in users
 
 .The `kibana` user has been replaced by `kibana_system`.
 [%collapsible]
@@ -267,7 +267,7 @@ user password. You must explicitly set a password for the `kibana_system` user.
 
 [discrete]
 [[builtin-roles-changes]]
-==== Changes to built-in roles
+===== Changes to built-in roles
 
 .The `kibana_user` role has been renamed `kibana_admin`.
 [%collapsible]

--- a/docs/reference/migration/migrate_8_0/settings.asciidoc
+++ b/docs/reference/migration/migrate_8_0/settings.asciidoc
@@ -224,7 +224,7 @@ Discontinue use of the removed settings. Specifying these settings in
 ====
 
 [[system-call-filter-setting]]
-.System call filter setting removed
+.The system call filter setting has been removed.
 [%collapsible]
 ====
 *Details* +
@@ -242,7 +242,7 @@ configuration will result in an error on startup.
 ====
 
 [[tier-filter-setting]]
-.Tier filtering settings removed
+.Tier filtering settings have been removed.
 [%collapsible]
 ====
 *Details* +
@@ -268,7 +268,7 @@ settings archived (and they will have no effect) when the index metadata is load
 ====
 
 [[shared-data-path-setting]]
-.Shared data path and per index data path settings deprecated
+.Shared data path and per index data path settings are deprecated.
 [%collapsible]
 ====
 *Details* +
@@ -283,7 +283,7 @@ Discontinue use of the deprecated settings.
 ====
 
 [[single-data-node-watermark-setting]]
-.Single data node watermark setting only accept true and is deprecated
+.The single data node watermark setting is deprecated and now only accepts `true`.
 [%collapsible]
 ====
 *Details* +


### PR DESCRIPTION
Changes:

* Adds the cross-cluster replication section to the TOC.
* Fixes the sort order for the breaking changes.
* Adds acronyms to CCR and ILM headings.
* Fixes capitalization for the search changes heading.
* Bumps the heading level for several nested security headings.
* Makes several labels sentences.