### PR TITLE
Fixes for Iron Bank (#76087)

### DIFF
--- a/distribution/docker/build.gradle
+++ b/distribution/docker/build.gradle
@@ -53,9 +53,9 @@ ext.expansions = { Architecture architecture, DockerBase base ->
   String buildArgs = ''
   if (base == DockerBase.IRON_BANK) {
     buildArgs = """
-ARG BASE_REGISTRY=nexus-docker-secure.levelup-nexus.svc.cluster.local:18082
-ARG BASE_IMAGE=redhat/ubi/ubi8
-ARG BASE_TAG=8.3
+ARG BASE_REGISTRY=registry1.dso.mil
+ARG BASE_IMAGE=ironbank/redhat/ubi/ubi8
+ARG BASE_TAG=8.4
 """
   }
 
@@ -68,7 +68,7 @@ ARG BASE_TAG=8.3
     'build_date'          : BuildParams.buildDate,
     'config_dir'          : base == DockerBase.IRON_BANK ? 'scripts' : 'config',
     'git_revision'        : BuildParams.gitRevision,
-    'license'             : 'Elastic-License-2.0',
+    'license'             : base == DockerBase.IRON_BANK ? 'Elastic License 1.0' : 'Elastic-License-2.0',
     'package_manager'     : base == DockerBase.UBI ? 'microdnf' : 'yum',
     'docker_base'         : base.name().toLowerCase(),
     'version'             : VersionProperties.elasticsearch,
@@ -202,20 +202,27 @@ void addBuildDockerContextTask(Architecture architecture, DockerBase base) {
   String configDirectory = base == DockerBase.IRON_BANK ? 'scripts' : 'config'
   String arch = architecture == Architecture.AARCH64 ? '-aarch64' : ''
 
-  tasks.register(taskName('build', architecture, base, 'DockerContext'), Tar) {
-    archiveExtension = 'tar.gz'
-    compression = Compression.GZIP
-    archiveClassifier = "docker-build-context${arch}"
-    archiveBaseName = "elasticsearch${base.suffix}"
-    with dockerBuildContext(architecture, base)
+  final TaskProvider<Tar> buildDockerContextTask =
+    tasks.register(taskName('build', architecture, base, 'DockerContext'), Tar) {
+      archiveExtension = 'tar.gz'
+      compression = Compression.GZIP
+      archiveClassifier = "docker-build-context${arch}"
+      archiveBaseName = "elasticsearch${base.suffix}"
+      with dockerBuildContext(architecture, base)
 
-    into(configDirectory) {
-      from(configurations.log4jConfig) {
-        filter TransformLog4jConfigFilter
+      into(configDirectory) {
+        from(configurations.log4jConfig) {
+          filter TransformLog4jConfigFilter
+        }
       }
+
+      onlyIf { Architecture.current() == architecture }
     }
 
-    onlyIf { Architecture.current() == architecture }
+  if (base == DockerBase.IRON_BANK) {
+    tasks.named("assemble").configure {
+      dependsOn(buildDockerContextTask)
+    }
   }
 }
 
@@ -303,8 +310,10 @@ void addBuildDockerImageTask(Architecture architecture, DockerBase base) {
       onlyIf { Architecture.current() == architecture }
     }
 
-  tasks.named("assemble").configure {
-    dependsOn(buildDockerImageTask)
+  if (base != DockerBase.IRON_BANK) {
+    tasks.named("assemble").configure {
+      dependsOn(buildDockerImageTask)
+    }
   }
 }
 

--- a/distribution/docker/src/docker/Dockerfile
+++ b/distribution/docker/src/docker/Dockerfile
@@ -221,12 +221,17 @@ FROM ${base_image} AS builder
 RUN mkdir /usr/share/elasticsearch
 WORKDIR /usr/share/elasticsearch
 
-<% /*
-  Fetch the appropriate Elasticsearch distribution for this architecture.
-  Keep this command on one line - it is replaced with a `COPY` during local builds.
-  It uses the `arch` command to fetch the correct distro for the build machine.
-*/ %>
+<% if (docker_base == "iron_bank") {
+  // Iron Bank always copies the local artifact
+%>
+COPY elasticsearch-${version}-linux-x86_64.tar.gz /opt/elasticsearch.tar.gz
+<% } else {
+  // Fetch the appropriate Elasticsearch distribution for this architecture.
+  // Keep this command on one line - it is replaced with a `COPY` during local builds.
+  // It uses the `arch` command to fetch the correct distro for the build machine.
+%>
 RUN curl --retry 10 -S -L --output /opt/elasticsearch.tar.gz https://artifacts-no-kpi.elastic.co/downloads/elasticsearch/elasticsearch-${version}-linux-\$(arch).tar.gz
+<% } %>
 
 RUN tar -zxf /opt/elasticsearch.tar.gz --strip-components=1
 

--- a/distribution/docker/src/docker/iron_bank/hardening_manifest.yaml
+++ b/distribution/docker/src/docker/iron_bank/hardening_manifest.yaml
@@ -39,6 +39,9 @@ labels:
 resources:
   - filename: "elasticsearch-${version}-linux-x86_64.tar.gz"
     url: "<artifact_path>/elasticsearch-${version}-linux-x86_64.tar.gz"
+    validation:
+      type: "sha512"
+      value: "<insert SHA 512 here>"
   - filename: "tini"
     url: "https://github.com/krallin/tini/releases/download/v0.19.0/tini-amd64"
     validation:
@@ -47,7 +50,14 @@ resources:
 
 # List of project maintainers
 maintainers:
-  - name: "Nassim Kammah"
-    email: "nassim.kammah@elastic.co"
   - name: "Rory Hunter"
     email: "rory.hunter@elastic.co"
+    username: "rory"
+  - email: "klepal_alexander@bah.com"
+    name: "Alexander Klepal"
+    username: "alexander.klepal"
+    cht_member: true
+  - email: "yalabe.dukuly@anchore.com"
+    name: "Yalabe Dukuly"
+    username: "yalabe.dukuly"
+    cht_member: true


### PR DESCRIPTION
Second attempt after reverting #76087.

This PR fixes a number of issues with the Iron Bank Docker context. Most notably it changes the generated `Dockerfile` in the build context to `COPY` the Elasticsearch archive, instead of downloading it, since Iron Bank images have a different process and will never be built on Docker Hub. This requires that the context task be wired to `assemble` instead of the build image task. The latter is only used for testing purposes.