### PR TITLE
[7.x] Fix generation of javadocs (#76382)

### DIFF
--- a/modules/lang-painless/build.gradle
+++ b/modules/lang-painless/build.gradle
@@ -57,7 +57,7 @@ tasks.named("test").configure {
  * Painless plugin */
 tasks.register("apiJavadoc", Javadoc) {
   source = sourceSets.main.allJava
-  classpath = sourceSets.main.runtimeClasspath + configurations.spi.classpath
+  classpath = sourceSets.main.compileClasspath + sourceSets.main.output
   include '**/org/elasticsearch/painless/api/'
   destinationDir = new File(docsDir, 'apiJavadoc')
 }
@@ -68,6 +68,9 @@ tasks.register("apiJavadocJar", Jar) {
 }
 
 tasks.named("assemble").configure {
+  dependsOn "apiJavadocJar"
+}
+tasks.named("check").configure {
   dependsOn "apiJavadocJar"
 }
 


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Fix generation of javadocs (#76382)