### PR TITLE
Emit multiple fields from a runtime field script (#75108)

### DIFF
--- a/modules/lang-painless/src/main/resources/org/elasticsearch/painless/org.elasticsearch.script.composite_field.txt
+++ b/modules/lang-painless/src/main/resources/org/elasticsearch/painless/org.elasticsearch.script.composite_field.txt
@@ -1,0 +1,21 @@
+#
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License
+# 2.0 and the Server Side Public License, v 1; you may not use this file except
+# in compliance with, at your election, the Elastic License 2.0 or the Server
+# Side Public License, v 1.
+#
+
+# The whitelist for composite runtime fields
+
+# These two whitelists are required for painless to find the classes
+class org.elasticsearch.script.CompositeFieldScript @no_import {
+}
+class org.elasticsearch.script.CompositeFieldScript$Factory @no_import {
+}
+
+static_import {
+    # The `emit` callback to collect values for the fields
+    void emit(org.elasticsearch.script.CompositeFieldScript, String, Object) bound_to org.elasticsearch.script.CompositeFieldScript$EmitField
+    void emit(org.elasticsearch.script.CompositeFieldScript, Map) bound_to org.elasticsearch.script.CompositeFieldScript$EmitMap
+}

--- a/modules/lang-painless/src/test/java/org/elasticsearch/painless/action/PainlessExecuteApiTests.java
+++ b/modules/lang-painless/src/test/java/org/elasticsearch/painless/action/PainlessExecuteApiTests.java
@@ -288,6 +288,20 @@ public class PainlessExecuteApiTests extends ESSingleNodeTestCase {
         assertEquals(Arrays.asList("test", "baz was not here", "Data", "-10", "20", "9"), response.getResult());
     }
 
+    public void testCompositeExecutionContext() throws IOException {
+        ScriptService scriptService = getInstanceFromNode(ScriptService.class);
+        IndexService indexService = createIndex("index", Settings.EMPTY, "doc", "rank", "type=long", "text", "type=keyword");
+
+        Request.ContextSetup contextSetup = new Request.ContextSetup("index", new BytesArray("{}"), new MatchAllQueryBuilder());
+        contextSetup.setXContentType(XContentType.JSON);
+        Request request = new Request(new Script(ScriptType.INLINE, "painless",
+            "emit(\"foo\", \"bar\"); emit(\"foo2\", 2);", emptyMap()), "composite_field", contextSetup);
+        Response response = innerShardOperation(request, scriptService, indexService);
+        assertEquals(org.elasticsearch.core.Map.of(
+            "composite_field.foo", Collections.singletonList("bar"),
+            "composite_field.foo2", Collections.singletonList(2)), response.getResult());
+    }
+
     public void testContextWhitelists() throws IOException {
         ScriptService scriptService = getInstanceFromNode(ScriptService.class);
         // score

--- a/modules/runtime-fields-common/src/yamlRestTest/resources/rest-api-spec/test/runtime_fields/110_composite.yml
+++ b/modules/runtime-fields-common/src/yamlRestTest/resources/rest-api-spec/test/runtime_fields/110_composite.yml
@@ -1,0 +1,104 @@
+---
+setup:
+  - do:
+      indices.create:
+        index: http_logs
+        body:
+          settings:
+            number_of_shards: 1
+            number_of_replicas: 0
+          mappings:
+            runtime:
+              http:
+                type: composite
+                script:
+                  source: |
+                    emit(grok('%{COMMONAPACHELOG}').extract(doc["message"].value));
+                fields:
+                  clientip:
+                    type: ip
+                  verb:
+                    type: keyword
+                  response:
+                    type: long
+            properties:
+              timestamp:
+                type: date
+              message:
+                type: keyword
+  - do:
+      bulk:
+        index: http_logs
+        refresh: true
+        body: |
+          {"index":{}}
+          {"timestamp": "1998-04-30T14:30:17-05:00", "message" : "40.135.0.0 - - [30/Apr/1998:14:30:17 -0500] \"GET /images/hm_bg.jpg HTTP/1.0\" 200 24736"}
+          {"index":{}}
+          {"timestamp": "1998-04-30T14:30:53-05:00", "message" : "232.0.0.0 - - [30/Apr/1998:14:30:53 -0500] \"GET /images/hm_bg.jpg HTTP/1.0\" 200 24736"}
+          {"index":{}}
+          {"timestamp": "1998-04-30T14:31:12-05:00", "message" : "26.1.0.0 - - [30/Apr/1998:14:31:12 -0500] \"GET /images/hm_bg.jpg HTTP/1.0\" 200 24736"}
+          {"index":{}}
+          {"timestamp": "1998-04-30T14:31:19-05:00", "message" : "247.37.0.0 - - [30/Apr/1998:14:31:19 -0500] \"GET /french/splash_inet.html HTTP/1.0\" 200 3781"}
+          {"index":{}}
+          {"timestamp": "1998-04-30T14:31:22-05:00", "message" : "247.37.0.0 - - [30/Apr/1998:14:31:22 -0500] \"GET /images/hm_nbg.jpg HTTP/1.0\" 304 0"}
+          {"index":{}}
+          {"timestamp": "1998-04-30T14:31:27-05:00", "message" : "252.0.0.0 - - [30/Apr/1998:14:31:27 -0500] \"GET /images/hm_bg.jpg HTTP/1.0\" 200 24736"}
+          {"index":{}}
+          {"timestamp": "1998-04-30T14:31:28-05:00", "message" : "not a valid apache log"}
+
+---
+fetch:
+  - do:
+      search:
+        index: http_logs
+        body:
+          sort: timestamp
+          fields:
+            - http.clientip
+            - http.verb
+            - http.response
+  - match: {hits.total.value: 7}
+  - match: {hits.hits.0.fields.http\.clientip: [40.135.0.0] }
+  - match: {hits.hits.0.fields.http\.verb: [GET] }
+  - match: {hits.hits.0.fields.http\.response: [200] }
+  - is_false: hits.hits.6.fields.http\.clientip
+  - is_false: hits.hits.6.fields.http\.verb
+  - is_false: hits.hits.6.fields.http\.response
+
+---
+query:
+  - do:
+      search:
+        index: http_logs
+        body:
+          query:
+            term:
+              http.verb: GET
+  - match: { hits.total.value: 6 }
+
+  - do:
+      search:
+        index: http_logs
+        body:
+          query:
+            range:
+              http.clientip:
+                from: 232.0.0.0
+                to: 253.0.0.0
+  - match: { hits.total.value: 4 }
+
+---
+"terms agg":
+  - do:
+      search:
+        index: http_logs
+        body:
+          aggs:
+            response:
+              terms:
+                field: http.response
+  - match: {hits.total.value: 7}
+  - match: {aggregations.response.buckets.0.key: 200 }
+  - match: {aggregations.response.buckets.0.doc_count: 5 }
+  - match: {aggregations.response.buckets.1.key: 304 }
+  - match: {aggregations.response.buckets.1.doc_count: 1 }

--- a/server/src/main/java/org/elasticsearch/index/mapper/BooleanScriptFieldType.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/BooleanScriptFieldType.java
@@ -18,6 +18,7 @@ import org.elasticsearch.core.Booleans;
 import org.elasticsearch.index.fielddata.BooleanScriptFieldData;
 import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.script.BooleanFieldScript;
+import org.elasticsearch.script.CompositeFieldScript;
 import org.elasticsearch.script.Script;
 import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.lookup.SearchLookup;
@@ -27,6 +28,7 @@ import org.elasticsearch.search.runtime.BooleanScriptFieldTermQuery;
 import java.time.ZoneId;
 import java.util.Collection;
 import java.util.Map;
+import java.util.function.Function;
 import java.util.function.Supplier;
 
 public final class BooleanScriptFieldType extends AbstractScriptFieldType<BooleanFieldScript.LeafFactory> {
@@ -35,7 +37,7 @@ public final class BooleanScriptFieldType extends AbstractScriptFieldType<Boolea
 
     private static class Builder extends AbstractScriptFieldType.Builder<BooleanFieldScript.Factory> {
         Builder(String name) {
-            super(name, BooleanFieldScript.CONTEXT, BooleanFieldScript.PARSE_FROM_SOURCE);
+            super(name, BooleanFieldScript.CONTEXT);
         }
 
         @Override
@@ -45,6 +47,17 @@ public final class BooleanScriptFieldType extends AbstractScriptFieldType<Boolea
                                                    Map<String, String> meta) {
             return new BooleanScriptFieldType(name, factory, script, meta);
         }
+
+        @Override
+        BooleanFieldScript.Factory getParseFromSourceFactory() {
+            return BooleanFieldScript.PARSE_FROM_SOURCE;
+        }
+
+        @Override
+        BooleanFieldScript.Factory getCompositeLeafFactory(Function<SearchLookup, CompositeFieldScript.LeafFactory> parentScriptFactory) {
+            return BooleanFieldScript.leafAdapter(parentScriptFactory);
+        }
+
     }
 
     public static RuntimeField sourceOnly(String name) {

--- a/server/src/main/java/org/elasticsearch/index/mapper/CompositeRuntimeField.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/CompositeRuntimeField.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.index.mapper;
+
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.script.CompositeFieldScript;
+import org.elasticsearch.script.Script;
+import org.elasticsearch.search.lookup.SearchLookup;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Stream;
+
+/**
+ * A runtime field of type object. Defines a script at the top level, which emits multiple sub-fields.
+ * The sub-fields are declared within the object in order to be made available to the field_caps and search API.
+ */
+public class CompositeRuntimeField implements RuntimeField {
+
+    public static final String CONTENT_TYPE = "composite";
+
+    public static final Parser PARSER = new Parser(name ->
+        new RuntimeField.Builder(name) {
+            private final FieldMapper.Parameter<Script> script = new FieldMapper.Parameter<>(
+                "script",
+                false,
+                () -> null,
+                RuntimeField::parseScript,
+                RuntimeField.initializerNotSupported()
+            ).setValidator(s -> {
+                if (s == null) {
+                    throw new IllegalArgumentException("composite runtime field [" + name + "] must declare a [script]");
+                }
+            });
+
+            private final FieldMapper.Parameter<Map<String, Object>> fields = new FieldMapper.Parameter<Map<String, Object>>(
+                "fields",
+                false,
+                Collections::emptyMap,
+                (f, p, o) -> parseFields(f, o),
+                RuntimeField.initializerNotSupported()
+            ).setValidator(objectMap -> {
+                if (objectMap == null || objectMap.isEmpty()) {
+                    throw new IllegalArgumentException("composite runtime field [" + name + "] must declare its [fields]");
+                }
+            });
+
+            @Override
+            protected List<FieldMapper.Parameter<?>> getParameters() {
+                List<FieldMapper.Parameter<?>> parameters = new ArrayList<>(super.getParameters());
+                parameters.add(script);
+                parameters.add(fields);
+                return Collections.unmodifiableList(parameters);
+            }
+
+            @Override
+            protected RuntimeField createChildRuntimeField(MappingParserContext parserContext,
+                                                      String parent,
+                                                      Function<SearchLookup, CompositeFieldScript.LeafFactory> parentScriptFactory) {
+                throw new IllegalArgumentException("Composite field [" + name + "] cannot be a child of composite field [" + parent + "]");
+            }
+
+            @Override
+            protected RuntimeField createRuntimeField(MappingParserContext parserContext) {
+                CompositeFieldScript.Factory factory = parserContext.scriptCompiler().compile(script.get(), CompositeFieldScript.CONTEXT);
+                Function<RuntimeField.Builder, RuntimeField> builder = b -> b.createChildRuntimeField(
+                    parserContext,
+                    name,
+                    lookup -> factory.newFactory(name, script.get().getParams(), lookup)
+                );
+                Map<String, RuntimeField> runtimeFields
+                    = RuntimeField.parseRuntimeFields(fields.getValue(), parserContext, builder, false);
+                return new CompositeRuntimeField(name, getParameters(), runtimeFields.values());
+            }
+        });
+
+    private final String name;
+    private final List<FieldMapper.Parameter<?>> parameters;
+    private final Collection<RuntimeField> subfields;
+
+    CompositeRuntimeField(String name, List<FieldMapper.Parameter<?>> parameters, Collection<RuntimeField> subfields) {
+        this.name = name;
+        this.parameters = parameters;
+        this.subfields = subfields;
+    }
+
+    @Override
+    public String name() {
+        return name;
+    }
+
+    @Override
+    public Stream<MappedFieldType> asMappedFieldTypes() {
+        return subfields.stream().flatMap(RuntimeField::asMappedFieldTypes);
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.startObject(name);
+        builder.field("type", "composite");
+        boolean includeDefaults = params.paramAsBoolean("include_defaults", false);
+        for (FieldMapper.Parameter<?> parameter : parameters) {
+            parameter.toXContent(builder, includeDefaults);
+        }
+        builder.startObject("fields");
+        for (RuntimeField subfield : subfields) {
+            subfield.toXContent(builder, params);
+        }
+        builder.endObject();
+        builder.endObject();
+        return builder;
+    }
+
+    private static Map<String, Object> parseFields(String name, Object fieldsObject) {
+        if (fieldsObject instanceof Map == false) {
+            throw new MapperParsingException("[fields] must be an object, got " + fieldsObject.getClass().getSimpleName() +
+                "[" + fieldsObject + "] for field [" + name +"]");
+        }
+        @SuppressWarnings("unchecked")
+        Map<String, Object> fields = (Map<String, Object>) fieldsObject;
+        return fields;
+    }
+}

--- a/server/src/main/java/org/elasticsearch/index/mapper/DoubleScriptFieldType.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DoubleScriptFieldType.java
@@ -18,6 +18,7 @@ import org.elasticsearch.index.fielddata.DoubleScriptFieldData;
 import org.elasticsearch.index.mapper.NumberFieldMapper.NumberType;
 import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.script.DoubleFieldScript;
+import org.elasticsearch.script.CompositeFieldScript;
 import org.elasticsearch.script.Script;
 import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.lookup.SearchLookup;
@@ -29,6 +30,7 @@ import org.elasticsearch.search.runtime.DoubleScriptFieldTermsQuery;
 import java.time.ZoneId;
 import java.util.Collection;
 import java.util.Map;
+import java.util.function.Function;
 import java.util.function.Supplier;
 
 public final class DoubleScriptFieldType extends AbstractScriptFieldType<DoubleFieldScript.LeafFactory> {
@@ -37,7 +39,7 @@ public final class DoubleScriptFieldType extends AbstractScriptFieldType<DoubleF
 
     private static class Builder extends AbstractScriptFieldType.Builder<DoubleFieldScript.Factory> {
         Builder(String name) {
-            super(name, DoubleFieldScript.CONTEXT, DoubleFieldScript.PARSE_FROM_SOURCE);
+            super(name, DoubleFieldScript.CONTEXT);
         }
 
         @Override
@@ -46,6 +48,16 @@ public final class DoubleScriptFieldType extends AbstractScriptFieldType<DoubleF
                                                    Script script,
                                                    Map<String, String> meta) {
             return new DoubleScriptFieldType(name, factory, script, meta);
+        }
+
+        @Override
+        DoubleFieldScript.Factory getParseFromSourceFactory() {
+            return DoubleFieldScript.PARSE_FROM_SOURCE;
+        }
+
+        @Override
+        DoubleFieldScript.Factory getCompositeLeafFactory(Function<SearchLookup, CompositeFieldScript.LeafFactory> parentScriptFactory) {
+            return DoubleFieldScript.leafAdapter(parentScriptFactory);
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/index/mapper/DynamicFieldsBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DynamicFieldsBuilder.java
@@ -196,8 +196,8 @@ final class DynamicFieldsBuilder {
             if (parser == null) {
                 throw new MapperParsingException("failed to find type parsed [" + mappingType + "] for [" + fullName + "]");
             }
-            RuntimeField runtimeField = parser.parse(fullName, mapping, parserContext);
-            Runtime.createDynamicField(runtimeField, context);
+            RuntimeField.Builder builder = parser.parse(fullName, mapping, parserContext);
+            Runtime.createDynamicField(builder.createRuntimeField(parserContext), context);
         } else {
             Mapper.Builder builder = parseDynamicTemplateMapping(name, mappingType, mapping, dateFormatter, context);
             CONCRETE.createDynamicField(builder, context);

--- a/server/src/main/java/org/elasticsearch/index/mapper/FieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/FieldMapper.java
@@ -741,7 +741,7 @@ public abstract class FieldMapper extends Mapper implements Cloneable {
             return this;
         }
 
-        private void validate() {
+        void validate() {
             if (validator != null) {
                 validator.accept(getValue());
             }

--- a/server/src/main/java/org/elasticsearch/index/mapper/GeoPointScriptFieldType.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/GeoPointScriptFieldType.java
@@ -22,6 +22,7 @@ import org.elasticsearch.geometry.Geometry;
 import org.elasticsearch.index.fielddata.GeoPointScriptFieldData;
 import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.script.GeoPointFieldScript;
+import org.elasticsearch.script.CompositeFieldScript;
 import org.elasticsearch.script.Script;
 import org.elasticsearch.search.lookup.SearchLookup;
 import org.elasticsearch.search.runtime.GeoPointScriptFieldDistanceFeatureQuery;
@@ -31,18 +32,30 @@ import org.elasticsearch.search.runtime.GeoPointScriptFieldGeoShapeQuery;
 import java.time.ZoneId;
 import java.util.Arrays;
 import java.util.Map;
+import java.util.function.Function;
 import java.util.function.Supplier;
 
 public final class GeoPointScriptFieldType extends AbstractScriptFieldType<GeoPointFieldScript.LeafFactory> implements GeoShapeQueryable {
 
     public static final RuntimeField.Parser PARSER = new RuntimeField.Parser(name ->
-        new Builder<GeoPointFieldScript.Factory>(name, GeoPointFieldScript.CONTEXT, GeoPointFieldScript.PARSE_FROM_SOURCE) {
+        new Builder<GeoPointFieldScript.Factory>(name, GeoPointFieldScript.CONTEXT) {
             @Override
             AbstractScriptFieldType<?> createFieldType(String name,
                                                        GeoPointFieldScript.Factory factory,
                                                        Script script,
                                                        Map<String, String> meta) {
                 return new GeoPointScriptFieldType(name, factory, getScript(), meta());
+            }
+
+            @Override
+            GeoPointFieldScript.Factory getParseFromSourceFactory() {
+                return GeoPointFieldScript.PARSE_FROM_SOURCE;
+            }
+
+            @Override
+            GeoPointFieldScript.Factory getCompositeLeafFactory(
+                Function<SearchLookup, CompositeFieldScript.LeafFactory> parentScriptFactory) {
+                return GeoPointFieldScript.leafAdapter(parentScriptFactory);
             }
         });
 

--- a/server/src/main/java/org/elasticsearch/index/mapper/IpScriptFieldType.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/IpScriptFieldType.java
@@ -22,6 +22,7 @@ import org.elasticsearch.core.Tuple;
 import org.elasticsearch.index.fielddata.IpScriptFieldData;
 import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.script.IpFieldScript;
+import org.elasticsearch.script.CompositeFieldScript;
 import org.elasticsearch.script.Script;
 import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.lookup.SearchLookup;
@@ -37,18 +38,29 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.function.Function;
 import java.util.function.Supplier;
 
 public final class IpScriptFieldType extends AbstractScriptFieldType<IpFieldScript.LeafFactory> {
 
     public static final RuntimeField.Parser PARSER = new RuntimeField.Parser(name ->
-        new Builder<IpFieldScript.Factory>(name, IpFieldScript.CONTEXT, IpFieldScript.PARSE_FROM_SOURCE) {
+        new Builder<IpFieldScript.Factory>(name, IpFieldScript.CONTEXT) {
             @Override
             AbstractScriptFieldType<?> createFieldType(String name,
                                                        IpFieldScript.Factory factory,
                                                        Script script,
                                                        Map<String, String> meta) {
                 return new IpScriptFieldType(name, factory, getScript(), meta());
+            }
+
+            @Override
+            IpFieldScript.Factory getParseFromSourceFactory() {
+                return IpFieldScript.PARSE_FROM_SOURCE;
+            }
+
+            @Override
+            IpFieldScript.Factory getCompositeLeafFactory(Function<SearchLookup, CompositeFieldScript.LeafFactory> parentScriptFactory) {
+                return IpFieldScript.leafAdapter(parentScriptFactory);
             }
         });
 

--- a/server/src/main/java/org/elasticsearch/index/mapper/KeywordScriptFieldType.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/KeywordScriptFieldType.java
@@ -16,6 +16,7 @@ import org.elasticsearch.common.time.DateMathParser;
 import org.elasticsearch.common.unit.Fuzziness;
 import org.elasticsearch.index.fielddata.StringScriptFieldData;
 import org.elasticsearch.index.query.SearchExecutionContext;
+import org.elasticsearch.script.CompositeFieldScript;
 import org.elasticsearch.script.Script;
 import org.elasticsearch.script.StringFieldScript;
 import org.elasticsearch.search.lookup.SearchLookup;
@@ -33,6 +34,7 @@ import java.util.Collection;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.function.Function;
 import java.util.function.Supplier;
 
 import static java.util.stream.Collectors.toSet;
@@ -43,7 +45,7 @@ public final class KeywordScriptFieldType extends AbstractScriptFieldType<String
 
     private static class Builder extends AbstractScriptFieldType.Builder<StringFieldScript.Factory> {
         Builder(String name) {
-            super(name, StringFieldScript.CONTEXT, StringFieldScript.PARSE_FROM_SOURCE);
+            super(name, StringFieldScript.CONTEXT);
         }
 
         @Override
@@ -52,6 +54,16 @@ public final class KeywordScriptFieldType extends AbstractScriptFieldType<String
                                                    Script script,
                                                    Map<String, String> meta) {
             return new KeywordScriptFieldType(name, factory, script, meta);
+        }
+
+        @Override
+        StringFieldScript.Factory getParseFromSourceFactory() {
+            return StringFieldScript.PARSE_FROM_SOURCE;
+        }
+
+        @Override
+        StringFieldScript.Factory getCompositeLeafFactory(Function<SearchLookup, CompositeFieldScript.LeafFactory> parentScriptFactory) {
+            return StringFieldScript.leafAdapter(parentScriptFactory);
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/index/mapper/LeafRuntimeField.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/LeafRuntimeField.java
@@ -11,13 +11,12 @@ package org.elasticsearch.index.mapper;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 
 import java.io.IOException;
-import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
+import java.util.stream.Stream;
 
 /**
- * RuntimeField base class for leaf fields that will only ever return
- * a single MappedFieldType from {@link RuntimeField#asMappedFieldTypes()}
+ * RuntimeField base class for leaf fields that will only ever return a single {@link MappedFieldType}
+ * from {@link RuntimeField#asMappedFieldTypes()}. Can be a standalone runtime field, or part of a composite.
  */
 public final class LeafRuntimeField implements RuntimeField {
     private final String name;
@@ -28,17 +27,17 @@ public final class LeafRuntimeField implements RuntimeField {
         this.name = name;
         this.mappedFieldType = mappedFieldType;
         this.parameters = parameters;
-        assert name.equals(mappedFieldType.name());
+        assert mappedFieldType.name().endsWith(name) : "full name: " + mappedFieldType.name() + " - leaf name: " + name;
     }
 
     @Override
     public String name() {
-        return name;
+        return mappedFieldType.name();
     }
 
     @Override
-    public Collection<MappedFieldType> asMappedFieldTypes() {
-        return Collections.singleton(mappedFieldType);
+    public Stream<MappedFieldType> asMappedFieldTypes() {
+        return Stream.of(mappedFieldType);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/index/mapper/LongScriptFieldType.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/LongScriptFieldType.java
@@ -18,6 +18,7 @@ import org.elasticsearch.index.fielddata.LongScriptFieldData;
 import org.elasticsearch.index.mapper.NumberFieldMapper.NumberType;
 import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.script.LongFieldScript;
+import org.elasticsearch.script.CompositeFieldScript;
 import org.elasticsearch.script.Script;
 import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.lookup.SearchLookup;
@@ -29,6 +30,7 @@ import org.elasticsearch.search.runtime.LongScriptFieldTermsQuery;
 import java.time.ZoneId;
 import java.util.Collection;
 import java.util.Map;
+import java.util.function.Function;
 import java.util.function.Supplier;
 
 public final class LongScriptFieldType extends AbstractScriptFieldType<LongFieldScript.LeafFactory> {
@@ -37,12 +39,22 @@ public final class LongScriptFieldType extends AbstractScriptFieldType<LongField
 
     private static class Builder extends AbstractScriptFieldType.Builder<LongFieldScript.Factory> {
         Builder(String name) {
-            super(name, LongFieldScript.CONTEXT, LongFieldScript.PARSE_FROM_SOURCE);
+            super(name, LongFieldScript.CONTEXT);
         }
 
         @Override
         AbstractScriptFieldType<?> createFieldType(String name, LongFieldScript.Factory factory, Script script, Map<String, String> meta) {
             return new LongScriptFieldType(name, factory, script, meta);
+        }
+
+        @Override
+        LongFieldScript.Factory getParseFromSourceFactory() {
+            return LongFieldScript.PARSE_FROM_SOURCE;
+        }
+
+        @Override
+        LongFieldScript.Factory getCompositeLeafFactory(Function<SearchLookup, CompositeFieldScript.LeafFactory> parentScriptFactory) {
+            return LongFieldScript.leafAdapter(parentScriptFactory);
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/index/mapper/MappingLookup.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/MappingLookup.java
@@ -163,9 +163,7 @@ public final class MappingLookup {
         
         this.shadowedFields = new HashSet<>();
         for (RuntimeField runtimeField : mapping.getRoot().runtimeFields()) {
-            for (MappedFieldType mft : runtimeField.asMappedFieldTypes()) {
-                shadowedFields.add(mft.name());
-            }
+            runtimeField.asMappedFieldTypes().forEach(mft -> shadowedFields.add(mft.name()));
         }
 
         this.fieldTypeLookup = new FieldTypeLookup(mapping.type(), mappers, aliasMappers, mapping.getRoot().runtimeFields());

--- a/server/src/main/java/org/elasticsearch/index/mapper/RootObjectMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/RootObjectMapper.java
@@ -213,7 +213,12 @@ public class RootObjectMapper extends ObjectMapper {
                 return true;
             } else if (fieldName.equals("runtime")) {
                 if (fieldNode instanceof Map) {
-                    builder.setRuntime(RuntimeField.parseRuntimeFields((Map<String, Object>) fieldNode, parserContext, true));
+                    Map<String, RuntimeField> fields = RuntimeField.parseRuntimeFields(
+                        (Map<String, Object>) fieldNode,
+                        parserContext,
+                        true
+                    );
+                    builder.setRuntime(fields);
                     return true;
                 } else {
                     throw new ElasticsearchParseException("runtime must be a map type");

--- a/server/src/main/java/org/elasticsearch/index/mapper/RuntimeField.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/RuntimeField.java
@@ -10,6 +10,10 @@ package org.elasticsearch.index.mapper;
 
 import org.elasticsearch.common.xcontent.ToXContentFragment;
 import org.elasticsearch.index.mapper.FieldMapper.Parameter;
+import org.elasticsearch.script.CompositeFieldScript;
+import org.elasticsearch.script.Script;
+import org.elasticsearch.script.ScriptType;
+import org.elasticsearch.search.lookup.SearchLookup;
 
 import java.util.Collection;
 import java.util.Collections;
@@ -19,6 +23,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * Definition of a runtime field that can be defined as part of the runtime section of the index mappings
@@ -35,7 +40,7 @@ public interface RuntimeField extends ToXContentFragment {
      * Exposes the {@link MappedFieldType}s backing this runtime field, used to execute queries, run aggs etc.
      * @return the {@link MappedFieldType}s backing this runtime field
      */
-    Collection<MappedFieldType> asMappedFieldTypes();
+    Stream<MappedFieldType> asMappedFieldTypes();
 
     abstract class Builder {
         final String name;
@@ -54,6 +59,12 @@ public interface RuntimeField extends ToXContentFragment {
         }
 
         protected abstract RuntimeField createRuntimeField(MappingParserContext parserContext);
+
+        protected abstract RuntimeField createChildRuntimeField(
+            MappingParserContext parserContext,
+            String parentName,
+            Function<SearchLookup, CompositeFieldScript.LeafFactory> parentScriptFactory
+        );
 
         public final void parse(String name, MappingParserContext parserContext, Map<String, Object> fieldNode) {
             Map<String, Parameter<?>> paramsMap = new HashMap<>();
@@ -78,6 +89,9 @@ public interface RuntimeField extends ToXContentFragment {
                 parameter.parse(name, parserContext, propNode);
                 iterator.remove();
             }
+            for (Parameter<?> parameter : getParameters()) {
+                parameter.validate();
+            }
         }
     }
 
@@ -92,12 +106,14 @@ public interface RuntimeField extends ToXContentFragment {
             this.builderFunction = builderFunction;
         }
 
-        RuntimeField parse(String name, Map<String, Object> node, MappingParserContext parserContext)
+        RuntimeField.Builder parse(String name,
+                           Map<String, Object> node,
+                           MappingParserContext parserContext)
             throws MapperParsingException {
 
             RuntimeField.Builder builder = builderFunction.apply(name);
             builder.parse(name, parserContext, node);
-            return builder.createRuntimeField(parserContext);
+            return builder;
         }
     }
 
@@ -111,6 +127,27 @@ public interface RuntimeField extends ToXContentFragment {
      */
     static Map<String, RuntimeField> parseRuntimeFields(Map<String, Object> node,
                                                         MappingParserContext parserContext,
+                                                        boolean supportsRemoval) {
+        return parseRuntimeFields(node, parserContext, b -> b.createRuntimeField(parserContext), supportsRemoval);
+    }
+
+    /**
+     * Parse runtime fields from the provided map, using the provided parser context.
+     *
+     * This method also allows you to define how the runtime field will be created from its
+     * builder, so that it can be used by composite fields to build child fields using
+     * parent factory parameters.
+     *
+     * @param node the map that holds the runtime fields configuration
+     * @param parserContext the parser context that holds info needed when parsing mappings
+     * @param builder a function to convert a RuntimeField.Builder into a RuntimeField
+     * @param supportsRemoval whether a null value for a runtime field should be properly parsed and
+     *                        translated to the removal of such runtime field
+     * @return the parsed runtime fields
+     */
+    static Map<String, RuntimeField> parseRuntimeFields(Map<String, Object> node,
+                                                        MappingParserContext parserContext,
+                                                        Function<RuntimeField.Builder, RuntimeField> builder,
                                                         boolean supportsRemoval) {
         Map<String, RuntimeField> runtimeFields = new HashMap<>();
         Iterator<Map.Entry<String, Object>> iterator = node.entrySet().iterator();
@@ -139,7 +176,7 @@ public interface RuntimeField extends ToXContentFragment {
                     throw new MapperParsingException("No handler for type [" + type +
                         "] declared on runtime field [" + fieldName + "]");
                 }
-                runtimeFields.put(fieldName, typeParser.parse(fieldName, propNode, parserContext));
+                runtimeFields.put(fieldName, builder.apply(typeParser.parse(fieldName, propNode, parserContext)));
                 propNode.remove("type");
                 MappingParser.checkNoRemainingFields(fieldName, propNode);
                 iterator.remove();
@@ -161,7 +198,7 @@ public interface RuntimeField extends ToXContentFragment {
     static Map<String, MappedFieldType> collectFieldTypes(Collection<RuntimeField> runtimeFields) {
         return runtimeFields.stream()
             .flatMap(runtimeField -> {
-                List<String> names = runtimeField.asMappedFieldTypes().stream().map(MappedFieldType::name)
+                List<String> names = runtimeField.asMappedFieldTypes().map(MappedFieldType::name)
                     .filter(name -> name.equals(runtimeField.name()) == false
                         && (name.startsWith(runtimeField.name() + ".") == false
                         || name.length() > runtimeField.name().length() + 1 == false))
@@ -170,11 +207,23 @@ public interface RuntimeField extends ToXContentFragment {
                     throw new IllegalStateException("Found sub-fields with name not belonging to the parent field they are part of "
                         + names);
                 }
-                return runtimeField.asMappedFieldTypes().stream();
+                return runtimeField.asMappedFieldTypes();
             })
             .collect(Collectors.toMap(MappedFieldType::name, mappedFieldType -> mappedFieldType,
                 (t, t2) -> {
                     throw new IllegalArgumentException("Found two runtime fields with same name [" + t.name() + "]");
                 }));
+    }
+
+    static <T> Function<FieldMapper, T> initializerNotSupported() {
+        return mapper -> { throw new UnsupportedOperationException(); };
+    }
+
+    static Script parseScript(String name, MappingParserContext parserContext, Object scriptObject) {
+        Script script = Script.parse(scriptObject);
+        if (script.getType() == ScriptType.STORED) {
+            throw new IllegalArgumentException("stored scripts are not supported for runtime field [" + name + "]");
+        }
+        return script;
     }
 }

--- a/server/src/main/java/org/elasticsearch/index/query/SearchExecutionContext.java
+++ b/server/src/main/java/org/elasticsearch/index/query/SearchExecutionContext.java
@@ -675,8 +675,12 @@ public class SearchExecutionContext extends QueryRewriteContext {
         if (runtimeMappings.isEmpty()) {
             return Collections.emptyMap();
         }
-        Map<String, RuntimeField> runtimeFields = RuntimeField.parseRuntimeFields(new HashMap<>(runtimeMappings),
-            mapperService.parserContext(), false);
+        //TODO add specific tests to SearchExecutionTests similar to the ones in FieldTypeLookupTests
+        MappingParserContext parserContext = mapperService.parserContext();
+        Map<String, RuntimeField> runtimeFields = RuntimeField.parseRuntimeFields(
+            new HashMap<>(runtimeMappings),
+            parserContext,
+            false);
         return RuntimeField.collectFieldTypes(runtimeFields.values());
     }
 

--- a/server/src/main/java/org/elasticsearch/indices/IndicesModule.java
+++ b/server/src/main/java/org/elasticsearch/indices/IndicesModule.java
@@ -21,23 +21,31 @@ import org.elasticsearch.common.io.stream.NamedWriteableRegistry.Entry;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 import org.elasticsearch.index.mapper.BinaryFieldMapper;
 import org.elasticsearch.index.mapper.BooleanFieldMapper;
+import org.elasticsearch.index.mapper.BooleanScriptFieldType;
 import org.elasticsearch.index.mapper.CompletionFieldMapper;
 import org.elasticsearch.index.mapper.DateFieldMapper;
+import org.elasticsearch.index.mapper.DateScriptFieldType;
 import org.elasticsearch.index.mapper.DocCountFieldMapper;
+import org.elasticsearch.index.mapper.DoubleScriptFieldType;
 import org.elasticsearch.index.mapper.FieldAliasMapper;
 import org.elasticsearch.index.mapper.FieldNamesFieldMapper;
 import org.elasticsearch.index.mapper.GeoPointFieldMapper;
+import org.elasticsearch.index.mapper.GeoPointScriptFieldType;
 import org.elasticsearch.index.mapper.IdFieldMapper;
 import org.elasticsearch.index.mapper.IgnoredFieldMapper;
 import org.elasticsearch.index.mapper.IndexFieldMapper;
 import org.elasticsearch.index.mapper.IpFieldMapper;
+import org.elasticsearch.index.mapper.IpScriptFieldType;
 import org.elasticsearch.index.mapper.KeywordFieldMapper;
+import org.elasticsearch.index.mapper.KeywordScriptFieldType;
+import org.elasticsearch.index.mapper.LongScriptFieldType;
 import org.elasticsearch.index.mapper.Mapper;
 import org.elasticsearch.index.mapper.MapperRegistry;
 import org.elasticsearch.index.mapper.MetadataFieldMapper;
 import org.elasticsearch.index.mapper.NestedObjectMapper;
 import org.elasticsearch.index.mapper.NumberFieldMapper;
 import org.elasticsearch.index.mapper.ObjectMapper;
+import org.elasticsearch.index.mapper.CompositeRuntimeField;
 import org.elasticsearch.index.mapper.RangeType;
 import org.elasticsearch.index.mapper.RoutingFieldMapper;
 import org.elasticsearch.index.mapper.RuntimeField;
@@ -57,13 +65,6 @@ import org.elasticsearch.indices.flush.SyncedFlushService;
 import org.elasticsearch.indices.store.IndicesStore;
 import org.elasticsearch.indices.store.TransportNodesListShardStoreMetadata;
 import org.elasticsearch.plugins.MapperPlugin;
-import org.elasticsearch.index.mapper.BooleanScriptFieldType;
-import org.elasticsearch.index.mapper.DateScriptFieldType;
-import org.elasticsearch.index.mapper.DoubleScriptFieldType;
-import org.elasticsearch.index.mapper.GeoPointScriptFieldType;
-import org.elasticsearch.index.mapper.IpScriptFieldType;
-import org.elasticsearch.index.mapper.KeywordScriptFieldType;
-import org.elasticsearch.index.mapper.LongScriptFieldType;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -160,6 +161,7 @@ public class IndicesModule extends AbstractModule {
         runtimeParsers.put(DateFieldMapper.CONTENT_TYPE, DateScriptFieldType.PARSER);
         runtimeParsers.put(KeywordFieldMapper.CONTENT_TYPE, KeywordScriptFieldType.PARSER);
         runtimeParsers.put(GeoPointFieldMapper.CONTENT_TYPE, GeoPointScriptFieldType.PARSER);
+        runtimeParsers.put(CompositeRuntimeField.CONTENT_TYPE, CompositeRuntimeField.PARSER);
 
         for (MapperPlugin mapperPlugin : mapperPlugins) {
             for (Map.Entry<String, RuntimeField.Parser> entry : mapperPlugin.getRuntimeFields().entrySet()) {

--- a/server/src/main/java/org/elasticsearch/script/AbstractFieldScript.java
+++ b/server/src/main/java/org/elasticsearch/script/AbstractFieldScript.java
@@ -84,7 +84,7 @@ public abstract class AbstractFieldScript {
     /**
      * Set the document to run the script against.
      */
-    public final void setDocument(int docId) {
+    public void setDocument(int docId) {
         this.leafSearchLookup.setDocument(docId);
     }
 
@@ -104,6 +104,16 @@ public abstract class AbstractFieldScript {
 
     protected List<Object> extractFromSource(String path) {
         return XContentMapValues.extractRawValues(path, leafSearchLookup.source().source());
+    }
+
+    protected final void emitFromCompositeScript(CompositeFieldScript compositeFieldScript) {
+        List<Object> values = compositeFieldScript.getValues(fieldName);
+        if (values == null) {
+            return;
+        }
+        for (Object value : values) {
+            emitFromObject(value);
+        }
     }
 
     protected abstract void emitFromObject(Object v);

--- a/server/src/main/java/org/elasticsearch/script/CompositeFieldScript.java
+++ b/server/src/main/java/org/elasticsearch/script/CompositeFieldScript.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.script;
+
+import org.apache.lucene.index.LeafReaderContext;
+import org.elasticsearch.search.lookup.SearchLookup;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * A script that emits a map of multiple values, that can then be accessed
+ * by child runtime fields.
+ */
+public abstract class CompositeFieldScript extends AbstractFieldScript {
+    public static final ScriptContext<CompositeFieldScript.Factory> CONTEXT = newContext("composite_field", Factory.class);
+
+    @SuppressWarnings("unused")
+    public static final String[] PARAMETERS = {};
+
+    public interface Factory extends ScriptFactory {
+        CompositeFieldScript.LeafFactory newFactory(String fieldName, Map<String, Object> params, SearchLookup searchLookup);
+    }
+
+    public interface LeafFactory {
+        CompositeFieldScript newInstance(LeafReaderContext ctx);
+    }
+
+    private final Map<String, List<Object>> fieldValues = new HashMap<>();
+
+    public CompositeFieldScript(String fieldName, Map<String, Object> params, SearchLookup searchLookup, LeafReaderContext ctx) {
+        super(fieldName, params, searchLookup, ctx);
+    }
+
+    /**
+     * Runs the object script and returns the values that were emitted for the provided field name
+     * @param field the field name to extract values from
+     * @return the values that were emitted for the provided field
+     */
+    public final List<Object> getValues(String field) {
+        //TODO for now we re-run the script every time a leaf field is accessed, but we could cache the values?
+        fieldValues.clear();
+        execute();
+        List<Object> values = fieldValues.get(field);
+        fieldValues.clear();    // don't hold on to values unnecessarily
+        return values;
+    }
+
+    public final Map<String, List<Object>> runForDoc(int doc) {
+        setDocument(doc);
+        fieldValues.clear();
+        execute();
+        return fieldValues;
+    }
+
+    protected final void emit(String field, Object value) {
+        //fields will be emitted without the prefix, yet they will be looked up using their full name, hence we store the full name
+        List<Object> values = this.fieldValues.computeIfAbsent(fieldName + "." + field, s -> new ArrayList<>());
+        values.add(value);
+    }
+
+    @Override
+    protected void emitFromObject(Object v) {
+        throw new UnsupportedOperationException();
+    }
+
+    public static class EmitField {
+        private final CompositeFieldScript script;
+
+        public EmitField(CompositeFieldScript script) {
+            this.script = script;
+        }
+
+        /**
+         * Emits a value for the provided field. Note that ideally we would have typed the value, and have
+         * one emit per supported data type, but the arity in Painless does not take arguments type into account, only method name and
+         * number of arguments. That means that we would have needed a different method name per type, and given that we need the Object
+         * variant anyways to be able to emit an entire map, we went for taking an object also for the keyed emit variant.
+         *
+         * @param field the field name
+         * @param value the value
+         */
+        public void emit(String field, Object value) {
+            script.emit(field, value);
+        }
+    }
+
+    public static class EmitMap {
+        private final CompositeFieldScript script;
+
+        public EmitMap(CompositeFieldScript script) {
+            this.script = script;
+        }
+
+        /**
+         * Emits all the subfields in one go. The key in the provided map is the field name, and the value their value(s)
+         * @param subfields the map that holds the key-value pairs
+         */
+        public void emit(Map<String, Object> subfields) {
+            if (subfields == null) {
+                return;
+            }
+            for (Map.Entry<String, Object> entry : subfields.entrySet()) {
+                script.emit(entry.getKey(), entry.getValue());
+            }
+        }
+    }
+}

--- a/server/src/main/java/org/elasticsearch/script/GeoPointFieldScript.java
+++ b/server/src/main/java/org/elasticsearch/script/GeoPointFieldScript.java
@@ -20,6 +20,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
+import java.util.function.Function;
 
 import static org.apache.lucene.geo.GeoEncodingUtils.encodeLatitude;
 import static org.apache.lucene.geo.GeoEncodingUtils.encodeLongitude;
@@ -45,6 +46,26 @@ public abstract class GeoPointFieldScript extends AbstractLongFieldScript {
             emitFromSource();
         }
     };
+
+    public static Factory leafAdapter(Function<SearchLookup, CompositeFieldScript.LeafFactory> parentFactory) {
+        return (leafFieldName, params, searchLookup) -> {
+            CompositeFieldScript.LeafFactory parentLeafFactory = parentFactory.apply(searchLookup);
+            return (LeafFactory) ctx -> {
+                CompositeFieldScript compositeFieldScript = parentLeafFactory.newInstance(ctx);
+                return new GeoPointFieldScript(leafFieldName, params, searchLookup, ctx) {
+                    @Override
+                    public void setDocument(int docId) {
+                        compositeFieldScript.setDocument(docId);
+                    }
+
+                    @Override
+                    public void execute() {
+                        emitFromCompositeScript(compositeFieldScript);
+                    }
+                };
+            };
+        };
+    }
 
     @SuppressWarnings("unused")
     public static final String[] PARAMETERS = {};

--- a/server/src/main/java/org/elasticsearch/script/ScriptModule.java
+++ b/server/src/main/java/org/elasticsearch/script/ScriptModule.java
@@ -28,9 +28,15 @@ import java.util.stream.Stream;
  */
 public class ScriptModule {
 
-    public static final Set<ScriptContext<?>> RUNTIME_FIELDS_CONTEXTS = org.elasticsearch.core.Set.of(BooleanFieldScript.CONTEXT,
-        DateFieldScript.CONTEXT, DoubleFieldScript.CONTEXT, LongFieldScript.CONTEXT, StringFieldScript.CONTEXT, GeoPointFieldScript.CONTEXT,
-        IpFieldScript.CONTEXT);
+    public static final Set<ScriptContext<?>> RUNTIME_FIELDS_CONTEXTS = org.elasticsearch.core.Set.of(
+        BooleanFieldScript.CONTEXT,
+        DateFieldScript.CONTEXT,
+        DoubleFieldScript.CONTEXT,
+        LongFieldScript.CONTEXT,
+        StringFieldScript.CONTEXT,
+        GeoPointFieldScript.CONTEXT,
+        IpFieldScript.CONTEXT,
+        CompositeFieldScript.CONTEXT);
 
     public static final Map<String, ScriptContext<?>> CORE_CONTEXTS;
     static {

--- a/server/src/main/java/org/elasticsearch/script/StringFieldScript.java
+++ b/server/src/main/java/org/elasticsearch/script/StringFieldScript.java
@@ -16,6 +16,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.function.Consumer;
+import java.util.function.Function;
 
 public abstract class StringFieldScript extends AbstractFieldScript {
     /**
@@ -38,6 +39,26 @@ public abstract class StringFieldScript extends AbstractFieldScript {
             emitFromSource();
         }
     };
+
+    public static Factory leafAdapter(Function<SearchLookup, CompositeFieldScript.LeafFactory> parentFactory) {
+        return (leafFieldName, params, searchLookup) -> {
+            CompositeFieldScript.LeafFactory parentLeafFactory = parentFactory.apply(searchLookup);
+            return (LeafFactory) ctx -> {
+                CompositeFieldScript compositeFieldScript = parentLeafFactory.newInstance(ctx);
+                return new StringFieldScript(leafFieldName, params, searchLookup, ctx) {
+                    @Override
+                    public void setDocument(int docId) {
+                        compositeFieldScript.setDocument(docId);
+                    }
+
+                    @Override
+                    public void execute() {
+                        emitFromCompositeScript(compositeFieldScript);
+                    }
+                };
+            };
+        };
+    }
 
     @SuppressWarnings("unused")
     public static final String[] PARAMETERS = {};

--- a/server/src/test/java/org/elasticsearch/index/mapper/CompositeRuntimeFieldTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/CompositeRuntimeFieldTests.java
@@ -1,0 +1,438 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.index.mapper;
+
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentType;
+import org.elasticsearch.script.LongFieldScript;
+import org.elasticsearch.script.CompositeFieldScript;
+import org.elasticsearch.script.Script;
+import org.elasticsearch.script.ScriptContext;
+import org.elasticsearch.search.lookup.LeafSearchLookup;
+import org.elasticsearch.search.lookup.SearchLookup;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.hamcrest.Matchers.containsString;
+
+public class CompositeRuntimeFieldTests extends MapperServiceTestCase {
+
+    @Override
+    @SuppressWarnings("unchecked")
+    protected <T> T compileScript(Script script, ScriptContext<T> context) {
+        if (context == CompositeFieldScript.CONTEXT) {
+            return (T) (CompositeFieldScript.Factory) (fieldName, params, searchLookup) -> ctx -> new CompositeFieldScript(
+                fieldName,
+                params,
+                searchLookup,
+                ctx
+            ){
+                @Override
+                public void execute() {
+                    if (script.getIdOrCode().equals("split-str-long")) {
+                        List<Object> values = extractFromSource("field");
+                        String input = values.get(0).toString();
+                        String[] parts = input.split(" ");
+                        emit("str", parts[0]);
+                        emit("long", parts[1]);
+                    }
+                }
+            };
+        }
+        if (context == LongFieldScript.CONTEXT) {
+            return (T) (LongFieldScript.Factory) (field, params, lookup) -> ctx -> new LongFieldScript(field, params, lookup, ctx) {
+                @Override
+                public void execute() {
+
+                }
+            };
+        }
+        throw new UnsupportedOperationException("Unknown context " + context.name);
+    }
+
+    public void testObjectDefinition() throws IOException {
+        MapperService mapperService = createMapperService(topMapping(b -> {
+            b.startObject("runtime");
+            b.startObject("obj");
+            b.field("type", "composite");
+            b.startObject("script").field("source", "dummy").endObject();
+            b.startObject("fields");
+            b.startObject("long-subfield").field("type", "long").endObject();
+            b.startObject("str-subfield").field("type", "keyword").endObject();
+            b.startObject("double-subfield").field("type", "double").endObject();
+            b.startObject("boolean-subfield").field("type", "boolean").endObject();
+            b.startObject("ip-subfield").field("type", "ip").endObject();
+            b.startObject("geopoint-subfield").field("type", "geo_point").endObject();
+            b.endObject();
+            b.endObject();
+            b.endObject();
+        }));
+
+        assertNull(mapperService.mappingLookup().getFieldType("obj"));
+        assertNull(mapperService.mappingLookup().getFieldType("long-subfield"));
+        assertNull(mapperService.mappingLookup().getFieldType("str-subfield"));
+        assertNull(mapperService.mappingLookup().getFieldType("double-subfield"));
+        assertNull(mapperService.mappingLookup().getFieldType("boolean-subfield"));
+        assertNull(mapperService.mappingLookup().getFieldType("ip-subfield"));
+        assertNull(mapperService.mappingLookup().getFieldType("geopoint-subfield"));
+        assertNull(mapperService.mappingLookup().getFieldType("obj.any-subfield"));
+        MappedFieldType longSubfield = mapperService.mappingLookup().getFieldType("obj.long-subfield");
+        assertEquals("obj.long-subfield", longSubfield.name());
+        assertEquals("long", longSubfield.typeName());
+        MappedFieldType strSubfield = mapperService.mappingLookup().getFieldType("obj.str-subfield");
+        assertEquals("obj.str-subfield", strSubfield.name());
+        assertEquals("keyword", strSubfield.typeName());
+        MappedFieldType doubleSubfield = mapperService.mappingLookup().getFieldType("obj.double-subfield");
+        assertEquals("obj.double-subfield", doubleSubfield.name());
+        assertEquals("double", doubleSubfield.typeName());
+        MappedFieldType booleanSubfield = mapperService.mappingLookup().getFieldType("obj.boolean-subfield");
+        assertEquals("obj.boolean-subfield", booleanSubfield.name());
+        assertEquals("boolean", booleanSubfield.typeName());
+        MappedFieldType ipSubfield = mapperService.mappingLookup().getFieldType("obj.ip-subfield");
+        assertEquals("obj.ip-subfield", ipSubfield.name());
+        assertEquals("ip", ipSubfield.typeName());
+        MappedFieldType geoPointSubfield = mapperService.mappingLookup().getFieldType("obj.geopoint-subfield");
+        assertEquals("obj.geopoint-subfield", geoPointSubfield.name());
+        assertEquals("geo_point", geoPointSubfield.typeName());
+
+        RuntimeField rf = mapperService.mappingLookup().getMapping().getRoot().getRuntimeField("obj");
+        assertEquals("obj", rf.name());
+        Collection<MappedFieldType> mappedFieldTypes = rf.asMappedFieldTypes().collect(Collectors.toList());
+        for (MappedFieldType mappedFieldType : mappedFieldTypes) {
+            if (mappedFieldType.name().equals("obj.long-subfield")) {
+                assertSame(longSubfield, mappedFieldType);
+            } else if (mappedFieldType.name().equals("obj.str-subfield")) {
+                assertSame(strSubfield, mappedFieldType);
+            }  else if (mappedFieldType.name().equals("obj.double-subfield")) {
+                assertSame(doubleSubfield, mappedFieldType);
+            }  else if (mappedFieldType.name().equals("obj.boolean-subfield")) {
+                assertSame(booleanSubfield, mappedFieldType);
+            }  else if (mappedFieldType.name().equals("obj.ip-subfield")) {
+                assertSame(ipSubfield, mappedFieldType);
+            }  else if (mappedFieldType.name().equals("obj.geopoint-subfield")) {
+                assertSame(geoPointSubfield, mappedFieldType);
+            } else {
+                fail("unexpected subfield [" + mappedFieldType.name() + "]");
+            }
+        }
+    }
+
+    public void testUnsupportedLeafType() {
+        Exception e = expectThrows(MapperParsingException.class, () -> createMapperService(topMapping(b -> {
+            b.startObject("runtime");
+            b.startObject("obj");
+            b.field("type", "composite");
+            b.startObject("script").field("source", "dummy").endObject();
+            b.startObject("fields");
+            b.startObject("long-subfield").field("type", "unsupported").endObject();
+            b.endObject();
+            b.endObject();
+            b.endObject();
+        })));
+        assertThat(e.getMessage(), containsString(""));
+    }
+
+    public void testToXContent() throws IOException {
+        MapperService mapperService = createMapperService(topMapping(b -> {
+            b.startObject("runtime");
+            b.startObject("message");
+            b.field("type", "composite");
+            b.field("script", "dummy");
+            b.startObject("meta").field("test-meta", "value").endObject();
+            b.startObject("fields").startObject("response").field("type", "long").endObject().endObject();
+            b.endObject();
+            b.endObject();
+        }));
+        assertEquals("{\"_doc\":{\"runtime\":{" +
+            "\"message\":{\"type\":\"composite\"," +
+            "\"meta\":{\"test-meta\":\"value\"}," +
+            "\"script\":{\"source\":\"dummy\",\"lang\":\"painless\"}," +
+            "\"fields\":{\"response\":{\"type\":\"long\"}}}}}}",
+            Strings.toString(mapperService.mappingLookup().getMapping()));
+    }
+
+    public void testScriptOnSubFieldThrowsError() {
+        Exception e = expectThrows(MapperParsingException.class, () -> createMapperService(runtimeMapping(b -> {
+            b.startObject("obj");
+            b.field("type", "composite");
+            b.field("script", "dummy");
+            b.startObject("fields");
+            b.startObject("long").field("type", "long").field("script", "dummy").endObject();
+            b.endObject();
+            b.endObject();
+        })));
+
+        assertThat(e.getMessage(), containsString("Cannot use [script] parameter on sub-field [long] of composite field [obj]"));
+    }
+
+    public void testObjectWithoutScript() {
+        Exception e = expectThrows(MapperParsingException.class, () -> createMapperService(runtimeMapping(b -> {
+            b.startObject("obj");
+            b.field("type", "composite");
+            b.startObject("fields");
+            b.startObject("long").field("type", "long").endObject();
+            b.endObject();
+            b.endObject();
+        })));
+        assertThat(e.getMessage(), containsString("composite runtime field [obj] must declare a [script]"));
+    }
+
+    public void testObjectNullScript() {
+        Exception e = expectThrows(MapperParsingException.class, () -> createMapperService(runtimeMapping(b -> {
+            b.startObject("obj");
+            b.field("type", "composite");
+            b.nullField("script");
+            b.startObject("fields");
+            b.startObject("long").field("type", "long").endObject();
+            b.endObject();
+            b.endObject();
+        })));
+        assertThat(e.getMessage(), containsString(" [script] on runtime field [obj] of type [composite] must not have a [null] value"));
+
+    }
+
+    public void testObjectWithoutFields() {
+        {
+            Exception e = expectThrows(MapperParsingException.class, () -> createMapperService(runtimeMapping(b -> {
+                b.startObject("obj");
+                b.field("type", "composite");
+                b.field("script", "dummy");
+                b.endObject();
+            })));
+            assertThat(e.getMessage(), containsString("composite runtime field [obj] must declare its [fields]"));
+        }
+        {
+            Exception e = expectThrows(MapperParsingException.class, () -> createMapperService(runtimeMapping(b -> {
+                b.startObject("obj");
+                b.field("type", "composite");
+                b.field("script", "dummy");
+                b.startObject("fields").endObject();
+                b.endObject();
+            })));
+            assertThat(e.getMessage(), containsString("composite runtime field [obj] must declare its [fields]"));
+        }
+    }
+
+    public void testMappingUpdate() throws IOException {
+        MapperService mapperService = createMapperService(topMapping(b -> {
+            b.startObject("runtime");
+            b.startObject("obj");
+            b.field("type", "composite");
+            b.startObject("script").field("source", "dummy").endObject();
+            b.startObject("fields");
+            b.startObject("long-subfield").field("type", "long").endObject();
+            b.startObject("str-subfield").field("type", "keyword").endObject();
+            b.endObject();
+            b.endObject();
+            b.endObject();
+        }));
+
+        XContentBuilder b = XContentBuilder.builder(XContentType.JSON.xContent());
+        b.startObject();
+        b.startObject("_doc");
+        b.startObject("runtime");
+        b.startObject("obj");
+        b.field("type", "composite");
+        b.startObject("script").field("source", "dummy2").endObject();
+        b.startObject("fields");
+        b.startObject("double-subfield").field("type", "double").endObject();
+        b.endObject();
+        b.endObject();
+        b.endObject();
+        b.endObject();
+        b.endObject();
+
+        merge(mapperService, b);
+
+        assertNull(mapperService.mappingLookup().getFieldType("obj.long-subfield"));
+        assertNull(mapperService.mappingLookup().getFieldType("obj.str-subfield"));
+        MappedFieldType doubleSubField = mapperService.mappingLookup().getFieldType("obj.double-subfield");
+        assertEquals("obj.double-subfield", doubleSubField.name());
+        assertEquals("double", doubleSubField.typeName());
+
+        RuntimeField rf = mapperService.mappingLookup().getMapping().getRoot().getRuntimeField("obj");
+        assertEquals("obj", rf.name());
+
+        Collection<MappedFieldType> mappedFieldTypes = rf.asMappedFieldTypes().collect(Collectors.toList());
+        assertEquals(1, mappedFieldTypes.size());
+        assertSame(doubleSubField, mappedFieldTypes.iterator().next());
+
+        assertEquals("{\"obj\":{\"type\":\"composite\"," +
+            "\"script\":{\"source\":\"dummy2\",\"lang\":\"painless\"}," +
+            "\"fields\":{\"double-subfield\":{\"type\":\"double\"}}}}", Strings.toString(rf));
+    }
+
+    public void testFieldDefinedTwiceWithSameName() throws IOException {
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> createMapperService(topMapping(b -> {
+            b.startObject("runtime");
+            b.startObject("obj.long-subfield").field("type", "long").endObject();
+            b.startObject("obj");
+            b.field("type", "composite");
+            b.startObject("script").field("source", "dummy").endObject();
+            b.startObject("fields");
+            b.startObject("long-subfield").field("type", "long").endObject();
+            b.endObject();
+            b.endObject();
+            b.endObject();
+        })));
+        assertThat(e.getMessage(), containsString("Found two runtime fields with same name [obj.long-subfield]"));
+
+        MapperService mapperService = createMapperService(topMapping(b -> {
+            b.startObject("runtime");
+            b.startObject("obj.str-subfield").field("type", "long").endObject();
+            b.startObject("obj");
+            b.field("type", "composite");
+            b.startObject("script").field("source", "dummy").endObject();
+            b.startObject("fields");
+            b.startObject("long-subfield").field("type", "long").endObject();
+            b.endObject();
+            b.endObject();
+            b.endObject();
+        }));
+
+        XContentBuilder builder = XContentBuilder.builder(XContentType.JSON.xContent());
+        builder.startObject();
+        builder.startObject("_doc");
+        builder.startObject("runtime");
+        builder.startObject("obj.long-subfield").field("type", "long").endObject();
+        builder.endObject();
+        builder.endObject();
+        builder.endObject();
+        IllegalArgumentException iae = expectThrows(IllegalArgumentException.class, () -> merge(mapperService, builder));
+        assertThat(iae.getMessage(), containsString("Found two runtime fields with same name [obj.long-subfield]"));
+    }
+
+    public void testParseDocumentSubFieldAccess() throws IOException {
+        MapperService mapperService = createMapperService(topMapping(b -> {
+            b.field("dynamic", false);
+            b.startObject("runtime");
+            b.startObject("obj");
+            b.field("type", "composite");
+            b.field("script", "split-str-long");
+            b.startObject("fields");
+            b.startObject("str").field("type", "keyword").endObject();
+            b.startObject("long").field("type", "long").endObject();
+            b.endObject();
+            b.endObject();
+            b.endObject();
+        }));
+
+        ParsedDocument doc1 = mapperService.documentMapper().parse(source(b -> b.field("field", "foo 1")));
+        ParsedDocument doc2 = mapperService.documentMapper().parse(source(b -> b.field("field", "bar 2")));
+
+        withLuceneIndex(mapperService, iw -> iw.addDocuments(Arrays.asList(doc1.rootDoc(), doc2.rootDoc())), reader -> {
+            SearchLookup searchLookup = new SearchLookup(
+                mapperService::fieldType,
+                (mft, lookupSupplier) -> mft.fielddataBuilder("test", lookupSupplier).build(null, null)
+            );
+
+            LeafSearchLookup leafSearchLookup = searchLookup.getLeafSearchLookup(reader.leaves().get(0));
+
+            leafSearchLookup.setDocument(0);
+            assertEquals("foo", leafSearchLookup.doc().get("obj.str").get(0));
+            assertEquals(1L, leafSearchLookup.doc().get("obj.long").get(0));
+
+            leafSearchLookup.setDocument(1);
+            assertEquals("bar", leafSearchLookup.doc().get("obj.str").get(0));
+            assertEquals(2L, leafSearchLookup.doc().get("obj.long").get(0));
+        });
+    }
+
+    public void testParseDocumentDynamicMapping() throws IOException {
+        MapperService mapperService = createMapperService(topMapping(b -> {
+            b.startObject("runtime");
+            b.startObject("obj");
+            b.field("type", "composite");
+            b.field("script", "dummy");
+            b.startObject("fields");
+            b.startObject("str").field("type", "keyword").endObject();
+            b.startObject("long").field("type", "long").endObject();
+            b.endObject();
+            b.endObject();
+            b.endObject();
+        }));
+
+        ParsedDocument doc1 = mapperService.documentMapper().parse(source(b -> b.field("obj.long", 1L).field("obj.str", "value")));
+        assertNull(doc1.rootDoc().get("obj.long"));
+        assertNull(doc1.rootDoc().get("obj.str"));
+
+        assertNull(mapperService.mappingLookup().getMapper("obj.long"));
+        assertNull(mapperService.mappingLookup().getMapper("obj.str"));
+        assertNotNull(mapperService.mappingLookup().getFieldType("obj.long"));
+        assertNotNull(mapperService.mappingLookup().getFieldType("obj.str"));
+
+        XContentBuilder builder = XContentBuilder.builder(XContentType.JSON.xContent());
+        builder.startObject();
+        builder.startObject("_doc");
+        builder.startObject("properties");
+        builder.startObject("obj");
+        builder.startObject("properties");
+        builder.startObject("long").field("type", "long").endObject();
+        builder.endObject();
+        builder.endObject();
+        builder.endObject();
+        builder.endObject();
+        builder.endObject();
+        merge(mapperService, builder);
+
+        ParsedDocument doc2 = mapperService.documentMapper().parse(source(b -> b.field("obj.long", 2L)));
+        assertNotNull(doc2.rootDoc().get("obj.long"));
+        assertNull(doc2.rootDoc().get("obj.str"));
+
+        assertNotNull(mapperService.mappingLookup().getMapper("obj.long"));
+        assertNull(mapperService.mappingLookup().getMapper("obj.str"));
+        assertNotNull(mapperService.mappingLookup().getFieldType("obj.long"));
+        assertNotNull(mapperService.mappingLookup().getFieldType("obj.str"));
+    }
+
+    public void testParseDocumentSubfieldsOutsideRuntimeObject() throws IOException{
+        MapperService mapperService = createMapperService(topMapping(b -> {
+            b.startObject("runtime");
+            b.startObject("obj");
+            b.field("type", "composite");
+            b.field("script", "dummy");
+            b.startObject("fields");
+            b.startObject("long").field("type", "long").endObject();
+            b.endObject();
+            b.endObject();
+            b.endObject();
+        }));
+
+        ParsedDocument doc1 = mapperService.documentMapper().parse(source(b -> b.field("obj.long", 1L).field("obj.bool", true)));
+        assertNull(doc1.rootDoc().get("obj.long"));
+        assertNotNull(doc1.rootDoc().get("obj.bool"));
+
+        assertEquals("{\"_doc\":{\"properties\":{\"obj\":{\"properties\":{\"bool\":{\"type\":\"boolean\"}}}}}}",
+            Strings.toString(doc1.dynamicMappingsUpdate()));
+
+        MapperService mapperService2 = createMapperService(topMapping(b -> {
+            b.field("dynamic", "runtime");
+            b.startObject("runtime");
+            b.startObject("obj");
+            b.field("type", "composite");
+            b.field("script", "dummy");
+            b.startObject("fields");
+            b.startObject("long").field("type", "long").endObject();
+            b.endObject();
+            b.endObject();
+            b.endObject();
+        }));
+
+        ParsedDocument doc2 = mapperService2.documentMapper().parse(source(b -> b.field("obj.long", 1L).field("obj.bool", true)));
+        assertNull(doc2.rootDoc().get("obj.long"));
+        assertNull(doc2.rootDoc().get("obj.bool"));
+        assertEquals("{\"_doc\":{\"dynamic\":\"runtime\",\"runtime\":{\"obj.bool\":{\"type\":\"boolean\"}}}}",
+            Strings.toString(doc2.dynamicMappingsUpdate()));
+    }
+}

--- a/server/src/test/java/org/elasticsearch/index/mapper/TestRuntimeField.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/TestRuntimeField.java
@@ -15,6 +15,7 @@ import org.elasticsearch.index.query.SearchExecutionContext;
 import java.io.IOException;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.stream.Stream;
 
 public final class TestRuntimeField implements RuntimeField {
 
@@ -38,8 +39,8 @@ public final class TestRuntimeField implements RuntimeField {
     }
 
     @Override
-    public Collection<MappedFieldType> asMappedFieldTypes() {
-        return subfields;
+    public Stream<MappedFieldType> asMappedFieldTypes() {
+        return subfields.stream();
     }
 
     @Override

--- a/test/framework/src/main/java/org/elasticsearch/script/MockScriptEngine.java
+++ b/test/framework/src/main/java/org/elasticsearch/script/MockScriptEngine.java
@@ -288,6 +288,15 @@ public class MockScriptEngine implements ScriptEngine {
                 }
             };
             return context.factoryClazz.cast(geoPointFieldScript);
+        } else if (context.instanceClazz.equals(CompositeFieldScript.class)) {
+            CompositeFieldScript.Factory objectFieldScript = (f, p, s) -> ctx -> new CompositeFieldScript(f, p, s, ctx) {
+                @Override
+                public void execute() {
+                    emit("field1", "value1");
+                    emit("field2", "value2");
+                }
+            };
+            return context.factoryClazz.cast(objectFieldScript);
         }
         ContextCompiler compiler = contexts.get(context);
         if (compiler != null) {


### PR DESCRIPTION
We have recently introduced support for grok and dissect to the runtime fields
Painless context that allows to split a field into multiple fields. However, each runtime
field can only emit values for a single field. This commit introduces support for emitting
multiple fields from the same script.

The API call to define a runtime field that emits multiple fields is the following:

```
PUT localhost:9200/logs/_mappings
{
    "runtime" : {
      "log" : {
        "type" : "composite",
        "script" : "emit(grok(\"%{COMMONAPACHELOG}\").extract(doc[\"message.keyword\"].value))",
        "fields" : {
            "clientip" : {
                "type" : "ip"
            },
            "response" : {
                "type" : "long"
            }
        }
      }
    }
}
```

The script context for this new field type accepts two emit signatures:

* `emit(String, Object)`
* `emit(Map)`

Sub-fields need to be declared under fields in order to be discoverable through
the field_caps API and accessible through the search API.

The way that it emits multiple fields is by returning multiple MappedFieldTypes
from RuntimeField#asMappedFieldTypes. The sub-fields are instances of the
runtime fields that are already supported, with a little tweak to adapt the script
defined by their parent to an artificial script factory for each of the sub-fields
that makes its corresponding sub-field accessible. This approach allows to reuse
all of the existing runtime fields code for the sub-fields.

The runtime section has been flat so far as it has not supported objects until now.
That stays the same, meaning that runtime fields can have dots in their names.
Because there are though two ways to create the same field with the introduction
of the ability to emit multiple fields, we have to make sure that a runtime field with
a certain name cannot be defined twice, which is why the following mappings are
rejected with the error `Found two runtime fields with same name [log.response]`:

```
PUT localhost:9200/logs/_mappings
{
    "runtime" : {
        "log.response" : {
            "type" : "keyword"
        },
        "log" : {
            "type" : "composite",
            "script" : "emit(\"response\", grok(\"%{COMMONAPACHELOG}\").extract(doc[\"message.keyword\"].value)?.response)",
            "fields" : {
                "response" : {
                    "type" : "long"
                }
            }
        }
    }
}
```

Closes #68203