### PR TITLE
Don't Circuit Break Shard Started/Failed Requests

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/action/shard/ShardStateAction.java
+++ b/server/src/main/java/org/elasticsearch/cluster/action/shard/ShardStateAction.java
@@ -91,11 +91,11 @@ public class ShardStateAction {
         this.clusterService = clusterService;
         this.threadPool = threadPool;
 
-        transportService.registerRequestHandler(SHARD_STARTED_ACTION_NAME, ThreadPool.Names.SAME, StartedShardEntry::new,
+        transportService.registerRequestHandler(SHARD_STARTED_ACTION_NAME, ThreadPool.Names.SAME, false, false, StartedShardEntry::new,
             new ShardStartedTransportHandler(clusterService,
                 new ShardStartedClusterStateTaskExecutor(allocationService, rerouteService, logger),
                 logger));
-        transportService.registerRequestHandler(SHARD_FAILED_ACTION_NAME, ThreadPool.Names.SAME, FailedShardEntry::new,
+        transportService.registerRequestHandler(SHARD_FAILED_ACTION_NAME, ThreadPool.Names.SAME, false, false, FailedShardEntry::new,
             new ShardFailedTransportHandler(clusterService,
                 new ShardFailedClusterStateTaskExecutor(allocationService, rerouteService, logger),
                 logger));


### PR DESCRIPTION
## Problem

Shard Started/Failed requests are likely to trip the circuit breaker under heavy load
which might lead to unfortunate side-effects in nodes under pressure. 

1. Shards that should have been removed and rerouted, are not processed and not in the right state.
2. The index requests to the shards will be stuck and wait for a retry. It will result in more pressure on memory, making the situation worse.
3.  [updateFailedShardsCache](https://github.com/elastic/elasticsearch/blob/master/server/src/main/java/org/elasticsearch/indices/cluster/IndicesClusterStateService.java#L209) can find out the previously failed shard had not been removed and resending shard failure. But it depends on cluster state updates and if there is no cluster state update task or the master is under heavy pressure, the previously failed shard  would never be handled

## Solution

Turn off the circuit breaker for shard failed and started. It will make shards recover faster and reduce the pressure from disaster at the same time.  