### PR TITLE
Re-enable integration tests for secure HDFS fixtures

### DIFF
--- a/plugins/repository-hdfs/build.gradle
+++ b/plugins/repository-hdfs/build.gradle
@@ -121,8 +121,8 @@ for (String fixtureName : ['hdfsFixture', 'haHdfsFixture', 'secureHdfsFixture', 
 
     // If it's a secure fixture, then depend on Kerberos Fixture and principals + add the krb5conf to the JVM options
     if (name.equals('secureHdfsFixture') || name.equals('secureHaHdfsFixture')) {
+      miniHDFSArgs.addAll(["--add-exports", "java.security.jgss/sun.security.krb5=ALL-UNNAMED"])
       miniHDFSArgs.add("-Djava.security.krb5.conf=${krb5conf}")
-      onlyIf { BuildParams.runtimeJavaVersion < JavaVersion.VERSION_16 }
     }
     // If it's an HA fixture, set a nameservice to use in the JVM options
     if (name.equals('haHdfsFixture') || name.equals('secureHaHdfsFixture')) {
@@ -157,7 +157,6 @@ for (String integTestTaskName : ['integTestHa', 'integTestSecure', 'integTestSec
     }
 
     if (name.contains("Secure")) {
-      onlyIf { BuildParams.runtimeJavaVersion < JavaVersion.VERSION_16 }
       if (name.contains("Ha")) {
         dependsOn "secureHaHdfsFixture"
       } else {
@@ -210,6 +209,7 @@ for (String integTestTaskName : ['integTestHa', 'integTestSecure', 'integTestSec
     plugin(bundlePlugin.archiveFile)
     if (integTestTaskName.contains("Secure")) {
       systemProperty "java.security.krb5.conf", krb5conf
+      jvmArgs "--add-exports", "java.security.jgss/sun.security.krb5=ALL-UNNAMED"
       extraConfigFile(
         "repository-hdfs/krb5.keytab",
         file("${project(':test:fixtures:krb5kdc-fixture').ext.krb5Keytabs("hdfs", "elasticsearch.keytab")}"), IGNORE_VALUE

--- a/x-pack/plugin/searchable-snapshots/qa/hdfs/build.gradle
+++ b/x-pack/plugin/searchable-snapshots/qa/hdfs/build.gradle
@@ -81,7 +81,6 @@ for (String fixtureName : ['hdfsFixture', 'secureHdfsFixture']) {
 
     // If it's a secure fixture, then depend on Kerberos Fixture and principals + add the krb5conf to the JVM options
     if (name.equals('secureHdfsFixture')) {
-      onlyIf { BuildParams.runtimeJavaVersion < JavaVersion.VERSION_16 }
       miniHDFSArgs.addAll(["--add-exports", "java.security.jgss/sun.security.krb5=ALL-UNNAMED"])
       miniHDFSArgs.add("-Djava.security.krb5.conf=${krb5conf}")
     }
@@ -123,7 +122,7 @@ tasks.register("integTestSecure", RestIntegTestTask) {
     "test.krb5.keytab.hdfs",
     project(':test:fixtures:krb5kdc-fixture').ext.krb5Keytabs("hdfs", "hdfs_hdfs.build.elastic.co.keytab")
   )
-  onlyIf { BuildParams.inFipsJvm == false && BuildParams.runtimeJavaVersion < JavaVersion.VERSION_16}
+  onlyIf { BuildParams.inFipsJvm == false }
 }
 tasks.named("check").configure { dependsOn("integTestSecure") }
 
@@ -140,6 +139,7 @@ testClusters.configureEach {
 
 testClusters.matching { it.name == "integTestSecure" }.configureEach {
   systemProperty "java.security.krb5.conf", krb5conf
+  jvmArgs "--add-exports", "java.security.jgss/sun.security.krb5=ALL-UNNAMED"
   extraConfigFile(
     "repository-hdfs/krb5.keytab",
     file("${project(':test:fixtures:krb5kdc-fixture').ext.krb5Keytabs("hdfs", "elasticsearch.keytab")}"), IGNORE_VALUE


### PR DESCRIPTION
When running Elasticsearch on JDK 16 we must add exports for the internal java security packages in a few places in order to make use of the HDFS client in Kerberos secured environments:

1) Add exports within MiniHDFS fixtures so that it can access security packages for Kerberos authentication server-side.
2) Add exports within Elasticsearch fixtures when HDFS client is in use so that it can access packages for Kerberos on the client-side.
3) Add exports in integration test JVMs when directly testing the HDFS client's Kerberos usage in integration test methods.

This does highlight that operating Elasticsearch on JDK 16 against secured HDFS installations requires the Elasticsearch JVM options to add exports for the internal java security packages in order for the HDFS client code in any plugins to function correctly. This should be highlighted in the documentation.

Resolves #68075