### PR TITLE
[ML] allow for larger models in the inference step for data frame analytics

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/InferenceToXContentCompressor.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/InferenceToXContentCompressor.java
@@ -37,9 +37,9 @@ import java.util.zip.GZIPOutputStream;
  */
 public final class InferenceToXContentCompressor {
     private static final int BUFFER_SIZE = 4096;
-    // Either 10% of the configured JVM heap, or 1 GB, which ever is smaller
+    // Either 25% of the configured JVM heap, or 1 GB, which ever is smaller
     private static final long MAX_INFLATED_BYTES = Math.min(
-        (long)((0.10) * JvmInfo.jvmInfo().getMem().getHeapMax().getBytes()),
+        (long)((0.25) * JvmInfo.jvmInfo().getMem().getHeapMax().getBytes()),
         ByteSizeValue.ofGb(1).getBytes());
 
     private InferenceToXContentCompressor() {}
@@ -47,6 +47,12 @@ public final class InferenceToXContentCompressor {
     public static <T extends ToXContentObject> BytesReference deflate(T objectToCompress) throws IOException {
         BytesReference reference = XContentHelper.toXContent(objectToCompress, XContentType.JSON, false);
         return deflate(reference);
+    }
+
+    public static <T> T inflateUnsafe(BytesReference compressedBytes,
+                                      CheckedFunction<XContentParser, T, IOException> parserFunction,
+                                      NamedXContentRegistry xContentRegistry) throws IOException {
+        return inflate(compressedBytes, parserFunction, xContentRegistry, Long.MAX_VALUE);
     }
 
     public static <T> T inflate(BytesReference compressedBytes,

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/TrainedModelConfig.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/TrainedModelConfig.java
@@ -286,6 +286,14 @@ public class TrainedModelConfig implements ToXContentObject, Writeable {
         return this;
     }
 
+    public TrainedModelConfig ensureParsedDefinitionUnsafe(NamedXContentRegistry xContentRegistry) throws IOException {
+        if (definition == null) {
+            return null;
+        }
+        definition.ensureParsedDefinitionUnsafe(xContentRegistry);
+        return this;
+    }
+
     @Nullable
     public TrainedModelDefinition getModelDefinition() {
         if (definition == null) {
@@ -867,6 +875,14 @@ public class TrainedModelConfig implements ToXContentObject, Writeable {
         private void ensureParsedDefinition(NamedXContentRegistry xContentRegistry) throws IOException {
             if (parsedDefinition == null) {
                 parsedDefinition = InferenceToXContentCompressor.inflate(compressedRepresentation,
+                    parser -> TrainedModelDefinition.fromXContent(parser, true).build(),
+                    xContentRegistry);
+            }
+        }
+
+        private void ensureParsedDefinitionUnsafe(NamedXContentRegistry xContentRegistry) throws IOException {
+            if (parsedDefinition == null) {
+                parsedDefinition = InferenceToXContentCompressor.inflateUnsafe(compressedRepresentation,
                     parser -> TrainedModelDefinition.fromXContent(parser, true).build(),
                     xContentRegistry);
             }

--- a/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/TrainedModelProviderIT.java
+++ b/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/TrainedModelProviderIT.java
@@ -339,7 +339,7 @@ public class TrainedModelProviderIT extends MlSingleNodeTestCase {
 
         AtomicReference<InferenceDefinition> definitionHolder = new AtomicReference<>();
         blockingCall(
-            listener -> trainedModelProvider.getTrainedModelForInference(modelId, listener),
+            listener -> trainedModelProvider.getTrainedModelForInference(modelId, false, listener),
             definitionHolder,
             exceptionHolder);
         assertThat(exceptionHolder.get(), is(nullValue()));

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/inference/InferenceRunner.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/inference/InferenceRunner.java
@@ -91,7 +91,7 @@ public class InferenceRunner {
         LOGGER.info("[{}] Started inference on test data against model [{}]", config.getId(), modelId);
         try {
             PlainActionFuture<LocalModel> localModelPlainActionFuture = new PlainActionFuture<>();
-            modelLoadingService.getModelForPipeline(modelId, localModelPlainActionFuture);
+            modelLoadingService.getModelForInternalInference(modelId, localModelPlainActionFuture);
             InferenceState inferenceState = restoreInferenceState();
             dataCountsTracker.setTestDocsCount(inferenceState.processedTestDocsCount);
             TestDocsIterator testDocsIterator = new TestDocsIterator(new OriginSettingClient(client, ClientHelper.ML_ORIGIN), config,

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/persistence/TrainedModelProvider.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/persistence/TrainedModelProvider.java
@@ -392,13 +392,17 @@ public class TrainedModelProvider {
      * do not.
      *
      * @param modelId The model tp get
+     * @param unsafe when true, the compressed bytes size is not checked and the circuit breaker is solely responsible for
+     *               preventing OOMs
      * @param listener The listener
      */
-    public void getTrainedModelForInference(final String modelId, final ActionListener<InferenceDefinition> listener) {
+    public void getTrainedModelForInference(final String modelId, boolean unsafe, final ActionListener<InferenceDefinition> listener) {
         // TODO Change this when we get more than just langIdent stored
         if (MODELS_STORED_AS_RESOURCE.contains(modelId)) {
             try {
-                TrainedModelConfig config = loadModelFromResource(modelId, false).build().ensureParsedDefinition(xContentRegistry);
+                TrainedModelConfig config = loadModelFromResource(modelId, false)
+                    .build()
+                    .ensureParsedDefinitionUnsafe(xContentRegistry);
                 assert config.getModelDefinition().getTrainedModel() instanceof LangIdentNeuralNetwork;
                 assert config.getModelType() == TrainedModelType.LANG_IDENT;
                 listener.onResponse(
@@ -425,10 +429,9 @@ public class TrainedModelProvider {
             success -> {
                 try {
                     BytesReference compressedData = getDefinitionFromDocs(docs, modelId);
-                    InferenceDefinition inferenceDefinition = InferenceToXContentCompressor.inflate(
-                        compressedData,
-                        InferenceDefinition::fromXContent,
-                        xContentRegistry);
+                    InferenceDefinition inferenceDefinition = unsafe ?
+                    InferenceToXContentCompressor.inflateUnsafe(compressedData, InferenceDefinition::fromXContent, xContentRegistry) :
+                    InferenceToXContentCompressor.inflate(compressedData, InferenceDefinition::fromXContent, xContentRegistry);
 
                     listener.onResponse(inferenceDefinition);
                 } catch (Exception e) {

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/loadingservice/ModelLoadingServiceTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/loadingservice/ModelLoadingServiceTests.java
@@ -143,9 +143,9 @@ public class ModelLoadingServiceTests extends ESTestCase {
             assertThat(future.get(), is(not(nullValue())));
         }
 
-        verify(trainedModelProvider, times(1)).getTrainedModelForInference(eq(model1), any());
-        verify(trainedModelProvider, times(1)).getTrainedModelForInference(eq(model2), any());
-        verify(trainedModelProvider, times(1)).getTrainedModelForInference(eq(model3), any());
+        verify(trainedModelProvider, times(1)).getTrainedModelForInference(eq(model1), eq(false), any());
+        verify(trainedModelProvider, times(1)).getTrainedModelForInference(eq(model2), eq(false), any());
+        verify(trainedModelProvider, times(1)).getTrainedModelForInference(eq(model3), eq(false), any());
 
         assertTrue(modelLoadingService.isModelCached(model1));
         assertTrue(modelLoadingService.isModelCached(model2));
@@ -160,10 +160,10 @@ public class ModelLoadingServiceTests extends ESTestCase {
             assertThat(future.get(), is(not(nullValue())));
         }
 
-        verify(trainedModelProvider, times(1)).getTrainedModelForInference(eq(model1), any());
-        verify(trainedModelProvider, times(1)).getTrainedModelForInference(eq(model2), any());
+        verify(trainedModelProvider, times(1)).getTrainedModelForInference(eq(model1), eq(false), any());
+        verify(trainedModelProvider, times(1)).getTrainedModelForInference(eq(model2), eq(false), any());
         // It is not referenced, so called eagerly
-        verify(trainedModelProvider, times(4)).getTrainedModelForInference(eq(model3), any());
+        verify(trainedModelProvider, times(4)).getTrainedModelForInference(eq(model3), eq(false), any());
     }
 
     public void testMaxCachedLimitReached() throws Exception {
@@ -196,9 +196,9 @@ public class ModelLoadingServiceTests extends ESTestCase {
         // the loading occurred or which models are currently in the cache due to evictions.
         // Verify that we have at least loaded all three
         assertBusy(() -> {
-            verify(trainedModelProvider, times(1)).getTrainedModelForInference(eq(model1), any());
-            verify(trainedModelProvider, times(1)).getTrainedModelForInference(eq(model2), any());
-            verify(trainedModelProvider, times(1)).getTrainedModelForInference(eq(model3), any());
+            verify(trainedModelProvider, times(1)).getTrainedModelForInference(eq(model1), eq(false), any());
+            verify(trainedModelProvider, times(1)).getTrainedModelForInference(eq(model2), eq(false), any());
+            verify(trainedModelProvider, times(1)).getTrainedModelForInference(eq(model3), eq(false), any());
         });
 
         // all models loaded put in the cache
@@ -215,10 +215,10 @@ public class ModelLoadingServiceTests extends ESTestCase {
         // Depending on the order the models were first loaded in the first step
         // models 1 & 2 may have been evicted by model 3 in which case they have
         // been loaded at most twice
-        verify(trainedModelProvider, atMost(2)).getTrainedModelForInference(eq(model1), any());
-        verify(trainedModelProvider, atMost(2)).getTrainedModelForInference(eq(model2), any());
+        verify(trainedModelProvider, atMost(2)).getTrainedModelForInference(eq(model1), eq(false), any());
+        verify(trainedModelProvider, atMost(2)).getTrainedModelForInference(eq(model2), eq(false), any());
         // Only loaded requested once on the initial load from the change event
-        verify(trainedModelProvider, times(1)).getTrainedModelForInference(eq(model3), any());
+        verify(trainedModelProvider, times(1)).getTrainedModelForInference(eq(model3), eq(false), any());
 
         // model 3 has been loaded and evicted exactly once
         verify(trainedModelStatsService, times(1)).queueStats(argThat(new ArgumentMatcher<>() {
@@ -234,7 +234,7 @@ public class ModelLoadingServiceTests extends ESTestCase {
             modelLoadingService.getModelForPipeline(model3, future3);
             assertThat(future3.get(), is(not(nullValue())));
         }
-        verify(trainedModelProvider, times(2)).getTrainedModelForInference(eq(model3), any());
+        verify(trainedModelProvider, times(2)).getTrainedModelForInference(eq(model3), eq(false), any());
 
         verify(trainedModelStatsService, atMost(2)).queueStats(argThat(new ArgumentMatcher<>() {
             @Override
@@ -255,7 +255,7 @@ public class ModelLoadingServiceTests extends ESTestCase {
             modelLoadingService.getModelForPipeline(model1, future1);
             assertThat(future1.get(), is(not(nullValue())));
         }
-        verify(trainedModelProvider, atMost(3)).getTrainedModelForInference(eq(model1), any());
+        verify(trainedModelProvider, atMost(3)).getTrainedModelForInference(eq(model1), eq(false), any());
         verify(trainedModelStatsService, times(2)).queueStats(argThat(new ArgumentMatcher<>() {
             @Override
             public boolean matches(final Object o) {
@@ -269,7 +269,7 @@ public class ModelLoadingServiceTests extends ESTestCase {
             modelLoadingService.getModelForPipeline(model2, future2);
             assertThat(future2.get(), is(not(nullValue())));
         }
-        verify(trainedModelProvider, atMost(3)).getTrainedModelForInference(eq(model2), any());
+        verify(trainedModelProvider, atMost(3)).getTrainedModelForInference(eq(model2), eq(false), any());
 
         // Test invalidate cache for model3
         // Now both model 1 and 2 should fit in cache without issues
@@ -281,9 +281,9 @@ public class ModelLoadingServiceTests extends ESTestCase {
             assertThat(future.get(), is(not(nullValue())));
         }
 
-        verify(trainedModelProvider, atMost(3)).getTrainedModelForInference(eq(model1), any());
-        verify(trainedModelProvider, atMost(3)).getTrainedModelForInference(eq(model2), any());
-        verify(trainedModelProvider, times(5)).getTrainedModelForInference(eq(model3), any());
+        verify(trainedModelProvider, atMost(3)).getTrainedModelForInference(eq(model1), eq(false), any());
+        verify(trainedModelProvider, atMost(3)).getTrainedModelForInference(eq(model2), eq(false), any());
+        verify(trainedModelProvider, times(5)).getTrainedModelForInference(eq(model3), eq(false), any());
     }
 
     public void testWhenCacheEnabledButNotIngestNode() throws Exception {
@@ -308,7 +308,7 @@ public class ModelLoadingServiceTests extends ESTestCase {
         }
 
         assertFalse(modelLoadingService.isModelCached(model1));
-        verify(trainedModelProvider, times(10)).getTrainedModelForInference(eq(model1), any());
+        verify(trainedModelProvider, times(10)).getTrainedModelForInference(eq(model1), eq(false), any());
         verify(trainedModelStatsService, never()).queueStats(any(InferenceStats.class), anyBoolean());
     }
 
@@ -337,7 +337,7 @@ public class ModelLoadingServiceTests extends ESTestCase {
         }
         assertFalse(modelLoadingService.isModelCached(model));
 
-        verify(trainedModelProvider, atMost(2)).getTrainedModelForInference(eq(model), any());
+        verify(trainedModelProvider, atMost(2)).getTrainedModelForInference(eq(model), eq(false), any());
         verify(trainedModelStatsService, never()).queueStats(any(InferenceStats.class), anyBoolean());
     }
 
@@ -384,7 +384,7 @@ public class ModelLoadingServiceTests extends ESTestCase {
             assertThat(future.get(), is(not(nullValue())));
         }
 
-        verify(trainedModelProvider, times(3)).getTrainedModelForInference(eq(model), any());
+        verify(trainedModelProvider, times(3)).getTrainedModelForInference(eq(model), eq(false), any());
         assertFalse(modelLoadingService.isModelCached(model));
         verify(trainedModelStatsService, never()).queueStats(any(InferenceStats.class), anyBoolean());
     }
@@ -410,7 +410,7 @@ public class ModelLoadingServiceTests extends ESTestCase {
 
         assertTrue(modelLoadingService.isModelCached(modelId));
 
-        verify(trainedModelProvider, times(1)).getTrainedModelForInference(eq(modelId), any());
+        verify(trainedModelProvider, times(1)).getTrainedModelForInference(eq(modelId), eq(false), any());
         verify(trainedModelStatsService, never()).queueStats(any(InferenceStats.class), anyBoolean());
     }
 
@@ -571,7 +571,7 @@ public class ModelLoadingServiceTests extends ESTestCase {
             assertThat(future.get(), is(not(nullValue())));
         }
 
-        verify(trainedModelProvider, times(1)).getTrainedModelForInference(eq(model1), any());
+        verify(trainedModelProvider, times(1)).getTrainedModelForInference(eq(model1), eq(false), any());
 
         assertTrue(modelLoadingService.isModelCached(model1));
         assertTrue(modelLoadingService.isModelCached("loaded_model"));
@@ -592,7 +592,7 @@ public class ModelLoadingServiceTests extends ESTestCase {
             assertThat(future.get(), is(not(nullValue())));
         }
 
-        verify(trainedModelProvider, times(1)).getTrainedModelForInference(eq(model2), any());
+        verify(trainedModelProvider, times(1)).getTrainedModelForInference(eq(model2), eq(false), any());
         assertTrue(modelLoadingService.isModelCached(model2));
         assertTrue(modelLoadingService.isModelCached("loaded_model"));
     }
@@ -647,10 +647,10 @@ public class ModelLoadingServiceTests extends ESTestCase {
         when(trainedModelConfig.getEstimatedHeapMemory()).thenReturn(size);
         doAnswer(invocationOnMock -> {
             @SuppressWarnings("rawtypes")
-            ActionListener listener = (ActionListener) invocationOnMock.getArguments()[1];
+            ActionListener listener = (ActionListener) invocationOnMock.getArguments()[2];
             listener.onResponse(definition);
             return null;
-        }).when(trainedModelProvider).getTrainedModelForInference(eq(modelId), any());
+        }).when(trainedModelProvider).getTrainedModelForInference(eq(modelId), eq(false), any());
         doAnswer(invocationOnMock -> {
             @SuppressWarnings("rawtypes")
             ActionListener listener = (ActionListener) invocationOnMock.getArguments()[2];
@@ -680,19 +680,19 @@ public class ModelLoadingServiceTests extends ESTestCase {
             }).when(trainedModelProvider).getTrainedModel(eq(modelId), eq(GetTrainedModelsAction.Includes.empty()), any());
             doAnswer(invocationOnMock -> {
                 @SuppressWarnings("rawtypes")
-                ActionListener listener = (ActionListener) invocationOnMock.getArguments()[1];
+                ActionListener listener = (ActionListener) invocationOnMock.getArguments()[2];
                 listener.onFailure(new ResourceNotFoundException(
                     Messages.getMessage(Messages.MODEL_DEFINITION_NOT_FOUND, modelId)));
                 return null;
-            }).when(trainedModelProvider).getTrainedModelForInference(eq(modelId), any());
+            }).when(trainedModelProvider).getTrainedModelForInference(eq(modelId), eq(false), any());
         }
         doAnswer(invocationOnMock -> {
             @SuppressWarnings("rawtypes")
-            ActionListener listener = (ActionListener) invocationOnMock.getArguments()[1];
+            ActionListener listener = (ActionListener) invocationOnMock.getArguments()[2];
             listener.onFailure(new ResourceNotFoundException(
                 Messages.getMessage(Messages.INFERENCE_NOT_FOUND, modelId)));
             return null;
-        }).when(trainedModelProvider).getTrainedModelForInference(eq(modelId), any());
+        }).when(trainedModelProvider).getTrainedModelForInference(eq(modelId), eq(false), any());
     }
 
     private static ClusterChangedEvent ingestChangedEvent(String... modelId) throws IOException {


### PR DESCRIPTION
When a user creates a Data frame analytics model, it is possible that the inference step fails due to he model being too large to fit in the JVM. 

Example error messages:
```
[foo] failed running inference on model [foo-1628085713000]; cause was [Data too large, data for [foo-1628085713000] would be [...], which is larger than the limit of [...]]
```
```
[foo] failed running inference on model [foo-1628085713000]; cause was [Cannot parse model definition as the content is larger than the maximum stream size of [...] bytes. Max stream size is 10% of the JVM heap or 1GB whichever is smallest]
```

This commit partially addresses these error by allowing the circuit breaker to handle the OOM prevention. Since the model was recently created by an internal process, this is acceptable.

relates to https://github.com/elastic/elasticsearch/issues/76093