### PR TITLE
Implement Sort By Repository Name in Get Snapshots API (#77049)

### DIFF
--- a/docs/reference/snapshot-restore/apis/get-snapshot-api.asciidoc
+++ b/docs/reference/snapshot-restore/apis/get-snapshot-api.asciidoc
@@ -118,6 +118,9 @@ Allows setting a sort order for the result. Defaults to `start_time`, i.e. sorti
 `name`::
   Sort snapshots by their name.
 
+`repository`::
+  Sort snapshots by their repository name and break ties by snapshot name.
+
 `index_count`::
   Sort snapshots by the number of indices they contain and break ties by snapshot name.
 

--- a/qa/smoke-test-http/src/test/java/org/elasticsearch/http/snapshots/RestGetSnapshotsIT.java
+++ b/qa/smoke-test-http/src/test/java/org/elasticsearch/http/snapshots/RestGetSnapshotsIT.java
@@ -96,6 +96,11 @@ public class RestGetSnapshotsIT extends AbstractSnapshotRestTestCase {
                 GetSnapshotsRequest.SortBy.FAILED_SHARDS,
                 order
         );
+        assertSnapshotListSorted(
+                allSnapshotsSorted(allSnapshotNames, repoName, GetSnapshotsRequest.SortBy.REPOSITORY, order),
+                GetSnapshotsRequest.SortBy.REPOSITORY,
+                order
+        );
     }
 
     public void testResponseSizeLimit() throws Exception {

--- a/server/src/internalClusterTest/java/org/elasticsearch/snapshots/GetSnapshotsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/snapshots/GetSnapshotsIT.java
@@ -38,21 +38,36 @@ public class GetSnapshotsIT extends AbstractSnapshotIntegTestCase {
     }
 
     public void testSortBy() throws Exception {
-        final String repoName = "test-repo";
+        final String repoNameA = "test-repo-a";
         final Path repoPath = randomRepoPath();
-        createRepository(repoName, "fs", repoPath);
-        maybeInitWithOldSnapshotVersion(repoName, repoPath);
-        final List<String> snapshotNamesWithoutIndex = createNSnapshots(repoName, randomIntBetween(3, 20));
+        createRepository(repoNameA, "fs", repoPath);
+        maybeInitWithOldSnapshotVersion(repoNameA, repoPath);
+        final String repoNameB = "test-repo-b";
+        createRepository(repoNameB, "fs");
+
+        final List<String> snapshotNamesWithoutIndexA = createNSnapshots(repoNameA, randomIntBetween(3, 20));
+        final List<String> snapshotNamesWithoutIndexB = createNSnapshots(repoNameB, randomIntBetween(3, 20));
 
         createIndexWithContent("test-index");
 
-        final List<String> snapshotNamesWithIndex = createNSnapshots(repoName, randomIntBetween(3, 20));
+        final List<String> snapshotNamesWithIndexA = createNSnapshots(repoNameA, randomIntBetween(3, 20));
+        final List<String> snapshotNamesWithIndexB = createNSnapshots(repoNameB, randomIntBetween(3, 20));
 
-        final Collection<String> allSnapshotNames = new HashSet<>(snapshotNamesWithIndex);
-        allSnapshotNames.addAll(snapshotNamesWithoutIndex);
+        final Collection<String> allSnapshotNamesA = new HashSet<>(snapshotNamesWithIndexA);
+        final Collection<String> allSnapshotNamesB = new HashSet<>(snapshotNamesWithIndexB);
+        allSnapshotNamesA.addAll(snapshotNamesWithoutIndexA);
+        allSnapshotNamesB.addAll(snapshotNamesWithoutIndexB);
 
-        doTestSortOrder(repoName, allSnapshotNames, SortOrder.ASC);
-        doTestSortOrder(repoName, allSnapshotNames, SortOrder.DESC);
+        doTestSortOrder(repoNameA, allSnapshotNamesA, SortOrder.ASC);
+        doTestSortOrder(repoNameA, allSnapshotNamesA, SortOrder.DESC);
+
+        doTestSortOrder(repoNameB, allSnapshotNamesB, SortOrder.ASC);
+        doTestSortOrder(repoNameB, allSnapshotNamesB, SortOrder.DESC);
+
+        final Collection<String> allSnapshots = new HashSet<>(allSnapshotNamesA);
+        allSnapshots.addAll(allSnapshotNamesB);
+        doTestSortOrder("*", allSnapshots, SortOrder.ASC);
+        doTestSortOrder("*", allSnapshots, SortOrder.DESC);
     }
 
     private void doTestSortOrder(String repoName, Collection<String> allSnapshotNames, SortOrder order) {
@@ -86,6 +101,11 @@ public class GetSnapshotsIT extends AbstractSnapshotIntegTestCase {
         assertSnapshotListSorted(
             allSnapshotsSorted(allSnapshotNames, repoName, GetSnapshotsRequest.SortBy.FAILED_SHARDS, order),
             GetSnapshotsRequest.SortBy.FAILED_SHARDS,
+            order
+        );
+        assertSnapshotListSorted(
+            allSnapshotsSorted(allSnapshotNames, repoName, GetSnapshotsRequest.SortBy.REPOSITORY, order),
+            GetSnapshotsRequest.SortBy.REPOSITORY,
             order
         );
     }

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/get/TransportGetSnapshotsAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/get/TransportGetSnapshotsAction.java
@@ -498,6 +498,9 @@ public class TransportGetSnapshotsAction extends TransportMasterNodeAction<GetSn
 
     private static final Comparator<SnapshotInfo> BY_NAME = Comparator.comparing(sni -> sni.snapshotId().getName());
 
+    private static final Comparator<SnapshotInfo> BY_REPOSITORY = Comparator.comparing(SnapshotInfo::repository)
+        .thenComparing(SnapshotInfo::snapshotId);
+
     private static SnapshotsInRepo sortSnapshots(
         final List<SnapshotInfo> snapshotInfos,
         final GetSnapshotsRequest.SortBy sortBy,
@@ -525,6 +528,9 @@ public class TransportGetSnapshotsAction extends TransportMasterNodeAction<GetSn
                 break;
             case FAILED_SHARDS:
                 comparator = BY_FAILED_SHARDS_COUNT;
+                break;
+            case REPOSITORY:
+                comparator = BY_REPOSITORY;
                 break;
             default:
                 throw new AssertionError("unexpected sort column [" + sortBy + "]");
@@ -576,6 +582,11 @@ public class TransportGetSnapshotsAction extends TransportMasterNodeAction<GetSn
                         order
                     );
                     break;
+                case REPOSITORY:
+                    isAfter = order == SortOrder.ASC
+                        ? (info -> compareRepositoryName(snapshotName, repoName, info) < 0)
+                        : (info -> compareRepositoryName(snapshotName, repoName, info) > 0);
+                    break;
                 default:
                     throw new AssertionError("unexpected sort column [" + sortBy + "]");
             }
@@ -610,6 +621,14 @@ public class TransportGetSnapshotsAction extends TransportMasterNodeAction<GetSn
             final long val = extractor.applyAsLong(info);
             return after > val || (after == val && compareName(snapshotName, repoName, info) > 0);
         };
+    }
+
+    private static int compareRepositoryName(String name, String repoName, SnapshotInfo info) {
+        final int res = repoName.compareTo(info.repository());
+        if (res != 0) {
+            return res;
+        }
+        return name.compareTo(info.snapshotId().getName());
     }
 
     private static int compareName(String name, String repoName, SnapshotInfo info) {

--- a/test/framework/src/main/java/org/elasticsearch/snapshots/AbstractSnapshotIntegTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/snapshots/AbstractSnapshotIntegTestCase.java
@@ -706,6 +706,9 @@ public abstract class AbstractSnapshotIntegTestCase extends ESIntegTestCase {
                 case FAILED_SHARDS:
                     assertion = (s1, s2) -> assertThat(s2.failedShards(), greaterThanOrEqualTo(s1.failedShards()));
                     break;
+                case REPOSITORY:
+                    assertion = (s1, s2) -> assertThat(s2.repository(), greaterThanOrEqualTo(s1.repository()));
+                    break;
                 default:
                     throw new AssertionError("unknown sort column [" + sort + "]");
             }


### PR DESCRIPTION
This one is the last sort column not yet implemented but used by Kibana.

backport of #77049 