### PR TITLE
[DOCS] Removes ml-cpp PR from release notes

### DIFF
--- a/docs/reference/release-notes/8.0.0-alpha1.asciidoc
+++ b/docs/reference/release-notes/8.0.0-alpha1.asciidoc
@@ -42,10 +42,3 @@ Machine learning::
   or Ubuntu 20.04 running clang 8 for cross compilation {ml-pull}1429[#1429]
 * The Linux build platform for the {ml} C++ code is now CentOS 7 running gcc 9.3 {ml-pull}1170[#1170]
 * Add a new application for evaluating PyTorch models. The app depends on LibTorch - the C++ front end to PyTorch and performs inference on models stored in the TorchScript format {ml-pull}1902[#1902]
-
-[[bug-8.0.0-alpha1]]
-[float]
-=== Bug Fixes
-
-Machine learning::
-* Ensure bucket `event_count` is calculated for jobs with 1 second bucket spans {ml-pull}1908[#1908]


### PR DESCRIPTION
Related to https://github.com/elastic/elasticsearch/pull/75703

This PR removes https://github.com/elastic/ml-cpp/issues/1908 from the 8.0.0-alpha1 release notes. https://github.com/elastic/elasticsearch/pull/75716 adds it to the 7.14.0 release notes instead.