### PR TITLE
Update redline library to 1.2.10

### DIFF
--- a/distribution/packages/build.gradle
+++ b/distribution/packages/build.gradle
@@ -54,9 +54,7 @@ buildscript {
   // Be aware that it seems the redline project hasnt been active for a while
   configurations.all {
     resolutionStrategy {
-        dependencySubstitution {
-          substitute module('org.redline-rpm:redline') using module('com.github.breskeby:redline:9c85270')
-        }
+      force 'org.redline-rpm:redline:1.2.10'
     }
   }
 

--- a/distribution/packages/build.gradle
+++ b/distribution/packages/build.gradle
@@ -48,10 +48,9 @@ buildscript {
     maven { url 'https://jitpack.io' }
   }
 
-  // We rely on a patched version of the redline library used to build rpm packages
+  // We rely on a specific version of the redline library used to build rpm packages
   // to support sha256header in our elasticsearch RPMs
-  // TODO: Update / remove this dependency once https://github.com/craigwblake/redline/pull/157 got merged
-  // Be aware that it seems the redline project hasnt been active for a while
+  // TODO: Remove once https://github.com/nebula-plugins/gradle-ospackage-plugin/pull/402 got merged and released
   configurations.all {
     resolutionStrategy {
       force 'org.redline-rpm:redline:1.2.10'
@@ -61,7 +60,6 @@ buildscript {
   dependencies {
     classpath "com.github.breskeby:gradle-ospackage-plugin:98455c1"
   }
-
 }
 
 apply plugin: "nebula.ospackage-base"


### PR DESCRIPTION
The redline team just released version 1.2.10 of the redline
library which contains our fix of the rpm signatures / headers.

Also a PR to update that dependency in the ospackage plugin has been
raised at https://github.com/nebula-plugins/gradle-ospackage-plugin/pull/402