### PR TITLE
[ML] Mute PyTorchModelIT in advance of input format changes

### DIFF
--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/PyTorchModelIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/PyTorchModelIT.java
@@ -84,6 +84,7 @@ public class PyTorchModelIT extends ESRestTestCase {
         RAW_MODEL_SIZE = Base64.getDecoder().decode(BASE_64_ENCODED_MODEL).length;
     }
 
+    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/pull/75759")
     public void testEvaluate() throws IOException {
         assumeFalse("https://github.com/elastic/elasticsearch/issues/75685", Constants.OS_ARCH.equals("aarch64"));
         createModelStoreIndex();


### PR DESCRIPTION
For the changes in elastic/ml-cpp#1961 and #75759