### PR TITLE
Changes to keep Checkstyle happy after reformatting (#76464)

### DIFF
--- a/build-tools-internal/src/main/groovy/elasticsearch.formatting.gradle
+++ b/build-tools-internal/src/main/groovy/elasticsearch.formatting.gradle
@@ -201,49 +201,52 @@ def projectPathsToExclude = [
 
 subprojects {
   plugins.withType(ElasticsearchJavaPlugin).whenPluginAdded {
-    if (projectPathsToExclude.contains(project.path) == false) {
-      project.apply plugin: "com.diffplug.spotless"
+    project.apply plugin: "com.diffplug.spotless"
 
-      spotless {
-        java {
-          if (project.path == ':server') {
-            target 'src/*/java/org/elasticsearch/action/admin/cluster/repositories/**/*.java',
-                   'src/*/java/org/elasticsearch/action/admin/cluster/snapshots/**/*.java',
-                   'src/*/java/org/elasticsearch/index/snapshots/**/*.java',
-                   'src/*/java/org/elasticsearch/repositories/**/*.java',
-                   'src/*/java/org/elasticsearch/snapshots/**/*.java'
+    spotless {
+      java {
+        if (project.path == ':server') {
+          target 'src/*/java/org/elasticsearch/action/admin/cluster/repositories/**/*.java',
+                 'src/*/java/org/elasticsearch/action/admin/cluster/snapshots/**/*.java',
+                 'src/*/java/org/elasticsearch/index/snapshots/**/*.java',
+                 'src/*/java/org/elasticsearch/repositories/**/*.java',
+                 'src/*/java/org/elasticsearch/snapshots/**/*.java'
 
-            targetExclude 'src/main/java/org/elasticsearch/search/aggregations/metrics/HyperLogLogPlusPlus.java'
-          } else {
-            // Normally this isn't necessary, but we have Java sources in
-            // non-standard places
-            target 'src/**/*.java'
-          }
+          targetExclude 'src/main/java/org/elasticsearch/search/aggregations/metrics/HyperLogLogPlusPlus.java'
+        } else {
+          // Normally this isn't necessary, but we have Java sources in
+          // non-standard places
+          target 'src/**/*.java'
+        }
 
-          toggleOffOn('@formatter:off', '@formatter:on') // use `@formatter:off` and `@formatter:on` to toggle formatting - ONLY IF STRICTLY NECESSARY
-          removeUnusedImports()
-          importOrderFile rootProject.file('build-tools-internal/elastic.importorder')
-          eclipse().configFile rootProject.file('build-tools-internal/formatterConfig.xml')
-          trimTrailingWhitespace()
+        toggleOffOn('@formatter:off', '@formatter:on') // use `@formatter:off` and `@formatter:on` to toggle formatting - ONLY IF STRICTLY NECESSARY
+        removeUnusedImports()
+        importOrderFile rootProject.file('build-tools-internal/elastic.importorder')
+        eclipse().configFile rootProject.file('build-tools-internal/formatterConfig.xml')
+        trimTrailingWhitespace()
 
-          // Sometimes Spotless will report a "misbehaving rule which can't make up its
-          // mind" and will recommend enabling the `paddedCell()` setting. If you
-          // enabled this setting and run the format check again,
-          // Spotless will write files to
-          // `$PROJECT/build/spotless-diagnose-java/` to aid diagnosis. It writes
-          // different copies of the formatted files, so that you can see how they
-          // differ and infer what is the problem.
+        // Sometimes Spotless will report a "misbehaving rule which can't make up its
+        // mind" and will recommend enabling the `paddedCell()` setting. If you
+        // enabled this setting and run the format check again,
+        // Spotless will write files to
+        // `$PROJECT/build/spotless-diagnose-java/` to aid diagnosis. It writes
+        // different copies of the formatted files, so that you can see how they
+        // differ and infer what is the problem.
 
-          // The `paddedCell()` option is disabled for normal operation so that any
-          // misbehaviour is detected, and not just suppressed. You can enabled the
-          // option from the command line by running Gradle with `-Dspotless.paddedcell`.
-          if (System.getProperty('spotless.paddedcell') != null) {
-            paddedCell()
-          }
+        // The `paddedCell()` option is disabled for normal operation so that any
+        // misbehaviour is detected, and not just suppressed. You can enabled the
+        // option from the command line by running Gradle with `-Dspotless.paddedcell`.
+        if (providers.systemProperty('spotless.paddedcell').forUseAtConfigurationTime().isPresent()) {
+          paddedCell()
         }
       }
-
-      tasks.named("precommit").configure { dependsOn 'spotlessJavaCheck' }
     }
+
+    if (projectPathsToExclude.contains(project.path)) {
+      tasks.named('spotlessJavaCheck').configure { enabled = false }
+      tasks.named('spotlessApply').configure { enabled = false }
+    }
+
+    tasks.named("precommit").configure { dependsOn 'spotlessJavaCheck' }
   }
 }

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/analytics/ParsedInference.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/analytics/ParsedInference.java
@@ -21,6 +21,8 @@ import org.elasticsearch.search.aggregations.ParsedAggregation;
 import java.io.IOException;
 import java.util.List;
 
+import static org.elasticsearch.common.xcontent.ConstructingObjectParser.optionalConstructorArg;
+
 /**
  * This class parses the superset of all possible fields that may be written by
  * InferenceResults. The warning field is mutually exclusive with all the other fields.
@@ -29,8 +31,6 @@ import java.util.List;
  * Boolean or a Double. For regression results {@link #getValue()} is always
  * a Double.
  */
-import static org.elasticsearch.common.xcontent.ConstructingObjectParser.optionalConstructorArg;
-
 public class ParsedInference extends ParsedAggregation {
 
     @SuppressWarnings("unchecked")

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/graph/Vertex.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/graph/Vertex.java
@@ -162,25 +162,31 @@ public class Vertex implements ToXContentFragment {
         this.weight = weight;
     }
 
+    // @formatter:off
     /**
      * If the {@link GraphExploreRequest#useSignificance(boolean)} is true (the default)
      * this statistic is available.
      * @return the number of documents in the index that contain this term (see bg_count in
- * <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-significantterms-aggregation.html">
-     * the significant_terms aggregation</a>)
+     * <a
+     * href="https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-significantterms-aggregation.html"
+     * >the significant_terms aggregation</a>)
      */
+    // @formatter:on
     public long getBg() {
         return bg;
     }
 
+    // @formatter:off
     /**
      * If the {@link GraphExploreRequest#useSignificance(boolean)} is true (the default)
      * this statistic is available.
      * Together with {@link #getBg()} these numbers are used to derive the significance of a term.
      * @return the number of documents in the sample of best matching documents that contain this term (see fg_count in
- * <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-significantterms-aggregation.html">
-     * the significant_terms aggregation</a>)
+     * <a
+     * href="https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-significantterms-aggregation.html"
+     * >the significant_terms aggregation</a>)
      */
+    // @formatter:on
     public long getFg() {
         return fg;
     }

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/IndicesClientIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/IndicesClientIT.java
@@ -1549,10 +1549,14 @@ public class IndicesClientIT extends ESRestHighLevelClientTestCase {
         exception = expectThrows(ElasticsearchException.class, () -> execute(indexUpdateSettingsRequest,
                 highLevelClient().indices()::putSettings, highLevelClient().indices()::putSettingsAsync));
         assertThat(exception.status(), equalTo(RestStatus.BAD_REQUEST));
-        assertThat(exception.getMessage(), equalTo(
+        assertThat(
+            exception.getMessage(),
+            equalTo(
                 "Elasticsearch exception [type=illegal_argument_exception, "
-                + "reason=unknown setting [index.no_idea_what_you_are_talking_about] please check that any required plugins are installed, "
-                + "or check the breaking changes documentation for removed settings]"));
+                    + "reason=unknown setting [index.no_idea_what_you_are_talking_about] please check that any required plugins "
+                    + "are installed, or check the breaking changes documentation for removed settings]"
+            )
+        );
     }
 
     @SuppressWarnings("unchecked")

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/MachineLearningGetResultsIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/MachineLearningGetResultsIT.java
@@ -35,13 +35,16 @@ import org.elasticsearch.client.ml.job.results.Influencer;
 import org.elasticsearch.client.ml.job.results.OverallBucket;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.common.xcontent.XContentType;
+import org.elasticsearch.test.XContentTestUtils;
 import org.junit.After;
 import org.junit.Before;
 
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Date;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import static org.hamcrest.Matchers.closeTo;
 import static org.hamcrest.Matchers.equalTo;
@@ -138,55 +141,133 @@ public class MachineLearningGetResultsIT extends ESRestHighLevelClientTestCase {
         }
     }
 
-    private void addModelSnapshotIndexRequests(BulkRequest bulkRequest) {
+    private void addModelSnapshotIndexRequests(BulkRequest bulkRequest) throws IOException {
         // Index a number of model snapshots, one of which contains the new model_size_stats fields
         // 'model_bytes_exceeded' and 'model_bytes_memory_limit' that were introduced in 7.2.0.
         // We want to verify that we can parse the snapshots whether or not these fields are present.
         {
             IndexRequest indexRequest = new IndexRequest(RESULTS_INDEX);
-            indexRequest.source("{\"job_id\":\"" + JOB_ID + "\", \"timestamp\":1541587919000, " +
-                "\"description\":\"State persisted due to job close at 2018-11-07T10:51:59+0000\", \"snapshot_id\":\"1541587919\"," +
-                "\"snapshot_doc_count\":1, \"model_size_stats\":{\"job_id\":\"" + JOB_ID + "\", \"result_type\":\"model_size_stats\"," +
-                "\"model_bytes\":51722, \"peak_model_bytes\":61322, \"model_bytes_exceeded\":10762, \"model_bytes_memory_limit\":40960," +
-                "\"total_by_field_count\":3, \"total_over_field_count\":0, \"total_partition_field_count\":2," +
-                "\"bucket_allocation_failures_count\":0, \"memory_status\":\"ok\", \"log_time\":1541587919000," +
-                " \"timestamp\":1519930800000},\"latest_record_time_stamp\":1519931700000, \"latest_result_time_stamp\":1519930800000," +
-                " \"retain\":false }", XContentType.JSON);
+            Map<String, Object> modelSizeStats = new HashMap<>();
+            modelSizeStats.put("job_id", JOB_ID);
+            modelSizeStats.put("result_type", "model_size_stats");
+            modelSizeStats.put("model_bytes", 51722);
+            modelSizeStats.put("peak_model_bytes", 61322);
+            modelSizeStats.put("model_bytes_exceeded", 10762);
+            modelSizeStats.put("model_bytes_memory_limit", 40960);
+            modelSizeStats.put("total_by_field_count", 3);
+            modelSizeStats.put("total_over_field_count", 0);
+            modelSizeStats.put("total_partition_field_count", 2);
+            modelSizeStats.put("bucket_allocation_failures_count", 0);
+            modelSizeStats.put("memory_status", "ok");
+            modelSizeStats.put("log_time", 1541587919000L);
+            modelSizeStats.put("timestamp", 1519930800000L);
+
+            Map<String, Object> source = new HashMap<>();
+            source.put("job_id", JOB_ID);
+            source.put("timestamp", 1541587919000L);
+            source.put("description", "State persisted due to job close at 2018-11-07T10:51:59+0000");
+            source.put("snapshot_id", "1541587919");
+            source.put("snapshot_doc_count", 1);
+            source.put("latest_record_time_stamp", 1519931700000L);
+            source.put("latest_result_time_stamp", 1519930800000L);
+            source.put("retain", false);
+            source.put("model_size_stats", modelSizeStats);
+
+            indexRequest.source(XContentTestUtils.convertToXContent(source, XContentType.JSON), XContentType.JSON);
             bulkRequest.add(indexRequest);
         }
         // Also index one that contains 'memory_assignment_basis', which was added in 7.11
         {
             IndexRequest indexRequest = new IndexRequest(RESULTS_INDEX);
-            indexRequest.source("{\"job_id\":\"" + JOB_ID + "\", \"timestamp\":1541587929000, " +
-                "\"description\":\"State persisted due to job close at 2018-11-07T10:52:09+0000\", \"snapshot_id\":\"1541587929\"," +
-                "\"snapshot_doc_count\":1, \"model_size_stats\":{\"job_id\":\"" + JOB_ID + "\", \"result_type\":\"model_size_stats\"," +
-                "\"model_bytes\":51722, \"peak_model_bytes\":61322, \"model_bytes_exceeded\":10762, \"model_bytes_memory_limit\":40960," +
-                "\"total_by_field_count\":3, \"total_over_field_count\":0, \"total_partition_field_count\":2," +
-                "\"bucket_allocation_failures_count\":0, \"memory_status\":\"ok\", \"assignment_memory_basis\":\"model_memory_limit\"," +
-                " \"log_time\":1541587929000, \"timestamp\":1519930800000},\"latest_record_time_stamp\":1519931700000," +
-                "\"latest_result_time_stamp\":1519930800000, \"retain\":false }", XContentType.JSON);
+
+            Map<String, Object> modelSizeStats = new HashMap<>();
+            modelSizeStats.put("job_id", JOB_ID);
+            modelSizeStats.put("result_type", "model_size_stats");
+            modelSizeStats.put("model_bytes", 51722);
+            modelSizeStats.put("peak_model_bytes", 61322);
+            modelSizeStats.put("model_bytes_exceeded", 10762);
+            modelSizeStats.put("model_bytes_memory_limit", 40960);
+            modelSizeStats.put("total_by_field_count", 3);
+            modelSizeStats.put("total_over_field_count", 0);
+            modelSizeStats.put("total_partition_field_count", 2);
+            modelSizeStats.put("bucket_allocation_failures_count", 0);
+            modelSizeStats.put("memory_status", "ok");
+            modelSizeStats.put("assignment_memory_basis", "model_memory_limit");
+            modelSizeStats.put("log_time", 1541587929000L);
+            modelSizeStats.put("timestamp", 1519930800000L);
+
+            Map<String, Object> source = new HashMap<>();
+            source.put("job_id", JOB_ID);
+            source.put("timestamp", 1541587929000L);
+            source.put("description", "State persisted due to job close at 2018-11-07T10:52:09+0000");
+            source.put("snapshot_id", "1541587929");
+            source.put("snapshot_doc_count", 1);
+            source.put("latest_record_time_stamp", 1519931700000L);
+            source.put("latest_result_time_stamp", 1519930800000L);
+            source.put("retain", false);
+            source.put("model_size_stats", modelSizeStats);
+
+            indexRequest.source(XContentTestUtils.convertToXContent(source, XContentType.JSON), XContentType.JSON);
             bulkRequest.add(indexRequest);
         }
         {
             IndexRequest indexRequest = new IndexRequest(RESULTS_INDEX);
-            indexRequest.source("{\"job_id\":\"" + JOB_ID + "\", \"timestamp\":1541588919000, " +
-                "\"description\":\"State persisted due to job close at 2018-11-07T11:08:39+0000\", \"snapshot_id\":\"1541588919\"," +
-                "\"snapshot_doc_count\":1, \"model_size_stats\":{\"job_id\":\"" + JOB_ID + "\", \"result_type\":\"model_size_stats\"," +
-                "\"model_bytes\":51722, \"peak_model_bytes\":61322, \"total_by_field_count\":3, \"total_over_field_count\":0," +
-                "\"total_partition_field_count\":2,\"bucket_allocation_failures_count\":0, \"memory_status\":\"ok\"," +
-                "\"log_time\":1541588919000,\"timestamp\":1519930800000},\"latest_record_time_stamp\":1519931700000," +
-                "\"latest_result_time_stamp\":1519930800000, \"retain\":false }", XContentType.JSON);
+
+            Map<String, Object> modelSizeStats = new HashMap<>();
+            modelSizeStats.put("job_id", JOB_ID);
+            modelSizeStats.put("result_type", "model_size_stats");
+            modelSizeStats.put("model_bytes", 51722);
+            modelSizeStats.put("peak_model_bytes", 61322);
+            modelSizeStats.put("total_by_field_count", 3);
+            modelSizeStats.put("total_over_field_count", 0);
+            modelSizeStats.put("total_partition_field_count", 2);
+            modelSizeStats.put("bucket_allocation_failures_count", 0);
+            modelSizeStats.put("memory_status", "ok");
+            modelSizeStats.put("log_time", 1541588919000L);
+            modelSizeStats.put("timestamp", 1519930800000L);
+
+            Map<String, Object> source = new HashMap<>();
+            source.put("job_id", JOB_ID);
+            source.put("timestamp", 1541588919000L);
+            source.put("description", "State persisted due to job close at 2018-11-07T11:08:39+0000");
+            source.put("snapshot_id", "1541588919");
+            source.put("snapshot_doc_count", 1);
+            source.put("latest_record_time_stamp", 1519931700000L);
+            source.put("latest_result_time_stamp", 1519930800000L);
+            source.put("retain", false);
+            source.put("model_size_stats", modelSizeStats);
+
+            indexRequest.source(XContentTestUtils.convertToXContent(source, XContentType.JSON), XContentType.JSON);
             bulkRequest.add(indexRequest);
         }
         {
             IndexRequest indexRequest = new IndexRequest(RESULTS_INDEX);
-            indexRequest.source("{\"job_id\":\"" + JOB_ID + "\", \"timestamp\":1541589919000, " +
-                "\"description\":\"State persisted due to job close at 2018-11-07T11:25:19+0000\", \"snapshot_id\":\"1541589919\"," +
-                "\"snapshot_doc_count\":1, \"model_size_stats\":{\"job_id\":\"" + JOB_ID + "\", \"result_type\":\"model_size_stats\"," +
-                "\"model_bytes\":51722, \"peak_model_bytes\":61322, \"total_by_field_count\":3, \"total_over_field_count\":0," +
-                "\"total_partition_field_count\":2,\"bucket_allocation_failures_count\":0, \"memory_status\":\"ok\"," +
-                "\"log_time\":1541589919000,\"timestamp\":1519930800000},\"latest_record_time_stamp\":1519931700000," +
-                "\"latest_result_time_stamp\":1519930800000, \"retain\":false }", XContentType.JSON);
+
+            Map<String, Object> modelSizeStats = new HashMap<>();
+            modelSizeStats.put("job_id", JOB_ID);
+            modelSizeStats.put("result_type", "model_size_stats");
+            modelSizeStats.put("model_bytes", 51722);
+            modelSizeStats.put("peak_model_bytes", 61322);
+            modelSizeStats.put("total_by_field_count", 3);
+            modelSizeStats.put("total_over_field_count", 0);
+            modelSizeStats.put("total_partition_field_count", 2);
+            modelSizeStats.put("bucket_allocation_failures_count", 0);
+            modelSizeStats.put("memory_status", "ok");
+            modelSizeStats.put("log_time", 1541589919000L);
+            modelSizeStats.put("timestamp", 1519930800000L);
+
+            Map<String, Object> source = new HashMap<>();
+            source.put("job_id", JOB_ID);
+            source.put("timestamp", 1541589919000L);
+            source.put("description", "State persisted due to job close at 2018-11-07T11:25:19+0000");
+            source.put("snapshot_id", "1541589919");
+            source.put("snapshot_doc_count", 1);
+            source.put("latest_record_time_stamp", 1519931700000L);
+            source.put("latest_result_time_stamp", 1519930800000L);
+            source.put("retain", false);
+            source.put("model_size_stats", modelSizeStats);
+
+            indexRequest.source(XContentTestUtils.convertToXContent(source, XContentType.JSON), XContentType.JSON);
             bulkRequest.add(indexRequest);
         }
     }

--- a/client/rest/src/main/java/org/elasticsearch/client/Response.java
+++ b/client/rest/src/main/java/org/elasticsearch/client/Response.java
@@ -121,6 +121,7 @@ public class Response {
      * Length of RFC 1123 format (with quotes and leading space), used in
      * matchWarningHeaderPatternByPrefix(String).
      */
+    // @formatter:off
     private static final int WARNING_HEADER_DATE_LENGTH = 0
             + 1
             + 1
@@ -131,6 +132,7 @@ public class Response {
             + 2 + 1 + 2 + 1 + 2 + 1
             + 3
             + 1;
+    // @formatter:on
 
     /**
      * Tests if a string matches the RFC 7234 specification for warning headers.

--- a/libs/cli/src/main/java/org/elasticsearch/cli/ExitCodes.java
+++ b/libs/cli/src/main/java/org/elasticsearch/cli/ExitCodes.java
@@ -13,19 +13,19 @@ package org.elasticsearch.cli;
  */
 public class ExitCodes {
     public static final int OK = 0;
-    public static final int USAGE = 64;          /* command line usage error */
-    public static final int DATA_ERROR = 65;     /* data format error */
-    public static final int NO_INPUT = 66;       /* cannot open input */
-    public static final int NO_USER = 67;        /* addressee unknown */
-    public static final int NO_HOST = 68;        /* host name unknown */
-    public static final int UNAVAILABLE = 69;    /* service unavailable */
-    public static final int CODE_ERROR = 70;     /* internal software error */
-    public static final int CANT_CREATE = 73;    /* can't create (user) output file */
-    public static final int IO_ERROR = 74;       /* input/output error */
-    public static final int TEMP_FAILURE = 75;   /* temp failure; user is invited to retry */
-    public static final int PROTOCOL = 76;       /* remote error in protocol */
-    public static final int NOPERM = 77;         /* permission denied */
-    public static final int CONFIG = 78;         /* configuration error */
+    public static final int USAGE = 64;          // command line usage error
+    public static final int DATA_ERROR = 65;     // data format error
+    public static final int NO_INPUT = 66;       // cannot open input
+    public static final int NO_USER = 67;        // addressee unknown
+    public static final int NO_HOST = 68;        // host name unknown
+    public static final int UNAVAILABLE = 69;    // service unavailable
+    public static final int CODE_ERROR = 70;     // internal software error
+    public static final int CANT_CREATE = 73;    // can't create (user) output file
+    public static final int IO_ERROR = 74;       // input/output error
+    public static final int TEMP_FAILURE = 75;   // temp failure; user is invited to retry
+    public static final int PROTOCOL = 76;       // remote error in protocol
+    public static final int NOPERM = 77;         // permission denied
+    public static final int CONFIG = 78;         // configuration error
 
     private ExitCodes() { /* no instance, just constants */ }
 }

--- a/libs/core/src/main/java/org/elasticsearch/jdk/JarHell.java
+++ b/libs/core/src/main/java/org/elasticsearch/jdk/JarHell.java
@@ -97,13 +97,17 @@ public class JarHell {
         String elements[] = classPath.split(pathSeparator);
         Set<URL> urlElements = new LinkedHashSet<>(); // order is already lost, but some filesystems have it
         for (String element : elements) {
-            // Technically empty classpath element behaves like CWD.
-            // So below is the "correct" code, however in practice with ES, this is usually just a misconfiguration,
-            // from old shell scripts left behind or something:
-            //   if (element.isEmpty()) {
-            //      element = System.getProperty("user.dir");
-            //   }
-            // Instead we just throw an exception, and keep it clean.
+            /*
+             * Technically empty classpath element behaves like CWD.
+             * So below is the "correct" code, however in practice with ES, this is usually just a misconfiguration,
+             * from old shell scripts left behind or something:
+             *
+             *   if (element.isEmpty()) {
+             *      element = System.getProperty("user.dir");
+             *   }
+             *
+             * Instead we just throw an exception, and keep it clean.
+             */
             if (element.isEmpty()) {
                 throw new IllegalStateException("Classpath should not contain empty elements! (outdated shell script from a previous" +
                     " version?) classpath='" + classPath + "'");

--- a/libs/ssl-config/src/test/java/org/elasticsearch/common/ssl/SslDiagnosticsTests.java
+++ b/libs/ssl-config/src/test/java/org/elasticsearch/common/ssl/SslDiagnosticsTests.java
@@ -253,7 +253,8 @@ public class SslDiagnosticsTests extends ESTestCase {
             " signed by (subject [CN=ca,OU=windows,DC=example,DC=com] fingerprint [" + MOCK_FINGERPRINT_3 + "])" +
             " signed by (subject [CN=issuing-ca,DC=example,DC=com] fingerprint [" + MOCK_FINGERPRINT_2 + "])" +
             " which is issued by [CN=root-ca,DC=example,DC=com] (but that issuer certificate was not provided in the chain);" +
-            " this ssl context ([xpack.security.authc.realms.ldap.ldap1.ssl]) is not configured to trust that issuer or any other issuer"));
+            " this ssl context ([xpack.security.authc.realms.ldap.ldap1.ssl])" +
+            " is not configured to trust that issuer or any other issuer"));
     }
 
     public void testDiagnosticMessageWhenServerProvidesASelfSignedCertThatIsDirectlyTrusted() throws Exception {
@@ -266,7 +267,8 @@ public class SslDiagnosticsTests extends ESTestCase {
             " the server provided a certificate with subject name [CN=Test CA 1]" +
             " and fingerprint [2b7b0416391bdf86502505c23149022d2213dadc];" +
             " the certificate does not have any subject alternative names;" +
-            " the certificate is self-issued; the [CN=Test CA 1] certificate is trusted in this ssl context ([xpack.http.ssl])"));
+            " the certificate is self-issued; the [CN=Test CA 1]" +
+            " certificate is trusted in this ssl context ([xpack.http.ssl])"));
     }
 
     public void testDiagnosticMessageWhenServerProvidesASelfSignedCertThatIsNotTrusted() throws Exception {
@@ -279,7 +281,8 @@ public class SslDiagnosticsTests extends ESTestCase {
             " the server provided a certificate with subject name [CN=Test CA 1]" +
             " and fingerprint [2b7b0416391bdf86502505c23149022d2213dadc];" +
             " the certificate does not have any subject alternative names;" +
-            " the certificate is self-issued; the [CN=Test CA 1] certificate is not trusted in this ssl context ([xpack.http.ssl])"));
+            " the certificate is self-issued; the [CN=Test CA 1]" +
+            " certificate is not trusted in this ssl context ([xpack.http.ssl])"));
     }
 
     public void testDiagnosticMessageWhenServerProvidesASelfSignedCertWithMimicName() throws Exception {
@@ -292,7 +295,8 @@ public class SslDiagnosticsTests extends ESTestCase {
             " the server provided a certificate with subject name [CN=Test CA 1]" +
             " and fingerprint [2b7b0416391bdf86502505c23149022d2213dadc];" +
             " the certificate does not have any subject alternative names;" +
-            " the certificate is self-issued; the [CN=Test CA 1] certificate is not trusted in this ssl context ([xpack.http.ssl]);" +
+            " the certificate is self-issued; the [CN=Test CA 1]" +
+            " certificate is not trusted in this ssl context ([xpack.http.ssl]);" +
             " this ssl context does trust a certificate with subject [CN=Test CA 1]" +
             " but the trusted certificate has fingerprint [b095bf2526be20783e1f26dfd69c7aae910e3663]"));
     }
