### PR TITLE
[7.x] [DOCS] Add admon for legacy prefix tree mapping params

### DIFF
--- a/docs/reference/mapping/types/geo-shape.asciidoc
+++ b/docs/reference/mapping/types/geo-shape.asciidoc
@@ -25,9 +25,8 @@ default. To use BKD encoding, do not specify the following
 * `tree_levels`
 * `tree`
 
-If you specify one or more of these options, the `geo_shape` field will instead
-use prefix tree encoding. Prefix tree encoding is deprecated and will be removed
-in a future release.
+If you specify one or more of these options, the field will use prefix tree
+encoding instead. Prefix tree encoding is deprecated and will be removed in 8.0.
 ====
 
 [[geo-shape-mapping-options]]

--- a/docs/reference/mapping/types/geo-shape.asciidoc
+++ b/docs/reference/mapping/types/geo-shape.asciidoc
@@ -12,6 +12,24 @@ contain shapes other than just points.
 You can query documents using this type using
 a <<query-dsl-geo-shape-query,`geo_shape` query>>.
 
+[IMPORTANT]
+====
+{es} encodes `geo_shape` values as <<geoshape-indexing-approach,BKD trees>> by
+default. To use BKD encoding, do not specify the following
+<<geo-shape-mapping-options,mapping options>>:
+
+* `distance_error_pct`
+* `points_only` 
+* `precision`
+* `strategy`
+* `tree_levels`
+* `tree`
+
+If you specify one or more of these options, the `geo_shape` field will instead
+use prefix tree encoding. Prefix tree encoding is deprecated and will be removed
+in a future release.
+====
+
 [[geo-shape-mapping-options]]
 [discrete]
 ==== Mapping Options

--- a/docs/reference/mapping/types/geo-shape.asciidoc
+++ b/docs/reference/mapping/types/geo-shape.asciidoc
@@ -26,7 +26,7 @@ default. To use BKD encoding, do not specify the following
 * `tree`
 
 If you specify one or more of these options, the field will use prefix tree
-encoding instead. Prefix tree encoding is deprecated and will be removed in 8.0.
+encoding instead. Prefix tree encoding is deprecated.
 ====
 
 [[geo-shape-mapping-options]]


### PR DESCRIPTION
If you specify a deprecated mapping parameter related to prefix trees, a
`geo_shape` field will use prefix tree encoding.

This adds a related admon to the top of the geoshape field docs page. This admon will
help users avoid accidentally switching from the default BKD tree encoding.

Closes #40266.

### Preview
https://elasticsearch_76582.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/7.x/geo-shape.html