### PR TITLE
Removing local abort availability checks

### DIFF
--- a/server/src/main/java/org/elasticsearch/persistent/PersistentTasksService.java
+++ b/server/src/main/java/org/elasticsearch/persistent/PersistentTasksService.java
@@ -9,7 +9,6 @@ package org.elasticsearch.persistent;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionType;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ActionRequest;
@@ -28,8 +27,6 @@ import org.elasticsearch.tasks.TaskId;
 import org.elasticsearch.threadpool.ThreadPool;
 
 import java.util.function.Predicate;
-
-import static org.elasticsearch.persistent.CompletionPersistentTaskAction.LOCAL_ABORT_AVAILABLE_VERSION;
 
 /**
  * This service is used by persistent tasks and allocated persistent tasks to communicate changes
@@ -71,18 +68,12 @@ public class PersistentTasksService {
      * At most one of {@code failure} and {@code localAbortReason} may be
      * provided. When both {@code failure} and {@code localAbortReason} are
      * {@code null}, the persistent task is considered as successfully completed.
-     * {@code localAbortReason} must not be provided unless all nodes in the cluster
-     * are on version {@link CompletionPersistentTaskAction#LOCAL_ABORT_AVAILABLE_VERSION}
-     * or higher.
      */
     public void sendCompletionRequest(final String taskId,
                                       final long taskAllocationId,
                                       final @Nullable Exception taskFailure,
                                       final @Nullable String localAbortReason,
                                       final ActionListener<PersistentTask<?>> listener) {
-        if (localAbortReason != null) {
-            validateLocalAbortSupported();
-        }
         CompletionPersistentTaskAction.Request request =
             new CompletionPersistentTaskAction.Request(taskId, taskAllocationId, taskFailure, localAbortReason);
         execute(request, CompletionPersistentTaskAction.INSTANCE, listener);
@@ -123,31 +114,6 @@ public class PersistentTasksService {
     public void sendRemoveRequest(final String taskId, final ActionListener<PersistentTask<?>> listener) {
         RemovePersistentTaskAction.Request request = new RemovePersistentTaskAction.Request(taskId);
         execute(request, RemovePersistentTaskAction.INSTANCE, listener);
-    }
-
-    /**
-     * Is the cluster able to support locally aborting persistent tasks?
-     * This requires that every node in the cluster is on version
-     * {@link CompletionPersistentTaskAction#LOCAL_ABORT_AVAILABLE_VERSION}
-     * or above.
-     */
-    public boolean isLocalAbortSupported() {
-        return isLocalAbortSupported(clusterService.state());
-    }
-
-    public static boolean isLocalAbortSupported(ClusterState state) {
-        return state.nodes().getMinNodeVersion().onOrAfter(LOCAL_ABORT_AVAILABLE_VERSION);
-    }
-
-    /**
-     * Throw an exception if the cluster is not able locally abort persistent tasks.
-     */
-    public void validateLocalAbortSupported() {
-        Version minNodeVersion = clusterService.state().nodes().getMinNodeVersion();
-        if (minNodeVersion.before(LOCAL_ABORT_AVAILABLE_VERSION)) {
-            throw new IllegalStateException("attempt to abort a persistent task locally in a cluster that does not support this: "
-                + "minimum node version [" + minNodeVersion + "], version required [" + LOCAL_ABORT_AVAILABLE_VERSION + "]");
-        }
     }
 
     /**

--- a/server/src/test/java/org/elasticsearch/persistent/CompletionPersistentTaskRequestTests.java
+++ b/server/src/test/java/org/elasticsearch/persistent/CompletionPersistentTaskRequestTests.java
@@ -32,13 +32,4 @@ public class CompletionPersistentTaskRequestTests extends AbstractWireSerializin
     protected Writeable.Reader<Request> instanceReader() {
         return Request::new;
     }
-
-    public void testSerializeToOldNodeThrows() {
-        Request request = new Request(randomAlphaOfLength(10), randomNonNegativeLong(), null, randomAlphaOfLength(20));
-        StreamOutput out = mock(StreamOutput.class);
-        when(out.getVersion()).thenReturn(Version.V_7_14_0);
-        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> request.writeTo(out));
-        assertThat(e.getMessage(), equalTo("attempt to abort a persistent task locally in a cluster that contains a node that is too "
-            + "old: found node version [7.14.0], minimum required [7.15.0]"));
-    }
 }

--- a/server/src/test/java/org/elasticsearch/persistent/CompletionPersistentTaskRequestTests.java
+++ b/server/src/test/java/org/elasticsearch/persistent/CompletionPersistentTaskRequestTests.java
@@ -7,15 +7,9 @@
  */
 package org.elasticsearch.persistent;
 
-import org.elasticsearch.Version;
-import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.persistent.CompletionPersistentTaskAction.Request;
 import org.elasticsearch.test.AbstractWireSerializingTestCase;
-
-import static org.hamcrest.Matchers.equalTo;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 public class CompletionPersistentTaskRequestTests extends AbstractWireSerializingTestCase<Request> {
 

--- a/server/src/test/java/org/elasticsearch/persistent/PersistentTasksNodeServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/persistent/PersistentTasksNodeServiceTests.java
@@ -243,18 +243,6 @@ public class PersistentTasksNodeServiceTests extends ESTestCase {
                                               final ActionListener<PersistentTask<?>> listener) {
                 fail("Shouldn't be called during Cluster State cancellation");
             }
-
-            @Override
-            public void validateLocalAbortSupported() {
-                if (isLocalAbortSupported() == false) {
-                    fail("this test should not cover local abort");
-                }
-            }
-
-            @Override
-            public boolean isLocalAbortSupported() {
-                return randomBoolean();
-            }
         };
         @SuppressWarnings("unchecked") PersistentTasksExecutor<TestParams> action = mock(PersistentTasksExecutor.class);
         when(action.getExecutor()).thenReturn(ThreadPool.Names.SAME);
@@ -341,15 +329,6 @@ public class PersistentTasksNodeServiceTests extends ESTestCase {
                 capturedLocalAbortReason.set(localAbortReason);
                 assertThat(taskFailure, nullValue());
             }
-
-            @Override
-            public void validateLocalAbortSupported() {
-            }
-
-            @Override
-            public boolean isLocalAbortSupported() {
-                return true;
-            }
         };
         @SuppressWarnings("unchecked") PersistentTasksExecutor<TestParams> action = mock(PersistentTasksExecutor.class);
         when(action.getExecutor()).thenReturn(ThreadPool.Names.SAME);
@@ -435,18 +414,6 @@ public class PersistentTasksNodeServiceTests extends ESTestCase {
                 assertThat(localAbortReason, nullValue());
                 listener.onResponse(mock(PersistentTask.class));
                 latch.countDown();
-            }
-
-            @Override
-            public void validateLocalAbortSupported() {
-                if (isLocalAbortSupported() == false) {
-                    fail("this test should not cover local abort");
-                }
-            }
-
-            @Override
-            public boolean isLocalAbortSupported() {
-                return randomBoolean();
             }
         };
 


### PR DESCRIPTION
Now that #74115 is backported to 7.x the code to check whether
local abort is supported within a cluster is redundant, as 8.x
only supports running in a mixed cluster with 7.last, and 7.last
contains the local abort functionality.

This change removes the redundant code.

Followup to #74115