### PR TITLE
[7.12] [DOCS] Fix links and TOC for breaking changes (#75966)

### DIFF
--- a/docs/reference/migration/migrate_7_10.asciidoc
+++ b/docs/reference/migration/migrate_7_10.asciidoc
@@ -9,8 +9,14 @@ your application to {es} 7.10.
 
 See also <<release-highlights>> and <<es-release-notes>>.
 
-// * <<breaking_710_blah_changes>>
-// * <<breaking_710_blah_changes>>
+* <<breaking_710_security_changes>>
+* <<breaking_710_java_changes>>
+* <<breaking_710_networking_changes>>
+* <<breaking_710_search_changes>>
+* <<breaking_710_indices_changes>>
+* <<breaking_710_ml_changes>>
+* <<breaking_710_mapping_changes>>
+* <<breaking_710_snapshot_restore_changes>>
 
 //NOTE: The notable-breaking-changes tagged regions are re-used in the
 //Installation and Upgrade Guide

--- a/docs/reference/migration/migrate_7_12.asciidoc
+++ b/docs/reference/migration/migrate_7_12.asciidoc
@@ -10,6 +10,8 @@ your application to {es} 7.12.
 See also <<release-highlights>> and <<es-release-notes>>.
 
 * <<breaking_712_engine_changes>>
+* <<breaking_712_search_changes>>
+* <<breaking_712_ssl_changes>>
 
 //NOTE: The notable-breaking-changes tagged regions are re-used in the
 //Installation and Upgrade Guide
@@ -81,9 +83,9 @@ LDAP authentication or access to snapshot repositories.
 Most {es} deployments will not be affected by this change, as these older
 TLS versions have known vulnerabilities and are no longer heavily used.
 
-For instructions on how to enable these older TLS versions in your {es} cluster, see
-{ref}/jdk-tls-versions.html#jdk-enable-tls-protocol[Enabling additional SSL/TLS versions on your JDK]
-
+For instructions on how to enable these older TLS versions in your {es} cluster,
+see {ref}/jdk-tls-versions.html#jdk-enable-tls-protocol[Enabling additional
+SSL/TLS versions on your JDK].
 ====
 
 ////


### PR DESCRIPTION
Backports the following commits to 7.12:
 - [DOCS] Fix links and TOC for breaking changes (#75966)