### PR TITLE
Add Sort By Shard Count and Failed Shard Count to Get Snapshots API

### DIFF
--- a/docs/reference/snapshot-restore/apis/get-snapshot-api.asciidoc
+++ b/docs/reference/snapshot-restore/apis/get-snapshot-api.asciidoc
@@ -122,10 +122,10 @@ Allows setting a sort order for the result. Defaults to `start_time`, i.e. sorti
   Sort snapshots by the number of indices they contain and break ties by snapshot name.
 
 `shard_count`::
-Sort snapshots by the number of shards they contain and break ties by snapshot name.
+  Sort snapshots by the number of shards they contain and break ties by snapshot name.
 
-`failed_shards_count`::
-Sort snapshots by the number of shards that they failed to snapshot break ties by snapshot name.
+`failed_shard_count`::
+  Sort snapshots by the number of shards that they failed to snapshot and break ties by snapshot name.
 ====
 
 `size`::

--- a/docs/reference/snapshot-restore/apis/get-snapshot-api.asciidoc
+++ b/docs/reference/snapshot-restore/apis/get-snapshot-api.asciidoc
@@ -120,6 +120,12 @@ Allows setting a sort order for the result. Defaults to `start_time`, i.e. sorti
 
 `index_count`::
   Sort snapshots by the number of indices they contain and break ties by snapshot name.
+
+`shard_count`::
+Sort snapshots by the number of shards they contain and break ties by snapshot name.
+
+`failed_shards_count`::
+Sort snapshots by the number of shards that they failed to snapshot break ties by snapshot name.
 ====
 
 `size`::

--- a/qa/smoke-test-http/src/test/java/org/elasticsearch/http/snapshots/RestGetSnapshotsIT.java
+++ b/qa/smoke-test-http/src/test/java/org/elasticsearch/http/snapshots/RestGetSnapshotsIT.java
@@ -86,6 +86,16 @@ public class RestGetSnapshotsIT extends AbstractSnapshotRestTestCase {
                 GetSnapshotsRequest.SortBy.START_TIME,
                 order
         );
