### PR TITLE
Report shard count per node in _nodes/stats

### DIFF
--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/nodes.stats/11_indices_metrics.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/nodes.stats/11_indices_metrics.yml
@@ -323,8 +323,8 @@
 "Metric - blank for indices shards":
   - skip:
       features: [arbitrary_key]
-      version: " - 7.99.99"
-      reason:  "total shard count added in version 8.0"
+      version: " - 7.14.99"
+      reason:  "total shard count added in version 7.15.0"
   - do:
       nodes.info: {}
   - set:
@@ -340,8 +340,8 @@
 "Metric - _all for indices shards":
   - skip:
       features: [arbitrary_key]
-      version: " - 7.99.99"
-      reason:  "total shard count added in version 8.0"
+      version: " - 7.14.99"
+      reason:  "total shard count added in version 7.15.0"
   - do:
       nodes.info: {}
   - set:
@@ -359,8 +359,8 @@
 
   - skip:
       features: ["allowed_warnings", arbitrary_key]
-      version: " - 7.99.99"
-      reason:  "total shard count added in version 8.0"
+      version: " - 7.14.99"
+      reason:  "total shard count added in version 7.15.0"
 
   - do:
       indices.create:


### PR DESCRIPTION
Fixing test version updates missed in shard count feature backport

This PR -- https://github.com/elastic/elasticsearch/pull/75760 -- backported adding a shart count to the _nodes/stats API from master, but missed updating the supported version in a yaml test.