### PR TITLE
Adjust logging levels for LDAP failures

### DIFF
--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/ldap/ActiveDirectorySessionFactory.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/ldap/ActiveDirectorySessionFactory.java
@@ -15,6 +15,7 @@ import com.unboundid.ldap.sdk.SearchResultEntry;
 import com.unboundid.ldap.sdk.ServerSet;
 import com.unboundid.ldap.sdk.SimpleBindRequest;
 import com.unboundid.ldap.sdk.controls.AuthorizationIdentityRequestControl;
+
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.ElasticsearchSecurityException;
 import org.elasticsearch.action.ActionListener;
@@ -25,8 +26,9 @@ import org.elasticsearch.common.logging.DeprecationCategory;
 import org.elasticsearch.common.logging.DeprecationLogger;
 import org.elasticsearch.common.settings.SecureString;
 import org.elasticsearch.common.settings.Setting;
-import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.common.util.concurrent.AbstractRunnable;
+import org.elasticsearch.core.CharArrays;
+import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.core.internal.io.IOUtils;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.xpack.core.security.authc.RealmConfig;
@@ -34,7 +36,6 @@ import org.elasticsearch.xpack.core.security.authc.RealmSettings;
 import org.elasticsearch.xpack.core.security.authc.ldap.ActiveDirectorySessionFactorySettings;
 import org.elasticsearch.xpack.core.security.authc.ldap.PoolingSessionFactorySettings;
 import org.elasticsearch.xpack.core.security.authc.ldap.support.LdapSearchScope;
-import org.elasticsearch.core.CharArrays;
 import org.elasticsearch.xpack.core.ssl.SSLService;
 import org.elasticsearch.xpack.security.authc.ldap.support.LdapMetadataResolver;
 import org.elasticsearch.xpack.security.authc.ldap.support.LdapSession;
