### PR TITLE
Keep track of data recovered from snapshots in RecoveryState (#76499)

### DIFF
--- a/docs/reference/indices/recovery.asciidoc
+++ b/docs/reference/indices/recovery.asciidoc
@@ -280,6 +280,8 @@ The API returns the following response:
           "reused_in_bytes" : 0,
           "recovered" : "65.7mb",
           "recovered_in_bytes" : 68891939,
+          "recovered_from_snapshot" : "0b",
+          "recovered_from_snapshot_in_bytes" : 0,
           "percent" : "87.1%"
         },
         "files" : {
@@ -380,6 +382,8 @@ The API returns the following response:
           "reused_in_bytes" : 26001617,
           "recovered" : "0b",
           "recovered_in_bytes" : 0,
+          "recovered_from_snapshot" : "0b",
+          "recovered_from_snapshot_in_bytes" : 0,
           "percent" : "100.0%"
         },
         "files" : {
@@ -394,11 +398,13 @@ The API returns the following response:
           }, {
             "name" : "_0.cfs",
             "length" : 135306,
-            "recovered" : 135306
+            "recovered" : 135306,
+            "recovered_from_snapshot": 0
           }, {
             "name" : "segments_2",
             "length" : 251,
-            "recovered" : 251
+            "recovered" : 251,
+            "recovered_from_snapshot": 0
           }
           ]
         },

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.recovery/10_basic.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.recovery/10_basic.yml
@@ -1,5 +1,52 @@
 ---
 "Indices recovery test":
+  - skip:
+      # todo: change after backport
+      version: " - 7.14.99"
+      reason: recovery from snapshot bytes not available until 7.15
+
+  - do:
+      indices.create:
+        index:  test_1
+        body:
+          settings:
+            index:
+              number_of_replicas: 0
+
+  - do:
+      cluster.health:
+        wait_for_status: green
+
+  - do:
+      indices.recovery:
+        index: [test_1]
+        human: true
+
+  - match: { test_1.shards.0.type:                                 "EMPTY_STORE"           }
+  - match: { test_1.shards.0.stage:                                "DONE"                  }
+  - match: { test_1.shards.0.primary:                              true                    }
+  - match: { test_1.shards.0.start_time:                           /^2\d\d\d-.+/           }
+  - match: { test_1.shards.0.target.ip:                            /^\d+\.\d+\.\d+\.\d+$/  }
+  - gte:   { test_1.shards.0.index.files.total:                    0                       }
+  - gte:   { test_1.shards.0.index.files.reused:                   0                       }
+  - gte:   { test_1.shards.0.index.files.recovered:                0                       }
+  - match: { test_1.shards.0.index.files.percent:                  /^\d+\.\d\%$/           }
+  - gte:   { test_1.shards.0.index.size.total_in_bytes:            0                       }
+  - gte:   { test_1.shards.0.index.size.reused_in_bytes:           0                       }
+  - gte:   { test_1.shards.0.index.size.recovered_in_bytes:        0                       }
+  - gte:   { test_1.shards.0.index.size.recovered_from_snapshot_in_bytes:   0                       }
+  - match: { test_1.shards.0.index.size.percent:                   /^\d+\.\d\%$/           }
+  - gte:   { test_1.shards.0.index.source_throttle_time_in_millis: 0                       }
+  - gte:   { test_1.shards.0.index.target_throttle_time_in_millis: 0                       }
+  - gte:   { test_1.shards.0.translog.recovered:                   0                       }
+  - gte:   { test_1.shards.0.translog.total:                       -1                      }
+  - gte:   { test_1.shards.0.translog.total_on_start:              0                       }
+  - gte:   { test_1.shards.0.translog.total_time_in_millis:        0                       }
+  - gte:   { test_1.shards.0.verify_index.check_index_time_in_millis:     0                       }
+  - gte:   { test_1.shards.0.verify_index.total_time_in_millis:           0                       }
+
+---
+"Indices recovery test without recovery from snapshot":
 
   - do:
       indices.create:
@@ -71,27 +118,27 @@
         index: [test_2]
         human: true
 
