### PR TITLE
Mute testMessageForPemKeyOutsideConfigDir on Windows

### DIFF
--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/ssl/SSLErrorMessageFileTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/ssl/SSLErrorMessageFileTests.java
@@ -119,6 +119,7 @@ public class SSLErrorMessageFileTests extends ESTestCase {
     }
 
     public void testMessageForPemKeyOutsideConfigDir() throws Exception {
+        assumeFalse("https://github.com/elastic/elasticsearch/issues/76166", Constants.WINDOWS);
         checkBlockedKeyManagerResource("PEM private key", "key", withCertificate("cert1a.crt"));
     }
 


### PR DESCRIPTION
... from the SSLErrorMessageFileTests suite.

Relates #76166
