### PR TITLE
[DOCS] Add retrieving runtime fields to introduction

### DIFF
--- a/docs/reference/mapping/runtime.asciidoc
+++ b/docs/reference/mapping/runtime.asciidoc
@@ -14,6 +14,11 @@ sees runtime fields no differently. You can define runtime fields in the
 <<runtime-search-request,search request>>. Your choice, which is part of the
 inherent flexibility of runtime fields.
 
+Use the <<search-fields,`fields`>> parameter on the `_search` API to
+<<runtime-retrieving-fields,retrieve the values of runtime fields>>. Runtime
+fields won't display in `_source`, but the `fields` API works for all fields,
+even those that were not sent as part of the original `_source`.
+
 Runtime fields are useful when working with log data
 (see <<runtime-examples,examples>>), especially when you're unsure about the
 data structure. Your search speed decreases, but your index size is much
@@ -624,6 +629,7 @@ which still returns in the response:
 
 [[runtime-retrieving-fields]]
 === Retrieve a runtime field
+
 Use the <<search-fields,`fields`>> parameter on the `_search` API to retrieve
 the values of runtime fields. Runtime fields won't display in `_source`, but
 the `fields` API works for all fields, even those that were not sent as part of


### PR DESCRIPTION
A community member was confused about how to retrieve runtime fields. They were unaware that they needed to use the `fields` parameter of the search API, and that this parameter has access to `_source`. This PR adds the first two sentences from the page for [Retrieving runtime fields](https://www.elastic.co/guide/en/elasticsearch/reference/7.14/runtime-retrieving-fields.html) to the main introduction for runtime fields so that users are informed from the outset about how to retrieve them.

cc: @benwtrent, who interacted with this community member and highlighted the issue.

Preview link: https://elasticsearch_76084.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/runtime.html