### PR TITLE
Fix 'accept' and 'content_type' fields for search_mvt API

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/search_mvt.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/search_mvt.json
@@ -8,10 +8,10 @@
     "visibility": "public",
     "headers": {
       "accept": [
-        "application/json"
+        "application/vnd.mapbox-vector-tile"
       ],
       "content_type": [
-        "application/vnd.mapbox-vector-tile"
+        "application/json"
       ]
     },
     "url": {
@@ -32,15 +32,15 @@
               "description": "Field containing geospatial data to return"
             },
             "zoom": {
-              "type": "integer",
+              "type": "int",
               "description": "Zoom level for the vector tile to search"
             },
             "x": {
-              "type": "integer",
+              "type": "int",
               "description": "X coordinate for the vector tile to search"
             },
             "y": {
-              "type": "integer",
+              "type": "int",
               "description": "Y coordinate for the vector tile to search"
             }
           }
@@ -54,12 +54,12 @@
         "default":false
       },
       "extent":{
-        "type":"number",
+        "type":"int",
         "description":"Size, in pixels, of a side of the vector tile.",
         "default":4096
       },
       "grid_precision":{
-        "type":"number",
+        "type":"int",
         "description":"Additional zoom levels available through the aggs layer. Accepts 0-8.",
         "default":8
       },
@@ -73,7 +73,7 @@
         "default":"grid"
       },
       "size":{
-        "type":"number",
+        "type":"int",
         "description":"Maximum number of features to return in the hits layer. Accepts 0-10000.",
         "default":10000
       }


### PR DESCRIPTION
In https://github.com/elastic/elasticsearch/pull/75384 it appears the `headers.content_type` and `headers.accept` fields were flipped. These fields are HTTP headers from a client perspective and the API takes a JSON request (`Content-Type` header is request body type) and returns a MapBox response (`Accept` header is expected response body type).

Also fixed the `number` / `integer` types to `int` since `number` includes floating point values.

Reference: https://github.com/elastic/elasticsearch/tree/master/rest-api-spec#type-definition