### PR TITLE
Fix Force Merge Action Invoking a Listener Twice

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/admin/indices/forcemerge/TransportForceMergeAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/forcemerge/TransportForceMergeAction.java
@@ -70,13 +70,13 @@ public class TransportForceMergeAction
     @Override
     protected void shardOperation(ForceMergeRequest request, ShardRouting shardRouting, Task task,
                                   ActionListener<TransportBroadcastByNodeAction.EmptyResult> listener) {
-        threadPool.executor(ThreadPool.Names.FORCE_MERGE).execute(ActionRunnable.run(listener,
+        assert (task instanceof CancellableTask) == false; // TODO: add cancellation handling here once the task supports it
+        threadPool.executor(ThreadPool.Names.FORCE_MERGE).execute(ActionRunnable.supply(listener,
             () -> {
-                assert (task instanceof CancellableTask) == false; // TODO: add cancellation handling here once the task supports it
                 IndexShard indexShard = indicesService.indexServiceSafe(shardRouting.shardId().getIndex())
                     .getShard(shardRouting.shardId().id());
                 indexShard.forceMerge(request);
-                listener.onResponse(EmptyResult.INSTANCE);
+                return EmptyResult.INSTANCE;
             }));
     }
 


### PR DESCRIPTION
Just a noisy thing, this isn't causing a bug since the listener is of
the notify-once kind here but still no need to call the listener redundantly with `null`
in `ActionRunnable.run` when we already resolve it with the correct response.
