### PR TITLE
Always enable soft-deletes in CcrRollingUpgradeIT

### DIFF
--- a/x-pack/qa/rolling-upgrade-multi-cluster/src/test/java/org/elasticsearch/upgrades/CcrRollingUpgradeIT.java
+++ b/x-pack/qa/rolling-upgrade-multi-cluster/src/test/java/org/elasticsearch/upgrades/CcrRollingUpgradeIT.java
@@ -6,7 +6,6 @@
  */
 package org.elasticsearch.upgrades;
 
-import org.elasticsearch.Version;
 import org.elasticsearch.client.Request;
 import org.elasticsearch.client.ResponseException;
 import org.elasticsearch.client.RestClient;
@@ -299,10 +298,8 @@ public class CcrRollingUpgradeIT extends AbstractMultiClusterUpgradeTestCase {
     private static void createLeaderIndex(RestClient client, String indexName) throws IOException {
         Settings.Builder indexSettings = Settings.builder()
             .put("index.number_of_shards", 1)
-            .put("index.number_of_replicas", 0);
-        if (UPGRADE_FROM_VERSION.before(Version.V_7_0_0) || randomBoolean()) {
-            indexSettings.put("index.soft_deletes.enabled", true);
-        }
+            .put("index.number_of_replicas", 0)
+            .put("index.soft_deletes.enabled", true);
         createIndex(client, indexName, indexSettings.build());
     }
 


### PR DESCRIPTION
Relates #76765


```
org.elasticsearch.upgrades.CcrRollingUpgradeIT > testUniDirectionalIndexFollowing FAILED
    org.elasticsearch.client.ResponseException: method [PUT], host [http://127.0.0.1:34865], URI [/follower_index3/_ccr/follow?wait_for_active_shards=1], status line [HTTP/1.1 400 Bad Request]
    {"error":{"root_cause":[{"type":"illegal_argument_exception","reason":"leader index [leader_index3] does not have soft deletes enabled. soft deletes must be enabled when the index is created by setting index.soft_deletes.enabled to true"}],"type":"illegal_argument_exception","reason":"leader index [leader_index3] does not have soft deletes enabled. soft deletes must be enabled when the index is created by setting index.soft_deletes.enabled to true"},"status":400}
        at __randomizedtesting.SeedInfo.seed([20A03E90B07D1D3:8E4E96ECDC3CF096]:0)
        at org.elasticsearch.client.RestClient.convertResponse(RestClient.java:326)
        at org.elasticsearch.client.RestClient.performRequest(RestClient.java:296)
        at org.elasticsearch.client.RestClient.performRequest(RestClient.java:270)
        at org.elasticsearch.upgrades.CcrRollingUpgradeIT.followIndex(CcrRollingUpgradeIT.java:319)
        at org.elasticsearch.upgrades.CcrRollingUpgradeIT.testUniDirectionalIndexFollowing(CcrRollingUpgradeIT.java:73)
REPRODUCE WITH: ./gradlew ':x-pack:qa:rolling-upgrade-multi-cluster:v6.8.19#follower#twoThirdsUpgradedTest' -Dtests.class="org.elasticsearch.upgrades.CcrRollingUpgradeIT" -Dtests.method="testUniDirectionalIndexFollowing" -Dtests.seed=20A03E90B07D1D3 -Dtests.bwc=true -Dtests.locale=es-CO -Dtests.timezone=Jamaica -Druntime.java=8
```