### PR TITLE
[7.14] [DOCS] Remove screenshot from managing CCR (#76193)

### DIFF
--- a/docs/reference/ccr/managing.asciidoc
+++ b/docs/reference/ccr/managing.asciidoc
@@ -80,9 +80,6 @@ To recreate a follower index,
 <<ccr-access-ccr,access Cross-Cluster Replication>> and choose the
 *Follower indices* tab.
 
-[role="screenshot"]
-image::images/ccr-follower-index.png["The Cross-Cluster Replication page in {kib}"]
-
 Select the follower index and pause replication. When the follower index status
 changes to Paused, reselect the follower index and choose to unfollow the
 leader index.


### PR DESCRIPTION
Backports the following commits to 7.14:
 - [DOCS] Remove screenshot from managing CCR (#76193)