### PR TITLE
[7.x] [Transform] Reduce indexes to query based on checkpoints (#75839)

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/transforms/TransformCheckpoint.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/transforms/TransformCheckpoint.java
@@ -21,10 +21,13 @@ import org.elasticsearch.xpack.core.transform.TransformField;
 
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Objects;
+import java.util.Set;
 import java.util.TreeMap;
 
 import static org.elasticsearch.common.xcontent.ConstructingObjectParser.constructorArg;
@@ -310,6 +313,23 @@ public class TransformCheckpoint implements Writeable, ToXContentObject {
         }
 
         return newCheckPointOperationsSum - oldCheckPointOperationsSum;
+    }
+
+    public static Collection<String> getChangedIndices(TransformCheckpoint oldCheckpoint, TransformCheckpoint newCheckpoint) {
+        if (oldCheckpoint.isEmpty()) {
+            return newCheckpoint.indicesCheckpoints.keySet();
+        }
+
+        Set<String> indices = new HashSet<>();
+
+        for (Entry<String, long[]> entry : newCheckpoint.indicesCheckpoints.entrySet()) {
+            // compare against the old checkpoint
+            if (Arrays.equals(entry.getValue(), oldCheckpoint.indicesCheckpoints.get(entry.getKey())) == false) {
+                indices.add(entry.getKey());
+            }
+        }
+
+        return indices;
     }
 
     private static Map<String, long[]> readCheckpoints(Map<String, Object> readMap) {

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/Function.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/Function.java
@@ -15,9 +15,11 @@ import org.elasticsearch.core.Tuple;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
 import org.elasticsearch.xpack.core.transform.transforms.SourceConfig;
+import org.elasticsearch.xpack.core.transform.transforms.TransformCheckpoint;
 import org.elasticsearch.xpack.core.transform.transforms.TransformIndexerStats;
 import org.elasticsearch.xpack.core.transform.transforms.TransformProgress;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
@@ -74,13 +76,20 @@ public interface Function {
         /**
          * Build the filter query to narrow the result set given the previously collected changes.
          *
-         * TODO: it might be useful to have the full checkpoint data.
-         *
-         * @param lastCheckpointTimestamp the timestamp of the last checkpoint
-         * @param nextCheckpointTimestamp the timestamp of the next (in progress) checkpoint
+         * @param lastCheckpoint the last checkpoint
+         * @param nextCheckpoint the next (in progress) checkpoint
          * @return a filter query, null in case of no filter
          */
-        QueryBuilder buildFilterQuery(long lastCheckpointTimestamp, long nextCheckpointTimestamp);
+        QueryBuilder buildFilterQuery(TransformCheckpoint lastCheckpoint, TransformCheckpoint nextCheckpoint);
+
+        /**
+         * Filter indices according to the given checkpoints.
+         *
+         * @param lastCheckpoint the last checkpoint
+         * @param nextCheckpoint the next (in progress) checkpoint
+         * @return set of indices to query
+         */
+        Collection<String> getIndicesToQuery(TransformCheckpoint lastCheckpoint, TransformCheckpoint nextCheckpoint);
 
         /**
          * Clear the internal state to free up memory.

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/TransformIndexer.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/TransformIndexer.java
@@ -1091,32 +1091,34 @@ public abstract class TransformIndexer extends AsyncTwoPhaseIndexer<TransformInd
         return queryBuilder;
     }
 
-    protected SearchRequest buildSearchRequest() {
+    protected Tuple<String, SearchRequest> buildSearchRequest() {
         assert nextCheckpoint != null;
 
-        SearchSourceBuilder sourceBuilder = new SearchSourceBuilder().runtimeMappings(getConfig().getSource().getRuntimeMappings());
         switch (runState) {
             case APPLY_RESULTS:
-                buildUpdateQuery(sourceBuilder);
-                break;
+                return new Tuple<>("apply_results", buildQueryToUpdateDestinationIndex());
             case IDENTIFY_CHANGES:
-                buildChangedBucketsQuery(sourceBuilder);
-                break;
+                return new Tuple<>("identify_changes", buildQueryToFindChanges());
             default:
                 // Any other state is a bug, should not happen
                 logger.warn("Encountered unexpected run state [" + runState + "]");
                 throw new IllegalStateException("Transform indexer job encountered an illegal state [" + runState + "]");
         }
-
-        return new SearchRequest(getConfig().getSource().getIndex()).allowPartialSearchResults(false)
-            .indicesOptions(IndicesOptions.LENIENT_EXPAND_OPEN)
-            .source(sourceBuilder);
     }
 
-    private SearchSourceBuilder buildChangedBucketsQuery(SearchSourceBuilder sourceBuilder) {
+    private SearchRequest buildQueryToFindChanges() {
         assert isContinuous();
 
         TransformIndexerPosition position = getPosition();
+        SearchSourceBuilder sourceBuilder = new SearchSourceBuilder().runtimeMappings(getConfig().getSource().getRuntimeMappings());
+
+        // reduce the indexes to query to the ones that have changes
+        SearchRequest request = new SearchRequest(
+            TransformCheckpoint.getChangedIndices(getLastCheckpoint(), getNextCheckpoint()).toArray(new String[0])
+        );
+
+        request.allowPartialSearchResults(false) // shard failures should fail the request
+            .indicesOptions(IndicesOptions.LENIENT_EXPAND_OPEN); // TODO: make configurable
 
         changeCollector.buildChangesQuery(sourceBuilder, position != null ? position.getBucketsPosition() : null, pageSize);
 
@@ -1130,16 +1132,18 @@ public abstract class TransformIndexer extends AsyncTwoPhaseIndexer<TransformInd
         sourceBuilder.query(filteredQuery);
 
         logger.debug("[{}] Querying for changes: {}", getJobId(), sourceBuilder);
-        return sourceBuilder;
+        return request.source(sourceBuilder);
     }
 
-    private SearchSourceBuilder buildUpdateQuery(SearchSourceBuilder sourceBuilder) {
+    private SearchRequest buildQueryToUpdateDestinationIndex() {
         TransformIndexerPosition position = getPosition();
 
         TransformConfig config = getConfig();
+        SearchSourceBuilder sourceBuilder = new SearchSourceBuilder().runtimeMappings(getConfig().getSource().getRuntimeMappings());
 
         function.buildSearchQuery(sourceBuilder, position != null ? position.getIndexerPosition() : null, pageSize);
 
+        SearchRequest request = new SearchRequest();
         QueryBuilder queryBuilder = config.getSource().getQueryConfig().getQuery();
 
         if (isContinuous()) {
@@ -1148,22 +1152,27 @@ public abstract class TransformIndexer extends AsyncTwoPhaseIndexer<TransformInd
 
             // Only apply extra filter if it is the subsequent run of the continuous transform
             if (nextCheckpoint.getCheckpoint() > 1 && changeCollector != null) {
-                QueryBuilder filter = changeCollector.buildFilterQuery(
-                    lastCheckpoint.getTimeUpperBound(),
-                    nextCheckpoint.getTimeUpperBound()
-                );
+                QueryBuilder filter = changeCollector.buildFilterQuery(lastCheckpoint, nextCheckpoint);
                 if (filter != null) {
                     filteredQuery.filter(filter);
                 }
+                request.indices(changeCollector.getIndicesToQuery(lastCheckpoint, nextCheckpoint).toArray(new String[0]));
+            } else {
+                request.indices(getConfig().getSource().getIndex());
             }
 
             queryBuilder = filteredQuery;
+
+        } else {
+            request.indices(getConfig().getSource().getIndex());
         }
 
         sourceBuilder.query(queryBuilder);
         logger.debug(() -> new ParameterizedMessage("[{}] Querying for data: {}", getJobId(), sourceBuilder));
 
-        return sourceBuilder;
+        return request.source(sourceBuilder)
+            .allowPartialSearchResults(false) // shard failures should fail the request
+            .indicesOptions(IndicesOptions.LENIENT_EXPAND_OPEN); // TODO: make configurable
     }
 
     /**

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/ClientTransformIndexerTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/ClientTransformIndexerTests.java
@@ -21,6 +21,7 @@ import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.search.ShardSearchFailure;
 import org.elasticsearch.client.Client;
+import org.elasticsearch.core.Tuple;
 import org.elasticsearch.search.SearchContextMissingException;
 import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.search.SearchHits;
@@ -52,7 +53,6 @@ import org.elasticsearch.xpack.transform.persistence.SeqNoPrimaryTermAndIndex;
 import java.time.Instant;
 import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -143,7 +143,6 @@ public class ClientTransformIndexerTests extends ESTestCase {
                 client,
                 mock(TransformIndexerStats.class),
                 config,
-                Collections.emptyMap(),
                 null,
                 new TransformCheckpoint(
                     "transform",
@@ -241,7 +240,6 @@ public class ClientTransformIndexerTests extends ESTestCase {
                 client,
                 mock(TransformIndexerStats.class),
                 config,
-                Collections.emptyMap(),
                 null,
                 new TransformCheckpoint(
                     "transform",
@@ -309,7 +307,6 @@ public class ClientTransformIndexerTests extends ESTestCase {
             Client client,
             TransformIndexerStats initialStats,
             TransformConfig transformConfig,
-            Map<String, String> fieldMappings,
             TransformProgress transformProgress,
             TransformCheckpoint lastCheckpoint,
             TransformCheckpoint nextCheckpoint,
@@ -336,8 +333,8 @@ public class ClientTransformIndexerTests extends ESTestCase {
         }
 
         @Override
-        protected SearchRequest buildSearchRequest() {
-            return new SearchRequest().source(new SearchSourceBuilder());
+        protected Tuple<String, SearchRequest> buildSearchRequest() {
+            return new Tuple<>("mock", new SearchRequest().source(new SearchSourceBuilder()));
         }
     }
 

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/TransformIndexerFailureHandlingTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/TransformIndexerFailureHandlingTests.java
@@ -177,7 +177,7 @@ public class TransformIndexerFailureHandlingTests extends ESTestCase {
             }
 
             try {
-                SearchResponse response = searchFunction.apply(buildSearchRequest());
+                SearchResponse response = searchFunction.apply(buildSearchRequest().v2());
                 nextPhase.onResponse(response);
             } catch (Exception e) {
                 nextPhase.onFailure(e);

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/latest/LatestChangeCollectorTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/latest/LatestChangeCollectorTests.java
@@ -12,8 +12,6 @@ import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.core.transform.transforms.TransformCheckpoint;
 
 import java.util.Collections;
-import java.util.Map;
-import java.util.Set;
 
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
@@ -58,7 +56,7 @@ public class LatestChangeCollectorTests extends ESTestCase {
                     "t_id",
                     123513L,
                     42L,
-                    Map.of(
+                    org.elasticsearch.core.Map.of(
                         "index-1",
                         indexSequenceIds1,
                         "index-2",
@@ -74,7 +72,7 @@ public class LatestChangeCollectorTests extends ESTestCase {
                     "t_id",
                     123456759L,
                     43L,
-                    Map.of(
+                    org.elasticsearch.core.Map.of(
                         "index-1",
                         indexSequenceIds1,
                         "index-2",
@@ -97,7 +95,7 @@ public class LatestChangeCollectorTests extends ESTestCase {
                     "t_id",
                     123513L,
                     42L,
-                    Map.of(
+                    org.elasticsearch.core.Map.of(
                         "index-1",
                         indexSequenceIds1,
                         "index-2",
@@ -113,7 +111,7 @@ public class LatestChangeCollectorTests extends ESTestCase {
                     "t_id",
                     123456759L,
                     43L,
-                    Map.of(
+                    org.elasticsearch.core.Map.of(
                         "index-1",
                         indexSequenceIds1,
                         "index-2",
@@ -126,7 +124,7 @@ public class LatestChangeCollectorTests extends ESTestCase {
                     123456789L
                 )
             ),
-            equalTo(Set.of("index-3", "index-4"))
+            equalTo(org.elasticsearch.core.Set.of("index-3", "index-4"))
         );
 
         // only 3 changed (no order)
@@ -136,7 +134,7 @@ public class LatestChangeCollectorTests extends ESTestCase {
                     "t_id",
                     123513L,
                     42L,
-                    Map.of(
+                    org.elasticsearch.core.Map.of(
                         "index-1",
                         indexSequenceIds1,
                         "index-2",
@@ -152,7 +150,7 @@ public class LatestChangeCollectorTests extends ESTestCase {
                     "t_id",
                     123456759L,
                     43L,
-                    Map.of(
+                    org.elasticsearch.core.Map.of(
                         "index-1",
                         indexSequenceIds1,
                         "index-2",
@@ -171,16 +169,22 @@ public class LatestChangeCollectorTests extends ESTestCase {
         // all have changed
         assertThat(
             changeCollector.getIndicesToQuery(
-                new TransformCheckpoint("t_id", 123513L, 42L, Map.of("index-3", indexSequenceIds3, "index-4", indexSequenceIds4), 123543L),
+                new TransformCheckpoint(
+                    "t_id",
+                    123513L,
+                    42L,
+                    org.elasticsearch.core.Map.of("index-3", indexSequenceIds3, "index-4", indexSequenceIds4),
+                    123543L
+                ),
                 new TransformCheckpoint(
                     "t_id",
                     123456759L,
                     43L,
-                    Map.of("index-3", indexSequenceIds3_1, "index-4", indexSequenceIds4_1),
+                    org.elasticsearch.core.Map.of("index-3", indexSequenceIds3_1, "index-4", indexSequenceIds4_1),
                     123456789L
                 )
             ),
-            equalTo(Set.of("index-3", "index-4"))
+            equalTo(org.elasticsearch.core.Set.of("index-3", "index-4"))
         );
 
         // a new index appeared
@@ -190,14 +194,14 @@ public class LatestChangeCollectorTests extends ESTestCase {
                     "t_id",
                     123513L,
                     42L,
-                    Map.of("index-2", indexSequenceIds2, "index-3", indexSequenceIds3, "index-4", indexSequenceIds4),
+                    org.elasticsearch.core.Map.of("index-2", indexSequenceIds2, "index-3", indexSequenceIds3, "index-4", indexSequenceIds4),
                     123543L
                 ),
                 new TransformCheckpoint(
                     "t_id",
                     123456759L,
                     43L,
-                    Map.of(
+                    org.elasticsearch.core.Map.of(
                         "index-1",
                         indexSequenceIds1,
                         "index-2",
@@ -210,7 +214,7 @@ public class LatestChangeCollectorTests extends ESTestCase {
                     123456789L
                 )
             ),
-            equalTo(Set.of("index-1", "index-3", "index-4"))
+            equalTo(org.elasticsearch.core.Set.of("index-1", "index-3", "index-4"))
         );
 
         // index disappeared
@@ -220,7 +224,7 @@ public class LatestChangeCollectorTests extends ESTestCase {
                     "t_id",
                     123513L,
                     42L,
-                    Map.of(
+                    org.elasticsearch.core.Map.of(
                         "index-1",
                         indexSequenceIds1,
                         "index-2",
@@ -236,11 +240,18 @@ public class LatestChangeCollectorTests extends ESTestCase {
                     "t_id",
                     123456759L,
                     43L,
-                    Map.of("index-2", indexSequenceIds2, "index-3", indexSequenceIds3_1, "index-4", indexSequenceIds4_1),
+                    org.elasticsearch.core.Map.of(
+                        "index-2",
+                        indexSequenceIds2,
+                        "index-3",
+                        indexSequenceIds3_1,
+                        "index-4",
+                        indexSequenceIds4_1
+                    ),
                     123456789L
                 )
             ),
-            equalTo(Set.of("index-3", "index-4"))
+            equalTo(org.elasticsearch.core.Set.of("index-3", "index-4"))
         );
     }
 }

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/latest/LatestChangeCollectorTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/latest/LatestChangeCollectorTests.java
@@ -9,6 +9,11 @@ package org.elasticsearch.xpack.transform.transforms.latest;
 
 import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.core.transform.transforms.TransformCheckpoint;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Set;
 
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
@@ -19,11 +24,223 @@ public class LatestChangeCollectorTests extends ESTestCase {
         LatestChangeCollector changeCollector = new LatestChangeCollector("timestamp");
 
         assertThat(
-            changeCollector.buildFilterQuery(0, 123456789),
-            is(equalTo(QueryBuilders.rangeQuery("timestamp").gte(0L).lt(123456789L).format("epoch_millis"))));
+            changeCollector.buildFilterQuery(
+                new TransformCheckpoint("t_id", 42L, 42L, Collections.emptyMap(), 0L),
+                new TransformCheckpoint("t_id", 42L, 42L, Collections.emptyMap(), 123456789L)
+            ),
+            is(equalTo(QueryBuilders.rangeQuery("timestamp").gte(0L).lt(123456789L).format("epoch_millis")))
+        );
 
         assertThat(
-            changeCollector.buildFilterQuery(123456789, 234567890),
-            is(equalTo(QueryBuilders.rangeQuery("timestamp").gte(123456789L).lt(234567890L).format("epoch_millis"))));
+            changeCollector.buildFilterQuery(
+                new TransformCheckpoint("t_id", 42L, 42L, Collections.emptyMap(), 123456789L),
+                new TransformCheckpoint("t_id", 42L, 42L, Collections.emptyMap(), 234567890L)
+            ),
+            is(equalTo(QueryBuilders.rangeQuery("timestamp").gte(123456789L).lt(234567890L).format("epoch_millis")))
+        );
+    }
+
+    public void testGetIndicesToQuery() {
+        LatestChangeCollector changeCollector = new LatestChangeCollector("timestamp");
+
+        long[] indexSequenceIds1 = { 25L, 25L, 25L };
+        long[] indexSequenceIds2 = { 324L, 2425L, 2225L };
+        long[] indexSequenceIds3 = { 244L, 225L, 2425L };
+        long[] indexSequenceIds4 = { 2005L, 2445L, 2425L };
+
+        long[] indexSequenceIds3_1 = { 246L, 255L, 2485L };
+        long[] indexSequenceIds4_1 = { 2105L, 2545L, 2525L };
+
+        // no changes
+        assertThat(
+            changeCollector.getIndicesToQuery(
+                new TransformCheckpoint(
+                    "t_id",
+                    123513L,
+                    42L,
+                    Map.of(
+                        "index-1",
+                        indexSequenceIds1,
+                        "index-2",
+                        indexSequenceIds2,
+                        "index-3",
+                        indexSequenceIds3,
+                        "index-4",
+                        indexSequenceIds4
+                    ),
+                    123543L
+                ),
+                new TransformCheckpoint(
+                    "t_id",
+                    123456759L,
+                    43L,
+                    Map.of(
+                        "index-1",
+                        indexSequenceIds1,
+                        "index-2",
+                        indexSequenceIds2,
+                        "index-3",
+                        indexSequenceIds3,
+                        "index-4",
+                        indexSequenceIds4
+                    ),
+                    123456789L
+                )
+            ),
+            equalTo(Collections.emptySet())
+        );
+
+        // 3 and 4 changed, 1 and 2 not
+        assertThat(
+            changeCollector.getIndicesToQuery(
+                new TransformCheckpoint(
+                    "t_id",
+                    123513L,
+                    42L,
+                    Map.of(
+                        "index-1",
+                        indexSequenceIds1,
+                        "index-2",
+                        indexSequenceIds2,
+                        "index-3",
+                        indexSequenceIds3,
+                        "index-4",
+                        indexSequenceIds4
+                    ),
+                    123543L
+                ),
+                new TransformCheckpoint(
+                    "t_id",
+                    123456759L,
+                    43L,
+                    Map.of(
+                        "index-1",
+                        indexSequenceIds1,
+                        "index-2",
+                        indexSequenceIds2,
+                        "index-3",
+                        indexSequenceIds3_1,
+                        "index-4",
+                        indexSequenceIds4_1
+                    ),
+                    123456789L
+                )
+            ),
+            equalTo(Set.of("index-3", "index-4"))
+        );
+
+        // only 3 changed (no order)
+        assertThat(
+            changeCollector.getIndicesToQuery(
+                new TransformCheckpoint(
+                    "t_id",
+                    123513L,
+                    42L,
+                    Map.of(
+                        "index-1",
+                        indexSequenceIds1,
+                        "index-2",
+                        indexSequenceIds2,
+                        "index-3",
+                        indexSequenceIds3,
+                        "index-4",
+                        indexSequenceIds4
+                    ),
+                    123543L
+                ),
+                new TransformCheckpoint(
+                    "t_id",
+                    123456759L,
+                    43L,
+                    Map.of(
+                        "index-1",
+                        indexSequenceIds1,
+                        "index-2",
+                        indexSequenceIds2,
+                        "index-3",
+                        indexSequenceIds3_1,
+                        "index-4",
+                        indexSequenceIds4
+                    ),
+                    123456789L
+                )
+            ),
+            equalTo(Collections.singleton("index-3"))
+        );
+
+        // all have changed
+        assertThat(
+            changeCollector.getIndicesToQuery(
+                new TransformCheckpoint("t_id", 123513L, 42L, Map.of("index-3", indexSequenceIds3, "index-4", indexSequenceIds4), 123543L),
+                new TransformCheckpoint(
+                    "t_id",
+                    123456759L,
+                    43L,
+                    Map.of("index-3", indexSequenceIds3_1, "index-4", indexSequenceIds4_1),
+                    123456789L
+                )
+            ),
+            equalTo(Set.of("index-3", "index-4"))
+        );
+
+        // a new index appeared
+        assertThat(
+            changeCollector.getIndicesToQuery(
+                new TransformCheckpoint(
+                    "t_id",
+                    123513L,
+                    42L,
+                    Map.of("index-2", indexSequenceIds2, "index-3", indexSequenceIds3, "index-4", indexSequenceIds4),
+                    123543L
+                ),
+                new TransformCheckpoint(
+                    "t_id",
+                    123456759L,
+                    43L,
+                    Map.of(
+                        "index-1",
+                        indexSequenceIds1,
+                        "index-2",
+                        indexSequenceIds2,
+                        "index-3",
+                        indexSequenceIds3_1,
+                        "index-4",
+                        indexSequenceIds4_1
+                    ),
+                    123456789L
+                )
+            ),
+            equalTo(Set.of("index-1", "index-3", "index-4"))
+        );
+
+        // index disappeared
+        assertThat(
+            changeCollector.getIndicesToQuery(
+                new TransformCheckpoint(
+                    "t_id",
+                    123513L,
+                    42L,
+                    Map.of(
+                        "index-1",
+                        indexSequenceIds1,
+                        "index-2",
+                        indexSequenceIds2,
+                        "index-3",
+                        indexSequenceIds3,
+                        "index-4",
+                        indexSequenceIds4
+                    ),
+                    123543L
+                ),
+                new TransformCheckpoint(
+                    "t_id",
+                    123456759L,
+                    43L,
+                    Map.of("index-2", indexSequenceIds2, "index-3", indexSequenceIds3_1, "index-4", indexSequenceIds4_1),
+                    123456789L
+                )
+            ),
+            equalTo(Set.of("index-3", "index-4"))
+        );
     }
 }

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/pivot/CompositeBucketsChangeCollectorTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/pivot/CompositeBucketsChangeCollectorTests.java
@@ -20,6 +20,7 @@ import org.elasticsearch.search.aggregations.bucket.histogram.DateHistogramInter
 import org.elasticsearch.search.aggregations.metrics.NumericMetricsAggregation.SingleValue;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.core.transform.transforms.TransformCheckpoint;
 import org.elasticsearch.xpack.core.transform.transforms.pivot.DateHistogramGroupSource;
 import org.elasticsearch.xpack.core.transform.transforms.pivot.GeoTileGroupSourceTests;
 import org.elasticsearch.xpack.core.transform.transforms.pivot.GroupConfig;
@@ -122,7 +123,10 @@ public class CompositeBucketsChangeCollectorTests extends ESTestCase {
 
         collector.processSearchResponse(response);
 
-        QueryBuilder queryBuilder = collector.buildFilterQuery(0, 0);
+        QueryBuilder queryBuilder = collector.buildFilterQuery(
+            new TransformCheckpoint("t_id", 42L, 42L, Collections.emptyMap(), 0L),
+            new TransformCheckpoint("t_id", 42L, 42L, Collections.emptyMap(), 0L)
+        );
         assertNotNull(queryBuilder);
         assertThat(queryBuilder, instanceOf(TermsQueryBuilder.class));
         assertThat(((TermsQueryBuilder) queryBuilder).values(), containsInAnyOrder("id1", "id2", "id3"));
@@ -142,7 +146,11 @@ public class CompositeBucketsChangeCollectorTests extends ESTestCase {
 
         ChangeCollector collector = CompositeBucketsChangeCollector.buildChangeCollector(groups, "timestamp");
 
-        QueryBuilder queryBuilder = collector.buildFilterQuery(66_666, 200_222);
+        QueryBuilder queryBuilder = collector.buildFilterQuery(
+            new TransformCheckpoint("t_id", 42L, 42L, Collections.emptyMap(), 66_666L),
+            new TransformCheckpoint("t_id", 42L, 42L, Collections.emptyMap(), 200_222L)
+        );
+
         assertNotNull(queryBuilder);
         assertThat(queryBuilder, instanceOf(RangeQueryBuilder.class));
         // rounded down
@@ -168,7 +176,11 @@ public class CompositeBucketsChangeCollectorTests extends ESTestCase {
         collector.processSearchResponse(response);
 
         // provide checkpoints, although they don't matter in this case
-        queryBuilder = collector.buildFilterQuery(66_666, 200_222);
+        queryBuilder = collector.buildFilterQuery(
+            new TransformCheckpoint("t_id", 42L, 42L, Collections.emptyMap(), 66_666L),
+            new TransformCheckpoint("t_id", 42L, 42L, Collections.emptyMap(), 200_222L)
+        );
+
         assertNotNull(queryBuilder);
         assertThat(queryBuilder, instanceOf(RangeQueryBuilder.class));
         // rounded down
@@ -190,7 +202,11 @@ public class CompositeBucketsChangeCollectorTests extends ESTestCase {
 
         // simulate the agg response, that should inject
         collector.processSearchResponse(response);
-        queryBuilder = collector.buildFilterQuery(66_666, 200_222);
+        queryBuilder = collector.buildFilterQuery(
+            new TransformCheckpoint("t_id", 42L, 42L, Collections.emptyMap(), 66_666L),
+            new TransformCheckpoint("t_id", 42L, 42L, Collections.emptyMap(), 200_222L)
+        );
+
         assertNotNull(queryBuilder);
 
         assertThat(queryBuilder, instanceOf(RangeQueryBuilder.class));
@@ -214,12 +230,18 @@ public class CompositeBucketsChangeCollectorTests extends ESTestCase {
 
         collector = CompositeBucketsChangeCollector.buildChangeCollector(groups, "timestamp");
 
-        queryBuilder = collector.buildFilterQuery(66_666, 200_222);
+        queryBuilder = collector.buildFilterQuery(
+            new TransformCheckpoint("t_id", 42L, 42L, Collections.emptyMap(), 66_666L),
+            new TransformCheckpoint("t_id", 42L, 42L, Collections.emptyMap(), 200_222L)
+        );
         assertNull(queryBuilder);
 
         collector = CompositeBucketsChangeCollector.buildChangeCollector(groups, "sync_timestamp");
 
-        queryBuilder = collector.buildFilterQuery(66_666, 200_222);
+        queryBuilder = collector.buildFilterQuery(
+            new TransformCheckpoint("t_id", 42L, 42L, Collections.emptyMap(), 66_666L),
+            new TransformCheckpoint("t_id", 42L, 42L, Collections.emptyMap(), 200_222L)
+        );
         assertNull(queryBuilder);
     }
 


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [Transform] Reduce indexes to query based on checkpoints (#75839)