### PR TITLE
[ML] Exceptions about starting native processes now include the node

### DIFF
--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/process/NativeAnalyticsProcessFactory.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/process/NativeAnalyticsProcessFactory.java
@@ -37,12 +37,13 @@ import java.util.function.Consumer;
 
 public class NativeAnalyticsProcessFactory implements AnalyticsProcessFactory<AnalyticsResult> {
 
-    private static final Logger LOGGER = LogManager.getLogger(NativeAnalyticsProcessFactory.class);
+    private static final Logger logger = LogManager.getLogger(NativeAnalyticsProcessFactory.class);
 
     private static final NamedPipeHelper NAMED_PIPE_HELPER = new NamedPipeHelper();
 
     private final Environment env;
     private final NativeController nativeController;
+    private final ClusterService clusterService;
     private final NamedXContentRegistry namedXContentRegistry;
     private final ResultsPersisterService resultsPersisterService;
     private final DataFrameAnalyticsAuditor auditor;
@@ -57,6 +58,7 @@ public class NativeAnalyticsProcessFactory implements AnalyticsProcessFactory<An
                                          DataFrameAnalyticsAuditor auditor) {
         this.env = Objects.requireNonNull(env);
         this.nativeController = Objects.requireNonNull(nativeController);
+        this.clusterService = Objects.requireNonNull(clusterService);
         this.namedXContentRegistry = Objects.requireNonNull(namedXContentRegistry);
         this.auditor = auditor;
         this.resultsPersisterService = resultsPersisterService;
@@ -97,11 +99,11 @@ public class NativeAnalyticsProcessFactory implements AnalyticsProcessFactory<An
             return analyticsProcess;
         } catch (IOException | EsRejectedExecutionException e) {
             String msg = "Failed to connect to data frame analytics process for job " + jobId;
-            LOGGER.error(msg);
+            logger.error(msg);
             try {
                 IOUtils.close(analyticsProcess);
             } catch (IOException ioe) {
-                LOGGER.error("Can't close data frame analytics process", ioe);
+                logger.error("Can't close data frame analytics process", ioe);
             }
             throw ExceptionsHelper.serverError(msg, e);
         }
@@ -125,11 +127,11 @@ public class NativeAnalyticsProcessFactory implements AnalyticsProcessFactory<An
             analyticsBuilder.build();
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
-            LOGGER.warn("[{}] Interrupted while launching data frame analytics process", jobId);
+            logger.warn("[{}] Interrupted while launching data frame analytics process", jobId);
         } catch (IOException e) {
             String msg = "[" + jobId + "] Failed to launch data frame analytics process";
-            LOGGER.error(msg);
-            throw ExceptionsHelper.serverError(msg, e);
+            logger.error(msg);
+            throw ExceptionsHelper.serverError(msg + " on [" + clusterService.getNodeName() + "]", e);
         }
     }
 }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/process/NativeAnalyticsProcessFactory.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/process/NativeAnalyticsProcessFactory.java
@@ -43,7 +43,7 @@ public class NativeAnalyticsProcessFactory implements AnalyticsProcessFactory<An
 
     private final Environment env;
     private final NativeController nativeController;
-    private final ClusterService clusterService;
+    private final String nodeName;
     private final NamedXContentRegistry namedXContentRegistry;
     private final ResultsPersisterService resultsPersisterService;
     private final DataFrameAnalyticsAuditor auditor;
@@ -58,7 +58,7 @@ public class NativeAnalyticsProcessFactory implements AnalyticsProcessFactory<An
                                          DataFrameAnalyticsAuditor auditor) {
         this.env = Objects.requireNonNull(env);
         this.nativeController = Objects.requireNonNull(nativeController);
-        this.clusterService = Objects.requireNonNull(clusterService);
+        this.nodeName = clusterService.getNodeName();
         this.namedXContentRegistry = Objects.requireNonNull(namedXContentRegistry);
         this.auditor = auditor;
         this.resultsPersisterService = resultsPersisterService;
@@ -131,7 +131,7 @@ public class NativeAnalyticsProcessFactory implements AnalyticsProcessFactory<An
         } catch (IOException e) {
             String msg = "[" + jobId + "] Failed to launch data frame analytics process";
             logger.error(msg);
-            throw ExceptionsHelper.serverError(msg + " on [" + clusterService.getNodeName() + "]", e);
+            throw ExceptionsHelper.serverError(msg + " on [" + nodeName + "]", e);
         }
     }
 }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/process/NativeMemoryUsageEstimationProcessFactory.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/process/NativeMemoryUsageEstimationProcessFactory.java
