### PR TITLE
[7.x] Remove unused build script extra property (#76324)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ import org.gradle.plugins.ide.eclipse.model.ProjectDependency
 import org.elasticsearch.gradle.internal.InternalPluginBuildPlugin
 import org.elasticsearch.gradle.internal.ResolveAllDependencies
 import java.nio.file.Files
-import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
+import static java.nio.file.StandardCopyOption.REPLACE_EXISTING
 
 plugins {
   id 'lifecycle-base'
@@ -79,13 +79,6 @@ tasks.register("updateCIBwcVersions") {
       yml << "  - \"$it\"\n"
     }
   }
-}
-
-//TODO port buildMetaData to use provider api
-String buildMetadataValue = providers.environmentVariable('BUILD_METADATA').forUseAtConfigurationTime().orElse("").get()
-Map<String, String> buildMetadataMap = buildMetadataValue.tokenize(';').collectEntries {
-  def (String key, String value) = it.split('=')
-  return [key, value]
 }
 
 tasks.register("verifyVersions") {
@@ -175,8 +168,6 @@ allprojects {
             System.getProperty("eclipse.application") != null ||    // Detects gradle launched from the Eclipse compiler server
             gradle.startParameter.taskNames.contains('eclipse') ||  // Detects gradle launched from the command line to do eclipse stuff
             gradle.startParameter.taskNames.contains('cleanEclipse')
-
-    buildMetadata = buildMetadataMap
   }
 
   ext.bwc_tests_enabled = bwc_tests_enabled


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Remove unused build script extra property (#76324)