### PR TITLE
[7.14] Gracefully handle very large sizes on terms (#76578)

### DIFF
--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.aggregation/20_terms.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.aggregation/20_terms.yml
@@ -1381,3 +1381,47 @@ precise size:
   - match: { aggregations.str_terms.buckets.0.doc_count: 2 }
   - match: { aggregations.str_terms.buckets.1.key: c }
   - match: { aggregations.str_terms.buckets.1.doc_count: 3 }
+
+---
+huge size:
+  - skip:
+        version: " - 7.99.99"
+        reason: "Fixed in 8.0.0 to be backported to 7.14.1"
+
+  - do:
+      bulk:
+        index: test_1
+        refresh: true
+        body: |
+          { "index": {} }
+          { "str": "a" }
+          { "index": {} }
+          { "str": "b" }
+          { "index": {} }
+          { "str": "c" }
+          { "index": {} }
+          { "str": "b" }
+          { "index": {} }
+          { "str": "c" }
+          { "index": {} }
+          { "str": "c" }
+
+  - do:
+      search:
+        index: test_1
+        body:
+          size: 0
+          aggs:
+            str_terms:
+              terms:
+                size: 2147483647
+                field: str
+                order:
+                  - _key : asc
+  - length: { aggregations.str_terms.buckets: 3 }
+  - match: { aggregations.str_terms.buckets.0.key: a }
+  - match: { aggregations.str_terms.buckets.0.doc_count: 1 }
+  - match: { aggregations.str_terms.buckets.1.key: b }
+  - match: { aggregations.str_terms.buckets.1.doc_count: 2 }
+  - match: { aggregations.str_terms.buckets.2.key: c }
+  - match: { aggregations.str_terms.buckets.2.doc_count: 3 }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/TopBucketBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/TopBucketBuilder.java
@@ -8,6 +8,7 @@
 
 package org.elasticsearch.search.aggregations;
 
+import org.apache.lucene.util.ArrayUtil;
 import org.apache.lucene.util.PriorityQueue;
 import org.elasticsearch.search.aggregations.bucket.MultiBucketsAggregation.Bucket;
 
@@ -20,26 +21,54 @@ import java.util.function.Consumer;
 /**
  * Merges many buckets into the "top" buckets as sorted by {@link BucketOrder}.
  */
-public class TopBucketBuilder<B extends InternalMultiBucketAggregation.InternalBucket> {
-    private final Consumer<DelayedBucket<B>> nonCompetitive;
-    private final PriorityQueue<DelayedBucket<B>> queue;
+public abstract class TopBucketBuilder<B extends InternalMultiBucketAggregation.InternalBucket> {
+    /**
+     * The number of buckets required before we switch to the
+     * {@link BufferingTopBucketBuilder}. If we need fewer buckets we use
+     * {@link PriorityQueueTopBucketBuilder}.
+     * <p>
+     * The value we picked for this boundary is fairly arbitrary, but it
+     * is important that its bigger than the default size of the terms
+     * aggregation. It's basically the amount of memory you are willing to
+     * waste when reduce small terms aggregations so it shouldn't be too
+     * large either. The value we have, {@code 1024}, preallocates about
+     * 32k for the priority queue.
+     */
+    static final int USE_BUFFERING_BUILDER = 1024;
 
     /**
      * Create a {@link TopBucketBuilder} to build a list of the top buckets.
+     * <p>
+     * If there are few required results we use a {@link PriorityQueueTopBucketBuilder}
+     * which is simpler and when the priority queue is full but allocates {@code size + 1}
+     * slots in an array. If there are many required results we prefer a
+     * {@link BufferingTopBucketBuilder} which doesn't preallocate and is faster for the
+     * first {@code size} results. But it's a little slower when the priority queue is full.
+     * <p>
+     * It's important for this <strong>not</strong> to preallocate a bunch of memory when
+     * {@code size} is very very large because this backs the reduction of the {@code terms}
+     * aggregation and folks often set the {@code size} of that to something quite large.
+     * The choice in the paragraph above handles this case.
+     *
      * @param size the requested size of the list
      * @param order the sort order of the buckets
      * @param nonCompetitive called with non-competitive buckets
      */
-    public TopBucketBuilder(int size, BucketOrder order, Consumer<DelayedBucket<B>> nonCompetitive) {
-        this.nonCompetitive = nonCompetitive;
-        queue = new PriorityQueue<DelayedBucket<B>>(size) {
-            private final Comparator<DelayedBucket<? extends Bucket>> comparator = order.delayedBucketComparator();
+    public static <B extends InternalMultiBucketAggregation.InternalBucket> TopBucketBuilder<B> build(
+        int size,
+        BucketOrder order,
+        Consumer<DelayedBucket<B>> nonCompetitive
+    ) {
+        if (size < USE_BUFFERING_BUILDER) {
+            return new PriorityQueueTopBucketBuilder<>(size, order, nonCompetitive);
+        }
+        return new BufferingTopBucketBuilder<>(size, order, nonCompetitive);
+    }
 
-            @Override
-            protected boolean lessThan(DelayedBucket<B> a, DelayedBucket<B> b) {
-                return comparator.compare(a, b) > 0;
-            }
-        };
+    protected final Consumer<DelayedBucket<B>> nonCompetitive;
+
+    private TopBucketBuilder(Consumer<DelayedBucket<B>> nonCompetitive) {
+        this.nonCompetitive = nonCompetitive;
     }
 
     /**
@@ -53,23 +82,105 @@ public class TopBucketBuilder<B extends InternalMultiBucketAggregation.InternalB
      * directly on the {@linkplain DelayedBucket}s so we only need to
      * merge <strong>exactly</strong> the sub-buckets we need.
      */
-    public void add(DelayedBucket<B> bucket) {
-        DelayedBucket<B> removed = queue.insertWithOverflow(bucket);
-        if (removed != null) {
-            nonCompetitive.accept(removed);
-            removed.nonCompetitive();
-        }
-    }
+    public abstract void add(DelayedBucket<B> bucket);
 
     /**
      * Return the most competitive buckets sorted by the comparator.
      */
-    public List<B> build() {
-        List<B> result = new ArrayList<>(queue.size());
-        for (int i = queue.size() - 1; i >= 0; i--) {
-            result.add(queue.pop().reduced());
+    public abstract List<B> build();
+
+    /**
+     * Collects the "top" buckets by adding them directly to a {@link PriorityQueue}.
+     * This is always going to be faster than {@link BufferingTopBucketBuilder}
+     * but it requires allocating an array of {@code size + 1}.
+     */
+    static class PriorityQueueTopBucketBuilder<B extends InternalMultiBucketAggregation.InternalBucket> extends TopBucketBuilder<B> {
+        private final PriorityQueue<DelayedBucket<B>> queue;
+
+        PriorityQueueTopBucketBuilder(int size, BucketOrder order, Consumer<DelayedBucket<B>> nonCompetitive) {
+            super(nonCompetitive);
+            if (size >= ArrayUtil.MAX_ARRAY_LENGTH) {
+                throw new IllegalArgumentException("can't reduce more than [" + ArrayUtil.MAX_ARRAY_LENGTH + "] buckets");
+            }
+            queue = new PriorityQueue<DelayedBucket<B>>(size) {
+                private final Comparator<DelayedBucket<? extends Bucket>> comparator = order.delayedBucketComparator();
+
+                @Override
+                protected boolean lessThan(DelayedBucket<B> a, DelayedBucket<B> b) {
+                    return comparator.compare(a, b) > 0;
+                }
+            };
         }
-        Collections.reverse(result);
-        return result;
+
+        @Override
+        public void add(DelayedBucket<B> bucket) {
+            DelayedBucket<B> removed = queue.insertWithOverflow(bucket);
+            if (removed != null) {
+                nonCompetitive.accept(removed);
+                removed.nonCompetitive();
+            }
+        }
+
+        @Override
+        public List<B> build() {
+            List<B> result = new ArrayList<>(queue.size());
+            for (int i = queue.size() - 1; i >= 0; i--) {
+                result.add(queue.pop().reduced());
+            }
+            Collections.reverse(result);
+            return result;
+        }
+    }
+
+    /**
+     * Collects the "top" buckets by adding them to a {@link List} that grows
+     * as more buckets arrive and is converting into a
+     * {@link PriorityQueueTopBucketBuilder} when {@code size} buckets arrive.
+     */
+    private static class BufferingTopBucketBuilder<B extends InternalMultiBucketAggregation.InternalBucket> extends TopBucketBuilder<B> {
+        private final int size;
+        private final BucketOrder order;
+
+        private List<DelayedBucket<B>> buffer;
+        private PriorityQueueTopBucketBuilder<B> next;
+
+        BufferingTopBucketBuilder(int size, BucketOrder order, Consumer<DelayedBucket<B>> nonCompetitive) {
+            super(nonCompetitive);
+            this.size = size;
+            this.order = order;
+            buffer = new ArrayList<>();
+        }
+
+        @Override
+        public void add(DelayedBucket<B> bucket) {
+            if (next != null) {
+                assert buffer == null;
+                next.add(bucket);
+                return;
+            }
+            buffer.add(bucket);
+            if (buffer.size() < size) {
+                return;
+            }
+            next = new PriorityQueueTopBucketBuilder<>(size, order, nonCompetitive);
+            for (DelayedBucket<B> b : buffer) {
+                next.queue.add(b);
+            }
+            buffer = null;
+        }
+
+        @Override
+        public List<B> build() {
+            if (next != null) {
+                assert buffer == null;
+                return next.build();
+            }
+            List<B> result = new ArrayList<>(buffer.size());
+            for (DelayedBucket<B> b : buffer) {
+                result.add(b.reduced());
+            }
+            result.sort(order.comparator());
+            return result;
+        }
     }
 }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/AbstractInternalTerms.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/AbstractInternalTerms.java
@@ -299,7 +299,7 @@ public abstract class AbstractInternalTerms<
         BucketOrder thisReduceOrder;
         List<B> result;
         if (reduceContext.isFinalReduce()) {
-            TopBucketBuilder<B> top = new TopBucketBuilder<>(getRequiredSize(), getOrder(), removed -> {
+            TopBucketBuilder<B> top = TopBucketBuilder.build(getRequiredSize(), getOrder(), removed -> {
                 otherDocCount[0] += removed.getDocCount();
             });
             thisReduceOrder = reduceBuckets(aggregations, reduceContext, bucket -> {

--- a/server/src/test/java/org/elasticsearch/search/aggregations/TopBucketBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/TopBucketBuilderTests.java
@@ -8,6 +8,7 @@
 
 package org.elasticsearch.search.aggregations;
 
+import org.apache.lucene.util.ArrayUtil;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.aggregations.InternalAggregation.ReduceContext;
@@ -29,7 +30,7 @@ public class TopBucketBuilderTests extends ESTestCase {
         int count = between(1, 1000);
         ReduceContext context = mock(ReduceContext.class);
         List<String> nonCompetitive = new ArrayList<>();
-        TopBucketBuilder<InternalBucket> builder = new TopBucketBuilder<>(1, BucketOrder.key(true), b -> nonCompetitive.add(b.toString()));
+        TopBucketBuilder<InternalBucket> builder = TopBucketBuilder.build(1, BucketOrder.key(true), b -> nonCompetitive.add(b.toString()));
 
         for (int i = 0; i < count; i++) {
             builder.add(new DelayedBucket<>(mockReduce(context), context, org.elasticsearch.core.List.of(bucket(i))));
@@ -37,7 +38,7 @@ public class TopBucketBuilderTests extends ESTestCase {
 
         List<InternalBucket> top = builder.build();
         assertThat(top, hasSize(1));
-        assertThat(top.get(0).getKeyAsString(), equalTo("0000"));
+        assertThat(top.get(0).getKeyAsString(), equalTo("000000"));
         assertThat(top.get(0).getDocCount(), equalTo(1L));
         for (int i = 1; i < count; i++) {
             assertThat(nonCompetitive.get(i - 1), equalTo("Delayed[" + bucketKey(i) + "]"));
@@ -48,7 +49,7 @@ public class TopBucketBuilderTests extends ESTestCase {
         int size = between(3, 1000);
         int count = between(1, size);
         ReduceContext context = mock(ReduceContext.class);
-        TopBucketBuilder<InternalBucket> builder = new TopBucketBuilder<>(
+        TopBucketBuilder<InternalBucket> builder = TopBucketBuilder.build(
             size,
             BucketOrder.key(true),
             b -> fail("unexpected uncompetitive bucket " + b)
@@ -66,12 +67,11 @@ public class TopBucketBuilderTests extends ESTestCase {
         }
     }
 
-    public void testSomNonCompetitive() {
-        int size = between(3, 1000);
-        int count = between(size + 1, size * 1000);
+    public void someNonCompetitiveTestCase(int size) {
+        int count = between(size + 1, size * 30);
         ReduceContext context = mock(ReduceContext.class);
         List<String> nonCompetitive = new ArrayList<>();
-        TopBucketBuilder<InternalBucket> builder = new TopBucketBuilder<>(
+        TopBucketBuilder<InternalBucket> builder = TopBucketBuilder.build(
             size,
             BucketOrder.key(true),
             b -> nonCompetitive.add(b.toString())
@@ -93,8 +93,51 @@ public class TopBucketBuilderTests extends ESTestCase {
         }
     }
 
+    public void testSomeNonCompetitiveSmall() {
+        someNonCompetitiveTestCase(between(2, TopBucketBuilder.USE_BUFFERING_BUILDER - 1));
+    }
+
+    public void testSomeNonCompetitiveLarge() {
+        someNonCompetitiveTestCase(between(TopBucketBuilder.USE_BUFFERING_BUILDER, TopBucketBuilder.USE_BUFFERING_BUILDER * 5));
+    }
+
+    public void testHuge() {
+        int count = between(1, 1000);
+        ReduceContext context = mock(ReduceContext.class);
+        TopBucketBuilder<InternalBucket> builder = TopBucketBuilder.build(
+            Integer.MAX_VALUE,
+            BucketOrder.key(true),
+            b -> fail("unexpected uncompetitive bucket " + b)
+        );
+
+        for (int i = 0; i < count; i++) {
+            builder.add(new DelayedBucket<>(mockReduce(context), context, List.of(bucket(i))));
+        }
+
+        List<InternalBucket> top = builder.build();
+        assertThat(top, hasSize(count));
+        assertThat(top.get(0).getKeyAsString(), equalTo("000000"));
+        assertThat(top.get(0).getDocCount(), equalTo(1L));
+        for (int i = 0; i < count; i++) {
+            assertThat(top.get(i).getKeyAsString(), equalTo(bucketKey(i)));
+            assertThat(top.get(i).getDocCount(), equalTo(1L));
+        }
+    }
+
+    public void testHugeQueueError() {
+        Exception e = expectThrows(
+            IllegalArgumentException.class,
+            () -> new TopBucketBuilder.PriorityQueueTopBucketBuilder<>(
+                ArrayUtil.MAX_ARRAY_LENGTH,
+                BucketOrder.key(true),
+                b -> fail("unexpected uncompetitive bucket " + b)
+            )
+        );
+        assertThat(e.getMessage(), equalTo("can't reduce more than [" + ArrayUtil.MAX_ARRAY_LENGTH + "] buckets"));
+    }
+
     private String bucketKey(int index) {
-        return String.format(Locale.ROOT, "%04d", index);
+        return String.format(Locale.ROOT, "%06d", index);
     }
 
     private InternalBucket bucket(int index) {

--- a/server/src/test/java/org/elasticsearch/search/aggregations/TopBucketBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/TopBucketBuilderTests.java
@@ -111,7 +111,7 @@ public class TopBucketBuilderTests extends ESTestCase {
         );
 
         for (int i = 0; i < count; i++) {
-            builder.add(new DelayedBucket<>(mockReduce(context), context, List.of(bucket(i))));
+            builder.add(new DelayedBucket<>(mockReduce(context), context, org.elasticsearch.core.List.of(bucket(i))));
         }
 
         List<InternalBucket> top = builder.build();


### PR DESCRIPTION
Backports the following commits to 7.14:
 - Gracefully handle very large sizes on terms (#76578)