### PR TITLE
Removing io.netty.allocator.numDirectArenas override

### DIFF
--- a/distribution/tools/launchers/src/main/java/org/elasticsearch/tools/launchers/SystemJvmOptions.java
+++ b/distribution/tools/launchers/src/main/java/org/elasticsearch/tools/launchers/SystemJvmOptions.java
@@ -50,7 +50,6 @@ final class SystemJvmOptions {
             "-Dio.netty.noUnsafe=true",
             "-Dio.netty.noKeySetOptimization=true",
             "-Dio.netty.recycler.maxCapacityPerThread=0",
-            "-Dio.netty.allocator.numDirectArenas=0",
             // log4j 2
             "-Dlog4j.shutdownHookEnabled=false",
             "-Dlog4j2.disable.jmx=true",


### PR DESCRIPTION
`io.netty.allocator.numDirectArenas` flag has already been removed by ES on Oct 21, 2019 ([commit](https://github.com/elastic/elasticsearch/commit/547e399dbfb493ab4b813ec528b969ed42207ab7)) after creating its own allocator.
However, in parallel, on Oct 28, 2019 all command line flags were moved from jvm.options file into the launcher ([commit](https://github.com/elastic/elasticsearch/commit/c4fbda3310c717252a45e895305f47a5092e62c4)), and this flag has been re-introduced.

We are seeing huge direct memory usage increase from our own plugin that implements TLS connections between nodes, and re-enabling direct memory pooling fixes our problem.

Please also see the reasoning from the original commit on why this flag is not needed anymore for ElasticSearch.