### PR TITLE
SQL: Change the rolled over file name to consider the compression

### DIFF
--- a/x-pack/plugin/sql/qa/server/security/build.gradle
+++ b/x-pack/plugin/sql/qa/server/security/build.gradle
@@ -50,7 +50,7 @@ subprojects {
     nonInputProperties.systemProperty 'tests.audit.logfile',
       "${-> testClusters.integTest.singleNode().getAuditLog()}"
     nonInputProperties.systemProperty 'tests.audit.yesterday.logfile',
-      "${-> testClusters.integTest.singleNode().getAuditLog().getParentFile()}/integTest_audit-${new Date().format('yyyy-MM-dd')}.json"
+      "${-> testClusters.integTest.singleNode().getAuditLog().getParentFile()}/integTest_audit-${new Date().format('yyyy-MM-dd')}-1.json.gz"
   }
 
   tasks.named("testingConventions").configure { enabled = false }

--- a/x-pack/plugin/sql/qa/server/security/src/test/java/org/elasticsearch/xpack/sql/qa/security/CliSecurityIT.java
+++ b/x-pack/plugin/sql/qa/server/security/src/test/java/org/elasticsearch/xpack/sql/qa/security/CliSecurityIT.java
@@ -28,19 +28,15 @@ import static org.hamcrest.Matchers.startsWith;
 public class CliSecurityIT extends SqlSecurityTestCase {
 
     @Override
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/76806")
     public void testDescribeWorksAsFullAccess() {}
 
     @Override
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/76806")
     public void testQuerySingleFieldGranted() {}
 
     @Override
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/76806")
     public void testScrollWithSingleFieldExcepted() {}
 
     @Override
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/76806")
     public void testQueryWorksAsAdmin() {}
 
     static SecurityConfig adminSecurityConfig() {

--- a/x-pack/plugin/sql/qa/server/security/src/test/java/org/elasticsearch/xpack/sql/qa/security/SqlSecurityTestCase.java
+++ b/x-pack/plugin/sql/qa/server/security/src/test/java/org/elasticsearch/xpack/sql/qa/security/SqlSecurityTestCase.java
@@ -28,7 +28,11 @@ import org.junit.AfterClass;
 import org.junit.Before;
 
 import java.io.BufferedReader;
+import java.io.FileInputStream;
 import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.Reader;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -44,6 +48,7 @@ import java.util.Map;
 import java.util.TreeMap;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+import java.util.zip.GZIPInputStream;
 
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonMap;
@@ -587,8 +592,12 @@ public abstract class SqlSecurityTestCase extends ESRestTestCase {
                             if (localAuditFileRolledOver == false && Files.exists(ROLLED_OVER_AUDIT_LOG_FILE)) {
                                 // once the audit file rolled over, it will stay like this
                                 auditFileRolledOver = true;
+                                // unzip the file
+                                InputStream fileStream = new FileInputStream(ROLLED_OVER_AUDIT_LOG_FILE.toFile());
+                                InputStream gzipStream = new GZIPInputStream(fileStream);
+                                Reader decoder = new InputStreamReader(gzipStream, StandardCharsets.UTF_8);
                                 // the order in the array matters, as the readers will be used in that order
-                                logReaders[0] = Files.newBufferedReader(ROLLED_OVER_AUDIT_LOG_FILE, StandardCharsets.UTF_8);
+                                logReaders[0] = new BufferedReader(decoder);
                             }
                             logReaders[1] = Files.newBufferedReader(AUDIT_LOG_FILE, StandardCharsets.UTF_8);
                             return null;

--- a/x-pack/plugin/sql/qa/server/security/src/test/java/org/elasticsearch/xpack/sql/qa/security/SqlSecurityTestCase.java
+++ b/x-pack/plugin/sql/qa/server/security/src/test/java/org/elasticsearch/xpack/sql/qa/security/SqlSecurityTestCase.java
@@ -28,7 +28,6 @@ import org.junit.AfterClass;
 import org.junit.Before;
 
 import java.io.BufferedReader;
-import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
@@ -593,8 +592,7 @@ public abstract class SqlSecurityTestCase extends ESRestTestCase {
                                 // once the audit file rolled over, it will stay like this
                                 auditFileRolledOver = true;
                                 // unzip the file
-                                InputStream fileStream = new FileInputStream(ROLLED_OVER_AUDIT_LOG_FILE.toFile());
-                                InputStream gzipStream = new GZIPInputStream(fileStream);
+                                InputStream gzipStream = new GZIPInputStream(Files.newInputStream(ROLLED_OVER_AUDIT_LOG_FILE));
                                 Reader decoder = new InputStreamReader(gzipStream, StandardCharsets.UTF_8);
                                 // the order in the array matters, as the readers will be used in that order
                                 logReaders[0] = new BufferedReader(decoder);


### PR DESCRIPTION
Following the change in https://github.com/elastic/elasticsearch/pull/64472, the rolled over audit file is now compressed. The IT tests that look at the audit file content should account for this change.

Fixes https://github.com/elastic/elasticsearch/issues/73657.