### PR TITLE
[7.14] Remove reaper debug output (#76285)

### DIFF
--- a/build-tools/src/main/java/org/elasticsearch/gradle/ReaperService.java
+++ b/build-tools/src/main/java/org/elasticsearch/gradle/ReaperService.java
@@ -151,7 +151,6 @@ public abstract class ReaperService implements BuildService<ReaperService.Params
                 OutputStream out = Files.newOutputStream(jarPath);
                 InputStream jarInput = this.getClass().getResourceAsStream("/META-INF/reaper.jar");
             ) {
-                System.out.println("jarInput = " + jarInput);
                 logger.info("Copying reaper.jar...");
                 jarInput.transferTo(out);
             } catch (IOException e) {


### PR DESCRIPTION
Backports the following commits to 7.14:
 - Remove reaper debug output (#76285)