### PR TITLE
SQL: Fix NULL ordering in derived fields

### DIFF
--- a/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/expression/gen/script/Scripts.java
+++ b/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/expression/gen/script/Scripts.java
@@ -79,6 +79,21 @@ public final class Scripts {
                 script.outputType());
     }
 
+    public static ScriptTemplate nullSafeEmitForSorting(ScriptTemplate script){
+        if (script.outputType().isNumeric()) {
+            return new ScriptTemplate(
+                "def r=" + script.template() + ";if(r!=null){emit(r)}",
+                script.params(),
+                DataTypes.DOUBLE);
+        } else {
+            return new ScriptTemplate(
+                "def r=" + script.template() + ";if(r!=null){emit(r.toString())}",
+                script.params(),
+                DataTypes.KEYWORD
+            );
+        }
+    }
+
     public static ScriptTemplate and(ScriptTemplate left, ScriptTemplate right) {
         return binaryMethod("{ql}", "and", left, right, DataTypes.BOOLEAN);
     }

--- a/x-pack/plugin/sql/qa/server/src/main/resources/date_nanos.csv-spec
+++ b/x-pack/plugin/sql/qa/server/src/main/resources/date_nanos.csv-spec
@@ -314,7 +314,7 @@ SELECT id, "@timestamp"::string AS ts_string FROM logs_nanos WHERE id < 20 ORDER
 
 orderByScalar
 schema::id:i|ts_string:s
-SELECT id, "@timestamp"::string AS ts_string FROM logs_nanos ORDER BY DATE_PART('nanoseconds', "@timestamp") DESC LIMIT 10;
+SELECT id, "@timestamp"::string AS ts_string FROM logs_nanos ORDER BY DATE_PART('nanoseconds', "@timestamp") DESC NULLS LAST LIMIT 10;
 
       id       |          ts_string
 ---------------+------------------------------

--- a/x-pack/plugin/sql/qa/server/src/main/resources/datetime.csv-spec
+++ b/x-pack/plugin/sql/qa/server/src/main/resources/datetime.csv-spec
@@ -110,7 +110,7 @@ d:i                  | l:s
 ;
 
 weekOfYear
-SELECT WEEK(birth_date) week, birth_date FROM test_emp ORDER BY WEEK(birth_date) DESC, birth_date DESC LIMIT 15;
+SELECT WEEK(birth_date) week, birth_date FROM test_emp ORDER BY WEEK(birth_date) DESC NULLS LAST, birth_date DESC LIMIT 15;
 
     week:i     |     birth_date:ts
 ---------------+------------------------
@@ -292,7 +292,7 @@ schema::languages:byte|first_name:s|gender:s|hire_date:ts|date_add:date
 SELECT languages, first_name, gender, hire_date,
 CAST(DATE_ADD(CASE WHEN gender = 'M' THEN CONCAT(gender, 'onths') WHEN gender = 'F' THEN NULL ELSE 'quarter' END,
     5, hire_date + INTERVAL 10 month) AS DATE) AS date_add
-FROM test_emp WHERE languages >= 3 AND first_name LIKE '%y%' ORDER BY date_add ASC, languages DESC;
+FROM test_emp WHERE languages >= 3 AND first_name LIKE '%y%' ORDER BY date_add ASC NULLS FIRST, languages DESC;
 
    languages   |  first_name   |    gender     |      hire_date          |   date_add
 ---------------+---------------+---------------+-------------------------+---------------
@@ -468,7 +468,7 @@ SELECT first_name, gender, birth_date, hire_date, DATE_DIFF(CASE WHEN gender = '
 birth_date, hire_date + INTERVAL 10 month) AS date_diff1,
 DATE_DIFF(CASE WHEN gender = 'M' THEN CONCAT(gender, 'onths') WHEN gender = 'F' THEN 'year' ELSE 'quarter' END,
 hire_date + INTERVAL 10 month, birth_date - INTERVAL 20 month) AS date_diff2
-FROM test_emp WHERE (date_diff2 IS NULL OR date_diff2 < -455) AND first_name LIKE '%y%' ORDER BY date_diff1 DESC;
+FROM test_emp WHERE (date_diff2 IS NULL OR date_diff2 < -455) AND first_name LIKE '%y%' ORDER BY date_diff1 DESC NULLS LAST;
 
   first_name   |     gender |      birth_date          |       hire_date          |   date_diff1  |   date_diff2
 ---------------+------------+--------------------------+--------------------------+---------------+-------------
