### PR TITLE
[7.x] Fix copyCurentStructure(MapXContentParser) (#76357)

### DIFF
--- a/libs/x-content/src/main/java/org/elasticsearch/common/xcontent/support/MapXContentParser.java
+++ b/libs/x-content/src/main/java/org/elasticsearch/common/xcontent/support/MapXContentParser.java
@@ -163,7 +163,7 @@ public class MapXContentParser extends AbstractXContentParser {
 
     @Override
     public boolean hasTextCharacters() {
-        throw new UnsupportedOperationException("use text() instead");
+        return false;
     }
 
     @Override

--- a/libs/x-content/src/test/java/org/elasticsearch/common/xcontent/MapXContentParserTests.java
+++ b/libs/x-content/src/test/java/org/elasticsearch/common/xcontent/MapXContentParserTests.java
@@ -71,7 +71,7 @@ public class MapXContentParserTests extends ESTestCase {
             new MapXContentParser(
                 xContentRegistry(),
                 LoggingDeprecationHandler.INSTANCE,
-                Map.of("a", "b"),
+                org.elasticsearch.core.Map.of("a", "b"),
                 randomFrom(XContentType.values())
             ).hasTextCharacters()
         );
@@ -82,7 +82,7 @@ public class MapXContentParserTests extends ESTestCase {
             XContentParser parser = new MapXContentParser(
                 xContentRegistry(),
                 LoggingDeprecationHandler.INSTANCE,
-                Map.of("a", "b"),
+                org.elasticsearch.core.Map.of("a", "b"),
                 randomFrom(XContentType.values())
             )
         ) {
@@ -90,7 +90,7 @@ public class MapXContentParserTests extends ESTestCase {
                 XContentBuilder builder = JsonXContent.contentBuilder().copyCurrentStructure(parser);
                 XContentParser copied = createParser(builder)
             ) {
-                assertEquals(copied.map(), Map.of("a", "b"));
+                assertEquals(copied.map(), org.elasticsearch.core.Map.of("a", "b"));
             }
         }
     }

--- a/libs/x-content/src/test/java/org/elasticsearch/common/xcontent/MapXContentParserTests.java
+++ b/libs/x-content/src/test/java/org/elasticsearch/common/xcontent/MapXContentParserTests.java
@@ -10,6 +10,7 @@ package org.elasticsearch.common.xcontent;
 
 import org.elasticsearch.core.CheckedConsumer;
 import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.xcontent.json.JsonXContent;
 import org.elasticsearch.common.xcontent.support.MapXContentParser;
 import org.elasticsearch.test.ESTestCase;
 
@@ -57,19 +58,51 @@ public class MapXContentParserTests extends ESTestCase {
         });
     }
 
-
     public void testRandomObject() throws IOException {
         compareTokens(builder -> generateRandomObject(builder, randomIntBetween(0, 10)));
     }
 
-    public void compareTokens(CheckedConsumer<XContentBuilder, IOException> consumer) throws IOException {
+    /**
+     * Assert that {@link XContentParser#hasTextCharacters()} returns false because
+     * we don't support {@link XContentParser#textCharacters()}.
+     */
+    public void testHasTextCharacters() throws IOException {
+        assertFalse(
+            new MapXContentParser(
+                xContentRegistry(),
+                LoggingDeprecationHandler.INSTANCE,
+                Map.of("a", "b"),
+                randomFrom(XContentType.values())
+            ).hasTextCharacters()
+        );
+    }
+
+    public void testCopyCurrentStructure() throws IOException {
+        try (
+            XContentParser parser = new MapXContentParser(
+                xContentRegistry(),
+                LoggingDeprecationHandler.INSTANCE,
+                Map.of("a", "b"),
+                randomFrom(XContentType.values())
+            )
+        ) {
+            try (
+                XContentBuilder builder = JsonXContent.contentBuilder().copyCurrentStructure(parser);
+                XContentParser copied = createParser(builder)
+            ) {
+                assertEquals(copied.map(), Map.of("a", "b"));
+            }
+        }
+    }
+
+    private void compareTokens(CheckedConsumer<XContentBuilder, IOException> consumer) throws IOException {
         for (XContentType xContentType : EnumSet.allOf(XContentType.class)) {
             logger.info("--> testing with xcontent type: {}", xContentType);
             compareTokens(consumer, xContentType);
         }
     }
 
-    public void compareTokens(CheckedConsumer<XContentBuilder, IOException> consumer, XContentType xContentType) throws IOException {
+    private void compareTokens(CheckedConsumer<XContentBuilder, IOException> consumer, XContentType xContentType) throws IOException {
         try (XContentBuilder builder = XContentBuilder.builder(xContentType.xContent())) {
             consumer.accept(builder);
             final Map<String, Object> map;


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Fix copyCurentStructure(MapXContentParser) (#76357)