### PR TITLE
[ML] Don't try to respond to shutdown API when disabled

### DIFF
--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MachineLearning.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MachineLearning.java
@@ -1529,11 +1529,16 @@ public class MachineLearning extends Plugin implements SystemIndexPlugin,
 
     @Override
     public boolean safeToShutdown(String nodeId, SingleNodeShutdownMetadata.Type shutdownType) {
+        if (enabled == false) {
+            return true;
+        }
         return mlLifeCycleService.get().isNodeSafeToShutdown(nodeId);
     }
 
     @Override
     public void signalShutdown(Collection<String> shutdownNodeIds) {
-        mlLifeCycleService.get().signalGracefulShutdown(shutdownNodeIds);
+        if (enabled) {
+            mlLifeCycleService.get().signalGracefulShutdown(shutdownNodeIds);
+        }
     }
 }


### PR DESCRIPTION
The ML plugin should not try to respond to shutdown API calls
when disabled.