### PR TITLE
[7.15] [DOCS] Add search xref tip to `query_string` docs (#76728)

### DIFF
--- a/docs/reference/query-dsl/query-string-query.asciidoc
+++ b/docs/reference/query-dsl/query-string-query.asciidoc
@@ -4,6 +4,9 @@
 <titleabbrev>Query string</titleabbrev>
 ++++
 
+TIP: This page contains information about the `query_string` query type. For
+information about running a search query in {es}, see <<search-your-data>>.
+
 Returns documents based on a provided query string, using a parser with a strict
 syntax.
 


### PR DESCRIPTION
Backports the following commits to 7.15:
 - [DOCS] Add search xref tip to `query_string` docs (#76728)