### PR TITLE
[ML] when setting upgrade mode ensure that internal actions don't throw unnecessary permissions errors

### DIFF
--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportSetUpgradeModeAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportSetUpgradeModeAction.java
@@ -17,6 +17,7 @@ import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.master.AcknowledgedResponse;
 import org.elasticsearch.action.support.master.AcknowledgedTransportMasterNodeAction;
 import org.elasticsearch.client.Client;
+import org.elasticsearch.client.OriginSettingClient;
 import org.elasticsearch.cluster.AckedClusterStateUpdateTask;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.block.ClusterBlockException;
@@ -48,7 +49,6 @@ import java.util.stream.Collectors;
 
 import static org.elasticsearch.ExceptionsHelper.rethrowAndSuppress;
 import static org.elasticsearch.xpack.core.ClientHelper.ML_ORIGIN;
-import static org.elasticsearch.xpack.core.ClientHelper.executeAsyncWithOrigin;
 import static org.elasticsearch.xpack.core.ml.MlTasks.AWAITING_UPGRADE;
 import static org.elasticsearch.xpack.core.ml.MlTasks.DATAFEED_TASK_NAME;
 import static org.elasticsearch.xpack.core.ml.MlTasks.JOB_TASK_NAME;
@@ -63,7 +63,7 @@ public class TransportSetUpgradeModeAction extends AcknowledgedTransportMasterNo
     private final PersistentTasksClusterService persistentTasksClusterService;
     private final PersistentTasksService persistentTasksService;
     private final ClusterService clusterService;
-    private final Client client;
+    private final OriginSettingClient client;
 
     @Inject
     public TransportSetUpgradeModeAction(TransportService transportService, ThreadPool threadPool, ClusterService clusterService,
@@ -74,7 +74,7 @@ public class TransportSetUpgradeModeAction extends AcknowledgedTransportMasterNo
             indexNameExpressionResolver, ThreadPool.Names.SAME);
         this.persistentTasksClusterService = persistentTasksClusterService;
         this.clusterService = clusterService;
-        this.client = client;
+        this.client = new OriginSettingClient(client, ML_ORIGIN);
         this.persistentTasksService = persistentTasksService;
     }
 
@@ -309,7 +309,7 @@ public class TransportSetUpgradeModeAction extends AcknowledgedTransportMasterNo
         datafeedsToIsolate.forEach(datafeedId -> {
             IsolateDatafeedAction.Request isolationRequest = new IsolateDatafeedAction.Request(datafeedId);
             isolateDatafeedsExecutor.add(isolateListener ->
-                executeAsyncWithOrigin(client, ML_ORIGIN, IsolateDatafeedAction.INSTANCE, isolationRequest, isolateListener)
+                client.execute(IsolateDatafeedAction.INSTANCE, isolationRequest, isolateListener)
             );
         });
 


### PR DESCRIPTION
When setting upgrade mode, if the calling user has very specific permissions, it may be they get an error stating
they don't have permissions to list tasks.

This would have been because we were not listing the tasks from the ML_ORIGIN. This would have been a fairly rare
occurrence as setting upgrade mode is an admin action.