### PR TITLE
fix npe in onQueryFailure when shardTarget is null

### DIFF
--- a/x-pack/plugin/async-search/src/main/java/org/elasticsearch/xpack/search/AsyncSearchTask.java
+++ b/x-pack/plugin/async-search/src/main/java/org/elasticsearch/xpack/search/AsyncSearchTask.java
@@ -379,7 +379,7 @@ final class AsyncSearchTask extends SearchTask implements AsyncTask {
             checkCancellation();
             searchResponse.get().addQueryFailure(shardIndex,
                 // the nodeId is null if all replicas of this shard failed
-                new ShardSearchFailure(exc, shardTarget.getNodeId() != null ? shardTarget : null));
+                new ShardSearchFailure(exc, shardTarget != null && shardTarget.getNodeId() != null ? shardTarget : null));
         }
 
         @Override


### PR DESCRIPTION
The `shardTarget` may be null in `onQueryFailure` of `SearchProgressActionListener`.
This npe happens when `AbstractSearchAsyncAction.performPhaseOnShard` is invoked and the shard is null.

```java
private void performPhaseOnShard(final int shardIndex, final SearchShardIterator shardIt, final SearchShardTarget shard) {
    /*
     * We capture the thread that this phase is starting on. When we are called back after executing the phase, we are either on the
     * same thread (because we never went async, or the same thread was selected from the thread pool) or a different thread. If we
     * continue on the same thread in the case that we never went async and this happens repeatedly we will end up recursing deeply and
     * could stack overflow. To prevent this, we fork if we are called back on the same thread that execution started on and otherwise
     * we can continue (cf. InitialSearchPhase#maybeFork).
     */
    if (shard == null) {
        fork(() -> onShardFailure(shardIndex, null, shardIt, new NoShardAvailableActionException(shardIt.shardId())));
    ...
```