### PR TITLE
[ML] Extend inference processor to work with allocated models

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/ml.infer_trained_model_deployment.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/ml.infer_trained_model_deployment.json
@@ -36,7 +36,7 @@
       }
     },
     "body":{
-      "description":"The input text to be evaluated.",
+      "description":"The docs to apply inference on",
       "required":true
     }
   }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/InferTrainedModelDeploymentAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/InferTrainedModelDeploymentAction.java
@@ -7,15 +7,16 @@
 
 package org.elasticsearch.xpack.core.ml.action;
 
+import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.ActionType;
 import org.elasticsearch.action.support.tasks.BaseTasksRequest;
 import org.elasticsearch.action.support.tasks.BaseTasksResponse;
 import org.elasticsearch.common.Strings;
-import org.elasticsearch.common.xcontent.ParseField;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.xcontent.ObjectParser;
+import org.elasticsearch.common.xcontent.ParseField;
 import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.ToXContentObject;
 import org.elasticsearch.common.xcontent.XContentBuilder;
@@ -23,10 +24,15 @@ import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.xpack.core.ml.inference.results.InferenceResults;
+import org.elasticsearch.xpack.core.ml.utils.ExceptionsHelper;
 
 import java.io.IOException;
 import java.util.Collections;
+import java.util.List;
+import java.util.Map;
 import java.util.Objects;
