### PR TITLE
[DOCS] EQL: Remove multi-value field limitation

### DIFF
--- a/docs/reference/eql/functions.asciidoc
+++ b/docs/reference/eql/functions.asciidoc
@@ -856,15 +856,6 @@ Value to convert to a string. If `null`, the function returns `null`.
 +
 If using a field as the argument, this parameter does not support the
 <<text,`text`>> field data type.
-+
-Avoid using complex expressions to pass `true` or `false` Boolean values to this
-parameter. If a field in the expression contains <<array,multiple values>>, the
-function may return inconsistent results. For example:
-+
-[source,eql]
-----
-where string(process.args_count > 2 and not process.args_count < 2 or not concat(destination.address, destination.port) == "127.0.0.1:8000") == "true"
-----
 
 *Returns:* string or `null`
 

--- a/docs/reference/eql/functions.asciidoc
+++ b/docs/reference/eql/functions.asciidoc
@@ -856,6 +856,15 @@ Value to convert to a string. If `null`, the function returns `null`.
 +
 If using a field as the argument, this parameter does not support the
 <<text,`text`>> field data type.
++
+Avoid using complex expressions to pass `true` or `false` Boolean values to this
+parameter. If a field in the expression contains <<array,multiple values>>, the
+function may return inconsistent results. For example:
++
+[source,eql]
+----
+where string(process.args_count > 2 and not process.args_count < 2 or not concat(destination.address, destination.port) == "127.0.0.1:8000") == "true"
+----
 
 *Returns:* string or `null`
 

--- a/docs/reference/eql/syntax.asciidoc
+++ b/docs/reference/eql/syntax.asciidoc
@@ -820,14 +820,6 @@ use the EQL search API's <<eql-search-filter-query-dsl,Query DSL `filter`>>
 parameter.
 
 [discrete]
-[[eql-array-fields]]
-==== Array field values are not supported
-
-EQL does not support <<array,array>> field values, also known as
-multi-value fields. EQL searches on array field values may return inconsistent
-results.
-
-[discrete]
 [[eql-nested-fields]]
 ==== EQL search on nested fields
 


### PR DESCRIPTION
Changes:
* Removes the limitation for multi-value fields.
* Adds a recommendation to avoid complex expressions for Boolean comparisons to the `string` fn.

Relates to #76610.


### Preview
* `string` fn: https://elasticsearch_76663.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/eql-function-ref.html#eql-fn-string