### PR TITLE
[7.x] Remove redundant enrich processor constructors

### DIFF
--- a/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/EnrichProcessorFactory.java
+++ b/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/EnrichProcessorFactory.java
@@ -6,7 +6,11 @@
  */
 package org.elasticsearch.xpack.enrich;
 
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.search.SearchRequest;
+import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.client.Client;
+import org.elasticsearch.client.OriginSettingClient;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.IndexAbstraction;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
@@ -19,9 +23,13 @@ import org.elasticsearch.ingest.Processor;
 import org.elasticsearch.script.ScriptService;
 import org.elasticsearch.script.TemplateScript;
 import org.elasticsearch.xpack.core.enrich.EnrichPolicy;
+import org.elasticsearch.xpack.enrich.action.EnrichCoordinatorProxyAction;
 
 import java.util.Map;
+import java.util.function.BiConsumer;
 import java.util.function.Consumer;
+
+import static org.elasticsearch.xpack.core.ClientHelper.ENRICH_ORIGIN;
 
 final class EnrichProcessorFactory implements Processor.Factory, Consumer<ClusterState> {
 
@@ -67,13 +75,13 @@ final class EnrichProcessorFactory implements Processor.Factory, Consumer<Cluste
         if (maxMatches < 1 || maxMatches > 128) {
             throw ConfigurationUtils.newConfigurationException(TYPE, tag, "max_matches", "should be between 1 and 128");
         }
-
+        BiConsumer<SearchRequest, BiConsumer<SearchResponse, Exception>> searchRunner = createSearchRunner(client);
         switch (policyType) {
             case EnrichPolicy.MATCH_TYPE:
                 return new MatchProcessor(
                     tag,
                     description,
-                    client,
+                    searchRunner,
                     policyName,
                     field,
                     targetField,
@@ -90,7 +98,7 @@ final class EnrichProcessorFactory implements Processor.Factory, Consumer<Cluste
                 return new GeoMatchProcessor(
                     tag,
                     description,
-                    client,
+                    searchRunner,
                     policyName,
                     field,
                     targetField,
@@ -111,4 +119,14 @@ final class EnrichProcessorFactory implements Processor.Factory, Consumer<Cluste
         metadata = state.getMetadata();
     }
 
+    private static BiConsumer<SearchRequest, BiConsumer<SearchResponse, Exception>> createSearchRunner(Client client) {
+        Client originClient = new OriginSettingClient(client, ENRICH_ORIGIN);
+        return (req, handler) -> {
+            originClient.execute(
+                EnrichCoordinatorProxyAction.INSTANCE,
+                req,
+                ActionListener.wrap(resp -> { handler.accept(resp, null); }, e -> { handler.accept(null, e); })
+            );
+        };
+    }
 }

--- a/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/GeoMatchProcessor.java
+++ b/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/GeoMatchProcessor.java
@@ -8,7 +8,6 @@ package org.elasticsearch.xpack.enrich;
 
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.search.SearchResponse;
-import org.elasticsearch.client.Client;
 import org.elasticsearch.common.geo.GeometryParser;
 import org.elasticsearch.common.geo.Orientation;
 import org.elasticsearch.common.geo.ShapeRelation;
@@ -24,26 +23,6 @@ public final class GeoMatchProcessor extends AbstractEnrichProcessor {
     private final ShapeRelation shapeRelation;
     private final GeometryParser parser;
 
-    GeoMatchProcessor(
-        String tag,
-        String description,
-        Client client,
-        String policyName,
-        TemplateScript.Factory field,
-        TemplateScript.Factory targetField,
-        boolean overrideEnabled,
-        boolean ignoreMissing,
-        String matchField,
-        int maxMatches,
-        ShapeRelation shapeRelation,
-        Orientation orientation
-    ) {
-        super(tag, description, client, policyName, field, targetField, ignoreMissing, overrideEnabled, matchField, maxMatches);
-        this.shapeRelation = shapeRelation;
-        parser = new GeometryParser(orientation.getAsBoolean(), true, true);
-    }
-
-    /** used in tests **/
     GeoMatchProcessor(
         String tag,
         String description,

--- a/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/MatchProcessor.java
+++ b/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/MatchProcessor.java
@@ -8,7 +8,6 @@ package org.elasticsearch.xpack.enrich;
 
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.search.SearchResponse;
-import org.elasticsearch.client.Client;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.index.query.TermQueryBuilder;
 import org.elasticsearch.index.query.TermsQueryBuilder;
@@ -19,22 +18,6 @@ import java.util.function.BiConsumer;
 
 public final class MatchProcessor extends AbstractEnrichProcessor {
 
-    MatchProcessor(
-        String tag,
-        String description,
-        Client client,
-        String policyName,
-        TemplateScript.Factory field,
-        TemplateScript.Factory targetField,
-        boolean overrideEnabled,
-        boolean ignoreMissing,
-        String matchField,
-        int maxMatches
-    ) {
-        super(tag, description, client, policyName, field, targetField, ignoreMissing, overrideEnabled, matchField, maxMatches);
-    }
-
-    /** used in tests **/
     MatchProcessor(
         String tag,
         String description,

--- a/x-pack/plugin/enrich/src/test/java/org/elasticsearch/xpack/enrich/EnrichProcessorFactoryTests.java
+++ b/x-pack/plugin/enrich/src/test/java/org/elasticsearch/xpack/enrich/EnrichProcessorFactoryTests.java
@@ -166,20 +166,22 @@ public class EnrichProcessorFactoryTests extends ESTestCase {
     public void testUnsupportedPolicy() throws Exception {
         List<String> enrichValues = Arrays.asList("globalRank", "tldRank", "tld");
         EnrichPolicy policy = new EnrichPolicy("unsupported", null, Collections.singletonList("source_index"), "my_key", enrichValues);
-        EnrichProcessorFactory factory = new EnrichProcessorFactory(null, scriptService);
-        factory.metadata = createMetadata("majestic", policy);
+        try (Client client = new NoOpClient(this.getClass().getSimpleName() + "TestClient")) {
+            EnrichProcessorFactory factory = new EnrichProcessorFactory(client, scriptService);
+            factory.metadata = createMetadata("majestic", policy);
 
-        Map<String, Object> config = new HashMap<>();
-        config.put("policy_name", "majestic");
-        config.put("field", "host");
-        config.put("target_field", "entry");
-        boolean keyIgnoreMissing = randomBoolean();
-        if (keyIgnoreMissing || randomBoolean()) {
-            config.put("ignore_missing", keyIgnoreMissing);
+            Map<String, Object> config = new HashMap<>();
+            config.put("policy_name", "majestic");
+            config.put("field", "host");
+            config.put("target_field", "entry");
+            boolean keyIgnoreMissing = randomBoolean();
+            if (keyIgnoreMissing || randomBoolean()) {
+                config.put("ignore_missing", keyIgnoreMissing);
+            }
+
+            Exception e = expectThrows(IllegalArgumentException.class, () -> factory.create(Collections.emptyMap(), "_tag", null, config));
+            assertThat(e.getMessage(), equalTo("unsupported policy type [unsupported]"));
         }
-
-        Exception e = expectThrows(IllegalArgumentException.class, () -> factory.create(Collections.emptyMap(), "_tag", null, config));
-        assertThat(e.getMessage(), equalTo("unsupported policy type [unsupported]"));
     }
 
     public void testCompactEnrichValuesFormat() throws Exception {


### PR DESCRIPTION
Backport of #76698 to 7.x branch.

By creating the search running in the processor factory
3 constructors are no longer needed.