### PR TITLE
[DOCS] Note assumptions for shard size and count recommendations

### DIFF
--- a/docs/reference/how-to/size-your-shards.asciidoc
+++ b/docs/reference/how-to/size-your-shards.asciidoc
@@ -167,10 +167,9 @@ have at most 600 shards. The further below this limit you can keep your nodes,
 the better. If you find your nodes exceeding more than 20 shards per GB,
 consider adding another node.
 
-This recommendation is not a hard limit. Enterprise Search and similar use cases
-may be able to safely exceed the recommended shard count. For example, some
-Enterprise Search indices are nearly empty and rarely used. Due to their low
-overhead, shards for these indices shouldn't count toward a node's shard limit.
+For [Enterprise Search], shards for nearly empty and rarely used systems indices
+don't count toward a node's shard limit. Due to their size and low usage, these
+shards have very low overhead.
 
 To check the current size of each node's heap, use the <<cat-nodes,cat nodes
 API>>.

--- a/docs/reference/how-to/size-your-shards.asciidoc
+++ b/docs/reference/how-to/size-your-shards.asciidoc
@@ -128,8 +128,10 @@ Large shards may make a cluster less likely to recover from failure. When a node
 fails, {es} rebalances the node's shards across the data tier's remaining nodes.
 Large shards can be harder to move across a network and may tax node resources.
 
-While not a hard limit, shards between 10GB and 50GB tend to work well. You may
-be able to use larger shards depending on your network and use case.
+While not a hard limit, shards between 10GB and 50GB tend to work well for logs
+and similar time series data. You may be able to use larger shards depending on
+your network and use case. Smaller shards may be appropriate for
+{enterprise-search-ref}/index.html[Enterprise Search] and similar use cases.
 
 If you use {ilm-init}, set the <<ilm-rollover,rollover action>>'s
 `max_primary_shard_size` threshold to `50gb` to avoid shards larger than 50GB.
@@ -159,11 +161,13 @@ index                                 prirep shard store
 [[shard-count-recommendation]]
 ==== Aim for 20 shards or fewer per GB of heap memory
 
-The number of shards a node can hold is proportional to the node's
-heap memory. For example, a node with 30GB of heap memory should
-have at most 600 shards. The further below this limit you can keep your nodes,
-the better. If you find your nodes exceeding more than 20 shards per GB,
-consider adding another node.
+The number of shards a node can hold is proportional to the node's heap memory.
+However, {es} doesn't enforce a fixed limit. If your shards are consistently
+between 10GB–50GB, we recommend limiting nodes to 20 shards or fewer per GB of
+heap memory. For example, a node with 30GB of heap memory should have at most
+600 shards. The further below this limit you can keep your nodes, the better. If
+you find your nodes exceeding more than 20 shards per GB, consider adding
+another node.
 
 To check the current size of each node's heap, use the <<cat-nodes,cat nodes
 API>>.

--- a/docs/reference/how-to/size-your-shards.asciidoc
+++ b/docs/reference/how-to/size-your-shards.asciidoc
@@ -167,9 +167,9 @@ have at most 600 shards. The further below this limit you can keep your nodes,
 the better. If you find your nodes exceeding more than 20 shards per GB,
 consider adding another node.
 
-For [Enterprise Search], shards for nearly empty and rarely used systems indices
-don't count toward a node's shard limit. Due to their size and low usage, these
-shards have very low overhead.
+{enterprise-search-ref}/index.html[Enterprise Search] creates system indices
+that are nearly empty and rarely used. Due to their low overhead, shards for
+these indices don't count toward a node's shard limit.
 
 To check the current size of each node's heap, use the <<cat-nodes,cat nodes
 API>>.

--- a/docs/reference/how-to/size-your-shards.asciidoc
+++ b/docs/reference/how-to/size-your-shards.asciidoc
@@ -129,7 +129,7 @@ fails, {es} rebalances the node's shards across the data tier's remaining nodes.
 Large shards can be harder to move across a network and may tax node resources.
 
 While not a hard limit, shards between 10GB and 50GB tend to work well for logs
