### PR TITLE
Fix GeoShapeWithDocValuesFieldTypeTests#testFetchVectorTile

### DIFF
--- a/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/index/mapper/GeoShapeWithDocValuesFieldTypeTests.java
+++ b/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/index/mapper/GeoShapeWithDocValuesFieldTypeTests.java
@@ -78,7 +78,6 @@ public class GeoShapeWithDocValuesFieldTypeTests extends FieldTypeTestCase {
         assertEquals(List.of(wktLineString, wktPoint), fetchSourceValue(mapper, sourceValue, "wkt"));
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/76059")
     public void testFetchVectorTile() throws IOException {
         fetchVectorTile(GeometryTestUtils.randomPoint());
         fetchVectorTile(GeometryTestUtils.randomMultiPoint(false));
@@ -108,7 +107,14 @@ public class GeoShapeWithDocValuesFieldTypeTests extends FieldTypeTestCase {
         }
 
         final List<?> sourceValue = fetchSourceValue(mapper, WellKnownText.toWKT(geometry), mvtString);
-        final List<byte[]> features = featureFactory.getFeatures(geometry);
+        List<byte[]> features;
+        try {
+            features = featureFactory.getFeatures(geometry);
+        } catch (IllegalArgumentException iae) {
+            // if parsing fails means that we must be ignoring malformed values. In case of mvt might
+            // happen that the geometry is out of range (close to the poles).
+            features = List.of();
+        }
         assertThat(features.size(), Matchers.equalTo(sourceValue.size()));
         for (int i = 0; i < features.size(); i++) {
             assertThat(sourceValue.get(i), Matchers.equalTo(features.get(i)));

--- a/x-pack/plugin/vector-tile/src/main/java/org/elasticsearch/xpack/vectortile/feature/FeatureFactory.java
+++ b/x-pack/plugin/vector-tile/src/main/java/org/elasticsearch/xpack/vectortile/feature/FeatureFactory.java
@@ -163,16 +163,7 @@ public class FeatureFactory {
 
         @Override
         public org.locationtech.jts.geom.Geometry visit(Polygon polygon) throws RuntimeException {
-            final org.locationtech.jts.geom.Polygon jtsPolygon = buildPolygon(polygon);
-            if (jtsPolygon.isValid() == false) {
-                // we only simplify the polygon if is valid, otherwise algorithm might fail.
-                return jtsPolygon;
-            }
-            if (jtsPolygon.contains(tile)) {
-                // shortcut, we return the tile
-                return tile;
-            }
-            return TopologyPreservingSimplifier.simplify(jtsPolygon, pixelPrecision);
+            return simplifyGeometry(buildPolygon(polygon));
         }
 
         @Override
@@ -182,16 +173,19 @@ public class FeatureFactory {
                 final org.locationtech.jts.geom.Polygon jtsPolygon = buildPolygon(multiPolygon.get(i));
                 polygons[i] = jtsPolygon;
             }
-            org.locationtech.jts.geom.MultiPolygon jtsMultiPolygon = geomFactory.createMultiPolygon(polygons);
-            if (jtsMultiPolygon.isValid() == false) {
-                // we only simplify the multi-polygon if is valid, otherwise algorithm might fail.
-                return jtsMultiPolygon;
+            return simplifyGeometry(geomFactory.createMultiPolygon(polygons));
+        }
+
+        private org.locationtech.jts.geom.Geometry simplifyGeometry(org.locationtech.jts.geom.Geometry geometry) {
+            if (geometry.isValid() == false) {
+                // we only simplify the geometry if it is valid, otherwise algorithm might fail.
+                return geometry;
             }
-            if (jtsMultiPolygon.contains(tile)) {
+            if (geometry.contains(tile)) {
                 // shortcut, we return the tile
                 return tile;
             }
-            return TopologyPreservingSimplifier.simplify(jtsMultiPolygon, pixelPrecision);
+            return TopologyPreservingSimplifier.simplify(geometry, pixelPrecision);
         }
 
         private org.locationtech.jts.geom.Polygon buildPolygon(Polygon polygon) {

--- a/x-pack/plugin/vector-tile/src/main/java/org/elasticsearch/xpack/vectortile/feature/FeatureFactory.java
+++ b/x-pack/plugin/vector-tile/src/main/java/org/elasticsearch/xpack/vectortile/feature/FeatureFactory.java
@@ -180,16 +180,16 @@ public class FeatureFactory {
             final org.locationtech.jts.geom.Polygon[] polygons = new org.locationtech.jts.geom.Polygon[multiPolygon.size()];
             for (int i = 0; i < multiPolygon.size(); i++) {
                 final org.locationtech.jts.geom.Polygon jtsPolygon = buildPolygon(multiPolygon.get(i));
-                if (jtsPolygon.contains(tile)) {
-                    // shortcut, we return the tile
-                    return tile;
-                }
                 polygons[i] = jtsPolygon;
             }
             org.locationtech.jts.geom.MultiPolygon jtsMultiPolygon = geomFactory.createMultiPolygon(polygons);
             if (jtsMultiPolygon.isValid() == false) {
                 // we only simplify the multi-polygon if is valid, otherwise algorithm might fail.
                 return jtsMultiPolygon;
+            }
+            if (jtsMultiPolygon.contains(tile)) {
+                // shortcut, we return the tile
+                return tile;
             }
             return TopologyPreservingSimplifier.simplify(jtsMultiPolygon, pixelPrecision);
         }

--- a/x-pack/plugin/vector-tile/src/main/java/org/elasticsearch/xpack/vectortile/feature/FeatureFactory.java
+++ b/x-pack/plugin/vector-tile/src/main/java/org/elasticsearch/xpack/vectortile/feature/FeatureFactory.java
@@ -182,7 +182,12 @@ public class FeatureFactory {
                 }
                 polygons[i] = jtsPolygon;
             }
-            return TopologyPreservingSimplifier.simplify(geomFactory.createMultiPolygon(polygons), pixelPrecision);
+            org.locationtech.jts.geom.MultiPolygon jtsMultiPolygon = geomFactory.createMultiPolygon(polygons);
+            if (jtsMultiPolygon.isValid() == false) {
+                // we only simplify the multi-polygon if is valid, otherwise algorithm might fail.
+                return jtsMultiPolygon;
+            }
+            return TopologyPreservingSimplifier.simplify(jtsMultiPolygon, pixelPrecision);
         }
 
         private org.locationtech.jts.geom.Polygon buildPolygon(Polygon polygon) {

--- a/x-pack/plugin/vector-tile/src/main/java/org/elasticsearch/xpack/vectortile/feature/FeatureFactory.java
+++ b/x-pack/plugin/vector-tile/src/main/java/org/elasticsearch/xpack/vectortile/feature/FeatureFactory.java
@@ -164,6 +164,10 @@ public class FeatureFactory {
         @Override
         public org.locationtech.jts.geom.Geometry visit(Polygon polygon) throws RuntimeException {
             final org.locationtech.jts.geom.Polygon jtsPolygon = buildPolygon(polygon);
+            if (jtsPolygon.isValid() == false) {
+                // we only simplify the polygon if is valid, otherwise algorithm might fail.
+                return jtsPolygon;
+            }
             if (jtsPolygon.contains(tile)) {
                 // shortcut, we return the tile
                 return tile;


### PR DESCRIPTION
Ignore invalid geometries the same way we are doing it in ArraySourceValueFetcher. In addition we only simplify (multi)
polygons if they are valid, otherwise the algorithm might fail and produce a stackoverflowerror.

closes https://github.com/elastic/elasticsearch/issues/76059