### PR TITLE
[7.11] [DOCS] Fix data type for create snapshot API's `metadata` param (#76465)

### DIFF
--- a/docs/reference/snapshot-restore/apis/create-snapshot-api.asciidoc
+++ b/docs/reference/snapshot-restore/apis/create-snapshot-api.asciidoc
@@ -126,7 +126,7 @@ The cluster state includes:
 IMPORTANT: By default, the entire snapshot will fail if one or more indices included in the snapshot do not have all primary shards available. You can change this behavior by setting <<create-snapshot-api-partial,`partial`>> to `true`.
 
 `metadata`::
-(Optional, string)
+(Optional, object)
 Attaches arbitrary metadata to the snapshot, such as a record of who took the snapshot, why it was taken, or any other useful data. Metadata must be less than 1024 bytes.
 
 [[create-snapshot-api-partial]]


### PR DESCRIPTION
Backports the following commits to 7.11:
 - [DOCS] Fix data type for create snapshot API's `metadata` param (#76465)