@@ -937,7 +937,7 @@ SELECT birth_date, DATE_TRUNC(CAST(CHAR(109) AS VARCHAR), birth_date + INTERVAL 
 ;
 
 selectDateTruncWithTruncArgFromField
-SELECT DATE_TRUNC(CONCAT(gender, 'illennium'), birth_date) AS dt FROM test_emp WHERE gender='M' ORDER BY 1 DESC LIMIT 2;
+SELECT DATE_TRUNC(CONCAT(gender, 'illennium'), birth_date) AS dt FROM test_emp WHERE gender='M' ORDER BY 1 DESC NULLS LAST LIMIT 2;
 
      dt:ts
 ------------------------

--- a/x-pack/plugin/sql/qa/server/src/main/resources/datetime.sql-spec
+++ b/x-pack/plugin/sql/qa/server/src/main/resources/datetime.sql-spec
@@ -38,7 +38,7 @@ dateTimeQuarter
 SELECT QUARTER(hire_date) q, hire_date FROM test_emp ORDER BY hire_date LIMIT 15;
 
 dateTimeDayOfWeek
-SELECT DAY_OF_WEEK(birth_date) day, birth_date FROM test_emp ORDER BY DAY_OF_WEEK(birth_date);
+SELECT DAY_OF_WEEK(birth_date) day, birth_date FROM test_emp ORDER BY DAY_OF_WEEK(birth_date) NULLS LAST;
 
 //
 // Filter

--- a/x-pack/plugin/sql/qa/server/src/main/resources/math.csv-spec
+++ b/x-pack/plugin/sql/qa/server/src/main/resources/math.csv-spec
@@ -62,7 +62,7 @@ SELECT TRUNC(salary, 2) TRUNCATED, salary FROM test_emp GROUP BY TRUNCATED, sala
 ;
 
 truncateWithAsciiAndOrderBy
-SELECT TRUNCATE(ASCII(LEFT(first_name,1)), -1) AS initial, first_name, ASCII(LEFT(first_name, 1)) FROM test_emp ORDER BY ASCII(LEFT(first_name, 1)) DESC LIMIT 15;
+SELECT TRUNCATE(ASCII(LEFT(first_name,1)), -1) AS initial, first_name, ASCII(LEFT(first_name, 1)) FROM test_emp ORDER BY ASCII(LEFT(first_name, 1)) DESC NULLS LAST LIMIT 15;
 
     initial    |  first_name   |ASCII(LEFT(first_name, 1))
 ---------------+---------------+--------------------------

--- a/x-pack/plugin/sql/qa/server/src/main/resources/select.csv-spec
+++ b/x-pack/plugin/sql/qa/server/src/main/resources/select.csv-spec
@@ -242,3 +242,55 @@ Vishv          |VISHV
 Valter         |VALTER         
 Valdiodio      |VALDIODIO
 ;
+
+//
+// SELECT with ORDER BY numeric field
+// (only queries with implicit NULLS FIRST/LAST in CSV specs as H2 uses different defaults)
+//
+orderByDerivedNumericField
+SELECT IFNULL(languages - 2, -99) l FROM test_emp WHERE salary > 73000 ORDER BY languages - 2;
+ l
+----
+ -1
+  0
+  1
+  2
+-99
+-99
+;
+
+orderByDerivedNumericFieldDesc
+SELECT IFNULL(languages - 2, -99) l FROM test_emp WHERE salary > 73000 ORDER BY languages - 2 DESC;
+ l
+----
+-99
+-99
+  2
+  1
+  0
+ -1
+;
+
+orderByDerivedKeywordericField
+SELECT IFNULL(LCASE(gender), '-') l FROM test_emp WHERE salary > 73000 ORDER BY LCASE(gender);
+       l
+---------------
+f
+f
+f
+m
+m
+-
+;
+
+orderByDerivedKeywordFieldDesc
+SELECT IFNULL(LCASE(gender), '-') l FROM test_emp WHERE salary > 73000 ORDER BY LCASE(gender) DESC;
+       l
+---------------
+-
+m
+m
+f
+f
+f
+;

--- a/x-pack/plugin/sql/qa/server/src/main/resources/select.sql-spec
+++ b/x-pack/plugin/sql/qa/server/src/main/resources/select.sql-spec
@@ -169,3 +169,23 @@ selectGroupByWithAliasedSubQuery
 SELECT max, languages FROM (SELECT max(salary) AS max, languages FROM test_emp GROUP BY languages ORDER BY max ASC NULLS LAST) AS subquery;
 selectConstantFromSubQuery
 SELECT * FROM (SELECT * FROM (SELECT 1));
+
+//
+// ORDER BY derived fields
+//
+orderByDerivedNumericFieldNullsFirst
+SELECT languages - 2 l FROM test_emp ORDER BY 1 NULLS LAST;
+orderByDerivedNumericFieldNullsLast
+SELECT languages - 2 l FROM test_emp ORDER BY 1 NULLS LAST;
+orderByDerivedNumericFieldDescNullsFirst
+SELECT languages - 2 l FROM test_emp ORDER BY 1 DESC NULLS LAST;
+orderByDerivedNumericFieldDescNullsLast
+SELECT languages - 2 l FROM test_emp ORDER BY 1 DESC NULLS LAST;
+orderByDerivedKeywordFieldNullsFirst
+SELECT LCASE(gender) l FROM test_emp ORDER BY 1 NULLS LAST;
+orderByDerivedKeywordFieldNullsLast
+SELECT LCASE(gender) l FROM test_emp ORDER BY 1 NULLS LAST;
+orderByDerivedKeywordFieldDescNullsFirst
+SELECT LCASE(gender) l FROM test_emp ORDER BY 1 DESC NULLS LAST;
+orderByDerivedKeywordFieldDescNullsLast
+SELECT LCASE(gender) l FROM test_emp ORDER BY 1 DESC NULLS LAST;

--- a/x-pack/plugin/sql/qa/server/src/main/resources/time.csv-spec
+++ b/x-pack/plugin/sql/qa/server/src/main/resources/time.csv-spec
@@ -44,7 +44,7 @@ SELECT count(*) FROM "test_emp" WHERE birth_date::TIME = CAST('12:34:56.789' AS 
 ;
 
 timeAsOrderBy
-SELECT last_name FROM "test_emp" ORDER BY birth_date::TIME, emp_no LIMIT 5;
+SELECT last_name FROM "test_emp" ORDER BY birth_date::TIME NULLS FIRST, emp_no LIMIT 5;
 
 last_name:s
 Meriste
@@ -125,7 +125,7 @@ FROM logs WHERE client_ip = '10.0.1.13' ORDER BY "@timestamp" desc;
 2017-11-10 20:36:15.000Z | 20:36:15.000Z
 2017-11-10 20:36:07.000Z | 20:36:07.000Z
 2017-11-10 20:35:55.000Z | 20:35:55.000Z
-2017-11-10 20:35:54.000Z | 20:35:54.000Z 
+2017-11-10 20:35:54.000Z | 20:35:54.000Z
 2017-11-10 17:54:43.000Z | 17:54:43.000Z
 ;
 

--- a/x-pack/plugin/sql/qa/server/src/main/resources/wildcard.csv-spec
+++ b/x-pack/plugin/sql/qa/server/src/main/resources/wildcard.csv-spec
@@ -39,7 +39,7 @@ SELECT COUNT(*) count FROM test_emp_copy WHERE wildcard_name IS NULL;
 ;
 
 functionOverAlias
-SELECT BIT_LENGTH(wildcard_name) bit, wildcard_name, length(wildcard_name) l FROM test_emp_copy ORDER BY bit DESC LIMIT 10;
+SELECT BIT_LENGTH(wildcard_name) bit, wildcard_name, length(wildcard_name) l FROM test_emp_copy ORDER BY bit DESC NULLS LAST LIMIT 10;
 
       bit      |    wildcard_name     |       l       
 ---------------+----------------------+---------------

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/execution/search/Querier.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/execution/search/Querier.java
@@ -74,6 +74,7 @@ import java.util.ArrayList;
 import java.util.BitSet;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.HashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
@@ -119,7 +120,9 @@ public class Querier {
 
         // set runtime mappings
         if (this.cfg.runtimeMappings() != null) {
-            sourceBuilder.runtimeMappings(this.cfg.runtimeMappings());
+            Map<String, Object> allMappings = new HashMap<>(sourceBuilder.runtimeMappings());
+            allMappings.putAll(this.cfg.runtimeMappings());
+            sourceBuilder.runtimeMappings(allMappings);
         }
 
         if (log.isTraceEnabled()) {

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/plugin/SqlPainlessExtension.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/plugin/SqlPainlessExtension.java
@@ -11,10 +11,12 @@ import org.elasticsearch.painless.spi.Whitelist;
 import org.elasticsearch.painless.spi.WhitelistLoader;
 import org.elasticsearch.script.AggregationScript;
 import org.elasticsearch.script.BucketAggregationSelectorScript;
+import org.elasticsearch.script.DoubleFieldScript;
 import org.elasticsearch.script.FieldScript;
 import org.elasticsearch.script.FilterScript;
 import org.elasticsearch.script.NumberSortScript;
 import org.elasticsearch.script.ScriptContext;
+import org.elasticsearch.script.StringFieldScript;
 import org.elasticsearch.script.StringSortScript;
 
 import java.util.HashMap;
@@ -37,6 +39,8 @@ public class SqlPainlessExtension implements PainlessExtension {
         whitelist.put(NumberSortScript.CONTEXT, list);
         whitelist.put(StringSortScript.CONTEXT, list);
         whitelist.put(BucketAggregationSelectorScript.CONTEXT, list);
+        whitelist.put(StringFieldScript.CONTEXT, list);
+        whitelist.put(DoubleFieldScript.CONTEXT, list);
         return whitelist;
     }
 }

--- a/x-pack/plugin/sql/src/test/resources/org/elasticsearch/xpack/sql/planner/querytranslator_tests.txt
+++ b/x-pack/plugin/sql/src/test/resources/org/elasticsearch/xpack/sql/planner/querytranslator_tests.txt
@@ -316,9 +316,8 @@ InternalSqlScriptUtils.intervalYearMonth(params.v1,params.v2)),params.v3)",
 
 OrderByYear
 SELECT YEAR(date) FROM test ORDER BY 1;
-"sort":[{"_script":{"script":{"source":"InternalQlScriptUtils.nullSafeSortNumeric(InternalSqlScriptUtils.dateTimeExtract(InternalQlScriptUtils.docValue(doc,params.v0),params.v1,params.v2))"
-"params":{"v0":"date","v1":"Z","v2":"YEAR"}},
-"type":"number","order":"asc"}}]}
+{"order":"asc","missing":"_last","unmapped_type":"double"}
+{"type":"double","script":{"source":"defr=InternalSqlScriptUtils.dateTimeExtract(InternalQlScriptUtils.docValue(doc,params.v0),params.v1,params.v2);if(r!=null){emit(r)}","lang":"painless","params":{"v0":"date","v1":"Z","v2":"YEAR"}}}
 ;
 
 // LIKE/RLIKE
