### PR TITLE
Add 'mvt' field type format to geo fields (#75367)

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/geo/GeoFormatterFactory.java
+++ b/server/src/main/java/org/elasticsearch/common/geo/GeoFormatterFactory.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.common.geo;
+
+import org.elasticsearch.geometry.Geometry;
+import org.elasticsearch.search.aggregations.bucket.geogrid.GeoTileUtils;
+
+import java.util.List;
+import java.util.Locale;
+import java.util.function.Function;
+
+/**
+ * Output formatters for geo fields. Adds support for vector tiles.
+ */
+public class GeoFormatterFactory {
+
+    @FunctionalInterface
+    public interface VectorTileEngine<T>  {
+        /**
+         * Returns a formatter for a specific tile.
+         */
+        Function<List<T>, List<Object>> getFormatter(int z, int x, int y, int extent);
+    }
+
+    private static final String MVT = "mvt";
+
+    /**
+     * Returns a formatter by name
+     */
+    public static <T> Function<List<T>, List<Object>> getFormatter(String format, Function<T, Geometry> toGeometry,
+                                                                          VectorTileEngine<T> mvt) {
+        final int start = format.indexOf('(');
+        if (start == -1)  {
+            return GeometryFormatterFactory.getFormatter(format, toGeometry);
+        }
+        final String formatName = format.substring(0, start);
+        if (MVT.equals(formatName) == false) {
+            throw new IllegalArgumentException("Invalid format: " + formatName);
+        }
+        final String param = format.substring(start + 1, format.length() - 1);
+        // we expect either z/x/y or z/x/y@extent
+        final String[] parts = param.split("@", 3);
+        if (parts.length > 2) {
+            throw new IllegalArgumentException(
+                "Invalid mvt formatter parameter [" + param + "]. Must have the form \"zoom/x/y\" or \"zoom/x/y@extent\"."
+            );
+        }
+        final int extent = parts.length == 2 ? Integer.parseInt(parts[1]) : 4096;
+        final String[] tileBits = parts[0].split("/", 4);
+        if (tileBits.length != 3) {
+            throw new IllegalArgumentException(
+                "Invalid tile string [" + parts[0] + "]. Must be three integers in a form \"zoom/x/y\"."
+            );
+        }
+        final int z = GeoTileUtils.checkPrecisionRange(Integer.parseInt(tileBits[0]));
+        final int tiles = 1 << z;
+        final int x = Integer.parseInt(tileBits[1]);
+        final int y = Integer.parseInt(tileBits[2]);
+        if (x < 0 || y < 0 || x >= tiles || y >= tiles) {
+            throw new IllegalArgumentException(String.format(Locale.ROOT, "Zoom/X/Y combination is not valid: %d/%d/%d", z, x, y));
+        }
+        return mvt.getFormatter(z, x, y, extent);
+    }
+}

--- a/server/src/main/java/org/elasticsearch/index/mapper/GeoPointFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/GeoPointFieldMapper.java
@@ -19,11 +19,13 @@ import org.apache.lucene.search.Query;
 import org.elasticsearch.ElasticsearchParseException;
 import org.elasticsearch.common.CheckedBiFunction;
 import org.elasticsearch.common.Explicit;
+import org.elasticsearch.common.geo.GeoFormatterFactory;
 import org.elasticsearch.common.geo.GeoPoint;
 import org.elasticsearch.common.geo.GeoShapeUtils;
 import org.elasticsearch.common.geo.GeoUtils;
 import org.elasticsearch.common.geo.GeometryFormatterFactory;
 import org.elasticsearch.common.geo.ShapeRelation;
+import org.elasticsearch.common.geo.SimpleFeatureFactory;
 import org.elasticsearch.common.unit.DistanceUnit;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.support.MapXContentParser;
@@ -243,7 +245,11 @@ public class GeoPointFieldMapper extends AbstractPointGeometryFieldMapper<GeoPoi
 
         @Override
         protected  Function<List<GeoPoint>, List<Object>> getFormatter(String format) {
-            return GeometryFormatterFactory.getFormatter(format, p -> new Point(p.lon(), p.lat()));
+            return GeoFormatterFactory.getFormatter(format, p -> new Point(p.getLon(), p.getLat()),
+                (z, x, y, extent) -> {
+                    final SimpleFeatureFactory featureFactory = new SimpleFeatureFactory(z, x, y, extent);
+                    return points -> org.elasticsearch.core.List.of(featureFactory.points(points));
+                });
         }
 
         @Override

--- a/server/src/test/java/org/elasticsearch/common/geo/SimpleFeatureFactoryTests.java
+++ b/server/src/test/java/org/elasticsearch/common/geo/SimpleFeatureFactoryTests.java
@@ -1,14 +1,14 @@
 /*
  * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
  * or more contributor license agreements. Licensed under the Elastic License
- * 2.0; you may not use this file except in compliance with the Elastic License
- * 2.0.
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
  */
 
-package org.elasticsearch.xpack.vectortile.feature;
+package org.elasticsearch.common.geo;
 
 import org.apache.lucene.geo.GeoTestUtil;
-import org.elasticsearch.geometry.Point;
 import org.elasticsearch.geometry.Rectangle;
 import org.elasticsearch.search.aggregations.bucket.geogrid.GeoTileUtils;
 import org.elasticsearch.test.ESTestCase;
@@ -48,7 +48,7 @@ public class SimpleFeatureFactoryTests extends ESTestCase {
         }
     }
 
