### PR TITLE
Name `BulkItemResponse` ctors (backport of #76439)

### DIFF
--- a/client/client-benchmark-noop-api-plugin/src/main/java/org/elasticsearch/plugin/noop/action/bulk/RestNoopBulkAction.java
+++ b/client/client-benchmark-noop-api-plugin/src/main/java/org/elasticsearch/plugin/noop/action/bulk/RestNoopBulkAction.java
@@ -78,7 +78,7 @@ public class RestNoopBulkAction extends BaseRestHandler {
     }
 
     private static class BulkRestBuilderListener extends RestBuilderListener<BulkRequest> {
-        private final BulkItemResponse ITEM_RESPONSE = new BulkItemResponse(1, DocWriteRequest.OpType.UPDATE,
+        private final BulkItemResponse ITEM_RESPONSE = BulkItemResponse.success(1, DocWriteRequest.OpType.UPDATE,
             new UpdateResponse(new ShardId("mock", "", 1), "mock_type", "1", 0L, 1L, 1L, DocWriteResponse.Result.CREATED));
 
         private final RestRequest request;

--- a/client/client-benchmark-noop-api-plugin/src/main/java/org/elasticsearch/plugin/noop/action/bulk/TransportNoopBulkAction.java
+++ b/client/client-benchmark-noop-api-plugin/src/main/java/org/elasticsearch/plugin/noop/action/bulk/TransportNoopBulkAction.java
@@ -22,7 +22,7 @@ import org.elasticsearch.tasks.Task;
 import org.elasticsearch.transport.TransportService;
 
 public class TransportNoopBulkAction extends HandledTransportAction<BulkRequest, BulkResponse> {
-    private static final BulkItemResponse ITEM_RESPONSE = new BulkItemResponse(1, DocWriteRequest.OpType.UPDATE,
+    private static final BulkItemResponse ITEM_RESPONSE = BulkItemResponse.success(1, DocWriteRequest.OpType.UPDATE,
         new UpdateResponse(new ShardId("mock", "", 1), "mock_type", "1", 0L, 1L, 1L, DocWriteResponse.Result.CREATED));
 
     @Inject

--- a/server/src/main/java/org/elasticsearch/action/bulk/BulkItemRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/bulk/BulkItemRequest.java
@@ -83,7 +83,7 @@ public class BulkItemRequest implements Writeable, Accountable {
         if (primaryResponse == null) {
             final BulkItemResponse.Failure failure = new BulkItemResponse.Failure(index, request.type(), request.id(),
                     Objects.requireNonNull(cause), true);
-            setPrimaryResponse(new BulkItemResponse(id, request.opType(), failure));
+            setPrimaryResponse(BulkItemResponse.failure(id, request.opType(), failure));
         } else {
             assert primaryResponse.isFailed() && primaryResponse.getFailure().isAborted()
                     : "response [" + Strings.toString(primaryResponse) + "]; cause [" + cause + "]";

--- a/server/src/main/java/org/elasticsearch/action/bulk/BulkItemResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/bulk/BulkItemResponse.java
@@ -143,9 +143,9 @@ public class BulkItemResponse implements Writeable, StatusToXContentObject {
         BulkItemResponse bulkItemResponse;
         if (exception != null) {
             Failure failure = new Failure(builder.getShardId().getIndexName(), builder.getType(), builder.getId(), exception, status);
-            bulkItemResponse = new BulkItemResponse(id, opType, failure);
+            bulkItemResponse = BulkItemResponse.failure(id, opType, failure);
         } else {
-            bulkItemResponse = new BulkItemResponse(id, opType, builder.build());
+            bulkItemResponse = BulkItemResponse.success(id, opType, builder.build());
         }
         return bulkItemResponse;
     }
@@ -346,66 +346,48 @@ public class BulkItemResponse implements Writeable, StatusToXContentObject {
         }
     }
 
-    private int id;
+    private final int id;
 
-    private OpType opType;
+    private final OpType opType;
 
-    private DocWriteResponse response;
+    private final DocWriteResponse response;
 
-    private Failure failure;
-
-    BulkItemResponse() {}
+    private final Failure failure;
 
     BulkItemResponse(ShardId shardId, StreamInput in) throws IOException {
         id = in.readVInt();
         opType = OpType.fromId(in.readByte());
-
-        byte type = in.readByte();
-        if (type == 0) {
-            response = new IndexResponse(shardId, in);
-        } else if (type == 1) {
-            response = new DeleteResponse(shardId, in);
-        } else if (type == 3) { // make 3 instead of 2, because 2 is already in use for 'no responses'
-            response = new UpdateResponse(shardId, in);
-        } else if (type != 2) {
-            throw new IllegalArgumentException("Unexpected type [" + type + "]");
-        }
-
-        if (in.readBoolean()) {
-            failure = new Failure(in);
-        }
+        response = readResponse(shardId, in);
+        failure = in.readBoolean() ? new Failure(in) : null;
+        assertConsistent();
     }
 
     BulkItemResponse(StreamInput in) throws IOException {
         id = in.readVInt();
         opType = OpType.fromId(in.readByte());
-
-        byte type = in.readByte();
-        if (type == 0) {
-            response = new IndexResponse(in);
-        } else if (type == 1) {
-            response = new DeleteResponse(in);
-        } else if (type == 3) { // make 3 instead of 2, because 2 is already in use for 'no responses'
-            response = new UpdateResponse(in);
-        } else if (type != 2) {
-            throw new IllegalArgumentException("Unexpected type [" + type + "]");
-        }
-
-        if (in.readBoolean()) {
-            failure = new Failure(in);
-        }
+        response = readResponse(in);
+        failure = in.readBoolean() ? new Failure(in) : null;
+        assertConsistent();
     }
 
-    public BulkItemResponse(int id, OpType opType, DocWriteResponse response) {
+    private BulkItemResponse(int id, OpType opType, DocWriteResponse response, Failure failure) {
         this.id = id;
         this.response = response;
         this.opType = opType;
+        this.failure = failure;
+        assertConsistent();
     }
 
-    public BulkItemResponse(int id, OpType opType, Failure failure) {
-        this.id = id;
-        this.opType = opType;
-        this.failure = failure;
+    private void assertConsistent() {
+        assert (response == null) ^ (failure == null) : "only one of response or failure may be set";
+    }
+
+    public static BulkItemResponse success(int id, OpType opType, DocWriteResponse response) {
+        return new BulkItemResponse(id, opType, response, null);
+    }
+
+    public static BulkItemResponse failure(int id, OpType opType, Failure failure) {
+        return new BulkItemResponse(id, opType, null, failure);
     }
 
     /**
@@ -541,6 +523,38 @@ public class BulkItemResponse implements Writeable, StatusToXContentObject {
             out.writeByte((byte) 3); // make 3 instead of 2, because 2 is already in use for 'no responses'
         } else {
             throw new IllegalStateException("Unexpected response type found [" + response.getClass() + "]");
+        }
+    }
+
+    private static DocWriteResponse readResponse(ShardId shardId, StreamInput in) throws IOException {
+        int type = in.readByte();
+        switch (type) {
+            case 0:
+                return new IndexResponse(shardId, in);
+            case 1:
+                return new DeleteResponse(shardId, in);
+            case 2:
+                return null;
+            case 3:
+                return new UpdateResponse(shardId, in);
+            default:
+                throw new IllegalArgumentException("Unexpected type [" + type + "]");
+        }
+    }
+
+    private static DocWriteResponse readResponse(StreamInput in) throws IOException {
+        int type = in.readByte();
+        switch (type) {
+            case 0:
+                return new IndexResponse(in);
+            case 1:
+                return new DeleteResponse(in);
+            case 2:
+                return null;
+            case 3:
+                return new UpdateResponse(in);
+            default:
+                throw new IllegalArgumentException("Unexpected type [" + type + "]");
         }
     }
 }

--- a/server/src/main/java/org/elasticsearch/action/bulk/BulkPrimaryExecutionContext.java
+++ b/server/src/main/java/org/elasticsearch/action/bulk/BulkPrimaryExecutionContext.java
@@ -216,7 +216,7 @@ class BulkPrimaryExecutionContext {
     /** completes the operation without doing anything on the primary */
     public void markOperationAsNoOp(DocWriteResponse response) {
         assertInvariants(ItemProcessingState.INITIAL);
-        executionResult = new BulkItemResponse(getCurrentItem().id(), getCurrentItem().request().opType(), response);
+        executionResult = BulkItemResponse.success(getCurrentItem().id(), getCurrentItem().request().opType(), response);
         currentItemState = ItemProcessingState.EXECUTED;
         assertInvariants(ItemProcessingState.EXECUTED);
     }
@@ -226,7 +226,7 @@ class BulkPrimaryExecutionContext {
         assert assertInvariants(ItemProcessingState.WAIT_FOR_MAPPING_UPDATE);
         currentItemState = ItemProcessingState.EXECUTED;
         final DocWriteRequest<?> docWriteRequest = getCurrentItem().request();
-        executionResult = new BulkItemResponse(getCurrentItem().id(), docWriteRequest.opType(),
+        executionResult = BulkItemResponse.failure(getCurrentItem().id(), docWriteRequest.opType(),
             // Make sure to use getCurrentItem().index() here, if you use docWriteRequest.index() it will use the
             // concrete index instead of an alias if used!
             new BulkItemResponse.Failure(getCurrentItem().index(), docWriteRequest.type(), docWriteRequest.id(), cause));
@@ -253,13 +253,13 @@ class BulkPrimaryExecutionContext {
                 } else {
                     throw new AssertionError("unknown result type :" + result.getResultType());
                 }
-                executionResult = new BulkItemResponse(current.id(), current.request().opType(), response);
+                executionResult = BulkItemResponse.success(current.id(), current.request().opType(), response);
                 // set a blank ShardInfo so we can safely send it to the replicas. We won't use it in the real response though.
                 executionResult.getResponse().setShardInfo(new ReplicationResponse.ShardInfo());
                 locationToSync = TransportWriteAction.locationToSync(locationToSync, result.getTranslogLocation());
                 break;
             case FAILURE:
-                executionResult = new BulkItemResponse(current.id(), docWriteRequest.opType(),
+                executionResult = BulkItemResponse.failure(current.id(), docWriteRequest.opType(),
                     // Make sure to use request.index() here, if you
                     // use docWriteRequest.index() it will use the
                     // concrete index instead of an alias if used!

--- a/server/src/main/java/org/elasticsearch/action/bulk/TransportShardBulkAction.java
+++ b/server/src/main/java/org/elasticsearch/action/bulk/TransportShardBulkAction.java
@@ -367,7 +367,11 @@ public class TransportShardBulkAction extends TransportWriteAction<BulkShardRequ
                                                   final UpdateHelper.Result translate) {
         final BulkItemResponse response;
         if (operationResponse.isFailed()) {
-            response = new BulkItemResponse(operationResponse.getItemId(), DocWriteRequest.OpType.UPDATE, operationResponse.getFailure());
+            response = BulkItemResponse.failure(
+                operationResponse.getItemId(),
+                DocWriteRequest.OpType.UPDATE,
+                operationResponse.getFailure()
+            );
         } else {
             final DocWriteResponse.Result translatedResult = translate.getResponseResult();
             final UpdateResponse updateResponse;
@@ -400,7 +404,7 @@ public class TransportShardBulkAction extends TransportWriteAction<BulkShardRequ
             } else {
                 throw new IllegalArgumentException("unknown operation type: " + translatedResult);
             }
-            response = new BulkItemResponse(operationResponse.getItemId(), DocWriteRequest.OpType.UPDATE, updateResponse);
+            response = BulkItemResponse.success(operationResponse.getItemId(), DocWriteRequest.OpType.UPDATE, updateResponse);
         }
         return response;
     }

--- a/server/src/test/java/org/elasticsearch/action/bulk/BulkItemResponseTests.java
+++ b/server/src/test/java/org/elasticsearch/action/bulk/BulkItemResponseTests.java
@@ -58,8 +58,8 @@ public class BulkItemResponseTests extends ESTestCase {
                 fail("Test does not support opType [" + opType + "]");
             }
 
-            BulkItemResponse bulkItemResponse = new BulkItemResponse(bulkItemId, opType, randomDocWriteResponses.v1());
-            BulkItemResponse expectedBulkItemResponse = new BulkItemResponse(bulkItemId, opType, randomDocWriteResponses.v2());
+            BulkItemResponse bulkItemResponse = BulkItemResponse.success(bulkItemId, opType, randomDocWriteResponses.v1());
+            BulkItemResponse expectedBulkItemResponse = BulkItemResponse.success(bulkItemId, opType, randomDocWriteResponses.v2());
             BytesReference originalBytes = toShuffledXContent(bulkItemResponse, xContentType, ToXContent.EMPTY_PARAMS, humanReadable);
 
             BulkItemResponse parsedBulkItemResponse;
@@ -85,9 +85,9 @@ public class BulkItemResponseTests extends ESTestCase {
 
         Exception bulkItemCause = (Exception) exceptions.v1();
         Failure bulkItemFailure = new Failure(index, type, id, bulkItemCause);
-        BulkItemResponse bulkItemResponse = new BulkItemResponse(itemId, opType, bulkItemFailure);
+        BulkItemResponse bulkItemResponse = BulkItemResponse.failure(itemId, opType, bulkItemFailure);
         Failure expectedBulkItemFailure = new Failure(index, type, id, exceptions.v2(), ExceptionsHelper.status(bulkItemCause));
-        BulkItemResponse expectedBulkItemResponse = new BulkItemResponse(itemId, opType, expectedBulkItemFailure);
+        BulkItemResponse expectedBulkItemResponse = BulkItemResponse.failure(itemId, opType, expectedBulkItemFailure);
         BytesReference originalBytes = toShuffledXContent(bulkItemResponse, xContentType, ToXContent.EMPTY_PARAMS, randomBoolean());
 
         // Shuffle the XContent fields

--- a/server/src/test/java/org/elasticsearch/action/bulk/BulkProcessorTests.java
+++ b/server/src/test/java/org/elasticsearch/action/bulk/BulkProcessorTests.java
@@ -13,14 +13,18 @@ import org.apache.logging.log4j.Logger;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.DocWriteRequest;
+import org.elasticsearch.action.DocWriteResponse;
 import org.elasticsearch.action.index.IndexRequest;
+import org.elasticsearch.action.index.IndexResponse;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.unit.ByteSizeUnit;
 import org.elasticsearch.common.unit.ByteSizeValue;
-import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.common.util.concurrent.EsRejectedExecutionException;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.common.xcontent.XContentType;
+import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.threadpool.Scheduler;
 import org.elasticsearch.threadpool.TestThreadPool;
@@ -181,7 +185,10 @@ public class BulkProcessorTests extends ESTestCase {
                 Math.min(concurrentBulkRequests + 1, concurrentClients);
         }
         assumeTrue("failed to find random values that allows test to run quickly", runTest);
-        BulkResponse bulkResponse = new BulkResponse(new BulkItemResponse[]{ new BulkItemResponse() }, 0);
+        BulkResponse bulkResponse = new BulkResponse(
+            new BulkItemResponse[] { BulkItemResponse.success(0, randomFrom(DocWriteRequest.OpType.values()), mockResponse()) },
+            0
+        );
         AtomicInteger failureCount = new AtomicInteger(0);
         AtomicInteger successCount = new AtomicInteger(0);
         AtomicInteger requestCount = new AtomicInteger(0);
@@ -268,7 +275,10 @@ public class BulkProcessorTests extends ESTestCase {
         final int maxBatchSize = Integer.MAX_VALUE; //don't flush based on size
         final int concurrentBulkRequests = randomIntBetween(0, 20);
         final int simulateWorkTimeInMillis = 5;
-        BulkResponse bulkResponse = new BulkResponse(new BulkItemResponse[]{ new BulkItemResponse() }, 0);
+        BulkResponse bulkResponse = new BulkResponse(
+            new BulkItemResponse[] { BulkItemResponse.success(0, randomFrom(DocWriteRequest.OpType.values()), mockResponse()) },
+            0
+        );
         AtomicInteger failureCount = new AtomicInteger(0);
         AtomicInteger successCount = new AtomicInteger(0);
         AtomicInteger requestCount = new AtomicInteger(0);
@@ -413,5 +423,9 @@ public class BulkProcessorTests extends ESTestCase {
                 }
             }
         };
+    }
+
+    private DocWriteResponse mockResponse() {
+        return new IndexResponse(new ShardId("index", "uid", 0), "type", "id", 1, 1, 1, true);
     }
 }

--- a/server/src/test/java/org/elasticsearch/action/bulk/BulkRequestModifierTests.java
+++ b/server/src/test/java/org/elasticsearch/action/bulk/BulkRequestModifierTests.java
@@ -107,7 +107,7 @@ public class BulkRequestModifierTests extends ESTestCase {
             IndexRequest indexRequest = (IndexRequest) actionRequest;
             IndexResponse indexResponse = new IndexResponse(new ShardId("index", "_na_", 0), indexRequest.type(),
                                                                indexRequest.id(), 1, 17, 1, true);
-            originalResponses.add(new BulkItemResponse(Integer.parseInt(indexRequest.id()), indexRequest.opType(), indexResponse));
+            originalResponses.add(BulkItemResponse.success(Integer.parseInt(indexRequest.id()), indexRequest.opType(), indexResponse));
         }
         bulkResponseListener.onResponse(new BulkResponse(originalResponses.toArray(new BulkItemResponse[originalResponses.size()]), 0));
 

--- a/server/src/test/java/org/elasticsearch/action/bulk/BulkResponseTests.java
+++ b/server/src/test/java/org/elasticsearch/action/bulk/BulkResponseTests.java
@@ -58,8 +58,8 @@ public class BulkResponseTests extends ESTestCase {
                     fail("Test does not support opType [" + opType + "]");
                 }
 
-                bulkItems[i] = new BulkItemResponse(i, opType, randomDocWriteResponses.v1());
-                expectedBulkItems[i] = new BulkItemResponse(i, opType, randomDocWriteResponses.v2());
+                bulkItems[i] = BulkItemResponse.success(i, opType, randomDocWriteResponses.v1());
+                expectedBulkItems[i] = BulkItemResponse.success(i, opType, randomDocWriteResponses.v2());
             } else {
                 String index = randomAlphaOfLength(5);
                 String type = randomAlphaOfLength(5);
@@ -68,9 +68,9 @@ public class BulkResponseTests extends ESTestCase {
                 Tuple<Throwable, ElasticsearchException> failures = randomExceptions();
 
                 Exception bulkItemCause = (Exception) failures.v1();
-                bulkItems[i] = new BulkItemResponse(i, opType,
+                bulkItems[i] = BulkItemResponse.failure(i, opType,
                         new BulkItemResponse.Failure(index, type, id, bulkItemCause));
-                expectedBulkItems[i] = new BulkItemResponse(i, opType,
+                expectedBulkItems[i] = BulkItemResponse.failure(i, opType,
                         new BulkItemResponse.Failure(index, type, id, failures.v2(), ExceptionsHelper.status(bulkItemCause)));
             }
         }

--- a/server/src/test/java/org/elasticsearch/action/bulk/RetryTests.java
+++ b/server/src/test/java/org/elasticsearch/action/bulk/RetryTests.java
@@ -13,8 +13,8 @@ import org.elasticsearch.action.DocWriteRequest.OpType;
 import org.elasticsearch.action.delete.DeleteResponse;
 import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.action.update.UpdateRequest;
-import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.common.util.concurrent.EsRejectedExecutionException;
+import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.client.NoOpClient;
@@ -216,12 +216,12 @@ public class RetryTests extends ESTestCase {
         }
 
         private BulkItemResponse successfulResponse() {
-            return new BulkItemResponse(1, OpType.DELETE, new DeleteResponse(
+            return BulkItemResponse.success(1, OpType.DELETE, new DeleteResponse(
                 new ShardId("test", "test", 0), "_doc", "test", 0, 0, 0, false));
         }
 
         private BulkItemResponse failedResponse() {
-            return new BulkItemResponse(1, OpType.INDEX, new BulkItemResponse.Failure("test", "test", "1",
+            return BulkItemResponse.failure(1, OpType.INDEX, new BulkItemResponse.Failure("test", "test", "1",
                 new EsRejectedExecutionException("pool full")));
         }
     }

--- a/server/src/test/java/org/elasticsearch/action/bulk/TransportBulkActionIngestTests.java
+++ b/server/src/test/java/org/elasticsearch/action/bulk/TransportBulkActionIngestTests.java
@@ -431,7 +431,7 @@ public class TransportBulkActionIngestTests extends ESTestCase {
         assertFalse(action.isExecuted); // no local index execution
         assertFalse(responseCalled.get()); // listener not called yet
 
-        BulkItemResponse itemResponse = new BulkItemResponse(0, DocWriteRequest.OpType.CREATE, indexResponse);
+        BulkItemResponse itemResponse = BulkItemResponse.success(0, DocWriteRequest.OpType.CREATE, indexResponse);
         BulkItemResponse[] bulkItemResponses = new BulkItemResponse[1];
         bulkItemResponses[0] = itemResponse;
         remoteResponseHandler.getValue().handleResponse(new BulkResponse(bulkItemResponses, 0)); // call the listener for the remote node

--- a/server/src/test/java/org/elasticsearch/action/bulk/TransportShardBulkActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/bulk/TransportShardBulkActionTests.java
@@ -737,7 +737,7 @@ public class TransportShardBulkActionTests extends IndexShardTestCase {
         BulkItemRequest itemRequest = new BulkItemRequest(0, new IndexRequest("index", "_doc").source(Requests.INDEX_CONTENT_TYPE));
         final String failureMessage = "simulated primary failure";
         final IOException exception = new IOException(failureMessage);
-        itemRequest.setPrimaryResponse(new BulkItemResponse(0,
+        itemRequest.setPrimaryResponse(BulkItemResponse.failure(0,
             randomFrom(
                 DocWriteRequest.OpType.CREATE,
                 DocWriteRequest.OpType.DELETE,
@@ -917,7 +917,7 @@ public class TransportShardBulkActionTests extends IndexShardTestCase {
     private void randomlySetIgnoredPrimaryResponse(BulkItemRequest primaryRequest) {
         if (randomBoolean()) {
             // add a response to the request and thereby check that it is ignored for the primary.
-            primaryRequest.setPrimaryResponse(new BulkItemResponse(0, DocWriteRequest.OpType.INDEX, new IndexResponse(shardId, "_doc",
+            primaryRequest.setPrimaryResponse(BulkItemResponse.success(0, DocWriteRequest.OpType.INDEX, new IndexResponse(shardId, "_doc",
                 "ignore-primary-response-on-primary", 42, 42, 42, false)));
         }
     }

--- a/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/ilm/history/ILMHistoryStoreTests.java
+++ b/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/ilm/history/ILMHistoryStoreTests.java
@@ -135,7 +135,7 @@ public class ILMHistoryStoreTests extends ESTestCase {
                 // The content of this BulkResponse doesn't matter, so just make it have the same number of responses
                 int responses = bulkRequest.numberOfActions();
                 return new BulkResponse(IntStream.range(0, responses)
-                    .mapToObj(i -> new BulkItemResponse(i, DocWriteRequest.OpType.INDEX,
+                    .mapToObj(i -> BulkItemResponse.success(i, DocWriteRequest.OpType.INDEX,
                         new IndexResponse(new ShardId("index", "uuid", 0), "_doc", randomAlphaOfLength(10), 1, 1, 1, true)))
                     .toArray(BulkItemResponse[]::new),
                     1000L);
@@ -175,7 +175,7 @@ public class ILMHistoryStoreTests extends ESTestCase {
                 // The content of this BulkResponse doesn't matter, so just make it have the same number of responses with failures
                 int responses = bulkRequest.numberOfActions();
                 return new BulkResponse(IntStream.range(0, responses)
-                    .mapToObj(i -> new BulkItemResponse(i, DocWriteRequest.OpType.INDEX,
+                    .mapToObj(i -> BulkItemResponse.failure(i, DocWriteRequest.OpType.INDEX,
                         new BulkItemResponse.Failure("index", "_doc", i + "", failureException)))
                     .toArray(BulkItemResponse[]::new),
                     1000L);

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/persistence/JobResultsPersister.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/persistence/JobResultsPersister.java
@@ -497,7 +497,7 @@ public class JobResultsPersister {
                 IndexResponse.Builder notCreatedResponse = new IndexResponse.Builder();
                 notCreatedResponse.setResult(Result.NOOP);
                 return new BulkResponse(
-                    new BulkItemResponse[]{new BulkItemResponse(0, DocWriteRequest.OpType.INDEX, notCreatedResponse.build())},
+                    new BulkItemResponse[]{BulkItemResponse.success(0, DocWriteRequest.OpType.INDEX, notCreatedResponse.build())},
                     0);
             }
         }

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/annotations/AnnotationPersisterTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/annotations/AnnotationPersisterTests.java
@@ -212,14 +212,14 @@ public class AnnotationPersisterTests extends ESTestCase {
     }
 
     private static BulkItemResponse bulkItemSuccess(String docId) {
-        return new BulkItemResponse(
+        return BulkItemResponse.success(
             1,
             DocWriteRequest.OpType.INDEX,
             new IndexResponse(new ShardId(AnnotationIndex.WRITE_ALIAS_NAME, "uuid", 1), "doc", docId, 0, 0, 1, true));
     }
 
     private static BulkItemResponse bulkItemFailure(String docId) {
-        return new BulkItemResponse(
+        return BulkItemResponse.failure(
             2,
             DocWriteRequest.OpType.INDEX,
             new BulkItemResponse.Failure("my-index", "doc", docId, new Exception("boom")));

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/datafeed/DatafeedJobTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/datafeed/DatafeedJobTests.java
@@ -519,7 +519,7 @@ public class DatafeedJobTests extends ESTestCase {
     }
 
     private static BulkItemResponse bulkItemSuccess(String docId) {
-        return new BulkItemResponse(
+        return BulkItemResponse.success(
             1,
             DocWriteRequest.OpType.INDEX,
             new IndexResponse(new ShardId(AnnotationIndex.WRITE_ALIAS_NAME, "uuid", 1), "doc", docId, 0, 0, 1, true));

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/process/autodetect/output/AutodetectResultProcessorTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/process/autodetect/output/AutodetectResultProcessorTests.java
@@ -380,8 +380,9 @@ public class AutodetectResultProcessorTests extends ESTestCase {
         when(result.getModelSnapshot()).thenReturn(modelSnapshot);
         IndexResponse indexResponse = new IndexResponse(new ShardId("ml", "uid", 0), "_doc", "1", 0L, 0L, 0L, true);
 
-        when(persister.persistModelSnapshot(any(), any(), any()))
-            .thenReturn(new BulkResponse(new BulkItemResponse[]{new BulkItemResponse(0, DocWriteRequest.OpType.INDEX, indexResponse)}, 0));
+        when(persister.persistModelSnapshot(any(), any(), any())).thenReturn(
+            new BulkResponse(new BulkItemResponse[] { BulkItemResponse.success(0, DocWriteRequest.OpType.INDEX, indexResponse) }, 0)
+        );
 
         processorUnderTest.setDeleteInterimRequired(false);
         processorUnderTest.processResult(result);

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/utils/persistence/ResultsPersisterServiceTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/utils/persistence/ResultsPersisterServiceTests.java
@@ -86,7 +86,7 @@ public class ResultsPersisterServiceTests extends ESTestCase {
     private static final IndexRequest INDEX_REQUEST_FAILURE =
         new IndexRequest("my-index").id("fail").source(Collections.singletonMap("data", "fail"));
     private static final BulkItemResponse BULK_ITEM_RESPONSE_SUCCESS =
-        new BulkItemResponse(
+        BulkItemResponse.success(
             1,
             DocWriteRequest.OpType.INDEX,
             new IndexResponse(new ShardId(AnomalyDetectorsIndex.jobResultsIndexPrefix() + "shared", "uuid", 1),
@@ -97,7 +97,7 @@ public class ResultsPersisterServiceTests extends ESTestCase {
                 1,
                 true));
     private static final BulkItemResponse BULK_ITEM_RESPONSE_FAILURE =
-        new BulkItemResponse(
+        BulkItemResponse.failure(
             2,
             DocWriteRequest.OpType.INDEX,
             new BulkItemResponse.Failure("my-index", "_doc", "fail", new Exception("boom")));
@@ -266,7 +266,7 @@ public class ResultsPersisterServiceTests extends ESTestCase {
     public void testBulkRequestChangeOnIrrecoverableFailures() {
         int maxFailureRetries = 10;
         resultsPersisterService.setMaxFailureRetries(maxFailureRetries);
-        BulkItemResponse irrecoverable = new BulkItemResponse(
+        BulkItemResponse irrecoverable = BulkItemResponse.failure(
             2,
             DocWriteRequest.OpType.INDEX,
             new BulkItemResponse.Failure("my-index", "_doc", "fail", new ElasticsearchStatusException("boom", RestStatus.BAD_REQUEST)));

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/ApiKeyServiceTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/ApiKeyServiceTests.java
@@ -215,7 +215,7 @@ public class ApiKeyServiceTests extends ESTestCase {
                 new ShardId(INTERNAL_SECURITY_MAIN_INDEX_7, randomAlphaOfLength(22), randomIntBetween(0, 1)),
                 SINGLE_MAPPING_NAME, apiKeyId, randomLongBetween(1, 99), randomLongBetween(1, 99), randomIntBetween(1, 99), true);
             listener.onResponse(new BulkResponse(new BulkItemResponse[]{
-                new BulkItemResponse(randomInt(), DocWriteRequest.OpType.INDEX, indexResponse)
+                BulkItemResponse.success(randomInt(), DocWriteRequest.OpType.INDEX, indexResponse)
             }, randomLongBetween(0, 100)));
             return null;
         }).when(client).execute(eq(BulkAction.INSTANCE), any(BulkRequest.class), any());

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/TokenServiceTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/TokenServiceTests.java
@@ -186,7 +186,7 @@ public class TokenServiceTests extends ESTestCase {
                 final UpdateResponse response = new UpdateResponse(shardId, "_doc", result.getId(), result.getSeqNo(),
                     result.getPrimaryTerm(), result.getVersion() + 1, DocWriteResponse.Result.UPDATED);
                 response.setGetResult(result);
-                responses[i] = new BulkItemResponse(i, DocWriteRequest.OpType.UPDATE, response);
+                responses[i] = BulkItemResponse.success(i, DocWriteRequest.OpType.UPDATE, response);
             }
             responseActionListener.onResponse(new BulkResponse(responses, randomLongBetween(1, 500)));
             return null;

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/service/IndexServiceAccountTokenStoreTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/service/IndexServiceAccountTokenStoreTests.java
@@ -389,7 +389,7 @@ public class IndexServiceAccountTokenStoreTests extends ESTestCase {
 
     private BulkResponse createSingleBulkResponse() {
         return new BulkResponse(new BulkItemResponse[] {
-            new BulkItemResponse(randomInt(), OpType.CREATE, new IndexResponse(
+            BulkItemResponse.success(randomInt(), OpType.CREATE, new IndexResponse(
                 mock(ShardId.class), randomAlphaOfLengthBetween(3, 8),
                 randomAlphaOfLengthBetween(3, 8), randomLong(), randomLong(), randomLong(), true
             ))

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/utils/ExceptionRootCauseFinderTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/utils/ExceptionRootCauseFinderTests.java
@@ -31,7 +31,7 @@ public class ExceptionRootCauseFinderTests extends ESTestCase {
         // 1
         bulkItemResponses.put(
             id,
-            new BulkItemResponse(
+            BulkItemResponse.failure(
                 id++,
                 OpType.INDEX,
                 new BulkItemResponse.Failure("the_index", "type", "id", new MapperParsingException("mapper parsing error"))
@@ -40,7 +40,7 @@ public class ExceptionRootCauseFinderTests extends ESTestCase {
         // 2
         bulkItemResponses.put(
             id,
-            new BulkItemResponse(
+            BulkItemResponse.failure(
                 id++,
                 OpType.INDEX,
                 new BulkItemResponse.Failure("the_index", "type", "id", new ResourceNotFoundException("resource not found error"))
@@ -49,7 +49,7 @@ public class ExceptionRootCauseFinderTests extends ESTestCase {
         // 3
         bulkItemResponses.put(
             id,
-            new BulkItemResponse(
+            BulkItemResponse.failure(
                 id++,
                 OpType.INDEX,
                 new BulkItemResponse.Failure("the_index", "type", "id", new IllegalArgumentException("illegal argument error"))
@@ -58,7 +58,7 @@ public class ExceptionRootCauseFinderTests extends ESTestCase {
         // 4 not irrecoverable
         bulkItemResponses.put(
             id,
-            new BulkItemResponse(
+            BulkItemResponse.failure(
                 id++,
                 OpType.INDEX,
                 new BulkItemResponse.Failure("the_index", "type", "id", new EsRejectedExecutionException("es rejected execution"))
@@ -67,7 +67,7 @@ public class ExceptionRootCauseFinderTests extends ESTestCase {
         // 5 not irrecoverable
         bulkItemResponses.put(
             id,
-            new BulkItemResponse(
+            BulkItemResponse.failure(
                 id++,
                 OpType.INDEX,
                 new BulkItemResponse.Failure(
@@ -81,7 +81,7 @@ public class ExceptionRootCauseFinderTests extends ESTestCase {
         // 6
         bulkItemResponses.put(
             id,
-            new BulkItemResponse(
+            BulkItemResponse.failure(
                 id++,
                 OpType.INDEX,
                 new BulkItemResponse.Failure(
@@ -95,7 +95,7 @@ public class ExceptionRootCauseFinderTests extends ESTestCase {
         // 7
         bulkItemResponses.put(
             id,
-            new BulkItemResponse(
+            BulkItemResponse.failure(
                 id++,
                 OpType.INDEX,
                 new BulkItemResponse.Failure(
@@ -109,7 +109,7 @@ public class ExceptionRootCauseFinderTests extends ESTestCase {
         // 8 not irrecoverable
         bulkItemResponses.put(
             id,
-            new BulkItemResponse(
+            BulkItemResponse.failure(
                 id++,
                 OpType.INDEX,
                 new BulkItemResponse.Failure(
@@ -123,7 +123,7 @@ public class ExceptionRootCauseFinderTests extends ESTestCase {
         // 9 not irrecoverable
         bulkItemResponses.put(
             id,
-            new BulkItemResponse(
+            BulkItemResponse.failure(
                 id++,
                 OpType.INDEX,
                 new BulkItemResponse.Failure(

--- a/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/actions/index/IndexActionTests.java
+++ b/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/actions/index/IndexActionTests.java
@@ -281,7 +281,7 @@ public class IndexActionTests extends ESTestCase {
         ArgumentCaptor<BulkRequest> captor = ArgumentCaptor.forClass(BulkRequest.class);
         PlainActionFuture<BulkResponse> listener = PlainActionFuture.newFuture();
         IndexResponse indexResponse = new IndexResponse(new ShardId(new Index("foo", "bar"), 0), "whatever", "whatever", 1, 1, 1, true);
-        BulkItemResponse response = new BulkItemResponse(0, DocWriteRequest.OpType.INDEX, indexResponse);
+        BulkItemResponse response = BulkItemResponse.success(0, DocWriteRequest.OpType.INDEX, indexResponse);
         BulkResponse bulkResponse = new BulkResponse(new BulkItemResponse[]{response}, 1);
         listener.onResponse(bulkResponse);
         when(client.bulk(captor.capture())).thenReturn(listener);
@@ -389,14 +389,14 @@ public class IndexActionTests extends ESTestCase {
         PlainActionFuture<BulkResponse> listener = PlainActionFuture.newFuture();
         BulkItemResponse.Failure failure = new BulkItemResponse.Failure("test-index", "test-type", "anything",
                 new ElasticsearchException("anything"));
-        BulkItemResponse firstResponse = new BulkItemResponse(0, DocWriteRequest.OpType.INDEX, failure);
+        BulkItemResponse firstResponse = BulkItemResponse.failure(0, DocWriteRequest.OpType.INDEX, failure);
         BulkItemResponse secondResponse;
         if (isPartialFailure) {
             ShardId shardId = new ShardId(new Index("foo", "bar"), 0);
             IndexResponse indexResponse = new IndexResponse(shardId, "whatever", "whatever", 1, 1, 1, true);
-            secondResponse = new BulkItemResponse(1, DocWriteRequest.OpType.INDEX, indexResponse);
+            secondResponse = BulkItemResponse.success(1, DocWriteRequest.OpType.INDEX, indexResponse);
         } else {
-            secondResponse = new BulkItemResponse(1, DocWriteRequest.OpType.INDEX, failure);
+            secondResponse = BulkItemResponse.failure(1, DocWriteRequest.OpType.INDEX, failure);
         }
         BulkResponse bulkResponse = new BulkResponse(new BulkItemResponse[]{firstResponse, secondResponse}, 1);
         listener.onResponse(bulkResponse);

--- a/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/execution/TriggeredWatchStoreTests.java
+++ b/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/execution/TriggeredWatchStoreTests.java
@@ -440,7 +440,7 @@ public class TriggeredWatchStoreTests extends ESTestCase {
                 DocWriteRequest<?> writeRequest = bulkRequest.requests().get(i);
                 ShardId shardId = new ShardId(TriggeredWatchStoreField.INDEX_NAME, "uuid", 0);
                 IndexResponse indexResponse = new IndexResponse(shardId, writeRequest.type(), writeRequest.id(), 1, 1, 1, true);
-                bulkItemResponse[i] = new BulkItemResponse(0, writeRequest.opType(), indexResponse);
+                bulkItemResponse[i] = BulkItemResponse.success(0, writeRequest.opType(), indexResponse);
             }
 
             listener.onResponse(new BulkResponse(bulkItemResponse, 123));
@@ -467,7 +467,7 @@ public class TriggeredWatchStoreTests extends ESTestCase {
                 DocWriteRequest<?> writeRequest = bulkRequest.requests().get(i);
                 ShardId shardId = new ShardId(TriggeredWatchStoreField.INDEX_NAME, "uuid", 0);
                 IndexResponse indexResponse = new IndexResponse(shardId, writeRequest.type(), writeRequest.id(), 1, 1, 1, true);
-                bulkItemResponse[i] = new BulkItemResponse(0, writeRequest.opType(), indexResponse);
+                bulkItemResponse[i] = BulkItemResponse.success(0, writeRequest.opType(), indexResponse);
             }
 
             listener.onResponse(new BulkResponse(bulkItemResponse, 123));

--- a/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/history/HistoryStoreTests.java
+++ b/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/history/HistoryStoreTests.java
@@ -107,7 +107,9 @@ public class HistoryStoreTests extends ESTestCase {
             IndexRequest indexRequest = (IndexRequest) request.requests().get(0);
             if (indexRequest.id().equals(wid.value()) &&
                 indexRequest.opType() == OpType.CREATE && indexRequest.index().equals(index)) {
-                listener.onResponse(new BulkResponse(new BulkItemResponse[]{ new BulkItemResponse(1, OpType.CREATE, indexResponse) }, 1));
+                listener.onResponse(
+                    new BulkResponse(new BulkItemResponse[] { BulkItemResponse.success(1, OpType.CREATE, indexResponse) }, 1)
+                );
             } else {
                 listener.onFailure(new ElasticsearchException("test issue"));
             }
@@ -173,7 +175,7 @@ public class HistoryStoreTests extends ESTestCase {
             ActionListener<BulkResponse> listener = (ActionListener<BulkResponse>) invocation.getArguments()[2];
 
             IndexResponse indexResponse = mock(IndexResponse.class);
-            listener.onResponse(new BulkResponse(new BulkItemResponse[]{ new BulkItemResponse(1, OpType.CREATE, indexResponse) }, 1));
+            listener.onResponse(new BulkResponse(new BulkItemResponse[] { BulkItemResponse.success(1, OpType.CREATE, indexResponse) }, 1));
             return null;
         }).when(client).bulk(requestCaptor.capture(), any());
 


### PR DESCRIPTION
`BulkItemResponse` can contain either a success or failure. This
replaces the two constructors used to build either case with named
static methods. So instead of
```
return new BulkItemResponse(0, OpType.CREATE, createResponse);
return new BulkItemResponse(0, OpType.CREATE, failure);
```
you now use
```
return BulkItemResponse.success(0, OpType.CREATE, createResponse);
return BulkItemResponse.failure(0, OpType.CREATE, failure);
```

This makes it marginally easier to read code building these things - you
don't have to know the type of the parameter to know if its a failure
or success.
