### PR TITLE
Make sure to include class name in Query hash codes

### DIFF
--- a/server/src/main/java/org/apache/lucene/queries/BinaryDocValuesRangeQuery.java
+++ b/server/src/main/java/org/apache/lucene/queries/BinaryDocValuesRangeQuery.java
@@ -116,7 +116,7 @@ public final class BinaryDocValuesRangeQuery extends Query {
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+        if (sameClassAs(o) == false) return false;
         BinaryDocValuesRangeQuery that = (BinaryDocValuesRangeQuery) o;
         return Objects.equals(fieldName, that.fieldName) &&
                 queryType == that.queryType &&
@@ -127,7 +127,7 @@ public final class BinaryDocValuesRangeQuery extends Query {
 
     @Override
     public int hashCode() {
-        return Objects.hash(getClass(), fieldName, queryType, lengthType, from, to);
+        return Objects.hash(classHash(), fieldName, queryType, lengthType, from, to);
     }
 
     public enum QueryType {

--- a/server/src/main/java/org/elasticsearch/common/lucene/search/function/ScriptScoreQuery.java
+++ b/server/src/main/java/org/elasticsearch/common/lucene/search/function/ScriptScoreQuery.java
@@ -174,7 +174,7 @@ public class ScriptScoreQuery extends Query {
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+        if (sameClassAs(o) == false) return false;
         ScriptScoreQuery that = (ScriptScoreQuery) o;
         return shardId == that.shardId &&
             subQuery.equals(that.subQuery) &&
@@ -186,7 +186,7 @@ public class ScriptScoreQuery extends Query {
 
     @Override
     public int hashCode() {
-        return Objects.hash(subQuery, script, minScore, indexName, shardId, indexVersion);
+        return Objects.hash(classHash(), subQuery, script, minScore, indexName, shardId, indexVersion);
     }
 
 

--- a/server/src/main/java/org/elasticsearch/index/query/DateRangeIncludingNowQuery.java
+++ b/server/src/main/java/org/elasticsearch/index/query/DateRangeIncludingNowQuery.java
@@ -51,13 +51,13 @@ public class DateRangeIncludingNowQuery extends Query {
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+        if (sameClassAs(o) == false) return false;
         DateRangeIncludingNowQuery that = (DateRangeIncludingNowQuery) o;
         return Objects.equals(in, that.in);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(in);
+        return Objects.hash(classHash(), in);
     }
 }

--- a/server/src/main/java/org/elasticsearch/index/search/ESToParentBlockJoinQuery.java
+++ b/server/src/main/java/org/elasticsearch/index/search/ESToParentBlockJoinQuery.java
@@ -94,7 +94,7 @@ public final class ESToParentBlockJoinQuery extends Query {
 
     @Override
     public int hashCode() {
-        return Objects.hash(getClass(), query, path);
+        return Objects.hash(classHash(), query, path);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/index/shard/ShardSplittingQuery.java
+++ b/server/src/main/java/org/elasticsearch/index/shard/ShardSplittingQuery.java
@@ -170,7 +170,7 @@ final class ShardSplittingQuery extends Query {
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+        if (sameClassAs(o) == false) return false;
 
         ShardSplittingQuery that = (ShardSplittingQuery) o;
 

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/filter/MergedPointRangeQuery.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/filter/MergedPointRangeQuery.java
@@ -172,7 +172,7 @@ public class MergedPointRangeQuery extends Query {
 
     @Override
     public boolean equals(Object obj) {
-        if (obj == null || obj.getClass() != getClass()) {
+        if (sameClassAs(obj) == false) {
             return false;
         }
         MergedPointRangeQuery other = (MergedPointRangeQuery) obj;

--- a/server/src/main/java/org/elasticsearch/search/runtime/AbstractScriptFieldQuery.java
+++ b/server/src/main/java/org/elasticsearch/search/runtime/AbstractScriptFieldQuery.java
@@ -99,12 +99,12 @@ public abstract class AbstractScriptFieldQuery<S extends AbstractFieldScript> ex
 
     @Override
     public int hashCode() {
-        return Objects.hash(getClass(), script, fieldName);
+        return Objects.hash(classHash(), script, fieldName);
     }
 
     @Override
     public boolean equals(Object obj) {
-        if (obj == null || getClass() != obj.getClass()) {
+        if (sameClassAs(obj) == false) {
             return false;
         }
         AbstractScriptFieldQuery<?> other = (AbstractScriptFieldQuery<?>) obj;

--- a/x-pack/plugin/wildcard/src/main/java/org/elasticsearch/xpack/wildcard/mapper/AutomatonQueryOnBinaryDv.java
+++ b/x-pack/plugin/wildcard/src/main/java/org/elasticsearch/xpack/wildcard/mapper/AutomatonQueryOnBinaryDv.java
@@ -90,9 +90,9 @@ public class AutomatonQueryOnBinaryDv extends Query {
 
     @Override
     public boolean equals(Object obj) {
-        if (obj == null || obj.getClass() != getClass()) {
+        if (sameClassAs(obj) == false) {
             return false;
-          }
+        }
         AutomatonQueryOnBinaryDv other = (AutomatonQueryOnBinaryDv) obj;
         return Objects.equals(field, other.field)  && Objects.equals(matchPattern, other.matchPattern)
             && Objects.equals(bytesMatcher, other.bytesMatcher);
@@ -100,7 +100,7 @@ public class AutomatonQueryOnBinaryDv extends Query {
 
     @Override
     public int hashCode() {
-        return Objects.hash(field, matchPattern, bytesMatcher);
+        return Objects.hash(classHash(), field, matchPattern, bytesMatcher);
     }
 
 }


### PR DESCRIPTION
In some Query subclasses, we forgot to include the class name when computing
hashCode. This could increase the chance of collision between query hash codes.
Hash code collisions shouldn't affect correctness, but could change query
caching behavior since UsageTrackingQueryCachingPolicy tracks query frequency
based on hash codes.

The PR also simplifies some 'equals' methods to use the helper method
sameClassAs.