### PR TITLE
[DOCS] Fixing field context examples

### DIFF
--- a/docs/painless/painless-contexts/painless-context-examples.asciidoc
+++ b/docs/painless/painless-contexts/painless-context-examples.asciidoc
@@ -86,9 +86,9 @@ POST seats/_bulk?pipeline=seats&refresh=true
 {"create":{"_index":"seats","_id":"1"}}
 {"theatre":"Skyline","play":"Rent","actors":["James Holland","Krissy Smith","Joe Muir","Ryan Earns"],"date":"2021-4-1","time":"3:00PM","cost":37,"row":1,"number":7,"sold":false}
 {"create":{"_index":"seats","_id":"2"}}
-{"theatre":"Graye","play":"Rent","actors":"Dave Christmas","date":"2021-4-1","time":"3:00PM","cost":30,"row":3,"number":5,"sold":false}
+{"theatre":"Graye","play":"Rent","actors":["Dave Christmas"],"date":"2021-4-1","time":"3:00PM","cost":30,"row":3,"number":5,"sold":false}
 {"create":{"_index":"seats","_id":"3"}}
-{"theatre":"Graye","play":"Rented","actors":"Dave Christmas","date":"2021-4-1","time":"3:00PM","cost":33,"row":2,"number":6,"sold":false}
+{"theatre":"Graye","play":"Rented","actors":["Dave Christmas"],"date":"2021-4-1","time":"3:00PM","cost":33,"row":2,"number":6,"sold":false}
 {"create":{"_index":"seats","_id":"4"}}
 {"theatre":"Skyline","play":"Rented","actors":["James Holland","Krissy Smith","Joe Muir","Ryan Earns"],"date":"2021-4-1","time":"3:00PM","cost":20,"row":5,"number":2,"sold":false}
 {"create":{"_index":"seats","_id":"5"}}

--- a/docs/painless/painless-contexts/painless-field-context.asciidoc
+++ b/docs/painless/painless-contexts/painless-field-context.asciidoc
@@ -38,47 +38,98 @@ You can then use these two example scripts to compute custom information
 for each search hit and output it to two new fields.
 
 The first script gets the doc value for the `datetime` field and calls
-the `getDayOfWeek` function to determine the corresponding day of the week.
+the `getDayOfWeekEnum` function to determine the corresponding day of the week.
 
 [source,Painless]
 ----
-doc['datetime'].value.getDayOfWeekEnum();
+doc['datetime'].value.getDayOfWeekEnum().getDisplayName(TextStyle.FULL, Locale.ROOT)
 ----
 
 The second script calculates the number of actors. Actors' names are stored
-as a text array in the `actors` field.
+as a keyword array in the `actors` field.
 
 [source,Painless]
 ----
-params['_source']['actors'].size();                        <1>
+doc['actors'].size()  <1>
 ----
 
-<1> By default, doc values are not available for text fields. However,
-    you can still calculate the number of actors by extracting actors
-    from `_source`. Note that `params['_source']['actors']` is a list.
+<1> By default, doc values are not available for `text` fields. If `actors` was
+a `text` field, you could still calculate the number of actors by extracting
+values from `_source` with `params['_source']['actors'].size()`.
 
-
-Submit the following request:
+The following request returns the calculated day of week and the number of
+actors that appear in each play:
 
 [source,console]
 ----
 GET seats/_search
 {
+  "size": 2, 
   "query": {
     "match_all": {}
   },
   "script_fields": {
     "day-of-week": {
       "script": {
-        "source": "doc['datetime'].value.getDayOfWeekEnum()"
+        "source": "doc['datetime'].value.getDayOfWeekEnum().getDisplayName(TextStyle.FULL, Locale.ROOT)"
       }
     },
     "number-of-actors": {
       "script": {
-        "source": "params['_source']['actors'].size()"
+        "source": "doc['actors'].size()"
       }
     }
   }
 }
 ----
 // TEST[setup:seats]
+
+[source,console-result]
+----
+{
+  "took" : 68,
+  "timed_out" : false,
+  "_shards" : {
+    "total" : 1,
+    "successful" : 1,
+    "skipped" : 0,
+    "failed" : 0
+  },
+  "hits" : {
+    "total" : {
+      "value" : 11,
+      "relation" : "eq"
+    },
+    "max_score" : 1.0,
+    "hits" : [
+      {
+        "_index" : "seats",
+        "_id" : "1",
+        "_score" : 1.0,
+        "fields" : {
+          "day-of-week" : [
+            "Thursday"
+          ],
+          "number-of-actors" : [
+            4
+          ]
+        }
+      },
+      {
+        "_index" : "seats",
+        "_id" : "2",
+        "_score" : 1.0,
+        "fields" : {
+          "day-of-week" : [
+            "Thursday"
+          ],
+          "number-of-actors" : [
+            1
+          ]
+        }
+      }
+    ]
+  }
+}
+----
+// TESTRESPONSE[s/"took" : 68/"took" : "$body.took"/]


### PR DESCRIPTION
Updates the examples for the Painless field context and also modifies the context examples so that all actors are lists. 

Preview link: https://elasticsearch_76887.docs-preview.app.elstc.co/guide/en/elasticsearch/painless/master/painless-field-context.html

Resolves #76799