### PR TITLE
[7.x] Remove unused CollectionUtils methods (#76387)

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/logging/Loggers.java
+++ b/server/src/main/java/org/elasticsearch/common/logging/Loggers.java
@@ -20,9 +20,9 @@ import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.index.shard.ShardId;
 
+import java.util.Arrays;
 import java.util.Map;
-
-import static org.elasticsearch.common.util.CollectionUtils.asArrayList;
+import java.util.stream.Stream;
 
 /**
  * A set of utilities around Logging.
@@ -38,7 +38,8 @@ public class Loggers {
             Setting.Property.NodeScope));
 
     public static Logger getLogger(Class<?> clazz, ShardId shardId, String... prefixes) {
-        return getLogger(clazz, shardId.getIndex(), asArrayList(Integer.toString(shardId.id()), prefixes).toArray(new String[0]));
+        return getLogger(clazz, shardId.getIndex(), Stream.concat(Stream.of(Integer.toString(shardId.id())),
+            Arrays.stream(prefixes)).toArray(String[]::new));
     }
 
     /**
@@ -51,7 +52,7 @@ public class Loggers {
     }
 
     public static Logger getLogger(Class<?> clazz, Index index, String... prefixes) {
-        return getLogger(clazz, asArrayList(Loggers.SPACE, index.getName(), prefixes).toArray(new String[0]));
+        return getLogger(clazz, Stream.concat(Stream.of(Loggers.SPACE, index.getName()), Arrays.stream(prefixes)).toArray(String[]::new));
     }
 
     public static Logger getLogger(Class<?> clazz, String... prefixes) {

--- a/server/src/main/java/org/elasticsearch/common/util/CollectionUtils.java
+++ b/server/src/main/java/org/elasticsearch/common/util/CollectionUtils.java
@@ -293,27 +293,6 @@ public class CollectionUtils {
         return new ArrayList<>(Arrays.asList(elements));
     }
 
-    public static <E> ArrayList<E> asArrayList(E first, E... other) {
-        if (other == null) {
-            throw new NullPointerException("other");
-        }
-        ArrayList<E> list = new ArrayList<>(1 + other.length);
-        list.add(first);
-        list.addAll(Arrays.asList(other));
-        return list;
-    }
-
-    public static<E> ArrayList<E> asArrayList(E first, E second, E... other) {
-        if (other == null) {
-            throw new NullPointerException("other");
-        }
-        ArrayList<E> list = new ArrayList<>(1 + 1 + other.length);
-        list.add(first);
-        list.add(second);
-        list.addAll(Arrays.asList(other));
-        return list;
-    }
-
     /**
      * Creates a copy of the given collection with the given element appended.
      *


### PR DESCRIPTION
Backports the following commits to 7.x: 

- Remove unused CollectionUtils methods #76387