### PR TITLE
Draft: preserve evaluated index expression and reuse for PIT search authorization 

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/shard/SearchOperationListener.java
+++ b/server/src/main/java/org/elasticsearch/index/shard/SearchOperationListener.java
@@ -87,6 +87,12 @@ public interface SearchOperationListener {
     default void onNewScrollContext(ReaderContext readerContext) {}
 
     /**
+     * Executed when a new PIT search {@link ReaderContext} was created
+     * @param readerContext the created reader context
+     */
+    default void onNewPITContext(ReaderContext readerContext) {}
+
+    /**
      * Executed when a scroll search {@link SearchContext} is freed.
      * This happens either when the scroll search execution finishes, if the
      * execution failed or if the search context as idle for and needs to be
@@ -222,6 +228,16 @@ public interface SearchOperationListener {
                     listener.onFreeScrollContext(readerContext);
                 } catch (Exception e) {
                     logger.warn(() -> new ParameterizedMessage("onFreeScrollContext listener [{}] failed", listener), e);
+                }
+            }
+        }
+
+        public void onNewPITContext(ReaderContext readerContext) {
+            for (SearchOperationListener listener : listeners) {
+                try {
+                    listener.onNewPITContext(readerContext);
+                } catch (Exception e) {
+                    logger.warn(() -> new ParameterizedMessage("onNewPITContext listener [{}] failed", listener), e);
                 }
             }
         }

--- a/server/src/main/java/org/elasticsearch/search/SearchService.java
+++ b/server/src/main/java/org/elasticsearch/search/SearchService.java
@@ -745,6 +745,7 @@ public class SearchService extends AbstractLifecycleComponent implements IndexEv
                 final ReaderContext finalReaderContext = readerContext;
                 searcherSupplier = null; // transfer ownership to reader context
                 searchOperationListener.onNewReaderContext(readerContext);
+                searchOperationListener.onNewPITContext(readerContext);
                 readerContext.addOnClose(() -> searchOperationListener.onFreeReaderContext(finalReaderContext));
                 putReaderContext(readerContext);
                 readerContext = null;

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/permission/Role.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/permission/Role.java
@@ -183,7 +183,7 @@ public class Role {
                 break;
             }
         }
-        return new IndicesAccessControl(granted, indexPermissions);
+        return new IndicesAccessControl(granted, requestedIndicesOrAliases, indexPermissions);
     }
 
     public static class Builder {

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/interceptor/SearchRequestInterceptor.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/interceptor/SearchRequestInterceptor.java
@@ -64,7 +64,8 @@ public class SearchRequestInterceptor extends FieldAndDocumentLevelSecurityReque
 
     @Override
     public boolean supports(IndicesRequest request) {
-        return request instanceof SearchRequest;
+        // unfortunately we have to skip these
+        return request instanceof SearchRequest && ((SearchRequest) request).pointInTimeBuilder() == null;
     }
 
     // package private for test

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/interceptor/ShardSearchRequestInterceptor.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/interceptor/ShardSearchRequestInterceptor.java
@@ -59,7 +59,7 @@ public class ShardSearchRequestInterceptor extends FieldAndDocumentLevelSecurity
 
     @Override
     public boolean supports(IndicesRequest request) {
-        return request instanceof ShardSearchRequest;
+        return request instanceof ShardSearchRequest && ((ShardSearchRequest)request).readerId() == null;
     }
 
     boolean dlsUsesStoredScripts(ShardSearchRequest request,


### PR DESCRIPTION
This is a draft implementation to change Security for PITs.
This has a lot of problems, but it is an example that shows how to bypass regular authorization for searches with PITs, and to defer it after the reader context has been resolved, using the evaluated index expression at the time of the PIT creation.