@@ -322,7 +326,8 @@ public class SslDiagnosticsTests extends ESTestCase {
             " and fingerprint [" + MOCK_FINGERPRINT_1 + "];" +
             " the certificate does not have any DNS/IP subject alternative names;" +
             " the certificate is self-issued;" +
-            " the [CN=foo,DC=example,DC=com] certificate is trusted in this ssl context ([xpack.monitoring.exporters.elastic-cloud.ssl])"));
+            " the [CN=foo,DC=example,DC=com] certificate is trusted" +
+            " in this ssl context ([xpack.monitoring.exporters.elastic-cloud.ssl])"));
     }
 
     public void testDiagnosticMessageWhenACertificateHasAnInvalidEncoding() throws Exception {
@@ -340,7 +345,8 @@ public class SslDiagnosticsTests extends ESTestCase {
             " and invalid encoding [java.security.cert.CertificateEncodingException: MOCK INVALID ENCODING];" +
             " the certificate does not have any subject alternative names;" +
             " the certificate is self-issued;" +
-            " the [CN=foo,DC=example,DC=com] certificate is not trusted in this ssl context ([xpack.security.transport.ssl])"));
+            " the [CN=foo,DC=example,DC=com] certificate is not trusted" +
+            " in this ssl context ([xpack.security.transport.ssl])"));
     }
 
     public void testDiagnosticMessageForClientCertificate() throws Exception {

--- a/libs/x-content/src/main/java/org/elasticsearch/common/xcontent/XContentBuilder.java
+++ b/libs/x-content/src/main/java/org/elasticsearch/common/xcontent/XContentBuilder.java
@@ -245,6 +245,12 @@ public final class XContentBuilder implements Closeable, Flushable {
     // Structure (object, array, field, null values...)
     //////////////////////////////////
 
+    public XContentBuilder object(String name, CheckedConsumer<XContentBuilder, IOException> callback) throws IOException {
+        field(name).startObject();
+        callback.accept(this);
+        return endObject();
+    }
+
     public XContentBuilder startObject() throws IOException {
         generator.writeStartObject();
         return this;
@@ -257,6 +263,12 @@ public final class XContentBuilder implements Closeable, Flushable {
     public XContentBuilder endObject() throws IOException {
         generator.writeEndObject();
         return this;
+    }
+
+    public XContentBuilder array(String name, CheckedConsumer<XContentBuilder, IOException> callback) throws IOException {
+        field(name).startArray();
+        callback.accept(this);
+        return endArray();
     }
 
     public XContentBuilder startArray() throws IOException {

--- a/modules/lang-painless/build.gradle
+++ b/modules/lang-painless/build.gradle
@@ -161,7 +161,15 @@ dependencies {
 }
 
 String grammarPath = 'src/main/antlr'
+// TODO: we shouldn't be generating files into the main source directory. Then we wouldn't
+// need to customize the spotless config below.
 String outputPath = 'src/main/java/org/elasticsearch/painless/antlr'
+
+spotless {
+  java {
+    targetExclude "${outputPath}/*.java"
+  }
+}
 
 tasks.register("cleanGenerated", Delete) {
   delete fileTree(grammarPath) {

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/phase/PainlessUserTreeToIRTreePhase.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/phase/PainlessUserTreeToIRTreePhase.java
@@ -324,15 +324,21 @@ public class PainlessUserTreeToIRTreePhase extends DefaultUserTreeToIRTreePhase 
         }
     }
 
-    // decorate the execute method with nodes to wrap the user statements with
-    // the sandboxed errors as follows:
-    // } catch (PainlessExplainError e) {
-    //     throw this.convertToScriptException(e, e.getHeaders($DEFINITION))
-    // }
-    // and
-    // } catch (PainlessError | LinkageError | OutOfMemoryError | StackOverflowError | Exception e) {
-    //     throw this.convertToScriptException(e, e.getHeaders())
-    // }
+    /*
+     * Decorate the execute method with nodes to wrap the user statements with
+     * the sandboxed errors as follows:
+     *
+     * } catch (PainlessExplainError e) {
+     *     throw this.convertToScriptException(e, e.getHeaders($DEFINITION))
+     * }
+     *
+     * and
+     *
+     * } catch (PainlessError | LinkageError | OutOfMemoryError | StackOverflowError | Exception e) {
+     *     throw this.convertToScriptException(e, e.getHeaders())
+     * }
+     *
+     */
     protected void injectSandboxExceptions(FunctionNode irFunctionNode) {
         try {
             Location internalLocation = new Location("$internal$ScriptInjectionPhase$injectSandboxExceptions", 0);

--- a/modules/reindex/src/test/java/org/elasticsearch/index/reindex/ReindexSourceTargetValidationTests.java
+++ b/modules/reindex/src/test/java/org/elasticsearch/index/reindex/ReindexSourceTargetValidationTests.java
@@ -87,9 +87,14 @@ public class ReindexSourceTargetValidationTests extends ESTestCase {
 
     public void testTargetIsAliasWithWriteIndexDisabled() {
         Exception e = expectThrows(IllegalArgumentException.class, () -> succeeds("target_alias_with_write_index_disabled", "foo"));
-        assertThat(e.getMessage(), containsString("no write index is defined for alias [target_alias_with_write_index_disabled]. " +
-            "The write index may be explicitly disabled using is_write_index=false or the alias points to multiple indices without one " +
-            "being designated as a write index"));
+        assertThat(
+            e.getMessage(),
+            containsString(
+                "no write index is defined for alias [target_alias_with_write_index_disabled]. "
+                    + "The write index may be explicitly disabled using is_write_index=false or the alias points to multiple "
+                    + "indices without one being designated as a write index"
+            )
+        );
         succeeds("qux", "foo"); // writing directly into the index of which this is the alias works though
     }
 

--- a/modules/transport-netty4/src/javaRestTest/java/org/elasticsearch/rest/Netty4HeadBodyIsEmptyIT.java
+++ b/modules/transport-netty4/src/javaRestTest/java/org/elasticsearch/rest/Netty4HeadBodyIsEmptyIT.java
@@ -133,15 +133,18 @@ public class Netty4HeadBodyIsEmptyIT extends ESRestTestCase {
             // The warnings only need to be checked in FIPS mode because we run default distribution for FIPS,
             // while the integ-test distribution is used otherwise.
             if (inFipsJvm()) {
-                request.setOptions(expectWarnings(
-                    "legacy template [template] has index patterns [*] matching patterns from existing composable templates " +
-                    "[.deprecation-indexing-template,.slm-history,.watch-history-13,ilm-history,logs," +
-                    "metrics,synthetics] with patterns (.deprecation-indexing-template => [.logs-deprecation.elasticsearch-default]," +
-                    ".slm-history => [.slm-history-5*]," +
-                    ".watch-history-13 => [.watcher-history-13*],ilm-history => [ilm-history-5*]," +
-                    "logs => [logs-*-*],metrics => [metrics-*-*],synthetics => [synthetics-*-*]" +
-                    "); this template [template] may be ignored in favor of a composable template at index creation time",
-                    RestPutIndexTemplateAction.DEPRECATION_WARNING));
+                request.setOptions(
+                    expectWarnings(
+                        "legacy template [template] has index patterns [*] matching patterns from existing composable templates "
+                            + "[.deprecation-indexing-template,.slm-history,.watch-history-13,ilm-history,logs,"
+                            + "metrics,synthetics] with patterns (.deprecation-indexing-template => "
+                            + "[.logs-deprecation.elasticsearch-default],.slm-history => [.slm-history-5*],"
+                            + ".watch-history-13 => [.watcher-history-13*],ilm-history => [ilm-history-5*],"
+                            + "logs => [logs-*-*],metrics => [metrics-*-*],synthetics => [synthetics-*-*]"
+                            + "); this template [template] may be ignored in favor of a composable template at index creation time",
+                    RestPutIndexTemplateAction.DEPRECATION_WARNING
+                    )
+                );
             } else {
                 request.setOptions(expectWarnings(RestPutIndexTemplateAction.DEPRECATION_WARNING));
             }

--- a/modules/transport-netty4/src/main/java/org/elasticsearch/transport/netty4/Netty4TcpServerChannel.java
+++ b/modules/transport-netty4/src/main/java/org/elasticsearch/transport/netty4/Netty4TcpServerChannel.java
@@ -47,8 +47,6 @@ public class Netty4TcpServerChannel implements TcpServerChannel {
 
     @Override
     public String toString() {
-        return "Netty4TcpChannel{" +
-            "localAddress=" + getLocalAddress() +
-            '}';
+        return "Netty4TcpChannel{localAddress=" + getLocalAddress() + '}';
     }
 }

--- a/plugins/analysis-icu/src/internalClusterTest/java/org/elasticsearch/index/mapper/ICUCollationKeywordFieldMapperIT.java
+++ b/plugins/analysis-icu/src/internalClusterTest/java/org/elasticsearch/index/mapper/ICUCollationKeywordFieldMapperIT.java
@@ -330,7 +330,8 @@ public class ICUCollationKeywordFieldMapperIT extends ESIntegTestCase {
             .source(new SearchSourceBuilder()
                 .fetchSource(false)
                 .sort("collate", SortOrder.ASC)
-                .sort("id", SortOrder.ASC) // secondary sort should kick in on docs 1 and 3 because same value collate value
+                // secondary sort should kick in on docs 1 and 3 because same value collate value
+                .sort("id", SortOrder.ASC)
             );
 
         SearchResponse response = client().search(request).actionGet();

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -123,19 +123,10 @@ dependencies {
   }
 }
 
-// Until this project is always being formatted with spotless, we need to
-// guard against `spotless()` not existing.
-try {
-  spotless {
-    java {
-      // Contains large data tables that do not format well.
-      targetExclude 'src/main/java/org/elasticsearch/search/aggregations/metrics/HyperLogLogPlusPlus.java'
-    }
-  }
-}
-catch (Exception e) {
-  if (e.getMessage().contains("Could not find method spotless") == false) {
-    throw e;
+spotless {
+  java {
+    // Contains large data tables that do not format well.
+    targetExclude 'src/main/java/org/elasticsearch/search/aggregations/metrics/HyperLogLogPlusPlus.java'
   }
 }
 

--- a/server/src/internalClusterTest/java/org/elasticsearch/index/shard/SearchIdleIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/index/shard/SearchIdleIT.java
@@ -141,8 +141,9 @@ public class SearchIdleIT extends ESSingleNodeTestCase {
         assertFalse(shard.scheduledRefresh());
         assertTrue(shard.isSearchIdle());
         CountDownLatch refreshLatch = new CountDownLatch(1);
+        // async on purpose to make sure it happens concurrently
         client().admin().indices().prepareRefresh()
-            .execute(ActionListener.wrap(refreshLatch::countDown));// async on purpose to make sure it happens concurrently
+            .execute(ActionListener.wrap(refreshLatch::countDown));
         assertHitCount(client().prepareSearch().get(), 1);
         client().prepareIndex("test", "test", "1").setSource("{\"foo\" : \"bar\"}", XContentType.JSON).get();
         assertFalse(shard.scheduledRefresh());

--- a/server/src/internalClusterTest/java/org/elasticsearch/index/store/CorruptedFileIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/index/store/CorruptedFileIT.java
@@ -163,7 +163,7 @@ public class CorruptedFileIT extends ESIntegTestCase {
         ShardRouting corruptedShardRouting = corruptRandomPrimaryFile();
         logger.info("--> {} corrupted", corruptedShardRouting);
         enableAllocation("test");
-         /*
+        /*
          * we corrupted the primary shard - now lets make sure we never recover from it successfully
          */
         Settings build = Settings.builder().put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, "2").build();
@@ -546,9 +546,10 @@ public class CorruptedFileIT extends ESIntegTestCase {
         assertAcked(prepareCreate("test").setSettings(Settings.builder()
             .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, cluster().numDataNodes() - 1)
             .put(MergePolicyConfig.INDEX_MERGE_ENABLED, false)
-            .put(MockFSIndexStore.INDEX_CHECK_INDEX_ON_CLOSE_SETTING.getKey(), false) // no checkindex - we corrupt shards on purpose
-            .put(IndexSettings.INDEX_TRANSLOG_FLUSH_THRESHOLD_SIZE_SETTING.getKey(),
-                new ByteSizeValue(1, ByteSizeUnit.PB)) // no translog based flush - it might change the .liv / segments.N files
+            // no checkindex - we corrupt shards on purpose
+            .put(MockFSIndexStore.INDEX_CHECK_INDEX_ON_CLOSE_SETTING.getKey(), false)
+            // no translog based flush - it might change the .liv / segments.N files
+            .put(IndexSettings.INDEX_TRANSLOG_FLUSH_THRESHOLD_SIZE_SETTING.getKey(), new ByteSizeValue(1, ByteSizeUnit.PB))
         ));
         ensureGreen();
         IndexRequestBuilder[] builders = new IndexRequestBuilder[numDocs];

--- a/server/src/internalClusterTest/java/org/elasticsearch/recovery/RelocationIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/recovery/RelocationIT.java
@@ -276,10 +276,10 @@ public class RelocationIT extends ESIntegTestCase {
         logger.info("--> creating test index ...");
         prepareCreate(
                 "test",
+                // set refresh_interval because we want to control refreshes
                 Settings.builder()
                         .put("index.number_of_shards", 1)
                         .put("index.number_of_replicas", numberOfReplicas)
-                        // we want to control refreshes
                         .put("index.refresh_interval", -1)
                ).get();
 
@@ -563,10 +563,10 @@ public class RelocationIT extends ESIntegTestCase {
         final String node1 = internalCluster().startNode();
 
         logger.info("--> creating test index ...");
-        prepareCreate("test", Settings.builder()
-            .put("index.number_of_shards", 1)
-            .put("index.number_of_replicas", 0)
-            .put("index.refresh_interval", -1) // we want to control refreshes
+        prepareCreate(
+            "test",
+            // we want to control refreshes
+            Settings.builder().put("index.number_of_shards", 1).put("index.number_of_replicas", 0).put("index.refresh_interval", -1)
         ).get();
 
         logger.info("--> index 10 docs");

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/metrics/ScriptedMetricIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/metrics/ScriptedMetricIT.java
@@ -115,18 +115,19 @@ public class ScriptedMetricIT extends ESIntegTestCase {
                         ((List<Object>) state.get("list")).add(XContentMapValues.extractValue("vars.multiplier", vars));
                     }));
 
-            // Equivalent to:
-            //
-            // newaggregation = [];
-            // sum = 0;
-            //
-            // for (s in state.list) {
-            //      sum += s
-            // };
-            //
-            // newaggregation.add(sum);
-            // return newaggregation"
-            //
+            /*
+             *  Equivalent to:
+             *
+             *  newaggregation = [];
+             *  sum = 0;
+             *
+             *  for (s in state.list) {
+             *       sum += s
+             *  };
+             *
+             *  newaggregation.add(sum);
+             *  return newaggregation"
+             */
             scripts.put("sum state values as a new aggregation", vars -> {
                 List<Integer> newAggregation = new ArrayList<>();
                 Map<String, Object> state = (Map<String, Object>) vars.get("state");
@@ -146,20 +147,21 @@ public class ScriptedMetricIT extends ESIntegTestCase {
 
             scripts.put("no-op list aggregation", vars -> vars.get("states"));
 
-            // Equivalent to:
-            //
-            // newaggregation = [];
-            // sum = 0;
-            //
-            // for (state in states) {
-            //      for (s in state) {
-            //          sum += s
-            //      }
-            // };
-            //
-            // newaggregation.add(sum);
-            // return newaggregation"
-            //
+            /*
+             * Equivalent to:
+             *
+             * newaggregation = [];
+             * sum = 0;
+             *
+             * for (state in states) {
+             *      for (s in state) {
+             *          sum += s
+             *      }
+             * };
+             *
+             * newaggregation.add(sum);
+             * return newaggregation"
+             */
             scripts.put("sum all states (lists) values as a new aggregation", vars -> {
                 List<Integer> newAggregation = new ArrayList<>();
                 int sum = 0;
@@ -198,20 +200,22 @@ public class ScriptedMetricIT extends ESIntegTestCase {
                 return newAggregation;
             });
 
-            // Equivalent to:
-            //
-            // newaggregation = [];
-            // sum = 0;
-            //
-            // for (state in states) {
-            //      for (s in state) {
-            //          sum += s
-            //      }
-            // };
-            //
-            // newaggregation.add(sum * multiplier);
-            // return newaggregation"
-            //
+            /*
+             * Equivalent to:
+             *
+             * newaggregation = [];
+             * sum = 0;
+             *
+             * for (state in states) {
+             *      for (s in state) {
+             *          sum += s
+             *      }
+             * };
+             *
+             * newaggregation.add(sum * multiplier);
+             * return newaggregation"
+             *
+             */
             scripts.put("multiplied sum all states (lists) values as a new aggregation", vars -> {
                 Integer multiplier = (Integer) vars.get("multiplier");
                 List<Integer> newAggregation = new ArrayList<>();

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/allocation/TransportClusterAllocationExplainAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/allocation/TransportClusterAllocationExplainAction.java
@@ -131,9 +131,11 @@ public class TransportClusterAllocationExplainAction
                 }
             }
             if (foundShard == null) {
-                throw new IllegalArgumentException("No shard was specified in the request which means the response should explain a " +
-                    "randomly-chosen unassigned shard, but there are no unassigned shards in this cluster. To explain the allocation of " +
-                    "an assigned shard you must specify the target shard in the request.");
+                throw new IllegalArgumentException(
+                    "No shard was specified in the request which means the response should explain a randomly-chosen unassigned shard, "
+                        + "but there are no unassigned shards in this cluster. To explain the allocation of an assigned shard you must "
+                        + "specify the target shard in the request."
+                );
             }
         } else {
             String index = request.getIndex();

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataCreateIndexService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataCreateIndexService.java
@@ -1338,9 +1338,12 @@ public class MetadataCreateIndexService {
         if (IndexSettings.INDEX_SOFT_DELETES_SETTING.get(indexSettings) &&
             (IndexSettings.INDEX_TRANSLOG_RETENTION_AGE_SETTING.exists(indexSettings)
                 || IndexSettings.INDEX_TRANSLOG_RETENTION_SIZE_SETTING.exists(indexSettings))) {
-            DEPRECATION_LOGGER.deprecate(DeprecationCategory.SETTINGS, "translog_retention",
+            DEPRECATION_LOGGER.deprecate(
+                DeprecationCategory.SETTINGS,
+                "translog_retention",
                 "Translog retention settings [index.translog.retention.age] "
-                + "and [index.translog.retention.size] are deprecated and effectively ignored. They will be removed in a future version.");
+                    + "and [index.translog.retention.size] are deprecated and "
+                    + "effectively ignored. They will be removed in a future version.");
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataUpdateSettingsService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataUpdateSettingsService.java
@@ -140,8 +140,8 @@ public class MetadataUpdateSettingsService {
                         shardLimitValidator.validateShardLimitOnReplicaUpdate(currentState, request.indices(), updatedNumberOfReplicas);
 
                         /*
-                         * We do not update the in-sync allocation IDs as they will be removed upon the first index operation which makes
-                         * these copies stale.
+                         * We do not update the in-sync allocation IDs as they will be removed upon the first index operation
+                         * which makes these copies stale.
                          *
                          * TODO: should we update the in-sync allocation IDs once the data is deleted by the node?
                          */
@@ -161,11 +161,12 @@ public class MetadataUpdateSettingsService {
                                 indexSettings.put(indexMetadata.getSettings());
                             }
                             /*
-                             * The setting index.number_of_replicas is special; we require that this setting has a value in the index. When
-                             * creating the index, we ensure this by explicitly providing a value for the setting to the default (one) if
-                             * there is a not value provided on the source of the index creation. A user can update this setting though,
-                             * including updating it to null, indicating that they want to use the default value. In this case, we again
-                             * have to provide an explicit value for the setting to the default (one).
+                             * The setting index.number_of_replicas is special; we require that this setting has a value
+                             * in the index. When creating the index, we ensure this by explicitly providing a value for
+                             * the setting to the default (one) if there is a not value provided on the source of the
+                             * index creation. A user can update this setting though, including updating it to null,
+                             * indicating that they want to use the default value. In this case, we again have to
+                             * provide an explicit value for the setting to the default (one).
                              */
                             if (IndexMetadata.INDEX_NUMBER_OF_REPLICAS_SETTING.exists(indexSettings) == false) {
                                 indexSettings.put(
@@ -190,11 +191,12 @@ public class MetadataUpdateSettingsService {
                                 indexSettings.put(indexMetadata.getSettings());
                             }
                             /*
-                             * The setting index.number_of_replicas is special; we require that this setting has a value in the index. When
-                             * creating the index, we ensure this by explicitly providing a value for the setting to the default (one) if
-                             * there is a not value provided on the source of the index creation. A user can update this setting though,
-                             * including updating it to null, indicating that they want to use the default value. In this case, we again
-                             * have to provide an explicit value for the setting to the default (one).
+                             * The setting index.number_of_replicas is special; we require that this setting has a value
+                             * in the index. When creating the index, we ensure this by explicitly providing a value for
+                             * the setting to the default (one) if there is a not value provided on the source of the
+                             * index creation. A user can update this setting though, including updating it to null,
+                             * indicating that they want to use the default value. In this case, we again have to
+                             * provide an explicit value for the setting to the default (one).
                              */
                             if (IndexMetadata.INDEX_NUMBER_OF_REPLICAS_SETTING.exists(indexSettings) == false) {
                                 indexSettings.put(

--- a/server/src/main/java/org/elasticsearch/cluster/routing/IndexRoutingTable.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/IndexRoutingTable.java
@@ -120,14 +120,19 @@ public class IndexRoutingTable extends AbstractDiffable<IndexRoutingTable> imple
             }
             for (ShardRouting shardRouting : indexShardRoutingTable) {
                 if (shardRouting.index().equals(index) == false) {
-                    throw new IllegalStateException("shard routing has an index [" + shardRouting.index() + "] that is different " +
-                                                    "from the routing table");
+                    throw new IllegalStateException(
+                        "shard routing has an index [" + shardRouting.index() + "] that is different from the routing table"
+                    );
                 }
                 final Set<String> inSyncAllocationIds = indexMetadata.inSyncAllocationIds(shardRouting.id());
                 if (shardRouting.active() &&
                     inSyncAllocationIds.contains(shardRouting.allocationId().getId()) == false) {
-                    throw new IllegalStateException("active shard routing " + shardRouting + " has no corresponding entry in the in-sync " +
-                        "allocation set " + inSyncAllocationIds);
+                    throw new IllegalStateException(
+                        "active shard routing "
+                            + shardRouting
+                            + " has no corresponding entry in the in-sync allocation set "
+                            + inSyncAllocationIds
+                    );
                 }
 
                 if (shardRouting.primary() && shardRouting.initializing() &&
@@ -139,9 +144,13 @@ public class IndexRoutingTable extends AbstractDiffable<IndexRoutingTable> imple
                                 "allocation set " + inSyncAllocationIds);
                         }
                     } else if (inSyncAllocationIds.contains(shardRouting.allocationId().getId()) == false) {
-                        throw new IllegalStateException("a primary shard routing " + shardRouting
-                            + " is a primary that is recovering from a known allocation id but has no corresponding entry in the in-sync " +
-                            "allocation set " + inSyncAllocationIds);
+                        throw new IllegalStateException(
+                            "a primary shard routing "
+                                + shardRouting
+                                + " is a primary that is recovering from a known allocation id but has no corresponding "
+                                + "entry in the in-sync allocation set "
+                                + inSyncAllocationIds
+                        );
                     }
                 }
             }

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/RestoreInProgressAllocationDecider.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/RestoreInProgressAllocationDecider.java
@@ -52,10 +52,16 @@ public class RestoreInProgressAllocationDecider extends AllocationDecider {
                 }
             }
         }
-        return allocation.decision(Decision.NO, NAME, "shard has failed to be restored from the snapshot [%s] because of [%s] - " +
-            "manually close or delete the index [%s] in order to retry to restore the snapshot again or use the reroute API to force the " +
-            "allocation of an empty primary shard",
-            source.snapshot(), shardRouting.unassignedInfo().getDetails(), shardRouting.getIndexName());
+        return allocation.decision(
+            Decision.NO,
+            NAME,
+            "shard has failed to be restored from the snapshot [%s] because of [%s] - manually close or delete the index [%s] "
+                + "in order to retry to restore the snapshot again or use the reroute API to force the "
+                + "allocation of an empty primary shard",
+            source.snapshot(),
+            shardRouting.unassignedInfo().getDetails(),
+            shardRouting.getIndexName()
+        );
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/gateway/LocalAllocateDangledIndices.java
+++ b/server/src/main/java/org/elasticsearch/gateway/LocalAllocateDangledIndices.java
@@ -104,10 +104,14 @@ public class LocalAllocateDangledIndices {
                     StringBuilder sb = new StringBuilder();
                     for (IndexMetadata indexMetadata : request.indices) {
                         if (indexMetadata.getCreationVersion().before(minIndexCompatibilityVersion)) {
-                            logger.warn("ignoring dangled index [{}] on node [{}]" +
-                                " since it's created version [{}] is not supported by at least one node in the cluster minVersion [{}]",
-                                indexMetadata.getIndex(), request.fromNode, indexMetadata.getCreationVersion(),
-                                minIndexCompatibilityVersion);
+                            logger.warn(
+                                "ignoring dangled index [{}] on node [{}] since it's created version [{}] is not supported by at "
+                                    + "least one node in the cluster minVersion [{}]",
+                                indexMetadata.getIndex(),
+                                request.fromNode,
+                                indexMetadata.getCreationVersion(),
+                                minIndexCompatibilityVersion
+                            );
                             continue;
                         }
                         if (currentState.nodes().getMinNodeVersion().before(indexMetadata.getCreationVersion())) {

--- a/server/src/main/java/org/elasticsearch/gateway/PersistedClusterStateService.java
+++ b/server/src/main/java/org/elasticsearch/gateway/PersistedClusterStateService.java
@@ -346,8 +346,12 @@ public class PersistedClusterStateService {
                                     logger.error("checkIndex: {}", line);
                                 }
                             }
-                            throw new IllegalStateException("the index containing the cluster metadata under the data path [" + dataPath +
-                                "] has been changed by an external force after it was last written by Elasticsearch and is now unreadable");
+                            throw new IllegalStateException(
+                                "the index containing the cluster metadata under the data path ["
+                                    + dataPath
+                                    + "] has been changed by an external force after it was last written by Elasticsearch and is "
+                                    + "now unreadable"
+                            );
                         }
                     }
                 }

--- a/server/src/main/java/org/elasticsearch/index/IndexModule.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexModule.java
@@ -488,8 +488,9 @@ public final class IndexModule {
         return factory;
     }
 
+    // By default we flush first so that the snapshot is as up-to-date as possible.
     public static final IndexStorePlugin.SnapshotCommitSupplier DEFAULT_SNAPSHOT_COMMIT_SUPPLIER
-            = e -> e.acquireLastIndexCommit(true); // by default we flush first so that the snapshot is as up-to-date as possible.
+            = e -> e.acquireLastIndexCommit(true);
 
     private static IndexStorePlugin.SnapshotCommitSupplier getSnapshotCommitSupplier(
             final IndexSettings indexSettings,

--- a/server/src/main/java/org/elasticsearch/index/mapper/TextParams.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/TextParams.java
@@ -98,8 +98,9 @@ public final class TextParams {
     }
 
     public static Parameter<Boolean> norms(boolean defaultValue, Function<FieldMapper, Boolean> initializer) {
+        // norms can be updated from 'true' to 'false' but not vv
         return Parameter.boolParam("norms", true, initializer, defaultValue)
-            .setMergeValidator((o, n, c) -> o == n || (o && n == false));  // norms can be updated from 'true' to 'false' but not vv
+            .setMergeValidator((o, n, c) -> o == n || (o && n == false));
     }
 
     public static Parameter<SimilarityProvider> similarity(Function<FieldMapper, SimilarityProvider> init) {

--- a/server/src/main/java/org/elasticsearch/script/ScriptMetadata.java
+++ b/server/src/main/java/org/elasticsearch/script/ScriptMetadata.java
@@ -247,9 +247,16 @@ public final class ScriptMetadata implements Metadata.Custom, Writeable, ToXCont
                             scripts.put(id, source);
                         }
                     } else if (exists.getLang().equals(source.getLang()) == false) {
-                        throw new IllegalArgumentException("illegal stored script, id [" + id + "] used for multiple scripts with " +
-                            "different languages [" + exists.getLang() + "] and [" + source.getLang() + "]; scripts using the old " +
-                            "namespace of [lang#id] as a stored script id will have to be updated to use only the new namespace of [id]");
+                        throw new IllegalArgumentException(
+                            "illegal stored script, id ["
+                                + id
+                                + "] used for multiple scripts with different languages ["
+                                + exists.getLang()
+                                + "] and ["
+                                + source.getLang()
+                                + "]; scripts using the old namespace of [lang#id] as a stored script id will have to be updated "
+                                + "to use only the new namespace of [id]"
+                        );
                     }
 
                     id = null;

--- a/server/src/main/java/org/elasticsearch/search/builder/SearchSourceBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/builder/SearchSourceBuilder.java
@@ -1250,9 +1250,16 @@ public final class SearchSourceBuilder implements Writeable, ToXContentObject, R
                         } else {
                             SearchExtBuilder searchExtBuilder = parser.namedObject(SearchExtBuilder.class, extSectionName, null);
                             if (searchExtBuilder.getWriteableName().equals(extSectionName) == false) {
-                                throw new IllegalStateException("The parsed [" + searchExtBuilder.getClass().getName() + "] object has a "
-                                        + "different writeable name compared to the name of the section that it was parsed from: found ["
-                                        + searchExtBuilder.getWriteableName() + "] expected [" + extSectionName + "]");
+                                throw new IllegalStateException(
+                                    "The parsed ["
+                                        + searchExtBuilder.getClass().getName()
+                                        + "] object has a different writeable name compared to the name of the section that "
+                                        + " it was parsed from: found ["
+                                        + searchExtBuilder.getWriteableName()
+                                        + "] expected ["
+                                        + extSectionName
+                                        + "]"
+                                );
                             }
                             extBuilders.add(searchExtBuilder);
                         }

--- a/server/src/test/java/org/elasticsearch/cluster/coordination/CoordinatorTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/CoordinatorTests.java
@@ -1316,9 +1316,10 @@ public class CoordinatorTests extends AbstractCoordinatorTestCase {
             // cf. DEFAULT_STABILISATION_TIME, but stabilisation is quicker when there's a single node - there's no meaningful fault
             // detection and ongoing publications do not time out
             cluster.runFor(ELECTION_INITIAL_TIMEOUT_SETTING.get(Settings.EMPTY).millis() + delayVariabilityMillis
-                + 4 * delayVariabilityMillis // two round trips for pre-voting and voting
-                + 7 * delayVariabilityMillis, // see definition of DEFAULT_CLUSTER_STATE_UPDATE_DELAY
-                "stabilising");
+                // two round trips for pre-voting and voting
+                + 4 * delayVariabilityMillis
+                // see definition of DEFAULT_CLUSTER_STATE_UPDATE_DELAY
+                + 7 * delayVariabilityMillis, "stabilising");
 
             assertThat(cluster.getAnyLeader(), sameInstance(clusterNode));
         }

--- a/server/src/test/java/org/elasticsearch/cluster/coordination/ReconfiguratorTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/ReconfiguratorTests.java
@@ -215,8 +215,9 @@ public class ReconfiguratorTests extends ESTestCase {
 
         // update to "false"
         clusterSettings.applySettings(Settings.builder().put(CLUSTER_AUTO_SHRINK_VOTING_CONFIGURATION.getKey(), "false").build());
+        // no quorum
         assertThat(reconfigurator.reconfigure(twoNodes, retired(), randomFrom(twoNodes), initialConfig),
-            sameInstance(initialConfig)); // no quorum
+            sameInstance(initialConfig));
         assertThat(reconfigurator.reconfigure(threeNodes, retired(), randomFrom(threeNodes), initialConfig),
             equalTo(conf("a", "b", "c", "d", "e")));
         assertThat(reconfigurator.reconfigure(threeNodes, retired("d"), randomFrom(threeNodes), initialConfig),

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataIndexTemplateServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataIndexTemplateServiceTests.java
@@ -619,8 +619,8 @@ public class MetadataIndexTemplateServiceTests extends ESSingleNodeTestCase {
         state = MetadataIndexTemplateService.innerPutTemplate(state, req, IndexTemplateMetadata.builder("v1-template"));
 
         assertWarnings("legacy template [v1-template] has index patterns [*, baz] matching patterns from existing " +
-            "composable templates [v2-template] with patterns (v2-template => [foo-bar-*, eggplant]); this template [v1-template] may " +
-            "be ignored in favor of a composable template at index creation time");
+            "composable templates [v2-template] with patterns (v2-template => [foo-bar-*, eggplant]); this template " +
+            "[v1-template] may be ignored in favor of a composable template at index creation time");
 
         assertNotNull(state.metadata().templates().get("v1-template"));
         assertThat(state.metadata().templates().get("v1-template").patterns(), containsInAnyOrder("*", "baz"));
@@ -679,8 +679,8 @@ public class MetadataIndexTemplateServiceTests extends ESSingleNodeTestCase {
         state = MetadataIndexTemplateService.innerPutTemplate(state, req, IndexTemplateMetadata.builder("v1-template"));
 
         assertWarnings("legacy template [v1-template] has index patterns [fo*, baz] matching patterns from existing " +
-            "composable templates [v2-template] with patterns (v2-template => [foo-bar-*, eggplant]); this template [v1-template] may " +
-            "be ignored in favor of a composable template at index creation time");
+            "composable templates [v2-template] with patterns (v2-template => [foo-bar-*, eggplant]); this template " +
+            "[v1-template] may be ignored in favor of a composable template at index creation time");
 
         assertNotNull(state.metadata().templates().get("v1-template"));
         assertThat(state.metadata().templates().get("v1-template").patterns(), containsInAnyOrder("fo*", "baz"));
@@ -736,8 +736,8 @@ public class MetadataIndexTemplateServiceTests extends ESSingleNodeTestCase {
             IllegalArgumentException e = expectThrows(IllegalArgumentException.class,
                 () -> metadataIndexTemplateService.addIndexTemplateV2(state, false, "foo2", newTemplate));
             assertThat(e.getMessage(), equalTo("index template [foo2] has index patterns [abc, baz*] matching patterns from existing " +
-                "templates [foo] with patterns (foo => [egg*, baz]) that have the same priority [1], multiple index templates may not " +
-                "match during index creation, please use a different priority"));
+                "templates [foo] with patterns (foo => [egg*, baz]) that have the same priority [1], multiple " +
+                "index templates may not match during index creation, please use a different priority"));
         }
 
         {
@@ -750,8 +750,8 @@ public class MetadataIndexTemplateServiceTests extends ESSingleNodeTestCase {
             IllegalArgumentException e = expectThrows(IllegalArgumentException.class,
                 () -> metadataIndexTemplateService.addIndexTemplateV2(state, false, "foo2", newTemplate));
             assertThat(e.getMessage(), equalTo("index template [foo2] has index patterns [abc, baz*] matching patterns from existing " +
-                "templates [foo] with patterns (foo => [egg*, baz]) that have the same priority [0], multiple index templates may not " +
-                "match during index creation, please use a different priority"));
+                "templates [foo] with patterns (foo => [egg*, baz]) that have the same priority [0], multiple " +
+                "index templates may not match during index creation, please use a different priority"));
         }
     }
 

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/AllocationServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/AllocationServiceTests.java
@@ -250,9 +250,13 @@ public class AllocationServiceTests extends ESTestCase {
             assertThat(nodeAllocationResult.getNodeDecision(), equalTo(AllocationDecision.NO));
             assertThat(nodeAllocationResult.getCanAllocateDecision().type(), equalTo(Decision.Type.NO));
             assertThat(nodeAllocationResult.getCanAllocateDecision().label(), equalTo("allocator_plugin"));
-            assertThat(nodeAllocationResult.getCanAllocateDecision().getExplanation(), equalTo("finding the previous copies of this " +
-                "shard requires an allocator called [unknown] but that allocator was not found; perhaps the corresponding plugin is " +
-                "not installed"));
+            assertThat(
+                nodeAllocationResult.getCanAllocateDecision().getExplanation(),
+                equalTo(
+                    "finding the previous copies of this shard requires an allocator called [unknown] but that allocator "
+                        + "was not found; perhaps the corresponding plugin is not installed"
+                )
+            );
         }
     }
 

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/decider/DiskThresholdDeciderUnitTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/decider/DiskThresholdDeciderUnitTests.java
@@ -239,9 +239,14 @@ public class DiskThresholdDeciderUnitTests extends ESAllocationTestCase {
             "there is enough disk on this node for the shard to remain, free: [10b]"));
         decision = decider.canRemain(test_1, new RoutingNode("node_1", node_1), allocation);
         assertEquals(Decision.Type.NO, decision.type());
-        assertThat(((Decision.Single) decision).getExplanation(), containsString("the shard cannot remain on this node because it is " +
-            "above the high watermark cluster setting [cluster.routing.allocation.disk.watermark.high=90%] and there is less than " +
-            "the required [10.0%] free disk on node, actual free: [9.0%]"));
+        assertThat(
+            ((Decision.Single) decision).getExplanation(),
+            containsString(
+                "the shard cannot remain on this node because it is above the high watermark cluster setting "
+                    + "[cluster.routing.allocation.disk.watermark.high=90%] and there is less than the required [10.0%] "
+                    + "free disk on node, actual free: [9.0%]"
+            )
+        );
         try {
             decider.canRemain(test_0, new RoutingNode("node_1", node_1), allocation);
             fail("not allocated on this node");

--- a/server/src/test/java/org/elasticsearch/common/unit/ByteSizeValueTests.java
+++ b/server/src/test/java/org/elasticsearch/common/unit/ByteSizeValueTests.java
@@ -234,9 +234,10 @@ public class ByteSizeValueTests extends AbstractWireSerializingTestCase<ByteSize
             mutateUnit = randomValueOtherThan(instanceUnit, () -> randomFrom(ByteSizeUnit.values()));
             final long newUnitBytes = mutateUnit.toBytes(1);
             /*
-             * If size is zero we can not reuse zero because zero with any unit will be equal to zero with any other unit so in this case we
-             * need to randomize a new size. Additionally, if the size unit pair is such that the representation would be such that the
-             * number of represented bytes would exceed Long.Max_VALUE, we have to randomize a new size too.
+             * If size is zero we can not reuse zero because zero with any unit will be equal to zero with any other
+             * unit so in this case we need to randomize a new size. Additionally, if the size unit pair is such that
+             * the representation would be such that the number of represented bytes would exceed Long.Max_VALUE, we
+             * have to randomize a new size too.
              */
             if (instanceSize == 0 || instanceSize >= Long.MAX_VALUE / newUnitBytes) {
                 mutateSize = randomValueOtherThanMany(

--- a/server/src/test/java/org/elasticsearch/index/shard/IndexShardTests.java
+++ b/server/src/test/java/org/elasticsearch/index/shard/IndexShardTests.java
@@ -3142,12 +3142,15 @@ public class IndexShardTests extends IndexShardTestCase {
         appender.start();
         Loggers.addAppender(LogManager.getLogger(IndexShard.class), appender);
         try {
-            appender.addExpectation(new MockLogAppender.SeenEventExpectation(
-                "expensive checks warning",
-                "org.elasticsearch.index.shard.IndexShard",
-                Level.WARN,
-                "performing expensive diagnostic checks during shard startup [index.shard.check_on_startup=*]; these checks should only " +
-                    "be enabled temporarily, you must remove this index setting as soon as possible"));
+            appender.addExpectation(
+                new MockLogAppender.SeenEventExpectation(
+                    "expensive checks warning",
+                    "org.elasticsearch.index.shard.IndexShard",
+                    Level.WARN,
+                    "performing expensive diagnostic checks during shard startup [index.shard.check_on_startup=*]; these checks "
+                        + "should only be enabled temporarily, you must remove this index setting as soon as possible"
+                )
+            );
 
             appender.addExpectation(new MockLogAppender.SeenEventExpectation(
                 "failure message",

--- a/server/src/test/java/org/elasticsearch/index/translog/TranslogTests.java
+++ b/server/src/test/java/org/elasticsearch/index/translog/TranslogTests.java
@@ -1743,11 +1743,15 @@ public class TranslogTests extends ESTestCase {
         final TranslogDeletionPolicy deletionPolicy = translog.getDeletionPolicy();
         final TranslogCorruptedException translogCorruptedException = expectThrows(TranslogCorruptedException.class, () ->
             new Translog(config, translogUUID, deletionPolicy, () -> SequenceNumbers.NO_OPS_PERFORMED, primaryTerm::get, seqNo -> { }));
-        assertThat(translogCorruptedException.getMessage(), endsWith(
-            "] is corrupted, checkpoint file translog-3.ckp already exists but has corrupted content: expected Checkpoint{offset=3025, " +
-                "numOps=55, generation=3, minSeqNo=45, maxSeqNo=99, globalCheckpoint=-1, minTranslogGeneration=1, trimmedAboveSeqNo=-2} " +
-                "but got Checkpoint{offset=0, numOps=0, generation=0, minSeqNo=-1, maxSeqNo=-1, globalCheckpoint=-1, " +
-                "minTranslogGeneration=0, trimmedAboveSeqNo=-2}"));
+        assertThat(
+            translogCorruptedException.getMessage(),
+            endsWith(
+                "] is corrupted, checkpoint file translog-3.ckp already exists but has corrupted content: expected Checkpoint{offset=3025, "
+                    + "numOps=55, generation=3, minSeqNo=45, maxSeqNo=99, globalCheckpoint=-1, minTranslogGeneration=1, "
+                    + "trimmedAboveSeqNo=-2} but got Checkpoint{offset=0, numOps=0, generation=0, minSeqNo=-1, maxSeqNo=-1, "
+                    + "globalCheckpoint=-1, minTranslogGeneration=0, trimmedAboveSeqNo=-2}"
+            )
+        );
         Checkpoint.write(FileChannel::open, config.getTranslogPath().resolve(Translog.getCommitCheckpointFileName(read.generation)),
             read, StandardOpenOption.WRITE, StandardOpenOption.TRUNCATE_EXISTING);
         try (Translog translog = new Translog(config, translogUUID, deletionPolicy,

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/terms/RareTermsAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/terms/RareTermsAggregatorTests.java
@@ -484,9 +484,14 @@ public class RareTermsAggregatorTests extends AggregatorTestCase {
                                 () -> searchAndReduce(newIndexSearcher(indexReader),
                                 // match root document only
                                 new DocValuesFieldExistsQuery(PRIMARY_TERM_NAME), nested, fieldType));
-                            assertThat(e.getMessage(), equalTo("RareTerms agg [terms] is the child of the nested agg [nested], " +
-                                "and also has a scoring child agg [top_hits].  This combination is not supported because it requires " +
-                                "executing in [depth_first] mode, which the RareTerms agg cannot do."));
+                            assertThat(
+                                e.getMessage(),
+                                equalTo(
+                                    "RareTerms agg [terms] is the child of the nested agg [nested], and also has a scoring "
+                                        + "child agg [top_hits].  This combination is not supported because it requires "
+                                        + "executing in [depth_first] mode, which the RareTerms agg cannot do."
+                                )
+                            );
                         } else {
                             InternalNested result = searchAndReduce(newIndexSearcher(indexReader),
                                 // match root document only

--- a/test/framework/src/main/java/org/elasticsearch/test/rest/ESRestTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/ESRestTestCase.java
@@ -1781,9 +1781,11 @@ public abstract class ESRestTestCase extends ESTestCase {
     static final Pattern CREATE_INDEX_MULTIPLE_MATCHING_TEMPLATES = Pattern.compile("^index \\[(.+)\\] matches multiple legacy " +
         "templates \\[(.+)\\], composable templates will only match a single template$");
 
-    static final Pattern PUT_TEMPLATE_MULTIPLE_MATCHING_TEMPLATES = Pattern.compile("^index template \\[(.+)\\] has index patterns " +
-        "\\[(.+)\\] matching patterns from existing older templates \\[(.+)\\] with patterns \\((.+)\\); this template \\[(.+)\\] will " +
-        "take precedence during new index creation$");
+    static final Pattern PUT_TEMPLATE_MULTIPLE_MATCHING_TEMPLATES = Pattern.compile(
+        "^index template \\[(.+)\\] has index patterns "
+            + "\\[(.+)\\] matching patterns from existing older templates \\[(.+)\\] with patterns \\((.+)\\); this "
+            + "template \\[(.+)\\] will take precedence during new index creation$"
+    );
 
     protected static void useIgnoreMultipleMatchingTemplatesWarningsHandler(Request request) throws IOException {
         RequestOptions.Builder options = request.getOptions().toBuilder();

--- a/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/section/ClientYamlTestSuite.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/section/ClientYamlTestSuite.java
@@ -158,7 +158,8 @@ public class ClientYamlTestSuite {
                 .isEmpty())
             .filter(section -> false == hasSkipFeature("warnings_regex", testSection, setupSection, teardownSection))
             .map(section -> "attempted to add a [do] with a [warnings_regex] section " +
-                "without a corresponding [\"skip\": \"features\": \"warnings_regex\"] so runners that do not support the [warnings_regex] "+
+                "without a corresponding [\"skip\": \"features\": \"warnings_regex\"] so runners that do not " +
+                "support the [warnings_regex] "+
                 "section can skip the test at line [" + section.getLocation().lineNumber + "]"));
 
         errors = Stream.concat(errors, sections.stream().filter(section -> section instanceof DoSection)

--- a/test/framework/src/test/java/org/elasticsearch/test/rest/yaml/section/ClientYamlTestSuiteTests.java
+++ b/test/framework/src/test/java/org/elasticsearch/test/rest/yaml/section/ClientYamlTestSuiteTests.java
@@ -36,22 +36,20 @@ public class ClientYamlTestSuiteTests extends AbstractClientYamlTestFragmentPars
         final boolean includeTeardown = randomBoolean();
         StringBuilder testSpecBuilder = new StringBuilder();
         if (includeSetup) {
-            testSpecBuilder
-                .append("---\n" +
-                        "setup:\n" +
-                        "  - do:\n" +
-                        "        indices.create:\n" +
-                        "          index: test_index\n" +
-                        "\n");
+            testSpecBuilder.append("---\n")
+                .append("setup:\n")
+                .append("  - do:\n")
+                .append("        indices.create:\n")
+                .append("          index: test_index\n")
+                .append("\n");
         }
         if (includeTeardown) {
-            testSpecBuilder
-                .append("---\n" +
-                        "teardown:\n" +
-                        "  - do:\n" +
-                        "      indices.delete:\n" +
-                        "        index: test_index\n" +
-                        "\n");
+            testSpecBuilder.append("---\n")
+                .append("teardown:\n")
+                .append("  - do:\n")
+                .append("      indices.delete:\n")
+                .append("        index: test_index\n")
+                .append("\n");
         }
         parser = createParser(YamlXContent.yamlXContent,
                         testSpecBuilder.toString() +
@@ -447,8 +445,8 @@ public class ClientYamlTestSuiteTests extends AbstractClientYamlTestFragmentPars
         Exception e = expectThrows(IllegalArgumentException.class, testSuite::validate);
         assertThat(e.getMessage(),
             containsString("api/name:\nattempted to add a [do] with a [warnings_regex] section without a corresponding " +
-            "[\"skip\": \"features\": \"warnings_regex\"] so runners that do not support the [warnings_regex] section can skip the test " +
-            "at line [" + lineNumber + "]"));
+            "[\"skip\": \"features\": \"warnings_regex\"] so runners that do not support the [warnings_regex] section can " +
+            "skip the test at line [" + lineNumber + "]"));
     }
 
     public void testAddingDoWithAllowedWarningWithoutSkipAllowedWarnings() {
@@ -485,8 +483,8 @@ public class ClientYamlTestSuiteTests extends AbstractClientYamlTestFragmentPars
         ClientYamlTestSuite testSuite = createTestSuite(SkipSection.EMPTY, doSection);
         Exception e = expectThrows(IllegalArgumentException.class, testSuite::validate);
         assertThat(e.getMessage(), containsString("api/name:\nattempted to add a [do] with a [headers] section without a corresponding " +
-            "[\"skip\": \"features\": \"headers\"] so runners that do not support the [headers] section can skip the test at line ["
-            + lineNumber + "]"));
+            "[\"skip\": \"features\": \"headers\"] so runners that do not support the [headers] section can skip the " +
+            "test at line [" + lineNumber + "]"));
     }
 
     public void testAddingDoWithNodeSelectorWithoutSkipNodeSelector() {
@@ -498,8 +496,8 @@ public class ClientYamlTestSuiteTests extends AbstractClientYamlTestFragmentPars
         ClientYamlTestSuite testSuite = createTestSuite(SkipSection.EMPTY, doSection);
         Exception e = expectThrows(IllegalArgumentException.class, testSuite::validate);
         assertThat(e.getMessage(), containsString("api/name:\nattempted to add a [do] with a [node_selector] section without a " +
-            "corresponding [\"skip\": \"features\": \"node_selector\"] so runners that do not support the [node_selector] section can " +
-            "skip the test at line [" + lineNumber + "]"));
+            "corresponding [\"skip\": \"features\": \"node_selector\"] so runners that do not support the [node_selector] " +
+            "section can skip the test at line [" + lineNumber + "]"));
     }
 
     public void testAddingContainsWithoutSkipContains() {
@@ -546,14 +544,23 @@ public class ClientYamlTestSuiteTests extends AbstractClientYamlTestFragmentPars
 
         ClientYamlTestSuite testSuite = new ClientYamlTestSuite("api", "name", SetupSection.EMPTY, TeardownSection.EMPTY, sections);
         Exception e = expectThrows(IllegalArgumentException.class, testSuite::validate);
-        assertEquals("api/name:\n" +
-            "attempted to add a [contains] assertion without a corresponding [\"skip\": \"features\": \"contains\"] so runners " +
-                "that do not support the [contains] assertion can skip the test at line [" + firstLineNumber + "],\n" +
-            "attempted to add a [do] with a [warnings] section without a corresponding [\"skip\": \"features\": \"warnings\"] so " +
-                "runners that do not support the [warnings] section can skip the test at line [" + secondLineNumber + "],\n" +
-            "attempted to add a [do] with a [node_selector] section without a corresponding [\"skip\": \"features\": \"node_selector\"] " +
-                "so runners that do not support the [node_selector] section can skip the test at line [" + thirdLineNumber + "]",
-            e.getMessage());
+        assertEquals(
+            "api/name:\n"
+                + "attempted to add a [contains] assertion without a corresponding [\"skip\": \"features\": \"contains\"] so runners "
+                + "that do not support the [contains] assertion can skip the test at line ["
+                + firstLineNumber
+                + "],\n"
+                + "attempted to add a [do] with a [warnings] section without a corresponding [\"skip\": \"features\": \"warnings\"] so "
+                + "runners that do not support the [warnings] section can skip the test at line ["
+                + secondLineNumber
+                + "],\n"
+                + "attempted to add a [do] with a [node_selector] section without a corresponding "
+                + "[\"skip\": \"features\": \"node_selector\"] "
+                + "so runners that do not support the [node_selector] section can skip the test at line ["
+                + thirdLineNumber
+                + "]",
+            e.getMessage()
+        );
     }
 
     public void testAddingDoWithWarningWithSkip() {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/protocol/xpack/graph/Vertex.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/protocol/xpack/graph/Vertex.java
@@ -176,25 +176,31 @@ public class Vertex implements ToXContentFragment {
         this.weight = weight;
     }
 
+    // @formatter:off
     /**
      * If the {@link GraphExploreRequest#useSignificance(boolean)} is true (the default)
      * this statistic is available.
      * @return the number of documents in the index that contain this term (see bg_count in
- * <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-significantterms-aggregation.html">
-     * the significant_terms aggregation</a>)
+     * <a
+     * href="https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-significantterms-aggregation.html"
+     * >the significant_terms aggregation</a>)
      */
+    // @formatter:on
     public long getBg() {
         return bg;
     }
 
+    // @formatter:off
     /**
      * If the {@link GraphExploreRequest#useSignificance(boolean)} is true (the default)
      * this statistic is available.
      * Together with {@link #getBg()} these numbers are used to derive the significance of a term.
      * @return the number of documents in the sample of best matching documents that contain this term (see fg_count in
- * <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-significantterms-aggregation.html">
-     * the significant_terms aggregation</a>)
+     * <a
+     * href="https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-significantterms-aggregation.html"
+     * >the significant_terms aggregation</a>)
      */
+    // @formatter:on
     public long getFg() {
         return fg;
     }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/RolloverStep.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/RolloverStep.java
@@ -67,8 +67,8 @@ public class RolloverStep extends AsyncActionStep {
 
             if (Strings.isNullOrEmpty(rolloverAlias)) {
                 listener.onFailure(new IllegalArgumentException(String.format(Locale.ROOT,
-                    "setting [%s] for index [%s] is empty or not defined, it must be set to the name of the alias pointing to the group " +
-                        "of indices being rolled over", RolloverAction.LIFECYCLE_ROLLOVER_ALIAS, indexName)));
+                    "setting [%s] for index [%s] is empty or not defined, it must be set to the name of the alias " +
+                        "pointing to the group of indices being rolled over", RolloverAction.LIFECYCLE_ROLLOVER_ALIAS, indexName)));
                 return;
             }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/transforms/TransformCheckpoint.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/transforms/TransformCheckpoint.java
@@ -231,10 +231,12 @@ public class TransformCheckpoint implements Writeable, ToXContentObject {
         }
 
         return Objects.equals(this.transformId, that.transformId)
-                && this.indicesCheckpoints.size() == that.indicesCheckpoints.size() // quick check
-                // do the expensive deep equal operation last
-                && this.indicesCheckpoints.entrySet().stream()
-                        .allMatch(e -> Arrays.equals(e.getValue(), that.indicesCheckpoints.get(e.getKey())));
+            // quick check
+            && this.indicesCheckpoints.size() == that.indicesCheckpoints.size()
+            // do the expensive deep equal operation last
+            && this.indicesCheckpoints.entrySet()
+                .stream()
+                .allMatch(e -> Arrays.equals(e.getValue(), that.indicesCheckpoints.get(e.getKey())));
     }
 
     @Override

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/license/ExpirationCallbackTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/license/ExpirationCallbackTests.java
@@ -24,7 +24,8 @@ public class ExpirationCallbackTests extends ESTestCase {
         long now = System.currentTimeMillis();
         long expiryDate = now + expiryDuration.getMillis();
         assertThat(post.delay(expiryDate, now),
-                equalTo(TimeValue.timeValueMillis(expiryDuration.getMillis() + min.getMillis()))); // before license expiry
+            // before license expiry
+            equalTo(TimeValue.timeValueMillis(expiryDuration.getMillis() + min.getMillis())));
         assertThat(post.delay(expiryDate, expiryDate), equalTo(min)); // on license expiry
         int latestValidTriggerDelay = (int) (expiryDuration.getMillis() + max.getMillis());
         int earliestValidTriggerDelay = (int) (expiryDuration.getMillis() + min.getMillis());

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/license/LicenseTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/license/LicenseTests.java
@@ -154,10 +154,13 @@ public class LicenseTests extends ESTestCase {
         for (License.LicenseType type : License.LicenseType.values()) {
             final License license1 = randomLicense(type)
                 // We need a signature that parses correctly, but it doesn't need to verify
-                .signature("AAAABQAAAA2MUoEqXb9K9Ie5d6JJAAAAIAo5/x6hrsGh1GqqrJmy4qgmEC7gK0U4zQ6q5ZEMhm4jAAABAAAwVZKGAmDELUlS5PScBkhQsZa" +
-                    "DaQTtJ4ZP5EnZ/nLpmCt9Dj7d/FRsgMtHmSJLrr2CdrIo4Vx5VuhmbwzZvXMttLz2lrJzG7770PX3TnC9e7F9GdnE9ec0FP2U0ZlLOBOtPuirX0q+j" +
-                    "6GfB+DLyE5D+Lo1NQ3eLJGvbd3DBYPWJxkb+EBVHczCH2OrIEVWnN/TafmkdZCPX5PcultkNOs3j7d3s7b51EXHKoye8UTcB/RGmzZwMah+E6I/VJk" +
-                    "qu7UHL8bB01wJeqo6WxI4LC/9+f5kpmHrUu3CHe5pHbmMGDk7O6/cwt1pw/hnJXKIFCi36IGaKcHLgORxQdN0uzE=")
+                .signature(
+                    "AAAABQAAAA2MUoEqXb9K9Ie5d6JJAAAAIAo5/x6hrsGh1GqqrJmy4qgmEC7gK0U4zQ6q5ZEMhm4jAAABAAAwVZKGAmDELUlS5PScBkhQsZa"
+                        + "DaQTtJ4ZP5EnZ/nLpmCt9Dj7d/FRsgMtHmSJLrr2CdrIo4Vx5VuhmbwzZvXMttLz2lrJzG7770PX3TnC9e7F9GdnE9ec0FP2U0ZlL"
+                        + "OBOtPuirX0q+j6GfB+DLyE5D+Lo1NQ3eLJGvbd3DBYPWJxkb+EBVHczCH2OrIEVWnN/TafmkdZCPX5PcultkNOs3j7d3s7b51EXHK"
+                        + "oye8UTcB/RGmzZwMah+E6I/VJkqu7UHL8bB01wJeqo6WxI4LC/9+f5kpmHrUu3CHe5pHbmMGDk7O6/cwt1pw/hnJXKIFCi36IGaKc"
+                        + "HLgORxQdN0uzE="
+                )
                 .build();
             XContentParser parser = XContentType.JSON.xContent().createParser(NamedXContentRegistry.EMPTY, THROW_UNSUPPORTED_OPERATION,
                 Strings.toString(license1));
@@ -176,10 +179,15 @@ public class LicenseTests extends ESTestCase {
 
     public void testSerializationOfLicenseForEveryLicenseType() throws Exception {
         for (License.LicenseType type : License.LicenseType.values()) {
-            final String signature = randomBoolean() ? null : "AAAABQAAAA2MUoEqXb9K9Ie5d6JJAAAAIAo5/x6hrsGh1GqqrJmy4qgmEC7gK0U4zQ6q5ZEM" +
-                "hm4jAAABAAAwVZKGAmDELUlS5PScBkhQsZaDaQTtJ4ZP5EnZ/nLpmCt9Dj7d/FRsgMtHmSJLrr2CdrIo4Vx5VuhmbwzZvXMttLz2lrJzG7770PX3TnC9e7" +
-                "F9GdnE9ec0FP2U0ZlLOBOtPuirX0q+j6GfB+DLyE5D+Lo1NQ3eLJGvbd3DBYPWJxkb+EBVHczCH2OrIEVWnN/TafmkdZCPX5PcultkNOs3j7d3s7b51EXH" +
-                "Koye8UTcB/RGmzZwMah+E6I/VJkqu7UHL8bB01wJeqo6WxI4LC/9+f5kpmHrUu3CHe5pHbmMGDk7O6/cwt1pw/hnJXKIFCi36IGaKcHLgORxQdN0uzE=";
+            final String signature = randomBoolean()
+                ? null
+                : "AAAABQAAAA2MUoEqXb9K9Ie5d6JJAAAAIAo5/x6hrsGh1GqqrJmy4qgmEC7gK0U4zQ6q5ZEM"
+                    + "hm4jAAABAAAwVZKGAmDELUlS5PScBkhQsZaDaQTtJ4ZP5EnZ/nLpmCt9Dj7d/FRsgMtH"
+                    + "mSJLrr2CdrIo4Vx5VuhmbwzZvXMttLz2lrJzG7770PX3TnC9e7F9GdnE9ec0FP2U0ZlL"
+                    + "OBOtPuirX0q+j6GfB+DLyE5D+Lo1NQ3eLJGvbd3DBYPWJxkb+EBVHczCH2OrIEVWnN/T"
+                    + "afmkdZCPX5PcultkNOs3j7d3s7b51EXHKoye8UTcB/RGmzZwMah+E6I/VJkqu7UHL8bB"
+                    + "01wJeqo6WxI4LC/9+f5kpmHrUu3CHe5pHbmMGDk7O6/cwt1pw/hnJXKIFCi36IGaKcHL"
+                    + "gORxQdN0uzE=";
             final int version;
             if (type == License.LicenseType.ENTERPRISE) {
                 version = randomIntBetween(License.VERSION_ENTERPRISE, License.VERSION_CURRENT);

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/DeleteStepTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/DeleteStepTests.java
@@ -140,9 +140,17 @@ public class DeleteStepTests extends AbstractStepTestCase<DeleteStep> {
                     fail("unexpected listener callback");
                 }
             }));
-        assertThat(illegalStateException.getMessage(),
-            is("index [" + indexName + "] is the write index for data stream [" + dataStreamName + "]. stopping execution of lifecycle" +
-                " [test-ilm-policy] as a data stream's write index cannot be deleted. manually rolling over the index will resume the " +
-                "execution of the policy as the index will not be the data stream's write index anymore"));
+        assertThat(
+            illegalStateException.getMessage(),
+            is(
+                "index ["
+                    + indexName
+                    + "] is the write index for data stream ["
+                    + dataStreamName
+                    + "]. stopping execution of lifecycle [test-ilm-policy] as a data stream's write index cannot be deleted. "
+                    + "manually rolling over the index will resume the execution of the policy as the index will not be the "
+                    + "data stream's write index anymore"
+            )
+        );
     }
 }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/TimeseriesLifecycleTypeTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/TimeseriesLifecycleTypeTests.java
@@ -807,10 +807,15 @@ public class TimeseriesLifecycleTypeTests extends ESTestCase {
             String err =
                 validateMonotonicallyIncreasingPhaseTimings(Arrays.asList(hotPhase, warmPhase, coldPhase, frozenPhase, deletePhase));
 
-            assertThat(err,
-                containsString("Your policy is configured to run the frozen phase "+
-                    "(min_age: 2d), the delete phase (min_age: 1d) and the warm phase (min_age: 2d) before the hot phase (min_age: 3d)."+
-                    " You should change the phase timing so that the phases will execute in the order of hot, warm, then cold."));
+            assertThat(
+                err,
+                containsString(
+                    "Your policy is configured to run the frozen phase "
+                        + "(min_age: 2d), the delete phase (min_age: 1d) and the warm phase (min_age: 2d) before the"
+                        + " hot phase (min_age: 3d). You should change the phase timing so that the phases will execute"
+                        + " in the order of hot, warm, then cold."
+                )
+            );
         }
 
         {
@@ -823,10 +828,15 @@ public class TimeseriesLifecycleTypeTests extends ESTestCase {
             String err =
                 validateMonotonicallyIncreasingPhaseTimings(Arrays.asList(hotPhase, warmPhase, coldPhase, frozenPhase, deletePhase));
 
-            assertThat(err,
-                containsString("Your policy is configured to run the cold phase (min_age: 2d), the frozen phase "+
-                    "(min_age: 2d), the delete phase (min_age: 1d) and the warm phase (min_age: 2d) before the hot phase (min_age: 3d)."+
-                    " You should change the phase timing so that the phases will execute in the order of hot, warm, then cold."));
+            assertThat(
+                err,
+                containsString(
+                    "Your policy is configured to run the cold phase (min_age: 2d), the frozen phase "
+                        + "(min_age: 2d), the delete phase (min_age: 1d) and the warm phase (min_age: 2d) before the"
+                        + " hot phase (min_age: 3d). You should change the phase timing so that the phases will execute"
+                        + " in the order of hot, warm, then cold."
+                )
+            );
         }
     }
 

--- a/x-pack/plugin/eql/build.gradle
+++ b/x-pack/plugin/eql/build.gradle
@@ -57,6 +57,12 @@ dependencies {
 String grammarPath = 'src/main/antlr'
 String outputPath = 'src/main/java/org/elasticsearch/xpack/eql/parser'
 
+spotless {
+  java {
+    targetExclude "${outputPath}/*.java"
+  }
+}
+
 tasks.register("cleanGenerated", Delete) {
   delete fileTree(grammarPath) {
     include '*.tokens'

--- a/x-pack/plugin/identity-provider/src/test/java/org/elasticsearch/xpack/idp/saml/idp/SamlIdpMetadataBuilderTests.java
+++ b/x-pack/plugin/identity-provider/src/test/java/org/elasticsearch/xpack/idp/saml/idp/SamlIdpMetadataBuilderTests.java
@@ -44,13 +44,19 @@ public class SamlIdpMetadataBuilderTests extends IdpSamlTestCase {
             .build();
         final Element element = new EntityDescriptorMarshaller().marshall(entityDescriptor);
         final String xml = samlFactory.toString(element, false);
-        assertThat(xml, equalTo("<?xml version=\"1.0\" encoding=\"UTF-8\"?>" +
-            "<md:EntityDescriptor xmlns:md=\"urn:oasis:names:tc:SAML:2.0:metadata\" entityID=\"https://idp.org\">" +
-            "<md:IDPSSODescriptor WantAuthnRequestsSigned=\"false\" protocolSupportEnumeration=\"urn:oasis:names:tc:SAML:2.0:protocol\">" +
-            "<md:SingleSignOnService Binding=\"urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect\" " +
-            "Location=\"https://idp.org/sso/redirect\"/>" +
-            "</md:IDPSSODescriptor>" +
-            "</md:EntityDescriptor>"));
+        assertThat(
+            xml,
+            equalTo(
+                "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+                    + "<md:EntityDescriptor xmlns:md=\"urn:oasis:names:tc:SAML:2.0:metadata\" entityID=\"https://idp.org\">"
+                    + "<md:IDPSSODescriptor WantAuthnRequestsSigned=\"false\" "
+                    + "protocolSupportEnumeration=\"urn:oasis:names:tc:SAML:2.0:protocol\">"
+                    + "<md:SingleSignOnService Binding=\"urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect\" "
+                    + "Location=\"https://idp.org/sso/redirect\"/>"
+                    + "</md:IDPSSODescriptor>"
+                    + "</md:EntityDescriptor>"
+            )
+        );
     }
 
     public void testMetadataGenerationWithAllParameters() throws Exception {

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/categorization/CategorizationAnalyzerTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/categorization/CategorizationAnalyzerTests.java
@@ -45,8 +45,8 @@ public class CategorizationAnalyzerTests extends ESTestCase {
          "10.8.0.11 - - [29/Nov/2020:21:34:56 +0000] \"POST /intake/v2/events HTTP/1.1\" 202 0 \"-\" " +
             "\"elasticapm-node/3.8.0 elastic-apm-http-client/9.4.2 node/12.20.0\" 4913 10.006 [default-apm-apm-server-8200] [] " +
             "10.8.1.18:8200 0 0.002 202 1eac41789ea9a60a8be4e476c54cbbc9\n" +
-         "10.8.0.14 - - [29/Nov/2020:21:34:57 +0000] \"POST /intake/v2/events HTTP/1.1\" 202 0 \"-\" \"elasticapm-python/5.10.0\" 1025 " +
-            "0.001 [default-apm-apm-server-8200] [] 10.8.1.18:8200 0 0.001 202 d27088936cadd3b8804b68998a5f94fa";
+         "10.8.0.14 - - [29/Nov/2020:21:34:57 +0000] \"POST /intake/v2/events HTTP/1.1\" 202 0 \"-\" \"elasticapm-python/5.10.0\" " +
+            "1025 0.001 [default-apm-apm-server-8200] [] 10.8.1.18:8200 0 0.001 202 d27088936cadd3b8804b68998a5f94fa";
 
     private AnalysisRegistry analysisRegistry;
 

--- a/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/RollupResponseTranslator.java
+++ b/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/RollupResponseTranslator.java
@@ -213,8 +213,8 @@ public class RollupResponseTranslator {
                 // If an index was deleted after execution, give a hint to the user that this is a transient error
                 if (e instanceof IndexNotFoundException) {
                     throw new ResourceNotFoundException("Index [" + ((IndexNotFoundException) e).getIndex() + "] was not found, " +
-                        "likely because it was deleted while the request was in-flight. Rollup does not support partial search results, " +
-                        "please try the request again.", e);
+                        "likely because it was deleted while the request was in-flight. Rollup does not support " +
+                        "partial search results, please try the request again.", e);
                 }
 
                 // Otherwise just throw

--- a/x-pack/plugin/rollup/src/test/java/org/elasticsearch/xpack/rollup/job/IndexerUtilsTests.java
+++ b/x-pack/plugin/rollup/src/test/java/org/elasticsearch/xpack/rollup/job/IndexerUtilsTests.java
@@ -580,7 +580,8 @@ public class IndexerUtilsTests extends AggregatorTestCase {
             = new DateHistogramValuesSourceBuilder("the_histo." + DateHistogramAggregationBuilder.NAME)
             .field(timestampField)
             .calendarInterval(new DateHistogramInterval("1d"))
-            .timeZone(ZoneId.of("-01:00", ZoneId.SHORT_IDS));  // adds a timezone so that we aren't on default UTC
+            // adds a timezone so that we aren't on default UTC
+            .timeZone(ZoneId.of("-01:00", ZoneId.SHORT_IDS));
 
         CompositeAggregationBuilder compositeBuilder = new CompositeAggregationBuilder(RollupIndexer.AGGREGATION_NAME,
             singletonList(dateHisto));
@@ -606,16 +607,16 @@ public class IndexerUtilsTests extends AggregatorTestCase {
         Map<String, Object> map = docs.get(0).sourceAsMap();
         assertNotNull(map.get(valueField + "." + MaxAggregationBuilder.NAME + "." + RollupField.VALUE));
         assertThat(map.get("the_histo." + DateHistogramAggregationBuilder.NAME + "." + RollupField.COUNT_FIELD), equalTo(1));
+        // 2015-09-30T00:00:00.000-01:00
         assertThat(map.get("the_histo." + DateHistogramAggregationBuilder.NAME + "." + RollupField.TIMESTAMP),
-            equalTo(1443574800000L)); // 2015-09-30T00:00:00.000-01:00
+            equalTo(1443574800000L));
 
         map = docs.get(1).sourceAsMap();
         assertNotNull(map.get(valueField + "." + MaxAggregationBuilder.NAME + "." + RollupField.VALUE));
         assertThat(map.get("the_histo." + DateHistogramAggregationBuilder.NAME + "." + RollupField.COUNT_FIELD), equalTo(1));
+        // 2015-10-01T00:00:00.000-01:00
         assertThat(map.get("the_histo." + DateHistogramAggregationBuilder.NAME + "." + RollupField.TIMESTAMP),
-            equalTo(1443661200000L)); // 2015-10-01T00:00:00.000-01:00
-
-
+            equalTo(1443661200000L));
     }
 
     interface Mock {

--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/integration/IndexPrivilegeTests.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/integration/IndexPrivilegeTests.java
@@ -592,16 +592,30 @@ public class IndexPrivilegeTests extends AbstractPrivilegeTestCase {
                     Response response = assertAccessIsAllowed(user, "PUT", "/" + index + "/_doc/4321", "{ \"" +
                             UUIDs.randomBase64UUID() + "\" : \"foo\" }");
                     String warningHeader = response.getHeader("Warning");
-                    assertThat(warningHeader, containsString("the index privilege [index] allowed the update mapping action " +
-                            "[indices:admin/mapping/auto_put] on index [" + index + "], this privilege will not permit mapping updates in" +
-                            " the next major release - users who require access to update mappings must be granted explicit privileges"));
+                    assertThat(
+                        warningHeader,
+                        containsString(
+                            "the index privilege [index] allowed the update mapping action "
+                                + "[indices:admin/mapping/auto_put] on index ["
+                                + index
+                                + "], this privilege will not permit mapping updates in the next major release - "
+                                + "users who require access to update mappings must be granted explicit privileges"
+                        )
+                    );
                     assertAccessIsAllowed(user, "POST", "/" + index + "/_update/321", "{ \"doc\" : { \"foo\" : \"baz\" } }");
                     response = assertAccessIsAllowed(user, "POST", "/" + index + "/_update/321",
                             "{ \"doc\" : { \"" + UUIDs.randomBase64UUID() + "\" : \"baz\" } }");
                     warningHeader = response.getHeader("Warning");
-                    assertThat(warningHeader, containsString("the index privilege [index] allowed the update mapping action " +
-                            "[indices:admin/mapping/auto_put] on index [" + index + "], this privilege will not permit mapping updates in" +
-                            " the next major release - users who require access to update mappings must be granted explicit privileges"));
+                    assertThat(
+                        warningHeader,
+                        containsString(
+                            "the index privilege [index] allowed the update mapping action "
+                                + "[indices:admin/mapping/auto_put] on index ["
+                                + index
+                                + "], this privilege will not permit mapping updates in the next major release - "
+                                + "users who require access to update mappings must be granted explicit privileges"
+                        )
+                    );
                 } else {
                     assertAccessIsDenied(user, "PUT", "/" + index + "/_doc/321", "{ \"foo\" : \"bar\" }");
                     assertAccessIsDenied(user, "PUT", "/" + index + "/_doc/321", "{ \"foo\" : \"bar\" }");

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/AuthorizationService.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/AuthorizationService.java
@@ -186,7 +186,8 @@ public class AuthorizationService {
          * When the returned {@code StoredContext} is closed, ALL the original headers are restored.
          */
         try (ThreadContext.StoredContext ignore = threadContext.newStoredContext(false,
-                ACTION_SCOPE_AUTHORIZATION_KEYS)) { // this does not clear {@code AuthorizationServiceField.ORIGINATING_ACTION_KEY}
+                ACTION_SCOPE_AUTHORIZATION_KEYS)) {
+            // this does not clear {@code AuthorizationServiceField.ORIGINATING_ACTION_KEY}
             // prior to doing any authorization lets set the originating action in the thread context
             // the originating action is the current action if no originating action has yet been set in the current thread context
             // if there is already an original action, that stays put (eg. the current action is a child action)

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/ldap/LdapSessionFactoryTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/ldap/LdapSessionFactoryTests.java
@@ -245,9 +245,11 @@ public class LdapSessionFactoryTests extends LdapTestCase {
      * (one failure, one success) depending on which file content is in place.
      */
     public void testSslTrustIsReloaded() throws Exception {
-        assumeFalse("NPE thrown in BCFIPS JSSE - addressed in " +
-            "https://github.com/bcgit/bc-java/commit/5aed687e17a3cd63f34373cafe92699b90076fb6#diff-8e5d8089bc0d504d93194a1e484d3950R179",
-            inFipsJvm());
+        assumeFalse(
+            "NPE thrown in BCFIPS JSSE - addressed in https://github.com/bcgit/bc-java/commit/"
+                + "5aed687e17a3cd63f34373cafe92699b90076fb6#diff-8e5d8089bc0d504d93194a1e484d3950R179",
+            inFipsJvm()
+        );
         InMemoryDirectoryServer ldapServer = randomFrom(ldapServers);
         InetAddress listenAddress = ldapServer.getListenAddress("ldaps");
         if (listenAddress == null) {

--- a/x-pack/plugin/sql/build.gradle
+++ b/x-pack/plugin/sql/build.gradle
@@ -71,6 +71,12 @@ dependencies {
 String grammarPath = 'src/main/antlr'
 String outputPath = 'src/main/java/org/elasticsearch/xpack/sql/parser'
 
+spotless {
+  java {
+    targetExclude "${outputPath}/*.java"
+  }
+}
+
 tasks.register("cleanGenerated", Delete) {
   delete fileTree(grammarPath) {
     include '*.tokens'

--- a/x-pack/plugin/sql/sql-client/src/test/java/org/elasticsearch/xpack/sql/client/RemoteFailureTests.java
+++ b/x-pack/plugin/sql/sql-client/src/test/java/org/elasticsearch/xpack/sql/client/RemoteFailureTests.java
@@ -120,7 +120,8 @@ public class RemoteFailureTests extends ESTestCase {
             }).streamInput()));
         assertThat(e.getMessage(),
             startsWith("Can't parse error from Elasticsearch [Unrecognized token 'ÿ': "
-                + "was expecting (JSON String, Number, Array, Object or token 'null', 'true' or 'false')] at [line 1 col 4]. Response:\n"));
+                + "was expecting (JSON String, Number, Array, Object or token 'null', 'true' or 'false')] "
+                + "at [line 1 col 4]. Response:\n"));
     }
 
     public void testTooBig() {

--- a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/notification/email/attachment/ReportingAttachmentParser.java
+++ b/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/notification/email/attachment/ReportingAttachmentParser.java
@@ -71,9 +71,11 @@ public class ReportingAttachmentParser implements EmailAttachmentParser<Reportin
     private static final ObjectParser<KibanaReportingPayload, Void> PAYLOAD_PARSER =
             new ObjectParser<>("reporting_attachment_kibana_payload", true, null);
 
-    static final Map<String, String> WARNINGS = Collections.singletonMap("kbn-csv-contains-formulas",
-        "Warning: The attachment [%s] contains characters which spreadsheet applications may interpret as formulas." +
-        "Please ensure that the attachment is safe prior to opening.");
+    static final Map<String, String> WARNINGS = Collections.singletonMap(
+        "kbn-csv-contains-formulas",
+        "Warning: The attachment [%s] contains characters which spreadsheet applications may interpret as formulas."
+            + "Please ensure that the attachment is safe prior to opening."
+    );
 
     static {
         PARSER.declareInt(Builder::retries, ReportingAttachment.RETRIES);


### PR DESCRIPTION
Backport of #76464.

* Reformatting to keep Checkstyle after formatting
* Configure spotless everywhere, and disable the tasks if necessary
* Add XContentBuilder helpers, fix test