### PR TITLE
Increase Timeout in WaitForRefreshAndCloseIT (#76078)

### DIFF
--- a/distribution/archives/integ-test-zip/src/test/java/org/elasticsearch/test/rest/WaitForRefreshAndCloseIT.java
+++ b/distribution/archives/integ-test-zip/src/test/java/org/elasticsearch/test/rest/WaitForRefreshAndCloseIT.java
@@ -83,7 +83,7 @@ public class WaitForRefreshAndCloseIT extends ESRestTestCase {
             Map<?, ?> refresh = (Map<?, ?>) total.get("refresh");
             int listeners = (Integer) refresh.get("listeners");
             assertEquals(1, listeners);
-        });
+        }, 30L, TimeUnit.SECONDS);
 
         // Close the index. That should flush the listener.
         final Request closeRequest = new Request("POST", "/test/_close");


### PR DESCRIPTION
The test cluster took slightly more than 10s to apply the cluster state for the mapping update
randomly which failed the run in #75941. This only ever failed once but since there's no real harm in doing so
increasing the timeout to 30s here like we did in other similar spots.

closes #75941

backport of #76078 