### PR TITLE
Removes the use of the authorized indices list for bulk items authorization

### DIFF
--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/AuthorizationService.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/AuthorizationService.java
@@ -527,7 +527,7 @@ public class AuthorizationService {
                     }
                     final String resolved = resolvedIndices.getLocal().get(0);
                     if (localIndices.contains(resolved) == false) {
-                        throw illegalArgument("Found bulk item that writes to index " + resolved + " but the request writes to " +
+                        throw illegalArgument("Found bulk item that writes to index [" + resolved + "] but the request writes to " +
                                 localIndices);
                     }
                     return resolved;


### PR DESCRIPTION
This PR reuses the resolved indices of bulk shard requests for authorizing their items.

Background
------

We use two sets of indices in authorization:

* "authorizedIndices" this is the long, troublesome, list that is constructed based on the action, the list of indices in the cluster state, and the user's roles. Crucially, it is not related to the request's indices expression.
* "resolvedIndices" this is the request's indices expression where wildcards have been replaced by the matching items from the aforementioned "authorizedIndices" list

For this PR the observation is that both the `BulkShardRequest` and its constituent `BulkItemRequest`s cannot contain wildcards, therefore evaluating the resolved indices does not necessitate using the authorized indices.

The ultimate goal is to avoid computing the authorized indices list as much as possible, possibly even replacing it with a predicate and a one time traversal of the `metadata#getIndicesLookup()` names.