### PR TITLE
Mute some security tests on problematic JDK8 build

### DIFF
--- a/x-pack/plugin/security/cli/src/test/java/org/elasticsearch/xpack/security/cli/CertificateGenerateToolTests.java
+++ b/x-pack/plugin/security/cli/src/test/java/org/elasticsearch/xpack/security/cli/CertificateGenerateToolTests.java
@@ -8,13 +8,12 @@ package org.elasticsearch.xpack.security.cli;
 
 import com.google.common.jimfs.Configuration;
 import com.google.common.jimfs.Jimfs;
-import org.bouncycastle.asn1.DLTaggedObject;
-import org.elasticsearch.jdk.JavaVersion;
-import org.elasticsearch.core.internal.io.IOUtils;
+
 import org.bouncycastle.asn1.ASN1ObjectIdentifier;
 import org.bouncycastle.asn1.ASN1Sequence;
 import org.bouncycastle.asn1.ASN1String;
 import org.bouncycastle.asn1.DEROctetString;
+import org.bouncycastle.asn1.DLTaggedObject;
 import org.bouncycastle.asn1.pkcs.Attribute;
 import org.bouncycastle.asn1.pkcs.PKCSObjectIdentifiers;
 import org.bouncycastle.asn1.x509.Extension;
@@ -27,23 +26,22 @@ import org.bouncycastle.openssl.PEMParser;
 import org.bouncycastle.pkcs.PKCS10CertificationRequest;
 import org.elasticsearch.cli.MockTerminal;
 import org.elasticsearch.common.Strings;
-import org.elasticsearch.core.SuppressForbidden;
-import org.elasticsearch.core.PathUtils;
 import org.elasticsearch.common.network.NetworkAddress;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.core.PathUtils;
+import org.elasticsearch.core.SuppressForbidden;
+import org.elasticsearch.core.internal.io.IOUtils;
 import org.elasticsearch.env.Environment;
 import org.elasticsearch.env.TestEnvironment;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.SecuritySettingsSourceField;
+import org.elasticsearch.xpack.core.ssl.CertParsingUtils;
+import org.elasticsearch.xpack.core.ssl.PemUtils;
 import org.elasticsearch.xpack.security.cli.CertificateGenerateTool.CAInfo;
 import org.elasticsearch.xpack.security.cli.CertificateGenerateTool.CertificateInformation;
 import org.elasticsearch.xpack.security.cli.CertificateGenerateTool.Name;
-import org.elasticsearch.xpack.core.ssl.CertParsingUtils;
-import org.elasticsearch.xpack.core.ssl.PemUtils;
 import org.junit.After;
 import org.junit.BeforeClass;
-
-import javax.security.auth.x500.X500Principal;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -74,6 +72,7 @@ import java.util.Map.Entry;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+import javax.security.auth.x500.X500Principal;
 
 import static org.elasticsearch.test.FileMatchers.pathExists;
 import static org.hamcrest.Matchers.containsString;
