### PR TITLE
[7.x] [DOCS] Fixes model_prune_window property description. (#76711)

### DIFF
--- a/docs/reference/ml/ml-shared.asciidoc
+++ b/docs/reference/ml/ml-shared.asciidoc
@@ -1235,8 +1235,7 @@ Affects the pruning of models that have not been updated for the given time
 duration. The value must be set to a multiple of the `bucket_span`. If set too 
 low, important information may be removed from the model. Typically, set to 
 `30d` or longer. If not set, model pruning only occurs if the model memory 
-status reaches the soft limit (`model_memory_limit`) or the hard limit 
-(`xpack.ml.max_model_memory_limit`).
+status reaches the soft limit or the hard limit.
 end::model-prune-window[]
 
 tag::model-snapshot-id[]


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [DOCS] Fixes model_prune_window property description. (#76711)