### PR TITLE
[DOCS] Adds ml-cpp PRs to 7.14 release notes

### DIFF
--- a/docs/reference/release-notes.asciidoc
+++ b/docs/reference/release-notes.asciidoc
@@ -6,6 +6,7 @@
 
 This section summarizes the changes in each release.
 
+* <<release-notes-7.14.0>>
 * <<release-notes-7.13.2>>
 * <<release-notes-7.13.1>>
 * <<release-notes-7.13.0>>
@@ -50,6 +51,7 @@ This section summarizes the changes in each release.
 
 --
 
+include::release-notes/7.14.asciidoc[]
 include::release-notes/7.13.asciidoc[]
 include::release-notes/7.12.asciidoc[]
 include::release-notes/7.11.asciidoc[]

--- a/docs/reference/release-notes/7.14.asciidoc
+++ b/docs/reference/release-notes/7.14.asciidoc
@@ -1,0 +1,22 @@
+[[release-notes-7.14.0]]
+== {es} version 7.14.0
+
+coming::[7.14.0]
+
+Also see <<breaking-changes-7.14,Breaking changes in 7.14>>.
+
+[discrete]
+[[enhancement-7.14.0]]
+=== Enhancements
+
+Machine Learning::
+* Give higher weight to multiple adjacent dictionary words when performing categorization {ml-pull}1903[#1903]
+
+[discrete]
+[[bug-7.14.0]]
+=== Bug fixes
+
+Machine Learning::
+* Make atomic operations safer for aarch64 {ml-pull}1893[#1893]
+
+* Ensure bucket event_count is calculated for jobs with 1 second bucket spans {ml-pull}1908[#1908]

--- a/docs/reference/release-notes/7.14.asciidoc
+++ b/docs/reference/release-notes/7.14.asciidoc
@@ -19,4 +19,4 @@ Machine Learning::
 Machine Learning::
 * Make atomic operations safer for aarch64 {ml-pull}1893[#1893]
 
-* Ensure bucket event_count is calculated for jobs with 1 second bucket spans {ml-pull}1908[#1908]
+* Ensure bucket event_count is calculated for jobs with 1 second bucket spans {ml-pull}1909[#1909]


### PR DESCRIPTION
This PR adds the content from https://raw.githubusercontent.com/elastic/ml-cpp/7.14/docs/CHANGELOG.asciidoc to the Elasticsearch release notes.