### PR TITLE
Resurrect _cluster/voting_config_exclusions/{node_name}

### DIFF
--- a/rest-api-spec/src/yamlRestCompatTest/resources/rest-api-spec/api/cluster.post_voting_config_exclusions_with_node_name_part.json
+++ b/rest-api-spec/src/yamlRestCompatTest/resources/rest-api-spec/api/cluster.post_voting_config_exclusions_with_node_name_part.json
@@ -1,0 +1,33 @@
+{
+  "cluster.post_voting_config_exclusions_with_node_name_part":{
+    "documentation":{
+      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/voting-config-exclusions.html",
+      "description":"Updates the cluster voting config exclusions by node_name (not node ids or node names)."
+    },
+    "stability":"stable",
+    "visibility":"public",
+    "headers":{
+      "accept": [ "application/vnd.elasticsearch+json;compatible-with=7"]
+    },
+    "url":{
+      "paths":[
+        {
+          "path":"/_cluster/voting_config_exclusions/{node_name}",
+          "methods":[
+            "POST"
+          ],
+          "parts":{
+            "node_name":{
+              "type":"string",
+              "description":"A comma-separated list of node descriptors of the nodes to exclude from the voting configuration."
+            }
+          },
+          "deprecated":{
+            "version":"7.8.0",
+            "description":"node_name is deprecated, use node_names or node_ids instead"
+          }
+        }
+      ]
+    }
+  }
+}

--- a/rest-api-spec/src/yamlRestCompatTest/resources/rest-api-spec/test/v7compat/cluster.voting_config_exclusions/10_basic_compat.yml
+++ b/rest-api-spec/src/yamlRestCompatTest/resources/rest-api-spec/test/v7compat/cluster.voting_config_exclusions/10_basic_compat.yml
@@ -1,0 +1,20 @@
+---
+setup:
+  - skip:
+      version: "9.0.0 - "
+      reason: "compatible from 8.x to 7.x"
+      features:
+        - "headers"
+        - "warnings_regex"
+
+---
+"Throw exception when adding voting config exclusion by specifying a 'node_name'":
+  - do:
+      headers:
+        Content-Type: "application/vnd.elasticsearch+json;compatible-with=7"
+        Accept: "application/vnd.elasticsearch+json;compatible-with=7"
+      cluster.post_voting_config_exclusions_with_node_name_part:
+        node_name: someNodeName
+      warnings_regex:
+        - ".* /_cluster/voting_config_exclusions/\\{node_name\\} has been removed. .*"
+      catch: /\[node_name\] has been removed, you must set \[node_names\] or \[node_ids\]/

--- a/rest-api-spec/src/yamlRestCompatTest/resources/rest-api-spec/test/v7compat/cluster.voting_config_exclusions/10_basic_compat.yml
+++ b/rest-api-spec/src/yamlRestCompatTest/resources/rest-api-spec/test/v7compat/cluster.voting_config_exclusions/10_basic_compat.yml
@@ -16,5 +16,5 @@ setup:
       cluster.post_voting_config_exclusions_with_node_name_part:
         node_name: someNodeName
       warnings_regex:
-        - "heh, actually this isn't evaluated at all because of elastic/elasticsearch#76316"
+        - ".* /_cluster/voting_config_exclusions/\\{node_name\\} has been removed. .*"
       catch: /\[node_name\] has been removed, you must set \[node_names\] or \[node_ids\]/

--- a/rest-api-spec/src/yamlRestCompatTest/resources/rest-api-spec/test/v7compat/cluster.voting_config_exclusions/10_basic_compat.yml
+++ b/rest-api-spec/src/yamlRestCompatTest/resources/rest-api-spec/test/v7compat/cluster.voting_config_exclusions/10_basic_compat.yml
@@ -16,5 +16,5 @@ setup:
       cluster.post_voting_config_exclusions_with_node_name_part:
         node_name: someNodeName
       warnings_regex:
