### PR TITLE
Add persistent licensed feature tracking

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/license/GetFeatureUsageResponse.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/license/GetFeatureUsageResponse.java
@@ -7,12 +7,14 @@
 
 package org.elasticsearch.license;
 
+import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.xcontent.ToXContentObject;
 import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.core.Nullable;
 
 import java.io.IOException;
 import java.time.Instant;
@@ -20,23 +22,31 @@ import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 
 public class GetFeatureUsageResponse extends ActionResponse implements ToXContentObject {
 
     public static class FeatureUsageInfo implements Writeable {
-        public final String name;
-        public final ZonedDateTime lastUsedTime;
+        private final String name;
+        private final ZonedDateTime lastUsedTime;
+        private final String context;
         public final String licenseLevel;
 
-        public FeatureUsageInfo(String name, ZonedDateTime lastUsedTime, String licenseLevel) {
-            this.name = name;
-            this.lastUsedTime = lastUsedTime;
-            this.licenseLevel = licenseLevel;
+        public FeatureUsageInfo(String name, ZonedDateTime lastUsedTime, @Nullable String context, String licenseLevel) {
+            this.name = Objects.requireNonNull(name, "Feature name may not be null");
+            this.lastUsedTime = Objects.requireNonNull(lastUsedTime, "Last used time may not be null");
+            this.context = context;
+            this.licenseLevel = Objects.requireNonNull(licenseLevel, "License level may not be null");
         }
 
         public FeatureUsageInfo(StreamInput in) throws IOException {
             this.name = in.readString();
             this.lastUsedTime = ZonedDateTime.ofInstant(Instant.ofEpochSecond(in.readLong()), ZoneOffset.UTC);
+            if (in.getVersion().onOrAfter(Version.V_7_15_0)) {
+                this.context = in.readOptionalString();
+            } else {
+                this.context = null;
+            }
             this.licenseLevel = in.readString();
         }
 
@@ -44,6 +54,9 @@ public class GetFeatureUsageResponse extends ActionResponse implements ToXConten
         public void writeTo(StreamOutput out) throws IOException {
             out.writeString(name);
             out.writeLong(lastUsedTime.toEpochSecond());
+            if (out.getVersion().onOrAfter(Version.V_7_15_0)) {
+                out.writeOptionalString(this.context);
+            }
             out.writeString(licenseLevel);
         }
     }
@@ -74,6 +87,7 @@ public class GetFeatureUsageResponse extends ActionResponse implements ToXConten
         for (FeatureUsageInfo feature : features) {
             builder.startObject();
             builder.field("name", feature.name);
+            builder.field("context", feature.context);
             builder.field("last_used", feature.lastUsedTime.toString());
             builder.field("license_level", feature.licenseLevel);
             builder.endObject();

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/license/LicenseService.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/license/LicenseService.java
@@ -33,6 +33,7 @@ import org.elasticsearch.protocol.xpack.XPackInfoResponse;
 import org.elasticsearch.protocol.xpack.license.DeleteLicenseRequest;
 import org.elasticsearch.protocol.xpack.license.LicensesStatus;
 import org.elasticsearch.protocol.xpack.license.PutLicenseResponse;
+import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.watcher.ResourceWatcherService;
 import org.elasticsearch.xpack.core.XPackPlugin;
 import org.elasticsearch.xpack.core.XPackSettings;
@@ -131,7 +132,7 @@ public class LicenseService extends AbstractLifecycleComponent implements Cluste
     private static final String ACKNOWLEDGEMENT_HEADER = "This license update requires acknowledgement. To acknowledge the license, " +
         "please read the following messages and update the license again, this time with the \"acknowledge=true\" parameter:";
 
-    public LicenseService(Settings settings, ClusterService clusterService, Clock clock, Environment env,
+    public LicenseService(Settings settings, ThreadPool threadPool, ClusterService clusterService, Clock clock, Environment env,
                           ResourceWatcherService resourceWatcherService, XPackLicenseState licenseState) {
         this.settings = settings;
         this.clusterService = clusterService;
@@ -144,6 +145,8 @@ public class LicenseService extends AbstractLifecycleComponent implements Cluste
             () -> updateLicenseState(getLicensesMetadata()));
         this.scheduler.register(this);
         populateExpirationCallbacks();
+
+        threadPool.scheduleWithFixedDelay(licenseState::cleanupUsageTracking, TimeValue.timeValueHours(1), ThreadPool.Names.GENERIC);
     }
 
     private void logExpirationWarning(long expirationMillis, boolean expired) {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/license/LicensedFeature.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/license/LicensedFeature.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.license;
+
+import java.util.Objects;
+
+/**
+ * A base class for checking licensed features against the license.
+ */
+public abstract class LicensedFeature {
+
+    /**
+     * A Momentary feature is one that is tracked at the moment the license is checked.
+     */
+    public static class Momentary extends LicensedFeature {
+
+        private Momentary(String name, License.OperationMode minimumOperationMode, boolean needsActive) {
+            super(name, minimumOperationMode, needsActive);
+        }
+
+        /**
+         * Checks whether the feature is allowed by the given license state, and
+         * updates the last time the feature was used.
+         */
+        public boolean check(XPackLicenseState state) {
+            if (state.isAllowed(this)) {
+                state.featureUsed(this);
+                return true;
+            } else {
+                return false;
+            }
+        }
+    }
+
+    /**
+     * A Persistent feature is one that is tracked starting when the license is checked, and later may be untracked.
+     */
+    public static class Persistent extends LicensedFeature {
+        private Persistent(String name, License.OperationMode minimumOperationMode, boolean needsActive) {
+            super(name, minimumOperationMode, needsActive);
+        }
+
+        /**
+         * Checks whether the feature is allowed by the given license state, and
+         * begins tracking the feature as "on" for the given context.
+         */
+        public boolean checkAndStartTracking(XPackLicenseState state, String contextName) {
+            if (state.isAllowed(this)) {
+                state.enableUsageTracking(this, contextName);
+                return true;
+            } else {
+                return false;
+            }
+        }
+
+        /**
+         * Stop tracking the feature so that the current time will be the last that it was used.
+         */
+        public void stopTracking(XPackLicenseState state, String contextName) {
+            state.disableUsageTracking(this, contextName);
+        }
+    }
+
+    final String name;
+    final License.OperationMode minimumOperationMode;
+    final boolean needsActive;
+
+    public LicensedFeature(String name, License.OperationMode minimumOperationMode, boolean needsActive) {
+        this.name = name;
+        this.minimumOperationMode = minimumOperationMode;
+        this.needsActive = needsActive;
+    }
+
+    /** Create a momentary feature for hte given license level */
+    public static Momentary momentary(String name, License.OperationMode licenseLevel) {
+        return new Momentary(name, licenseLevel, true);
+    }
+
+    /** Create a persistent feature for the given license level */
+    public static Persistent persistent(String name, License.OperationMode licenseLevel) {
+        return new Persistent(name, licenseLevel, true);
+    }
+
+    /**
+     * Creates a momentary feature, but one that is lenient as
+     * to whether the license needs to be active to allow the feature.
+     */
+    @Deprecated
+    public static Momentary momentaryLenient(String name, License.OperationMode licenseLevel) {
+        return new Momentary(name, licenseLevel, false);
+    }
+
+    /**
+     * Creates a persistent feature, but one that is lenient as
+     * to whether the license needs to be active to allow the feature.
+     */
+    @Deprecated
+    public static Persistent persistentLenient(String name, License.OperationMode licenseLevel) {
+        return new Persistent(name, licenseLevel, false);
+    }
+
+    /**
+     * Returns whether the feature is allowed by the current license
+     * without affecting feature tracking.
+     */
+    public final boolean checkWithoutTracking(XPackLicenseState state) {
+        return state.isAllowed(this);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        LicensedFeature that = (LicensedFeature) o;
+        return Objects.equals(name, that.name);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name);
+    }
+}

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/license/XPackLicenseState.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/license/XPackLicenseState.java
@@ -7,28 +7,26 @@
 package org.elasticsearch.license;
 
 import org.elasticsearch.Version;
-import org.elasticsearch.core.Nullable;
 import org.elasticsearch.common.Strings;
-import org.elasticsearch.core.SuppressForbidden;
 import org.elasticsearch.common.logging.HeaderWarning;
 import org.elasticsearch.common.logging.LoggerMessageFormat;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.core.Nullable;
+import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.license.License.OperationMode;
 import org.elasticsearch.xpack.core.XPackField;
 import org.elasticsearch.xpack.core.XPackSettings;
 import org.elasticsearch.xpack.core.monitoring.MonitoringField;
 
 import java.util.Collections;
-import java.util.EnumMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.LongAccumulator;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.function.LongSupplier;
@@ -48,11 +46,8 @@ public class XPackLicenseState {
      * Each value defines the licensed state necessary for the feature to be allowed.
      */
     public enum Feature {
-        SECURITY_IP_FILTERING(OperationMode.GOLD, false),
         SECURITY_AUDITING(OperationMode.GOLD, false),
         SECURITY_DLS_FLS(OperationMode.PLATINUM, false),
-        SECURITY_ALL_REALMS(OperationMode.PLATINUM, false),
-        SECURITY_STANDARD_REALMS(OperationMode.GOLD, false),
         SECURITY_CUSTOM_ROLE_PROVIDERS(OperationMode.PLATINUM, true),
         SECURITY_TOKEN_SERVICE(OperationMode.STANDARD, false),
         SECURITY_AUTHORIZATION_REALM(OperationMode.PLATINUM, true),
@@ -89,23 +84,20 @@ public class XPackLicenseState {
 
         AUTOSCALING(OperationMode.ENTERPRISE, true);
 
-        final OperationMode minimumOperationMode;
-        final boolean needsActive;
+        // NOTE: this is temporary. The Feature enum will go away in favor of LicensedFeature.
+        // Embedding the feature instance here is a stopgap to allow smaller initial PR,
+        // followed by PRs to convert the current consumers of the license state.
+        final LicensedFeature.Momentary feature;
 
         Feature(OperationMode minimumOperationMode, boolean needsActive) {
             assert minimumOperationMode.compareTo(OperationMode.BASIC) > 0: minimumOperationMode.toString();
-            this.minimumOperationMode = minimumOperationMode;
-            this.needsActive = needsActive;
+            if (needsActive) {
+                this.feature = LicensedFeature.momentary(name().toLowerCase(Locale.ROOT), minimumOperationMode);
+            } else {
+                this.feature = LicensedFeature.momentaryLenient(name().toLowerCase(Locale.ROOT), minimumOperationMode);
+            }
         }
     }
-
-    // temporarily non tracked feeatures which need rework in how they are checked
-    // so they are not tracked as always used
-    private static final Set<Feature> NON_TRACKED_FEATURES = org.elasticsearch.core.Set.of(
-        Feature.SECURITY_IP_FILTERING,
-        Feature.SECURITY_ALL_REALMS,
-        Feature.SECURITY_STANDARD_REALMS
-    );
 
     /** Messages for each feature which are printed when the license expires. */
     static final Map<String, String[]> EXPIRATION_MESSAGES;
@@ -403,7 +395,14 @@ public class XPackLicenseState {
     private final List<LicenseStateListener> listeners;
     private final boolean isSecurityEnabled;
     private final boolean isSecurityExplicitlyEnabled;
-    private final Map<Feature, LongAccumulator> lastUsed;
+
+    /**
+     * A Map of features for which usage is tracked by a feature identifier and a last-used-time.
+     * A last used time of {@code -1} means that the feature is "on" and should report the current time as the last-used-time
+     * (See: {@link #epochMillisProvider}, {@link #getLastUsed}).
+     */
+    private final Map<FeatureUsage, Long> usage;
+
     private final LongSupplier epochMillisProvider;
 
     // Since Status is the only field that can be updated, we do not need to synchronize access to
@@ -416,26 +415,23 @@ public class XPackLicenseState {
         this.listeners = new CopyOnWriteArrayList<>();
         this.isSecurityEnabled = XPackSettings.SECURITY_ENABLED.get(settings);
         this.isSecurityExplicitlyEnabled = isSecurityEnabled && isSecurityExplicitlyEnabled(settings);
-
-        // prepopulate feature last used map with entries for non basic features, which are the ones we
-        // care to actually keep track of
-        Map<Feature, LongAccumulator> lastUsed = new EnumMap<>(Feature.class);
-        for (Feature feature : Feature.values()) {
-            if (NON_TRACKED_FEATURES.contains(feature) == false) {
-                lastUsed.put(feature, new LongAccumulator(Long::max, 0));
-            }
-        }
-        this.lastUsed = lastUsed;
+        this.usage = new ConcurrentHashMap<>();
         this.epochMillisProvider = epochMillisProvider;
     }
 
-    private XPackLicenseState(List<LicenseStateListener> listeners, boolean isSecurityEnabled, boolean isSecurityExplicitlyEnabled,
-                              Status status, Map<Feature, LongAccumulator> lastUsed, LongSupplier epochMillisProvider) {
+    private XPackLicenseState(
+        List<LicenseStateListener> listeners,
+        boolean isSecurityEnabled,
+        boolean isSecurityExplicitlyEnabled,
+        Status status,
+        Map<FeatureUsage, Long> usage,
+        LongSupplier epochMillisProvider
+    ) {
         this.listeners = listeners;
         this.isSecurityEnabled = isSecurityEnabled;
         this.isSecurityExplicitlyEnabled = isSecurityExplicitlyEnabled;
         this.status = status;
-        this.lastUsed = lastUsed;
+        this.usage = usage;
         this.epochMillisProvider = epochMillisProvider;
     }
 
@@ -463,7 +459,7 @@ public class XPackLicenseState {
      *                               May be {@code null} if they have never generated a trial license on this cluster, or the most recent
      *                               trial was prior to this metadata being tracked (6.1)
      */
-    void update(OperationMode mode, boolean active, long expirationDate, @Nullable Version mostRecentTrialVersion) {
+    protected void update(OperationMode mode, boolean active, long expirationDate, @Nullable Version mostRecentTrialVersion) {
         status = new Status(mode, active, expirationDate);
         listeners.forEach(LicenseStateListener::licenseStateChanged);
     }
@@ -483,33 +479,66 @@ public class XPackLicenseState {
         return executeAgainstStatus(status -> status.mode);
     }
 
-    /**
-     * Checks that the cluster has a valid licence of any level.
-     * @see #isActive()
-     */
-    public boolean allowForAllLicenses() {
-        return checkAgainstStatus(status -> status.active);
-    }
-
     // Package private for tests
     /** Return true if the license is currently within its time boundaries, false otherwise. */
     public boolean isActive() {
         return checkAgainstStatus(status -> status.active);
     }
 
-    /**
-     * Checks whether the given feature is allowed, tracking the last usage time.
-     */
-    @SuppressForbidden(reason = "Argument to Math.abs() is definitely not Long.MIN_VALUE")
+    @Deprecated
     public boolean checkFeature(Feature feature) {
-        boolean allowed = isAllowed(feature);
-        LongAccumulator maxEpochAccumulator = lastUsed.get(feature);
-        final long licenseExpiryDate = getLicenseExpiryDate();
-        final long diff = licenseExpiryDate - System.currentTimeMillis();
-        if (maxEpochAccumulator != null) {
-            maxEpochAccumulator.accumulate(epochMillisProvider.getAsLong());
-        }
+        return feature.feature.check(this);
+    }
 
+    void featureUsed(LicensedFeature feature) {
+        usage.put(new FeatureUsage(feature, null), epochMillisProvider.getAsLong());
+        checkForExpiry(feature);
+    }
+
+    void enableUsageTracking(LicensedFeature feature, String contextName) {
+        Objects.requireNonNull(contextName, "Context name cannot be null");
+        usage.put(new FeatureUsage(feature, contextName), -1L);
+        checkForExpiry(feature);
+    }
+
+    void disableUsageTracking(LicensedFeature feature, String contextName) {
+        Objects.requireNonNull(contextName, "Context name cannot be null");
+        usage.replace(new FeatureUsage(feature, contextName), -1L, epochMillisProvider.getAsLong());
+    }
+
+    void cleanupUsageTracking() {
+        long cutoffTime = epochMillisProvider.getAsLong() - TimeValue.timeValueHours(24).getMillis();
+        usage.entrySet().removeIf(e -> {
+            long timeMillis = e.getValue();
+            if (timeMillis == -1) {
+                return false; // feature is still on, don't remove
+            }
+            return timeMillis < cutoffTime; // true if it has not been used in more than 24 hours
+        });
+    }
+
+    /**
+     * Checks whether the given feature is allowed by the current license.
+     * <p>
+     * This method should only be used when serializing whether a feature is allowed for telemetry.
+     */
+    @Deprecated
+    public boolean isAllowed(Feature feature) {
+        return isAllowed(feature.feature);
+    }
+
+    // Package protected: Only allowed to be called by LicensedFeature
+    boolean isAllowed(LicensedFeature feature) {
+        if (isAllowedByLicense(feature.minimumOperationMode, feature.needsActive)) {
+            return true;
+        }
+        return false;
+    }
+
+    private void checkForExpiry(LicensedFeature feature) {
+        final long licenseExpiryDate = getLicenseExpiryDate();
+        // TODO: this should use epochMillisProvider to avoid a system call + testability
+        final long diff = licenseExpiryDate - System.currentTimeMillis();
         if (feature.minimumOperationMode.compareTo(OperationMode.BASIC) > 0 &&
             LICENSE_EXPIRATION_WARNING_PERIOD.getMillis() > diff) {
             final long days = TimeUnit.MILLISECONDS.toDays(diff);
@@ -519,17 +548,6 @@ public class XPackLicenseState {
             HeaderWarning.addWarning("Your license {}. " +
                 "Contact your administrator or update your license for continued use of features", expiryMessage);
         }
-
-        return allowed;
-    }
-
-    /**
-     * Checks whether the given feature is allowed by the current license.
-     * <p>
-     * This method should only be used when serializing whether a feature is allowed for telemetry.
-     */
-    public boolean isAllowed(Feature feature) {
-        return isAllowedByLicense(feature.minimumOperationMode, feature.needsActive);
     }
 
     /**
@@ -537,10 +555,10 @@ public class XPackLicenseState {
      *
      * Note that if a feature has not been used, it will not appear in the map.
      */
-    public Map<Feature, Long> getLastUsed() {
-        return lastUsed.entrySet().stream()
-            .filter(e -> e.getValue().get() != 0) // feature was never used
-            .collect(Collectors.toMap(Map.Entry::getKey, e -> e.getValue().get()));
+    public Map<FeatureUsage, Long> getLastUsed() {
+        long currentTimeMillis = epochMillisProvider.getAsLong();
+        Function<Long, Long> timeConverter = v -> v == -1 ? currentTimeMillis : v;
+        return usage.entrySet().stream().collect(Collectors.toMap(Map.Entry::getKey, e -> timeConverter.apply(e.getValue())));
     }
 
     public static boolean isMachineLearningAllowedForOperationMode(final OperationMode operationMode) {
@@ -611,7 +629,7 @@ public class XPackLicenseState {
      */
     public XPackLicenseState copyCurrentLicenseState() {
         return executeAgainstStatus(status ->
-            new XPackLicenseState(listeners, isSecurityEnabled, isSecurityExplicitlyEnabled, status, lastUsed, epochMillisProvider));
+            new XPackLicenseState(listeners, isSecurityEnabled, isSecurityExplicitlyEnabled, status, usage, epochMillisProvider));
     }
 
     /**
@@ -622,6 +640,7 @@ public class XPackLicenseState {
      *
      * @return true if feature is allowed, otherwise false
      */
+    @Deprecated
     public boolean isAllowedByLicense(OperationMode minimumMode, boolean needActive) {
         return checkAgainstStatus(status -> {
             if (needActive && false == status.active) {
@@ -646,4 +665,45 @@ public class XPackLicenseState {
         return isAllowedByLicense(minimumMode, true);
     }
 
+    public static class FeatureUsage {
+        private final LicensedFeature feature;
+
+        @Nullable
+        private final String context;
+
+        private FeatureUsage(LicensedFeature feature, String context) {
+            this.feature = Objects.requireNonNull(feature, "Feature cannot be null");
+            this.context = context;
+        }
+
+        @Override
+        public String toString() {
+            return context == null ? feature.name : feature.name + ":" + context;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            FeatureUsage usage = (FeatureUsage) o;
+            return Objects.equals(feature, usage.feature) && Objects.equals(context, usage.context);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(feature, context);
+        }
+
+        public String featureName() {
+            return feature.name;
+        }
+
+        public String contextName() {
+            return context;
+        }
+
+        public OperationMode minimumOperationMode() {
+            return feature.minimumOperationMode;
+        }
+    }
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/XPackPlugin.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/XPackPlugin.java
@@ -299,7 +299,7 @@ public class XPackPlugin extends XPackClientPlugin
         List<Object> components = new ArrayList<>();
 
         final SSLService sslService = createSSLService(environment, resourceWatcherService);
-        setLicenseService(new LicenseService(settings, clusterService, getClock(),
+        setLicenseService(new LicenseService(settings, threadPool, clusterService, getClock(),
                 environment, resourceWatcherService, getLicenseState()));
 
         setEpochMillisSupplier(threadPool::absoluteTimeInMillis);

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/license/AbstractLicenseServiceTestCase.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/license/AbstractLicenseServiceTestCase.java
@@ -18,6 +18,8 @@ import org.elasticsearch.common.component.Lifecycle;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.env.Environment;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.threadpool.TestThreadPool;
+import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.watcher.ResourceWatcherService;
 import org.elasticsearch.xpack.core.XPackPlugin;
 import org.elasticsearch.xpack.core.watcher.watch.ClockMock;
@@ -40,6 +42,7 @@ public abstract class AbstractLicenseServiceTestCase extends ESTestCase {
     protected ClockMock clock;
     protected DiscoveryNodes discoveryNodes;
     protected Environment environment;
+    protected ThreadPool threadPool;
     protected String licenseType;
 
     @Before
@@ -49,6 +52,12 @@ public abstract class AbstractLicenseServiceTestCase extends ESTestCase {
         discoveryNodes = mock(DiscoveryNodes.class);
         resourceWatcherService = mock(ResourceWatcherService.class);
         environment = mock(Environment.class);
+        threadPool = new TestThreadPool("license-test");
+    }
+
+    @After
+    public void shutdown() {
+        threadPool.shutdown();
     }
 
     protected void setInitialState(License license, XPackLicenseState licenseState, Settings settings) {
@@ -60,7 +69,7 @@ public abstract class AbstractLicenseServiceTestCase extends ESTestCase {
         when(environment.configFile()).thenReturn(tempDir);
         licenseType = selfGeneratedType;
         settings = Settings.builder().put(settings).put(LicenseService.SELF_GENERATED_LICENSE_TYPE.getKey(), licenseType).build();
-        licenseService = new LicenseService(settings, clusterService, clock, environment, resourceWatcherService, licenseState);
+        licenseService = new LicenseService(settings, threadPool, clusterService, clock, environment, resourceWatcherService, licenseState);
         ClusterState state = mock(ClusterState.class);
         final ClusterBlocks noBlock = ClusterBlocks.builder().build();
         when(state.blocks()).thenReturn(noBlock);

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/license/LicenseServiceTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/license/LicenseServiceTests.java
@@ -27,6 +27,7 @@ import org.elasticsearch.protocol.xpack.license.LicensesStatus;
 import org.elasticsearch.protocol.xpack.license.PutLicenseResponse;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.TestMatchers;
+import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.watcher.ResourceWatcherService;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
@@ -46,6 +47,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.startsWith;
 import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
@@ -127,17 +129,19 @@ public class LicenseServiceTests extends ESTestCase {
             .put("discovery.type", "single-node") // So we skip TLS checks
             .build();
 
-        final ClusterState clusterState = Mockito.mock(ClusterState.class);
+        final ClusterState clusterState = mock(ClusterState.class);
         Mockito.when(clusterState.metadata()).thenReturn(Metadata.EMPTY_METADATA);
 
-        final ClusterService clusterService = Mockito.mock(ClusterService.class);
+        final ClusterService clusterService = mock(ClusterService.class);
         Mockito.when(clusterService.state()).thenReturn(clusterState);
 
         final Clock clock = randomBoolean() ? Clock.systemUTC() : Clock.systemDefaultZone();
         final Environment env = TestEnvironment.newEnvironment(settings);
-        final ResourceWatcherService resourceWatcherService = Mockito.mock(ResourceWatcherService.class);
-        final XPackLicenseState licenseState = Mockito.mock(XPackLicenseState.class);
-        final LicenseService service = new LicenseService(settings, clusterService, clock, env, resourceWatcherService, licenseState);
+        final ResourceWatcherService resourceWatcherService = mock(ResourceWatcherService.class);
+        final XPackLicenseState licenseState = mock(XPackLicenseState.class);
+        final ThreadPool threadPool = mock(ThreadPool.class);
+        final LicenseService service =
+            new LicenseService(settings, threadPool, clusterService, clock, env, resourceWatcherService, licenseState);
 
         final PutLicenseRequest request = new PutLicenseRequest();
         request.license(spec(licenseType, TimeValue.timeValueDays(randomLongBetween(1, 1000))), XContentType.JSON);

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/license/MockLicenseState.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/license/MockLicenseState.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.license;
+
+import org.elasticsearch.common.settings.Settings;
+
+import java.util.function.LongSupplier;
+
+/** A license state that may be mocked by testing because the internal methods are made public */
+public class MockLicenseState extends XPackLicenseState {
+
+    public MockLicenseState(Settings settings, LongSupplier epochMillisProvider) {
+        super(settings, epochMillisProvider);
+    }
+
+    @Override
+    public boolean isAllowed(LicensedFeature feature) {
+        return super.isAllowed(feature);
+    }
+
+    @Override
+    public void enableUsageTracking(LicensedFeature feature, String contextName) {
+        super.enableUsageTracking(feature, contextName);
+    }
+}

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/license/TestUtils.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/license/TestUtils.java
@@ -46,6 +46,9 @@ import static org.elasticsearch.test.ESTestCase.randomFrom;
 import static org.elasticsearch.test.ESTestCase.randomIntBetween;
 import static org.hamcrest.core.IsEqual.equalTo;
 import static org.junit.Assert.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class TestUtils {
 
@@ -368,7 +371,7 @@ public class TestUtils {
         }
 
         @Override
-        void update(License.OperationMode mode, boolean active, long expirationDate, Version mostRecentTrialVersion) {
+        protected void update(License.OperationMode mode, boolean active, long expirationDate, Version mostRecentTrialVersion) {
             modeUpdates.add(mode);
             activeUpdates.add(active);
             expirationDateUpdates.add(expirationDate);
@@ -401,5 +404,15 @@ public class TestUtils {
 
     public static void putLicense(Metadata.Builder builder, License license) {
         builder.putCustom(LicensesMetadata.TYPE, new LicensesMetadata(license, null));
+    }
+
+    public static MockLicenseState newMockLicenceState() {
+        MockLicenseState mock = mock(MockLicenseState.class);
+        // These are deprecated methods, but we haven't replaced all usage of them yet
+        // By calling the real methods, we force everything through a small number of mockable methods like
+        //  XPackLicenseState.isAllowed(LicensedFeature)
+        when(mock.isAllowed(any(XPackLicenseState.Feature.class))).thenCallRealMethod();
+        when(mock.checkFeature(any(XPackLicenseState.Feature.class))).thenCallRealMethod();
+        return mock;
     }
 }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/license/XPackLicenseStateTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/license/XPackLicenseStateTests.java
@@ -8,6 +8,7 @@ package org.elasticsearch.license;
 
 import org.elasticsearch.Version;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.iterable.Iterables;
 import org.elasticsearch.license.License.OperationMode;
 import org.elasticsearch.license.XPackLicenseState.Feature;
 import org.elasticsearch.test.ESTestCase;
@@ -16,6 +17,7 @@ import org.elasticsearch.xpack.core.XPackField;
 import org.elasticsearch.xpack.core.XPackSettings;
 
 import java.util.Arrays;
+import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
@@ -27,8 +29,11 @@ import static org.elasticsearch.license.License.OperationMode.MISSING;
 import static org.elasticsearch.license.License.OperationMode.PLATINUM;
 import static org.elasticsearch.license.License.OperationMode.STANDARD;
 import static org.elasticsearch.license.License.OperationMode.TRIAL;
+import static org.hamcrest.Matchers.aMapWithSize;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
-import static org.hamcrest.collection.IsMapContaining.hasEntry;
+import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.collection.IsMapContaining.hasKey;
 import static org.hamcrest.core.IsNot.not;
 
@@ -85,10 +90,8 @@ public class XPackLicenseStateTests extends ESTestCase {
         Settings settings = Settings.builder().put(XPackSettings.SECURITY_ENABLED.getKey(), true).build();
         XPackLicenseState licenseState = new XPackLicenseState(settings, () -> 0);
         assertThat(licenseState.isSecurityEnabled(), is(true));
-        assertThat(licenseState.checkFeature(Feature.SECURITY_IP_FILTERING), is(true));
         assertThat(licenseState.checkFeature(Feature.SECURITY_AUDITING), is(true));
         assertThat(licenseState.checkFeature(Feature.SECURITY_DLS_FLS), is(true));
-        assertThat(licenseState.checkFeature(Feature.SECURITY_ALL_REALMS), is(true));
         assertThat(licenseState.checkFeature(Feature.SECURITY_CUSTOM_ROLE_PROVIDERS), is(true));
 
         licenseState = TestUtils.newTestLicenseState();
@@ -106,7 +109,6 @@ public class XPackLicenseStateTests extends ESTestCase {
         licenseState.update(BASIC, true, Long.MAX_VALUE, null);
 
         assertThat(licenseState.isSecurityEnabled(), is(false));
-        assertThat(licenseState.checkFeature(Feature.SECURITY_IP_FILTERING), is(false));
         assertThat(licenseState.checkFeature(Feature.SECURITY_AUDITING), is(false));
         assertThat(licenseState.checkFeature(Feature.SECURITY_DLS_FLS), is(false));
         assertThat(licenseState.checkFeature(Feature.SECURITY_CUSTOM_ROLE_PROVIDERS), is(false));
@@ -119,9 +121,7 @@ public class XPackLicenseStateTests extends ESTestCase {
         final Settings settings = Settings.builder().put(XPackSettings.SECURITY_ENABLED.getKey(), true).build();
         XPackLicenseState licenseState = new XPackLicenseState(settings, () -> 0);
         licenseState.update(BASIC, true, Long.MAX_VALUE, null);
-
         assertThat(licenseState.isSecurityEnabled(), is(true));
-        assertThat(licenseState.checkFeature(Feature.SECURITY_IP_FILTERING), is(false));
         assertThat(licenseState.checkFeature(Feature.SECURITY_AUDITING), is(false));
         assertThat(licenseState.checkFeature(Feature.SECURITY_DLS_FLS), is(false));
         assertThat(licenseState.checkFeature(Feature.SECURITY_CUSTOM_ROLE_PROVIDERS), is(false));
@@ -137,7 +137,6 @@ public class XPackLicenseStateTests extends ESTestCase {
         licenseState.update(STANDARD, true, Long.MAX_VALUE, null);
 
         assertThat(licenseState.isSecurityEnabled(), is(true));
-        assertThat(licenseState.checkFeature(Feature.SECURITY_IP_FILTERING), is(false));
         assertThat(licenseState.checkFeature(Feature.SECURITY_AUDITING), is(false));
         assertThat(licenseState.checkFeature(Feature.SECURITY_DLS_FLS), is(false));
         assertThat(licenseState.checkFeature(Feature.SECURITY_CUSTOM_ROLE_PROVIDERS), is(false));
@@ -151,7 +150,6 @@ public class XPackLicenseStateTests extends ESTestCase {
         licenseState.update(STANDARD, false, Long.MAX_VALUE, null);
 
         assertThat(licenseState.isSecurityEnabled(), is(true));
-        assertThat(licenseState.checkFeature(Feature.SECURITY_IP_FILTERING), is(false));
         assertThat(licenseState.checkFeature(Feature.SECURITY_AUDITING), is(false));
         assertThat(licenseState.checkFeature(Feature.SECURITY_DLS_FLS), is(false));
         assertThat(licenseState.checkFeature(Feature.SECURITY_CUSTOM_ROLE_PROVIDERS), is(false));
@@ -165,10 +163,8 @@ public class XPackLicenseStateTests extends ESTestCase {
         licenseState.update(GOLD, true, Long.MAX_VALUE, null);
 
         assertThat(licenseState.isSecurityEnabled(), is(true));
-        assertThat(licenseState.checkFeature(Feature.SECURITY_IP_FILTERING), is(true));
         assertThat(licenseState.checkFeature(Feature.SECURITY_AUDITING), is(true));
         assertThat(licenseState.checkFeature(Feature.SECURITY_DLS_FLS), is(false));
-        assertThat(licenseState.checkFeature(Feature.SECURITY_STANDARD_REALMS), is(true));
         assertThat(licenseState.checkFeature(Feature.SECURITY_CUSTOM_ROLE_PROVIDERS), is(false));
         assertThat(licenseState.checkFeature(Feature.SECURITY_TOKEN_SERVICE), is(true));
     }
@@ -180,10 +176,8 @@ public class XPackLicenseStateTests extends ESTestCase {
         licenseState.update(GOLD, false, Long.MAX_VALUE, null);
 
         assertThat(licenseState.isSecurityEnabled(), is(true));
-        assertThat(licenseState.checkFeature(Feature.SECURITY_IP_FILTERING), is(true));
         assertThat(licenseState.checkFeature(Feature.SECURITY_AUDITING), is(true));
         assertThat(licenseState.checkFeature(Feature.SECURITY_DLS_FLS), is(false));
-        assertThat(licenseState.checkFeature(Feature.SECURITY_STANDARD_REALMS), is(true));
         assertThat(licenseState.checkFeature(Feature.SECURITY_CUSTOM_ROLE_PROVIDERS), is(false));
         assertThat(licenseState.checkFeature(Feature.SECURITY_TOKEN_SERVICE), is(true));
     }
@@ -195,10 +189,8 @@ public class XPackLicenseStateTests extends ESTestCase {
         licenseState.update(PLATINUM, true, Long.MAX_VALUE, null);
 
         assertThat(licenseState.isSecurityEnabled(), is(true));
-        assertThat(licenseState.checkFeature(Feature.SECURITY_IP_FILTERING), is(true));
         assertThat(licenseState.checkFeature(Feature.SECURITY_AUDITING), is(true));
         assertThat(licenseState.checkFeature(Feature.SECURITY_DLS_FLS), is(true));
-        assertThat(licenseState.checkFeature(Feature.SECURITY_ALL_REALMS), is(true));
         assertThat(licenseState.checkFeature(Feature.SECURITY_CUSTOM_ROLE_PROVIDERS), is(true));
         assertThat(licenseState.checkFeature(Feature.SECURITY_TOKEN_SERVICE), is(true));
     }
@@ -210,10 +202,8 @@ public class XPackLicenseStateTests extends ESTestCase {
         licenseState.update(PLATINUM, false, Long.MAX_VALUE, null);
 
         assertThat(licenseState.isSecurityEnabled(), is(true));
-        assertThat(licenseState.checkFeature(Feature.SECURITY_IP_FILTERING), is(true));
         assertThat(licenseState.checkFeature(Feature.SECURITY_AUDITING), is(true));
         assertThat(licenseState.checkFeature(Feature.SECURITY_DLS_FLS), is(true));
-        assertThat(licenseState.checkFeature(Feature.SECURITY_ALL_REALMS), is(true));
         assertThat(licenseState.checkFeature(Feature.SECURITY_CUSTOM_ROLE_PROVIDERS), is(false));
         assertThat(licenseState.checkFeature(Feature.SECURITY_TOKEN_SERVICE), is(true));
     }
@@ -512,17 +502,63 @@ public class XPackLicenseStateTests extends ESTestCase {
         assertAckMessages(XPackField.CCR, randomTrialOrPlatinumMode(), randomBasicStandardOrGold(), 1);
     }
 
-    public void testLastUsed() {
-        Feature goldFeature = Feature.SECURITY_DLS_FLS;
+    public void testLastUsedMomentaryFeature() {
+        LicensedFeature.Momentary goldFeature = LicensedFeature.momentary("goldFeature", GOLD);
         AtomicInteger currentTime = new AtomicInteger(100); // non zero start time
         XPackLicenseState licenseState = new XPackLicenseState(Settings.EMPTY, currentTime::get);
-        assertThat("initial epoch time", licenseState.getLastUsed(), not(hasKey(goldFeature)));
+        Map<XPackLicenseState.FeatureUsage, Long> lastUsed = licenseState.getLastUsed();
+        assertThat("initial epoch time", lastUsed, not(hasKey(goldFeature)));
+
         licenseState.isAllowed(goldFeature);
-        assertThat("isAllowed does not track", licenseState.getLastUsed(), not(hasKey(goldFeature)));
-        licenseState.checkFeature(goldFeature);
-        assertThat("checkFeature tracks used time", licenseState.getLastUsed(), hasEntry(goldFeature, 100L));
+        lastUsed = licenseState.getLastUsed();
+        assertThat("isAllowed does not track", lastUsed, not(hasKey(goldFeature)));
+
+        goldFeature.check(licenseState);
+        lastUsed = licenseState.getLastUsed();
+        assertThat("feature.check tracks usage", lastUsed, aMapWithSize(1));
+
+        XPackLicenseState.FeatureUsage usage = Iterables.get(lastUsed.keySet(), 0);
+        assertThat(usage.featureName(), equalTo("goldFeature"));
+        assertThat(usage.contextName(), nullValue());
+        assertThat(lastUsed.get(usage), equalTo(100L));
+
         currentTime.set(200);
-        licenseState.checkFeature(goldFeature);
-        assertThat("checkFeature updates tracked time", licenseState.getLastUsed(), hasEntry(goldFeature, 200L));
+        goldFeature.check(licenseState);
+        lastUsed = licenseState.getLastUsed();
+        assertThat("feature.check updates usage", lastUsed.keySet(), containsInAnyOrder(usage));
+        assertThat(lastUsed.get(usage), equalTo(200L));
+    }
+
+    public void testLastUsedPersistentFeature() {
+        LicensedFeature.Persistent goldFeature = LicensedFeature.persistent("goldFeature", GOLD);
+        AtomicInteger currentTime = new AtomicInteger(100); // non zero start time
+        XPackLicenseState licenseState = new XPackLicenseState(Settings.EMPTY, currentTime::get);
+        Map<XPackLicenseState.FeatureUsage, Long> lastUsed = licenseState.getLastUsed();
+        assertThat("initial epoch time", lastUsed, not(hasKey(goldFeature)));
+
+        licenseState.isAllowed(goldFeature);
+        lastUsed = licenseState.getLastUsed();
+        assertThat("isAllowed does not track", lastUsed, not(hasKey(goldFeature)));
+
+        goldFeature.checkAndStartTracking(licenseState, "somecontext");
+        currentTime.set(200); // advance time after starting tracking
+        lastUsed = licenseState.getLastUsed();
+        assertThat(lastUsed, aMapWithSize(1));
+
+        XPackLicenseState.FeatureUsage usage = Iterables.get(lastUsed.keySet(), 0);
+        assertThat(usage.featureName(), equalTo("goldFeature"));
+        assertThat(usage.contextName(), equalTo("somecontext"));
+        assertThat(lastUsed.get(usage), equalTo(200L));
+
+        currentTime.set(300);
+        goldFeature.stopTracking(licenseState, "somecontext");
+        lastUsed = licenseState.getLastUsed();
+        assertThat("stopTracking sets time to current", lastUsed.keySet(), containsInAnyOrder(usage));
+        assertThat(lastUsed.get(usage), equalTo(300L));
+
+        currentTime.set(400);
+        lastUsed = licenseState.getLastUsed();
+        assertThat("last used no longer returns current", lastUsed.keySet(), containsInAnyOrder(usage));
+        assertThat(lastUsed.get(usage), equalTo(300L));
     }
 }

--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/license/LicensingTests.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/license/LicensingTests.java
@@ -37,6 +37,7 @@ import org.elasticsearch.test.SecuritySettingsSourceField;
 import org.elasticsearch.transport.Netty4Plugin;
 import org.elasticsearch.transport.TransportInfo;
 import org.elasticsearch.xpack.core.XPackField;
+import org.elasticsearch.xpack.core.security.authc.support.Hasher;
 import org.elasticsearch.xpack.security.LocalStateSecurity;
 import org.hamcrest.Matchers;
 import org.junit.After;
@@ -63,6 +64,9 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 
 public class LicensingTests extends SecurityIntegTestCase {
+
+    private static final SecureString HASH_PASSWD = new SecureString(Hasher.BCRYPT4.hash(new SecureString("passwd".toCharArray())));
+
     private static final String ROLES =
             SecuritySettingsSource.TEST_ROLE + ":\n" +
                     "  cluster: [ all ]\n" +
@@ -80,6 +84,9 @@ public class LicensingTests extends SecurityIntegTestCase {
                     "  indices:\n" +
                     "    - names: 'a'\n" +
                     "      privileges: [all]\n" +
+                    "    - names: 'test-dls'\n" +
+                    "      privileges: [read]\n" +
+                    "      query: '{\"term\":{\"field\":\"value\"} }'\n" +
                     "\n" +
                     "role_b:\n" +
                     "  indices:\n" +
@@ -99,8 +106,8 @@ public class LicensingTests extends SecurityIntegTestCase {
     @Override
     protected String configUsers() {
         return SecuritySettingsSource.CONFIG_STANDARD_USER +
-            "user_a:{plain}passwd\n" +
-            "user_b:{plain}passwd\n";
+            "user_a:" + HASH_PASSWD + "\n" +
+            "user_b:" + HASH_PASSWD + "\n";
     }
 
     @Override
@@ -204,22 +211,24 @@ public class LicensingTests extends SecurityIntegTestCase {
     }
 
     public void testWarningHeader() throws Exception {
-        Request request = new Request("GET", "/_security/user");
+        License.OperationMode mode = randomFrom(License.OperationMode.PLATINUM, License.OperationMode.ENTERPRISE);
+        enableLicensing(mode);
+
+        // We test with "user_a" (that has a DLS-enabled role), so that we exercise licensed functionality and generate the warning header.
+        // Functionality under a basic (or SSPL) license does not necessarily generate expiration warnings
+        Request request = new Request("GET", "/_security/_authenticate");
         RequestOptions.Builder options = request.getOptions().toBuilder();
-        options.addHeader("Authorization", basicAuthHeaderValue(SecuritySettingsSource.TEST_USER_NAME,
-            new SecureString(SecuritySettingsSourceField.TEST_PASSWORD.toCharArray())));
+        options.addHeader("Authorization", basicAuthHeaderValue("user_a", new SecureString("passwd".toCharArray())));
         request.setOptions(options);
         Response response = getRestClient().performRequest(request);
         List<String> beforeWarningHeaders = getWarningHeaders(response.getHeaders());
         assertTrue(beforeWarningHeaders.isEmpty());
-        License.OperationMode mode = randomFrom(License.OperationMode.GOLD, License.OperationMode.PLATINUM,
-            License.OperationMode.ENTERPRISE, License.OperationMode.STANDARD);
         long now = System.currentTimeMillis();
 
         long newExpirationDate = now + LICENSE_EXPIRATION_WARNING_PERIOD.getMillis() - 1;
         setLicensingExpirationDate(mode, newExpirationDate);
         response = getRestClient().performRequest(request);
-        List<String> afterWarningHeaders= getWarningHeaders(response.getHeaders());
+        List<String> afterWarningHeaders = getWarningHeaders(response.getHeaders());
         assertThat(afterWarningHeaders, Matchers.hasSize(1));
         assertThat(afterWarningHeaders.get(0), Matchers.containsString("Your license will expire in [6] days. " +
             "Contact your administrator or update your license for continued use of features"));
@@ -244,7 +253,7 @@ public class LicensingTests extends SecurityIntegTestCase {
             "Contact your administrator or update your license for continued use of features"));
     }
 
-    public void  testNoWarningHeaderWhenAuthenticationFailed() throws Exception {
+    public void testNoWarningHeaderWhenAuthenticationFailed() throws Exception {
         Request request = new Request("GET", "/_security/user");
         RequestOptions.Builder options = request.getOptions().toBuilder();
         options.addHeader("Authorization", basicAuthHeaderValue(SecuritySettingsSource.TEST_USER_NAME,

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/Security.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/Security.java
@@ -55,6 +55,7 @@ import org.elasticsearch.indices.breaker.CircuitBreakerService;
 import org.elasticsearch.ingest.Processor;
 import org.elasticsearch.license.License;
 import org.elasticsearch.license.LicenseService;
+import org.elasticsearch.license.LicensedFeature;
 import org.elasticsearch.license.XPackLicenseState;
 import org.elasticsearch.license.XPackLicenseState.Feature;
 import org.elasticsearch.plugins.ClusterPlugin;
@@ -343,6 +344,20 @@ public class Security extends Plugin implements SystemIndexPlugin, IngestPlugin,
 
     public static final String SECURITY_CRYPTO_THREAD_POOL_NAME = XPackField.SECURITY + "-crypto";
     public static final Version FLATTENED_FIELD_TYPE_INTRODUCED = Version.V_7_3_0;
+
+    // TODO: ip filtering does not actually track license usage yet
+    public static final LicensedFeature.Momentary IP_FILTERING_FEATURE =
+        LicensedFeature.momentaryLenient("security_ip_filtering", License.OperationMode.GOLD);
+    public static final LicensedFeature.Momentary AUDITING_FEATURE =
+        LicensedFeature.momentaryLenient("security_auditing", License.OperationMode.GOLD);
+
+    // Builtin realms (file/native) realms are Basic licensed, so don't need to be checked or tracked
+    // Standard realms (LDAP, AD, PKI, etc) are Gold+
+    // SSO realms are Platinum+
+    public static final LicensedFeature.Persistent STANDARD_REALMS_FEATURE =
+        LicensedFeature.persistentLenient("security_standard_realms", License.OperationMode.GOLD);
+    public static final LicensedFeature.Persistent ALL_REALMS_FEATURE =
+        LicensedFeature.persistentLenient("security_all_realms", License.OperationMode.PLATINUM);
 
     private static final Logger logger = LogManager.getLogger(Security.class);
 

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/InternalRealms.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/InternalRealms.java
@@ -68,17 +68,6 @@ public final class InternalRealms {
     private static final Set<String> STANDARD_TYPES = Collections.unmodifiableSet(Sets.newHashSet(NativeRealmSettings.TYPE,
         FileRealmSettings.TYPE, LdapRealmSettings.AD_TYPE, LdapRealmSettings.LDAP_TYPE, PkiRealmSettings.TYPE));
 
-    /**
-     * Determines whether <code>type</code> is an internal realm-type that is provided by x-pack,
-     * including the {@link ReservedRealm}
-     */
-    static boolean isXPackRealm(String type) {
-        if (XPACK_TYPES.contains(type)) {
-            return true;
-        }
-        return ReservedRealm.TYPE.equals(type);
-    }
-
     public static Collection<String> getConfigurableRealmsTypes() {
         return Collections.unmodifiableSet(XPACK_TYPES);
     }
@@ -90,6 +79,10 @@ public final class InternalRealms {
      */
     static boolean isStandardRealm(String type) {
         return STANDARD_TYPES.contains(type);
+    }
+
+    static boolean isBuiltinRealm(String type) {
+        return FileRealmSettings.TYPE.equals(type) || NativeRealmSettings.TYPE.equals(type);
     }
 
     /**
@@ -136,4 +129,5 @@ public final class InternalRealms {
             .collect(Collectors.toList());
         return checks;
     }
+
 }

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/Realms.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/Realms.java
@@ -146,8 +146,28 @@ public class Realms implements Iterable<Realm> {
             return Collections.emptyList();
         }
         // TODO : Recalculate this when the license changes rather than on every call
-        return Collections.unmodifiableList(
-            realms.stream().filter(r -> checkLicense(r, licenseStateSnapshot)).collect(Collectors.toList()));
+        List<Realm> licensedRealms = Collections.unmodifiableList(
+            this.realms.stream().filter(r -> checkLicense(r, licenseStateSnapshot)).collect(Collectors.toList()));
+
+        if (hasUserRealm(licensedRealms)) {
+            return licensedRealms;
+        } else {
+            // Automatically enable native/file realms if no other (non-reserved) realms are permitted by the active license
+            return nativeRealmsOnly;
+        }
+    }
+
+    /**
+     * Returns true if this list contains at least one non-reserved realm
+     */
+    private boolean hasUserRealm(List<Realm> licensedRealms) {
+        if (licensedRealms.isEmpty()) {
+            return false;
+        }
+        if (licensedRealms.size() == 1 && licensedRealms.get(0) == reservedRealm) {
+            return false;
+        }
+        return true;
     }
 
     private static boolean checkLicense(Realm realm, XPackLicenseState licenseState) {

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/Realms.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/Realms.java
@@ -19,13 +19,13 @@ import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.common.util.set.Sets;
 import org.elasticsearch.env.Environment;
 import org.elasticsearch.license.XPackLicenseState;
-import org.elasticsearch.license.XPackLicenseState.Feature;
 import org.elasticsearch.xpack.core.security.authc.Realm;
 import org.elasticsearch.xpack.core.security.authc.RealmConfig;
 import org.elasticsearch.xpack.core.security.authc.RealmSettings;
 import org.elasticsearch.xpack.core.security.authc.esnative.NativeRealmSettings;
 import org.elasticsearch.xpack.core.security.authc.file.FileRealmSettings;
 import org.elasticsearch.xpack.core.security.authc.kerberos.KerberosRealmSettings;
+import org.elasticsearch.xpack.security.Security;
 import org.elasticsearch.xpack.security.authc.esnative.ReservedRealm;
 
 import java.util.ArrayList;
@@ -86,7 +86,7 @@ public class Realms implements Iterable<Realm> {
                 standardRealms.add(realm);
             }
 
-            if (FileRealmSettings.TYPE.equals(realm.type()) || NativeRealmSettings.TYPE.equals(realm.type())) {
+            if (InternalRealms.isBuiltinRealm(realm.type())) {
                 nativeRealms.add(realm);
             }
         }
@@ -122,7 +122,7 @@ public class Realms implements Iterable<Realm> {
         }
 
         // If all realms are allowed, then nothing is unlicensed
-        if (licenseStateSnapshot.checkFeature(Feature.SECURITY_ALL_REALMS)) {
+        if (Security.ALL_REALMS_FEATURE.checkWithoutTracking(licenseStateSnapshot)) {
             return Collections.emptyList();
         }
 
@@ -133,8 +133,7 @@ public class Realms implements Iterable<Realm> {
         }
 
         // Otherwise, we return anything in "all realms" that is not in the allowed realm list
-        List<Realm> unlicensed = realms.stream().filter(r -> allowedRealms.contains(r) == false).collect(Collectors.toList());
-        return Collections.unmodifiableList(unlicensed);
+        return Collections.unmodifiableList(realms.stream().filter(r -> allowedRealms.contains(r) == false).collect(Collectors.toList()));
     }
 
     public Stream<Realm> stream() {
@@ -146,14 +145,22 @@ public class Realms implements Iterable<Realm> {
         if (licenseStateSnapshot.isSecurityEnabled() == false) {
             return Collections.emptyList();
         }
-        if (licenseStateSnapshot.checkFeature(Feature.SECURITY_ALL_REALMS)) {
-            return realms;
-        } else if (licenseStateSnapshot.checkFeature(Feature.SECURITY_STANDARD_REALMS)) {
-            return standardRealmsOnly;
-        } else {
-            // native realms are basic licensed, and always allowed, even for an expired license
-            return nativeRealmsOnly;
+        // TODO : Recalculate this when the license changes rather than on every call
+        return Collections.unmodifiableList(
+            realms.stream().filter(r -> checkLicense(r, licenseStateSnapshot)).collect(Collectors.toList()));
+    }
+
+    private static boolean checkLicense(Realm realm, XPackLicenseState licenseState) {
+        if (ReservedRealm.TYPE.equals(realm.type())) {
+            return true;
         }
+        if (InternalRealms.isBuiltinRealm(realm.type())) {
+            return true;
+        }
+        if (InternalRealms.isStandardRealm(realm.type())) {
+            return Security.STANDARD_REALMS_FEATURE.checkAndStartTracking(licenseState, realm.name());
+        }
+        return Security.ALL_REALMS_FEATURE.checkAndStartTracking(licenseState, realm.name());
     }
 
     public Realm realm(String name) {
@@ -356,12 +363,12 @@ public class Realms implements Iterable<Realm> {
     }
 
     public static boolean isRealmTypeAvailable(XPackLicenseState licenseState, String type) {
-        if (licenseState.checkFeature(Feature.SECURITY_ALL_REALMS)) {
+        if (Security.ALL_REALMS_FEATURE.checkWithoutTracking(licenseState)) {
             return true;
-        } else if (licenseState.checkFeature(Feature.SECURITY_STANDARD_REALMS)) {
+        } else if (Security.STANDARD_REALMS_FEATURE.checkWithoutTracking(licenseState)) {
             return InternalRealms.isStandardRealm(type) || ReservedRealm.TYPE.equals(type);
         } else {
-            return FileRealmSettings.TYPE.equals(type) || NativeRealmSettings.TYPE.equals(type);
+            return InternalRealms.isBuiltinRealm(type);
         }
     }
 

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/rest/action/RestDelegatePkiAuthenticationAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/rest/action/RestDelegatePkiAuthenticationAction.java
@@ -15,7 +15,6 @@ import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.license.LicenseUtils;
 import org.elasticsearch.license.XPackLicenseState;
-import org.elasticsearch.license.XPackLicenseState.Feature;
 import org.elasticsearch.rest.BytesRestResponse;
 import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.rest.RestResponse;
@@ -25,6 +24,7 @@ import org.elasticsearch.xpack.core.security.action.DelegatePkiAuthenticationAct
 import org.elasticsearch.xpack.core.security.action.DelegatePkiAuthenticationRequest;
 import org.elasticsearch.xpack.core.security.action.DelegatePkiAuthenticationResponse;
 import org.elasticsearch.xpack.core.security.authc.pki.PkiRealmSettings;
+import org.elasticsearch.xpack.security.Security;
 import org.elasticsearch.xpack.security.action.TransportDelegatePkiAuthenticationAction;
 
 import java.io.IOException;
@@ -56,7 +56,7 @@ public final class RestDelegatePkiAuthenticationAction extends SecurityBaseRestH
         Exception failedFeature = super.checkFeatureAvailable(request);
         if (failedFeature != null) {
             return failedFeature;
-        } else if (licenseState.checkFeature(Feature.SECURITY_STANDARD_REALMS)) {
+        } else if (Security.STANDARD_REALMS_FEATURE.checkWithoutTracking(licenseState)) {
             return null;
         } else {
             logger.info("The '{}' realm is not available under the current license", PkiRealmSettings.TYPE);

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/transport/filter/IPFilter.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/transport/filter/IPFilter.java
@@ -19,8 +19,8 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.transport.BoundTransportAddress;
 import org.elasticsearch.common.transport.TransportAddress;
 import org.elasticsearch.license.XPackLicenseState;
-import org.elasticsearch.license.XPackLicenseState.Feature;
 import org.elasticsearch.transport.TransportSettings;
+import org.elasticsearch.xpack.security.Security;
 import org.elasticsearch.xpack.security.audit.AuditTrail;
 import org.elasticsearch.xpack.security.audit.AuditTrailService;
 
@@ -248,7 +248,7 @@ public class IPFilter {
 
     public boolean accept(String profile, InetSocketAddress peerAddress) {
         if (licenseState.isSecurityEnabled() == false ||
-            licenseState.checkFeature(Feature.SECURITY_IP_FILTERING) == false) {
+            Security.IP_FILTERING_FEATURE.checkWithoutTracking(licenseState) == false) {
             return true;
         }
 

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/AuthenticationServiceTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/AuthenticationServiceTests.java
@@ -51,6 +51,7 @@ import org.elasticsearch.env.TestEnvironment;
 import org.elasticsearch.index.get.GetResult;
 import org.elasticsearch.index.seqno.SequenceNumbers;
 import org.elasticsearch.index.shard.ShardId;
+import org.elasticsearch.license.MockLicenseState;
 import org.elasticsearch.license.XPackLicenseState;
 import org.elasticsearch.license.XPackLicenseState.Feature;
 import org.elasticsearch.rest.RestRequest;
@@ -86,6 +87,7 @@ import org.elasticsearch.xpack.core.security.support.ValidationTests;
 import org.elasticsearch.xpack.core.security.user.AnonymousUser;
 import org.elasticsearch.xpack.core.security.user.SystemUser;
 import org.elasticsearch.xpack.core.security.user.User;
+import org.elasticsearch.xpack.security.Security;
 import org.elasticsearch.xpack.security.audit.AuditTrail;
 import org.elasticsearch.xpack.security.audit.AuditTrailService;
 import org.elasticsearch.xpack.security.audit.AuditUtil;
@@ -141,6 +143,7 @@ import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Matchers.same;
+import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
@@ -211,8 +214,8 @@ public class AuthenticationServiceTests extends ESTestCase {
             .put(XPackSettings.TOKEN_SERVICE_ENABLED_SETTING.getKey(), true)
             .put(XPackSettings.API_KEY_SERVICE_ENABLED_SETTING.getKey(), true)
             .build();
-        XPackLicenseState licenseState = mock(XPackLicenseState.class);
-        when(licenseState.checkFeature(Feature.SECURITY_ALL_REALMS)).thenReturn(true);
+        MockLicenseState licenseState = mock(MockLicenseState.class);
+        when(licenseState.isAllowed(Security.ALL_REALMS_FEATURE)).thenReturn(true);
         when(licenseState.isSecurityEnabled()).thenReturn(true);
         when(licenseState.checkFeature(Feature.SECURITY_TOKEN_SERVICE)).thenReturn(true);
         when(licenseState.copyCurrentLicenseState()).thenReturn(licenseState);
@@ -441,8 +444,9 @@ public class AuthenticationServiceTests extends ESTestCase {
 
         verify(auditTrail).authenticationFailed(reqId.get(), firstRealm.name(), token, "_action", transportRequest);
         verify(firstRealm, times(2)).name(); // used above one time
-        verify(secondRealm, times(2)).name();
-        verify(secondRealm, times(2)).type(); // used to create realm ref
+        verify(firstRealm, atLeastOnce()).type();
+        verify(secondRealm, Mockito.atLeast(3)).name(); // also used in license tracking
+        verify(secondRealm, Mockito.atLeast(3)).type(); // used to create realm ref, and license tracking
         verify(firstRealm, times(2)).token(threadContext);
         verify(secondRealm, times(2)).token(threadContext);
         verify(firstRealm).supports(token);
@@ -566,8 +570,9 @@ public class AuthenticationServiceTests extends ESTestCase {
         }, this::logAndFail));
         verify(auditTrail, times(2)).authenticationFailed(reqId.get(), firstRealm.name(), token, "_action", transportRequest);
         verify(firstRealm, times(3)).name(); // used above one time
-        verify(secondRealm, times(2)).name();
-        verify(secondRealm, times(2)).type(); // used to create realm ref
+        verify(firstRealm, atLeastOnce()).type();
+        verify(secondRealm, Mockito.atLeast(3)).name();
+        verify(secondRealm, Mockito.atLeast(3)).type(); // used to create realm ref
         verify(firstRealm, times(2)).token(threadContext);
         verify(secondRealm, times(2)).token(threadContext);
         verify(firstRealm, times(2)).supports(token);
@@ -630,8 +635,10 @@ public class AuthenticationServiceTests extends ESTestCase {
         assertThat(result.v1(), is(authentication));
         assertThat(result.v1().getAuthenticationType(), is(AuthenticationType.REALM));
         verifyZeroInteractions(auditTrail);
-        verifyZeroInteractions(firstRealm);
-        verifyZeroInteractions(secondRealm);
+        verify(firstRealm, atLeastOnce()).type();
+        verify(secondRealm, atLeastOnce()).type();
+        verify(secondRealm, atLeastOnce()).name(); // This realm is license-tracked, which uses the name
+        verifyNoMoreInteractions(firstRealm, secondRealm);
         verifyZeroInteractions(operatorPrivilegesService);
     }
 
@@ -910,7 +917,9 @@ public class AuthenticationServiceTests extends ESTestCase {
                     verifyZeroInteractions(operatorPrivilegesService);
                 }, this::logAndFail));
             assertTrue(completed.compareAndSet(true, false));
-            verifyZeroInteractions(firstRealm);
+            verify(firstRealm, atLeastOnce()).type();
+            verify(firstRealm, atLeastOnce()).name();
+            verifyNoMoreInteractions(firstRealm);
             reset(firstRealm);
         } finally {
             terminate(threadPool1);
@@ -958,7 +967,9 @@ public class AuthenticationServiceTests extends ESTestCase {
                     verifyZeroInteractions(operatorPrivilegesService);
                 }, this::logAndFail));
             assertTrue(completed.get());
-            verifyZeroInteractions(firstRealm);
+            verify(firstRealm, atLeastOnce()).type();
+            verify(firstRealm, atLeastOnce()).name();
+            verifyNoMoreInteractions(firstRealm);
         } finally {
             terminate(threadPool2);
         }

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/RealmsTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/RealmsTests.java
@@ -13,8 +13,7 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.env.Environment;
 import org.elasticsearch.env.TestEnvironment;
-import org.elasticsearch.license.XPackLicenseState;
-import org.elasticsearch.license.XPackLicenseState.Feature;
+import org.elasticsearch.license.MockLicenseState;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.core.security.authc.AuthenticationResult;
 import org.elasticsearch.xpack.core.security.authc.AuthenticationToken;
@@ -27,6 +26,7 @@ import org.elasticsearch.xpack.core.security.authc.ldap.LdapRealmSettings;
 import org.elasticsearch.xpack.core.security.authc.oidc.OpenIdConnectRealmSettings;
 import org.elasticsearch.xpack.core.security.authc.saml.SamlRealmSettings;
 import org.elasticsearch.xpack.core.security.user.User;
+import org.elasticsearch.xpack.security.Security;
 import org.elasticsearch.xpack.security.authc.esnative.ReservedRealm;
 import org.junit.Before;
 
@@ -54,11 +54,12 @@ import static org.hamcrest.Matchers.iterableWithSize;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.sameInstance;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 public class RealmsTests extends ESTestCase {
     private Map<String, Realm.Factory> factories;
-    private XPackLicenseState licenseState;
+    private MockLicenseState licenseState;
     private ThreadContext threadContext;
     private ReservedRealm reservedRealm;
     private int randomRealmTypesCount;
@@ -74,7 +75,7 @@ public class RealmsTests extends ESTestCase {
             String name = "type_" + i;
             factories.put(name, config -> new DummyRealm(name, config));
         }
-        licenseState = mock(XPackLicenseState.class);
+        licenseState = mock(MockLicenseState.class);
         when(licenseState.copyCurrentLicenseState()).thenReturn(licenseState);
         threadContext = new ThreadContext(Settings.EMPTY);
         reservedRealm = mock(ReservedRealm.class);
@@ -85,18 +86,18 @@ public class RealmsTests extends ESTestCase {
     }
 
     private void allowAllRealms() {
-        when(licenseState.checkFeature(Feature.SECURITY_ALL_REALMS)).thenReturn(true);
-        when(licenseState.checkFeature(Feature.SECURITY_STANDARD_REALMS)).thenReturn(true);
+        when(licenseState.isAllowed(Security.ALL_REALMS_FEATURE)).thenReturn(true);
+        when(licenseState.isAllowed(Security.STANDARD_REALMS_FEATURE)).thenReturn(true);
     }
 
     private void allowOnlyStandardRealms() {
-        when(licenseState.checkFeature(Feature.SECURITY_ALL_REALMS)).thenReturn(false);
-        when(licenseState.checkFeature(Feature.SECURITY_STANDARD_REALMS)).thenReturn(true);
+        when(licenseState.isAllowed(Security.ALL_REALMS_FEATURE)).thenReturn(false);
+        when(licenseState.isAllowed(Security.STANDARD_REALMS_FEATURE)).thenReturn(true);
     }
 
     private void allowOnlyNativeRealms() {
-        when(licenseState.checkFeature(Feature.SECURITY_ALL_REALMS)).thenReturn(false);
-        when(licenseState.checkFeature(Feature.SECURITY_STANDARD_REALMS)).thenReturn(false);
+        when(licenseState.isAllowed(Security.ALL_REALMS_FEATURE)).thenReturn(false);
+        when(licenseState.isAllowed(Security.STANDARD_REALMS_FEATURE)).thenReturn(false);
     }
 
     public void testWithSettings() throws Exception {
@@ -270,6 +271,9 @@ public class RealmsTests extends ESTestCase {
 
         assertThat(realms.getUnlicensedRealms(), empty());
         assertThat(realms.getUnlicensedRealms(), sameInstance(realms.getUnlicensedRealms()));
+        for (i = 0; i < randomRealmTypesCount; i++) {
+            verify(licenseState).enableUsageTracking(Security.ALL_REALMS_FEATURE, "realm_" + i);
+        }
 
         allowOnlyNativeRealms();
 
@@ -331,9 +335,10 @@ public class RealmsTests extends ESTestCase {
     public void testUnlicensedWithInternalRealms() throws Exception {
         factories.put(LdapRealmSettings.LDAP_TYPE, config -> new DummyRealm(LdapRealmSettings.LDAP_TYPE, config));
         assertThat(factories.get("type_0"), notNullValue());
+        String ldapRealmName = randomAlphaOfLengthBetween(3, 8);
         Settings.Builder builder = Settings.builder()
                 .put("path.home", createTempDir())
-                .put("xpack.security.authc.realms.ldap.foo.order", "0")
+                .put("xpack.security.authc.realms.ldap." + ldapRealmName + ".order", "0")
                 .put("xpack.security.authc.realms.type_0.custom.order", "1");
         disableFileAndNativeRealms(builder);
         Settings settings = builder.build();
@@ -355,6 +360,7 @@ public class RealmsTests extends ESTestCase {
         assertThat(types, contains("ldap", "type_0"));
         assertThat(realms.getUnlicensedRealms(), empty());
         assertThat(realms.getUnlicensedRealms(), sameInstance(realms.getUnlicensedRealms()));
+        verify(licenseState).enableUsageTracking(Security.STANDARD_REALMS_FEATURE, ldapRealmName);
 
         allowOnlyStandardRealms();
         iter = realms.iterator();
@@ -392,7 +398,7 @@ public class RealmsTests extends ESTestCase {
         assertThat(realms.getUnlicensedRealms(), iterableWithSize(2));
         realm = realms.getUnlicensedRealms().get(0);
         assertThat(realm.type(), equalTo("ldap"));
-        assertThat(realm.name(), equalTo("foo"));
+        assertThat(realm.name(), equalTo(ldapRealmName));
         realm = realms.getUnlicensedRealms().get(1);
         assertThat(realm.type(), equalTo("type_0"));
         assertThat(realm.name(), equalTo("custom"));
@@ -421,6 +427,7 @@ public class RealmsTests extends ESTestCase {
         assertThat(realm.type(), is(type));
         assertThat(iter.hasNext(), is(false));
         assertThat(realms.getUnlicensedRealms(), empty());
+        verify(licenseState).enableUsageTracking(Security.STANDARD_REALMS_FEATURE, "foo");
 
         allowOnlyNativeRealms();
         iter = realms.iterator();
@@ -441,9 +448,10 @@ public class RealmsTests extends ESTestCase {
     public void testUnlicensedWithNonStandardRealms() throws Exception {
         final String selectedRealmType = randomFrom(SamlRealmSettings.TYPE, KerberosRealmSettings.TYPE, OpenIdConnectRealmSettings.TYPE);
         factories.put(selectedRealmType, config -> new DummyRealm(selectedRealmType, config));
+        String realmName = randomAlphaOfLengthBetween(3, 8);
         Settings.Builder builder = Settings.builder()
                 .put("path.home", createTempDir())
-                .put("xpack.security.authc.realms." + selectedRealmType + ".foo.order", "0");
+                .put("xpack.security.authc.realms." + selectedRealmType + "." + realmName + ".order", "0");
         disableFileAndNativeRealms(builder);
         Settings settings = builder.build();
         Environment env = TestEnvironment.newEnvironment(settings);
@@ -457,6 +465,7 @@ public class RealmsTests extends ESTestCase {
         assertThat(realm.type(), is(selectedRealmType));
         assertThat(iter.hasNext(), is(false));
         assertThat(realms.getUnlicensedRealms(), empty());
+        verify(licenseState).enableUsageTracking(Security.ALL_REALMS_FEATURE, realmName);
 
         allowOnlyStandardRealms();
         iter = realms.iterator();
@@ -474,7 +483,7 @@ public class RealmsTests extends ESTestCase {
         assertThat(realms.getUnlicensedRealms(), iterableWithSize(1));
         realm = realms.getUnlicensedRealms().get(0);
         assertThat(realm.type(), equalTo(selectedRealmType));
-        assertThat(realm.name(), equalTo("foo"));
+        assertThat(realm.name(), equalTo(realmName));
 
         allowOnlyNativeRealms();
         iter = realms.iterator();
@@ -492,7 +501,7 @@ public class RealmsTests extends ESTestCase {
         assertThat(realms.getUnlicensedRealms(), iterableWithSize(1));
         realm = realms.getUnlicensedRealms().get(0);
         assertThat(realm.type(), equalTo(selectedRealmType));
-        assertThat(realm.name(), equalTo("foo"));
+        assertThat(realm.name(), equalTo(realmName));
     }
 
     public void testDisabledRealmsAreNotAdded() throws Exception {

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/transport/filter/IPFilterTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/transport/filter/IPFilterTests.java
@@ -15,8 +15,8 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.transport.BoundTransportAddress;
 import org.elasticsearch.common.transport.TransportAddress;
 import org.elasticsearch.http.HttpServerTransport;
-import org.elasticsearch.license.XPackLicenseState;
-import org.elasticsearch.license.XPackLicenseState.Feature;
+import org.elasticsearch.license.MockLicenseState;
+import org.elasticsearch.license.TestUtils;
 import org.elasticsearch.node.MockNode;
 import org.elasticsearch.node.Node;
 import org.elasticsearch.test.ESTestCase;
@@ -24,6 +24,7 @@ import org.elasticsearch.test.junit.annotations.Network;
 import org.elasticsearch.transport.Transport;
 import org.elasticsearch.xpack.core.XPackSettings;
 import org.elasticsearch.xpack.security.LocalStateSecurity;
+import org.elasticsearch.xpack.security.Security;
 import org.elasticsearch.xpack.security.audit.AuditTrail;
 import org.elasticsearch.xpack.security.audit.AuditTrailService;
 import org.junit.Before;
@@ -52,7 +53,7 @@ import static org.mockito.Mockito.when;
 
 public class IPFilterTests extends ESTestCase {
     private IPFilter ipFilter;
-    private XPackLicenseState licenseState;
+    private MockLicenseState licenseState;
     private AuditTrail auditTrail;
     private AuditTrailService auditTrailService;
     private Transport transport;
@@ -61,10 +62,10 @@ public class IPFilterTests extends ESTestCase {
 
     @Before
     public void init() {
-        licenseState = mock(XPackLicenseState.class);
+        licenseState = TestUtils.newMockLicenceState();
         when(licenseState.isSecurityEnabled()).thenReturn(true);
-        when(licenseState.checkFeature(Feature.SECURITY_IP_FILTERING)).thenReturn(true);
-        when(licenseState.checkFeature(Feature.SECURITY_AUDITING)).thenReturn(true);
+        when(licenseState.isAllowed(Security.IP_FILTERING_FEATURE)).thenReturn(true);
+        when(licenseState.isAllowed(Security.AUDITING_FEATURE)).thenReturn(true);
         auditTrail = mock(AuditTrail.class);
         auditTrailService = new AuditTrailService(Collections.singletonList(auditTrail), licenseState);
         clusterSettings = new ClusterSettings(Settings.EMPTY, new HashSet<>(Arrays.asList(
@@ -254,7 +255,7 @@ public class IPFilterTests extends ESTestCase {
         Settings settings = Settings.builder()
                 .put("xpack.security.transport.filter.deny", "_all")
                 .build();
-        when(licenseState.checkFeature(Feature.SECURITY_IP_FILTERING)).thenReturn(false);
+        when(licenseState.isAllowed(Security.IP_FILTERING_FEATURE)).thenReturn(false);
         ipFilter = new IPFilter(settings, auditTrailService, clusterSettings, licenseState);
         ipFilter.setBoundTransportAddress(transport.boundAddress(), transport.profileBoundAddresses());
 
@@ -265,7 +266,7 @@ public class IPFilterTests extends ESTestCase {
         verifyZeroInteractions(auditTrail);
 
         // for sanity enable license and check that it is denied
-        when(licenseState.checkFeature(Feature.SECURITY_IP_FILTERING)).thenReturn(true);
+        when(licenseState.isAllowed(Security.IP_FILTERING_FEATURE)).thenReturn(true);
         ipFilter = new IPFilter(settings, auditTrailService, clusterSettings, licenseState);
         ipFilter.setBoundTransportAddress(transport.boundAddress(), transport.profileBoundAddresses());
 

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/transport/netty4/IpFilterRemoteAddressFilterTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/transport/netty4/IpFilterRemoteAddressFilterTests.java
@@ -14,10 +14,11 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.transport.BoundTransportAddress;
 import org.elasticsearch.common.transport.TransportAddress;
 import org.elasticsearch.http.HttpServerTransport;
-import org.elasticsearch.license.XPackLicenseState;
-import org.elasticsearch.license.XPackLicenseState.Feature;
+import org.elasticsearch.license.MockLicenseState;
+import org.elasticsearch.license.TestUtils;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.transport.Transport;
+import org.elasticsearch.xpack.security.Security;
 import org.elasticsearch.xpack.security.audit.AuditTrailService;
 import org.elasticsearch.xpack.security.transport.filter.IPFilter;
 import org.junit.Before;
@@ -57,9 +58,9 @@ public class IpFilterRemoteAddressFilterTests extends ESTestCase {
                 IPFilter.TRANSPORT_FILTER_DENY_SETTING,
                 IPFilter.PROFILE_FILTER_ALLOW_SETTING,
                 IPFilter.PROFILE_FILTER_DENY_SETTING)));
-        XPackLicenseState licenseState = mock(XPackLicenseState.class);
+        MockLicenseState licenseState = TestUtils.newMockLicenceState();
         when(licenseState.isSecurityEnabled()).thenReturn(true);
-        when(licenseState.checkFeature(Feature.SECURITY_IP_FILTERING)).thenReturn(true);
+        when(licenseState.isAllowed(Security.IP_FILTERING_FEATURE)).thenReturn(true);
         AuditTrailService auditTrailService = new AuditTrailService(Collections.emptyList(), licenseState);
         IPFilter ipFilter = new IPFilter(settings, auditTrailService, clusterSettings, licenseState);
         ipFilter.setBoundTransportAddress(transport.boundAddress(), transport.profileBoundAddresses());

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/transport/nio/NioIPFilterTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/transport/nio/NioIPFilterTests.java
@@ -13,11 +13,12 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.transport.BoundTransportAddress;
 import org.elasticsearch.common.transport.TransportAddress;
 import org.elasticsearch.http.HttpServerTransport;
-import org.elasticsearch.license.XPackLicenseState;
-import org.elasticsearch.license.XPackLicenseState.Feature;
+import org.elasticsearch.license.MockLicenseState;
+import org.elasticsearch.license.TestUtils;
 import org.elasticsearch.nio.NioChannelHandler;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.transport.Transport;
+import org.elasticsearch.xpack.security.Security;
 import org.elasticsearch.xpack.security.audit.AuditTrailService;
 import org.elasticsearch.xpack.security.transport.filter.IPFilter;
 import org.junit.Before;
@@ -60,9 +61,9 @@ public class NioIPFilterTests extends ESTestCase {
             IPFilter.TRANSPORT_FILTER_DENY_SETTING,
             IPFilter.PROFILE_FILTER_ALLOW_SETTING,
             IPFilter.PROFILE_FILTER_DENY_SETTING)));
-        XPackLicenseState licenseState = mock(XPackLicenseState.class);
+        MockLicenseState licenseState = TestUtils.newMockLicenceState();
         when(licenseState.isSecurityEnabled()).thenReturn(true);
-        when(licenseState.checkFeature(Feature.SECURITY_IP_FILTERING)).thenReturn(true);
+        when(licenseState.isAllowed(Security.IP_FILTERING_FEATURE)).thenReturn(true);
         AuditTrailService auditTrailService = new AuditTrailService(Collections.emptyList(), licenseState);
         ipFilter = new IPFilter(settings, auditTrailService, clusterSettings, licenseState);
         ipFilter.setBoundTransportAddress(transport.boundAddress(), transport.profileBoundAddresses());


### PR DESCRIPTION
backport of #76476

Licensed feature tracking utilizes the existing license level checks to
track when a feature is used. However, some features check the license
level at the start of an operation or when enabling a feature, but then
the tracking only captures the beginning time.

This commit reworks the licensed feature framework to use a new
LicensedFeature class which will eventually replace
XPackLicenseState.Feature values. There are two LicensedFeature
implementations, one for "momentary" features that are tracked just at
the moment they are used, and "persistent" features that are considered
"on" until the feature is untracked. The usage map of tracked features
is cleaned up every hour, and those features that have not been used in
the last 24 hours are removed from tracking.

Not all features are converted to LicensedFeature yet. Instead, a few
features have been converted to demonstrate how it can be done, so that
the rest can be done in parallel at a future time.

Co-authored-by: Tim Vernum <tim@adjective.org>