-    public void testMultiPoint() throws IOException {
+    public void testMultiPoint() {
         int z = randomIntBetween(3, 10);
         int x = randomIntBetween(0, (1 << z) - 1);
         int y = randomIntBetween(0, (1 << z) - 1);
@@ -57,12 +57,12 @@ public class SimpleFeatureFactoryTests extends ESTestCase {
         Rectangle rectangle = GeoTileUtils.toBoundingBox(x, y, z);
         int numPoints = randomIntBetween(2, 10);
         {
-            List<Point> points = new ArrayList<>();
+            List<GeoPoint> points = new ArrayList<>();
             double lat = randomValueOtherThanMany((l) -> rectangle.getMinY() >= l || rectangle.getMaxY() <= l, GeoTestUtil::nextLatitude);
             double lon = randomValueOtherThanMany((l) -> rectangle.getMinX() >= l || rectangle.getMaxX() <= l, GeoTestUtil::nextLongitude);
-            points.add(new Point(lon, lat));
+            points.add(new GeoPoint(lat, lon));
             for (int i = 0; i < numPoints - 1; i++) {
-                points.add(new Point(GeoTestUtil.nextLongitude(), GeoTestUtil.nextLatitude()));
+                points.add(new GeoPoint(GeoTestUtil.nextLatitude(), GeoTestUtil.nextLongitude()));
             }
             assertThat(builder.points(points).length, Matchers.greaterThan(0));
         }
@@ -70,7 +70,7 @@ public class SimpleFeatureFactoryTests extends ESTestCase {
             int xNew = randomValueOtherThanMany(v -> Math.abs(v - x) < 2, () -> randomIntBetween(0, (1 << z) - 1));
             int yNew = randomValueOtherThanMany(v -> Math.abs(v - y) < 2, () -> randomIntBetween(0, (1 << z) - 1));
             Rectangle rectangleNew = GeoTileUtils.toBoundingBox(xNew, yNew, z);
-            List<Point> points = new ArrayList<>();
+            List<GeoPoint> points = new ArrayList<>();
             for (int i = 0; i < numPoints; i++) {
                 double lat = randomValueOtherThanMany(
                     (l) -> rectangleNew.getMinY() >= l || rectangleNew.getMaxY() <= l,
@@ -80,7 +80,7 @@ public class SimpleFeatureFactoryTests extends ESTestCase {
                     (l) -> rectangleNew.getMinX() >= l || rectangleNew.getMaxX() <= l,
                     GeoTestUtil::nextLongitude
                 );
-                points.add(new Point(lon, lat));
+                points.add(new GeoPoint(lat, lon));
             }
             assertThat(builder.points(points).length, Matchers.equalTo(0));
         }
@@ -95,24 +95,24 @@ public class SimpleFeatureFactoryTests extends ESTestCase {
         Rectangle rectangle = GeoTileUtils.toBoundingBox(x, y, z);
         int extraPoints = randomIntBetween(1, 10);
         {
-            List<Point> points = new ArrayList<>();
+            List<GeoPoint> points = new ArrayList<>();
             double lat = randomValueOtherThanMany((l) -> rectangle.getMinY() > l || rectangle.getMaxY() < l, GeoTestUtil::nextLatitude);
             double lon = randomValueOtherThanMany((l) -> rectangle.getMinX() > l || rectangle.getMaxX() < l, GeoTestUtil::nextLongitude);
-            points.add(new Point(lon, lat));
+            points.add(new GeoPoint(lat, lon));
             assertArrayEquals(builder.points(points), builder.point(lon, lat));
             for (int i = 0; i < extraPoints; i++) {
-                points.add(new Point(lon, lat));
+                points.add(new GeoPoint(lat, lon));
             }
             assertArrayEquals(builder.points(points), builder.point(lon, lat));
         }
         {
-            List<Point> points = new ArrayList<>();
+            List<GeoPoint> points = new ArrayList<>();
             double lat = randomValueOtherThanMany((l) -> rectangle.getMinY() <= l && rectangle.getMaxY() >= l, GeoTestUtil::nextLatitude);
             double lon = randomValueOtherThanMany((l) -> rectangle.getMinX() <= l && rectangle.getMaxX() >= l, GeoTestUtil::nextLongitude);
-            points.add(new Point(lon, lat));
+            points.add(new GeoPoint(lat, lon));
             assertArrayEquals(builder.points(points), builder.point(lon, lat));
             for (int i = 0; i < extraPoints; i++) {
-                points.add(new Point(lon, lat));
+                points.add(new GeoPoint(lat, lon));
             }
             assertArrayEquals(builder.points(points), builder.point(lon, lat));
         }

--- a/x-pack/plugin/spatial/build.gradle
+++ b/x-pack/plugin/spatial/build.gradle
@@ -12,6 +12,7 @@ esplugin {
 dependencies {
   compileOnly project(path: xpackModule('core'))
   testImplementation(testArtifact(project(xpackModule('core'))))
+  testImplementation project(path: xpackModule('vector-tile'))
   yamlRestTestImplementation(testArtifact(project(xpackModule('core'))))
   api project(path: ':modules:geo')
   restTestConfig project(path: ':modules:geo', configuration: 'restTests')

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/SpatialPlugin.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/SpatialPlugin.java
@@ -6,6 +6,7 @@
  */
 package org.elasticsearch.xpack.spatial;
 
+import org.apache.lucene.util.SetOnce;
 import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.common.inject.Module;
@@ -16,6 +17,7 @@ import org.elasticsearch.ingest.Processor;
 import org.elasticsearch.license.LicenseUtils;
 import org.elasticsearch.license.XPackLicenseState;
 import org.elasticsearch.plugins.ActionPlugin;
+import org.elasticsearch.plugins.ExtensiblePlugin;
 import org.elasticsearch.plugins.IngestPlugin;
 import org.elasticsearch.plugins.MapperPlugin;
 import org.elasticsearch.plugins.SearchPlugin;
@@ -60,7 +62,7 @@ import java.util.function.Consumer;
 
 import static java.util.Collections.singletonList;
 
-public class SpatialPlugin extends GeoPlugin implements MapperPlugin, ActionPlugin, SearchPlugin, IngestPlugin {
+public class SpatialPlugin extends GeoPlugin implements MapperPlugin, ActionPlugin, SearchPlugin, IngestPlugin, ExtensiblePlugin {
     private final SpatialUsage usage = new SpatialUsage();
 
     public Collection<Module> createGuiceModules() {
@@ -74,6 +76,9 @@ public class SpatialPlugin extends GeoPlugin implements MapperPlugin, ActionPlug
         return XPackPlugin.getSharedLicenseState();
     }
 
+    // register the vector tile factory from a different module
+    private final SetOnce<VectorTileExtension> vectorTileExtension = new SetOnce<>();
+
     @Override
     public List<ActionPlugin.ActionHandler<? extends ActionRequest, ? extends ActionResponse>> getActions() {
         return singletonList(new ActionPlugin.ActionHandler<>(SpatialStatsAction.INSTANCE, SpatialStatsTransportAction.class));
@@ -84,7 +89,8 @@ public class SpatialPlugin extends GeoPlugin implements MapperPlugin, ActionPlug
         Map<String, Mapper.TypeParser> mappers = new HashMap<>(super.getMappers());
         mappers.put(ShapeFieldMapper.CONTENT_TYPE, ShapeFieldMapper.PARSER);
         mappers.put(PointFieldMapper.CONTENT_TYPE, PointFieldMapper.PARSER);
-        mappers.put(GeoShapeWithDocValuesFieldMapper.CONTENT_TYPE, GeoShapeWithDocValuesFieldMapper.PARSER);
+        mappers.put(GeoShapeWithDocValuesFieldMapper.CONTENT_TYPE,
+            new GeoShapeWithDocValuesFieldMapper.TypeParser(vectorTileExtension.get()));
         return Collections.unmodifiableMap(mappers);
     }
 
@@ -204,5 +210,11 @@ public class SpatialPlugin extends GeoPlugin implements MapperPlugin, ActionPlug
             }
             return realParser.parse(parser, name);
         };
+    }
+
+    @Override
+    public void loadExtensions(ExtensionLoader loader) {
+        // we only expect one vector tile extension that comes from the vector tile module.
+        loader.loadExtensions(VectorTileExtension.class).forEach(vectorTileExtension::set);
     }
 }

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/VectorTileExtension.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/VectorTileExtension.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.spatial;
+
+import org.elasticsearch.common.geo.GeoFormatterFactory;
+import org.elasticsearch.geometry.Geometry;
+
+
+public interface VectorTileExtension {
+    /**
+     * Get the vector tile engine. This is called when user ask for the MVT format on the field API.
+     * We are only expecting one instance of a vector tile engine coming from the vector tile module.
+     */
+    GeoFormatterFactory.VectorTileEngine<Geometry> getVectorTileEngine();
+}

--- a/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/index/mapper/GeoShapeWithDocValuesFieldTypeTests.java
+++ b/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/index/mapper/GeoShapeWithDocValuesFieldTypeTests.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.spatial.index.mapper;
+
+import org.elasticsearch.Version;
+import org.elasticsearch.geo.GeometryTestUtils;
+import org.elasticsearch.geometry.Geometry;
+import org.elasticsearch.geometry.utils.WellKnownText;
+import org.elasticsearch.index.mapper.ContentPath;
+import org.elasticsearch.index.mapper.FieldTypeTestCase;
+import org.elasticsearch.index.mapper.GeoShapeFieldMapper;
+import org.elasticsearch.index.mapper.MappedFieldType;
+import org.elasticsearch.xpack.vectortile.SpatialVectorTileExtension;
+import org.elasticsearch.xpack.vectortile.feature.FeatureFactory;
+import org.hamcrest.Matchers;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+public class GeoShapeWithDocValuesFieldTypeTests extends FieldTypeTestCase {
+
+    public void testFetchSourceValue() throws IOException {
+        MappedFieldType mapper
+            = new GeoShapeFieldMapper.Builder("field", true, true).build(new ContentPath()).fieldType();
+
+        Map<String, Object> jsonLineString = Map.of("type", "LineString", "coordinates",
+            List.of(List.of(42.0, 27.1), List.of(30.0, 50.0)));
+        Map<String, Object> jsonPoint = Map.of("type", "Point", "coordinates", List.of(14.0, 15.0));
+        Map<String, Object> jsonMalformed = Map.of("type", "Point", "coordinates", "foo");
+        String wktLineString = "LINESTRING (42.0 27.1, 30.0 50.0)";
+        String wktPoint = "POINT (14.0 15.0)";
+        String wktMalformed = "POINT foo";
+
+        // Test a single shape in geojson format.
+        Object sourceValue = jsonLineString;
+        assertEquals(List.of(jsonLineString), fetchSourceValue(mapper, sourceValue, null));
+        assertEquals(List.of(wktLineString), fetchSourceValue(mapper, sourceValue, "wkt"));
+
+        // Test a malformed single shape in geojson format
+        sourceValue = jsonMalformed;
+        assertEquals(List.of(), fetchSourceValue(mapper, sourceValue, null));
+        assertEquals(List.of(), fetchSourceValue(mapper, sourceValue, "wkt"));
+
+        // Test a list of shapes in geojson format.
+        sourceValue = List.of(jsonLineString, jsonPoint);
+        assertEquals(List.of(jsonLineString, jsonPoint), fetchSourceValue(mapper, sourceValue, null));
+        assertEquals(List.of(wktLineString, wktPoint), fetchSourceValue(mapper, sourceValue, "wkt"));
+
+        // Test a list of shapes including one malformed in geojson format
+        sourceValue = List.of(jsonLineString, jsonMalformed, jsonPoint);
+        assertEquals(List.of(jsonLineString, jsonPoint), fetchSourceValue(mapper, sourceValue, null));
+        assertEquals(List.of(wktLineString, wktPoint), fetchSourceValue(mapper, sourceValue, "wkt"));
+
+        // Test a single shape in wkt format.
+        sourceValue = wktLineString;
+        assertEquals(List.of(jsonLineString), fetchSourceValue(mapper, sourceValue, null));
+        assertEquals(List.of(wktLineString), fetchSourceValue(mapper, sourceValue, "wkt"));
+
+        // Test a single malformed shape in wkt format
+        sourceValue = wktMalformed;
+        assertEquals(List.of(), fetchSourceValue(mapper, sourceValue, null));
+        assertEquals(List.of(), fetchSourceValue(mapper, sourceValue, "wkt"));
+
+        // Test a list of shapes in wkt format.
+        sourceValue = List.of(wktLineString, wktPoint);
+        assertEquals(List.of(jsonLineString, jsonPoint), fetchSourceValue(mapper, sourceValue, null));
+        assertEquals(List.of(wktLineString, wktPoint), fetchSourceValue(mapper, sourceValue, "wkt"));
+
+        // Test a list of shapes including one malformed in wkt format
+        sourceValue = List.of(wktLineString, wktMalformed, wktPoint);
+        assertEquals(List.of(jsonLineString, jsonPoint), fetchSourceValue(mapper, sourceValue, null));
+        assertEquals(List.of(wktLineString, wktPoint), fetchSourceValue(mapper, sourceValue, "wkt"));
+    }
+
+    public void testFetchVectorTile() throws IOException {
+        fetchVectorTile(GeometryTestUtils.randomPoint());
+        fetchVectorTile(GeometryTestUtils.randomMultiPoint(false));
+        fetchVectorTile(GeometryTestUtils.randomRectangle());
+        fetchVectorTile(GeometryTestUtils.randomLine(false));
+        fetchVectorTile(GeometryTestUtils.randomMultiLine(false));
+        fetchVectorTile(GeometryTestUtils.randomPolygon(false));
+        fetchVectorTile(GeometryTestUtils.randomMultiPolygon(false));
+    }
+
+    private void fetchVectorTile(Geometry geometry) throws IOException {
+        final MappedFieldType mapper
+            = new GeoShapeWithDocValuesFieldMapper.Builder("field", Version.CURRENT, false, false, new SpatialVectorTileExtension())
+            .build(new ContentPath()).fieldType();
+        final int z = randomIntBetween(1, 10);
+        int x = randomIntBetween(0, (1 << z) - 1);
+        int y = randomIntBetween(0, (1 << z) - 1);
+        final FeatureFactory featureFactory;
+        final String mvtString;
+        if (randomBoolean()) {
+            int extent = randomIntBetween(1 << 8, 1 << 14);
+            mvtString = "mvt(" + z + "/" + x + "/" + y + "@" + extent + ")";
+            featureFactory = new FeatureFactory(z, x, y, extent);
+        } else {
+            mvtString = "mvt(" + z + "/" + x + "/" + y + ")";
+            featureFactory = new FeatureFactory(z, x, y, 4096);
+        }
+
+        final List<?> sourceValue = fetchSourceValue(mapper, WellKnownText.toWKT(geometry), mvtString);
+        final List<byte[]> features = featureFactory.getFeatures(geometry);
+        assertThat(features.size(), Matchers.equalTo(sourceValue.size()));
+        for (int i = 0; i < features.size(); i++) {
+            assertThat(sourceValue.get(i), Matchers.equalTo(features.get(i)));
+        }
+    }
+}

--- a/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/index/mapper/GeoShapeWithDocValuesFieldTypeTests.java
+++ b/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/index/mapper/GeoShapeWithDocValuesFieldTypeTests.java
@@ -29,53 +29,54 @@ public class GeoShapeWithDocValuesFieldTypeTests extends FieldTypeTestCase {
         MappedFieldType mapper
             = new GeoShapeFieldMapper.Builder("field", true, true).build(new ContentPath()).fieldType();
 
-        Map<String, Object> jsonLineString = Map.of("type", "LineString", "coordinates",
-            List.of(List.of(42.0, 27.1), List.of(30.0, 50.0)));
-        Map<String, Object> jsonPoint = Map.of("type", "Point", "coordinates", List.of(14.0, 15.0));
-        Map<String, Object> jsonMalformed = Map.of("type", "Point", "coordinates", "foo");
+        Map<String, Object> jsonLineString = org.elasticsearch.core.Map.of("type", "LineString", "coordinates",
+            org.elasticsearch.core.List.of(org.elasticsearch.core.List.of(42.0, 27.1), org.elasticsearch.core.List.of(30.0, 50.0)));
+        Map<String, Object> jsonPoint = org.elasticsearch.core.Map.of("type", "Point", "coordinates",
+            org.elasticsearch.core.List.of(14.0, 15.0));
+        Map<String, Object> jsonMalformed = org.elasticsearch.core.Map.of("type", "Point", "coordinates", "foo");
         String wktLineString = "LINESTRING (42.0 27.1, 30.0 50.0)";
         String wktPoint = "POINT (14.0 15.0)";
         String wktMalformed = "POINT foo";
 
         // Test a single shape in geojson format.
         Object sourceValue = jsonLineString;
-        assertEquals(List.of(jsonLineString), fetchSourceValue(mapper, sourceValue, null));
-        assertEquals(List.of(wktLineString), fetchSourceValue(mapper, sourceValue, "wkt"));
+        assertEquals(org.elasticsearch.core.List.of(jsonLineString), fetchSourceValue(mapper, sourceValue, null));
+        assertEquals(org.elasticsearch.core.List.of(wktLineString), fetchSourceValue(mapper, sourceValue, "wkt"));
 
         // Test a malformed single shape in geojson format
         sourceValue = jsonMalformed;
-        assertEquals(List.of(), fetchSourceValue(mapper, sourceValue, null));
-        assertEquals(List.of(), fetchSourceValue(mapper, sourceValue, "wkt"));
+        assertEquals(org.elasticsearch.core.List.of(), fetchSourceValue(mapper, sourceValue, null));
+        assertEquals(org.elasticsearch.core.List.of(), fetchSourceValue(mapper, sourceValue, "wkt"));
 
         // Test a list of shapes in geojson format.
-        sourceValue = List.of(jsonLineString, jsonPoint);
-        assertEquals(List.of(jsonLineString, jsonPoint), fetchSourceValue(mapper, sourceValue, null));
-        assertEquals(List.of(wktLineString, wktPoint), fetchSourceValue(mapper, sourceValue, "wkt"));
+        sourceValue = org.elasticsearch.core.List.of(jsonLineString, jsonPoint);
+        assertEquals(org.elasticsearch.core.List.of(jsonLineString, jsonPoint), fetchSourceValue(mapper, sourceValue, null));
+        assertEquals(org.elasticsearch.core.List.of(wktLineString, wktPoint), fetchSourceValue(mapper, sourceValue, "wkt"));
 
         // Test a list of shapes including one malformed in geojson format
-        sourceValue = List.of(jsonLineString, jsonMalformed, jsonPoint);
-        assertEquals(List.of(jsonLineString, jsonPoint), fetchSourceValue(mapper, sourceValue, null));
-        assertEquals(List.of(wktLineString, wktPoint), fetchSourceValue(mapper, sourceValue, "wkt"));
+        sourceValue = org.elasticsearch.core.List.of(jsonLineString, jsonMalformed, jsonPoint);
+        assertEquals(org.elasticsearch.core.List.of(jsonLineString, jsonPoint), fetchSourceValue(mapper, sourceValue, null));
+        assertEquals(org.elasticsearch.core.List.of(wktLineString, wktPoint), fetchSourceValue(mapper, sourceValue, "wkt"));
 
         // Test a single shape in wkt format.
         sourceValue = wktLineString;
-        assertEquals(List.of(jsonLineString), fetchSourceValue(mapper, sourceValue, null));
-        assertEquals(List.of(wktLineString), fetchSourceValue(mapper, sourceValue, "wkt"));
+        assertEquals(org.elasticsearch.core.List.of(jsonLineString), fetchSourceValue(mapper, sourceValue, null));
+        assertEquals(org.elasticsearch.core.List.of(wktLineString), fetchSourceValue(mapper, sourceValue, "wkt"));
 
         // Test a single malformed shape in wkt format
         sourceValue = wktMalformed;
-        assertEquals(List.of(), fetchSourceValue(mapper, sourceValue, null));
-        assertEquals(List.of(), fetchSourceValue(mapper, sourceValue, "wkt"));
+        assertEquals(org.elasticsearch.core.List.of(), fetchSourceValue(mapper, sourceValue, null));
+        assertEquals(org.elasticsearch.core.List.of(), fetchSourceValue(mapper, sourceValue, "wkt"));
 
         // Test a list of shapes in wkt format.
-        sourceValue = List.of(wktLineString, wktPoint);
-        assertEquals(List.of(jsonLineString, jsonPoint), fetchSourceValue(mapper, sourceValue, null));
-        assertEquals(List.of(wktLineString, wktPoint), fetchSourceValue(mapper, sourceValue, "wkt"));
+        sourceValue = org.elasticsearch.core.List.of(wktLineString, wktPoint);
+        assertEquals(org.elasticsearch.core.List.of(jsonLineString, jsonPoint), fetchSourceValue(mapper, sourceValue, null));
+        assertEquals(org.elasticsearch.core.List.of(wktLineString, wktPoint), fetchSourceValue(mapper, sourceValue, "wkt"));
 
         // Test a list of shapes including one malformed in wkt format
-        sourceValue = List.of(wktLineString, wktMalformed, wktPoint);
-        assertEquals(List.of(jsonLineString, jsonPoint), fetchSourceValue(mapper, sourceValue, null));
-        assertEquals(List.of(wktLineString, wktPoint), fetchSourceValue(mapper, sourceValue, "wkt"));
+        sourceValue = org.elasticsearch.core.List.of(wktLineString, wktMalformed, wktPoint);
+        assertEquals(org.elasticsearch.core.List.of(jsonLineString, jsonPoint), fetchSourceValue(mapper, sourceValue, null));
+        assertEquals(org.elasticsearch.core.List.of(wktLineString, wktPoint), fetchSourceValue(mapper, sourceValue, "wkt"));
     }
 
     public void testFetchVectorTile() throws IOException {

--- a/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/ingest/CircleProcessorTests.java
+++ b/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/ingest/CircleProcessorTests.java
@@ -213,7 +213,7 @@ public class CircleProcessorTests extends ESTestCase {
         Geometry geometry = SpatialUtils.createRegularGeoShapePolygon(circle, numSides);
 
         GeoShapeWithDocValuesFieldType shapeType
-            = new GeoShapeWithDocValuesFieldType(fieldName, true, false, Orientation.RIGHT, null, Collections.emptyMap());
+            = new GeoShapeWithDocValuesFieldType(fieldName, true, false, Orientation.RIGHT, null, null, Collections.emptyMap());
 
         SearchExecutionContext mockedContext = mock(SearchExecutionContext.class);
         when(mockedContext.getFieldType(any())).thenReturn(shapeType);

--- a/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/search/aggregations/bucket/geogrid/GeoShapeGeoGridTestCase.java
+++ b/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/search/aggregations/bucket/geogrid/GeoShapeGeoGridTestCase.java
@@ -294,7 +294,7 @@ public abstract class GeoShapeGeoGridTestCase<T extends InternalGeoGridBucket> e
         }
 
         MappedFieldType fieldType
-            = new GeoShapeWithDocValuesFieldType(FIELD_NAME, true, true, Orientation.RIGHT, null, Collections.emptyMap());
+            = new GeoShapeWithDocValuesFieldType(FIELD_NAME, true, true, Orientation.RIGHT, null, null, Collections.emptyMap());
 
         Aggregator aggregator = createAggregator(aggregationBuilder, indexSearcher, fieldType);
         aggregator.preCollection();

--- a/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/search/aggregations/metrics/GeoShapeBoundsAggregatorTests.java
+++ b/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/search/aggregations/metrics/GeoShapeBoundsAggregatorTests.java
@@ -58,7 +58,7 @@ public class GeoShapeBoundsAggregatorTests extends AggregatorTestCase {
                 .wrapLongitude(false);
 
             MappedFieldType fieldType
-                = new GeoShapeWithDocValuesFieldType("field", true, true, Orientation.RIGHT, null, Collections.emptyMap());
+                = new GeoShapeWithDocValuesFieldType("field", true, true, Orientation.RIGHT, null, null, Collections.emptyMap());
             try (IndexReader reader = w.getReader()) {
                 IndexSearcher searcher = new IndexSearcher(reader);
                 InternalGeoBounds bounds = searchAndReduce(searcher, new MatchAllDocsQuery(), aggBuilder, fieldType);
@@ -86,7 +86,7 @@ public class GeoShapeBoundsAggregatorTests extends AggregatorTestCase {
                 .wrapLongitude(false);
 
             MappedFieldType fieldType
-                = new GeoShapeWithDocValuesFieldType("field", true, true, Orientation.RIGHT, null, Collections.emptyMap());
+                = new GeoShapeWithDocValuesFieldType("field", true, true, Orientation.RIGHT, null, null, Collections.emptyMap());
             try (IndexReader reader = w.getReader()) {
                 IndexSearcher searcher = new IndexSearcher(reader);
                 InternalGeoBounds bounds = searchAndReduce(searcher, new MatchAllDocsQuery(), aggBuilder, fieldType);
@@ -108,7 +108,7 @@ public class GeoShapeBoundsAggregatorTests extends AggregatorTestCase {
             w.addDocument(doc);
 
             MappedFieldType fieldType
-                = new GeoShapeWithDocValuesFieldType("field", true, true, Orientation.RIGHT, null, Collections.emptyMap());
+                = new GeoShapeWithDocValuesFieldType("field", true, true, Orientation.RIGHT, null, null, Collections.emptyMap());
 
             Point point = GeometryTestUtils.randomPoint(false);
             double lon = GeoEncodingUtils.decodeLongitude(GeoEncodingUtils.encodeLongitude(point.getX()));
@@ -140,7 +140,7 @@ public class GeoShapeBoundsAggregatorTests extends AggregatorTestCase {
             w.addDocument(doc);
 
             MappedFieldType fieldType
-                = new GeoShapeWithDocValuesFieldType("field", true, true, Orientation.RIGHT, null, Collections.emptyMap());
+                = new GeoShapeWithDocValuesFieldType("field", true, true, Orientation.RIGHT, null, null, Collections.emptyMap());
 
             GeoBoundsAggregationBuilder aggBuilder = new GeoBoundsAggregationBuilder("my_agg")
                 .field("field")
@@ -200,7 +200,7 @@ public class GeoShapeBoundsAggregatorTests extends AggregatorTestCase {
                 .wrapLongitude(false);
 
             MappedFieldType fieldType
-                = new GeoShapeWithDocValuesFieldType("field", true, true, Orientation.RIGHT, null, Collections.emptyMap());
+                = new GeoShapeWithDocValuesFieldType("field", true, true, Orientation.RIGHT, null, null, Collections.emptyMap());
             try (IndexReader reader = w.getReader()) {
                 IndexSearcher searcher = new IndexSearcher(reader);
                 InternalGeoBounds bounds = searchAndReduce(searcher, new MatchAllDocsQuery(), aggBuilder, fieldType);

--- a/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/search/aggregations/metrics/GeoShapeCentroidAggregatorTests.java
+++ b/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/search/aggregations/metrics/GeoShapeCentroidAggregatorTests.java
@@ -64,7 +64,7 @@ public class GeoShapeCentroidAggregatorTests extends AggregatorTestCase {
                 .field("field");
 
             MappedFieldType fieldType
-                = new GeoShapeWithDocValuesFieldType("field", true, true, Orientation.RIGHT, null, Collections.emptyMap());
+                = new GeoShapeWithDocValuesFieldType("field", true, true, Orientation.RIGHT, null, null, Collections.emptyMap());
             try (IndexReader reader = w.getReader()) {
                 IndexSearcher searcher = new IndexSearcher(reader);
                 InternalGeoCentroid result = searchAndReduce(searcher, new MatchAllDocsQuery(), aggBuilder, fieldType);
@@ -87,12 +87,12 @@ public class GeoShapeCentroidAggregatorTests extends AggregatorTestCase {
                 IndexSearcher searcher = new IndexSearcher(reader);
 
                 MappedFieldType fieldType = new GeoShapeWithDocValuesFieldType("another_field",
-                    true, true, Orientation.RIGHT, null, Collections.emptyMap());
+                    true, true, Orientation.RIGHT, null, null, Collections.emptyMap());
                 InternalGeoCentroid result = searchAndReduce(searcher, new MatchAllDocsQuery(), aggBuilder, fieldType);
                 assertNull(result.centroid());
 
                 fieldType = new GeoShapeWithDocValuesFieldType("field",
-                    true, true, Orientation.RIGHT, null, Collections.emptyMap());
+                    true, true, Orientation.RIGHT, null, null, Collections.emptyMap());
                 result = searchAndReduce(searcher, new MatchAllDocsQuery(), aggBuilder, fieldType);
                 assertNull(result.centroid());
                 assertFalse(AggregationInspectionHelper.hasValue(result));
@@ -117,7 +117,7 @@ public class GeoShapeCentroidAggregatorTests extends AggregatorTestCase {
                 IndexSearcher searcher = new IndexSearcher(reader);
 
                 MappedFieldType fieldType = new GeoShapeWithDocValuesFieldType("another_field",
-                    true, true, Orientation.RIGHT, null, Collections.emptyMap());
+                    true, true, Orientation.RIGHT, null, null, Collections.emptyMap());
                 InternalGeoCentroid result = searchAndReduce(searcher, new MatchAllDocsQuery(), aggBuilder, fieldType);
                 assertThat(result.centroid(), equalTo(expectedCentroid));
                 assertTrue(AggregationInspectionHelper.hasValue(result));
@@ -180,7 +180,7 @@ public class GeoShapeCentroidAggregatorTests extends AggregatorTestCase {
 
     private void assertCentroid(RandomIndexWriter w, GeoPoint expectedCentroid) throws IOException {
         MappedFieldType fieldType = new GeoShapeWithDocValuesFieldType("field",
-            true, true, Orientation.RIGHT, null, Collections.emptyMap());
+            true, true, Orientation.RIGHT, null, null, Collections.emptyMap());
         GeoCentroidAggregationBuilder aggBuilder = new GeoCentroidAggregationBuilder("my_agg")
             .field("field");
         try (IndexReader reader = w.getReader()) {

--- a/x-pack/plugin/vector-tile/build.gradle
+++ b/x-pack/plugin/vector-tile/build.gradle
@@ -22,11 +22,12 @@ esplugin {
   name 'vector-tile'
   description 'A plugin for mapbox vector tile features'
   classname 'org.elasticsearch.xpack.vectortile.VectorTilePlugin'
-  extendedPlugins = ['x-pack-core']
+  extendedPlugins = ['spatial']
 }
 
 dependencies {
   compileOnly project(path: xpackModule('core'))
+  compileOnly project(path: xpackModule('spatial'))
   testImplementation(testArtifact(project(xpackModule('core'))))
   api "com.wdtinc:mapbox-vector-tile:3.1.0"
   api "com.google.protobuf:protobuf-java:3.14.0"

--- a/x-pack/plugin/vector-tile/src/main/java/org/elasticsearch/xpack/vectortile/SpatialVectorTileExtension.java
+++ b/x-pack/plugin/vector-tile/src/main/java/org/elasticsearch/xpack/vectortile/SpatialVectorTileExtension.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.vectortile;
+
+import org.elasticsearch.common.geo.GeoFormatterFactory;
+import org.elasticsearch.geometry.Geometry;
+import org.elasticsearch.geometry.GeometryCollection;
+import org.elasticsearch.xpack.spatial.VectorTileExtension;
+import org.elasticsearch.xpack.vectortile.feature.FeatureFactory;
+
+import java.util.ArrayList;
+
+/**
+ * Unique implementation of VectorTileExtension so we can transform geometries
+ * into its vector tile representation from the spatial module.
+ */
+public class SpatialVectorTileExtension implements VectorTileExtension {
+
+    @Override
+    public GeoFormatterFactory.VectorTileEngine<Geometry> getVectorTileEngine() {
+        return (z, x, y, extent) -> {
+            final FeatureFactory featureFactory = new FeatureFactory(z, x, y, extent);
+            return geometries -> {
+                final Geometry geometry = (geometries.size() == 1) ? geometries.get(0) : new GeometryCollection<>(geometries);
+                return new ArrayList<>(featureFactory.getFeatures(geometry));
+            };
+        };
+    }
+}

--- a/x-pack/plugin/vector-tile/src/main/java/org/elasticsearch/xpack/vectortile/rest/RestVectorTileAction.java
+++ b/x-pack/plugin/vector-tile/src/main/java/org/elasticsearch/xpack/vectortile/rest/RestVectorTileAction.java
@@ -7,7 +7,6 @@
 package org.elasticsearch.xpack.vectortile.rest;
 
 import com.wdtinc.mapbox_vector_tile.VectorTile;
-import com.wdtinc.mapbox_vector_tile.adapt.jts.IUserDataConverter;
 import com.wdtinc.mapbox_vector_tile.build.MvtLayerProps;
 
 import org.elasticsearch.action.search.SearchRequestBuilder;
@@ -17,10 +16,9 @@ import org.elasticsearch.client.node.NodeClient;
 import org.elasticsearch.common.document.DocumentField;
 import org.elasticsearch.common.geo.GeoBoundingBox;
 import org.elasticsearch.common.geo.GeoPoint;
-import org.elasticsearch.common.geo.GeometryParser;
+import org.elasticsearch.common.geo.SimpleFeatureFactory;
 import org.elasticsearch.common.io.Streams;
 import org.elasticsearch.common.io.stream.BytesStream;
-import org.elasticsearch.geometry.Geometry;
 import org.elasticsearch.geometry.Rectangle;
 import org.elasticsearch.index.query.BoolQueryBuilder;
 import org.elasticsearch.index.query.QueryBuilder;
@@ -49,8 +47,6 @@ import org.elasticsearch.search.aggregations.pipeline.StatsBucketPipelineAggrega
 import org.elasticsearch.search.fetch.subphase.FieldAndFormat;
 import org.elasticsearch.search.profile.SearchProfileShardResults;
 import org.elasticsearch.search.sort.SortBuilder;
-import org.elasticsearch.xpack.vectortile.feature.FeatureFactory;
-import org.elasticsearch.xpack.vectortile.feature.SimpleFeatureFactory;
 
 import java.io.IOException;
 import java.util.Collection;
@@ -176,8 +172,12 @@ public class RestVectorTileAction extends BaseRestHandler {
         final SearchRequestBuilder searchRequestBuilder = client.prepareSearch(request.getIndexes());
         searchRequestBuilder.setSize(request.getSize());
         searchRequestBuilder.setFetchSource(false);
-        // TODO: I wonder if we can leverage field and format so what we get in the result is already the mvt commands.
-        searchRequestBuilder.addFetchField(new FieldAndFormat(request.getField(), null));
+        searchRequestBuilder.addFetchField(
+            new FieldAndFormat(
+                request.getField(),
+                "mvt(" + request.getZ() + "/" + request.getX() + "/" + request.getY() + "@" + request.getExtent() + ")"
+            )
+        );
         for (FieldAndFormat field : request.getFieldAndFormats()) {
             searchRequestBuilder.addFetchField(field);
         }
@@ -225,13 +225,20 @@ public class RestVectorTileAction extends BaseRestHandler {
         return searchRequestBuilder;
     }
 
-    private static VectorTile.Tile.Layer.Builder buildHitsLayer(SearchHit[] hits, VectorTileRequest request) {
-        final FeatureFactory featureFactory = new FeatureFactory(request.getZ(), request.getX(), request.getY(), request.getExtent());
-        final GeometryParser parser = new GeometryParser(true, false, false);
+    @SuppressWarnings("unchecked")
+    private static VectorTile.Tile.Layer.Builder buildHitsLayer(SearchHit[] hits, VectorTileRequest request) throws IOException {
         final VectorTile.Tile.Layer.Builder hitsLayerBuilder = VectorTileUtils.createLayerBuilder(HITS_LAYER, request.getExtent());
         final List<FieldAndFormat> fields = request.getFieldAndFormats();
+        final MvtLayerProps layerProps = new MvtLayerProps();
+        final VectorTile.Tile.Feature.Builder featureBuilder = VectorTile.Tile.Feature.newBuilder();
         for (SearchHit searchHit : hits) {
-            final IUserDataConverter tags = (userData, layerProps, featureBuilder) -> {
+            final DocumentField geoField = searchHit.field(request.getField());
+            if (geoField == null) {
+                continue;
+            }
+            for (Object feature : geoField) {
+                featureBuilder.clear();
+                featureBuilder.mergeFrom((byte[]) feature);
                 VectorTileUtils.addPropertyToFeature(featureBuilder, layerProps, ID_TAG, searchHit.getId());
                 if (fields != null) {
                     for (FieldAndFormat field : fields) {
@@ -241,12 +248,10 @@ public class RestVectorTileAction extends BaseRestHandler {
                         }
                     }
                 }
-            };
-            // TODO: See comment on field formats.
-            final Geometry geometry = parser.parseGeometry(searchHit.field(request.getField()).getValue());
-            hitsLayerBuilder.addAllFeatures(featureFactory.getFeatures(geometry, tags));
+                hitsLayerBuilder.addFeatures(featureBuilder);
+            }
         }
-        VectorTileUtils.addPropertiesToLayer(hitsLayerBuilder, featureFactory.getLayerProps());
+        VectorTileUtils.addPropertiesToLayer(hitsLayerBuilder, layerProps);
         return hitsLayerBuilder;
     }
 

--- a/x-pack/plugin/vector-tile/src/main/resources/META-INF/services/org.elasticsearch.xpack.spatial.VectorTileExtension
+++ b/x-pack/plugin/vector-tile/src/main/resources/META-INF/services/org.elasticsearch.xpack.spatial.VectorTileExtension
@@ -1,0 +1,8 @@
+#
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License
+# 2.0; you may not use this file except in compliance with the Elastic License
+# 2.0.
+#
+
+org.elasticsearch.xpack.vectortile.SpatialVectorTileExtension

--- a/x-pack/plugin/vector-tile/src/test/java/org/elasticsearch/xpack/vectortile/feature/FeatureFactoriesConsistencyTests.java
+++ b/x-pack/plugin/vector-tile/src/test/java/org/elasticsearch/xpack/vectortile/feature/FeatureFactoriesConsistencyTests.java
@@ -7,10 +7,9 @@
 
 package org.elasticsearch.xpack.vectortile.feature;
 
-import com.wdtinc.mapbox_vector_tile.VectorTile;
-import com.wdtinc.mapbox_vector_tile.adapt.jts.UserDataIgnoreConverter;
-
 import org.apache.lucene.geo.GeoTestUtil;
+import org.elasticsearch.common.geo.GeoPoint;
+import org.elasticsearch.common.geo.SimpleFeatureFactory;
 import org.elasticsearch.common.geo.SphericalMercatorUtils;
 import org.elasticsearch.geometry.MultiPoint;
 import org.elasticsearch.geometry.Point;
@@ -37,21 +36,19 @@ public class FeatureFactoriesConsistencyTests extends ESTestCase {
         SimpleFeatureFactory builder = new SimpleFeatureFactory(z, x, y, extent);
         FeatureFactory factory = new FeatureFactory(z, x, y, extent);
         List<Point> points = new ArrayList<>();
+        List<GeoPoint> geoPoints = new ArrayList<>();
         for (int i = 0; i < 10; i++) {
             double lat = randomValueOtherThanMany((l) -> rectangle.getMinY() > l || rectangle.getMaxY() < l, GeoTestUtil::nextLatitude);
             double lon = randomValueOtherThanMany((l) -> rectangle.getMinX() > l || rectangle.getMaxX() < l, GeoTestUtil::nextLongitude);
             byte[] b1 = builder.point(lon, lat);
             Point point = new Point(lon, lat);
-            List<VectorTile.Tile.Feature> features = factory.getFeatures(point, new UserDataIgnoreConverter());
-            assertThat(features.size(), Matchers.equalTo(1));
-            byte[] b2 = features.get(0).toByteArray();
+            byte[] b2 = factory.getFeatures(point).get(0);
             assertArrayEquals(b1, b2);
             points.add(point);
+            geoPoints.add(new GeoPoint(lat, lon));
         }
-        byte[] b1 = builder.points(points);
-        List<VectorTile.Tile.Feature> features = factory.getFeatures(new MultiPoint(points), new UserDataIgnoreConverter());
-        assertThat(features.size(), Matchers.equalTo(1));
-        byte[] b2 = features.get(0).toByteArray();
+        byte[] b1 = builder.points(geoPoints);
+        byte[] b2 = factory.getFeatures(new MultiPoint(points)).get(0);
         assertArrayEquals(b1, b2);
     }
 
@@ -68,9 +65,7 @@ public class FeatureFactoriesConsistencyTests extends ESTestCase {
         FeatureFactory factory = new FeatureFactory(z, x, y, extent);
         byte[] b1 = builder.point(lon, lat);
         Point point = new Point(lon, lat);
-        List<VectorTile.Tile.Feature> features = factory.getFeatures(point, new UserDataIgnoreConverter());
-        assertThat(features.size(), Matchers.equalTo(1));
-        byte[] b2 = features.get(0).toByteArray();
+        byte[] b2 = factory.getFeatures(point).get(0);
         assertThat(Arrays.equals(b1, b2), Matchers.equalTo(false));
     }
 
@@ -91,9 +86,7 @@ public class FeatureFactoriesConsistencyTests extends ESTestCase {
         Rectangle r = GeoTileUtils.toBoundingBox(x, y, z);
         for (int i = 0; i < extent; i++) {
             byte[] b1 = builder.box(r.getMinLon(), r.getMaxLon(), r.getMinLat(), r.getMaxLat());
-            List<VectorTile.Tile.Feature> features = factory.getFeatures(r, new UserDataIgnoreConverter());
-            assertThat(features.size(), Matchers.equalTo(1));
-            byte[] b2 = features.get(0).toByteArray();
+            byte[] b2 = factory.getFeatures(r).get(0);
             assertArrayEquals(extent + "", b1, b2);
         }
     }


### PR DESCRIPTION
In this commit we extend the Fields API formats for geo data in order to produce vector tiles features directly
on the data nodes. That helps the vector tile API to reduce the size of the data that needs to pull in order to
create the answer.

backport #75367