### PR TITLE
Test fix -WildcardFieldMapperTests bad test data. (#76819)

### DIFF
--- a/x-pack/plugin/wildcard/src/test/java/org/elasticsearch/xpack/wildcard/mapper/WildcardFieldMapperTests.java
+++ b/x-pack/plugin/wildcard/src/test/java/org/elasticsearch/xpack/wildcard/mapper/WildcardFieldMapperTests.java
@@ -130,7 +130,7 @@ public class WildcardFieldMapperTests extends MapperTestCase {
         RandomIndexWriter iw = new RandomIndexWriter(random(), dir, iwc);
 
         // Create a string that is too large and will not be indexed
-        String docContent = randomABString(MAX_FIELD_LENGTH + 1);
+        String docContent = "a" + randomABString(MAX_FIELD_LENGTH);
         Document doc = new Document();
         LuceneDocument parseDoc = new LuceneDocument();
         addFields(parseDoc, doc, docContent);


### PR DESCRIPTION
Seed produced a random document field value that didn’t produce any of the characters we were searching for.
Closes #76811
