### PR TITLE
Fix alias resolution in match query with synonyms

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/search/MatchQueryParser.java
+++ b/server/src/main/java/org/elasticsearch/index/search/MatchQueryParser.java
@@ -248,9 +248,9 @@ public class MatchQueryParser {
         switch (type) {
             case BOOLEAN:
                 if (commonTermsCutoff == null) {
-                    query = builder.createBooleanQuery(fieldName, value.toString(), occur);
+                    query = builder.createBooleanQuery(resolvedFieldName, value.toString(), occur);
                 } else {
-                    query = createCommonTermsQuery(builder, fieldName, value.toString(), occur, occur, commonTermsCutoff);
+                    query = createCommonTermsQuery(builder, resolvedFieldName, value.toString(), occur, occur, commonTermsCutoff);
                 }
                 break;
             case BOOLEAN_PREFIX:

--- a/server/src/test/java/org/elasticsearch/index/query/MatchQueryBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/MatchQueryBuilderTests.java
@@ -44,6 +44,7 @@ import org.hamcrest.Matchers;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
@@ -488,16 +489,18 @@ public class MatchQueryBuilderTests extends AbstractQueryTestCase<MatchQueryBuil
         assertEquals(expected, actual);
     }
 
-
     public void testAliasWithSynonyms() throws Exception {
-        final MatchQueryParser matchQueryParser = new MatchQueryParser(createSearchExecutionContext());
+        MatchQueryParser matchQueryParser = new MatchQueryParser(createSearchExecutionContext());
         matchQueryParser.setAnalyzer(new MockSynonymAnalyzer());
-        final Query actual = matchQueryParser.parse(Type.PHRASE, TEXT_ALIAS_FIELD_NAME, "dogs");
-        Query expected = new SynonymQuery.Builder(TEXT_FIELD_NAME)
-            .addTerm(new Term(TEXT_FIELD_NAME, "dogs"))
-            .addTerm(new Term(TEXT_FIELD_NAME, "dog"))
-            .build();
-        assertEquals(expected, actual);
+
+        for (Type type : Arrays.asList(Type.BOOLEAN, Type.PHRASE)) {
+            Query actual = matchQueryParser.parse(type, TEXT_ALIAS_FIELD_NAME, "dogs");
+            Query expected = new SynonymQuery.Builder(TEXT_FIELD_NAME)
+                .addTerm(new Term(TEXT_FIELD_NAME, "dogs"))
+                .addTerm(new Term(TEXT_FIELD_NAME, "dog"))
+                .build();
+            assertEquals(expected, actual);
+        }
     }
 
     public void testMaxBooleanClause() {


### PR DESCRIPTION
When backporting #68795, we introduced a regression around `match` queries on
field aliases. If the `match` query parses to a `synonym` query (because its
analyzer can produce multiple tokens at a single position), then we don't
resolve the field alias to its concrete field. This means the query will not
have any results.

We already had a test for this case but it was too narrow. Note this regression
only affects 7.x, there is no bug on master.