### PR TITLE
Ensure `tar` is present in Docker image

### DIFF
--- a/distribution/docker/src/docker/Dockerfile
+++ b/distribution/docker/src/docker/Dockerfile
@@ -98,7 +98,7 @@ RUN mkdir -m 755 /rootfs/dev && \\
 # Install a minimal set of dependencies, and some for Elasticsearch
 RUN ${package_manager} --installroot=/rootfs --releasever=/ --setopt=tsflags=nodocs \\
       --setopt=group_package_types=mandatory -y  \\
-      install bash curl findutils nc procps-ng shadow-utils unzip yum zip
+      install bash curl findutils nc procps-ng shadow-utils tar unzip yum zip
 
 # `tini` is a tiny but valid init for containers. This is used to cleanly
 # control how ES and any child processes are shut down.

--- a/qa/os/src/test/java/org/elasticsearch/packaging/util/Docker.java
+++ b/qa/os/src/test/java/org/elasticsearch/packaging/util/Docker.java
@@ -466,8 +466,9 @@ public class Docker {
         assertThat(dockerShell.run(es.bin("elasticsearch-keystore") + " list").stdout, containsString("keystore.seed"));
 
         // nc is useful for checking network issues
+        // tar is required in some k8s situations: https://github.com/kubernetes/kubernetes/issues/58512
         // zip/unzip are installed to help users who are working with certificates.
-        Stream.of("nc", "unzip", "zip")
+        Stream.of("nc", "tar", "unzip", "zip")
             .forEach(
                 cliBinary -> assertTrue(
                     cliBinary + " ought to be available.",


### PR DESCRIPTION
Closes #76695.

Due to a Kubernetes quirk, we need to ensure that the `tar` CLI tool is
present in the Docker image. It was removed in #75079 because we
reworked how the image was built, and anything not explicitly installed
was left out.