### PR TITLE
[DOCS] [7.14] Execute enrich policy wait_for_completion docfix (#77046)

### DIFF
--- a/docs/reference/ingest/apis/enrich/execute-enrich-policy.asciidoc
+++ b/docs/reference/ingest/apis/enrich/execute-enrich-policy.asciidoc
@@ -102,8 +102,8 @@ it may take a while to return a response.
 (Required, string)
 Enrich policy to execute.
 
-[[execute-enrich-policy-api-request-body]]
-==== {api-request-body-title}
+[[execute-enrich-policy-api-query-params]]
+==== {api-query-parms-title}
 
 `wait_for_completion`::
 (Required, Boolean)


### PR DESCRIPTION
Backports the following commits to 7.14:
 - Execute enrich policy wait_for_completion docfix (#77046)