### PR TITLE
[ML] Unmute BWC tests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -145,9 +145,9 @@ tasks.register("verifyVersions") {
  * after the backport of the backcompat code is complete.
  */
 
-boolean bwc_tests_enabled = false
+boolean bwc_tests_enabled = true
 // place a PR link here when committing bwc changes:
-String bwc_tests_disabled_issue = "https://github.com/elastic/elasticsearch/pull/75741"
+String bwc_tests_disabled_issue = ""
 /*
  * FIPS 140-2 behavior was fixed in 7.11.0. Before that there is no way to run elasticsearch in a
  * JVM that is properly configured to be in fips mode with BCFIPS. For now we need to disable

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/config/AnalysisConfig.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/config/AnalysisConfig.java
@@ -153,7 +153,7 @@ public class AnalysisConfig implements ToXContentObject, Writeable {
         influencers = Collections.unmodifiableList(in.readStringList());
 
         multivariateByFields = in.readOptionalBoolean();
-        if (in.getVersion().onOrAfter(Version.V_8_0_0)) {
+        if (in.getVersion().onOrAfter(Version.V_7_15_0)) {
             modelPruneWindow = in.readOptionalTimeValue();
         } else {
             modelPruneWindow = null;
@@ -179,7 +179,7 @@ public class AnalysisConfig implements ToXContentObject, Writeable {
 
         out.writeOptionalBoolean(multivariateByFields);
 
-        if (out.getVersion().onOrAfter(Version.V_8_0_0)) {
+        if (out.getVersion().onOrAfter(Version.V_7_15_0)) {
             out.writeOptionalTimeValue(modelPruneWindow);
         }
     }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/config/JobUpdate.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/config/JobUpdate.java
@@ -169,7 +169,7 @@ public class JobUpdate implements Writeable, ToXContentObject {
         allowLazyOpen = in.readOptionalBoolean();
         blocked = in.readOptionalWriteable(Blocked::new);
 
-        if (in.getVersion().onOrAfter(Version.V_8_0_0)) {
+        if (in.getVersion().onOrAfter(Version.V_7_15_0)) {
             modelPruneWindow = in.readOptionalTimeValue();
         } else {
             modelPruneWindow = null;
@@ -217,7 +217,7 @@ public class JobUpdate implements Writeable, ToXContentObject {
         out.writeOptionalBoolean(allowLazyOpen);
         out.writeOptionalWriteable(blocked);
 
-        if (out.getVersion().onOrAfter(Version.V_8_0_0)) {
+        if (out.getVersion().onOrAfter(Version.V_7_15_0)) {
             out.writeOptionalTimeValue(modelPruneWindow);
         }
     }


### PR DESCRIPTION
Unmute the the BWC tests and alter the BWC version for the
model_prune_window field to be 7_15_0

Note that the CI BWC tests are expected to fail for this PR until the backport PR #75999 has been merged.

Relates #75741, #76003