### PR TITLE
[7.x] Take into account base path on AzureBlobStoreRepositoryTests#testNotFoundErrorMessageContainsFullKey (#75934)

### DIFF
--- a/plugins/repository-azure/src/internalClusterTest/java/org/elasticsearch/repositories/azure/AzureBlobStoreRepositoryTests.java
+++ b/plugins/repository-azure/src/internalClusterTest/java/org/elasticsearch/repositories/azure/AzureBlobStoreRepositoryTests.java
@@ -7,14 +7,15 @@
  */
 package org.elasticsearch.repositories.azure;
 
+import fixture.azure.AzureHttpHandler;
+
 import com.azure.storage.common.policy.RequestRetryOptions;
 import com.azure.storage.common.policy.RetryPolicyType;
 import com.sun.net.httpserver.Headers;
 import com.sun.net.httpserver.HttpExchange;
 import com.sun.net.httpserver.HttpHandler;
-import fixture.azure.AzureHttpHandler;
+
 import org.elasticsearch.common.Randomness;
-import org.elasticsearch.core.SuppressForbidden;
 import org.elasticsearch.common.blobstore.BlobContainer;
 import org.elasticsearch.common.blobstore.BlobPath;
 import org.elasticsearch.common.blobstore.BlobStore;
@@ -24,6 +25,7 @@ import org.elasticsearch.common.settings.MockSecureSettings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.ByteSizeUnit;
 import org.elasticsearch.common.unit.ByteSizeValue;
+import org.elasticsearch.core.SuppressForbidden;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.repositories.blobstore.ESMockAPIBasedRepositoryIntegTestCase;
 import org.elasticsearch.rest.RestStatus;
@@ -40,7 +42,7 @@ import java.util.Map;
 import java.util.regex.Pattern;
 
 import static org.hamcrest.Matchers.anEmptyMap;
-import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
 
 @SuppressForbidden(reason = "this test uses a HttpServer to emulate an Azure endpoint")
@@ -249,7 +251,7 @@ public class AzureBlobStoreRepositoryTests extends ESMockAPIBasedRepositoryInteg
         try (BlobStore store = newBlobStore()) {
             BlobContainer container = store.blobContainer(BlobPath.EMPTY.add("nested").add("dir"));
             NoSuchFileException exception = expectThrows(NoSuchFileException.class, () -> container.readBlob("blob"));
-            assertThat(exception.getMessage(), equalTo("Blob [nested/dir/blob] not found"));
+            assertThat(exception.getMessage(), containsString("nested/dir/blob] not found"));
         }
     }
 }


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Take into account base path on AzureBlobStoreRepositoryTests#testNotFoundErrorMessageContainsFullKey (#75934)