### PR TITLE
Mention "warn threshold" in master service slowlog

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/service/MasterService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/service/MasterService.java
@@ -601,7 +601,13 @@ public class MasterService extends AbstractLifecycleComponent {
 
     private void logExecutionTime(TimeValue executionTime, String activity, String summary) {
         if (executionTime.getMillis() > slowTaskLoggingThreshold.getMillis()) {
-            logger.warn("took [{}], which is over [{}], to {} for [{}]", executionTime, slowTaskLoggingThreshold, activity, summary);
+            logger.warn(
+                "took [{}/{}ms] to {} for [{}], which exceeds the warn threshold of [{}]",
+                executionTime,
+                executionTime.getMillis(),
+                activity,
+                summary,
+                slowTaskLoggingThreshold);
         } else {
             logger.debug("took [{}] to {} for [{}]", executionTime, activity, summary);
         }

--- a/server/src/test/java/org/elasticsearch/cluster/service/MasterServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/service/MasterServiceTests.java
@@ -686,19 +686,19 @@ public class MasterServiceTests extends ESTestCase {
                 "test2",
                 MasterService.class.getCanonicalName(),
                 Level.WARN,
-                "*took [*], which is over [10s], to compute cluster state update for [test2]"));
+                "*took [*] to compute cluster state update for [test2], which exceeds the warn threshold of [10s]"));
         mockAppender.addExpectation(
             new MockLogAppender.SeenEventExpectation(
                 "test3",
                 MasterService.class.getCanonicalName(),
                 Level.WARN,
-                "*took [*], which is over [10s], to compute cluster state update for [test3]"));
+                "*took [*] to compute cluster state update for [test3], which exceeds the warn threshold of [10s]"));
         mockAppender.addExpectation(
             new MockLogAppender.SeenEventExpectation(
                 "test4",
                 MasterService.class.getCanonicalName(),
                 Level.WARN,
-                "*took [*], which is over [10s], to compute cluster state update for [test4]"));
+                "*took [*] to compute cluster state update for [test4], which exceeds the warn threshold of [10s]"));
         mockAppender.addExpectation(
             new MockLogAppender.UnseenEventExpectation(
                 "test5 should not log despite publishing slowly",


### PR DESCRIPTION
We tend to include the phrase `warn threshold` in log messages
indicating that something took much longer than we expected. The
`MasterService` has some log messages that date from before the adoption
of this convention. This commit adds the phrase `warn threshold` to
those logs.

Relates #76625