### PR TITLE
Change env var prefix in Docker settings support

### DIFF
--- a/distribution/src/bin/elasticsearch-env
+++ b/distribution/src/bin/elasticsearch-env
@@ -123,34 +123,17 @@ if [[ "$ES_DISTRIBUTION_TYPE" == "docker" ]]; then
   do
     # Elasticsearch settings need to have at least two dot separated lowercase
     # words, e.g. `cluster.name`, or uppercased with underscore separators and
-    # prefixed with `ES_`, e.g. `ES_CLUSTER_NAME`. Underscores in setting names
+    # prefixed with `ES_SETTING_`, e.g. `ES_SETTING_CLUSTER_NAME`. Underscores in setting names
     # are escaped by writing them as a double-underscore e.g. "__"
     if [[ ! -z "$envvar_value" ]]; then
       if [[ "$envvar_key" =~ ^[a-z0-9_]+\.[a-z0-9_]+ ]]; then
         es_opt="-E${envvar_key}=${envvar_value}"
         es_arg_array+=("${es_opt}")
-      elif [[ "$envvar_key" =~ ^ES(_{1,2}[A-Z]+)+$ ]]; then
-        case "$envvar_key" in
-          # Do nothing for these. Not all of these are actually exported into the environment by our scripts,
-          # and so don't appear in the output of the `env` command, but it's better to be safe than sorry
-          # in case a user exported them in their own shell for some reason.
-          ES_DISTRIBUTION_FLAVOR) ;;
-          ES_DISTRIBUTION_TYPE) ;;
-          ES_HOME) ;;
-          ES_JAVA_HOME) ;;
-          ES_JAVA_OPTS) ;;
-          ES_KEYSTORE_PASSPHRASE_FILE) ;;
-          ES_LOG_STYLE) ;;
-          ES_PATH_CONF) ;;
-          ES_SD_NOTIFY) ;;
-          ES_TMPDIR) ;;
-          *)
-            # The long-hand sed `y` command works in any sed variant.
-            envvar_key="$(echo "$envvar_key" | sed -e 's/^ES_//; s/_/./g ; s/\.\./_/g; y/ABCDEFGHIJKLMNOPQRSTUVWXYZ/abcdefghijklmnopqrstuvwxyz/' )"
-            es_opt="-E${envvar_key}=${envvar_value}"
-            es_arg_array+=("${es_opt}")
-            ;;
-        esac
+      elif [[ "$envvar_key" =~ ^ES_SETTING(_{1,2}[A-Z]+)+$ ]]; then
+          # The long-hand sed `y` command works in any sed variant.
+          envvar_key="$(echo "$envvar_key" | sed -e 's/^ES_SETTING_//; s/_/./g ; s/\.\./_/g; y/ABCDEFGHIJKLMNOPQRSTUVWXYZ/abcdefghijklmnopqrstuvwxyz/' )"
+          es_opt="-E${envvar_key}=${envvar_value}"
+          es_arg_array+=("${es_opt}")
       fi
     fi
   done <<< "$(env)"

--- a/docs/changelog/76192.yaml
+++ b/docs/changelog/76192.yaml
@@ -1,0 +1,10 @@
+pr: 76192
+summary: Change env var prefix in Docker settings support
+area: Packaging
+type: enhancement
+issues:
+ - 76148
+ - 74327
+versions:
+ - v8.0.0
+ - v7.15.0

--- a/docs/reference/setup/install/docker.asciidoc
+++ b/docs/reference/setup/install/docker.asciidoc
@@ -346,16 +346,17 @@ periods in environment variable names, then you can use an alternative
 style by converting the setting name as follows.
 
 . Change the setting name to uppercase
-. Prefix it with `ES_`
+. Prefix it with `ES_SETTING_`
 . Escape any underscores (`_`) by duplicating them
 . Convert all periods (`.`) to underscores (`_`)
 
 For example, `-e bootstrap.memory_lock=true` becomes
-`-e ES_BOOTSTRAP_MEMORY__LOCK=true`.
+`-e ES_SETTING_BOOTSTRAP_MEMORY__LOCK=true`.
 
-To use the contents of a file to set an environment variable, suffix the environment
-variable name with `_FILE`. This is useful for passing secrets such as passwords to {es}
-without specifying them directly.
+You can use the contents of a file to set the value of the
+`ELASTIC_PASSWORD` or `KEYSTORE_PASSWORD` environment variables, by
+suffixing the environment variable name with `_FILE`. This is useful for
+passing secrets such as passwords to {es} without specifying them directly.
 
 For example, to set the {es} bootstrap password from a file, you can bind mount the
 file and set the `ELASTIC_PASSWORD_FILE` environment variable to the mount location.
@@ -366,7 +367,7 @@ If you mount the password file to `/run/secrets/bootstrapPassword.txt`, specify:
 -e ELASTIC_PASSWORD_FILE=/run/secrets/bootstrapPassword.txt
 --------------------------------------------
 
-You can also override the default command for the image to pass {es} configuration
+You can override the default command for the image to pass {es} configuration
 parameters as command line options. For example:
 
 [source,sh]

--- a/qa/os/src/test/java/org/elasticsearch/packaging/test/DockerTests.java
+++ b/qa/os/src/test/java/org/elasticsearch/packaging/test/DockerTests.java
@@ -489,7 +489,7 @@ public class DockerTests extends PackagingTestCase {
     /**
      * Check that settings are applied when they are supplied as environment variables with names that are:
      * <ul>
-     *     <li>Prefixed with {@code ES_}</li>
+     *     <li>Prefixed with {@code ES_SETTING_}</li>
      *     <li>All uppercase</li>
      *     <li>Dots (periods) are converted to underscores</li>
      *     <li>Underscores in setting names are escaped by doubling them</li>
@@ -497,7 +497,7 @@ public class DockerTests extends PackagingTestCase {
      */
     public void test086EnvironmentVariablesInSnakeCaseAreTranslated() {
         // Note the double-underscore in the var name here, which retains the underscore in translation
-        installation = runContainer(distribution(), builder().envVars(Map.of("ES_XPACK_SECURITY_FIPS__MODE_ENABLED", "false")));
+        installation = runContainer(distribution(), builder().envVars(Map.of("ES_SETTING_XPACK_SECURITY_FIPS__MODE_ENABLED", "false")));
 
         final Optional<String> commandLine = sh.run("bash -c 'COLUMNS=2000 ps ax'").stdout.lines()
             .filter(line -> line.contains("org.elasticsearch.bootstrap.Elasticsearch"))
@@ -513,8 +513,10 @@ public class DockerTests extends PackagingTestCase {
      */
     public void test087EnvironmentVariablesInIncorrectFormatAreIgnored() {
         final Map<String, String> envVars = new HashMap<>();
-        // No ES_ prefix
+        // No ES_SETTING_ prefix
         envVars.put("XPACK_SECURITY_FIPS__MODE_ENABLED", "false");
+        // Incomplete prefix
+        envVars.put("ES_XPACK_SECURITY_FIPS__MODE_ENABLED", "false");
         // Not underscore-separated
         envVars.put("ES.XPACK.SECURITY.FIPS_MODE.ENABLED", "false");
         // Not uppercase


### PR DESCRIPTION
Closes #76148. Previously, in #74327, we added support for setting
Elasticsearch settings in the Docker image via environment variables.
However there are scenarios e.g in Kubernetes where it is easy to
accidentally define environment variables that the ES startup process
rejects.

Work around this by using the more explicit env var prefix
`ES_SETTING_`.