### PR TITLE
Resurrect _xpack/monitoring routes (attempt 2)

### DIFF
--- a/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/rest/action/RestMonitoringBulkAction.java
+++ b/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/rest/action/RestMonitoringBulkAction.java
@@ -10,6 +10,7 @@ import org.elasticsearch.ElasticsearchParseException;
 import org.elasticsearch.client.node.NodeClient;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.core.RestApiVersion;
 import org.elasticsearch.rest.BaseRestHandler;
 import org.elasticsearch.rest.BytesRestResponse;
 import org.elasticsearch.rest.RestChannel;
@@ -50,8 +51,11 @@ public class RestMonitoringBulkAction extends BaseRestHandler {
     @Override
     public List<Route> routes() {
         return List.of(
-            new Route(POST, "/_monitoring/bulk"),
-            new Route(PUT, "/_monitoring/bulk"));
+            Route.builder(POST, "/_monitoring/bulk")
+                .replaces(POST, "/_xpack/monitoring/_bulk", RestApiVersion.V_7).build(),
+            Route.builder(PUT, "/_monitoring/bulk")
+                .replaces(PUT, "/_xpack/monitoring/_bulk", RestApiVersion.V_7).build()
+        );
     }
 
     @Override

--- a/x-pack/plugin/src/yamlRestCompatTest/resources/rest-api-spec/api/xpack-monitoring.bulk.json
+++ b/x-pack/plugin/src/yamlRestCompatTest/resources/rest-api-spec/api/xpack-monitoring.bulk.json
@@ -1,0 +1,48 @@
+{
+  "xpack-monitoring.bulk":{
+    "documentation":{
+      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/monitor-elasticsearch-cluster.html",
+      "description":"Used by the monitoring features to send monitoring data."
+    },
+    "stability":"experimental",
+    "visibility":"public",
+    "headers":{
+      "accept": [ "application/vnd.elasticsearch+json;compatible-with=7"],
+      "content_type": ["application/x-ndjson;compatible-with=7"]
+    },
+    "url":{
+      "paths":[
+        {
+          "path":"/_xpack/monitoring/_bulk",
+          "methods":[
+            "POST",
+            "PUT"
+          ],
+          "deprecated":{
+            "version":"7.0.0",
+            "description":"all _xpack prefix have been deprecated"
+          }
+        }
+      ]
+    },
+    "params":{
+      "system_id":{
+        "type":"string",
+        "description":"Identifier of the monitored system"
+      },
+      "system_api_version":{
+        "type":"string",
+        "description":"API Version of the monitored system"
+      },
+      "interval":{
+        "type":"string",
+        "description":"Collection interval (e.g., '10s' or '10000ms') of the payload"
+      }
+    },
+    "body":{
+      "description":"The operation definition and data (action-data pairs), separated by newlines",
+      "required":true,
+      "serialize":"bulk"
+    }
+  }
+}

--- a/x-pack/plugin/src/yamlRestCompatTest/resources/rest-api-spec/test/v7compat/monitoring/bulk/10_basic_compat.yml
+++ b/x-pack/plugin/src/yamlRestCompatTest/resources/rest-api-spec/test/v7compat/monitoring/bulk/10_basic_compat.yml
@@ -1,0 +1,33 @@
+---
+setup:
+  - skip:
+      version: "9.0.0 - "
+      reason: "compatible from 8.x to 7.x"
+      features:
+        - "headers"
+        - "warnings"
+
+---
+"Bulk indexing of monitoring data":
+
+  - do:
+      headers:
+        Content-Type: "application/vnd.elasticsearch+json;compatible-with=7"
+        Accept: "application/vnd.elasticsearch+json;compatible-with=7"
+      xpack-monitoring.bulk:
+        system_id:          "kibana"
+        system_api_version: "6"
+        interval:           "10s"
+        body:
+          - index:
+              _type:  test_type
+          - avg-cpu:
+              user:   13.26
+              nice:   0.17
+              system: 1.51
+              iowait: 0.85
+              idle:   84.20
+      warnings:
+        - "[POST /_xpack/monitoring/_bulk] is deprecated! Use [POST /_monitoring/bulk] instead."
+
+  - is_false: errors

--- a/x-pack/plugin/src/yamlRestCompatTest/resources/rest-api-spec/test/v7compat/monitoring/bulk/10_basic_compat.yml
+++ b/x-pack/plugin/src/yamlRestCompatTest/resources/rest-api-spec/test/v7compat/monitoring/bulk/10_basic_compat.yml
@@ -5,7 +5,7 @@ setup:
       reason: "compatible from 8.x to 7.x"
       features:
         - "headers"
-        - "warnings"
+        - "warnings_regex"
 
 ---
 "Bulk indexing of monitoring data":
@@ -27,7 +27,7 @@ setup:
               system: 1.51
               iowait: 0.85
               idle:   84.20
-      warnings:
-        - "[POST /_xpack/monitoring/_bulk] is deprecated! Use [POST /_monitoring/bulk] instead."
+      warnings_regex:
+        - "\\[.* /_xpack/monitoring/_bulk\\] is deprecated! Use \\[.* /_monitoring/bulk\\] instead."
 
   - is_false: errors


### PR DESCRIPTION
Replaying #75948, but with a new commit this time that correctly accounts for POST *and* PUT.