### PR TITLE
[7.13] Suggest DEBUG level logging instead for SAML (#74661)

### DIFF
--- a/x-pack/docs/en/security/troubleshooting.asciidoc
+++ b/x-pack/docs/en/security/troubleshooting.asciidoc
@@ -682,19 +682,19 @@ the `basic` `authProvider` in {kib}. The process is documented in the
 
 *Logging:*
 
-Very detailed trace logging can be enabled specifically for the SAML realm by
-setting the following transient setting:
+If the previous resolutions do not solve your issue, enable additional
+logging for the SAML realm to troubleshoot further. You can enable debug
+logging by configuring the following transient setting:
 
-[source, shell]
------------------------------------------------
+[source, console]
+----
 PUT /_cluster/settings
 {
   "transient": {
-    "logger.org.elasticsearch.xpack.security.authc.saml": "trace"
+    "logger.org.elasticsearch.xpack.security.authc.saml": "debug"
   }
 }
------------------------------------------------
-
+----
 
 Alternatively, you can add the following lines to the end of the
 `log4j2.properties` configuration file in the `ES_PATH_CONF`:
@@ -702,8 +702,11 @@ Alternatively, you can add the following lines to the end of the
 [source,properties]
 ----------------
 logger.saml.name = org.elasticsearch.xpack.security.authc.saml
-logger.saml.level = TRACE
+logger.saml.level = DEBUG
 ----------------
+
+Refer to <<configuring-logging-levels,configuring logging levels>> for more
+information.
 
 [[trb-security-internalserver]]
 === Internal Server Error in Kibana


### PR DESCRIPTION
Backports the following commits to 7.13:
 - Suggest DEBUG level logging instead for SAML (#74661)