### PR TITLE
[7.15] Upgrade build scan plugin to 3.6.4 (#76784)

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -1,5 +1,5 @@
 plugins {
-  id "com.gradle.enterprise" version "3.6.2"
+  id "com.gradle.enterprise" version "3.6.4"
 }
 
 includeBuild "build-conventions"


### PR DESCRIPTION
Backports the following commits to 7.15:
 - Upgrade build scan plugin to 3.6.4 (#76784)