### PR TITLE
Mute AllocationRoutedStepTests.testExecuteAllocateUnassigned

### DIFF
--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/AllocationRoutedStepTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/AllocationRoutedStepTests.java
@@ -302,6 +302,7 @@ public class AllocationRoutedStepTests extends AbstractStepTestCase<AllocationRo
                 new ClusterStateWaitStep.Result(false, allShardsActiveAllocationInfo(0, 1)));
     }
 
+    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/76633")
     public void testExecuteAllocateUnassigned() throws Exception {
         Index index = new Index(randomAlphaOfLengthBetween(1, 20), randomAlphaOfLengthBetween(1, 20));
         Map<String, String> includes = AllocateActionTests.randomAllocationRoutingMap(1, 5);


### PR DESCRIPTION
(cherry picked from commit 241dae950c52a75c95f5c79572d30192a0666ada)
Signed-off-by: Andrei Dan <andrei.dan@elastic.co>

Relates to #76633