### PR TITLE
set a specific shard id to force merge and clean commit logs.

### DIFF
--- a/docs/reference/indices/forcemerge.asciidoc
+++ b/docs/reference/indices/forcemerge.asciidoc
@@ -118,6 +118,18 @@ Defaults to checking if a merge needs to execute.
 If so, executes it.
 --
 
+`shard_id`::
++
+--
+(Optional, integer)
+The Id of shard to merge to.
+To fully merge a specific shard of indices,
+set it to `Shard Id`.
+
+Defaults to force merge all shard of indices.
+If so, executes it.
+--
+
 `only_expunge_deletes`::
 +
 --

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/forcemerge/ForceMergeRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/forcemerge/ForceMergeRequest.java
@@ -38,11 +38,13 @@ public class ForceMergeRequest extends BroadcastRequest<ForceMergeRequest> {
         public static final int MAX_NUM_SEGMENTS = -1;
         public static final boolean ONLY_EXPUNGE_DELETES = false;
         public static final boolean FLUSH = true;
+        public static final int SHARD_ID = -1;
     }
 
     private int maxNumSegments = Defaults.MAX_NUM_SEGMENTS;
     private boolean onlyExpungeDeletes = Defaults.ONLY_EXPUNGE_DELETES;
     private boolean flush = Defaults.FLUSH;
+    private int shardId = Defaults.SHARD_ID;
 
     private static final Version FORCE_MERGE_UUID_SIMPLE_VERSION = Version.V_8_0_0;
 
