### PR TITLE
Fix up Zen1IT

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/coordination/Zen1IT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/coordination/Zen1IT.java
@@ -61,15 +61,14 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 
 @ESIntegTestCase.ClusterScope(scope = ESIntegTestCase.Scope.TEST, numDataNodes = 0)
-@LuceneTestCase.AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/76847")
 public class Zen1IT extends ESIntegTestCase {
 
-    private static Settings ZEN1_SETTINGS = Coordinator.addZen1Attribute(true, Settings.builder()
+    private static final Settings ZEN1_SETTINGS = Coordinator.addZen1Attribute(true, Settings.builder()
         .put(DiscoveryModule.DISCOVERY_TYPE_SETTING.getKey(), DiscoveryModule.ZEN_DISCOVERY_TYPE)
         .put(IndicesService.WRITE_DANGLING_INDICES_INFO_SETTING.getKey(), false)
         ).build();
 
-    private static Settings ZEN2_SETTINGS = Settings.builder()
+    private static final Settings ZEN2_SETTINGS = Settings.builder()
         .put(DiscoveryModule.DISCOVERY_TYPE_SETTING.getKey(), DiscoveryModule.ZEN2_DISCOVERY_TYPE)
         .build();
 

--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/coordination/Zen1IT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/coordination/Zen1IT.java
@@ -7,7 +7,6 @@
  */
 package org.elasticsearch.cluster.coordination;
 
-import org.apache.lucene.util.LuceneTestCase;
 import org.elasticsearch.action.admin.cluster.configuration.AddVotingConfigExclusionsAction;
 import org.elasticsearch.action.admin.cluster.configuration.AddVotingConfigExclusionsRequest;
 import org.elasticsearch.action.admin.cluster.configuration.ClearVotingConfigExclusionsAction;

--- a/server/src/main/java/org/elasticsearch/discovery/zen/ZenDiscovery.java
+++ b/server/src/main/java/org/elasticsearch/discovery/zen/ZenDiscovery.java
@@ -317,6 +317,12 @@ public class ZenDiscovery extends AbstractLifecycleComponent implements Discover
         assert newState.getNodes().isLocalNodeElectedMaster()
             : "Shouldn't publish state when not master " + clusterStatePublicationEvent.getSummary();
 
+        // don't record timing stats in legacy discovery
+        clusterStatePublicationEvent.setPublicationContextConstructionElapsedMillis(0L);
+        clusterStatePublicationEvent.setPublicationCommitElapsedMillis(0L);
+        clusterStatePublicationEvent.setMasterApplyElapsedMillis(0L);
+        clusterStatePublicationEvent.setPublicationCompletionElapsedMillis(0L);
+
         try {
 
             // state got changed locally (maybe because another master published to us)


### PR DESCRIPTION
Legacy "zen" discovery doesn't record any timing stats, but these stats
are required. Fixes this by recording zeroes for everything.

Closes #76847