### PR TITLE
[DOCS] Fix upgrade version logic for `-alpha` and `-beta` releases

### DIFF
--- a/docs/reference/upgrade.asciidoc
+++ b/docs/reference/upgrade.asciidoc
@@ -10,7 +10,7 @@ process so upgrading does not interrupt service. Rolling upgrades are supported:
 * From 5.6 to 6.8
 * From 6.8 to {prev-major-version}
 * From {prev-major-version} to {version}
-ifeval::[ "{version}" != "{minor-version}.0" ]
+ifeval::[ "{bare_version}" != "{minor-version}.0" ]
 * From any version since {minor-version}.0 to {version}
 endif::[]
 
@@ -33,7 +33,7 @@ The following table shows the recommended upgrade paths to {version}.
 |Upgrade from   
 |Recommended upgrade path to {version}
 
-ifeval::[ "{version}" != "{minor-version}.0" ]
+ifeval::[ "{bare_version}" != "{minor-version}.0" ]
 |A previous {minor-version} version (e.g., {minor-version}.0)
 |<<rolling-upgrades,Rolling upgrade>> to {version}
 endif::[]
@@ -41,7 +41,7 @@ endif::[]
 |{prev-major-version}
 |<<rolling-upgrades,Rolling upgrade>> to {version}
 
-|7.0–7.7
+|7.0–7.15
 a|
 . https://www.elastic.co/guide/en/elasticsearch/reference/{prev-major-version}/rolling-upgrades.html[Rolling upgrade] to {prev-major-version}
 . <<rolling-upgrades,Rolling upgrade>> to {version}

--- a/docs/reference/upgrade/rolling_upgrade.asciidoc
+++ b/docs/reference/upgrade/rolling_upgrade.asciidoc
@@ -35,7 +35,7 @@ Rolling upgrades are supported:
 * {stack-ref-68}/upgrading-elastic-stack.html[From 5.6 to 6.8]
 * {stack-ref-70}/upgrading-elastic-stack.html[From 6.8 to 7.0]
 * From {prev-major-version} to {version}
-ifeval::[ "{version}" != "{minor-version}.0" ]
+ifeval::[ "{bare_version}" != "{minor-version}.0" ]
 * From any version since {minor-version}.0 to {version}
 endif::[]
 


### PR DESCRIPTION
Currently, this displays incorrectly for the 8.0 `-alpha` and `-beta` releases:

<img width="460" alt="Screen Shot 2021-08-19 at 1 32 37 PM" src="https://user-images.githubusercontent.com/40268737/130116582-a0ce3e43-b11b-4f2d-8307-decce28e948b.PNG">

After the change:

<img width="740" alt="Screen Shot 2021-08-19 at 1 50 44 PM" src="https://user-images.githubusercontent.com/40268737/130119183-280a5a7e-72fc-4594-8ea7-33fe7faaa5fb.PNG">
