### PR TITLE
[Test] More robust assertions for sorting and pagination (#76654)

### DIFF
--- a/x-pack/plugin/security/qa/security-basic/src/javaRestTest/java/org/elasticsearch/xpack/security/QueryApiKeyIT.java
+++ b/x-pack/plugin/security/qa/security-basic/src/javaRestTest/java/org/elasticsearch/xpack/security/QueryApiKeyIT.java
@@ -233,13 +233,12 @@ public class QueryApiKeyIT extends SecurityInBasicRestTestCase {
         final int from = randomIntBetween(0, 3);
         final int size = randomIntBetween(2, 5);
         final int remaining = total - from;
-        final List<String> sortFields = org.elasticsearch.core.List.of(randomFrom("name", "creation"), "_doc");
-        final String sortFieldsString = sortFields.stream().map(f -> "\"" + f + "\"").collect(Collectors.joining(","));
+        final String sortField = randomFrom("name", "creation");
 
         final List<Map<String, Object>> apiKeyInfos = new ArrayList<>(remaining);
         final Request request1 = new Request("GET", "/_security/_query/api_key");
         request1.setOptions(request1.getOptions().toBuilder().addHeader(HttpHeaders.AUTHORIZATION, authHeader));
-        request1.setJsonEntity("{\"from\":" + from + ",\"size\":" + size + ",\"sort\":[" + sortFieldsString + "]}");
+        request1.setJsonEntity("{\"from\":" + from + ",\"size\":" + size + ",\"sort\":[\"" + sortField + "\"]}");
         int actualSize = collectApiKeys(apiKeyInfos, request1, total, size);
         assertThat(actualSize, equalTo(size));  // first batch should be a full page
 
@@ -248,13 +247,12 @@ public class QueryApiKeyIT extends SecurityInBasicRestTestCase {
             request2.setOptions(request2.getOptions().toBuilder().addHeader(HttpHeaders.AUTHORIZATION, authHeader));
             final StringBuilder searchAfter = new StringBuilder();
             final List<Object> sortValues = extractSortValues(apiKeyInfos.get(apiKeyInfos.size() - 1));
-            if (sortFields.get(0).equals("name")) {
+            if ("name".equals(sortField)) {
                 searchAfter.append("\"").append(sortValues.get(0)).append("\"");
             } else {
                 searchAfter.append(sortValues.get(0));
             }
-            searchAfter.append(",").append(sortValues.get(1));
-            request2.setJsonEntity("{\"size\":" + size + ",\"sort\":[" + sortFieldsString + "],\"search_after\":[" + searchAfter + "]}");
+            request2.setJsonEntity("{\"size\":" + size + ",\"sort\":[\"" + sortField + "\"],\"search_after\":[" + searchAfter + "]}");
             actualSize = collectApiKeys(apiKeyInfos, request2, total, size);
             if (actualSize == 0 && apiKeyInfos.size() < remaining) {
                 fail("fail to retrieve all API keys, expect [" + remaining + "] keys, got [" + apiKeyInfos + "]");
@@ -266,7 +264,7 @@ public class QueryApiKeyIT extends SecurityInBasicRestTestCase {
         }
 
         // assert sort values match the field of API key information
-        if ("name".equals(sortFields.get(0))) {
+        if ("name".equals(sortField)) {
             assertThat(
                 apiKeyInfos.stream().map(m -> (String) m.get("name")).collect(Collectors.toList()),
                 equalTo(apiKeyInfos.stream().map(m -> (String) extractSortValues(m).get(0)).collect(Collectors.toList())));
@@ -276,11 +274,11 @@ public class QueryApiKeyIT extends SecurityInBasicRestTestCase {
                 equalTo(apiKeyInfos.stream().map(m -> (long) extractSortValues(m).get(0)).collect(Collectors.toList())));
         }
         assertThat(
-            apiKeyInfos.stream().map(m -> (String) m.get("name")).collect(Collectors.toList()),
-            equalTo(apiKeyNames.subList(from, total)));
-        assertThat(
             apiKeyInfos.stream().map(m -> (String) m.get("id")).collect(Collectors.toList()),
             equalTo(apiKeyIds.subList(from, total)));
+        assertThat(
+            apiKeyInfos.stream().map(m -> (String) m.get("name")).collect(Collectors.toList()),
+            equalTo(apiKeyNames.subList(from, total)));
 
         // size can be zero, but total should still reflect the number of keys matched
         final Request request2 = new Request("GET", "/_security/_query/api_key");
@@ -338,10 +336,13 @@ public class QueryApiKeyIT extends SecurityInBasicRestTestCase {
 
         assertQuery(authHeader, "{\"sort\":[\"_doc\"]}", apiKeys -> {
             assertThat(apiKeys.size(), equalTo(3));
+            final List<String> ids = new ArrayList<>(3);
             for (int i = 0; i < 3; i++) {
-                assertThat(apiKeys.get(i).get("id"), equalTo(apiKeyIds.get(i)));
+                ids.add((String) apiKeys.get(i).get("id"));
                 assertThat(apiKeys.get(i).get("_sort"), notNullValue());
             }
+            // There is no guarantee that _doc order is the same as creation order
+            assertThat(ids, containsInAnyOrder(apiKeyIds.toArray()));
         });
 
         final String invalidFieldName = randomFrom("doc_type", "api_key_invalidated", "metadata_flattened.letter");


### PR DESCRIPTION
Remove potential duplicates from results gathered with sorting
and search_after. Pagination does not use _doc anymore since it could
change between requests.

Resolves: #76542
