### PR TITLE
[DOCS] Update routing formulas

### DIFF
--- a/docs/reference/index-modules.asciidoc
+++ b/docs/reference/index-modules.asciidoc
@@ -47,8 +47,8 @@ NOTE: The number of shards are limited to `1024` per index. This limitation is a
 `index.number_of_routing_shards`::
 +
 ====
-Integer value used to assign documents to a primary shard. Must be a multiple of
-`index.number_of_shards`. See <<mapping-routing-field>>.
+Integer value used with <<index-number-of-shards,`index.number_of_shards`>> to
+assign documents to a primary shard. See <<mapping-routing-field>>.
 
 {es} also uses this value when <<indices-split-index,splitting>> an index.
 For example, a 5 shard index with `number_of_routing_shards` set to `30` (`5 x

--- a/docs/reference/index-modules.asciidoc
+++ b/docs/reference/index-modules.asciidoc
@@ -47,8 +47,10 @@ NOTE: The number of shards are limited to `1024` per index. This limitation is a
 `index.number_of_routing_shards`::
 +
 ====
-Number of routing shards used to <<indices-split-index,split>> an index.
+Integer value used to assign documents to a primary shard. Must be a multiple of
+`index.number_of_shards`. See <<mapping-routing-field>>.
 
+{es} also uses this value when <<indices-split-index,splitting>> an index.
 For example, a 5 shard index with `number_of_routing_shards` set to `30` (`5 x
 2 x 3`) could be split by a factor of `2` or `3`. In other words, it could be
 split as follows:

--- a/docs/reference/index-modules.asciidoc
+++ b/docs/reference/index-modules.asciidoc
@@ -48,7 +48,7 @@ NOTE: The number of shards are limited to `1024` per index. This limitation is a
 +
 ====
 Integer value used with <<index-number-of-shards,`index.number_of_shards`>> to
-assign documents to a primary shard. See <<mapping-routing-field>>.
+route documents to a primary shard. See <<mapping-routing-field>>.
 
 {es} also uses this value when <<indices-split-index,splitting>> an index.
 For example, a 5 shard index with `number_of_routing_shards` set to `30` (`5 x

--- a/docs/reference/index-modules.asciidoc
+++ b/docs/reference/index-modules.asciidoc
@@ -50,7 +50,7 @@ NOTE: The number of shards are limited to `1024` per index. This limitation is a
 Integer value used with <<index-number-of-shards,`index.number_of_shards`>> to
 route documents to a primary shard. See <<mapping-routing-field>>.
 
-{es} also uses this value when <<indices-split-index,splitting>> an index.
+{es} uses this value when <<indices-split-index,splitting>> an index.
 For example, a 5 shard index with `number_of_routing_shards` set to `30` (`5 x
 2 x 3`) could be split by a factor of `2` or `3`. In other words, it could be
 split as follows:

--- a/docs/reference/mapping/fields/routing-field.asciidoc
+++ b/docs/reference/mapping/fields/routing-field.asciidoc
@@ -10,9 +10,9 @@ formulas:
 `num_routing_shards` is the value of the
 <<index-number-of-routing-shards,`index.number_of_routing_shards`>> index
 setting. `num_primary_shards` is the value of the
-<<index-number-of-shards,`index.number_of_shards`>> index setting. The default
-value used for `_routing` is the document's <<mapping-id-field,`_id`>>.
+<<index-number-of-shards,`index.number_of_shards`>> index setting.\
 
+The default `_routing` value is the document's <<mapping-id-field,`_id`>>.
 Custom routing patterns can be implemented by specifying a custom `routing`
 value per document. For instance:
 

--- a/docs/reference/mapping/fields/routing-field.asciidoc
+++ b/docs/reference/mapping/fields/routing-field.asciidoc
@@ -1,36 +1,57 @@
 [[mapping-routing-field]]
 === `_routing` field
 
-A document is routed to a particular shard in an index using the following
-formula:
+By default, {es} uses a hash of the <<mapping-id-field,document `_id`>> to
+assign new documents to a primary shard. This default is designed to spread an
+index's data evenly across multiple shards. However, it also means a search on
+the index must hit each shard.
 
-    shard_num = hash(_routing) % num_primary_shards
+Custom routing lets you add data to a specific shard. You can later limit
+searches to this shard to drastically improve search speeds.
 
-The default value used for `_routing` is the document's <<mapping-id-field,`_id`>>.
+[[use-custom-routing]]
+==== Use custom routing
 
-Custom routing patterns can be implemented by specifying a custom `routing`
-value per document. For instance:
+To use custom routing, specify a `routing` string when you add a document. {es}
+uses a hash of this string to route documents to a primary shard. Documents with
+the same routing value are routed to the same shard. The routing value is stored
+in the document's `_routing` metadata field.
+
+Data streams don't support custom routing.
 
 [source,console]
-------------------------------
-PUT my-index-000001/_doc/1?routing=user1&refresh=true <1>
+----
+PUT my-index-000001/_doc/1?refresh&routing=user1
 {
-  "title": "This is a document"
+  "my-field": "A field value"
 }
-
-GET my-index-000001/_doc/1?routing=user1 <2>
-------------------------------
+----
 // TESTSETUP
 
-<1> This document uses `user1` as its routing value, instead of its ID.
-<2> The same `routing` value needs to be provided when
-    <<docs-get,getting>>, <<docs-delete,deleting>>, or <<docs-update,updating>>
-    the document.
+You can later specify these same `routing` values in a search request. If
+specified, the request will only search shards associated with the routing
+values.
 
-The value of the `_routing` field is accessible in queries:
+For example, the following request only searches shards for the `user1` and
+`user2` routing values. For more search routing options, see
+<<search-shard-routing>>.
 
 [source,console]
---------------------------
+----
+GET my-index-000001/_search?routing=user1,user2
+{
+  "query": {
+    "match": {
+      "my-field": "value"
+    }
+  }
+}
+----
+
+The value of the `_routing` field is also accessible in queries:
+
+[source,console]
+----
 GET my-index-000001/_search
 {
   "query": {
@@ -39,39 +60,15 @@ GET my-index-000001/_search
     }
   }
 }