+
+import static org.elasticsearch.action.ValidateActions.addValidationError;
 
 public class InferTrainedModelDeploymentAction extends ActionType<InferTrainedModelDeploymentAction.Response> {
 
@@ -42,54 +48,46 @@ public class InferTrainedModelDeploymentAction extends ActionType<InferTrainedMo
     public static class Request extends BaseTasksRequest<Request> implements ToXContentObject {
 
         public static final ParseField DEPLOYMENT_ID = new ParseField("deployment_id");
-        public static final ParseField INPUT = new ParseField("input");
+        public static final ParseField DOCS = new ParseField("docs");
         public static final ParseField TIMEOUT = new ParseField("timeout");
 
         public static final TimeValue DEFAULT_TIMEOUT = TimeValue.timeValueSeconds(10);
 
-        static final ObjectParser<Request, Void> PARSER = new ObjectParser<>(NAME, Request::new);
+        static final ObjectParser<Request.Builder, Void> PARSER = new ObjectParser<>(NAME, Request.Builder::new);
         static {
-            PARSER.declareString(Request::setDeploymentId, DEPLOYMENT_ID);
-            PARSER.declareString((request, inputs) -> request.input = inputs, INPUT);
-            PARSER.declareString((r, value) -> r.setTimeout(TimeValue.parseTimeValue(value, TIMEOUT.getPreferredName())),
-                TIMEOUT);
+            PARSER.declareString(Request.Builder::setDeploymentId, DEPLOYMENT_ID);
+            PARSER.declareObjectArray(Request.Builder::setDocs, (p, c) -> p.mapOrdered(), DOCS);
+            PARSER.declareString(Request.Builder::setTimeout, TIMEOUT);
         }
 
         public static Request parseRequest(String deploymentId, XContentParser parser) {
-            Request r = PARSER.apply(parser, null);
+            Request.Builder builder = PARSER.apply(parser, null);
             if (deploymentId != null) {
-                r.deploymentId = deploymentId;
+                builder.setDeploymentId(deploymentId);
             }
-            return r;
+            return builder.build();
         }
 
         private String deploymentId;
-        private String input;
+        private List<Map<String, Object>> docs;
 
-        private Request() {
-        }
-
-        Request(String deploymentId, String input) {
-            this.deploymentId = Objects.requireNonNull(deploymentId);
-            this.input = Objects.requireNonNull(input);
+        public Request(String deploymentId, List<Map<String, Object>> docs) {
+            this.deploymentId = ExceptionsHelper.requireNonNull(deploymentId, DEPLOYMENT_ID);
+            this.docs = ExceptionsHelper.requireNonNull(Collections.unmodifiableList(docs), DOCS);
         }
 
         public Request(StreamInput in) throws IOException {
             super(in);
             deploymentId = in.readString();
-            input = in.readString();
+            docs = Collections.unmodifiableList(in.readList(StreamInput::readMap));
         }
 
         public String getDeploymentId() {
             return deploymentId;
         }
 
-        private void setDeploymentId(String deploymentId) {
-            this.deploymentId = deploymentId;
-        }
-
-        public String getInput() {
-            return input;
+        public List<Map<String, Object>> getDocs() {
+            return docs;
         }
 
         @Override
@@ -102,17 +100,37 @@ public class InferTrainedModelDeploymentAction extends ActionType<InferTrainedMo
         }
 
         @Override
+        public ActionRequestValidationException validate() {
+            ActionRequestValidationException validationException = super.validate();
+            if (docs == null) {
+                validationException = addValidationError("[" + DOCS.getPreferredName() + "] must not be null",
+                    validationException);
+            } else {
+                if (docs.isEmpty()) {
+                    validationException = addValidationError("at least one document is required",
+                        validationException);
+                }
+                if (docs.size() > 1) {
+                    // TODO support multiple docs
+                    validationException = addValidationError("multiple documents are not supported",
+                        validationException);
+                }
+            }
+            return validationException;
+        }
+
+        @Override
         public void writeTo(StreamOutput out) throws IOException {
             super.writeTo(out);
             out.writeString(deploymentId);
-            out.writeString(input);
+            out.writeCollection(docs, StreamOutput::writeMap);
         }
 
         @Override
         public XContentBuilder toXContent(XContentBuilder builder, ToXContent.Params params) throws IOException {
             builder.startObject();
             builder.field(DEPLOYMENT_ID.getPreferredName(), deploymentId);
-            builder.field(INPUT.getPreferredName(), input);
+            builder.field(DOCS.getPreferredName(), docs);
             builder.field(TIMEOUT.getPreferredName(), getTimeout().getStringRep());
             builder.endObject();
             return builder;
@@ -129,18 +147,54 @@ public class InferTrainedModelDeploymentAction extends ActionType<InferTrainedMo
             if (o == null || getClass() != o.getClass()) return false;
             InferTrainedModelDeploymentAction.Request that = (InferTrainedModelDeploymentAction.Request) o;
             return Objects.equals(deploymentId, that.deploymentId)
-                && Objects.equals(input, that.input)
+                && Objects.equals(docs, that.docs)
                 && Objects.equals(getTimeout(), that.getTimeout());
         }
 
         @Override
         public int hashCode() {
-            return Objects.hash(deploymentId, input, getTimeout());
+            return Objects.hash(deploymentId, docs, getTimeout());
         }
 
         @Override
         public String toString() {
             return Strings.toString(this);
+        }
+
+        public static class Builder {
+
+            private String deploymentId;
+            private List<Map<String, Object>> docs;
+            private TimeValue timeout;
+
+            private Builder() {}
+
+            public Builder setDeploymentId(String deploymentId) {
+                this.deploymentId = ExceptionsHelper.requireNonNull(deploymentId, DEPLOYMENT_ID);
+                return this;
+            }
+
+            public Builder setDocs(List<Map<String, Object>> docs) {
+                this.docs = ExceptionsHelper.requireNonNull(docs, DOCS);
+                return this;
+            }
+
+            public Builder setTimeout(TimeValue timeout) {
+                this.timeout = timeout;
+                return this;
+            }
+
+            private Builder setTimeout(String timeout) {
+                return setTimeout(TimeValue.parseTimeValue(timeout, TIMEOUT.getPreferredName()));
+            }
+
+            public Request build() {
+                Request request = new Request(deploymentId, docs);
+                if (timeout != null) {
+                    request.setTimeout(timeout);
+                }
+                return request;
+            }
         }
     }
 
@@ -170,6 +224,10 @@ public class InferTrainedModelDeploymentAction extends ActionType<InferTrainedMo
         public void writeTo(StreamOutput out) throws IOException {
             super.writeTo(out);
             out.writeNamedWriteable(results);
+        }
+
+        public InferenceResults getResults() {
+            return results;
         }
     }
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/TrainedModelConfig.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/TrainedModelConfig.java
@@ -334,6 +334,10 @@ public class TrainedModelConfig implements ToXContentObject, Writeable {
         return licenseLevel;
     }
 
+    public boolean isAllocateOnly() {
+        return inferenceConfig.isAllocateOnly();
+    }
+
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         out.writeString(modelId);

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/BertPassThroughConfig.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/BertPassThroughConfig.java
@@ -87,6 +87,11 @@ public class BertPassThroughConfig implements NlpConfig {
     }
 
     @Override
+    public boolean isAllocateOnly() {
+        return true;
+    }
+
+    @Override
     public String getName() {
         return NAME;
     }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/ClassificationConfig.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/ClassificationConfig.java
@@ -128,6 +128,11 @@ public class ClassificationConfig implements LenientlyParsedInferenceConfig, Str
     }
 
     @Override
