### PR TITLE
[7.x] Watcher: Fix index action simulation when indexing several documents (#76820)

### DIFF
--- a/x-pack/plugin/watcher/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/watcher/execute_watch/50_action_mode.yml
+++ b/x-pack/plugin/watcher/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/watcher/execute_watch/50_action_mode.yml
@@ -71,3 +71,37 @@ teardown:
   - match: { watch_record.result.actions.0.id: "logging" }
   - match: { watch_record.result.actions.0.status: "simulated" }
 
+---
+"Test simulate index action":
+  - do:
+      watcher.execute_watch:
+        body: >
+          {
+            "watch": {
+              "trigger": {
+                "schedule" : { "cron" : "0 0 0 1 * ? 2099" }
+              },
+              "input": {
+                "simple": {
+                  "foo": "bar"
+                }
+              },
+              "actions": {
+                "index_payload" : {
+                  "transform": { "script": "return ['_doc':[['_id':'the-id','_index':'the-index','a':'b']]]"},
+                  "index" : {}
+                }
+              }
+            },
+            "action_modes" : {
+              "_all" : "simulate"
+            }
+          }
+
+  - match: { watch_record.trigger_event.type: "manual" }
+  - match: { watch_record.state: "executed" }
+  - match: { watch_record.status.execution_state: "executed" }
+  - match: { watch_record.result.actions.0.id: "index_payload" }
+  - match: { watch_record.result.actions.0.status: "simulated" }
+  - match: { watch_record.result.actions.0.index.request.source.0._id: "the-id" }
+  - match: { watch_record.result.actions.0.index.request.source.0._index: "the-index" }

--- a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/actions/index/ExecutableIndexAction.java
+++ b/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/actions/index/ExecutableIndexAction.java
@@ -7,6 +7,7 @@
 package org.elasticsearch.xpack.watcher.actions.index;
 
 import org.apache.logging.log4j.Logger;
+import org.elasticsearch.action.DocWriteRequest;
 import org.elasticsearch.action.DocWriteResponse;
 import org.elasticsearch.action.bulk.BulkItemResponse;
 import org.elasticsearch.action.bulk.BulkRequest;
@@ -15,9 +16,9 @@ import org.elasticsearch.action.index.IndexRequest;
 import org.elasticsearch.action.index.IndexResponse;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.common.bytes.BytesReference;
-import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentType;
+import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.xpack.core.ClientHelper;
 import org.elasticsearch.xpack.core.watcher.actions.Action;
 import org.elasticsearch.xpack.core.watcher.actions.Action.Result.Status;
@@ -147,6 +148,22 @@ public class ExecutableIndexAction extends ExecutableAction<IndexAction> {
             }
             bulkRequest.add(indexRequest);
         }
+
+        if (ctx.simulateAction(actionId)) {
+            try (XContentBuilder builder = jsonBuilder().startArray()) {
+                for (DocWriteRequest<?> request : bulkRequest.requests()) {
+                    builder.startObject();
+                    builder.field("_id", request.id());
+                    builder.field("_index", request.index());
+                    builder.endObject();
+                }
+                builder.endArray();
+
+                return new IndexAction.Simulated("", "",
+                    action.refreshPolicy, new XContentSource(BytesReference.bytes(builder), XContentType.JSON));
+            }
+        }
+
         ClientHelper.assertNoAuthorizationHeader(ctx.watch().status().getHeaders());
         BulkResponse bulkResponse = ClientHelper.executeWithHeaders(ctx.watch().status().getHeaders(), ClientHelper.WATCHER_ORIGIN, client,
                 () -> client.bulk(bulkRequest).actionGet(bulkDefaultTimeout));

--- a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/actions/index/ExecutableIndexAction.java
+++ b/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/actions/index/ExecutableIndexAction.java
@@ -159,7 +159,7 @@ public class ExecutableIndexAction extends ExecutableAction<IndexAction> {
                 }
                 builder.endArray();
 
-                return new IndexAction.Simulated("", "",
+                return new IndexAction.Simulated("", "", "",
                     action.refreshPolicy, new XContentSource(BytesReference.bytes(builder), XContentType.JSON));
             }
         }

--- a/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/actions/index/IndexActionTests.java
+++ b/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/actions/index/IndexActionTests.java
@@ -419,7 +419,8 @@ public class IndexActionTests extends ESTestCase {
             TimeValue.timeValueSeconds(30), TimeValue.timeValueSeconds(30));
 
         String docId = randomAlphaOfLength(5);
-        final List<Map<String, String>> docs = List.of(Map.of("foo", "bar", "_id", docId));
+        final List<Map<String, String>> docs = org.elasticsearch.core.List.of(
+            org.elasticsearch.core.Map.of("foo", "bar", "_id", docId));
         Payload payload;
         if (randomBoolean()) {
             payload = new Payload.Simple("_doc", docs);

--- a/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/actions/index/IndexActionTests.java
+++ b/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/actions/index/IndexActionTests.java
@@ -58,6 +58,7 @@ import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.startsWith;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
 
 public class IndexActionTests extends ESTestCase {
@@ -410,5 +411,26 @@ public class IndexActionTests extends ESTestCase {
         } else {
             assertThat(result.status(), is(Status.FAILURE));
         }
+    }
+
+    public void testIndexSeveralDocumentsIsSimulated() throws Exception {
+        IndexAction action = new IndexAction("test-index", null, null, "@timestamp", null, null, refreshPolicy);
+        ExecutableIndexAction executable = new ExecutableIndexAction(action, logger, client,
+            TimeValue.timeValueSeconds(30), TimeValue.timeValueSeconds(30));
+
+        String docId = randomAlphaOfLength(5);
+        final List<Map<String, String>> docs = List.of(Map.of("foo", "bar", "_id", docId));
+        Payload payload;
+        if (randomBoolean()) {
+            payload = new Payload.Simple("_doc", docs);
+        } else {
+            payload = new Payload.Simple("_doc", docs.toArray());
+        }
+        WatchExecutionContext ctx = WatcherTestUtils.mockExecutionContext("_id", ZonedDateTime.now(ZoneOffset.UTC), payload);
+        when(ctx.simulateAction("my_id")).thenReturn(true);
+
+        Action.Result result = executable.execute("my_id", ctx, payload);
+        assertThat(result.status(), is(Status.SIMULATED));
+        verifyZeroInteractions(client);
     }
 }


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Watcher: Fix index action simulation when indexing several documents (#76820)