### PR TITLE
Introduce `ClusterStatePublicationEvent`

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/ClusterStatePublicationEvent.java
+++ b/server/src/main/java/org/elasticsearch/cluster/ClusterStatePublicationEvent.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.cluster;
+
+/**
+ * Represents a cluster state update computed by the {@link org.elasticsearch.cluster.service.MasterService} for publication to the cluster.
+ * If publication is successful then this creates a {@link ClusterChangedEvent} which is applied on every node.
+ */
+public class ClusterStatePublicationEvent {
+
+    private final String summary;
+    private final ClusterState oldState;
+    private final ClusterState newState;
+
+    public ClusterStatePublicationEvent(String summary, ClusterState oldState, ClusterState newState) {
+        this.summary = summary;
+        this.oldState = oldState;
+        this.newState = newState;
+    }
+
+    public String getSummary() {
+        return summary;
+    }
+
+    public ClusterState getOldState() {
+        return oldState;
+    }
+
+    public ClusterState getNewState() {
+        return newState;
+    }
+}

--- a/server/src/main/java/org/elasticsearch/cluster/ClusterStateTaskExecutor.java
+++ b/server/src/main/java/org/elasticsearch/cluster/ClusterStateTaskExecutor.java
@@ -33,10 +33,9 @@ public interface ClusterStateTaskExecutor<T> {
      *
      * Note that this method will be executed using system context.
      *
-     * @param clusterChangedEvent the change event for this cluster state change, containing
-     *                            both old and new states
+     * @param clusterStatePublicationEvent the change event for this cluster state publication, containing both old and new states
      */
-    default void clusterStatePublished(ClusterChangedEvent clusterChangedEvent) {
+    default void clusterStatePublished(ClusterStatePublicationEvent clusterStatePublicationEvent) {
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/cluster/ClusterStateUpdateTask.java
+++ b/server/src/main/java/org/elasticsearch/cluster/ClusterStateUpdateTask.java
@@ -70,7 +70,7 @@ public abstract class ClusterStateUpdateTask
     public abstract void onFailure(String source, Exception e);
 
     @Override
-    public final void clusterStatePublished(ClusterChangedEvent clusterChangedEvent) {
+    public final void clusterStatePublished(ClusterStatePublicationEvent clusterStatePublicationEvent) {
         // final, empty implementation here as this method should only be defined in combination
         // with a batching executor as it will always be executed within the system context.
     }

--- a/server/src/main/java/org/elasticsearch/cluster/action/shard/ShardStateAction.java
+++ b/server/src/main/java/org/elasticsearch/cluster/action/shard/ShardStateAction.java
@@ -16,9 +16,10 @@ import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
-import org.elasticsearch.cluster.ClusterChangedEvent;
+import org.elasticsearch.action.ResultDeduplicator;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.ClusterStateObserver;
+import org.elasticsearch.cluster.ClusterStatePublicationEvent;
 import org.elasticsearch.cluster.ClusterStateTaskConfig;
 import org.elasticsearch.cluster.ClusterStateTaskExecutor;
 import org.elasticsearch.cluster.ClusterStateTaskListener;
@@ -35,17 +36,17 @@ import org.elasticsearch.cluster.routing.allocation.AllocationService;
 import org.elasticsearch.cluster.routing.allocation.FailedShard;
 import org.elasticsearch.cluster.routing.allocation.StaleShard;
 import org.elasticsearch.cluster.service.ClusterService;
-import org.elasticsearch.core.Nullable;
 import org.elasticsearch.common.Priority;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.settings.Setting;
+import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.index.shard.IndexLongFieldRange;
-import org.elasticsearch.index.shard.ShardLongFieldRange;
 import org.elasticsearch.index.shard.ShardId;
+import org.elasticsearch.index.shard.ShardLongFieldRange;
 import org.elasticsearch.node.NodeClosedException;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.threadpool.ThreadPool;
@@ -55,7 +56,6 @@ import org.elasticsearch.transport.RemoteTransportException;
 import org.elasticsearch.transport.TransportChannel;
 import org.elasticsearch.transport.TransportException;
 import org.elasticsearch.transport.TransportRequest;
-import org.elasticsearch.action.ResultDeduplicator;
 import org.elasticsearch.transport.TransportRequestHandler;
 import org.elasticsearch.transport.TransportResponse;
 import org.elasticsearch.transport.TransportService;
@@ -412,8 +412,8 @@ public class ShardStateAction {
         }
 
         @Override
-        public void clusterStatePublished(ClusterChangedEvent clusterChangedEvent) {
-            int numberOfUnassignedShards = clusterChangedEvent.state().getRoutingNodes().unassigned().size();
+        public void clusterStatePublished(ClusterStatePublicationEvent clusterStatePublicationEvent) {
+            int numberOfUnassignedShards = clusterStatePublicationEvent.getNewState().getRoutingNodes().unassigned().size();
             if (numberOfUnassignedShards > 0) {
                 // The reroute called after failing some shards will not assign any shard back to the node on which it failed. If there were
                 // no other options for a failed shard then it is left unassigned. However, absent other options it's better to try and
@@ -690,7 +690,7 @@ public class ShardStateAction {
         }
 
         @Override
-        public void clusterStatePublished(ClusterChangedEvent clusterChangedEvent) {
+        public void clusterStatePublished(ClusterStatePublicationEvent clusterStatePublicationEvent) {
             rerouteService.reroute("reroute after starting shards", prioritySupplier.get(), ActionListener.wrap(
                 r -> logger.trace("reroute after starting shards succeeded"),
                 e -> logger.debug("reroute after starting shards failed", e)));

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/ClusterStatePublisher.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/ClusterStatePublisher.java
@@ -8,7 +8,7 @@
 package org.elasticsearch.cluster.coordination;
 
 import org.elasticsearch.action.ActionListener;
-import org.elasticsearch.cluster.ClusterChangedEvent;
+import org.elasticsearch.cluster.ClusterStatePublicationEvent;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.TimeValue;
@@ -25,7 +25,7 @@ public interface ClusterStatePublisher {
      * The {@link AckListener} allows to keep track of the ack received from nodes, and verify whether
      * they updated their own cluster state or not.
      */
-    void publish(ClusterChangedEvent clusterChangedEvent, ActionListener<Void> publishListener, AckListener ackListener);
+    void publish(ClusterStatePublicationEvent clusterStatePublicationEvent, ActionListener<Void> publishListener, AckListener ackListener);
 
     interface AckListener {
         /**

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/Coordinator.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/Coordinator.java
@@ -14,8 +14,8 @@ import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.apache.lucene.util.SetOnce;
 import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
-import org.elasticsearch.cluster.ClusterChangedEvent;
 import org.elasticsearch.cluster.ClusterName;
+import org.elasticsearch.cluster.ClusterStatePublicationEvent;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.ClusterStateTaskConfig;
 import org.elasticsearch.cluster.ClusterStateUpdateTask;
@@ -1064,35 +1064,39 @@ public class Coordinator extends AbstractLifecycleComponent implements Discovery
     }
 
     @Override
-    public void publish(ClusterChangedEvent clusterChangedEvent, ActionListener<Void> publishListener, AckListener ackListener) {
+    public void publish(
+        ClusterStatePublicationEvent clusterStatePublicationEvent,
+        ActionListener<Void> publishListener,
+        AckListener ackListener
+    ) {
         try {
             synchronized (mutex) {
-                if (mode != Mode.LEADER || getCurrentTerm() != clusterChangedEvent.state().term()) {
+                if (mode != Mode.LEADER || getCurrentTerm() != clusterStatePublicationEvent.getNewState().term()) {
                     logger.debug(() -> new ParameterizedMessage("[{}] failed publication as node is no longer master for term {}",
-                        clusterChangedEvent.source(), clusterChangedEvent.state().term()));
+                        clusterStatePublicationEvent.getSummary(), clusterStatePublicationEvent.getNewState().term()));
                     publishListener.onFailure(new FailedToCommitClusterStateException("node is no longer master for term " +
-                        clusterChangedEvent.state().term() + " while handling publication"));
+                        clusterStatePublicationEvent.getNewState().term() + " while handling publication"));
                     return;
                 }
 
                 if (currentPublication.isPresent()) {
                     assert false : "[" + currentPublication.get() + "] in progress, cannot start new publication";
                     logger.warn(() -> new ParameterizedMessage("[{}] failed publication as already publication in progress",
-                        clusterChangedEvent.source()));
+                        clusterStatePublicationEvent.getSummary()));
                     publishListener.onFailure(new FailedToCommitClusterStateException("publication " + currentPublication.get() +
                         " already in progress"));
                     return;
                 }
 
-                assert assertPreviousStateConsistency(clusterChangedEvent);
+                assert assertPreviousStateConsistency(clusterStatePublicationEvent);
 
-                final ClusterState clusterState = clusterChangedEvent.state();
+                final ClusterState clusterState = clusterStatePublicationEvent.getNewState();
 
                 assert getLocalNode().equals(clusterState.getNodes().get(getLocalNode().getId())) :
                     getLocalNode() + " should be in published " + clusterState;
 
                 final PublicationTransportHandler.PublicationContext publicationContext =
-                    publicationHandler.newPublicationContext(clusterChangedEvent);
+                    publicationHandler.newPublicationContext(clusterStatePublicationEvent);
 
                 final PublishRequest publishRequest = coordinationState.get().handleClientValue(clusterState);
                 final CoordinatorPublication publication = new CoordinatorPublication(publishRequest, publicationContext,
@@ -1106,23 +1110,23 @@ public class Coordinator extends AbstractLifecycleComponent implements Discovery
                 publication.start(followersChecker.getFaultyNodes());
             }
         } catch (Exception e) {
-            logger.debug(() -> new ParameterizedMessage("[{}] publishing failed", clusterChangedEvent.source()), e);
+            logger.debug(() -> new ParameterizedMessage("[{}] publishing failed", clusterStatePublicationEvent.getSummary()), e);
             publishListener.onFailure(new FailedToCommitClusterStateException("publishing failed", e));
         }
     }
 
     // there is no equals on cluster state, so we just serialize it to XContent and compare Maps
     // deserialized from the resulting JSON
-    private boolean assertPreviousStateConsistency(ClusterChangedEvent event) {
-        assert event.previousState() == coordinationState.get().getLastAcceptedState() ||
+    private boolean assertPreviousStateConsistency(ClusterStatePublicationEvent clusterStatePublicationEvent) {
+        assert clusterStatePublicationEvent.getOldState() == coordinationState.get().getLastAcceptedState() ||
             XContentHelper.convertToMap(
-                JsonXContent.jsonXContent, Strings.toString(event.previousState()), false
+                JsonXContent.jsonXContent, Strings.toString(clusterStatePublicationEvent.getOldState()), false
             ).equals(
                 XContentHelper.convertToMap(
                     JsonXContent.jsonXContent,
                     Strings.toString(clusterStateWithNoMasterBlock(coordinationState.get().getLastAcceptedState())),
                     false))
-            : Strings.toString(event.previousState()) + " vs "
+            : Strings.toString(clusterStatePublicationEvent.getOldState()) + " vs "
             + Strings.toString(clusterStateWithNoMasterBlock(coordinationState.get().getLastAcceptedState()));
         return true;
     }

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/PublicationTransportHandler.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/PublicationTransportHandler.java
@@ -13,7 +13,7 @@ import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
-import org.elasticsearch.cluster.ClusterChangedEvent;
+import org.elasticsearch.cluster.ClusterStatePublicationEvent;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.Diff;
 import org.elasticsearch.cluster.IncompatibleClusterStateVersionException;
@@ -219,8 +219,8 @@ public class PublicationTransportHandler {
         return handlePublishRequest.apply(new PublishRequest(incomingState));
     }
 
-    public PublicationContext newPublicationContext(ClusterChangedEvent clusterChangedEvent) {
-        final PublicationContext publicationContext = new PublicationContext(clusterChangedEvent);
+    public PublicationContext newPublicationContext(ClusterStatePublicationEvent clusterStatePublicationEvent) {
+        final PublicationContext publicationContext = new PublicationContext(clusterStatePublicationEvent);
 
         // Build the serializations we expect to need now, early in the process, so that an error during serialization fails the publication
         // straight away. This isn't watertight since we send diffs on a best-effort basis and may fall back to sending a full state (and
@@ -266,10 +266,10 @@ public class PublicationTransportHandler {
         private final Map<Version, BytesReference> serializedStates = new HashMap<>();
         private final Map<Version, BytesReference> serializedDiffs = new HashMap<>();
 
-        PublicationContext(ClusterChangedEvent clusterChangedEvent) {
-            discoveryNodes = clusterChangedEvent.state().nodes();
-            newState = clusterChangedEvent.state();
-            previousState = clusterChangedEvent.previousState();
+        PublicationContext(ClusterStatePublicationEvent clusterStatePublicationEvent) {
+            discoveryNodes = clusterStatePublicationEvent.getNewState().nodes();
+            newState = clusterStatePublicationEvent.getNewState();
+            previousState = clusterStatePublicationEvent.getOldState();
             sendFullVersion = previousState.getBlocks().disableStatePersistence();
         }
 

--- a/server/src/main/java/org/elasticsearch/discovery/zen/NodeJoinController.java
+++ b/server/src/main/java/org/elasticsearch/discovery/zen/NodeJoinController.java
@@ -11,8 +11,8 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.apache.lucene.store.AlreadyClosedException;
-import org.elasticsearch.cluster.ClusterChangedEvent;
 import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.ClusterStatePublicationEvent;
 import org.elasticsearch.cluster.ClusterStateTaskConfig;
 import org.elasticsearch.cluster.ClusterStateTaskListener;
 import org.elasticsearch.cluster.NotMasterException;
@@ -55,8 +55,10 @@ public class NodeJoinController {
         this.masterService = masterService;
         joinTaskExecutor = new JoinTaskExecutor(settings, allocationService, logger, rerouteService) {
             @Override
-            public void clusterStatePublished(ClusterChangedEvent event) {
-                electMaster.logMinimumMasterNodesWarningIfNecessary(event.previousState(), event.state());
+            public void clusterStatePublished(ClusterStatePublicationEvent clusterStatePublicationEvent) {
+                electMaster.logMinimumMasterNodesWarningIfNecessary(
+                    clusterStatePublicationEvent.getOldState(),
+                    clusterStatePublicationEvent.getNewState());
             }
         };
     }

--- a/server/src/main/java/org/elasticsearch/discovery/zen/PublishClusterStateAction.java
+++ b/server/src/main/java/org/elasticsearch/discovery/zen/PublishClusterStateAction.java
@@ -14,10 +14,11 @@ import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
-import org.elasticsearch.cluster.ClusterChangedEvent;
 import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.ClusterStatePublicationEvent;
 import org.elasticsearch.cluster.Diff;
 import org.elasticsearch.cluster.IncompatibleClusterStateVersionException;
+import org.elasticsearch.cluster.coordination.FailedToCommitClusterStateException;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
 import org.elasticsearch.common.bytes.BytesReference;
@@ -36,7 +37,6 @@ import org.elasticsearch.discovery.AckClusterStatePublishResponseHandler;
 import org.elasticsearch.discovery.BlockingClusterStatePublishResponseHandler;
 import org.elasticsearch.discovery.Discovery;
 import org.elasticsearch.discovery.DiscoverySettings;
-import org.elasticsearch.cluster.coordination.FailedToCommitClusterStateException;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.BytesTransportRequest;
@@ -118,7 +118,7 @@ public class PublishClusterStateAction {
      * if the change is not committed and should be rejected.
      * Any other exception signals the something wrong happened but the change is committed.
      */
-    public void publish(final ClusterChangedEvent clusterChangedEvent, final int minMasterNodes,
+    public void publish(final ClusterStatePublicationEvent clusterStatePublicationEvent, final int minMasterNodes,
                         final Discovery.AckListener ackListener) throws FailedToCommitClusterStateException {
         final DiscoveryNodes nodes;
         final SendingController sendingController;
@@ -127,7 +127,7 @@ public class PublishClusterStateAction {
         final Map<Version, BytesReference> serializedDiffs;
         final boolean sendFullVersion;
         try {
-            nodes = clusterChangedEvent.state().nodes();
+            nodes = clusterStatePublicationEvent.getNewState().nodes();
             nodesToPublishTo = new HashSet<>(nodes.getSize());
             DiscoveryNode localNode = nodes.getLocalNode();
             final int totalMasterNodes = nodes.getMasterNodes().size();
@@ -136,7 +136,7 @@ public class PublishClusterStateAction {
                     nodesToPublishTo.add(node);
                 }
             }
-            sendFullVersion = discoverySettings.getPublishDiff() == false || clusterChangedEvent.previousState() == null;
+            sendFullVersion = discoverySettings.getPublishDiff() == false || clusterStatePublicationEvent.getOldState() == null;
             serializedStates = new HashMap<>();
             serializedDiffs = new HashMap<>();
 
@@ -144,19 +144,19 @@ public class PublishClusterStateAction {
             // sadly this is not water tight as it may that a failed diff based publishing to a node
             // will cause a full serialization based on an older version, which may fail after the
             // change has been committed.
-            buildDiffAndSerializeStates(clusterChangedEvent.state(), clusterChangedEvent.previousState(),
+            buildDiffAndSerializeStates(clusterStatePublicationEvent.getNewState(), clusterStatePublicationEvent.getOldState(),
                     nodesToPublishTo, sendFullVersion, serializedStates, serializedDiffs);
 
             final BlockingClusterStatePublishResponseHandler publishResponseHandler =
                 new AckClusterStatePublishResponseHandler(nodesToPublishTo, ackListener);
-            sendingController = new SendingController(clusterChangedEvent.state(), minMasterNodes,
+            sendingController = new SendingController(clusterStatePublicationEvent.getNewState(), minMasterNodes,
                 totalMasterNodes, publishResponseHandler);
         } catch (Exception e) {
             throw new FailedToCommitClusterStateException("unexpected error while preparing to publish", e);
         }
 
         try {
-            innerPublish(clusterChangedEvent, nodesToPublishTo, sendingController, ackListener, sendFullVersion, serializedStates,
+            innerPublish(clusterStatePublicationEvent, nodesToPublishTo, sendingController, ackListener, sendFullVersion, serializedStates,
                 serializedDiffs);
         } catch (FailedToCommitClusterStateException t) {
             throw t;
@@ -171,13 +171,13 @@ public class PublishClusterStateAction {
         }
     }
 
-    private void innerPublish(final ClusterChangedEvent clusterChangedEvent, final Set<DiscoveryNode> nodesToPublishTo,
+    private void innerPublish(final ClusterStatePublicationEvent clusterStatePublicationEvent, final Set<DiscoveryNode> nodesToPublishTo,
                               final SendingController sendingController, final Discovery.AckListener ackListener,
                               final boolean sendFullVersion, final Map<Version, BytesReference> serializedStates,
                               final Map<Version, BytesReference> serializedDiffs) {
 
-        final ClusterState clusterState = clusterChangedEvent.state();
-        final ClusterState previousState = clusterChangedEvent.previousState();
+        final ClusterState clusterState = clusterStatePublicationEvent.getNewState();
+        final ClusterState previousState = clusterStatePublicationEvent.getOldState();
         final TimeValue publishTimeout = discoverySettings.getPublishTimeout();
 
         final long publishingStartInNanos = System.nanoTime();
@@ -216,7 +216,7 @@ public class PublishClusterStateAction {
             Set<DiscoveryNode> failedNodes = publishResponseHandler.getFailedNodes();
             if (failedNodes.isEmpty() == false) {
                 logger.warn("publishing cluster state with version [{}] failed for the following nodes: [{}]",
-                    clusterChangedEvent.state().version(), failedNodes);
+                    clusterStatePublicationEvent.getNewState().version(), failedNodes);
             }
         } catch (InterruptedException e) {
             // ignore & restore interrupt

--- a/server/src/test/java/org/elasticsearch/cluster/coordination/NodeJoinTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/NodeJoinTests.java
@@ -121,8 +121,8 @@ public class NodeJoinTests extends ESTestCase {
         FakeThreadPoolMasterService fakeMasterService = new FakeThreadPoolMasterService("test_node","test",
             fakeThreadPool, deterministicTaskQueue::scheduleNow);
         setupMasterServiceAndCoordinator(term, initialState, fakeMasterService, fakeThreadPool, Randomness.get(), nodeHealthService);
-        fakeMasterService.setClusterStatePublisher((event, publishListener, ackListener) -> {
-            coordinator.handlePublishRequest(new PublishRequest(event.state()));
+        fakeMasterService.setClusterStatePublisher((clusterStatePublicationEvent, publishListener, ackListener) -> {
+            coordinator.handlePublishRequest(new PublishRequest(clusterStatePublicationEvent.getNewState()));
             publishListener.onResponse(null);
         });
         fakeMasterService.start();
@@ -132,8 +132,8 @@ public class NodeJoinTests extends ESTestCase {
         MasterService masterService = new MasterService(Settings.builder().put(Node.NODE_NAME_SETTING.getKey(), "test_node").build(),
             new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS), threadPool);
         AtomicReference<ClusterState> clusterStateRef = new AtomicReference<>(initialState);
-        masterService.setClusterStatePublisher((event, publishListener, ackListener) -> {
-            clusterStateRef.set(event.state());
+        masterService.setClusterStatePublisher((clusterStatePublicationEvent, publishListener, ackListener) -> {
+            clusterStateRef.set(clusterStatePublicationEvent.getNewState());
             publishListener.onResponse(null);
         });
         setupMasterServiceAndCoordinator(term, initialState, masterService, threadPool, new Random(Randomness.get().nextLong()),

--- a/server/src/test/java/org/elasticsearch/cluster/coordination/PublicationTransportHandlerTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/PublicationTransportHandlerTests.java
@@ -9,7 +9,7 @@ package org.elasticsearch.cluster.coordination;
 
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.Version;
-import org.elasticsearch.cluster.ClusterChangedEvent;
+import org.elasticsearch.cluster.ClusterStatePublicationEvent;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.Diff;
 import org.elasticsearch.cluster.coordination.CoordinationMetadata.VotingConfiguration;
@@ -70,7 +70,7 @@ public class PublicationTransportHandlerTests extends ESTestCase {
         };
 
         ElasticsearchException e = expectThrows(ElasticsearchException.class, () ->
-            handler.newPublicationContext(new ClusterChangedEvent("test", unserializableClusterState, clusterState)));
+            handler.newPublicationContext(new ClusterStatePublicationEvent("test", clusterState, unserializableClusterState)));
         assertNotNull(e.getCause());
         assertThat(e.getCause(), instanceOf(IOException.class));
         assertThat(e.getCause().getMessage(), containsString("Simulated failure of diff serialization"));

--- a/server/src/test/java/org/elasticsearch/discovery/zen/PublishClusterStateActionTests.java
+++ b/server/src/test/java/org/elasticsearch/discovery/zen/PublishClusterStateActionTests.java
@@ -17,6 +17,7 @@ import org.elasticsearch.cluster.ClusterModule;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.ClusterStateListener;
+import org.elasticsearch.cluster.ClusterStatePublicationEvent;
 import org.elasticsearch.cluster.Diff;
 import org.elasticsearch.cluster.block.ClusterBlocks;
 import org.elasticsearch.cluster.coordination.FailedToCommitClusterStateException;
@@ -817,8 +818,8 @@ public class PublishClusterStateActionTests extends ESTestCase {
     public AssertingAckListener publishState(PublishClusterStateAction action, ClusterState state,
                                              ClusterState previousState, int minMasterNodes) throws InterruptedException {
         AssertingAckListener assertingAckListener = new AssertingAckListener(state.nodes().getSize() - 1);
-        ClusterChangedEvent changedEvent = new ClusterChangedEvent("test update", state, previousState);
-        action.publish(changedEvent, minMasterNodes, assertingAckListener);
+        ClusterStatePublicationEvent clusterStatePublicationEvent = new ClusterStatePublicationEvent("test update", previousState, state);
+        action.publish(clusterStatePublicationEvent, minMasterNodes, assertingAckListener);
         return assertingAckListener;
     }
 

--- a/server/src/test/java/org/elasticsearch/discovery/zen/ZenDiscoveryUnitTests.java
+++ b/server/src/test/java/org/elasticsearch/discovery/zen/ZenDiscoveryUnitTests.java
@@ -11,10 +11,10 @@ package org.elasticsearch.discovery.zen;
 import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.replication.ClusterStateCreationUtils;
-import org.elasticsearch.cluster.ClusterChangedEvent;
 import org.elasticsearch.cluster.ClusterModule;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.ClusterStatePublicationEvent;
 import org.elasticsearch.cluster.ClusterStateTaskExecutor;
 import org.elasticsearch.cluster.ESAllocationTestCase;
 import org.elasticsearch.cluster.coordination.FailedToCommitClusterStateException;
@@ -244,11 +244,11 @@ public class ZenDiscoveryUnitTests extends ESTestCase {
             ).build();
 
             // publishing a new cluster state
-            ClusterChangedEvent clusterChangedEvent = new ClusterChangedEvent("testing", newState, state);
+            ClusterStatePublicationEvent clusterStatePublicationEvent = new ClusterStatePublicationEvent("testing", state, newState);
             AssertingAckListener listener = new AssertingAckListener(newState.nodes().getSize() - 1);
             expectedFDNodes = masterZen.getFaultDetectionNodes();
             AwaitingPublishListener awaitingPublishListener = new AwaitingPublishListener();
-            masterZen.publish(clusterChangedEvent, awaitingPublishListener, listener);
+            masterZen.publish(clusterStatePublicationEvent, awaitingPublishListener, listener);
             awaitingPublishListener.await();
             if (awaitingPublishListener.getException() == null) {
                 // publication succeeded, wait for acks
@@ -303,10 +303,10 @@ public class ZenDiscoveryUnitTests extends ESTestCase {
             ).build();
 
             // publishing a new cluster state
-            ClusterChangedEvent clusterChangedEvent = new ClusterChangedEvent("testing", newState, state);
+            ClusterStatePublicationEvent clusterStatePublicationEvent = new ClusterStatePublicationEvent("testing", state, newState);
             AssertingAckListener listener = new AssertingAckListener(newState.nodes().getSize() - 1);
             AwaitingPublishListener awaitingPublishListener = new AwaitingPublishListener();
-            masterZen.publish(clusterChangedEvent, awaitingPublishListener, listener);
+            masterZen.publish(clusterStatePublicationEvent, awaitingPublishListener, listener);
             awaitingPublishListener.await();
             if (awaitingPublishListener.getException() == null) {
                 // publication succeeded, wait for acks

--- a/server/src/test/java/org/elasticsearch/test/NoopDiscovery.java
+++ b/server/src/test/java/org/elasticsearch/test/NoopDiscovery.java
@@ -8,7 +8,7 @@
 package org.elasticsearch.test;
 
 import org.elasticsearch.action.ActionListener;
-import org.elasticsearch.cluster.ClusterChangedEvent;
+import org.elasticsearch.cluster.ClusterStatePublicationEvent;
 import org.elasticsearch.common.component.Lifecycle;
 import org.elasticsearch.common.component.LifecycleListener;
 import org.elasticsearch.discovery.Discovery;
@@ -17,7 +17,11 @@ import org.elasticsearch.discovery.DiscoveryStats;
 public class NoopDiscovery implements Discovery {
 
     @Override
-    public void publish(ClusterChangedEvent clusterChangedEvent, ActionListener<Void> publishListener, AckListener ackListener) {
+    public void publish(
+        ClusterStatePublicationEvent clusterStatePublicationEvent,
+        ActionListener<Void> publishListener,
+        AckListener ackListener
+    ) {
         publishListener.onResponse(null);
     }
 

--- a/test/framework/src/main/java/org/elasticsearch/cluster/service/FakeThreadPoolMasterService.java
+++ b/test/framework/src/main/java/org/elasticsearch/cluster/service/FakeThreadPoolMasterService.java
@@ -10,16 +10,16 @@ package org.elasticsearch.cluster.service;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.action.ActionListener;
-import org.elasticsearch.cluster.ClusterChangedEvent;
+import org.elasticsearch.cluster.ClusterStatePublicationEvent;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.coordination.ClusterStatePublisher.AckListener;
 import org.elasticsearch.common.UUIDs;
 import org.elasticsearch.common.settings.ClusterSettings;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.common.util.concurrent.PrioritizedEsThreadPoolExecutor;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
+import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.node.Node;
 import org.elasticsearch.threadpool.ThreadPool;
 
@@ -111,10 +111,10 @@ public class FakeThreadPoolMasterService extends MasterService {
     }
 
     @Override
-    protected void publish(ClusterChangedEvent clusterChangedEvent, TaskOutputs taskOutputs, long startTimeMillis) {
+    protected void publish(ClusterStatePublicationEvent clusterStatePublicationEvent, TaskOutputs taskOutputs, long startTimeMillis) {
         assert waitForPublish == false;
         waitForPublish = true;
-        final AckListener ackListener = taskOutputs.createAckListener(threadPool, clusterChangedEvent.state());
+        final AckListener ackListener = taskOutputs.createAckListener(threadPool, clusterStatePublicationEvent.getNewState());
         final ActionListener<Void> publishListener = new ActionListener<Void>() {
 
             private boolean listenerCalled = false;
@@ -126,7 +126,7 @@ public class FakeThreadPoolMasterService extends MasterService {
                 assert waitForPublish;
                 waitForPublish = false;
                 try {
-                    onPublicationSuccess(clusterChangedEvent, taskOutputs);
+                    onPublicationSuccess(clusterStatePublicationEvent, taskOutputs);
                 } finally {
                     taskInProgress = false;
                     scheduleNextTaskIfNecessary();
@@ -140,7 +140,7 @@ public class FakeThreadPoolMasterService extends MasterService {
                 assert waitForPublish;
                 waitForPublish = false;
                 try {
-                    onPublicationFailed(clusterChangedEvent, taskOutputs, startTimeMillis, e);
+                    onPublicationFailed(clusterStatePublicationEvent, taskOutputs, startTimeMillis, e);
                 } finally {
                     taskInProgress = false;
                     scheduleNextTaskIfNecessary();
@@ -150,14 +150,15 @@ public class FakeThreadPoolMasterService extends MasterService {
         threadPool.generic().execute(threadPool.getThreadContext().preserveContext(new Runnable() {
             @Override
             public void run() {
-                clusterStatePublisher.publish(clusterChangedEvent, publishListener, wrapAckListener(ackListener));
+                clusterStatePublisher.publish(clusterStatePublicationEvent, publishListener, wrapAckListener(ackListener));
             }
 
             @Override
             public String toString() {
-                return "publish change of cluster state from version [" + clusterChangedEvent.previousState().version() + "] in term [" +
-                        clusterChangedEvent.previousState().term() + "] to version [" + clusterChangedEvent.state().version()
-                        + "] in term [" + clusterChangedEvent.state().term() + "]";
+                return "publish change of cluster state from version [" + clusterStatePublicationEvent.getOldState().version() +
+                    "] in term [" + clusterStatePublicationEvent.getOldState().term() + "] to version [" +
+                    clusterStatePublicationEvent.getNewState().version() + "] in term [" +
+                    clusterStatePublicationEvent.getNewState().term() + "]";
             }
         }));
     }

--- a/test/framework/src/test/java/org/elasticsearch/cluster/service/FakeThreadPoolMasterServiceTests.java
+++ b/test/framework/src/test/java/org/elasticsearch/cluster/service/FakeThreadPoolMasterServiceTests.java
@@ -57,8 +57,8 @@ public class FakeThreadPoolMasterServiceTests extends ESTestCase {
 
         FakeThreadPoolMasterService masterService = new FakeThreadPoolMasterService("test_node","test", mockThreadPool, runnableTasks::add);
         masterService.setClusterStateSupplier(lastClusterStateRef::get);
-        masterService.setClusterStatePublisher((event, publishListener, ackListener) -> {
-            lastClusterStateRef.set(event.state());
+        masterService.setClusterStatePublisher((clusterStatePublicationEvent, publishListener, ackListener) -> {
+            lastClusterStateRef.set(clusterStatePublicationEvent.getNewState());
             publishingCallback.set(publishListener);
         });
         masterService.start();


### PR DESCRIPTION
Today we use `ClusterChangedEvent` to represent a committed change to
the cluster state while it's being applied, and also to represent the
proposed change while it's being published. These are quite different
usages in practice, so this commit separates them by introducing a
`ClusterStatePublicationEvent` to represent the change to be published.

Relates #76625 in that we will be able to use the new
`ClusterStatePublicationEvent` to track various stats about the
publication as it progresses, but which don't make sense on a
`ClusterChangedEvent`.

Backport of #76723