### PR TITLE
[7.x] Expand the minimum utc timestamp used in fetching timezone transitions (#75584)

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/LocalTimeOffset.java
+++ b/server/src/main/java/org/elasticsearch/common/LocalTimeOffset.java
@@ -28,8 +28,9 @@ import java.util.Locale;
  * utc. So converting from utc is as simple as adding the offset.
  * <p>
  * Getting from local time back to utc is harder. Most local times happen once.
- * But some local times happen twice. And some don't happen at all. Take, for
- * example, the time in my house. Most days I don't touch my clocks and I'm a
+ * But some local times happen twice (DST overlap).
+ * And some don't happen at all (DST gap).  Take, for example,
+ * the time in my house. Most days I don't touch my clocks and I'm a
  * constant offset from UTC. But once in the fall at 2am I roll my clock back.
  * So at 5am utc my clocks say 1am. Then at 6am utc my clocks say 1am AGAIN.
  * I do similarly terrifying things again in the spring when I skip my clocks
@@ -37,6 +38,8 @@ import java.util.Locale;
  * <p>
  * So there are two methods to convert from local time back to utc,
  * {@link #localToUtc(long, Strategy)} and {@link #localToUtcInThisOffset(long)}.
+ * @see ZoneOffsetTransition#isGap()
+ * @see ZoneOffsetTransition#isOverlap()
  */
 public abstract class LocalTimeOffset {
     /**

--- a/server/src/main/java/org/elasticsearch/common/Rounding.java
+++ b/server/src/main/java/org/elasticsearch/common/Rounding.java
@@ -521,7 +521,14 @@ public abstract class Rounding implements Writeable {
         }
 
         private TimeUnitPreparedRounding prepareOffsetOrJavaTimeRounding(long minUtcMillis, long maxUtcMillis) {
-            long minLookup = minUtcMillis - unit.extraLocalOffsetLookup();
+            /*
+             minUtcMillis has to be decreased by 2 units.
+             This is because if a minUtcMillis can be rounded down up to unit.extraLocalOffsetLookup
+             and that rounding down might still fall within DST gap/overlap.
+             Meaning that minUtcMillis has to be decreased by additional unit
+             so that the transition just before the minUtcMillis is applied
+             */
+            long minLookup = minUtcMillis - 2 * unit.extraLocalOffsetLookup();
             long maxLookup = maxUtcMillis;
 
             long unitMillis = 0;

--- a/server/src/test/java/org/elasticsearch/common/RoundingTests.java
+++ b/server/src/test/java/org/elasticsearch/common/RoundingTests.java
@@ -232,6 +232,20 @@ public class RoundingTests extends ESTestCase {
         }
     }
 
+    /**
+     * This test chooses a date in the middle of the transition, so that we can test
+     * if the transition which is before the minLookup, but still should be applied
+     * is not skipped
+     */
+    public void testRoundingAroundDST() {
+        Rounding.DateTimeUnit unit = Rounding.DateTimeUnit.DAY_OF_MONTH;
+        ZoneId tz = ZoneId.of("Canada/Newfoundland");
+        long minLookup = 688618001000L; // 1991-10-28T02:46:41.527Z
+        long maxLookup = 688618001001L; // +1sec
+        // there is a Transition[Overlap at 1991-10-27T00:01-02:30 to -03:30] ”
+        assertUnitRoundingSameAsJavaUtilTimeImplementation(unit, tz, minLookup, maxLookup);
+    }
+
     private void assertUnitRoundingSameAsJavaUtilTimeImplementation(Rounding.DateTimeUnit unit, ZoneId tz, long start, long end) {
         Rounding rounding = new Rounding.TimeUnitRounding(unit, tz);
         Rounding.Prepared prepared = rounding.prepare(start, end);


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Expand the minimum utc timestamp used in fetching timezone transitions (#75584)