### PR TITLE
[DOCS] Document regex circuit breaker

### DIFF
--- a/docs/reference/ingest.asciidoc
+++ b/docs/reference/ingest.asciidoc
@@ -770,10 +770,10 @@ PUT _ingest/pipeline/my-pipeline
 }
 ----
 
-If the static `script.painless.regex.enabled` cluster setting is enabled, you
-can use regular expressions in your `if` condition scripts. For supported
-syntax, see the {painless}/painless-regexes.html[Painless regexes]
-documentation.
+If the <<script-painless-regex-enabled,`script.painless.regex.enabled`>> cluster
+setting is enabled, you can use regular expressions in your `if` condition
+scripts. For supported syntax, see {painless}/painless-regexes.html[Painless
+regular expressions].
 
 TIP: If possible, avoid using regular expressions. Expensive regular expressions
 can slow indexing speeds.

--- a/docs/reference/modules/indices/circuit_breaker.asciidoc
+++ b/docs/reference/modules/indices/circuit_breaker.asciidoc
@@ -153,8 +153,8 @@ cluster setting.
 Enables regex with no complexity limits. Disables the regex circuit breaker.
 
 `false`:::
-Disables regex. Any Painless script containing a regular expression triggers the
-regex circuit breaker and returns an error.
+Disables regex. Any Painless script containing a regular expression returns an
+error.
 
 [[script-painless-regex-limit-factor]]
 `script.painless.regex.limit-factor`::

--- a/docs/reference/modules/indices/circuit_breaker.asciidoc
+++ b/docs/reference/modules/indices/circuit_breaker.asciidoc
@@ -131,3 +131,41 @@ documentation for more information.
     Limit for the number of unique dynamic scripts within a certain interval
     that are allowed to be compiled for a given context. Defaults to `75/5m`,
     meaning 75 every 5 minutes.
+
+[[regex-circuit-breaker]]
+[discrete]
+==== Regex circuit breaker
+
+Poorly written regular expressions can degrade cluster stability and
+performance. The regex circuit breaker limits the use and complexity of
+{painless}/painless-regexes.html[regex in Painless scripts].
+
+[[script-painless-regex-enabled]]
+`script.painless.regex.enabled`::
+(<<static-cluster-setting,Static>>) Enables regex in Painless scripts. Accepts:
+
+`limit` (Default):::
+Enables regex but limits complexity using the
+<<script-painless-regex-limit-factor,`script.painless.regex.limit-factor`>>
+cluster setting.
+
+`true`:::
+Enables regex with no complexity limits. Disables the regex circuit breaker.
+
+`false`:::
+Disables regex. Any Painless script containing a regular expression triggers the
+regex circuit breaker and returns an error.
+
+[[script-painless-regex-limit-factor]]
+`script.painless.regex.limit-factor`::
+(<<static-cluster-setting,Static>>) Limits the number of characters a regular
+expression in a Painless script can consider. {es} calculates this limit by
+multiplying the setting value by the script input's character length.
++
+For example, the input `foobarbaz` has a character length of `9`. If
+`script.painless.regex.limit-factor` is `6`, a regular expression on `foobarbaz`
+can consider up to 54 (9 * 6) characters. If the expression exceeds this limit,
+it triggers the regex circuit breaker and returns an error.
++
+{es} only applies this limit if
+<<script-painless-regex-enabled,`script.painless.regex.enabled`>> is `limit`.


### PR DESCRIPTION
Documents the `script.painless.regex.enabled` and
`script.painless.regex.limit-factor` cluster settings.

Relates to #63029.

Closes #75199.

### Preview
https://elasticsearch_76048.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/circuit-breaker.html#regex-circuit-breaker