### PR TITLE
Update aliases.asciidoc

### DIFF
--- a/docs/reference/alias.asciidoc
+++ b/docs/reference/alias.asciidoc
@@ -208,9 +208,9 @@ GET _alias/logs
 [[write-index]]
 === Write index
 
-If an alias points to multiple indices or data streams, you can use
-`is_write_index` to specify a write index or data stream. {es} routes any write
-requests for the alias to this index or data stream.
+You can use `is_write_index` to specify a write index or data stream for an
+alias. {es} routes any write requests for the alias to this index or data
+stream.
 
 [source,console]
 ----

--- a/docs/reference/alias.asciidoc
+++ b/docs/reference/alias.asciidoc
@@ -208,9 +208,9 @@ GET _alias/logs
 [[write-index]]
 === Write index
 
-If an alias points to multiple indices, you can use `is_write_index` to specify
-a write index or data stream. {es} routes any write requests for the alias to
-this index or data stream.
+If an alias points to multiple indices or data streams, you can use
+`is_write_index` to specify a write index or data stream. {es} routes any write
+requests for the alias to this index or data stream.
 
 [source,console]
 ----

--- a/docs/reference/alias.asciidoc
+++ b/docs/reference/alias.asciidoc
@@ -235,11 +235,7 @@ POST _aliases
 ----
 // TEST[s/^/PUT _data_stream\/logs-nginx.access-prod\nPUT _data_stream\/logs-my_app-default\n/]
 
-If an alias points to multiple indices or data streams and `is_write_index`
-isn't set, the alias rejects write requests. If an index alias points to one
-index and `is_write_index` isn't set, the index automatically acts as the write
-index. Data stream aliases don't automatically set a write data stream, even if
-the alias points to one data stream.
+include::{es-repo-dir}/indices/aliases.asciidoc[tag=write-index-defaults]
 
 TIP: We recommend using data streams to store append-only time series data. If
 you frequently update or delete existing time series data, use an index alias

--- a/docs/reference/indices/aliases.asciidoc
+++ b/docs/reference/indices/aliases.asciidoc
@@ -132,7 +132,7 @@ Only the `add` action supports this parameter.
 // tag::alias-options[]
 `is_write_index`::
 (Optional, Boolean) If `true`, sets the <<write-index,write index or data
-stream>> for the alias. Defaults to `false`.
+stream>> for the alias. Defaults to `true`.
 // end::alias-options[]
 +
 Only the `add` action supports this parameter.

--- a/docs/reference/indices/aliases.asciidoc
+++ b/docs/reference/indices/aliases.asciidoc
@@ -131,8 +131,8 @@ Only the `add` action supports this parameter.
 
 // tag::alias-options[]
 `is_write_index`::
-(Optional, Boolean) If `true`, sets the <<write-index,write index or data
-stream>> for the alias. Defaults to `true`.
+(Optional, Boolean) If `true`, sets the write index or data stream for the
+alias. For default behavior, see <<write-index>>.
 // end::alias-options[]
 +
 Only the `add` action supports this parameter.

--- a/docs/reference/indices/aliases.asciidoc
+++ b/docs/reference/indices/aliases.asciidoc
@@ -132,7 +132,15 @@ Only the `add` action supports this parameter.
 // tag::alias-options[]
 `is_write_index`::
 (Optional, Boolean) If `true`, sets the write index or data stream for the
-alias. For default behavior, see <<write-index>>.
+alias.
++
+// tag::write-index-defaults[]
+If an alias points to multiple indices or data streams and `is_write_index`
+isn't set, the alias rejects write requests. If an index alias points to one
+index and `is_write_index` isn't set, the index automatically acts as the write
+index. Data stream aliases don't automatically set a write data stream, even if
+the alias points to one data stream.
+// end::write-index-defaults[]
 // end::alias-options[]
 +
 Only the `add` action supports this parameter.


### PR DESCRIPTION
The default behavior for `is_write_index` can vary based on:

1. Whether the alias is used for indices or data streams.
2. If an index alias, whether the alias points to multiple indices.

This updates the default for the `is_write_index` parameter of the aliases API and create alias API.

### Previews
* Aliases guide: https://elasticsearch_77006.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/current/alias.html#write-index
* Aliases API: https://elasticsearch_77006.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/current/indices-aliases.html#indices-aliases-api-request-body
* Create alias API: https://elasticsearch_77006.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/current/indices-add-alias.html#add-alias-api-request-body
