### PR TITLE
[DOCS] Change execute enrich policy wait_for_completion to query parameters

### DIFF
--- a/docs/reference/ingest/apis/enrich/execute-enrich-policy.asciidoc
+++ b/docs/reference/ingest/apis/enrich/execute-enrich-policy.asciidoc
@@ -102,8 +102,8 @@ it may take a while to return a response.
 (Required, string)
 Enrich policy to execute.
 
-[[execute-enrich-policy-api-request-body]]
-==== {api-request-body-title}
+[[execute-enrich-policy-api-query-params]]
+==== {api-query-parms-title}
 
 `wait_for_completion`::
 (Required, Boolean)


### PR DESCRIPTION
In the [Execute Enrich Policy API](https://www.elastic.co/guide/en/elasticsearch/reference/current/execute-enrich-policy-api.html) documentation `wait_for_completion` shows as Request Body.

Executing:
```
PUT /_enrich/policy/my-policy/_execute
{
  "wait_for_completion": true
}
```
or 
```
POST /_enrich/policy/my-policy/_execute
{
  "wait_for_completion": true
}
```

will fail with: 
```
"reason" : "request [PUT /_enrich/policy/my-policy/_execute] does not support having a body"
```

Looking at https://github.com/elastic/elasticsearch/pull/47886, `wait_for_completion` seems to be a query paramter instead:
https://github.com/elastic/elasticsearch/blob/d71544976608bdb53fa4d29521fb328e1033ee2f/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/rest/RestExecuteEnrichPolicyAction.java#L36

`PUT /_enrich/policy/my-policy/_execute?wait_for_completion=true` works as expected.

This PR will adjust the [Execute Enrich Policy API](https://www.elastic.co/guide/en/elasticsearch/reference/current/execute-enrich-policy-api.html) doc to define `wait_for_completion` as a Query Parameter.

Backport to 7.x is needed.

Thanks.
