### PR TITLE
[7.x] Remove vector tile feature flag (#76068)

### DIFF
--- a/x-pack/plugin/vector-tile/build.gradle
+++ b/x-pack/plugin/vector-tile/build.gradle
@@ -41,15 +41,6 @@ testClusters.all {
   setting 'xpack.license.self_generated.type', 'trial'
   testDistribution = 'DEFAULT'
   setting 'xpack.security.enabled', 'false'
-  if (BuildParams.isSnapshotBuild() == false) {
-    systemProperty 'es.vector_tile_feature_flag_registered', 'true'
-  }
-}
-
-tasks.named("test").configure {
-  if (BuildParams.isSnapshotBuild() == false) {
-    systemProperty 'es.vector_tile_feature_flag_registered', 'true'
-  }
 }
 
 tasks.named("thirdPartyAudit").configure {

--- a/x-pack/plugin/vector-tile/src/main/java/org/elasticsearch/xpack/vectortile/VectorTilePlugin.java
+++ b/x-pack/plugin/vector-tile/src/main/java/org/elasticsearch/xpack/vectortile/VectorTilePlugin.java
@@ -6,14 +6,12 @@
  */
 package org.elasticsearch.xpack.vectortile;
 
-import org.elasticsearch.Build;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
 import org.elasticsearch.common.settings.ClusterSettings;
 import org.elasticsearch.common.settings.IndexScopedSettings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.settings.SettingsFilter;
-import org.elasticsearch.core.Booleans;
 import org.elasticsearch.license.XPackLicenseState;
 import org.elasticsearch.plugins.ActionPlugin;
 import org.elasticsearch.plugins.Plugin;
@@ -35,20 +33,6 @@ public class VectorTilePlugin extends Plugin implements ActionPlugin {
         return XPackPlugin.getSharedLicenseState();
     }
 
-    private static final Boolean VECTOR_TILE_FEATURE_FLAG_REGISTERED;
-
-    static {
-        final String property = System.getProperty("es.vector_tile_feature_flag_registered");
-        if (Build.CURRENT.isSnapshot() && property != null) {
-            throw new IllegalArgumentException("es.vector_tile_feature_flag_registered is only supported in non-snapshot builds");
-        }
-        VECTOR_TILE_FEATURE_FLAG_REGISTERED = Booleans.parseBoolean(property, null);
-    }
-
-    public boolean isVectorTileEnabled() {
-        return Build.CURRENT.isSnapshot() || (VECTOR_TILE_FEATURE_FLAG_REGISTERED != null && VECTOR_TILE_FEATURE_FLAG_REGISTERED);
-    }
-
     @Override
     public List<RestHandler> getRestHandlers(
         Settings settings,
@@ -59,11 +43,7 @@ public class VectorTilePlugin extends Plugin implements ActionPlugin {
         IndexNameExpressionResolver indexNameExpressionResolver,
         Supplier<DiscoveryNodes> nodesInCluster
     ) {
-        if (isVectorTileEnabled()) {
-            return org.elasticsearch.core.List.of(new RestVectorTileAction());
-        } else {
-            return org.elasticsearch.core.List.of();
-        }
+        return Collections.singletonList(new RestVectorTileAction());
     }
 
     @Override


### PR DESCRIPTION
Vector tile development is completed and this feature is ready to be released on 7.15. It is initially release as an experimental feature.

In particular this new feature introduces a new endpoint for generating vector tiles from geospatial data stored in Elasticsearch. This is a functionality that is interesting for any application that wants to render geospatial information stored in Elasticsearch on a map. The basic way to call this new end point looks like:

```
GET {index}/_mvt/{geo_field}/{z}/{x}/{y}
```

The return of this call is a vector tile as defined in the [MapBox vector tile specification](https://github.com/mapbox/vector-tile-spec/tree/master/2.1) so it can be easily render by any map supporting this format.
