### PR TITLE
[DOCS] Add stub docs for QueryApiKey API

### DIFF
--- a/x-pack/docs/en/rest-api/security.asciidoc
+++ b/x-pack/docs/en/rest-api/security.asciidoc
@@ -69,6 +69,7 @@ without requiring basic authentication:
 * <<security-api-invalidate-api-key,Invalidate API key>>
 * <<security-api-clear-api-key-cache,Clear API key cache>>
 * <<security-api-grant-api-key,Grant API key>>
+* <<security-api-query-api-key,Query API key>>
 
 [discrete]
 [[security-user-apis]]
@@ -172,6 +173,7 @@ include::security/invalidate-tokens.asciidoc[]
 include::security/oidc-prepare-authentication-api.asciidoc[]
 include::security/oidc-authenticate-api.asciidoc[]
 include::security/oidc-logout-api.asciidoc[]
+include::security/query-api-key.asciidoc[]
 include::security/saml-prepare-authentication-api.asciidoc[]
 include::security/saml-authenticate-api.asciidoc[]
 include::security/saml-logout-api.asciidoc[]

--- a/x-pack/docs/en/rest-api/security/query-api-key.asciidoc
+++ b/x-pack/docs/en/rest-api/security/query-api-key.asciidoc
@@ -1,0 +1,6 @@
+[role="xpack"]
+[[security-api-query-api-key]]
+=== Query API key information API
+
+coming::[8.0.0]
+


### PR DESCRIPTION
This PR addresses the following documentation build failure:

> 09:39:38 INFO:build_docs:Bad cross-document links:
09:39:38 INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/elasticsearch/client/javascript-api/7.x/api-reference.html contains broken links to:
09:39:38 INFO:build_docs:   - en/elasticsearch/reference/7.x/security-api-query-api-key.html
09:39:38 INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/elasticsearch/client/javascript-api/current/api-reference.html contains broken links to:
09:39:38 INFO:build_docs:   - en/elasticsearch/reference/7.x/security-api-query-api-key.html
09:39:38 INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/elasticsearch/client/javascript-api/master/api-reference.html contains broken links to:
09:39:38 INFO:build_docs:   - en/elasticsearch/reference/master/security-api-query-api-key.html
09:39:51 runbld>>> <<<<<<<<<<<< SCRIPT EXECUTION END <<<<<<<<<<<<

It is related to a URL that was added to the rest api spec in https://github.com/elastic/elasticsearch/pull/76238, but which won't exist until https://github.com/elastic/elasticsearch/pull/76521 is merged.  This PR creates a stop-gap stub of that page.