### PR TITLE
Fix eclipse compilation of hasValue

### DIFF
--- a/server/src/main/java/org/elasticsearch/search/aggregations/support/AggregationInspectionHelper.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/support/AggregationInspectionHelper.java
@@ -134,7 +134,7 @@ public class AggregationInspectionHelper {
         return agg.getDocCount() > 0;
     }
 
-    public static <B extends InternalRange.Bucket, R extends InternalRange<B, R>> boolean hasValue(InternalRange<B, R> agg) {
+    public static boolean hasValue(InternalRange<?, ?> agg) {
         return agg.getBuckets().stream().anyMatch(bucket -> bucket.getDocCount() > 0);
     }
 
@@ -142,8 +142,7 @@ public class AggregationInspectionHelper {
         return agg.getDocCount() > 0;
     }
 
-    public static <A extends InternalSignificantTerms<A, B>,
-        B extends InternalSignificantTerms.Bucket<B>> boolean hasValue(InternalSignificantTerms<A, B> agg) {
+    public static boolean hasValue(InternalSignificantTerms<?, ?> agg) {
         return agg.getBuckets().stream().anyMatch(bucket -> bucket.getDocCount() > 0);
     }
 


### PR DESCRIPTION
In #76302 we removed a few warnings in a way that javac was happy with
but confused Eclipse. This makes eclipse happy by dropping our overly
strict bounds in `AggregationInspectionHelper`. We really weren't using
any of the type bounds we'd declared there at all.
