### PR TITLE
[Docs] Include index param in geo_point docs

### DIFF
--- a/docs/reference/mapping/types/geo-point.asciidoc
+++ b/docs/reference/mapping/types/geo-point.asciidoc
@@ -135,6 +135,10 @@ The following parameters are accepted by `geo_point` fields:
     (two dimensions) values throw an exception and reject the whole document. Note
     that this cannot be set if the `script` parameter is used.
 
+<<mapping-index,`index`>>::
+
+    Should the field be searchable? Accepts `true` (default) and `false`.
+
 <<null-value,`null_value`>>::
 
     Accepts an geopoint value which is substituted for any explicit `null` values.


### PR DESCRIPTION
<!--
Thank you for your interest in and contributing to Elasticsearch! There
are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.
-->
Based on local testing in docker it seems that `geo_point` type fields actually support the `index` param. Docs don't seem to mention that currently.

Tested by creating an index with the following mapping on 6.8.16:
```
{
    "mappings": {
        "_doc": {
            "properties": {
                "fieldValue": {
                    "type": "geo_point",
                    "index": "false"
                }
            }
        }
    }
}
```
Also tested on 7.13.4 without nesting inside the `_doc` type.

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)? Yes
- Have you followed the [contributor guidelines](https://github.com/elastic/elasticsearch/blob/master/CONTRIBUTING.md)? Yes

Would be nice to port this back to previous versions too.