### PR TITLE
[7.x] [ML][Transform] reset failure count when a transform aggregation page is handled successfully (#76355)

### DIFF
--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/ClientTransformIndexer.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/ClientTransformIndexer.java
@@ -143,71 +143,72 @@ class ClientTransformIndexer extends TransformIndexer {
             client,
             BulkAction.INSTANCE,
             request,
-            ActionListener.wrap(bulkResponse -> {
-                if (bulkResponse.hasFailures()) {
-                    int failureCount = 0;
-                    // dedup the failures by the type of the exception, as they most likely have the same cause
-                    Map<String, BulkItemResponse> deduplicatedFailures = new LinkedHashMap<>();
-
-                    for (BulkItemResponse item : bulkResponse.getItems()) {
-                        if (item.isFailed()) {
-                            deduplicatedFailures.putIfAbsent(item.getFailure().getCause().getClass().getSimpleName(), item);
-                            failureCount++;
-                        }
-                    }
-
-                    // note: bulk failures are audited/logged in {@link TransformIndexer#handleFailure(Exception)}
-
-                    // This calls AsyncTwoPhaseIndexer#finishWithIndexingFailure
-                    // Determine whether the failure is irrecoverable (transform should go into failed state) or not (transform increments
-                    // the indexing failure counter
-                    // and possibly retries)
-                    Throwable irrecoverableException = ExceptionRootCauseFinder.getFirstIrrecoverableExceptionFromBulkResponses(
-                        deduplicatedFailures.values()
-                    );
-                    if (irrecoverableException == null) {
-                        String failureMessage = getBulkIndexDetailedFailureMessage("Significant failures: ", deduplicatedFailures);
-                        logger.debug("[{}] Bulk index experienced [{}] failures. {}", getJobId(), failureCount, failureMessage);
-
-                        Exception firstException = deduplicatedFailures.values().iterator().next().getFailure().getCause();
-                        nextPhase.onFailure(
-                            new BulkIndexingException(
-                                "Bulk index experienced [{}] failures. {}",
-                                firstException,
-                                false,
-                                failureCount,
-                                failureMessage
-                            )
-                        );
-                    } else {
-                        deduplicatedFailures.remove(irrecoverableException.getClass().getSimpleName());
-                        String failureMessage = getBulkIndexDetailedFailureMessage("Other failures: ", deduplicatedFailures);
-                        irrecoverableException = decorateBulkIndexException(irrecoverableException);
-
-                        logger.debug(
-                            "[{}] Bulk index experienced [{}] failures and at least 1 irrecoverable [{}]. {}",
-                            getJobId(),
-                            failureCount,
-                            ExceptionRootCauseFinder.getDetailedMessage(irrecoverableException),
-                            failureMessage
-                        );
-
-                        nextPhase.onFailure(
-                            new BulkIndexingException(
-                                "Bulk index experienced [{}] failures and at least 1 irrecoverable [{}]. {}",
-                                irrecoverableException,
-                                true,
-                                failureCount,
-                                ExceptionRootCauseFinder.getDetailedMessage(irrecoverableException),
-                                failureMessage
-                            )
-                        );
-                    }
-                } else {
-                    nextPhase.onResponse(bulkResponse);
-                }
-            }, nextPhase::onFailure)
+            ActionListener.wrap(bulkResponse -> handleBulkResponse(bulkResponse, nextPhase), nextPhase::onFailure)
         );
+    }
+
+    protected void handleBulkResponse(BulkResponse bulkResponse, ActionListener<BulkResponse> nextPhase) {
+        if (bulkResponse.hasFailures() == false) {
+            // We don't know the of failures that have occurred (searching, processing, indexing, etc.),
+            // but if we search, process and bulk index then we have
+            // successfully processed an entire page of the transform and should reset the counter, even if we are in the middle
+            // of a checkpoint
+            context.resetReasonAndFailureCounter();
+            nextPhase.onResponse(bulkResponse);
+            return;
+        }
+        int failureCount = 0;
+        // dedup the failures by the type of the exception, as they most likely have the same cause
+        Map<String, BulkItemResponse> deduplicatedFailures = new LinkedHashMap<>();
+
+        for (BulkItemResponse item : bulkResponse.getItems()) {
+            if (item.isFailed()) {
+                deduplicatedFailures.putIfAbsent(item.getFailure().getCause().getClass().getSimpleName(), item);
+                failureCount++;
+            }
+        }
+
+        // note: bulk failures are audited/logged in {@link TransformIndexer#handleFailure(Exception)}
+
+        // This calls AsyncTwoPhaseIndexer#finishWithIndexingFailure
+        // Determine whether the failure is irrecoverable (transform should go into failed state) or not (transform increments
+        // the indexing failure counter
+        // and possibly retries)
+        Throwable irrecoverableException = ExceptionRootCauseFinder.getFirstIrrecoverableExceptionFromBulkResponses(
+            deduplicatedFailures.values()
+        );
+        if (irrecoverableException == null) {
+            String failureMessage = getBulkIndexDetailedFailureMessage("Significant failures: ", deduplicatedFailures);
+            logger.debug("[{}] Bulk index experienced [{}] failures. {}", getJobId(), failureCount, failureMessage);
+
+            Exception firstException = deduplicatedFailures.values().iterator().next().getFailure().getCause();
+            nextPhase.onFailure(
+                new BulkIndexingException("Bulk index experienced [{}] failures. {}", firstException, false, failureCount, failureMessage)
+            );
+        } else {
+            deduplicatedFailures.remove(irrecoverableException.getClass().getSimpleName());
+            String failureMessage = getBulkIndexDetailedFailureMessage("Other failures: ", deduplicatedFailures);
+            irrecoverableException = decorateBulkIndexException(irrecoverableException);
+
+            logger.debug(
+                "[{}] Bulk index experienced [{}] failures and at least 1 irrecoverable [{}]. {}",
+                getJobId(),
+                failureCount,
+                ExceptionRootCauseFinder.getDetailedMessage(irrecoverableException),
+                failureMessage
+            );
+
+            nextPhase.onFailure(
+                new BulkIndexingException(
+                    "Bulk index experienced [{}] failures and at least 1 irrecoverable [{}]. {}",
+                    irrecoverableException,
+                    true,
+                    failureCount,
+                    ExceptionRootCauseFinder.getDetailedMessage(irrecoverableException),
+                    failureMessage
+                )
+            );
+        }
     }
 
     @Override

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/TransformIndexer.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/TransformIndexer.java
@@ -144,7 +144,7 @@ public abstract class TransformIndexer extends AsyncTwoPhaseIndexer<TransformInd
         this.checkpointProvider = ExceptionsHelper.requireNonNull(checkpointProvider, "checkpointProvider");
         this.auditor = transformServices.getAuditor();
         this.transformConfig = ExceptionsHelper.requireNonNull(transformConfig, "transformConfig");
-        this.progress = progress != null ? progress : new TransformProgress();
+        this.progress = transformProgress != null ? transformProgress : new TransformProgress();
         this.lastCheckpoint = ExceptionsHelper.requireNonNull(lastCheckpoint, "lastCheckpoint");
         this.nextCheckpoint = ExceptionsHelper.requireNonNull(nextCheckpoint, "nextCheckpoint");
         this.context = ExceptionsHelper.requireNonNull(context, "context");

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/TransformIndexerFailureHandlingTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/TransformIndexerFailureHandlingTests.java
@@ -749,7 +749,7 @@ public class TransformIndexerFailureHandlingTests extends ESTestCase {
         );
 
         AtomicReference<IndexerState> state = new AtomicReference<>(IndexerState.STOPPED);
-        Function<SearchRequest, SearchResponse> searchFunction = new Function<>() {
+        Function<SearchRequest, SearchResponse> searchFunction = new Function<SearchRequest, SearchResponse>() {
             final AtomicInteger calls = new AtomicInteger(0);
 
             @Override


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [ML][Transform] reset failure count when a transform aggregation page is handled successfully (#76355)