### PR TITLE
[7.x] Update redline library to 1.2.10 (#76440)

### DIFF
--- a/distribution/packages/build.gradle
+++ b/distribution/packages/build.gradle
@@ -48,15 +48,12 @@ buildscript {
     maven { url 'https://jitpack.io' }
   }
 
-  // We rely on a patched version of the redline library used to build rpm packages
+  // We rely on a specific version of the redline library used to build rpm packages
   // to support sha256header in our elasticsearch RPMs
-  // TODO: Update / remove this dependency once https://github.com/craigwblake/redline/pull/157 got merged
-  // Be aware that it seems the redline project hasnt been active for a while
+  // TODO: Remove once https://github.com/nebula-plugins/gradle-ospackage-plugin/pull/402 got merged and released
   configurations.all {
     resolutionStrategy {
-        dependencySubstitution {
-          substitute module('org.redline-rpm:redline') using module('com.github.breskeby:redline:9c85270')
-        }
+      force 'org.redline-rpm:redline:1.2.10'
     }
   }
 


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Update redline library to 1.2.10 (#76440)