### PR TITLE
Report shard count per node in _nodes/stats

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -145,9 +145,9 @@ tasks.register("verifyVersions") {
  * after the backport of the backcompat code is complete.
  */
 
-boolean bwc_tests_enabled = false
+boolean bwc_tests_enabled = true
 // place a PR link here when committing bwc changes:
-String bwc_tests_disabled_issue = "https://github.com/elastic/elasticsearch/pull/75760"
+String bwc_tests_disabled_issue = ""
 /*
  * FIPS 140-2 behavior was fixed in 7.11.0. Before that there is no way to run elasticsearch in a
  * JVM that is properly configured to be in fips mode with BCFIPS. For now we need to disable

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/nodes.stats/11_indices_metrics.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/nodes.stats/11_indices_metrics.yml
@@ -324,8 +324,8 @@
 "Metric - blank for indices shards":
   - skip:
       features: [arbitrary_key]
-      version: " - 7.99.99"
-      reason:  "total shard count added in version 8.0"
+      version: " - 7.14.99"
+      reason:  "total shard count added in version 7.15.0"
   - do:
       nodes.info: {}
   - set:
@@ -341,8 +341,8 @@
 "Metric - _all for indices shards":
   - skip:
       features: [arbitrary_key]
-      version: " - 7.99.99"
-      reason:  "total shard count added in version 8.0"
+      version: " - 7.14.99"
+      reason:  "total shard count added in version 7.15.0"
   - do:
       nodes.info: {}
   - set:
@@ -360,8 +360,8 @@
 
   - skip:
       features: ["allowed_warnings", arbitrary_key]
-      version: " - 7.99.99"
-      reason:  "total shard count added in version 8.0"
+      version: " - 7.14.99"
+      reason:  "total shard count added in version 7.15.0"
 
   - do:
       indices.create:

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/stats/CommonStats.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/stats/CommonStats.java
@@ -257,6 +257,8 @@ public class CommonStats implements Writeable, ToXContentFragment {
         recoveryStats = in.readOptionalWriteable(RecoveryStats::new);
         if (in.getVersion().onOrAfter(Version.V_8_0_0)) {
             bulk = in.readOptionalWriteable(BulkStats::new);
+        }
+        if (in.getVersion().onOrAfter(Version.V_7_15_0)) {
             shards = in.readOptionalWriteable(ShardCountStats::new);
         }
     }
@@ -281,6 +283,8 @@ public class CommonStats implements Writeable, ToXContentFragment {
         out.writeOptionalWriteable(recoveryStats);
         if (out.getVersion().onOrAfter(Version.V_8_0_0)) {
             out.writeOptionalWriteable(bulk);
+        }
+        if (out.getVersion().onOrAfter(Version.V_7_15_0)) {
             out.writeOptionalWriteable(shards);
         }
     }


### PR DESCRIPTION
Re-enabling BWC tests, and updating supported versions for shard count feature after backport

This closes #75052. This commit re-enables the BWC tests. It also updates the supported version
of the shard count feature in the _nodes/stats API now that that has been backported to 7.15.