### PR TITLE
[7.x] Map iteration support for ForEach processor (#64062)

### DIFF
--- a/modules/ingest-common/src/main/java/org/elasticsearch/ingest/common/ForEachProcessor.java
+++ b/modules/ingest-common/src/main/java/org/elasticsearch/ingest/common/ForEachProcessor.java
@@ -8,6 +8,7 @@
 
 package org.elasticsearch.ingest.common;
 
+import org.elasticsearch.common.Strings;
 import org.elasticsearch.ingest.AbstractProcessor;
 import org.elasticsearch.ingest.ConfigurationUtils;
 import org.elasticsearch.ingest.IngestDocument;
@@ -16,6 +17,7 @@ import org.elasticsearch.ingest.WrappingProcessor;
 import org.elasticsearch.script.ScriptService;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -28,12 +30,10 @@ import static org.elasticsearch.ingest.ConfigurationUtils.readMap;
 import static org.elasticsearch.ingest.ConfigurationUtils.readStringProperty;
 
 /**
- * A processor that for each value in a list executes a one or more processors.
+ * Processor that executes another processor for each value in a list or map field.
  *
- * This can be useful in cases to do string operations on json array of strings,
- * or remove a field from objects inside a json array.
- *
- * Note that this processor is experimental.
+ * This can be useful for performing string operations on arrays of strings,
+ * removing or modifying a field in objects inside arrays or maps, etc.
  */
 public final class ForEachProcessor extends AbstractProcessor implements WrappingProcessor {
 
@@ -56,20 +56,61 @@ public final class ForEachProcessor extends AbstractProcessor implements Wrappin
 
     @Override
     public void execute(IngestDocument ingestDocument, BiConsumer<IngestDocument, Exception> handler) {
-        List<?> values = ingestDocument.getFieldValue(field, List.class, ignoreMissing);
-        if (values == null) {
+        Object o = ingestDocument.getFieldValue(field, Object.class, ignoreMissing);
+        if (o == null) {
             if (ignoreMissing) {
                 handler.accept(ingestDocument, null);
             } else {
                 handler.accept(null, new IllegalArgumentException("field [" + field + "] is null, cannot loop over its elements."));
             }
+        } else if (o instanceof Map) {
+            Map<?, ?> map = (Map<?, ?>) o;
+            List<?> keys = new ArrayList<>(map.keySet());
+            innerExecuteMap(0, new HashMap<Object, Object>(map), keys, new HashMap<>(map.size()), ingestDocument, handler);
+        } else if (o instanceof List) {
+            List<?> list = (List<?>) o;
+            innerExecuteList(0, new ArrayList<>(list), new ArrayList<>(list.size()), ingestDocument, handler);
         } else {
-            innerExecute(0, new ArrayList<>(values), new ArrayList<>(values.size()), ingestDocument, handler);
+            throw new IllegalArgumentException("field [" + field + "] of type [" + o.getClass().getName() + "] cannot be cast to a " +
+                "list or map");
         }
     }
 
-    void innerExecute(int index, List<?> values, List<Object> newValues, IngestDocument document,
-                      BiConsumer<IngestDocument, Exception> handler) {
+    void innerExecuteMap(int keyIndex, Map<?, ?> map, List<?> keys, Map<Object, Object> newValues, IngestDocument document,
+                         BiConsumer<IngestDocument, Exception> handler) {
+        for (; keyIndex < keys.size(); keyIndex++) {
+            AtomicBoolean shouldContinueHere = new AtomicBoolean();
+            String key = (String) keys.get(keyIndex);
+            Object previousKey = document.getIngestMetadata().put("_key", key);
+            Object value = map.get(key);
+            Object previousValue = document.getIngestMetadata().put("_value", value);
+            int nextIndex = keyIndex + 1;
+            processor.execute(document, (result, e) -> {
+                String newKey = (String) document.getIngestMetadata().get("_key");
+                if (Strings.hasText(newKey)) {
+                    newValues.put(newKey, document.getIngestMetadata().put("_value", previousValue));
+                }
+                document.getIngestMetadata().put("_key", previousKey);
+                if (e != null || result == null) {
+                    handler.accept(result, e);
+                } else if (shouldContinueHere.getAndSet(true)) {
+                    innerExecuteMap(nextIndex, map, keys, newValues, document, handler);
+                }
+            });
+
+            if (shouldContinueHere.getAndSet(true) == false) {
+                return;
+            }
+        }
+
+        if (keyIndex == keys.size()) {
+            document.setFieldValue(field, new HashMap<>(newValues));
+            handler.accept(document, null);
+        }
+    }
+
+    void innerExecuteList(int index, List<?> values, List<Object> newValues, IngestDocument document,
+                          BiConsumer<IngestDocument, Exception> handler) {
         for (; index < values.size(); index++) {
             AtomicBoolean shouldContinueHere = new AtomicBoolean();
             Object value = values.get(index);
@@ -80,7 +121,7 @@ public final class ForEachProcessor extends AbstractProcessor implements Wrappin
                 if (e != null || result == null) {
                     handler.accept(result, e);
                 } else if (shouldContinueHere.getAndSet(true)) {
-                    innerExecute(nextIndex, values, newValues, document, handler);
+                    innerExecuteList(nextIndex, values, newValues, document, handler);
                 }
             });
 

--- a/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/ForEachProcessorTests.java
+++ b/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/ForEachProcessorTests.java
@@ -23,11 +23,15 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import static org.elasticsearch.ingest.IngestDocumentMatcher.assertIngestDocument;
+import static org.hamcrest.Matchers.arrayContainingInAnyOrder;
 import static org.hamcrest.Matchers.equalTo;
 
 public class ForEachProcessorTests extends ESTestCase {
@@ -271,6 +275,54 @@ public class ForEachProcessorTests extends ESTestCase {
         assertThat(result2.get(1), equalTo("JKL"));
     }
 
+    public void testNestedForEachWithMapIteration() throws Exception {
+        Map<String, Object> innerMap1 = Map.of("foo1", 1, "bar1", 2, "baz1", 3);
+        Map<String, Object> innerMap2 = Map.of("foo2", 4, "bar2", 5, "baz2", 6);
+        Map<String, Object> innerMap3 = Map.of("foo3", 7, "bar3", 8, "baz3", 9, "otherKey", 42);
+
+        Map<String, Object> outerMap = Map.of("foo", innerMap1, "bar", innerMap2, "baz", innerMap3);
+        IngestDocument ingestDocument = new IngestDocument("_index", "_id", null, null, null, Map.of("field", outerMap));
+
+        List<String> visitedKeys = new ArrayList<>();
+        List<Object> visitedValues = new ArrayList<>();
+        TestProcessor testProcessor = new TestProcessor(
+            doc -> {
+                String key = (String) doc.getIngestMetadata().get("_key");
+                Object value = doc.getIngestMetadata().get("_value");
+                visitedKeys.add(key);
+                visitedValues.add(value);
+
+                // change some of the keys
+                if (key.startsWith("bar")) {
+                    doc.setFieldValue("_ingest._key", "bar2");
+                }
+                // change some of the values
+                if (key.startsWith("baz")) {
+                    doc.setFieldValue("_ingest._value", ((Integer) value) * 2);
+                }
+            }
+        );
+
+        ForEachProcessor processor = new ForEachProcessor(
+            "_tag", null, "field", new ForEachProcessor("_tag", null, "_ingest._value", testProcessor, false),
+            false);
+        processor.execute(ingestDocument, (result, e) -> {});
+
+        assertThat(testProcessor.getInvokedCounter(), equalTo(10));
+        assertThat(
+            visitedKeys.toArray(),
+            arrayContainingInAnyOrder("foo1", "bar1", "baz1", "foo2", "bar2", "baz2", "foo3", "bar3", "baz3", "otherKey")
+        );
+        assertThat(visitedValues.toArray(), arrayContainingInAnyOrder(1, 2, 3, 4, 5, 6, 7, 8, 9, 42));
+        assertThat(ingestDocument.getFieldValue("field", Map.class).entrySet().toArray(),
+            arrayContainingInAnyOrder(
+                Map.entry("foo", Map.of("foo1", 1, "bar2", 2, "baz1", 6)),
+                Map.entry("bar", Map.of("foo2", 4, "bar2", 5, "baz2", 12)),
+                Map.entry("baz", Map.of("foo3", 7, "bar2", 8, "baz3", 18, "otherKey", 42))
+            )
+        );
+    }
+
     public void testIgnoreMissing() throws Exception {
         IngestDocument originalIngestDocument = new IngestDocument(
             "_index", "_type", "_id", null, null, null, Collections.emptyMap()
@@ -305,6 +357,106 @@ public class ForEachProcessorTests extends ESTestCase {
         assertThat(testProcessor.getInvokedCounter(), equalTo(2));
         ingestDocument.removeField("_ingest._value");
         assertThat(ingestDocument, equalTo(originalIngestDocument));
+    }
+
+    public void testMapIteration() {
+        Map<String, Object> mapValue = Map.of("foo", 1, "bar", 2, "baz", 3);
+        IngestDocument ingestDocument = new IngestDocument("_index", "_id", null, null, null, Map.of("field", mapValue));
+
+        List<String> encounteredKeys = new ArrayList<>();
+        List<Object> encounteredValues = new ArrayList<>();
+        TestProcessor testProcessor = new TestProcessor(id -> {
+            String key = (String) id.getIngestMetadata().get("_key");
+            Object value = id.getIngestMetadata().get("_value");
+            encounteredKeys.add(key);
+            encounteredValues.add(value);
+            if (key.equals("bar")) {
+                id.setFieldValue("_ingest._key", "bar2");
+            }
+            if (key.equals("baz")) {
+                id.setFieldValue("_ingest._value", 33);
+            }
+        });
+        ForEachProcessor processor = new ForEachProcessor("_tag", null, "field", testProcessor, true);
+        processor.execute(ingestDocument, (result, e) -> {});
+        assertThat(testProcessor.getInvokedCounter(), equalTo(3));
+        assertThat(encounteredKeys.toArray(), arrayContainingInAnyOrder("foo", "bar", "baz"));
+        assertThat(encounteredValues.toArray(), arrayContainingInAnyOrder(1, 2, 3));
+        assertThat(ingestDocument.getFieldValue("field", Map.class).entrySet().toArray(),
+            arrayContainingInAnyOrder(Map.entry("foo", 1), Map.entry("bar2", 2), Map.entry("baz", 33)));
+    }
+
+    public void testRemovalOfMapKey() {
+        Map<String, Object> mapValue = Map.of("foo", 1, "bar", 2, "baz", 3);
+        IngestDocument ingestDocument = new IngestDocument("_index", "_id", null, null, null, Map.of("field", mapValue));
+
+        List<String> encounteredKeys = new ArrayList<>();
+        List<Object> encounteredValues = new ArrayList<>();
+        TestProcessor testProcessor = new TestProcessor(id -> {
+            String key = (String) id.getIngestMetadata().get("_key");
+            encounteredKeys.add(key);
+            encounteredValues.add(id.getIngestMetadata().get("_value"));
+            if (key.equals("bar")) {
+                id.setFieldValue("_ingest._key", "");
+            }
+        });
+        ForEachProcessor processor = new ForEachProcessor("_tag", null, "field", testProcessor, true);
+        processor.execute(ingestDocument, (result, e) -> {});
+        assertThat(testProcessor.getInvokedCounter(), equalTo(3));
+        assertThat(encounteredKeys.toArray(), arrayContainingInAnyOrder("foo", "bar", "baz"));
+        assertThat(encounteredValues.toArray(), arrayContainingInAnyOrder(1, 2, 3));
+        assertThat(ingestDocument.getFieldValue("field", Map.class).entrySet().toArray(),
+            arrayContainingInAnyOrder(Map.entry("foo", 1), Map.entry("baz", 3)));
+    }
+
+    public void testMapIterationWithAsyncProcessor() throws Exception {
+        Map<String, Object> innerMap1 = Map.of("foo1", 1, "bar1", 2, "baz1", 3);
+        Map<String, Object> innerMap2 = Map.of("foo2", 4, "bar2", 5, "baz2", 6);
+        Map<String, Object> innerMap3 = Map.of("foo3", 7, "bar3", 8, "baz3", 9, "otherKey", 42);
+
+        Map<String, Object> outerMap = Map.of("foo", innerMap1, "bar", innerMap2, "baz", innerMap3);
+        IngestDocument ingestDocument = new IngestDocument("_index", "_id", null, null, null, Map.of("field", outerMap));
+
+        List<String> visitedKeys = new ArrayList<>();
+        List<Object> visitedValues = new ArrayList<>();
+        TestAsyncProcessor testProcessor = new TestAsyncProcessor(
+            doc -> {
+                String key = (String) doc.getIngestMetadata().get("_key");
+                Object value = doc.getIngestMetadata().get("_value");
+                visitedKeys.add(key);
+                visitedValues.add(value);
+
+                // change some of the keys
+                if (key.startsWith("bar")) {
+                    doc.setFieldValue("_ingest._key", "bar2");
+                }
+                // change some of the values
+                if (key.startsWith("baz")) {
+                    doc.setFieldValue("_ingest._value", ((Integer) value) * 2);
+                }
+            }
+        );
+
+        ForEachProcessor processor = new ForEachProcessor(
+            "_tag", null, "field", new ForEachProcessor("_tag", null, "_ingest._value", testProcessor, false),
+            false);
+        processor.execute(ingestDocument, (result, e) -> {});
+
+        assertBusy(() -> {
+            assertThat(testProcessor.getInvokedCounter(), equalTo(10));
+            assertThat(
+                visitedKeys.toArray(),
+                arrayContainingInAnyOrder("foo1", "bar1", "baz1", "foo2", "bar2", "baz2", "foo3", "bar3", "baz3", "otherKey")
+            );
+            assertThat(visitedValues.toArray(), arrayContainingInAnyOrder(1, 2, 3, 4, 5, 6, 7, 8, 9, 42));
+            assertThat(ingestDocument.getFieldValue("field", Map.class).entrySet().toArray(),
+                arrayContainingInAnyOrder(
+                    Map.entry("foo", Map.of("foo1", 1, "bar2", 2, "baz1", 6)),
+                    Map.entry("bar", Map.of("foo2", 4, "bar2", 5, "baz2", 12)),
+                    Map.entry("baz", Map.of("foo3", 7, "bar2", 8, "baz3", 18, "otherKey", 42))
+                )
+            );
+        });
     }
 
     private class AsyncUpperCaseProcessor implements Processor {
@@ -346,6 +498,55 @@ public class ForEachProcessorTests extends ESTestCase {
         @Override
         public String getDescription() {
             return "async uppercase processor description";
+        }
+    }
+
+    private class TestAsyncProcessor implements Processor {
+
+        private final Function<IngestDocument, IngestDocument> ingestDocumentMapper;
+        private final AtomicInteger invokedCounter = new AtomicInteger();
+
+        private TestAsyncProcessor(Consumer<IngestDocument> ingestDocumentConsumer) {
+            this.ingestDocumentMapper = ingestDocument -> {
+                ingestDocumentConsumer.accept(ingestDocument);
+                return ingestDocument;
+            };
+        }
+
+        @Override
+        public void execute(IngestDocument document, BiConsumer<IngestDocument, Exception> handler) {
+            new Thread(() -> {
+                invokedCounter.incrementAndGet();
+                try {
+                    handler.accept(ingestDocumentMapper.apply(document), null);
+                } catch (Exception e) {
+                    handler.accept(null, e);
+                }
+            }).start();
+        }
+
+        public int getInvokedCounter() {
+            return invokedCounter.get();
+        }
+
+        @Override
+        public IngestDocument execute(IngestDocument ingestDocument) throws Exception {
+            throw new UnsupportedOperationException("this is an async processor, don't call this");
+        }
+
+        @Override
+        public String getType() {
+            return "test-async-processor";
+        }
+
+        @Override
+        public String getTag() {
+            return getType();
+        }
+
+        @Override
+        public String getDescription() {
+            return "test async processor description";
         }
     }
 

--- a/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/ForEachProcessorTests.java
+++ b/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/ForEachProcessorTests.java
@@ -8,6 +8,7 @@
 
 package org.elasticsearch.ingest.common;
 
+import org.elasticsearch.core.Map;
 import org.elasticsearch.ingest.CompoundProcessor;
 import org.elasticsearch.ingest.IngestDocument;
 import org.elasticsearch.ingest.Processor;
@@ -22,7 +23,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
-import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
@@ -96,7 +96,7 @@ public class ForEachProcessorTests extends ESTestCase {
     }
 
     public void testMetadataAvailable() throws Exception {
-        List<Map<String, Object>> values = new ArrayList<>();
+        List<java.util.Map<String, Object>> values = new ArrayList<>();
         values.add(new HashMap<>());
         values.add(new HashMap<>());
         IngestDocument ingestDocument = new IngestDocument(
@@ -121,13 +121,13 @@ public class ForEachProcessorTests extends ESTestCase {
     }
 
     public void testRestOfTheDocumentIsAvailable() throws Exception {
-        List<Map<String, Object>> values = new ArrayList<>();
+        List<java.util.Map<String, Object>> values = new ArrayList<>();
         for (int i = 0; i < 5; i++) {
-            Map<String, Object> object = new HashMap<>();
+            java.util.Map<String, Object> object = new HashMap<>();
             object.put("field", "value");
             values.add(object);
         }
-        Map<String, Object> document = new HashMap<>();
+        java.util.Map<String, Object> document = new HashMap<>();
         document.put("values", values);
         document.put("flat_values", new ArrayList<>());
         document.put("other", "value");
@@ -220,7 +220,7 @@ public class ForEachProcessorTests extends ESTestCase {
         values.add("please");
         values.add("change");
         values.add("me");
-        Map<String, Object> source = new HashMap<>();
+        java.util.Map<String, Object> source = new HashMap<>();
         source.put("_value", "new_value");
         source.put("values", values);
         IngestDocument ingestDocument = new IngestDocument(
@@ -239,11 +239,11 @@ public class ForEachProcessorTests extends ESTestCase {
     }
 
     public void testNestedForEach() throws Exception {
-        List<Map<String, Object>> values = new ArrayList<>();
+        List<java.util.Map<String, Object>> values = new ArrayList<>();
         List<Object> innerValues = new ArrayList<>();
         innerValues.add("abc");
         innerValues.add("def");
-        Map<String, Object> value = new HashMap<>();
+        java.util.Map<String, Object> value = new HashMap<>();
         value.put("values2", innerValues);
         values.add(value);
 
@@ -276,12 +276,12 @@ public class ForEachProcessorTests extends ESTestCase {
     }
 
     public void testNestedForEachWithMapIteration() throws Exception {
-        Map<String, Object> innerMap1 = Map.of("foo1", 1, "bar1", 2, "baz1", 3);
-        Map<String, Object> innerMap2 = Map.of("foo2", 4, "bar2", 5, "baz2", 6);
-        Map<String, Object> innerMap3 = Map.of("foo3", 7, "bar3", 8, "baz3", 9, "otherKey", 42);
+        java.util.Map<String, Object> innerMap1 = Map.of("foo1", 1, "bar1", 2, "baz1", 3);
+        java.util.Map<String, Object> innerMap2 = Map.of("foo2", 4, "bar2", 5, "baz2", 6);
+        java.util.Map<String, Object> innerMap3 = Map.of("foo3", 7, "bar3", 8, "baz3", 9, "otherKey", 42);
 
-        Map<String, Object> outerMap = Map.of("foo", innerMap1, "bar", innerMap2, "baz", innerMap3);
-        IngestDocument ingestDocument = new IngestDocument("_index", "_id", null, null, null, Map.of("field", outerMap));
+        java.util.Map<String, Object> outerMap = Map.of("foo", innerMap1, "bar", innerMap2, "baz", innerMap3);
+        IngestDocument ingestDocument = new IngestDocument("_index", "_type", "_id", null, null, null, Map.of("field", outerMap));
 
         List<String> visitedKeys = new ArrayList<>();
         List<Object> visitedValues = new ArrayList<>();
@@ -314,7 +314,7 @@ public class ForEachProcessorTests extends ESTestCase {
             arrayContainingInAnyOrder("foo1", "bar1", "baz1", "foo2", "bar2", "baz2", "foo3", "bar3", "baz3", "otherKey")
         );
         assertThat(visitedValues.toArray(), arrayContainingInAnyOrder(1, 2, 3, 4, 5, 6, 7, 8, 9, 42));
-        assertThat(ingestDocument.getFieldValue("field", Map.class).entrySet().toArray(),
+        assertThat(ingestDocument.getFieldValue("field", java.util.Map.class).entrySet().toArray(),
             arrayContainingInAnyOrder(
                 Map.entry("foo", Map.of("foo1", 1, "bar2", 2, "baz1", 6)),
                 Map.entry("bar", Map.of("foo2", 4, "bar2", 5, "baz2", 12)),
@@ -336,7 +336,7 @@ public class ForEachProcessorTests extends ESTestCase {
     }
 
     public void testAppendingToTheSameField() {
-        Map<String, Object> source = Collections.singletonMap("field", Arrays.asList("a", "b"));
+        java.util.Map<String, Object> source = Collections.singletonMap("field", Arrays.asList("a", "b"));
         IngestDocument originalIngestDocument = new IngestDocument("_index", "_type", "_id", null, null, null, source);
         IngestDocument ingestDocument = new IngestDocument(originalIngestDocument);
         TestProcessor testProcessor = new TestProcessor(id->id.appendFieldValue("field", "a"));
@@ -348,7 +348,7 @@ public class ForEachProcessorTests extends ESTestCase {
     }
 
     public void testRemovingFromTheSameField() {
-        Map<String, Object> source = Collections.singletonMap("field", Arrays.asList("a", "b"));
+        java.util.Map<String, Object> source = Collections.singletonMap("field", Arrays.asList("a", "b"));
         IngestDocument originalIngestDocument = new IngestDocument("_index", "_id", "_type", null, null, null, source);
         IngestDocument ingestDocument = new IngestDocument(originalIngestDocument);
         TestProcessor testProcessor = new TestProcessor(id -> id.removeField("field.0"));
@@ -360,8 +360,8 @@ public class ForEachProcessorTests extends ESTestCase {
     }
 
     public void testMapIteration() {
-        Map<String, Object> mapValue = Map.of("foo", 1, "bar", 2, "baz", 3);
-        IngestDocument ingestDocument = new IngestDocument("_index", "_id", null, null, null, Map.of("field", mapValue));
+        java.util.Map<String, Object> mapValue = Map.of("foo", 1, "bar", 2, "baz", 3);
+        IngestDocument ingestDocument = new IngestDocument("_index", "_type", "_id", null, null, null, Map.of("field", mapValue));
 
         List<String> encounteredKeys = new ArrayList<>();
         List<Object> encounteredValues = new ArrayList<>();
@@ -382,13 +382,13 @@ public class ForEachProcessorTests extends ESTestCase {
         assertThat(testProcessor.getInvokedCounter(), equalTo(3));
         assertThat(encounteredKeys.toArray(), arrayContainingInAnyOrder("foo", "bar", "baz"));
         assertThat(encounteredValues.toArray(), arrayContainingInAnyOrder(1, 2, 3));
-        assertThat(ingestDocument.getFieldValue("field", Map.class).entrySet().toArray(),
+        assertThat(ingestDocument.getFieldValue("field", java.util.Map.class).entrySet().toArray(),
             arrayContainingInAnyOrder(Map.entry("foo", 1), Map.entry("bar2", 2), Map.entry("baz", 33)));
     }
 
     public void testRemovalOfMapKey() {
-        Map<String, Object> mapValue = Map.of("foo", 1, "bar", 2, "baz", 3);
-        IngestDocument ingestDocument = new IngestDocument("_index", "_id", null, null, null, Map.of("field", mapValue));
+        java.util.Map<String, Object> mapValue = Map.of("foo", 1, "bar", 2, "baz", 3);
+        IngestDocument ingestDocument = new IngestDocument("_index", "_type", "_id", null, null, null, Map.of("field", mapValue));
 
         List<String> encounteredKeys = new ArrayList<>();
         List<Object> encounteredValues = new ArrayList<>();
@@ -405,17 +405,17 @@ public class ForEachProcessorTests extends ESTestCase {
         assertThat(testProcessor.getInvokedCounter(), equalTo(3));
         assertThat(encounteredKeys.toArray(), arrayContainingInAnyOrder("foo", "bar", "baz"));
         assertThat(encounteredValues.toArray(), arrayContainingInAnyOrder(1, 2, 3));
-        assertThat(ingestDocument.getFieldValue("field", Map.class).entrySet().toArray(),
+        assertThat(ingestDocument.getFieldValue("field", java.util.Map.class).entrySet().toArray(),
             arrayContainingInAnyOrder(Map.entry("foo", 1), Map.entry("baz", 3)));
     }
 
     public void testMapIterationWithAsyncProcessor() throws Exception {
-        Map<String, Object> innerMap1 = Map.of("foo1", 1, "bar1", 2, "baz1", 3);
-        Map<String, Object> innerMap2 = Map.of("foo2", 4, "bar2", 5, "baz2", 6);
-        Map<String, Object> innerMap3 = Map.of("foo3", 7, "bar3", 8, "baz3", 9, "otherKey", 42);
+        java.util.Map<String, Object> innerMap1 = Map.of("foo1", 1, "bar1", 2, "baz1", 3);
+        java.util.Map<String, Object> innerMap2 = Map.of("foo2", 4, "bar2", 5, "baz2", 6);
+        java.util.Map<String, Object> innerMap3 = Map.of("foo3", 7, "bar3", 8, "baz3", 9, "otherKey", 42);
 
-        Map<String, Object> outerMap = Map.of("foo", innerMap1, "bar", innerMap2, "baz", innerMap3);
-        IngestDocument ingestDocument = new IngestDocument("_index", "_id", null, null, null, Map.of("field", outerMap));
+        java.util.Map<String, Object> outerMap = Map.of("foo", innerMap1, "bar", innerMap2, "baz", innerMap3);
+        IngestDocument ingestDocument = new IngestDocument("_index", "_type", "_id", null, null, null, Map.of("field", outerMap));
 
         List<String> visitedKeys = new ArrayList<>();
         List<Object> visitedValues = new ArrayList<>();
@@ -449,7 +449,7 @@ public class ForEachProcessorTests extends ESTestCase {
                 arrayContainingInAnyOrder("foo1", "bar1", "baz1", "foo2", "bar2", "baz2", "foo3", "bar3", "baz3", "otherKey")
             );
             assertThat(visitedValues.toArray(), arrayContainingInAnyOrder(1, 2, 3, 4, 5, 6, 7, 8, 9, 42));
-            assertThat(ingestDocument.getFieldValue("field", Map.class).entrySet().toArray(),
+            assertThat(ingestDocument.getFieldValue("field", java.util.Map.class).entrySet().toArray(),
                 arrayContainingInAnyOrder(
                     Map.entry("foo", Map.of("foo1", 1, "bar2", 2, "baz1", 6)),
                     Map.entry("bar", Map.of("foo2", 4, "bar2", 5, "baz2", 12)),


### PR DESCRIPTION
Adds support to the ForEach processor for iterating over map fields in addition to array fields. When iterating over maps, an additional ingest metadata field `_ingest._key` is populated with the value of the map entry's key. Both the map entry's key and value can be changed. Map entries can also be removed completely by setting the key to a null or empty string value.

Resolves https://github.com/elastic/elasticsearch/issues/55215

Backport of #64062