-  - match: { test_2.shards.0.type:                                 "EXISTING_STORE"        }
-  - match: { test_2.shards.0.stage:                                "DONE"                  }
-  - match: { test_2.shards.0.primary:                              true                    }
-  - match: { test_2.shards.0.start_time:                           /^2\d\d\d-.+/           }
-  - match: { test_2.shards.0.target.ip:                            /^\d+\.\d+\.\d+\.\d+$/  }
-  - gte:   { test_2.shards.0.index.files.total:                    0                       }
-  - gte:   { test_2.shards.0.index.files.reused:                   0                       }
-  - gte:   { test_2.shards.0.index.files.recovered:                0                       }
-  - match: { test_2.shards.0.index.files.percent:                  /^\d+\.\d\%$/           }
-  - gte:   { test_2.shards.0.index.size.total_in_bytes:            0                       }
-  - gte:   { test_2.shards.0.index.size.reused_in_bytes:           0                       }
-  - gte:   { test_2.shards.0.index.size.recovered_in_bytes:        0                       }
-  - match: { test_2.shards.0.index.size.percent:                   /^\d+\.\d\%$/           }
-  - gte:   { test_2.shards.0.index.source_throttle_time_in_millis: 0                       }
-  - gte:   { test_2.shards.0.index.target_throttle_time_in_millis: 0                       }
-  - gte:   { test_2.shards.0.translog.recovered:                   0                       }
-  - gte:   { test_2.shards.0.translog.total:                       0                       }
-  - gte:   { test_2.shards.0.translog.total_on_start:              0                       }
-  - gte:   { test_2.shards.0.translog.total_time_in_millis:        0                       }
-  - gte:   { test_2.shards.0.verify_index.check_index_time_in_millis:     0                }
-  - gte:   { test_2.shards.0.verify_index.total_time_in_millis:           0                }
+  - match: { test_2.shards.0.type:                                          "EXISTING_STORE"        }
+  - match: { test_2.shards.0.stage:                                         "DONE"                  }
+  - match: { test_2.shards.0.primary:                                       true                    }
+  - match: { test_2.shards.0.start_time:                                    /^2\d\d\d-.+/           }
+  - match: { test_2.shards.0.target.ip:                                     /^\d+\.\d+\.\d+\.\d+$/  }
+  - gte:   { test_2.shards.0.index.files.total:                             0                       }
+  - gte:   { test_2.shards.0.index.files.reused:                            0                       }
+  - gte:   { test_2.shards.0.index.files.recovered:                         0                       }
+  - match: { test_2.shards.0.index.files.percent:                           /^\d+\.\d\%$/           }
+  - gte:   { test_2.shards.0.index.size.total_in_bytes:                     0                       }
+  - gte:   { test_2.shards.0.index.size.reused_in_bytes:                    0                       }
+  - gte:   { test_2.shards.0.index.size.recovered_in_bytes:                 0                       }
+  - match: { test_2.shards.0.index.size.percent:                            /^\d+\.\d\%$/           }
+  - gte:   { test_2.shards.0.index.source_throttle_time_in_millis:          0                       }
+  - gte:   { test_2.shards.0.index.target_throttle_time_in_millis:          0                       }
+  - gte:   { test_2.shards.0.translog.recovered:                            0                       }
+  - gte:   { test_2.shards.0.translog.total:                                0                       }
+  - gte:   { test_2.shards.0.translog.total_on_start:                       0                       }
+  - gte:   { test_2.shards.0.translog.total_time_in_millis:                 0                       }
+  - gte:   { test_2.shards.0.verify_index.check_index_time_in_millis:       0                       }
+  - gte:   { test_2.shards.0.verify_index.total_time_in_millis:             0                       }
 ---
 "Indices recovery test index name not matching":
 

--- a/server/src/internalClusterTest/java/org/elasticsearch/indices/recovery/SnapshotBasedIndexRecoveryIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/indices/recovery/SnapshotBasedIndexRecoveryIT.java
@@ -252,7 +252,9 @@ public class SnapshotBasedIndexRecoveryIT extends AbstractSnapshotIntegTestCase 
 
         // segments_N and .si files are recovered from the file metadata directly
         long expectedRecoveredBytesFromRepo = 0;
