### PR TITLE
[7.14] SQL: Fix disjunctions (and `IN`) with multiple date math expressions (#76424)

### DIFF
--- a/docs/reference/sql/functions/date-time.asciidoc
+++ b/docs/reference/sql/functions/date-time.asciidoc
@@ -53,6 +53,20 @@ s|Description
 | `INTERVAL '45:01.23' MINUTES TO SECONDS`      | 45 minutes, 1 second and 230000000 nanoseconds
 |===
 
+==== Comparison
+
+Date/time fields can be compared to <<date-math, date math>> expressions with the equality (`=`) and `IN` operators:
+
+[source, sql]
+--------------------------------------------------
+include-tagged::{sql-specs}/docs/docs.csv-spec[dtDateMathEquals]
+--------------------------------------------------
+
+[source, sql]
+--------------------------------------------------
+include-tagged::{sql-specs}/docs/docs.csv-spec[dtDateMathIn]
+--------------------------------------------------
+
 ==== Operators
 
 Basic arithmetic operators (`+`, `-`, `*`) support date/time parameters as indicated below:

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/planner/QueryTranslator.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/planner/QueryTranslator.java
@@ -96,25 +96,22 @@ final class QueryTranslator {
         }
 
         private static Query translate(InsensitiveBinaryComparison bc, TranslatorHandler handler) {
+            FieldAttribute field = checkIsFieldAttribute(bc.left());
             Source source = bc.source();
-            String name = handler.nameOf(bc.left());
             Object value = valueOf(bc.right());
 
             if (bc instanceof InsensitiveEquals || bc instanceof InsensitiveNotEquals) {
-                if (bc.left() instanceof FieldAttribute) {
-                    // equality should always be against an exact match
-                    // (which is important for strings)
-                    name = ((FieldAttribute) bc.left()).exactAttribute().name();
-                }
+                // equality should always be against an exact match
+                // (which is important for strings)
+                String name = field.exactAttribute().name();
+
                 Query query = new TermQuery(source, name, value, true);
 
                 if (bc instanceof InsensitiveNotEquals) {
                     query = new NotQuery(source, query);
                 }
-
                 return query;
             }
-
             throw new QlIllegalArgumentException("Don't know how to translate binary comparison [{}] in [{}]", bc.right().nodeString(), bc);
         }
     }

