### PR TITLE
[7.x] Configurable media_type for mustache template encoding on append processor

### DIFF
--- a/docs/reference/ingest/processors/append.asciidoc
+++ b/docs/reference/ingest/processors/append.asciidoc
@@ -15,10 +15,13 @@ Accepts a single value or an array of values.
 [options="header"]
 |======
 | Name      | Required  | Default  | Description
-| `field`  | yes       | -        | The field to be appended to. Supports <<template-snippets,template snippets>>.
-| `value`  | yes       | -        | The value to be appended. Supports <<template-snippets,template snippets>>.
+| `field`   | yes       | -        | The field to be appended to. Supports <<template-snippets,template snippets>>.
+| `value`   | yes       | -        | The value to be appended. Supports <<template-snippets,template snippets>>.
 | `allow_duplicates` | no | true  | If `false`, the processor does not append
 values already present in the field.
+| `media_type` | no | `application/json` | The media type for encoding `value`. Applies only when `value` is a
+<<template-snippets,template snippet>>. Must be one of `application/json`, `text/plain`, or
+`application/x-www-form-urlencoded`.
 include::common-options.asciidoc[]
 |======
 

--- a/modules/ingest-common/src/main/java/org/elasticsearch/ingest/common/AppendProcessor.java
+++ b/modules/ingest-common/src/main/java/org/elasticsearch/ingest/common/AppendProcessor.java
@@ -78,7 +78,7 @@ public final class AppendProcessor extends AbstractProcessor {
                 processorTag,
                 description,
                 compiledTemplate,
-                ValueSource.wrap(value, scriptService, Map.of(Script.CONTENT_TYPE_OPTION, mediaType)),
+                ValueSource.wrap(value, scriptService, org.elasticsearch.core.Map.of(Script.CONTENT_TYPE_OPTION, mediaType)),
                 allowDuplicates
             );
         }

--- a/modules/ingest-common/src/main/java/org/elasticsearch/ingest/common/AppendProcessor.java
+++ b/modules/ingest-common/src/main/java/org/elasticsearch/ingest/common/AppendProcessor.java
@@ -13,6 +13,7 @@ import org.elasticsearch.ingest.ConfigurationUtils;
 import org.elasticsearch.ingest.IngestDocument;
 import org.elasticsearch.ingest.Processor;
 import org.elasticsearch.ingest.ValueSource;
+import org.elasticsearch.script.Script;
 import org.elasticsearch.script.ScriptService;
 import org.elasticsearch.script.TemplateScript;
 
@@ -71,10 +72,15 @@ public final class AppendProcessor extends AbstractProcessor {
             String field = ConfigurationUtils.readStringProperty(TYPE, processorTag, config, "field");
             Object value = ConfigurationUtils.readObject(TYPE, processorTag, config, "value");
             boolean allowDuplicates = ConfigurationUtils.readBooleanProperty(TYPE, processorTag, config, "allow_duplicates", true);
-            TemplateScript.Factory compiledTemplate = ConfigurationUtils.compileTemplate(TYPE, processorTag,
-                "field", field, scriptService);
-            return new AppendProcessor(processorTag, description, compiledTemplate, ValueSource.wrap(value, scriptService),
-                allowDuplicates);
+            TemplateScript.Factory compiledTemplate = ConfigurationUtils.compileTemplate(TYPE, processorTag, "field", field, scriptService);
+            String mediaType = ConfigurationUtils.readMediaTypeProperty(TYPE, processorTag, config, "media_type", "application/json");
+            return new AppendProcessor(
+                processorTag,
+                description,
+                compiledTemplate,
+                ValueSource.wrap(value, scriptService, Map.of(Script.CONTENT_TYPE_OPTION, mediaType)),
+                allowDuplicates
+            );
         }
     }
 }


### PR DESCRIPTION
Adds the same capability to the append processor that was added to the set processor in #65314.

Backport of #76210
