### PR TITLE
[DOCS] typo in parent-child example request

### DIFF
--- a/docs/reference/query-dsl/parent-id-query.asciidoc
+++ b/docs/reference/query-dsl/parent-id-query.asciidoc
@@ -61,7 +61,7 @@ PUT /my-index-000001/_doc/1?refresh
 PUT /my-index-000001/_doc/2?routing=1&refresh
 {
   "text": "This is a child document.",
-  "my_join_field": {
+  "my-join-field": {
     "name": "my-child",
     "parent": "1"
   }


### PR DESCRIPTION
Use dash instead of underscore in `my-join-field`.
It will need backporting.