--- a/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/optimizer/OptimizerRules.java
+++ b/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/optimizer/OptimizerRules.java
@@ -344,7 +344,8 @@ public final class OptimizerRules {
                 } else if (ex instanceof Equals || ex instanceof NullEquals) {
                     BinaryComparison otherEq = (BinaryComparison) ex;
                     // equals on different values evaluate to FALSE
-                    if (otherEq.right().foldable()) {
+                    // ignore date/time fields as equality comparison might actually be a range check
+                    if (otherEq.right().foldable() && DataTypes.isDateTime(otherEq.left().dataType()) == false) {
                         for (BinaryComparison eq : equals) {
                             if (otherEq.left().semanticEquals(eq.left())) {
                                     Integer comp = BinaryComparison.compare(eq.right().fold(), otherEq.right().fold());

--- a/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/planner/ExpressionTranslator.java
+++ b/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/planner/ExpressionTranslator.java
@@ -11,6 +11,7 @@ import org.elasticsearch.xpack.ql.expression.Expression;
 import org.elasticsearch.xpack.ql.expression.FieldAttribute;
 import org.elasticsearch.xpack.ql.querydsl.query.NestedQuery;
 import org.elasticsearch.xpack.ql.querydsl.query.Query;
+import org.elasticsearch.xpack.ql.util.Check;
 import org.elasticsearch.xpack.ql.util.ReflectionUtils;
 
 public abstract class ExpressionTranslator<E extends Expression> {
@@ -32,5 +33,10 @@ public abstract class ExpressionTranslator<E extends Expression> {
             }
         }
         return query;
+    }
+
+    public static FieldAttribute checkIsFieldAttribute(Expression e) {
+        Check.isTrue(e instanceof FieldAttribute, "Expected a FieldAttribute but received [{}]", e);
+        return (FieldAttribute) e;
     }
 }

--- a/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/planner/ExpressionTranslators.java
+++ b/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/planner/ExpressionTranslators.java
@@ -50,16 +50,15 @@ import org.elasticsearch.xpack.ql.querydsl.query.TermQuery;
 import org.elasticsearch.xpack.ql.querydsl.query.TermsQuery;
 import org.elasticsearch.xpack.ql.querydsl.query.WildcardQuery;
 import org.elasticsearch.xpack.ql.tree.Source;
-import org.elasticsearch.xpack.ql.type.DataType;
 import org.elasticsearch.xpack.ql.type.DataTypes;
 import org.elasticsearch.xpack.ql.util.Check;
-import org.elasticsearch.xpack.ql.util.CollectionUtils;
 
 import java.time.OffsetTime;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.time.temporal.TemporalAccessor;
 import java.util.Arrays;
+import java.util.ArrayList;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
@@ -221,13 +220,7 @@ public final class ExpressionTranslators {
         }
 
         private static Query translate(IsNotNull isNotNull, TranslatorHandler handler) {
-            Query query = null;
-            if (isNotNull.field() instanceof FieldAttribute) {
-                query = new ExistsQuery(isNotNull.source(), handler.nameOf(isNotNull.field()));
-            } else {
-                query = new ScriptQuery(isNotNull.source(), isNotNull.asScript());
-            }
-            return query;
+            return new ExistsQuery(isNotNull.source(), handler.nameOf(isNotNull.field()));
         }
     }
 
@@ -243,15 +236,7 @@ public final class ExpressionTranslators {
         }
 
         private static Query translate(IsNull isNull, TranslatorHandler handler) {
-            Query query = null;
-
-            if (isNull.field() instanceof FieldAttribute) {
-                query = new NotQuery(isNull.source(), new ExistsQuery(isNull.source(), handler.nameOf(isNull.field())));
-            } else {
-                query = new ScriptQuery(isNull.source(), isNull.asScript());
-            }
-
-            return query;
+            return new NotQuery(isNull.source(), new ExistsQuery(isNull.source(), handler.nameOf(isNull.field())));
         }
     }
 
@@ -275,9 +260,10 @@ public final class ExpressionTranslators {
             return handler.wrapFunctionQuery(bc, bc.left(), () -> translate(bc, handler));
         }
 
-        private static Query translate(BinaryComparison bc, TranslatorHandler handler) {
+        static Query translate(BinaryComparison bc, TranslatorHandler handler) {
+            FieldAttribute field = checkIsFieldAttribute(bc.left());
             Source source = bc.source();
-            String name = handler.nameOf(bc.left());
+            String name = handler.nameOf(field);
             Object value = valueOf(bc.right());
             String format = null;
             boolean isDateLiteralComparison = false;
@@ -301,7 +287,7 @@ public final class ExpressionTranslators {
             }
 
             ZoneId zoneId = null;
-            if (DataTypes.isDateTime(bc.left().dataType())) {
+            if (DataTypes.isDateTime(field.dataType())) {
                 zoneId = bc.zoneId();
             }
             if (bc instanceof GreaterThan) {
@@ -317,11 +303,10 @@ public final class ExpressionTranslators {
                 return new RangeQuery(source, name, null, false, value, true, format, zoneId);
             }
             if (bc instanceof Equals || bc instanceof NullEquals || bc instanceof NotEquals) {
-                if (bc.left() instanceof FieldAttribute) {
-                    // equality should always be against an exact match
-                    // (which is important for strings)
-                    name = ((FieldAttribute) bc.left()).exactAttribute().name();
-                }
+                // equality should always be against an exact match
+                // (which is important for strings)
+                name = field.exactAttribute().name();
+
                 Query query;
                 if (isDateLiteralComparison) {
                     // dates equality uses a range query because it's the one that has a "format" parameter
@@ -347,11 +332,11 @@ public final class ExpressionTranslators {
             return doTranslate(r, handler);
         }
 
-        public static Query doTranslate(Range r, TranslatorHandler handler) {            
+        public static Query doTranslate(Range r, TranslatorHandler handler) {
             return handler.wrapFunctionQuery(r, r.value(), () -> translate(r, handler));
         }
 
-        private static RangeQuery translate(Range r, TranslatorHandler handler) {            
+        private static RangeQuery translate(Range r, TranslatorHandler handler) {
             Object lower = valueOf(r.lower());
             Object upper = valueOf(r.upper());
             String format = null;
@@ -393,41 +378,36 @@ public final class ExpressionTranslators {
         }
 
         private static Query translate(In in, TranslatorHandler handler) {
-            Query q;
-            if (in.value() instanceof FieldAttribute) {
-                // equality should always be against an exact match (which is important for strings)
-                FieldAttribute fa = (FieldAttribute) in.value();
-                DataType dt = fa.dataType();
+            FieldAttribute field = checkIsFieldAttribute(in.value());
+            boolean isDateTimeComparison = DataTypes.isDateTime(field.dataType());
 
-                List<Expression> list = in.list();
-                Set<Object> set = new LinkedHashSet<>(CollectionUtils.mapSize(list.size()));
-                list.forEach(e -> {
-                    // TODO: this needs to be handled inside the optimizer
-                    if (DataTypes.isNull(e.dataType()) == false) {
-                        set.add(handler.convert(valueOf(e), dt));
+            Set<Object> terms = new LinkedHashSet<>();
+            List<Query> queries = new ArrayList<>();
+
+            for (Expression rhs : in.list()) {
+                if (DataTypes.isNull(rhs.dataType()) == false) {
+                    if (isDateTimeComparison) {
+                        // delegates to BinaryComparisons translator to ensure consistent handling of date and time values
+                        Query query = BinaryComparisons.translate(new Equals(in.source(), in.value(), rhs, in.zoneId()), handler);
+
+                        if (query instanceof TermQuery) {
+                            terms.add(((TermQuery) query).value());
+                        } else {
+                            queries.add(query);
+                        }
+                    } else {
+                        terms.add(valueOf(rhs));
                     }
-                });
-
-                if (DataTypes.isDateTime(dt)) {
-                    DateFormatter formatter = DateFormatter.forPattern(DATE_FORMAT);
-
-                    q = null;
-                    for (Object o : set) {
-                        assert o instanceof ZonedDateTime : "expected a ZonedDateTime, but got: " + o.getClass().getName();
-                        // see comment in Ranges#doTranslate() as to why formatting as String is required
-                        String zdt = formatter.format((ZonedDateTime) o);
-                        RangeQuery right = new RangeQuery(
-                            in.source(), fa.exactAttribute().name(),
-                            zdt, true, zdt, true, formatter.pattern(), in.zoneId());
-                        q = q == null ? right : new BoolQuery(in.source(), false, q, right);
-                    }
-                } else {
-                    q = new TermsQuery(in.source(), fa.exactAttribute().name(), set);
                 }
-            } else {
-                q = new ScriptQuery(in.source(), in.asScript());
             }
-            return q;
+
+            if (terms.isEmpty() == false) {
+                String fieldName = field.exactAttribute().name();
+                queries.add(new TermsQuery(in.source(), fieldName, terms));
+            }
+
+            return queries.stream()
+                .reduce((q1, q2) -> or(in.source(), q1, q2)).get();
         }
     }
 

--- a/x-pack/plugin/ql/src/test/java/org/elasticsearch/xpack/ql/optimizer/OptimizerRulesTests.java
+++ b/x-pack/plugin/ql/src/test/java/org/elasticsearch/xpack/ql/optimizer/OptimizerRulesTests.java
@@ -55,6 +55,7 @@ import org.elasticsearch.xpack.ql.plan.logical.Project;
 import org.elasticsearch.xpack.ql.tree.NodeInfo;
 import org.elasticsearch.xpack.ql.tree.Source;
 import org.elasticsearch.xpack.ql.type.DataType;
+import org.elasticsearch.xpack.ql.type.DataTypes;
 import org.elasticsearch.xpack.ql.type.EsField;
 import org.elasticsearch.xpack.ql.util.StringUtils;
 
@@ -1411,6 +1412,18 @@ public class OptimizerRulesTests extends ESTestCase {
         PropagateEquals rule = new PropagateEquals();
         Expression exp = rule.rule((Or) Predicates.combineOr(asList(eq, range, neq, gt)));
         assertEquals(TRUE, exp);
+    }
+
+    // a == 1 AND a == 2 -> nop for date/time fields
+    public void testPropagateEquals_ignoreDateTimeFields() {
+        FieldAttribute fa = getFieldAttribute("a", DataTypes.DATETIME);
+        Equals eq1 = equalsOf(fa, ONE);
+        Equals eq2 = equalsOf(fa, TWO);
+        And and = new And(EMPTY, eq1, eq2);
+
+        PropagateEquals rule = new PropagateEquals();
+        Expression exp = rule.rule(and);
+        assertEquals(and, exp);
     }
 
     //

--- a/x-pack/plugin/sql/qa/server/src/main/resources/date.csv-spec
+++ b/x-pack/plugin/sql/qa/server/src/main/resources/date.csv-spec
@@ -42,16 +42,16 @@ SELECT first_name FROM test_emp WHERE hire_date > CURRENT_DATE() - INTERVAL 45 Y
 
     first_name
 -----------------
-Alejandro      
-Amabile        
-Anneke         
-Anoosh         
-Arumugam       
-Basil          
-Berhard        
-Berni          
-Bezalel        
-Bojan          
+Alejandro
+Amabile
+Anneke
+Anoosh
+Arumugam
+Basil
+Berhard
+Berni
+Bezalel
+Bojan
 ;
 
 currentDateFilterScript
@@ -169,9 +169,9 @@ selectDateParse
 schema::date1:date
 SELECT DATE_PARSE('07/04/2020', 'dd/MM/uuuu') AS date1;
 
-   date1       
+   date1
 ------------
-2020-04-07 
+2020-04-07
 ;
 
 
@@ -265,4 +265,142 @@ HAVING DATE_PARSE(DATETIME_FORMAT(MAX(birth_date), 'dd/MM/uuuu'), 'dd/MM/uuuu') 
 1963-03-21 00:00:00.000Z | 03
 1962-12-29 00:00:00.000Z | 12
 null                     | null
+;
+
+filterDateMath
+SELECT emp_no FROM test_emp WHERE hire_date = '2021-02-03||-27y/y';
+
+    emp_no
+---------------
+10008
+10030
+10044
+10085
+;
+
+filterDateMathIn
+SELECT emp_no FROM test_emp WHERE hire_date IN ('2021-02-03||-27y/y');
+
+    emp_no
+---------------
+10008
+10030
+10044
+10085
+;
+
+filterDateMathDisjunction
+SELECT emp_no FROM test_emp WHERE hire_date = '2021-02-03||-27y/y' OR hire_date = '2021-02-03||-28y/y';
+
+    emp_no
+---------------
+10008
+10017
+10030
+10040
+10042
+10044
+10085
+;
+
+filterInWithMultipleDateMath
+SELECT emp_no FROM test_emp WHERE hire_date IN ('2021-02-03||-27y/y', '2021-02-03||-28y/y');
+
+    emp_no
+---------------
+10008
+10017
+10030
+10040
+10042
+10044
+10085
+;
+
+filterDateMathDisjunctionWithExactDate
+SELECT emp_no FROM test_emp WHERE hire_date = '2021-02-03||-27y/y' OR hire_date = '1993-08-03'::datetime;
+
+    emp_no
+---------------
+10008
+10017
+10030
+10044
+10085
+;
+
+filterInWithDateMathAndDateTime
+SELECT emp_no FROM test_emp WHERE hire_date IN ('2021-02-03||-27y/y', '1993-08-03'::datetime);
+
+    emp_no
+---------------
+10008
+10017
+10030
+10044
+10085
+;
+
+filterMixedDatetimeDisjunction
+SELECT emp_no FROM test_emp
+WHERE hire_date = '2000-02-18||-1y/y'
+   OR hire_date = '1997-05-19T00:00:00.000Z'::datetime
+   OR hire_date = '1996-11-05T00:00:00.000Z'
+   OR hire_date = '1995-12-15';
+
+    emp_no
+---------------
+10019
+10024
+10084
+10093
+;
+
+filterMixedDatetimeIn
+SELECT emp_no FROM test_emp
+WHERE hire_date IN ('2000-02-18||-1y/y', '1997-05-19T00:00:00.000Z'::datetime, '1996-11-05T00:00:00.000Z', '1995-12-15');
+
+    emp_no
+---------------
+10019
+10024
+10084
+10093
+;
+
+filterDateMathDisjunctionWithIn
+SELECT emp_no FROM test_emp WHERE hire_date = '2021-02-03||-27y/y' OR hire_date = '1992-12-18'::datetime
+    OR hire_date IN ('2021-02-03||-28y/y', '1992-01-03T00:00:00.000Z'::datetime);
+
+    emp_no
+---------------
+10008
+10012
+10017
+10030
+10036
+10040
+10042
+10044
+10085
+;
+
+filterDateMathConjunction
+SELECT emp_no FROM test_emp WHERE hire_date = '2021-09-03||-27y/y' AND hire_date = '2021-09-03||-27y/M';
+
+    emp_no
+---------------
+10008
+;
+
+// currently not supported
+filterDateMathDerivedValue-Ignore
+SELECT emp_no FROM test_emp WHERE DATE_ADD('day', 1, hire_date) = '2021-02-03||-27y/y';
+
+    emp_no
+---------------
+10008
+10030
+10044
+10085
 ;

--- a/x-pack/plugin/sql/qa/server/src/main/resources/docs/docs.csv-spec
+++ b/x-pack/plugin/sql/qa/server/src/main/resources/docs/docs.csv-spec
@@ -883,6 +883,31 @@ null           |10
 //
 ///////////////////////////////
 
+dtDateMathEquals
+// tag::dtDateMathEquals
+SELECT hire_date FROM emp WHERE hire_date = '1987-03-01||+4y/y';
+
+       hire_date
+------------------------
+1991-01-26T00:00:00.000Z
+1991-10-22T00:00:00.000Z
+1991-09-01T00:00:00.000Z
+1991-06-26T00:00:00.000Z
+1991-08-30T00:00:00.000Z
+1991-12-01T00:00:00.000Z
+// end::dtDateMathEquals
+;
+
+dtDateMathIn
+// tag::dtDateMathIn
+SELECT hire_date FROM emp WHERE hire_date IN ('1987-03-01||+2y/M', '1987-03-01||+3y/M');
+
+       hire_date
+------------------------
+1989-03-31T00:00:00.000Z
+1990-03-02T00:00:00.000Z
+// end::dtDateMathIn
+;
 
 dtIntervalPlusInterval
 // tag::dtIntervalPlusInterval

--- a/x-pack/plugin/sql/qa/server/src/main/resources/filter.sql-spec
+++ b/x-pack/plugin/sql/qa/server/src/main/resources/filter.sql-spec
@@ -131,6 +131,8 @@ whereWithInAndNullHandling1
 SELECT last_name l FROM "test_emp" WHERE languages in (2, 10)AND (emp_no = 10018 OR emp_no = 10019 OR emp_no = 10020) ORDER BY emp_no;
 whereWithInAndNullHandling2
 SELECT last_name l FROM "test_emp" WHERE languages in (2, null, 10) AND (emp_no = 10018 OR emp_no = 10019 OR emp_no = 10020) ORDER BY emp_no;
+whereWithInNull
+SELECT last_name l FROM test_emp WHERE languages in (null);
 
 whereWithInAndMultipleValueTypes
 SELECT last_name l FROM test_emp WHERE hire_date in('1986-06-26T00:00:00.000Z'::datetime, '1986-08-28T00:00:00.000Z');

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/planner/QueryTranslatorTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/planner/QueryTranslatorTests.java
@@ -6,8 +6,8 @@
  */
 package org.elasticsearch.xpack.sql.planner;
 
-import org.elasticsearch.core.Tuple;
 import org.elasticsearch.common.time.DateFormatter;
+import org.elasticsearch.core.Tuple;
 import org.elasticsearch.index.query.ExistsQueryBuilder;
 import org.elasticsearch.search.aggregations.AggregationBuilder;
 import org.elasticsearch.search.aggregations.bucket.filter.FilterAggregationBuilder;
@@ -114,7 +114,6 @@ import static org.hamcrest.Matchers.endsWith;
 import static org.hamcrest.Matchers.everyItem;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.instanceOf;
-import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.startsWith;
 
 public class QueryTranslatorTests extends ESTestCase {
@@ -411,18 +410,6 @@ public class QueryTranslatorTests extends ESTestCase {
         assertNotEquals(eqe.output().get(0).id(), eqe.output().get(1).id());
     }
 
-    public void testInOutOfRangeValues() {
-        QlIllegalArgumentException ex = expectThrows(QlIllegalArgumentException.class,
-            () -> optimizeAndPlan("SELECT int FROM test WHERE int IN (1, 2, 3, " + Long.MAX_VALUE + ", 5, 6, 7)"));
-        assertThat(ex.getMessage(), is("[" + Long.MAX_VALUE + "] out of [integer] range"));
-    }
-
-    public void testInInRangeValues() {
-        TestContext testContext = new TestContext("mapping-numeric.json");
-        PhysicalPlan p = testContext.optimizeAndPlan("SELECT long FROM test WHERE long IN (1, 2, 3, " + Long.MAX_VALUE + ", 5, 6, 7)");
-        assertEquals(EsQueryExec.class, p.getClass());
-    }
-
     // Datetime
     ///////////
     public void testTermEqualityForDateWithLiteralDate() {
@@ -673,7 +660,7 @@ public class QueryTranslatorTests extends ESTestCase {
     public void testDateRangeWithESDateMath() {
         ZoneId zoneId = randomZone();
         String operator = randomFrom(">", ">=", "<", "<=", "=", "!=");
-        String dateMath = randomFrom("now", "now/d", "now/h", "now-2h", "now+2h", "now-5d", "now+5d");
+        String dateMath = randomFrom("now", "now/d", "now/h", "now-2h", "now+2h", "now-5d", "now+5d", "2021-01-01||/M");
         LogicalPlan p = plan("SELECT some.string FROM test WHERE date" + operator + "'" + dateMath + "'", zoneId);
         assertTrue(p instanceof Project);
         p = ((Project) p).child();


### PR DESCRIPTION
Backports the following commits to 7.14:
 - SQL: Fix disjunctions (and `IN`) with multiple date math expressions (#76424)