### PR TITLE
[7.x] Use version-specific documentation link in jvm.options file (#76323)

### DIFF
--- a/distribution/build.gradle
+++ b/distribution/build.gradle
@@ -9,10 +9,10 @@
 
 import org.apache.tools.ant.filters.FixCrLfFilter
 import org.apache.tools.ant.filters.ReplaceTokens
+import org.elasticsearch.gradle.VersionProperties
 import org.elasticsearch.gradle.internal.ConcatFilesTask
 import org.elasticsearch.gradle.internal.DependenciesInfoTask
 import org.elasticsearch.gradle.internal.NoticeTask
-import org.elasticsearch.gradle.VersionProperties
 import org.elasticsearch.gradle.internal.info.BuildParams
 
 import java.nio.file.Files
@@ -487,6 +487,7 @@ subprojects {
     Map<String, Object> expansions = [
       'project.name': project.name,
       'project.version': version,
+      'project.minor.version': "${VersionProperties.elasticsearchVersion.major}.${VersionProperties.elasticsearchVersion.minor}",
 
       'path.conf': [
         'deb': '/etc/elasticsearch',

--- a/distribution/src/config/jvm.options
+++ b/distribution/src/config/jvm.options
@@ -9,7 +9,7 @@
 ## should create one or more files in the jvm.options.d
 ## directory containing your adjustments.
 ##
-## See https://www.elastic.co/guide/en/elasticsearch/reference/current/jvm-options.html
+## See https://www.elastic.co/guide/en/elasticsearch/reference/@project.minor.version@/jvm-options.html
 ## for more information.
 ##
 ################################################################
@@ -31,7 +31,7 @@
 ## -Xms4g
 ## -Xmx4g
 ##
-## See https://www.elastic.co/guide/en/elasticsearch/reference/current/heap-size.html
+## See https://www.elastic.co/guide/en/elasticsearch/reference/@project.minor.version@/heap-size.html
 ## for more information
 ##
 ################################################################


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Use version-specific documentation link in jvm.options file (#76323)