### PR TITLE
JarHell Bootstrap Check can yield false positives

### DIFF
--- a/server/src/main/java/org/elasticsearch/plugins/PluginsService.java
+++ b/server/src/main/java/org/elasticsearch/plugins/PluginsService.java
@@ -568,7 +568,11 @@ public class PluginsService implements ReportingService<PluginsAndModules> {
             union.addAll(bundle.urls);
             JarHell.checkJarHell(union, logger::debug);
         } catch (Exception e) {
-            throw new IllegalStateException("failed to load plugin " + bundle.plugin.getName() + " due to jar hell", e);
+            if(intersection.isEmpty() == false) {
+                throw new (bundle.plugin.getName() + " due to jar hell", e);
+            } else {
+                throw new IllegalStateException("failed to load plugin ", e);
+            }
         }
     }
 


### PR DESCRIPTION
Issue  #75701 | JarHell Bootstrap Check can yield false positives | 

Changes made:
- [x] separated Exception e into 2 separate parts
- [x] Separated jar hell and Failed to load plugin

<!--
Thank you for your interest in and contributing to Elasticsearch! There
are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.
-->

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/elasticsearch/blob/master/CONTRIBUTING.md)?
- If submitting code, have you built your formula locally prior to submission with `gradle check`?
- If submitting code, is your pull request against master? Unless there is a good reason otherwise, we prefer pull requests against master and will backport as needed.
- If submitting code, have you checked that your submission is for an [OS and architecture that we support](https://www.elastic.co/support/matrix#show_os)?
- If you are submitting this code for a class then read our [policy](https://github.com/elastic/elasticsearch/blob/master/CONTRIBUTING.md#contributing-as-part-of-a-class) for that.
