### PR TITLE
Ensuring that the ShrinkAction does not hang if total shards per node is too low

### DIFF
--- a/docs/reference/ilm/actions/ilm-shrink.asciidoc
+++ b/docs/reference/ilm/actions/ilm-shrink.asciidoc
@@ -17,6 +17,10 @@ stream. You cannot perform the `shrink` action on a write index.
 To use the `shrink` action in the `hot` phase, the `rollover` action *must* be
 present. If no rollover action is configured, {ilm-init} will reject the policy.
 
+The shrink action will set the index's index.routing.allocation.total_shards_per_node
+setting to -1 to ensure that all shards of the index can be copied to a single node.
+This setting will persist on the index even after the step completes.
+
 [IMPORTANT]
 If the shrink action is used on a <<ccr-put-follow,follower index>>, policy
 execution waits until the leader index rolls over (or is <<skipping-rollover,

--- a/docs/reference/ilm/actions/ilm-shrink.asciidoc
+++ b/docs/reference/ilm/actions/ilm-shrink.asciidoc
@@ -17,9 +17,10 @@ stream. You cannot perform the `shrink` action on a write index.
 To use the `shrink` action in the `hot` phase, the `rollover` action *must* be
 present. If no rollover action is configured, {ilm-init} will reject the policy.
 
-The shrink action will set the index's index.routing.allocation.total_shards_per_node
-setting to -1 to ensure that all shards of the index can be copied to a single node.
-This setting will persist on the index even after the step completes.
+The shrink action will unset the index's index.routing.allocation.total_shards_per_node
+setting, meaning that there will be no limit. This is to ensure that all shards of the
+index can be copied to a single node. This setting change will persist on the index
+even after the step completes.
 
 [IMPORTANT]
 If the shrink action is used on a <<ccr-put-follow,follower index>>, policy

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/SetSingleNodeAllocateStep.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/SetSingleNodeAllocateStep.java
@@ -24,6 +24,7 @@ import org.elasticsearch.cluster.routing.allocation.decider.Decision;
 import org.elasticsearch.cluster.routing.allocation.decider.FilterAllocationDecider;
 import org.elasticsearch.cluster.routing.allocation.decider.NodeShutdownAllocationDecider;
 import org.elasticsearch.cluster.routing.allocation.decider.NodeVersionAllocationDecider;
+import org.elasticsearch.cluster.routing.allocation.decider.ShardsLimitAllocationDecider;
 import org.elasticsearch.common.Randomness;
 import org.elasticsearch.common.settings.ClusterSettings;
 import org.elasticsearch.common.settings.Settings;
@@ -95,7 +96,8 @@ public class SetSingleNodeAllocateStep extends AsyncActionStep {
 
             if (nodeId.isPresent()) {
                 Settings settings = Settings.builder()
-                        .put(IndexMetadata.INDEX_ROUTING_REQUIRE_GROUP_SETTING.getKey() + "_id", nodeId.get()).build();
+                        .put(IndexMetadata.INDEX_ROUTING_REQUIRE_GROUP_SETTING.getKey() + "_id", nodeId.get())
+                        .put(ShardsLimitAllocationDecider.INDEX_TOTAL_SHARDS_PER_NODE_SETTING.getKey(), -1).build();
                 UpdateSettingsRequest updateSettingsRequest = new UpdateSettingsRequest(indexName)
                         .masterNodeTimeout(TimeValue.MAX_VALUE)
                         .settings(settings);
@@ -113,5 +115,4 @@ public class SetSingleNodeAllocateStep extends AsyncActionStep {
             listener.onFailure(new IndexNotFoundException(indexMetadata.getIndex()));
         }
     }
-
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/SetSingleNodeAllocateStep.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/SetSingleNodeAllocateStep.java
@@ -97,7 +97,7 @@ public class SetSingleNodeAllocateStep extends AsyncActionStep {
             if (nodeId.isPresent()) {
                 Settings settings = Settings.builder()
                         .put(IndexMetadata.INDEX_ROUTING_REQUIRE_GROUP_SETTING.getKey() + "_id", nodeId.get())
-                        .put(ShardsLimitAllocationDecider.INDEX_TOTAL_SHARDS_PER_NODE_SETTING.getKey(), -1).build();
+                        .putNull(ShardsLimitAllocationDecider.INDEX_TOTAL_SHARDS_PER_NODE_SETTING.getKey()).build();
                 UpdateSettingsRequest updateSettingsRequest = new UpdateSettingsRequest(indexName)
                         .masterNodeTimeout(TimeValue.MAX_VALUE)
                         .settings(settings);
@@ -115,4 +115,5 @@ public class SetSingleNodeAllocateStep extends AsyncActionStep {
             listener.onFailure(new IndexNotFoundException(indexMetadata.getIndex()));
         }
     }
+
 }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/SetSingleNodeAllocateStepTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/SetSingleNodeAllocateStepTests.java
@@ -85,7 +85,7 @@ public class SetSingleNodeAllocateStepTests extends AbstractStepTestCase<SetSing
         assertArrayEquals(expectedIndices, request.indices());
         assertThat(request.settings().get(settingsKey), anyOf(acceptableValues.stream().map(e -> equalTo(e)).collect(Collectors.toList())));
         if (assertOnlyKeyInSettings) {
-            assertEquals(1, request.settings().size());
+            assertEquals(2, request.settings().size());
         }
     }
 

--- a/x-pack/plugin/ilm/qa/multi-node/src/javaRestTest/java/org/elasticsearch/xpack/ilm/actions/ShrinkActionIT.java
+++ b/x-pack/plugin/ilm/qa/multi-node/src/javaRestTest/java/org/elasticsearch/xpack/ilm/actions/ShrinkActionIT.java
@@ -328,7 +328,7 @@ public class ShrinkActionIT extends ESRestTestCase {
             assertThat(settings.get(SETTING_NUMBER_OF_SHARDS), equalTo(String.valueOf(expectedFinalShards)));
             assertThat(settings.get(IndexMetadata.INDEX_BLOCKS_WRITE_SETTING.getKey()), equalTo("true"));
             assertThat(settings.get(IndexMetadata.INDEX_ROUTING_REQUIRE_GROUP_SETTING.getKey() + "_id"), nullValue());
-            assertThat(settings.get(ShardsLimitAllocationDecider.INDEX_TOTAL_SHARDS_PER_NODE_SETTING.getKey()), equalTo("-1"));
+            assertNull(settings.get(ShardsLimitAllocationDecider.INDEX_TOTAL_SHARDS_PER_NODE_SETTING.getKey()));
         });
         expectThrows(ResponseException.class, () -> indexDocument(client(), index));
     }


### PR DESCRIPTION
We added configuration to AllocateAction to set the total shards per node property on the index. This makes it possible that a user could set this to a value lower than the total number of shards in the index that is about to be shrunk, meaning that all of the shards could not be moved to a single node in the ShrinkAction. This commit sets the total shards per node property to -1 (unlimited) in the ShrinkAction to avoid this.
Relates to #44070