### PR TITLE
[Test] Mute more certificate tests on JDK8 u292

### DIFF
--- a/x-pack/plugin/security/cli/src/test/java/org/elasticsearch/xpack/security/cli/CertificateToolTests.java
+++ b/x-pack/plugin/security/cli/src/test/java/org/elasticsearch/xpack/security/cli/CertificateToolTests.java
@@ -40,7 +40,6 @@ import org.elasticsearch.core.SuppressForbidden;
 import org.elasticsearch.core.internal.io.IOUtils;
 import org.elasticsearch.env.Environment;
 import org.elasticsearch.env.TestEnvironment;
-import org.elasticsearch.jdk.JavaVersion;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.SecuritySettingsSourceField;
 import org.elasticsearch.xpack.core.ssl.CertParsingUtils;
@@ -419,6 +418,9 @@ public class CertificateToolTests extends ESTestCase {
     }
 
     public void testHandleLongPasswords() throws Exception {
+        assumeFalse("JDK bug JDK-8266279, https://github.com/elastic/elasticsearch/issues/75571",
+            "1.8.0_292".equals(System.getProperty("java.version")));
+
         final Path tempDir = initTempDir();
 
         final MockTerminal terminal = new MockTerminal();
@@ -631,8 +633,8 @@ public class CertificateToolTests extends ESTestCase {
      * - Checks that all 3 certificates have the right values based on the command line options provided during generation
      */
     public void testCreateCaAndMultipleInstances() throws Exception {
-        assumeFalse("JDK bug JDK-8266279, https://github.com/elastic/elasticsearch/issues/72359",
-                JavaVersion.current().compareTo(JavaVersion.parse("8")) == 0);
+        assumeFalse("JDK bug JDK-8266279, https://github.com/elastic/elasticsearch/issues/75571",
+            "1.8.0_292".equals(System.getProperty("java.version")));
         final Path tempDir = initTempDir();
 
         final MockTerminal terminal = new MockTerminal();
@@ -782,8 +784,8 @@ public class CertificateToolTests extends ESTestCase {
      * - Checks that the PKCS12 certificate and the PEM certificate trust one another
      */
     public void testTrustBetweenPEMandPKCS12() throws Exception {
-        assumeFalse("JDK bug JDK-8266279, https://github.com/elastic/elasticsearch/issues/72359",
-                JavaVersion.current().compareTo(JavaVersion.parse("8")) == 0);
+        assumeFalse("JDK bug JDK-8266279, https://github.com/elastic/elasticsearch/issues/75571",
+            "1.8.0_292".equals(System.getProperty("java.version")));
         final Path tempDir = initTempDir();
 
         final MockTerminal terminal = new MockTerminal();


### PR DESCRIPTION
JDK 1.8.0_292 has a race condition that sometimes causes the
PBEWithSHA1AndDESede algorithm to appear as unavailable.

This change mutes additional tests on this JDK build

Relates: #75952, #75571, #75718
