### PR TITLE
[7.9] [DOCS] Add missing `timeout` param to create pipeline API docs (#76432)

### DIFF
--- a/docs/reference/ingest/apis/put-pipeline.asciidoc
+++ b/docs/reference/ingest/apis/put-pipeline.asciidoc
@@ -40,7 +40,7 @@ PUT _ingest/pipeline/my-pipeline-id
 [[put-pipeline-api-query-params]]
 ==== {api-query-parms-title}
 
-include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=master-timeout]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=timeoutparms]
 
 
 [[put-pipeline-api-request-body]]


### PR DESCRIPTION
Backports the following commits to 7.9:
 - [DOCS] Add missing `timeout` param to create pipeline API docs (#76432)