### PR TITLE
Re-enable BWC tests after backport of #76771

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -138,9 +138,9 @@ tasks.register("verifyVersions") {
  * after the backport of the backcompat code is complete.
  */
 
-boolean bwc_tests_enabled = false
+boolean bwc_tests_enabled = true
 // place a PR link here when committing bwc changes:
-String bwc_tests_disabled_issue = "https://github.com/elastic/elasticsearch/pull/76771"
+String bwc_tests_disabled_issue = ""
 /*
  * FIPS 140-2 behavior was fixed in 7.11.0. Before that there is no way to run elasticsearch in a
  * JVM that is properly configured to be in fips mode with BCFIPS. For now we need to disable

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/nodes.stats/30_discovery.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/nodes.stats/30_discovery.yml
@@ -45,8 +45,8 @@
 "Master timing stats":
   - skip:
       features: [arbitrary_key]
-      version: "- 7.99.99"
-      reason: "master timing stats added in 8.0.0"
+      version: "- 7.15.99"
+      reason: "master timing stats added in 7.16.0"
 
   - do:
       nodes.info:

--- a/server/src/main/java/org/elasticsearch/cluster/service/ClusterStateUpdateStats.java
+++ b/server/src/main/java/org/elasticsearch/cluster/service/ClusterStateUpdateStats.java
@@ -117,7 +117,7 @@ public class ClusterStateUpdateStats implements Writeable, ToXContentFragment {
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        assert out.getVersion().onOrAfter(Version.V_8_0_0) : out.getVersion();
+        assert out.getVersion().onOrAfter(Version.V_7_16_0) : out.getVersion();
         out.writeVLong(unchangedTaskCount);
         out.writeVLong(publicationSuccessCount);
         out.writeVLong(publicationFailureCount);

--- a/server/src/main/java/org/elasticsearch/discovery/DiscoveryStats.java
+++ b/server/src/main/java/org/elasticsearch/discovery/DiscoveryStats.java
@@ -39,7 +39,7 @@ public class DiscoveryStats implements Writeable, ToXContentFragment {
     public DiscoveryStats(StreamInput in) throws IOException {
         queueStats = in.readOptionalWriteable(PendingClusterStateStats::new);
         publishStats = in.readOptionalWriteable(PublishClusterStateStats::new);
-        if (in.getVersion().onOrAfter(Version.V_8_0_0)) {
+        if (in.getVersion().onOrAfter(Version.V_7_16_0)) {
             clusterStateUpdateStats = in.readOptionalWriteable(ClusterStateUpdateStats::new);
         } else {
             clusterStateUpdateStats = null;
@@ -50,7 +50,7 @@ public class DiscoveryStats implements Writeable, ToXContentFragment {
     public void writeTo(StreamOutput out) throws IOException {
         out.writeOptionalWriteable(queueStats);
         out.writeOptionalWriteable(publishStats);
-        if (out.getVersion().onOrAfter(Version.V_8_0_0)) {
+        if (out.getVersion().onOrAfter(Version.V_7_16_0)) {
             out.writeOptionalWriteable(clusterStateUpdateStats);
         }
     }


### PR DESCRIPTION
Adjusts the wire compatibility constraints and reverts commit
18e657aed9e8dd0d89522befc720175df1435d3d.