### PR TITLE
[7.13] [DOCS] Add missing `timeout` param to create pipeline API docs (#76432)

### DIFF
--- a/docs/reference/ingest/apis/put-pipeline.asciidoc
+++ b/docs/reference/ingest/apis/put-pipeline.asciidoc
@@ -48,7 +48,7 @@ PUT _ingest/pipeline/my-pipeline-id
 [[put-pipeline-api-query-params]]
 ==== {api-query-parms-title}
 
-include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=master-timeout]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=timeoutparms]
 
 
 [[put-pipeline-api-request-body]]
@@ -70,7 +70,7 @@ specified. {es} will not attempt to run the pipeline's remaining processors.
 
 `processors`::
 (Required, array of <<processors,processor>> objects)
-Processors used to preform transformations on documents before indexing.
+Processors used to perform transformations on documents before indexing.
 Processors run sequentially in the order specified.
 
 `version`::


### PR DESCRIPTION
Backports the following commits to 7.13:
 - [DOCS] Add missing `timeout` param to create pipeline API docs (#76432)