### PR TITLE
[7.x] fix the error message for instance methods that don't exist (#76512)

### DIFF
--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/phase/DefaultSemanticAnalysisPhase.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/phase/DefaultSemanticAnalysisPhase.java
@@ -1769,7 +1769,7 @@ public class DefaultSemanticAnalysisPhase extends UserTreeBaseVisitor<SemanticSc
 
                             if (instanceBinding == null) {
                                 throw userCallLocalNode.createError(new IllegalArgumentException(
-                                        "Unknown call [" + methodName + "] with [" + userArgumentNodes + "] arguments."));
+                                        "Unknown call [" + methodName + "] with [" + userArgumentsSize + "] arguments."));
                             }
                         }
                     }

--- a/modules/lang-painless/src/test/java/org/elasticsearch/painless/WhenThingsGoWrongTests.java
+++ b/modules/lang-painless/src/test/java/org/elasticsearch/painless/WhenThingsGoWrongTests.java
@@ -850,4 +850,11 @@ public class WhenThingsGoWrongTests extends ScriptTestCase {
                 exec("def test = ['hostname': 'somehostname']; test?.hostname && params.host.hostname != ''"));
         expectScriptThrows(NullPointerException.class, () -> exec("params?.host?.hostname && params.host?.hostname != ''"));
     }
+
+    public void testInstanceMethodNotFound() {
+        IllegalArgumentException iae = expectScriptThrows(IllegalArgumentException.class, () -> exec("doesNotExist()"));
+        assertEquals(iae.getMessage(), "Unknown call [doesNotExist] with [0] arguments.");
+        iae = expectScriptThrows(IllegalArgumentException.class, () -> exec("doesNotExist(1, 'string', false)"));
+        assertEquals(iae.getMessage(), "Unknown call [doesNotExist] with [3] arguments.");
+    }
 }


### PR DESCRIPTION
Backports the following commits to 7.x:
 - fix the error message for instance methods that don't exist (#76512)