### PR TITLE
[7.x] [ML] Allow for slow CI machines in MlNodeShutdownIT (#76242)

### DIFF
--- a/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/MlNodeShutdownIT.java
+++ b/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/MlNodeShutdownIT.java
@@ -94,7 +94,7 @@ public class MlNodeShutdownIT extends BaseMlIntegTestCase {
                 .filter(stats -> stats.getNode() != null && nodeNameToShutdown.equals(stats.getNode().getName()) == false).count();
             assertThat(numJobsOnNodeToShutdown, is(0L));
             assertThat(numJobsOnOtherNodes, is(6L));
-        });
+        }, 30, TimeUnit.SECONDS);
     }
 
     public void testCloseJobVacatingShuttingDownNode() throws Exception {
@@ -183,7 +183,7 @@ public class MlNodeShutdownIT extends BaseMlIntegTestCase {
                 .filter(stats -> stats.getNode() != null && nodeNameToShutdown.equals(stats.getNode().getName()) == false).count();
             assertThat(numJobsOnNodeToShutdown, is(0L));
             assertThat(numJobsOnOtherNodes, is(5L)); // 5 rather than 6 because we closed one
-        });
+        }, 30, TimeUnit.SECONDS);
     }
 
     private void setupJobAndDatafeed(String jobId, ByteSizeValue modelMemoryLimit) throws Exception {


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [ML] Allow for slow CI machines in MlNodeShutdownIT (#76242)