### PR TITLE
Give rollling upgrade tests more information (backport of #76360)

### DIFF
--- a/qa/rolling-upgrade/build.gradle
+++ b/qa/rolling-upgrade/build.gradle
@@ -52,7 +52,6 @@ for (Version bwcVersion : BuildParams.bwcVersions.wireCompatible) {
     doFirst {
       delete("${buildDir}/cluster/shared/repo/${baseName}")
     }
-    systemProperty 'tests.upgrade_from_version', bwcVersionStr
     systemProperty 'tests.rest.suite', 'old_cluster'
     systemProperty 'tests.upgrade_from_version', oldVersion
     nonInputProperties.systemProperty('tests.rest.cluster', "${-> testClusters."${baseName}".allHttpSocketURI.join(",")}")

--- a/qa/rolling-upgrade/build.gradle
+++ b/qa/rolling-upgrade/build.gradle
@@ -30,11 +30,10 @@ for (Version bwcVersion : BuildParams.bwcVersions.wireCompatible) {
    * </ul>
    */
   String baseName = "v${bwcVersion}"
-  String bwcVersionStr = "${bwcVersion}"
 
   testClusters {
     "${baseName}" {
-      versions = [bwcVersionStr, project.version]
+      versions = [bwcVersion.toString(), project.version]
       numberOfNodes = 3
 
       setting 'repositories.url.allowed_urls', 'http://snapshot.test*'
@@ -43,6 +42,8 @@ for (Version bwcVersion : BuildParams.bwcVersions.wireCompatible) {
       setting 'http.content_type.required', 'true'
     }
   }
+
+  String oldVersion = bwcVersion.toString()
 
   tasks.register("${baseName}#oldClusterTest", StandaloneRestIntegTestTask) {
     dependsOn "processTestResources"
@@ -53,6 +54,7 @@ for (Version bwcVersion : BuildParams.bwcVersions.wireCompatible) {
     }
     systemProperty 'tests.upgrade_from_version', bwcVersionStr
     systemProperty 'tests.rest.suite', 'old_cluster'
+    systemProperty 'tests.upgrade_from_version', oldVersion
     nonInputProperties.systemProperty('tests.rest.cluster', "${-> testClusters."${baseName}".allHttpSocketURI.join(",")}")
     nonInputProperties.systemProperty('tests.clustername', "${-> testClusters."${baseName}".getName()}")
   }
@@ -64,7 +66,7 @@ for (Version bwcVersion : BuildParams.bwcVersions.wireCompatible) {
       testClusters."${baseName}".nextNodeToNextVersion()
     }
     systemProperty 'tests.rest.suite', 'mixed_cluster'
-    systemProperty 'tests.upgrade_from_version', bwcVersionStr
+    systemProperty 'tests.upgrade_from_version', oldVersion
     systemProperty 'tests.first_round', 'true'
     nonInputProperties.systemProperty('tests.rest.cluster', "${-> testClusters."${baseName}".allHttpSocketURI.join(",")}")
     nonInputProperties.systemProperty('tests.clustername', "${-> testClusters."${baseName}".getName()}")
@@ -77,7 +79,7 @@ for (Version bwcVersion : BuildParams.bwcVersions.wireCompatible) {
       testClusters."${baseName}".nextNodeToNextVersion()
     }
     systemProperty 'tests.rest.suite', 'mixed_cluster'
-    systemProperty 'tests.upgrade_from_version', bwcVersionStr
+    systemProperty 'tests.upgrade_from_version', oldVersion
     systemProperty 'tests.first_round', 'false'
     nonInputProperties.systemProperty('tests.rest.cluster', "${-> testClusters."${baseName}".allHttpSocketURI.join(",")}")
     nonInputProperties.systemProperty('tests.clustername', "${-> testClusters."${baseName}".getName()}")
@@ -90,8 +92,7 @@ for (Version bwcVersion : BuildParams.bwcVersions.wireCompatible) {
     }
     useCluster testClusters."${baseName}"
     systemProperty 'tests.rest.suite', 'upgraded_cluster'
-    systemProperty 'tests.upgrade_from_version', bwcVersionStr
-
+    systemProperty 'tests.upgrade_from_version', oldVersion
     nonInputProperties.systemProperty('tests.rest.cluster', "${-> testClusters."${baseName}".allHttpSocketURI.join(",")}")
     nonInputProperties.systemProperty('tests.clustername', "${-> testClusters."${baseName}".getName()}")
   }

--- a/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/AbstractRollingTestCase.java
+++ b/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/AbstractRollingTestCase.java
@@ -25,15 +25,15 @@ public abstract class AbstractRollingTestCase extends ESRestTestCase {
                     return MIXED;
                 case "upgraded_cluster":
                     return UPGRADED;
-                    default:
-                        throw new AssertionError("unknown cluster type: " + value);
+                default:
+                    throw new AssertionError("unknown cluster type: " + value);
             }
         }
     }
 
     protected static final ClusterType CLUSTER_TYPE = ClusterType.parse(System.getProperty("tests.rest.suite"));
+    protected static final boolean FIRST_MIXED_ROUND = Boolean.parseBoolean(System.getProperty("tests.first_round", "false"));
     protected static final Version UPGRADE_FROM_VERSION = Version.fromString(System.getProperty("tests.upgrade_from_version"));
-    protected static final boolean firstMixedRound = Boolean.parseBoolean(System.getProperty("tests.first_round", "false"));
 
     @Override
     protected final boolean preserveIndicesUponCompletion() {

--- a/x-pack/qa/rolling-upgrade/build.gradle
+++ b/x-pack/qa/rolling-upgrade/build.gradle
@@ -93,7 +93,8 @@ for (Version bwcVersion : BuildParams.bwcVersions.wireCompatible) {
     }
   }
 
-  String oldVersion = bwcVersion.toString().replace('-SNAPSHOT', '')
+  String oldVersion = bwcVersion.toString()
+
   tasks.register("${baseName}#oldClusterTest", StandaloneRestIntegTestTask) {
     useCluster testClusters."${baseName}"
     mustRunAfter("precommit")


### PR DESCRIPTION
This passes the version that rolling upgrade tests are coming *from*
into the actual tests so they can reason about it. This is useful
because we have features that are not supported on early versions and
we want to write rolling upgrade tests for them. We can't run those
features or assert anything about them in when they don't exist. You'd
think we could use the minimum version of a node in the cluster, but
that only works in the unupgraded phases - once we've completed the
upgrade we need to have the version that we came from to know what we
did in the mixed version.
