### PR TITLE
[DOCS] Updating cluster privilege for create API key

### DIFF
--- a/x-pack/docs/en/rest-api/security/create-api-keys.asciidoc
+++ b/x-pack/docs/en/rest-api/security/create-api-keys.asciidoc
@@ -17,7 +17,7 @@ Creates an API key for access without requiring basic authentication.
 [[security-api-create-api-key-prereqs]]
 ==== {api-prereq-title}
 
-* To use this API, you must have at least the `manage_api_key` cluster privilege.
+* To use this API, you must have at least the `manage_own_api_key` cluster privilege.
 
 IMPORTANT: If the credential that is used to authenticate this request is
 an API key, the derived API key cannot have any privileges. If you specify privileges, the API returns an error.


### PR DESCRIPTION
Updates the cluster privileges for the create API key API to `manage_own_api_key`.

Closes #62340