@@ -391,10 +390,9 @@ InternalSqlScriptUtils.cast(InternalSqlScriptUtils.abs(InternalSqlScriptUtils.da
 
 OrderByWithCastWithMissingRefs
 SELECT keyword FROM test ORDER BY date::TIME, int LIMIT 5;
-"sort":[{"_script":{"script":{"source":"InternalQlScriptUtils.nullSafeSortString(InternalSqlScriptUtils.cast(InternalQlScriptUtils.docValue(doc,params.v0),params.v1))
-"params":{"v0":"date","v1":"TIME"}
-"type":"string",
-"order":"asc"}},{"int":{"order":"asc","missing":"_last","unmapped_type":"integer"}}]}
+{"order":"asc","missing":"_last","unmapped_type":"keyword"}
+{"int":{"order":"asc","missing":"_last","unmapped_type":"integer"}}
+{"type":"keyword","script":{"source":"defr=InternalSqlScriptUtils.cast(InternalQlScriptUtils.docValue(doc,params.v0),params.v1);if(r!=null){emit(r.toString())}","lang":"painless","params":{"v0":"date","v1":"TIME"}}}
 ;
 
 


### PR DESCRIPTION
Resolves https://github.com/elastic/elasticsearch/issues/58820

This PR uses runtime fields to delegate NULL ordering to the search API's `missing` option (that is only available for attribute sort and not for script sort). Previously, `NULL` results from derived values have been replaced by "empty" values (`""` for Strings, `0` for numbers) and ordered accordingly.

Example mapping for the query `SELECT * FROM test_emp ORDER BY languages - 2`:

```
{
  ...
  "sort": [
    {
      "41753968": {
        "order": "asc",
        "missing": "_last",
        "unmapped_type": "double"
      }
    }
  ],
  "runtime_mappings": {
    "41753968": {
      "type": "double",
      "script": {
        "source": "def r=InternalSqlScriptUtils.sub(InternalQlScriptUtils.docValue(doc,params.v0),params.v1);if(r!=null){emit(r)}",
        "lang": "painless",
        "params": {
          "v0": "languages",
          "v1": 2
        }
      }
    }
  }
}
```