@@ -267,7 +266,8 @@ public class CertificateGenerateToolTests extends ESTestCase {
 
     public void testGeneratingSignedCertificates() throws Exception {
         assumeFalse("JDK bug JDK-8266279, https://github.com/elastic/elasticsearch/issues/72639",
-            JavaVersion.current().compareTo(JavaVersion.parse("8")) == 0);
+            "1.8.0_292".equals(System.getProperty("java.version")));
+
         Path tempDir = initTempDir();
         Path outputFile = tempDir.resolve("out.zip");
         Path instanceFile = writeInstancesTo(tempDir.resolve("instances.yml"));

--- a/x-pack/plugin/security/cli/src/test/java/org/elasticsearch/xpack/security/cli/HttpCertificateCommandTests.java
+++ b/x-pack/plugin/security/cli/src/test/java/org/elasticsearch/xpack/security/cli/HttpCertificateCommandTests.java
@@ -7,9 +7,11 @@
 
 package org.elasticsearch.xpack.security.cli;
 
+import joptsimple.OptionSet;
+
 import com.google.common.jimfs.Configuration;
 import com.google.common.jimfs.Jimfs;
-import joptsimple.OptionSet;
+
 import org.bouncycastle.asn1.DERIA5String;
 import org.bouncycastle.asn1.DEROctetString;
 import org.bouncycastle.asn1.DLSequence;
@@ -23,12 +25,11 @@ import org.bouncycastle.pkcs.PKCS10CertificationRequest;
 import org.bouncycastle.pkcs.jcajce.JcaPKCS10CertificationRequest;
 import org.bouncycastle.util.io.pem.PemObject;
 import org.bouncycastle.util.io.pem.PemReader;
-import org.elasticsearch.jdk.JavaVersion;
 import org.elasticsearch.cli.MockTerminal;
 import org.elasticsearch.common.CheckedBiFunction;
+import org.elasticsearch.common.network.NetworkAddress;
 import org.elasticsearch.core.CheckedFunction;
 import org.elasticsearch.core.Tuple;
-import org.elasticsearch.common.network.NetworkAddress;
 import org.elasticsearch.core.internal.io.IOUtils;
 import org.elasticsearch.env.Environment;
 import org.elasticsearch.test.ESTestCase;
@@ -39,7 +40,6 @@ import org.hamcrest.Matchers;
 import org.junit.Before;
 import org.junit.BeforeClass;
 
-import javax.security.auth.x500.X500Principal;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -81,6 +81,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import javax.security.auth.x500.X500Principal;
 
 import static java.util.Collections.singletonMap;
 import static org.elasticsearch.test.FileMatchers.isDirectory;
@@ -116,10 +117,13 @@ public class HttpCertificateCommandTests extends ESTestCase {
         assumeFalse("Can't run in a FIPS JVM", inFipsJvm());
     }
 
-    public void testGenerateSingleCertificateSigningRequest() throws Exception {
+    @BeforeClass
+    public static void muteOnBrokenJdk() {
         assumeFalse("JDK bug JDK-8266279, https://github.com/elastic/elasticsearch/issues/72359",
-                JavaVersion.current().compareTo(JavaVersion.parse("8")) == 0);
+            "1.8.0_292".equals(System.getProperty("java.version")));
+    }
 
+    public void testGenerateSingleCertificateSigningRequest() throws Exception {
         final Path outFile = testRoot.resolve("csr.zip").toAbsolutePath();
 
         final List<String> hostNames = randomHostNames();
@@ -220,8 +224,6 @@ public class HttpCertificateCommandTests extends ESTestCase {
     }
 
     public void testGenerateSingleCertificateWithExistingCA() throws Exception {
-        assumeFalse("JDK bug JDK-8266279, https://github.com/elastic/elasticsearch/issues/72359",
-                JavaVersion.current().compareTo(JavaVersion.parse("8")) == 0);
         final Path outFile = testRoot.resolve("certs.zip").toAbsolutePath();
 
         final List<String> hostNames = randomHostNames();
@@ -335,8 +337,6 @@ public class HttpCertificateCommandTests extends ESTestCase {
     }
 
     public void testGenerateMultipleCertificateWithNewCA() throws Exception {
-        assumeFalse("JDK bug JDK-8266279, https://github.com/elastic/elasticsearch/issues/72359",
-                JavaVersion.current().compareTo(JavaVersion.parse("8")) == 0);
         final Path outFile = testRoot.resolve("certs.zip").toAbsolutePath();
 
         final int numberCerts = randomIntBetween(3, 6);
@@ -478,8 +478,6 @@ public class HttpCertificateCommandTests extends ESTestCase {
     }
 
     public void testParsingValidityPeriod() throws Exception {
-        assumeFalse("JDK bug JDK-8266279, https://github.com/elastic/elasticsearch/issues/72359",
-                JavaVersion.current().compareTo(JavaVersion.parse("8")) == 0);
         final HttpCertificateCommand command = new HttpCertificateCommand();
         final MockTerminal terminal = new MockTerminal();
 
@@ -533,8 +531,6 @@ public class HttpCertificateCommandTests extends ESTestCase {
     }
 
     public void testValidityPeriodToString() throws Exception {
-        assumeFalse("JDK bug JDK-8266279, https://github.com/elastic/elasticsearch/issues/72359",
-                JavaVersion.current().compareTo(JavaVersion.parse("8")) == 0);
         assertThat(HttpCertificateCommand.toString(Period.ofYears(2)), is("2y"));
         assertThat(HttpCertificateCommand.toString(Period.ofMonths(5)), is("5m"));
         assertThat(HttpCertificateCommand.toString(Period.ofDays(60)), is("60d"));
@@ -548,8 +544,6 @@ public class HttpCertificateCommandTests extends ESTestCase {
     }
 
     public void testGuessFileType() throws Exception {
-        assumeFalse("JDK bug JDK-8266279, https://github.com/elastic/elasticsearch/issues/72359",
-                JavaVersion.current().compareTo(JavaVersion.parse("8")) == 0);
         MockTerminal terminal = new MockTerminal();
 
         final Path caCert = getDataPath("ca.crt");
@@ -577,8 +571,6 @@ public class HttpCertificateCommandTests extends ESTestCase {
     }
 
     public void testTextFileSubstitutions() throws Exception {
-        assumeFalse("JDK bug JDK-8266279, https://github.com/elastic/elasticsearch/issues/72359",
-                JavaVersion.current().compareTo(JavaVersion.parse("8")) == 0);
         CheckedBiFunction<String, Map<String, String>, String, Exception> copy = (source, subs) -> {
             try (InputStream in = new ByteArrayInputStream(source.getBytes(StandardCharsets.UTF_8));
                  StringWriter out = new StringWriter();

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/saml/SamlRealmTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/saml/SamlRealmTests.java
@@ -40,6 +40,7 @@ import org.elasticsearch.xpack.security.authc.support.MockLookupRealm;
 import org.elasticsearch.xpack.core.security.authc.support.UserRoleMapper;
 import org.hamcrest.Matchers;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.mockito.Mockito;
 import org.opensaml.saml.common.xml.SAMLConstants;
 import org.opensaml.saml.metadata.resolver.impl.AbstractReloadingMetadataResolver;
@@ -112,6 +113,12 @@ public class SamlRealmTests extends SamlTestCase {
         globalSettings = Settings.builder().put("path.home", createTempDir()).build();
         env = TestEnvironment.newEnvironment(globalSettings);
         threadContext = new ThreadContext(globalSettings);
+    }
+
+    @BeforeClass
+    public static void muteOnBrokenJdk() {
+        assumeFalse("JDK bug JDK-8266279, https://github.com/elastic/elasticsearch/issues/75571",
+            "1.8.0_292".equals(System.getProperty("java.version")));
     }
 
     public void testReadIdpMetadataFromFile() throws Exception {


### PR DESCRIPTION
This commit adds some `assumeFalse` (or modifies exising ones) to mute
tests on JDK 1.8.0_292 due to JDK-8266279

On this JDK build, a race condition sometimes causes the
PBEWithSHA1AndDESede algorithm to appear as though it is unavailable.

Relates: #75571, #75417, #75379, #72639, #72359
