### PR TITLE
Make persistent task cluster service test more stable

### DIFF
--- a/server/src/test/java/org/elasticsearch/persistent/PersistentTasksClusterServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/persistent/PersistentTasksClusterServiceTests.java
@@ -670,15 +670,15 @@ public class PersistentTasksClusterServiceTests extends ESTestCase {
         Thread t2 = new Thread(service::reassignPersistentTasks);
         try {
             t1.start();
-            t2.start();
             // Make sure we have at least one reassign check before we count down the latch
             assertBusy(
                 () -> verify(recheckTestClusterService, atLeastOnce()).submitStateUpdateTask(eq("reassign persistent tasks"), any())
             );
+            t2.start();
         } finally {
+            t2.join();
             latch.countDown();
             t1.join();
-            t2.join();
             service.reassignPersistentTasks();
         }
         // verify that our reassignment is possible again, here we have once from the previous reassignment in the `try` block


### PR DESCRIPTION
Previously, it was possible to have:

 - both threads start
 - One sits in the submit update task
 - The other has not even scheduled to run yet
 - Latch counts down
 - Thread 1 finishes, allowing another submit task
 - Thread 2 now gets scheduled and ran and submits a cluster update request

Fixes #76337