### PR TITLE
Add docs for production ready compression settings

### DIFF
--- a/docs/reference/modules/remote-clusters.asciidoc
+++ b/docs/reference/modules/remote-clusters.asciidoc
@@ -292,8 +292,17 @@ separately.
   to a specific remote cluster. This setting impacts only requests
   sent to the remote cluster. If the inbound request is compressed,
   Elasticsearch compresses the response. The setting options are `true`,
-  `indexing_data`, and `false`. The option `indexing_data` is experimental.
-  If unset, the global `transport.compress` is used as the fallback setting.
+  `indexing_data`, and `false`. If unset, the global `transport.compress` is
+  used as the fallback setting.
+
+`cluster.remote.<cluster_alias>.transport.compression_scheme`::
+
+  Per cluster setting that enables you to configure compression scheme for
+  requests to a specific remote cluster. This setting impacts only requests
+  sent to the remote cluster. If an inbound request is compressed, {es}
+  compresses the response using the same compression scheme. The setting options
+  are `deflate` and `lz4`. If unset, the global `transport.compression_scheme`
+  is used as the fallback setting.
 
 [discrete]
 [[remote-cluster-sniff-settings]]

--- a/docs/reference/modules/transport.asciidoc
+++ b/docs/reference/modules/transport.asciidoc
@@ -53,15 +53,14 @@ Set to `true`, `indexing_data`, or `false` to configure transport compression
 between nodes. The option `true` will compress all data. The option
 `indexing_data` will compress only the raw index data sent between nodes during
 ingest, ccr following (excluding bootstrap), and operations based shard recovery
-(excluding transferring lucene files). The `indexing_data` option is experimental.
-Defaults to `false`.
+(excluding transferring lucene files). Defaults to `false`.
 
 `transport.compression_scheme`::
 (<<static-cluster-setting,Static>>)
 Configures the compression scheme for `transport.compress`. The options are
-`deflate` or `lz4`. The option `lz4` is experimental. If `lz4` is configured and
- the remote node has not been upgraded to a version supporting `lz4`, the traffic
- will be sent uncompressed. Defaults to `deflate`.
+`deflate` or `lz4`. If `lz4` is configured and the remote node has not been
+upgraded to a version supporting `lz4`, the traffic will be sent uncompressed.
+Defaults to `deflate`.
 
 `transport.ping_schedule`::
 (<<static-cluster-setting,Static>>)
@@ -186,7 +185,7 @@ connections between nodes.
 The `transport.compress` configuration option `indexing_data` will only
 compress requests that relate to the transport of raw indexing source data
 between nodes. This option primarily compresses data sent during ingest,
-ccr, and shard recovery. This option is experimental.
+ccr, and shard recovery.
 
 The `transport.compress` setting always configures local cluster request
 compression and is the fallback setting for remote cluster request compression.


### PR DESCRIPTION
In 7.15, we intend for the indexing_data compression level and the
compression scheme lz4 to no longer be experimental. This commit
updates the documentation to reflect this. Additionally, it adds
missing docs for the cluster.remote.*.transport.compression_scheme
setting.

Relates to #73497.