### PR TITLE
[DOCS] Remove screenshot from managing CCR

### DIFF
--- a/docs/reference/ccr/managing.asciidoc
+++ b/docs/reference/ccr/managing.asciidoc
@@ -80,9 +80,6 @@ To recreate a follower index,
 <<ccr-access-ccr,access Cross-Cluster Replication>> and choose the
 *Follower indices* tab.
 
-[role="screenshot"]
-image::images/ccr-follower-index.png["The Cross-Cluster Replication page in {kib}"]
-
 Select the follower index and pause replication. When the follower index status
 changes to Paused, reselect the follower index and choose to unfollow the
 leader index.


### PR DESCRIPTION
Removes an unnecessary screenshot from the [Recreate a follower index](https://www.elastic.co/guide/en/elasticsearch/reference/master/ccr-managing.html#ccr-recreate-follower-index) section of the _Managing cross-cluster replication_ page. 

Relates to #75393