### PR TITLE
Add kibana-system service account

### DIFF
--- a/rest-api-spec/build.gradle
+++ b/rest-api-spec/build.gradle
@@ -85,7 +85,7 @@ def v7compatibilityNotSupportedTests = {
           'search/340_type_query/type query', //#47207 type query throws exception in compatible mode
           'search.aggregation/200_top_hits_metric/top_hits aggregation with sequence numbers', // #42809 the use nested path and filter sort throws an exception
           'search/310_match_bool_prefix/multi_match multiple fields with cutoff_frequency throws exception', //#42654 cutoff_frequency, common terms are not supported. Throwing an exception
-
+          'service_accounts/10_basic/Test get service accounts', //#76449, will remove upon backport
 
   ]
 }

--- a/rest-api-spec/build.gradle
+++ b/rest-api-spec/build.gradle
@@ -85,7 +85,6 @@ def v7compatibilityNotSupportedTests = {
           'search/340_type_query/type query', //#47207 type query throws exception in compatible mode
           'search.aggregation/200_top_hits_metric/top_hits aggregation with sequence numbers', // #42809 the use nested path and filter sort throws an exception
           'search/310_match_bool_prefix/multi_match multiple fields with cutoff_frequency throws exception', //#42654 cutoff_frequency, common terms are not supported. Throwing an exception
-          'service_accounts/10_basic/Test get service accounts', //#76449, will remove upon backport
 
   ]
 }

--- a/x-pack/docs/en/security/authentication/service-accounts.asciidoc
+++ b/x-pack/docs/en/security/authentication/service-accounts.asciidoc
@@ -40,10 +40,14 @@ the format of `<namespace>/<service>`, where the `namespace` is a top-level
 grouping of service accounts, and `service` is the name of the service and
 must be unique within its namespace.
 
-Service accounts are predefined in code. Currently, only one service account is available:
+Service accounts are predefined in code. The following service accounts are
+available:
 
 `elastic/fleet-server`:: The service account used by the {fleet} server to
 communicate with {es}.
+
+`elastic/kibana-system`:: The service account used by {kib} to communicate with
+{es}.
 
 // tag::service-accounts-usage[]
 IMPORTANT: Do not attempt to use service accounts for authenticating individual

--- a/x-pack/docs/en/security/authentication/service-accounts.asciidoc
+++ b/x-pack/docs/en/security/authentication/service-accounts.asciidoc
@@ -18,12 +18,12 @@ prevents credential sharing between multiple instances of the same
 external service. Each instance can assume the same identity while using
 their own distinct service token for authentication.
 
-Service accounts provide flexibility over <<built-in-users,built-in users>> 
+Service accounts provide flexibility over <<built-in-users,built-in users>>
 because they:
 
 * Do not rely on the <<native-realm,internal `native` realm>>, and aren't
 always required to rely on the `.security` index
-* Use a role descriptor named after the service account principal instead of 
+* Use a role descriptor named after the service account principal instead of
 traditional roles
 * Support multiple credentials through service account tokens
 
@@ -46,7 +46,7 @@ available:
 `elastic/fleet-server`:: The service account used by the {fleet} server to
 communicate with {es}.
 
-`elastic/kibana-system`:: The service account used by {kib} to communicate with
+`elastic/kibana`:: The service account used by {kib} to communicate with
 {es}.
 
 // tag::service-accounts-usage[]
@@ -87,11 +87,11 @@ the bearer token in the HTTP response
 
 Both of these methods create a service token with a guaranteed secret string
 length of `22`. The minimal, acceptable length of a secret string for a service
-token is `10`. If the secret string doesn't meet this minimal length, 
+token is `10`. If the secret string doesn't meet this minimal length,
 authentication with {es} will fail without even checking the value of the
 service token.
 
-Service tokens never expire. You must actively 
+Service tokens never expire. You must actively
 <<security-api-delete-service-token,delete>> them if they are no longer needed.
 
 [discrete]

