### PR TITLE
[7.x] Fix eclipse compilation after plugin spi (#76437)

### DIFF
--- a/modules/lang-painless/build.gradle
+++ b/modules/lang-painless/build.gradle
@@ -25,6 +25,10 @@ testClusters.all {
 configurations {
   spi
   compileOnlyApi.extendsFrom(spi)
+  if (isEclipse) {
+    // Eclipse buildship doesn't know about compileOnlyApi
+    api.extendsFrom(spi)
+  }
 }
 
 dependencies {


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Fix eclipse compilation after plugin spi (#76437)