### PR TITLE
remove dashboard only reserved role

### DIFF
--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/SecurityDocumentationIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/SecurityDocumentationIT.java
@@ -705,8 +705,8 @@ public class SecurityDocumentationIT extends ESRestHighLevelClientTestCase {
 
             List<Role> roles = response.getRoles();
             assertNotNull(response);
-            // 31 system roles plus the three we created
-            assertThat(roles.size(), equalTo(31 + 3));
+            // 30 system roles plus the three we created
+            assertThat(roles.size(), equalTo(30 + 3));
         }
 
         {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStore.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStore.java
@@ -115,16 +115,6 @@ public class ReservedRolesStore implements BiConsumer<Set<String>, ActionListene
                     null,
                     MetadataUtils.getDeprecatedReservedMetadata("Please use Kibana feature privileges instead"),
                     null))
-                .put("kibana_dashboard_only_user", new RoleDescriptor(
-                        "kibana_dashboard_only_user",
-                        null,
-                        null,
-                        new RoleDescriptor.ApplicationResourcePrivileges[] {
-                            RoleDescriptor.ApplicationResourcePrivileges.builder()
-                            .application("kibana-.kibana").resources("*").privileges("read").build() },
-                        null, null,
-                        MetadataUtils.getDeprecatedReservedMetadata("Please use Kibana feature privileges instead"),
-                        null))
                 .put(KibanaSystemUser.ROLE_NAME, kibanaSystemRoleDescriptor(KibanaSystemUser.ROLE_NAME))
                 .put("logstash_system", new RoleDescriptor("logstash_system", new String[] { "monitor", MonitoringBulkAction.NAME},
                         null, null, MetadataUtils.DEFAULT_RESERVED_METADATA))


### PR DESCRIPTION
Removes the deprecated `kibana_dashboard_only_user` from the set of reserved roles in Elasticsearch as this legacy functionality is being removed from Kibana.

Relates: https://github.com/elastic/kibana/issues/54755.

