### PR TITLE
[DOCS] Remove _all for <snapshot> parameter

### DIFF
--- a/docs/reference/snapshot-restore/apis/get-snapshot-api.asciidoc
+++ b/docs/reference/snapshot-restore/apis/get-snapshot-api.asciidoc
@@ -58,9 +58,6 @@ Use the get snapshot API to return information about one or more snapshots, incl
 `<repository>`::
 (Required, string)
 Snapshot repository name used to limit the request.
-+
-To get information about all snapshot repositories registered in the
-cluster, omit this parameter or use `*` or `_all`.
 
 `<snapshot>`::
 (Required, string)


### PR DESCRIPTION
Removes the _all option for the <snapshot> parameter of the get snapshot API. The _all option is supported only for the <repository> parameter in 7.13.

Closes #75997