### PR TITLE
Implement Sort By Repository Name in Get Snapshots API

### DIFF
--- a/docs/reference/snapshot-restore/apis/get-snapshot-api.asciidoc
+++ b/docs/reference/snapshot-restore/apis/get-snapshot-api.asciidoc
@@ -118,6 +118,9 @@ Allows setting a sort order for the result. Defaults to `start_time`, i.e. sorti
 `name`::
   Sort snapshots by their name.
 
+`repository`::
+  Sort snapshots by their repository name and break ties by snapshot name.
+
 `index_count`::
   Sort snapshots by the number of indices they contain and break ties by snapshot name.
 

--- a/qa/smoke-test-http/src/test/java/org/elasticsearch/http/snapshots/RestGetSnapshotsIT.java
+++ b/qa/smoke-test-http/src/test/java/org/elasticsearch/http/snapshots/RestGetSnapshotsIT.java
@@ -96,6 +96,11 @@ public class RestGetSnapshotsIT extends AbstractSnapshotRestTestCase {
                 GetSnapshotsRequest.SortBy.FAILED_SHARDS,
                 order
         );
+        assertSnapshotListSorted(
+                allSnapshotsSorted(allSnapshotNames, repoName, GetSnapshotsRequest.SortBy.REPOSITORY, order),
+                GetSnapshotsRequest.SortBy.REPOSITORY,
+                order
+        );
     }
 
     public void testResponseSizeLimit() throws Exception {

--- a/server/src/internalClusterTest/java/org/elasticsearch/snapshots/GetSnapshotsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/snapshots/GetSnapshotsIT.java
@@ -38,21 +38,36 @@ public class GetSnapshotsIT extends AbstractSnapshotIntegTestCase {
     }
 
     public void testSortBy() throws Exception {
-        final String repoName = "test-repo";
+        final String repoNameA = "test-repo-a";
         final Path repoPath = randomRepoPath();
-        createRepository(repoName, "fs", repoPath);
-        maybeInitWithOldSnapshotVersion(repoName, repoPath);
-        final List<String> snapshotNamesWithoutIndex = createNSnapshots(repoName, randomIntBetween(3, 20));
+        createRepository(repoNameA, "fs", repoPath);
+        maybeInitWithOldSnapshotVersion(repoNameA, repoPath);
+        final String repoNameB = "test-repo-b";
+        createRepository(repoNameB, "fs");
+
+        final List<String> snapshotNamesWithoutIndexA = createNSnapshots(repoNameA, randomIntBetween(3, 20));
+        final List<String> snapshotNamesWithoutIndexB = createNSnapshots(repoNameB, randomIntBetween(3, 20));
 
         createIndexWithContent("test-index");
 
-        final List<String> snapshotNamesWithIndex = createNSnapshots(repoName, randomIntBetween(3, 20));
+        final List<String> snapshotNamesWithIndexA = createNSnapshots(repoNameA, randomIntBetween(3, 20));
+        final List<String> snapshotNamesWithIndexB = createNSnapshots(repoNameB, randomIntBetween(3, 20));
 
-        final Collection<String> allSnapshotNames = new HashSet<>(snapshotNamesWithIndex);
-        allSnapshotNames.addAll(snapshotNamesWithoutIndex);
+        final Collection<String> allSnapshotNamesA = new HashSet<>(snapshotNamesWithIndexA);
+        final Collection<String> allSnapshotNamesB = new HashSet<>(snapshotNamesWithIndexB);
+        allSnapshotNamesA.addAll(snapshotNamesWithoutIndexA);
+        allSnapshotNamesB.addAll(snapshotNamesWithoutIndexB);
 
-        doTestSortOrder(repoName, allSnapshotNames, SortOrder.ASC);
-        doTestSortOrder(repoName, allSnapshotNames, SortOrder.DESC);
+        doTestSortOrder(repoNameA, allSnapshotNamesA, SortOrder.ASC);
+        doTestSortOrder(repoNameA, allSnapshotNamesA, SortOrder.DESC);
+
+        doTestSortOrder(repoNameB, allSnapshotNamesB, SortOrder.ASC);
+        doTestSortOrder(repoNameB, allSnapshotNamesB, SortOrder.DESC);
+
+        final Collection<String> allSnapshots = new HashSet<>(allSnapshotNamesA);
+        allSnapshots.addAll(allSnapshotNamesB);
+        doTestSortOrder("*", allSnapshots, SortOrder.ASC);
+        doTestSortOrder("*", allSnapshots, SortOrder.DESC);
     }
 
     private void doTestSortOrder(String repoName, Collection<String> allSnapshotNames, SortOrder order) {
@@ -86,6 +101,11 @@ public class GetSnapshotsIT extends AbstractSnapshotIntegTestCase {
         assertSnapshotListSorted(
             allSnapshotsSorted(allSnapshotNames, repoName, GetSnapshotsRequest.SortBy.FAILED_SHARDS, order),
             GetSnapshotsRequest.SortBy.FAILED_SHARDS,
+            order
+        );
+        assertSnapshotListSorted(
+            allSnapshotsSorted(allSnapshotNames, repoName, GetSnapshotsRequest.SortBy.REPOSITORY, order),
+            GetSnapshotsRequest.SortBy.REPOSITORY,
             order
         );
     }

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/get/GetSnapshotsRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/get/GetSnapshotsRequest.java
@@ -46,7 +46,7 @@ public class GetSnapshotsRequest extends MasterNodeRequest<GetSnapshotsRequest> 
 
     public static final Version NUMERIC_PAGINATION_VERSION = Version.V_7_15_0;
 
-    private static final Version SORT_BY_SHARD_COUNTS_VERSION = Version.V_7_16_0;
+    private static final Version SORT_BY_SHARDS_OR_REPO_VERSION = Version.V_7_16_0;
 
     public static final int NO_LIMIT = -1;
 
@@ -138,8 +138,11 @@ public class GetSnapshotsRequest extends MasterNodeRequest<GetSnapshotsRequest> 
         out.writeBoolean(verbose);
         if (out.getVersion().onOrAfter(PAGINATED_GET_SNAPSHOTS_VERSION)) {
             out.writeOptionalWriteable(after);
-            if ((sort == SortBy.SHARDS || sort == SortBy.FAILED_SHARDS) && out.getVersion().before(SORT_BY_SHARD_COUNTS_VERSION)) {
-                throw new IllegalArgumentException("can't use sort by shard count with node version [" + out.getVersion() + "]");
+            if ((sort == SortBy.SHARDS || sort == SortBy.FAILED_SHARDS || sort == SortBy.REPOSITORY)
+                && out.getVersion().before(SORT_BY_SHARDS_OR_REPO_VERSION)) {
+                throw new IllegalArgumentException(
+                    "can't use sort by shard count or repository name with node version [" + out.getVersion() + "]"
+                );
             }
             out.writeEnum(sort);
             out.writeVInt(size);
@@ -327,7 +330,8 @@ public class GetSnapshotsRequest extends MasterNodeRequest<GetSnapshotsRequest> 
         DURATION("duration"),
         INDICES("index_count"),
         SHARDS("shard_count"),
-        FAILED_SHARDS("failed_shard_count");
+        FAILED_SHARDS("failed_shard_count"),
+        REPOSITORY("repository");
 
         private final String param;
 
@@ -354,6 +358,8 @@ public class GetSnapshotsRequest extends MasterNodeRequest<GetSnapshotsRequest> 
                     return SHARDS;
                 case "failed_shard_count":
                     return FAILED_SHARDS;
+                case "repository":
+                    return REPOSITORY;
                 default:
                     throw new IllegalArgumentException("unknown sort order [" + value + "]");
             }
@@ -404,6 +410,9 @@ public class GetSnapshotsRequest extends MasterNodeRequest<GetSnapshotsRequest> 
                     break;
                 case FAILED_SHARDS:
                     afterValue = String.valueOf(snapshotInfo.failedShards());
+                    break;
+                case REPOSITORY:
+                    afterValue = snapshotInfo.repository();
                     break;
                 default:
                     throw new AssertionError("unknown sort column [" + sortBy + "]");

--- a/test/framework/src/main/java/org/elasticsearch/snapshots/AbstractSnapshotIntegTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/snapshots/AbstractSnapshotIntegTestCase.java
@@ -704,6 +704,9 @@ public abstract class AbstractSnapshotIntegTestCase extends ESIntegTestCase {
                 case FAILED_SHARDS:
                     assertion = (s1, s2) -> assertThat(s2.failedShards(), greaterThanOrEqualTo(s1.failedShards()));
                     break;
+                case REPOSITORY:
+                    assertion = (s1, s2) -> assertThat(s2.repository(), greaterThanOrEqualTo(s1.repository()));
+                    break;
                 default:
                     throw new AssertionError("unknown sort column [" + sort + "]");
             }


### PR DESCRIPTION
This one is the last sort column not yet implemented but used by Kibana.
