### PR TITLE
Fix NPE in Cat Snapshots API Default (#76161)

### DIFF
--- a/qa/smoke-test-http/src/test/java/org/elasticsearch/http/snapshots/RestCatSnapshotsIT.java
+++ b/qa/smoke-test-http/src/test/java/org/elasticsearch/http/snapshots/RestCatSnapshotsIT.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+package org.elasticsearch.http.snapshots;
+
+import org.apache.http.client.methods.HttpGet;
+import org.elasticsearch.client.Request;
+import org.elasticsearch.client.Response;
+import org.elasticsearch.common.io.Streams;
+import org.elasticsearch.snapshots.AbstractSnapshotIntegTestCase;
+import org.hamcrest.Matchers;
+
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.util.List;
+
+public class RestCatSnapshotsIT extends AbstractSnapshotRestTestCase {
+
+    public void testCatSnapshotsDefaultsToAllRepositories() throws Exception {
+        final String repoName1 = "test-repo-1";
+        final String repoName2 = "test-repo-2";
+        AbstractSnapshotIntegTestCase.createRepository(logger, repoName1, "fs");
+        AbstractSnapshotIntegTestCase.createRepository(logger, repoName2, "fs");
+        final int snapshotsRepo1 = randomIntBetween(1, 20);
+        AbstractSnapshotIntegTestCase.createNSnapshots(logger, repoName1, snapshotsRepo1);
+        final int snapshotsRepo2 = randomIntBetween(1, 20);
+        AbstractSnapshotIntegTestCase.createNSnapshots(logger, repoName2, snapshotsRepo2);
+        final Response response = getRestClient().performRequest(new Request(HttpGet.METHOD_NAME, "/_cat/snapshots"));
+        assertEquals(HttpURLConnection.HTTP_OK, response.getStatusLine().getStatusCode());
+        final List<String> allLines;
+        try (InputStream in = response.getEntity().getContent()) {
+            allLines = Streams.readAllLines(in);
+        }
+        assertThat(allLines, Matchers.hasSize(snapshotsRepo1 + snapshotsRepo2));
+        assertEquals(allLines.stream().filter(l -> l.contains(repoName1)).count(), snapshotsRepo1);
+        assertEquals(allLines.stream().filter(l -> l.contains(repoName2)).count(), snapshotsRepo2);
+    }
+}

--- a/server/src/main/java/org/elasticsearch/rest/action/cat/RestSnapshotAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/cat/RestSnapshotAction.java
@@ -52,7 +52,7 @@ public class RestSnapshotAction extends AbstractCatAction {
     @Override
     protected RestChannelConsumer doCatRequest(final RestRequest request, NodeClient client) {
         GetSnapshotsRequest getSnapshotsRequest = new GetSnapshotsRequest()
-                .repository(request.param("repository"))
+                .repositories(request.paramAsStringArray("repository", new String[]{"_all"}))
                 .snapshots(new String[]{GetSnapshotsRequest.ALL_SNAPSHOTS});
 
         getSnapshotsRequest.ignoreUnavailable(request.paramAsBoolean("ignore_unavailable", getSnapshotsRequest.ignoreUnavailable()));


### PR DESCRIPTION
When backporting get-snapshots pagination I missed the cat snapshots API that needed adjustment
to be in line with how `8.x` works as well, leading to an NPE. Fixed by making the code the same
as in `8.x` and adding a test (that should be forward-ported to 8.x as well).

closes #76158

backport of #76161 