### PR TITLE
Fixing bwc yaml test version after #76730 backport

### DIFF
--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.aggregation/30_sig_terms.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.aggregation/30_sig_terms.yml
@@ -75,9 +75,8 @@
 ---
 "Test background filter count ":
   - skip:
-      # TODO Fix after backport
-      version: " - 7.99.99"
-      reason: introduced in 7.15.0
+      version: " - 7.14.99"
+      reason: bugfix introduced in 7.15.0
 
   - do:
       indices.create:


### PR DESCRIPTION
related: https://github.com/elastic/elasticsearch/pull/76730