### PR TITLE
Vector tiles: order hits by geometry size by default (#75621)

### DIFF
--- a/modules/lang-painless/src/main/resources/org/elasticsearch/painless/spi/org.elasticsearch.txt
+++ b/modules/lang-painless/src/main/resources/org/elasticsearch/painless/spi/org.elasticsearch.txt
@@ -158,6 +158,8 @@ class org.elasticsearch.index.fielddata.ScriptDocValues$Geometry {
   int getDimensionalType()
   org.elasticsearch.common.geo.GeoPoint getCentroid()
   org.elasticsearch.common.geo.GeoBoundingBox getBoundingBox()
+  double getMercatorWidth()
+  double getMercatorHeight()
 }
 
 class org.elasticsearch.index.fielddata.ScriptDocValues$GeoPoints {

--- a/modules/lang-painless/src/yamlRestTest/resources/rest-api-spec/test/painless/50_script_doc_values.yml
+++ b/modules/lang-painless/src/yamlRestTest/resources/rest-api-spec/test/painless/50_script_doc_values.yml
@@ -182,6 +182,20 @@ setup:
                             source: "doc['geo_point'].getDimensionalType()"
     - match: { hits.hits.0.fields.type.0: 0 }
 
+    - do:
+        search:
+          rest_total_hits_as_int: true
+          body:
+            script_fields:
+              width:
+                script:
+                  source: "doc['geo_point'].getMercatorWidth()"
+              height:
+                script:
+                  source: "doc['geo_point'].getMercatorHeight()"
+    - match: { hits.hits.0.fields.width.0: 0.0 }
+    - match: { hits.hits.0.fields.height.0: 0.0 }
+
 ---
 "ip":
     - do:

--- a/server/src/main/java/org/elasticsearch/common/geo/SphericalMercatorUtils.java
+++ b/server/src/main/java/org/elasticsearch/common/geo/SphericalMercatorUtils.java
@@ -1,20 +1,22 @@
 /*
  * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
  * or more contributor license agreements. Licensed under the Elastic License
- * 2.0; you may not use this file except in compliance with the Elastic License
- * 2.0.
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
  */
 
-package org.elasticsearch.xpack.vectortile.feature;
+package org.elasticsearch.common.geo;
 
 import org.elasticsearch.geometry.Rectangle;
 
 /**
  * Utility functions to transforms WGS84 coordinates into spherical mercator.
  */
-class SphericalMercatorUtils {
+public class SphericalMercatorUtils {
 
-    private static double MERCATOR_FACTOR = 20037508.34 / 180.0;
+    public static final double MERCATOR_BOUNDS = 20037508.34;
+    private static final double MERCATOR_FACTOR = MERCATOR_BOUNDS / 180.0;
 
     /**
      * Transforms WGS84 longitude to a Spherical mercator longitude

--- a/server/src/main/java/org/elasticsearch/index/fielddata/ScriptDocValues.java
+++ b/server/src/main/java/org/elasticsearch/index/fielddata/ScriptDocValues.java
@@ -255,6 +255,10 @@ public abstract class ScriptDocValues<T> extends AbstractList<T> {
         public abstract GeoBoundingBox getBoundingBox();
         /** Returns the centroid of this geometry  */
         public abstract GeoPoint getCentroid();
+        /** Returns the width of the bounding box diagonal in the spherical Mercator projection (meters)  */
+        public abstract double getMercatorWidth();
+        /** Returns the height of the bounding box diagonal in the spherical Mercator projection (meters) */
+        public abstract double getMercatorHeight();
     }
 
     public static final class GeoPoints extends Geometry<GeoPoint> {
@@ -416,6 +420,16 @@ public abstract class ScriptDocValues<T> extends AbstractList<T> {
         @Override
         public GeoPoint getCentroid() {
             return size() == 0 ? null : centroid;
+        }
+
+        @Override
+        public double getMercatorWidth() {
+            return 0;
+        }
+
+        @Override
+        public double getMercatorHeight() {
+            return 0;
         }
 
         @Override

--- a/server/src/test/java/org/elasticsearch/common/geo/SphericalMercatorUtilTests.java
+++ b/server/src/test/java/org/elasticsearch/common/geo/SphericalMercatorUtilTests.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.common.geo;
+
+import org.elasticsearch.geo.GeometryTestUtils;
+import org.elasticsearch.geometry.Rectangle;
+import org.elasticsearch.search.aggregations.bucket.geogrid.GeoTileUtils;
+import org.elasticsearch.test.ESTestCase;
+import org.hamcrest.Matchers;
+
+import static org.elasticsearch.common.geo.SphericalMercatorUtils.MERCATOR_BOUNDS;
+import static org.elasticsearch.common.geo.SphericalMercatorUtils.lonToSphericalMercator;
+import static org.elasticsearch.common.geo.SphericalMercatorUtils.latToSphericalMercator;
+import static org.elasticsearch.common.geo.SphericalMercatorUtils.recToSphericalMercator;
+
+public class SphericalMercatorUtilTests extends ESTestCase {
+
+    public void testLon() {
+        assertThat(lonToSphericalMercator(180.0), Matchers.equalTo(MERCATOR_BOUNDS));
+        assertThat(lonToSphericalMercator(-180.0), Matchers.equalTo(-MERCATOR_BOUNDS));
+        assertThat(lonToSphericalMercator(0.0), Matchers.equalTo(0.0));
+        final double lon = lonToSphericalMercator(GeometryTestUtils.randomLon());
+        assertThat(lon, Matchers.greaterThanOrEqualTo(-MERCATOR_BOUNDS));
+        assertThat(lon, Matchers.lessThanOrEqualTo(MERCATOR_BOUNDS));
+    }
+
+    public void testLat() {
+        assertThat(latToSphericalMercator(GeoTileUtils.LATITUDE_MASK), Matchers.closeTo(MERCATOR_BOUNDS, 1e-7));
+        assertThat(latToSphericalMercator(-GeoTileUtils.LATITUDE_MASK), Matchers.closeTo(-MERCATOR_BOUNDS, 1e-7));
+        assertThat(latToSphericalMercator(0.0), Matchers.closeTo(0, 1e-7));
+        final double lat = latToSphericalMercator(randomValueOtherThanMany(
+            l -> l >= GeoTileUtils.LATITUDE_MASK || l <= -GeoTileUtils.LATITUDE_MASK,
+            GeometryTestUtils::randomLat
+        ));
+        assertThat(lat, Matchers.greaterThanOrEqualTo(-MERCATOR_BOUNDS));
+        assertThat(lat, Matchers.lessThanOrEqualTo(MERCATOR_BOUNDS));
+    }
+
+    public void testRectangle() {
+        Rectangle rect = GeometryTestUtils.randomRectangle();
+        Rectangle mercatorRect = recToSphericalMercator(rect);
+        assertThat(mercatorRect.getMinX(), Matchers.equalTo(lonToSphericalMercator(rect.getMinX())));
+        assertThat(mercatorRect.getMaxX(), Matchers.equalTo(lonToSphericalMercator(rect.getMaxX())));
+        assertThat(mercatorRect.getMinY(), Matchers.equalTo(latToSphericalMercator(rect.getMinY())));
+        assertThat(mercatorRect.getMaxY(), Matchers.equalTo(latToSphericalMercator(rect.getMaxY())));
+    }
+}

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/fielddata/plain/AbstractAtomicGeoShapeShapeFieldData.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/fielddata/plain/AbstractAtomicGeoShapeShapeFieldData.java
@@ -19,6 +19,9 @@ import java.io.IOException;
 import java.util.Collection;
 import java.util.Collections;
 
+import static org.elasticsearch.common.geo.SphericalMercatorUtils.latToSphericalMercator;
+import static org.elasticsearch.common.geo.SphericalMercatorUtils.lonToSphericalMercator;
+
 public abstract class AbstractAtomicGeoShapeShapeFieldData implements LeafGeoShapeFieldData {
 
     @Override
@@ -86,6 +89,16 @@ public abstract class AbstractAtomicGeoShapeShapeFieldData implements LeafGeoSha
         @Override
         public GeoPoint getCentroid() {
             return value == null ? null : centroid;
+        }
+
+        @Override
+        public double getMercatorWidth() {
+            return lonToSphericalMercator(boundingBox.right()) - lonToSphericalMercator(boundingBox.left());
+        }
+
+        @Override
+        public double getMercatorHeight() {
+            return latToSphericalMercator(boundingBox.top()) - latToSphericalMercator(boundingBox.bottom());
         }
 
         @Override

--- a/x-pack/plugin/spatial/src/yamlRestTest/resources/rest-api-spec/test/70_script_doc_values.yml
+++ b/x-pack/plugin/spatial/src/yamlRestTest/resources/rest-api-spec/test/70_script_doc_values.yml
@@ -91,3 +91,19 @@ setup:
                 source: "doc['geo_shape'].get(0)"
 
   - match: { error.root_cause.0.reason: "cannot write xcontent for geo_shape doc value" }
+
+---
+"diagonal length":
+  - do:
+      search:
+        rest_total_hits_as_int: true
+        body:
+          script_fields:
+            width:
+              script:
+                source: "doc['geo_shape'].getMercatorWidth()"
+            height:
+              script:
+                source: "doc['geo_shape'].getMercatorHeight()"
+  - match: { hits.hits.0.fields.width.0: 389.62170283915475 }
+  - match: { hits.hits.0.fields.height.0: 333.37976840604097 }

--- a/x-pack/plugin/vector-tile/src/javaRestTest/java/org/elasticsearch/xpack/vectortile/VectorTileRestIT.java
+++ b/x-pack/plugin/vector-tile/src/javaRestTest/java/org/elasticsearch/xpack/vectortile/VectorTileRestIT.java
@@ -237,7 +237,7 @@ public class VectorTileRestIT extends ESRestTestCase {
         assertThat(tile.getLayersCount(), Matchers.equalTo(3));
         assertLayer(tile, HITS_LAYER, 4096, 33, 1);
         assertLayer(tile, AGGS_LAYER, 4096, 1, 1);
-        assertLayer(tile, META_LAYER, 4096, 1, 14);
+        assertLayer(tile, META_LAYER, 4096, 1, 13);
     }
 
     public void testIndexAllGet() throws Exception {
@@ -248,7 +248,7 @@ public class VectorTileRestIT extends ESRestTestCase {
         // 33 points, 1 polygon and two from geometry collection
         assertLayer(tile, HITS_LAYER, 4096, 36, 1);
         assertLayer(tile, AGGS_LAYER, 4096, 256 * 256, 1);
-        assertLayer(tile, META_LAYER, 4096, 1, 14);
+        assertLayer(tile, META_LAYER, 4096, 1, 13);
     }
 
     public void testExtent() throws Exception {
@@ -258,7 +258,7 @@ public class VectorTileRestIT extends ESRestTestCase {
         assertThat(tile.getLayersCount(), Matchers.equalTo(3));
         assertLayer(tile, HITS_LAYER, 256, 33, 1);
         assertLayer(tile, AGGS_LAYER, 256, 1, 1);
-        assertLayer(tile, META_LAYER, 256, 1, 14);
+        assertLayer(tile, META_LAYER, 256, 1, 13);
     }
 
     public void testExtentURL() throws Exception {
@@ -271,7 +271,7 @@ public class VectorTileRestIT extends ESRestTestCase {
         assertThat(tile.getLayersCount(), Matchers.equalTo(3));
         assertLayer(tile, HITS_LAYER, 512, 33, 1);
         assertLayer(tile, AGGS_LAYER, 512, 1, 1);
-        assertLayer(tile, META_LAYER, 512, 1, 14);
+        assertLayer(tile, META_LAYER, 512, 1, 13);
     }
 
     public void testExactBounds() throws Exception {
@@ -327,7 +327,7 @@ public class VectorTileRestIT extends ESRestTestCase {
             assertThat(tile.getLayersCount(), Matchers.equalTo(3));
             assertLayer(tile, HITS_LAYER, 4096, 33, 1);
             assertLayer(tile, AGGS_LAYER, 4096, 1, 1);
-            assertLayer(tile, META_LAYER, 4096, 1, 14);
+            assertLayer(tile, META_LAYER, 4096, 1, 13);
         }
         {
             final Request mvtRequest = new Request(getHttpMethod(), INDEX_POINTS + "/_mvt/location/" + z + "/" + x + "/" + y);
@@ -345,7 +345,7 @@ public class VectorTileRestIT extends ESRestTestCase {
             assertThat(tile.getLayersCount(), Matchers.equalTo(3));
             assertLayer(tile, HITS_LAYER, 4096, 33, 1);
             assertLayer(tile, AGGS_LAYER, 4096, 1, 1);
-            assertLayer(tile, META_LAYER, 4096, 1, 14);
+            assertLayer(tile, META_LAYER, 4096, 1, 13);
             assertFeatureType(tile, AGGS_LAYER, VectorTile.Tile.GeomType.POINT);
         }
         {
@@ -355,7 +355,7 @@ public class VectorTileRestIT extends ESRestTestCase {
             assertThat(tile.getLayersCount(), Matchers.equalTo(3));
             assertLayer(tile, HITS_LAYER, 4096, 33, 1);
             assertLayer(tile, AGGS_LAYER, 4096, 1, 1);
-            assertLayer(tile, META_LAYER, 4096, 1, 14);
+            assertLayer(tile, META_LAYER, 4096, 1, 13);
             assertFeatureType(tile, AGGS_LAYER, VectorTile.Tile.GeomType.POLYGON);
         }
         {
@@ -376,7 +376,7 @@ public class VectorTileRestIT extends ESRestTestCase {
         assertThat(tile.getLayersCount(), Matchers.equalTo(3));
         assertLayer(tile, HITS_LAYER, 4096, 33, 1);
         assertLayer(tile, AGGS_LAYER, 4096, 1, 1);
-        assertLayer(tile, META_LAYER, 4096, 1, 14);
+        assertLayer(tile, META_LAYER, 4096, 1, 13);
         assertFeatureType(tile, AGGS_LAYER, VectorTile.Tile.GeomType.POLYGON);
     }
 
@@ -386,7 +386,7 @@ public class VectorTileRestIT extends ESRestTestCase {
         final VectorTile.Tile tile = execute(mvtRequest);
         assertThat(tile.getLayersCount(), Matchers.equalTo(2));
         assertLayer(tile, HITS_LAYER, 4096, 33, 1);
-        assertLayer(tile, META_LAYER, 4096, 1, 9);
+        assertLayer(tile, META_LAYER, 4096, 1, 8);
     }
 
     public void testNoAggLayerURL() throws Exception {
@@ -398,7 +398,7 @@ public class VectorTileRestIT extends ESRestTestCase {
         final VectorTile.Tile tile = execute(mvtRequest);
         assertThat(tile.getLayersCount(), Matchers.equalTo(2));
         assertLayer(tile, HITS_LAYER, 4096, 33, 1);
-        assertLayer(tile, META_LAYER, 4096, 1, 9);
+        assertLayer(tile, META_LAYER, 4096, 1, 8);
     }
 
     public void testNoHitsLayer() throws Exception {
@@ -417,6 +417,31 @@ public class VectorTileRestIT extends ESRestTestCase {
         assertThat(tile.getLayersCount(), Matchers.equalTo(2));
         assertLayer(tile, AGGS_LAYER, 4096, 1, 1);
         assertLayer(tile, META_LAYER, 4096, 1, 13);
+    }
+
+    public void testDefaultSort() throws Exception {
+        {
+            final Request mvtRequest = new Request(getHttpMethod(), INDEX_POINTS_SHAPES + "/_mvt/location/" + z + "/" + x + "/" + y);
+            mvtRequest.setJsonEntity("{\"size\": 100 }");
+            final VectorTile.Tile tile = execute(mvtRequest);
+            assertThat(tile.getLayersCount(), Matchers.equalTo(3));
+            assertLayer(tile, HITS_LAYER, 4096, 34, 1);
+            final VectorTile.Tile.Layer layer = getLayer(tile, HITS_LAYER);
+            assertThat(layer.getFeatures(0).getType(), Matchers.equalTo(VectorTile.Tile.GeomType.POLYGON));
+            assertLayer(tile, AGGS_LAYER, 4096, 256 * 256, 1);
+            assertLayer(tile, META_LAYER, 4096, 1, 13);
+        }
+        {
+            final Request mvtRequest = new Request(getHttpMethod(), INDEX_POINTS_SHAPES + "/_mvt/location/" + z + "/" + x + "/" + y);
+            mvtRequest.setJsonEntity("{\"size\": 100, \"sort\" : []}"); // override default sort
+            final VectorTile.Tile tile = execute(mvtRequest);
+            assertThat(tile.getLayersCount(), Matchers.equalTo(3));
+            assertLayer(tile, HITS_LAYER, 4096, 34, 1);
+            final VectorTile.Tile.Layer layer = getLayer(tile, HITS_LAYER);
+            assertThat(layer.getFeatures(0).getType(), Matchers.equalTo(VectorTile.Tile.GeomType.POINT));
+            assertLayer(tile, AGGS_LAYER, 4096, 256 * 256, 1);
+            assertLayer(tile, META_LAYER, 4096, 1, 14);
+        }
     }
 
     public void testRuntimeFieldWithSort() throws Exception {
@@ -498,7 +523,7 @@ public class VectorTileRestIT extends ESRestTestCase {
         assertThat(tile.getLayersCount(), Matchers.equalTo(3));
         assertLayer(tile, HITS_LAYER, 4096, 1, 1);
         assertLayer(tile, AGGS_LAYER, 4096, 1, 1);
-        assertLayer(tile, META_LAYER, 4096, 1, 14);
+        assertLayer(tile, META_LAYER, 4096, 1, 13);
     }
 
     public void testBasicShape() throws Exception {
@@ -507,7 +532,7 @@ public class VectorTileRestIT extends ESRestTestCase {
         assertThat(tile.getLayersCount(), Matchers.equalTo(3));
         assertLayer(tile, HITS_LAYER, 4096, 1, 1);
         assertLayer(tile, AGGS_LAYER, 4096, 256 * 256, 1);
-        assertLayer(tile, META_LAYER, 4096, 1, 14);
+        assertLayer(tile, META_LAYER, 4096, 1, 13);
     }
 
     public void testWithFields() throws Exception {
@@ -517,7 +542,7 @@ public class VectorTileRestIT extends ESRestTestCase {
         assertThat(tile.getLayersCount(), Matchers.equalTo(3));
         assertLayer(tile, HITS_LAYER, 4096, 1, 3);
         assertLayer(tile, AGGS_LAYER, 4096, 256 * 256, 1);
-        assertLayer(tile, META_LAYER, 4096, 1, 14);
+        assertLayer(tile, META_LAYER, 4096, 1, 13);
     }
 
     public void testMinAgg() throws Exception {
@@ -537,7 +562,7 @@ public class VectorTileRestIT extends ESRestTestCase {
         assertThat(tile.getLayersCount(), Matchers.equalTo(3));
         assertLayer(tile, HITS_LAYER, 4096, 1, 1);
         assertLayer(tile, AGGS_LAYER, 4096, 256 * 256, 2);
-        assertLayer(tile, META_LAYER, 4096, 1, 19);
+        assertLayer(tile, META_LAYER, 4096, 1, 18);
     }
 
     private String getHttpMethod() {

--- a/x-pack/plugin/vector-tile/src/main/java/org/elasticsearch/xpack/vectortile/feature/FeatureFactory.java
+++ b/x-pack/plugin/vector-tile/src/main/java/org/elasticsearch/xpack/vectortile/feature/FeatureFactory.java
@@ -15,6 +15,7 @@ import com.wdtinc.mapbox_vector_tile.adapt.jts.TileGeomResult;
 import com.wdtinc.mapbox_vector_tile.build.MvtLayerParams;
 import com.wdtinc.mapbox_vector_tile.build.MvtLayerProps;
 
+import org.elasticsearch.common.geo.SphericalMercatorUtils;
 import org.elasticsearch.geometry.Circle;
 import org.elasticsearch.geometry.Geometry;
 import org.elasticsearch.geometry.GeometryCollection;

--- a/x-pack/plugin/vector-tile/src/main/java/org/elasticsearch/xpack/vectortile/feature/SimpleFeatureFactory.java
+++ b/x-pack/plugin/vector-tile/src/main/java/org/elasticsearch/xpack/vectortile/feature/SimpleFeatureFactory.java
@@ -8,6 +8,7 @@
 package org.elasticsearch.xpack.vectortile.feature;
 
 import org.apache.lucene.util.BitUtil;
+import org.elasticsearch.common.geo.SphericalMercatorUtils;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.geometry.Point;
 import org.elasticsearch.geometry.Rectangle;

--- a/x-pack/plugin/vector-tile/src/main/java/org/elasticsearch/xpack/vectortile/rest/VectorTileRequest.java
+++ b/x-pack/plugin/vector-tile/src/main/java/org/elasticsearch/xpack/vectortile/rest/VectorTileRequest.java
@@ -328,11 +328,16 @@ class VectorTileRequest {
         if (sortBuilders == null) {
             if (size == 0) {
                 // no need to add sorting
-                return List.of();
+                return org.elasticsearch.core.List.of();
             }
-            return List.of(
+            return org.elasticsearch.core.List.of(
                 new ScriptSortBuilder(
-                    new Script(Script.DEFAULT_SCRIPT_TYPE, Script.DEFAULT_SCRIPT_LANG, SCRIPT, Map.of(FIELD_PARAM, getField())),
+                    new Script(
+                        Script.DEFAULT_SCRIPT_TYPE,
+                        Script.DEFAULT_SCRIPT_LANG,
+                        SCRIPT,
+                        org.elasticsearch.core.Map.of(FIELD_PARAM, getField())
+                    ),
                     ScriptSortBuilder.ScriptSortType.NUMBER
                 ).order(SortOrder.DESC)
             );

--- a/x-pack/plugin/vector-tile/src/test/java/org/elasticsearch/xpack/vectortile/feature/FeatureFactoriesConsistencyTests.java
+++ b/x-pack/plugin/vector-tile/src/test/java/org/elasticsearch/xpack/vectortile/feature/FeatureFactoriesConsistencyTests.java
@@ -11,6 +11,7 @@ import com.wdtinc.mapbox_vector_tile.VectorTile;
 import com.wdtinc.mapbox_vector_tile.adapt.jts.UserDataIgnoreConverter;
 
 import org.apache.lucene.geo.GeoTestUtil;
+import org.elasticsearch.common.geo.SphericalMercatorUtils;
 import org.elasticsearch.geometry.MultiPoint;
 import org.elasticsearch.geometry.Point;
 import org.elasticsearch.geometry.Rectangle;

--- a/x-pack/plugin/vector-tile/src/test/java/org/elasticsearch/xpack/vectortile/rest/VectorTileRequestTests.java
+++ b/x-pack/plugin/vector-tile/src/test/java/org/elasticsearch/xpack/vectortile/rest/VectorTileRequestTests.java
@@ -25,6 +25,8 @@ import org.elasticsearch.search.aggregations.bucket.geogrid.GeoTileUtils;
 import org.elasticsearch.search.aggregations.metrics.AvgAggregationBuilder;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
 import org.elasticsearch.search.sort.FieldSortBuilder;
+import org.elasticsearch.search.sort.ScriptSortBuilder;
+import org.elasticsearch.search.sort.SortOrder;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.rest.FakeRestRequest;
 import org.hamcrest.Matchers;
@@ -52,7 +54,6 @@ public class VectorTileRequestTests extends ESTestCase {
             assertThat(vectorTileRequest.getGridPrecision(), Matchers.equalTo(VectorTileRequest.Defaults.GRID_PRECISION));
             assertThat(vectorTileRequest.getExactBounds(), Matchers.equalTo(VectorTileRequest.Defaults.EXACT_BOUNDS));
             assertThat(vectorTileRequest.getRuntimeMappings(), Matchers.equalTo(VectorTileRequest.Defaults.RUNTIME_MAPPINGS));
-            assertThat(vectorTileRequest.getSortBuilders(), Matchers.equalTo(VectorTileRequest.Defaults.SORT));
             assertThat(vectorTileRequest.getQueryBuilder(), Matchers.equalTo(VectorTileRequest.Defaults.QUERY));
         });
     }
@@ -140,6 +141,14 @@ public class VectorTileRequestTests extends ESTestCase {
         }, (vectorTileRequest) -> {
             assertThat(vectorTileRequest.getRuntimeMappings(), Matchers.aMapWithSize(1));
             assertThat(vectorTileRequest.getRuntimeMappings().get(fieldName), Matchers.notNullValue());
+        });
+    }
+
+    public void testDefaultFieldSort() throws IOException {
+        assertRestRequest((builder) -> {}, (vectorTileRequest) -> {
+            assertThat(vectorTileRequest.getSortBuilders(), Matchers.iterableWithSize(1));
+            ScriptSortBuilder sortBuilder = (ScriptSortBuilder) vectorTileRequest.getSortBuilders().get(0);
+            assertThat(sortBuilder.order(), Matchers.equalTo(SortOrder.DESC));
         });
     }
 


### PR DESCRIPTION
Vector tiles can only display polygons and lines that are big enough for the precision of the tile. This might create strange results where the hits layer of a vector tile contains no data even though the query have hits. In order to provide expected results we are ordering the hits result by geometry size so we always render polygon and lines which are big enough on respect to the tile precision.

The first issue is to define how to compute the geometry size. This size needs to computed in respect to the spherical mercator projection as it introduces distortion. In this approach we use the diagonal size of the geometry bounding in the spherical mercator projection as ordering value.

In order to perform this, we introduce the following changes:

Introduce two new methods in our ScriptDocValue geometry interface:
** getMercatorWidth(): width of the geometry in the spherical mercator projection.
** getMercatorHeight(): Height of the geometry in the spherical mercator projection.

Move SphericalMercatorUtil to server under common/geo.

Then if there is no ordering provided by the user when calling the _mvt API and the size of the request > 0, then we add a order by using a script that computes the diagonal of the geometry square. This is used to order the results.

Note: We have consider to use filtering but this would affect the results on the aggregation.

backport #75621