### PR TITLE
Set elastic password from stored hash

### DIFF
--- a/qa/os/src/test/java/org/elasticsearch/packaging/test/PackageSecurityAutoconfigurationTests.java
+++ b/qa/os/src/test/java/org/elasticsearch/packaging/test/PackageSecurityAutoconfigurationTests.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.packaging.test;
+
+import org.elasticsearch.packaging.util.Shell;
+import org.junit.BeforeClass;
+
+import static org.elasticsearch.packaging.util.Packages.assertInstalled;
+import static org.elasticsearch.packaging.util.Packages.assertRemoved;
+import static org.elasticsearch.packaging.util.Packages.installPackage;
+import static org.elasticsearch.packaging.util.Packages.verifyPackageInstallation;
+import static org.elasticsearch.packaging.util.ServerUtils.validateCredentials;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.junit.Assume.assumeTrue;
+
+public class PackageSecurityAutoconfigurationTests extends PackagingTestCase {
+
+    @BeforeClass
+    public static void filterDistros() {
+        assumeTrue("rpm or deb", distribution.isPackage());
+    }
+
+    public void test10ElasticPasswordHash() throws Exception {
+        assertRemoved(distribution());
+        installation = installPackage(sh, distribution());
+        assertInstalled(distribution());
+        verifyPackageInstallation(installation, distribution(), sh);
+        Shell.Result keystoreListResult = installation.executables().keystoreTool.run("list");
+        // Keystore should be created already by the installation and it should contain only "keystore.seed" at this point
+        assertThat(keystoreListResult.stdout, containsString("keystore.seed"));
+        // With future changes merged, this would be automatically populated on installation. For now, add it manually
+        installation.executables().keystoreTool.
+            // $2a$10$R2oFwbHR/9x9.e/bQpJ6IeHKUVP08KHQ9LcZPMlWeyuQuYboR82fm is the hash of thisisalongenoughpassword
+            run("add -x autoconfiguration.password_hash", "$2a$10$R2oFwbHR/9x9.e/bQpJ6IeHKUVP08KHQ9LcZPMlWeyuQuYboR82fm");
+        startElasticsearch();
+        validateCredentials("elastic", "thisisalongenoughpassword", null);
+    }
+}

