### PR TITLE
[7.x] Add ability to allow list instance methods on the script class (#76045)

### DIFF
--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/phase/DefaultUserTreeToIRTreePhase.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/phase/DefaultUserTreeToIRTreePhase.java
@@ -185,6 +185,7 @@ import org.elasticsearch.painless.symbol.Decorations.StandardPainlessInstanceBin
 import org.elasticsearch.painless.symbol.Decorations.StandardPainlessMethod;
 import org.elasticsearch.painless.symbol.Decorations.StaticType;
 import org.elasticsearch.painless.symbol.Decorations.TargetType;
+import org.elasticsearch.painless.symbol.Decorations.ThisPainlessMethod;
 import org.elasticsearch.painless.symbol.Decorations.TypeParameters;
 import org.elasticsearch.painless.symbol.Decorations.UnaryType;
 import org.elasticsearch.painless.symbol.Decorations.UpcastPainlessCast;
@@ -239,6 +240,7 @@ import org.elasticsearch.painless.symbol.IRDecorations.IRDShiftType;
 import org.elasticsearch.painless.symbol.IRDecorations.IRDSize;
 import org.elasticsearch.painless.symbol.IRDecorations.IRDStoreType;
 import org.elasticsearch.painless.symbol.IRDecorations.IRDSymbol;
+import org.elasticsearch.painless.symbol.IRDecorations.IRDThisMethod;
 import org.elasticsearch.painless.symbol.IRDecorations.IRDTypeParameters;
 import org.elasticsearch.painless.symbol.IRDecorations.IRDUnaryType;
 import org.elasticsearch.painless.symbol.IRDecorations.IRDValue;
@@ -1221,6 +1223,10 @@ public class DefaultUserTreeToIRTreePhase implements UserTreeVisitor<ScriptScope
         if (scriptScope.hasDecoration(callLocalNode, StandardLocalFunction.class)) {
             LocalFunction localFunction = scriptScope.getDecoration(callLocalNode, StandardLocalFunction.class).getLocalFunction();
             irInvokeCallMemberNode.attachDecoration(new IRDFunction(localFunction));
+        } else if (scriptScope.hasDecoration(callLocalNode, ThisPainlessMethod.class)) {
+            PainlessMethod thisMethod =
+                    scriptScope.getDecoration(callLocalNode, ThisPainlessMethod.class).getThisPainlessMethod();
+            irInvokeCallMemberNode.attachDecoration(new IRDThisMethod(thisMethod));
         } else if (scriptScope.hasDecoration(callLocalNode, StandardPainlessMethod.class)) {
             PainlessMethod importedMethod =
                     scriptScope.getDecoration(callLocalNode, StandardPainlessMethod.class).getStandardPainlessMethod();

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/symbol/Decorations.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/symbol/Decorations.java
@@ -417,6 +417,19 @@ public class Decorations {
         }
     }
 
+    public static class ThisPainlessMethod implements Decoration {
+
+        private final PainlessMethod thisPainlessMethod;
+
+        public ThisPainlessMethod(PainlessMethod thisPainlessMethod) {
+            this.thisPainlessMethod = Objects.requireNonNull(thisPainlessMethod);
+        }
+
+        public PainlessMethod getThisPainlessMethod() {
+            return thisPainlessMethod;
+        }
+    }
+
     public static class StandardPainlessClassBinding implements Decoration {
 
         private final PainlessClassBinding painlessClassBinding;

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/symbol/IRDecorations.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/symbol/IRDecorations.java
@@ -370,6 +370,19 @@ public class IRDecorations {
         }
     }
 
+    /** describes a method for a node on the script class; which method depends on node type */
+    public static class IRDThisMethod extends IRDecoration<PainlessMethod> {
+
+        public IRDThisMethod(PainlessMethod value) {
+            super(value);
+        }
+
+        @Override
+        public String toString() {
+            return PainlessLookupUtility.buildPainlessMethodKey(getValue().javaMethod.getName(), getValue().typeParameters.size());
+        }
+    }
+
     /** describes the call to a class binding */
     public static class IRDClassBinding extends IRDecoration<PainlessClassBinding> {
 

--- a/modules/lang-painless/src/test/java/org/elasticsearch/painless/ThisTests.java
+++ b/modules/lang-painless/src/test/java/org/elasticsearch/painless/ThisTests.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.painless;
+
+import org.elasticsearch.painless.spi.Whitelist;
+import org.elasticsearch.painless.spi.WhitelistLoader;
+import org.elasticsearch.script.ScriptContext;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class ThisTests extends ScriptTestCase {
+
+    public abstract static class ThisBaseScript {
+
+        protected String baseString;
+
+        public ThisBaseScript(String baseString) {
+            this.baseString = baseString;
+        }
+
+        public String getBaseString() {
+            return baseString;
+        }
+
+        public void setBaseString(String testString) {
+            this.baseString = testString;
+        }
+
+        public int getBaseLength() {
+            return baseString.length();
+        }
+    }
+
+    public abstract static class ThisScript extends ThisBaseScript {
+
+        protected String thisString;
+
+        public ThisScript(String baseString, String thisString) {
+            super(baseString);
+
+            this.thisString = thisString;
+        }
+
+        public String thisString() {
+            return thisString;
+        }
+
+        public void thisString(String testString) {
+            this.thisString = testString;
+        }
+
+        public int thisLength() {
+            return thisString.length();
+        }
+
+        public abstract Object execute();
+
+        public interface Factory {
+
+            ThisScript newInstance(String baseString, String testString);
+        }
+
+        public static final String[] PARAMETERS = {};
+        public static final ScriptContext<ThisScript.Factory> CONTEXT =
+                new ScriptContext<>("this_test", ThisScript.Factory.class);
+    }
+
+    @Override
+    protected Map<ScriptContext<?>, List<Whitelist>> scriptContexts() {
+        Map<ScriptContext<?>, List<Whitelist>> contexts = new HashMap<>();
+        List<Whitelist> whitelists = new ArrayList<>(Whitelist.BASE_WHITELISTS);
+        whitelists.add(WhitelistLoader.loadFromResourceFiles(Whitelist.class, "org.elasticsearch.painless.this"));
+        contexts.put(ThisScript.CONTEXT, whitelists);
+        return contexts;
+    }
+
+    public Object exec(String script, String baseString, String testString) {
+        ThisScript.Factory factory = scriptEngine.compile(null, script, ThisScript.CONTEXT, new HashMap<>());
+        ThisScript testThisScript = factory.newInstance(baseString, testString);
+        return testThisScript.execute();
+    }
+
+    public void testThisMethods() {
+        assertEquals("basethis", exec("getBaseString() + thisString()", "base", "this"));
+        assertEquals(8, exec("getBaseLength() + thisLength()", "yyy", "xxxxx"));
+
+        List<String> result = new ArrayList<>();
+        result.add("this");
+        result.add("base");
+        assertEquals(result, exec("List result = []; " +
+                "thisString('this');" +
+                "setBaseString('base');" +
+                "result.add(thisString()); " +
+                "result.add(getBaseString());" +
+                "result;", "", ""));
+    }
+}

--- a/modules/lang-painless/src/test/resources/org/elasticsearch/painless/spi/org.elasticsearch.painless.this
+++ b/modules/lang-painless/src/test/resources/org/elasticsearch/painless/spi/org.elasticsearch.painless.this
@@ -1,0 +1,12 @@
+class org.elasticsearch.painless.ThisTests$ThisBaseScript @no_import {
+  String getBaseString();
+  void setBaseString(String);
+  int getBaseLength();
+}
+
+
+class org.elasticsearch.painless.ThisTests$ThisScript @no_import {
+  String thisString();
+  void thisString(String);
+  int thisLength();
+}


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Add ability to allow list instance methods on the script class (#76045)