### PR TITLE
[7.x] Ensure norms is non-zero in IndexDiskUsageAnalyzerIT (#76894)

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/action/admin/indices/diskusage/IndexDiskUsageAnalyzerIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/action/admin/indices/diskusage/IndexDiskUsageAnalyzerIT.java
@@ -69,7 +69,7 @@ public class IndexDiskUsageAnalyzerIT extends ESIntegTestCase {
                 .startObject()
                 .field("english_text", "A long sentence to make sure that norms is non-zero")
                 .endObject();
-            client().prepareIndex(index)
+            client().prepareIndex(index, "_doc")
                 .setId("id")
                 .setSource(doc)
                 .get();

--- a/server/src/internalClusterTest/java/org/elasticsearch/action/admin/indices/diskusage/IndexDiskUsageAnalyzerIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/action/admin/indices/diskusage/IndexDiskUsageAnalyzerIT.java
@@ -63,6 +63,17 @@ public class IndexDiskUsageAnalyzerIT extends ESIntegTestCase {
                 .setSource(doc)
                 .get();
         }
+        final boolean forceNorms = randomBoolean();
+        if (forceNorms) {
+            final XContentBuilder doc = XContentFactory.jsonBuilder()
+                .startObject()
+                .field("english_text", "A long sentence to make sure that norms is non-zero")
+                .endObject();
+            client().prepareIndex(index)
+                .setId("id")
+                .setSource(doc)
+                .get();
+        }
         PlainActionFuture<AnalyzeIndexDiskUsageResponse> future = PlainActionFuture.newFuture();
         client().execute(AnalyzeIndexDiskUsageAction.INSTANCE,
             new AnalyzeIndexDiskUsageRequest(new String[] {index}, AnalyzeIndexDiskUsageRequest.DEFAULT_INDICES_OPTIONS, true),
@@ -77,8 +88,9 @@ public class IndexDiskUsageAnalyzerIT extends ESIntegTestCase {
         final IndexDiskUsageStats.PerFieldDiskUsage englishField = stats.getFields().get("english_text");
         assertThat(englishField.getInvertedIndexBytes(), greaterThan(0L));
         assertThat(englishField.getStoredFieldBytes(), equalTo(0L));
-        assertThat(englishField.getNormsBytes(), greaterThan(0L));
-
+        if (forceNorms) {
+            assertThat(englishField.getNormsBytes(), greaterThan(0L));
+        }
         final IndexDiskUsageStats.PerFieldDiskUsage valueField = stats.getFields().get("value");
         assertThat(valueField.getInvertedIndexBytes(), equalTo(0L));
         assertThat(valueField.getStoredFieldBytes(), equalTo(0L));


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Ensure norms is non-zero in IndexDiskUsageAnalyzerIT (#76894)