### PR TITLE
[DOCS] Comments out links that points to regression loss functions

### DIFF
--- a/docs/reference/ml/df-analytics/apis/get-trained-models.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/get-trained-models.asciidoc
@@ -222,10 +222,11 @@ List of the available hyperparameters optimized during the
 .Properties of hyperparameters
 [%collapsible%open]
 ======
-`absolute_importance`::::
+`absolute_importance`::::g
 (double)
 A positive number showing how much the parameter influences the variation of the 
-{ml-docs}/ml-dfa-regression.html#dfa-regression-lossfunction[loss function]. For 
+// {ml-docs}/dfa-regression-lossfunction.html[loss function]. 
+loss function. For 
 hyperparameters with values that are not specified by the user but tuned during 
 hyperparameter optimization. 
 

--- a/docs/reference/ml/df-analytics/apis/get-trained-models.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/get-trained-models.asciidoc
@@ -222,7 +222,7 @@ List of the available hyperparameters optimized during the
 .Properties of hyperparameters
 [%collapsible%open]
 ======
-`absolute_importance`::::g
+`absolute_importance`::::
 (double)
 A positive number showing how much the parameter influences the variation of the 
 // {ml-docs}/dfa-regression-lossfunction.html[loss function]. 

--- a/docs/reference/ml/df-analytics/apis/put-dfanalytics.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/put-dfanalytics.asciidoc
@@ -392,9 +392,9 @@ include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=lambda]
 The loss function used during {regression}. Available options are `mse` (mean
 squared error), `msle` (mean squared logarithmic error),  `huber` (Pseudo-Huber
 loss). Defaults to `mse`.
-Refer to
-{ml-docs}/ml-dfa-regression.html#dfa-regression-lossfunction[Loss functions for {regression} analyses]
-to learn more.
+// Refer to
+// {ml-docs}/dfa-regression-lossfunction.html[Loss functions for {regression} analyses]
+// to learn more.
 
 `loss_function_parameter`::::
 (Optional, double)


### PR DESCRIPTION
## Overview

This PR comments out links that point to the regression loss functions in the DFA conceptual docs. The reason why it is necessary is that https://github.com/elastic/stack-docs/pull/1783 restructures those pages, so the links temporarily won't work.