@@ -146,7 +147,7 @@ class ActiveDirectorySessionFactory extends PoolingSessionFactory {
         }
         try {
             final LDAPConnection connection = LdapUtils.privilegedConnect(serverSet::getConnection);
-            LdapUtils.maybeForkThenBind(connection, bindCredentials, threadPool, new AbstractRunnable() {
+            LdapUtils.maybeForkThenBind(connection, bindCredentials, true, threadPool, new AbstractRunnable() {
 
                 @Override
                 public void onFailure(Exception e) {
@@ -245,7 +246,7 @@ class ActiveDirectorySessionFactory extends PoolingSessionFactory {
             final byte[] passwordBytes = CharArrays.toUtf8Bytes(password.getChars());
             final SimpleBindRequest userBind = new SimpleBindRequest(bindUsername(username), passwordBytes,
                     new AuthorizationIdentityRequestControl());
-            LdapUtils.maybeForkThenBind(connection, userBind, threadPool, new ActionRunnable<LdapSession>(listener) {
+            LdapUtils.maybeForkThenBind(connection, userBind, false, threadPool, new ActionRunnable<LdapSession>(listener) {
                 @Override
                 protected void doRun() throws Exception {
                     final ActionRunnable<LdapSession> searchRunnable = new ActionRunnable<LdapSession>(listener) {
@@ -269,7 +270,7 @@ class ActiveDirectorySessionFactory extends PoolingSessionFactory {
                         searchRunnable.run();
                     } else {
                         final SimpleBindRequest bind = new SimpleBindRequest(bindDN, CharArrays.toUtf8Bytes(bindPassword.getChars()));
-                        LdapUtils.maybeForkThenBind(connection, bind, threadPool, searchRunnable);
+                        LdapUtils.maybeForkThenBind(connection, bind, true, threadPool, searchRunnable);
                     }
                 }
             });
@@ -431,23 +432,29 @@ class ActiveDirectorySessionFactory extends PoolingSessionFactory {
                                     finalLdapConnection.getConnectedAddress(),
                                     finalLdapConnection.getSSLSession() != null ? ldapsPort : ldapPort));
                     final byte[] passwordBytes = CharArrays.toUtf8Bytes(password.getChars());
-                    final SimpleBindRequest bind = bindDN.isEmpty()
+                    final boolean bindAsAuthenticatingUser = this.bindDN.isEmpty();
+                    final SimpleBindRequest bind = bindAsAuthenticatingUser
                             ? new SimpleBindRequest(username, passwordBytes)
                             : new SimpleBindRequest(bindDN, CharArrays.toUtf8Bytes(bindPassword.getChars()));
-                    LdapUtils.maybeForkThenBind(searchConnection, bind, threadPool, new ActionRunnable<String>(listener) {
+                    ActionRunnable<String> body = new ActionRunnable<String>(listener) {
                         @Override
                         protected void doRun() throws Exception {
-                            search(searchConnection, "CN=Configuration," + domainDN, LdapSearchScope.SUB_TREE.scope(), filter,
-                                    timeLimitSeconds, ignoreReferralErrors,
-                                    ActionListener.wrap(
-                                            results -> {
-                                                IOUtils.close(searchConnection);
-                                                handleSearchResults(results, netBiosDomainName, domainNameCache, listener);
-                                            }, e -> {
-                                                IOUtils.closeWhileHandlingException(searchConnection);
-                                                listener.onFailure(e);
-                                            }),
-                                    "ncname");
+                            search(
+                                searchConnection,
+                                "CN=Configuration," + domainDN,
+                                LdapSearchScope.SUB_TREE.scope(),
+                                filter,
+                                timeLimitSeconds,
+                                ignoreReferralErrors,
+                                ActionListener.wrap(results -> {
+                                    IOUtils.close(searchConnection);
+                                    handleSearchResults(results, netBiosDomainName, domainNameCache, listener);
+                                }, e -> {
+                                    IOUtils.closeWhileHandlingException(searchConnection);
+                                    listener.onFailure(e);
+                                }),
+                                "ncname"
+                            );
                         }
 
                         @Override
@@ -455,7 +462,8 @@ class ActiveDirectorySessionFactory extends PoolingSessionFactory {
                             IOUtils.closeWhileHandlingException(searchConnection);
                             listener.onFailure(e);
                         }
-                    });
+                    };
+                    LdapUtils.maybeForkThenBind(searchConnection, bind, bindAsAuthenticatingUser == false, threadPool, body);
                 }
             } catch (LDAPException e) {
                 listener.onFailure(e);

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/ldap/LdapSessionFactory.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/ldap/LdapSessionFactory.java
@@ -9,11 +9,12 @@ package org.elasticsearch.xpack.security.authc.ldap;
 import com.unboundid.ldap.sdk.LDAPConnection;
 import com.unboundid.ldap.sdk.LDAPException;
 import com.unboundid.ldap.sdk.SimpleBindRequest;
+
 import org.elasticsearch.action.ActionListener;
-import org.elasticsearch.core.CharArrays;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.settings.SecureString;
 import org.elasticsearch.common.util.concurrent.AbstractRunnable;
+import org.elasticsearch.core.CharArrays;
 import org.elasticsearch.core.internal.io.IOUtils;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.xpack.core.security.authc.RealmConfig;
@@ -99,7 +100,7 @@ public class LdapSessionFactory extends SessionFactory {
                 void loop() {
                     final String template = userDnTemplates[loopIndex++];
                     final SimpleBindRequest bind = new SimpleBindRequest(buildDnFromTemplate(username, template), passwordBytes);
-                    LdapUtils.maybeForkThenBind(connection, bind, threadPool, this);
+                    LdapUtils.maybeForkThenBind(connection, bind, false, threadPool, this);
                 }
             }.loop();
         } catch (LDAPException e) {

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/ldap/LdapUserSearchSessionFactory.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/ldap/LdapUserSearchSessionFactory.java
@@ -13,6 +13,7 @@ import com.unboundid.ldap.sdk.LDAPException;
 import com.unboundid.ldap.sdk.LDAPInterface;
 import com.unboundid.ldap.sdk.SearchResultEntry;
 import com.unboundid.ldap.sdk.SimpleBindRequest;
+
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ActionRunnable;
 import org.elasticsearch.common.settings.SecureString;
@@ -106,7 +107,7 @@ class LdapUserSearchSessionFactory extends PoolingSessionFactory {
     void getSessionWithoutPool(String user, SecureString password, ActionListener<LdapSession> listener) {
         try {
             final LDAPConnection connection = LdapUtils.privilegedConnect(serverSet::getConnection);
-            LdapUtils.maybeForkThenBind(connection, bindCredentials, threadPool, new AbstractRunnable() {
+            LdapUtils.maybeForkThenBind(connection, bindCredentials, true, threadPool, new AbstractRunnable() {
                 @Override
                 protected void doRun() throws Exception {
                     findUser(user, connection, ActionListener.wrap((entry) -> {
@@ -117,10 +118,10 @@ class LdapUserSearchSessionFactory extends PoolingSessionFactory {
                             final String dn = entry.getDN();
                             final byte[] passwordBytes = CharArrays.toUtf8Bytes(password.getChars());
                             final SimpleBindRequest userBind = new SimpleBindRequest(dn, passwordBytes);
-                            LdapUtils.maybeForkThenBind(connection, userBind, threadPool, new AbstractRunnable() {
+                            LdapUtils.maybeForkThenBind(connection, userBind, false, threadPool, new AbstractRunnable() {
                                 @Override
                                 protected void doRun() throws Exception {
-                                    LdapUtils.maybeForkThenBind(connection, bindCredentials, threadPool, new AbstractRunnable() {
+                                    LdapUtils.maybeForkThenBind(connection, bindCredentials, true, threadPool, new AbstractRunnable() {
 
                                         @Override
                                         protected void doRun() throws Exception {
@@ -183,7 +184,7 @@ class LdapUserSearchSessionFactory extends PoolingSessionFactory {
     void getUnauthenticatedSessionWithoutPool(String user, ActionListener<LdapSession> listener) {
         try {
             final LDAPConnection connection = LdapUtils.privilegedConnect(serverSet::getConnection);
-            LdapUtils.maybeForkThenBind(connection, bindCredentials, threadPool, new AbstractRunnable() {
+            LdapUtils.maybeForkThenBind(connection, bindCredentials, true, threadPool, new AbstractRunnable() {
                 @Override
                 protected void doRun() throws Exception {
                     findUser(user, connection, ActionListener.wrap((entry) -> {

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/ldap/support/LdapUtils.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/ldap/support/LdapUtils.java
@@ -23,6 +23,8 @@ import com.unboundid.ldap.sdk.SearchResult;
 import com.unboundid.ldap.sdk.SearchResultEntry;
 import com.unboundid.ldap.sdk.SearchResultReference;
 import com.unboundid.ldap.sdk.SearchScope;
+
+import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.message.ParameterizedMessage;
@@ -57,8 +59,7 @@ public final class LdapUtils {
 
     private static final Logger LOGGER = LogManager.getLogger(LdapUtils.class);
 
-    private LdapUtils() {
-    }
+    private LdapUtils() {}
 
     public static DN dn(String dn) {
         try {
@@ -68,8 +69,7 @@ public final class LdapUtils {
         }
     }
 
-    public static <T> T privilegedConnect(CheckedSupplier<T, LDAPException> supplier)
-            throws LDAPException {
+    public static <T> T privilegedConnect(CheckedSupplier<T, LDAPException> supplier) throws LDAPException {
         SpecialPermission.check();
         try {
             return AccessController.doPrivileged((PrivilegedExceptionAction<T>) supplier::get);
@@ -113,7 +113,7 @@ public final class LdapUtils {
      * Reader thread (as returned by {@code LdapUtils#isLdapConnectionThread}), the
      * thread will be blocked until it is interrupted by something else such as a
      * timeout timer. <b>Do not call bind</b> outside this method or
-     * {@link LdapUtils#maybeForkThenBind(LDAPConnection, BindRequest, ThreadPool, AbstractRunnable)}
+     * {@link LdapUtils#maybeForkThenBind}
      *
      * @param ldapPool
      *            The LDAP connection pool on which to submit the bind operation.
@@ -127,8 +127,12 @@ public final class LdapUtils {
      *            The runnable that continues the program flow after the bind
      *            operation. It is executed on the same thread as the prior bind.
      */
-    public static void maybeForkThenBindAndRevert(LDAPConnectionPool ldapPool, BindRequest bind, ThreadPool threadPool,
-                                                  AbstractRunnable runnable) {
+    public static void maybeForkThenBindAndRevert(
+        LDAPConnectionPool ldapPool,
+        BindRequest bind,
+        ThreadPool threadPool,
+        AbstractRunnable runnable
+    ) {
         final Runnable bindRunnable = new AbstractRunnable() {
             @Override
             @SuppressForbidden(reason = "Bind allowed if forking of the LDAP Connection Reader Thread.")
@@ -161,21 +165,28 @@ public final class LdapUtils {
      * Reader thread (as returned by {@code LdapUtils#isLdapConnectionThread}), the
      * thread will be blocked until it is interrupted by something else such as a
      * timeout timer. <b>Do not call bind</b> outside this method or
-     * {@link LdapUtils#maybeForkThenBind(LDAPConnection, BindRequest, ThreadPool, AbstractRunnable)}
-     *
-     * @param ldap
+     * {@link LdapUtils#maybeForkThenBindAndRevert}
+     *  @param ldap
      *            The LDAP connection on which to submit the bind operation.
      * @param bind
      *            The request object of the bind operation.
+     * @param systemBind
+     *            {@code true} if this bind is a "system" user, configured by an administrator (e.g. bind_dn / bind_password on a realm),
+     *            {@code false} if the bind credentials are supplied by an end user (e.g. basic authentication username / password)
      * @param threadPool
      *            The threads that will call the blocking bind operation, in case
      *            the calling thread is a connection reader, see:
      *            {@code LdapUtils#isLdapConnectionThread}.
      * @param runnable
-     *            The runnable that continues the program flow after the bind
-     *            operation. It is executed on the same thread as the prior bind.
+    *            The runnable that continues the program flow after the bind
      */
-    public static void maybeForkThenBind(LDAPConnection ldap, BindRequest bind, ThreadPool threadPool, AbstractRunnable runnable) {
+    public static void maybeForkThenBind(
+        LDAPConnection ldap,
+        BindRequest bind,
+        boolean systemBind,
+        ThreadPool threadPool,
+        AbstractRunnable runnable
+    ) {
         final Runnable bindRunnable = new AbstractRunnable() {
             @Override
             @SuppressForbidden(reason = "Bind allowed if forking of the LDAP Connection Reader Thread.")
@@ -187,7 +198,8 @@ public final class LdapUtils {
 
             @Override
             public void onFailure(Exception e) {
-                LOGGER.debug("LDAP bind [{}] failed for [{}] - [{}]", bind, ldap, e.toString());
+                Level logLevel = systemBind ? Level.WARN : Level.DEBUG;
+                LOGGER.log(logLevel, "LDAP {} bind [{}] failed for [{}] - [{}]", systemBind ? "system" : "user", bind, ldap, e.toString());
                 runnable.onFailure(e);
             }
 
@@ -202,17 +214,20 @@ public final class LdapUtils {
     /**
      * This method performs an asynchronous ldap search operation that could have multiple results
      */
-    public static void searchForEntry(LDAPInterface ldap, String baseDN, SearchScope scope,
-                                      Filter filter, int timeLimitSeconds,
-                                      boolean ignoreReferralErrors,
-                                      ActionListener<SearchResultEntry> listener,
-                                      String... attributes) {
+    public static void searchForEntry(
+        LDAPInterface ldap,
+        String baseDN,
+        SearchScope scope,
+        Filter filter,
+        int timeLimitSeconds,
+        boolean ignoreReferralErrors,
+        ActionListener<SearchResultEntry> listener,
+        String... attributes
+    ) {
         if (ldap instanceof LDAPConnection) {
-            searchForEntry((LDAPConnection) ldap, baseDN, scope, filter, timeLimitSeconds,
-                    ignoreReferralErrors, listener, attributes);
+            searchForEntry((LDAPConnection) ldap, baseDN, scope, filter, timeLimitSeconds, ignoreReferralErrors, listener, attributes);
         } else if (ldap instanceof LDAPConnectionPool) {
-            searchForEntry((LDAPConnectionPool) ldap, baseDN, scope, filter, timeLimitSeconds,
-                    ignoreReferralErrors, listener, attributes);
+            searchForEntry((LDAPConnectionPool) ldap, baseDN, scope, filter, timeLimitSeconds, ignoreReferralErrors, listener, attributes);
         } else {
             throw new IllegalArgumentException("unsupported LDAPInterface implementation: " + ldap);
         }
@@ -226,16 +241,29 @@ public final class LdapUtils {
      * If the LDAP server returns an error {@link ResultCode} then this is handled as a
      * {@link ActionListener#onFailure(Exception) failure}
      */
-    public static void searchForEntry(LDAPConnection ldap, String baseDN, SearchScope scope,
-                                      Filter filter, int timeLimitSeconds,
-                                      boolean ignoreReferralErrors,
-                                      ActionListener<SearchResultEntry> listener,
-                                      String... attributes) {
-        LdapSearchResultListener searchResultListener = new SingleEntryListener(ldap, listener,
-                filter, ignoreReferralErrors);
+    public static void searchForEntry(
+        LDAPConnection ldap,
+        String baseDN,
+        SearchScope scope,
+        Filter filter,
+        int timeLimitSeconds,
+        boolean ignoreReferralErrors,
+        ActionListener<SearchResultEntry> listener,
+        String... attributes
+    ) {
+        LdapSearchResultListener searchResultListener = new SingleEntryListener(ldap, listener, filter, ignoreReferralErrors);
         try {
-            SearchRequest request = new SearchRequest(searchResultListener, baseDN, scope,
-                    DereferencePolicy.NEVER, 0, timeLimitSeconds, false, filter, attributes);
+            SearchRequest request = new SearchRequest(
+                searchResultListener,
+                baseDN,
+                scope,
+                DereferencePolicy.NEVER,
+                0,
+                timeLimitSeconds,
+                false,
+                filter,
+                attributes
+            );
             searchResultListener.setSearchRequest(request);
             ldap.asyncSearch(request);
         } catch (LDAPException e) {
@@ -251,32 +279,36 @@ public final class LdapUtils {
      * If the LDAP server returns an error {@link ResultCode} then this is handled as a
      * {@link ActionListener#onFailure(Exception) failure}
      */
-    public static void searchForEntry(LDAPConnectionPool ldap, String baseDN, SearchScope scope,
-                                      Filter filter, int timeLimitSeconds,
-                                      boolean ignoreReferralErrors,
-                                      ActionListener<SearchResultEntry> listener,
-                                      String... attributes) {
+    public static void searchForEntry(
+        LDAPConnectionPool ldap,
+        String baseDN,
+        SearchScope scope,
+        Filter filter,
+        int timeLimitSeconds,
+        boolean ignoreReferralErrors,
+        ActionListener<SearchResultEntry> listener,
+        String... attributes
+    ) {
         boolean searching = false;
         LDAPConnection ldapConnection = null;
         try {
             ldapConnection = privilegedConnect(ldap::getConnection);
             final LDAPConnection finalConnection = ldapConnection;
-            searchForEntry(finalConnection, baseDN, scope, filter, timeLimitSeconds,
-                    ignoreReferralErrors, ActionListener.wrap(
-                            entry -> {
-                                assert isLdapConnectionThread(Thread.currentThread()) : "Expected current thread [" + Thread.currentThread()
-                                        + "] to be an LDAPConnectionReader Thread. Probably the new library has changed the thread's name.";
-                                IOUtils.close(() -> ldap.releaseConnection(finalConnection));
-                                listener.onResponse(entry);
-                            },
-                            e -> {
-                                IOUtils.closeWhileHandlingException(
-                                        () -> ldap.releaseConnection(finalConnection)
-                                );
-                                listener.onFailure(e);
-                            }), attributes);
+            searchForEntry(finalConnection, baseDN, scope, filter, timeLimitSeconds, ignoreReferralErrors, ActionListener.wrap(entry -> {
+                assert isLdapConnectionThread(Thread.currentThread()) : "Expected current thread ["
+                    + Thread.currentThread()
+                    + "] to be an LDAPConnectionReader Thread. Probably the new library has changed the thread's name.";
+                IOUtils.close(() -> ldap.releaseConnection(finalConnection));
+                listener.onResponse(entry);
+            }, e -> {
+                IOUtils.closeWhileHandlingException(() -> ldap.releaseConnection(finalConnection));
+                listener.onFailure(e);
+            }), attributes);
             searching = true;
         } catch (LDAPException e) {
+            if (ldapConnection == null) {
+                LOGGER.warn("Failed to obtain LDAP connection from pool - {}", e.toString());
+            }
             listener.onFailure(e);
         } finally {
             if (searching == false) {
@@ -289,17 +321,20 @@ public final class LdapUtils {
     /**
      * This method performs an asynchronous ldap search operation that could have multiple results
      */
-    public static void search(LDAPInterface ldap, String baseDN, SearchScope scope,
-                              Filter filter, int timeLimitSeconds,
-                              boolean ignoreReferralErrors,
-                              ActionListener<List<SearchResultEntry>> listener,
-                              String... attributes) {
+    public static void search(
+        LDAPInterface ldap,
+        String baseDN,
+        SearchScope scope,
+        Filter filter,
+        int timeLimitSeconds,
+        boolean ignoreReferralErrors,
+        ActionListener<List<SearchResultEntry>> listener,
+        String... attributes
+    ) {
         if (ldap instanceof LDAPConnection) {
-            search((LDAPConnection) ldap, baseDN, scope, filter, timeLimitSeconds,
-                    ignoreReferralErrors, listener, attributes);
+            search((LDAPConnection) ldap, baseDN, scope, filter, timeLimitSeconds, ignoreReferralErrors, listener, attributes);
         } else if (ldap instanceof LDAPConnectionPool) {
-            search((LDAPConnectionPool) ldap, baseDN, scope, filter, timeLimitSeconds,
-                    ignoreReferralErrors, listener, attributes);
+            search((LDAPConnectionPool) ldap, baseDN, scope, filter, timeLimitSeconds, ignoreReferralErrors, listener, attributes);
         } else {
             throw new IllegalArgumentException("unsupported LDAPInterface implementation: " + ldap);
         }
@@ -308,25 +343,39 @@ public final class LdapUtils {
     /**
      * This method performs an asynchronous ldap search operation that could have multiple results
      */
-    public static void search(LDAPConnection ldap, String baseDN, SearchScope scope,
-                              Filter filter, int timeLimitSeconds,
-                              boolean ignoreReferralErrors,
-                              ActionListener<List<SearchResultEntry>> listener,
-                              String... attributes) {
+    public static void search(
+        LDAPConnection ldap,
+        String baseDN,
+        SearchScope scope,
+        Filter filter,
+        int timeLimitSeconds,
+        boolean ignoreReferralErrors,
+        ActionListener<List<SearchResultEntry>> listener,
+        String... attributes
+    ) {
         LdapSearchResultListener searchResultListener = new LdapSearchResultListener(
-                ldap,
-                ignoreReferralErrors,
-                ActionListener.wrap(
-                        searchResult -> {
-                            assert isLdapConnectionThread(Thread.currentThread()) : "Expected current thread [" + Thread.currentThread()
-                                    + "] to be an LDAPConnectionReader Thread. Probably the new library has changed the thread's name.";
-                            listener.onResponse(Collections.unmodifiableList(searchResult.getSearchEntries()));
-                        },
-                        listener::onFailure),
-                1);
+            ldap,
+            ignoreReferralErrors,
+            ActionListener.wrap(searchResult -> {
+                assert isLdapConnectionThread(Thread.currentThread()) : "Expected current thread ["
+                    + Thread.currentThread()
+                    + "] to be an LDAPConnectionReader Thread. Probably the new library has changed the thread's name.";
+                listener.onResponse(Collections.unmodifiableList(searchResult.getSearchEntries()));
+            }, listener::onFailure),
+            1
+        );
         try {
-            SearchRequest request = new SearchRequest(searchResultListener, baseDN, scope,
-                    DereferencePolicy.NEVER, 0, timeLimitSeconds, false, filter, attributes);
+            SearchRequest request = new SearchRequest(
+                searchResultListener,
+                baseDN,
+                scope,
+                DereferencePolicy.NEVER,
+                0,
+                timeLimitSeconds,
+                false,
+                filter,
+                attributes
+            );
             searchResultListener.setSearchRequest(request);
             ldap.asyncSearch(request);
         } catch (LDAPException e) {
@@ -337,11 +386,16 @@ public final class LdapUtils {
     /**
      * This method performs an asynchronous ldap search operation that could have multiple results
      */
-    public static void search(LDAPConnectionPool ldap, String baseDN, SearchScope scope,
-                              Filter filter, int timeLimitSeconds,
-                              boolean ignoreReferralErrors,
-                              ActionListener<List<SearchResultEntry>> listener,
-                              String... attributes) {
+    public static void search(
+        LDAPConnectionPool ldap,
+        String baseDN,
+        SearchScope scope,
+        Filter filter,
+        int timeLimitSeconds,
+        boolean ignoreReferralErrors,
+        ActionListener<List<SearchResultEntry>> listener,
+        String... attributes
+    ) {
         boolean searching = false;
         LDAPConnection ldapConnection = null;
         try {
@@ -356,6 +410,9 @@ public final class LdapUtils {
             }), attributes);
             searching = true;
         } catch (LDAPException e) {
+            if (ldapConnection == null) {
+                LOGGER.warn("Failed to obtain LDAP connection from pool - {}", e.toString());
+            }
             listener.onFailure(e);
         } finally {
             if (searching == false && ldapConnection != null) {
@@ -388,31 +445,31 @@ public final class LdapUtils {
 
     private static SearchResult emptyResult(SearchResult parentResult) {
         return new SearchResult(
-                parentResult.getMessageID(),
-                ResultCode.SUCCESS,
-                "Empty result",
-                parentResult.getMatchedDN(),
-                null,
-                0,
-                0,
-                null
+            parentResult.getMessageID(),
+            ResultCode.SUCCESS,
+            "Empty result",
+            parentResult.getMatchedDN(),
+            null,
+            0,
+            0,
+            null
         );
     }
 
     private static LDAPException toException(SearchResult searchResult) {
         return new LDAPException(
-                searchResult.getResultCode(),
-                searchResult.getDiagnosticMessage(),
-                searchResult.getMatchedDN(),
-                searchResult.getReferralURLs(),
-                searchResult.getResponseControls()
+            searchResult.getResultCode(),
+            searchResult.getDiagnosticMessage(),
+            searchResult.getMatchedDN(),
+            searchResult.getReferralURLs(),
+            searchResult.getResponseControls()
         );
     }
 
     public static Filter createFilter(String filterTemplate, String... arguments) throws LDAPException {
-        return Filter.create(new MessageFormat(filterTemplate, Locale.ROOT)
-                .format(encodeFilterValues(arguments), new StringBuffer(), null)
-                .toString());
+        return Filter.create(
+            new MessageFormat(filterTemplate, Locale.ROOT).format(encodeFilterValues(arguments), new StringBuffer(), null).toString()
+        );
     }
 
     public static String[] attributesToSearchFor(String[] attributes) {
@@ -426,8 +483,7 @@ public final class LdapUtils {
                 attributes.addAll(Arrays.asList(array));
             }
         }
-        return attributes.isEmpty() ? attributesToSearchFor((String[]) null)
-                : attributes.toArray(new String[attributes.size()]);
+        return attributes.isEmpty() ? attributesToSearchFor((String[]) null) : attributes.toArray(new String[attributes.size()]);
     }
 
     private static String[] encodeFilterValues(String... arguments) {
@@ -439,21 +495,22 @@ public final class LdapUtils {
 
     private static class SingleEntryListener extends LdapSearchResultListener {
 
-        SingleEntryListener(LDAPConnection ldapConnection,
-                            ActionListener<SearchResultEntry> listener, Filter filter,
-                            boolean ignoreReferralErrors) {
+        SingleEntryListener(
+            LDAPConnection ldapConnection,
+            ActionListener<SearchResultEntry> listener,
+            Filter filter,
+            boolean ignoreReferralErrors
+        ) {
             super(ldapConnection, ignoreReferralErrors, ActionListener.wrap(searchResult -> {
-                        final List<SearchResultEntry> entryList = searchResult.getSearchEntries();
-                        if (entryList.size() > 1) {
-                            listener.onFailure(Exceptions.authenticationError(
-                                    "multiple search results found for [{}]", filter));
-                        } else if (entryList.size() == 1) {
-                            listener.onResponse(entryList.get(0));
-                        } else {
-                            listener.onResponse(null);
-                        }
-                    }, listener::onFailure)
-                    , 1);
+                final List<SearchResultEntry> entryList = searchResult.getSearchEntries();
+                if (entryList.size() > 1) {
+                    listener.onFailure(Exceptions.authenticationError("multiple search results found for [{}]", filter));
+                } else if (entryList.size() == 1) {
+                    listener.onResponse(entryList.get(0));
+                } else {
+                    listener.onResponse(null);
+                }
+            }, listener::onFailure), 1);
         }
     }
 
@@ -468,8 +525,12 @@ public final class LdapUtils {
         private final ActionListener<SearchResult> listener;
         private final int depth;
 
-        LdapSearchResultListener(LDAPConnection ldapConnection, boolean ignoreReferralErrors,
-                                 ActionListener<SearchResult> listener, int depth) {
+        LdapSearchResultListener(
+            LDAPConnection ldapConnection,
+            boolean ignoreReferralErrors,
+            ActionListener<SearchResult> listener,
+            int depth
+        ) {
             this.ldapConnection = ldapConnection;
             this.listener = listener;
             this.depth = depth;
@@ -493,9 +554,9 @@ public final class LdapUtils {
             // different LDAP server/partition. There are cases where we need to follow a referral
             // in order to get the actual object we are searching for
             final String[] referralUrls = referenceList.stream()
-                    .flatMap((ref) -> Arrays.stream(ref.getReferralURLs()))
-                    .collect(Collectors.toList())
-                    .toArray(Strings.EMPTY_ARRAY);
+                .flatMap((ref) -> Arrays.stream(ref.getReferralURLs()))
+                .collect(Collectors.toList())
+                .toArray(Strings.EMPTY_ARRAY);
             final SearchRequest request = searchRequestRef.get();
             if (referralUrls.length == 0 || request.followReferrals(ldapConnection) == false) {
                 // either no referrals to follow or we have explicitly disabled referral following
@@ -503,63 +564,87 @@ public final class LdapUtils {
                 // collected. The search result passed to this method will not have of the entries
                 // as we are using a result listener and the results are not being collected by the
                 // LDAP library
-                LOGGER.trace("LDAP Search {} => {} ({})", request, searchResult, entryList);
                 if (isSuccess(searchResult)) {
-                    SearchResult resultWithValues = new SearchResult(searchResult.getMessageID(),
-                            searchResult.getResultCode(), searchResult.getDiagnosticMessage(),
-                            searchResult.getMatchedDN(), referralUrls, entryList, referenceList,
-                            entryList.size(), referenceList.size(),
-                            searchResult.getResponseControls());
+                    LOGGER.trace("LDAP Search {} => {} ({})", request, searchResult, entryList);
+                    SearchResult resultWithValues = new SearchResult(
+                        searchResult.getMessageID(),
+                        searchResult.getResultCode(),
+                        searchResult.getDiagnosticMessage(),
+                        searchResult.getMatchedDN(),
+                        referralUrls,
+                        entryList,
+                        referenceList,
+                        entryList.size(),
+                        referenceList.size(),
+                        searchResult.getResponseControls()
+                    );
                     listener.onResponse(resultWithValues);
                 } else {
+                    LOGGER.debug(
+                        "LDAP Search failed; request=[{}] result=[{}] entries=[{}] references=[{}]",
+                        request,
+                        searchResult,
+                        entryList,
+                        referenceList
+                    );
                     listener.onFailure(toException(searchResult));
                 }
             } else if (depth >= ldapConnection.getConnectionOptions().getReferralHopLimit()) {
                 // we've gone through too many levels of referrals so we terminate with the values
                 // collected so far and the proper result code to indicate the search was
                 // terminated early
-                LOGGER.trace("Referral limit exceeded {} => {} ({})",
-                        request, searchResult, entryList);
-                listener.onFailure(new LDAPException(ResultCode.REFERRAL_LIMIT_EXCEEDED,
+                LOGGER.debug("Referral limit exceeded {} => {} ({})", request, searchResult, entryList);
+                listener.onFailure(
+                    new LDAPException(
+                        ResultCode.REFERRAL_LIMIT_EXCEEDED,
                         "Referral limit exceeded (" + depth + ")",
-                        searchResult.getMatchedDN(), referralUrls,
-                        searchResult.getResponseControls()));
+                        searchResult.getMatchedDN(),
+                        referralUrls,
+                        searchResult.getResponseControls()
+                    )
+                );
             } else {
                 if (LOGGER.isTraceEnabled()) {
-                    LOGGER.trace("LDAP referred elsewhere {} => {}",
-                            request, Arrays.toString(referralUrls));
+                    LOGGER.trace("LDAP referred elsewhere {} => {}", request, Arrays.toString(referralUrls));
                 }
                 // there are referrals to follow, so we start the process to follow the referrals
                 final CountDown countDown = new CountDown(referralUrls.length);
                 final List<String> referralUrlsList = new ArrayList<>(Arrays.asList(referralUrls));
 
                 ActionListener<SearchResult> referralListener = ActionListener.wrap(
-                        innerResult -> {
-                            // synchronize here since we are possibly sending out a lot of requests
-                            // and the result lists are not thread safe and this also provides us
-                            // with a consistent view
-                            synchronized (this) {
-                                if (innerResult.getSearchEntries() != null) {
-                                    entryList.addAll(innerResult.getSearchEntries());
-                                }
-                                if (innerResult.getSearchReferences() != null) {
-                                    referenceList.addAll(innerResult.getSearchReferences());
-                                }
+                    innerResult -> {
+                        // synchronize here since we are possibly sending out a lot of requests
+                        // and the result lists are not thread safe and this also provides us
+                        // with a consistent view
+                        synchronized (this) {
+                            if (innerResult.getSearchEntries() != null) {
+                                entryList.addAll(innerResult.getSearchEntries());
                             }
+                            if (innerResult.getSearchReferences() != null) {
+                                referenceList.addAll(innerResult.getSearchReferences());
+                            }
+                        }
 
-                            // count down and once all referrals have been traversed then we can
-                            // create the results
-                            if (countDown.countDown()) {
-                                SearchResult resultWithValues = new SearchResult(
-                                        searchResult.getMessageID(), searchResult.getResultCode(),
-                                        searchResult.getDiagnosticMessage(),
-                                        searchResult.getMatchedDN(),
-                                        referralUrlsList.toArray(Strings.EMPTY_ARRAY), entryList,
-                                        referenceList, entryList.size(), referenceList.size(),
-                                        searchResult.getResponseControls());
-                                listener.onResponse(resultWithValues);
-                            }
-                        }, listener::onFailure);
+                        // count down and once all referrals have been traversed then we can
+                        // create the results
+                        if (countDown.countDown()) {
+                            SearchResult resultWithValues = new SearchResult(
+                                searchResult.getMessageID(),
+                                searchResult.getResultCode(),
+                                searchResult.getDiagnosticMessage(),
+                                searchResult.getMatchedDN(),
+                                referralUrlsList.toArray(Strings.EMPTY_ARRAY),
+                                entryList,
+                                referenceList,
+                                entryList.size(),
+                                referenceList.size(),
+                                searchResult.getResponseControls()
+                            );
+                            listener.onResponse(resultWithValues);
+                        }
+                    },
+                    listener::onFailure
+                );
 
                 for (String referralUrl : referralUrls) {
                     try {
@@ -567,12 +652,23 @@ public final class LdapUtils {
                         // get to a depth that is greater than or equal to the referral hop limit
                         // or all referrals have been followed. Each time referrals are followed
                         // from a search result, the depth increases by 1
-                        followReferral(ldapConnection, referralUrl, request, referralListener,
-                                depth + 1, ignoreReferralErrors, searchResult);
+                        followReferral(
+                            ldapConnection,
+                            referralUrl,
+                            request,
+                            referralListener,
+                            depth + 1,
+                            ignoreReferralErrors,
+                            searchResult
+                        );
                     } catch (LDAPException e) {
-                        LOGGER.warn((Supplier<?>) () -> new ParameterizedMessage(
+                        LOGGER.warn(
+                            (Supplier<?>) () -> new ParameterizedMessage(
                                 "caught exception while trying to follow referral [{}]",
-                                referralUrl), e);
+                                referralUrl
+                            ),
+                            e
+                        );
                         if (ignoreReferralErrors) {
                             // Needed in order for the countDown to be correct
                             referralListener.onResponse(emptyResult(searchResult));
@@ -593,11 +689,15 @@ public final class LdapUtils {
      * Performs the actual connection and following of a referral given a URL string.
      * This referral is being followed as it may contain a result that is relevant to our search
      */
-    private static void followReferral(LDAPConnection ldapConnection, String urlString,
-                                       SearchRequest searchRequest,
-                                       ActionListener<SearchResult> listener, int depth,
-                                       boolean ignoreErrors, SearchResult originatingResult)
-            throws LDAPException {
+    private static void followReferral(
+        LDAPConnection ldapConnection,
+        String urlString,
+        SearchRequest searchRequest,
+        ActionListener<SearchResult> listener,
+        int depth,
+        boolean ignoreErrors,
+        SearchResult originatingResult
+    ) throws LDAPException {
 
         final LDAPURL referralURL = new LDAPURL(urlString);
         final String host = referralURL.getHost();
@@ -634,38 +734,48 @@ public final class LdapUtils {
 
         // in order to follow the referral we need to open a new connection and we do so using the
         // referral connector on the ldap connection
-        final LDAPConnection referralConn =
-                privilegedConnect(() -> ldapConnection.getReferralConnector().getReferralConnection(referralURL, ldapConnection));
+        final LDAPConnection referralConn = privilegedConnect(
+            () -> ldapConnection.getReferralConnector().getReferralConnection(referralURL, ldapConnection)
+        );
         final LdapSearchResultListener ldapListener = new LdapSearchResultListener(
-                referralConn, ignoreErrors,
-                ActionListener.wrap(
-                        searchResult -> {
-                            IOUtils.close(referralConn);
-                            listener.onResponse(searchResult);
-                        },
-                        e -> {
-                            IOUtils.closeWhileHandlingException(referralConn);
-                            if (ignoreErrors) {
-                                if (LOGGER.isDebugEnabled()) {
-                                    LOGGER.debug(new ParameterizedMessage(
-                                            "Failed to retrieve results from referral URL [{}]." +
-                                                    " Treating as 'no results'",
-                                            referralURL), e);
-                                }
-                                listener.onResponse(emptyResult(originatingResult));
-                            } else {
-                                listener.onFailure(e);
-                            }
-                        }),
-                depth);
+            referralConn,
+            ignoreErrors,
+            ActionListener.wrap(searchResult -> {
+                IOUtils.close(referralConn);
+                listener.onResponse(searchResult);
+            }, e -> {
+                IOUtils.closeWhileHandlingException(referralConn);
+                if (ignoreErrors) {
+                    if (LOGGER.isDebugEnabled()) {
+                        LOGGER.debug(
+                            new ParameterizedMessage(
+                                "Failed to retrieve results from referral URL [{}]." + " Treating as 'no results'",
+                                referralURL
+                            ),
+                            e
+                        );
+                    }
+                    listener.onResponse(emptyResult(originatingResult));
+                } else {
+                    listener.onFailure(e);
+                }
+            }),
+            depth
+        );
         boolean success = false;
         try {
-            final SearchRequest referralSearchRequest =
-                    new SearchRequest(ldapListener, searchRequest.getControls(),
-                            requestBaseDN, requestScope, searchRequest.getDereferencePolicy(),
-                            searchRequest.getSizeLimit(), searchRequest.getTimeLimitSeconds(),
-                            searchRequest.typesOnly(), requestFilter,
-                            searchRequest.getAttributes());
+            final SearchRequest referralSearchRequest = new SearchRequest(
+                ldapListener,
+                searchRequest.getControls(),
+                requestBaseDN,
+                requestScope,
+                searchRequest.getDereferencePolicy(),
+                searchRequest.getSizeLimit(),
+                searchRequest.getTimeLimitSeconds(),
+                searchRequest.typesOnly(),
+                requestFilter,
+                searchRequest.getAttributes()
+            );
             ldapListener.setSearchRequest(searchRequest);
             referralConn.asyncSearch(referralSearchRequest);
             success = true;


### PR DESCRIPTION
This change increases the logging level for LDAP failures in 3 cases:

1. When a search fails, the failure details are now logged at DEBUG
rather than TRACE. The errors are useful for diagnostic purposes and
it should not be necessary to turn on TRACE to see them

2. When a failure occurs when attempting to bind using the configured
"bind_dn" and password, this is now a WARN rather than DEBUG. Failures
for user supplied credentials (e.g. basic auth) are still logged as
DEBUG because these are typically not under the control of the cluster
administrator.

3. When a failure occurs while attempting to retrieve a connection
from an LDAP connection pool, this will be logged at a WARN level.
This is almost always an error that the cluster administrator should
be aware of and seek to resolve.

In some cases this may cause 2 sets of log messages (one from LDAP and
one from the authentication service) however it is not always the case
that both are logged, and even when they are they may have different
levels of detail (for example, the authentication service message does
not always include the DN of the bind user).

Backport of: #76058