---------------------------
+----
 
 <1> Querying on the `_routing` field (also see the <<query-dsl-ids-query,`ids` query>>)
 
-NOTE: Data streams do not support custom routing. Instead, target the
-appropriate backing index for the stream.
-
-==== Searching with custom routing
-
-Custom routing can reduce the impact of searches. Instead of having to fan
-out a search request to all the shards in an index, the request can be sent to
-just the shard that matches the specific routing value (or values):
-
-[source,console]
-------------------------------
-GET my-index-000001/_search?routing=user1,user2 <1>
-{
-  "query": {
-    "match": {
-      "title": "document"
-    }
-  }
-}
-------------------------------
-
-<1> This search request will only be executed on the shards associated with the `user1` and `user2` routing values.
-
-
 ==== Making a routing value required
 
-When using custom routing, it is important to provide the routing value
-whenever <<docs-index_,indexing>>, <<docs-get,getting>>,
-<<docs-delete,deleting>>, or <<docs-update,updating>> a document.
+When you add a document with custom routing, you must provide the same routing
+value when you <<docs-index_,index>>, <<docs-get,get>>, <<docs-delete,delete>>,
+or <<docs-update,update>> the document.
 
 Forgetting the routing value can lead to a document being indexed on more than
 one shard. As a safeguard, the `_routing` field can be configured to make a
@@ -110,23 +107,16 @@ It is up to the user to ensure that IDs are unique across the index.
 [[routing-index-partition]]
 ==== Routing to an index partition
 
-An index can be configured such that custom routing values will go to a subset of the shards rather
-than a single shard. This helps mitigate the risk of ending up with an imbalanced cluster while still
-reducing the impact of searches.
+Use the <<routing-partition-size,`index.routing_partition_size`>> index setting
+to route a document to a set of shards rather than a single shard.
 
-This is done by providing the index level setting <<routing-partition-size,`index.routing_partition_size`>> at index creation.
-As the partition size increases, the more evenly distributed the data will become at the
-expense of having to search more shards per request.
+When the setting is enabled, {es} uses the document’s `_routing` value to select
+a set of shards. {es} then uses the document `_id` to assign the document to a
+shard from the set.
 
