### PR TITLE
[DOCS] Updates description of model_prune_window property in ML shared

### DIFF
--- a/docs/reference/ml/ml-shared.asciidoc
+++ b/docs/reference/ml/ml-shared.asciidoc
@@ -1230,9 +1230,12 @@ Only the specified `terms` can be viewed when using the Single Metric Viewer.
 end::model-plot-config-terms[]
 
 tag::model-prune-window[]
-Advanced configuration option, which affects the pruning of models that have not
-been updated for the given time duration. The value of this option must be at least
-two whole multiples of `bucket_span`. If not set, a default value is not supplied.
+Advanced configuration option. 
+Affects the pruning of models that have not been updated for the given time 
+duration. The value must be set to a multiple of the `bucket_span`. If set too 
+low, important information may be removed from the model. If not set, model 
+pruning only occurs if the model memory status reaches the soft limit 
+(`model_memory_limit`) or the hard limit (`xpack.ml.max_model_memory_limit`).
 end::model-prune-window[]
 
 tag::model-snapshot-id[]

--- a/docs/reference/ml/ml-shared.asciidoc
+++ b/docs/reference/ml/ml-shared.asciidoc
@@ -1233,9 +1233,10 @@ tag::model-prune-window[]
 Advanced configuration option. 
 Affects the pruning of models that have not been updated for the given time 
 duration. The value must be set to a multiple of the `bucket_span`. If set too 
-low, important information may be removed from the model. If not set, model 
-pruning only occurs if the model memory status reaches the soft limit 
-(`model_memory_limit`) or the hard limit (`xpack.ml.max_model_memory_limit`).
+low, important information may be removed from the model. Typically, set to 
+`30d` or longer. If not set, model pruning only occurs if the model memory 
+status reaches the soft limit (`model_memory_limit`) or the hard limit 
+(`xpack.ml.max_model_memory_limit`).
 end::model-prune-window[]
 
 tag::model-snapshot-id[]


### PR DESCRIPTION
## Overview

Updates the description of the `model_prune_window` property of the PUT job and the Update job APIs.

Related issue: https://github.com/elastic/ml-team/issues/495#issuecomment-897791066

### Preview

[PUT job](https://elasticsearch_76487.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/ml-put-job.html)
[Update job](https://elasticsearch_76487.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/ml-update-job.html)