### PR TITLE
[7.15] Make sure copy_to accepts null values (#76665)

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/mapper/DocumentParser.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DocumentParser.java
@@ -556,7 +556,7 @@ public final class DocumentParser {
             List<String> copyToFields = fieldMapper.copyTo().copyToFields();
             if (context.isWithinCopyTo() == false && copyToFields.isEmpty() == false) {
                 XContentParser.Token currentToken = context.parser().currentToken();
-                if (currentToken.isValue() == false) {
+                if (currentToken.isValue() == false && currentToken != XContentParser.Token.VALUE_NULL) {
                     // sanity check, we currently support copy-to only for value-type field, not objects
                     throw new MapperParsingException("Cannot copy field [" + mapper.name() + "] to fields " + copyToFields +
                         ". Copy-to currently only works for value-type fields, not objects.");

--- a/server/src/test/java/org/elasticsearch/index/mapper/CopyToMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/CopyToMapperTests.java
@@ -644,6 +644,30 @@ public class CopyToMapperTests extends MapperServiceTestCase {
         );
     }
 
+    public void testCopyToWithNullValue() throws Exception {
+        DocumentMapper docMapper = createDocumentMapper(topMapping(b ->
+            b.startObject("properties")
+                .startObject("keyword_copy")
+                    .field("type", "keyword")
+                    .field("null_value", "default-value")
+                .endObject()
+                .startObject("keyword")
+                    .field("type", "keyword")
+                    .array("copy_to", "keyword_copy")
+                .endObject()
+            .endObject()));
+
+        BytesReference json = BytesReference.bytes(jsonBuilder().startObject()
+                .nullField("keyword")
+            .endObject());
+
+        LuceneDocument document = docMapper.parse(new SourceToParse("test", "1", json, XContentType.JSON)).rootDoc();
+        assertEquals(0, document.getFields("keyword").length);
+
+        IndexableField[] fields = document.getFields("keyword_copy");
+        assertEquals(2, fields.length);
+    }
+
     public void testCopyToGeoPoint() throws Exception {
         DocumentMapper docMapper = createDocumentMapper(topMapping(b -> {
                 b.startObject("properties");

--- a/server/src/test/java/org/elasticsearch/index/mapper/CopyToMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/CopyToMapperTests.java
@@ -13,6 +13,7 @@ import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.common.xcontent.json.JsonXContent;
 import org.hamcrest.Matchers;
 
@@ -661,7 +662,8 @@ public class CopyToMapperTests extends MapperServiceTestCase {
                 .nullField("keyword")
             .endObject());
 
-        LuceneDocument document = docMapper.parse(new SourceToParse("test", "1", json, XContentType.JSON)).rootDoc();
+        LuceneDocument document = docMapper.parse(new SourceToParse("test", MapperService.SINGLE_MAPPING_NAME,
+            "1", json, XContentType.JSON)).rootDoc();
         assertEquals(0, document.getFields("keyword").length);
 
         IndexableField[] fields = document.getFields("keyword_copy");


### PR DESCRIPTION
Backports the following commits to 7.15:
 - Make sure copy_to accepts null values (#76665)