### PR TITLE
[7.x] [DOCS] Fix upgrade version logic for `-alpha` and `-beta` releases (#76727)

### DIFF
--- a/docs/reference/upgrade.asciidoc
+++ b/docs/reference/upgrade.asciidoc
@@ -9,7 +9,7 @@ process so upgrading does not interrupt service. Rolling upgrades are supported:
 * Between minor versions
 * From 5.6 to 6.8
 * From 6.8 to {version}
-ifeval::[ "{version}" != "{minor-version}.0" ]
+ifeval::[ "{bare_version}" != "{minor-version}.0" ]
 * From any version since {minor-version}.0 to {version}
 endif::[]
 
@@ -32,12 +32,12 @@ The following table shows the recommended upgrade paths to {version}.
 |Upgrade from   
 |Recommended upgrade path to {version}
 
-ifeval::[ "{version}" != "{minor-version}.0" ]
+ifeval::[ "{bare_version}" != "{minor-version}.0" ]
 |A previous {minor-version} version (e.g., {minor-version}.0)
 |<<rolling-upgrades,Rolling upgrade>> to {version}
 endif::[]
 
-|7.0–7.14
+|7.0–7.15
 |<<rolling-upgrades,Rolling upgrade>> to {version}
 
 |6.8

--- a/docs/reference/upgrade/rolling_upgrade.asciidoc
+++ b/docs/reference/upgrade/rolling_upgrade.asciidoc
@@ -34,7 +34,7 @@ Rolling upgrades are supported:
 * Between minor versions
 * {stack-ref-68}/upgrading-elastic-stack.html[From 5.6 to 6.8]
 * From 6.8 to {version}
-ifeval::[ "{version}" != "{minor-version}.0" ]
+ifeval::[ "{bare_version}" != "{minor-version}.0" ]
 * From any version since {minor-version}.0 to {version}
 endif::[]
 


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [DOCS] Fix upgrade version logic for `-alpha` and `-beta` releases (#76727)