### PR TITLE
Remove redundant enrich processor constructors

### DIFF
--- a/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/AbstractEnrichProcessor.java
+++ b/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/AbstractEnrichProcessor.java
@@ -6,11 +6,8 @@
  */
 package org.elasticsearch.xpack.enrich;
 
-import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.search.SearchResponse;
-import org.elasticsearch.client.Client;
-import org.elasticsearch.client.OriginSettingClient;
 import org.elasticsearch.cluster.routing.Preference;
 import org.elasticsearch.index.query.ConstantScoreQueryBuilder;
 import org.elasticsearch.index.query.QueryBuilder;
@@ -20,14 +17,11 @@ import org.elasticsearch.script.TemplateScript;
 import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
 import org.elasticsearch.xpack.core.enrich.EnrichPolicy;
-import org.elasticsearch.xpack.enrich.action.EnrichCoordinatorProxyAction;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.function.BiConsumer;
-
-import static org.elasticsearch.xpack.core.ClientHelper.ENRICH_ORIGIN;
 
 public abstract class AbstractEnrichProcessor extends AbstractProcessor {
 
@@ -39,32 +33,6 @@ public abstract class AbstractEnrichProcessor extends AbstractProcessor {
     private final boolean overrideEnabled;
     protected final String matchField;
     protected final int maxMatches;
-
-    protected AbstractEnrichProcessor(
-        String tag,
-        String description,
-        Client client,
-        String policyName,
-        TemplateScript.Factory field,
-        TemplateScript.Factory targetField,
-        boolean ignoreMissing,
-        boolean overrideEnabled,
-        String matchField,
-        int maxMatches
-    ) {
-        this(
-            tag,
-            description,
-            createSearchRunner(client),
-            policyName,
-            field,
-            targetField,
-            ignoreMissing,
-            overrideEnabled,
-            matchField,
-            maxMatches
-        );
-    }
 
     protected AbstractEnrichProcessor(
         String tag,
@@ -191,14 +159,4 @@ public abstract class AbstractEnrichProcessor extends AbstractProcessor {
         return maxMatches;
     }
 
-    private static BiConsumer<SearchRequest, BiConsumer<SearchResponse, Exception>> createSearchRunner(Client client) {
-        Client originClient = new OriginSettingClient(client, ENRICH_ORIGIN);
-        return (req, handler) -> {
-            originClient.execute(
-                EnrichCoordinatorProxyAction.INSTANCE,
-                req,
-                ActionListener.wrap(resp -> { handler.accept(resp, null); }, e -> { handler.accept(null, e); })
-            );
-        };
-    }
 }

--- a/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/EnrichProcessorFactory.java
+++ b/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/EnrichProcessorFactory.java
@@ -6,7 +6,11 @@
  */
 package org.elasticsearch.xpack.enrich;
 
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.search.SearchRequest;
+import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.client.Client;
+import org.elasticsearch.client.OriginSettingClient;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.IndexAbstraction;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
@@ -19,9 +23,13 @@ import org.elasticsearch.ingest.Processor;
 import org.elasticsearch.script.ScriptService;
 import org.elasticsearch.script.TemplateScript;
 import org.elasticsearch.xpack.core.enrich.EnrichPolicy;
+import org.elasticsearch.xpack.enrich.action.EnrichCoordinatorProxyAction;
 
 import java.util.Map;
+import java.util.function.BiConsumer;
 import java.util.function.Consumer;
+
+import static org.elasticsearch.xpack.core.ClientHelper.ENRICH_ORIGIN;
 
 final class EnrichProcessorFactory implements Processor.Factory, Consumer<ClusterState> {
 
@@ -67,13 +75,13 @@ final class EnrichProcessorFactory implements Processor.Factory, Consumer<Cluste
         if (maxMatches < 1 || maxMatches > 128) {
             throw ConfigurationUtils.newConfigurationException(TYPE, tag, "max_matches", "should be between 1 and 128");
         }
-
+        BiConsumer<SearchRequest, BiConsumer<SearchResponse, Exception>> searchRunner = createSearchRunner(client);
         switch (policyType) {
             case EnrichPolicy.MATCH_TYPE:
                 return new MatchProcessor(
                     tag,
                     description,
-                    client,
+                    searchRunner,
                     policyName,
                     field,
                     targetField,
@@ -90,7 +98,7 @@ final class EnrichProcessorFactory implements Processor.Factory, Consumer<Cluste
                 return new GeoMatchProcessor(
                     tag,
                     description,
-                    client,
+                    searchRunner,
                     policyName,
                     field,
                     targetField,
@@ -111,4 +119,14 @@ final class EnrichProcessorFactory implements Processor.Factory, Consumer<Cluste
         metadata = state.getMetadata();
     }
 
+    private static BiConsumer<SearchRequest, BiConsumer<SearchResponse, Exception>> createSearchRunner(Client client) {
+        Client originClient = new OriginSettingClient(client, ENRICH_ORIGIN);
+        return (req, handler) -> {
+            originClient.execute(
+                EnrichCoordinatorProxyAction.INSTANCE,
+                req,
+                ActionListener.wrap(resp -> { handler.accept(resp, null); }, e -> { handler.accept(null, e); })
+            );
+        };
+    }
 }

--- a/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/GeoMatchProcessor.java
+++ b/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/GeoMatchProcessor.java
@@ -8,7 +8,6 @@ package org.elasticsearch.xpack.enrich;
 
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.search.SearchResponse;
-import org.elasticsearch.client.Client;
 import org.elasticsearch.common.geo.GeometryParser;
 import org.elasticsearch.common.geo.Orientation;
 import org.elasticsearch.common.geo.ShapeRelation;
@@ -24,26 +23,6 @@ public final class GeoMatchProcessor extends AbstractEnrichProcessor {
     private final ShapeRelation shapeRelation;
     private final GeometryParser parser;
 
-    GeoMatchProcessor(
-        String tag,
-        String description,
-        Client client,
-        String policyName,
-        TemplateScript.Factory field,
-        TemplateScript.Factory targetField,
-        boolean overrideEnabled,
-        boolean ignoreMissing,
-        String matchField,
-        int maxMatches,
-        ShapeRelation shapeRelation,
-        Orientation orientation
-    ) {
-        super(tag, description, client, policyName, field, targetField, ignoreMissing, overrideEnabled, matchField, maxMatches);
-        this.shapeRelation = shapeRelation;
-        parser = new GeometryParser(orientation.getAsBoolean(), true, true);
-    }
-
-    /** used in tests **/
     GeoMatchProcessor(
         String tag,
         String description,

--- a/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/MatchProcessor.java
+++ b/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/MatchProcessor.java
@@ -8,7 +8,6 @@ package org.elasticsearch.xpack.enrich;
 
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.search.SearchResponse;
-import org.elasticsearch.client.Client;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.index.query.TermQueryBuilder;
 import org.elasticsearch.index.query.TermsQueryBuilder;
@@ -19,22 +18,6 @@ import java.util.function.BiConsumer;
 
 public final class MatchProcessor extends AbstractEnrichProcessor {
 
-    MatchProcessor(
-        String tag,
-        String description,
-        Client client,
-        String policyName,
-        TemplateScript.Factory field,
-        TemplateScript.Factory targetField,
-        boolean overrideEnabled,
-        boolean ignoreMissing,
-        String matchField,
-        int maxMatches
-    ) {
-        super(tag, description, client, policyName, field, targetField, ignoreMissing, overrideEnabled, matchField, maxMatches);
-    }
-
-    /** used in tests **/
     MatchProcessor(
         String tag,
         String description,


### PR DESCRIPTION
By creating the search running in the processor factory
3 constructors are no longer needed.