### PR TITLE
[7.14] EQL: correct time accounting for an intermediary response (#75804)

### DIFF
--- a/x-pack/plugin/eql/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/eql/10_basic.yml
+++ b/x-pack/plugin/eql/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/eql/10_basic.yml
@@ -309,6 +309,7 @@ setup:
 
   - is_true: id
   - set: {id: id}
+  - gte: {took: 0}
 
   - do:
       eql.get:

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/plugin/TransportEqlSearchAction.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/plugin/TransportEqlSearchAction.java
@@ -100,7 +100,7 @@ public class TransportEqlSearchAction extends HandledTransportAction<EqlSearchRe
     @Override
     public EqlSearchResponse initialResponse(EqlSearchTask task) {
         return new EqlSearchResponse(EqlSearchResponse.Hits.EMPTY,
-            threadPool.relativeTimeInMillis() - task.getStartTime(), false, task.getExecutionId().getEncoded(), true, true);
+            TimeValue.nsecToMSec(System.nanoTime() - task.getStartTimeNanos()), false, task.getExecutionId().getEncoded(), true, true);
     }
 
     @Override


### PR DESCRIPTION
Backports the following commits to 7.14:
 - EQL: correct time accounting for an intermediary response (#75804)