### PR TITLE
Break up and simplify TransportFieldCapabilitiesAction

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/fieldcaps/TransportFieldCapabilitiesIndexAction.java
+++ b/server/src/main/java/org/elasticsearch/action/fieldcaps/TransportFieldCapabilitiesIndexAction.java
@@ -12,24 +12,21 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.elasticsearch.action.ActionListener;
-import org.elasticsearch.action.ActionType;
 import org.elasticsearch.action.NoShardAvailableActionException;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.ChannelActionListener;
 import org.elasticsearch.action.support.HandledTransportAction;
 import org.elasticsearch.cluster.ClusterState;
-import org.elasticsearch.cluster.block.ClusterBlockException;
-import org.elasticsearch.cluster.block.ClusterBlockLevel;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
 import org.elasticsearch.cluster.routing.GroupShardsIterator;
 import org.elasticsearch.cluster.routing.ShardIterator;
 import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.cluster.service.ClusterService;
-import org.elasticsearch.core.Nullable;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.logging.LoggerMessageFormat;
+import org.elasticsearch.core.Nullable;
 import org.elasticsearch.index.IndexService;
 import org.elasticsearch.index.engine.Engine;
 import org.elasticsearch.index.mapper.MappedFieldType;
@@ -69,8 +66,6 @@ public class TransportFieldCapabilitiesIndexAction
 
     private static final String ACTION_NAME = FieldCapabilitiesAction.NAME + "[index]";
     private static final String ACTION_SHARD_NAME = ACTION_NAME + "[s]";
-    public static final ActionType<FieldCapabilitiesIndexResponse> TYPE =
-        new ActionType<>(ACTION_NAME, FieldCapabilitiesIndexResponse::new);
 
     private final ClusterService clusterService;
     private final TransportService transportService;
@@ -166,14 +161,6 @@ public class TransportFieldCapabilitiesIndexAction
         return SearchService.queryStillMatchesAfterRewrite(searchRequest, searchExecutionContext);
     }
 
-    private static ClusterBlockException checkGlobalBlock(ClusterState state) {
-        return state.blocks().globalBlockedException(ClusterBlockLevel.READ);
-    }
-
-    private static ClusterBlockException checkRequestBlock(ClusterState state, String concreteIndex) {
-        return state.blocks().indexBlockedException(ClusterBlockLevel.READ, concreteIndex);
-    }
-
     /**
      * An action that executes on each shard sequentially until it finds one that can match the provided
      * {@link FieldCapabilitiesIndexRequest#indexFilter()}. In which case the shard is used
@@ -200,17 +187,7 @@ public class TransportFieldCapabilitiesIndexAction
                 logger.trace("executing [{}] based on cluster state version [{}]", request, clusterState.version());
             }
             nodes = clusterState.nodes();
-            ClusterBlockException blockException = checkGlobalBlock(clusterState);
-            if (blockException != null) {
-                throw blockException;
-            }
-
             this.request = request;
-            blockException = checkRequestBlock(clusterState, request.index());
-            if (blockException != null) {
-                throw blockException;
-            }
-
             shardsIt = clusterService.operationRouting().searchShards(clusterService.state(),
                 new String[]{request.index()}, null, null, null, null);
         }


### PR DESCRIPTION
`TransportFieldCapabilitiesAction` currently holds a lot of logic. This PR
breaks it up into smaller pieces and simplifies its large `doExecute` method.
Simplifying the class will help before we start to make field caps
optimizations.

Changes:
* Factor some methods out of `doExecute` to reduce its length
* Streamline index block checking

This backport doesn't include the change "Pull AsyncShardAction out into its
own class", since it's already part of a separate class in 7.x.