### PR TITLE
[7.x] Fix dependency report link to JDK sources (#75742)

### DIFF
--- a/distribution/build.gradle
+++ b/distribution/build.gradle
@@ -40,7 +40,7 @@ tasks.register("generateDependenciesReport", ConcatFilesTask) {
   // explicitly add our dependency on the JDK
   String jdkVersion = VersionProperties.versions.get('bundled_jdk').split('@')[0]
   String jdkMajorVersion = jdkVersion.split('[+.]')[0]
-  String sourceUrl = "https://hg.openjdk.java.net/jdk-updates/jdk${jdkMajorVersion}u/archive/jdk-${jdkVersion}.tar.gz"
+  String sourceUrl = "https://github.com/openjdk/jdk${jdkMajorVersion}u/archive/refs/tags/jdk-${jdkVersion}.tar.gz"
   additionalLines << "OpenJDK,${jdkVersion},https://openjdk.java.net/,GPL-2.0-with-classpath-exception,${sourceUrl}".toString()
 
   // Explicitly add the dependency on the RHEL UBI Docker base image


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Fix dependency report link to JDK sources (#75742)