### PR TITLE
[ML] Fix serialization of datafeed running state for relocated datafeed

### DIFF
--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetDatafeedRunningStateAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetDatafeedRunningStateAction.java
@@ -79,7 +79,7 @@ public class TransportGetDatafeedRunningStateAction extends TransportTasksAction
         TransportStartDatafeedAction.DatafeedTask datafeedTask,
         ActionListener<Response> listener
     ) {
-        listener.onResponse(Response.fromTaskAndState(datafeedTask.getDatafeedId(), datafeedTask.getRunningState().orElse(null)));
+        listener.onResponse(Response.fromTaskAndState(datafeedTask.getDatafeedId(), datafeedTask.getRunningState()));
     }
 
     @Override

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportStartDatafeedAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportStartDatafeedAction.java
@@ -596,16 +596,19 @@ public class TransportStartDatafeedAction extends TransportMasterNodeAction<Star
             }
         }
 
-        public Optional<GetDatafeedRunningStateAction.Response.RunningState> getRunningState() {
+        public GetDatafeedRunningStateAction.Response.RunningState getRunningState() {
             synchronized (this) {
                 if (datafeedRunner == null) {
-                    return Optional.empty();
+                    // In this case we don't know for sure if lookback has completed.  It may be that the
+                    // datafeed has just moved nodes, but with so little delay that there's no lookback to
+                    // do on the new node.  However, there _might_ be some catching up required, so it's
+                    // reasonable to say real-time running hasn't started yet.  The state will quickly
+                    // change once the datafeed runner gets going and determines where the datafeed is up
+                    // to.
+                    return new GetDatafeedRunningStateAction.Response.RunningState(endTime == null,false);
                 }
             }
-            return Optional.of(new GetDatafeedRunningStateAction.Response.RunningState(
-                this.endTime == null,
-                datafeedRunner.finishedLookBack(this)
-            ));
+            return new GetDatafeedRunningStateAction.Response.RunningState(endTime == null, datafeedRunner.finishedLookBack(this));
         }
     }
 


### PR DESCRIPTION
The datafeed running state was set to null for a datafeed that
had recently moved to a different node. This resulted in an
exception while serializing between nodes (but would also
cause incomplete information in the datafeed stats response).

This change makes the datafeed running state return the best
information available in this case:

- real_time_configured will return the correct value
- real_time_running will return false, which is reasonable
  since the datafeed has yet got started on the new node

Fixes #75507