### PR TITLE
[DOCS] Add search xref tip to `query_string` docs

### DIFF
--- a/docs/reference/query-dsl/query-string-query.asciidoc
+++ b/docs/reference/query-dsl/query-string-query.asciidoc
@@ -4,6 +4,8 @@
 <titleabbrev>Query string</titleabbrev>
 ++++
 
+TIP: To get started with {es} queries, see <<search-your-data>>.
+
 Returns documents based on a provided query string, using a parser with a strict
 syntax.
 

--- a/docs/reference/query-dsl/query-string-query.asciidoc
+++ b/docs/reference/query-dsl/query-string-query.asciidoc
@@ -4,7 +4,8 @@
 <titleabbrev>Query string</titleabbrev>
 ++++
 
-TIP: To get started with {es} queries, see <<search-your-data>>.
+TIP: This page contains information about the `query_string` query type. For
+information about running a search query in {es}, see <<search-your-data>>.
 
 Returns documents based on a provided query string, using a parser with a strict
 syntax.


### PR DESCRIPTION
Adds a tip containing a cross-reference to the "Search your data" docs.
This is the preferred starting point for ES search.

### Preview
https://elasticsearch_76728.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/query-dsl-query-string-query.html