### PR TITLE
Doc: extracted date is wrong

### DIFF
--- a/docs/reference/ingest/processors/dissect.asciidoc
+++ b/docs/reference/ingest/processors/dissect.asciidoc
@@ -194,7 +194,7 @@ Reference key modifier example
 | *Pattern* | `[%{ts}] [%{level}] %{*p1}:%{&p1} %{*p2}:%{&p2}`
 | *Input*   | [2018-08-10T17:15:42,466] [ERR] ip:1.2.3.4 error:REFUSED
 | *Result*  a|
-* ts = 1998-08-10T17:15:42,466
+* ts = 2018-08-10T17:15:42,466
 * level = ERR
 * ip = 1.2.3.4
 * error = REFUSED


### PR DESCRIPTION
In the example, we have a date with year `2018` but the extracted date is `1998`.