-When this setting is present, the formula for calculating the shard becomes:
-
-    shard_num = (hash(_routing) + hash(_id) % routing_partition_size) % num_primary_shards
-
-That is, the `_routing` field is used to calculate a set of shards within the index and then the
-`_id` is used to pick a shard within that set.
-
-To enable this feature, the `index.routing_partition_size` should have a value greater than 1 and
-less than `index.number_of_shards`.
+The `index.routing_partition_size` value determines the number of shards in the
+set. A larger set means your data is more evenly distributed. However, it also
+means searches will hit more shards.
 
 Once enabled, the partitioned index will have the following limitations:
 

--- a/docs/reference/mapping/fields/routing-field.asciidoc
+++ b/docs/reference/mapping/fields/routing-field.asciidoc
@@ -4,7 +4,7 @@
 By default, {es} uses a hash of the <<mapping-id-field,document `_id`>> to
 assign new documents to a primary shard. This default is designed to spread an
 index's data evenly across multiple shards. However, it also means a search on
-the index must hit each shard.
+the index must hit each shard or one of its replicas.
 
 Custom routing lets you add data to a specific shard. You can later limit
 searches to this shard to drastically improve search speeds.
@@ -12,10 +12,9 @@ searches to this shard to drastically improve search speeds.
 [[use-custom-routing]]
 ==== Use custom routing
 
-To use custom routing, specify a `routing` string when you add a document. {es}
-uses a hash of this string to route documents to a primary shard. Documents with
-the same routing value are routed to the same shard. The routing value is stored
-in the document's `_routing` metadata field.
+To use custom routing, specify a `routing` string when you add a document.
+Documents with the same `routing` value are assigned to the same shard. The
+document's routing value is stored in the `_routing` metadata field.
 
 Data streams don't support custom routing.
 
@@ -29,8 +28,7 @@ PUT my-index-000001/_doc/1?refresh&routing=user1
 // TESTSETUP
 
 You can later specify these same `routing` values in a search request. If
-specified, the request will only search shards associated with the routing
-values.
+specified, the request will only search shards for the routing values.
 
 For example, the following request only searches shards for the `user1` and
 `user2` routing values. For more search routing options, see

--- a/docs/reference/mapping/fields/routing-field.asciidoc
+++ b/docs/reference/mapping/fields/routing-field.asciidoc
@@ -5,7 +5,7 @@ A document is routed to a particular shard in an index using the following
 formulas:
     
     routing_factor = num_routing_shards / num_primary_shards
-    shard_num = hash(_routing) % ( num_routing_shards / routing_factor )
+    shard_num = (hash(_routing) % num_routing_shards) / routing_factor
 
 `num_routing_shards` is the value of the
 <<index-number-of-routing-shards,`index.number_of_routing_shards`>> index
@@ -125,7 +125,8 @@ expense of having to search more shards per request.
 
 When this setting is present, the formula for calculating the shard becomes:
 
-    shard_num = (hash(_routing) + hash(_id) % routing_partition_size) % ( num_routing_shards / routing_factor )
+    routing_value = hash(_routing) + hash(_id) % routing_partition_size
+    shard_num = (routing_value %  num_routing_shards) / routing_factor
 
 That is, the `_routing` field is used to calculate a set of shards within the index and then the
 `_id` is used to pick a shard within that set.

