### PR TITLE
Normalize BlobPath Building to Fix S3 Issue

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/blobstore/BlobPath.java
+++ b/server/src/main/java/org/elasticsearch/common/blobstore/BlobPath.java
@@ -35,12 +35,12 @@ public class BlobPath {
     }
 
     public BlobPath add(String path) {
-        return new BlobPath(CollectionUtils.appendToCopy(this.paths, path));
+        return new BlobPath(CollectionUtils.appendToCopy(this.paths, path.endsWith("/") ? path.substring(0, path.length() - 1) : path));
     }
 
     public String buildAsString() {
         String p = String.join(SEPARATOR, paths);
-        if (p.isEmpty() || p.endsWith(SEPARATOR)) {
+        if (p.isEmpty()) {
             return p;
         }
         return p + SEPARATOR;

--- a/server/src/main/java/org/elasticsearch/common/blobstore/BlobPath.java
+++ b/server/src/main/java/org/elasticsearch/common/blobstore/BlobPath.java
@@ -35,7 +35,8 @@ public class BlobPath {
     }
 
     public BlobPath add(String path) {
-        return new BlobPath(CollectionUtils.appendToCopy(this.paths, path.endsWith("/") ? path.substring(0, path.length() - 1) : path));
+        return new BlobPath(
+            CollectionUtils.appendToCopy(this.paths, path.endsWith(SEPARATOR) ? path.substring(0, path.length() - 1) : path));
     }
 
     public String buildAsString() {

--- a/server/src/test/java/org/elasticsearch/common/blobstore/BlobPathTests.java
+++ b/server/src/test/java/org/elasticsearch/common/blobstore/BlobPathTests.java
@@ -27,4 +27,14 @@ public class BlobPathTests extends ESTestCase {
         path = path.add("d/");
         assertThat(path.buildAsString(), is("a/b/c/d/"));
     }
+
+    public void testPathsWithTrailingSlash() {
+        final BlobPath withTrailingSlash = BlobPath.EMPTY.add("foo/bar/");
+        final BlobPath withOutTrailingSlash = BlobPath.EMPTY.add("foo").add("bar");
+        assertThat(withTrailingSlash.buildAsString(), is(withOutTrailingSlash.buildAsString()));
+        final BlobPath subFolderFromWithTrailingSlash = withTrailingSlash.add("indices");
+        final BlobPath subFolderFromWithoutTrailingSlash = withOutTrailingSlash.add("indices");
+        assertThat(subFolderFromWithoutTrailingSlash.buildAsString(), is("foo/bar/indices/"));
+        assertThat(subFolderFromWithTrailingSlash.buildAsString(), is("foo/bar/indices/"));
+    }
 }


### PR DESCRIPTION
Align blob path building such that two paths that build to the
same string will also build the same subpath strings consistently.

closes #59333
