### PR TITLE
Remove unnecessary test task dependency

### DIFF
--- a/x-pack/plugin/sql/qa/mixed-node/build.gradle
+++ b/x-pack/plugin/sql/qa/mixed-node/build.gradle
@@ -62,9 +62,4 @@ for (Version bwcVersion : BuildParams.bwcVersions.wireCompatible.findAll { it.on
   tasks.register(bwcTaskName(bwcVersion)) {
     dependsOn "${baseName}#mixedClusterTest"
   }
-
-  // run these bwc tests as part of the "check" task
-  tasks.named("check").configure {
-    dependsOn "${baseName}#mixedClusterTest"
-  }
 }


### PR DESCRIPTION
We auto-wire the bwcTestSnapshots task to the check task. This dependOn
means we run the full wire compatible test suite on every build which
is not what we want since we run those explicitly in parallel CI jobs.
Running check should only test unreleased versions.
