### PR TITLE
Fix for JarHell Bootstrap Check can yield false positives

### DIFF
--- a/server/src/main/java/org/elasticsearch/plugins/PluginsService.java
+++ b/server/src/main/java/org/elasticsearch/plugins/PluginsService.java
@@ -36,7 +36,6 @@ import java.io.IOException;
 import java.lang.reflect.Constructor;
 import java.net.URL;
 import java.net.URLClassLoader;
-import java.net.URISyntaxException;
 import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -568,12 +567,10 @@ public class PluginsService implements ReportingService<PluginsAndModules> {
             Set<URL> union = new HashSet<>(classpath);
             union.addAll(bundle.urls);
             JarHell.checkJarHell(union, logger::debug);
-        } catch (final IOException ioe) {
-            throw new IllegalStateException("failed to load plugin " + bundle.plugin.getName() + " due to io error, caused when checking for Jar Hell", ioe);
-        } catch (final URISyntaxException urie) {
-            throw new IllegalStateException("failed to load plugin " + bundle.plugin.getName() + " due to malformed uri, caused when checking for Jar Hell", urie);
+        } catch (final IllegalStateException ise) {
+            throw new IllegalStateException("failed to load plugin " + bundle.plugin.getName() + " due to jar hell", ise);
         } catch (final Exception e) {
-            throw new IllegalStateException("failed to load plugin " + bundle.plugin.getName() + " due to jar hell", e);
+            throw new IllegalStateException("failed to load plugin " + bundle.plugin.getName() + " while checking for jar hell", e);
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/plugins/PluginsService.java
+++ b/server/src/main/java/org/elasticsearch/plugins/PluginsService.java
@@ -36,6 +36,7 @@ import java.io.IOException;
 import java.lang.reflect.Constructor;
 import java.net.URL;
 import java.net.URLClassLoader;
+import java.net.URISyntaxException;
 import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -567,7 +568,11 @@ public class PluginsService implements ReportingService<PluginsAndModules> {
             Set<URL> union = new HashSet<>(classpath);
             union.addAll(bundle.urls);
             JarHell.checkJarHell(union, logger::debug);
-        } catch (Exception e) {
+        } catch (final IOException ioe) {
+            throw new IllegalStateException("failed to load plugin " + bundle.plugin.getName() + " due to io error, caused when checking for Jar Hell", ioe);
+        } catch (final URISyntaxException urie) {
+            throw new IllegalStateException("failed to load plugin " + bundle.plugin.getName() + " due to malformed uri, caused when checking for Jar Hell", urie);
+        } catch (final Exception e) {
             throw new IllegalStateException("failed to load plugin " + bundle.plugin.getName() + " due to jar hell", e);
         }
     }

