### PR TITLE
[ML] Exceptions about starting native processes now include the node

### DIFF
--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/process/NativeMemoryUsageEstimationProcessFactory.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/process/NativeMemoryUsageEstimationProcessFactory.java
@@ -33,18 +33,20 @@ import java.util.function.Consumer;
 
 public class NativeMemoryUsageEstimationProcessFactory implements AnalyticsProcessFactory<MemoryUsageEstimationResult> {
 
-    private static final Logger LOGGER = LogManager.getLogger(NativeMemoryUsageEstimationProcessFactory.class);
+    private static final Logger logger = LogManager.getLogger(NativeMemoryUsageEstimationProcessFactory.class);
 
     private static final NamedPipeHelper NAMED_PIPE_HELPER = new NamedPipeHelper();
 
     private final Environment env;
     private final NativeController nativeController;
+    private final String nodeName;
     private final AtomicLong counter;
     private volatile Duration processConnectTimeout;
 
     public NativeMemoryUsageEstimationProcessFactory(Environment env, NativeController nativeController, ClusterService clusterService) {
         this.env = Objects.requireNonNull(env);
         this.nativeController = Objects.requireNonNull(nativeController);
+        this.nodeName = clusterService.getNodeName();
         this.counter = new AtomicLong(0);
         setProcessConnectTimeout(MachineLearning.PROCESS_CONNECT_TIMEOUT.get(env.settings()));
         clusterService.getClusterSettings().addSettingsUpdateConsumer(
@@ -84,11 +86,11 @@ public class NativeMemoryUsageEstimationProcessFactory implements AnalyticsProce
             return process;
         } catch (IOException | EsRejectedExecutionException e) {
             String msg = "Failed to connect to data frame analytics memory usage estimation process for job " + config.getId();
-            LOGGER.error(msg);
+            logger.error(msg);
             try {
                 IOUtils.close(process);
             } catch (IOException ioe) {
-                LOGGER.error("Can't close data frame analytics memory usage estimation process", ioe);
+                logger.error("Can't close data frame analytics memory usage estimation process", ioe);
             }
             throw ExceptionsHelper.serverError(msg, e);
         }
@@ -103,11 +105,11 @@ public class NativeMemoryUsageEstimationProcessFactory implements AnalyticsProce
             analyticsBuilder.build();
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
-            LOGGER.warn("[{}] Interrupted while launching data frame analytics memory usage estimation process", jobId);
+            logger.warn("[{}] Interrupted while launching data frame analytics memory usage estimation process", jobId);
         } catch (IOException e) {
             String msg = "[" + jobId + "] Failed to launch data frame analytics memory usage estimation process";
-            LOGGER.error(msg);
-            throw ExceptionsHelper.serverError(msg, e);
+            logger.error(msg);
+            throw ExceptionsHelper.serverError(msg + " on [" + nodeName + "]", e);
         }
     }
 }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/process/normalizer/NativeNormalizerProcessFactory.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/process/normalizer/NativeNormalizerProcessFactory.java
@@ -28,17 +28,19 @@ import java.util.concurrent.atomic.AtomicLong;
 
 public class NativeNormalizerProcessFactory implements NormalizerProcessFactory {
 
-    private static final Logger LOGGER = LogManager.getLogger(NativeNormalizerProcessFactory.class);
+    private static final Logger logger = LogManager.getLogger(NativeNormalizerProcessFactory.class);
     private static final NamedPipeHelper NAMED_PIPE_HELPER = new NamedPipeHelper();
 
     private final Environment env;
     private final NativeController nativeController;
+    private final String nodeName;
     private final AtomicLong counter;
     private volatile Duration processConnectTimeout;
 
     public NativeNormalizerProcessFactory(Environment env, NativeController nativeController, ClusterService clusterService) {
         this.env = Objects.requireNonNull(env);
         this.nativeController = Objects.requireNonNull(nativeController);
+        this.nodeName = clusterService.getNodeName();
         this.counter = new AtomicLong(0);
         setProcessConnectTimeout(MachineLearning.PROCESS_CONNECT_TIMEOUT.get(env.settings()));
         clusterService.getClusterSettings().addSettingsUpdateConsumer(MachineLearning.PROCESS_CONNECT_TIMEOUT,
@@ -66,11 +68,11 @@ public class NativeNormalizerProcessFactory implements NormalizerProcessFactory 
             return normalizerProcess;
         } catch (IOException | EsRejectedExecutionException e) {
             String msg = "Failed to connect to normalizer for job " + jobId;
-            LOGGER.error(msg);
+            logger.error(msg);
             try {
                 IOUtils.close(normalizerProcess);
             } catch (IOException ioe) {
-                LOGGER.error("Can't close normalizer", ioe);
+                logger.error("Can't close normalizer", ioe);
             }
             throw ExceptionsHelper.serverError(msg, e);
         }
@@ -84,11 +86,11 @@ public class NativeNormalizerProcessFactory implements NormalizerProcessFactory 
             nativeController.startProcess(command);
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
-            LOGGER.warn("[{}] Interrupted while launching normalizer", jobId);
+            logger.warn("[{}] Interrupted while launching normalizer", jobId);
         } catch (IOException e) {
             String msg = "[" + jobId + "] Failed to launch normalizer";
-            LOGGER.error(msg);
-            throw ExceptionsHelper.serverError(msg, e);
+            logger.error(msg);
+            throw ExceptionsHelper.serverError(msg + " on [" + nodeName + "]", e);
         }
     }
 }


### PR DESCRIPTION
Previously exceptions about starting native processes did not
include the name of the node where the attempt to start the
process failed.

Although this doesn't matter when looking at the log of the
node where the attempt was made, it is crippling when the
report of the problem is just the exception received by a
client. When the initial report comes from a client exception
we need to be able to easily determine which node to ask for
the logs for, or to look at operating system level issues on.

Backport of #75937