--- a/x-pack/plugin/build.gradle
+++ b/x-pack/plugin/build.gradle
@@ -153,7 +153,8 @@ def v7compatibilityNotSupportedTests = {
 
     // a type field was added to cat.ml_trained_models #73660, this is a backwards compatible change.
     // still this is a cat api, and we don't support them with rest api compatibility. (the test would be very hard to transform too)
-    'ml/trained_model_cat_apis/Test cat trained models'
+    'ml/trained_model_cat_apis/Test cat trained models',
+    'service_accounts/10_basic/Test get service accounts', //#76449, will remove upon backport
   ]
 }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStore.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStore.java
@@ -125,7 +125,7 @@ public class ReservedRolesStore implements BiConsumer<Set<String>, ActionListene
                         null, null,
                         MetadataUtils.getDeprecatedReservedMetadata("Please use Kibana feature privileges instead"),
                         null))
-                .put(KibanaSystemUser.ROLE_NAME, kibanaSystemUserRole(KibanaSystemUser.ROLE_NAME))
+                .put(KibanaSystemUser.ROLE_NAME, kibanaSystemRoleDescriptor(KibanaSystemUser.ROLE_NAME))
                 .put("logstash_system", new RoleDescriptor("logstash_system", new String[] { "monitor", MonitoringBulkAction.NAME},
                         null, null, MetadataUtils.DEFAULT_RESERVED_METADATA))
                 .put("beats_admin", new RoleDescriptor("beats_admin",
@@ -363,7 +363,7 @@ public class ReservedRolesStore implements BiConsumer<Set<String>, ActionListene
             null, null, metadata, null);
     }
 
