### PR TITLE
[7.x] [ML] allow for larger models in the inference step for data frame analytics (#76116)

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/InferenceToXContentCompressor.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/InferenceToXContentCompressor.java
@@ -40,9 +40,9 @@ import java.util.zip.GZIPOutputStream;
  */
 public final class InferenceToXContentCompressor {
     private static final int BUFFER_SIZE = 4096;
-    // Either 10% of the configured JVM heap, or 1 GB, which ever is smaller
+    // Either 25% of the configured JVM heap, or 1 GB, which ever is smaller
     private static final long MAX_INFLATED_BYTES = Math.min(
-        (long)((0.10) * JvmInfo.jvmInfo().getMem().getHeapMax().getBytes()),
+        (long)((0.25) * JvmInfo.jvmInfo().getMem().getHeapMax().getBytes()),
         ByteSizeValue.ofGb(1).getBytes());
 
     private InferenceToXContentCompressor() {}
@@ -50,6 +50,12 @@ public final class InferenceToXContentCompressor {
     public static <T extends ToXContentObject> String deflate(T objectToCompress) throws IOException {
         BytesReference reference = XContentHelper.toXContent(objectToCompress, XContentType.JSON, false);
         return deflate(reference);
+    }
+
+    public static <T> T inflateUnsafe(String compressedString,
+                                      CheckedFunction<XContentParser, T, IOException> parserFunction,
+                                      NamedXContentRegistry xContentRegistry) throws IOException {
+        return inflate(compressedString, parserFunction, xContentRegistry, Long.MAX_VALUE);
     }
 
     public static <T> T inflate(String compressedString,

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/TrainedModelConfig.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/TrainedModelConfig.java
@@ -257,6 +257,14 @@ public class TrainedModelConfig implements ToXContentObject, Writeable {
         return this;
     }
 
+    public TrainedModelConfig ensureParsedDefinitionUnsafe(NamedXContentRegistry xContentRegistry) throws IOException {
+        if (definition == null) {
+            return null;
+        }
+        definition.ensureParsedDefinitionUnsafe(xContentRegistry);
+        return this;
+    }
+
     @Nullable
     public TrainedModelDefinition getModelDefinition() {
         if (definition == null) {
@@ -770,6 +778,14 @@ public class TrainedModelConfig implements ToXContentObject, Writeable {
                 compressedString = InferenceToXContentCompressor.deflate(parsedDefinition);
             }
             return compressedString;
+        }
+
+        private void ensureParsedDefinitionUnsafe(NamedXContentRegistry xContentRegistry) throws IOException {
+            if (parsedDefinition == null) {
+                parsedDefinition = InferenceToXContentCompressor.inflateUnsafe(compressedString,
+                    parser -> TrainedModelDefinition.fromXContent(parser, true).build(),
+                    xContentRegistry);
+            }
         }
 
         @Override

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/inference/InferenceRunner.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/inference/InferenceRunner.java
@@ -91,7 +91,7 @@ public class InferenceRunner {
         LOGGER.info("[{}] Started inference on test data against model [{}]", config.getId(), modelId);
         try {
             PlainActionFuture<LocalModel> localModelPlainActionFuture = new PlainActionFuture<>();
-            modelLoadingService.getModelForPipeline(modelId, localModelPlainActionFuture);
+            modelLoadingService.getModelForInternalInference(modelId, localModelPlainActionFuture);
             InferenceState inferenceState = restoreInferenceState();
             dataCountsTracker.setTestDocsCount(inferenceState.processedTestDocsCount);
             TestDocsIterator testDocsIterator = new TestDocsIterator(new OriginSettingClient(client, ClientHelper.ML_ORIGIN), config,

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/loadingservice/ModelLoadingServiceTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/loadingservice/ModelLoadingServiceTests.java
@@ -143,9 +143,9 @@ public class ModelLoadingServiceTests extends ESTestCase {
             assertThat(future.get(), is(not(nullValue())));
         }
 
-        verify(trainedModelProvider, times(1)).getTrainedModelForInference(eq(model1), any());
-        verify(trainedModelProvider, times(1)).getTrainedModelForInference(eq(model2), any());
-        verify(trainedModelProvider, times(1)).getTrainedModelForInference(eq(model3), any());
+        verify(trainedModelProvider, times(1)).getTrainedModelForInference(eq(model1), eq(false), any());
+        verify(trainedModelProvider, times(1)).getTrainedModelForInference(eq(model2), eq(false), any());
+        verify(trainedModelProvider, times(1)).getTrainedModelForInference(eq(model3), eq(false), any());
 
         assertTrue(modelLoadingService.isModelCached(model1));
         assertTrue(modelLoadingService.isModelCached(model2));
@@ -160,10 +160,10 @@ public class ModelLoadingServiceTests extends ESTestCase {
             assertThat(future.get(), is(not(nullValue())));
         }
 
-        verify(trainedModelProvider, times(1)).getTrainedModelForInference(eq(model1), any());
-        verify(trainedModelProvider, times(1)).getTrainedModelForInference(eq(model2), any());
+        verify(trainedModelProvider, times(1)).getTrainedModelForInference(eq(model1), eq(false), any());
+        verify(trainedModelProvider, times(1)).getTrainedModelForInference(eq(model2), eq(false), any());
         // It is not referenced, so called eagerly
-        verify(trainedModelProvider, times(4)).getTrainedModelForInference(eq(model3), any());
+        verify(trainedModelProvider, times(4)).getTrainedModelForInference(eq(model3), eq(false), any());
     }
 
     public void testMaxCachedLimitReached() throws Exception {
@@ -196,9 +196,9 @@ public class ModelLoadingServiceTests extends ESTestCase {
         // the loading occurred or which models are currently in the cache due to evictions.
         // Verify that we have at least loaded all three
         assertBusy(() -> {
-            verify(trainedModelProvider, times(1)).getTrainedModelForInference(eq(model1), any());
-            verify(trainedModelProvider, times(1)).getTrainedModelForInference(eq(model2), any());
-            verify(trainedModelProvider, times(1)).getTrainedModelForInference(eq(model3), any());
+            verify(trainedModelProvider, times(1)).getTrainedModelForInference(eq(model1), eq(false), any());
+            verify(trainedModelProvider, times(1)).getTrainedModelForInference(eq(model2), eq(false), any());
+            verify(trainedModelProvider, times(1)).getTrainedModelForInference(eq(model3), eq(false), any());
         });
 
         // all models loaded put in the cache
@@ -215,10 +215,10 @@ public class ModelLoadingServiceTests extends ESTestCase {
         // Depending on the order the models were first loaded in the first step
         // models 1 & 2 may have been evicted by model 3 in which case they have
         // been loaded at most twice
-        verify(trainedModelProvider, atMost(2)).getTrainedModelForInference(eq(model1), any());
-        verify(trainedModelProvider, atMost(2)).getTrainedModelForInference(eq(model2), any());
+        verify(trainedModelProvider, atMost(2)).getTrainedModelForInference(eq(model1), eq(false), any());
+        verify(trainedModelProvider, atMost(2)).getTrainedModelForInference(eq(model2), eq(false), any());
         // Only loaded requested once on the initial load from the change event
-        verify(trainedModelProvider, times(1)).getTrainedModelForInference(eq(model3), any());
+        verify(trainedModelProvider, times(1)).getTrainedModelForInference(eq(model3), eq(false), any());
 
         // model 3 has been loaded and evicted exactly once
         verify(trainedModelStatsService, times(1)).queueStats(argThat(new ArgumentMatcher<InferenceStats>() {
@@ -234,7 +234,7 @@ public class ModelLoadingServiceTests extends ESTestCase {
             modelLoadingService.getModelForPipeline(model3, future3);
             assertThat(future3.get(), is(not(nullValue())));
         }
-        verify(trainedModelProvider, times(2)).getTrainedModelForInference(eq(model3), any());
+        verify(trainedModelProvider, times(2)).getTrainedModelForInference(eq(model3), eq(false), any());
 
         verify(trainedModelStatsService, atMost(2)).queueStats(argThat(new ArgumentMatcher<InferenceStats>() {
             @Override
@@ -255,7 +255,7 @@ public class ModelLoadingServiceTests extends ESTestCase {
             modelLoadingService.getModelForPipeline(model1, future1);
             assertThat(future1.get(), is(not(nullValue())));
         }
-        verify(trainedModelProvider, atMost(3)).getTrainedModelForInference(eq(model1), any());
+        verify(trainedModelProvider, atMost(3)).getTrainedModelForInference(eq(model1), eq(false), any());
         verify(trainedModelStatsService, times(2)).queueStats(argThat(new ArgumentMatcher<InferenceStats>() {
             @Override
             public boolean matches(final Object o) {
@@ -269,7 +269,7 @@ public class ModelLoadingServiceTests extends ESTestCase {
             modelLoadingService.getModelForPipeline(model2, future2);
             assertThat(future2.get(), is(not(nullValue())));
         }
-        verify(trainedModelProvider, atMost(3)).getTrainedModelForInference(eq(model2), any());
+        verify(trainedModelProvider, atMost(3)).getTrainedModelForInference(eq(model2), eq(false), any());
 
         // Test invalidate cache for model3
         // Now both model 1 and 2 should fit in cache without issues
@@ -281,9 +281,9 @@ public class ModelLoadingServiceTests extends ESTestCase {
             assertThat(future.get(), is(not(nullValue())));
         }
 
-        verify(trainedModelProvider, atMost(3)).getTrainedModelForInference(eq(model1), any());
-        verify(trainedModelProvider, atMost(3)).getTrainedModelForInference(eq(model2), any());
-        verify(trainedModelProvider, times(5)).getTrainedModelForInference(eq(model3), any());
+        verify(trainedModelProvider, atMost(3)).getTrainedModelForInference(eq(model1), eq(false), any());
+        verify(trainedModelProvider, atMost(3)).getTrainedModelForInference(eq(model2), eq(false), any());
+        verify(trainedModelProvider, times(5)).getTrainedModelForInference(eq(model3), eq(false), any());
     }
 
     public void testWhenCacheEnabledButNotIngestNode() throws Exception {
@@ -308,7 +308,7 @@ public class ModelLoadingServiceTests extends ESTestCase {
         }
 
         assertFalse(modelLoadingService.isModelCached(model1));
-        verify(trainedModelProvider, times(10)).getTrainedModelForInference(eq(model1), any());
+        verify(trainedModelProvider, times(10)).getTrainedModelForInference(eq(model1), eq(false), any());
         verify(trainedModelStatsService, never()).queueStats(any(InferenceStats.class), anyBoolean());
     }
 
@@ -337,7 +337,7 @@ public class ModelLoadingServiceTests extends ESTestCase {
         }
         assertFalse(modelLoadingService.isModelCached(model));
 
-        verify(trainedModelProvider, atMost(2)).getTrainedModelForInference(eq(model), any());
+        verify(trainedModelProvider, atMost(2)).getTrainedModelForInference(eq(model), eq(false), any());
         verify(trainedModelStatsService, never()).queueStats(any(InferenceStats.class), anyBoolean());
     }
 
@@ -384,7 +384,7 @@ public class ModelLoadingServiceTests extends ESTestCase {
             assertThat(future.get(), is(not(nullValue())));
         }
 
-        verify(trainedModelProvider, times(3)).getTrainedModelForInference(eq(model), any());
+        verify(trainedModelProvider, times(3)).getTrainedModelForInference(eq(model), eq(false), any());
         assertFalse(modelLoadingService.isModelCached(model));
         verify(trainedModelStatsService, never()).queueStats(any(InferenceStats.class), anyBoolean());
     }
@@ -410,7 +410,7 @@ public class ModelLoadingServiceTests extends ESTestCase {
 
         assertTrue(modelLoadingService.isModelCached(modelId));
 
-        verify(trainedModelProvider, times(1)).getTrainedModelForInference(eq(modelId), any());
+        verify(trainedModelProvider, times(1)).getTrainedModelForInference(eq(modelId), eq(false), any());
         verify(trainedModelStatsService, never()).queueStats(any(InferenceStats.class), anyBoolean());
     }
 
@@ -571,7 +571,7 @@ public class ModelLoadingServiceTests extends ESTestCase {
             assertThat(future.get(), is(not(nullValue())));
         }
 
-        verify(trainedModelProvider, times(1)).getTrainedModelForInference(eq(model1), any());
+        verify(trainedModelProvider, times(1)).getTrainedModelForInference(eq(model1), eq(false), any());
 
         assertTrue(modelLoadingService.isModelCached(model1));
         assertTrue(modelLoadingService.isModelCached("loaded_model"));
@@ -592,7 +592,7 @@ public class ModelLoadingServiceTests extends ESTestCase {
             assertThat(future.get(), is(not(nullValue())));
         }
 
-        verify(trainedModelProvider, times(1)).getTrainedModelForInference(eq(model2), any());
+        verify(trainedModelProvider, times(1)).getTrainedModelForInference(eq(model2), eq(false), any());
         assertTrue(modelLoadingService.isModelCached(model2));
         assertTrue(modelLoadingService.isModelCached("loaded_model"));
     }
@@ -647,10 +647,10 @@ public class ModelLoadingServiceTests extends ESTestCase {
         when(trainedModelConfig.getEstimatedHeapMemory()).thenReturn(size);
         doAnswer(invocationOnMock -> {
             @SuppressWarnings("rawtypes")
-            ActionListener listener = (ActionListener) invocationOnMock.getArguments()[1];
+            ActionListener listener = (ActionListener) invocationOnMock.getArguments()[2];
             listener.onResponse(definition);
             return null;
-        }).when(trainedModelProvider).getTrainedModelForInference(eq(modelId), any());
+        }).when(trainedModelProvider).getTrainedModelForInference(eq(modelId), eq(false), any());
         doAnswer(invocationOnMock -> {
             @SuppressWarnings("rawtypes")
             ActionListener listener = (ActionListener) invocationOnMock.getArguments()[2];
@@ -680,19 +680,19 @@ public class ModelLoadingServiceTests extends ESTestCase {
             }).when(trainedModelProvider).getTrainedModel(eq(modelId), eq(GetTrainedModelsAction.Includes.empty()), any());
             doAnswer(invocationOnMock -> {
                 @SuppressWarnings("rawtypes")
-                ActionListener listener = (ActionListener) invocationOnMock.getArguments()[1];
+                ActionListener listener = (ActionListener) invocationOnMock.getArguments()[2];
                 listener.onFailure(new ResourceNotFoundException(
                     Messages.getMessage(Messages.MODEL_DEFINITION_NOT_FOUND, modelId)));
                 return null;
-            }).when(trainedModelProvider).getTrainedModelForInference(eq(modelId), any());
+            }).when(trainedModelProvider).getTrainedModelForInference(eq(modelId), eq(false), any());
         }
         doAnswer(invocationOnMock -> {
             @SuppressWarnings("rawtypes")
-            ActionListener listener = (ActionListener) invocationOnMock.getArguments()[1];
+            ActionListener listener = (ActionListener) invocationOnMock.getArguments()[2];
             listener.onFailure(new ResourceNotFoundException(
                 Messages.getMessage(Messages.INFERENCE_NOT_FOUND, modelId)));
             return null;
-        }).when(trainedModelProvider).getTrainedModelForInference(eq(modelId), any());
+        }).when(trainedModelProvider).getTrainedModelForInference(eq(modelId), eq(false), any());
     }
 
     private static ClusterChangedEvent ingestChangedEvent(String... modelId) throws IOException {


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [ML] allow for larger models in the inference step for data frame analytics (#76116)