### PR TITLE
[7.x] allow prefixing field names in random object creation. Fix test failure (#75928)

### DIFF
--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/transform/transforms/pivot/DateHistogramGroupSourceTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/transform/transforms/pivot/DateHistogramGroupSourceTests.java
@@ -34,20 +34,28 @@ public class DateHistogramGroupSourceTests extends AbstractSerializingTestCase<D
         return randomDateHistogramGroupSource(Version.CURRENT, false);
     }
 
+    public static DateHistogramGroupSource randomDateHistogramGroupSourceNoScript(String fieldPrefix) {
+        return randomDateHistogramGroupSource(Version.CURRENT, false, fieldPrefix);
+    }
+
     public static DateHistogramGroupSource randomDateHistogramGroupSource(Version version) {
         return randomDateHistogramGroupSource(version, randomBoolean());
     }
 
     public static DateHistogramGroupSource randomDateHistogramGroupSource(Version version, boolean withScript) {
+        return randomDateHistogramGroupSource(version, withScript, "");
+    }
+
+    public static DateHistogramGroupSource randomDateHistogramGroupSource(Version version, boolean withScript, String fieldPrefix) {
         ScriptConfig scriptConfig = null;
         String field;
 
         // either a field or a script must be specified, it's possible to have both, but disallowed to have none
         if (version.onOrAfter(Version.V_7_7_0) && withScript) {
             scriptConfig = ScriptConfigTests.randomScriptConfig();
-            field = randomBoolean() ? null : randomAlphaOfLengthBetween(1, 20);
+            field = randomBoolean() ? null : fieldPrefix + randomAlphaOfLengthBetween(1, 20);
         } else {
-            field = randomAlphaOfLengthBetween(1, 20);
+            field = fieldPrefix + randomAlphaOfLengthBetween(1, 20);
         }
         boolean missingBucket = version.onOrAfter(Version.V_7_10_0) ? randomBoolean() : false;
 

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/transform/transforms/pivot/HistogramGroupSourceTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/transform/transforms/pivot/HistogramGroupSourceTests.java
@@ -24,20 +24,28 @@ public class HistogramGroupSourceTests extends AbstractSerializingTestCase<Histo
         return randomHistogramGroupSource(Version.CURRENT, false);
     }
 
+    public static HistogramGroupSource randomHistogramGroupSourceNoScript(String fieldPrefix) {
+        return randomHistogramGroupSource(Version.CURRENT, false, fieldPrefix);
+    }
+
     public static HistogramGroupSource randomHistogramGroupSource(Version version) {
         return randomHistogramGroupSource(version, randomBoolean());
     }
 
     public static HistogramGroupSource randomHistogramGroupSource(Version version, boolean withScript) {
+        return randomHistogramGroupSource(version, withScript, "");
+    }
+
+    public static HistogramGroupSource randomHistogramGroupSource(Version version, boolean withScript, String fieldPrefix) {
         ScriptConfig scriptConfig = null;
         String field;
 
         // either a field or a script must be specified, it's possible to have both, but disallowed to have none
         if (version.onOrAfter(Version.V_7_7_0) && withScript) {
             scriptConfig = ScriptConfigTests.randomScriptConfig();
-            field = randomBoolean() ? null : randomAlphaOfLengthBetween(1, 20);
+            field = randomBoolean() ? null : fieldPrefix + randomAlphaOfLengthBetween(1, 20);
         } else {
-            field = randomAlphaOfLengthBetween(1, 20);
+            field = fieldPrefix + randomAlphaOfLengthBetween(1, 20);
         }
 
         boolean missingBucket = version.onOrAfter(Version.V_7_10_0) ? randomBoolean() : false;

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/transform/transforms/pivot/TermsGroupSourceTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/transform/transforms/pivot/TermsGroupSourceTests.java
@@ -31,20 +31,28 @@ public class TermsGroupSourceTests extends AbstractSerializingTestCase<TermsGrou
         return randomTermsGroupSource(Version.CURRENT, false);
     }
 
+    public static TermsGroupSource randomTermsGroupSourceNoScript(String fieldPrefix) {
+        return randomTermsGroupSource(Version.CURRENT, false, fieldPrefix);
+    }
+
     public static TermsGroupSource randomTermsGroupSource(Version version) {
         return randomTermsGroupSource(Version.CURRENT, randomBoolean());
     }
 
     public static TermsGroupSource randomTermsGroupSource(Version version, boolean withScript) {
+        return randomTermsGroupSource(Version.CURRENT, withScript, "");
+    }
+
+    public static TermsGroupSource randomTermsGroupSource(Version version, boolean withScript, String fieldPrefix) {
         ScriptConfig scriptConfig = null;
         String field;
 
         // either a field or a script must be specified, it's possible to have both, but disallowed to have none
         if (version.onOrAfter(Version.V_7_7_0) && withScript) {
             scriptConfig = ScriptConfigTests.randomScriptConfig();
-            field = randomBoolean() ? null : randomAlphaOfLengthBetween(1, 20);
+            field = randomBoolean() ? null : fieldPrefix + randomAlphaOfLengthBetween(1, 20);
         } else {
-            field = randomAlphaOfLengthBetween(1, 20);
+            field = fieldPrefix + randomAlphaOfLengthBetween(1, 20);
         }
 
         boolean missingBucket = version.onOrAfter(Version.V_7_10_0) ? randomBoolean() : false;

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/pivot/GroupByOptimizerTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/pivot/GroupByOptimizerTests.java
@@ -74,12 +74,12 @@ public class GroupByOptimizerTests extends ESTestCase {
     public void testOrderByScriptAndType() {
         Map<String, SingleGroupSource> groups = new LinkedHashMap<>();
 
-        groups.put("terms1", randomTermsGroupSourceNoScript());
+        groups.put("terms1", randomTermsGroupSourceNoScript("t1"));
         // create with scripts
-        groups.put("date1", randomDateHistogramGroupSource(Version.CURRENT, true));
-        groups.put("terms2", randomTermsGroupSource(Version.CURRENT, true));
-        groups.put("date2", randomDateHistogramGroupSourceNoScript());
-        groups.put("date3", randomDateHistogramGroupSourceNoScript());
+        groups.put("date1", randomDateHistogramGroupSource(Version.CURRENT, true, "d1"));
+        groups.put("terms2", randomTermsGroupSource(Version.CURRENT, true, "t2"));
+        groups.put("date2", randomDateHistogramGroupSourceNoScript("d2"));
+        groups.put("date3", randomDateHistogramGroupSourceNoScript("d3"));
 
         List<String> groupNames = GroupByOptimizer.reorderGroups(Collections.unmodifiableMap(groups), Collections.emptySet())
             .stream()


### PR DESCRIPTION
Backports the following commits to 7.x:
 - allow prefixing field names in random object creation. Fix test failure (#75928)