### PR TITLE
Update Azul JVM on Apple M1

### DIFF
--- a/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/JdkDownloadPluginFuncTest.groovy
+++ b/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/JdkDownloadPluginFuncTest.groovy
@@ -214,8 +214,8 @@ class JdkDownloadPluginFuncTest extends AbstractGradleFuncTest {
             return "/java/GA/" + versionPath + "/GPL/" + filename;
         } else if (vendor.equals(VENDOR_AZUL)) {
             final String module = isMac(platform) ? "macosx" : platform;
-            // we only test zulu 15 darwin aarch64 for now
-            return "/zulu${module.equals('linux') ? '-embedded' : ''}/bin/zulu16.28.11-ca-jdk16.0.0-${module}_${arch}.tar.gz";
+            // we only test zulu 16 darwin aarch64 for now
+            return "/zulu${module.equals('linux') ? '-embedded' : ''}/bin/zulu16.32.15-ca-jdk16.0.2-${module}_${arch}.tar.gz";
         }
     }
 

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/JdkDownloadPlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/JdkDownloadPlugin.java
@@ -138,7 +138,7 @@ public class JdkDownloadPlugin implements Plugin<Project> {
                         + zuluPathSuffix
                         + "/bin/zulu"
                         + jdk.getMajor()
-                        + ".28.11-ca-jdk16.0.0-"
+                        + ".32.15-ca-jdk16.0.2-"
                         + azulPlatform(jdk)
                         + "_[classifier].[ext]";
                     break;


### PR DESCRIPTION
Closes #76901. Bump the Azul JVM version for `aarch64` M1 i.e. Apple silicon.