### PR TITLE
[master] [DOCS] Fix typo in mount searchable snapshots API docs (#75786)

### DIFF
--- a/docs/reference/searchable-snapshots/apis/mount-snapshot.asciidoc
+++ b/docs/reference/searchable-snapshots/apis/mount-snapshot.asciidoc
@@ -129,7 +129,7 @@ POST /_snapshot/my_repository/my_snapshot/_mount?wait_for_completion=true
   "index_settings": { <3>
     "index.number_of_replicas": 0
   },
-  "ignored_index_settings": [ "index.refresh_interval" ] <4>
+  "ignore_index_settings": [ "index.refresh_interval" ] <4>
 }
 --------------------------------------------------
 // TEST[continued]


### PR DESCRIPTION
Backports the following commits to master:
 - [DOCS] Fix typo in mount searchable snapshots API docs (#75786)