### PR TITLE
[7.x] Add `replace` shutdown type (#75908)

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/metadata/SingleNodeShutdownMetadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/SingleNodeShutdownMetadata.java
@@ -316,13 +316,16 @@ public class SingleNodeShutdownMetadata extends AbstractDiffable<SingleNodeShutd
      */
     public enum Type {
         REMOVE,
-        RESTART;
+        RESTART,
+        REPLACE;
 
         public static Type parse(String type) {
             if ("remove".equals(type.toLowerCase(Locale.ROOT))) {
                 return REMOVE;
             } else if ("restart".equals(type.toLowerCase(Locale.ROOT))) {
                 return RESTART;
+            } else if ("replace".equals(type.toLowerCase(Locale.ROOT))) {
+                return REPLACE;
             } else {
                 throw new IllegalArgumentException("unknown shutdown type: " + type);
             }

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/NodeShutdownAllocationDecider.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/NodeShutdownAllocationDecider.java
@@ -46,6 +46,7 @@ public class NodeShutdownAllocationDecider extends AllocationDecider {
         }
 
         switch (thisNodeShutdownMetadata.getType()) {
+            case REPLACE:
             case REMOVE:
                 return allocation.decision(Decision.NO, NAME, "node [%s] is preparing to be removed from the cluster", node.nodeId());
             case RESTART:
@@ -98,6 +99,7 @@ public class NodeShutdownAllocationDecider extends AllocationDecider {
                     "node [%s] is preparing to restart, auto-expansion waiting until it is complete",
                     node.getId()
                 );
+            case REPLACE:
             case REMOVE:
                 return allocation.decision(Decision.NO, NAME, "node [%s] is preparing for removal from the cluster", node.getId());
             default:

--- a/server/src/main/java/org/elasticsearch/shutdown/PluginShutdownService.java
+++ b/server/src/main/java/org/elasticsearch/shutdown/PluginShutdownService.java
@@ -26,6 +26,7 @@ import org.elasticsearch.cluster.metadata.SingleNodeShutdownMetadata;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.plugins.ShutdownAwarePlugin;
 
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -56,13 +57,14 @@ public class PluginShutdownService implements ClusterStateListener {
     }
 
     /**
-     * Return all nodes shutting down with the given shutdown type from the given cluster state
+     * Return all nodes shutting down with the given shutdown types from the given cluster state
      */
-    public static Set<String> shutdownTypeNodes(final ClusterState clusterState, final SingleNodeShutdownMetadata.Type shutdownType) {
+    public static Set<String> shutdownTypeNodes(final ClusterState clusterState, final SingleNodeShutdownMetadata.Type... shutdownTypes) {
+        Set<SingleNodeShutdownMetadata.Type> types = Arrays.stream(shutdownTypes).collect(Collectors.toSet());
         return NodesShutdownMetadata.getShutdowns(clusterState)
             .map(NodesShutdownMetadata::getAllNodeMetadataMap)
             .map(m -> m.entrySet().stream()
-                .filter(e -> e.getValue().getType() == shutdownType)
+                .filter(e -> types.contains(e.getValue().getType()))
                 .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue)))
             .map(Map::keySet)
             .orElse(Collections.emptySet());

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/decider/NodeShutdownAllocationDeciderTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/decider/NodeShutdownAllocationDeciderTests.java
@@ -98,7 +98,7 @@ public class NodeShutdownAllocationDeciderTests extends ESAllocationTestCase {
     public void testCannotAllocateShardsToRemovingNode() {
         ClusterState state = prepareState(
             service.reroute(ClusterState.EMPTY_STATE, "initial state"),
-            SingleNodeShutdownMetadata.Type.REMOVE
+            randomFrom(SingleNodeShutdownMetadata.Type.REMOVE, SingleNodeShutdownMetadata.Type.REPLACE)
         );
         RoutingAllocation allocation = new RoutingAllocation(allocationDeciders, state.getRoutingNodes(), state, null, null, 0);
         RoutingNode routingNode = new RoutingNode(DATA_NODE.getId(), DATA_NODE, shard);
@@ -132,7 +132,7 @@ public class NodeShutdownAllocationDeciderTests extends ESAllocationTestCase {
     public void testShardsCannotRemainOnRemovingNode() {
         ClusterState state = prepareState(
             service.reroute(ClusterState.EMPTY_STATE, "initial state"),
-            SingleNodeShutdownMetadata.Type.REMOVE
+            randomFrom(SingleNodeShutdownMetadata.Type.REMOVE, SingleNodeShutdownMetadata.Type.REPLACE)
         );
         RoutingAllocation allocation = new RoutingAllocation(allocationDeciders, state.getRoutingNodes(), state, null, null, 0);
         RoutingNode routingNode = new RoutingNode(DATA_NODE.getId(), DATA_NODE, shard);
@@ -165,7 +165,7 @@ public class NodeShutdownAllocationDeciderTests extends ESAllocationTestCase {
     public void testCannotAutoExpandToRemovingNode() {
         ClusterState state = prepareState(
             service.reroute(ClusterState.EMPTY_STATE, "initial state"),
-            SingleNodeShutdownMetadata.Type.REMOVE
+            randomFrom(SingleNodeShutdownMetadata.Type.REMOVE, SingleNodeShutdownMetadata.Type.REPLACE)
         );
         RoutingAllocation allocation = new RoutingAllocation(allocationDeciders, state.getRoutingNodes(), state, null, null, 0);
         allocation.debugDecision(true);

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/CheckShrinkReadyStep.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/CheckShrinkReadyStep.java
@@ -76,7 +76,10 @@ public class CheckShrinkReadyStep extends ClusterStateWaitStep {
         boolean nodeBeingRemoved = NodesShutdownMetadata.getShutdowns(clusterState)
             .map(NodesShutdownMetadata::getAllNodeMetadataMap)
             .map(shutdownMetadataMap -> shutdownMetadataMap.get(idShardsShouldBeOn))
-            .map(singleNodeShutdown -> singleNodeShutdown.getType() == SingleNodeShutdownMetadata.Type.REMOVE)
+            .map(
+                singleNodeShutdown -> singleNodeShutdown.getType() == SingleNodeShutdownMetadata.Type.REMOVE
+                    || singleNodeShutdown.getType() == SingleNodeShutdownMetadata.Type.REPLACE
+            )
             .orElse(false);
 
         final IndexRoutingTable routingTable = clusterState.getRoutingTable().index(index);

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/CheckShrinkReadyStepTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/CheckShrinkReadyStepTests.java
@@ -361,7 +361,7 @@ public class CheckShrinkReadyStepTests extends AbstractStepTestCase<CheckShrinkR
                 .indices(indices.build())
                 .putCustom(NodesShutdownMetadata.TYPE, new NodesShutdownMetadata(Collections.singletonMap("node1",
                     SingleNodeShutdownMetadata.builder()
-                        .setType(SingleNodeShutdownMetadata.Type.REMOVE)
+                        .setType(randomFrom(SingleNodeShutdownMetadata.Type.REMOVE, SingleNodeShutdownMetadata.Type.REPLACE))
                         .setStartedAtMillis(randomNonNegativeLong())
                         .setReason("test")
                         .setNodeId("node1")
@@ -412,7 +412,7 @@ public class CheckShrinkReadyStepTests extends AbstractStepTestCase<CheckShrinkR
                 .indices(indices.build())
             .putCustom(NodesShutdownMetadata.TYPE, new NodesShutdownMetadata(Collections.singletonMap("node1",
                 SingleNodeShutdownMetadata.builder()
-                    .setType(SingleNodeShutdownMetadata.Type.REMOVE)
+                    .setType(randomFrom(SingleNodeShutdownMetadata.Type.REMOVE, SingleNodeShutdownMetadata.Type.REPLACE))
                     .setStartedAtMillis(randomNonNegativeLong())
                     .setReason("test")
                     .setNodeId("node1")

--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/IndexLifecycleService.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/IndexLifecycleService.java
@@ -424,7 +424,8 @@ public class IndexLifecycleService
     }
 
     static Set<String> indicesOnShuttingDownNodesInDangerousStep(ClusterState state, String nodeId) {
-        final Set<String> shutdownNodes = PluginShutdownService.shutdownTypeNodes(state, SingleNodeShutdownMetadata.Type.REMOVE);
+        final Set<String> shutdownNodes = PluginShutdownService.shutdownTypeNodes(state,
+            SingleNodeShutdownMetadata.Type.REMOVE, SingleNodeShutdownMetadata.Type.REPLACE);
         if (shutdownNodes.isEmpty()) {
             return Collections.emptySet();
         }
@@ -462,6 +463,7 @@ public class IndexLifecycleService
             case RESTART:
                 // It is safe to restart during ILM operation
                 return true;
+            case REPLACE:
             case REMOVE:
                 Set<String> indices = indicesOnShuttingDownNodesInDangerousStep(clusterService.state(), nodeId);
                 return indices.isEmpty();

--- a/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/ilm/IndexLifecycleServiceTests.java
+++ b/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/ilm/IndexLifecycleServiceTests.java
@@ -587,7 +587,7 @@ public class IndexLifecycleServiceTests extends ESTestCase {
                         .setNodeId("shutdown_node")
                         .setReason("shut down for test")
                         .setStartedAtMillis(randomNonNegativeLong())
-                        .setType(SingleNodeShutdownMetadata.Type.REMOVE)
+                        .setType(randomFrom(SingleNodeShutdownMetadata.Type.REMOVE, SingleNodeShutdownMetadata.Type.REPLACE))
                         .build())))
                 .build())
             .build();

--- a/x-pack/plugin/shutdown/src/main/java/org/elasticsearch/xpack/shutdown/TransportPutShutdownNodeAction.java
+++ b/x-pack/plugin/shutdown/src/main/java/org/elasticsearch/xpack/shutdown/TransportPutShutdownNodeAction.java
@@ -104,7 +104,8 @@ public class TransportPutShutdownNodeAction extends AcknowledgedTransportMasterN
 
             @Override
             public void clusterStateProcessed(String source, ClusterState oldState, ClusterState newState) {
-                if (SingleNodeShutdownMetadata.Type.REMOVE.equals(request.getType())) {
+                if (SingleNodeShutdownMetadata.Type.REMOVE.equals(request.getType())
+                    || SingleNodeShutdownMetadata.Type.REPLACE.equals(request.getType())) {
                     clusterService.getRerouteService()
                         .reroute("node registered for removal from cluster", Priority.NORMAL, new ActionListener<ClusterState>() {
                             @Override

--- a/x-pack/plugin/shutdown/src/test/java/org/elasticsearch/xpack/shutdown/GetShutdownStatusResponseTests.java
+++ b/x-pack/plugin/shutdown/src/test/java/org/elasticsearch/xpack/shutdown/GetShutdownStatusResponseTests.java
@@ -48,7 +48,7 @@ public class GetShutdownStatusResponseTests extends AbstractWireSerializingTestC
     public static SingleNodeShutdownMetadata randomNodeShutdownMetadata() {
         return SingleNodeShutdownMetadata.builder()
             .setNodeId(randomAlphaOfLength(5))
-            .setType(randomBoolean() ? SingleNodeShutdownMetadata.Type.REMOVE : SingleNodeShutdownMetadata.Type.RESTART)
+            .setType(randomFrom(EnumSet.allOf(SingleNodeShutdownMetadata.Type.class)))
             .setReason(randomAlphaOfLength(5))
             .setStartedAtMillis(randomNonNegativeLong())
             .build();


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Add `replace` shutdown type (#75908)