### PR TITLE
Fix TransportFieldCapabilitiesAction Blocking Transport Thread (#75022) (#75081)

### DIFF
--- a/x-pack/plugin/eql/src/internalClusterTest/java/org/elasticsearch/xpack/eql/action/AbstractEqlBlockingIntegTestCase.java
+++ b/x-pack/plugin/eql/src/internalClusterTest/java/org/elasticsearch/xpack/eql/action/AbstractEqlBlockingIntegTestCase.java
@@ -209,18 +209,8 @@ public abstract class AbstractEqlBlockingIntegTestCase extends AbstractEqlIntegT
                             }
                             logger.trace("unblocking field caps on " + nodeId);
                         };
-                        final Thread originalThread = Thread.currentThread();
                         chain.proceed(task, action, request,
-                            ActionListener.wrap(
-                                resp -> {
-                                    if (originalThread == Thread.currentThread()) {
-                                        // async if we never exited the original thread
-                                        executorService.execute(() -> actionWrapper.accept(resp));
-                                    } else {
-                                        actionWrapper.accept(resp);
-                                    }
-                                },
-                                listener::onFailure)
+                            ActionListener.wrap(resp -> executorService.execute(() -> actionWrapper.accept(resp)), listener::onFailure)
                         );
                     } else {
                         chain.proceed(task, action, request, listener);

--- a/x-pack/plugin/sql/src/internalClusterTest/java/org/elasticsearch/xpack/sql/action/AbstractSqlBlockingIntegTestCase.java
+++ b/x-pack/plugin/sql/src/internalClusterTest/java/org/elasticsearch/xpack/sql/action/AbstractSqlBlockingIntegTestCase.java
@@ -227,18 +227,8 @@ public abstract class AbstractSqlBlockingIntegTestCase extends ESIntegTestCase {
                             }
                             logger.trace("unblocking field caps on " + nodeId);
                         };
-                        final Thread originalThread = Thread.currentThread();
                         chain.proceed(task, action, request,
-                            ActionListener.wrap(
-                                resp -> {
-                                    if (originalThread == Thread.currentThread()) {
-                                        // async if we never exited the original thread
-                                        executorService.execute(() -> actionWrapper.accept(resp));
-                                    } else {
-                                        actionWrapper.accept(resp);
-                                    }
-                                },
-                                listener::onFailure)
+                            ActionListener.wrap(resp -> executorService.execute(() -> actionWrapper.accept(resp)), listener::onFailure)
                         );
                     } else {
                         chain.proceed(task, action, request, listener);


### PR DESCRIPTION
Running a request per index could take a very long time here if the request covers
a larger number of shards (especially when security is enabled).
Forking it to the management pool saves the transport thread from getting blocked.
Also, to make this request run quicker (again especially with security enabled)
I removed the redundant index-level request fan-out here as well to save one step
of redundant request handling and authorization (the shard level request is authorized
separately again anyway). In a follow-up to 8.x because of 7.x BwC issues, we can
refactor away the redundant  index-level fan out as well.

backport of #75022 