### PR TITLE
Bump bundled JDK to 16.0.2

### DIFF
--- a/build-tools-internal/version.properties
+++ b/build-tools-internal/version.properties
@@ -1,8 +1,8 @@
 elasticsearch     = 8.0.0
 lucene            = 8.9.0
 
-bundled_jdk_vendor = adoptopenjdk
-bundled_jdk = 16.0.1+9
+bundled_jdk_vendor = openjdk
+bundled_jdk = 16.0.2+7@d4a915d82b4c4fbb9bde534da945d746
 
 checkstyle = 8.42
 

--- a/docs/changelog/75981.yaml
+++ b/docs/changelog/75981.yaml
@@ -4,5 +4,6 @@ area: Packaging
 type: upgrade
 issues: []
 versions:
+ - v8.0.0
  - v7.14.1
  - v7.15.0

--- a/docs/changelog/75981.yaml
+++ b/docs/changelog/75981.yaml
@@ -1,0 +1,8 @@
+pr: 75981
+summary: Bump bundled JDK to 16.0.2
+area: Packaging
+type: upgrade
+issues: []
+versions:
+ - v7.14.1
+ - v7.15.0


### PR DESCRIPTION
Move to using Oracle JDK builds since AdoptOpenJDK has moved to
Adoptium for latest builds, but no aarch64 build yet exists.