### PR TITLE
[DOCS] Remove coming tags from release highlights

### DIFF
--- a/docs/reference/redirects.asciidoc
+++ b/docs/reference/redirects.asciidoc
@@ -826,7 +826,7 @@ See <<ccs-gateway-seed-nodes>> and <<ccs-min-roundtrips>>.
 [role="exclude",id="indices-component-templates"]
 === Component template APIs
 
-coming::[7.x]
+See <<index-templates-apis,index template APIs>>.
 
 [role="exclude",id="modules-indices"]
 === Indices module

--- a/docs/reference/release-notes/highlights.asciidoc
+++ b/docs/reference/release-notes/highlights.asciidoc
@@ -1,8 +1,6 @@
 [[release-highlights]]
 == What's new in {minor-version}
 
-coming::[{minor-version}]
-
 Here are the highlights of what's new and improved in {es} {minor-version}!
 
 For detailed information about this release, see the <<es-release-notes>> and


### PR DESCRIPTION
This PR removes coming tag from the release highlights.

Our 7.x and 8.x docs already have a "preliminary docs" advisory until they're released:

<img width="744" alt="Screen Shot 2021-08-03 at 11 01 37 AM" src="https://user-images.githubusercontent.com/40268737/128038574-32058d6f-4e63-484f-ab79-1d7ffc820dad.PNG">

This coming tag duplicates that message. Removing it creates an unneeded chore at release.

This also replaces an outdated coming tag for component template API redirects.