### PR TITLE
Resolve system properties in build scripts via provider factory

### DIFF
--- a/build-conventions/src/main/java/org/elasticsearch/gradle/internal/conventions/info/ParallelDetector.java
+++ b/build-conventions/src/main/java/org/elasticsearch/gradle/internal/conventions/info/ParallelDetector.java
@@ -9,6 +9,7 @@
 package org.elasticsearch.gradle.internal.conventions.info;
 
 import org.gradle.api.Project;
+import org.gradle.api.provider.ProviderFactory;
 
 import java.io.BufferedReader;
 import java.io.ByteArrayOutputStream;
@@ -58,7 +59,7 @@ public class ParallelDetector {
                     throw new UncheckedIOException(e);
                 }
                 _defaultParallel = socketToCore.values().stream().mapToInt(i -> i).sum();
-            } else if (isMac()) {
+            } else if (isMac(project.getProviders())) {
                 // Ask macOS to count physical CPUs for us
                 ByteArrayOutputStream stdout = new ByteArrayOutputStream();
                 project.exec(spec -> {
@@ -76,8 +77,8 @@ public class ParallelDetector {
         return _defaultParallel;
     }
 
-    private static boolean isMac() {
-        return System.getProperty("os.name", "").startsWith("Mac");
+    private static boolean isMac(ProviderFactory providers) {
+        return providers.systemProperty("os.name").forUseAtConfigurationTime().getOrElse("").startsWith("Mac");
     }
 
 }

--- a/build-tools-internal/build.gradle
+++ b/build-tools-internal/build.gradle
@@ -26,7 +26,7 @@ group = 'org.elasticsearch.gradle'
 // we update the version property to reflect if we are building a snapshot or a release build
 // we write this back out below to load it in the Build.java which will be shown in rest main action
 // to indicate this being a snapshot build or a release build.
-Properties props = VersionPropertiesLoader.loadBuildSrcVersion(project.file('version.properties'))
+Properties props = VersionPropertiesLoader.loadBuildSrcVersion(project.file('version.properties'), project.getProviders())
 version = props.getProperty("elasticsearch")
 
 gradlePlugin {

--- a/build-tools-internal/src/main/groovy/elasticsearch.formatting.gradle
+++ b/build-tools-internal/src/main/groovy/elasticsearch.formatting.gradle
@@ -235,7 +235,7 @@ subprojects {
           // The `paddedCell()` option is disabled for normal operation so that any
           // misbehaviour is detected, and not just suppressed. You can enabled the
           // option from the command line by running Gradle with `-Dspotless.paddedcell`.
-          if (System.getProperty('spotless.paddedcell') != null) {
+          if (providers.systemProperty('spotless.paddedcell').forUseAtConfigurationTime().isPresent()) {
             paddedCell()
           }
         }

--- a/build-tools-internal/src/main/groovy/elasticsearch.ide.gradle
+++ b/build-tools-internal/src/main/groovy/elasticsearch.ide.gradle
@@ -69,7 +69,7 @@ tasks.register('configureIdeCheckstyle') {
 }
 
 // Applying this stuff, particularly the idea-ext plugin, has a cost so avoid it unless we're running in the IDE
-if (System.getProperty('idea.active') == 'true') {
+if (providers.systemProperty('idea.active').forUseAtConfigurationTime().getOrNull() == 'true') {
   project.apply(plugin: org.jetbrains.gradle.ext.IdeaExtPlugin)
 
   tasks.register('configureIdeaGradleJvm') {

--- a/build-tools-internal/src/main/groovy/elasticsearch.run.gradle
+++ b/build-tools-internal/src/main/groovy/elasticsearch.run.gradle
@@ -15,9 +15,9 @@ import org.elasticsearch.gradle.testclusters.RunTask
 
 testClusters {
   runTask {
-    testDistribution = System.getProperty('run.distribution', 'default')
-    if (System.getProperty('run.distribution', 'default') == 'default') {
-      String licenseType = System.getProperty("run.license_type", "basic")
+    testDistribution = providers.systemProperty('run.distribution').orElse('default').forUseAtConfigurationTime().get()
+    if (providers.systemProperty('run.distribution').orElse('default').forUseAtConfigurationTime().get() == 'default') {
+      String licenseType = providers.systemProperty("run.license_type").orElse("basic").forUseAtConfigurationTime().get()
       if (licenseType == 'trial') {
         setting 'xpack.ml.enabled', 'true'
         setting 'xpack.graph.enabled', 'true'

--- a/build-tools/build.gradle
+++ b/build-tools/build.gradle
@@ -20,7 +20,7 @@ description = "The elasticsearch build tools"
 // we update the version property to reflect if we are building a snapshot or a release build
 // we write this back out below to load it in the Build.java which will be shown in rest main action
 // to indicate this being a snapshot build or a release build.
-Properties props = VersionPropertiesLoader.loadBuildSrcVersion(project.file('../build-tools-internal/version.properties'))
+Properties props = VersionPropertiesLoader.loadBuildSrcVersion(project.file('../build-tools-internal/version.properties'), project.getProviders())
 def minRuntimeJava = JavaVersion.toVersion(file('../build-tools-internal/src/main/resources/minimumRuntimeVersion').text)
 
 allprojects {

--- a/build.gradle
+++ b/build.gradle
@@ -85,7 +85,7 @@ tasks.register("updateCIBwcVersions") {
 }
 
 //TODO port buildMetaData to use provider api
-String buildMetadataValue = providers.environmentVariable('BUILD_METADATA').forUseAtConfigurationTime().orElse("").get()
+String buildMetadataValue = providers.environmentVariable('BUILD_METADATA').orElse("").forUseAtConfigurationTime().get()
 Map<String, String> buildMetadataMap = buildMetadataValue.tokenize(';').collectEntries {
   def (String key, String value) = it.split('=')
   return [key, value]
@@ -196,8 +196,8 @@ allprojects {
   // injecting groovy property variables into all projects
   project.ext {
     // for ide hacks...
-    isEclipse = System.getProperty("eclipse.launcher") != null ||   // Detects gradle launched from Eclipse's IDE
-            System.getProperty("eclipse.application") != null ||    // Detects gradle launched from the Eclipse compiler server
+    isEclipse = providers.systemProperty("eclipse.launcher").forUseAtConfigurationTime().isPresent() ||   // Detects gradle launched from Eclipse's IDE
+            providers.systemProperty("eclipse.application").forUseAtConfigurationTime().isPresent() ||    // Detects gradle launched from the Eclipse compiler server
             gradle.startParameter.taskNames.contains('eclipse') ||  // Detects gradle launched from the command line to do eclipse stuff
             gradle.startParameter.taskNames.contains('cleanEclipse')
 

--- a/client/rest-high-level/build.gradle
+++ b/client/rest-high-level/build.gradle
@@ -69,17 +69,24 @@ File nodeCert = file("./testnode.crt")
 File nodeTrustStore = file("./testnode.jks")
 File pkiTrustCert = file("./src/test/resources/org/elasticsearch/client/security/delegate_pki/testRootCA.crt")
 
+def clusterUserNameProvider = providers.systemProperty('tests.rest.cluster.username')
+        .orElse('test_user')
+        .forUseAtConfigurationTime()
+
+def clusterPasswordProvider = providers.systemProperty('tests.rest.cluster.password')
+        .orElse('test-user-password')
+        .forUseAtConfigurationTime()
+
 tasks.named("integTest").configure {
   systemProperty 'tests.rest.async', 'false'
-  systemProperty 'tests.rest.cluster.username', System.getProperty('tests.rest.cluster.username', 'test_user')
-  systemProperty 'tests.rest.cluster.password', System.getProperty('tests.rest.cluster.password', 'test-user-password')
+  systemProperty 'tests.rest.cluster.username', clusterUserNameProvider.get()
+  systemProperty 'tests.rest.cluster.password', clusterPasswordProvider.get()
 }
 
-// Requires https://github.com/elastic/elasticsearch/pull/64403 to have this moved to task avoidance api.
 TaskProvider<RestIntegTestTask> asyncIntegTest = tasks.register("asyncIntegTest", RestIntegTestTask) {
     systemProperty 'tests.rest.async', 'true'
-    systemProperty 'tests.rest.cluster.username', System.getProperty('tests.rest.cluster.username', 'test_user')
-    systemProperty 'tests.rest.cluster.password', System.getProperty('tests.rest.cluster.password', 'test-user-password')
+    systemProperty 'tests.rest.cluster.username', clusterUserNameProvider.get()
+    systemProperty 'tests.rest.cluster.password', clusterPasswordProvider.get()
 }
 
 tasks.named("check").configure {
@@ -109,9 +116,9 @@ testClusters.all {
   setting 'indices.lifecycle.history_index_enabled', 'false'
   keystore 'xpack.security.transport.ssl.truststore.secure_password', 'testnode'
   extraConfigFile 'roles.yml', file('roles.yml')
-  user username: System.getProperty('tests.rest.cluster.username', 'test_user'),
-    password: System.getProperty('tests.rest.cluster.password', 'test-user-password'),
-    role: System.getProperty('tests.rest.cluster.role', 'admin')
+  user username: clusterUserNameProvider.get(),
+    password: clusterPasswordProvider.get(),
+    role: providers.systemProperty('tests.rest.cluster.role').orElse('admin').forUseAtConfigurationTime().get()
   user username: 'admin_user', password: 'admin-password'
 
   extraConfigFile nodeCert.name, nodeCert

--- a/client/rest-high-level/qa/ssl-enabled/build.gradle
+++ b/client/rest-high-level/qa/ssl-enabled/build.gradle
@@ -16,8 +16,14 @@ dependencies {
 
 tasks.matching{ it.name == "javaRestTest" }.configureEach {
   onlyIf { BuildParams.inFipsJvm == false}
-  systemProperty 'tests.rest.cluster.username', System.getProperty('tests.rest.cluster.username', 'test_user')
-  systemProperty 'tests.rest.cluster.password', System.getProperty('tests.rest.cluster.password', 'test-user-password')
+  systemProperty 'tests.rest.cluster.username', providers.systemProperty('tests.rest.cluster.username')
+          .orElse('test_user')
+          .forUseAtConfigurationTime()
+          .get()
+  systemProperty 'tests.rest.cluster.password', providers.systemProperty('tests.rest.cluster.password')
+          .orElse('test-user-password')
+          .forUseAtConfigurationTime()
+          .get()
 }
 
 testClusters.matching { it.name == 'javaRestTest' }.configureEach {

--- a/distribution/build.gradle
+++ b/distribution/build.gradle
@@ -35,8 +35,11 @@ tasks.register("generateDependenciesReport", ConcatFilesTask) {
   dependsOn rootProject.allprojects.collect { it.tasks.withType(DependenciesInfoTask) }
   files = fileTree(dir: project.rootDir, include: '**/dependencies.csv')
   headerLine = "name,version,url,license,sourceURL"
-  target = new File(System.getProperty('csv') ?: "${project.buildDir}/reports/dependencies/es-dependencies.csv")
-
+  target = new File(providers.systemProperty('csv')
+                      .orElse("${project.buildDir}/reports/dependencies/es-dependencies.csv")
+                      .forUseAtConfigurationTime()
+                      .get()
+  )
   // explicitly add our dependency on the JDK
   String jdkVersion = VersionProperties.versions.get('bundled_jdk').split('@')[0]
   String jdkMajorVersion = jdkVersion.split('[+.]')[0]

--- a/distribution/packages/build.gradle
+++ b/distribution/packages/build.gradle
@@ -308,7 +308,7 @@ ospackage {
     signingKeyPassphrase = project.property('signing.password')
     signingKeyRingFile = project.hasProperty('signing.secretKeyRingFile') ?
       project.file(project.property('signing.secretKeyRingFile')) :
-      new File(new File(System.getProperty('user.home'), '.gnupg'), 'secring.gpg')
+      new File(new File(project.providers.systemProperty('user.home').orElse('.gnupg').forUseAtConfigurationTime().get()), 'secring.gpg')
   }
 
   // version found on oldest supported distro, centos-6

--- a/modules/lang-painless/build.gradle
+++ b/modules/lang-painless/build.gradle
@@ -129,8 +129,8 @@ tasks.register("generateContextApiSpec", DefaultTestClustersTask) {
       mainClass = 'org.elasticsearch.painless.ContextApiSpecGenerator'
       classpath = sourceSets.doc.runtimeClasspath
       systemProperty "cluster.uri", "${-> testClusters.generateContextApiSpecCluster.singleNode().getAllHttpSocketURI().get(0)}"
-      systemProperty "jdksrc", System.getProperty("jdksrc")
-      systemProperty "packageSources", System.getProperty("packageSources")
+      systemProperty "jdksrc", providers.systemProperty("jdksrc").forUseAtConfigurationTime().getOrNull()
+      systemProperty "packageSources", providers.systemProperty("packageSources").forUseAtConfigurationTime().getOrNull()
     }.assertNormalExitValue()
   }
 }

--- a/plugins/repository-azure/build.gradle
+++ b/plugins/repository-azure/build.gradle
@@ -1,4 +1,5 @@
 import org.apache.tools.ant.filters.ReplaceTokens
+import org.elasticsearch.gradle.PropertyNormalization
 import org.elasticsearch.gradle.internal.info.BuildParams
 import org.elasticsearch.gradle.internal.test.InternalClusterTestPlugin
 
@@ -362,7 +363,9 @@ testClusters.matching { it.name == "yamlRestTest" }.configureEach {
     if (useFixture) {
       setting 'azure.client.integration_test.endpoint_suffix', azureAddress
       String firstPartOfSeed = BuildParams.testSeed.tokenize(':').get(0)
-      setting 'thread_pool.repository_azure.max', (Math.abs(Long.parseUnsignedLong(firstPartOfSeed, 16) % 10) + 1).toString(), System.getProperty('ignore.tests.seed') == null ? DEFAULT : IGNORE_VALUE
+
+      def ignoreTestSeed = providers.systemProperty('ignore.tests.seed').forUseAtConfigurationTime().isPresent() ? PropertyNormalization.IGNORE_VALUE : PropertyNormalization.DEFAULT
+      setting 'thread_pool.repository_azure.max', (Math.abs(Long.parseUnsignedLong(firstPartOfSeed, 16) % 10) + 1).toString(), ignoreTestSeed
     }
 }
 

--- a/qa/remote-clusters/build.gradle
+++ b/qa/remote-clusters/build.gradle
@@ -65,7 +65,7 @@ tasks.named("preProcessFixture").configure {
 
 dockerCompose {
   tcpPortsToIgnoreWhenWaiting = [9600, 9601]
-  if ('default'.equalsIgnoreCase(System.getProperty('tests.distribution', 'default'))) {
+  if ('default'.equalsIgnoreCase(providers.systemProperty('tests.distribution').orElse('default').forUseAtConfigurationTime().get())) {
     useComposeFiles = ['docker-compose.yml']
   } else {
     useComposeFiles = ['docker-compose-oss.yml']

--- a/x-pack/plugin/core/build.gradle
+++ b/x-pack/plugin/core/build.gradle
@@ -77,7 +77,7 @@ tasks.named("processResources").configure {
     inputs.properties(expansions)
     filter("tokens" : expansions, ReplaceTokens.class)
   }
-  String licenseKey = System.getProperty("license.key")
+  String licenseKey = providers.systemProperty("license.key").forUseAtConfigurationTime().getOrNull()
   if (licenseKey != null) {
     println "Using provided license key from ${licenseKey}"
   } else if (BuildParams.isSnapshotBuild()) {

--- a/x-pack/plugin/ilm/qa/rest/build.gradle
+++ b/x-pack/plugin/ilm/qa/rest/build.gradle
@@ -11,8 +11,16 @@ restResources {
   }
 }
 
-def clusterCredentials = [username: System.getProperty('tests.rest.cluster.username', 'test_admin'),
-                          password: System.getProperty('tests.rest.cluster.password', 'x-pack-test-password')]
+def clusterCredentials = [
+        username: providers.systemProperty('tests.rest.cluster.username')
+                .orElse('test_admin')
+                .forUseAtConfigurationTime()
+                .get(),
+        password: providers.systemProperty('tests.rest.cluster.password')
+                .orElse('x-pack-test-password')
+                .forUseAtConfigurationTime()
+                .get()
+]
 
 tasks.withType(Test).configureEach {
   systemProperty 'tests.rest.cluster.username', clusterCredentials.username

--- a/x-pack/plugin/ilm/qa/with-security/build.gradle
+++ b/x-pack/plugin/ilm/qa/with-security/build.gradle
@@ -4,8 +4,16 @@ dependencies {
   javaRestTestImplementation(testArtifact(project(xpackModule('core'))))
 }
 
-def clusterCredentials = [username: System.getProperty('tests.rest.cluster.username', 'test_admin'),
-                          password: System.getProperty('tests.rest.cluster.password', 'x-pack-test-password')]
+def clusterCredentials = [
+        username: providers.systemProperty('tests.rest.cluster.username')
+                .orElse('test_admin')
+                .forUseAtConfigurationTime()
+                .get(),
+        password: providers.systemProperty('tests.rest.cluster.password')
+                .orElse('x-pack-test-password')
+                .forUseAtConfigurationTime()
+                .get()
+]
 
 tasks.named("javaRestTest").configure {
   systemProperty 'tests.rest.cluster.username', clusterCredentials.username

--- a/x-pack/plugin/ml/build.gradle
+++ b/x-pack/plugin/ml/build.gradle
@@ -16,7 +16,7 @@ repositories {
     forRepository {
       ivy {
         name "ml-cpp"
-        url System.getProperty('build.ml_cpp.repo', 'https://prelert-artifacts.s3.amazonaws.com')
+        url providers.systemProperty('build.ml_cpp.repo').orElse('https://prelert-artifacts.s3.amazonaws.com').forUseAtConfigurationTime().get()
         metadataSources {
           // no repository metadata, look directly for the artifact
           artifact()

--- a/x-pack/plugin/shutdown/qa/multi-node/build.gradle
+++ b/x-pack/plugin/shutdown/qa/multi-node/build.gradle
@@ -6,8 +6,16 @@ dependencies {
   javaRestTestImplementation(testArtifact(project(xpackModule('core'))))
 }
 
-def clusterCredentials = [username: System.getProperty('tests.rest.cluster.username', 'test_admin'),
-                          password: System.getProperty('tests.rest.cluster.password', 'x-pack-test-password')]
+def clusterCredentials = [
+        username: providers.systemProperty('tests.rest.cluster.username')
+                .orElse('test_admin')
+                .forUseAtConfigurationTime()
+                .get(),
+        password: providers.systemProperty('tests.rest.cluster.password')
+                .orElse('x-pack-test-password')
+                .forUseAtConfigurationTime()
+                .get()
+]
 
 tasks.named("javaRestTest").configure {
   systemProperty 'tests.rest.cluster.username', clusterCredentials.username

--- a/x-pack/plugin/sql/sql-cli/build.gradle
+++ b/x-pack/plugin/sql/sql-cli/build.gradle
@@ -59,10 +59,10 @@ tasks.register("runcli") {
   dependsOn "shadowJar"
   doLast {
     List command = ["${BuildParams.runtimeJavaHome}/bin/java"]
-    if ('true'.equals(System.getProperty('debug', 'false'))) {
+    if ('true'.equals(providers.systemProperty('debug').orElse('false').forUseAtConfigurationTime().get())) {
       command += '-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=8000'
     }
-    command += ['-jar', shadowJar.archivePath.absolutePath]
+    command += ['-jar', shadowJar.archiveFile.get().asFile.absolutePath]
     logger.info("running the cli with: ${command}")
 
     new ProcessBuilder(command)

--- a/x-pack/plugin/stack/qa/rest/build.gradle
+++ b/x-pack/plugin/stack/qa/rest/build.gradle
@@ -11,8 +11,16 @@ restResources {
   }
 }
 
-def clusterCredentials = [username: System.getProperty('tests.rest.cluster.username', 'test_admin'),
-                          password: System.getProperty('tests.rest.cluster.password', 'x-pack-test-password')]
+def clusterCredentials = [
+        username: providers.systemProperty('tests.rest.cluster.username')
+                .orElse('test_admin')
+                .forUseAtConfigurationTime()
+                .get(),
+        password: providers.systemProperty('tests.rest.cluster.password')
+                .orElse('x-pack-test-password')
+                .forUseAtConfigurationTime()
+                .get()
+]
 
 tasks.withType(Test).configureEach {
   systemProperty 'tests.rest.cluster.username', clusterCredentials.username

--- a/x-pack/qa/core-rest-tests-with-security/build.gradle
+++ b/x-pack/qa/core-rest-tests-with-security/build.gradle
@@ -13,6 +13,17 @@ restResources {
   }
 }
 
+def clusterCredentials = [
+        username: providers.systemProperty('tests.rest.cluster.username')
+                .orElse('test_admin')
+                .forUseAtConfigurationTime()
+                .get(),
+        password: providers.systemProperty('tests.rest.cluster.password')
+                .orElse('x-pack-test-password')
+                .forUseAtConfigurationTime()
+                .get()
+]
+
 tasks.named("integTest").configure {
     systemProperty 'tests.rest.blacklist',
       [
@@ -20,8 +31,8 @@ tasks.named("integTest").configure {
         'indices.get_alias/10_basic/Get alias against closed indices'
       ].join(',')
 
-    systemProperty 'tests.rest.cluster.username', System.getProperty('tests.rest.cluster.username', 'test_user')
-    systemProperty 'tests.rest.cluster.password', System.getProperty('tests.rest.cluster.password', 'x-pack-test-password')
+    systemProperty 'tests.rest.cluster.username', clusterCredentials.username
+    systemProperty 'tests.rest.cluster.password', clusterCredentials.password
 }
 
 testClusters.matching { it.name == "integTest" }.configureEach {
@@ -32,6 +43,6 @@ testClusters.matching { it.name == "integTest" }.configureEach {
   setting 'xpack.license.self_generated.type', 'trial'
   setting 'indices.lifecycle.history_index_enabled', 'false'
 
-  user username: System.getProperty('tests.rest.cluster.username', 'test_user'),
-    password: System.getProperty('tests.rest.cluster.password', 'x-pack-test-password')
+  user username: clusterCredentials.username,
+    password: clusterCredentials.password
 }

--- a/x-pack/qa/runtime-fields/with-security/build.gradle
+++ b/x-pack/qa/runtime-fields/with-security/build.gradle
@@ -4,8 +4,16 @@ dependencies {
   javaRestTestImplementation(testArtifact(project(xpackModule('core'))))
 }
 
-def clusterCredentials = [username: System.getProperty('tests.rest.cluster.username', 'test_admin'),
-                          password: System.getProperty('tests.rest.cluster.password', 'x-pack-test-password')]
+def clusterCredentials = [
+        username: providers.systemProperty('tests.rest.cluster.username')
+                .orElse('test_admin')
+                .forUseAtConfigurationTime()
+                .get(),
+        password: providers.systemProperty('tests.rest.cluster.password')
+                .orElse('x-pack-test-password')
+                .forUseAtConfigurationTime()
+                .get()
+]
 
 tasks.named("javaRestTest").configure {
   systemProperty 'tests.rest.cluster.username', clusterCredentials.username


### PR DESCRIPTION
This allows tracking system properties used in the build configuration and brings us
one step closer to be gradle configuration cache compliant.