### PR TITLE
Add frequently shared Painless field catch script

### DIFF
--- a/docs/painless/painless-guide/painless-walkthrough.asciidoc
+++ b/docs/painless/painless-guide/painless-walkthrough.asciidoc
@@ -110,16 +110,23 @@ GET hockey/_search
 }
 ----------------------------------------------------------------
 
+[discrete]
+==== Missing keys
+
+`doc['myfield'].value` throws an exception if
+the field is missing in a document.
+
+For more dynamic index mappings, you may consider writting a catch equation
+
+```
+if (!doc.containsKey('myfield') || doc['myfield'].empty) { return "unavailable" } else { return doc['myfield'].value }
+```
 
 [discrete]
 ==== Missing values
 
-`doc['field'].value` throws an exception if
-the field is missing in a document.
-
 To check if a document is missing a value, you can call
-`doc['field'].size() == 0`.
-
+`doc['myfield'].size() == 0`.
 
 [discrete]
 ==== Updating Fields with Painless


### PR DESCRIPTION
Support frequently shares https://gist.github.com/jclosure/8e103dee2f7e9491845a2c0bb64c6b7a#gistcomment-3780127 with users which are doing widespread index pattern searches or across index mappings they can't guarantee are par over time. 

Adds check/catch reference into docs:

```
if (!doc.containsKey('myfield') || doc['myfield'].empty) { return "unavailable" } else { return doc['myfield'].value }
```