### PR TITLE
Fix Bug Causing Queued Snapshots of Deleted Indices to Never Finalize (#75942)

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/SnapshotsInProgress.java
+++ b/server/src/main/java/org/elasticsearch/cluster/SnapshotsInProgress.java
@@ -824,6 +824,7 @@ public class SnapshotsInProgress extends AbstractNamedDiffable<Custom> implement
         }
 
         public Index indexByName(String name) {
+            assert isClone() == false : "tried to get routing index for clone entry [" + this + "]";
             return snapshotIndices.get(name);
         }
 

--- a/server/src/main/java/org/elasticsearch/snapshots/SnapshotsService.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/SnapshotsService.java
@@ -1681,8 +1681,18 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
                 // this shard snapshot is waiting for a previous snapshot to finish execution for this shard
                 final ShardSnapshotStatus knownFailure = knownFailures.get(shardId);
                 if (knownFailure == null) {
-                    // if no failure is known for the shard we keep waiting
-                    shards.put(shardId, shardStatus);
+                    final IndexRoutingTable indexShardRoutingTable = routingTable.index(shardId.getIndex());
+                    if (indexShardRoutingTable == null) {
+                        // shard became unassigned while queued so we fail as missing here
+                        assert entry.partial();
+                        snapshotChanged = true;
+                        logger.debug("failing snapshot of shard [{}] because index got deleted", shardId);
+                        shards.put(shardId, ShardSnapshotStatus.MISSING);
+                        knownFailures.put(shardId, ShardSnapshotStatus.MISSING);
+                    } else {
+                        // if no failure is known for the shard we keep waiting
+                        shards.put(shardId, shardStatus);
+                    }
                 } else {
                     // If a failure is known for an execution we waited on for this shard then we fail with the same exception here
                     // as well
@@ -1750,9 +1760,10 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
 
     private static boolean waitingShardsStartedOrUnassigned(SnapshotsInProgress snapshotsInProgress, ClusterChangedEvent event) {
         for (SnapshotsInProgress.Entry entry : snapshotsInProgress.entries()) {
-            if (entry.state() == State.STARTED) {
+            if (entry.state() == State.STARTED && entry.isClone() == false) {
                 for (ObjectObjectCursor<RepositoryShardId, ShardSnapshotStatus> shardStatus : entry.shardsByRepoShardId()) {
-                    if (shardStatus.value.state() != ShardState.WAITING) {
+                    final ShardState state = shardStatus.value.state();
+                    if (state != ShardState.WAITING && state != ShardState.QUEUED) {
                         continue;
                     }
                     final RepositoryShardId shardId = shardStatus.key;
@@ -1761,7 +1772,7 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
                             .getRoutingTable()
                             .index(entry.indexByName(shardId.indexName()));
                         if (indexShardRoutingTable == null) {
-                            // index got removed concurrently and we have to fail WAITING state shards
+                            // index got removed concurrently and we have to fail WAITING or QUEUED state shards
                             return true;
                         }
                         ShardRouting shardRouting = indexShardRoutingTable.shard(shardId.shardId()).primaryShard();


### PR DESCRIPTION
 We have to run the loop checking for completed snapshots if we see an index disappearing.
Otherwise, we never get around to finalizing a queued snapshot stuck after a clone if the
index is deleted during cloning.

backport #75942 