### PR TITLE
Fix privileges for GetRollupIndexCapabilities API (#75614)

### DIFF
--- a/docs/reference/rollup/apis/rollup-index-caps.asciidoc
+++ b/docs/reference/rollup/apis/rollup-index-caps.asciidoc
@@ -19,8 +19,9 @@ experimental[]
 [[rollup-get-rollup-index-caps-prereqs]]
 ==== {api-prereq-title}
 
-* If the {es} {security-features} are enabled, you must have the `read` index
-privilege on the index that stores the rollup results. For more information, see
+* If the {es} {security-features} are enabled, you must have any of the `read`,
+`view_index_metadata`, or `manage` <<privileges-list-indices,index privilege>>
+on the index that stores the rollup results. For more information, see
 <<security-privileges>>.
 
 [[rollup-get-rollup-index-caps-desc]]
@@ -46,7 +47,7 @@ Wildcard (`*`) expressions are supported.
 ==== {api-examples-title}
 
 Imagine we have an index named `sensor-1` full of raw data. We know that the
-data will grow over time, so there will be a `sensor-2`, `sensor-3`, etc. 
+data will grow over time, so there will be a `sensor-2`, `sensor-3`, etc.
 Let's create a {rollup-job} that stores its data in `sensor_rollup`:
 
 [source,console]
@@ -145,7 +146,7 @@ original rollup configuration, but formatted differently. First, there are some
 house-keeping details: the {rollup-job} ID, the index that holds the rolled data,
 the index pattern that the job was targeting.
 
-Next it shows a list of fields that contain data eligible for rollup searches. 
+Next it shows a list of fields that contain data eligible for rollup searches.
 Here we see four fields: `node`, `temperature`, `timestamp` and `voltage`. Each
 of these fields list the aggregations that are possible. For example, you can
 use a min, max, or sum aggregation on the `temperature` field, but only a
@@ -164,4 +165,3 @@ instead of explicit indices:
 GET /*_rollup/_rollup/data
 --------------------------------------------------
 // TEST[continued]
-

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/privilege/IndexPrivilege.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/privilege/IndexPrivilege.java
@@ -36,6 +36,7 @@ import org.elasticsearch.xpack.core.ccr.action.ForgetFollowerAction;
 import org.elasticsearch.xpack.core.ccr.action.PutFollowAction;
 import org.elasticsearch.xpack.core.ccr.action.UnfollowAction;
 import org.elasticsearch.xpack.core.ilm.action.ExplainLifecycleAction;
+import org.elasticsearch.xpack.core.rollup.action.GetRollupIndexCapsAction;
 import org.elasticsearch.xpack.core.security.support.Automatons;
 
 import java.util.Arrays;
@@ -70,14 +71,16 @@ public final class IndexPrivilege extends Privilege {
     private static final Automaton WRITE_AUTOMATON = patterns("indices:data/write/*", AutoPutMappingAction.NAME);
     private static final Automaton MONITOR_AUTOMATON = patterns("indices:monitor/*");
     private static final Automaton MANAGE_AUTOMATON =
-            unionAndMinimize(Arrays.asList(MONITOR_AUTOMATON, patterns("indices:admin/*", FieldCapabilitiesAction.NAME + "*")));
+            unionAndMinimize(Arrays.asList(MONITOR_AUTOMATON, patterns("indices:admin/*", FieldCapabilitiesAction.NAME + "*",
+                GetRollupIndexCapsAction.NAME + "*")));
     private static final Automaton CREATE_INDEX_AUTOMATON = patterns(CreateIndexAction.NAME, AutoCreateAction.NAME,
             CreateDataStreamAction.NAME);
     private static final Automaton DELETE_INDEX_AUTOMATON = patterns(DeleteIndexAction.NAME, DeleteDataStreamAction.NAME);
     private static final Automaton VIEW_METADATA_AUTOMATON = patterns(GetAliasesAction.NAME, AliasesExistAction.NAME,
         GetIndexAction.NAME, IndicesExistsAction.NAME, GetFieldMappingsAction.NAME + "*", GetMappingsAction.NAME,
         ClusterSearchShardsAction.NAME, TypesExistsAction.NAME, ValidateQueryAction.NAME + "*", GetSettingsAction.NAME,
-        ExplainLifecycleAction.NAME, GetDataStreamAction.NAME, ResolveIndexAction.NAME, FieldCapabilitiesAction.NAME + "*");
+        ExplainLifecycleAction.NAME, GetDataStreamAction.NAME, ResolveIndexAction.NAME, FieldCapabilitiesAction.NAME + "*",
+        GetRollupIndexCapsAction.NAME + "*");
     private static final Automaton MANAGE_FOLLOW_INDEX_AUTOMATON = patterns(PutFollowAction.NAME, UnfollowAction.NAME,
         CloseIndexAction.NAME + "*", PromoteDataStreamAction.NAME, RolloverAction.NAME);
     private static final Automaton MANAGE_LEADER_INDEX_AUTOMATON = patterns(ForgetFollowerAction.NAME + "*");

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/privilege/IndexPrivilegeTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/privilege/IndexPrivilegeTests.java
@@ -16,8 +16,10 @@ import org.elasticsearch.action.search.SearchAction;
 import org.elasticsearch.action.update.UpdateAction;
 import org.elasticsearch.common.util.iterable.Iterables;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.core.rollup.action.GetRollupIndexCapsAction;
 
 import org.elasticsearch.core.List;
+import java.util.Collection;
 import java.util.Set;
 
 import static org.elasticsearch.xpack.core.security.authz.privilege.IndexPrivilege.findPrivilegesThatGrant;
@@ -58,6 +60,12 @@ public class IndexPrivilegeTests extends ESTestCase {
         assertThat(findPrivilegesThatGrant(IndicesStatsAction.NAME), equalTo(List.of("monitor", "manage", "all")));
         assertThat(findPrivilegesThatGrant(RefreshAction.NAME), equalTo(List.of("maintenance", "manage", "all")));
         assertThat(findPrivilegesThatGrant(ShrinkAction.NAME), equalTo(List.of("manage", "all")));
+    }
+
+    public void testPrivilegesForRollupFieldCapsAction() {
+        final Collection<String> privileges = findPrivilegesThatGrant(GetRollupIndexCapsAction.NAME);
+        assertThat(org.elasticsearch.core.Set.copyOf(privileges),
+            equalTo(org.elasticsearch.core.Set.of("read", "view_index_metadata", "manage", "all")));
     }
 
 }


### PR DESCRIPTION
In addition to read, access to this API is now also granted by
view_index_metadata and manage.

