### PR TITLE
[DOCS] Add missing HTML anchors

### DIFF
--- a/docs/reference/index-modules.asciidoc
+++ b/docs/reference/index-modules.asciidoc
@@ -168,6 +168,7 @@ specific index module:
 
     The number of replicas each primary shard has. Defaults to 1.
 
+[[dynamic-index-auto-expand-replicas]]
 `index.auto_expand_replicas`::
 Auto-expand the number of replicas based on the number of data nodes in the
 cluster. Set to a dash delimited lower and upper bound (e.g. `0-5`) or use `all`
@@ -183,6 +184,7 @@ awareness>> and
 <<cluster-routing-allocation-same-shard-host,`cluster.routing.allocation.same_shard.host`>>
 are ignored for this index.
 
+[[dynamic-index-search-idle-after]]
 `index.search.idle.after`::
     How long a shard can not receive a search or get request until it's considered
     search idle. (default is `30s`)


### PR DESCRIPTION
Adding some HTML anchors for some parameters in the index modules section