### PR TITLE
[7.x] Create data stream aliases from component templates (#75956)

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/admin/indices/rollover/MetadataRolloverService.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/rollover/MetadataRolloverService.java
@@ -330,7 +330,7 @@ public class MetadataRolloverService {
                                                       @Nullable Boolean isHidden) {
         final String matchedV2Template = findV2Template(metadata, rolloverIndexName, isHidden == null ? false : isHidden);
         if (matchedV2Template != null) {
-            List<Map<String, AliasMetadata>> aliases = MetadataIndexTemplateService.resolveAliases(metadata, matchedV2Template, false);
+            List<Map<String, AliasMetadata>> aliases = MetadataIndexTemplateService.resolveAliases(metadata, matchedV2Template);
             for (Map<String, AliasMetadata> aliasConfig : aliases) {
                 if (aliasConfig.containsKey(rolloverRequestAlias)) {
                     throw new IllegalArgumentException(String.format(Locale.ROOT,

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/template/post/TransportSimulateIndexTemplateAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/template/post/TransportSimulateIndexTemplateAction.java
@@ -149,7 +149,7 @@ public class TransportSimulateIndexTemplateAction
         Settings settings = resolveSettings(simulatedState.metadata(), matchingTemplate);
 
         List<Map<String, AliasMetadata>> resolvedAliases = MetadataIndexTemplateService.resolveAliases(simulatedState.metadata(),
-            matchingTemplate, true);
+            matchingTemplate);
 
         // create the index with dummy settings in the cluster state so we can parse and validate the aliases
         Settings dummySettings = Settings.builder()

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataCreateDataStreamService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataCreateDataStreamService.java
@@ -228,8 +228,9 @@ public class MetadataCreateDataStreamService {
         Metadata.Builder builder = Metadata.builder(currentState.metadata()).put(newDataStream);
 
         List<String> aliases = new ArrayList<>();
-        if (template.template() != null && template.template().aliases() != null) {
-            for (AliasMetadata alias : template.template().aliases().values()) {
+        var resolvedAliases = MetadataIndexTemplateService.resolveAliases(currentState.metadata(), template);
+        for (var resolvedAliasMap : resolvedAliases) {
+            for (var alias : resolvedAliasMap.values()) {
                 aliases.add(alias.getAlias());
                 builder.put(alias.getAlias(), dataStreamName, alias.writeIndex(), alias.filter() == null ? null : alias.filter().string());
             }

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataCreateDataStreamService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataCreateDataStreamService.java
@@ -229,7 +229,7 @@ public class MetadataCreateDataStreamService {
 
         List<String> aliases = new ArrayList<>();
         List<Map<String, AliasMetadata>> resolvedAliases =
-            MetadataIndexTemplateService.resolveAliases(currentState.metadata(), template, false);
+            MetadataIndexTemplateService.resolveAliases(currentState.metadata(), template);
         for (Map<String, AliasMetadata> resolvedAliasMap : resolvedAliases) {
             for (AliasMetadata alias : resolvedAliasMap.values()) {
                 aliases.add(alias.getAlias());

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataCreateDataStreamService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataCreateDataStreamService.java
@@ -228,9 +228,10 @@ public class MetadataCreateDataStreamService {
         Metadata.Builder builder = Metadata.builder(currentState.metadata()).put(newDataStream);
 
         List<String> aliases = new ArrayList<>();
-        var resolvedAliases = MetadataIndexTemplateService.resolveAliases(currentState.metadata(), template);
-        for (var resolvedAliasMap : resolvedAliases) {
-            for (var alias : resolvedAliasMap.values()) {
+        List<Map<String, AliasMetadata>> resolvedAliases =
+            MetadataIndexTemplateService.resolveAliases(currentState.metadata(), template, false);
+        for (Map<String, AliasMetadata> resolvedAliasMap : resolvedAliases) {
+            for (AliasMetadata alias : resolvedAliasMap.values()) {
                 aliases.add(alias.getAlias());
                 builder.put(alias.getAlias(), dataStreamName, alias.writeIndex(), alias.filter() == null ? null : alias.filter().string());
             }

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataCreateIndexService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataCreateIndexService.java
@@ -542,7 +542,7 @@ public class MetadataCreateIndexService {
                 isDataStream ? Collections.emptySet() : request.aliases(),
                 isDataStream ?
                     Collections.emptyList() :
-                    MetadataIndexTemplateService.resolveAliases(currentState.metadata(), templateName, false),
+                    MetadataIndexTemplateService.resolveAliases(currentState.metadata(), templateName),
                 currentState.metadata(),
                 aliasValidator,
                 xContentRegistry,

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataCreateIndexService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataCreateIndexService.java
@@ -588,7 +588,7 @@ public class MetadataCreateIndexService {
 
         return applyCreateIndexWithTemporaryService(currentState, request, silent, null, tmpImd, mappings,
             indexService -> resolveAndValidateAliases(request.index(), request.aliases(),
-                MetadataIndexTemplateService.resolveAliases(template, componentTemplates, false, null), currentState.metadata(),
+                MetadataIndexTemplateService.resolveAliases(template, componentTemplates), currentState.metadata(),
                 // the context is only used for validation so it's fine to pass fake values for the
                 // shard id and the current timestamp
                 aliasValidator, xContentRegistry, indexService.newSearchExecutionContext(0, 0, null, () -> 0L, null, emptyMap()),

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataIndexTemplateService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataIndexTemplateService.java
@@ -1095,45 +1095,32 @@ public class MetadataIndexTemplateService {
 
     /**
      * Resolve the given v2 template name into an ordered list of aliases
-     *
-     * @param failIfTemplateHasDataStream Whether to skip validating if a template has a data stream definition and an alias definition.
-     *                                    This validation is needed so that no template gets created that creates data stream and also
-     *                                    an alias pointing to the backing indices of a data stream. Unfortunately this validation
-     *                                    was missing in versions prior to 7.11, which mean that there are cluster states out there
-     *                                    that have this malformed templates. This method is used when rolling over a data stream
-     *                                    or creating new data streams. In order for these clusters to avoid failing these operations
-     *                                    immediately after an upgrade the failure should be optional. So that there is time to change
-     *                                    these templates. The logic that adds/updates index and component templates shouldn't skip this
-     *                                    validation.
      */
     public static List<Map<String, AliasMetadata>> resolveAliases(final Metadata metadata,
-                                                                  final String templateName,
-                                                                  final boolean failIfTemplateHasDataStream) {
+                                                                  final String templateName) {
         final ComposableIndexTemplate template = metadata.templatesV2().get(templateName);
         assert template != null : "attempted to resolve aliases for a template [" + templateName +
             "] that did not exist in the cluster state";
-        return resolveAliases(metadata, template, failIfTemplateHasDataStream);
+        return resolveAliases(metadata, template);
     }
 
     /**
      * Resolve the given v2 template into an ordered list of aliases
      */
     static List<Map<String, AliasMetadata>> resolveAliases(final Metadata metadata,
-                                                           final ComposableIndexTemplate template,
-                                                           final boolean failIfTemplateHasDataStream) {
+                                                           final ComposableIndexTemplate template) {
         if (template == null) {
             return Collections.emptyList();
         }
         final Map<String, ComponentTemplate> componentTemplates = metadata.componentTemplates();
-        return resolveAliases(template, componentTemplates, failIfTemplateHasDataStream);
+        return resolveAliases(template, componentTemplates);
     }
 
     /**
      * Resolve the given v2 template and component templates into an ordered list of aliases
      */
     static List<Map<String, AliasMetadata>> resolveAliases(final ComposableIndexTemplate template,
-                                                           final Map<String, ComponentTemplate> componentTemplates,
-                                                           final boolean failIfTemplateHasDataStream) {
+                                                           final Map<String, ComponentTemplate> componentTemplates) {
         Objects.requireNonNull(template, "attempted to resolve aliases for a null template");
         Objects.requireNonNull(componentTemplates, "attempted to resolve aliases with null component templates");
         List<Map<String, AliasMetadata>> aliases = template.composedOf().stream()
@@ -1200,7 +1187,7 @@ public class MetadataIndexTemplateService {
             tempIndexService -> {
                 // Validate aliases
                 MetadataCreateIndexService.resolveAndValidateAliases(temporaryIndexName, Collections.emptySet(),
-                    MetadataIndexTemplateService.resolveAliases(stateWithIndex.metadata(), templateName, true), stateWithIndex.metadata(),
+                    MetadataIndexTemplateService.resolveAliases(stateWithIndex.metadata(), templateName), stateWithIndex.metadata(),
                     new AliasValidator(),
                     // the context is only used for validation so it's fine to pass fake values for the
                     // shard id and the current timestamp

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataIndexTemplateService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataIndexTemplateService.java
@@ -1094,7 +1094,7 @@ public class MetadataIndexTemplateService {
     }
 
     /**
-     * Resolve the given v2 template into an ordered list of aliases
+     * Resolve the given v2 template name into an ordered list of aliases
      *
      * @param failIfTemplateHasDataStream Whether to skip validating if a template has a data stream definition and an alias definition.
      *                                    This validation is needed so that no template gets created that creates data stream and also
@@ -1112,11 +1112,20 @@ public class MetadataIndexTemplateService {
         final ComposableIndexTemplate template = metadata.templatesV2().get(templateName);
         assert template != null : "attempted to resolve aliases for a template [" + templateName +
             "] that did not exist in the cluster state";
+        return resolveAliases(metadata, template, failIfTemplateHasDataStream);
+    }
+
+    /**
+     * Resolve the given v2 template into an ordered list of aliases
+     */
+    static List<Map<String, AliasMetadata>> resolveAliases(final Metadata metadata,
+                                                           final ComposableIndexTemplate template,
+                                                           final boolean failIfTemplateHasDataStream) {
         if (template == null) {
             return Collections.emptyList();
         }
         final Map<String, ComponentTemplate> componentTemplates = metadata.componentTemplates();
-        return resolveAliases(template, componentTemplates, failIfTemplateHasDataStream, templateName);
+        return resolveAliases(template, componentTemplates, failIfTemplateHasDataStream);
     }
 
     /**
@@ -1124,8 +1133,7 @@ public class MetadataIndexTemplateService {
      */
     static List<Map<String, AliasMetadata>> resolveAliases(final ComposableIndexTemplate template,
                                                            final Map<String, ComponentTemplate> componentTemplates,
-                                                           final boolean failIfTemplateHasDataStream,
-                                                           @Nullable String templateName) {
+                                                           final boolean failIfTemplateHasDataStream) {
         Objects.requireNonNull(template, "attempted to resolve aliases for a null template");
         Objects.requireNonNull(componentTemplates, "attempted to resolve aliases with null component templates");
         List<Map<String, AliasMetadata>> aliases = template.composedOf().stream()

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataCreateDataStreamServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataCreateDataStreamServiceTests.java
@@ -27,6 +27,7 @@ import org.elasticsearch.test.ESTestCase;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import static org.elasticsearch.cluster.metadata.DataStreamTestHelper.createFirstBackingIndex;
@@ -129,14 +130,14 @@ public class MetadataCreateDataStreamServiceTests extends ESTestCase {
 
         List<String> ctNames = new ArrayList<>();
         List<Map<String, AliasMetadata>> allAliases = new ArrayList<>();
-        var metadataBuilder = Metadata.builder();
+        Metadata.Builder metadataBuilder = Metadata.builder();
         final List<ComponentTemplate> componentTemplates = new ArrayList<>(componentTemplateCount);
         for (int k = 0; k < componentTemplateCount; k++) {
             final String ctName = randomAlphaOfLength(5);
             ctNames.add(ctName);
             final int ctAliasCount = randomIntBetween(0, 3);
             totalAliasCount += ctAliasCount;
-            final var ctAliasMap = new HashMap<String, AliasMetadata>(ctAliasCount);
+            final Map<String, AliasMetadata> ctAliasMap = new HashMap<>(ctAliasCount);
             allAliases.add(ctAliasMap);
             for (int m = 0; m < ctAliasCount; m++) {
                 final AliasMetadata am = randomAlias(ctName);
@@ -147,7 +148,7 @@ public class MetadataCreateDataStreamServiceTests extends ESTestCase {
         allAliases.add(aliases);
 
         ComposableIndexTemplate template = new ComposableIndexTemplate.Builder()
-            .indexPatterns(List.of(dataStreamName + "*"))
+            .indexPatterns(org.elasticsearch.core.List.of(dataStreamName + "*"))
             .dataStreamTemplate(new DataStreamTemplate())
             .template(new Template(null, null, aliases))
             .componentTemplates(ctNames)
@@ -165,9 +166,9 @@ public class MetadataCreateDataStreamServiceTests extends ESTestCase {
         assertThat(newState.metadata().dataStreams().get(dataStreamName).isHidden(), is(false));
         assertThat(newState.metadata().dataStreams().get(dataStreamName).isReplicated(), is(false));
         assertThat(newState.metadata().dataStreamAliases().size(), is(totalAliasCount));
-        for (var aliasMap : allAliases) {
-            for (var alias : aliasMap.values()) {
-                var actualAlias = newState.metadata().dataStreamAliases().get(alias.alias());
+        for (Map<String, AliasMetadata> aliasMap : allAliases) {
+            for (AliasMetadata alias : aliasMap.values()) {
+                DataStreamAlias actualAlias = newState.metadata().dataStreamAliases().get(alias.alias());
                 assertThat(actualAlias, is(notNullValue()));
                 assertThat(actualAlias.getName(), equalTo(alias.alias()));
                 assertThat(actualAlias.getFilter(), equalTo(alias.filter()));
@@ -184,9 +185,12 @@ public class MetadataCreateDataStreamServiceTests extends ESTestCase {
 
     private static AliasMetadata randomAlias(String prefix) {
         final String aliasName = (Strings.isNullOrEmpty(prefix) ? "" : prefix + "-") + randomAlphaOfLength(6);
-        var builder = AliasMetadata.newAliasMetadataBuilder(aliasName);
+        AliasMetadata.Builder builder = AliasMetadata.newAliasMetadataBuilder(aliasName);
         if (randomBoolean()) {
-            builder.filter(Map.of("term", Map.of("user", Map.of("value", randomAlphaOfLength(5)))));
+            builder.filter(org.elasticsearch.core.Map.of(
+                "term",
+                org.elasticsearch.core.Map.of("user", org.elasticsearch.core.Map.of("value", randomAlphaOfLength(5)))
+            ));
         }
         builder.writeIndex(randomBoolean());
         return builder.build();

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataCreateDataStreamServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataCreateDataStreamServiceTests.java
@@ -14,6 +14,7 @@ import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.ComposableIndexTemplate.DataStreamTemplate;
 import org.elasticsearch.cluster.metadata.MetadataCreateDataStreamService.CreateDataStreamClusterStateUpdateRequest;
+import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.indices.ExecutorNames;
@@ -75,19 +76,9 @@ public class MetadataCreateDataStreamServiceTests extends ESTestCase {
         final int aliasCount = randomIntBetween(0, 3);
         Map<String, AliasMetadata> aliases = new HashMap<>(aliasCount);
         for (int k = 0; k < aliasCount; k++) {
-            final String aliasName = randomAlphaOfLength(6);
-            AliasMetadata.Builder builder = AliasMetadata.newAliasMetadataBuilder(aliasName);
-            if (randomBoolean()) {
-                builder.filter(org.elasticsearch.core.Map.of(
-                    "term",
-                    org.elasticsearch.core.Map.of(
-                        "user",
-                        org.elasticsearch.core.Map.of("value", randomAlphaOfLength(5)))
-                    )
-                );
-            }
-            builder.writeIndex(randomBoolean());
-            aliases.put(aliasName, builder.build());
+
+            final AliasMetadata am = randomAlias(null);
+            aliases.put(am.alias(), am);
         }
         ComposableIndexTemplate template = new ComposableIndexTemplate.Builder()
             .indexPatterns(org.elasticsearch.core.List.of(dataStreamName + "*"))
@@ -122,6 +113,83 @@ public class MetadataCreateDataStreamServiceTests extends ESTestCase {
         assertThat(newState.metadata().index(DataStream.getDefaultBackingIndexName(dataStreamName, 1)).getSettings().get("index.hidden"),
             equalTo("true"));
         assertThat(newState.metadata().index(DataStream.getDefaultBackingIndexName(dataStreamName, 1)).isSystem(), is(false));
+    }
+
+    public void testCreateDataStreamWithAliasFromComponentTemplate() throws Exception {
+        final MetadataCreateIndexService metadataCreateIndexService = getMetadataCreateIndexService();
+        final String dataStreamName = "my-data-stream";
+        final int componentTemplateCount = randomIntBetween(0, 3);
+        final int aliasCount = randomIntBetween(0, 3);
+        int totalAliasCount = aliasCount;
+        Map<String, AliasMetadata> aliases = new HashMap<>();
+        for (int k = 0; k < aliasCount; k++) {
+            final AliasMetadata am = randomAlias(null);
+            aliases.put(am.alias(), am);
+        }
+
+        List<String> ctNames = new ArrayList<>();
+        List<Map<String, AliasMetadata>> allAliases = new ArrayList<>();
+        var metadataBuilder = Metadata.builder();
+        final List<ComponentTemplate> componentTemplates = new ArrayList<>(componentTemplateCount);
+        for (int k = 0; k < componentTemplateCount; k++) {
+            final String ctName = randomAlphaOfLength(5);
+            ctNames.add(ctName);
+            final int ctAliasCount = randomIntBetween(0, 3);
+            totalAliasCount += ctAliasCount;
+            final var ctAliasMap = new HashMap<String, AliasMetadata>(ctAliasCount);
+            allAliases.add(ctAliasMap);
+            for (int m = 0; m < ctAliasCount; m++) {
+                final AliasMetadata am = randomAlias(ctName);
+                ctAliasMap.put(am.alias(), am);
+            }
+            metadataBuilder.put(ctName, new ComponentTemplate(new Template(null, null, ctAliasMap), null, null));
+        }
+        allAliases.add(aliases);
+
+        ComposableIndexTemplate template = new ComposableIndexTemplate.Builder()
+            .indexPatterns(List.of(dataStreamName + "*"))
+            .dataStreamTemplate(new DataStreamTemplate())
+            .template(new Template(null, null, aliases))
+            .componentTemplates(ctNames)
+            .build();
+
+        ClusterState cs = ClusterState.builder(new ClusterName("_name"))
+            .metadata(metadataBuilder.put("template", template).build())
+            .build();
+        CreateDataStreamClusterStateUpdateRequest req =
+            new CreateDataStreamClusterStateUpdateRequest(dataStreamName, TimeValue.ZERO, TimeValue.ZERO);
+        ClusterState newState = MetadataCreateDataStreamService.createDataStream(metadataCreateIndexService, cs, req);
+        assertThat(newState.metadata().dataStreams().size(), equalTo(1));
+        assertThat(newState.metadata().dataStreams().get(dataStreamName).getName(), equalTo(dataStreamName));
+        assertThat(newState.metadata().dataStreams().get(dataStreamName).isSystem(), is(false));
+        assertThat(newState.metadata().dataStreams().get(dataStreamName).isHidden(), is(false));
+        assertThat(newState.metadata().dataStreams().get(dataStreamName).isReplicated(), is(false));
+        assertThat(newState.metadata().dataStreamAliases().size(), is(totalAliasCount));
+        for (var aliasMap : allAliases) {
+            for (var alias : aliasMap.values()) {
+                var actualAlias = newState.metadata().dataStreamAliases().get(alias.alias());
+                assertThat(actualAlias, is(notNullValue()));
+                assertThat(actualAlias.getName(), equalTo(alias.alias()));
+                assertThat(actualAlias.getFilter(), equalTo(alias.filter()));
+                assertThat(actualAlias.getWriteDataStream(), equalTo(alias.writeIndex() ? dataStreamName : null));
+            }
+        }
+
+        assertThat(newState.metadata().index(DataStream.getDefaultBackingIndexName(dataStreamName, 1)), notNullValue());
+        assertThat(newState.metadata().index(DataStream.getDefaultBackingIndexName(dataStreamName, 1)).getAliases().size(), is(0));
+        assertThat(newState.metadata().index(DataStream.getDefaultBackingIndexName(dataStreamName, 1)).getSettings().get("index.hidden"),
+            equalTo("true"));
+        assertThat(newState.metadata().index(DataStream.getDefaultBackingIndexName(dataStreamName, 1)).isSystem(), is(false));
+    }
+
+    private static AliasMetadata randomAlias(String prefix) {
+        final String aliasName = (Strings.isNullOrEmpty(prefix) ? "" : prefix + "-") + randomAlphaOfLength(6);
+        var builder = AliasMetadata.newAliasMetadataBuilder(aliasName);
+        if (randomBoolean()) {
+            builder.filter(Map.of("term", Map.of("user", Map.of("value", randomAlphaOfLength(5)))));
+        }
+        builder.writeIndex(randomBoolean());
+        return builder.build();
     }
 
     public void testCreateSystemDataStream() throws Exception {

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataIndexTemplateServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataIndexTemplateServiceTests.java
@@ -1266,8 +1266,7 @@ public class MetadataIndexTemplateServiceTests extends ESSingleNodeTestCase {
             Arrays.asList("ct_low", "ct_high"), 0L, 1L, null, null, null);
         state = service.addIndexTemplateV2(state, true, "my-template", it);
 
-        List<Map<String, AliasMetadata>> resolvedAliases =
-            MetadataIndexTemplateService.resolveAliases(state.metadata(), "my-template", true);
+        List<Map<String, AliasMetadata>> resolvedAliases = MetadataIndexTemplateService.resolveAliases(state.metadata(), "my-template");
 
         // These should be order of precedence, so the index template (a3), then ct_high (a1), then ct_low (a2)
         assertThat(resolvedAliases, equalTo(Arrays.asList(a3, a1, a2)));


### PR DESCRIPTION
#73867 added the ability to create data stream aliases but only from aliases defined in the top-level composable template. This amends that to include aliases defined in any component templates included in the composable template.

Relates to #66163

Backport of #75956
