### PR TITLE
[7.15] [DOCS] Reuse snapshot config in put SLM policy API docs (#76712)

### DIFF
--- a/docs/reference/slm/apis/slm-put.asciidoc
+++ b/docs/reference/slm/apis/slm-put.asciidoc
@@ -54,20 +54,9 @@ Configuration for each snapshot created by the policy.
 .Properties of `config`
 [%collapsible%open]
 ====
-`ignore_unavailable`::
-(Optional, Boolean)
-If `true`, missing data streams or indices do *not* cause snapshot creation to fail and return
-an error. Defaults to `false`.
-
-`include_global_state`::
-(Optional, Boolean)
-If `true`, cluster states are included in snapshots. Defaults to `false`.
-
-`indices`::
-(Optional, array of strings)
-Array of data streams and indices to include in snapshots.
-<<date-math-index-names,Date math>> and wildcard (`*`) expressions are
-supported.
+:page-id: put-slm-api
+include::{es-repo-dir}/snapshot-restore/apis/create-snapshot-api.asciidoc[tag=snapshot-config]
+:!page-id:
 ====
 
 `name`::

--- a/docs/reference/snapshot-restore/apis/create-snapshot-api.asciidoc
+++ b/docs/reference/snapshot-restore/apis/create-snapshot-api.asciidoc
@@ -93,11 +93,14 @@ initializes. Defaults to `false`.
 [[create-snapshot-api-request-body]]
 ==== {api-request-body-title}
 
+// Set an attribute so we can reuse these params with anchors
+:page-id: create-snapshot-api
+// tag::snapshot-config[]
 `ignore_unavailable`::
 (Optional, Boolean)
-If `false`, the request returns an error for any data stream or index that is missing or closed. Defaults to `false`.
-+
-If `true`, the request ignores data streams and indices in `indices` that are missing or closed.
+If `false`, the snapshot fails if any data stream or index in `indices` is
+missing or closed. If `true`, the snapshot ignores missing or closed data
+streams and indices. Defaults to `false`.
 
 `indices`::
 (Optional, string)
@@ -123,10 +126,8 @@ The global state includes:
 * {ilm-init} lifecycle policies
 * Data stored in system indices, such as Watches and task records (configurable via `feature_states`)
 --
-+
-IMPORTANT: By default, the entire snapshot will fail if one or more indices included in the snapshot do not have all primary shards available. You can change this behavior by setting <<create-snapshot-api-partial,`partial`>> to `true`.
 
-[[create-snapshot-api-feature-states]]
+[id="{page-id}-feature-states"]
 `feature_states`::
 (Optional, array of strings)
 A list of feature states to be included in this snapshot. A list of features
@@ -144,12 +145,15 @@ is `false`.
 (Optional, object)
 Attaches arbitrary metadata to the snapshot, such as a record of who took the snapshot, why it was taken, or any other useful data. Metadata must be less than 1024 bytes.
 
-[[create-snapshot-api-partial]]
+[id="{page-id}-partial"]
 `partial`::
 (Optional, Boolean)
 If `false`, the entire snapshot will fail if one or more indices included in the snapshot do not have all primary shards available. Defaults to `false`.
 +
 If `true`, allows taking a partial snapshot of indices with unavailable shards.
+// end::snapshot-config[]
+// Unset the attribute
+:!page-id:
 
 [[create-snapshot-api-example]]
 ==== {api-examples-title}


### PR DESCRIPTION
Backports the following commits to 7.15:
 - [DOCS] Reuse snapshot config in put SLM policy API docs (#76712)