### PR TITLE
[7.x] [DOCS] Fix query params for create snapshot API (#76436)

### DIFF
--- a/docs/reference/snapshot-restore/apis/create-snapshot-api.asciidoc
+++ b/docs/reference/snapshot-restore/apis/create-snapshot-api.asciidoc
@@ -79,6 +79,16 @@ Name of the repository to create a snapshot in.
 (Required, string)
 Name of the snapshot to create. This name must be unique in the snapshot repository.
 
+[[create-snapshot-api-query-params]]
+==== {api-query-parms-title}
+
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=master-timeout]
+
+`wait_for_completion`::
+(Optional, Boolean) If `true`, the request returns a response when the snapshot
+is complete. If `false`, the request returns a response when the snapshot
+initializes. Defaults to `false`.
+
 [role="child_attributes"]
 [[create-snapshot-api-request-body]]
 ==== {api-request-body-title}
@@ -130,8 +140,6 @@ By default, all available feature states will be included in the snapshot if
 `include_global_state` is `true`, or no feature states if `include_global_state`
 is `false`.
 
-include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=master-timeout]
-
 `metadata`::
 (Optional, string)
 Attaches arbitrary metadata to the snapshot, such as a record of who took the snapshot, why it was taken, or any other useful data. Metadata must be less than 1024 bytes.
@@ -142,12 +150,6 @@ Attaches arbitrary metadata to the snapshot, such as a record of who took the sn
 If `false`, the entire snapshot will fail if one or more indices included in the snapshot do not have all primary shards available. Defaults to `false`.
 +
 If `true`, allows taking a partial snapshot of indices with unavailable shards.
-
-`wait_for_completion`::
-(Optional, Boolean)
-If `true`, the request returns a response when the snapshot is complete.
-If `false`, the request returns a response when the snapshot initializes.
-Defaults to `false`.
 
 [[create-snapshot-api-example]]
 ==== {api-examples-title}


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [DOCS] Fix query params for create snapshot API (#76436)