### PR TITLE
Add utility for tracking licensed persistent tasks

### DIFF
--- a/server/src/main/java/org/elasticsearch/persistent/AllocatedPersistentTask.java
+++ b/server/src/main/java/org/elasticsearch/persistent/AllocatedPersistentTask.java
@@ -99,7 +99,7 @@ public class AllocatedPersistentTask extends CancellableTask {
         return state.get() == State.COMPLETED || state.get() == State.LOCAL_ABORTED;
     }
 
-    boolean markAsCancelled() {
+    protected boolean markAsCancelled() {
         return state.compareAndSet(State.STARTED, State.PENDING_CANCEL);
     }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/license/LicensedAllocatedPersistentTask.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/license/LicensedAllocatedPersistentTask.java
@@ -37,27 +37,43 @@ public class LicensedAllocatedPersistentTask extends AllocatedPersistentTask {
     }
 
     @Override
-    protected boolean markAsCancelled() {
+    protected final boolean markAsCancelled() {
         stopTracking();
+        return doMarkAsCancelled();
+    }
+
+    protected boolean doMarkAsCancelled() {
         return super.markAsCancelled();
     }
 
     @Override
-    public void markAsCompleted() {
+    public final void markAsCompleted() {
         stopTracking();
         super.markAsCompleted();
     }
 
-    @Override
-    public void markAsFailed(Exception e) {
-        stopTracking();
-        super.markAsFailed(e);
+    protected void doMarkAsCompleted() {
+        super.markAsCompleted();
     }
 
     @Override
-    public void markAsLocallyAborted(String localAbortReason) {
+    public final void markAsFailed(Exception e) {
         stopTracking();
-        super.markAsLocallyAborted(localAbortReason);
+        doMarkAsFailed(e);
+    }
+
+    protected boolean doMarkAsFailed(Exception e) {
+        return super.markAsFailed(e);
+    }
+
+    @Override
+    public final void markAsLocallyAborted(String localAbortReason) {
+        stopTracking();
+        doMarkAsLocallyAborted(localAbortReason);
+    }
+
+    protected boolean doMarkAsLocallyAborted(String localAbortReason) {
+        return super.markAsLocallyAborted(localAbortReason);
     }
 
     // this is only overridden so that tests can run it

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/license/LicensedAllocatedPersistentTask.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/license/LicensedAllocatedPersistentTask.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.license;
+
+import org.elasticsearch.persistent.AllocatedPersistentTask;
+import org.elasticsearch.persistent.PersistentTasksService;
+import org.elasticsearch.tasks.TaskId;
+import org.elasticsearch.tasks.TaskManager;
+
+import java.util.Map;
+
+/**
+ * An AllocatedPersistentTask which automatically tracks as a licensed feature usage.
+ */
+public class LicensedAllocatedPersistentTask extends AllocatedPersistentTask {
+    private final LicensedFeature.Persistent licensedFeature;
+    private final String featureContext;
+    private final XPackLicenseState licenseState;
+
+    public LicensedAllocatedPersistentTask(long id, String type, String action, String description, TaskId parentTask,
+                                           Map<String, String> headers, LicensedFeature.Persistent feature, String featureContext,
+                                           XPackLicenseState licenseState) {
+        super(id, type, action, description, parentTask, headers);
+        this.licensedFeature = feature;
+        this.featureContext = featureContext;
+        this.licenseState = licenseState;
+        licensedFeature.startTracking(licenseState, featureContext);
+    }
+
+    private void stopTracking() {
+        licensedFeature.stopTracking(licenseState, featureContext);
+    }
+
+    @Override
+    protected boolean markAsCancelled() {
+        stopTracking();
+        return super.markAsCancelled();
+    }
+
+    @Override
+    public void markAsCompleted() {
+        stopTracking();
+        super.markAsCompleted();
+    }
+
+    @Override
+    public void markAsFailed(Exception e) {
+        stopTracking();
+        super.markAsFailed(e);
+    }
+
+    @Override
+    public void markAsLocallyAborted(String localAbortReason) {
+        stopTracking();
+        super.markAsLocallyAborted(localAbortReason);
+    }
+
+    // this is only overridden so that tests can run it
+    @Override
+    protected void init(PersistentTasksService persistentTasksService, TaskManager taskManager,
+                        String persistentTaskId, long allocationId) {
+        super.init(persistentTasksService, taskManager, persistentTaskId, allocationId);
+    }
+}

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/license/LicensedAllocatedPersistentTask.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/license/LicensedAllocatedPersistentTask.java
@@ -62,8 +62,8 @@ public class LicensedAllocatedPersistentTask extends AllocatedPersistentTask {
         doMarkAsFailed(e);
     }
 
-    protected boolean doMarkAsFailed(Exception e) {
-        return super.markAsFailed(e);
+    protected void doMarkAsFailed(Exception e) {
+        super.markAsFailed(e);
     }
 
     @Override
@@ -72,13 +72,13 @@ public class LicensedAllocatedPersistentTask extends AllocatedPersistentTask {
         doMarkAsLocallyAborted(localAbortReason);
     }
 
-    protected boolean doMarkAsLocallyAborted(String localAbortReason) {
-        return super.markAsLocallyAborted(localAbortReason);
+    protected void doMarkAsLocallyAborted(String localAbortReason) {
+        super.markAsLocallyAborted(localAbortReason);
     }
 
-    // this is only overridden so that tests can run it
+    // this is made public for tests, and final to ensure it is not overridden with something that may throw
     @Override
-    protected void init(PersistentTasksService persistentTasksService, TaskManager taskManager,
+    public final void init(PersistentTasksService persistentTasksService, TaskManager taskManager,
                         String persistentTaskId, long allocationId) {
         super.init(persistentTasksService, taskManager, persistentTaskId, allocationId);
     }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/license/LicensedAllocatedPersistentTask.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/license/LicensedAllocatedPersistentTask.java
@@ -49,7 +49,7 @@ public class LicensedAllocatedPersistentTask extends AllocatedPersistentTask {
     @Override
     public final void markAsCompleted() {
         stopTracking();
-        super.markAsCompleted();
+        doMarkAsCompleted();
     }
 
     protected void doMarkAsCompleted() {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/license/LicensedFeature.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/license/LicensedFeature.java
@@ -51,11 +51,21 @@ public abstract class LicensedFeature {
          */
         public boolean checkAndStartTracking(XPackLicenseState state, String contextName) {
             if (state.isAllowed(this)) {
-                state.enableUsageTracking(this, contextName);
+                startTracking(state, contextName);
                 return true;
             } else {
                 return false;
             }
+        }
+
+        /**
+         * Starts tracking the feature.
+         *
+         * This is an alternative to {@link #checkAndStartTracking(XPackLicenseState, String)}
+         * where the license state has already been checked.
+         */
+        public void startTracking(XPackLicenseState state, String contextName) {
+            state.enableUsageTracking(this, contextName);
         }
 
         /**

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/license/LicensedAllocatedPersistentTaskTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/license/LicensedAllocatedPersistentTaskTests.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.license;
+
+import org.elasticsearch.persistent.AllocatedPersistentTask;
+import org.elasticsearch.persistent.PersistentTasksService;
+import org.elasticsearch.tasks.TaskId;
+import org.elasticsearch.tasks.TaskManager;
+import org.elasticsearch.test.ESTestCase;
+
+import java.util.Map;
+import java.util.function.Consumer;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+public class LicensedAllocatedPersistentTaskTests extends ESTestCase {
+
+    void assertTrackingComplete(Consumer<LicensedAllocatedPersistentTask> method) {
+        XPackLicenseState licenseState = mock(XPackLicenseState.class);
+        LicensedFeature.Persistent feature = LicensedFeature.persistent("somefeature", License.OperationMode.PLATINUM);
+        var task = new LicensedAllocatedPersistentTask(0, "type", "action", "description", TaskId.EMPTY_TASK_ID, Map.of(),
+            feature, "context", licenseState);
+        PersistentTasksService service = mock(PersistentTasksService.class);
+        TaskManager taskManager = mock(TaskManager.class);
+        task.init(service, taskManager, "id", 0);
+        verify(licenseState, times(1)).enableUsageTracking(feature, "context");
+        method.accept(task);
+        verify(licenseState, times(1)).disableUsageTracking(feature, "context");
+    }
+
+    public void testCompleted() {
+        assertTrackingComplete(LicensedAllocatedPersistentTask::markAsCompleted);
+    }
+
+    public void testCancelled() {
+        assertTrackingComplete(LicensedAllocatedPersistentTask::markAsCancelled);
+    }
+
+    public void testFailed() {
+        assertTrackingComplete(t -> t.markAsFailed(null));
+    }
+
+    public void testLocallyAborted() {
+        assertTrackingComplete(t -> t.markAsLocallyAborted("reason"));
+    }
+}

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/license/LicensedAllocatedPersistentTaskTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/license/LicensedAllocatedPersistentTaskTests.java
@@ -7,7 +7,6 @@
 
 package org.elasticsearch.license;
 
-import org.elasticsearch.persistent.AllocatedPersistentTask;
 import org.elasticsearch.persistent.PersistentTasksService;
 import org.elasticsearch.tasks.TaskId;
 import org.elasticsearch.tasks.TaskManager;

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/license/LicensedAllocatedPersistentTaskTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/license/LicensedAllocatedPersistentTaskTests.java
@@ -25,7 +25,7 @@ public class LicensedAllocatedPersistentTaskTests extends ESTestCase {
 
     void assertTrackingComplete(Consumer<LicensedAllocatedPersistentTask> method) {
         XPackLicenseState licenseState = mock(XPackLicenseState.class);
-        LicensedFeature.Persistent feature = LicensedFeature.persistent("somefeature", License.OperationMode.PLATINUM);
+        LicensedFeature.Persistent feature = LicensedFeature.persistent("family", "somefeature", License.OperationMode.PLATINUM);
         var task = new LicensedAllocatedPersistentTask(0, "type", "action", "description", TaskId.EMPTY_TASK_ID, Map.of(),
             feature, "context", licenseState);
         PersistentTasksService service = mock(PersistentTasksService.class);
@@ -54,7 +54,7 @@ public class LicensedAllocatedPersistentTaskTests extends ESTestCase {
 
     public void testDoOverrides() {
         XPackLicenseState licenseState = mock(XPackLicenseState.class);
-        LicensedFeature.Persistent feature = LicensedFeature.persistent("somefeature", License.OperationMode.PLATINUM);
+        LicensedFeature.Persistent feature = LicensedFeature.persistent("family", "somefeature", License.OperationMode.PLATINUM);
 
         AtomicBoolean completedCalled = new AtomicBoolean();
         AtomicBoolean cancelledCalled = new AtomicBoolean();

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MachineLearning.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MachineLearning.java
@@ -53,6 +53,8 @@ import org.elasticsearch.indices.SystemIndexDescriptor;
 import org.elasticsearch.indices.analysis.AnalysisModule.AnalysisProvider;
 import org.elasticsearch.indices.breaker.BreakerSettings;
 import org.elasticsearch.ingest.Processor;
+import org.elasticsearch.license.License;
+import org.elasticsearch.license.LicensedFeature;
 import org.elasticsearch.license.XPackLicenseState;
 import org.elasticsearch.monitor.jvm.JvmInfo;
 import org.elasticsearch.monitor.os.OsProbe;
@@ -440,6 +442,9 @@ public class MachineLearning extends Plugin implements SystemIndexPlugin,
     // This is for performance testing.  It's not exposed to the end user.
     // Recompile if you want to compare performance with C++ tokenization.
     public static final boolean CATEGORIZATION_TOKENIZATION_IN_JAVA = true;
+
+    public static final LicensedFeature.Persistent ML_JOBS_FEATURE =
+        LicensedFeature.persistent("machine-learning-job", License.OperationMode.PLATINUM);
 
     @Override
     public Map<String, Processor.Factory> getProcessors(Processor.Parameters parameters) {
@@ -942,7 +947,8 @@ public class MachineLearning extends Plugin implements SystemIndexPlugin,
                     datafeedConfigProvider.get(),
                     memoryTracker.get(),
                     client,
-                    expressionResolver),
+                    expressionResolver,
+                    getLicenseState()),
                 new TransportStartDatafeedAction.StartDatafeedPersistentTasksExecutor(datafeedRunner.get(), expressionResolver),
                 new TransportStartDataFrameAnalyticsAction.TaskExecutor(settings,
                     client,

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MachineLearning.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MachineLearning.java
@@ -444,7 +444,7 @@ public class MachineLearning extends Plugin implements SystemIndexPlugin,
     public static final boolean CATEGORIZATION_TOKENIZATION_IN_JAVA = true;
 
     public static final LicensedFeature.Persistent ML_JOBS_FEATURE =
-        LicensedFeature.persistent("machine-learning-job", License.OperationMode.PLATINUM);
+        LicensedFeature.persistent("machine-learning-anomaly-detection-job", License.OperationMode.PLATINUM);
 
     @Override
     public Map<String, Processor.Factory> getProcessors(Processor.Parameters parameters) {

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MachineLearning.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MachineLearning.java
@@ -444,7 +444,7 @@ public class MachineLearning extends Plugin implements SystemIndexPlugin,
     public static final boolean CATEGORIZATION_TOKENIZATION_IN_JAVA = true;
 
     public static final LicensedFeature.Persistent ML_JOBS_FEATURE =
-        LicensedFeature.persistent("machine-learning-anomaly-detection-job", License.OperationMode.PLATINUM);
+        LicensedFeature.persistent("machine-learning", "anomaly-detection-job", License.OperationMode.PLATINUM);
 
     @Override
     public Map<String, Processor.Factory> getProcessors(Processor.Parameters parameters) {

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/task/JobTask.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/task/JobTask.java
@@ -35,7 +35,7 @@ public class JobTask extends LicensedAllocatedPersistentTask implements OpenJobA
     private final AtomicReference<ClosingOrVacating> closingOrVacating = new AtomicReference<>(ClosingOrVacating.NEITHER);
     private volatile AutodetectProcessManager autodetectProcessManager;
 
-    JobTask(String jobId, long id, String type, String action, TaskId parentTask, Map<String, String> headers,
+    protected JobTask(String jobId, long id, String type, String action, TaskId parentTask, Map<String, String> headers,
             XPackLicenseState licenseState) {
         super(id, type, action, "job-" + jobId, parentTask, headers, MachineLearning.ML_JOBS_FEATURE, "job-" + jobId, licenseState);
         this.jobId = jobId;

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/task/JobTask.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/task/JobTask.java
@@ -12,7 +12,6 @@ import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.elasticsearch.license.LicensedAllocatedPersistentTask;
 import org.elasticsearch.license.XPackLicenseState;
-import org.elasticsearch.persistent.AllocatedPersistentTask;
 import org.elasticsearch.tasks.TaskId;
 import org.elasticsearch.xpack.core.ml.action.OpenJobAction;
 import org.elasticsearch.xpack.ml.MachineLearning;

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/task/JobTask.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/task/JobTask.java
@@ -10,15 +10,18 @@ package org.elasticsearch.xpack.ml.job.task;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.message.ParameterizedMessage;
+import org.elasticsearch.license.LicensedAllocatedPersistentTask;
+import org.elasticsearch.license.XPackLicenseState;
 import org.elasticsearch.persistent.AllocatedPersistentTask;
 import org.elasticsearch.tasks.TaskId;
 import org.elasticsearch.xpack.core.ml.action.OpenJobAction;
+import org.elasticsearch.xpack.ml.MachineLearning;
 import org.elasticsearch.xpack.ml.job.process.autodetect.AutodetectProcessManager;
 
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
 
-public class JobTask extends AllocatedPersistentTask implements OpenJobAction.JobTaskMatcher {
+public class JobTask extends LicensedAllocatedPersistentTask implements OpenJobAction.JobTaskMatcher {
 
     /**
      * We should only progress forwards through these states: close takes precedence over vacate
@@ -33,8 +36,9 @@ public class JobTask extends AllocatedPersistentTask implements OpenJobAction.Jo
     private final AtomicReference<ClosingOrVacating> closingOrVacating = new AtomicReference<>(ClosingOrVacating.NEITHER);
     private volatile AutodetectProcessManager autodetectProcessManager;
 
-    JobTask(String jobId, long id, String type, String action, TaskId parentTask, Map<String, String> headers) {
-        super(id, type, action, "job-" + jobId, parentTask, headers);
+    JobTask(String jobId, long id, String type, String action, TaskId parentTask, Map<String, String> headers,
+            XPackLicenseState licenseState) {
+        super(id, type, action, "job-" + jobId, parentTask, headers, MachineLearning.ML_JOBS_FEATURE, "job-" + jobId, licenseState);
         this.jobId = jobId;
     }
 

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/process/autodetect/AutodetectProcessManagerTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/process/autodetect/AutodetectProcessManagerTests.java
@@ -28,6 +28,10 @@ import org.elasticsearch.env.Environment;
 import org.elasticsearch.env.TestEnvironment;
 import org.elasticsearch.index.analysis.AnalysisRegistry;
 import org.elasticsearch.indices.TestIndexNameExpressionResolver;
+import org.elasticsearch.license.XPackLicenseState;
+import org.elasticsearch.persistent.PersistentTasksService;
+import org.elasticsearch.tasks.TaskId;
+import org.elasticsearch.tasks.TaskManager;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.xpack.core.ml.annotations.AnnotationIndex;
@@ -74,12 +78,14 @@ import java.util.Collections;
 import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiConsumer;
@@ -579,12 +585,19 @@ public class AutodetectProcessManagerTests extends ESTestCase {
 
     public void testKillingAMissingJobFinishesTheTask() {
         AutodetectProcessManager manager = createSpyManager();
-        JobTask jobTask = mock(JobTask.class);
-        when(jobTask.getJobId()).thenReturn("foo");
+        XPackLicenseState licenseState = mock(XPackLicenseState.class);
+        AtomicBoolean markCalled = new AtomicBoolean();
+        JobTask jobTask = new JobTask("foo", 0, "type", "action", TaskId.EMPTY_TASK_ID, Map.of(), licenseState) {
+            @Override
+            protected void doMarkAsCompleted() {
+                markCalled.set(true);
+            }
+        };
+        jobTask.init(mock(PersistentTasksService.class), mock(TaskManager.class), "taskid", 0);
 
         manager.killProcess(jobTask, false, null);
 
-        verify(jobTask).markAsCompleted();
+        assertThat(markCalled.get(), is(true));
     }
 
     public void testProcessData_GivenStateNotOpened() {

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/task/JobTaskTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/task/JobTaskTests.java
@@ -7,6 +7,7 @@
 
 package org.elasticsearch.xpack.ml.job.task;
 
+import org.elasticsearch.license.XPackLicenseState;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.core.ml.action.OpenJobAction;
@@ -18,11 +19,13 @@ import static org.mockito.Mockito.verify;
 
 public class JobTaskTests extends ESTestCase {
 
+    XPackLicenseState licenseState = mock(XPackLicenseState.class);
+
     public void testJobTaskMatcherMatch() {
         Task nonJobTask1 = mock(Task.class);
         Task nonJobTask2 = mock(Task.class);
-        JobTask jobTask1 = new JobTask("ml-1", 0, "persistent", "", null, null);
-        JobTask jobTask2 = new JobTask("ml-2", 1, "persistent", "", null, null);
+        JobTask jobTask1 = new JobTask("ml-1", 0, "persistent", "", null, null, licenseState);
+        JobTask jobTask2 = new JobTask("ml-2", 1, "persistent", "", null, null, licenseState);
 
         assertThat(OpenJobAction.JobTaskMatcher.match(nonJobTask1, "_all"), is(false));
         assertThat(OpenJobAction.JobTaskMatcher.match(nonJobTask2, "_all"), is(false));
@@ -35,7 +38,7 @@ public class JobTaskTests extends ESTestCase {
     }
 
     public void testKillJob() {
-        JobTask jobTask = new JobTask("job-to-kill", 0, "persistent", "", null, null);
+        JobTask jobTask = new JobTask("job-to-kill", 0, "persistent", "", null, null, licenseState);
         AutodetectProcessManager processManager = mock(AutodetectProcessManager.class);
         jobTask.setAutodetectProcessManager(processManager);
 
@@ -47,7 +50,7 @@ public class JobTaskTests extends ESTestCase {
 
     public void testCloseOrVacateTransitions() {
 
-        JobTask jobTask = new JobTask("transition-test-task", 0, "persistent", "", null, null);
+        JobTask jobTask = new JobTask("transition-test-task", 0, "persistent", "", null, null, licenseState);
 
         assertThat(jobTask.isClosing(), is(false));
         assertThat(jobTask.isVacating(), is(false));

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/task/OpenJobPersistentTasksExecutorTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/task/OpenJobPersistentTasksExecutorTests.java
@@ -32,6 +32,7 @@ import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.indices.TestIndexNameExpressionResolver;
+import org.elasticsearch.license.XPackLicenseState;
 import org.elasticsearch.persistent.PersistentTasksCustomMetadata;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.test.ESTestCase;
@@ -82,6 +83,7 @@ public class OpenJobPersistentTasksExecutorTests extends ESTestCase {
     private DatafeedConfigProvider datafeedConfigProvider;
     private Client client;
     private MlMemoryTracker mlMemoryTracker;
+    private XPackLicenseState licenseState;
 
     @Before
     public void setUpMocks() {
@@ -105,6 +107,7 @@ public class OpenJobPersistentTasksExecutorTests extends ESTestCase {
         datafeedConfigProvider = mock(DatafeedConfigProvider.class);
         client = mock(Client.class);
         mlMemoryTracker = mock(MlMemoryTracker.class);
+        licenseState = mock(XPackLicenseState.class);
     }
 
     public void testValidate_jobMissing() {
@@ -269,6 +272,6 @@ public class OpenJobPersistentTasksExecutorTests extends ESTestCase {
     private OpenJobPersistentTasksExecutor createExecutor(Settings settings) {
         return new OpenJobPersistentTasksExecutor(
             settings, clusterService, autodetectProcessManager, datafeedConfigProvider, mlMemoryTracker, client,
-            TestIndexNameExpressionResolver.newInstance());
+            TestIndexNameExpressionResolver.newInstance(), licenseState);
     }
 }


### PR DESCRIPTION
Licensed feature tracking of long running features happens now by
starting and stopping the tracking of a feature. This commit adds an
intermediate base class to be used by features that utilize persistent
tasks. The base class only requires specifying the feature and context,
and then any tasks created automatically are tracked. An example using
marchine learning's JobTask is also added here, using a new machine
learning job feature object.