### PR TITLE
[ML] fix count ks test aggregator test consistency

### DIFF
--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/aggs/kstest/BucketCountKSTestAggregatorTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/aggs/kstest/BucketCountKSTestAggregatorTests.java
@@ -32,8 +32,8 @@ public class BucketCountKSTestAggregatorTests extends ESTestCase {
         new double[] { 40, 60, 20, 30, 30, 10, 10, 10, 10, 10 }
     );
     private static final MlAggsHelper.DoubleBucketValues LOWER_TAILED_VALUES_SPARSE = new MlAggsHelper.DoubleBucketValues(
-        new long[] { 4, 6, 2, 3, 3, 2, 1, 1, 1, 1 },
-        new double[] { 4, 6, 2, 3, 3, 2, 1, 1, 1, 1 }
+        new long[] { 4, 8, 2, 3, 3, 2, 1, 1, 1, 0 },
+        new double[] { 4, 8, 2, 3, 3, 2, 1, 1, 1, 0 }
     );
 
     private static final MlAggsHelper.DoubleBucketValues UPPER_TAILED_VALUES = new MlAggsHelper.DoubleBucketValues(


### PR DESCRIPTION
testKsTest_LowerTailedValues is failing due to distribution
issues. The random variables in the sparse case are too
uniform and causing two-sided alternative
tests to not be consistent.

closes #74909