### PR TITLE
[7.15] Remove unnecessary test task dependency (#76938)

### DIFF
--- a/x-pack/plugin/sql/qa/mixed-node/build.gradle
+++ b/x-pack/plugin/sql/qa/mixed-node/build.gradle
@@ -62,9 +62,4 @@ for (Version bwcVersion : BuildParams.bwcVersions.wireCompatible.findAll { it.on
   tasks.register(bwcTaskName(bwcVersion)) {
     dependsOn "${baseName}#mixedClusterTest"
   }
-
-  // run these bwc tests as part of the "check" task
-  tasks.named("check").configure {
-    dependsOn "${baseName}#mixedClusterTest"
-  }
 }


### PR DESCRIPTION
Backports the following commits to 7.15:
 - Remove unnecessary test task dependency (#76938)