### PR TITLE
Add  refcounting  to avoid close connection by mistake

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/coordination/Coordinator.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/Coordinator.java
@@ -211,6 +211,7 @@ public class Coordinator extends AbstractLifecycleComponent implements Discovery
     private void removeNode(DiscoveryNode discoveryNode, String reason) {
         synchronized (mutex) {
             if (mode == Mode.LEADER) {
+                transportService.getConnectionManager().setIsDeleting(discoveryNode);
                 masterService.submitStateUpdateTask("node-left",
                     new NodeRemovalClusterStateTaskExecutor.Task(discoveryNode, reason),
                     ClusterStateTaskConfig.build(Priority.IMMEDIATE),

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/Coordinator.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/Coordinator.java
@@ -211,7 +211,7 @@ public class Coordinator extends AbstractLifecycleComponent implements Discovery
     private void removeNode(DiscoveryNode discoveryNode, String reason) {
         synchronized (mutex) {
             if (mode == Mode.LEADER) {
-                transportService.getConnectionManager().setIsDeleting(discoveryNode);
+                transportService.getConnectionManager().setDeleting(discoveryNode);
                 masterService.submitStateUpdateTask("node-left",
                     new NodeRemovalClusterStateTaskExecutor.Task(discoveryNode, reason),
                     ClusterStateTaskConfig.build(Priority.IMMEDIATE),

--- a/server/src/main/java/org/elasticsearch/transport/ClusterConnectionManager.java
+++ b/server/src/main/java/org/elasticsearch/transport/ClusterConnectionManager.java
@@ -109,7 +109,7 @@ public class ClusterConnectionManager implements ConnectionManager {
 
         ConnectedNodeRefCounter connectedNodeRefCounter = connectedNodes.get(node);
         if (connectedNodeRefCounter != null) {
-            if (connectedNodeRefCounter.isDeleting) {
+            if (connectedNodeRefCounter.isDeleting()) {
                 connectedNodeRefCounter.incRef();
             }
             connectingRefCounter.decRef();

--- a/server/src/main/java/org/elasticsearch/transport/ClusterConnectionManager.java
+++ b/server/src/main/java/org/elasticsearch/transport/ClusterConnectionManager.java
@@ -282,7 +282,9 @@ public class ClusterConnectionManager implements ConnectionManager {
 
     @Override
     public void setIsDeleting(DiscoveryNode discoveryNode) {
-        connectedNodes.get(discoveryNode).setIsDeleting(true);
+        if (connectedNodes.containsKey(discoveryNode)) {
+            connectedNodes.get(discoveryNode).setIsDeleting(true);
+        }
     }
 
     public static final class ConnectedNodeRefCounter extends AbstractRefCounted implements Closeable {

--- a/server/src/main/java/org/elasticsearch/transport/ConnectionManager.java
+++ b/server/src/main/java/org/elasticsearch/transport/ConnectionManager.java
@@ -44,6 +44,8 @@ public interface ConnectionManager extends Closeable {
 
     ConnectionProfile getConnectionProfile();
 
+    void setIsDeleting(DiscoveryNode discoveryNode);
+
     @FunctionalInterface
     interface ConnectionValidator {
         void validate(Transport.Connection connection, ConnectionProfile profile, ActionListener<Void> listener);

--- a/server/src/main/java/org/elasticsearch/transport/ConnectionManager.java
+++ b/server/src/main/java/org/elasticsearch/transport/ConnectionManager.java
@@ -44,12 +44,12 @@ public interface ConnectionManager extends Closeable {
 
     ConnectionProfile getConnectionProfile();
 
-    void setIsDeleting(DiscoveryNode discoveryNode);
-
     @FunctionalInterface
     interface ConnectionValidator {
         void validate(Transport.Connection connection, ConnectionProfile profile, ActionListener<Void> listener);
     }
+
+    void setDeleting(DiscoveryNode node);
 
     final class DelegatingNodeConnectionListener implements TransportConnectionListener {
 

--- a/server/src/main/java/org/elasticsearch/transport/RemoteConnectionManager.java
+++ b/server/src/main/java/org/elasticsearch/transport/RemoteConnectionManager.java
@@ -131,6 +131,11 @@ public class RemoteConnectionManager implements ConnectionManager {
         delegate.closeNoBlock();
     }
 
+    @Override
+    public void setIsDeleting(DiscoveryNode discoveryNode) {
+        this.delegate.setIsDeleting(discoveryNode);
+    }
+
     private synchronized void addConnectedNode(DiscoveryNode addedNode) {
         this.connectedNodes = CollectionUtils.appendToCopy(this.connectedNodes, addedNode);
     }

--- a/server/src/main/java/org/elasticsearch/transport/RemoteConnectionManager.java
+++ b/server/src/main/java/org/elasticsearch/transport/RemoteConnectionManager.java
@@ -132,8 +132,8 @@ public class RemoteConnectionManager implements ConnectionManager {
     }
 
     @Override
-    public void setIsDeleting(DiscoveryNode discoveryNode) {
-        this.delegate.setIsDeleting(discoveryNode);
+    public void setDeleting(DiscoveryNode node) {
+        delegate.setDeleting(node);
     }
 
     private synchronized void addConnectedNode(DiscoveryNode addedNode) {

--- a/test/framework/src/main/java/org/elasticsearch/test/transport/StubbableConnectionManager.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/transport/StubbableConnectionManager.java
@@ -126,7 +126,6 @@ public class StubbableConnectionManager implements ConnectionManager {
         this.delegate.setIsDeleting(discoveryNode);
     }
 
-
     @FunctionalInterface
     public interface GetConnectionBehavior {
         Transport.Connection getConnection(ConnectionManager connectionManager, DiscoveryNode discoveryNode);

--- a/test/framework/src/main/java/org/elasticsearch/test/transport/StubbableConnectionManager.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/transport/StubbableConnectionManager.java
@@ -121,6 +121,12 @@ public class StubbableConnectionManager implements ConnectionManager {
         return delegate.getConnectionProfile();
     }
 
+    @Override
+    public void setIsDeleting(DiscoveryNode discoveryNode) {
+        this.delegate.setIsDeleting(discoveryNode);
+    }
+
+
     @FunctionalInterface
     public interface GetConnectionBehavior {
         Transport.Connection getConnection(ConnectionManager connectionManager, DiscoveryNode discoveryNode);

--- a/test/framework/src/main/java/org/elasticsearch/test/transport/StubbableConnectionManager.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/transport/StubbableConnectionManager.java
@@ -122,8 +122,8 @@ public class StubbableConnectionManager implements ConnectionManager {
     }
 
     @Override
-    public void setIsDeleting(DiscoveryNode discoveryNode) {
-        this.delegate.setIsDeleting(discoveryNode);
+    public void setDeleting(DiscoveryNode node) {
+        delegate.setDeleting(node);
     }
 
     @FunctionalInterface


### PR DESCRIPTION
The connection will be closed by `node-left` task, at the same time the connection maybe have been reused by join request, This commit import refcounting to solve the problem. 

Relates #67873 
