### PR TITLE
Save some Memory in Watcher XContent -> Map Round Trip

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/watcher/support/WatcherUtils.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/watcher/support/WatcherUtils.java
@@ -30,8 +30,8 @@ public final class WatcherUtils {
     }
 
     public static Map<String, Object> responseToData(ToXContentObject response, ToXContent.Params params) throws IOException {
-        return XContentHelper.convertToMap(XContentHelper.toXContent(response, XContentType.JSON, params, false), false,
-            XContentType.JSON).v2();
+        return XContentHelper.convertToMap(XContentHelper.toXContent(response, XContentType.SMILE, params, false), false,
+            XContentType.SMILE).v2();
     }
 
     public static Map<String, Object> flattenModel(Map<String, Object> map) {

--- a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/input/search/ExecutableSearchInput.java
+++ b/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/input/search/ExecutableSearchInput.java
@@ -96,10 +96,10 @@ public class ExecutableSearchInput extends ExecutableInput<SearchInput, SearchIn
             params = EMPTY_PARAMS;
         }
         if (input.getExtractKeys() != null) {
-            BytesReference bytes = XContentHelper.toXContent(response, XContentType.JSON, params, false);
+            BytesReference bytes = XContentHelper.toXContent(response, XContentType.SMILE, params, false);
             // EMPTY is safe here because we never use namedObject
             try (XContentParser parser = XContentHelper
-                    .createParser(NamedXContentRegistry.EMPTY, LoggingDeprecationHandler.INSTANCE, bytes, XContentType.JSON)) {
+                    .createParser(NamedXContentRegistry.EMPTY, LoggingDeprecationHandler.INSTANCE, bytes, XContentType.SMILE)) {
                 Map<String, Object> filteredKeys = XContentFilterKeysUtils.filterMapOrdered(input.getExtractKeys(), parser);
                 payload = new Payload.Simple(filteredKeys);
             }


### PR DESCRIPTION
Low effort quick-fix to improve efficiency of this round trip and push the  boundary of what search responses we can still convert before the 2G buffer size limit kicks in until we have a real fix. Also, should be faster and more memory efficient in all other non-broken cases as well to use SMILE here.

relates #74513

