### PR TITLE
Update rpm build to add sha256 payload and file digest

### DIFF
--- a/distribution/packages/build.gradle
+++ b/distribution/packages/build.gradle
@@ -55,7 +55,7 @@ buildscript {
   configurations.all {
     resolutionStrategy {
         dependencySubstitution {
-          substitute module('org.redline-rpm:redline') using module('com.github.breskeby:redline:caa0ede')
+          substitute module('org.redline-rpm:redline') using module('com.github.breskeby:redline:9c85270')
         }
     }
   }


### PR DESCRIPTION
This is a follow up on #75569 and should fix installation problems in FIPS enabled environments.

I have updated the PR on redline to add sha256 payload and file digests 
(see https://github.com/craigwblake/redline/pull/157 for details). This should enable the installation of our RPM packages in FIPS enabled environments. 

The patch provided to redline adds some overhead to the rpm packaging as we need to run through the payload twice to calculate the payload digest first. I haven't found a more elegant way to do this at the moment as this would required way more rework in redline IMO but it should unblock us from not being installable on FIPS environments.