### PR TITLE
Changing wait_for_snapshot to check start time rather than finish time

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/WaitForSnapshotStep.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/WaitForSnapshotStep.java
@@ -6,6 +6,8 @@
  */
 package org.elasticsearch.xpack.core.ilm;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.common.xcontent.ToXContentObject;
@@ -19,18 +21,19 @@ import java.util.Objects;
 
 /***
  * A step that waits for snapshot to be taken by SLM to ensure we have backup before we delete the index.
- * It will signal error if it can't get data needed to do the check (phase time from ILM and SLM metadata)
- * and will only return success if execution of SLM policy took place after index entered deleted phase.
+ * It will signal error if it can't get data needed to do the check (action time from ILM and SLM metadata)
+ * and will only return success if execution of SLM policy took place after index entered the wait for snapshot action.
  */
 public class WaitForSnapshotStep extends ClusterStateWaitStep {
 
     static final String NAME = "wait-for-snapshot";
+    private static final Logger logger = LogManager.getLogger(WaitForSnapshotStep.class);
 
     private static final String MESSAGE_FIELD = "message";
     private static final String POLICY_NOT_EXECUTED_MESSAGE = "waiting for policy '%s' to be executed since %s";
     private static final String POLICY_NOT_FOUND_MESSAGE = "configured policy '%s' not found";
     private static final String NO_INDEX_METADATA_MESSAGE = "no index metadata found for index '%s'";
-    private static final String NO_PHASE_TIME_MESSAGE = "no information about ILM phase start in index metadata for index '%s'";
+    private static final String NO_ACTION_TIME_MESSAGE = "no information about ILM action start in index metadata for index '%s'";
 
     private final String policy;
 
@@ -46,10 +49,10 @@ public class WaitForSnapshotStep extends ClusterStateWaitStep {
             throw error(NO_INDEX_METADATA_MESSAGE, index.getName());
         }
 
-        Long phaseTime = LifecycleExecutionState.fromIndexMetadata(indexMetadata).getPhaseTime();
+        Long actionTime = LifecycleExecutionState.fromIndexMetadata(indexMetadata).getActionTime();
 
-        if (phaseTime == null) {
-            throw error(NO_PHASE_TIME_MESSAGE, index.getName());
+        if (actionTime == null) {
+            throw error(NO_ACTION_TIME_MESSAGE, index.getName());
         }
 
         SnapshotLifecycleMetadata snapMeta = clusterState.metadata().custom(SnapshotLifecycleMetadata.TYPE);
@@ -57,10 +60,30 @@ public class WaitForSnapshotStep extends ClusterStateWaitStep {
             throw error(POLICY_NOT_FOUND_MESSAGE, policy);
         }
         SnapshotLifecyclePolicyMetadata snapPolicyMeta = snapMeta.getSnapshotConfigurations().get(policy);
-        if (snapPolicyMeta.getLastSuccess() == null || snapPolicyMeta.getLastSuccess().getTimestamp() < phaseTime) {
-            return new Result(false, notExecutedMessage(phaseTime));
+        if (snapPolicyMeta.getLastSuccess() == null || snapPolicyMeta.getLastSuccess().getSnapshotStartTimestamp() == null ||
+            snapPolicyMeta.getLastSuccess().getSnapshotStartTimestamp() < actionTime) {
+            if (snapPolicyMeta.getLastSuccess() == null) {
+                logger.debug("skipping ILM policy execution because there is no last snapshot success, action time: {}", actionTime);
+            } else if (snapPolicyMeta.getLastSuccess().getSnapshotStartTimestamp() == null) {
+                /*
+                 * This is because we are running in mixed cluster mode, and the snapshot was taken on an older master, which then went
+                 * down before this check could happen. We'll wait until a snapshot is taken on this newer master before passing this check.
+                 */
+                logger.debug("skipping ILM policy execution because no last snapshot start date, action time: {}", actionTime);
+            }
+            else {
+                logger.debug("skipping ILM policy execution because snapshot start time {} is before action time {}, snapshot timestamp " +
+                        "is {}",
+                    snapPolicyMeta.getLastSuccess().getSnapshotStartTimestamp(),
+                    actionTime,
+                    snapPolicyMeta.getLastSuccess().getSnapshotFinishTimestamp());
+            }
+            return new Result(false, notExecutedMessage(actionTime));
         }
-
+        logger.debug("executing policy because snapshot start time {} is after action time {}, snapshot timestamp is {}",
+            snapPolicyMeta.getLastSuccess().getSnapshotStartTimestamp(),
+            actionTime,
+            snapPolicyMeta.getLastSuccess().getSnapshotFinishTimestamp());
         return new Result(true, null);
     }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/slm/SnapshotInvocationRecord.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/slm/SnapshotInvocationRecord.java
@@ -7,16 +7,18 @@
 
 package org.elasticsearch.xpack.core.slm;
 
+import org.elasticsearch.Version;
 import org.elasticsearch.cluster.AbstractDiffable;
 import org.elasticsearch.cluster.Diffable;
-import org.elasticsearch.common.xcontent.ParseField;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.xcontent.ConstructingObjectParser;
+import org.elasticsearch.common.xcontent.ParseField;
 import org.elasticsearch.common.xcontent.ToXContentObject;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.core.Nullable;
 
 import java.io.IOException;
 import java.util.Objects;
@@ -29,19 +31,22 @@ public class SnapshotInvocationRecord extends AbstractDiffable<SnapshotInvocatio
     implements Writeable, ToXContentObject, Diffable<SnapshotInvocationRecord> {
 
     static final ParseField SNAPSHOT_NAME = new ParseField("snapshot_name");
+    static final ParseField START_TIMESTAMP = new ParseField("start_time");
     static final ParseField TIMESTAMP = new ParseField("time");
     static final ParseField DETAILS = new ParseField("details");
 
     private String snapshotName;
-    private long timestamp;
+    private Long snapshotStartTimestamp;
+    private long snapshotFinishTimestamp;
     private String details;
 
     public static final ConstructingObjectParser<SnapshotInvocationRecord, String> PARSER =
         new ConstructingObjectParser<>("snapshot_policy_invocation_record", true,
-            a -> new SnapshotInvocationRecord((String) a[0], (long) a[1], (String) a[2]));
+            a -> new SnapshotInvocationRecord((String) a[0], (Long) a[1], (long) a[2], (String) a[3]));
 
     static {
         PARSER.declareString(ConstructingObjectParser.constructorArg(), SNAPSHOT_NAME);
+        PARSER.declareLong(ConstructingObjectParser.optionalConstructorArg(), START_TIMESTAMP);
         PARSER.declareLong(ConstructingObjectParser.constructorArg(), TIMESTAMP);
         PARSER.declareString(ConstructingObjectParser.optionalConstructorArg(), DETAILS);
     }
@@ -50,15 +55,21 @@ public class SnapshotInvocationRecord extends AbstractDiffable<SnapshotInvocatio
         return PARSER.apply(parser, name);
     }
 
-    public SnapshotInvocationRecord(String snapshotName, long timestamp, String details) {
+    public SnapshotInvocationRecord(String snapshotName, Long snapshotStartTimestamp, long snapshotFinishTimestamp, String details) {
         this.snapshotName = Objects.requireNonNull(snapshotName, "snapshot name must be provided");
-        this.timestamp = timestamp;
+        this.snapshotStartTimestamp = snapshotStartTimestamp;
+        this.snapshotFinishTimestamp = snapshotFinishTimestamp;
         this.details = details;
     }
 
     public SnapshotInvocationRecord(StreamInput in) throws IOException {
         this.snapshotName = in.readString();
-        this.timestamp = in.readVLong();
+        if (in.getVersion().onOrAfter(Version.V_7_15_0)) {
+            this.snapshotStartTimestamp = in.readOptionalVLong();
+        } else {
+            this.snapshotStartTimestamp = null;
+        }
+        this.snapshotFinishTimestamp = in.readVLong();
         this.details = in.readOptionalString();
     }
 
@@ -66,8 +77,13 @@ public class SnapshotInvocationRecord extends AbstractDiffable<SnapshotInvocatio
         return snapshotName;
     }
 
-    public long getTimestamp() {
-        return timestamp;
+    @Nullable
+    public Long getSnapshotStartTimestamp() {
+        return snapshotStartTimestamp;
+    }
+
+    public long getSnapshotFinishTimestamp() {
+        return snapshotFinishTimestamp;
     }
 
     public String getDetails() {
@@ -77,7 +93,10 @@ public class SnapshotInvocationRecord extends AbstractDiffable<SnapshotInvocatio
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         out.writeString(snapshotName);
-        out.writeVLong(timestamp);
+        if (out.getVersion().onOrAfter(Version.V_7_15_0)) {
+            out.writeOptionalVLong(snapshotStartTimestamp);
+        }
+        out.writeVLong(snapshotFinishTimestamp);
         out.writeOptionalString(details);
     }
 
@@ -86,7 +105,10 @@ public class SnapshotInvocationRecord extends AbstractDiffable<SnapshotInvocatio
         builder.startObject();
         {
             builder.field(SNAPSHOT_NAME.getPreferredName(), snapshotName);
-            builder.timeField(TIMESTAMP.getPreferredName(), "time_string", timestamp);
+            if (snapshotStartTimestamp != null) {
+                builder.timeField(START_TIMESTAMP.getPreferredName(), "start_time_string", snapshotStartTimestamp);
+            }
+            builder.timeField(TIMESTAMP.getPreferredName(), "time_string", snapshotFinishTimestamp);
             if (Objects.nonNull(details)) {
                 builder.field(DETAILS.getPreferredName(), details);
             }
@@ -100,13 +122,14 @@ public class SnapshotInvocationRecord extends AbstractDiffable<SnapshotInvocatio
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         SnapshotInvocationRecord that = (SnapshotInvocationRecord) o;
-        return getTimestamp() == that.getTimestamp() &&
+        return getSnapshotFinishTimestamp() == that.getSnapshotFinishTimestamp() &&
+            Objects.equals(getSnapshotStartTimestamp(), that.getSnapshotStartTimestamp()) &&
             Objects.equals(getSnapshotName(), that.getSnapshotName()) &&
             Objects.equals(getDetails(), that.getDetails());
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(getSnapshotName(), getTimestamp(), getDetails());
+        return Objects.hash(getSnapshotName(), getSnapshotStartTimestamp(), getSnapshotFinishTimestamp(), getDetails());
     }
 }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/WaitForSnapshotStepTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/WaitForSnapshotStepTests.java
@@ -58,7 +58,7 @@ public class WaitForSnapshotStepTests extends AbstractStepTestCase<WaitForSnapsh
 
     public void testNoSlmPolicies() {
         IndexMetadata indexMetadata = IndexMetadata.builder(randomAlphaOfLength(10))
-            .putCustom(LifecycleExecutionState.ILM_CUSTOM_METADATA_KEY, Collections.singletonMap("phase_time", Long.toString(randomLong())))
+            .putCustom(LifecycleExecutionState.ILM_CUSTOM_METADATA_KEY, Collections.singletonMap("action_time", Long.toString(randomLong())))
             .settings(settings(Version.CURRENT))
             .numberOfShards(randomIntBetween(1, 5)).numberOfReplicas(randomIntBetween(0, 5)).build();
         ImmutableOpenMap.Builder<String, IndexMetadata> indices =
@@ -82,7 +82,7 @@ public class WaitForSnapshotStepTests extends AbstractStepTestCase<WaitForSnapsh
 
 
         IndexMetadata indexMetadata = IndexMetadata.builder(randomAlphaOfLength(10))
-            .putCustom(LifecycleExecutionState.ILM_CUSTOM_METADATA_KEY, Collections.singletonMap("phase_time", Long.toString(randomLong())))
+            .putCustom(LifecycleExecutionState.ILM_CUSTOM_METADATA_KEY, Collections.singletonMap("action_time", Long.toString(randomLong())))
             .settings(settings(Version.CURRENT))
             .numberOfShards(randomIntBetween(1, 5)).numberOfReplicas(randomIntBetween(0, 5)).build();
         ImmutableOpenMap.Builder<String, IndexMetadata> indices =
@@ -95,38 +95,62 @@ public class WaitForSnapshotStepTests extends AbstractStepTestCase<WaitForSnapsh
     }
 
     public void testSlmPolicyExecutedBeforeStep() throws IOException {
-        long phaseTime = randomLong();
-
-        WaitForSnapshotStep instance = createRandomInstance();
-        SnapshotLifecyclePolicyMetadata slmPolicy = SnapshotLifecyclePolicyMetadata.builder()
-            .setModifiedDate(randomLong())
-            .setPolicy(new SnapshotLifecyclePolicy("", "", "", "", null, null))
-            .setLastSuccess(new SnapshotInvocationRecord("", phaseTime - 10, ""))
-            .build();
-        SnapshotLifecycleMetadata smlMetadata = new SnapshotLifecycleMetadata(Collections.singletonMap(instance.getPolicy(), slmPolicy),
-            OperationMode.RUNNING, null);
-
-        IndexMetadata indexMetadata = IndexMetadata.builder(randomAlphaOfLength(10))
-            .putCustom(LifecycleExecutionState.ILM_CUSTOM_METADATA_KEY, Collections.singletonMap("phase_time", Long.toString(phaseTime)))
-            .settings(settings(Version.CURRENT))
-            .numberOfShards(randomIntBetween(1, 5)).numberOfReplicas(randomIntBetween(0, 5)).build();
-        ImmutableOpenMap.Builder<String, IndexMetadata> indices =
-            ImmutableOpenMap.<String, IndexMetadata>builder().fPut(indexMetadata.getIndex().getName(), indexMetadata);
-        Metadata.Builder meta = Metadata.builder().indices(indices.build()).putCustom(SnapshotLifecycleMetadata.TYPE, smlMetadata);
-        ClusterState clusterState = ClusterState.builder(ClusterName.DEFAULT).metadata(meta).build();
-        ClusterStateWaitStep.Result result = instance.isConditionMet(indexMetadata.getIndex(), clusterState);
-        assertFalse(result.isComplete());
-        assertTrue(getMessage(result).contains("to be executed"));
+        // The snapshot was started and finished before the phase time, so we do not expect the step to finish:
+        assertSlmPolicyExecuted(false, false);
     }
 
     public void testSlmPolicyExecutedAfterStep() throws IOException {
+        // The snapshot was started and finished after the phase time, so we do expect the step to finish:
+        assertSlmPolicyExecuted(true, true);
+    }
+
+    public void testSlmPolicyNotExecutedWhenStartIsBeforePhaseTime() throws IOException {
+        // The snapshot was started before the phase time and finished after, so we do expect the step to finish:
+        assertSlmPolicyExecuted(false, true);
+    }
+
+    private void assertSlmPolicyExecuted(boolean startTimeAfterPhaseTime, boolean finishTimeAfterPhaseTime) throws IOException {
         long phaseTime = randomLong();
 
         WaitForSnapshotStep instance = createRandomInstance();
         SnapshotLifecyclePolicyMetadata slmPolicy = SnapshotLifecyclePolicyMetadata.builder()
             .setModifiedDate(randomLong())
             .setPolicy(new SnapshotLifecyclePolicy("", "", "", "", null, null))
-            .setLastSuccess(new SnapshotInvocationRecord("", phaseTime + 10, ""))
+            .setLastSuccess(new SnapshotInvocationRecord("",
+                phaseTime + (startTimeAfterPhaseTime ? 10 : -100),
+                phaseTime + (finishTimeAfterPhaseTime ? 100 : -10), ""))
+            .build();
+        SnapshotLifecycleMetadata smlMetadata = new SnapshotLifecycleMetadata(Collections.singletonMap(instance.getPolicy(), slmPolicy),
+            OperationMode.RUNNING, null);
+
+        IndexMetadata indexMetadata = IndexMetadata.builder(randomAlphaOfLength(10))
+            .putCustom(LifecycleExecutionState.ILM_CUSTOM_METADATA_KEY, Collections.singletonMap("action_time", Long.toString(phaseTime)))
+            .settings(settings(Version.CURRENT))
+            .numberOfShards(randomIntBetween(1, 5)).numberOfReplicas(randomIntBetween(0, 5)).build();
+        ImmutableOpenMap.Builder<String, IndexMetadata> indices =
+            ImmutableOpenMap.<String, IndexMetadata>builder().fPut(indexMetadata.getIndex().getName(), indexMetadata);
+        Metadata.Builder meta = Metadata.builder().indices(indices.build()).putCustom(SnapshotLifecycleMetadata.TYPE, smlMetadata);
+        ClusterState clusterState = ClusterState.builder(ClusterName.DEFAULT).metadata(meta).build();
+        ClusterStateWaitStep.Result result = instance.isConditionMet(indexMetadata.getIndex(), clusterState);
+        if (startTimeAfterPhaseTime) {
+            assertTrue(result.isComplete());
+            assertNull(result.getInfomationContext());
+        } else {
+            assertFalse(result.isComplete());
+            assertTrue(getMessage(result).contains("to be executed"));
+        }
+    }
+
+    public void testNullStartTime() throws IOException {
+        long phaseTime = randomLong();
+
+        WaitForSnapshotStep instance = createRandomInstance();
+        SnapshotLifecyclePolicyMetadata slmPolicy = SnapshotLifecyclePolicyMetadata.builder()
+            .setModifiedDate(randomLong())
+            .setPolicy(new SnapshotLifecyclePolicy("", "", "", "", null, null))
+            .setLastSuccess(new SnapshotInvocationRecord("",
+                null,
+                phaseTime + 100, ""))
             .build();
         SnapshotLifecycleMetadata smlMetadata = new SnapshotLifecycleMetadata(Collections.singletonMap(instance.getPolicy(), slmPolicy),
             OperationMode.RUNNING, null);
@@ -139,9 +163,9 @@ public class WaitForSnapshotStepTests extends AbstractStepTestCase<WaitForSnapsh
             ImmutableOpenMap.<String, IndexMetadata>builder().fPut(indexMetadata.getIndex().getName(), indexMetadata);
         Metadata.Builder meta = Metadata.builder().indices(indices.build()).putCustom(SnapshotLifecycleMetadata.TYPE, smlMetadata);
         ClusterState clusterState = ClusterState.builder(ClusterName.DEFAULT).metadata(meta).build();
-        ClusterStateWaitStep.Result result = instance.isConditionMet(indexMetadata.getIndex(), clusterState);
-        assertTrue(result.isComplete());
-        assertNull(result.getInfomationContext());
+        IllegalStateException e = expectThrows(IllegalStateException.class, () -> instance.isConditionMet(indexMetadata.getIndex(),
+            clusterState));
+        assertTrue(e.getMessage().contains("no information about ILM action start"));
     }
 
     private String getMessage(ClusterStateWaitStep.Result result) throws IOException {

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/WaitForSnapshotStepTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/WaitForSnapshotStepTests.java
@@ -58,7 +58,8 @@ public class WaitForSnapshotStepTests extends AbstractStepTestCase<WaitForSnapsh
 
     public void testNoSlmPolicies() {
         IndexMetadata indexMetadata = IndexMetadata.builder(randomAlphaOfLength(10))
-            .putCustom(LifecycleExecutionState.ILM_CUSTOM_METADATA_KEY, Collections.singletonMap("action_time", Long.toString(randomLong())))
+            .putCustom(LifecycleExecutionState.ILM_CUSTOM_METADATA_KEY,
+                Collections.singletonMap("action_time", Long.toString(randomLong())))
             .settings(settings(Version.CURRENT))
             .numberOfShards(randomIntBetween(1, 5)).numberOfReplicas(randomIntBetween(0, 5)).build();
         ImmutableOpenMap.Builder<String, IndexMetadata> indices =
@@ -82,7 +83,8 @@ public class WaitForSnapshotStepTests extends AbstractStepTestCase<WaitForSnapsh
 
 
         IndexMetadata indexMetadata = IndexMetadata.builder(randomAlphaOfLength(10))
-            .putCustom(LifecycleExecutionState.ILM_CUSTOM_METADATA_KEY, Collections.singletonMap("action_time", Long.toString(randomLong())))
+            .putCustom(LifecycleExecutionState.ILM_CUSTOM_METADATA_KEY,
+                Collections.singletonMap("action_time", Long.toString(randomLong())))
             .settings(settings(Version.CURRENT))
             .numberOfShards(randomIntBetween(1, 5)).numberOfReplicas(randomIntBetween(0, 5)).build();
         ImmutableOpenMap.Builder<String, IndexMetadata> indices =

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/slm/SnapshotInvocationRecordTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/slm/SnapshotInvocationRecordTests.java
@@ -37,15 +37,17 @@ public class SnapshotInvocationRecordTests extends AbstractSerializingTestCase<S
             case 0:
                 return new SnapshotInvocationRecord(
                     randomValueOtherThan(instance.getSnapshotName(), () -> randomAlphaOfLengthBetween(2,10)),
-                    instance.getTimestamp(),
+                    instance.getSnapshotFinishTimestamp() - 100,
+                    instance.getSnapshotFinishTimestamp(),
                     instance.getDetails());
             case 1:
+                long timestamp = randomValueOtherThan(instance.getSnapshotFinishTimestamp(), ESTestCase::randomNonNegativeLong);
                 return new SnapshotInvocationRecord(instance.getSnapshotName(),
-                    randomValueOtherThan(instance.getTimestamp(), ESTestCase::randomNonNegativeLong),
+                    timestamp - 100, timestamp,
                     instance.getDetails());
             case 2:
                 return new SnapshotInvocationRecord(instance.getSnapshotName(),
-                    instance.getTimestamp(),
+                    instance.getSnapshotFinishTimestamp() - 100, instance.getSnapshotFinishTimestamp(),
                     randomValueOtherThan(instance.getDetails(), () -> randomAlphaOfLengthBetween(2,10)));
             default:
                 throw new AssertionError("failure, got illegal switch case");
@@ -55,8 +57,18 @@ public class SnapshotInvocationRecordTests extends AbstractSerializingTestCase<S
     public static SnapshotInvocationRecord randomSnapshotInvocationRecord() {
         return new SnapshotInvocationRecord(
             randomAlphaOfLengthBetween(5,10),
+            randomNonNegativeNullableLong(),
             randomNonNegativeLong(),
             randomBoolean() ? null : randomAlphaOfLengthBetween(5, 10));
+    }
+
+    private static Long randomNonNegativeNullableLong() {
+        long value = randomLong();
+        if (value < 0) {
+            return null;
+        } else {
+            return value;
+        }
     }
 
 }

--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/slm/SnapshotLifecycleTask.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/slm/SnapshotLifecycleTask.java
@@ -98,13 +98,13 @@ public class SnapshotLifecycleTask implements SchedulerEngine.Listener {
                     logger.debug("snapshot response for [{}]: {}",
                         policyMetadata.getPolicy().getId(), Strings.toString(createSnapshotResponse));
                     final SnapshotInfo snapInfo = createSnapshotResponse.getSnapshotInfo();
-
                     // Check that there are no failed shards, since the request may not entirely
                     // fail, but may still have failures (such as in the case of an aborted snapshot)
                     if (snapInfo.failedShards() == 0) {
+                        long snapshotStartTime = snapInfo.startTime();
                         final long timestamp = Instant.now().toEpochMilli();
                         clusterService.submitStateUpdateTask("slm-record-success-" + policyMetadata.getPolicy().getId(),
-                            WriteJobStatus.success(policyMetadata.getPolicy().getId(), request.snapshot(), timestamp));
+                            WriteJobStatus.success(policyMetadata.getPolicy().getId(), request.snapshot(), snapshotStartTime, timestamp));
                         historyStore.putAsync(SnapshotHistoryItem.creationSuccessRecord(timestamp, policyMetadata.getPolicy(),
                             request.snapshot()));
                     } else {
@@ -166,22 +166,25 @@ public class SnapshotLifecycleTask implements SchedulerEngine.Listener {
 
         private final String policyName;
         private final String snapshotName;
-        private final long timestamp;
+        private final long snapshotStartTime;
+        private final long snapshotFinishTime;
         private final Optional<Exception> exception;
 
-        private WriteJobStatus(String policyName, String snapshotName, long timestamp, Optional<Exception> exception) {
+        private WriteJobStatus(String policyName, String snapshotName, long snapshotStartTime, long snapshotFinishTime,
+                               Optional<Exception> exception) {
             this.policyName = policyName;
             this.snapshotName = snapshotName;
             this.exception = exception;
-            this.timestamp = timestamp;
+            this.snapshotStartTime = snapshotStartTime;
+            this.snapshotFinishTime = snapshotFinishTime;
         }
 
-        static WriteJobStatus success(String policyId, String snapshotName, long timestamp) {
-            return new WriteJobStatus(policyId, snapshotName, timestamp, Optional.empty());
+        static WriteJobStatus success(String policyId, String snapshotName, long snapshotStartTime, long snapshotFinishTime) {
+            return new WriteJobStatus(policyId, snapshotName, snapshotStartTime, snapshotFinishTime, Optional.empty());
         }
 
         static WriteJobStatus failure(String policyId, String snapshotName, long timestamp, Exception exception) {
-            return new WriteJobStatus(policyId, snapshotName, timestamp, Optional.of(exception));
+            return new WriteJobStatus(policyId, snapshotName, timestamp, timestamp, Optional.of(exception));
         }
 
         private String exceptionToString() throws IOException {
@@ -220,10 +223,11 @@ public class SnapshotLifecycleTask implements SchedulerEngine.Listener {
 
             if (exception.isPresent()) {
                 stats.snapshotFailed(policyName);
-                newPolicyMetadata.setLastFailure(new SnapshotInvocationRecord(snapshotName, timestamp, exceptionToString()));
+                newPolicyMetadata.setLastFailure(new SnapshotInvocationRecord(snapshotName, null, snapshotFinishTime,
+                    exceptionToString()));
             } else {
                 stats.snapshotTaken(policyName);
-                newPolicyMetadata.setLastSuccess(new SnapshotInvocationRecord(snapshotName, timestamp, null));
+                newPolicyMetadata.setLastSuccess(new SnapshotInvocationRecord(snapshotName, snapshotStartTime, snapshotFinishTime, null));
             }
 
             snapLifecycles.put(policyName, newPolicyMetadata.build());


### PR DESCRIPTION
Backporting #75644. The wait_for_snapshot ILM action had been checking whether a snapshot had finished in the given time. However what is more important is that it had started in the given time. Since we weren't capturing the snapshot start time in the state store, most of this PR is about grabbing that information and putting it in the state store so that it is available (without having to do an expensive query).