### PR TITLE
[7.12] [DOCS] Fix data type for create snapshot API's `metadata` param (#76465)

### DIFF
--- a/docs/reference/snapshot-restore/apis/create-snapshot-api.asciidoc
+++ b/docs/reference/snapshot-restore/apis/create-snapshot-api.asciidoc
@@ -141,7 +141,7 @@ By default, all available feature states will be included in the snapshot if
 is `false`.
 
 `metadata`::
-(Optional, string)
+(Optional, object)
 Attaches arbitrary metadata to the snapshot, such as a record of who took the snapshot, why it was taken, or any other useful data. Metadata must be less than 1024 bytes.
 
 [[create-snapshot-api-partial]]


### PR DESCRIPTION
Backports the following commits to 7.12:
 - [DOCS] Fix data type for create snapshot API's `metadata` param (#76465)