### PR TITLE
[DOCS] Changes link to outlier detection docs in PUT DFA API docs

### DIFF
--- a/docs/reference/ml/df-analytics/apis/put-dfanalytics.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/put-dfanalytics.asciidoc
@@ -300,7 +300,7 @@ include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=training-percent]
 `outlier_detection`:::
 (Required^*^, object)
 The configuration information necessary to perform
-{ml-docs}/ml-dfa-finding-outliers.html#dfa-outlier-detection[{oldetection}]:
+{ml-docs}/ml-dfa-finding-outliers.html[{oldetection}]:
 +
 .Properties of `outlier_detection`
 [%collapsible%open]


### PR DESCRIPTION
## Overview

This PR changes a link in the PUT DFA API docs that points to the outlier detection documentation in stack docs. The reason why it is necessary is that https://github.com/elastic/stack-docs/pull/1758 will delete the referenced section ID.

### Preview

[PUT DFA API docs]()