### PR TITLE
Test fix for WildcardFieldMapperTests

### DIFF
--- a/x-pack/plugin/wildcard/src/test/java/org/elasticsearch/xpack/wildcard/mapper/WildcardFieldMapperTests.java
+++ b/x-pack/plugin/wildcard/src/test/java/org/elasticsearch/xpack/wildcard/mapper/WildcardFieldMapperTests.java
@@ -130,7 +130,7 @@ public class WildcardFieldMapperTests extends MapperTestCase {
         RandomIndexWriter iw = new RandomIndexWriter(random(), dir, iwc);
 
         // Create a string that is too large and will not be indexed
-        String docContent = randomABString(MAX_FIELD_LENGTH + 1);
+        String docContent = "a" + randomABString(MAX_FIELD_LENGTH);
         Document doc = new Document();
         LuceneDocument parseDoc = new LuceneDocument();
         addFields(parseDoc, doc, docContent);


### PR DESCRIPTION
Test was relying on seed producing a 31 character length string made of only letters from `AaBb` and having at least one `a`. 
Lady luck threw up a seed that broke this assumption so I added code to ensure it was in there.

Closes #76811
