### PR TITLE
Re-enable REST compatibility test after backport of #76752

### DIFF
--- a/modules/ingest-common/build.gradle
+++ b/modules/ingest-common/build.gradle
@@ -47,9 +47,3 @@ tasks.named("thirdPartyAudit").configure {
 tasks.named("transformV7RestTests").configure({ task ->
   task.addAllowedWarningRegex("\\[types removal\\].*")
 })
-
-tasks.named("yamlRestCompatTest").configure {
-  systemProperty 'tests.rest.blacklist', ([
-    'ingest/120_grok/Test Grok Patterns Retrieval' // un-mute this test after backporting
-  ]).join(',')
-}


### PR DESCRIPTION
Completes the backport of #76752 to 7.x.