-    public static RoleDescriptor kibanaSystemUserRole(String name) {
+    public static RoleDescriptor kibanaSystemRoleDescriptor(String name) {
         return new RoleDescriptor(name,
             new String[] {
                 "monitor", "manage_index_templates", MonitoringBulkAction.NAME, "manage_saml", "manage_token", "manage_oidc",

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/service/ElasticServiceAccounts.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/service/ElasticServiceAccounts.java
@@ -9,6 +9,7 @@ package org.elasticsearch.xpack.security.authc.service;
 
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.xpack.core.security.authz.RoleDescriptor;
+import org.elasticsearch.xpack.core.security.authz.store.ReservedRolesStore;
 import org.elasticsearch.xpack.core.security.user.User;
 
 import java.util.List;
@@ -43,8 +44,10 @@ final class ElasticServiceAccounts {
             null,
             null
         ));
+    private static final ServiceAccount KIBANA_SYSTEM_ACCOUNT =
+        new ElasticServiceAccount("kibana-system", ReservedRolesStore.kibanaSystemUserRole(NAMESPACE + "/kibana-system"));
 
-    static final Map<String, ServiceAccount> ACCOUNTS = List.of(FLEET_ACCOUNT).stream()
+    static final Map<String, ServiceAccount> ACCOUNTS = List.of(FLEET_ACCOUNT, KIBANA_SYSTEM_ACCOUNT).stream()
         .collect(Collectors.toMap(a -> a.id().asPrincipal(), Function.identity()));;
 
     private ElasticServiceAccounts() {}

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/service/ElasticServiceAccounts.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/service/ElasticServiceAccounts.java
@@ -45,7 +45,7 @@ final class ElasticServiceAccounts {
             null
         ));
     private static final ServiceAccount KIBANA_SYSTEM_ACCOUNT =
-        new ElasticServiceAccount("kibana-system", ReservedRolesStore.kibanaSystemUserRole(NAMESPACE + "/kibana-system"));
+        new ElasticServiceAccount("kibana", ReservedRolesStore.kibanaSystemRoleDescriptor(NAMESPACE + "/kibana"));
 
     static final Map<String, ServiceAccount> ACCOUNTS = List.of(FLEET_ACCOUNT, KIBANA_SYSTEM_ACCOUNT).stream()
         .collect(Collectors.toMap(a -> a.id().asPrincipal(), Function.identity()));;

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/action/service/TransportGetServiceAccountActionTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/action/service/TransportGetServiceAccountActionTests.java
@@ -14,11 +14,15 @@ import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.xpack.core.security.action.service.GetServiceAccountRequest;
 import org.elasticsearch.xpack.core.security.action.service.GetServiceAccountResponse;
+import org.elasticsearch.xpack.core.security.action.service.ServiceAccountInfo;
 import org.elasticsearch.xpack.security.authc.support.HttpTlsRuntimeCheck;
 import org.junit.Before;
 
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.stream.Collectors;
 
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.equalTo;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.doAnswer;
@@ -43,23 +47,33 @@ public class TransportGetServiceAccountActionTests extends ESTestCase {
     }
 
     public void testDoExecute() {
-        final GetServiceAccountRequest request1 = randomFrom(
-            new GetServiceAccountRequest(null, null),
-            new GetServiceAccountRequest("elastic", null),
-            new GetServiceAccountRequest("elastic", "fleet-server"));
+        final GetServiceAccountRequest request1 = randomFrom(new GetServiceAccountRequest(null, null),
+            new GetServiceAccountRequest("elastic", null));
         final PlainActionFuture<GetServiceAccountResponse> future1 = new PlainActionFuture<>();
         transportGetServiceAccountAction.doExecute(mock(Task.class), request1, future1);
         final GetServiceAccountResponse getServiceAccountResponse1 = future1.actionGet();
-        assertThat(getServiceAccountResponse1.getServiceAccountInfos().length, equalTo(1));
-        assertThat(getServiceAccountResponse1.getServiceAccountInfos()[0].getPrincipal(), equalTo("elastic/fleet-server"));
+        assertThat(getServiceAccountResponse1.getServiceAccountInfos().length, equalTo(2));
+        assertThat(
+            Arrays.stream(getServiceAccountResponse1.getServiceAccountInfos())
+                .map(ServiceAccountInfo::getPrincipal)
+                .collect(Collectors.toList()),
+            containsInAnyOrder("elastic/fleet-server", "elastic/kibana")
+        );
 
-        final GetServiceAccountRequest request2 = randomFrom(
-            new GetServiceAccountRequest("foo", null),
-            new GetServiceAccountRequest("elastic", "foo"),
-            new GetServiceAccountRequest("foo", "bar"));
+        final GetServiceAccountRequest request2 = new GetServiceAccountRequest("elastic", "fleet-server");
         final PlainActionFuture<GetServiceAccountResponse> future2 = new PlainActionFuture<>();
         transportGetServiceAccountAction.doExecute(mock(Task.class), request2, future2);
         final GetServiceAccountResponse getServiceAccountResponse2 = future2.actionGet();
-        assertThat(getServiceAccountResponse2.getServiceAccountInfos().length, equalTo(0));
+        assertThat(getServiceAccountResponse2.getServiceAccountInfos().length, equalTo(1));
+        assertThat(getServiceAccountResponse2.getServiceAccountInfos()[0].getPrincipal(), equalTo("elastic/fleet-server"));
+
+        final GetServiceAccountRequest request3 = randomFrom(
+            new GetServiceAccountRequest("foo", null),
+            new GetServiceAccountRequest("elastic", "foo"),
+            new GetServiceAccountRequest("foo", "bar"));
+        final PlainActionFuture<GetServiceAccountResponse> future3 = new PlainActionFuture<>();
+        transportGetServiceAccountAction.doExecute(mock(Task.class), request3, future3);
+        final GetServiceAccountResponse getServiceAccountResponse3 = future3.actionGet();
+        assertThat(getServiceAccountResponse3.getServiceAccountInfos().length, equalTo(0));
     }
 }

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/service/ServiceAccountServiceTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/service/ServiceAccountServiceTests.java
@@ -122,7 +122,7 @@ public class ServiceAccountServiceTests extends ESTestCase {
 
     public void testGetServiceAccountPrincipals() {
         assertThat(ServiceAccountService.getServiceAccountPrincipals(),
-            containsInAnyOrder("elastic/fleet-server", "elastic/kibana-system"));
+            containsInAnyOrder("elastic/fleet-server", "elastic/kibana"));
     }
 
     public void testTryParseToken() throws IOException, IllegalAccessException {

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/service/ServiceAccountServiceTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/service/ServiceAccountServiceTests.java
@@ -59,12 +59,12 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
@@ -121,7 +121,8 @@ public class ServiceAccountServiceTests extends ESTestCase {
     }
 
     public void testGetServiceAccountPrincipals() {
-        assertThat(ServiceAccountService.getServiceAccountPrincipals(), equalTo(Set.of("elastic/fleet-server")));
+        assertThat(ServiceAccountService.getServiceAccountPrincipals(),
+            containsInAnyOrder("elastic/fleet-server", "elastic/kibana-system"));
     }
 
     public void testTryParseToken() throws IOException, IllegalAccessException {

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/service_accounts/10_basic.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/service_accounts/10_basic.yml
@@ -10,21 +10,30 @@ teardown:
       security.delete_service_token:
         namespace: elastic
         service: fleet-server
-        name: api-token-1
+        name: api-token-fleet
+        ignore: 404
+
+  - do:
+      security.delete_service_token:
+        namespace: elastic
+        service: kibana-system
+        name: api-token-kibana
         ignore: 404
 
 ---
 "Test get service accounts":
   - do:
       security.get_service_accounts: {}
-  - length: { '': 1 }
+  - length: { '': 2 }
   - is_true: "elastic/fleet-server"
+  - is_true: "elastic/kibana-system"
 
   - do:
       security.get_service_accounts:
         namespace: elastic
-  - length: { '': 1 }
+  - length: { '': 2 }
   - is_true: "elastic/fleet-server"
+  - is_true: "elastic/kibana-system"
 
   - do:
       security.get_service_accounts:
@@ -41,26 +50,36 @@ teardown:
       security.create_service_token:
         namespace: elastic
         service: fleet-server
-        name: api-token-1
+        name: api-token-fleet
 
   - is_true: created
-  - match: { "token.name": "api-token-1" }
-  - set: { "token.value": service_token }
+  - match: { "token.name": "api-token-fleet" }
+  - set: { "token.value": service_token_fleet }
+
+  - do:
+      security.create_service_token:
+        namespace: elastic
+        service: kibana-system
+        name: api-token-kibana
+
+  - is_true: created
+  - match: { "token.name": "api-token-kibana" }
+  - set: { "token.value": service_token_kibana }
 
   - do:
       headers:
-        Authorization: Bearer ${service_token}
+        Authorization: Bearer ${service_token_fleet}
       security.authenticate: {}
 
   - match: { username: "elastic/fleet-server" }
   - match: { roles:  [] }
   - match: { full_name: "Service account - elastic/fleet-server" }
-  - match: { "token.name": "api-token-1" }
+  - match: { "token.name": "api-token-fleet" }
 
   - do:
       catch: forbidden
       headers:
-        Authorization: Bearer ${service_token}
+        Authorization: Bearer ${service_token_fleet}
       security.delete_user:
         username: foo
 
@@ -69,13 +88,23 @@ teardown:
       error.reason: "action [cluster:admin/xpack/security/user/delete] is unauthorized for user [elastic/fleet-server], this action is granted by the cluster privileges [manage_security,all]"
 
   - do:
+      headers:
+        Authorization: Bearer ${service_token_kibana}
+      security.authenticate: {}
+
+  - match: { username: "elastic/kibana-system" }
+  - match: { roles:  [] }
+  - match: { full_name: "Service account - elastic/kibana-system" }
+  - match: { "token.name": "api-token-kibana" }
+
+  - do:
       security.get_service_credentials:
         namespace: elastic
         service: fleet-server
 
   - match: { "service_account": "elastic/fleet-server" }
   - match: { "count": 2 }
-  - match: { "tokens": { "api-token-1": {} } }
+  - match: { "tokens": { "api-token-fleet": {} } }
   - match: { "nodes_credentials._nodes.failed": 0 }
   - is_true: nodes_credentials.file_tokens.token1
   - is_true: nodes_credentials.file_tokens.token1.nodes
@@ -85,7 +114,15 @@ teardown:
       security.clear_cached_service_tokens:
         namespace: elastic
         service: fleet-server
-        name: api-token-1
+        name: api-token-fleet
+
+  - match: { _nodes.failed: 0 }
+
+  - do:
+      security.clear_cached_service_tokens:
+        namespace: elastic
+        service: kibana-system
+        name: api-token-kibana
 
   - match: { _nodes.failed: 0 }
 
@@ -93,9 +130,16 @@ teardown:
       security.clear_cached_service_tokens:
         namespace: elastic
         service: fleet-server
-        name: [ "api-token-1", "does-not-exist" ]
+        name: [ "api-token-fleet", "does-not-exist" ]
 
   - match: { _nodes.failed: 0 }
 
+  - do:
+      security.clear_cached_service_tokens:
+        namespace: elastic
+        service: kibana-system
+        name: [ "api-token-kibana", "does-not-exist-either" ]
+
+  - match: { _nodes.failed: 0 }
 
 

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/service_accounts/10_basic.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/service_accounts/10_basic.yml
@@ -16,7 +16,7 @@ teardown:
   - do:
       security.delete_service_token:
         namespace: elastic
-        service: kibana-system
+        service: kibana
         name: api-token-kibana
         ignore: 404
 
@@ -26,14 +26,14 @@ teardown:
       security.get_service_accounts: {}
   - length: { '': 2 }
   - is_true: "elastic/fleet-server"
-  - is_true: "elastic/kibana-system"
+  - is_true: "elastic/kibana"
 
   - do:
       security.get_service_accounts:
         namespace: elastic
   - length: { '': 2 }
   - is_true: "elastic/fleet-server"
-  - is_true: "elastic/kibana-system"
+  - is_true: "elastic/kibana"
 
   - do:
       security.get_service_accounts:
@@ -59,7 +59,7 @@ teardown:
   - do:
       security.create_service_token:
         namespace: elastic
-        service: kibana-system
+        service: kibana
         name: api-token-kibana
 
   - is_true: created
@@ -92,9 +92,9 @@ teardown:
         Authorization: Bearer ${service_token_kibana}
       security.authenticate: {}
 
-  - match: { username: "elastic/kibana-system" }
+  - match: { username: "elastic/kibana" }
   - match: { roles:  [] }
-  - match: { full_name: "Service account - elastic/kibana-system" }
+  - match: { full_name: "Service account - elastic/kibana" }
   - match: { "token.name": "api-token-kibana" }
 
   - do:
@@ -121,7 +121,7 @@ teardown:
   - do:
       security.clear_cached_service_tokens:
         namespace: elastic
-        service: kibana-system
+        service: kibana
         name: api-token-kibana
 
   - match: { _nodes.failed: 0 }
@@ -137,7 +137,7 @@ teardown:
   - do:
       security.clear_cached_service_tokens:
         namespace: elastic
-        service: kibana-system
+        service: kibana
         name: [ "api-token-kibana", "does-not-exist-either" ]
 
   - match: { _nodes.failed: 0 }


### PR DESCRIPTION
This change introduces a Service Account for Kibana to use when
authenticating to Elasticsearch. The Service Account with
kibana-system service name under the elastic namespace,
uses the same RoleDescriptor as the existing kibana_system
built-in user and is its functional equivalent when it comes to
AuthZ.

deprecates: https://github.com/elastic/elasticsearch/pull/73738
