### PR TITLE
Ensure indexing_data is compressed appropriately

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/bulk/BulkRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/bulk/BulkRequest.java
@@ -30,6 +30,7 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.search.fetch.subphase.FetchSourceContext;
+import org.elasticsearch.transport.RawIndexingDataTransportRequest;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -48,7 +49,8 @@ import static org.elasticsearch.action.ValidateActions.addValidationError;
  * Note that we only support refresh on the bulk request not per item.
  * @see org.elasticsearch.client.Client#bulk(BulkRequest)
  */
-public class BulkRequest extends ActionRequest implements CompositeIndicesRequest, WriteRequest<BulkRequest>, Accountable {
+public class BulkRequest extends ActionRequest
+    implements CompositeIndicesRequest, WriteRequest<BulkRequest>, Accountable, RawIndexingDataTransportRequest {
 
     private static final long SHALLOW_SIZE = RamUsageEstimator.shallowSizeOfInstance(BulkRequest.class);
 

--- a/server/src/main/java/org/elasticsearch/action/resync/ResyncReplicationRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/resync/ResyncReplicationRequest.java
@@ -12,6 +12,7 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.index.translog.Translog;
+import org.elasticsearch.transport.RawIndexingDataTransportRequest;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -20,7 +21,8 @@ import java.util.Objects;
 /**
  * Represents a batch of operations sent from the primary to its replicas during the primary-replica resync.
  */
-public final class ResyncReplicationRequest extends ReplicatedWriteRequest<ResyncReplicationRequest> {
+public final class ResyncReplicationRequest extends ReplicatedWriteRequest<ResyncReplicationRequest>
+    implements RawIndexingDataTransportRequest {
 
     private final long trimAboveSeqNo;
     private final Translog.Operation[] operations;


### PR DESCRIPTION
Currently resync and bulk requests are not compressed when compression
level indexing_data is enabled. Since both of these messages propogate
raw source documents, these should be compressed.

Related to #73497.