### PR TITLE
Default hasher to PBKDF2_STRETCH on FIPS mode

### DIFF
--- a/docs/reference/migration/migrate_8_0/security.asciidoc
+++ b/docs/reference/migration/migrate_8_0/security.asciidoc
@@ -308,3 +308,31 @@ Assign users with the `kibana_user` role to the `kibana_admin` role.
 Discontinue use of the `kibana_user` role.
 ====
 // end::notable-breaking-changes[]
+
+// These are non-notable changes
+
+// This change is not notable because it should not have any impact on upgrades
+// However we document it here out of an abundance of caution
+[[fips-default-hash-changed]]
+.When FIPS mode is enabled the default password hash is now PBKDF2_STRETCH
+[%collapsible]
+====
+*Details* +
+If `xpack.security.fips_mode.enabled` is true (see <<fips-140-compliance>>), 
+the value of `xpack.security.authc.password_hashing.algorithm` now defaults to
+`pbkdf2_stretch`.
+
+In earlier versions this setting would always default to `bcrypt` and a runtime
+check would prevent a node from starting unless the value was explicitly set to
+a "pbkdf2" variant.
+
+There is no change for clusters that do not enable FIPS 140 mode.
+
+*Impact* +
+This change should not have any impact on upgraded nodes.
+Any node with an explicitly configured value for the password hashing algorithm
+will continue to use that configured value.
+Any node that did not have an explicitly configured password hashing algorithm in
+{es} 6.x or {es} 7.x would have failed to start.
+====
+

--- a/docs/reference/migration/migrate_8_0/security.asciidoc
+++ b/docs/reference/migration/migrate_8_0/security.asciidoc
@@ -234,7 +234,7 @@ on startup.
 
 [discrete]
 [[ssl-misc-changes]]
-==== Other SSL/TLS changes 
+===== Other SSL/TLS changes 
 
 .PKCS#11 keystores and trustores cannot be configured in `elasticsearch.yml`
 [%collapsible]
@@ -311,9 +311,11 @@ Discontinue use of the `kibana_user` role.
 
 // These are non-notable changes
 
+[discrete]
 // This change is not notable because it should not have any impact on upgrades
 // However we document it here out of an abundance of caution
 [[fips-default-hash-changed]]
+===== Changes to FIPS 140 mode
 .When FIPS mode is enabled the default password hash is now PBKDF2_STRETCH
 [%collapsible]
 ====

--- a/docs/reference/settings/security-settings.asciidoc
+++ b/docs/reference/settings/security-settings.asciidoc
@@ -63,7 +63,9 @@ Enables fips mode of operation. Set this to `true` if you run this {es} instance
 `xpack.security.authc.password_hashing.algorithm`::
 (<<static-cluster-setting,Static>>)
 Specifies the hashing algorithm that is used for secure user credential storage.
-See <<password-hashing-algorithms>>. Defaults to `bcrypt`.
+See <<password-hashing-algorithms>>.
+If `xpack.security.fips_mode.enabled` is true (see <<fips-140-compliance>>), defaults to `pbkdf2_stretch`. 
+In all other cases, defaults to `bcrypt`.
 
 [discrete]
 [[anonymous-access-settings]]

--- a/x-pack/docs/en/security/fips-140-compliance.asciidoc
+++ b/x-pack/docs/en/security/fips-140-compliance.asciidoc
@@ -128,6 +128,8 @@ native, and file realms are longer than 14 bytes.
 You must set the `cache.hash_algo` realm settings
 and the `xpack.security.authc.password_hashing.algorithm` setting to one of the
 available `pbkdf_stretch_*` values.
+When FIPS-140 mode is enabled, the default value for
+`xpack.security.authc.password_hashing.algorithm` is `pbkdf2_stretch`.
 See <<hashing-settings>>.
 
 Password hashing configuration changes are not retroactive so the stored hashed

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/XPackSettings.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/XPackSettings.java
@@ -145,9 +145,9 @@ public class XPackSettings {
         new Setting.SimpleKey("xpack.security.authc.password_hashing.algorithm"),
         (s) -> {
             if (XPackSettings.FIPS_MODE_ENABLED.get(s)) {
-                return "PBKDF2";
+                return Hasher.PBKDF2_STRETCH.name();
             } else {
-                return "BCRYPT";
+                return Hasher.BCRYPT.name();
             }
         },
         Function.identity(),

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/XPackSettingsTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/XPackSettingsTests.java
@@ -61,7 +61,7 @@ public class XPackSettingsTests extends ESTestCase {
         final Settings.Builder builder = Settings.builder();
         if (inFipsJvm()) {
             builder.put(XPackSettings.FIPS_MODE_ENABLED.getKey(), true);
-            assertThat(XPackSettings.PASSWORD_HASHING_ALGORITHM.get(builder.build()), equalTo("PBKDF2"));
+            assertThat(XPackSettings.PASSWORD_HASHING_ALGORITHM.get(builder.build()), equalTo("PBKDF2_STRETCH"));
         } else {
             assertThat(XPackSettings.PASSWORD_HASHING_ALGORITHM.get(builder.build()), equalTo("BCRYPT"));
         }


### PR DESCRIPTION
When running in FIPS mode, (fips_mode.enabled: true), the default
password hasher is now "pbkdf2_stretch"

In non-FIPS mode the default is still "bcrypt"

In 7.x and earlier, the default hasher was always "bcrypt"
In 8.0-alpha1, the default hasher on FIPS was "pbkdf2"
