### PR TITLE
Fix RestSnapshotsStatusCancellationIT (#75524)

### DIFF
--- a/qa/smoke-test-http/src/test/java/org/elasticsearch/http/snapshots/AbstractSnapshotRestTestCase.java
+++ b/qa/smoke-test-http/src/test/java/org/elasticsearch/http/snapshots/AbstractSnapshotRestTestCase.java
@@ -8,6 +8,7 @@
 
 package org.elasticsearch.http.snapshots;
 
+import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.CollectionUtils;
 import org.elasticsearch.http.HttpSmokeTestCase;
 import org.elasticsearch.plugins.Plugin;
@@ -18,6 +19,13 @@ import java.util.Collection;
 
 @ESIntegTestCase.ClusterScope(scope = ESIntegTestCase.Scope.TEST, numDataNodes = 0, numClientNodes = 0)
 public abstract class AbstractSnapshotRestTestCase extends HttpSmokeTestCase {
+
+    /**
+     * We use single threaded metadata fetching in some tests to make sure that once the snapshot meta thread is stuck on a blocked repo,
+     * no other snapshot meta thread can concurrently finish a request/task
+     */
+    protected static final Settings SINGLE_THREADED_SNAPSHOT_META_SETTINGS =
+        Settings.builder().put("thread_pool.snapshot_meta.core", 1).put("thread_pool.snapshot_meta.max", 1).build();
 
     @Override
     protected Collection<Class<? extends Plugin>> nodePlugins() {

--- a/qa/smoke-test-http/src/test/java/org/elasticsearch/http/snapshots/RestGetSnapshotsCancellationIT.java
+++ b/qa/smoke-test-http/src/test/java/org/elasticsearch/http/snapshots/RestGetSnapshotsCancellationIT.java
@@ -14,7 +14,6 @@ import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.client.Cancellable;
 import org.elasticsearch.client.Request;
 import org.elasticsearch.client.Response;
-import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.snapshots.AbstractSnapshotIntegTestCase;
 import org.elasticsearch.snapshots.mockstore.MockRepository;
 
@@ -30,10 +29,7 @@ import static org.hamcrest.core.IsEqual.equalTo;
 public class RestGetSnapshotsCancellationIT extends AbstractSnapshotRestTestCase {
 
     public void testGetSnapshotsCancellation() throws Exception {
-        // use single threaded metadata fetching to make sure that once the snapshot meta thread is stuck on the blocked repo below, no
-        // other snapshot meta thread can concurrently finish the request/task
-        internalCluster().startMasterOnlyNode(
-            Settings.builder().put("thread_pool.snapshot_meta.core", 1).put("thread_pool.snapshot_meta.max", 1).build());
+        internalCluster().startMasterOnlyNode(SINGLE_THREADED_SNAPSHOT_META_SETTINGS);
         internalCluster().startDataOnlyNode();
         ensureStableCluster(2);
 

--- a/qa/smoke-test-http/src/test/java/org/elasticsearch/http/snapshots/RestSnapshotsStatusCancellationIT.java
+++ b/qa/smoke-test-http/src/test/java/org/elasticsearch/http/snapshots/RestSnapshotsStatusCancellationIT.java
@@ -29,7 +29,7 @@ import static org.elasticsearch.test.TaskAssertions.awaitTaskWithPrefix;
 public class RestSnapshotsStatusCancellationIT extends AbstractSnapshotRestTestCase {
 
     public void testSnapshotStatusCancellation() throws Exception {
-        internalCluster().startMasterOnlyNode();
+        internalCluster().startMasterOnlyNode(SINGLE_THREADED_SNAPSHOT_META_SETTINGS);
         internalCluster().startDataOnlyNode();
         ensureStableCluster(2);
 


### PR DESCRIPTION
Reused the fix from the other snapshot API test.

closes #75075

backport of #75524