### PR TITLE
[ML] remove process context on stop, fail, and crash

### DIFF
--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/deployment/DeploymentManager.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/deployment/DeploymentManager.java
@@ -165,7 +165,7 @@ public class DeploymentManager {
     public void stopDeployment(TrainedModelDeploymentTask task) {
         ProcessContext processContext;
         synchronized (processContextByAllocation) {
-            processContext = processContextByAllocation.remove(task.getId());
+            processContext = processContextByAllocation.get(task.getId());
         }
         if (processContext != null) {
             logger.info("[{}] Stopping deployment", task.getModelId());
@@ -277,6 +277,7 @@ public class DeploymentManager {
             try {
                 stateStreamer.cancel();
                 process.get().kill(true);
+                processContextByAllocation.remove(taskId);
             } catch (IOException e) {
                 logger.error(new ParameterizedMessage("[{}] Failed to kill process", modelId), e);
             }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/deployment/DeploymentManager.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/deployment/DeploymentManager.java
@@ -78,15 +78,23 @@ public class DeploymentManager {
         doStartDeployment(task, listener);
     }
 
-    private void doStartDeployment(TrainedModelDeploymentTask task, ActionListener<TrainedModelDeploymentTask> listener) {
+    private void doStartDeployment(TrainedModelDeploymentTask task, ActionListener<TrainedModelDeploymentTask> finalListener) {
         logger.debug("[{}] Starting model deployment", task.getModelId());
 
-        ProcessContext processContext = new ProcessContext(task.getModelId(), task.getIndex(), executorServiceForProcess);
+        ProcessContext processContext = new ProcessContext(task.getModelId(), task.getIndex(), executorServiceForProcess, task.getId());
 
         if (processContextByAllocation.putIfAbsent(task.getId(), processContext) != null) {
-            listener.onFailure(ExceptionsHelper.serverError("[{}] Could not create process as one already exists", task.getModelId()));
+            finalListener.onFailure(ExceptionsHelper.serverError("[{}] Could not create process as one already exists", task.getModelId()));
             return;
         }
+
+        ActionListener<TrainedModelDeploymentTask> listener = ActionListener.wrap(
+            finalListener::onResponse,
+            failure -> {
+                processContextByAllocation.remove(task.getId());
+                finalListener.onFailure(failure);
+            }
+        );
 
         String taskConfigDocId = NlpTaskConfig.documentId(task.getModelId());
 
@@ -116,7 +124,7 @@ public class DeploymentManager {
                 // here, we are being called back on the searching thread, which MAY be a network thread
                 // `startAndLoad` creates named pipes, blocking the calling thread, better to execute that in our utility
                 // executor.
-                executorServiceForProcess.execute(() -> startAndLoad(processContext, modelLoadedListener));
+                executorServiceForDeployment.execute(() -> startAndLoad(processContext, modelLoadedListener));
             },
             listener::onFailure
         );
@@ -157,7 +165,7 @@ public class DeploymentManager {
     public void stopDeployment(TrainedModelDeploymentTask task) {
         ProcessContext processContext;
         synchronized (processContextByAllocation) {
-            processContext = processContextByAllocation.get(task.getId());
+            processContext = processContextByAllocation.remove(task.getId());
         }
         if (processContext != null) {
             logger.info("[{}] Stopping deployment", task.getModelId());
@@ -243,16 +251,18 @@ public class DeploymentManager {
 
         private final String modelId;
         private final String index;
+        private final long taskId;
         private final SetOnce<NativePyTorchProcess> process = new SetOnce<>();
         private final SetOnce<NlpTask.Processor> nlpTaskProcessor = new SetOnce<>();
         private final PyTorchResultProcessor resultProcessor;
         private final PyTorchStateStreamer stateStreamer;
 
-        ProcessContext(String modelId, String index, ExecutorService executorService) {
+        ProcessContext(String modelId, String index, ExecutorService executorService, long taskId) {
             this.modelId = Objects.requireNonNull(modelId);
             this.index = Objects.requireNonNull(index);
             resultProcessor = new PyTorchResultProcessor(modelId);
             this.stateStreamer = new PyTorchStateStreamer(client, executorService, xContentRegistry);
+            this.taskId = taskId;
         }
 
         synchronized void startProcess() {
@@ -273,7 +283,10 @@ public class DeploymentManager {
         }
 
         private Consumer<String> onProcessCrash() {
-            return reason -> logger.error("[{}] process crashed due to reason [{}]", modelId, reason);
+            return reason -> {
+                logger.error("[{}] process crashed due to reason [{}]", modelId, reason);
+                processContextByAllocation.remove(taskId);
+            };
         }
 
         void loadModel(ActionListener<Boolean> listener) {

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/deployment/DeploymentManager.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/deployment/DeploymentManager.java
@@ -178,8 +178,19 @@ public class DeploymentManager {
     public void infer(TrainedModelDeploymentTask task,
                       String input, TimeValue timeout,
                       ActionListener<InferenceResults> listener) {
-        ProcessContext processContext = processContextByAllocation.get(task.getId());
+        if (task.isStopped()) {
+            listener.onFailure(
+                new IllegalStateException("["
+                    + task.getModelId()
+                    + "] is stopping or stopped due to ["
+                    + task.stoppedReason().orElse("")
+                    + "]"
+                )
+            );
+            return;
+        }
 
+        ProcessContext processContext = processContextByAllocation.get(task.getId());
         if (processContext == null) {
             listener.onFailure(new IllegalStateException("[" + task.getModelId() + "] process context missing"));
             return;

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/deployment/TrainedModelDeploymentTask.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/deployment/TrainedModelDeploymentTask.java
@@ -9,6 +9,7 @@ package org.elasticsearch.xpack.ml.inference.deployment;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.apache.lucene.util.SetOnce;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.tasks.CancellableTask;
@@ -21,6 +22,7 @@ import org.elasticsearch.xpack.core.ml.utils.ExceptionsHelper;
 import org.elasticsearch.xpack.ml.inference.allocation.TrainedModelAllocationNodeService;
 
 import java.util.Map;
+import java.util.Optional;
 
 public class TrainedModelDeploymentTask extends CancellableTask implements StartTrainedModelDeploymentAction.TaskMatcher {
 
@@ -29,6 +31,7 @@ public class TrainedModelDeploymentTask extends CancellableTask implements Start
     private final TaskParams params;
     private final TrainedModelAllocationNodeService trainedModelAllocationNodeService;
     private volatile boolean stopped;
+    private final SetOnce<String> stoppedReason = new SetOnce<>();
 
     public TrainedModelDeploymentTask(
         long id,
@@ -62,16 +65,22 @@ public class TrainedModelDeploymentTask extends CancellableTask implements Start
     public void stop(String reason) {
         logger.debug("[{}] Stopping due to reason [{}]", getModelId(), reason);
         stopped = true;
-        trainedModelAllocationNodeService.stopDeploymentAndNotify(this);
+        stoppedReason.trySet(reason);
+        trainedModelAllocationNodeService.stopDeploymentAndNotify(this, reason);
     }
 
     public void stopWithoutNotification(String reason) {
         logger.debug("[{}] Stopping due to reason [{}]", getModelId(), reason);
+        stoppedReason.trySet(reason);
         stopped = true;
     }
 
     public boolean isStopped() {
         return stopped;
+    }
+
+    public Optional<String> stoppedReason() {
+        return Optional.ofNullable(stoppedReason.get());
     }
 
     @Override


### PR DESCRIPTION
This PR fixes a bug where the process context for a given task ID isn't removed from the map.

This may cause a minor data leak as processes are started and stopped.

Additionally, it unmutes the pytorch integration tests and makes the calls multi-threaded to ensure correctness.