### PR TITLE
Noop repository update should skip verification

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/repositories/RepositoriesServiceIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/repositories/RepositoriesServiceIT.java
@@ -12,6 +12,7 @@ import org.elasticsearch.action.admin.cluster.repositories.get.GetRepositoriesRe
 import org.elasticsearch.client.Client;
 import org.elasticsearch.cluster.metadata.RepositoryMetadata;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.env.Environment;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.repositories.fs.FsRepository;
 import org.elasticsearch.snapshots.mockstore.MockRepository;
@@ -81,5 +82,11 @@ public class RepositoriesServiceIT extends ESIntegTestCase {
 
         final Repository updatedRepository = repositoriesService.repository(repositoryName);
         assertThat(updatedRepository, updated ? not(sameInstance(originalRepository)) : sameInstance(originalRepository));
+
+        // check that a noop update does not verify.
+        internalCluster().startDataOnlyNode(Settings.builder().put(Environment.PATH_REPO_SETTING.getKey(), createTempDir()).build());
+        assertAcked(
+            client.admin().cluster().preparePutRepository(repositoryName).setType(updatedRepositoryType).setSettings(repoSettings).get()
+        );
     }
 }

--- a/server/src/internalClusterTest/java/org/elasticsearch/repositories/RepositoriesServiceIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/repositories/RepositoriesServiceIT.java
@@ -83,7 +83,8 @@ public class RepositoriesServiceIT extends ESIntegTestCase {
         final Repository updatedRepository = repositoriesService.repository(repositoryName);
         assertThat(updatedRepository, updated ? not(sameInstance(originalRepository)) : sameInstance(originalRepository));
 
-        // check that a noop update does not verify.
+        // check that a noop update does not verify. Since the new data node does not share the same `path.repo`, verification will fail if
+        // it runs.
         internalCluster().startDataOnlyNode(Settings.builder().put(Environment.PATH_REPO_SETTING.getKey(), createTempDir()).build());
         assertAcked(
             client.admin().cluster().preparePutRepository(repositoryName).setType(updatedRepositoryType).setSettings(repoSettings).get()

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/RepositoryMetadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/RepositoryMetadata.java
@@ -167,18 +167,6 @@ public class RepositoryMetadata implements Writeable {
         return name.equals(other.name) && uuid.equals(other.uuid()) && type.equals(other.type()) && settings.equals(other.settings());
     }
 
-    /**
-     * Checks if this instance contains the same data as the updated instance, ignoring {@link #uuid}, {@link #generation} and
-     * {@link #pendingGeneration}.
-     * @param updated the metadata with the updated type and settings.
-     * @return true if it is a noop update, false if data changed.
-     */
-    public boolean isNoopUpdate(RepositoryMetadata updated) {
-        assert name.equals(updated.name);
-        //noinspection ConstantConditions
-        return name.equals(updated.name) && type.equals(updated.type()) && settings.equals(updated.settings());
-    }
-
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/RepositoryMetadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/RepositoryMetadata.java
@@ -167,6 +167,18 @@ public class RepositoryMetadata implements Writeable {
         return name.equals(other.name) && uuid.equals(other.uuid()) && type.equals(other.type()) && settings.equals(other.settings());
     }
 
+    /**
+     * Checks if this instance contains the same data as the updated instance, ignoring {@link #uuid}, {@link #generation} and
+     * {@link #pendingGeneration}.
+     * @param updated the metadata with the updated type and settings.
+     * @return true if it is a noop update, false if data changed.
+     */
+    public boolean isNoopUpdate(RepositoryMetadata updated) {
+        assert name.equals(updated.name);
+        //noinspection ConstantConditions
+        return name.equals(updated.name) && type.equals(updated.type()) && settings.equals(updated.settings());
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;

--- a/server/src/main/java/org/elasticsearch/repositories/RepositoriesService.java
+++ b/server/src/main/java/org/elasticsearch/repositories/RepositoriesService.java
@@ -201,10 +201,6 @@ public class RepositoriesService extends AbstractLifecycleComponent implements C
                     List<RepositoryMetadata> repositoriesMetadata = new ArrayList<>(repositories.repositories().size() + 1);
                     for (RepositoryMetadata repositoryMetadata : repositories.repositories()) {
                         if (repositoryMetadata.name().equals(newRepositoryMetadata.name())) {
-                            if (newRepositoryMetadata.isNoopUpdate(repositoryMetadata)) {
-                                // Previous version is the same as this one no update is needed.
-                                return currentState;
-                            }
                             Repository existing = RepositoriesService.this.repositories.get(request.name());
                             if (existing == null) {
                                 existing = RepositoriesService.this.internalRepositories.get(request.name());
@@ -213,6 +209,10 @@ public class RepositoriesService extends AbstractLifecycleComponent implements C
                             assert existing.getMetadata() == repositoryMetadata;
                             final RepositoryMetadata updatedMetadata;
                             if (canUpdateInPlace(newRepositoryMetadata, existing)) {
+                                if (repositoryMetadata.settings().equals(newRepositoryMetadata.settings())) {
+                                    // Previous version is the same as this one no update is needed.
+                                    return currentState;
+                                }
                                 // we're updating in place so the updated metadata must point at the same uuid and generations
                                 updatedMetadata = repositoryMetadata.withSettings(newRepositoryMetadata.settings());
                             } else {


### PR DESCRIPTION
It is common to do an idempotent PUT of a repo, just to ensure it is
there. This commit ensures that if the change is in fact a noop change,
we no longer do any repository verification, since a node having trouble
(for instance running out of heap) could then mean such a no-change
repo update failing.

Closes #76012
