### PR TITLE
[DOCS] Adds links that point to loss function to ML API docs

### DIFF
--- a/docs/reference/ml/df-analytics/apis/get-trained-models.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/get-trained-models.asciidoc
@@ -225,8 +225,7 @@ List of the available hyperparameters optimized during the
 `absolute_importance`::::
 (double)
 A positive number showing how much the parameter influences the variation of the 
-// {ml-docs}/dfa-regression-lossfunction.html[loss function]. 
-loss function. For 
+{ml-docs}/dfa-regression-lossfunction.html[loss function]. For 
 hyperparameters with values that are not specified by the user but tuned during 
 hyperparameter optimization. 
 

--- a/docs/reference/ml/df-analytics/apis/put-dfanalytics.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/put-dfanalytics.asciidoc
@@ -392,9 +392,9 @@ include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=lambda]
 The loss function used during {regression}. Available options are `mse` (mean
 squared error), `msle` (mean squared logarithmic error),  `huber` (Pseudo-Huber
 loss). Defaults to `mse`.
-// Refer to
-// {ml-docs}/dfa-regression-lossfunction.html[Loss functions for {regression} analyses]
-// to learn more.
+Refer to
+{ml-docs}/dfa-regression-lossfunction.html[Loss functions for {regression} analyses]
+to learn more.
 
 `loss_function_parameter`::::
 (Optional, double)


### PR DESCRIPTION
## Overview

This PR adds back links to the API docs that point to the regression loss function page in the ML DFA conceptual docs. 

## NOTE

DO NOT MERGE BEFORE https://github.com/elastic/stack-docs/pull/1783