### PR TITLE
Upgrade build scan plugin to 3.6.4

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -1,5 +1,5 @@
 plugins {
-  id "com.gradle.enterprise" version "3.6.2"
+  id "com.gradle.enterprise" version "3.6.4"
 }
 
 includeBuild "build-conventions"


### PR DESCRIPTION
New build scan plugin is out with some fixes so we should go ahead and upgrade.