### PR TITLE
Respond with same compression scheme received

### DIFF
--- a/docs/reference/modules/transport.asciidoc
+++ b/docs/reference/modules/transport.asciidoc
@@ -200,4 +200,6 @@ request compression, you can set it on a per-remote cluster basis using the
 The compression settings do not configure compression for responses. {es} will
 compress a response if the inbound request was compressed--even when compression
 is not enabled. Similarly, {es} will not compress a response if the inbound
-request was uncompressed--even when compression is enabled.
+request was uncompressed--even when compression is enabled. The compression
+scheme used to compress a response will be the same scheme the remote node used
+to compress the request.

--- a/server/src/main/java/org/elasticsearch/transport/DeflateTransportDecompressor.java
+++ b/server/src/main/java/org/elasticsearch/transport/DeflateTransportDecompressor.java
@@ -113,6 +113,11 @@ public class DeflateTransportDecompressor implements TransportDecompressor {
     }
 
     @Override
+    public Compression.Scheme getScheme() {
+        return Compression.Scheme.DEFLATE;
+    }
+
+    @Override
     public void close() {
         inflater.end();
         for (Recycler.V<byte[]> page : pages) {

--- a/server/src/main/java/org/elasticsearch/transport/Header.java
+++ b/server/src/main/java/org/elasticsearch/transport/Header.java
@@ -32,6 +32,7 @@ public class Header {
     String actionName;
     Tuple<Map<String, String>, Map<String, Set<String>>> headers;
     Set<String> features;
+    private Compression.Scheme compressionScheme = null;
 
     Header(int networkMessageSize, long requestId, byte status, Version version) {
         this.networkMessageSize = networkMessageSize;
@@ -80,6 +81,10 @@ public class Header {
         return actionName;
     }
 
+    public Compression.Scheme getCompressionScheme() {
+        return compressionScheme;
+    }
+
     boolean needsToReadVariableHeader() {
         return headers == null;
     }
@@ -110,6 +115,11 @@ public class Header {
         } else {
             this.actionName = RESPONSE_NAME;
         }
+    }
+
+    void setCompressionScheme(Compression.Scheme compressionScheme) {
+        assert isCompressed();
+        this.compressionScheme = compressionScheme;
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/transport/InboundDecoder.java
+++ b/server/src/main/java/org/elasticsearch/transport/InboundDecoder.java
@@ -83,6 +83,7 @@ public class InboundDecoder implements Releasable {
                     return 0;
                 } else {
                     this.decompressor = decompressor;
+                    fragmentConsumer.accept(this.decompressor.getScheme());
                 }
             }
             int remainingToConsume = totalNetworkSize - bytesConsumed;

--- a/server/src/main/java/org/elasticsearch/transport/InboundHandler.java
+++ b/server/src/main/java/org/elasticsearch/transport/InboundHandler.java
@@ -160,7 +160,7 @@ public class InboundHandler {
             final StreamInput stream = namedWriteableStream(message.openOrGetStreamInput());
             assertRemoteVersion(stream, header.getVersion());
             final TransportChannel transportChannel = new TcpTransportChannel(outboundHandler, channel, action, requestId, version,
-                header.getFeatures(), header.isCompressed(), header.isHandshake(), message.takeBreakerReleaseControl());
+                header.getFeatures(), header.getCompressionScheme(), header.isHandshake(), message.takeBreakerReleaseControl());
             try {
                 handshaker.handleHandshake(transportChannel, requestId, stream);
             } catch (Exception e) {
@@ -175,7 +175,7 @@ public class InboundHandler {
             }
         } else {
             final TransportChannel transportChannel = new TcpTransportChannel(outboundHandler, channel, action, requestId, version,
-                header.getFeatures(), header.isCompressed(), header.isHandshake(), message.takeBreakerReleaseControl());
+                header.getFeatures(), header.getCompressionScheme(), header.isHandshake(), message.takeBreakerReleaseControl());
             try {
                 messageListener.onRequestReceived(requestId, action);
                 if (message.isShortCircuit()) {

--- a/server/src/main/java/org/elasticsearch/transport/InboundPipeline.java
+++ b/server/src/main/java/org/elasticsearch/transport/InboundPipeline.java
@@ -119,6 +119,9 @@ public class InboundPipeline implements Releasable {
             if (fragment instanceof Header) {
                 assert aggregator.isAggregating() == false;
                 aggregator.headerReceived((Header) fragment);
+            } else if (fragment instanceof Compression.Scheme) {
+                assert aggregator.isAggregating();
+                aggregator.updateCompressionScheme((Compression.Scheme) fragment);
             } else if (fragment == InboundDecoder.PING) {
                 assert aggregator.isAggregating() == false;
                 messageHandler.accept(channel, PING_MESSAGE);

--- a/server/src/main/java/org/elasticsearch/transport/Lz4TransportDecompressor.java
+++ b/server/src/main/java/org/elasticsearch/transport/Lz4TransportDecompressor.java
@@ -157,6 +157,11 @@ public class Lz4TransportDecompressor implements TransportDecompressor {
     }
 
     @Override
+    public Compression.Scheme getScheme() {
+        return Compression.Scheme.LZ4;
+    }
+
+    @Override
     public void close() {
         for (Recycler.V<byte[]> page : pages) {
             page.close();

--- a/server/src/main/java/org/elasticsearch/transport/OutboundHandler.java
+++ b/server/src/main/java/org/elasticsearch/transport/OutboundHandler.java
@@ -99,7 +99,6 @@ final class OutboundHandler {
                       final boolean isHandshake)
         throws IOException {
         Version version = Version.min(this.version, nodeVersion);
-        assert compressionScheme != Compression.Scheme.LZ4 || version.onOrAfter(Compression.Scheme.LZ4_VERSION);
         OutboundMessage.Response message = new OutboundMessage.Response(threadPool.getThreadContext(), features, response, version,
             requestId, isHandshake, compressionScheme);
         ActionListener<Void> listener = ActionListener.wrap(() -> messageListener.onResponseSent(requestId, action, response));

--- a/server/src/main/java/org/elasticsearch/transport/OutboundHandler.java
+++ b/server/src/main/java/org/elasticsearch/transport/OutboundHandler.java
@@ -40,21 +40,19 @@ final class OutboundHandler {
     private final StatsTracker statsTracker;
     private final ThreadPool threadPool;
     private final BigArrays bigArrays;
-    private final Compression.Scheme configuredCompressionScheme;
 
     private volatile long slowLogThresholdMs = Long.MAX_VALUE;
 
     private volatile TransportMessageListener messageListener = TransportMessageListener.NOOP_LISTENER;
 
     OutboundHandler(String nodeName, Version version, String[] features, StatsTracker statsTracker, ThreadPool threadPool,
-                    BigArrays bigArrays, Compression.Scheme compressionScheme) {
+                    BigArrays bigArrays) {
         this.nodeName = nodeName;
         this.version = version;
         this.features = features;
         this.statsTracker = statsTracker;
         this.threadPool = threadPool;
         this.bigArrays = bigArrays;
-        this.configuredCompressionScheme = compressionScheme;
     }
 
     void setSlowLogThreshold(TimeValue slowLogThreshold) {
@@ -71,14 +69,8 @@ final class OutboundHandler {
      */
     void sendRequest(final DiscoveryNode node, final TcpChannel channel, final long requestId, final String action,
                      final TransportRequest request, final TransportRequestOptions options, final Version channelVersion,
-                     final boolean compressRequest, final boolean isHandshake) throws IOException, TransportException {
+                     final Compression.Scheme compressionScheme, final boolean isHandshake) throws IOException, TransportException {
         Version version = Version.min(this.version, channelVersion);
-        final Compression.Scheme compressionScheme;
-        if (compressRequest) {
-            compressionScheme = configuredCompressionScheme;
-        } else {
-            compressionScheme = null;
-        }
         OutboundMessage.Request message =
             new OutboundMessage.Request(threadPool.getThreadContext(), features, request, version, action, requestId, isHandshake,
                 compressionScheme);
@@ -103,15 +95,11 @@ final class OutboundHandler {
      * @see #sendErrorResponse(Version, Set, TcpChannel, long, String, Exception) for sending error responses
      */
     void sendResponse(final Version nodeVersion, final Set<String> features, final TcpChannel channel, final long requestId,
-                      final String action, final TransportResponse response, final boolean compressResponse, final boolean isHandshake)
+                      final String action, final TransportResponse response, final Compression.Scheme compressionScheme,
+                      final boolean isHandshake)
         throws IOException {
         Version version = Version.min(this.version, nodeVersion);
-        final Compression.Scheme compressionScheme;
-        if (compressResponse) {
-            compressionScheme = configuredCompressionScheme;
-        } else {
-            compressionScheme = null;
-        }
+        assert compressionScheme != Compression.Scheme.LZ4 || version.onOrAfter(Compression.Scheme.LZ4_VERSION);
         OutboundMessage.Response message = new OutboundMessage.Response(threadPool.getThreadContext(), features, response, version,
             requestId, isHandshake, compressionScheme);
         ActionListener<Void> listener = ActionListener.wrap(() -> messageListener.onResponseSent(requestId, action, response));

--- a/server/src/main/java/org/elasticsearch/transport/TcpTransportChannel.java
+++ b/server/src/main/java/org/elasticsearch/transport/TcpTransportChannel.java
@@ -24,19 +24,19 @@ public final class TcpTransportChannel implements TransportChannel {
     private final long requestId;
     private final Version version;
     private final Set<String> features;
-    private final boolean compressResponse;
+    private final Compression.Scheme compressionScheme;
     private final boolean isHandshake;
     private final Releasable breakerRelease;
 
     TcpTransportChannel(OutboundHandler outboundHandler, TcpChannel channel, String action, long requestId, Version version,
-                        Set<String> features, boolean compressResponse, boolean isHandshake, Releasable breakerRelease) {
+                        Set<String> features, Compression.Scheme compressionScheme, boolean isHandshake, Releasable breakerRelease) {
         this.version = version;
         this.features = features;
         this.channel = channel;
         this.outboundHandler = outboundHandler;
         this.action = action;
         this.requestId = requestId;
-        this.compressResponse = compressResponse;
+        this.compressionScheme = compressionScheme;
         this.isHandshake = isHandshake;
         this.breakerRelease = breakerRelease;
     }
@@ -49,7 +49,7 @@ public final class TcpTransportChannel implements TransportChannel {
     @Override
     public void sendResponse(TransportResponse response) throws IOException {
         try {
-            outboundHandler.sendResponse(version, features, channel, requestId, action, response, compressResponse, isHandshake);
+            outboundHandler.sendResponse(version, features, channel, requestId, action, response, compressionScheme, isHandshake);
         } finally {
             release(false);
         }

--- a/server/src/main/java/org/elasticsearch/transport/TransportDecompressor.java
+++ b/server/src/main/java/org/elasticsearch/transport/TransportDecompressor.java
@@ -27,6 +27,8 @@ public interface TransportDecompressor extends Releasable {
 
     ReleasableBytesReference pollDecompressedPage(boolean isEOS);
 
+    Compression.Scheme getScheme();
+
     @Override
     void close();
 

--- a/server/src/test/java/org/elasticsearch/transport/InboundHandlerTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/InboundHandlerTests.java
@@ -66,7 +66,7 @@ public class InboundHandlerTests extends ESTestCase {
         TransportHandshaker handshaker = new TransportHandshaker(version, threadPool, (n, c, r, v) -> {});
         TransportKeepAlive keepAlive = new TransportKeepAlive(threadPool, TcpChannel::sendMessage);
         OutboundHandler outboundHandler = new OutboundHandler("node", version, new String[0], new StatsTracker(), threadPool,
-            BigArrays.NON_RECYCLING_INSTANCE, randomFrom(Compression.Scheme.DEFLATE, Compression.Scheme.LZ4));
+            BigArrays.NON_RECYCLING_INSTANCE);
         requestHandlers = new Transport.RequestHandlers();
         responseHandlers = new Transport.ResponseHandlers();
         handler = new InboundHandler(threadPool, outboundHandler, namedWriteableRegistry, handshaker, keepAlive, requestHandlers,

--- a/server/src/test/java/org/elasticsearch/transport/InboundPipelineTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/InboundPipelineTests.java
@@ -55,15 +55,20 @@ public class InboundPipelineTests extends ESTestCase {
                 final Version version = header.getVersion();
                 final boolean isRequest = header.isRequest();
                 final long requestId = header.getRequestId();
-                final boolean isCompressed = header.isCompressed();
+                final Compression.Scheme compressionScheme = header.getCompressionScheme();
+                if (header.isCompressed()) {
+                    assertNotNull(compressionScheme);
+                } else {
+                    assertNull(compressionScheme);
+                }
                 if (m.isShortCircuit()) {
-                    actualData = new MessageData(version, requestId, isRequest, isCompressed, header.getActionName(), null);
+                    actualData = new MessageData(version, requestId, isRequest, compressionScheme, header.getActionName(), null);
                 } else if (isRequest) {
                     final TestRequest request = new TestRequest(m.openOrGetStreamInput());
-                    actualData = new MessageData(version, requestId, isRequest, isCompressed, header.getActionName(), request.value);
+                    actualData = new MessageData(version, requestId, isRequest, compressionScheme, header.getActionName(), request.value);
                 } else {
                     final TestResponse response = new TestResponse(m.openOrGetStreamInput());
-                    actualData = new MessageData(version, requestId, isRequest, isCompressed, null, response.value);
+                    actualData = new MessageData(version, requestId, isRequest, compressionScheme, null, response.value);
                 }
                 actual.add(new Tuple<>(actualData, m.getException()));
             } catch (IOException e) {
@@ -96,14 +101,7 @@ public class InboundPipelineTests extends ESTestCase {
                     final Version version = randomFrom(Version.CURRENT, Version.CURRENT.minimumCompatibilityVersion());
                     final String value = randomRealisticUnicodeOfCodepointLength(randomIntBetween(200, 400));
                     final boolean isRequest = randomBoolean();
-
-                    Compression.Scheme scheme;
-                    if (randomBoolean()) {
-                        scheme = null;
-                    } else {
-                        scheme = randomFrom(Compression.Scheme.DEFLATE, Compression.Scheme.LZ4);
-                    }
-                    boolean isCompressed = isCompressed(version, scheme);
+                    Compression.Scheme compressionScheme = getCompressionScheme(version);
                     final long requestId = totalMessages++;
 
                     final MessageData messageData;
@@ -112,19 +110,19 @@ public class InboundPipelineTests extends ESTestCase {
                     OutboundMessage message;
                     if (isRequest) {
                         if (rarely()) {
-                            messageData = new MessageData(version, requestId, true, isCompressed, breakThisAction, null);
+                            messageData = new MessageData(version, requestId, true, compressionScheme, breakThisAction, null);
                             message = new OutboundMessage.Request(threadContext, new String[0], new TestRequest(value),
-                                version, breakThisAction, requestId, false, scheme);
+                                version, breakThisAction, requestId, false, compressionScheme);
                             expectedExceptionClass = new CircuitBreakingException("", CircuitBreaker.Durability.PERMANENT);
                         } else {
-                            messageData = new MessageData(version, requestId, true, isCompressed, actionName, value);
+                            messageData = new MessageData(version, requestId, true, compressionScheme, actionName, value);
                             message = new OutboundMessage.Request(threadContext, new String[0], new TestRequest(value),
-                                version, actionName, requestId, false, scheme);
+                                version, actionName, requestId, false, compressionScheme);
                         }
                     } else {
-                        messageData = new MessageData(version, requestId, false, isCompressed, null, value);
+                        messageData = new MessageData(version, requestId, false, compressionScheme, null, value);
                         message = new OutboundMessage.Response(threadContext, Collections.emptySet(), new TestResponse(value),
-                            version, requestId, false, scheme);
+                            version, requestId, false, compressionScheme);
                     }
 
                     expected.add(new Tuple<>(messageData, expectedExceptionClass));
@@ -154,7 +152,7 @@ public class InboundPipelineTests extends ESTestCase {
                     final MessageData actualMessageData = actualTuple.v1();
                     assertEquals(expectedMessageData.requestId, actualMessageData.requestId);
                     assertEquals(expectedMessageData.isRequest, actualMessageData.isRequest);
-                    assertEquals(expectedMessageData.isCompressed, actualMessageData.isCompressed);
+                    assertEquals(expectedMessageData.compressionScheme, actualMessageData.compressionScheme);
                     assertEquals(expectedMessageData.actionName, actualMessageData.actionName);
                     assertEquals(expectedMessageData.value, actualMessageData.value);
                     if (expectedTuple.v2() != null) {
@@ -173,11 +171,15 @@ public class InboundPipelineTests extends ESTestCase {
         }
     }
 
-    private static boolean isCompressed(Version version, Compression.Scheme scheme) {
-        if (version.before(Compression.Scheme.LZ4_VERSION) && scheme == Compression.Scheme.LZ4) {
-            return false;
+    private static Compression.Scheme getCompressionScheme(Version version) {
+        if (randomBoolean()) {
+            return null;
         } else {
-            return scheme != null;
+            if (version.before(Compression.Scheme.LZ4_VERSION)) {
+                return Compression.Scheme.DEFLATE;
+            } else {
+                return randomFrom(Compression.Scheme.DEFLATE, Compression.Scheme.LZ4);
+            }
         }
     }
 
@@ -273,15 +275,16 @@ public class InboundPipelineTests extends ESTestCase {
         private final Version version;
         private final long requestId;
         private final boolean isRequest;
-        private final boolean isCompressed;
+        private final Compression.Scheme compressionScheme;
         private final String value;
         private final String actionName;
 
-        private MessageData(Version version, long requestId, boolean isRequest, boolean isCompressed, String actionName, String value) {
+        private MessageData(Version version, long requestId, boolean isRequest, Compression.Scheme compressionScheme, String actionName,
+                            String value) {
             this.version = version;
             this.requestId = requestId;
             this.isRequest = isRequest;
-            this.isCompressed = isCompressed;
+            this.compressionScheme = compressionScheme;
             this.actionName = actionName;
             this.value = value;
         }
@@ -294,7 +297,7 @@ public class InboundPipelineTests extends ESTestCase {
             MessageData that = (MessageData) o;
             return requestId == that.requestId &&
                 isRequest == that.isRequest &&
-                isCompressed == that.isCompressed &&
+                Objects.equals(compressionScheme, that.compressionScheme) &&
                 Objects.equals(version, that.version) &&
                 Objects.equals(value, that.value) &&
                 Objects.equals(actionName, that.actionName);
@@ -302,7 +305,7 @@ public class InboundPipelineTests extends ESTestCase {
 
         @Override
         public int hashCode() {
-            return Objects.hash(version, requestId, isRequest, isCompressed, value, actionName);
+            return Objects.hash(version, requestId, isRequest, compressionScheme, value, actionName);
         }
     }
 }

--- a/server/src/test/java/org/elasticsearch/transport/TcpTransportTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/TcpTransportTests.java
@@ -403,7 +403,7 @@ public class TcpTransportTests extends ESTestCase {
 
             TcpTransport.handleException(channel, exception, lifecycle,
                 new OutboundHandler(randomAlphaOfLength(10), Version.CURRENT, new String[0], new StatsTracker(), testThreadPool,
-                    BigArrays.NON_RECYCLING_INSTANCE, randomFrom(Compression.Scheme.DEFLATE, Compression.Scheme.LZ4)));
+                    BigArrays.NON_RECYCLING_INSTANCE));
 
             if (expectClosed) {
                 assertTrue(listener.isDone());

--- a/test/framework/src/main/java/org/elasticsearch/transport/AbstractSimpleTransportTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/transport/AbstractSimpleTransportTestCase.java
@@ -2418,7 +2418,7 @@ public abstract class AbstractSimpleTransportTestCase extends ESTestCase {
                 transportResponseHandler);
             receivedLatch.await();
             assertBusy(() -> { // netty for instance invokes this concurrently so we better use assert busy here
-                TransportStats transportStats = serviceC.transport.getStats(); // request has ben send
+                TransportStats transportStats = serviceC.transport.getStats(); // request has been send
                 assertEquals(1, transportStats.getRxCount());
                 assertEquals(2, transportStats.getTxCount());
                 assertEquals(25, transportStats.getRxSize().getBytes());

--- a/test/framework/src/main/java/org/elasticsearch/transport/TestTransportChannels.java
+++ b/test/framework/src/main/java/org/elasticsearch/transport/TestTransportChannels.java
@@ -14,15 +14,12 @@ import org.elasticsearch.threadpool.ThreadPool;
 
 import java.util.Collections;
 
-import static org.elasticsearch.test.ESTestCase.randomFrom;
-
 public class TestTransportChannels {
 
     public static TcpTransportChannel newFakeTcpTransportChannel(String nodeName, TcpChannel channel, ThreadPool threadPool,
                                                                  String action, long requestId, Version version) {
         return new TcpTransportChannel(
-            new OutboundHandler(nodeName, version, new String[0], new StatsTracker(), threadPool, BigArrays.NON_RECYCLING_INSTANCE,
-                randomFrom(Compression.Scheme.DEFLATE, Compression.Scheme.LZ4)),
-            channel, action, requestId, version, Collections.emptySet(), false, false, () -> {});
+            new OutboundHandler(nodeName, version, new String[0], new StatsTracker(), threadPool, BigArrays.NON_RECYCLING_INSTANCE),
+            channel, action, requestId, version, Collections.emptySet(), null, false, () -> {});
     }
 }


### PR DESCRIPTION
This is related to #73497. Currently, we only use the configured
transport.compression_scheme setting when compressing a request or a
response. Additionally, the cluster.remote.*.compression_scheme
setting is ignored. This commit fixes this behavior by respecting the
per-cluster setting. Additionally, it resolves confusion around inbound
and outbound connections by always responding with the same scheme that
was received. This allows remote connections to have different schemes
than local connections.