### PR TITLE
Allow for setting the total shards per node in the Allocate ILM action #76775

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/AllocateAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/AllocateAction.java
@@ -93,7 +93,7 @@ public class AllocateAction implements LifecycleAction {
 
     @SuppressWarnings("unchecked")
     public AllocateAction(StreamInput in) throws IOException {
-        this(in.readOptionalVInt(), in.getVersion().onOrAfter(Version.V_8_0_0) ? in.readOptionalInt() : null,
+        this(in.readOptionalVInt(), in.getVersion().onOrAfter(Version.V_7_16_0) ? in.readOptionalInt() : null,
             (Map<String, String>) in.readGenericValue(), (Map<String, String>) in.readGenericValue(),
             (Map<String, String>) in.readGenericValue());
     }
@@ -121,7 +121,7 @@ public class AllocateAction implements LifecycleAction {
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         out.writeOptionalVInt(numberOfReplicas);
-        if (out.getVersion().onOrAfter(Version.V_8_0_0)) {
+        if (out.getVersion().onOrAfter(Version.V_7_16_0)) {
             out.writeOptionalInt(totalShardsPerNode);
         }
         out.writeGenericValue(include);


### PR DESCRIPTION
Updating the version where the total_shards_per_node parameter is supported, after backporting the feature to 7.16.
Relates to #76775 44070