### PR TITLE
Fix SnapshotInfo#toXContent delegation

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/create/CreateSnapshotResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/create/CreateSnapshotResponse.java
@@ -95,7 +95,7 @@ public class CreateSnapshotResponse extends ActionResponse implements ToXContent
         builder.startObject();
         if (snapshotInfo != null) {
             builder.field("snapshot");
-            snapshotInfo.toXContent(builder, params);
+            snapshotInfo.toXContentExternal(builder, params);
         } else {
             builder.field("accepted", true);
         }

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/get/GetSnapshotsResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/get/GetSnapshotsResponse.java
@@ -127,7 +127,7 @@ public class GetSnapshotsResponse extends ActionResponse implements ToXContentOb
         builder.startObject();
         builder.startArray("snapshots");
         for (SnapshotInfo snapshotInfo : snapshots) {
-            snapshotInfo.toXContent(builder, params);
+            snapshotInfo.toXContentExternal(builder, params);
         }
         builder.endArray();
         if (failures.isEmpty() == false) {

--- a/server/src/main/java/org/elasticsearch/snapshots/SnapshotInfo.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/SnapshotInfo.java
@@ -715,7 +715,8 @@ public final class SnapshotInfo implements Comparable<SnapshotInfo>, ToXContentF
     }
 
     /**
-     * Serialize this {@link SnapshotInfo} for external consumption, i.e. REST responses, from which we don't need to be able to read it back again.
+     * Serialize this {@link SnapshotInfo} for external consumption, i.e. REST responses, from which we don't need to be able to read it
+     * back again.
      */
     public XContentBuilder toXContentExternal(final XContentBuilder builder, final ToXContent.Params params) throws IOException {
         assert Metadata.CONTEXT_MODE_SNAPSHOT.equals(params.param(Metadata.CONTEXT_MODE_PARAM)) == false

--- a/server/src/main/java/org/elasticsearch/snapshots/SnapshotInfo.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/SnapshotInfo.java
@@ -716,7 +716,7 @@ public final class SnapshotInfo implements Comparable<SnapshotInfo>, ToXContentF
 
     /**
      * Serialize this {@link SnapshotInfo} for external consumption, i.e. REST responses, from which we don't need to be able to read it
-     * back again.
+     * back again. This method builds a well-formed object, not a fragment like {@link #toXContent} does.
      */
     public XContentBuilder toXContentExternal(final XContentBuilder builder, final ToXContent.Params params) throws IOException {
         assert Metadata.CONTEXT_MODE_SNAPSHOT.equals(params.param(Metadata.CONTEXT_MODE_PARAM)) == false

--- a/server/src/main/java/org/elasticsearch/snapshots/SnapshotInfo.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/SnapshotInfo.java
@@ -21,6 +21,7 @@ import org.elasticsearch.common.xcontent.ConstructingObjectParser;
 import org.elasticsearch.common.xcontent.ObjectParser;
 import org.elasticsearch.common.xcontent.ParseField;
 import org.elasticsearch.common.xcontent.ToXContent;
+import org.elasticsearch.common.xcontent.ToXContentFragment;
 import org.elasticsearch.common.xcontent.ToXContentObject;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
@@ -43,7 +44,7 @@ import java.util.Objects;
 /**
  * Information about a snapshot
  */
-public final class SnapshotInfo implements Comparable<SnapshotInfo>, ToXContent, Writeable {
+public final class SnapshotInfo implements Comparable<SnapshotInfo>, ToXContentFragment, Writeable {
 
     public static final String INDEX_DETAILS_XCONTENT_PARAM = "index_details";
     public static final String INCLUDE_REPOSITORY_XCONTENT_PARAM = "include_repository";
@@ -713,12 +714,12 @@ public final class SnapshotInfo implements Comparable<SnapshotInfo>, ToXContent,
         );
     }
 
-    @Override
-    public XContentBuilder toXContent(final XContentBuilder builder, final Params params) throws IOException {
-        // write snapshot info to repository snapshot blob format
-        if (Metadata.CONTEXT_MODE_SNAPSHOT.equals(params.param(Metadata.CONTEXT_MODE_PARAM))) {
-            return toXContentInternal(builder, params);
-        }
+    /**
+     * Serialize this {@link SnapshotInfo} for external consumption, i.e. REST responses, from which we don't need to be able to read it back again.
+     */
+    public XContentBuilder toXContentExternal(final XContentBuilder builder, final ToXContent.Params params) throws IOException {
+        assert Metadata.CONTEXT_MODE_SNAPSHOT.equals(params.param(Metadata.CONTEXT_MODE_PARAM)) == false
+            : "use toXContent() in SNAPSHOT context";
 
         final boolean verbose = params.paramAsBoolean("verbose", GetSnapshotsRequest.DEFAULT_VERBOSE_MODE);
         // write snapshot info for the API and any other situations
@@ -802,7 +803,11 @@ public final class SnapshotInfo implements Comparable<SnapshotInfo>, ToXContent,
         return builder;
     }
 
-    private XContentBuilder toXContentInternal(final XContentBuilder builder, final ToXContent.Params params) throws IOException {
+    @Override
+    public XContentBuilder toXContent(final XContentBuilder builder, final ToXContent.Params params) throws IOException {
+        assert Metadata.CONTEXT_MODE_SNAPSHOT.equals(params.param(Metadata.CONTEXT_MODE_PARAM))
+            : "use toXContentExternal() in external context";
+
         builder.startObject(SNAPSHOT);
         final SnapshotId snapshotId = snapshot.getSnapshotId();
         builder.field(NAME, snapshotId.getName());


### PR DESCRIPTION
Today `SnapshotInfo#toXContent` returns a well-formed object in
`SNAPSHOT` context but a fragment in other contexts, which is pretty
confusing: `ToXContent#isFragment` doesn't let you change your mind
based on the context.

With this commit we remove the delegation and have
`CreateSnapshotResponse` and `GetSnapshotsResponse` call a dedicated
`toXContentExternal` method.