--- a/docs/reference/mapping/fields/routing-field.asciidoc
+++ b/docs/reference/mapping/fields/routing-field.asciidoc
@@ -123,9 +123,10 @@ This is done by providing the index level setting <<routing-partition-size,`inde
 As the partition size increases, the more evenly distributed the data will become at the
 expense of having to search more shards per request.
 
-When this setting is present, the formula for calculating the shard becomes:
+When this setting is present, the formulas for calculating the shard becomes:
 
     routing_value = hash(_routing) + hash(_id) % routing_partition_size
+    routing_factor = num_routing_shards / num_primary_shards
     shard_num = (routing_value % num_routing_shards) / routing_factor
 
 That is, the `_routing` field is used to calculate a set of shards within the index and then the

--- a/docs/reference/mapping/fields/routing-field.asciidoc
+++ b/docs/reference/mapping/fields/routing-field.asciidoc
@@ -2,7 +2,7 @@
 === `_routing` field
 
 A document is routed to a particular shard in an index using the following
-formulae:
+formulas:
     
     routing_factor = num_routing_shards / num_primary_shards
     shard_num = hash(_routing) % ( num_routing_shards / routing_factor )

--- a/docs/reference/mapping/fields/routing-field.asciidoc
+++ b/docs/reference/mapping/fields/routing-field.asciidoc
@@ -126,7 +126,7 @@ expense of having to search more shards per request.
 When this setting is present, the formula for calculating the shard becomes:
 
     routing_value = hash(_routing) + hash(_id) % routing_partition_size
-    shard_num = (routing_value %  num_routing_shards) / routing_factor
+    shard_num = (routing_value % num_routing_shards) / routing_factor
 
 That is, the `_routing` field is used to calculate a set of shards within the index and then the
 `_id` is used to pick a shard within that set.

--- a/docs/reference/mapping/fields/routing-field.asciidoc
+++ b/docs/reference/mapping/fields/routing-field.asciidoc
@@ -10,7 +10,7 @@ formulas:
 `num_routing_shards` is the value of the
 <<index-number-of-routing-shards,`index.number_of_routing_shards`>> index
 setting. `num_primary_shards` is the value of the
-<<index-number-of-shards,`index.number_of_shards`>> index setting.\
+<<index-number-of-shards,`index.number_of_shards`>> index setting.
 
 The default `_routing` value is the document's <<mapping-id-field,`_id`>>.
 Custom routing patterns can be implemented by specifying a custom `routing`

--- a/docs/reference/mapping/fields/routing-field.asciidoc
+++ b/docs/reference/mapping/fields/routing-field.asciidoc
@@ -1,55 +1,41 @@
 [[mapping-routing-field]]
 === `_routing` field
 
-By default, {es} uses a hash of the <<mapping-id-field,document `_id`>> to
-assign new documents to a primary shard. This default is designed to spread an
-index's data evenly across multiple shards. However, it also means a search on
-the index must hit each shard or one of its replicas.
+A document is routed to a particular shard in an index using the following
+formulae:
+    
+    routing_factor = num_routing_shards / num_primary_shards
+    shard_num = hash(_routing) % ( num_routing_shards / routing_factor )
 
-Custom routing lets you add data to a specific shard. You can later limit
-searches to this shard to drastically improve search speeds.
+`num_routing_shards` is the value of the
+<<index-number-of-routing-shards,`index.number_of_routing_shards`>> index
+setting. `num_primary_shards` is the value of the
+<<index-number-of-shards,`index.number_of_shards`>> index setting. The default
+value used for `_routing` is the document's <<mapping-id-field,`_id`>>.
 
-[[use-custom-routing]]
-==== Use custom routing
-
-To use custom routing, specify a `routing` string when you add a document.
-Documents with the same `routing` value are assigned to the same shard. The
-document's routing value is stored in the `_routing` metadata field.
-
-Data streams don't support custom routing.
+Custom routing patterns can be implemented by specifying a custom `routing`
+value per document. For instance:
 
 [source,console]
-----
-PUT my-index-000001/_doc/1?refresh&routing=user1
+------------------------------
+PUT my-index-000001/_doc/1?routing=user1&refresh=true <1>
 {
-  "my-field": "A field value"
+  "title": "This is a document"
 }
-----
+
+GET my-index-000001/_doc/1?routing=user1 <2>
+------------------------------
 // TESTSETUP
 
-You can later specify these same `routing` values in a search request. If
-specified, the request will only search shards for the routing values.
+<1> This document uses `user1` as its routing value, instead of its ID.
+<2> The same `routing` value needs to be provided when
+    <<docs-get,getting>>, <<docs-delete,deleting>>, or <<docs-update,updating>>
+    the document.
 
-For example, the following request only searches shards for the `user1` and
-`user2` routing values. For more search routing options, see
-<<search-shard-routing>>.
-
-[source,console]
-----
-GET my-index-000001/_search?routing=user1,user2
-{
-  "query": {
-    "match": {
-      "my-field": "value"
-    }
-  }
-}
-----
-
-The value of the `_routing` field is also accessible in queries:
+The value of the `_routing` field is accessible in queries:
 
 [source,console]
-----
+--------------------------
 GET my-index-000001/_search
 {
   "query": {
@@ -58,15 +44,39 @@ GET my-index-000001/_search
     }
   }
 }
-----
+--------------------------
 
 <1> Querying on the `_routing` field (also see the <<query-dsl-ids-query,`ids` query>>)
 
+NOTE: Data streams do not support custom routing. Instead, target the
+appropriate backing index for the stream.
+
+==== Searching with custom routing
+
+Custom routing can reduce the impact of searches. Instead of having to fan
+out a search request to all the shards in an index, the request can be sent to
+just the shard that matches the specific routing value (or values):
+
+[source,console]
+------------------------------
+GET my-index-000001/_search?routing=user1,user2 <1>
+{
+  "query": {
+    "match": {
+      "title": "document"
+    }
+  }
+}
+------------------------------
+
+<1> This search request will only be executed on the shards associated with the `user1` and `user2` routing values.
+
+
 ==== Making a routing value required
 
-When you add a document with custom routing, you must provide the same routing
-value when you <<docs-index_,index>>, <<docs-get,get>>, <<docs-delete,delete>>,
-or <<docs-update,update>> the document.
+When using custom routing, it is important to provide the routing value
+whenever <<docs-index_,indexing>>, <<docs-get,getting>>,
+<<docs-delete,deleting>>, or <<docs-update,updating>> a document.
 
 Forgetting the routing value can lead to a document being indexed on more than
 one shard. As a safeguard, the `_routing` field can be configured to make a
@@ -105,16 +115,23 @@ It is up to the user to ensure that IDs are unique across the index.
 [[routing-index-partition]]
 ==== Routing to an index partition
 
-Use the <<routing-partition-size,`index.routing_partition_size`>> index setting
-to route a document to a set of shards rather than a single shard.
+An index can be configured such that custom routing values will go to a subset of the shards rather
+than a single shard. This helps mitigate the risk of ending up with an imbalanced cluster while still
+reducing the impact of searches.
 
-When the setting is enabled, {es} uses the document’s `_routing` value to select
-a set of shards. {es} then uses the document `_id` to assign the document to a
-shard from the set.
+This is done by providing the index level setting <<routing-partition-size,`index.routing_partition_size`>> at index creation.
+As the partition size increases, the more evenly distributed the data will become at the
+expense of having to search more shards per request.
 
-The `index.routing_partition_size` value determines the number of shards in the
-set. A larger set means your data is more evenly distributed. However, it also
-means searches will hit more shards.
+When this setting is present, the formula for calculating the shard becomes:
+
+    shard_num = (hash(_routing) + hash(_id) % routing_partition_size) % ( num_routing_shards / routing_factor )
+
+That is, the `_routing` field is used to calculate a set of shards within the index and then the
+`_id` is used to pick a shard within that set.
+
+To enable this feature, the `index.routing_partition_size` should have a value greater than 1 and
+less than `index.number_of_shards`.
 
 Once enabled, the partitioned index will have the following limitations:
 

--- a/docs/reference/mapping/fields/routing-field.asciidoc
+++ b/docs/reference/mapping/fields/routing-field.asciidoc
@@ -126,7 +126,6 @@ expense of having to search more shards per request.
 When this setting is present, the formulas for calculating the shard becomes:
 
     routing_value = hash(_routing) + hash(_id) % routing_partition_size
-    routing_factor = num_routing_shards / num_primary_shards
     shard_num = (routing_value % num_routing_shards) / routing_factor
 
 That is, the `_routing` field is used to calculate a set of shards within the index and then the

--- a/docs/reference/mapping/fields/routing-field.asciidoc
+++ b/docs/reference/mapping/fields/routing-field.asciidoc
@@ -123,7 +123,7 @@ This is done by providing the index level setting <<routing-partition-size,`inde
 As the partition size increases, the more evenly distributed the data will become at the
 expense of having to search more shards per request.
 
-When this setting is present, the formulas for calculating the shard becomes:
+When this setting is present, the formulas for calculating the shard become:
 
     routing_value = hash(_routing) + hash(_id) % routing_partition_size
     shard_num = (routing_value % num_routing_shards) / routing_factor


### PR DESCRIPTION
The `_routing` metadata field docs currently include formulas for how Elasticsearch routes documents to shards. However,
these formulas were not updated for #18699.  This updates the routing formulas and adds xrefs for related settings.

Closes #76072

### Preview
https://elasticsearch_76203.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/mapping-routing-field.html