### PR TITLE
Fix Broken Serialization of SnapshotsInProgress in 7.x

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/SnapshotsInProgress.java
+++ b/server/src/main/java/org/elasticsearch/cluster/SnapshotsInProgress.java
@@ -558,7 +558,7 @@ public class SnapshotsInProgress extends AbstractNamedDiffable<Custom> implement
                       List<String> dataStreams, List<SnapshotFeatureInfo> featureStates, long startTime, long repositoryStateId,
                       ImmutableOpenMap<ShardId, ShardSnapshotStatus> shards, String failure, Map<String, Object> userMetadata,
                       Version version, @Nullable SnapshotId source,
-                      ImmutableOpenMap<RepositoryShardId, ShardSnapshotStatus> shardStatusByRepoShardId) {
+                      @Nullable ImmutableOpenMap<RepositoryShardId, ShardSnapshotStatus> shardStatusByRepoShardId) {
             this.state = state;
             this.snapshot = snapshot;
             this.includeGlobalState = includeGlobalState;
@@ -658,7 +658,7 @@ public class SnapshotsInProgress extends AbstractNamedDiffable<Custom> implement
             }
             return new SnapshotsInProgress.Entry(
                     snapshot, includeGlobalState, partial, state, indices, dataStreams, featureStates, startTime, repositoryStateId,
-                    shards, failure, userMetadata, version, source, source == null ? null : clones);
+                    shards, failure, userMetadata, version, source, clones);
         }
 
         private static boolean assertShardsConsistent(SnapshotId source, State state, Map<String, IndexId> indices,
@@ -1028,7 +1028,11 @@ public class SnapshotsInProgress extends AbstractNamedDiffable<Custom> implement
             }
             if (out.getVersion().onOrAfter(SnapshotsService.CLONE_SNAPSHOT_VERSION)) {
                 out.writeOptionalWriteable(source);
-                out.writeMap(shardStatusByRepoShardId);
+                if (source == null) {
+                    out.writeMap(ImmutableOpenMap.of());
+                } else {
+                    out.writeMap(shardStatusByRepoShardId);
+                }
             }
             if (out.getVersion().onOrAfter(FEATURE_STATES_VERSION)) {
                 out.writeList(featureStates);


### PR DESCRIPTION
We must not send the by-repo-shard-id map for normal
snapshots. The conditional got lost in `7.x` and `7.14`
because of a merge error. This aligns master and 7.x behavior.

closes #76552

backport of #76553 