### PR TITLE
[DOCS] Remove _all for <snapshot> parameter

### DIFF
--- a/docs/reference/snapshot-restore/apis/get-snapshot-api.asciidoc
+++ b/docs/reference/snapshot-restore/apis/get-snapshot-api.asciidoc
@@ -67,13 +67,9 @@ cluster, omit this parameter or use `*` or `_all`.
 
 `<snapshot>`::
 (Required, string)
-Comma-separated list of snapshot names to retrieve. Also accepts wildcards (`*`).
+Comma-separated list of snapshot names to retrieve. Also accepts wildcards (`*`) when a repository is specified.
 +
-* To get information about all snapshots in a registered repository, use a wildcard (`*`) or `_all`.
-* To get information about any snapshots that are currently running, use `_current`.
-+
-NOTE: Using `_all` in a request fails if any snapshots are unavailable.
-Set <<get-snapshot-api-ignore-unavailable,`ignore_unavailable`>> to `true` to return only available snapshots.
+To get information about any snapshots that are currently running, use `_current`.
 
 [role="child_attributes"]
 [[get-snapshot-api-query-params]]


### PR DESCRIPTION
Removes the `_all` option for the `<snapshot>` parameter of the get snapshot API. The `_all` option is supported only for the `<repository>` parameter in 7.13.

Closes #75997