### PR TITLE
Don't export docker images on assemble

### DIFF
--- a/distribution/docker/build.gradle
+++ b/distribution/docker/build.gradle
@@ -469,9 +469,5 @@ subprojects { Project subProject ->
       name artifactName
       builtBy exportTaskName
     }
-
-    tasks.named("assemble").configure {
-      dependsOn(exportTaskName)
-    }
   }
 }


### PR DESCRIPTION
Our packaging tests set up dependencies so that the tests depend on the
artifact that is going to be tested. For Docker, the tests depend on an
export of the Docker image, partly to follow the pattern, but partly to
support loading the image when the tests are executed inside Vagrant.

There is a sub-project for each type of image that can be exported. The
main Docker build file adds an export task and an artifact to the
sub-project. However, it also makes the export task a dependency of the
sub-project's `assemble` task. This last step isn't necessary for the
tests to run, and causes extra and needless work to be done when running
`assemble` on the entire build. Therefore, removing the last bit of task
wiring.