+        long totalBytesRecoveredFromSnapshot = 0;
         for (RecoveryState.FileDetail fileDetail : recoveryState.getIndex().fileDetails()) {
+            totalBytesRecoveredFromSnapshot += fileDetail.recoveredFromSnapshot();
             if (fileDetail.name().startsWith("segments") || fileDetail.name().endsWith(".si")) {
                 continue;
             }
@@ -264,6 +266,7 @@ public class SnapshotBasedIndexRecoveryIT extends AbstractSnapshotIntegTestCase 
         long snapshotSizeForIndex = getSnapshotSizeForIndex(repoName, snapshot, indexName);
         assertThat(repository.totalBytesRead.get(), is(greaterThan(0L)));
         assertThat(repository.totalBytesRead.get(), is(lessThanOrEqualTo(snapshotSizeForIndex)));
+        assertThat(totalBytesRecoveredFromSnapshot, is(equalTo(snapshotSizeForIndex)));
 
         assertDocumentsAreEqual(indexName, numDocs);
     }

--- a/server/src/main/java/org/elasticsearch/indices/recovery/MultiFileWriter.java
+++ b/server/src/main/java/org/elasticsearch/indices/recovery/MultiFileWriter.java
@@ -90,7 +90,7 @@ public class MultiFileWriter extends AbstractRefCounted implements Releasable {
             long bytesWritten = 0;
             while ((length = stream.read(buffer)) > 0) {
                 indexOutput.writeBytes(buffer, length);
-                indexState.addRecoveredBytesToFile(fileName, length);
+                indexState.addRecoveredFromSnapshotBytesToFile(fileName, length);
                 bytesWritten += length;
             }
 

--- a/server/src/main/java/org/elasticsearch/indices/recovery/RecoveryState.java
+++ b/server/src/main/java/org/elasticsearch/indices/recovery/RecoveryState.java
@@ -346,6 +346,8 @@ public class RecoveryState implements ToXContentFragment, Writeable {
         static final String VERIFY_INDEX = "verify_index";
         static final String RECOVERED = "recovered";
         static final String RECOVERED_IN_BYTES = "recovered_in_bytes";
+        static final String RECOVERED_FROM_SNAPSHOT = "recovered_from_snapshot";
+        static final String RECOVERED_FROM_SNAPSHOT_IN_BYTES = "recovered_from_snapshot_in_bytes";
         static final String CHECK_INDEX_TIME = "check_index_time";
         static final String CHECK_INDEX_TIME_IN_MILLIS = "check_index_time_in_millis";
         static final String LENGTH = "length";
@@ -611,6 +613,7 @@ public class RecoveryState implements ToXContentFragment, Writeable {
         private long length;
         private long recovered;
         private boolean reused;
+        private long recoveredFromSnapshot;
 
         public FileDetail(String name, long length, boolean reused) {
             assert name != null;
@@ -624,6 +627,9 @@ public class RecoveryState implements ToXContentFragment, Writeable {
             length = in.readVLong();
             recovered = in.readVLong();
             reused = in.readBoolean();
+            if (in.getVersion().onOrAfter(RecoverySettings.SNAPSHOT_RECOVERIES_SUPPORTED_VERSION)) {
+                recoveredFromSnapshot = in.readLong();
+            }
         }
 
         @Override
@@ -632,6 +638,9 @@ public class RecoveryState implements ToXContentFragment, Writeable {
             out.writeVLong(length);
             out.writeVLong(recovered);
             out.writeBoolean(reused);
+            if (out.getVersion().onOrAfter(RecoverySettings.SNAPSHOT_RECOVERIES_SUPPORTED_VERSION)) {
+                out.writeLong(recoveredFromSnapshot);
+            }
         }
 
         void addRecoveredBytes(long bytes) {
@@ -642,8 +651,14 @@ public class RecoveryState implements ToXContentFragment, Writeable {
 
         void resetRecoveredBytes() {
             assert reused == false : "file is marked as reused, can't update recovered bytes";
-            // TODO: change this once we keep track of recovered data broke down by snapshot/primary
             recovered = 0;
+        }
+
+        void addRecoveredFromSnapshotBytes(long bytes) {
+            assert reused == false : "file is marked as reused, can't update recovered bytes";
+            assert bytes >= 0 : "can't recovered negative bytes. got [" + bytes + "]";
+            recoveredFromSnapshot += bytes;
+            recovered += bytes;
         }
 
         /**
@@ -668,6 +683,13 @@ public class RecoveryState implements ToXContentFragment, Writeable {
         }
 
         /**
+         * number of bytes recovered from this file (so far) from a snapshot.
+         */
+        public long recoveredFromSnapshot() {
+            return recoveredFromSnapshot;
+        }
+
+        /**
          * returns true if the file is reused from a local copy
          */
         public boolean reused() {
@@ -685,6 +707,9 @@ public class RecoveryState implements ToXContentFragment, Writeable {
             builder.humanReadableField(Fields.LENGTH_IN_BYTES, Fields.LENGTH, new ByteSizeValue(length));
             builder.field(Fields.REUSED, reused);
             builder.humanReadableField(Fields.RECOVERED_IN_BYTES, Fields.RECOVERED, new ByteSizeValue(recovered));
+            builder.humanReadableField(
+                Fields.RECOVERED_FROM_SNAPSHOT_IN_BYTES, Fields.RECOVERED_FROM_SNAPSHOT, new ByteSizeValue(recoveredFromSnapshot)
+            );
             builder.endObject();
             return builder;
         }
@@ -693,7 +718,11 @@ public class RecoveryState implements ToXContentFragment, Writeable {
         public boolean equals(Object obj) {
             if (obj instanceof FileDetail) {
                 FileDetail other = (FileDetail) obj;
-                return name.equals(other.name) && length == other.length() && reused == other.reused() && recovered == other.recovered();
+                return name.equals(other.name) &&
+                    length == other.length() &&
+                    reused == other.reused() &&
+                    recovered == other.recovered &&
+                    recoveredFromSnapshot == other.recoveredFromSnapshot;
             }
             return false;
         }
@@ -703,13 +732,15 @@ public class RecoveryState implements ToXContentFragment, Writeable {
             int result = name.hashCode();
             result = 31 * result + Long.hashCode(length);
             result = 31 * result + Long.hashCode(recovered);
+            result = 31 * result + Long.hashCode(recoveredFromSnapshot);
             result = 31 * result + (reused ? 1 : 0);
             return result;
         }
 
         @Override
         public String toString() {
-            return "file (name [" + name + "], reused [" + reused + "], length [" + length + "], recovered [" + recovered + "])";
+            return "file (name [" + name + "], reused [" + reused + "], length [" + length + "], " +
+                "recovered [" + recovered + "], recovered from snapshot [" + recoveredFromSnapshot + "]) ";
         }
     }
 
@@ -778,6 +809,12 @@ public class RecoveryState implements ToXContentFragment, Writeable {
             FileDetail file = fileDetails.get(name);
             assert file != null : "file [" + name + "] hasn't been reported";
             file.resetRecoveredBytes();
+        }
+
+        public void addRecoveredFromSnapshotBytesToFile(String name, long bytes) {
+            FileDetail file = fileDetails.get(name);
+            assert file != null : "file [" + name + "] hasn't been reported";
+            file.addRecoveredFromSnapshotBytes(bytes);
         }
 
         public FileDetail get(String name) {
@@ -866,6 +903,10 @@ public class RecoveryState implements ToXContentFragment, Writeable {
 
         public synchronized void resetRecoveredBytesOfFile(String name) {
             fileDetails.resetRecoveredBytesOfFile(name);
+        }
+
+        public synchronized void addRecoveredFromSnapshotBytesToFile(String name, long bytes) {
+            fileDetails.addRecoveredFromSnapshotBytesToFile(name, bytes);
         }
 
         public synchronized void addSourceThrottling(long timeInNanos) {
@@ -972,6 +1013,14 @@ public class RecoveryState implements ToXContentFragment, Writeable {
             return recovered;
         }
 
+        public synchronized long recoveredFromSnapshotBytes() {
+            long recoveredFromSnapshot = 0;
+            for (FileDetail fileDetail : fileDetails.values()) {
+                recoveredFromSnapshot += fileDetail.recoveredFromSnapshot();
+            }
+            return recoveredFromSnapshot;
+        }
+
         /**
          * total bytes of files to be recovered (potentially not yet done)
          */
@@ -1052,6 +1101,9 @@ public class RecoveryState implements ToXContentFragment, Writeable {
             builder.humanReadableField(Fields.TOTAL_IN_BYTES, Fields.TOTAL, new ByteSizeValue(totalBytes()));
             builder.humanReadableField(Fields.REUSED_IN_BYTES, Fields.REUSED, new ByteSizeValue(reusedBytes()));
             builder.humanReadableField(Fields.RECOVERED_IN_BYTES, Fields.RECOVERED, new ByteSizeValue(recoveredBytes()));
+            builder.humanReadableField(
+                Fields.RECOVERED_FROM_SNAPSHOT_IN_BYTES, Fields.RECOVERED_FROM_SNAPSHOT, new ByteSizeValue(recoveredFromSnapshotBytes())
+            );
             builder.field(Fields.PERCENT, String.format(Locale.ROOT, "%1.1f%%", recoveredBytesPercent()));
             builder.endObject();
 

--- a/server/src/test/java/org/elasticsearch/indices/recovery/PeerRecoveryTargetServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/indices/recovery/PeerRecoveryTargetServiceTests.java
@@ -401,6 +401,7 @@ public class PeerRecoveryTargetServiceTests extends IndexShardTestCase {
 
         RecoveryState.FileDetail fileDetails = recoveryStateIndex.getFileDetails(storeFileMetadata.name());
         assertThat(fileDetails.recovered(), equalTo(storeFileMetadata.length()));
+        assertThat(fileDetails.recoveredFromSnapshot(), equalTo(storeFileMetadata.length()));
 
         recoveryTarget.decRef();
         closeShards(shard);
@@ -516,6 +517,8 @@ public class PeerRecoveryTargetServiceTests extends IndexShardTestCase {
         ReleasableBytesReference bytesRef = ReleasableBytesReference.wrap(new BytesArray(fileData));
         recoveryTarget.writeFileChunk(storeFileMetadata, 0, bytesRef, true, 0, writeChunkFuture);
         writeChunkFuture.get();
+
+        assertThat(fileDetails.recovered(), equalTo(storeFileMetadata.length()));
 
         recoveryTarget.decRef();
         closeShards(shard);

--- a/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/collector/indices/IndexRecoveryMonitoringDocTests.java
+++ b/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/collector/indices/IndexRecoveryMonitoringDocTests.java
@@ -159,6 +159,7 @@ public class IndexRecoveryMonitoringDocTests extends BaseMonitoringDocTestCase<I
                               + "\"total_in_bytes\":0,"
                               + "\"reused_in_bytes\":0,"
                               + "\"recovered_in_bytes\":0,"
+                              + "\"recovered_from_snapshot_in_bytes\": 0,"
                               + "\"percent\":\"0.0%\""
                             + "},"
                             + "\"files\":{"

--- a/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/collector/indices/IndexRecoveryMonitoringDocTests.java
+++ b/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/collector/indices/IndexRecoveryMonitoringDocTests.java
@@ -159,7 +159,7 @@ public class IndexRecoveryMonitoringDocTests extends BaseMonitoringDocTestCase<I
                               + "\"total_in_bytes\":0,"
                               + "\"reused_in_bytes\":0,"
                               + "\"recovered_in_bytes\":0,"
-                              + "\"recovered_from_snapshot_in_bytes\": 0,"
+                              + "\"recovered_from_snapshot_in_bytes\":0,"
                               + "\"percent\":\"0.0%\""
                             + "},"
                             + "\"files\":{"


### PR DESCRIPTION
Backport of #76499 

Adds new field to recovery API to keep track of amount of data
recovered from snapshots.

The normal recovered_bytes field remains and is also increased for
recovery from snapshot but can go backwards in the unlikely case
that recovery from snapshot fails to download a file.

Relates #73496