### PR TITLE
[7.x] [DOCS] Remove `.com` from `elasticsearch.host` setup snippet (#76200)

### DIFF
--- a/x-pack/docs/en/security/securing-communications/security-basic-setup-https.asciidoc
+++ b/x-pack/docs/en/security/securing-communications/security-basic-setup-https.asciidoc
@@ -171,7 +171,7 @@ cluster.
 +
 [source,yaml]
 ----
-elasticsearch.hosts: https://<your_elasticsearch_host>.com:9200
+elasticsearch.hosts: https://<your_elasticsearch_host>:9200
 ----
 
 4. Restart {kib}.


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [DOCS] Remove `.com` from `elasticsearch.host` setup snippet (#76200)