### PR TITLE
[7.14] [ML][Transform] reset failure count when a transform aggregation page is handled successfully (#76355)

### DIFF
--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/ClientTransformIndexer.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/ClientTransformIndexer.java
@@ -133,71 +133,72 @@ class ClientTransformIndexer extends TransformIndexer {
             client,
             BulkAction.INSTANCE,
             request,
-            ActionListener.wrap(bulkResponse -> {
-                if (bulkResponse.hasFailures()) {
-                    int failureCount = 0;
-                    // dedup the failures by the type of the exception, as they most likely have the same cause
-                    Map<String, BulkItemResponse> deduplicatedFailures = new LinkedHashMap<>();
-
-                    for (BulkItemResponse item : bulkResponse.getItems()) {
-                        if (item.isFailed()) {
-                            deduplicatedFailures.putIfAbsent(item.getFailure().getCause().getClass().getSimpleName(), item);
-                            failureCount++;
-                        }
-                    }
-
-                    // note: bulk failures are audited/logged in {@link TransformIndexer#handleFailure(Exception)}
-
-                    // This calls AsyncTwoPhaseIndexer#finishWithIndexingFailure
-                    // Determine whether the failure is irrecoverable (transform should go into failed state) or not (transform increments
-                    // the indexing failure counter
-                    // and possibly retries)
-                    Throwable irrecoverableException = ExceptionRootCauseFinder.getFirstIrrecoverableExceptionFromBulkResponses(
-                        deduplicatedFailures.values()
-                    );
-                    if (irrecoverableException == null) {
-                        String failureMessage = getBulkIndexDetailedFailureMessage("Significant failures: ", deduplicatedFailures);
-                        logger.debug("[{}] Bulk index experienced [{}] failures. {}", getJobId(), failureCount, failureMessage);
-
-                        Exception firstException = deduplicatedFailures.values().iterator().next().getFailure().getCause();
-                        nextPhase.onFailure(
-                            new BulkIndexingException(
-                                "Bulk index experienced [{}] failures. {}",
-                                firstException,
-                                false,
-                                failureCount,
-                                failureMessage
-                            )
-                        );
-                    } else {
-                        deduplicatedFailures.remove(irrecoverableException.getClass().getSimpleName());
-                        String failureMessage = getBulkIndexDetailedFailureMessage("Other failures: ", deduplicatedFailures);
-                        irrecoverableException = decorateBulkIndexException(irrecoverableException);
-
-                        logger.debug(
-                            "[{}] Bulk index experienced [{}] failures and at least 1 irrecoverable [{}]. {}",
-                            getJobId(),
-                            failureCount,
-                            ExceptionRootCauseFinder.getDetailedMessage(irrecoverableException),
-                            failureMessage
-                        );
-
-                        nextPhase.onFailure(
-                            new BulkIndexingException(
-                                "Bulk index experienced [{}] failures and at least 1 irrecoverable [{}]. {}",
-                                irrecoverableException,
-                                true,
-                                failureCount,
-                                ExceptionRootCauseFinder.getDetailedMessage(irrecoverableException),
-                                failureMessage
-                            )
-                        );
-                    }
-                } else {
-                    nextPhase.onResponse(bulkResponse);
-                }
-            }, nextPhase::onFailure)
+            ActionListener.wrap(bulkResponse -> handleBulkResponse(bulkResponse, nextPhase), nextPhase::onFailure)
         );
+    }
+
+    protected void handleBulkResponse(BulkResponse bulkResponse, ActionListener<BulkResponse> nextPhase) {
+        if (bulkResponse.hasFailures() == false) {
+            // We don't know the of failures that have occurred (searching, processing, indexing, etc.),
+            // but if we search, process and bulk index then we have
+            // successfully processed an entire page of the transform and should reset the counter, even if we are in the middle
+            // of a checkpoint
+            context.resetReasonAndFailureCounter();
+            nextPhase.onResponse(bulkResponse);
+            return;
+        }
+        int failureCount = 0;
+        // dedup the failures by the type of the exception, as they most likely have the same cause
+        Map<String, BulkItemResponse> deduplicatedFailures = new LinkedHashMap<>();
+
+        for (BulkItemResponse item : bulkResponse.getItems()) {
+            if (item.isFailed()) {
+                deduplicatedFailures.putIfAbsent(item.getFailure().getCause().getClass().getSimpleName(), item);
+                failureCount++;
+            }
+        }
+
+        // note: bulk failures are audited/logged in {@link TransformIndexer#handleFailure(Exception)}
+
+        // This calls AsyncTwoPhaseIndexer#finishWithIndexingFailure
+        // Determine whether the failure is irrecoverable (transform should go into failed state) or not (transform increments
+        // the indexing failure counter
+        // and possibly retries)
+        Throwable irrecoverableException = ExceptionRootCauseFinder.getFirstIrrecoverableExceptionFromBulkResponses(
+            deduplicatedFailures.values()
+        );
+        if (irrecoverableException == null) {
+            String failureMessage = getBulkIndexDetailedFailureMessage("Significant failures: ", deduplicatedFailures);
+            logger.debug("[{}] Bulk index experienced [{}] failures. {}", getJobId(), failureCount, failureMessage);
+
+            Exception firstException = deduplicatedFailures.values().iterator().next().getFailure().getCause();
+            nextPhase.onFailure(
+                new BulkIndexingException("Bulk index experienced [{}] failures. {}", firstException, false, failureCount, failureMessage)
+            );
+        } else {
+            deduplicatedFailures.remove(irrecoverableException.getClass().getSimpleName());
+            String failureMessage = getBulkIndexDetailedFailureMessage("Other failures: ", deduplicatedFailures);
+            irrecoverableException = decorateBulkIndexException(irrecoverableException);
+
+            logger.debug(
+                "[{}] Bulk index experienced [{}] failures and at least 1 irrecoverable [{}]. {}",
+                getJobId(),
+                failureCount,
+                ExceptionRootCauseFinder.getDetailedMessage(irrecoverableException),
+                failureMessage
+            );
+
+            nextPhase.onFailure(
+                new BulkIndexingException(
+                    "Bulk index experienced [{}] failures and at least 1 irrecoverable [{}]. {}",
+                    irrecoverableException,
+                    true,
+                    failureCount,
+                    ExceptionRootCauseFinder.getDetailedMessage(irrecoverableException),
+                    failureMessage
+                )
+            );
+        }
     }
 
     @Override

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/ClientTransformIndexer.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/ClientTransformIndexer.java
@@ -65,7 +65,7 @@ class ClientTransformIndexer extends TransformIndexer {
 
     private final AtomicReference<SeqNoPrimaryTermAndIndex> seqNoPrimaryTermAndIndex;
 
-    protected ClientTransformIndexer(
+    ClientTransformIndexer(
         ThreadPool threadPool,
         TransformConfigManager transformsConfigManager,
         CheckpointProvider checkpointProvider,

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/ClientTransformIndexer.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/ClientTransformIndexer.java
@@ -65,7 +65,7 @@ class ClientTransformIndexer extends TransformIndexer {
 
     private final AtomicReference<SeqNoPrimaryTermAndIndex> seqNoPrimaryTermAndIndex;
 
-    ClientTransformIndexer(
+    protected ClientTransformIndexer(
         ThreadPool threadPool,
         TransformConfigManager transformsConfigManager,
         CheckpointProvider checkpointProvider,

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/TransformIndexerFailureHandlingTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/TransformIndexerFailureHandlingTests.java
@@ -99,7 +99,7 @@ public class TransformIndexerFailureHandlingTests extends ESTestCase {
         // used for synchronizing with the test
         private CountDownLatch latch;
 
-        MockedTransformIndexer(
+        protected MockedTransformIndexer(
             ThreadPool threadPool,
             String executorName,
             IndexBasedTransformConfigManager transformsConfigManager,
@@ -119,11 +119,10 @@ public class TransformIndexerFailureHandlingTests extends ESTestCase {
                 threadPool,
                 transformsConfigManager,
                 checkpointProvider,
-                auditor,
-                transformConfig,
                 initialState,
                 initialPosition,
                 mock(Client.class),
+                auditor,
                 jobStats,
                 transformConfig,
                 /* TransformProgress */ null,
@@ -745,7 +744,7 @@ public class TransformIndexerFailureHandlingTests extends ESTestCase {
         );
 
         AtomicReference<IndexerState> state = new AtomicReference<>(IndexerState.STOPPED);
-        Function<SearchRequest, SearchResponse> searchFunction = new Function<>() {
+        Function<SearchRequest, SearchResponse> searchFunction = new Function<SearchRequest, SearchResponse>() {
             final AtomicInteger calls = new AtomicInteger(0);
 
             @Override

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/TransformIndexerFailureHandlingTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/TransformIndexerFailureHandlingTests.java
@@ -50,6 +50,7 @@ import org.elasticsearch.xpack.transform.checkpoint.CheckpointProvider;
 import org.elasticsearch.xpack.transform.notifications.MockTransformAuditor;
 import org.elasticsearch.xpack.transform.notifications.TransformAuditor;
 import org.elasticsearch.xpack.transform.persistence.IndexBasedTransformConfigManager;
+import org.elasticsearch.xpack.transform.persistence.SeqNoPrimaryTermAndIndex;
 import org.junit.After;
 import org.junit.Before;
 
@@ -60,6 +61,7 @@ import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -86,7 +88,7 @@ public class TransformIndexerFailureHandlingTests extends ESTestCase {
     private Client client;
     private ThreadPool threadPool;
 
-    class MockedTransformIndexer extends TransformIndexer {
+    static class MockedTransformIndexer extends ClientTransformIndexer {
 
         private final Function<SearchRequest, SearchResponse> searchFunction;
         private final Function<BulkRequest, BulkResponse> bulkFunction;
@@ -121,11 +123,15 @@ public class TransformIndexerFailureHandlingTests extends ESTestCase {
                 transformConfig,
                 initialState,
                 initialPosition,
+                mock(Client.class),
                 jobStats,
+                transformConfig,
                 /* TransformProgress */ null,
                 TransformCheckpoint.EMPTY,
                 TransformCheckpoint.EMPTY,
-                context
+                new SeqNoPrimaryTermAndIndex(1, 1, "foo"),
+                context,
+                false
             );
             this.searchFunction = searchFunction;
             this.bulkFunction = bulkFunction;
@@ -180,7 +186,7 @@ public class TransformIndexerFailureHandlingTests extends ESTestCase {
 
             try {
                 BulkResponse response = bulkFunction.apply(request);
-                nextPhase.onResponse(response);
+                super.handleBulkResponse(response, nextPhase);
             } catch (Exception e) {
                 nextPhase.onFailure(e);
             }
@@ -245,7 +251,7 @@ public class TransformIndexerFailureHandlingTests extends ESTestCase {
         }
 
         @Override
-        void doDeleteByQuery(DeleteByQueryRequest deleteByQueryRequest, ActionListener<BulkByScrollResponse> responseListener) {
+        protected void doDeleteByQuery(DeleteByQueryRequest deleteByQueryRequest, ActionListener<BulkByScrollResponse> responseListener) {
             try {
                 BulkByScrollResponse response = deleteByQueryFunction.apply(deleteByQueryRequest);
                 responseListener.onResponse(response);
@@ -255,7 +261,7 @@ public class TransformIndexerFailureHandlingTests extends ESTestCase {
         }
 
         @Override
-        void refreshDestinationIndex(ActionListener<RefreshResponse> responseListener) {
+        protected void refreshDestinationIndex(ActionListener<RefreshResponse> responseListener) {
             responseListener.onResponse(new RefreshResponse(1, 1, 0, Collections.emptyList()));
         }
 
@@ -698,6 +704,116 @@ public class TransformIndexerFailureHandlingTests extends ESTestCase {
         assertThat(indexer.getState(), equalTo(IndexerState.STARTED));
         auditor.assertAllExpectationsMatched();
         assertEquals(1, context.getFailureCount());
+    }
+
+    public void testFailureCounterIsResetOnSuccess() throws Exception {
+        String transformId = randomAlphaOfLength(10);
+        TransformConfig config = new TransformConfig(
+            transformId,
+            randomSourceConfig(),
+            randomDestConfig(),
+            null,
+            null,
+            null,
+            randomPivotConfig(),
+            null,
+            randomBoolean() ? null : randomAlphaOfLengthBetween(1, 1000),
+            null,
+            null,
+            null,
+            null
+        );
+
+        final SearchResponse searchResponse = new SearchResponse(
+            new InternalSearchResponse(
+                new SearchHits(new SearchHit[] { new SearchHit(1) }, new TotalHits(1L, TotalHits.Relation.EQUAL_TO), 1.0f),
+                // Simulate completely null aggs
+                null,
+                new Suggest(Collections.emptyList()),
+                new SearchProfileShardResults(Collections.emptyMap()),
+                false,
+                false,
+                1
+            ),
+            "",
+            1,
+            1,
+            0,
+            0,
+            ShardSearchFailure.EMPTY_ARRAY,
+            SearchResponse.Clusters.EMPTY
+        );
+
+        AtomicReference<IndexerState> state = new AtomicReference<>(IndexerState.STOPPED);
+        Function<SearchRequest, SearchResponse> searchFunction = new Function<>() {
+            final AtomicInteger calls = new AtomicInteger(0);
+
+            @Override
+            public SearchResponse apply(SearchRequest searchRequest) {
+                int call = calls.getAndIncrement();
+                if (call == 0) {
+                    throw new SearchPhaseExecutionException(
+                        "query",
+                        "Partial shards failure",
+                        new ShardSearchFailure[] { new ShardSearchFailure(new Exception()) }
+                    );
+                }
+                return searchResponse;
+            }
+        };
+
+        Function<BulkRequest, BulkResponse> bulkFunction = request -> new BulkResponse(new BulkItemResponse[0], 1);
+
+        final AtomicBoolean failIndexerCalled = new AtomicBoolean(false);
+        final AtomicReference<String> failureMessage = new AtomicReference<>();
+        Consumer<String> failureConsumer = message -> {
+            failIndexerCalled.compareAndSet(false, true);
+            failureMessage.compareAndSet(null, message);
+        };
+
+        MockTransformAuditor auditor = MockTransformAuditor.createMockAuditor();
+        TransformContext.Listener contextListener = mock(TransformContext.Listener.class);
+        TransformContext context = new TransformContext(TransformTaskState.STARTED, "", 0, contextListener);
+
+        MockedTransformIndexer indexer = createMockIndexer(
+            config,
+            state,
+            searchFunction,
+            bulkFunction,
+            null,
+            failureConsumer,
+            threadPool,
+            ThreadPool.Names.GENERIC,
+            auditor,
+            context
+        );
+
+        final CountDownLatch latch = indexer.newLatch(1);
+
+        indexer.start();
+        assertThat(indexer.getState(), equalTo(IndexerState.STARTED));
+        assertTrue(indexer.maybeTriggerAsyncJob(System.currentTimeMillis()));
+        assertThat(indexer.getState(), equalTo(IndexerState.INDEXING));
+
+        latch.countDown();
+        assertBusy(() -> assertThat(indexer.getState(), equalTo(IndexerState.STARTED)), 10, TimeUnit.SECONDS);
+        assertFalse(failIndexerCalled.get());
+        assertThat(indexer.getState(), equalTo(IndexerState.STARTED));
+        assertEquals(1, context.getFailureCount());
+
+        final CountDownLatch secondLatch = indexer.newLatch(1);
+
+        indexer.start();
+        assertThat(indexer.getState(), equalTo(IndexerState.STARTED));
+        assertTrue(indexer.maybeTriggerAsyncJob(System.currentTimeMillis()));
+        assertThat(indexer.getState(), equalTo(IndexerState.INDEXING));
+
+        secondLatch.countDown();
+        assertBusy(() -> assertThat(indexer.getState(), equalTo(IndexerState.STARTED)), 10, TimeUnit.SECONDS);
+        assertFalse(failIndexerCalled.get());
+        assertThat(indexer.getState(), equalTo(IndexerState.STARTED));
+        auditor.assertAllExpectationsMatched();
+        assertEquals(0, context.getFailureCount());
     }
 
     private MockedTransformIndexer createMockIndexer(


### PR DESCRIPTION
Backports the following commits to 7.14:
 - [ML][Transform] reset failure count when a transform aggregation page is handled successfully (#76355)