### PR TITLE
Introduce elasticsearch base plugin

### DIFF
--- a/build-tools-internal/build.gradle
+++ b/build-tools-internal/build.gradle
@@ -34,6 +34,10 @@ gradlePlugin {
   // with the java-gradle-plugin
   automatedPublishing = false
   plugins {
+    base {
+      id = 'elasticsearch.base'
+      implementationClass = 'org.elasticsearch.gradle.internal.BasePlugin'
+    }
     build {
       id = 'elasticsearch.build'
       implementationClass = 'org.elasticsearch.gradle.internal.BuildPlugin'

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/BasePlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/BasePlugin.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.gradle.internal;
+
+import org.elasticsearch.gradle.VersionProperties;
+import org.gradle.api.Plugin;
+import org.gradle.api.Project;
+
+public class BasePlugin implements Plugin<Project> {
+    @Override
+    public void apply(Project project) {
+        configureProjectProperties(project);
+
+    }
+
+    private void configureProjectProperties(Project project) {
+        project.setGroup("org.elasticsearch");
+        project.setVersion(VersionProperties.getElasticsearch());
+        project.setDescription("Elasticsearch subproject " + project.getPath());
+    }
+}


### PR DESCRIPTION
- applies common logic for all elasticsearch subprojects
- simplifies root build script configuration
- brings us closer to get rid of allprojects and leveraging gradle configuration cache