### PR TITLE
[7.x] [DOCS] Add placeholder for 7.14.1 release notes (#76945)

### DIFF
--- a/docs/reference/release-notes.asciidoc
+++ b/docs/reference/release-notes.asciidoc
@@ -6,6 +6,7 @@
 
 This section summarizes the changes in each release.
 
+* <<release-notes-7.14.1>>
 * <<release-notes-7.14.0>>
 * <<release-notes-7.13.2>>
 * <<release-notes-7.13.1>>

--- a/docs/reference/release-notes/7.14.asciidoc
+++ b/docs/reference/release-notes/7.14.asciidoc
@@ -1,3 +1,10 @@
+[[release-notes-7.14.1]]
+== {es} version 7.14.1
+
+coming::[7.14.1]
+
+Also see <<breaking-changes-7.14,Breaking changes in 7.14>>.
+
 [[release-notes-7.14.0]]
 == {es} version 7.14.0
 


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [DOCS] Add placeholder for 7.14.2 release notes (#76945)