### PR TITLE
Fix spotless gradle config

### DIFF
--- a/build-tools-internal/src/main/groovy/elasticsearch.formatting.gradle
+++ b/build-tools-internal/src/main/groovy/elasticsearch.formatting.gradle
@@ -199,52 +199,49 @@ def projectPathsToExclude = [
 
 subprojects {
   plugins.withType(ElasticsearchJavaPlugin).whenPluginAdded {
-    project.apply plugin: "com.diffplug.spotless"
+    if (projectPathsToExclude.contains(project.path) == false) {
+      project.apply plugin: "com.diffplug.spotless"
 
-    spotless {
-      java {
-        if (project.path == ':server') {
-          target 'src/*/java/org/elasticsearch/action/admin/cluster/repositories/**/*.java',
-                 'src/*/java/org/elasticsearch/action/admin/cluster/snapshots/**/*.java',
-                 'src/*/java/org/elasticsearch/index/snapshots/**/*.java',
-                 'src/*/java/org/elasticsearch/repositories/**/*.java',
-                 'src/*/java/org/elasticsearch/snapshots/**/*.java'
+      spotless {
+        java {
+          if (project.path == ':server') {
+            target 'src/*/java/org/elasticsearch/action/admin/cluster/repositories/**/*.java',
+                   'src/*/java/org/elasticsearch/action/admin/cluster/snapshots/**/*.java',
+                   'src/*/java/org/elasticsearch/index/snapshots/**/*.java',
+                   'src/*/java/org/elasticsearch/repositories/**/*.java',
+                   'src/*/java/org/elasticsearch/snapshots/**/*.java'
 
-          targetExclude 'src/main/java/org/elasticsearch/search/aggregations/metrics/HyperLogLogPlusPlus.java'
-        } else {
-          // Normally this isn't necessary, but we have Java sources in
-          // non-standard places
-          target 'src/**/*.java'
-        }
+            targetExclude 'src/main/java/org/elasticsearch/search/aggregations/metrics/HyperLogLogPlusPlus.java'
+          } else {
+            // Normally this isn't necessary, but we have Java sources in
+            // non-standard places
+            target 'src/**/*.java'
+          }
 
-        toggleOffOn('@formatter:off', '@formatter:on') // use `@formatter:off` and `@formatter:on` to toggle formatting - ONLY IF STRICTLY NECESSARY
-        removeUnusedImports()
-        importOrderFile rootProject.file('build-tools-internal/elastic.importorder')
-        eclipse().configFile rootProject.file('build-tools-internal/formatterConfig.xml')
-        trimTrailingWhitespace()
+          toggleOffOn('@formatter:off', '@formatter:on') // use `@formatter:off` and `@formatter:on` to toggle formatting - ONLY IF STRICTLY NECESSARY
+          removeUnusedImports()
+          importOrderFile rootProject.file('build-tools-internal/elastic.importorder')
+          eclipse().configFile rootProject.file('build-tools-internal/formatterConfig.xml')
+          trimTrailingWhitespace()
 
-        // Sometimes Spotless will report a "misbehaving rule which can't make up its
-        // mind" and will recommend enabling the `paddedCell()` setting. If you
-        // enabled this setting and run the format check again,
-        // Spotless will write files to
-        // `$PROJECT/build/spotless-diagnose-java/` to aid diagnosis. It writes
-        // different copies of the formatted files, so that you can see how they
-        // differ and infer what is the problem.
+          // Sometimes Spotless will report a "misbehaving rule which can't make up its
+          // mind" and will recommend enabling the `paddedCell()` setting. If you
+          // enabled this setting and run the format check again,
+          // Spotless will write files to
+          // `$PROJECT/build/spotless-diagnose-java/` to aid diagnosis. It writes
+          // different copies of the formatted files, so that you can see how they
+          // differ and infer what is the problem.
 
-        // The `paddedCell()` option is disabled for normal operation so that any
-        // misbehaviour is detected, and not just suppressed. You can enabled the
-        // option from the command line by running Gradle with `-Dspotless.paddedcell`.
-        if (providers.systemProperty('spotless.paddedcell').forUseAtConfigurationTime().isPresent()) {
-          paddedCell()
+          // The `paddedCell()` option is disabled for normal operation so that any
+          // misbehaviour is detected, and not just suppressed. You can enabled the
+          // option from the command line by running Gradle with `-Dspotless.paddedcell`.
+          if (providers.systemProperty('spotless.paddedcell').forUseAtConfigurationTime().isPresent()) {
+            paddedCell()
+          }
         }
       }
-    }
 
-    if (projectPathsToExclude.contains(project.path)) {
-      tasks.named('spotlessJavaCheck').configure { enabled = false }
-      tasks.named('spotlessApply').configure { enabled = false }
+      tasks.named("precommit").configure { dependsOn 'spotlessJavaCheck' }
     }
-
-    tasks.named("precommit").configure { dependsOn 'spotlessJavaCheck' }
   }
 }

--- a/modules/lang-painless/build.gradle
+++ b/modules/lang-painless/build.gradle
@@ -171,9 +171,11 @@ String grammarPath = 'src/main/antlr'
 // need to customize the spotless config below.
 String outputPath = 'src/main/java/org/elasticsearch/painless/antlr'
 
-spotless {
-  java {
-    targetExclude "${outputPath}/*.java"
+pluginManager.withPlugin('com.diffplug.spotless') {
+  spotless {
+    java {
+      targetExclude "${outputPath}/*.java"
+    }
   }
 }
 

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -85,13 +85,6 @@ dependencies {
 
 }
 
-spotless {
-  java {
-    // Contains large data tables that do not format well.
-    targetExclude 'src/main/java/org/elasticsearch/search/aggregations/metrics/HyperLogLogPlusPlus.java'
-  }
-}
-
 tasks.named("forbiddenPatterns").configure {
     exclude '**/*.json'
     exclude '**/*.jmx'

--- a/x-pack/plugin/eql/build.gradle
+++ b/x-pack/plugin/eql/build.gradle
@@ -57,9 +57,11 @@ dependencies {
 String grammarPath = 'src/main/antlr'
 String outputPath = 'src/main/java/org/elasticsearch/xpack/eql/parser'
 
-spotless {
-  java {
-    targetExclude "${outputPath}/*.java"
+pluginManager.withPlugin('com.diffplug.spotless') {
+  spotless {
+    java {
+      targetExclude "${outputPath}/*.java"
+    }
   }
 }
 

--- a/x-pack/plugin/sql/build.gradle
+++ b/x-pack/plugin/sql/build.gradle
@@ -71,9 +71,11 @@ dependencies {
 String grammarPath = 'src/main/antlr'
 String outputPath = 'src/main/java/org/elasticsearch/xpack/sql/parser'
 
-spotless {
-  java {
-    targetExclude "${outputPath}/*.java"
+pluginManager.withPlugin('com.diffplug.spotless') {
+  spotless {
+    java {
+      targetExclude "${outputPath}/*.java"
+    }
   }
 }
 


### PR DESCRIPTION
An attempt to apply the spotless plugin everywhere and then disable
where it wasn't appropriate didn't work, and instead everything was
formatted. Revert how we apply the plugin, and use a different approach
to applying extra configuration in build files.
