### PR TITLE
[7.x] Fix join keys ordering in a sequence (#76699)

### DIFF
--- a/x-pack/plugin/eql/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/eql/10_basic.yml
+++ b/x-pack/plugin/eql/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/eql/10_basic.yml
@@ -41,6 +41,42 @@ setup:
             user: SYSTEM
             id: 123
             valid: true
+          - index:
+              _index: eql_test
+              _id:    4
+          - event:
+              - category: network
+            "@timestamp": 2020-02-06T12:34:56Z
+            user: ADMIN
+            id: 123
+            valid: true
+          - index:
+              _index: eql_test
+              _id:    5
+          - event:
+              - category: network
+            "@timestamp": 2020-02-07T12:34:56Z
+            user: SYSTEM
+            id: 123
+            valid: true
+          - index:
+              _index: eql_test
+              _id:    6
+          - event:
+              - category: network
+            "@timestamp": 2020-02-08T12:34:56Z
+            user: ADMIN
+            id: 123
+            valid: true
+          - index:
+              _index: eql_test
+              _id:    7
+          - event:
+              - category: network
+            "@timestamp": 2020-02-09T12:34:56Z
+            user: SYSTEM
+            id: 123
+            valid: true
 
 ---
 # Testing round-trip and the basic shape of the response
@@ -381,3 +417,13 @@ setup:
       catch: missing
       eql.get_status:
         id: $id
+---
+"Sequence checking correct join key ordering.":
+
+  - do:
+      eql.search:
+        index: eql_test
+        body:
+          query: 'sequence by user [network where valid == true] [network where true]'
+  - match: {hits.sequences.0.join_keys.0: "ADMIN"}
+  - match: {hits.sequences.1.join_keys.0: "SYSTEM"}

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/execution/sequence/TumblingWindow.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/execution/sequence/TumblingWindow.java
@@ -26,6 +26,7 @@ import org.elasticsearch.xpack.eql.session.Payload.Type;
 import org.elasticsearch.xpack.eql.util.ReversedIterator;
 import org.elasticsearch.xpack.ql.util.ActionListeners;
 
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -548,6 +549,9 @@ public class TumblingWindow implements Executable {
 
         // get results through search (to keep using PIT)
         client.fetchHits(hits(completed), ActionListeners.map(listener, listOfHits -> {
+            if (criteria.get(0).descending()) {
+                Collections.reverse(completed);
+            }
             SequencePayload payload = new SequencePayload(completed, listOfHits, false, timeTook());
             close(listener);
             return payload;


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Fix join keys ordering in a sequence (#76699)