-and similar time series data. You may be able to use larger shards depending on
+and time series data. You may be able to use larger shards depending on
 your network and use case. Smaller shards may be appropriate for
 {enterprise-search-ref}/index.html[Enterprise Search] and similar use cases.
 

--- a/docs/reference/how-to/size-your-shards.asciidoc
+++ b/docs/reference/how-to/size-your-shards.asciidoc
@@ -161,14 +161,15 @@ index                                 prirep shard store
 [[shard-count-recommendation]]
 ==== Aim for 20 shards or fewer per GB of heap memory
 
-The number of shards a node can hold is proportional to the node's heap memory.
-For example, a node with 30GB of heap memory should have at most 600 shards. The
-further below this limit you can keep your nodes, the better. Consider adding
-another node if you find your nodes exceeding more than 20 shards per GB.
+The number of shards a node can hold is proportional to the node's
+heap memory. For example, a node with 30GB of heap memory should
+have at most 600 shards. The further below this limit you can keep your nodes,
+the better. If you find your nodes exceeding more than 20 shards per GB,
+consider adding another node.
 
 {enterprise-search-ref}/index.html[Enterprise Search] creates system indices
-that are nearly empty and rarely used. Due to their low overhead, shards for
-these indices don't count toward a node's limit.
+that are nearly empty and rarely used. Due to their low overhead, you shouldn't
+count shards for these indices toward a node's limit.
 
 To check the current size of each node's heap, use the <<cat-nodes,cat nodes
 API>>.

--- a/docs/reference/how-to/size-your-shards.asciidoc
+++ b/docs/reference/how-to/size-your-shards.asciidoc
@@ -169,7 +169,7 @@ consider adding another node.
 
 Some system indices for {enterprise-search-ref}/index.html[Enterprise Search]
 are nearly empty and rarely used. Due to their low overhead, you shouldn't count
-shards for these indices toward a node's limit.
+shards for these indices toward a node's shard limit.
 
 To check the current size of each node's heap, use the <<cat-nodes,cat nodes
 API>>.

--- a/docs/reference/how-to/size-your-shards.asciidoc
+++ b/docs/reference/how-to/size-your-shards.asciidoc
@@ -163,10 +163,10 @@ index                                 prirep shard store
 
 The number of shards a node can hold is proportional to the node's heap memory.
 For example, a node with 30GB of heap memory should have at most 600 shards. The
-further below this limit you can keep your nodes, the better. While not a hard
-limit, consider adding another node if you find your nodes exceeding more than
-20 shards per GB.
+further below this limit you can keep your nodes, the better. Consider adding
+another node if you find your nodes exceeding more than 20 shards per GB.
 
+This recommendation is not a hard limit.
 {enterprise-search-ref}/index.html[Enterprise Search] creates system indices
 that are nearly empty and rarely used. Due to their low overhead, shards for
 these indices don't count toward a node's limit.

--- a/docs/reference/how-to/size-your-shards.asciidoc
+++ b/docs/reference/how-to/size-your-shards.asciidoc
@@ -163,7 +163,7 @@ index                                 prirep shard store
 
 The number of shards a node can hold is proportional to the node's heap memory.
 However, {es} doesn't enforce a fixed limit. If your shards are consistently
-between 10GB–50GB, we recommend limiting nodes to 20 shards or fewer per GB of
+between 10–50GB, we recommend limiting nodes to 20 shards or fewer per GB of
 heap memory. For example, a node with 30GB of heap memory should have at most
 600 shards. The further below this limit you can keep your nodes, the better. If
 you find your nodes exceeding more than 20 shards per GB, consider adding

--- a/docs/reference/how-to/size-your-shards.asciidoc
+++ b/docs/reference/how-to/size-your-shards.asciidoc
@@ -161,15 +161,15 @@ index                                 prirep shard store
 [[shard-count-recommendation]]
 ==== Aim for 20 shards or fewer per GB of heap memory
 
