### PR TITLE
[DOCS] Change `_routing` to `routing` in mget API docs

### DIFF
--- a/docs/reference/docs/multi-get.asciidoc
+++ b/docs/reference/docs/multi-get.asciidoc
@@ -100,7 +100,7 @@ document:
 The index that contains the document.
 Required if no index is specified in the request URI.
 
-`_routing`::
+`routing`::
 (Optional, string) The key for the primary shard the document resides on.
 Required if routing is used during indexing.
 


### PR DESCRIPTION
Just a small docs update for the mget API.