### PR TITLE
[7.14] Bump bundled JDK to 16.0.2 (#75981)

### DIFF
--- a/build-tools-internal/version.properties
+++ b/build-tools-internal/version.properties
@@ -1,8 +1,8 @@
 elasticsearch     = 7.14.1
 lucene            = 8.9.0
 
-bundled_jdk_vendor = adoptopenjdk
-bundled_jdk = 16.0.1+9
+bundled_jdk_vendor = openjdk
+bundled_jdk = 16.0.2+7@d4a915d82b4c4fbb9bde534da945d746
 
 checkstyle = 8.39
 

--- a/docs/changelog/75981.yaml
+++ b/docs/changelog/75981.yaml
@@ -1,0 +1,9 @@
+pr: 75981
+summary: Bump bundled JDK to 16.0.2
+area: Packaging
+type: upgrade
+issues: []
+versions:
+ - v8.0.0
+ - v7.14.1
+ - v7.15.0


### PR DESCRIPTION
Backports the following commits to 7.14:
 - Bump bundled JDK to 16.0.2 (#75981)