@@ -67,6 +69,7 @@ public class ForceMergeRequest extends BroadcastRequest<ForceMergeRequest> {
         maxNumSegments = in.readInt();
         onlyExpungeDeletes = in.readBoolean();
         flush = in.readBoolean();
+        shardId = in.readInt();
         if (in.getVersion().onOrAfter(FORCE_MERGE_UUID_SIMPLE_VERSION)) {
             forceMergeUUID = in.readString();
         } else {
@@ -89,6 +92,23 @@ public class ForceMergeRequest extends BroadcastRequest<ForceMergeRequest> {
      */
     public ForceMergeRequest maxNumSegments(int maxNumSegments) {
         this.maxNumSegments = maxNumSegments;
+        return this;
+    }
+
+    /**
+     * Will merge the specific shard of index down to &lt;= maxNumSegments. By default, will cause the merge
+     * process to merge down to half the configured number of segments.
+     */
+    public int shardId() {
+        return shardId;
+    }
+
+    /**
+     * Will merge the specific shard of index down to &lt;= maxNumSegments. By default, will cause the merge
+     * process to merge down to half the configured number of segments.
+     */
+    public ForceMergeRequest shardId(int shardId) {
+        this.shardId = shardId;
         return this;
     }
 
@@ -135,6 +155,7 @@ public class ForceMergeRequest extends BroadcastRequest<ForceMergeRequest> {
     public String getDescription() {
         return "Force-merge indices " + Arrays.toString(indices()) +
             ", maxSegments[" + maxNumSegments +
+            "], shardId[" + shardId +
             "], onlyExpungeDeletes[" + onlyExpungeDeletes +
             "], flush[" + flush + "]";
     }
@@ -145,6 +166,7 @@ public class ForceMergeRequest extends BroadcastRequest<ForceMergeRequest> {
         out.writeInt(maxNumSegments);
         out.writeBoolean(onlyExpungeDeletes);
         out.writeBoolean(flush);
+        out.writeInt(shardId);
         if (out.getVersion().onOrAfter(FORCE_MERGE_UUID_SIMPLE_VERSION)) {
             out.writeString(forceMergeUUID);
         } else {
@@ -166,6 +188,7 @@ public class ForceMergeRequest extends BroadcastRequest<ForceMergeRequest> {
     public String toString() {
         return "ForceMergeRequest{" +
                 "maxNumSegments=" + maxNumSegments +
+                ", shardId=" + shardId +
                 ", onlyExpungeDeletes=" + onlyExpungeDeletes +
                 ", flush=" + flush +
                 '}';

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/forcemerge/ForceMergeRequestBuilder.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/forcemerge/ForceMergeRequestBuilder.java
@@ -36,6 +36,16 @@ public class ForceMergeRequestBuilder
     }
 
     /**
+     * Will force merge the specific shard of index down to &lt;= maxNumSegments. By default, will
+     * cause the merge process to merge down to half the configured number of
+     * segments.
+     */
+    public ForceMergeRequestBuilder setShardId(int shardId) {
+        request.shardId(shardId);
+        return this;
+    }
+
+    /**
      * Should the merge only expunge deletes from the index, without full merging.
      * Defaults to full merging ({@code false}).
      */

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/forcemerge/TransportForceMergeAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/forcemerge/TransportForceMergeAction.java
@@ -73,9 +73,11 @@ public class TransportForceMergeAction
         assert (task instanceof CancellableTask) == false; // TODO: add cancellation handling here once the task supports it
         threadPool.executor(ThreadPool.Names.FORCE_MERGE).execute(ActionRunnable.supply(listener,
             () -> {
-                IndexShard indexShard = indicesService.indexServiceSafe(shardRouting.shardId().getIndex())
-                    .getShard(shardRouting.shardId().id());
-                indexShard.forceMerge(request);
+                if ( request.shardId() == -1 || request.shardId() == shardRouting.shardId().id() ) {
+                    IndexShard indexShard = indicesService.indexServiceSafe(shardRouting.shardId().getIndex())
+                        .getShard(shardRouting.shardId().id());
+                    indexShard.forceMerge(request);
+                }
                 return EmptyResult.INSTANCE;
             }));
     }

--- a/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestForceMergeAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestForceMergeAction.java
@@ -42,6 +42,7 @@ public class RestForceMergeAction extends BaseRestHandler {
         mergeRequest.maxNumSegments(request.paramAsInt("max_num_segments", mergeRequest.maxNumSegments()));
         mergeRequest.onlyExpungeDeletes(request.paramAsBoolean("only_expunge_deletes", mergeRequest.onlyExpungeDeletes()));
         mergeRequest.flush(request.paramAsBoolean("flush", mergeRequest.flush()));
+        mergeRequest.shardId(request.paramAsInt("shard_id", mergeRequest.shardId()));
         return channel -> client.admin().indices().forceMerge(mergeRequest, new RestToXContentListener<>(channel));
     }
 

--- a/server/src/test/java/org/elasticsearch/action/admin/indices/forcemerge/ForceMergeRequestTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/forcemerge/ForceMergeRequestTests.java
@@ -21,15 +21,18 @@ public class ForceMergeRequestTests extends ESTestCase {
         final boolean flush = randomBoolean();
         final boolean onlyExpungeDeletes = randomBoolean();
         final int maxNumSegments = randomIntBetween(ForceMergeRequest.Defaults.MAX_NUM_SEGMENTS, 100);
+        final int shardId = randomIntBetween(ForceMergeRequest.Defaults.SHARD_ID, 100);
 
         final ForceMergeRequest request = new ForceMergeRequest();
         request.flush(flush);
         request.onlyExpungeDeletes(onlyExpungeDeletes);
         request.maxNumSegments(maxNumSegments);
+        request.shardId(shardId);
 
         assertThat(request.flush(), equalTo(flush));
         assertThat(request.onlyExpungeDeletes(), equalTo(onlyExpungeDeletes));
         assertThat(request.maxNumSegments(), equalTo(maxNumSegments));
+        assertThat(request.shardId(), equalTo(shardId));
 
         ActionRequestValidationException validation = request.validate();
         if (onlyExpungeDeletes && maxNumSegments != ForceMergeRequest.Defaults.MAX_NUM_SEGMENTS) {
@@ -43,15 +46,16 @@ public class ForceMergeRequestTests extends ESTestCase {
 
     public void testDescription() {
         ForceMergeRequest request = new ForceMergeRequest();
-        assertEquals("Force-merge indices [], maxSegments[-1], onlyExpungeDeletes[false], flush[true]", request.getDescription());
+        assertEquals("Force-merge indices [], maxSegments[-1], shardId[-1], onlyExpungeDeletes[false], flush[true]", request.getDescription());
 
         request = new ForceMergeRequest("shop", "blog");
-        assertEquals("Force-merge indices [shop, blog], maxSegments[-1], onlyExpungeDeletes[false], flush[true]", request.getDescription());
+        assertEquals("Force-merge indices [shop, blog], maxSegments[-1], shardId[-1], onlyExpungeDeletes[false], flush[true]", request.getDescription());
 
         request = new ForceMergeRequest();
         request.maxNumSegments(12);
+        request.shardId(12);
         request.onlyExpungeDeletes(true);
         request.flush(false);
-        assertEquals("Force-merge indices [], maxSegments[12], onlyExpungeDeletes[true], flush[false]", request.getDescription());
+        assertEquals("Force-merge indices [], maxSegments[12], shardId[12], onlyExpungeDeletes[true], flush[false]", request.getDescription());
     }
 }


### PR DESCRIPTION
This is force merge about a specific shard of index using _routing.

When we use _routing, a specific shard increase a lot of segment files and shard size.

I think, it doesn't need to force merge all shard of index.

Thanks.

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/elasticsearch/blob/master/CONTRIBUTING.md)?
- If submitting code, have you built your formula locally prior to submission with `gradle check`?
- If submitting code, is your pull request against master? Unless there is a good reason otherwise, we prefer pull requests against master and will backport as needed.
- If submitting code, have you checked that your submission is for an [OS and architecture that we support](https://www.elastic.co/support/matrix#show_os)?
- If you are submitting this code for a class then read our [policy](https://github.com/elastic/elasticsearch/blob/master/CONTRIBUTING.md#contributing-as-part-of-a-class) for that.
