### PR TITLE
[7.15] [DOCS] EQL: Remove multi-value field limitation (#76663)

### DIFF
--- a/docs/reference/eql/syntax.asciidoc
+++ b/docs/reference/eql/syntax.asciidoc
@@ -820,14 +820,6 @@ use the EQL search API's <<eql-search-filter-query-dsl,Query DSL `filter`>>
 parameter.
 
 [discrete]
-[[eql-array-fields]]
-==== Array field values are not supported
-
-EQL does not support <<array,array>> field values, also known as
-_multi-value fields_. EQL searches on array field values may return inconsistent
-results.
-
-[discrete]
 [[eql-nested-fields]]
 ==== EQL search on nested fields
 


### PR DESCRIPTION
Backports the following commits to 7.15:
 - [DOCS] EQL: Remove multi-value field limitation (#76663)