### PR TITLE
Introduce `ClusterStatePublicationEvent`

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/ClusterStatePublicationEvent.java
+++ b/server/src/main/java/org/elasticsearch/cluster/ClusterStatePublicationEvent.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.cluster;
+
+/**
+ * Represents a cluster state update computed by the {@link org.elasticsearch.cluster.service.MasterService} for publication to the cluster.
+ * If publication is successful then this creates a {@link ClusterChangedEvent} which is applied on every node.
+ */
+public class ClusterStatePublicationEvent {
+
+    private final String summary;
+    private final ClusterState oldState;
+    private final ClusterState newState;
+
+    public ClusterStatePublicationEvent(String summary, ClusterState oldState, ClusterState newState) {
+        this.summary = summary;
+        this.oldState = oldState;
+        this.newState = newState;
+    }
+
+    public String getSummary() {
+        return summary;
+    }
+
+    public ClusterState getOldState() {
+        return oldState;
+    }
+
+    public ClusterState getNewState() {
+        return newState;
+    }
+}

--- a/server/src/main/java/org/elasticsearch/cluster/ClusterStateTaskExecutor.java
+++ b/server/src/main/java/org/elasticsearch/cluster/ClusterStateTaskExecutor.java
@@ -33,10 +33,9 @@ public interface ClusterStateTaskExecutor<T> {
      *
      * Note that this method will be executed using system context.
      *
-     * @param clusterChangedEvent the change event for this cluster state change, containing
-     *                            both old and new states
+     * @param clusterStatePublicationEvent the change event for this cluster state publication, containing both old and new states
      */
-    default void clusterStatePublished(ClusterChangedEvent clusterChangedEvent) {
+    default void clusterStatePublished(ClusterStatePublicationEvent clusterStatePublicationEvent) {
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/cluster/ClusterStateUpdateTask.java
+++ b/server/src/main/java/org/elasticsearch/cluster/ClusterStateUpdateTask.java
@@ -70,7 +70,7 @@ public abstract class ClusterStateUpdateTask
     public abstract void onFailure(String source, Exception e);
 
     @Override
-    public final void clusterStatePublished(ClusterChangedEvent clusterChangedEvent) {
+    public final void clusterStatePublished(ClusterStatePublicationEvent clusterStatePublicationEvent) {
         // final, empty implementation here as this method should only be defined in combination
         // with a batching executor as it will always be executed within the system context.
     }

--- a/server/src/main/java/org/elasticsearch/cluster/action/shard/ShardStateAction.java
+++ b/server/src/main/java/org/elasticsearch/cluster/action/shard/ShardStateAction.java
@@ -15,7 +15,8 @@ import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.action.ActionListener;
-import org.elasticsearch.cluster.ClusterChangedEvent;
+import org.elasticsearch.action.ResultDeduplicator;
+import org.elasticsearch.cluster.ClusterStatePublicationEvent;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.ClusterStateObserver;
 import org.elasticsearch.cluster.ClusterStateTaskConfig;
@@ -34,16 +35,16 @@ import org.elasticsearch.cluster.routing.allocation.AllocationService;
 import org.elasticsearch.cluster.routing.allocation.FailedShard;
 import org.elasticsearch.cluster.routing.allocation.StaleShard;
 import org.elasticsearch.cluster.service.ClusterService;
-import org.elasticsearch.core.Nullable;
 import org.elasticsearch.common.Priority;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.index.shard.IndexLongFieldRange;
-import org.elasticsearch.index.shard.ShardLongFieldRange;
 import org.elasticsearch.index.shard.ShardId;
+import org.elasticsearch.index.shard.ShardLongFieldRange;
 import org.elasticsearch.node.NodeClosedException;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.threadpool.ThreadPool;
@@ -53,7 +54,6 @@ import org.elasticsearch.transport.RemoteTransportException;
 import org.elasticsearch.transport.TransportChannel;
 import org.elasticsearch.transport.TransportException;
 import org.elasticsearch.transport.TransportRequest;
-import org.elasticsearch.action.ResultDeduplicator;
 import org.elasticsearch.transport.TransportRequestHandler;
 import org.elasticsearch.transport.TransportResponse;
 import org.elasticsearch.transport.TransportService;
@@ -372,8 +372,8 @@ public class ShardStateAction {
         }
 
         @Override
-        public void clusterStatePublished(ClusterChangedEvent clusterChangedEvent) {
-            int numberOfUnassignedShards = clusterChangedEvent.state().getRoutingNodes().unassigned().size();
+        public void clusterStatePublished(ClusterStatePublicationEvent clusterStatePublicationEvent) {
+            int numberOfUnassignedShards = clusterStatePublicationEvent.getNewState().getRoutingNodes().unassigned().size();
             if (numberOfUnassignedShards > 0) {
                 // The reroute called after failing some shards will not assign any shard back to the node on which it failed. If there were
                 // no other options for a failed shard then it is left unassigned. However, absent other options it's better to try and
@@ -641,7 +641,7 @@ public class ShardStateAction {
         }
 
         @Override
-        public void clusterStatePublished(ClusterChangedEvent clusterChangedEvent) {
+        public void clusterStatePublished(ClusterStatePublicationEvent clusterStatePublicationEvent) {
             rerouteService.reroute("reroute after starting shards", Priority.NORMAL, ActionListener.wrap(
                 r -> logger.trace("reroute after starting shards succeeded"),
                 e -> logger.debug("reroute after starting shards failed", e)));

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/ClusterStatePublisher.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/ClusterStatePublisher.java
@@ -8,7 +8,7 @@
 package org.elasticsearch.cluster.coordination;
 
 import org.elasticsearch.action.ActionListener;
-import org.elasticsearch.cluster.ClusterChangedEvent;
+import org.elasticsearch.cluster.ClusterStatePublicationEvent;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.TimeValue;
@@ -25,7 +25,7 @@ public interface ClusterStatePublisher {
      * The {@link AckListener} allows to keep track of the ack received from nodes, and verify whether
      * they updated their own cluster state or not.
      */
-    void publish(ClusterChangedEvent clusterChangedEvent, ActionListener<Void> publishListener, AckListener ackListener);
+    void publish(ClusterStatePublicationEvent clusterStatePublicationEvent, ActionListener<Void> publishListener, AckListener ackListener);
 
     interface AckListener {
         /**

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/PublicationTransportHandler.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/PublicationTransportHandler.java
@@ -13,7 +13,7 @@ import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
-import org.elasticsearch.cluster.ClusterChangedEvent;
+import org.elasticsearch.cluster.ClusterStatePublicationEvent;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.Diff;
 import org.elasticsearch.cluster.IncompatibleClusterStateVersionException;
@@ -195,8 +195,8 @@ public class PublicationTransportHandler {
         return handlePublishRequest.apply(new PublishRequest(incomingState));
     }
 
-    public PublicationContext newPublicationContext(ClusterChangedEvent clusterChangedEvent) {
-        final PublicationContext publicationContext = new PublicationContext(clusterChangedEvent);
+    public PublicationContext newPublicationContext(ClusterStatePublicationEvent clusterStatePublicationEvent) {
+        final PublicationContext publicationContext = new PublicationContext(clusterStatePublicationEvent);
 
         // Build the serializations we expect to need now, early in the process, so that an error during serialization fails the publication
         // straight away. This isn't watertight since we send diffs on a best-effort basis and may fall back to sending a full state (and
@@ -242,10 +242,10 @@ public class PublicationTransportHandler {
         private final Map<Version, BytesReference> serializedStates = new HashMap<>();
         private final Map<Version, BytesReference> serializedDiffs = new HashMap<>();
 
-        PublicationContext(ClusterChangedEvent clusterChangedEvent) {
-            discoveryNodes = clusterChangedEvent.state().nodes();
-            newState = clusterChangedEvent.state();
-            previousState = clusterChangedEvent.previousState();
+        PublicationContext(ClusterStatePublicationEvent clusterStatePublicationEvent) {
+            discoveryNodes = clusterStatePublicationEvent.getNewState().nodes();
+            newState = clusterStatePublicationEvent.getNewState();
+            previousState = clusterStatePublicationEvent.getOldState();
             sendFullVersion = previousState.getBlocks().disableStatePersistence();
         }
 

--- a/server/src/main/java/org/elasticsearch/cluster/service/MasterService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/service/MasterService.java
@@ -14,7 +14,7 @@ import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.elasticsearch.Assertions;
 import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.cluster.AckedClusterStateTaskListener;
-import org.elasticsearch.cluster.ClusterChangedEvent;
+import org.elasticsearch.cluster.ClusterStatePublicationEvent;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.ClusterState.Builder;
 import org.elasticsearch.cluster.ClusterStateTaskConfig;
@@ -28,20 +28,20 @@ import org.elasticsearch.cluster.metadata.ProcessClusterEventTimeoutException;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
 import org.elasticsearch.cluster.routing.RoutingTable;
-import org.elasticsearch.core.Nullable;
 import org.elasticsearch.common.Priority;
 import org.elasticsearch.common.component.AbstractLifecycleComponent;
 import org.elasticsearch.common.settings.ClusterSettings;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.text.Text;
-import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.common.util.concurrent.CountDown;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.common.util.concurrent.EsRejectedExecutionException;
 import org.elasticsearch.common.util.concurrent.FutureUtils;
 import org.elasticsearch.common.util.concurrent.PrioritizedEsThreadPoolExecutor;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
+import org.elasticsearch.core.Nullable;
+import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.discovery.Discovery;
 import org.elasticsearch.node.Node;
 import org.elasticsearch.threadpool.Scheduler;
@@ -234,9 +234,10 @@ public class MasterService extends AbstractLifecycleComponent {
             }
             final long publicationStartTime = threadPool.relativeTimeInMillis();
             try {
-                ClusterChangedEvent clusterChangedEvent = new ClusterChangedEvent(summary, newClusterState, previousClusterState);
+                ClusterStatePublicationEvent clusterStatePublicationEvent =
+                    new ClusterStatePublicationEvent(summary, previousClusterState, newClusterState);
                 // new cluster state, notify all listeners
-                final DiscoveryNodes.Delta nodesDelta = clusterChangedEvent.nodesDelta();
+                final DiscoveryNodes.Delta nodesDelta = newClusterState.nodes().delta(previousClusterState.nodes());
                 if (nodesDelta.hasChanges() && logger.isInfoEnabled()) {
                     String nodesDeltaSummary = nodesDelta.shortSummary();
                     if (nodesDeltaSummary.length() > 0) {
@@ -246,7 +247,7 @@ public class MasterService extends AbstractLifecycleComponent {
                 }
 
                 logger.debug("publishing cluster state version [{}]", newClusterState.version());
-                publish(clusterChangedEvent, taskOutputs, publicationStartTime);
+                publish(clusterStatePublicationEvent, taskOutputs, publicationStartTime);
             } catch (Exception e) {
                 handleException(summary, publicationStartTime, newClusterState, e);
             }
@@ -257,49 +258,67 @@ public class MasterService extends AbstractLifecycleComponent {
         return TimeValue.timeValueMillis(Math.max(0, threadPool.relativeTimeInMillis() - startTimeMillis));
     }
 
-    protected void publish(ClusterChangedEvent clusterChangedEvent, TaskOutputs taskOutputs, long startTimeMillis) {
+    protected void publish(ClusterStatePublicationEvent clusterStatePublicationEvent, TaskOutputs taskOutputs, long startTimeMillis) {
         final PlainActionFuture<Void> fut = new PlainActionFuture<Void>() {
             @Override
             protected boolean blockingAllowed() {
                 return isMasterUpdateThread() || super.blockingAllowed();
             }
         };
-        clusterStatePublisher.publish(clusterChangedEvent, fut, taskOutputs.createAckListener(threadPool, clusterChangedEvent.state()));
+        clusterStatePublisher.publish(
+            clusterStatePublicationEvent,
+            fut,
+            taskOutputs.createAckListener(threadPool, clusterStatePublicationEvent.getNewState()));
 
         // indefinitely wait for publication to complete
         try {
             FutureUtils.get(fut);
-            onPublicationSuccess(clusterChangedEvent, taskOutputs);
+            onPublicationSuccess(clusterStatePublicationEvent, taskOutputs);
         } catch (Exception e) {
-            onPublicationFailed(clusterChangedEvent, taskOutputs, startTimeMillis, e);
+            onPublicationFailed(clusterStatePublicationEvent, taskOutputs, startTimeMillis, e);
         }
     }
 
-    void onPublicationSuccess(ClusterChangedEvent clusterChangedEvent, TaskOutputs taskOutputs) {
+    void onPublicationSuccess(ClusterStatePublicationEvent clusterStatePublicationEvent, TaskOutputs taskOutputs) {
         final long notificationStartTime = threadPool.relativeTimeInMillis();
-        taskOutputs.processedDifferentClusterState(clusterChangedEvent.previousState(), clusterChangedEvent.state());
+        taskOutputs.processedDifferentClusterState(clusterStatePublicationEvent.getOldState(), clusterStatePublicationEvent.getNewState());
 
         try {
-            taskOutputs.clusterStatePublished(clusterChangedEvent);
+            taskOutputs.clusterStatePublished(clusterStatePublicationEvent);
         } catch (Exception e) {
             logger.error(() -> new ParameterizedMessage(
                 "exception thrown while notifying executor of new cluster state publication [{}]",
-                clusterChangedEvent.source()), e);
+                clusterStatePublicationEvent.getSummary()), e);
         }
         final TimeValue executionTime = getTimeSince(notificationStartTime);
-        logExecutionTime(executionTime, "notify listeners on successful publication of cluster state (version: "
-            + clusterChangedEvent.state().version() + ", uuid: " + clusterChangedEvent.state().stateUUID() + ')',
-            clusterChangedEvent.source());
+        logExecutionTime(
+            executionTime,
+            "notify listeners on successful publication of cluster state (version: " + clusterStatePublicationEvent.getNewState().version()
+                + ", uuid: " + clusterStatePublicationEvent.getNewState().stateUUID() + ')',
+            clusterStatePublicationEvent.getSummary());
     }
 
-    void onPublicationFailed(ClusterChangedEvent clusterChangedEvent, TaskOutputs taskOutputs, long startTimeMillis, Exception exception) {
+    void onPublicationFailed(
+        ClusterStatePublicationEvent clusterStatePublicationEvent,
+        TaskOutputs taskOutputs,
+        long startTimeMillis,
+        Exception exception
+    ) {
         if (exception instanceof FailedToCommitClusterStateException) {
-            final long version = clusterChangedEvent.state().version();
-            logger.warn(() -> new ParameterizedMessage(
-                "failing [{}]: failed to commit cluster state version [{}]", clusterChangedEvent.source(), version), exception);
+            final long version = clusterStatePublicationEvent.getNewState().version();
+            logger.warn(
+                () -> new ParameterizedMessage(
+                    "failing [{}]: failed to commit cluster state version [{}]",
+                    clusterStatePublicationEvent.getSummary(),
+                    version),
+                exception);
             taskOutputs.publishingFailed((FailedToCommitClusterStateException) exception);
         } else {
-            handleException(clusterChangedEvent.source(), startTimeMillis, clusterChangedEvent.state(), exception);
+            handleException(
+                clusterStatePublicationEvent.getSummary(),
+                startTimeMillis,
+                clusterStatePublicationEvent.getNewState(),
+                exception);
         }
     }
 
@@ -420,8 +439,8 @@ public class MasterService extends AbstractLifecycleComponent {
             nonFailedTasks.forEach(task -> task.listener.clusterStateProcessed(task.source(), previousClusterState, newClusterState));
         }
 
-        void clusterStatePublished(ClusterChangedEvent clusterChangedEvent) {
-            taskInputs.executor.clusterStatePublished(clusterChangedEvent);
+        void clusterStatePublished(ClusterStatePublicationEvent clusterStatePublicationEvent) {
+            taskInputs.executor.clusterStatePublished(clusterStatePublicationEvent);
         }
 
         Discovery.AckListener createAckListener(ThreadPool threadPool, ClusterState newClusterState) {

--- a/server/src/test/java/org/elasticsearch/cluster/coordination/NodeJoinTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/NodeJoinTests.java
@@ -120,8 +120,8 @@ public class NodeJoinTests extends ESTestCase {
         FakeThreadPoolMasterService fakeMasterService = new FakeThreadPoolMasterService("test_node","test",
             fakeThreadPool, deterministicTaskQueue::scheduleNow);
         setupMasterServiceAndCoordinator(term, initialState, fakeMasterService, fakeThreadPool, Randomness.get(), nodeHealthService);
-        fakeMasterService.setClusterStatePublisher((event, publishListener, ackListener) -> {
-            coordinator.handlePublishRequest(new PublishRequest(event.state()));
+        fakeMasterService.setClusterStatePublisher((clusterStatePublicationEvent, publishListener, ackListener) -> {
+            coordinator.handlePublishRequest(new PublishRequest(clusterStatePublicationEvent.getNewState()));
             publishListener.onResponse(null);
         });
         fakeMasterService.start();
@@ -131,8 +131,8 @@ public class NodeJoinTests extends ESTestCase {
         MasterService masterService = new MasterService(Settings.builder().put(Node.NODE_NAME_SETTING.getKey(), "test_node").build(),
             new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS), threadPool);
         AtomicReference<ClusterState> clusterStateRef = new AtomicReference<>(initialState);
-        masterService.setClusterStatePublisher((event, publishListener, ackListener) -> {
-            clusterStateRef.set(event.state());
+        masterService.setClusterStatePublisher((clusterStatePublicationEvent, publishListener, ackListener) -> {
+            clusterStateRef.set(clusterStatePublicationEvent.getNewState());
             publishListener.onResponse(null);
         });
         setupMasterServiceAndCoordinator(term, initialState, masterService, threadPool, new Random(Randomness.get().nextLong()),

--- a/server/src/test/java/org/elasticsearch/cluster/coordination/PublicationTransportHandlerTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/PublicationTransportHandlerTests.java
@@ -9,7 +9,7 @@ package org.elasticsearch.cluster.coordination;
 
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.Version;
-import org.elasticsearch.cluster.ClusterChangedEvent;
+import org.elasticsearch.cluster.ClusterStatePublicationEvent;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.Diff;
 import org.elasticsearch.cluster.coordination.CoordinationMetadata.VotingConfiguration;
@@ -70,7 +70,7 @@ public class PublicationTransportHandlerTests extends ESTestCase {
         };
 
         ElasticsearchException e = expectThrows(ElasticsearchException.class, () ->
-            handler.newPublicationContext(new ClusterChangedEvent("test", unserializableClusterState, clusterState)));
+            handler.newPublicationContext(new ClusterStatePublicationEvent("test", clusterState, unserializableClusterState)));
         assertNotNull(e.getCause());
         assertThat(e.getCause(), instanceOf(IOException.class));
         assertThat(e.getCause().getMessage(), containsString("Simulated failure of diff serialization"));

--- a/server/src/test/java/org/elasticsearch/test/NoopDiscovery.java
+++ b/server/src/test/java/org/elasticsearch/test/NoopDiscovery.java
@@ -8,7 +8,7 @@
 package org.elasticsearch.test;
 
 import org.elasticsearch.action.ActionListener;
-import org.elasticsearch.cluster.ClusterChangedEvent;
+import org.elasticsearch.cluster.ClusterStatePublicationEvent;
 import org.elasticsearch.common.component.Lifecycle;
 import org.elasticsearch.common.component.LifecycleListener;
 import org.elasticsearch.discovery.Discovery;
@@ -17,7 +17,11 @@ import org.elasticsearch.discovery.DiscoveryStats;
 public class NoopDiscovery implements Discovery {
 
     @Override
-    public void publish(ClusterChangedEvent clusterChangedEvent, ActionListener<Void> publishListener, AckListener ackListener) {
+    public void publish(
+        ClusterStatePublicationEvent clusterStatePublicationEvent,
+        ActionListener<Void> publishListener,
+        AckListener ackListener
+    ) {
         publishListener.onResponse(null);
     }
 

--- a/test/framework/src/main/java/org/elasticsearch/cluster/service/FakeThreadPoolMasterService.java
+++ b/test/framework/src/main/java/org/elasticsearch/cluster/service/FakeThreadPoolMasterService.java
@@ -10,16 +10,16 @@ package org.elasticsearch.cluster.service;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.action.ActionListener;
-import org.elasticsearch.cluster.ClusterChangedEvent;
+import org.elasticsearch.cluster.ClusterStatePublicationEvent;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.coordination.ClusterStatePublisher.AckListener;
 import org.elasticsearch.common.UUIDs;
 import org.elasticsearch.common.settings.ClusterSettings;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.common.util.concurrent.PrioritizedEsThreadPoolExecutor;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
+import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.node.Node;
 import org.elasticsearch.threadpool.ThreadPool;
 
@@ -111,10 +111,10 @@ public class FakeThreadPoolMasterService extends MasterService {
     }
 
     @Override
-    protected void publish(ClusterChangedEvent clusterChangedEvent, TaskOutputs taskOutputs, long startTimeMillis) {
+    protected void publish(ClusterStatePublicationEvent clusterStatePublicationEvent, TaskOutputs taskOutputs, long startTimeMillis) {
         assert waitForPublish == false;
         waitForPublish = true;
-        final AckListener ackListener = taskOutputs.createAckListener(threadPool, clusterChangedEvent.state());
+        final AckListener ackListener = taskOutputs.createAckListener(threadPool, clusterStatePublicationEvent.getNewState());
         final ActionListener<Void> publishListener = new ActionListener<>() {
 
             private boolean listenerCalled = false;
@@ -126,7 +126,7 @@ public class FakeThreadPoolMasterService extends MasterService {
                 assert waitForPublish;
                 waitForPublish = false;
                 try {
-                    onPublicationSuccess(clusterChangedEvent, taskOutputs);
+                    onPublicationSuccess(clusterStatePublicationEvent, taskOutputs);
                 } finally {
                     taskInProgress = false;
                     scheduleNextTaskIfNecessary();
@@ -140,7 +140,7 @@ public class FakeThreadPoolMasterService extends MasterService {
                 assert waitForPublish;
                 waitForPublish = false;
                 try {
-                    onPublicationFailed(clusterChangedEvent, taskOutputs, startTimeMillis, e);
+                    onPublicationFailed(clusterStatePublicationEvent, taskOutputs, startTimeMillis, e);
                 } finally {
                     taskInProgress = false;
                     scheduleNextTaskIfNecessary();
@@ -150,14 +150,15 @@ public class FakeThreadPoolMasterService extends MasterService {
         threadPool.generic().execute(threadPool.getThreadContext().preserveContext(new Runnable() {
             @Override
             public void run() {
-                clusterStatePublisher.publish(clusterChangedEvent, publishListener, wrapAckListener(ackListener));
+                clusterStatePublisher.publish(clusterStatePublicationEvent, publishListener, wrapAckListener(ackListener));
             }
 
             @Override
             public String toString() {
-                return "publish change of cluster state from version [" + clusterChangedEvent.previousState().version() + "] in term [" +
-                        clusterChangedEvent.previousState().term() + "] to version [" + clusterChangedEvent.state().version()
-                        + "] in term [" + clusterChangedEvent.state().term() + "]";
+                return "publish change of cluster state from version [" + clusterStatePublicationEvent.getOldState().version() +
+                    "] in term [" + clusterStatePublicationEvent.getOldState().term() + "] to version [" +
+                    clusterStatePublicationEvent.getNewState().version() + "] in term [" +
+                    clusterStatePublicationEvent.getNewState().term() + "]";
             }
         }));
     }

--- a/test/framework/src/main/java/org/elasticsearch/test/ClusterServiceUtils.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/ClusterServiceUtils.java
@@ -135,8 +135,10 @@ public class ClusterServiceUtils {
     }
 
     public static ClusterStatePublisher createClusterStatePublisher(ClusterApplier clusterApplier) {
-        return (event, publishListener, ackListener) ->
-            clusterApplier.onNewClusterState("mock_publish_to_self[" + event.source() + "]", () -> event.state(),
+        return (clusterStatePublicationEvent, publishListener, ackListener) ->
+            clusterApplier.onNewClusterState(
+                "mock_publish_to_self[" + clusterStatePublicationEvent.getSummary() + "]",
+                clusterStatePublicationEvent::getNewState,
                 new ClusterApplyListener() {
                     @Override
                     public void onSuccess(String source) {

--- a/test/framework/src/test/java/org/elasticsearch/cluster/service/FakeThreadPoolMasterServiceTests.java
+++ b/test/framework/src/test/java/org/elasticsearch/cluster/service/FakeThreadPoolMasterServiceTests.java
@@ -57,8 +57,8 @@ public class FakeThreadPoolMasterServiceTests extends ESTestCase {
 
         FakeThreadPoolMasterService masterService = new FakeThreadPoolMasterService("test_node","test", mockThreadPool, runnableTasks::add);
         masterService.setClusterStateSupplier(lastClusterStateRef::get);
-        masterService.setClusterStatePublisher((event, publishListener, ackListener) -> {
-            lastClusterStateRef.set(event.state());
+        masterService.setClusterStatePublisher((clusterStatePublicationEvent, publishListener, ackListener) -> {
+            lastClusterStateRef.set(clusterStatePublicationEvent.getNewState());
             publishingCallback.set(publishListener);
         });
         masterService.start();


### PR DESCRIPTION
Today we use `ClusterChangedEvent` to represent a committed change to
the cluster state while it's being applied, and also to represent the
proposed change while it's being published. These are quite different
usages in practice, so this commit separates them by introducing a
`ClusterStatePublicationEvent` to represent the change to be published.

Relates #76625 in that we will be able to use the new
`ClusterStatePublicationEvent` to track various stats about the
publication as it progresses, but which don't make sense on a
`ClusterChangedEvent`.