### PR TITLE
Avoid running all EQL BWC tasks when running check

### DIFF
--- a/x-pack/plugin/eql/qa/mixed-node/build.gradle
+++ b/x-pack/plugin/eql/qa/mixed-node/build.gradle
@@ -58,9 +58,4 @@ for (Version bwcVersion : BuildParams.bwcVersions.wireCompatible.findAll { it.on
   tasks.register(bwcTaskName(bwcVersion)) {
     dependsOn "${baseName}#mixedClusterTest"
   }
-
-  // run these bwc tests as part of the "check" task
-  tasks.named("check").configure {
-    dependsOn "${baseName}#mixedClusterTest"
-  }
 }


### PR DESCRIPTION
The bwc-test plugin automatically wires up BWC tasks to the appropriate
lifecycle tasks for us. There's no need to do this explicitly. Running
'check' should only run BWC tests against unreleased versions as-per
convention. Released version tests are run via periodic jobs in CI.