### PR TITLE
Log reindex bulk request completion

### DIFF
--- a/modules/reindex/src/main/java/org/elasticsearch/index/reindex/AbstractAsyncBulkByScrollAction.java
+++ b/modules/reindex/src/main/java/org/elasticsearch/index/reindex/AbstractAsyncBulkByScrollAction.java
@@ -353,8 +353,9 @@ public abstract class AbstractAsyncBulkByScrollAction<Request extends AbstractBu
      * Send a bulk request, handling retries.
      */
     void sendBulkRequest(BulkRequest request, Runnable onSuccess) {
+        final int requestSize = request.requests().size();
         if (logger.isDebugEnabled()) {
-            logger.debug("[{}]: sending [{}] entry, [{}] bulk request", task.getId(), request.requests().size(),
+            logger.debug("[{}]: sending [{}] entry, [{}] bulk request", task.getId(), requestSize,
                     new ByteSizeValue(request.estimatedSizeInBytes()));
         }
         if (task.isCancelled()) {
@@ -365,6 +366,7 @@ public abstract class AbstractAsyncBulkByScrollAction<Request extends AbstractBu
         bulkRetry.withBackoff(bulkClient::bulk, request, new ActionListener<BulkResponse>() {
             @Override
             public void onResponse(BulkResponse response) {
+                logger.debug("[{}]: completed [{}] entry bulk request", task.getId(), requestSize);
                 onBulkResponse(response, onSuccess);
             }
 

--- a/server/src/main/java/org/elasticsearch/index/reindex/ScrollableHitSource.java
+++ b/server/src/main/java/org/elasticsearch/index/reindex/ScrollableHitSource.java
@@ -85,7 +85,7 @@ public abstract class ScrollableHitSource {
     }
 
     private void onResponse(Response response) {
-        logger.debug("scroll returned [{}] documents with a scroll id of [{}]", response.getHits().size(), response.getScrollId());
+        logger.trace("scroll returned [{}] documents with a scroll id of [{}]", response.getHits().size(), response.getScrollId());
         setScroll(response.getScrollId());
         onResponse.accept(new AsyncResponse() {
             private AtomicBoolean alreadyDone = new AtomicBoolean();


### PR DESCRIPTION
Today we log at `DEBUG` when we receive a scroll response and send the
bulk request but do not log the completion of the bulk request or the
start of the next scroll request. This makes it impossible to tell from
the logs how long these things are taking.

This commit adds the missing logging.