### PR TITLE
Remove keystore initial_md5sum

### DIFF
--- a/distribution/packages/src/common/scripts/postinst
+++ b/distribution/packages/src/common/scripts/postinst
@@ -79,7 +79,6 @@ if [ "$PACKAGE" = "deb" ]; then
         /usr/share/elasticsearch/bin/elasticsearch-keystore create
         chown root:elasticsearch "${ES_PATH_CONF}"/elasticsearch.keystore
         chmod 660 "${ES_PATH_CONF}"/elasticsearch.keystore
-        md5sum "${ES_PATH_CONF}"/elasticsearch.keystore > "${ES_PATH_CONF}"/.elasticsearch.keystore.initial_md5sum
     else
         if /usr/share/elasticsearch/bin/elasticsearch-keystore has-passwd --silent ; then
           echo "### Warning: unable to upgrade encrypted keystore" 1>&2

--- a/distribution/packages/src/common/scripts/postrm
+++ b/distribution/packages/src/common/scripts/postrm
@@ -18,6 +18,7 @@ export ES_PATH_CONF=${ES_PATH_CONF:-@path.conf@}
 
 REMOVE_DIRS=false
 REMOVE_JVM_OPTIONS_DIRECTORY=false
+REMOVE_ELASTICSEARCH_KEYSTORE=false
 REMOVE_USER_AND_GROUP=false
 
 case "$1" in
@@ -30,6 +31,7 @@ case "$1" in
     purge)
         REMOVE_DIRS=true
         REMOVE_JVM_OPTIONS_DIRECTORY=true
+        REMOVE_ELASTICSEARCH_KEYSTORE=true
         REMOVE_USER_AND_GROUP=true
     ;;
     failed-upgrade|abort-install|abort-upgrade|disappear|upgrade|disappear)
@@ -94,6 +96,15 @@ if [ "$REMOVE_DIRS" = "true" ]; then
         echo -n "Deleting jvm.options.d directory..."
         rm -rf "${ES_PATH_CONF}/jvm.options.d"
         echo " OK"
+      fi
+    fi
+
+    # delete the elasticsearch keystore if we are purging
+    if [ "$REMOVE_ELASTICSEARCH_KEYSTORE" = "true" ]; then
+      if [ -e "${ES_PATH_CONF}/elasticsearch.keystore" ]; then
+        echo -n "Deleting elasticsearch.keystore..."
+        rm -f "${ES_PATH_CONF}/elasticsearch.keystore"
+        echo "OK"
       fi
     fi
 

--- a/distribution/packages/src/common/scripts/posttrans
+++ b/distribution/packages/src/common/scripts/posttrans
@@ -9,7 +9,6 @@ if [ ! -f "${ES_PATH_CONF}"/elasticsearch.keystore ]; then
     /usr/share/elasticsearch/bin/elasticsearch-keystore create
     chown root:elasticsearch "${ES_PATH_CONF}"/elasticsearch.keystore
     chmod 660 "${ES_PATH_CONF}"/elasticsearch.keystore
-    md5sum "${ES_PATH_CONF}"/elasticsearch.keystore > "${ES_PATH_CONF}"/.elasticsearch.keystore.initial_md5sum
 else
     if /usr/share/elasticsearch/bin/elasticsearch-keystore has-passwd --silent ; then
       echo "### Warning: unable to upgrade encrypted keystore" 1>&2

--- a/distribution/packages/src/common/scripts/prerm
+++ b/distribution/packages/src/common/scripts/prerm
@@ -58,12 +58,6 @@ if [ "$STOP_REQUIRED" = "true" ]; then
     echo " OK"
 fi
 
-if [ -f "${ES_PATH_CONF}"/elasticsearch.keystore ]; then
-  if md5sum --status -c "${ES_PATH_CONF}"/.elasticsearch.keystore.initial_md5sum; then
-    rm "${ES_PATH_CONF}"/elasticsearch.keystore "${ES_PATH_CONF}"/.elasticsearch.keystore.initial_md5sum
-  fi
-fi
-
 if [ "$REMOVE_SERVICE" = "true" ]; then
     if command -v systemctl >/dev/null; then
         systemctl disable elasticsearch.service > /dev/null 2>&1 || true

--- a/qa/os/src/test/java/org/elasticsearch/packaging/test/DebPreservationTests.java
+++ b/qa/os/src/test/java/org/elasticsearch/packaging/test/DebPreservationTests.java
@@ -63,10 +63,6 @@ public class DebPreservationTests extends PackagingTestCase {
             installation.config("users_roles")
         );
 
-        // keystore was removed
-
-        assertPathsDoNotExist(installation.config("elasticsearch.keystore"), installation.config(".elasticsearch.keystore.initial_md5sum"));
-
         // doc files were removed
 
         assertPathsDoNotExist(Paths.get("/usr/share/doc/elasticsearch"), Paths.get("/usr/share/doc/elasticsearch/copyright"));

--- a/qa/os/src/test/java/org/elasticsearch/packaging/test/DebPreservationTests.java
+++ b/qa/os/src/test/java/org/elasticsearch/packaging/test/DebPreservationTests.java
@@ -63,8 +63,10 @@ public class DebPreservationTests extends PackagingTestCase {
             installation.config("users_roles")
         );
 
-        // doc files were removed
+        // keystore was not removed
+        assertPathsExist(installation.config("elasticsearch.keystore"));
 
+        // doc files were removed
         assertPathsDoNotExist(Paths.get("/usr/share/doc/elasticsearch"), Paths.get("/usr/share/doc/elasticsearch/copyright"));
 
         // defaults file was not removed

--- a/qa/os/src/test/java/org/elasticsearch/packaging/util/Packages.java
+++ b/qa/os/src/test/java/org/elasticsearch/packaging/util/Packages.java
@@ -187,7 +187,6 @@ public class Packages {
 
         Stream.of("elasticsearch.keystore", "elasticsearch.yml", "jvm.options", "log4j2.properties")
             .forEach(configFile -> assertThat(es.config(configFile), file(File, "root", "elasticsearch", p660)));
-        assertThat(es.config(".elasticsearch.keystore.initial_md5sum"), file(File, "root", "elasticsearch", p644));
 
         assertThat(sh.run("sudo -u elasticsearch " + es.bin("elasticsearch-keystore") + " list").stdout, containsString("keystore.seed"));
 


### PR DESCRIPTION
Elasticsearch's keystore initial md5sum was added in #28928 with
the intention to allow us to remove the elasticsearch.keystore
file upon package removal, if this hadn't been altered after
installation. At that time this decision made perfect sense as
the elasticsearch keystore only contains transient data by
default ( keystore.seed ) that is meant to be useful for bootstrap
related actions, and doesn't need to survive re-installations.

With Security ON by default, we will be storing additional
settings in the keystore upon installation(namely, the passwords
for the PKCS#12 keystores used for TLS) and these have a more
persistent nature. Since `remove` doesn't delete the configuration
directories and files where said PKCS#12 keystores are stored, it
makes sense to also not delete the elasticsearch.keystore which
stores the passwords.