--- a/server/src/test/java/org/elasticsearch/plugins/PluginsServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/plugins/PluginsServiceTests.java
@@ -517,7 +517,7 @@ public class PluginsServiceTests extends ESTestCase {
     	IllegalStateException e = expectThrows(IllegalStateException.class, () ->
             PluginsService.checkBundleJarHell(JarHell.parseClassPath(), bundle, transitiveUrls));
 
-    	assertEquals("failed to load plugin dummy due to io error, caused when checking for Jar Hell", e.getMessage());
+    	assertEquals("failed to load plugin dummy while checking for jar hell", e.getMessage());
     }
 
     public void testJarHellDuplicateClassWithDep() throws Exception {

--- a/server/src/test/java/org/elasticsearch/plugins/PluginsServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/plugins/PluginsServiceTests.java
@@ -501,23 +501,23 @@ public class PluginsServiceTests extends ESTestCase {
     }
 
     public void testJarHellWhenExtendedPluginJarNotFound() throws Exception {
-    	Path pluginDir = createTempDir();
-    	Path pluginJar = pluginDir.resolve("dummy.jar");
+        Path pluginDir = createTempDir();
+        Path pluginJar = pluginDir.resolve("dummy.jar");
 
-    	Path otherDir = createTempDir();
-    	Path extendedPlugin = otherDir.resolve("extendedDep-not-present.jar");
+        Path otherDir = createTempDir();
+        Path extendedPlugin = otherDir.resolve("extendedDep-not-present.jar");
 
-    	PluginInfo info = new PluginInfo("dummy", "desc", "1.0", Version.CURRENT, "1.8",
+        PluginInfo info = new PluginInfo("dummy", "desc", "1.0", Version.CURRENT, "1.8",
             "Dummy", Arrays.asList("extendedPlugin"), false, PluginType.ISOLATED, "", false);
 
-    	PluginsService.Bundle bundle = new PluginsService.Bundle(info, pluginDir);
-    	Map<String, Set<URL>> transitiveUrls = new HashMap<>();
-    	transitiveUrls.put("extendedPlugin", Collections.singleton(extendedPlugin.toUri().toURL()));
+        PluginsService.Bundle bundle = new PluginsService.Bundle(info, pluginDir);
+        Map<String, Set<URL>> transitiveUrls = new HashMap<>();
+        transitiveUrls.put("extendedPlugin", Collections.singleton(extendedPlugin.toUri().toURL()));
 
-    	IllegalStateException e = expectThrows(IllegalStateException.class, () ->
+        IllegalStateException e = expectThrows(IllegalStateException.class, () ->
             PluginsService.checkBundleJarHell(JarHell.parseClassPath(), bundle, transitiveUrls));
 
-    	assertEquals("failed to load plugin dummy while checking for jar hell", e.getMessage());
+        assertEquals("failed to load plugin dummy while checking for jar hell", e.getMessage());
     }
 
     public void testJarHellDuplicateClassWithDep() throws Exception {

--- a/server/src/test/java/org/elasticsearch/plugins/PluginsServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/plugins/PluginsServiceTests.java
@@ -500,6 +500,26 @@ public class PluginsServiceTests extends ESTestCase {
         assertThat(e.getCause().getMessage(), containsString("Level"));
     }
 
+    public void testJarHellWhenExtendedPluginJarNotFound() throws Exception {
+    	Path pluginDir = createTempDir();
+    	Path pluginJar = pluginDir.resolve("dummy.jar");
+
+    	Path otherDir = createTempDir();
+    	Path extendedPlugin = otherDir.resolve("extendedDep-not-present.jar");
+
+    	PluginInfo info = new PluginInfo("dummy", "desc", "1.0", Version.CURRENT, "1.8",
+            "Dummy", Arrays.asList("extendedPlugin"), false, PluginType.ISOLATED, "", false);
+
+    	PluginsService.Bundle bundle = new PluginsService.Bundle(info, pluginDir);
+    	Map<String, Set<URL>> transitiveUrls = new HashMap<>();
+    	transitiveUrls.put("extendedPlugin", Collections.singleton(extendedPlugin.toUri().toURL()));
+
+    	IllegalStateException e = expectThrows(IllegalStateException.class, () ->
+            PluginsService.checkBundleJarHell(JarHell.parseClassPath(), bundle, transitiveUrls));
+
+    	assertEquals("failed to load plugin dummy due to io error, caused when checking for Jar Hell", e.getMessage());
+    }
+
     public void testJarHellDuplicateClassWithDep() throws Exception {
         Path pluginDir = createTempDir();
         Path pluginJar = pluginDir.resolve("plugin.jar");


### PR DESCRIPTION
Possible fix for Issue #75701 | JarHell Bootstrap Check can yield false positives |

Changes made:
1. Added separate checks for IOException and URISyntaxException which can be thrown from JarHell.checkJarHell() if Jar file is missing or not properly read
2. Added a unit test that checks whether the io error message gets thrown or not from checkBundleJarHell

---

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)? 
**Yes**

- Have you followed the [contributor guidelines](https://github.com/elastic/elasticsearch/blob/master/CONTRIBUTING.md)? **Yes**

- If submitting code, have you built your formula locally prior to submission with `gradle check`? 
**Yes**

- If submitting code, is your pull request against master? Unless there is a good reason otherwise, we prefer pull requests against master and will backport as needed. 
**Yes**

- If submitting code, have you checked that your submission is for an [OS and architecture that we support](https://www.elastic.co/support/matrix#show_os)? 
**I think so**

- If you are submitting this code for a class then read our [policy] (https://github.com/elastic/elasticsearch/blob/master/CONTRIBUTING.md#contributing-as-part-of-a-class) for that.
**No**