### PR TITLE
HDFS repository test code fix for java 8

### DIFF
--- a/x-pack/plugin/snapshot-repo-test-kit/qa/hdfs/build.gradle
+++ b/x-pack/plugin/snapshot-repo-test-kit/qa/hdfs/build.gradle
@@ -83,7 +83,9 @@ for (String fixtureName : ['hdfsFixture', 'secureHdfsFixture']) {
     // If it's a secure fixture, then depend on Kerberos Fixture and principals + add the krb5conf to the JVM options
     if (name.equals('secureHdfsFixture')) {
       onlyIf { BuildParams.runtimeJavaVersion < JavaVersion.VERSION_16 }
-      miniHDFSArgs.addAll(["--add-exports", "java.security.jgss/sun.security.krb5=ALL-UNNAMED"])
+      if (BuildParams.runtimeJavaVersion.isJava9Compatible()) {
+        miniHDFSArgs.addAll(["--add-exports", "java.security.jgss/sun.security.krb5=ALL-UNNAMED"])
+      }
       miniHDFSArgs.add("-Djava.security.krb5.conf=${krb5conf}")
     }
     // configure port dynamically


### PR DESCRIPTION
The secure HDFS test code used by the repo analysis test did not work on java 8 because it was passing in the "--add-exports" flag to the JVM, which was only introduced in Java 9.
Relates to #73708 