### PR TITLE
[7.15] [ML] Avoid very low p-values if the term is only a tiny fraction of the foreground set (#76764)

### DIFF
--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/aggs/heuristic/PValueScoreTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/aggs/heuristic/PValueScoreTests.java
@@ -22,7 +22,6 @@ import java.util.function.Function;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.closeTo;
 import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
 
@@ -110,7 +109,7 @@ public class PValueScoreTests extends AbstractNXYSignificanceHeuristicTestCase {
         );
         assertThat(
             FastMath.exp(-new PValueScore(false).getScore(10, 100, 10, 1000)),
-            closeTo(0.002988594884934073, eps)
+            closeTo(0.003972388976814195, eps)
         );
         assertThat(
             FastMath.exp(-new PValueScore(false).getScore(10, 100, 200, 1000)),
@@ -118,23 +117,23 @@ public class PValueScoreTests extends AbstractNXYSignificanceHeuristicTestCase {
         );
         assertThat(
             FastMath.exp(-new PValueScore(false).getScore(20, 10000, 5, 10000)),
-            closeTo(0.6309430298306147, eps)
+            closeTo(1.0, eps)
         );
     }
 
     public void testSmallChanges() {
         assertThat(
             FastMath.exp(-new PValueScore(false).getScore(1, 4205, 0, 821496)),
-            closeTo(0.9572480202044421, eps)
+            closeTo(0.9999037287868853, eps)
         );
         // Same(ish) ratios
         assertThat(
             FastMath.exp(-new PValueScore(false).getScore(10, 4205, 195, 82149)),
-            closeTo(0.9893886454928338, eps)
+            closeTo(0.9995943820612134, eps)
         );
         assertThat(
             FastMath.exp(-new PValueScore(false).getScore(10, 4205, 1950, 821496)),
-            closeTo(0.9867689169546193, eps)
+            closeTo(0.9999942565428899, eps)
         );
 
         // 4% vs 0%
@@ -145,12 +144,12 @@ public class PValueScoreTests extends AbstractNXYSignificanceHeuristicTestCase {
         // 4% vs 2%
         assertThat(
             FastMath.exp(-new PValueScore(false).getScore(168, 4205, 16429, 821496)),
-            closeTo(4.78464746423625e-06, eps)
+            closeTo(8.542608559219833e-5, eps)
         );
         // 4% vs 3.5%
         assertThat(
             FastMath.exp(-new PValueScore(false).getScore(168, 4205, 28752, 821496)),
-            closeTo(0.4728938449949742, eps)
+            closeTo(0.8833950526957098, eps)
         );
     }
 
@@ -186,7 +185,7 @@ public class PValueScoreTests extends AbstractNXYSignificanceHeuristicTestCase {
         for (int j = 1; j < 11; j++) {
             double nextScore = getScore.apply(j*10L);
             assertThat(nextScore, greaterThanOrEqualTo(0.0));
-            assertThat(nextScore, greaterThan(priorScore));
+            assertThat(nextScore, greaterThanOrEqualTo(priorScore));
             priorScore = nextScore;
         }
     }


### PR DESCRIPTION
Backports the following commits to 7.15:
 - [ML] Avoid very low p-values if the term is only a tiny fraction of the foreground set (#76764)