### PR TITLE
[7.15] [DOCS] Fix formatting for `snapshot_meta` thread pool (#76973)

### DIFF
--- a/docs/reference/modules/threadpool.asciidoc
+++ b/docs/reference/modules/threadpool.asciidoc
@@ -46,7 +46,7 @@ There are several thread pools, but the important ones include:
 `snapshot_meta`::
     For snapshot repository metadata read operations. Thread pool type is `scaling` with a
     keep-alive of `5m` and a max of `min(50, (`<<node.processors,
-    `# of allocated processors`>>` pass:[ * ]3))`.
+    `# of allocated processors`>>`* 3))`.
 
 `warmer`::
     For segment warm-up operations. Thread pool type is `scaling` with a


### PR DESCRIPTION
Backports the following commits to 7.15:
 - [DOCS] Fix formatting for `snapshot_meta` thread pool (#76973)