### PR TITLE
Fix Broken Serialization of SnapshotsInProgress in 7.x

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/SnapshotsInProgress.java
+++ b/server/src/main/java/org/elasticsearch/cluster/SnapshotsInProgress.java
@@ -1043,6 +1043,7 @@ public class SnapshotsInProgress extends AbstractNamedDiffable<Custom> implement
                 out.writeStringCollection(dataStreams);
             }
             if (out.getVersion().onOrAfter(SnapshotsService.CLONE_SNAPSHOT_VERSION)) {
+                out.writeOptionalWriteable(source);
                 if (source == null) {
                     out.writeMap(ImmutableOpenMap.of());
                 } else {


### PR DESCRIPTION
We must not send the by-repo-shard-id map for normal
snapshots. The conditional got lost in `7.x` and `7.14`
because of a merge error. This aligns master and 7.x behavior.

closes #76552

non-issue as this bug hasn't been released yet