@@ -33,18 +33,20 @@ import java.util.function.Consumer;
 
 public class NativeMemoryUsageEstimationProcessFactory implements AnalyticsProcessFactory<MemoryUsageEstimationResult> {
 
-    private static final Logger LOGGER = LogManager.getLogger(NativeMemoryUsageEstimationProcessFactory.class);
+    private static final Logger logger = LogManager.getLogger(NativeMemoryUsageEstimationProcessFactory.class);
 
     private static final NamedPipeHelper NAMED_PIPE_HELPER = new NamedPipeHelper();
 
     private final Environment env;
     private final NativeController nativeController;
+    private final ClusterService clusterService;
     private final AtomicLong counter;
     private volatile Duration processConnectTimeout;
 
     public NativeMemoryUsageEstimationProcessFactory(Environment env, NativeController nativeController, ClusterService clusterService) {
         this.env = Objects.requireNonNull(env);
         this.nativeController = Objects.requireNonNull(nativeController);
+        this.clusterService = Objects.requireNonNull(clusterService);
         this.counter = new AtomicLong(0);
         setProcessConnectTimeout(MachineLearning.PROCESS_CONNECT_TIMEOUT.get(env.settings()));
         clusterService.getClusterSettings().addSettingsUpdateConsumer(
@@ -85,11 +87,11 @@ public class NativeMemoryUsageEstimationProcessFactory implements AnalyticsProce
             return process;
         } catch (IOException | EsRejectedExecutionException e) {
             String msg = "Failed to connect to data frame analytics memory usage estimation process for job " + config.getId();
-            LOGGER.error(msg);
+            logger.error(msg);
             try {
                 IOUtils.close(process);
             } catch (IOException ioe) {
-                LOGGER.error("Can't close data frame analytics memory usage estimation process", ioe);
+                logger.error("Can't close data frame analytics memory usage estimation process", ioe);
             }
             throw ExceptionsHelper.serverError(msg, e);
         }
@@ -104,11 +106,11 @@ public class NativeMemoryUsageEstimationProcessFactory implements AnalyticsProce
             analyticsBuilder.build();
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
-            LOGGER.warn("[{}] Interrupted while launching data frame analytics memory usage estimation process", jobId);
+            logger.warn("[{}] Interrupted while launching data frame analytics memory usage estimation process", jobId);
         } catch (IOException e) {
             String msg = "[" + jobId + "] Failed to launch data frame analytics memory usage estimation process";
-            LOGGER.error(msg);
-            throw ExceptionsHelper.serverError(msg, e);
+            logger.error(msg);
+            throw ExceptionsHelper.serverError(msg + " on [" + clusterService.getNodeName() + "]", e);
         }
     }
 }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/process/NativeMemoryUsageEstimationProcessFactory.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/process/NativeMemoryUsageEstimationProcessFactory.java
@@ -39,14 +39,14 @@ public class NativeMemoryUsageEstimationProcessFactory implements AnalyticsProce
 
     private final Environment env;
     private final NativeController nativeController;
-    private final ClusterService clusterService;
+    private final String nodeName;
     private final AtomicLong counter;
     private volatile Duration processConnectTimeout;
 
     public NativeMemoryUsageEstimationProcessFactory(Environment env, NativeController nativeController, ClusterService clusterService) {
         this.env = Objects.requireNonNull(env);
         this.nativeController = Objects.requireNonNull(nativeController);
-        this.clusterService = Objects.requireNonNull(clusterService);
+        this.nodeName = clusterService.getNodeName();
         this.counter = new AtomicLong(0);
         setProcessConnectTimeout(MachineLearning.PROCESS_CONNECT_TIMEOUT.get(env.settings()));
         clusterService.getClusterSettings().addSettingsUpdateConsumer(
@@ -110,7 +110,7 @@ public class NativeMemoryUsageEstimationProcessFactory implements AnalyticsProce
         } catch (IOException e) {
             String msg = "[" + jobId + "] Failed to launch data frame analytics memory usage estimation process";
             logger.error(msg);
-            throw ExceptionsHelper.serverError(msg + " on [" + clusterService.getNodeName() + "]", e);
+            throw ExceptionsHelper.serverError(msg + " on [" + nodeName + "]", e);
         }
     }
 }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/pytorch/process/NativePyTorchProcessFactory.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/pytorch/process/NativePyTorchProcessFactory.java
