### PR TITLE
Add a unit test verifying that the IPv6 scope id is optional for node ips

### DIFF
--- a/server/src/test/java/org/elasticsearch/common/network/InetAddressesTests.java
+++ b/server/src/test/java/org/elasticsearch/common/network/InetAddressesTests.java
@@ -25,6 +25,8 @@ import java.net.NetworkInterface;
 import java.net.UnknownHostException;
 import java.util.Enumeration;
 
+import static org.hamcrest.Matchers.equalTo;
+
 public class InetAddressesTests extends ESTestCase {
     public void testForStringBogusInput() {
         String[] bogusInputs = {
@@ -110,6 +112,11 @@ public class InetAddressesTests extends ESTestCase {
             // expected behavior
         }
         assertFalse(InetAddresses.isInetAddress("016.016.016.016"));
+    }
+
+    public void testIpv6WithZeroScopeIdIsEqualToIpv6AddressWithOptionalScopeId() {
+        assertThat(InetAddresses.forString("fdbd:dc00:111:222:0:0:0:333"),
+            equalTo(InetAddresses.forString("fdbd:dc00:111:222::333")));
     }
 
     public void testForStringIPv4Input() throws UnknownHostException {


### PR DESCRIPTION
Support for parsing of IPv6 scope ids was introduced in #60172, but the PR was merged only in ES 7.10. The customer reported the issue on 7.6.2 where it's not supported. Add a test to verify that node ips with zeroed scope ids are equal to node ips with the optional scope id.

Closes #72091
Ref #60172