### PR TITLE
Replace Lucene DataInput/DataOutput with Elasticsearch StreamInput/StreamOutput when reading/writing geo_shape doc values (#76162)

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/io/stream/ByteArrayStreamInput.java
+++ b/server/src/main/java/org/elasticsearch/common/io/stream/ByteArrayStreamInput.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.common.io.stream;
+
+import org.apache.lucene.util.BytesRef;
+
+import java.io.EOFException;
+import java.io.IOException;
+
+/**
+ * Resettable {@link StreamInput} that wraps a byte array. It is heavily inspired in Lucene's
+ * {@link org.apache.lucene.store.ByteArrayDataInput}.
+ */
+public class ByteArrayStreamInput extends StreamInput {
+
+    private byte[] bytes;
+    private int pos;
+    private int limit;
+
+    public ByteArrayStreamInput() {
+        reset(BytesRef.EMPTY_BYTES);
+    }
+
+    @Override
+    public int read() throws IOException {
+        return readByte() & 0xFF;
+    }
+
+    public void reset(byte[] bytes) {
+        reset(bytes, 0, bytes.length);
+    }
+
+    public int getPosition() {
+        return pos;
+    }
+
+    public void setPosition(int pos) {
+        this.pos = pos;
+    }
+
+    public void reset(byte[] bytes, int offset, int len) {
+        this.bytes = bytes;
+        pos = offset;
+        limit = offset + len;
+    }
+
+    public int length() {
+        return limit;
+    }
+
+    public void skipBytes(long count) {
+        pos += count;
+    }
+
+    @Override
+    public void close() {
+        // No-op
+    }
+
+    @Override
+    public int available() {
+        return limit - pos;
+    }
+
+    @Override
+    protected void ensureCanReadBytes(int length) throws EOFException {
+        if (pos + length  > limit) {
+            throw new EOFException("tried to read: " + length + " bytes but only " + available() + " remaining");
+        }
+    }
+
+    @Override
+    public byte readByte() {
+        return bytes[pos++];
+    }
+
+    @Override
+    public void readBytes(byte[] b, int offset, int len) {
+        System.arraycopy(bytes, pos, b, offset, len);
+        pos += len;
+    }
+}

--- a/server/src/test/java/org/elasticsearch/common/io/stream/AbstractStreamTests.java
+++ b/server/src/test/java/org/elasticsearch/common/io/stream/AbstractStreamTests.java
@@ -10,17 +10,17 @@ package org.elasticsearch.common.io.stream;
 
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.CheckedBiConsumer;
-import org.elasticsearch.core.CheckedConsumer;
-import org.elasticsearch.core.CheckedFunction;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.bytes.BytesReference;
-import org.elasticsearch.core.Tuple;
 import org.elasticsearch.common.settings.SecureString;
+import org.elasticsearch.core.CheckedConsumer;
+import org.elasticsearch.core.CheckedFunction;
+import org.elasticsearch.core.Tuple;
 import org.elasticsearch.test.ESTestCase;
 
-import java.io.ByteArrayInputStream;
 import java.io.EOFException;
 import java.io.IOException;
+import java.nio.ByteBuffer;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -46,7 +46,9 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.iterableWithSize;
 import static org.hamcrest.Matchers.nullValue;
 
-public class StreamTests extends ESTestCase {
+public abstract class AbstractStreamTests extends ESTestCase {
+
+    protected abstract StreamInput getStreamInput(BytesReference bytesReference) throws IOException;
 
     public void testBooleanSerialization() throws IOException {
         final BytesStreamOutput output = new BytesStreamOutput();
@@ -61,7 +63,7 @@ public class StreamTests extends ESTestCase {
         assertThat(bytes[0], equalTo((byte) 0));
         assertThat(bytes[1], equalTo((byte) 1));
 
-        final StreamInput input = bytesReference.streamInput();
+        final StreamInput input = getStreamInput(bytesReference);
         assertFalse(input.readBoolean());
         assertTrue(input.readBoolean());
 
@@ -70,7 +72,7 @@ public class StreamTests extends ESTestCase {
         set.remove((byte) 1);
         final byte[] corruptBytes = new byte[]{randomFrom(set)};
         final BytesReference corrupt = new BytesArray(corruptBytes);
-        final IllegalStateException e = expectThrows(IllegalStateException.class, () -> corrupt.streamInput().readBoolean());
+        final IllegalStateException e = expectThrows(IllegalStateException.class, () -> getStreamInput(corrupt).readBoolean());
         final String message = String.format(Locale.ROOT, "unexpected byte [0x%02x]", corruptBytes[0]);
         assertThat(e, hasToString(containsString(message)));
     }
@@ -90,7 +92,7 @@ public class StreamTests extends ESTestCase {
         assertThat(bytes[1], equalTo((byte) 1));
         assertThat(bytes[2], equalTo((byte) 2));
 
-        final StreamInput input = bytesReference.streamInput();
+        final StreamInput input = getStreamInput(bytesReference);
         final Boolean maybeFalse = input.readOptionalBoolean();
         assertNotNull(maybeFalse);
         assertFalse(maybeFalse);
@@ -105,7 +107,7 @@ public class StreamTests extends ESTestCase {
         set.remove((byte) 2);
         final byte[] corruptBytes = new byte[]{randomFrom(set)};
         final BytesReference corrupt = new BytesArray(corruptBytes);
-        final IllegalStateException e = expectThrows(IllegalStateException.class, () -> corrupt.streamInput().readOptionalBoolean());
+        final IllegalStateException e = expectThrows(IllegalStateException.class, () -> getStreamInput(corrupt).readOptionalBoolean());
         final String message = String.format(Locale.ROOT, "unexpected byte [0x%02x]", corruptBytes[0]);
         assertThat(e, hasToString(containsString(message)));
     }
@@ -115,7 +117,7 @@ public class StreamTests extends ESTestCase {
             long write = randomLong();
             BytesStreamOutput out = new BytesStreamOutput();
             out.writeZLong(write);
-            long read = out.bytes().streamInput().readZLong();
+            long read = getStreamInput(out.bytes()).readZLong();
             assertEquals(write, read);
         }
     }
@@ -137,7 +139,7 @@ public class StreamTests extends ESTestCase {
             out.writeZLong(value.v1());
             assertArrayEquals(Long.toString(value.v1()), value.v2(), BytesReference.toBytes(out.bytes()));
             BytesReference bytes = new BytesArray(value.v2());
-            assertEquals(Arrays.toString(value.v2()), (long) value.v1(), bytes.streamInput().readZLong());
+            assertEquals(Arrays.toString(value.v2()), (long) value.v1(), getStreamInput(bytes).readZLong());
         }
     }
 
@@ -162,7 +164,7 @@ public class StreamTests extends ESTestCase {
         BytesStreamOutput out = new BytesStreamOutput();
         out.writeGenericValue(write);
         @SuppressWarnings("unchecked")
-        LinkedHashMap<String, Integer> read = (LinkedHashMap<String, Integer>) out.bytes().streamInput().readGenericValue();
+        LinkedHashMap<String, Integer> read = (LinkedHashMap<String, Integer>) getStreamInput(out.bytes()).readGenericValue();
         assertEquals(size, read.size());
         int index = 0;
         for (Map.Entry<String, Integer> entry : read.entrySet()) {
@@ -170,48 +172,6 @@ public class StreamTests extends ESTestCase {
             assertEquals(list.get(index).v2(), entry.getValue());
             index++;
         }
-    }
-
-    public void testFilterStreamInputDelegatesAvailable() throws IOException {
-        final int length = randomIntBetween(1, 1024);
-        StreamInput delegate = StreamInput.wrap(new byte[length]);
-
-        FilterStreamInput filterInputStream = new FilterStreamInput(delegate) {
-        };
-        assertEquals(filterInputStream.available(), length);
-
-        // read some bytes
-        final int bytesToRead = randomIntBetween(1, length);
-        filterInputStream.readBytes(new byte[bytesToRead], 0, bytesToRead);
-        assertEquals(filterInputStream.available(), length - bytesToRead);
-    }
-
-    public void testInputStreamStreamInputDelegatesAvailable() throws IOException {
-        final int length = randomIntBetween(1, 1024);
-        ByteArrayInputStream is = new ByteArrayInputStream(new byte[length]);
-        InputStreamStreamInput streamInput = new InputStreamStreamInput(is);
-        assertEquals(streamInput.available(), length);
-
-        // read some bytes
-        final int bytesToRead = randomIntBetween(1, length);
-        streamInput.readBytes(new byte[bytesToRead], 0, bytesToRead);
-        assertEquals(streamInput.available(), length - bytesToRead);
-    }
-
-    public void testReadArraySize() throws IOException {
-        BytesStreamOutput stream = new BytesStreamOutput();
-        byte[] array = new byte[randomIntBetween(1, 10)];
-        for (int i = 0; i < array.length; i++) {
-            array[i] = randomByte();
-        }
-        stream.writeByteArray(array);
-        InputStreamStreamInput streamInput = new InputStreamStreamInput(StreamInput.wrap(BytesReference.toBytes(stream.bytes())), array
-            .length - 1);
-        expectThrows(EOFException.class, streamInput::readByteArray);
-        streamInput = new InputStreamStreamInput(StreamInput.wrap(BytesReference.toBytes(stream.bytes())), BytesReference.toBytes(stream
-            .bytes()).length);
-
-        assertArrayEquals(array, streamInput.readByteArray());
     }
 
     public void testWritableArrays() throws IOException {
@@ -225,10 +185,10 @@ public class StreamTests extends ESTestCase {
                 sourceArray = null;
             }
             out.writeOptionalArray(sourceArray);
-            targetArray = out.bytes().streamInput().readOptionalArray(WriteableString::new, WriteableString[]::new);
+            targetArray = getStreamInput(out.bytes()).readOptionalArray(WriteableString::new, WriteableString[]::new);
         } else {
             out.writeArray(sourceArray);
-            targetArray = out.bytes().streamInput().readArray(WriteableString::new, WriteableString[]::new);
+            targetArray = getStreamInput(out.bytes()).readArray(WriteableString::new, WriteableString[]::new);
         }
 
         assertThat(targetArray, equalTo(sourceArray));
@@ -247,11 +207,11 @@ public class StreamTests extends ESTestCase {
                 strings = generateRandomStringArray(10, 10, false, true);
             }
             out.writeOptionalArray(writer, strings);
-            deserialized = out.bytes().streamInput().readOptionalArray(reader, String[]::new);
+            deserialized = getStreamInput(out.bytes()).readOptionalArray(reader, String[]::new);
         } else {
             strings = generateRandomStringArray(10, 10, false, true);
             out.writeArray(writer, strings);
-            deserialized = out.bytes().streamInput().readArray(reader, String[]::new);
+            deserialized = getStreamInput(out.bytes()).readArray(reader, String[]::new);
         }
         assertThat(deserialized, equalTo(strings));
     }
@@ -294,7 +254,7 @@ public class StreamTests extends ESTestCase {
         }
 
         runWriteReadCollectionTest(
-                () -> new FooBar(randomInt(), randomInt()), StreamOutput::writeCollection, in -> in.readList(FooBar::new));
+            () -> new FooBar(randomInt(), randomInt()), StreamOutput::writeCollection, in -> in.readList(FooBar::new));
     }
 
     public void testStringCollection() throws IOException {
@@ -302,9 +262,9 @@ public class StreamTests extends ESTestCase {
     }
 
     private <T> void runWriteReadCollectionTest(
-            final Supplier<T> supplier,
-            final CheckedBiConsumer<StreamOutput, Collection<T>, IOException> writer,
-            final CheckedFunction<StreamInput, Collection<T>, IOException> reader) throws IOException {
+        final Supplier<T> supplier,
+        final CheckedBiConsumer<StreamOutput, Collection<T>, IOException> writer,
+        final CheckedFunction<StreamInput, Collection<T>, IOException> reader) throws IOException {
         final int length = randomIntBetween(0, 10);
         final Collection<T> collection = new ArrayList<>(length);
         for (int i = 0; i < length; i++) {
@@ -312,7 +272,7 @@ public class StreamTests extends ESTestCase {
         }
         try (BytesStreamOutput out = new BytesStreamOutput()) {
             writer.accept(out, collection);
-            try (StreamInput in = out.bytes().streamInput()) {
+            try (StreamInput in = getStreamInput(out.bytes())) {
                 assertThat(collection, equalTo(reader.apply(in)));
             }
         }
@@ -329,7 +289,7 @@ public class StreamTests extends ESTestCase {
         final BytesStreamOutput out = new BytesStreamOutput();
         out.writeCollection(sourceSet, StreamOutput::writeLong);
 
-        final Set<Long> targetSet = out.bytes().streamInput().readSet(StreamInput::readLong);
+        final Set<Long> targetSet = getStreamInput(out.bytes()).readSet(StreamInput::readLong);
         assertThat(targetSet, equalTo(sourceSet));
     }
 
@@ -337,7 +297,7 @@ public class StreamTests extends ESTestCase {
         final Instant instant = Instant.now();
         try (BytesStreamOutput out = new BytesStreamOutput()) {
             out.writeInstant(instant);
-            try (StreamInput in = out.bytes().streamInput()) {
+            try (StreamInput in = getStreamInput(out.bytes())) {
                 final Instant serialized = in.readInstant();
                 assertEquals(instant, serialized);
             }
@@ -348,7 +308,7 @@ public class StreamTests extends ESTestCase {
         final Instant instant = Instant.now();
         try (BytesStreamOutput out = new BytesStreamOutput()) {
             out.writeOptionalInstant(instant);
-            try (StreamInput in = out.bytes().streamInput()) {
+            try (StreamInput in = getStreamInput(out.bytes())) {
                 final Instant serialized = in.readOptionalInstant();
                 assertEquals(instant, serialized);
             }
@@ -357,7 +317,7 @@ public class StreamTests extends ESTestCase {
         final Instant missing = null;
         try (BytesStreamOutput out = new BytesStreamOutput()) {
             out.writeOptionalInstant(missing);
-            try (StreamInput in = out.bytes().streamInput()) {
+            try (StreamInput in = getStreamInput(out.bytes())) {
                 final Instant serialized = in.readOptionalInstant();
                 assertEquals(missing, serialized);
             }
@@ -407,7 +367,7 @@ public class StreamTests extends ESTestCase {
             output.writeSecureString(secureString);
 
             final BytesReference bytesReference = output.bytes();
-            final StreamInput input = bytesReference.streamInput();
+            final StreamInput input = getStreamInput(bytesReference);
 
             assertThat(secureString, is(equalTo(input.readSecureString())));
         }
@@ -417,7 +377,7 @@ public class StreamTests extends ESTestCase {
             output.writeOptionalSecureString(secureString);
 
             final BytesReference bytesReference = output.bytes();
-            final StreamInput input = bytesReference.streamInput();
+            final StreamInput input = getStreamInput(bytesReference);
 
             if (secureString != null) {
                 assertThat(input.readOptionalSecureString(), is(equalTo(secureString)));
@@ -434,6 +394,36 @@ public class StreamTests extends ESTestCase {
         List<String> list = new ArrayList<>(set);
         Collections.reverse(list);
         assertGenericRoundtrip(new LinkedHashSet<>(list));
+    }
+
+    public void testReadArraySize() throws IOException {
+        BytesStreamOutput stream = new BytesStreamOutput();
+        byte[] array = new byte[randomIntBetween(1, 10)];
+        for (int i = 0; i < array.length; i++) {
+            array[i] = randomByte();
+        }
+        stream.writeByteArray(array);
+        StreamInput streamInput = new InputStreamStreamInput(getStreamInput(stream.bytes()), array
+            .length - 1);
+        expectThrows(EOFException.class, streamInput::readByteArray);
+        streamInput = new InputStreamStreamInput(getStreamInput(stream.bytes()), BytesReference.toBytes(stream
+            .bytes()).length);
+
+        assertArrayEquals(array, streamInput.readByteArray());
+    }
+
+    public void testFilterStreamInputDelegatesAvailable() throws IOException {
+        final int length = randomIntBetween(1, 1024);
+        StreamInput delegate = getStreamInput(BytesReference.fromByteBuffer(ByteBuffer.wrap(new byte[length])));
+
+        FilterStreamInput filterInputStream = new FilterStreamInput(delegate) {
+        };
+        assertEquals(filterInputStream.available(), length);
+
+        // read some bytes
+        final int bytesToRead = randomIntBetween(1, length);
+        filterInputStream.readBytes(new byte[bytesToRead], 0, bytesToRead);
+        assertEquals(filterInputStream.available(), length - bytesToRead);
     }
 
     private static class Unwriteable {}
@@ -474,8 +464,7 @@ public class StreamTests extends ESTestCase {
                                      CheckedConsumer<StreamInput, IOException> inputAssertions) throws IOException {
         try (BytesStreamOutput output = new BytesStreamOutput()) {
             outputAssertions.accept(output);
-            final BytesReference bytesReference = output.bytes();
-            final StreamInput input = bytesReference.streamInput();
+            final StreamInput input = getStreamInput(output.bytes());
             inputAssertions.accept(input);
         }
     }
@@ -488,5 +477,4 @@ public class StreamTests extends ESTestCase {
             assertThat(read, equalTo(original));
         });
     }
-
 }

--- a/server/src/test/java/org/elasticsearch/common/io/stream/ByteArrayStreamInputTests.java
+++ b/server/src/test/java/org/elasticsearch/common/io/stream/ByteArrayStreamInputTests.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.common.io.stream;
+
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.bytes.BytesReference;
+
+public class ByteArrayStreamInputTests extends AbstractStreamTests {
+    @Override
+    protected StreamInput getStreamInput(BytesReference bytesReference) {
+        final BytesRef bytesRef = bytesReference.toBytesRef();
+        final ByteArrayStreamInput byteArrayStreamInput = new ByteArrayStreamInput();
+        byteArrayStreamInput.reset(bytesRef.bytes, bytesRef.offset, bytesRef.length);
+        return byteArrayStreamInput;
+    }
+}

--- a/server/src/test/java/org/elasticsearch/common/io/stream/ByteBufferStreamInputTests.java
+++ b/server/src/test/java/org/elasticsearch/common/io/stream/ByteBufferStreamInputTests.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.common.io.stream;
+
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.bytes.BytesReference;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+
+public class ByteBufferStreamInputTests extends AbstractStreamTests {
+    @Override
+    protected StreamInput getStreamInput(BytesReference bytesReference) throws IOException {
+        final BytesRef bytesRef = bytesReference.toBytesRef();
+        return new ByteBufferStreamInput(ByteBuffer.wrap(bytesRef.bytes, bytesRef.offset, bytesRef.length));
+    }
+}

--- a/server/src/test/java/org/elasticsearch/common/io/stream/BytesReferenceStreamInputTests.java
+++ b/server/src/test/java/org/elasticsearch/common/io/stream/BytesReferenceStreamInputTests.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.common.io.stream;
+
+import org.elasticsearch.common.bytes.BytesReference;
+
+import java.io.IOException;
+
+public class BytesReferenceStreamInputTests extends AbstractStreamTests {
+    @Override
+    protected StreamInput getStreamInput(BytesReference bytesReference) throws IOException {
+        return bytesReference.streamInput();
+    }
+}

--- a/server/src/test/java/org/elasticsearch/common/io/stream/InputStreamStreamInputTests.java
+++ b/server/src/test/java/org/elasticsearch/common/io/stream/InputStreamStreamInputTests.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.common.io.stream;
+
+import org.elasticsearch.common.bytes.BytesReference;
+
+import java.io.IOException;
+
+public class InputStreamStreamInputTests extends AbstractStreamTests {
+    @Override
+    protected StreamInput getStreamInput(BytesReference bytesReference) throws IOException {
+        return new InputStreamStreamInput(StreamInput.wrap(BytesReference.toBytes(bytesReference)));
+    }
+}

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/fielddata/DimensionalShapeType.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/fielddata/DimensionalShapeType.java
@@ -7,8 +7,8 @@
 
 package org.elasticsearch.xpack.spatial.index.fielddata;
 
-import org.apache.lucene.store.ByteArrayDataInput;
-import org.apache.lucene.store.ByteBuffersDataOutput;
+import org.elasticsearch.common.io.stream.ByteArrayStreamInput;
+import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.geometry.GeometryCollection;
 import org.elasticsearch.geometry.ShapeType;
 
@@ -29,11 +29,11 @@ public enum DimensionalShapeType {
         return values[Byte.toUnsignedInt(ordinal)];
     }
 
-    public void writeTo(ByteBuffersDataOutput out) {
+    public void writeTo(BytesStreamOutput out) {
         out.writeByte((byte) ordinal());
     }
 
-    public static DimensionalShapeType readFrom(ByteArrayDataInput in) {
+    public static DimensionalShapeType readFrom(ByteArrayStreamInput in) {
         return fromOrdinalByte(in.readByte());
     }
 }

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/fielddata/Extent.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/fielddata/Extent.java
@@ -7,8 +7,8 @@
 
 package org.elasticsearch.xpack.spatial.index.fielddata;
 
-import org.apache.lucene.store.ByteArrayDataInput;
-import org.apache.lucene.store.ByteBuffersDataOutput;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
 
 import java.io.IOException;
 import java.util.Objects;
@@ -88,7 +88,7 @@ class Extent {
         }
     }
 
-    static void readFromCompressed(ByteArrayDataInput input, Extent extent) {
+    static void readFromCompressed(StreamInput input, Extent extent) throws IOException {
         final int top = input.readInt();
         final int bottom = Math.toIntExact(top - input.readVLong());
         final int negLeft;
@@ -133,7 +133,7 @@ class Extent {
         extent.reset(top, bottom, negLeft, negRight, posLeft, posRight);
     }
 
-    void writeCompressed(ByteBuffersDataOutput output) throws IOException {
+    void writeCompressed(StreamOutput output) throws IOException {
         output.writeInt(this.top);
         output.writeVLong((long) this.top - this.bottom);
         byte type;

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/fielddata/GeoShapeValues.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/fielddata/GeoShapeValues.java
@@ -98,7 +98,7 @@ public abstract class GeoShapeValues {
         /**
          * reset the geometry.
          */
-        public void reset(BytesRef bytesRef) {
+        public void reset(BytesRef bytesRef) throws IOException {
             this.reader.reset(bytesRef);
             this.boundingBox.reset(reader.getExtent(), CoordinateEncoder.GEO);
         }
@@ -107,7 +107,7 @@ public abstract class GeoShapeValues {
             return boundingBox;
         }
 
-        public GeoRelation relate(Rectangle rectangle) {
+        public GeoRelation relate(Rectangle rectangle) throws IOException {
             int minX = CoordinateEncoder.GEO.encodeX(rectangle.getMinX());
             int maxX = CoordinateEncoder.GEO.encodeX(rectangle.getMaxX());
             int minY = CoordinateEncoder.GEO.encodeY(rectangle.getMinY());
@@ -121,21 +121,21 @@ public abstract class GeoShapeValues {
             return reader.getDimensionalShapeType();
         }
 
-        public double weight() {
+        public double weight() throws IOException {
             return reader.getSumCentroidWeight();
         }
 
         /**
          * @return the latitude of the centroid of the shape
          */
-        public double lat() {
+        public double lat() throws IOException {
             return CoordinateEncoder.GEO.decodeY(reader.getCentroidY());
         }
 
         /**
          * @return the longitude of the centroid of the shape
          */
-        public double lon() {
+        public double lon() throws IOException {
             return CoordinateEncoder.GEO.decodeX(reader.getCentroidX());
         }
 

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/fielddata/GeometryDocValueReader.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/fielddata/GeometryDocValueReader.java
@@ -7,8 +7,10 @@
 
 package org.elasticsearch.xpack.spatial.index.fielddata;
 
-import org.apache.lucene.store.ByteArrayDataInput;
 import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.io.stream.ByteArrayStreamInput;
+
+import java.io.IOException;
 
 /**
  * A reusable Geometry doc value reader for a previous serialized {@link org.elasticsearch.geometry.Geometry} using
@@ -34,20 +36,20 @@ import org.apache.lucene.util.BytesRef;
  * -----------------------------------------
  */
 public class GeometryDocValueReader {
-    private final ByteArrayDataInput input;
+    private final ByteArrayStreamInput input;
     private final Extent extent;
     private int treeOffset;
     private int docValueOffset;
 
     public GeometryDocValueReader() {
         this.extent = new Extent();
-        this.input = new ByteArrayDataInput();
+        this.input = new ByteArrayStreamInput();
     }
 
     /**
      * reset the geometry.
      */
-    public void reset(BytesRef bytesRef) {
+    public void reset(BytesRef bytesRef) throws IOException {
         this.input.reset(bytesRef.bytes, bytesRef.offset, bytesRef.length);
         docValueOffset = bytesRef.offset;
         treeOffset = 0;
@@ -56,7 +58,7 @@ public class GeometryDocValueReader {
     /**
      * returns the {@link Extent} of this geometry.
      */
-    protected Extent getExtent() {
+    protected Extent getExtent() throws IOException {
         if (treeOffset == 0) {
             getSumCentroidWeight(); // skip CENTROID_HEADER + var-long sum-weight
             Extent.readFromCompressed(input, extent);
@@ -70,7 +72,7 @@ public class GeometryDocValueReader {
     /**
      * returns the encoded X coordinate of the centroid.
      */
-    protected int getCentroidX() {
+    protected int getCentroidX() throws IOException {
         input.setPosition(docValueOffset + 0);
         return input.readInt();
     }
@@ -78,7 +80,7 @@ public class GeometryDocValueReader {
     /**
      * returns the encoded Y coordinate of the centroid.
      */
-    protected int getCentroidY() {
+    protected int getCentroidY() throws IOException {
         input.setPosition(docValueOffset + 4);
         return input.readInt();
     }
@@ -88,7 +90,7 @@ public class GeometryDocValueReader {
         return DimensionalShapeType.readFrom(input);
     }
 
-    protected double getSumCentroidWeight() {
+    protected double getSumCentroidWeight() throws IOException {
         input.setPosition(docValueOffset + 9);
         return Double.longBitsToDouble(input.readVLong());
     }
@@ -96,7 +98,7 @@ public class GeometryDocValueReader {
     /**
      * Visit the triangle tree with the provided visitor
      */
-    public void visit(TriangleTreeReader.Visitor visitor) {
+    public void visit(TriangleTreeReader.Visitor visitor) throws IOException {
         Extent extent = getExtent();
         int thisMaxX = extent.maxX();
         int thisMinX = extent.minX();

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/fielddata/GeometryDocValueWriter.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/fielddata/GeometryDocValueWriter.java
@@ -8,8 +8,8 @@
 package org.elasticsearch.xpack.spatial.index.fielddata;
 
 import org.apache.lucene.index.IndexableField;
-import org.apache.lucene.store.ByteBuffersDataOutput;
 import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.io.stream.BytesStreamOutput;
 
 import java.io.IOException;
 import java.util.List;
@@ -27,13 +27,13 @@ public class GeometryDocValueWriter {
     public static BytesRef write(List<IndexableField> fields,
                                  CoordinateEncoder coordinateEncoder,
                                  CentroidCalculator centroidCalculator) throws IOException {
-        final ByteBuffersDataOutput out = new ByteBuffersDataOutput();
+        final BytesStreamOutput out = new BytesStreamOutput();
         // normalization may be required due to floating point precision errors
         out.writeInt(coordinateEncoder.encodeX(coordinateEncoder.normalizeX(centroidCalculator.getX())));
         out.writeInt(coordinateEncoder.encodeY(coordinateEncoder.normalizeY(centroidCalculator.getY())));
         centroidCalculator.getDimensionalShapeType().writeTo(out);
         out.writeVLong(Double.doubleToLongBits(centroidCalculator.sumWeight()));
         TriangleTreeWriter.writeTo(out, fields);
-        return new BytesRef(out.toArrayCopy(), 0, Math.toIntExact(out.size()));
+        return out.bytes().toBytesRef();
     }
 }

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/fielddata/TriangleTreeReader.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/fielddata/TriangleTreeReader.java
@@ -7,7 +7,9 @@
 
 package org.elasticsearch.xpack.spatial.index.fielddata;
 
-import org.apache.lucene.store.ByteArrayDataInput;
+import org.elasticsearch.common.io.stream.ByteArrayStreamInput;
+
+import java.io.IOException;
 
 /**
  * A tree reader for a previous serialized {@link org.elasticsearch.geometry.Geometry} using
@@ -24,12 +26,13 @@ class TriangleTreeReader {
     /**
      * Visit the Triangle tree using the {@link Visitor} provided.
      */
-    public static void visit(ByteArrayDataInput input, TriangleTreeReader.Visitor visitor, int thisMaxX, int thisMaxY) {
+    public static void visit(ByteArrayStreamInput input, TriangleTreeReader.Visitor visitor, int thisMaxX, int thisMaxY)
+        throws IOException {
         visit(input, visitor, true, thisMaxX, thisMaxY, true);
     }
 
-    private static boolean visit(ByteArrayDataInput input, TriangleTreeReader.Visitor visitor,
-                                 boolean splitX, int thisMaxX, int thisMaxY, boolean isRoot) {
+    private static boolean visit(ByteArrayStreamInput input, TriangleTreeReader.Visitor visitor,
+                                 boolean splitX, int thisMaxX, int thisMaxY, boolean isRoot) throws IOException {
         byte metadata = input.readByte();
         int thisMinX;
         int thisMinY;
@@ -82,8 +85,8 @@ class TriangleTreeReader {
         return visitor.push();
     }
 
-    private static boolean pushLeft(ByteArrayDataInput input, TriangleTreeReader.Visitor visitor,
-                                    int thisMaxX, int thisMaxY, boolean splitX) {
+    private static boolean pushLeft(ByteArrayStreamInput input, TriangleTreeReader.Visitor visitor,
+                                    int thisMaxX, int thisMaxY, boolean splitX)  throws IOException {
         int nextMaxX = Math.toIntExact(thisMaxX - input.readVLong());
         int nextMaxY = Math.toIntExact(thisMaxY - input.readVLong());
         int size = input.readVInt();
@@ -95,8 +98,8 @@ class TriangleTreeReader {
         }
     }
 
-    private static boolean pushRight(ByteArrayDataInput input, TriangleTreeReader.Visitor visitor, int thisMaxX,
-                                     int thisMaxY, int thisMinX, int thisMinY, boolean splitX, int rightSize) {
+    private static boolean pushRight(ByteArrayStreamInput input, TriangleTreeReader.Visitor visitor, int thisMaxX,
+                                     int thisMaxY, int thisMinX, int thisMinY, boolean splitX, int rightSize) throws IOException {
         if ((splitX == false && visitor.pushY(thisMinY)) || (splitX && visitor.pushX(thisMinX))) {
             int nextMaxX = Math.toIntExact(thisMaxX - input.readVLong());
             int nextMaxY = Math.toIntExact(thisMaxY - input.readVLong());

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/fielddata/TriangleTreeWriter.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/fielddata/TriangleTreeWriter.java
@@ -9,9 +9,10 @@ package org.elasticsearch.xpack.spatial.index.fielddata;
 
 import org.apache.lucene.document.ShapeField;
 import org.apache.lucene.index.IndexableField;
-import org.apache.lucene.store.ByteBuffersDataOutput;
 import org.apache.lucene.util.ArrayUtil;
 import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.io.stream.BytesStreamOutput;
+import org.elasticsearch.common.io.stream.StreamOutput;
 
 import java.io.IOException;
 import java.util.Comparator;
@@ -27,7 +28,7 @@ class TriangleTreeWriter {
     }
 
     /*** Serialize the interval tree in the provided data output */
-    public static void writeTo(ByteBuffersDataOutput out, List<IndexableField> fields) throws IOException {
+    public static void writeTo(StreamOutput out, List<IndexableField> fields) throws IOException {
         final Extent extent = new Extent();
         final TriangleTreeNode node = build(fields, extent); ;
         extent.writeCompressed(out);
@@ -114,8 +115,8 @@ class TriangleTreeWriter {
             this.component = component;
         }
 
-        private void writeTo(ByteBuffersDataOutput out) throws IOException {
-            ByteBuffersDataOutput scratchBuffer = ByteBuffersDataOutput.newResettableInstance();
+        private void writeTo(StreamOutput out) throws IOException {
+            BytesStreamOutput scratchBuffer = new BytesStreamOutput();
             writeMetadata(out);
             writeComponent(out);
             if (left != null) {
@@ -126,8 +127,8 @@ class TriangleTreeWriter {
             }
         }
 
-        private void writeNode(ByteBuffersDataOutput out, int parentMaxX, int parentMaxY,
-                               ByteBuffersDataOutput scratchBuffer) throws IOException {
+        private void writeNode(StreamOutput out, int parentMaxX, int parentMaxY,
+                               BytesStreamOutput scratchBuffer) throws IOException {
             out.writeVLong((long) parentMaxX - maxX);
             out.writeVLong((long) parentMaxY - maxY);
             int size = nodeSize(false, parentMaxX, parentMaxY, scratchBuffer);
@@ -144,7 +145,7 @@ class TriangleTreeWriter {
             }
         }
 
-        private void writeMetadata(ByteBuffersDataOutput out) {
+        private void writeMetadata(StreamOutput out) throws IOException {
             byte metadata = 0;
             metadata |= (left != null) ? (1 << 0) : 0;
             metadata |= (right != null) ? (1 << 1) : 0;
@@ -161,7 +162,7 @@ class TriangleTreeWriter {
             out.writeByte(metadata);
         }
 
-        private void writeComponent(ByteBuffersDataOutput out) throws IOException {
+        private void writeComponent(StreamOutput out) throws IOException {
             out.writeVLong((long) maxX - component.aX);
             out.writeVLong((long) maxY - component.aY);
             if (component.type == ShapeField.DecodedTriangle.TYPE.POINT) {
@@ -176,7 +177,7 @@ class TriangleTreeWriter {
             out.writeVLong((long) maxY - component.cY);
         }
 
-        private int nodeSize(boolean includeBox, int parentMaxX, int parentMaxY, ByteBuffersDataOutput scratchBuffer) throws IOException {
+        private int nodeSize(boolean includeBox, int parentMaxX, int parentMaxY, BytesStreamOutput scratchBuffer) throws IOException {
             int size =0;
             size++; //metadata
             size += componentSize(scratchBuffer);
@@ -201,7 +202,7 @@ class TriangleTreeWriter {
             return size;
         }
 
-        private int componentSize(ByteBuffersDataOutput scratchBuffer) throws IOException {
+        private int componentSize(BytesStreamOutput scratchBuffer) throws IOException {
             scratchBuffer.reset();
             if (component.type == ShapeField.DecodedTriangle.TYPE.POINT) {
                 scratchBuffer.writeVLong((long) maxX - component.aX);

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/search/aggregations/bucket/geogrid/AbstractGeoTileGridTiler.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/search/aggregations/bucket/geogrid/AbstractGeoTileGridTiler.java
@@ -11,6 +11,8 @@ import org.elasticsearch.search.aggregations.bucket.geogrid.GeoTileUtils;
 import org.elasticsearch.xpack.spatial.index.fielddata.GeoRelation;
 import org.elasticsearch.xpack.spatial.index.fielddata.GeoShapeValues;
 
+import java.io.IOException;
+
 /**
  * Implements most of the logic for the GeoTile aggregation.
  */
@@ -44,7 +46,7 @@ abstract class AbstractGeoTileGridTiler extends GeoGridTiler {
      * @return the number of tiles set by the shape
      */
     @Override
-    public int setValues(GeoShapeCellValues values, GeoShapeValues.GeoShapeValue geoValue) {
+    public int setValues(GeoShapeCellValues values, GeoShapeValues.GeoShapeValue geoValue) throws IOException {
         GeoShapeValues.BoundingBox bounds = geoValue.boundingBox();
         assert bounds.minX() <= bounds.maxX();
 
@@ -72,7 +74,7 @@ abstract class AbstractGeoTileGridTiler extends GeoGridTiler {
         }
     }
 
-    private GeoRelation relateTile(GeoShapeValues.GeoShapeValue geoValue, int xTile, int yTile, int precision) {
+    private GeoRelation relateTile(GeoShapeValues.GeoShapeValue geoValue, int xTile, int yTile, int precision) throws IOException {
         return validTile(xTile, yTile, precision) ?
             geoValue.relate(GeoTileUtils.toBoundingBox(xTile, yTile, precision)) : GeoRelation.QUERY_DISJOINT;
     }
@@ -96,7 +98,7 @@ abstract class AbstractGeoTileGridTiler extends GeoGridTiler {
      * @return the number of buckets the geoValue is found in
      */
     protected int setValuesByBruteForceScan(GeoShapeCellValues values, GeoShapeValues.GeoShapeValue geoValue,
-                                            int minXTile, int minYTile, int maxXTile, int maxYTile) {
+                                            int minXTile, int minYTile, int maxXTile, int maxYTile) throws IOException {
         int idx = 0;
         for (int i = minXTile; i <= maxXTile; i++) {
             for (int j = minYTile; j <= maxYTile; j++) {
@@ -111,7 +113,7 @@ abstract class AbstractGeoTileGridTiler extends GeoGridTiler {
     }
 
     protected int setValuesByRasterization(int xTile, int yTile, int zTile, GeoShapeCellValues values, int valuesIndex,
-                                           GeoShapeValues.GeoShapeValue geoValue) {
+                                           GeoShapeValues.GeoShapeValue geoValue) throws IOException {
         zTile++;
         for (int i = 0; i < 2; i++) {
             for (int j = 0; j < 2; j++) {

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/search/aggregations/bucket/geogrid/GeoGridTiler.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/search/aggregations/bucket/geogrid/GeoGridTiler.java
@@ -9,6 +9,8 @@ package org.elasticsearch.xpack.spatial.search.aggregations.bucket.geogrid;
 
 import org.elasticsearch.xpack.spatial.index.fielddata.GeoShapeValues;
 
+import java.io.IOException;
+
 /**
  * The tiler to use to convert a geo value into long-encoded bucket keys for aggregating.
  */
@@ -42,7 +44,7 @@ public abstract class GeoGridTiler {
      *
      * @return the number of cells the geoValue intersects
      */
-    public abstract int setValues(GeoShapeCellValues docValues, GeoShapeValues.GeoShapeValue geoValue);
+    public abstract int setValues(GeoShapeCellValues docValues, GeoShapeValues.GeoShapeValue geoValue) throws IOException;
 
     /** Maximum number of cells that can be created by this tiler */
     protected abstract long getMaxCells();

--- a/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/index/fielddata/Tile2DVisitorTests.java
+++ b/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/index/fielddata/Tile2DVisitorTests.java
@@ -269,7 +269,7 @@ public class Tile2DVisitorTests extends ESTestCase {
         });
     }
 
-    static void assertRelation(GeoRelation expectedRelation, GeometryDocValueReader reader, Extent extent) {
+    static void assertRelation(GeoRelation expectedRelation, GeometryDocValueReader reader, Extent extent) throws IOException {
         Tile2DVisitor tile2DVisitor = new Tile2DVisitor();
         tile2DVisitor.reset(extent.minX(), extent.minY(), extent.maxX(), extent.maxY());
         reader.visit(tile2DVisitor);

--- a/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/index/fielddata/TriangleTreeTests.java
+++ b/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/index/fielddata/TriangleTreeTests.java
@@ -8,8 +8,9 @@
 package org.elasticsearch.xpack.spatial.index.fielddata;
 
 import org.apache.lucene.index.IndexableField;
-import org.apache.lucene.store.ByteArrayDataInput;
-import org.apache.lucene.store.ByteBuffersDataOutput;
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.io.stream.ByteArrayStreamInput;
+import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.geo.GeometryTestUtils;
 import org.elasticsearch.geometry.Geometry;
 import org.elasticsearch.index.mapper.GeoShapeIndexer;
@@ -27,10 +28,12 @@ public class TriangleTreeTests extends ESTestCase {
         // write tree
         GeoShapeIndexer indexer = new GeoShapeIndexer(true, "test");
         List<IndexableField> fieldList = indexer.indexShape(geometry);
-        ByteBuffersDataOutput output = new ByteBuffersDataOutput();
+        BytesStreamOutput output = new BytesStreamOutput();
         TriangleTreeWriter.writeTo(output, fieldList);
         // read tree
-        ByteArrayDataInput input = new ByteArrayDataInput(output.toArrayCopy());
+        ByteArrayStreamInput input = new ByteArrayStreamInput();
+        BytesRef bytesRef = output.bytes().toBytesRef();
+        input.reset(bytesRef.bytes, bytesRef.offset, bytesRef.length);
         Extent extent = new Extent();
         Extent.readFromCompressed(input, extent);
         TriangleCounterVisitor visitor = new TriangleCounterVisitor();

--- a/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/search/aggregations/bucket/geogrid/GeoHashTilerTests.java
+++ b/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/search/aggregations/bucket/geogrid/GeoHashTilerTests.java
@@ -14,6 +14,7 @@ import org.elasticsearch.geometry.utils.Geohash;
 import org.elasticsearch.xpack.spatial.index.fielddata.GeoRelation;
 import org.elasticsearch.xpack.spatial.index.fielddata.GeoShapeValues;
 
+import java.io.IOException;
 import java.util.Arrays;
 
 import static org.elasticsearch.xpack.spatial.util.GeoTestUtils.geoShapeValue;
@@ -95,7 +96,7 @@ public class GeoHashTilerTests extends GeoGridTilerTestCase {
     }
 
     private int computeBuckets(String hash, GeoBoundingBox bbox,
-                               GeoShapeValues.GeoShapeValue geoValue, int finalPrecision) {
+                               GeoShapeValues.GeoShapeValue geoValue, int finalPrecision) throws IOException {
         int count = 0;
         String[] hashes = Geohash.getSubGeohashes(hash);
         for (int i = 0; i < hashes.length; i++) {

--- a/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/util/GeoTestUtils.java
+++ b/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/util/GeoTestUtils.java
@@ -55,7 +55,7 @@ public class GeoTestUtils {
         return field;
     }
 
-    public static GeoShapeValues.GeoShapeValue geoShapeValue(Geometry geometry) {
+    public static GeoShapeValues.GeoShapeValue geoShapeValue(Geometry geometry) throws IOException {
         GeoShapeValues.GeoShapeValue value = new GeoShapeValues.GeoShapeValue();
         value.reset(binaryGeoShapeDocValuesField("test", geometry).binaryValue());
         return value;


### PR DESCRIPTION
Currently we are using Lucene abstractions DataInput / DataOutput to read / write geoshape doc values. This is problematic once we move to Lucene 9.0 as it has changed the endianness. This PR replaces this abstraction with Elasticsearch StreamInput / StreamOuput. In order to do that we have done the following replacements:

* Lucene ByteBuffersDataOutput has been replaced with Elasticsearch BytesStreamOutput.
* There is not Elasticsearch equivalent to Lucene ByteArrayDataInput. Therefore we have added a new class called ByteArrayStreamInput that is heavily based in Lucene implementation and use it as replacement.

We assume Elasticsearch StreamInput/StreamOutput is compatible with Lucene one so we can replace one with the other without worrying on backwards compatibility.

backport #76162