+    public boolean isAllocateOnly() {
+        return false;
+    }
+
+    @Override
     public void writeTo(StreamOutput out) throws IOException {
         out.writeInt(numTopClasses);
         out.writeString(topClassesResultsField);

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/FillMaskConfig.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/FillMaskConfig.java
@@ -115,4 +115,9 @@ public class FillMaskConfig implements NlpConfig {
     public TokenizationParams getTokenizationParams() {
         return tokenizationParams;
     }
+
+    @Override
+    public boolean isAllocateOnly() {
+        return true;
+    }
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/InferenceConfig.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/InferenceConfig.java
@@ -23,4 +23,6 @@ public interface InferenceConfig extends NamedXContentObject, NamedWriteable {
     default boolean requestingImportance() {
         return false;
     }
+
+    boolean isAllocateOnly();
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/NerConfig.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/NerConfig.java
@@ -133,4 +133,9 @@ public class NerConfig implements NlpConfig {
     public List<String> getClassificationLabels() {
         return classificationLabels;
     }
+
+    @Override
+    public boolean isAllocateOnly() {
+        return true;
+    }
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/NullInferenceConfig.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/NullInferenceConfig.java
@@ -58,4 +58,9 @@ public class NullInferenceConfig implements InferenceConfig {
     public boolean requestingImportance() {
         return requestingFeatureImportance;
     }
+
+    @Override
+    public boolean isAllocateOnly() {
+        return false;
+    }
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/RegressionConfig.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/RegressionConfig.java
@@ -83,6 +83,11 @@ public class RegressionConfig implements LenientlyParsedInferenceConfig, Strictl
     }
 
     @Override
+    public boolean isAllocateOnly() {
+        return false;
+    }
+
+    @Override
     public String getWriteableName() {
         return NAME.getPreferredName();
     }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/SentimentAnalysisConfig.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/SentimentAnalysisConfig.java
@@ -132,4 +132,9 @@ public class SentimentAnalysisConfig implements NlpConfig {
     public List<String> getClassificationLabels() {
         return classificationLabels;
     }
+
+    @Override
+    public boolean isAllocateOnly() {
+        return true;
+    }
 }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/InferTrainedModelDeploymentRequestsTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/InferTrainedModelDeploymentRequestsTests.java
@@ -9,9 +9,12 @@ package org.elasticsearch.xpack.core.ml.action;
 
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.core.Tuple;
 import org.elasticsearch.test.AbstractSerializingTestCase;
 
 import java.io.IOException;
+import java.util.List;
+import java.util.Map;
 
 public class InferTrainedModelDeploymentRequestsTests extends AbstractSerializingTestCase<InferTrainedModelDeploymentAction.Request> {
     @Override
@@ -26,8 +29,11 @@ public class InferTrainedModelDeploymentRequestsTests extends AbstractSerializin
 
     @Override
     protected InferTrainedModelDeploymentAction.Request createTestInstance() {
+        List<Map<String, Object>> docs = randomList(5, () -> randomMap(1, 3,
+            () -> Tuple.tuple(randomAlphaOfLength(7), randomAlphaOfLength(7))));
+
         InferTrainedModelDeploymentAction.Request request =
-            new InferTrainedModelDeploymentAction.Request(randomAlphaOfLength(4), randomAlphaOfLength(6));
+            new InferTrainedModelDeploymentAction.Request(randomAlphaOfLength(4), docs);
         if (randomBoolean()) {
             request.setTimeout(randomTimeValue());
         }

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/PyTorchModelIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/PyTorchModelIT.java
@@ -242,7 +242,7 @@ public class PyTorchModelIT extends ESRestTestCase {
     private Response infer(String input) throws IOException {
         Request request = new Request("POST", "/_ml/trained_models/" + MODEL_ID + "/deployment/_infer");
         request.setJsonEntity("{  " +
-            "\"input\": \"" + input + "\"\n" +
+            "\"docs\": [{\"input\":\"" + input + "\"}]\n" +
             "}");
         return client().performRequest(request);
     }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportInferTrainedModelDeploymentAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportInferTrainedModelDeploymentAction.java
@@ -80,7 +80,7 @@ public class TransportInferTrainedModelDeploymentAction extends TransportTasksAc
     @Override
     protected void taskOperation(InferTrainedModelDeploymentAction.Request request, TrainedModelDeploymentTask task,
                                  ActionListener<InferTrainedModelDeploymentAction.Response> listener) {
-        task.infer(request.getInput(), request.getTimeout(),
+        task.infer(request.getDocs().get(0), request.getTimeout(),
             ActionListener.wrap(
                 pyTorchResult -> listener.onResponse(new InferTrainedModelDeploymentAction.Response(pyTorchResult)),
                 listener::onFailure)

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportInternalInferModelAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportInternalInferModelAction.java
@@ -10,6 +10,7 @@ import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.HandledTransportAction;
 import org.elasticsearch.client.Client;
+import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.license.LicenseUtils;
 import org.elasticsearch.license.XPackLicenseState;
@@ -18,20 +19,30 @@ import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.xpack.core.XPackField;
 import org.elasticsearch.xpack.core.ml.action.GetTrainedModelsAction;
+import org.elasticsearch.xpack.core.ml.action.InferTrainedModelDeploymentAction;
 import org.elasticsearch.xpack.core.ml.action.InternalInferModelAction;
 import org.elasticsearch.xpack.core.ml.action.InternalInferModelAction.Request;
 import org.elasticsearch.xpack.core.ml.action.InternalInferModelAction.Response;
 import org.elasticsearch.xpack.core.ml.inference.results.InferenceResults;
+import org.elasticsearch.xpack.core.ml.inference.results.WarningInferenceResults;
+import org.elasticsearch.xpack.ml.inference.allocation.TrainedModelAllocationMetadata;
 import org.elasticsearch.xpack.ml.inference.loadingservice.LocalModel;
 import org.elasticsearch.xpack.ml.inference.loadingservice.ModelLoadingService;
 import org.elasticsearch.xpack.ml.inference.persistence.TrainedModelProvider;
 import org.elasticsearch.xpack.ml.utils.TypedChainTaskExecutor;
+
+import java.util.Collections;
+import java.util.Map;
+
+import static org.elasticsearch.xpack.core.ClientHelper.ML_ORIGIN;
+import static org.elasticsearch.xpack.core.ClientHelper.executeAsyncWithOrigin;
 
 
 public class TransportInternalInferModelAction extends HandledTransportAction<Request, Response> {
 
     private final ModelLoadingService modelLoadingService;
     private final Client client;
+    private final ClusterService clusterService;
     private final XPackLicenseState licenseState;
     private final TrainedModelProvider trainedModelProvider;
 
@@ -40,11 +51,13 @@ public class TransportInternalInferModelAction extends HandledTransportAction<Re
                                              ActionFilters actionFilters,
                                              ModelLoadingService modelLoadingService,
                                              Client client,
+                                             ClusterService clusterService,
                                              XPackLicenseState licenseState,
                                              TrainedModelProvider trainedModelProvider) {
         super(InternalInferModelAction.NAME, transportService, actionFilters, InternalInferModelAction.Request::new);
         this.modelLoadingService = modelLoadingService;
         this.client = client;
+        this.clusterService = clusterService;
         this.licenseState = licenseState;
         this.trainedModelProvider = trainedModelProvider;
     }
@@ -54,14 +67,46 @@ public class TransportInternalInferModelAction extends HandledTransportAction<Re
 
         Response.Builder responseBuilder = Response.builder();
 
+        if (licenseState.checkFeature(XPackLicenseState.Feature.MACHINE_LEARNING)) {
+            responseBuilder.setLicensed(true);
+            doInfer(request, responseBuilder, listener);
+        } else {
+            trainedModelProvider.getTrainedModel(request.getModelId(), GetTrainedModelsAction.Includes.empty(), ActionListener.wrap(
+                trainedModelConfig -> {
+                    responseBuilder.setLicensed(licenseState.isAllowedByLicense(trainedModelConfig.getLicenseLevel()));
+                    if (licenseState.isAllowedByLicense(trainedModelConfig.getLicenseLevel()) || request.isPreviouslyLicensed()) {
+                        doInfer(request, responseBuilder, listener);
+                    } else {
+                        listener.onFailure(LicenseUtils.newComplianceException(XPackField.MACHINE_LEARNING));
+                    }
+                },
+                listener::onFailure
+            ));
+        }
+    }
+
+    private void doInfer(Request request, Response.Builder responseBuilder, ActionListener<Response> listener) {
+        if (isAllocatedModel(request.getModelId())) {
+            inferAgainstAllocatedModel(request, responseBuilder, listener);
+        } else {
+            getModelAndInfer(request, responseBuilder, listener);
+        }
+    }
+
+    private boolean isAllocatedModel(String modelId) {
+        TrainedModelAllocationMetadata trainedModelAllocationMetadata = TrainedModelAllocationMetadata.fromState(clusterService.state());
+        return trainedModelAllocationMetadata.isAllocated(modelId);
+    }
+
+    private void getModelAndInfer(Request request, Response.Builder responseBuilder, ActionListener<Response> listener) {
         ActionListener<LocalModel> getModelListener = ActionListener.wrap(
             model -> {
                 TypedChainTaskExecutor<InferenceResults> typedChainTaskExecutor =
                     new TypedChainTaskExecutor<>(client.threadPool().executor(ThreadPool.Names.SAME),
-                    // run through all tasks
-                    r -> true,
-                    // Always fail immediately and return an error
-                    ex -> true);
+                        // run through all tasks
+                        r -> true,
+                        // Always fail immediately and return an error
+                        ex -> true);
                 request.getObjectsToInfer().forEach(stringObjectMap ->
                     typedChainTaskExecutor.add(chainedTask ->
                         model.infer(stringObjectMap, request.getUpdate(), chainedTask)));
@@ -82,21 +127,36 @@ public class TransportInternalInferModelAction extends HandledTransportAction<Re
             listener::onFailure
         );
 
-        if (licenseState.checkFeature(XPackLicenseState.Feature.MACHINE_LEARNING)) {
-            responseBuilder.setLicensed(true);
-            this.modelLoadingService.getModelForPipeline(request.getModelId(), getModelListener);
-        } else {
-            trainedModelProvider.getTrainedModel(request.getModelId(), GetTrainedModelsAction.Includes.empty(), ActionListener.wrap(
-                trainedModelConfig -> {
-                    responseBuilder.setLicensed(licenseState.isAllowedByLicense(trainedModelConfig.getLicenseLevel()));
-                    if (licenseState.isAllowedByLicense(trainedModelConfig.getLicenseLevel()) || request.isPreviouslyLicensed()) {
-                        this.modelLoadingService.getModelForPipeline(request.getModelId(), getModelListener);
-                    } else {
-                        listener.onFailure(LicenseUtils.newComplianceException(XPackField.MACHINE_LEARNING));
-                    }
-                },
-                listener::onFailure
-            ));
-        }
+        modelLoadingService.getModelForPipeline(request.getModelId(), getModelListener);
+    }
+
+    private void inferAgainstAllocatedModel(Request request, Response.Builder responseBuilder, ActionListener<Response> listener) {
+        TypedChainTaskExecutor<InferenceResults> typedChainTaskExecutor =
+            new TypedChainTaskExecutor<>(client.threadPool().executor(ThreadPool.Names.SAME),
+                // run through all tasks
+                r -> true,
+                // Always fail immediately and return an error
+                ex -> true);
+        request.getObjectsToInfer().forEach(stringObjectMap -> typedChainTaskExecutor.add(
+            chainedTask -> inferSingleDocAgainstAllocatedModel(request.getModelId(), stringObjectMap, chainedTask)));
+
+        typedChainTaskExecutor.execute(ActionListener.wrap(
+            inferenceResults -> listener.onResponse(responseBuilder.setInferenceResults(inferenceResults)
+                    .setModelId(request.getModelId())
+                    .build()),
+            listener::onFailure
+        ));
+    }
+
+    private void inferSingleDocAgainstAllocatedModel(String modelId, Map<String, Object> doc, ActionListener<InferenceResults> listener) {
+        executeAsyncWithOrigin(client,
+            ML_ORIGIN,
+            InferTrainedModelDeploymentAction.INSTANCE,
+            new InferTrainedModelDeploymentAction.Request(modelId, Collections.singletonList(doc)),
+            ActionListener.wrap(
+                r -> listener.onResponse(r.getResults()),
+                e -> listener.onResponse(new WarningInferenceResults(e.getMessage()))
+            )
+        );
     }
 }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/allocation/TrainedModelAllocationMetadata.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/allocation/TrainedModelAllocationMetadata.java
@@ -75,6 +75,10 @@ public class TrainedModelAllocationMetadata implements Metadata.Custom {
         return modelRoutingEntries.get(modelId);
     }
 
+    public boolean isAllocated(String modelId) {
+        return modelRoutingEntries.containsKey(modelId);
+    }
+
     public Map<String, TrainedModelAllocation> modelAllocations() {
         return Collections.unmodifiableMap(modelRoutingEntries);
     }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/allocation/TrainedModelAllocationNodeService.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/allocation/TrainedModelAllocationNodeService.java
@@ -225,8 +225,9 @@ public class TrainedModelAllocationNodeService implements ClusterStateListener {
         );
     }
 
-    public void infer(TrainedModelDeploymentTask task, String input, TimeValue timeout, ActionListener<InferenceResults> listener) {
-        deploymentManager.infer(task, input, timeout, listener);
+    public void infer(TrainedModelDeploymentTask task, Map<String, Object> doc, TimeValue timeout,
+                      ActionListener<InferenceResults> listener) {
+        deploymentManager.infer(task, doc, timeout, listener);
     }
 
     private TaskAwareRequest taskAwareRequest(StartTrainedModelDeploymentAction.TaskParams params) {

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/deployment/DeploymentManager.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/deployment/DeploymentManager.java
@@ -31,6 +31,7 @@ import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.xpack.core.ml.action.GetTrainedModelsAction;
 import org.elasticsearch.xpack.core.ml.inference.TrainedModelConfig;
+import org.elasticsearch.xpack.core.ml.inference.TrainedModelInput;
 import org.elasticsearch.xpack.core.ml.inference.results.InferenceResults;
 import org.elasticsearch.xpack.core.ml.inference.trainedmodel.IndexLocation;
 import org.elasticsearch.xpack.core.ml.inference.trainedmodel.NlpConfig;
@@ -48,6 +49,7 @@ import org.elasticsearch.xpack.ml.inference.pytorch.process.PyTorchStateStreamer
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -113,6 +115,8 @@ public class DeploymentManager {
             getModelResponse -> {
                 assert getModelResponse.getResources().results().size() == 1;
                 TrainedModelConfig modelConfig = getModelResponse.getResources().results().get(0);
+                processContext.modelInput.set(modelConfig.getInput());
+
                 assert modelConfig.getInferenceConfig() instanceof NlpConfig;
                 NlpConfig nlpConfig = (NlpConfig) modelConfig.getInferenceConfig();
 
@@ -188,7 +192,7 @@ public class DeploymentManager {
     }
 
     public void infer(TrainedModelDeploymentTask task,
-                      String input, TimeValue timeout,
+                      Map<String, Object> doc, TimeValue timeout,
                       ActionListener<InferenceResults> listener) {
         if (task.isStopped()) {
             listener.onFailure(
@@ -219,9 +223,10 @@ public class DeploymentManager {
             @Override
             protected void doRun() {
                 try {
+                    String text = NlpTask.extractInput(processContext.modelInput.get(), doc);
                     NlpTask.Processor processor = processContext.nlpTaskProcessor.get();
-                    processor.validateInputs(input);
-                    BytesReference request = processor.getRequestBuilder().buildRequest(input, requestId);
+                    processor.validateInputs(text);
+                    BytesReference request = processor.getRequestBuilder().buildRequest(text, requestId);
                     logger.trace(() -> "Inference Request "+ request.utf8ToString());
                     PyTorchResultProcessor.PendingResult pendingResult = processContext.resultProcessor.requestWritten(requestId);
                     processContext.process.get().writeInferenceRequest(request);
@@ -229,6 +234,8 @@ public class DeploymentManager {
                 } catch (IOException e) {
                     logger.error(new ParameterizedMessage("[{}] error writing to process", processContext.modelId), e);
                     onFailure(ExceptionsHelper.serverError("error writing to process", e));
+                } catch (Exception e) {
+                    onFailure(e);
                 } finally {
                     processContext.resultProcessor.requestAccepted(requestId);
                 }
@@ -276,6 +283,7 @@ public class DeploymentManager {
         private final long taskId;
         private final SetOnce<NativePyTorchProcess> process = new SetOnce<>();
         private final SetOnce<NlpTask.Processor> nlpTaskProcessor = new SetOnce<>();
+        private final SetOnce<TrainedModelInput> modelInput = new SetOnce<>();
         private final PyTorchResultProcessor resultProcessor;
         private final PyTorchStateStreamer stateStreamer;
 

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/deployment/TrainedModelDeploymentTask.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/deployment/TrainedModelDeploymentTask.java
@@ -85,7 +85,7 @@ public class TrainedModelDeploymentTask extends CancellableTask implements Start
         stop(reason);
     }
 
-    public void infer(String input, TimeValue timeout, ActionListener<InferenceResults> listener) {
-        trainedModelAllocationNodeService.infer(this, input, timeout, listener);
+    public void infer(Map<String, Object> doc, TimeValue timeout, ActionListener<InferenceResults> listener) {
+        trainedModelAllocationNodeService.infer(this, doc, timeout, listener);
     }
 }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/nlp/NlpTask.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/nlp/NlpTask.java
@@ -9,12 +9,16 @@ package org.elasticsearch.xpack.ml.inference.nlp;
 
 import org.elasticsearch.common.ValidationException;
 import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.xcontent.support.XContentMapValues;
+import org.elasticsearch.xpack.core.ml.inference.TrainedModelInput;
 import org.elasticsearch.xpack.core.ml.inference.trainedmodel.NlpConfig;
+import org.elasticsearch.xpack.core.ml.utils.ExceptionsHelper;
 import org.elasticsearch.xpack.ml.inference.deployment.PyTorchResult;
 import org.elasticsearch.xpack.core.ml.inference.results.InferenceResults;
 import org.elasticsearch.xpack.ml.inference.nlp.tokenizers.BertTokenizer;
 
 import java.io.IOException;
+import java.util.Map;
 
 public class NlpTask {
 
@@ -57,5 +61,18 @@ public class NlpTask {
 
         RequestBuilder getRequestBuilder();
         ResultProcessor getResultProcessor();
+    }
+
+    public static String extractInput(TrainedModelInput input, Map<String, Object> doc) {
+        assert input.getFieldNames().size() == 1;
+        String inputField = input.getFieldNames().get(0);
+        Object inputValue = XContentMapValues.extractValue(inputField, doc);
+        if (inputValue == null) {
+            throw ExceptionsHelper.badRequestException("no value could be found for input field [{}]", inputField);
+        }
+        if (inputValue instanceof String) {
+            return (String) inputValue;
+        }
+        throw ExceptionsHelper.badRequestException("input value [{}] for field [{}] is not a string", inputValue, inputField);
     }
 }

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/allocation/TrainedModelAllocationMetadataTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/allocation/TrainedModelAllocationMetadataTests.java
@@ -93,6 +93,15 @@ public class TrainedModelAllocationMetadataTests extends AbstractSerializingTest
         assertThat(builder.isChanged(), is(true));
     }
 
+    public void testIsAllocated() {
+        String allocatedModelId = "test_model_id";
+        TrainedModelAllocationMetadata metadata = TrainedModelAllocationMetadata.Builder.empty()
+            .addNewAllocation(randomParams(allocatedModelId))
+            .build();
+        assertThat(metadata.isAllocated(allocatedModelId), is(true));
+        assertThat(metadata.isAllocated("unknown_model_id"), is(false));
+    }
+
     private static TrainedModelAllocationMetadata.Builder assertUnchanged(
         TrainedModelAllocationMetadata.Builder builder,
         Function<TrainedModelAllocationMetadata.Builder, TrainedModelAllocationMetadata.Builder> function

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/nlp/NlpTaskTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/nlp/NlpTaskTests.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.ml.inference.nlp;
+
+import org.elasticsearch.ElasticsearchStatusException;
+import org.elasticsearch.rest.RestStatus;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.core.ml.inference.TrainedModelInput;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.hamcrest.Matchers.equalTo;
+
+public class NlpTaskTests extends ESTestCase {
+
+    public void testExtractInput_GivenValidField() {
+        String fieldName = randomAlphaOfLength(7);
+        Map<String, Object> doc = new HashMap<>();
+        doc.put(fieldName, "value");
+        doc.put("some other field", "some_other_value");
+
+        String input = NlpTask.extractInput(new TrainedModelInput(Collections.singletonList(fieldName)), doc);
+
+        assertThat(input, equalTo("value"));
+    }
+
+    public void testExtractInput_GivenFieldIsNotPresent() {
+        String fieldName = randomAlphaOfLength(7);
+        Map<String, Object> doc = new HashMap<>();
+        doc.put("some other field", 42);
+
+        ElasticsearchStatusException e = expectThrows(ElasticsearchStatusException.class,
+            () -> NlpTask.extractInput(new TrainedModelInput(Collections.singletonList(fieldName)), doc));
+
+        assertThat(e.status(), equalTo(RestStatus.BAD_REQUEST));
+        assertThat(e.getMessage(), equalTo("no value could be found for input field [" + fieldName + "]"));
+    }
+
+    public void testExtractInput_GivenFieldIsNotString() {
+        String fieldName = randomAlphaOfLength(7);
+        Map<String, Object> doc = new HashMap<>();
+        doc.put(fieldName, 42);
+        doc.put("some other field", 42);
+
+        ElasticsearchStatusException e = expectThrows(ElasticsearchStatusException.class,
+            () -> NlpTask.extractInput(new TrainedModelInput(Collections.singletonList(fieldName)), doc));
+
+        assertThat(e.status(), equalTo(RestStatus.BAD_REQUEST));
+        assertThat(e.getMessage(), equalTo("input value [42] for field [" + fieldName + "] is not a string"));
+    }
+}


### PR DESCRIPTION
This commit extends the `inference_processor` to support allocated
models. In particular, the internal infer action is now checking
if the model is allocated, and if so, it redirects the request
to an instance of the allocated model. If not, then it proceeds
as previously to load the model through the `ModelLoadingService`.

In addition, we now check that a model is not allocated when
the `StopTrainedModelDeploymentAction`.

Note that no new `InferenceConfigUpdate` objects are introduced
as there are no settings currently that can be set on inference time
for allocated models.
