### PR TITLE
[7.14] [DOCS] Clarify usage of optional human readable jvm uptime metric in Nodes Stats API (#76545)

### DIFF
--- a/docs/reference/cluster/nodes-stats.asciidoc
+++ b/docs/reference/cluster/nodes-stats.asciidoc
@@ -1264,7 +1264,8 @@ Last time JVM statistics were refreshed.
 
 `uptime`::
 (<<time-units,time value>>)
-JVM uptime.
+Human-readable JVM uptime. Only returned if the
+<<_human_readable_output,`human`>> query parameter is `true`.
 
 `uptime_in_millis`::
 (integer)


### PR DESCRIPTION
Backports the following commits to 7.14:
 - [DOCS] Clarify usage of optional human readable jvm uptime metric in Nodes Stats API (#76545)