### PR TITLE
Support 2b and 2y prefixes in bcrypt

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authc/support/BCrypt.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authc/support/BCrypt.java
@@ -667,7 +667,7 @@ public class BCrypt {
             off = 3;
         else {
             minor = salt.charAt(2);
-            if (minor != 'a' || salt.charAt(3) != '$')
+            if (valid_minor(minor) == false || salt.charAt(3) != '$')
                 throw new IllegalArgumentException ("Invalid salt revision");
             off = 4;
         }
@@ -725,6 +725,17 @@ public class BCrypt {
         rs.append(encode_base64(hashed,
                 bf_crypt_ciphertext.length * 4 - 1));
         return rs.toString();
+    }
+
+    static boolean valid_minor(char minor) {
+        switch (minor) {
+            case 'a':
+            case 'b':
+            case 'y':
+                return true;
+            default:
+                return false;
+        }
     }
 
     /**

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authc/support/Hasher.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authc/support/Hasher.java
@@ -475,7 +475,7 @@ public enum Hasher {
         }
     };
 
-    private static final String BCRYPT_PREFIX = "$2a$";
+    private static final int BCRYPT_PREFIX_LENGTH = 4;
     private static final String SHA1_PREFIX = "{SHA}";
     private static final String MD5_PREFIX = "{MD5}";
     private static final String SSHA256_PREFIX = "{SSHA256}";
@@ -572,8 +572,8 @@ public enum Hasher {
      * @return the hasher that can be used for validation
      */
     public static Hasher resolveFromHash(char[] hash) {
-        if (CharArrays.charsBeginsWith(BCRYPT_PREFIX, hash)) {
-            int cost = Integer.parseInt(new String(Arrays.copyOfRange(hash, BCRYPT_PREFIX.length(), hash.length - 54)));
+        if (isBcryptPrefix(hash)) {
+            int cost = Integer.parseInt(new String(Arrays.copyOfRange(hash, BCRYPT_PREFIX_LENGTH, hash.length - 54)));
             return cost == BCRYPT_DEFAULT_COST ? Hasher.BCRYPT : resolve("bcrypt" + cost);
         } else if (CharArrays.charsBeginsWith(PBKDF2_STRETCH_PREFIX, hash)) {
             int cost = Integer.parseInt(new String(Arrays.copyOfRange(hash, PBKDF2_STRETCH_PREFIX.length(), hash.length - 90)));
@@ -591,6 +591,16 @@ public enum Hasher {
             // This is either a non hashed password from cache or a corrupted hash string.
             return Hasher.NOOP;
         }
+    }
+
+    private static boolean isBcryptPrefix(char[] hash) {
+        if (hash.length < 4) {
+            return false;
+        }
+        if (hash[0] == '$' && hash[1] == '2' && hash[3] == '$') {
+            return BCrypt.valid_minor(hash[2]);
+        }
+        return false;
     }
 
     /**
@@ -673,7 +683,7 @@ public enum Hasher {
 
     private static boolean verifyBcryptHash(SecureString text, char[] hash) {
         String hashStr = new String(hash);
-        if (hashStr.startsWith(BCRYPT_PREFIX) == false) {
+        if (isBcryptPrefix(hash) == false) {
             return false;
         }
         return BCrypt.checkpw(text, hashStr);

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authc/support/BCryptTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authc/support/BCryptTests.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+package org.elasticsearch.xpack.core.security.authc.support;
+
+import org.elasticsearch.common.settings.SecureString;
+import org.elasticsearch.test.ESTestCase;
+
+import java.util.function.Consumer;
+
+import static org.hamcrest.Matchers.equalTo;
+
+public class BCryptTests extends ESTestCase {
+
+    private static final SecureString PASSWORD = new SecureString("U21VniQwdEWATfqO".toCharArray());
+    private static final String[] VALID_HASHES = {
+        "$2a$04$OLNTeJiq3vjYqTZwgDi62OU5MvzkV3Jqz.KiR3pwgQv70pD6bUsGa",
+        "$2a$05$XNLcDk8PSYbU70A4bWjY1ugWlNSVM.VPMp6lb9qLotOB9oPV5TyM6",
+        "$2a$06$KMO7CTXk.rzWPve.dRYXgu8x028/6QlBmRTCijvbwFH5Xx4Xhn4tW",
+        "$2a$07$tr.C.OmBfdIBg7gcMruQX.UHZtmoZfi6xNpK6A0/oa.ulR4rXj6Ny",
+        "$2a$08$Er.JIbUaPM7JmIN0iFEhW.H2hgtRT9weKtLdqEgSMAzmEe2xZ0B7a",
+        "$2a$09$OmkfXJKIWhUmnrIlOy9Cd.SOu337FXAKcbB10nMUwpKSez5G4jz8e",
+        "$2a$10$qyfYQcOK13wQmGO3Y.nVj.he5w1.Z0WV81HqBW6NlV.nkmg90utxO",
+        "$2a$11$oNdrIn9.RBEg.XXnZkqwk..2wBrU6SjEJkQTLyxEXVQQcw4BokSaa",
+        "$2a$12$WMLT/yjmMvBTgBnnZw1EhO6r4g7cWoxEOhS9ln4dNVg8gK3es/BZm",
+        "$2a$13$WHkGwOCLz8SnX13tYH0Ez.qwKK0YFD8DA4Anz0a0Laozw75vqmBee",
+        "$2a$14$8Urbk50As1LIgDBWPmXcFOpMWJfy3ddFLgvDlH3G1y4TFo4sLXU9y" };
+
+    public void testVerifyHash() {
+        for (String hash : VALID_HASHES) {
+            runWithValidRevisions(hash, h -> assertTrue("Hash " + h, BCrypt.checkpw(PASSWORD, h)));
+            runWithInvalidRevisions(hash, h -> expectThrows(IllegalArgumentException.class, () -> BCrypt.checkpw(PASSWORD, h)));
+
+            // Replace a random character in the hash
+            int index = randomIntBetween(10, hash.length() - 1);
+            String replace = randomValueOtherThan(hash.substring(index, index + 1), () -> randomAlphaOfLength(1));
+            String invalid = hash.substring(0, index) + replace + hash.substring(index + 1);
+            assertThat(invalid.length(), equalTo(hash.length()));
+            runWithValidRevisions(invalid, h -> assertFalse("Hash " + h, BCrypt.checkpw(PASSWORD, h)));
+        }
+    }
+
+    static void runWithValidRevisions(String baseHash, Consumer<String> action) {
+        for (String revision : new String[] { "$2a$", "$2b$", "$2y$" }) {
+            action.accept(revision + baseHash.substring(4));
+        }
+    }
+
+    static void runWithInvalidRevisions(String baseHash, Consumer<String> action) {
+        for (String revision : new String[] { "$2c$", "$2x$", "$2z$" }) {
+            action.accept(revision + baseHash.substring(4));
+        }
+    }
+
+}

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/support/HasherTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/support/HasherTests.java
@@ -12,6 +12,7 @@ import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.core.security.authc.support.Hasher;
 
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.sameInstance;
 
 public class HasherTests extends ESTestCase {
@@ -28,6 +29,21 @@ public class HasherTests extends ESTestCase {
         testHasherSelfGenerated(Hasher.BCRYPT12);
         testHasherSelfGenerated(Hasher.BCRYPT13);
         testHasherSelfGenerated(Hasher.BCRYPT14);
+    }
+
+    public void testBcryptFromExternalSources() throws Exception {
+        check("$2b$12$0313KXrdhWp6HLREsKxW/OWJQCxy2uYprv44b8MBk6dOj3PY6WSFG", "my-password", true);
+        check("$2b$12$0313KXrdhWp6HLREsKxW/OWJQCxy2uYprv44b8MBk6dOj3PY6WSFG", "not-the-password", false);
+
+        check("$2b$12$4bf6s1NIUhyA5FtLn1UrpuZTByjNCC7f0r5OFJP9ra8U2LtcpcK7C", "changeme", true);
+        check("$2b$12$4bf6s1NIUhyA5FtLn1UrpuZTByjNCC7f0r5OFJP9ra8U2LtcpcK7C", "changed-it", false);
+
+        check("$2b$09$OLrfKSXQJxohtFnkU.VZCO1gKywaTSFi4KPHqhuyY3qetAbI8v6/S", "NjJmOWRmMjJmODEyZmQ1NjFhNWVmZmIwOWMwNjk4MmMK", true);
+        check("$2b$09$OLrfKSXQJxohtFnkU.VZCO1gKywaTSFi4KPHqhuyY3qetAbI8v6/S", "nJjMowrMmJjModeYzMq1nJfHnwvMzMiWowmWnJK4mMmk", false);
+
+        check("$2b$14$azbTD0EotrQtoSsxFpbx/.HG8hCAojDFmN4hsD8khuevk/9j0yPlK", "python 3.9.6; bcrypt 3.2.0", true);
+        check("$2a$06$aQVRp5ajsIn3fzx2MnXKy.KlhxFLHaCOh8jSElqCtmYFbRkmTy..C", "https://bcrypt-generator.com/", true);
+        check("$2y$10$flKBxak./o.7Hql0il/98ejdZyob67TmPhHbRy3qOnMtCBosAVSRy", "php", true);
     }
 
     public void testPBKDF2FamilySelfGenerated() throws Exception {
@@ -184,9 +200,25 @@ public class HasherTests extends ESTestCase {
     }
 
     private static void testHasherSelfGenerated(Hasher hasher) {
-        //In FIPS 140 mode, passwords for PBKDF2 need to be at least 14 chars
+        // In FIPS 140 mode, passwords for PBKDF2 need to be at least 14 chars
         SecureString passwd = new SecureString(randomAlphaOfLength(between(14, 18)).toCharArray());
         char[] hash = hasher.hash(passwd);
         assertTrue(hasher.verify(passwd, hash));
+
+        SecureString incorrectPasswd = randomValueOtherThan(
+            passwd,
+            () -> new SecureString(randomAlphaOfLength(between(14, 18)).toCharArray())
+        );
+        assertFalse(hasher.verify(incorrectPasswd, hash));
+    }
+
+    private void check(String hash, String password, boolean shouldMatch) {
+        char[] hashChars = hash.toCharArray();
+        Hasher hasher = Hasher.resolveFromHash(hashChars);
+        assertThat(
+            "Verify " + password + " against " + hash + " using " + hasher.name(),
+            hasher.verify(new SecureString(password.toCharArray()), hashChars),
+            equalTo(shouldMatch)
+        );
     }
 }


### PR DESCRIPTION
Adds support for parsing "$2b$" and "$2y$" prefixes in bcrypt hashes.

These non standard prefixes are commonly used by some other tools
(e.g. python defaults to "$2b$" and PHP defaults to "$2y$").

Our implementation will continue to generate "$2a$" hashes, but will
support hashes imported from tools that use these other prefixes.

Closes: #56086, #51132

Co-authored-by: cactot <aprus@protonmail.com>