-The number of shards a node can hold is proportional to the node's
-heap memory. For example, a node with 30GB of heap memory should
-have at most 600 shards. The further below this limit you can keep your nodes,
-the better. If you find your nodes exceeding more than 20 shards per GB,
-consider adding another node.
+The number of shards a node can hold is proportional to the node's heap memory.
+For example, a node with 30GB of heap memory should have at most 600 shards. The
+further below this limit you can keep your nodes, the better. While not a hard
+limit, consider adding another node if you find your nodes exceeding more than
+20 shards per GB.
 
 {enterprise-search-ref}/index.html[Enterprise Search] creates system indices
 that are nearly empty and rarely used. Due to their low overhead, shards for
-these indices don't count toward a node's shard limit.
+these indices don't count toward a node's limit.
 
 To check the current size of each node's heap, use the <<cat-nodes,cat nodes
 API>>.

--- a/docs/reference/how-to/size-your-shards.asciidoc
+++ b/docs/reference/how-to/size-your-shards.asciidoc
@@ -167,9 +167,9 @@ have at most 600 shards. The further below this limit you can keep your nodes,
 the better. If you find your nodes exceeding more than 20 shards per GB,
 consider adding another node.
 
-{enterprise-search-ref}/index.html[Enterprise Search] creates system indices
-that are nearly empty and rarely used. Due to their low overhead, you shouldn't
-count shards for these indices toward a node's limit.
+Some system indices for {enterprise-search-ref}/index.html[Enterprise Search]
+are nearly empty and rarely used. Due to their low overhead, you shouldn't count
+shards for these indices toward a node's limit.
 
 To check the current size of each node's heap, use the <<cat-nodes,cat nodes
 API>>.

--- a/docs/reference/how-to/size-your-shards.asciidoc
+++ b/docs/reference/how-to/size-your-shards.asciidoc
@@ -166,7 +166,6 @@ For example, a node with 30GB of heap memory should have at most 600 shards. The
 further below this limit you can keep your nodes, the better. Consider adding
 another node if you find your nodes exceeding more than 20 shards per GB.
 
-This recommendation is not a hard limit.
 {enterprise-search-ref}/index.html[Enterprise Search] creates system indices
 that are nearly empty and rarely used. Due to their low overhead, shards for
 these indices don't count toward a node's limit.

--- a/docs/reference/how-to/size-your-shards.asciidoc
+++ b/docs/reference/how-to/size-your-shards.asciidoc
@@ -161,13 +161,16 @@ index                                 prirep shard store
 [[shard-count-recommendation]]
 ==== Aim for 20 shards or fewer per GB of heap memory
 
-The number of shards a node can hold is proportional to the node's heap memory.
-However, {es} doesn't enforce a fixed limit. If your shards are consistently
-between 10–50GB, we recommend limiting nodes to 20 shards or fewer per GB of
-heap memory. For example, a node with 30GB of heap memory should have at most
-600 shards. The further below this limit you can keep your nodes, the better. If
-you find your nodes exceeding more than 20 shards per GB, consider adding
-another node.
+The number of shards a node can hold is proportional to the node's
+heap memory. For example, a node with 30GB of heap memory should
+have at most 600 shards. The further below this limit you can keep your nodes,
+the better. If you find your nodes exceeding more than 20 shards per GB,
+consider adding another node.
+
+This recommendation is not a hard limit. Enterprise Search and similar use cases
+may be able to safely exceed the recommended shard count. For example, some
+Enterprise Search indices are nearly empty and rarely used. Due to their low
+overhead, shards for these indices shouldn't count toward a node's shard limit.
 
 To check the current size of each node's heap, use the <<cat-nodes,cat nodes
 API>>.


### PR DESCRIPTION
On the "Size your shards" page, the shard size recommendation assumes a time
series use case. Similarly, users shouldn't count nearly empty and rarely used
Enterprise Search system indices against the recommended shard count limit.

Closes #76328.

### Preview
https://elasticsearch_76353.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/size-your-shards.html#shard-size-recommendation