### PR TITLE
Reenable BwC Snapshot Rest Tests

### DIFF
--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/cat.snapshots/10_basic.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/cat.snapshots/10_basic.yml
@@ -1,8 +1,5 @@
 ---
 "Help":
-  - skip:
-      version: " - 7.99.99"
-      reason: Repository field added in 8.0
 
   - do:
       cat.snapshots:
@@ -26,10 +23,6 @@
                $/
 ---
 "Test cat snapshots output":
-  - skip:
-      version: " - 7.99.99"
-      reason: Repository field added in 8.0
-
   - do:
       snapshot.create_repository:
         repository: test_cat_snapshots_1

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/snapshot.get/10_basic.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/snapshot.get/10_basic.yml
@@ -235,9 +235,6 @@ setup:
 
 ---
 "Get snapshot info without repository names":
-  - skip:
-      version: " - 7.99.99"
-      reason: "8.0 changes get snapshots response format"
 
   - do:
       indices.create:


### PR DESCRIPTION
These tests should work now that we aligned 7.x and 8.x snapshot apis.
