### PR TITLE
[Rest Api Compatibility] Allow first empty line for msearch

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/search/MultiSearchRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/search/MultiSearchRequest.java
@@ -53,7 +53,9 @@ public class MultiSearchRequest extends ActionRequest implements CompositeIndice
     private static final DeprecationLogger deprecationLogger = DeprecationLogger.getLogger(RestSearchAction.class);
     public static final String TYPES_DEPRECATION_MESSAGE = "[types removal]" +
         " Specifying types in search requests is deprecated.";
-
+    public static final String FIRST_LINE_EMPTY_DEPRECATION_MESSAGE =
+        "support for empty first line before any action metadata in msearch API is deprecated " +
+            "and will be removed in the next major version";
     public static final int MAX_CONCURRENT_SEARCH_REQUESTS_DEFAULT = 0;
 
     private int maxConcurrentSearchRequests = 0;
@@ -185,6 +187,13 @@ public class MultiSearchRequest extends ActionRequest implements CompositeIndice
             if (nextMarker == -1) {
                 break;
             }
+            // support first line with \n
+            if (restApiVersion == RestApiVersion.V_7 && nextMarker == 0) {
+                deprecationLogger.compatibleApiWarning("msearch_first_line_empty", FIRST_LINE_EMPTY_DEPRECATION_MESSAGE);
+                from = nextMarker + 1;
+                continue;
+            }
+
             SearchRequest searchRequest = new SearchRequest();
             if (indices != null) {
                 searchRequest.indices(indices);

--- a/server/src/test/java/org/elasticsearch/action/search/MultiSearchRequestTests.java
+++ b/server/src/test/java/org/elasticsearch/action/search/MultiSearchRequestTests.java
@@ -209,10 +209,15 @@ public class MultiSearchRequestTests extends ESTestCase {
         assertEquals(3, msearchRequest.requests().size());
     }
 
+    private MultiSearchRequest parseMultiSearchRequestFromString(String request, RestApiVersion restApiVersion) throws IOException {
+        return parseMultiSearchRequest(createRestRequest(request.getBytes(StandardCharsets.UTF_8), restApiVersion));
+    }
+
     private MultiSearchRequest parseMultiSearchRequest(String sample) throws IOException {
-        byte[] data = StreamsUtils.copyToBytesFromClasspath(sample);
-        RestRequest restRequest = new FakeRestRequest.Builder(xContentRegistry())
-            .withContent(new BytesArray(data), XContentType.JSON).build();
+        return parseMultiSearchRequest(createRestRequest(sample, null));
+    }
+
+    private MultiSearchRequest parseMultiSearchRequest(RestRequest restRequest) throws IOException {
 
         MultiSearchRequest request = new MultiSearchRequest();
         RestMultiSearchAction.parseMultiLineRequest(restRequest, SearchRequest.DEFAULT_INDICES_OPTIONS, true,
@@ -222,6 +227,26 @@ public class MultiSearchRequestTests extends ESTestCase {
             });
         return request;
     }
+
+    private RestRequest createRestRequest(String sample, RestApiVersion restApiVersion) throws IOException {
+        byte[] data = StreamsUtils.copyToBytesFromClasspath(sample);
+        return createRestRequest(data, restApiVersion);
+    }
+
+    private FakeRestRequest createRestRequest(byte[] data, RestApiVersion restApiVersion) {
+        if (restApiVersion != null) {
+            final List<String> contentTypeHeader =
+                Collections.singletonList(compatibleMediaType(XContentType.VND_JSON, RestApiVersion.V_7));
+            return new FakeRestRequest.Builder(xContentRegistry())
+                .withHeaders(Map.of("Content-Type", contentTypeHeader, "Accept", contentTypeHeader))
+                .withContent(new BytesArray(data), null)
+                .build();
+        } else {
+            return new FakeRestRequest.Builder(xContentRegistry())
+                .withContent(new BytesArray(data), XContentType.JSON).build();
+        }
+    }
+
 
     @Override
     protected NamedXContentRegistry xContentRegistry() {
@@ -269,6 +294,48 @@ public class MultiSearchRequestTests extends ESTestCase {
             randomBoolean(), randomBoolean(), randomBoolean()), "hidden");
         assertExpandWildcardsValue(IndicesOptions.fromOptions(randomBoolean(), randomBoolean(), false, false, false, randomBoolean(),
             randomBoolean(), randomBoolean(), randomBoolean()), "none");
+    }
+
+    public void testEmptyFirstLine1() throws Exception {
+        MultiSearchRequest request = parseMultiSearchRequestFromString(
+            "\n" +
+                "\n" +
+                "{ \"query\": {\"match_all\": {}}}\n" +
+                "{}\n" +
+                "{ \"query\": {\"match_all\": {}}}\n" +
+                "\n" +
+                "{ \"query\": {\"match_all\": {}}}\n" +
+                "{}\n" +
+                "{ \"query\": {\"match_all\": {}}}\n",
+            RestApiVersion.V_7);
+        assertThat(request.requests().size(), equalTo(4));
+        for (SearchRequest searchRequest : request.requests()) {
+            assertThat(searchRequest.indices().length, equalTo(0));
+            assertThat(searchRequest.source().query(), instanceOf(MatchAllQueryBuilder.class));
+        }
+        assertWarnings("support for empty first line before any action metadata in msearch API is deprecated and will be removed " +
+            "in the next major version");
+    }
+
+    public void testEmptyFirstLine2() throws Exception {
+        MultiSearchRequest request = parseMultiSearchRequestFromString(
+            "\n" +
+                "{}\n" +
+                "{ \"query\": {\"match_all\": {}}}\n" +
+                "\n" +
+                "{ \"query\": {\"match_all\": {}}}\n" +
+                "{}\n" +
+                "{ \"query\": {\"match_all\": {}}}\n" +
+                "\n" +
+                "{ \"query\": {\"match_all\": {}}}\n",
+            RestApiVersion.V_7);
+        assertThat(request.requests().size(), equalTo(4));
+        for (SearchRequest searchRequest : request.requests()) {
+            assertThat(searchRequest.indices().length, equalTo(0));
+            assertThat(searchRequest.source().query(), instanceOf(MatchAllQueryBuilder.class));
+        }
+        assertWarnings("support for empty first line before any action metadata in msearch API is deprecated and will be removed " +
+            "in the next major version");
     }
 
     private void assertExpandWildcardsValue(IndicesOptions options, String expectedValue) throws IOException {

--- a/server/src/test/resources/org/elasticsearch/action/search/msearch-empty-first-line1.json
+++ b/server/src/test/resources/org/elasticsearch/action/search/msearch-empty-first-line1.json
@@ -1,0 +1,9 @@
+
+
+{ "query": {"match_all": {}}}
+{}
+{ "query": {"match_all": {}}}
+
+{ "query": {"match_all": {}}}
+{}
+{ "query": {"match_all": {}}}

--- a/server/src/test/resources/org/elasticsearch/action/search/msearch-empty-first-line2.json
+++ b/server/src/test/resources/org/elasticsearch/action/search/msearch-empty-first-line2.json
@@ -1,0 +1,10 @@
+
+
+{}
+{ "query": {"match_all": {}}}
+
+{ "query": {"match_all": {}}}
+{}
+{ "query": {"match_all": {}}}
+
+{ "query": {"match_all": {}}}


### PR DESCRIPTION
The support for this lenient behaviour was removed in #41011
however since this is a change that affects a request shape it should
still be available to use it in rest api compatibility

relates #51816

<!--
Thank you for your interest in and contributing to Elasticsearch! There
are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.
-->

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/elasticsearch/blob/master/CONTRIBUTING.md)?
- If submitting code, have you built your formula locally prior to submission with `gradle check`?
- If submitting code, is your pull request against master? Unless there is a good reason otherwise, we prefer pull requests against master and will backport as needed.
- If submitting code, have you checked that your submission is for an [OS and architecture that we support](https://www.elastic.co/support/matrix#show_os)?
- If you are submitting this code for a class then read our [policy](https://github.com/elastic/elasticsearch/blob/master/CONTRIBUTING.md#contributing-as-part-of-a-class) for that.
