### PR TITLE
Fix Stack Overflow in UnassignedInfo in Corner Case (#76480)

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/routing/UnassignedInfo.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/UnassignedInfo.java
@@ -242,7 +242,7 @@ public final class UnassignedInfo implements ToXContentFragment, Writeable {
         this.failure = failure;
         this.failedAllocations = failedAllocations;
         this.lastAllocationStatus = Objects.requireNonNull(lastAllocationStatus);
-        this.failedNodeIds = Collections.unmodifiableSet(failedNodeIds);
+        this.failedNodeIds = org.elasticsearch.core.Set.copyOf(failedNodeIds);
         assert (failedAllocations > 0) == (reason == Reason.ALLOCATION_FAILED) :
             "failedAllocations: " + failedAllocations + " for reason " + reason;
         assert (message == null && failure != null) == false : "provide a message if a failure exception is provided";


### PR DESCRIPTION
We kept wrapping the collection over and over again which in extreme corner cases could lead to a SOE.

Closes #76490

backport of #76480 