### PR TITLE
Tweak external cluster test parallelism

### DIFF
--- a/build-tools/src/main/java/org/elasticsearch/gradle/testclusters/TestClustersPlugin.java
+++ b/build-tools/src/main/java/org/elasticsearch/gradle/testclusters/TestClustersPlugin.java
@@ -95,7 +95,7 @@ public class TestClustersPlugin implements Plugin<Project> {
             .registerIfAbsent(
                 THROTTLE_SERVICE_NAME,
                 TestClustersThrottle.class,
-                spec -> spec.getMaxParallelUsages().set(Math.max(1, project.getGradle().getStartParameter().getMaxWorkerCount() / 2))
+                spec -> spec.getMaxParallelUsages().set(Math.max(1, project.getGradle().getStartParameter().getMaxWorkerCount() * 2 / 3))
             );
 
         // register cluster hooks


### PR DESCRIPTION
Bump maximum number of test cluster nodes to 2/3 of Gradle max workers
vs 1/2. This should give us much better parallelism for builds that are
mostly multi-node clusters, such as our BWC tests.
