### PR TITLE
[ML] Adapt wire serialization code and re-enable BWC tests after backport

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -145,9 +145,9 @@ tasks.register("verifyVersions") {
  * after the backport of the backcompat code is complete.
  */
 
-boolean bwc_tests_enabled = false
+boolean bwc_tests_enabled = true
 // place a PR link here when committing bwc changes:
-String bwc_tests_disabled_issue = "https://github.com/elastic/elasticsearch/pull/75617"
+String bwc_tests_disabled_issue = ""
 /*
  * FIPS 140-2 behavior was fixed in 7.11.0. Before that there is no way to run elasticsearch in a
  * JVM that is properly configured to be in fips mode with BCFIPS. For now we need to disable

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/config/Job.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/config/Job.java
@@ -248,11 +248,7 @@ public class Job extends AbstractDiffable<Job> implements Writeable, ToXContentO
         modelSnapshotRetentionDays = in.readOptionalLong();
         dailyModelSnapshotRetentionAfterDays = in.readOptionalLong();
         resultsRetentionDays = in.readOptionalLong();
-        if (in.getVersion().onOrAfter(Version.V_8_0_0)) {  // TODO: 7.15
-            systemAnnotationsRetentionDays = in.readOptionalLong();
-        } else {
-            systemAnnotationsRetentionDays = null;
-        }
+        systemAnnotationsRetentionDays = in.readOptionalLong();
         Map<String, Object> readCustomSettings = in.readMap();
         customSettings = readCustomSettings == null ? null : Collections.unmodifiableMap(readCustomSettings);
         modelSnapshotId = in.readOptionalString();
@@ -539,9 +535,7 @@ public class Job extends AbstractDiffable<Job> implements Writeable, ToXContentO
         out.writeOptionalLong(modelSnapshotRetentionDays);
         out.writeOptionalLong(dailyModelSnapshotRetentionAfterDays);
         out.writeOptionalLong(resultsRetentionDays);
-        if (out.getVersion().onOrAfter(Version.V_8_0_0)) {  // TODO: 7.15
-            out.writeOptionalLong(systemAnnotationsRetentionDays);
-        }
+        out.writeOptionalLong(systemAnnotationsRetentionDays);
         out.writeMap(customSettings);
         out.writeOptionalString(modelSnapshotId);
         if (modelSnapshotMinVersion != null) {
@@ -795,9 +789,7 @@ public class Job extends AbstractDiffable<Job> implements Writeable, ToXContentO
             modelSnapshotRetentionDays = in.readOptionalLong();
             dailyModelSnapshotRetentionAfterDays = in.readOptionalLong();
             resultsRetentionDays = in.readOptionalLong();
-            if (in.getVersion().onOrAfter(Version.V_8_0_0)) {  // TODO: 7.15
-                systemAnnotationsRetentionDays = in.readOptionalLong();
-            }
+            systemAnnotationsRetentionDays = in.readOptionalLong();
             customSettings = in.readMap();
             modelSnapshotId = in.readOptionalString();
             if (in.readBoolean()) {
@@ -1030,9 +1022,7 @@ public class Job extends AbstractDiffable<Job> implements Writeable, ToXContentO
             out.writeOptionalLong(modelSnapshotRetentionDays);
             out.writeOptionalLong(dailyModelSnapshotRetentionAfterDays);
             out.writeOptionalLong(resultsRetentionDays);
-            if (out.getVersion().onOrAfter(Version.V_8_0_0)) {  // TODO: 7.15
-                out.writeOptionalLong(systemAnnotationsRetentionDays);
-            }
+            out.writeOptionalLong(systemAnnotationsRetentionDays);
             out.writeMap(customSettings);
             out.writeOptionalString(modelSnapshotId);
             if (modelSnapshotMinVersion != null) {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/config/JobUpdate.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/config/JobUpdate.java
@@ -142,11 +142,7 @@ public class JobUpdate implements Writeable, ToXContentObject {
         modelSnapshotRetentionDays = in.readOptionalLong();
         dailyModelSnapshotRetentionAfterDays = in.readOptionalLong();
         resultsRetentionDays = in.readOptionalLong();
-        if (in.getVersion().onOrAfter(Version.V_8_0_0)) {  // TODO: 7.15
-            systemAnnotationsRetentionDays = in.readOptionalLong();
-        } else {
-            systemAnnotationsRetentionDays = null;
-        }
+        systemAnnotationsRetentionDays = in.readOptionalLong();
         if (in.readBoolean()) {
             categorizationFilters = in.readStringList();
         } else {
@@ -187,9 +183,7 @@ public class JobUpdate implements Writeable, ToXContentObject {
         out.writeOptionalLong(modelSnapshotRetentionDays);
         out.writeOptionalLong(dailyModelSnapshotRetentionAfterDays);
         out.writeOptionalLong(resultsRetentionDays);
-        if (out.getVersion().onOrAfter(Version.V_8_0_0)) {  // TODO: 7.15
-            out.writeOptionalLong(systemAnnotationsRetentionDays);
-        }
+        out.writeOptionalLong(systemAnnotationsRetentionDays);
         out.writeBoolean(categorizationFilters != null);
         if (categorizationFilters != null) {
             out.writeStringCollection(categorizationFilters);


### PR DESCRIPTION
Finish backport of https://github.com/elastic/elasticsearch/pull/75617

Relates #75572