-        - ".* /_cluster/voting_config_exclusions/\\{node_name\\} has been removed. .*"
+        - "heh, actually this isn't evaluated at all because of elastic/elasticsearch#76316"
       catch: /\[node_name\] has been removed, you must set \[node_names\] or \[node_ids\]/

--- a/server/src/main/java/org/elasticsearch/rest/action/admin/cluster/RestAddVotingConfigExclusionAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/admin/cluster/RestAddVotingConfigExclusionAction.java
@@ -12,6 +12,7 @@ import org.elasticsearch.action.admin.cluster.configuration.AddVotingConfigExclu
 import org.elasticsearch.action.admin.cluster.configuration.AddVotingConfigExclusionsRequest;
 import org.elasticsearch.client.node.NodeClient;
 import org.elasticsearch.common.Strings;
+import org.elasticsearch.core.RestApiVersion;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.rest.BaseRestHandler;
 import org.elasticsearch.rest.RestRequest;
@@ -25,6 +26,10 @@ import static org.elasticsearch.rest.RestRequest.Method.POST;
 public class RestAddVotingConfigExclusionAction extends BaseRestHandler {
     private static final TimeValue DEFAULT_TIMEOUT = TimeValue.timeValueSeconds(30L);
 
+    private static final String DEPRECATION_MESSAGE = "POST /_cluster/voting_config_exclusions/{node_name} " +
+        "has been removed. You must use POST /_cluster/voting_config_exclusions?node_ids=... " +
+        "or POST /_cluster/voting_config_exclusions?node_names=... instead.";
+
     @Override
     public String getName() {
         return "add_voting_config_exclusions_action";
@@ -32,7 +37,11 @@ public class RestAddVotingConfigExclusionAction extends BaseRestHandler {
 
     @Override
     public List<Route> routes() {
-        return List.of(new Route(POST, "/_cluster/voting_config_exclusions"));
+        return List.of(
+            new Route(POST, "/_cluster/voting_config_exclusions"),
+            Route.builder(POST, "/_cluster/voting_config_exclusions/{node_name}")
+                .deprecated(DEPRECATION_MESSAGE, RestApiVersion.V_7).build()
+        );
     }
 
     @Override
@@ -48,6 +57,10 @@ public class RestAddVotingConfigExclusionAction extends BaseRestHandler {
     AddVotingConfigExclusionsRequest resolveVotingConfigExclusionsRequest(final RestRequest request) {
         String nodeIds = null;
         String nodeNames = null;
+
+        if (request.getRestApiVersion() == RestApiVersion.V_7 && request.hasParam("node_name")) {
+            throw new IllegalArgumentException("[node_name] has been removed, you must set [node_names] or [node_ids]");
+        }
 
         if (request.hasParam("node_ids")) {
             nodeIds = request.param("node_ids");

--- a/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/section/DoSection.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/section/DoSection.java
@@ -367,6 +367,11 @@ public class DoSection implements ExecutableSection {
             } else {
                 throw new UnsupportedOperationException("catch value [" + catchParam + "] not supported");
             }
+
+            final String testPath = executionContext.getClientYamlTestCandidate() != null
+                ? executionContext.getClientYamlTestCandidate().getTestPath()
+                : null;
+            checkWarningHeaders(restTestResponse.getWarningHeaders(), testPath);
         }
     }
 

--- a/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/section/DoSection.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/section/DoSection.java
@@ -367,11 +367,6 @@ public class DoSection implements ExecutableSection {
             } else {
                 throw new UnsupportedOperationException("catch value [" + catchParam + "] not supported");
             }
-
-            final String testPath = executionContext.getClientYamlTestCandidate() != null
-                ? executionContext.getClientYamlTestCandidate().getTestPath()
-                : null;
-            checkWarningHeaders(restTestResponse.getWarningHeaders(), testPath);
         }
     }
 


### PR DESCRIPTION
Adds back the `_cluster/voting_config_exclusions/{node_name}` route via rest api compatibility, but just so that we can have a better error message. Related to #51816, and a little bit of a follow up to #75406.

See also #76316 -- the last four commits here are a best effort at making sure that the test I'm adding will do what I want it to when that bug doesn't exist anymore.