### PR TITLE
[7.14] Avoid running all EQL BWC tasks when running check (#75743)

### DIFF
--- a/x-pack/plugin/eql/qa/mixed-node/build.gradle
+++ b/x-pack/plugin/eql/qa/mixed-node/build.gradle
@@ -58,9 +58,4 @@ for (Version bwcVersion : BuildParams.bwcVersions.wireCompatible.findAll { it.on
   tasks.register(bwcTaskName(bwcVersion)) {
     dependsOn "${baseName}#mixedClusterTest"
   }
-
-  // run these bwc tests as part of the "check" task
-  tasks.named("check").configure {
-    dependsOn "${baseName}#mixedClusterTest"
-  }
 }


### PR DESCRIPTION
Backports the following commits to 7.14:
 - Avoid running all EQL BWC tasks when running check (#75743)