### PR TITLE
Fix Mutable Data Structure in SnapshotsInProgress (#76505)

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/SnapshotsInProgress.java
+++ b/server/src/main/java/org/elasticsearch/cluster/SnapshotsInProgress.java
@@ -568,7 +568,7 @@ public class SnapshotsInProgress extends AbstractNamedDiffable<Custom> implement
             this.partial = partial;
             this.indices = org.elasticsearch.core.Map.copyOf(indices);
             this.dataStreams = org.elasticsearch.core.List.copyOf(dataStreams);
-            this.featureStates = Collections.unmodifiableList(featureStates);
+            this.featureStates = org.elasticsearch.core.List.copyOf(featureStates);
             this.startTime = startTime;
             this.shards = shards;
             this.repositoryStateId = repositoryStateId;

--- a/server/src/main/java/org/elasticsearch/snapshots/SnapshotFeatureInfo.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/SnapshotFeatureInfo.java
@@ -44,12 +44,11 @@ public class SnapshotFeatureInfo implements Writeable, ToXContentObject {
 
     public SnapshotFeatureInfo(String pluginName, List<String> indices) {
         this.pluginName = pluginName;
-        this.indices = indices;
+        this.indices = org.elasticsearch.core.List.copyOf(indices);
     }
 
     public SnapshotFeatureInfo(final StreamInput in) throws IOException {
-        this.pluginName = in.readString();
-        this.indices = in.readStringList();
+        this(in.readString(), in.readStringList());
     }
 
     @Override


### PR DESCRIPTION
The feature info instances shouldn't be mutable to prevent accidental bugs down the line.

backport of #76505 