### PR TITLE
Fix memory/breaker leaks for outbound responses

### DIFF
--- a/server/src/main/java/org/elasticsearch/transport/OutboundHandler.java
+++ b/server/src/main/java/org/elasticsearch/transport/OutboundHandler.java
@@ -109,7 +109,13 @@ final class OutboundHandler {
         }
         OutboundMessage.Response message = new OutboundMessage.Response(threadPool.getThreadContext(), response, version,
             requestId, isHandshake, compressionScheme);
-        ActionListener<Void> listener = ActionListener.wrap(() -> messageListener.onResponseSent(requestId, action, response));
+        ActionListener<Void> listener = ActionListener.wrap(() -> {
+                try {
+                    messageListener.onResponseSent(requestId, action, response);
+                } finally {
+                    response.decRef();
+                }
+        });
         sendMessage(channel, message, listener);
     }
 

--- a/server/src/main/java/org/elasticsearch/transport/TransportActionProxy.java
+++ b/server/src/main/java/org/elasticsearch/transport/TransportActionProxy.java
@@ -81,6 +81,7 @@ public final class TransportActionProxy {
         @Override
         public void handleResponse(T response) {
             try {
+                response.incRef();
                 channel.sendResponse(response);
             } catch (IOException e) {
                 throw new UncheckedIOException(e);

--- a/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/CcrIntegTestCase.java
+++ b/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/CcrIntegTestCase.java
@@ -259,6 +259,9 @@ public abstract class CcrIntegTestCase extends ESTestCase {
             clusterGroup.leaderCluster.wipe(Collections.emptySet());
             clusterGroup.followerCluster.wipe(Collections.emptySet());
         }
+
+        clusterGroup.leaderCluster.assertAfterTest();
+        clusterGroup.followerCluster.assertAfterTest();
     }
 
     private NodeConfigurationSource createNodeConfigurationSource(final String leaderSeedAddress, final boolean leaderCluster) {


### PR DESCRIPTION
Outbound responses would not get the expected `decRef`, resulting in
memory and/or circuit breaker leaks. In particular, the
`GetCcrRestoreFileChunkResponse` expects this, causing a leak when
a follower bootstraps.

Relates #65921
