### PR TITLE
Lazily initialize template model - take II

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/util/LazyMap.java
+++ b/server/src/main/java/org/elasticsearch/common/util/LazyMap.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.common.util;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.function.Supplier;
+
+public class LazyMap<K, V> implements Map<K, V> {
+
+    private final Supplier<Map<K, V>> mapSupplier;
+    private volatile Map<K, V> map;
+
+    public LazyMap(Supplier<Map<K, V>> mapSupplier) {
+        this.mapSupplier = mapSupplier;
+    }
+
+    private Map<K, V> get() {
+        if (map == null) {
+            synchronized (this) {
+                if (map == null) {
+                    map = Objects.requireNonNullElse(mapSupplier.get(), Collections.emptyMap());
+                }
+            }
+        }
+        return map;
+    }
+
+    public int size() {
+        return get().size();
+    }
+
+    public boolean isEmpty() {
+        return get().isEmpty();
+    }
+
+    public boolean containsKey(Object key) {
+        return get().containsKey(key);
+    }
+
+    public boolean containsValue(Object value) {
+        return get().containsValue(value);
+    }
+
+    public V get(Object key) {
+        return get().get(key);
+    }
+
+    public V put(K key, V value) {
+        return get().put(key, value);
+    }
+
+    public V remove(Object key) {
+        return get().remove(key);
+    }
+
+    public void putAll(Map<? extends K, ? extends V> m) {
+        get().putAll(m);
+    }
+
+    public void clear() {
+        get().clear();
+    }
+
+    public Set<K> keySet() {
+        return get().keySet();
+    }
+
+    public Collection<V> values() {
+        return get().values();
+    }
+
+    public Set<Entry<K, V>> entrySet() {
+        return get().entrySet();
+    }
+
+    public boolean equals(Object o) {
+        return get().equals(o);
+    }
+
+    public int hashCode() {
+        return get().hashCode();
+    }
+}

--- a/server/src/main/java/org/elasticsearch/common/util/LazyMap.java
+++ b/server/src/main/java/org/elasticsearch/common/util/LazyMap.java
@@ -13,6 +13,9 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.function.BiConsumer;
+import java.util.function.BiFunction;
+import java.util.function.Function;
 import java.util.function.Supplier;
 
 public class LazyMap<K, V> implements Map<K, V> {
@@ -35,59 +38,141 @@ public class LazyMap<K, V> implements Map<K, V> {
         return map;
     }
 
+    @Override
     public int size() {
         return get().size();
     }
 
+    @Override
     public boolean isEmpty() {
         return get().isEmpty();
     }
 
+    @Override
     public boolean containsKey(Object key) {
         return get().containsKey(key);
     }
 
+    @Override
     public boolean containsValue(Object value) {
         return get().containsValue(value);
     }
 
+    @Override
     public V get(Object key) {
         return get().get(key);
     }
 
+    @Override
     public V put(K key, V value) {
         return get().put(key, value);
     }
 
+    @Override
     public V remove(Object key) {
         return get().remove(key);
     }
 
+    @Override
     public void putAll(Map<? extends K, ? extends V> m) {
         get().putAll(m);
     }
 
+    @Override
     public void clear() {
         get().clear();
     }
 
+    @Override
     public Set<K> keySet() {
         return get().keySet();
     }
 
+    @Override
     public Collection<V> values() {
         return get().values();
     }
 
+    @Override
     public Set<Entry<K, V>> entrySet() {
         return get().entrySet();
     }
 
+    @Override
     public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
         return get().equals(o);
     }
 
+    @Override
     public int hashCode() {
         return get().hashCode();
+    }
+
+    @Override
+    public String toString() {
+        return get().toString();
+    }
+
+    // Override default methods in Map
+    @Override
+    public V getOrDefault(Object k, V defaultValue) {
+        return get().getOrDefault(k, defaultValue);
+    }
+
+    @Override
+    public void forEach(BiConsumer<? super K, ? super V> action) {
+        get().forEach(action);
+    }
+
+    @Override
+    public void replaceAll(BiFunction<? super K, ? super V, ? extends V> function) {
+        get().replaceAll(function);
+    }
+
+    @Override
+    public V putIfAbsent(K key, V value) {
+        return get().putIfAbsent(key, value);
+    }
+
+    @Override
+    public boolean remove(Object key, Object value) {
+        return get().remove(key, value);
+    }
+
+    @Override
+    public boolean replace(K key, V oldValue, V newValue) {
+        return get().replace(key, oldValue, newValue);
+    }
+
+    @Override
+    public V replace(K key, V value) {
+        return get().replace(key, value);
+    }
+
+    @Override
+    public V computeIfAbsent(K key,
+                             Function<? super K, ? extends V> mappingFunction) {
+        return get().computeIfAbsent(key, mappingFunction);
+    }
+
+    @Override
+    public V computeIfPresent(K key,
+                              BiFunction<? super K, ? super V, ? extends V> remappingFunction) {
+        return get().computeIfPresent(key, remappingFunction);
+    }
+
+    @Override
+    public V compute(K key,
+                     BiFunction<? super K, ? super V, ? extends V> remappingFunction) {
+        return get().compute(key, remappingFunction);
+    }
+
+    @Override
+    public V merge(K key, V value,
+                   BiFunction<? super V, ? super V, ? extends V> remappingFunction) {
+        return get().merge(key, value, remappingFunction);
     }
 }

--- a/server/src/main/java/org/elasticsearch/ingest/IngestDocument.java
+++ b/server/src/main/java/org/elasticsearch/ingest/IngestDocument.java
@@ -9,6 +9,7 @@
 package org.elasticsearch.ingest;
 
 import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.util.LazyMap;
 import org.elasticsearch.index.VersionType;
 import org.elasticsearch.index.mapper.IdFieldMapper;
 import org.elasticsearch.index.mapper.IndexFieldMapper;
@@ -660,12 +661,14 @@ public final class IngestDocument {
     }
 
     private Map<String, Object> createTemplateModel() {
-        Map<String, Object> model = new HashMap<>(sourceAndMetadata);
-        model.put(SourceFieldMapper.NAME, sourceAndMetadata);
-        // If there is a field in the source with the name '_ingest' it gets overwritten here,
-        // if access to that field is required then it get accessed via '_source._ingest'
-        model.put(INGEST_KEY, ingestMetadata);
-        return model;
+        return new LazyMap<>(() -> {
+            Map<String, Object> model = new HashMap<>(sourceAndMetadata);
+            model.put(SourceFieldMapper.NAME, sourceAndMetadata);
+            // If there is a field in the source with the name '_ingest' it gets overwritten here,
+            // if access to that field is required then it get accessed via '_source._ingest'
+            model.put(INGEST_KEY, ingestMetadata);
+            return model;
+        });
     }
 
     /**


### PR DESCRIPTION
Fixes #76346

Similar to https://github.com/elastic/elasticsearch/pull/76356 but takes a different approach without API changes. This makes the compatibility tests pass and requires fewer code changes overall.

Before:
![flamegraph](https://user-images.githubusercontent.com/2163464/129027817-a2777f88-0a0f-4642-ad0b-9fbc97656918.png)

After:
![flamegraph_lazy_model](https://user-images.githubusercontent.com/2163464/129047155-bf17a0c7-10c9-4445-8e19-1a51c4be171f.png)
