### PR TITLE
Enroll API to return CA cert using standard Base64

### DIFF
--- a/client/rest-high-level/qa/ssl-enabled/src/javaRestTest/java/org/elasticsearch/client/EnrollmentIT.java
+++ b/client/rest-high-level/qa/ssl-enabled/src/javaRestTest/java/org/elasticsearch/client/EnrollmentIT.java
@@ -64,7 +64,7 @@ public class EnrollmentIT  extends ESRestHighLevelClientTestCase {
         assertThat(nodeEnrollmentResponse, notNullValue());
         assertThat(nodeEnrollmentResponse.getHttpCaKey(), endsWith("K2S3vidA="));
         assertThat(nodeEnrollmentResponse.getHttpCaCert(), endsWith("LfkRjirc="));
-        assertThat(nodeEnrollmentResponse.getTransportKey(), endsWith("1I-r8vOQ=="));
+        assertThat(nodeEnrollmentResponse.getTransportKey(), endsWith("1I+r8vOQ=="));
         assertThat(nodeEnrollmentResponse.getTransportCert(), endsWith("OpTdtgJo="));
         List<String> nodesAddresses = nodeEnrollmentResponse.getNodesAddresses();
         assertThat(nodesAddresses.size(), equalTo(2));
@@ -75,7 +75,7 @@ public class EnrollmentIT  extends ESRestHighLevelClientTestCase {
             execute(highLevelClient().security()::enrollKibana, highLevelClient().security()::enrollKibanaAsync, RequestOptions.DEFAULT);
         assertThat(kibanaResponse, notNullValue());
         assertThat(kibanaResponse.getHttpCa()
-            , endsWith("brcNC5xq6YE7C4_06nH7F6le4kE4Uo6c9fpkl4ehOxQxndNLn462tFF-8VBA8IftJ1PPWzqGxLsCTzM6p6w8sa-XhgNYglLfkRjirc="));
+            , endsWith("brcNC5xq6YE7C4/06nH7F6le4kE4Uo6c9fpkl4ehOxQxndNLn462tFF+8VBA8IftJ1PPWzqGxLsCTzM6p6w8sa+XhgNYglLfkRjirc="));
         assertNotNull(kibanaResponse.getPassword());
         assertThat(kibanaResponse.getPassword().toString().length(), equalTo(14));
     }

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/enrollment/TransportKibanaEnrollmentAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/enrollment/TransportKibanaEnrollmentAction.java
@@ -91,7 +91,7 @@ public class TransportKibanaEnrollmentAction extends HandledTransportAction<Kiba
         } else {
             String httpCa;
             try {
-                httpCa = Base64.getUrlEncoder().encodeToString(caCertificates.get(0).getEncoded());
+                httpCa = Base64.getEncoder().encodeToString(caCertificates.get(0).getEncoded());
             } catch (CertificateEncodingException cee) {
                 listener.onFailure(new ElasticsearchException(
                     "Unable to enroll kibana instance. Elasticsearch node HTTP layer SSL configuration uses a malformed CA certificate",

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/enrollment/TransportNodeEnrollmentAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/enrollment/TransportNodeEnrollmentAction.java
@@ -102,12 +102,12 @@ public class TransportNodeEnrollmentAction extends HandledTransportAction<NodeEn
                     nodeList.add(nodeInfo.getInfo(TransportInfo.class).getAddress().publishAddress().toString());
                 }
                 try {
-                    final String httpCaKey = Base64.getUrlEncoder().encodeToString(httpCaKeysAndCertificates.get(0).v1().getEncoded());
-                    final String httpCaCert = Base64.getUrlEncoder().encodeToString(httpCaKeysAndCertificates.get(0).v2().getEncoded());
+                    final String httpCaKey = Base64.getEncoder().encodeToString(httpCaKeysAndCertificates.get(0).v1().getEncoded());
+                    final String httpCaCert = Base64.getEncoder().encodeToString(httpCaKeysAndCertificates.get(0).v2().getEncoded());
                     final String transportKey =
-                        Base64.getUrlEncoder().encodeToString(transportKeysAndCertificates.get(0).v1().getEncoded());
+                        Base64.getEncoder().encodeToString(transportKeysAndCertificates.get(0).v1().getEncoded());
                     final String transportCert =
-                        Base64.getUrlEncoder().encodeToString(transportKeysAndCertificates.get(0).v2().getEncoded());
+                        Base64.getEncoder().encodeToString(transportKeysAndCertificates.get(0).v2().getEncoded());
                     listener.onResponse(new NodeEnrollmentResponse(httpCaKey,
                         httpCaCert,
                         transportKey,

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/action/enrollment/TransportKibanaEnrollmentActionTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/action/enrollment/TransportKibanaEnrollmentActionTests.java
@@ -104,7 +104,7 @@ public class TransportKibanaEnrollmentActionTests extends ESTestCase {
         final KibanaEnrollmentResponse response = future.actionGet();
         assertThat(response.getHttpCa(), startsWith("MIIDSjCCAjKgAwIBAgIVALCgZXvbceUrjJaQMheDCX0kXnRJMA0GCSqGSIb3DQEBCwUAMDQxMjAw" +
             "BgNVBAMTKUVsYXN0aWMgQ2VydGlmaWNhdGUgVG9vbCBBdXRvZ2VuZXJhdGVkIENBMB4XDTIxMDQyODEyNTY0MVoXDTI0MDQyNzEyNTY0MVowNDEyMDAGA1UEA" +
-            "xMpRWxhc3RpYyBDZXJ0aWZpY2F0ZSBUb29sIEF1dG9nZW5lcmF0ZWQgQ0EwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCCJbOU4JvxDD_F"));
+            "xMpRWxhc3RpYyBDZXJ0aWZpY2F0ZSBUb29sIEF1dG9nZW5lcmF0ZWQgQ0EwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCCJbOU4JvxDD/F"));
         assertNotNull(response.getPassword());
         assertThat(changePasswordRequests.size(), equalTo(1));
     }

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/action/enrollment/TransportNodeEnrollmentActionTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/action/enrollment/TransportNodeEnrollmentActionTests.java
@@ -148,7 +148,7 @@ public class TransportNodeEnrollmentActionTests extends ESTestCase {
     private void assertSameCertificate(String cert, Path original, char[] originalPassword, boolean isCa) throws Exception{
         Map<Certificate, Key> originalKeysAndCerts = CertParsingUtils.readPkcs12KeyPairs(original, originalPassword, p -> originalPassword);
         Certificate deserializedCert = CertParsingUtils.readCertificates(
-            new ByteArrayInputStream(Base64.getUrlDecoder().decode(cert.getBytes(StandardCharsets.UTF_8)))).get(0);
+            new ByteArrayInputStream(Base64.getDecoder().decode(cert.getBytes(StandardCharsets.UTF_8)))).get(0);
         assertThat(originalKeysAndCerts, hasKey(deserializedCert));
         assertThat(deserializedCert, instanceOf(X509Certificate.class));
         if (isCa) {


### PR DESCRIPTION
Enrollment APIs (Kibana and Node) should return certs
and keys encoded by standard Base64 encoding,
not the Url safe Base64 one.
PEM files require standard Base64 encoding, so using
safe Url encoding creates unnecessary complexity.
This change changes the encoding of the standard one.

Resolves #75781