### PR TITLE
Make constructor private for util Maps.java

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/util/Maps.java
+++ b/server/src/main/java/org/elasticsearch/common/util/Maps.java
@@ -23,6 +23,8 @@ import static java.util.Map.entry;
 
 public class Maps {
 
+    private Maps() {}
+    
     /**
      * Adds an entry to an immutable map by copying the underlying map and adding the new entry. This method expects there is not already a
      * mapping for the specified key in the map.


### PR DESCRIPTION
Made the constructor for the class Maps.java private since it only contains static utilities.