### PR TITLE
In MultiCommand, show command list when required

### DIFF
--- a/distribution/tools/plugin-cli/src/test/java/org/elasticsearch/plugins/RemovePluginActionTests.java
+++ b/distribution/tools/plugin-cli/src/test/java/org/elasticsearch/plugins/RemovePluginActionTests.java
@@ -34,6 +34,7 @@ import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasToString;
 
@@ -259,12 +260,13 @@ public class RemovePluginActionTests extends ESTestCase {
             BufferedReader reader = new BufferedReader(new StringReader(terminal.getOutput()));
             BufferedReader errorReader = new BufferedReader(new StringReader(terminal.getErrorOutput()))
         ) {
-            assertEquals(
-                "ERROR: plugin [fake] not found; run 'elasticsearch-plugin list' to get list of installed plugins",
-                errorReader.readLine()
+            assertThat(errorReader.readLine(), equalTo(""));
+            assertThat(
+                errorReader.readLine(),
+                equalTo("ERROR: plugin [fake] not found; run 'elasticsearch-plugin list' to get list of installed plugins")
             );
-            assertNull(reader.readLine());
-            assertNull(errorReader.readLine());
+            assertThat(reader.readLine(), nullValue());
+            assertThat(errorReader.readLine(), nullValue());
         }
     }
 

--- a/libs/cli/src/main/java/org/elasticsearch/cli/Command.java
+++ b/libs/cli/src/main/java/org/elasticsearch/cli/Command.java
@@ -86,9 +86,7 @@ public abstract class Command implements Closeable {
             if (e.exitCode == ExitCodes.USAGE) {
                 printHelp(terminal, true);
             }
-            if (e.getMessage() != null) {
-                terminal.errorPrintln(Terminal.Verbosity.SILENT, "ERROR: " + e.getMessage());
-            }
+            printUserException(terminal, e);
             return e.exitCode;
         }
         return ExitCodes.OK;
@@ -132,6 +130,13 @@ public abstract class Command implements Closeable {
 
     /** Prints additional help information, specific to the command */
     protected void printAdditionalHelp(Terminal terminal) {}
+
+    protected void printUserException(Terminal terminal, UserException e) {
+        if (e.getMessage() != null) {
+            terminal.errorPrintln("");
+            terminal.errorPrintln(Terminal.Verbosity.SILENT, "ERROR: " + e.getMessage());
+        }
+    }
 
     @SuppressForbidden(reason = "Allowed to exit explicitly from #main()")
     protected static void exit(int status) {

--- a/libs/cli/src/main/java/org/elasticsearch/cli/MultiCommand.java
+++ b/libs/cli/src/main/java/org/elasticsearch/cli/MultiCommand.java
@@ -12,6 +12,7 @@ import joptsimple.NonOptionArgumentSpec;
 import joptsimple.OptionSet;
 import joptsimple.OptionSpec;
 import joptsimple.util.KeyValuePair;
+
 import org.elasticsearch.core.internal.io.IOUtils;
 
 import java.io.IOException;
@@ -19,6 +20,7 @@ import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Consumer;
 
 /**
  * A cli tool which is made up of multiple subcommands.
@@ -44,15 +46,28 @@ public class MultiCommand extends Command {
 
     @Override
     protected void printAdditionalHelp(Terminal terminal) {
+        printSubCommandList(terminal::println);
+    }
+
+    @Override
+    protected void printUserException(Terminal terminal, UserException e) {
+        super.printUserException(terminal, e);
+        if (e instanceof MissingCommandException) {
+            terminal.errorPrintln("");
+            printSubCommandList(terminal::errorPrintln);
+        }
+    }
+
+    private void printSubCommandList(Consumer<String> println) {
         if (subcommands.isEmpty()) {
             throw new IllegalStateException("No subcommands configured");
         }
-        terminal.println("Commands");
-        terminal.println("--------");
+        println.accept("Commands");
+        println.accept("--------");
         for (Map.Entry<String, Command> subcommand : subcommands.entrySet()) {
-            terminal.println(subcommand.getKey() + " - " + subcommand.getValue().description);
+            println.accept(subcommand.getKey() + " - " + subcommand.getValue().description);
         }
-        terminal.println("");
+        println.accept("");
     }
 
     @Override
@@ -64,7 +79,7 @@ public class MultiCommand extends Command {
         // .values(...) returns an unmodifiable list
         final List<String> args = new ArrayList<>(arguments.values(options));
         if (args.isEmpty()) {
-            throw new UserException(ExitCodes.USAGE, "Missing command");
+            throw new MissingCommandException();
         }
 
         String subcommandName = args.remove(0);
@@ -85,4 +100,9 @@ public class MultiCommand extends Command {
         IOUtils.close(subcommands.values());
     }
 
+    static final class MissingCommandException extends UserException {
+        MissingCommandException() {
+            super(ExitCodes.USAGE, "Missing required command");
+        }
+    }
 }

--- a/server/src/test/java/org/elasticsearch/cli/MultiCommandTests.java
+++ b/server/src/test/java/org/elasticsearch/cli/MultiCommandTests.java
@@ -11,6 +11,7 @@ package org.elasticsearch.cli;
 import joptsimple.ArgumentAcceptingOptionSpec;
 import joptsimple.OptionSet;
 import joptsimple.util.KeyValuePair;
+
 import org.junit.Before;
 
 import java.io.IOException;
@@ -111,11 +112,13 @@ public class MultiCommandTests extends CommandTestCase {
         assertEquals("Unknown command [somethingelse]", e.getMessage());
     }
 
-    public void testMissingCommand() {
+    public void testMissingCommand() throws Exception {
         multiCommand.subcommands.put("command1", new DummySubCommand());
-        UserException e = expectThrows(UserException.class, this::execute);
+        MultiCommand.MissingCommandException e = expectThrows(MultiCommand.MissingCommandException.class, this::execute);
         assertEquals(ExitCodes.USAGE, e.exitCode);
-        assertEquals("Missing command", e.getMessage());
+        assertEquals("Missing required command", e.getMessage());
+        multiCommand.printUserException(terminal, e);
+        assertThat(terminal.getErrorOutput(), containsString("command1"));
     }
 
     public void testHelp() throws Exception {


### PR DESCRIPTION
A MultiCommand requires that a (sub)command is provided for each
execution. Previously, the error handling for MultiCommand would
simply state "ERROR: Missing command" but give no assistance about
what commands were accepted. The user was required to pass "-help" in
order to get the command list.

This commit changes the behaviour so that the list of commands is
printed after the error message.

Backport of: #75993
