### PR TITLE
[7.x] [ML][Transform] fixing testFailureCounterIsResetOnSuccess test failure #76397 (#76417)

### DIFF
--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/TransformIndexerFailureHandlingTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/TransformIndexerFailureHandlingTests.java
@@ -41,6 +41,7 @@ import org.elasticsearch.xpack.core.indexing.IterationResult;
 import org.elasticsearch.xpack.core.scheduler.SchedulerEngine;
 import org.elasticsearch.xpack.core.transform.transforms.SettingsConfig;
 import org.elasticsearch.xpack.core.transform.transforms.TimeRetentionPolicyConfig;
+import org.elasticsearch.xpack.core.transform.transforms.TimeSyncConfig;
 import org.elasticsearch.xpack.core.transform.transforms.TransformCheckpoint;
 import org.elasticsearch.xpack.core.transform.transforms.TransformConfig;
 import org.elasticsearch.xpack.core.transform.transforms.TransformIndexerPosition;
@@ -717,7 +718,7 @@ public class TransformIndexerFailureHandlingTests extends ESTestCase {
             randomSourceConfig(),
             randomDestConfig(),
             null,
-            null,
+            new TimeSyncConfig("time", TimeSyncConfig.DEFAULT_DELAY),
             null,
             randomPivotConfig(),
             null,
@@ -809,7 +810,7 @@ public class TransformIndexerFailureHandlingTests extends ESTestCase {
 
         indexer.start();
         assertThat(indexer.getState(), equalTo(IndexerState.STARTED));
-        assertTrue(indexer.maybeTriggerAsyncJob(System.currentTimeMillis()));
+        assertBusy(() -> assertTrue(indexer.maybeTriggerAsyncJob(System.currentTimeMillis())));
         assertThat(indexer.getState(), equalTo(IndexerState.INDEXING));
 
         secondLatch.countDown();


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [ML][Transform] fixing testFailureCounterIsResetOnSuccess test failure #76397 (#76417)