### PR TITLE
[DOCS] Clarify usage of optional human readable jvm uptime metric in Nodes Stats API

### DIFF
--- a/docs/reference/cluster/nodes-stats.asciidoc
+++ b/docs/reference/cluster/nodes-stats.asciidoc
@@ -1263,8 +1263,8 @@ Contains Java Virtual Machine (JVM) statistics for the node.
 Last time JVM statistics were refreshed.
 
 `uptime`::
-(<<time-units,time value>>)
-JVM uptime.
+(optional, <<time-units,time value>>)
+Human readable JVM uptime. Enabled by the `human` parameter.
 
 `uptime_in_millis`::
 (integer)


### PR DESCRIPTION
Better explain the human readable `uptime` metric is optional and requires the `human` parameter to reveal it.
eg:
`GET _nodes/stats?filter_path=nodes.*.jvm.uptime*&human`