### PR TITLE
[ML][Transform] fixing testFailureCounterIsResetOnSuccess test failure #76397

### DIFF
--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/TransformIndexerFailureHandlingTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/TransformIndexerFailureHandlingTests.java
@@ -41,6 +41,7 @@ import org.elasticsearch.xpack.core.indexing.IterationResult;
 import org.elasticsearch.xpack.core.scheduler.SchedulerEngine;
 import org.elasticsearch.xpack.core.transform.transforms.SettingsConfig;
 import org.elasticsearch.xpack.core.transform.transforms.TimeRetentionPolicyConfig;
+import org.elasticsearch.xpack.core.transform.transforms.TimeSyncConfig;
 import org.elasticsearch.xpack.core.transform.transforms.TransformCheckpoint;
 import org.elasticsearch.xpack.core.transform.transforms.TransformConfig;
 import org.elasticsearch.xpack.core.transform.transforms.TransformIndexerPosition;
@@ -723,7 +724,7 @@ public class TransformIndexerFailureHandlingTests extends ESTestCase {
             randomSourceConfig(),
             randomDestConfig(),
             null,
-            null,
+            new TimeSyncConfig("time", TimeSyncConfig.DEFAULT_DELAY),
             null,
             randomPivotConfig(),
             null,
@@ -815,7 +816,7 @@ public class TransformIndexerFailureHandlingTests extends ESTestCase {
 
         indexer.start();
         assertThat(indexer.getState(), equalTo(IndexerState.STARTED));
-        assertTrue(indexer.maybeTriggerAsyncJob(System.currentTimeMillis()));
+        assertBusy(() -> assertTrue(indexer.maybeTriggerAsyncJob(System.currentTimeMillis())));
         assertThat(indexer.getState(), equalTo(IndexerState.INDEXING));
 
         secondLatch.countDown();


### PR DESCRIPTION
There are two possible race conditions that were not
previously handled in this test.

- Since the syncconfig was null, it may be that the
  transform actually gets set to stopping/stopped
  and its unable to kick off another indexing pass
- It may also be that the indexer thread is still
  finishing up work when the second execution is
  requested, so it returns false.

Adding a sync config and assertBusy handles these
cases. Ran 1k+ times locally with this change
and it never failed. Without, it failed ~10 runs.

closes https://github.com/elastic/elasticsearch/issues/76397
