### PR TITLE
Fix eclipse compilation after plugin spi

### DIFF
--- a/modules/lang-painless/build.gradle
+++ b/modules/lang-painless/build.gradle
@@ -26,6 +26,10 @@ testClusters.all {
 configurations {
   spi
   compileOnlyApi.extendsFrom(spi)
+  if (isEclipse) {
+    // Eclipse buildship doesn't know about compileOnlyApi
+    compileOnly.extendsFrom(spi)
+  }
 }
 
 dependencies {

--- a/modules/lang-painless/build.gradle
+++ b/modules/lang-painless/build.gradle
@@ -28,7 +28,7 @@ configurations {
   compileOnlyApi.extendsFrom(spi)
   if (isEclipse) {
     // Eclipse buildship doesn't know about compileOnlyApi
-    compileOnly.extendsFrom(spi)
+    api.extendsFrom(spi)
   }
 }
 


### PR DESCRIPTION
Painless extensions now compile against it's `spi` subproject. Gradle
and IntelliJ rig the dependencies correctly but Eclipse doesn't seem to
manage it. This temporarily declares the `spi` as a `compileOnly`
dependency when in Eclipse land so Eclipse can see the classes.
