### PR TITLE
[7.14] [DOCS] Remove 'step' from headings (#76753)

### DIFF
--- a/docs/reference/data-streams/set-up-a-data-stream.asciidoc
+++ b/docs/reference/data-streams/set-up-a-data-stream.asciidoc
@@ -4,11 +4,11 @@
 
 To set up a data stream, follow these steps:
 
-* <<create-index-lifecycle-policy>>
-* <<create-component-templates>>
-* <<create-index-template>>
-* <<create-data-stream>>
-* <<secure-data-stream>>
+. <<create-index-lifecycle-policy>>
+. <<create-component-templates>>
+. <<create-index-template>>
+. <<create-data-stream>>
+. <<secure-data-stream>>
 
 You can also <<convert-index-alias-to-data-stream,convert an index alias to
 a data stream>>.
@@ -19,7 +19,7 @@ IMPORTANT: If you use {fleet} or {agent}, skip this tutorial. {fleet} and
 
 [discrete]
 [[create-index-lifecycle-policy]]
-=== Step 1. Create an index lifecycle policy
+=== Create an index lifecycle policy
 
 While optional, we recommend using {ilm-init} to automate the management of your
 data stream's backing indices. {ilm-init} requires an index lifecycle policy.
@@ -84,7 +84,7 @@ PUT _ilm/policy/my-lifecycle-policy
 
 [discrete]
 [[create-component-templates]]
-=== Step 2. Create component templates
+=== Create component templates
 
 // tag::ds-create-component-templates[]
 A data stream requires a matching index template. In most cases, you compose
@@ -162,7 +162,7 @@ PUT _component_template/my-settings
 
 [discrete]
 [[create-index-template]]
-=== Step 3. Create an index template
+=== Create an index template
 
 // tag::ds-create-index-template[]
 Use your component templates to create an index template. Specify:
@@ -204,7 +204,7 @@ PUT _index_template/my-index-template
 
 [discrete]
 [[create-data-stream]]
-=== Step 4. Create the data stream
+=== Create the data stream
 
 // tag::ds-create-data-stream[]
 <<add-documents-to-a-data-stream,Indexing requests>> add documents to a data
@@ -245,7 +245,7 @@ PUT _data_stream/my-data-stream
 
 [discrete]
 [[secure-data-stream]]
-=== Step 5. Secure the data stream
+=== Secure the data stream
 
 include::{xes-repo-dir}/security/authorization/alias-privileges.asciidoc[tag=data-stream-security]
 

--- a/docs/reference/getting-started.asciidoc
+++ b/docs/reference/getting-started.asciidoc
@@ -11,7 +11,7 @@ This guide helps beginners learn how to:
 
 [discrete]
 [[run-elasticsearch]]
-=== Step 1. Run {es}
+=== Run {es}
 
 The simplest way to set up {es} is to create a managed deployment with {ess} on
 {ecloud}. If you prefer to manage your own test environment, you can install and
@@ -22,7 +22,7 @@ include::{es-repo-dir}/tab-widgets/quick-start-install-widget.asciidoc[]
 
 [discrete]
 [[send-requests-to-elasticsearch]]
-=== Step 2. Send requests to {es}
+=== Send requests to {es}
 
 You send data and other requests to {es} using REST APIs. This lets you interact
 with {es} using any client that sends HTTP requests, such as
@@ -33,7 +33,7 @@ include::{es-repo-dir}/tab-widgets/api-call-widget.asciidoc[]
 
 [discrete]
 [[add-data]]
-=== Step 3. Add data
+=== Add data
 
 You add data to {es} as JSON objects called documents. {es} stores these
 documents in searchable indices.
@@ -112,7 +112,7 @@ PUT logs-my_app-default/_bulk
 
 [discrete]
 [[qs-search-data]]
-=== Step 4. Search data
+=== Search data
 
 Indexed documents are available for search in near real-time. The following
 search matches all log entries in `logs-my_app-default` and sorts them by
@@ -487,7 +487,7 @@ To keep exploring, index more data to your data stream and check out <<common-se
 
 [discrete]
 [[clean-up]]
-=== Step 5. Clean up
+=== Clean up
 
 When you're done, delete your test data stream and its backing indices.
 

--- a/docs/reference/how-to/use-elasticsearch-for-time-series-data.asciidoc
+++ b/docs/reference/how-to/use-elasticsearch-for-time-series-data.asciidoc
@@ -7,7 +7,7 @@ using {kib} and other {stack} features.
 
 [discrete]
 [[set-up-data-tiers]]
-=== Step 1. Set up data tiers
+=== Set up data tiers
 
 {es}'s <<index-lifecycle-management,{ilm-init}>> feature uses <<data-tiers,data
 tiers>> to automatically move older data to nodes with less expensive hardware
@@ -31,7 +31,7 @@ include::{es-repo-dir}/tab-widgets/data-tiers-widget.asciidoc[]
 
 [discrete]
 [[register-snapshot-repository]]
-=== Step 2. Register a snapshot repository
+=== Register a snapshot repository
 
 The cold and frozen tiers can use <<searchable-snapshots,{search-snaps}>> to
 reduce local storage costs.
@@ -44,7 +44,7 @@ include::{es-repo-dir}/tab-widgets/snapshot-repo-widget.asciidoc[]
 
 [discrete]
 [[create-edit-index-lifecycle-policy]]
-=== Step 3. Create or edit an index lifecycle policy
+=== Create or edit an index lifecycle policy
 
 A <<data-streams,data stream>> stores your data across multiple backing
 indices. {ilm-init} uses an <<ilm-index-lifecycle,index lifecycle policy>> to
@@ -63,7 +63,7 @@ include::{es-repo-dir}/tab-widgets/ilm-widget.asciidoc[]
 
 [discrete]
 [[create-ts-component-templates]]
-=== Step 4. Create component templates
+=== Create component templates
 
 TIP: If you use {fleet} or {agent}, skip to <<search-visualize-your-data>>.
 {fleet} and {agent} use built-in templates to create data streams for you.
@@ -73,19 +73,19 @@ include::{es-repo-dir}/data-streams/set-up-a-data-stream.asciidoc[tag=ds-create-
 
 [discrete]
 [[create-ts-index-template]]
-=== Step 5. Create an index template
+=== Create an index template
 
 include::{es-repo-dir}/data-streams/set-up-a-data-stream.asciidoc[tag=ds-create-index-template]
 
 [discrete]
 [[add-data-to-data-stream]]
-=== Step 6. Add data to a data stream
+=== Add data to a data stream
 
 include::{es-repo-dir}/data-streams/set-up-a-data-stream.asciidoc[tag=ds-create-data-stream]
 
 [discrete]
 [[search-visualize-your-data]]
-=== Step 7. Search and visualize your data
+=== Search and visualize your data
 
 To explore and search your data in {kib}, open the main menu and select
 **Discover**. See {kib}'s {kibana-ref}/discover.html[Discover documentation].


### PR DESCRIPTION
Backports the following commits to 7.14:
 - [DOCS] Remove 'step' from headings (#76753)