+        assertSnapshotListSorted(
+                allSnapshotsSorted(allSnapshotNames, repoName, GetSnapshotsRequest.SortBy.SHARDS, order),
+                GetSnapshotsRequest.SortBy.SHARDS,
+                order
+        );
+        assertSnapshotListSorted(
+                allSnapshotsSorted(allSnapshotNames, repoName, GetSnapshotsRequest.SortBy.FAILED_SHARDS, order),
+                GetSnapshotsRequest.SortBy.FAILED_SHARDS,
+                order
+        );
     }
 
     public void testResponseSizeLimit() throws Exception {

--- a/server/src/internalClusterTest/java/org/elasticsearch/snapshots/GetSnapshotsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/snapshots/GetSnapshotsIT.java
@@ -78,6 +78,16 @@ public class GetSnapshotsIT extends AbstractSnapshotIntegTestCase {
             GetSnapshotsRequest.SortBy.START_TIME,
             order
         );
+        assertSnapshotListSorted(
+            allSnapshotsSorted(allSnapshotNames, repoName, GetSnapshotsRequest.SortBy.SHARDS, order),
+            GetSnapshotsRequest.SortBy.SHARDS,
+            order
+        );
+        assertSnapshotListSorted(
+            allSnapshotsSorted(allSnapshotNames, repoName, GetSnapshotsRequest.SortBy.FAILED_SHARDS, order),
+            GetSnapshotsRequest.SortBy.FAILED_SHARDS,
+            order
+        );
     }
 
     public void testResponseSizeLimit() throws Exception {

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/get/GetSnapshotsRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/get/GetSnapshotsRequest.java
@@ -327,7 +327,7 @@ public class GetSnapshotsRequest extends MasterNodeRequest<GetSnapshotsRequest> 
         DURATION("duration"),
         INDICES("index_count"),
         SHARDS("shard_count"),
-        FAILED_SHARDS("failed_shards_count");
+        FAILED_SHARDS("failed_shard_count");
 
         private final String param;
 
@@ -352,7 +352,7 @@ public class GetSnapshotsRequest extends MasterNodeRequest<GetSnapshotsRequest> 
                     return INDICES;
                 case "shard_count":
                     return SHARDS;
-                case "failed_shards_count":
+                case "failed_shard_count":
                     return FAILED_SHARDS;
                 default:
                     throw new IllegalArgumentException("unknown sort order [" + value + "]");

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/get/GetSnapshotsRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/get/GetSnapshotsRequest.java
@@ -46,6 +46,8 @@ public class GetSnapshotsRequest extends MasterNodeRequest<GetSnapshotsRequest> 
 
     public static final Version NUMERIC_PAGINATION_VERSION = Version.V_7_15_0;
 
+    private static final Version SORT_BY_SHARD_COUNTS_VERSION = Version.V_8_0_0;
+
     public static final int NO_LIMIT = -1;
 
     /**
@@ -136,6 +138,9 @@ public class GetSnapshotsRequest extends MasterNodeRequest<GetSnapshotsRequest> 
         out.writeBoolean(verbose);
         if (out.getVersion().onOrAfter(PAGINATED_GET_SNAPSHOTS_VERSION)) {
             out.writeOptionalWriteable(after);
+            if ((sort == SortBy.SHARDS || sort == SortBy.FAILED_SHARDS) && out.getVersion().before(SORT_BY_SHARD_COUNTS_VERSION)) {
+                throw new IllegalArgumentException("can't use sort by shard count with node version [" + out.getVersion() + "]");
+            }
             out.writeEnum(sort);
             out.writeVInt(size);
             order.writeTo(out);
@@ -320,7 +325,9 @@ public class GetSnapshotsRequest extends MasterNodeRequest<GetSnapshotsRequest> 
         START_TIME("start_time"),
         NAME("name"),
         DURATION("duration"),
-        INDICES("index_count");
+        INDICES("index_count"),
+        SHARDS("shard_count"),
+        FAILED_SHARDS("failed_shards_count");
 
         private final String param;
 
@@ -343,6 +350,10 @@ public class GetSnapshotsRequest extends MasterNodeRequest<GetSnapshotsRequest> 
                     return DURATION;
                 case "index_count":
                     return INDICES;
+                case "shard_count":
+                    return SHARDS;
+                case "failed_shards_count":
+                    return FAILED_SHARDS;
                 default:
                     throw new IllegalArgumentException("unknown sort order [" + value + "]");
             }
@@ -387,6 +398,12 @@ public class GetSnapshotsRequest extends MasterNodeRequest<GetSnapshotsRequest> 
                     break;
                 case INDICES:
                     afterValue = String.valueOf(snapshotInfo.indices().size());
+                    break;
+                case SHARDS:
+                    afterValue = String.valueOf(snapshotInfo.totalShards());
+                    break;
+                case FAILED_SHARDS:
+                    afterValue = String.valueOf(snapshotInfo.failedShards());
                     break;
                 default:
                     throw new AssertionError("unknown sort column [" + sortBy + "]");

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/get/TransportGetSnapshotsAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/get/TransportGetSnapshotsAction.java
@@ -484,6 +484,12 @@ public class TransportGetSnapshotsAction extends TransportMasterNodeAction<GetSn
     private static final Comparator<SnapshotInfo> BY_INDICES_COUNT = Comparator.<SnapshotInfo>comparingInt(sni -> sni.indices().size())
         .thenComparing(SnapshotInfo::snapshotId);
 
+    private static final Comparator<SnapshotInfo> BY_SHARDS_COUNT = Comparator.comparingInt(SnapshotInfo::totalShards)
+        .thenComparing(SnapshotInfo::snapshotId);
+
+    private static final Comparator<SnapshotInfo> BY_FAILED_SHARDS_COUNT = Comparator.comparingInt(SnapshotInfo::failedShards)
+        .thenComparing(SnapshotInfo::snapshotId);
+
     private static final Comparator<SnapshotInfo> BY_NAME = Comparator.comparing(sni -> sni.snapshotId().getName());
 
     private static SnapshotsInRepo sortSnapshots(
@@ -507,6 +513,12 @@ public class TransportGetSnapshotsAction extends TransportMasterNodeAction<GetSn
                 break;
             case INDICES:
                 comparator = BY_INDICES_COUNT;
+                break;
+            case SHARDS:
+                comparator = BY_SHARDS_COUNT;
+                break;
+            case FAILED_SHARDS:
+                comparator = BY_FAILED_SHARDS_COUNT;
                 break;
             default:
                 throw new AssertionError("unexpected sort column [" + sortBy + "]");
@@ -540,6 +552,18 @@ public class TransportGetSnapshotsAction extends TransportMasterNodeAction<GetSn
                 case INDICES:
                     isAfter = filterByLongOffset(
                         info -> info.indices().size(),
+                        Integer.parseInt(after.value()),
+                        snapshotName,
+                        repoName,
+                        order
+                    );
+                    break;
+                case SHARDS:
+                    isAfter = filterByLongOffset(SnapshotInfo::totalShards, Integer.parseInt(after.value()), snapshotName, repoName, order);
+                    break;
+                case FAILED_SHARDS:
+                    isAfter = filterByLongOffset(
+                        SnapshotInfo::failedShards,
                         Integer.parseInt(after.value()),
                         snapshotName,
                         repoName,

--- a/test/framework/src/main/java/org/elasticsearch/snapshots/AbstractSnapshotIntegTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/snapshots/AbstractSnapshotIntegTestCase.java
@@ -698,6 +698,12 @@ public abstract class AbstractSnapshotIntegTestCase extends ESIntegTestCase {
                 case INDICES:
                     assertion = (s1, s2) -> assertThat(s2.indices().size(), greaterThanOrEqualTo(s1.indices().size()));
                     break;
+                case SHARDS:
+                    assertion = (s1, s2) -> assertThat(s2.totalShards(), greaterThanOrEqualTo(s1.totalShards()));
+                    break;
+                case FAILED_SHARDS:
+                    assertion = (s1, s2) -> assertThat(s2.failedShards(), greaterThanOrEqualTo(s1.failedShards()));
+                    break;
                 default:
                     throw new AssertionError("unknown sort column [" + sort + "]");
             }


### PR DESCRIPTION
It's in the title. As requested by the Kibana team, adding these two additional sort columns.
