### PR TITLE
Fix path.data as comma separated string

### DIFF
--- a/server/src/main/java/org/elasticsearch/env/Environment.java
+++ b/server/src/main/java/org/elasticsearch/env/Environment.java
@@ -161,6 +161,7 @@ public class Environment {
                 finalSettings.putList(PATH_DATA_SETTING.getKey(),
                     Arrays.stream(dataFiles).map(Path::toString).collect(Collectors.toList()));
             } else {
+                assert dataFiles.length == 1;
                 finalSettings.put(PATH_DATA_SETTING.getKey(), dataFiles[0]);
             }
         }
@@ -324,7 +325,7 @@ public class Environment {
             return false;
         }
         String rawDataPath = settings.get(PATH_DATA_SETTING.getKey());
-        return rawDataPath.startsWith("[");
+        return rawDataPath.startsWith("[") || rawDataPath.contains(",");
     }
 
     public static FileStore getFileStore(final Path path) throws IOException {

--- a/server/src/test/java/org/elasticsearch/env/EnvironmentTests.java
+++ b/server/src/test/java/org/elasticsearch/env/EnvironmentTests.java
@@ -76,6 +76,15 @@ public class EnvironmentTests extends ESTestCase {
         assertFalse(Environment.PATH_DATA_SETTING.exists(environment.settings()));
     }
 
+    public void testPathDataLegacyCommaList() {
+        final Settings settings = Settings.builder()
+            .put("path.home", createTempDir().toAbsolutePath())
+            .put("path.data", createTempDir().toAbsolutePath() + "," + createTempDir().toAbsolutePath())
+            .build();
+        final Environment environment = new Environment(settings, null);
+        assertThat(environment.dataFiles(), arrayWithSize(2));
+    }
+
     public void testPathLogsWhenNotSet() {
         final Path pathHome = createTempDir().toAbsolutePath();
         final Settings settings = Settings.builder().put("path.home", pathHome).build();
@@ -212,6 +221,11 @@ public class EnvironmentTests extends ESTestCase {
         {
             final Settings settings = Settings.builder()
                 .putList(Environment.PATH_DATA_SETTING.getKey(), createTempDir().toString()).build();
+            assertThat(Environment.dataPathUsesList(settings), is(true));
+        }
+        {
+            final Settings settings = Settings.builder()
+                .put(Environment.PATH_DATA_SETTING.getKey(), createTempDir().toString() + "," + createTempDir().toString()).build();
             assertThat(Environment.dataPathUsesList(settings), is(true));
         }
     }


### PR DESCRIPTION
For multiple data paths, there are several allowed varieties of
specifcying the paths. The yaml list forms, both single and multi line,
are allowed, but another form is a string containing commas that is
parsed as a list. This latter form was broken recently by the
refactoring of path.data parsing to emit deprecation warnings for MDP.
This commit fixes the comma separated string case and adds a test.

closes #76181
