### PR TITLE
Add license family attribute to feature usage tracking (#76622)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -113,9 +113,9 @@ tasks.register("verifyVersions") {
  * after the backport of the backcompat code is complete.
  */
 
-boolean bwc_tests_enabled = true
+boolean bwc_tests_enabled = false
 // place a PR link here when committing bwc changes:
-String bwc_tests_disabled_issue = ""
+String bwc_tests_disabled_issue = "https://github.com/elastic/elasticsearch/pull/76622"
 /*
  * FIPS 140-2 behavior was fixed in 7.11.0. Before that there is no way to run elasticsearch in a
  * JVM that is properly configured to be in fips mode with BCFIPS. For now we need to disable

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/license/LicensedFeature.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/license/LicensedFeature.java
@@ -19,8 +19,8 @@ public abstract class LicensedFeature {
      */
     public static class Momentary extends LicensedFeature {
 
-        private Momentary(String name, License.OperationMode minimumOperationMode, boolean needsActive) {
-            super(name, minimumOperationMode, needsActive);
+        private Momentary(String family, String name, License.OperationMode minimumOperationMode, boolean needsActive) {
+            super(family, name, minimumOperationMode, needsActive);
         }
 
         /**
@@ -41,8 +41,8 @@ public abstract class LicensedFeature {
      * A Persistent feature is one that is tracked starting when the license is checked, and later may be untracked.
      */
     public static class Persistent extends LicensedFeature {
-        private Persistent(String name, License.OperationMode minimumOperationMode, boolean needsActive) {
-            super(name, minimumOperationMode, needsActive);
+        private Persistent(String family, String name, License.OperationMode minimumOperationMode, boolean needsActive) {
+            super(family, name, minimumOperationMode, needsActive);
         }
 
         /**
@@ -66,24 +66,26 @@ public abstract class LicensedFeature {
         }
     }
 
+    final String family;
     final String name;
     final License.OperationMode minimumOperationMode;
     final boolean needsActive;
 
-    public LicensedFeature(String name, License.OperationMode minimumOperationMode, boolean needsActive) {
+    protected LicensedFeature(String family, String name, License.OperationMode minimumOperationMode, boolean needsActive) {
+        this.family = family;
         this.name = name;
         this.minimumOperationMode = minimumOperationMode;
         this.needsActive = needsActive;
     }
 
     /** Create a momentary feature for hte given license level */
-    public static Momentary momentary(String name, License.OperationMode licenseLevel) {
-        return new Momentary(name, licenseLevel, true);
+    public static Momentary momentary(String family, String name, License.OperationMode licenseLevel) {
+        return new Momentary(family, name, licenseLevel, true);
     }
 
     /** Create a persistent feature for the given license level */
-    public static Persistent persistent(String name, License.OperationMode licenseLevel) {
-        return new Persistent(name, licenseLevel, true);
+    public static Persistent persistent(String family, String name, License.OperationMode licenseLevel) {
+        return new Persistent(family, name, licenseLevel, true);
     }
 
     /**
@@ -91,8 +93,8 @@ public abstract class LicensedFeature {
      * to whether the license needs to be active to allow the feature.
      */
     @Deprecated
-    public static Momentary momentaryLenient(String name, License.OperationMode licenseLevel) {
-        return new Momentary(name, licenseLevel, false);
+    public static Momentary momentaryLenient(String family, String name, License.OperationMode licenseLevel) {
+        return new Momentary(family, name, licenseLevel, false);
     }
 
     /**
@@ -100,8 +102,8 @@ public abstract class LicensedFeature {
      * to whether the license needs to be active to allow the feature.
      */
     @Deprecated
-    public static Persistent persistentLenient(String name, License.OperationMode licenseLevel) {
-        return new Persistent(name, licenseLevel, false);
+    public static Persistent persistentLenient(String family, String name, License.OperationMode licenseLevel) {
+        return new Persistent(family, name, licenseLevel, false);
     }
 
     /**

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/license/TransportGetFeatureUsageAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/license/TransportGetFeatureUsageAction.java
@@ -45,10 +45,11 @@ public class TransportGetFeatureUsageAction extends HandledTransportAction<GetFe
             ZonedDateTime lastUsedTime = Instant.ofEpochMilli(lastUsed).atZone(ZoneOffset.UTC);
             usageInfos.add(
                 new GetFeatureUsageResponse.FeatureUsageInfo(
-                    usage.featureName(),
+                    usage.feature().family,
+                    usage.feature().name,
                     lastUsedTime,
                     usage.contextName(),
-                    usage.minimumOperationMode().description()
+                    usage.feature().minimumOperationMode.description()
                 )
             );
         });

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/license/XPackLicenseState.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/license/XPackLicenseState.java
@@ -91,10 +91,11 @@ public class XPackLicenseState {
 
         Feature(OperationMode minimumOperationMode, boolean needsActive) {
             assert minimumOperationMode.compareTo(OperationMode.BASIC) > 0: minimumOperationMode.toString();
+            String name = name().toLowerCase(Locale.ROOT);
             if (needsActive) {
-                this.feature = LicensedFeature.momentary(name().toLowerCase(Locale.ROOT), minimumOperationMode);
+                this.feature = LicensedFeature.momentary(name, name, minimumOperationMode);
             } else {
-                this.feature = LicensedFeature.momentaryLenient(name().toLowerCase(Locale.ROOT), minimumOperationMode);
+                this.feature = LicensedFeature.momentaryLenient(name, name, minimumOperationMode);
             }
         }
     }
@@ -694,16 +695,12 @@ public class XPackLicenseState {
             return Objects.hash(feature, context);
         }
 
-        public String featureName() {
-            return feature.name;
+        public LicensedFeature feature() {
+            return feature;
         }
 
         public String contextName() {
             return context;
-        }
-
-        public OperationMode minimumOperationMode() {
-            return feature.minimumOperationMode;
         }
     }
 }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/license/GetFeatureUsageResponseTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/license/GetFeatureUsageResponseTests.java
@@ -17,7 +17,6 @@ import org.elasticsearch.test.VersionUtils;
 import java.io.IOException;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
-import java.util.List;
 
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/license/GetFeatureUsageResponseTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/license/GetFeatureUsageResponseTests.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.license;
+
+import org.elasticsearch.Version;
+import org.elasticsearch.common.io.stream.BytesStreamOutput;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.license.GetFeatureUsageResponse.FeatureUsageInfo;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.VersionUtils;
+
+import java.io.IOException;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.util.List;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
+
+public class GetFeatureUsageResponseTests extends ESTestCase {
+
+    public void assertStreamInputOutput(Version version, String family, String context) throws IOException {
+        ZonedDateTime zdt = ZonedDateTime.now();
+        FeatureUsageInfo fui = new FeatureUsageInfo(family, "feature", zdt, context, "gold");
+        GetFeatureUsageResponse originalResponse = new GetFeatureUsageResponse(List.of(fui));
+        BytesStreamOutput output = new BytesStreamOutput();
+        output.setVersion(version);
+        originalResponse.writeTo(output);
+
+        StreamInput input = output.bytes().streamInput();
+        input.setVersion(version);
+        GetFeatureUsageResponse finalResponse = new GetFeatureUsageResponse(input);
+        assertThat(finalResponse.getFeatures(), hasSize(1));
+        FeatureUsageInfo fui2 = finalResponse.getFeatures().get(0);
+        assertThat(fui2.family, equalTo(family));
+        assertThat(fui2.name, equalTo("feature"));
+        // time is truncated to nearest second
+        assertThat(fui2.lastUsedTime, equalTo(zdt.withZoneSameInstant(ZoneOffset.UTC).withNano(0)));
+        assertThat(fui2.context, equalTo(context));
+        assertThat(fui2.licenseLevel, equalTo("gold"));
+    }
+
+    public void testPre715StreamFormat() throws IOException {
+        assertStreamInputOutput(VersionUtils.getPreviousVersion(Version.V_7_15_0), null, null);
+    }
+
+    public void testStreamFormat() throws IOException {
+        assertStreamInputOutput(Version.CURRENT, "family", "context");
+        // family and context are optional
+        assertStreamInputOutput(Version.CURRENT, null, null);
+    }
+}

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/license/GetFeatureUsageResponseTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/license/GetFeatureUsageResponseTests.java
@@ -27,7 +27,7 @@ public class GetFeatureUsageResponseTests extends ESTestCase {
     public void assertStreamInputOutput(Version version, String family, String context) throws IOException {
         ZonedDateTime zdt = ZonedDateTime.now();
         FeatureUsageInfo fui = new FeatureUsageInfo(family, "feature", zdt, context, "gold");
-        GetFeatureUsageResponse originalResponse = new GetFeatureUsageResponse(List.of(fui));
+        GetFeatureUsageResponse originalResponse = new GetFeatureUsageResponse(org.elasticsearch.core.List.of(fui));
         BytesStreamOutput output = new BytesStreamOutput();
         output.setVersion(version);
         originalResponse.writeTo(output);

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/license/XPackLicenseStateTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/license/XPackLicenseStateTests.java
@@ -503,7 +503,7 @@ public class XPackLicenseStateTests extends ESTestCase {
     }
 
     public void testLastUsedMomentaryFeature() {
-        LicensedFeature.Momentary goldFeature = LicensedFeature.momentary("goldFeature", GOLD);
+        LicensedFeature.Momentary goldFeature = LicensedFeature.momentary("family", "goldFeature", GOLD);
         AtomicInteger currentTime = new AtomicInteger(100); // non zero start time
         XPackLicenseState licenseState = new XPackLicenseState(Settings.EMPTY, currentTime::get);
         Map<XPackLicenseState.FeatureUsage, Long> lastUsed = licenseState.getLastUsed();
@@ -518,7 +518,7 @@ public class XPackLicenseStateTests extends ESTestCase {
         assertThat("feature.check tracks usage", lastUsed, aMapWithSize(1));
 
         XPackLicenseState.FeatureUsage usage = Iterables.get(lastUsed.keySet(), 0);
-        assertThat(usage.featureName(), equalTo("goldFeature"));
+        assertThat(usage.feature().name, equalTo("goldFeature"));
         assertThat(usage.contextName(), nullValue());
         assertThat(lastUsed.get(usage), equalTo(100L));
 
@@ -530,7 +530,7 @@ public class XPackLicenseStateTests extends ESTestCase {
     }
 
     public void testLastUsedPersistentFeature() {
-        LicensedFeature.Persistent goldFeature = LicensedFeature.persistent("goldFeature", GOLD);
+        LicensedFeature.Persistent goldFeature = LicensedFeature.persistent("family", "goldFeature", GOLD);
         AtomicInteger currentTime = new AtomicInteger(100); // non zero start time
         XPackLicenseState licenseState = new XPackLicenseState(Settings.EMPTY, currentTime::get);
         Map<XPackLicenseState.FeatureUsage, Long> lastUsed = licenseState.getLastUsed();
@@ -546,7 +546,7 @@ public class XPackLicenseStateTests extends ESTestCase {
         assertThat(lastUsed, aMapWithSize(1));
 
         XPackLicenseState.FeatureUsage usage = Iterables.get(lastUsed.keySet(), 0);
-        assertThat(usage.featureName(), equalTo("goldFeature"));
+        assertThat(usage.feature().name, equalTo("goldFeature"));
         assertThat(usage.contextName(), equalTo("somecontext"));
         assertThat(lastUsed.get(usage), equalTo(200L));
 

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/Security.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/Security.java
@@ -347,17 +347,17 @@ public class Security extends Plugin implements SystemIndexPlugin, IngestPlugin,
 
     // TODO: ip filtering does not actually track license usage yet
     public static final LicensedFeature.Momentary IP_FILTERING_FEATURE =
-        LicensedFeature.momentaryLenient("security_ip_filtering", License.OperationMode.GOLD);
+        LicensedFeature.momentaryLenient(null, "security_ip_filtering", License.OperationMode.GOLD);
     public static final LicensedFeature.Momentary AUDITING_FEATURE =
-        LicensedFeature.momentaryLenient("security_auditing", License.OperationMode.GOLD);
+        LicensedFeature.momentaryLenient(null, "security_auditing", License.OperationMode.GOLD);
 
     // Builtin realms (file/native) realms are Basic licensed, so don't need to be checked or tracked
     // Standard realms (LDAP, AD, PKI, etc) are Gold+
     // SSO realms are Platinum+
     public static final LicensedFeature.Persistent STANDARD_REALMS_FEATURE =
-        LicensedFeature.persistentLenient("security_standard_realms", License.OperationMode.GOLD);
+        LicensedFeature.persistentLenient(null, "security_standard_realms", License.OperationMode.GOLD);
     public static final LicensedFeature.Persistent ALL_REALMS_FEATURE =
-        LicensedFeature.persistentLenient("security_all_realms", License.OperationMode.PLATINUM);
+        LicensedFeature.persistentLenient(null, "security_all_realms", License.OperationMode.PLATINUM);
 
     private static final Logger logger = LogManager.getLogger(Security.class);
 


### PR DESCRIPTION
The feature usage tracking data currently contains an opaque "name"
attribute which identifies the feature that was used. This name needs to
be unique enough that certain features can be identified independently
of others. For example, distinguishing machine learning jobs from
trained models. Yet both those examples are all "machine learning".

This commit adds a "family" attribute so that similar tracked features
can be grouped together. The output format of the feature usage api is
essentially the same; it is still a flat list of features and their last
used times. The family attribute can be used on the receiving end to
group many features.
