### PR TITLE
Add support for QueryString-parsed wildcard queries on runtime keyword fields. (#76867)

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/mapper/KeywordScriptFieldType.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/KeywordScriptFieldType.java
@@ -215,4 +215,10 @@ public final class KeywordScriptFieldType extends AbstractScriptFieldType<String
         checkAllowExpensiveQueries(context);
         return new StringScriptFieldWildcardQuery(script, leafFactory(context), name(), value, caseInsensitive);
     }
+
+    @Override
+    public Query normalizedWildcardQuery(String value, RewriteMethod method, SearchExecutionContext context) {
+        checkAllowExpensiveQueries(context);
+        return new StringScriptFieldWildcardQuery(script, leafFactory(context), name(), value, false);
+    }
 }

--- a/server/src/test/java/org/elasticsearch/index/mapper/KeywordScriptFieldTypeTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/KeywordScriptFieldTypeTests.java
@@ -335,6 +335,18 @@ public class KeywordScriptFieldTypeTests extends AbstractScriptFieldTypeTestCase
             }
         }
     }
+    
+    // Normalized WildcardQueries are requested by the QueryStringQueryParser
+    public void testNormalizedWildcardQuery() throws IOException {
+        try (Directory directory = newDirectory(); RandomIndexWriter iw = new RandomIndexWriter(random(), directory)) {
+            iw.addDocument(List.of(new StoredField("_source", new BytesRef("{\"foo\": [\"aab\"]}"))));
+            iw.addDocument(List.of(new StoredField("_source", new BytesRef("{\"foo\": [\"b\"]}"))));
+            try (DirectoryReader reader = iw.getReader()) {
+                IndexSearcher searcher = newSearcher(reader);
+                assertThat(searcher.count(simpleMappedFieldType().normalizedWildcardQuery("a*b", null, mockContext())), equalTo(1));
+            }
+        }
+    }    
 
     public void testWildcardQueryIsExpensive() {
         checkExpensiveQuery(this::randomWildcardQuery);

--- a/server/src/test/java/org/elasticsearch/index/mapper/KeywordScriptFieldTypeTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/KeywordScriptFieldTypeTests.java
@@ -339,8 +339,8 @@ public class KeywordScriptFieldTypeTests extends AbstractScriptFieldTypeTestCase
     // Normalized WildcardQueries are requested by the QueryStringQueryParser
     public void testNormalizedWildcardQuery() throws IOException {
         try (Directory directory = newDirectory(); RandomIndexWriter iw = new RandomIndexWriter(random(), directory)) {
-            iw.addDocument(List.of(new StoredField("_source", new BytesRef("{\"foo\": [\"aab\"]}"))));
-            iw.addDocument(List.of(new StoredField("_source", new BytesRef("{\"foo\": [\"b\"]}"))));
+            iw.addDocument(org.elasticsearch.core.List.of(new StoredField("_source", new BytesRef("{\"foo\": [\"aab\"]}"))));
+            iw.addDocument(org.elasticsearch.core.List.of(new StoredField("_source", new BytesRef("{\"foo\": [\"b\"]}"))));
             try (DirectoryReader reader = iw.getReader()) {
                 IndexSearcher searcher = newSearcher(reader);
                 assertThat(searcher.count(simpleMappedFieldType().normalizedWildcardQuery("a*b", null, mockContext())), equalTo(1));


### PR DESCRIPTION
The QueryStringQuery parser assumes that wildcard queries should use normalized values in queries.
The KeywordScriptFieldType did not support this so was throwing an error. Given there is currently no concept of normalisation in scripted fields I assume it is safe to just add support for this in the same way un-normalized wildcard queries are handled - it feels right that they should behave the same rather than throw an error.
Added a test too.

Closes #76838