### PR TITLE
[7.x] [ML] Ignore exceptions while opening job after SIGTERM to JVM (#75850)

### DIFF
--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/process/autodetect/AutodetectProcessManager.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/process/autodetect/AutodetectProcessManager.java
@@ -222,6 +222,10 @@ public class AutodetectProcessManager implements ClusterStateListener {
         }
     }
 
+    public boolean isNodeDying() {
+        return nodeDying;
+    }
+
     /**
      * Makes open jobs on this node go through the motions of closing but
      * without completing the persistent task and instead telling the

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/task/OpenJobPersistentTasksExecutor.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/task/OpenJobPersistentTasksExecutor.java
@@ -196,6 +196,9 @@ public class OpenJobPersistentTasksExecutor extends AbstractJobPersistentTasksEx
     }
 
     @Override
+    // Exceptions that occur while the node is dying, i.e. after the JVM has received a SIGTERM,
+    // are ignored.  Core services will be stopping in response to the SIGTERM and we want the
+    // job to try to open again on another node, not spuriously fail on the dying node.
     protected void nodeOperation(AllocatedPersistentTask task, OpenJobAction.JobParams params, PersistentTaskState state) {
         JobTask jobTask = (JobTask) task;
         jobTask.setAutodetectProcessManager(autodetectProcessManager);
@@ -205,13 +208,17 @@ public class OpenJobPersistentTasksExecutor extends AbstractJobPersistentTasksEx
             mappingsUpdate -> jobResultsProvider.setRunningForecastsToFailed(params.getJobId(), ActionListener.wrap(
                 r -> runJob(jobTask, jobState, params),
                 e -> {
-                    logger.warn(new ParameterizedMessage("[{}] failed to set forecasts to failed", params.getJobId()), e);
-                    runJob(jobTask, jobState, params);
+                    if (autodetectProcessManager.isNodeDying() == false) {
+                        logger.warn(new ParameterizedMessage("[{}] failed to set forecasts to failed", params.getJobId()), e);
+                        runJob(jobTask, jobState, params);
+                    }
                 }
             )),
             e -> {
-                logger.error(new ParameterizedMessage("[{}] Failed to update results mapping", params.getJobId()), e);
-                jobTask.markAsFailed(e);
+                if (autodetectProcessManager.isNodeDying() == false) {
+                    logger.error(new ParameterizedMessage("[{}] Failed to update results mapping", params.getJobId()), e);
+                    jobTask.markAsFailed(e);
+                }
             }
         );
         // We need to update the results index as we MAY update the current forecast results, setting the running forcasts to failed
@@ -225,7 +232,16 @@ public class OpenJobPersistentTasksExecutor extends AbstractJobPersistentTasksEx
             resultsMappingUpdateHandler);
     }
 
+    // Exceptions that occur while the node is dying, i.e. after the JVM has received a SIGTERM,
+    // are ignored.  Core services will be stopping in response to the SIGTERM and we want the
+    // job to try to open again on another node, not spuriously fail on the dying node.
     private void runJob(JobTask jobTask, JobState jobState, OpenJobAction.JobParams params) {
+        // If the node is already running its exit handlers then do nothing - shortly
+        // the persistent task will get assigned to a new node and the code below will
+        // run there instead.
+        if (autodetectProcessManager.isNodeDying()) {
+            return;
+        }
         // If the job is closing, simply stop and return
         if (JobState.CLOSING.equals(jobState)) {
             // Mark as completed instead of using `stop` as stop assumes native processes have started
@@ -246,12 +262,23 @@ public class OpenJobPersistentTasksExecutor extends AbstractJobPersistentTasksEx
 
                     // This job has a running datafeed attached to it.
                     // In order to prevent gaps in the model we revert to the current snapshot deleting intervening results.
-                    revertToCurrentSnapshot(jobTask.getJobId(), ActionListener.wrap(response -> openJob(jobTask), jobTask::markAsFailed));
+                    revertToCurrentSnapshot(jobTask.getJobId(), ActionListener.wrap(
+                        response -> openJob(jobTask),
+                        e -> {
+                            if (autodetectProcessManager.isNodeDying() == false) {
+                                jobTask.markAsFailed(e);
+                            }
+                        }
+                    ));
                 } else {
                     openJob(jobTask);
                 }
             },
-            jobTask::markAsFailed
+            e -> {
+                if (autodetectProcessManager.isNodeDying() == false) {
+                    jobTask.markAsFailed(e);
+                }
+            }
         );
 
         hasRunningDatafeedTask(jobTask.getJobId(), hasRunningDatafeedTaskListener);
@@ -322,6 +349,9 @@ public class OpenJobPersistentTasksExecutor extends AbstractJobPersistentTasksEx
         executeAsyncWithOrigin(client, ML_ORIGIN, GetJobsAction.INSTANCE, request, jobListener);
     }
 
+    // Exceptions that occur while the node is dying, i.e. after the JVM has received a SIGTERM,
+    // are ignored.  Core services will be stopping in response to the SIGTERM and we want the
+    // job to try to open again on another node, not spuriously fail on the dying node.
     private void openJob(JobTask jobTask) {
         String jobId = jobTask.getJobId();
         autodetectProcessManager.openJob(jobTask, clusterState, PERSISTENT_TASK_MASTER_NODE_TIMEOUT, (e2, shouldFinalizeJob) -> {
@@ -337,11 +367,17 @@ public class OpenJobPersistentTasksExecutor extends AbstractJobPersistentTasksEx
                         ActionListener.wrap(
                             response -> jobTask.markAsCompleted(),
                             e -> {
+                                // This error is logged even if the node is dying.  This is a nasty place for the node to get killed,
+                                // as most of the job's close sequence has executed, just not the finalization step.  The job will
+                                // restart on a different node.  If the coordinating node for the close request notices that the job
+                                // changed nodes while waiting for it to close then it will remove the persistent task, which should
+                                // stop the job doing anything significant on its new node.  However, the finish time of the job will
+                                // not be set correctly.
                                 logger.error(new ParameterizedMessage("[{}] error finalizing job", jobId), e);
                                 Throwable unwrapped = ExceptionsHelper.unwrapCause(e);
                                 if (unwrapped instanceof DocumentMissingException || unwrapped instanceof ResourceNotFoundException) {
                                     jobTask.markAsCompleted();
-                                } else {
+                                } else if (autodetectProcessManager.isNodeDying() == false) {
                                     jobTask.markAsFailed(e);
                                 }
                             }
@@ -349,7 +385,7 @@ public class OpenJobPersistentTasksExecutor extends AbstractJobPersistentTasksEx
                 } else {
                     jobTask.markAsCompleted();
                 }
-            } else {
+            } else if (autodetectProcessManager.isNodeDying() == false) {
                 jobTask.markAsFailed(e2);
             }
         });


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [ML] Ignore exceptions while opening job after SIGTERM to JVM (#75850)