--- a/qa/os/src/test/java/org/elasticsearch/packaging/test/PackageSecurityAutoconfigurationTests.java
+++ b/qa/os/src/test/java/org/elasticsearch/packaging/test/PackageSecurityAutoconfigurationTests.java
@@ -36,7 +36,7 @@ public class PackageSecurityAutoconfigurationTests extends PackagingTestCase {
         assertThat(keystoreListResult.stdout, containsString("keystore.seed"));
         // With future changes merged, this would be automatically populated on installation. For now, add it manually
         installation.executables().keystoreTool.
-            // $2a$10$R2oFwbHR/9x9.e/bQpJ6IeHKUVP08KHQ9LcZPMlWeyuQuYboR82fm is the hash of thisisalongenoughpassword
+        // $2a$10$R2oFwbHR/9x9.e/bQpJ6IeHKUVP08KHQ9LcZPMlWeyuQuYboR82fm is the hash of thisisalongenoughpassword
             run("add -x autoconfiguration.password_hash", "$2a$10$R2oFwbHR/9x9.e/bQpJ6IeHKUVP08KHQ9LcZPMlWeyuQuYboR82fm");
         startElasticsearch();
         validateCredentials("elastic", "thisisalongenoughpassword", null);

--- a/qa/os/src/test/java/org/elasticsearch/packaging/util/ServerUtils.java
+++ b/qa/os/src/test/java/org/elasticsearch/packaging/util/ServerUtils.java
@@ -272,6 +272,13 @@ public class ServerUtils {
         makeRequest(Request.Delete("http://localhost:9200/library"), username, password, null);
     }
 
+    public static void validateCredentials(String username, String password, Path caCert) throws Exception {
+        final HttpResponse response = execute(Request.Get("http://localhost:9200/"), username, password, caCert);
+        if (response.getStatusLine().getStatusCode() == 401) {
+            throw new RuntimeException("Failed to authenticate as [" + username + ":" + password + "]");
+        }
+    }
+
     public static String makeRequest(Request request) throws Exception {
         return makeRequest(request, null, null, null);
     }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/XPackSettings.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/XPackSettings.java
@@ -8,6 +8,8 @@
 package org.elasticsearch.xpack.core;
 
 import org.apache.logging.log4j.LogManager;
+import org.elasticsearch.common.settings.SecureSetting;
+import org.elasticsearch.common.settings.SecureString;
 import org.elasticsearch.common.ssl.SslVerificationMode;
 import org.elasticsearch.jdk.JavaVersion;
 import org.elasticsearch.common.settings.Setting;
@@ -213,6 +215,8 @@ public class XPackSettings {
     public static final String TRANSPORT_SSL_PREFIX = SecurityField.setting("transport.ssl.");
     private static final SSLConfigurationSettings TRANSPORT_SSL = SSLConfigurationSettings.withPrefix(TRANSPORT_SSL_PREFIX, true);
 
+    public static final Setting<SecureString> ELASTIC_PASSWORD_HASH = SecureSetting.secureString("autoconfiguration.password_hash", null);
+
     /** Returns all settings created in {@link XPackSettings}. */
     public static List<Setting<?>> getAllSettings() {
         ArrayList<Setting<?>> settings = new ArrayList<>();
@@ -232,6 +236,7 @@ public class XPackSettings {
         settings.add(USER_SETTING);
         settings.add(PASSWORD_HASHING_ALGORITHM);
         settings.add(ENROLLMENT_ENABLED);
+        settings.add(ELASTIC_PASSWORD_HASH);
         return Collections.unmodifiableList(settings);
     }
 

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/SecurityTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/SecurityTests.java
@@ -25,6 +25,7 @@ import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.logging.Loggers;
 import org.elasticsearch.common.network.NetworkModule;
 import org.elasticsearch.common.settings.ClusterSettings;
+import org.elasticsearch.common.settings.MockSecureSettings;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.settings.SettingsModule;
@@ -93,6 +94,7 @@ import java.util.stream.Collectors;
 
 import static java.util.Collections.emptyMap;
 import static org.elasticsearch.cluster.metadata.IndexMetadata.INDEX_FORMAT_SETTING;
+import static org.elasticsearch.xpack.core.XPackSettings.ELASTIC_PASSWORD_HASH;
 import static org.elasticsearch.xpack.core.security.index.RestrictedIndicesNames.SECURITY_MAIN_ALIAS;
 import static org.elasticsearch.xpack.security.support.SecurityIndexManager.INTERNAL_MAIN_INDEX_FORMAT;
 import static org.hamcrest.Matchers.containsString;
@@ -649,6 +651,19 @@ public class SecurityTests extends ESTestCase {
             appender.stop();
             Loggers.removeAppender(mockLogger, appender);
         }
+    }
+
+    public void testNoElasticPasswordHashInKeystore() throws Exception {
+        createComponents(Settings.EMPTY);
+        assertNull(security.getElasticPasswordHash());
+    }
+
+    public void testElasticPasswordHashInKeystore() throws Exception {
+        MockSecureSettings secureSettings = new MockSecureSettings();
+        secureSettings.setString(ELASTIC_PASSWORD_HASH.getKey(), "some_hash_here");
+        Settings settings = Settings.builder().setSecureSettings(secureSettings).build();
+        createComponents(settings);
+        assertThat(security.getElasticPasswordHash().toString(), equalTo("some_hash_here"));
     }
 
     private void logAndFail(Exception e) {


### PR DESCRIPTION
In package installations, we will be generating the password of
the elastic user on installation and we will be storing the hash
of it to the elasticsearch.keystore.
This change ensures that this password hash will be picked up by
the Security plugin in the starting node and will be set as the
password of the elastic user in the security index.