### PR TITLE
Updating permissions so that CryptoOutputStream works

### DIFF
--- a/plugins/repository-hdfs/build.gradle
+++ b/plugins/repository-hdfs/build.gradle
@@ -26,7 +26,7 @@ esplugin {
 }
 
 versions << [
-  'hadoop2': '2.10.1'
+  'hadoop2': '2.8.5'
 ]
 
 testFixtures.useFixture ":test:fixtures:krb5kdc-fixture", "hdfs"

--- a/plugins/repository-hdfs/build.gradle
+++ b/plugins/repository-hdfs/build.gradle
@@ -26,7 +26,7 @@ esplugin {
 }
 
 versions << [
-  'hadoop2': '2.8.5'
+  'hadoop2': '2.10.1'
 ]
 
 testFixtures.useFixture ":test:fixtures:krb5kdc-fixture", "hdfs"

--- a/plugins/repository-hdfs/src/main/java/org/elasticsearch/repositories/hdfs/HdfsSecurityContext.java
+++ b/plugins/repository-hdfs/src/main/java/org/elasticsearch/repositories/hdfs/HdfsSecurityContext.java
@@ -67,10 +67,13 @@ class HdfsSecurityContext {
             new AuthPermission("modifyPrincipals"),
             new PrivateCredentialPermission("org.apache.hadoop.security.Credentials * \"*\"", "read"),
             new PrivateCredentialPermission("javax.security.auth.kerberos.KerberosTicket * \"*\"", "read"),
-            new PrivateCredentialPermission("javax.security.auth.kerberos.KeyTab * \"*\"", "read")
+            new PrivateCredentialPermission("javax.security.auth.kerberos.KeyTab * \"*\"", "read"),
             // Included later:
             // 7) allow code to initiate kerberos connections as the logged in user
             // Still far and away fewer permissions than the original full plugin policy
+            // The following are required by CryptoOutputStream:
+            new RuntimePermission("accessClassInPackage.sun.nio.ch"),
+            new RuntimePermission("accessClassInPackage.sun.misc")
         };
     }
 

--- a/plugins/repository-hdfs/src/main/plugin-metadata/plugin-security.policy
+++ b/plugins/repository-hdfs/src/main/plugin-metadata/plugin-security.policy
@@ -38,6 +38,9 @@ grant {
   // Hadoop depends on the Kerberos login module for kerberos authentication
   // com.sun.security.auth.module.Krb5LoginModule.login()
   permission java.lang.RuntimePermission "accessClassInPackage.sun.security.krb5";
+  // CryptoOutputStream depends on the following two permissions:
+  permission java.lang.RuntimePermission "accessClassInPackage.sun.nio.ch";
+  permission java.lang.RuntimePermission "accessClassInPackage.sun.misc";
 
   // com.sun.security.auth.module.Krb5LoginModule.commit()
   permission javax.security.auth.AuthPermission "modifyPrivateCredentials";


### PR DESCRIPTION
From what I can tell, CryptoOutputStream fails right now because we don't run it with adequate permissions to access the private sun classes that it uses. And it fails on java 11 because in addition to those permissions, the hadoop library uses a class that doesn't exist in Java 9 and later.
