### PR TITLE
Handle a edge case for validation of API key role descriptors (#76959)

### DIFF
--- a/x-pack/plugin/security/qa/service-account/src/javaRestTest/java/org/elasticsearch/xpack/security/authc/service/ServiceAccountIT.java
+++ b/x-pack/plugin/security/qa/service-account/src/javaRestTest/java/org/elasticsearch/xpack/security/authc/service/ServiceAccountIT.java
@@ -15,7 +15,6 @@ import org.elasticsearch.client.ResponseException;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.xcontent.ToXContent;
-import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.json.JsonXContent;
 import org.elasticsearch.core.PathUtils;
 import org.elasticsearch.common.settings.SecureString;
@@ -32,7 +31,9 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
+import java.util.Base64;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -398,9 +399,29 @@ public class ServiceAccountIT extends ESRestTestCase {
         createApiKeyRequest1.setOptions(requestOptions);
         final Response createApiKeyResponse1 = client().performRequest(createApiKeyRequest1);
         assertOK(createApiKeyResponse1);
-        final String apiKeyId1 = (String) responseAsMap(createApiKeyResponse1).get("id");
+        final Map<String, Object> createApiKeyResponseMap1 = responseAsMap(createApiKeyResponse1);
+        final String apiKeyId1 = (String) createApiKeyResponseMap1.get("id");
 
         assertApiKeys(apiKeyId1, "key-1", false, requestOptions);
+
+        final String base64ApiKeyKeyValue = Base64.getEncoder().encodeToString(
+            (apiKeyId1 + ":" + createApiKeyResponseMap1.get("api_key")).getBytes(StandardCharsets.UTF_8));
+
+        // API key can monitor cluster
+        final Request mainRequest = new Request("GET", "/");
+        mainRequest.setOptions(mainRequest.getOptions().toBuilder().addHeader(
+            "Authorization", "ApiKey " + base64ApiKeyKeyValue
+        ));
+        assertOK(client().performRequest(mainRequest));
+
+        // API key cannot get user
+        final Request getUserRequest = new Request("GET", "_security/user");
+        getUserRequest.setOptions(getUserRequest.getOptions().toBuilder().addHeader(
+            "Authorization", "ApiKey " + base64ApiKeyKeyValue
+        ));
+        final ResponseException e = expectThrows(ResponseException.class, () -> client().performRequest(getUserRequest));
+        assertThat(e.getResponse().getStatusLine().getStatusCode(), equalTo(403));
+        assertThat(e.getMessage(), containsString("is unauthorized for API key"));
 
         final Request invalidateApiKeysRequest = new Request("DELETE", "_security/api_key");
         invalidateApiKeysRequest.setJsonEntity("{\"ids\":[\"" + apiKeyId1 + "\"],\"owner\":true}");

--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/authc/apikey/ApiKeySingleNodeTests.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/authc/apikey/ApiKeySingleNodeTests.java
@@ -7,21 +7,51 @@
 
 package org.elasticsearch.xpack.security.authc.apikey;
 
+import org.elasticsearch.ElasticsearchSecurityException;
+import org.elasticsearch.action.admin.indices.create.CreateIndexAction;
+import org.elasticsearch.action.admin.indices.create.CreateIndexRequest;
+import org.elasticsearch.action.get.GetAction;
+import org.elasticsearch.action.get.GetRequest;
+import org.elasticsearch.action.get.GetResponse;
+import org.elasticsearch.action.main.MainAction;
+import org.elasticsearch.action.main.MainRequest;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.settings.SecureString;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.test.SecuritySingleNodeTestCase;
+import org.elasticsearch.test.XContentTestUtils;
 import org.elasticsearch.xpack.core.XPackSettings;
 import org.elasticsearch.xpack.core.security.action.CreateApiKeyAction;
 import org.elasticsearch.xpack.core.security.action.CreateApiKeyRequest;
+import org.elasticsearch.xpack.core.security.action.CreateApiKeyResponse;
+import org.elasticsearch.xpack.core.security.action.GrantApiKeyAction;
+import org.elasticsearch.xpack.core.security.action.GrantApiKeyRequest;
 import org.elasticsearch.xpack.core.security.action.apikey.QueryApiKeyAction;
 import org.elasticsearch.xpack.core.security.action.apikey.QueryApiKeyRequest;
 import org.elasticsearch.xpack.core.security.action.apikey.QueryApiKeyResponse;
+import org.elasticsearch.xpack.core.security.action.service.CreateServiceAccountTokenAction;
+import org.elasticsearch.xpack.core.security.action.service.CreateServiceAccountTokenRequest;
+import org.elasticsearch.xpack.core.security.action.service.CreateServiceAccountTokenResponse;
+import org.elasticsearch.xpack.core.security.action.user.PutUserAction;
+import org.elasticsearch.xpack.core.security.action.user.PutUserRequest;
+import org.elasticsearch.xpack.core.security.authc.support.Hasher;
+import org.elasticsearch.xpack.core.security.authz.RoleDescriptor;
+import org.elasticsearch.xpack.security.authc.service.ServiceAccountService;
 
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.time.Instant;
+import java.util.Base64;
+import java.util.Map;
 
+import static org.elasticsearch.xpack.core.security.index.RestrictedIndicesNames.SECURITY_MAIN_ALIAS;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.emptyArray;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasKey;
 
 public class ApiKeySingleNodeTests extends SecuritySingleNodeTestCase {
 
@@ -52,5 +82,86 @@ public class ApiKeySingleNodeTests extends SecuritySingleNodeTestCase {
         assertThat(queryApiKeyResponse.getItems()[0].getApiKey().getId(), equalTo(id2));
         assertThat(queryApiKeyResponse.getItems()[0].getApiKey().getName(), equalTo("long-lived"));
         assertThat(queryApiKeyResponse.getItems()[0].getSortValues(), emptyArray());
+    }
+
+    public void testCreatingApiKeyWithNoAccess() {
+        final PutUserRequest putUserRequest = new PutUserRequest();
+        final String username = randomAlphaOfLength(8);
+        putUserRequest.username(username);
+        final SecureString password = new SecureString("super-strong-password".toCharArray());
+        putUserRequest.passwordHash(Hasher.PBKDF2.hash(password));
+        putUserRequest.roles(Strings.EMPTY_ARRAY);
+        client().execute(PutUserAction.INSTANCE, putUserRequest).actionGet();
+
+        final GrantApiKeyRequest grantApiKeyRequest = new GrantApiKeyRequest();
+        grantApiKeyRequest.getGrant().setType("password");
+        grantApiKeyRequest.getGrant().setUsername(username);
+        grantApiKeyRequest.getGrant().setPassword(password);
+        grantApiKeyRequest.getApiKeyRequest().setName(randomAlphaOfLength(8));
+        grantApiKeyRequest.getApiKeyRequest().setRoleDescriptors(org.elasticsearch.core.List.of(
+            new RoleDescriptor("x", new String[] { "all" },
+                new RoleDescriptor.IndicesPrivileges[]{
+                    RoleDescriptor.IndicesPrivileges.builder().indices("*").privileges("all").allowRestrictedIndices(true).build()
+                },
+                null, null, null, null, null)));
+        final CreateApiKeyResponse createApiKeyResponse = client().execute(GrantApiKeyAction.INSTANCE, grantApiKeyRequest).actionGet();
+
+        final String base64ApiKeyKeyValue = Base64.getEncoder().encodeToString(
+            (createApiKeyResponse.getId() + ":" + createApiKeyResponse.getKey().toString()).getBytes(StandardCharsets.UTF_8));
+
+        // No cluster access
+        final ElasticsearchSecurityException e1 = expectThrows(
+            ElasticsearchSecurityException.class,
+            () -> client().filterWithHeader(org.elasticsearch.core.Map.of("Authorization", "ApiKey " + base64ApiKeyKeyValue))
+                .execute(MainAction.INSTANCE, new MainRequest())
+                .actionGet());
+        assertThat(e1.status().getStatus(), equalTo(403));
+        assertThat(e1.getMessage(), containsString("is unauthorized for API key"));
+
+        // No index access
+        final ElasticsearchSecurityException e2 = expectThrows(
+            ElasticsearchSecurityException.class,
+            () -> client().filterWithHeader(org.elasticsearch.core.Map.of("Authorization", "ApiKey " + base64ApiKeyKeyValue))
+                .execute(CreateIndexAction.INSTANCE, new CreateIndexRequest(
+                    randomFrom(randomAlphaOfLengthBetween(3, 8), SECURITY_MAIN_ALIAS)))
+                .actionGet());
+        assertThat(e2.status().getStatus(), equalTo(403));
+        assertThat(e2.getMessage(), containsString("is unauthorized for API key"));
+    }
+
+    public void testServiceAccountApiKey() throws IOException {
+        final CreateServiceAccountTokenRequest createServiceAccountTokenRequest =
+            new CreateServiceAccountTokenRequest("elastic", "fleet-server", randomAlphaOfLength(8));
+        final CreateServiceAccountTokenResponse createServiceAccountTokenResponse =
+            client().execute(CreateServiceAccountTokenAction.INSTANCE, createServiceAccountTokenRequest).actionGet();
+
+        final CreateApiKeyResponse createApiKeyResponse =
+            client()
+                .filterWithHeader(org.elasticsearch.core.Map.of("Authorization", "Bearer " + createServiceAccountTokenResponse.getValue()))
+                .execute(CreateApiKeyAction.INSTANCE, new CreateApiKeyRequest(randomAlphaOfLength(8), null, null))
+                .actionGet();
+
+        final Map<String, Object> apiKeyDocument = getApiKeyDocument(createApiKeyResponse.getId());
+
+        @SuppressWarnings("unchecked")
+        final Map<String, Object> fleetServerRoleDescriptor =
+            (Map<String, Object>) apiKeyDocument.get("limited_by_role_descriptors");
+        assertThat(fleetServerRoleDescriptor.size(), equalTo(1));
+        assertThat(fleetServerRoleDescriptor, hasKey("elastic/fleet-server"));
+
+        @SuppressWarnings("unchecked")
+        final Map<String, ?> descriptor = (Map<String, ?>) fleetServerRoleDescriptor.get("elastic/fleet-server");
+
+        final RoleDescriptor roleDescriptor = RoleDescriptor.parse("elastic/fleet-server",
+            XContentTestUtils.convertToXContent(descriptor, XContentType.JSON),
+            false,
+            XContentType.JSON);
+        assertThat(roleDescriptor, equalTo(ServiceAccountService.getServiceAccounts().get("elastic/fleet-server").roleDescriptor()));
+    }
+
+    private Map<String, Object> getApiKeyDocument(String apiKeyId) {
+        final GetResponse getResponse =
+            client().execute(GetAction.INSTANCE, new GetRequest(".security-7", apiKeyId)).actionGet();
+        return getResponse.getSource();
     }
 }

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/service/ElasticServiceAccounts.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/service/ElasticServiceAccounts.java
@@ -48,7 +48,7 @@ final class ElasticServiceAccounts {
         new ElasticServiceAccount("kibana", ReservedRolesStore.kibanaSystemRoleDescriptor(NAMESPACE + "/kibana"));
 
     static final Map<String, ServiceAccount> ACCOUNTS = List.of(FLEET_ACCOUNT, KIBANA_SYSTEM_ACCOUNT).stream()
-        .collect(Collectors.toMap(a -> a.id().asPrincipal(), Function.identity()));;
+        .collect(Collectors.toMap(a -> a.id().asPrincipal(), Function.identity()));
 
     private ElasticServiceAccounts() {}
 

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/store/CompositeRolesStore.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/store/CompositeRolesStore.java
@@ -275,7 +275,7 @@ public class CompositeRolesStore {
                     } else {
                         buildAndCacheRoleForApiKey(authentication, true, ActionListener.wrap(
                             limitedByRole -> roleActionListener.onResponse(
-                                limitedByRole == Role.EMPTY ? role : LimitedRole.createLimitedRole(role, limitedByRole)),
+                                LimitedRole.createLimitedRole(role, limitedByRole)),
                             roleActionListener::onFailure
                         ));
                     }

--- a/x-pack/qa/full-cluster-restart/src/test/java/org/elasticsearch/xpack/restart/FullClusterRestartIT.java
+++ b/x-pack/qa/full-cluster-restart/src/test/java/org/elasticsearch/xpack/restart/FullClusterRestartIT.java
@@ -297,6 +297,46 @@ public class FullClusterRestartIT extends AbstractFullClusterRestartTestCase {
         }
     }
 
+    public void testServiceAccountApiKey() throws IOException {
+        assumeTrue("no service accounts in versions before " + Version.V_7_13_0, getOldClusterVersion().onOrAfter(Version.V_7_13_0));
+        if (isRunningAgainstOldCluster()) {
+            final Request createServiceTokenRequest = new Request("POST", "/_security/service/elastic/fleet-server/credential/token");
+            final Response createServiceTokenResponse = client().performRequest(createServiceTokenRequest);
+            assertOK(createServiceTokenResponse);
+            @SuppressWarnings("unchecked")
+            final String serviceToken = ((Map<String, String>) responseAsMap(createServiceTokenResponse).get("token")).get("value");
+            final Request createApiKeyRequest = new Request("PUT", "/_security/api_key");
+            createApiKeyRequest.setOptions(RequestOptions.DEFAULT.toBuilder().addHeader("Authorization", "Bearer " + serviceToken));
+            createApiKeyRequest.setJsonEntity("{\"name\":\"key-1\"}");
+            final Response createApiKeyResponse = client().performRequest(createApiKeyRequest);
+            final Map<String, Object> createApiKeyResponseMap = entityAsMap(createApiKeyResponse);
+            final String authHeader = "ApiKey " + Base64.getEncoder().encodeToString(
+                (createApiKeyResponseMap.get("id") + ":" + createApiKeyResponseMap.get("api_key")).getBytes(StandardCharsets.UTF_8));
+
+            final Request indexRequest = new Request("PUT", "/api_keys/_doc/key-1");
+            indexRequest.setJsonEntity("{\"auth_header\":\"" + authHeader + "\"}");
+            assertOK(client().performRequest(indexRequest));
+        } else {
+            final Request getRequest = new Request("GET", "/api_keys/_doc/key-1");
+            final Response getResponse = client().performRequest(getRequest);
+            assertOK(getResponse);
+            final Map<String, Object> getResponseMap = responseAsMap(getResponse);
+            @SuppressWarnings("unchecked")
+            final String authHeader = ((Map<String, String>) getResponseMap.get("_source")).get("auth_header");
+
+            final Request mainRequest = new Request("GET", "/");
+            mainRequest.setOptions(RequestOptions.DEFAULT.toBuilder().addHeader("Authorization", authHeader));
+            assertOK(client().performRequest(mainRequest));
+
+            final Request getUserRequest = new Request("GET", "/_security/user");
+            getUserRequest.setOptions(RequestOptions.DEFAULT.toBuilder().addHeader("Authorization", authHeader));
+            final ResponseException e =
+                expectThrows(ResponseException.class, () -> client().performRequest(getUserRequest));
+            assertThat(e.getResponse().getStatusLine().getStatusCode(), equalTo(403));
+            assertThat(e.getMessage(), containsString("is unauthorized"));
+        }
+    }
+
     /**
      * Tests that a RollUp job created on a old cluster is correctly restarted after the upgrade.
      */


### PR DESCRIPTION
This PR fixes a BWC edge case: In a mixed cluster, e.g. rolling upgrade, API
keys can sometimes fail to validate due to mismatch of role descriptors
depending on where the request is initially authenticated.
