### PR TITLE
[ML] Unmute PyTorchModelIT.testEvaluate on Aarch64

### DIFF
--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/PyTorchModelIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/PyTorchModelIT.java
@@ -8,7 +8,6 @@
 package org.elasticsearch.xpack.ml.integration;
 
 import org.apache.http.util.EntityUtils;
-import org.apache.lucene.util.Constants;
 import org.elasticsearch.client.Request;
 import org.elasticsearch.client.Response;
 import org.elasticsearch.common.settings.Settings;
@@ -86,7 +85,6 @@ public class PyTorchModelIT extends ESRestTestCase {
 
     @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/pull/75759")
     public void testEvaluate() throws IOException {
-        assumeFalse("https://github.com/elastic/elasticsearch/issues/75685", Constants.OS_ARCH.equals("aarch64"));
         createModelStoreIndex();
         putTaskConfig();
         putModelDefinition();


### PR DESCRIPTION
It stands a chance of working now due to
https://github.com/elastic/ml-cpp/pull/1974