### PR TITLE
Fork Building Aggregate Index Capabilities Response to Management Pool (#76333)

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/fieldcaps/TransportFieldCapabilitiesAction.java
+++ b/server/src/main/java/org/elasticsearch/action/fieldcaps/TransportFieldCapabilitiesAction.java
@@ -92,7 +92,13 @@ public class TransportFieldCapabilitiesAction extends HandledTransportAction<Fie
                 List<FieldCapabilitiesFailure> failures = indexFailures.values();
                 if (indexResponses.size() > 0) {
                     if (request.isMergeResults()) {
-                        listener.onResponse(merge(indexResponses, request.includeUnmapped(), new ArrayList<>(failures)));
+                        // fork off to the management pool for merging the responses as the operation can run for longer than is acceptable
+                        // on a transport thread in case of large numbers of indices and/or fields
+                        threadPool.executor(ThreadPool.Names.MANAGEMENT).submit(
+                            ActionRunnable.supply(
+                                listener,
+                                () -> merge(indexResponses, request.includeUnmapped(), new ArrayList<>(failures)))
+                        );
                     } else {
                         listener.onResponse(new FieldCapabilitiesResponse(indexResponses, new ArrayList<>(failures)));
                     }


### PR DESCRIPTION
It's in the title. It has been observed that the merge step can run for
non-trivial amounts of time for very large states so we should fork
it to guard the transport threads.

backport of #76333 