@@ -37,7 +37,7 @@ public class NativePyTorchProcessFactory implements PyTorchProcessFactory {
 
     private final Environment env;
     private final NativeController nativeController;
-    private final ClusterService clusterService;
+    private final String nodeName;
     private volatile Duration processConnectTimeout;
 
     public NativePyTorchProcessFactory(Environment env,
@@ -45,7 +45,7 @@ public class NativePyTorchProcessFactory implements PyTorchProcessFactory {
                                        ClusterService clusterService) {
         this.env = Objects.requireNonNull(env);
         this.nativeController = Objects.requireNonNull(nativeController);
-        this.clusterService = Objects.requireNonNull(clusterService);
+        this.nodeName = clusterService.getNodeName();
         setProcessConnectTimeout(MachineLearning.PROCESS_CONNECT_TIMEOUT.get(env.settings()));
         clusterService.getClusterSettings().addSettingsUpdateConsumer(MachineLearning.PROCESS_CONNECT_TIMEOUT,
             this::setProcessConnectTimeout);
@@ -101,7 +101,7 @@ public class NativePyTorchProcessFactory implements PyTorchProcessFactory {
         } catch (IOException e) {
             String msg = "Failed to launch PyTorch process";
             logger.error(msg);
-            throw ExceptionsHelper.serverError(msg + " on [" + clusterService.getNodeName() + "]", e);
+            throw ExceptionsHelper.serverError(msg + " on [" + nodeName + "]", e);
         }
     }
 

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/pytorch/process/NativePyTorchProcessFactory.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/pytorch/process/NativePyTorchProcessFactory.java
@@ -37,6 +37,7 @@ public class NativePyTorchProcessFactory implements PyTorchProcessFactory {
 
     private final Environment env;
     private final NativeController nativeController;
+    private final ClusterService clusterService;
     private volatile Duration processConnectTimeout;
 
     public NativePyTorchProcessFactory(Environment env,
@@ -44,6 +45,7 @@ public class NativePyTorchProcessFactory implements PyTorchProcessFactory {
                                        ClusterService clusterService) {
         this.env = Objects.requireNonNull(env);
         this.nativeController = Objects.requireNonNull(nativeController);
+        this.clusterService = Objects.requireNonNull(clusterService);
         setProcessConnectTimeout(MachineLearning.PROCESS_CONNECT_TIMEOUT.get(env.settings()));
         clusterService.getClusterSettings().addSettingsUpdateConsumer(MachineLearning.PROCESS_CONNECT_TIMEOUT,
             this::setProcessConnectTimeout);
@@ -95,8 +97,11 @@ public class NativePyTorchProcessFactory implements PyTorchProcessFactory {
             pyTorchBuilder.build();
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
+            logger.warn("Interrupted while launching PyTorch process");
         } catch (IOException e) {
-            throw ExceptionsHelper.serverError("Failed to launch PyTorch process");
+            String msg = "Failed to launch PyTorch process";
+            logger.error(msg);
+            throw ExceptionsHelper.serverError(msg + " on [" + clusterService.getNodeName() + "]", e);
         }
     }
 

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/process/normalizer/NativeNormalizerProcessFactory.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/process/normalizer/NativeNormalizerProcessFactory.java
@@ -33,14 +33,14 @@ public class NativeNormalizerProcessFactory implements NormalizerProcessFactory 
 
     private final Environment env;
     private final NativeController nativeController;
-    private final ClusterService clusterService;
+    private final String nodeName;
     private final AtomicLong counter;
     private volatile Duration processConnectTimeout;
 
     public NativeNormalizerProcessFactory(Environment env, NativeController nativeController, ClusterService clusterService) {
         this.env = Objects.requireNonNull(env);
         this.nativeController = Objects.requireNonNull(nativeController);
-        this.clusterService = Objects.requireNonNull(clusterService);
+        this.nodeName = clusterService.getNodeName();
         this.counter = new AtomicLong(0);
         setProcessConnectTimeout(MachineLearning.PROCESS_CONNECT_TIMEOUT.get(env.settings()));
         clusterService.getClusterSettings().addSettingsUpdateConsumer(MachineLearning.PROCESS_CONNECT_TIMEOUT,
@@ -90,7 +90,7 @@ public class NativeNormalizerProcessFactory implements NormalizerProcessFactory 
         } catch (IOException e) {
             String msg = "[" + jobId + "] Failed to launch normalizer";
             logger.error(msg);
-            throw ExceptionsHelper.serverError(msg + " on [" + clusterService.getNodeName() + "]", e);
+            throw ExceptionsHelper.serverError(msg + " on [" + nodeName + "]", e);
         }
     }
 }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/process/normalizer/NativeNormalizerProcessFactory.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/process/normalizer/NativeNormalizerProcessFactory.java
@@ -28,17 +28,19 @@ import java.util.concurrent.atomic.AtomicLong;
 
 public class NativeNormalizerProcessFactory implements NormalizerProcessFactory {
 
-    private static final Logger LOGGER = LogManager.getLogger(NativeNormalizerProcessFactory.class);
+    private static final Logger logger = LogManager.getLogger(NativeNormalizerProcessFactory.class);
     private static final NamedPipeHelper NAMED_PIPE_HELPER = new NamedPipeHelper();
 
     private final Environment env;
     private final NativeController nativeController;
+    private final ClusterService clusterService;
     private final AtomicLong counter;
     private volatile Duration processConnectTimeout;
 
     public NativeNormalizerProcessFactory(Environment env, NativeController nativeController, ClusterService clusterService) {
         this.env = Objects.requireNonNull(env);
         this.nativeController = Objects.requireNonNull(nativeController);
+        this.clusterService = Objects.requireNonNull(clusterService);
         this.counter = new AtomicLong(0);
         setProcessConnectTimeout(MachineLearning.PROCESS_CONNECT_TIMEOUT.get(env.settings()));
         clusterService.getClusterSettings().addSettingsUpdateConsumer(MachineLearning.PROCESS_CONNECT_TIMEOUT,
@@ -66,11 +68,11 @@ public class NativeNormalizerProcessFactory implements NormalizerProcessFactory 
             return normalizerProcess;
         } catch (IOException | EsRejectedExecutionException e) {
             String msg = "Failed to connect to normalizer for job " + jobId;
-            LOGGER.error(msg);
+            logger.error(msg);
             try {
                 IOUtils.close(normalizerProcess);
             } catch (IOException ioe) {
-                LOGGER.error("Can't close normalizer", ioe);
+                logger.error("Can't close normalizer", ioe);
             }
             throw ExceptionsHelper.serverError(msg, e);
         }
@@ -84,11 +86,11 @@ public class NativeNormalizerProcessFactory implements NormalizerProcessFactory 
             nativeController.startProcess(command);
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
-            LOGGER.warn("[{}] Interrupted while launching normalizer", jobId);
+            logger.warn("[{}] Interrupted while launching normalizer", jobId);
         } catch (IOException e) {
             String msg = "[" + jobId + "] Failed to launch normalizer";
-            LOGGER.error(msg);
-            throw ExceptionsHelper.serverError(msg, e);
+            logger.error(msg);
+            throw ExceptionsHelper.serverError(msg + " on [" + clusterService.getNodeName() + "]", e);
         }
     }
 }


### PR DESCRIPTION
Previously exceptions about starting native processes did not
include the name of the node where the attempt to start the
process failed.

Although this doesn't matter when looking at the log of the
node where the attempt was made, it is crippling when the
report of the problem is just the exception received by a
client. When the initial report comes from a client exception
we need to be able to easily determine which node to ask for
the logs for, or to look at operating system level issues on.