### PR TITLE
Indexing_data/lz4, recover from snapshot ESS only

### DIFF
--- a/docs/reference/modules/indices/recovery.asciidoc
+++ b/docs/reference/modules/indices/recovery.asciidoc
@@ -76,6 +76,8 @@ the resources available to handle the extra load that will result.
 `indices.recovery.use_snapshots`::
 (<<cluster-update-settings,Dynamic>>, Expert) Enables snapshot-based peer recoveries.
 +
+NOTE: This feature is designed for indirect use by Elasticsearch Service. Direct use is not supported. Elastic reserves the right to change or remove this feature in future releases without prior notice.
+
 {es} recovers replicas and relocates primary shards using the _peer recovery_
 process, which involves constructing a new copy of a shard on the target node.
 When `indices.recovery.use_snapshots` is `false` {es} will construct this new

--- a/docs/reference/modules/remote-clusters.asciidoc
+++ b/docs/reference/modules/remote-clusters.asciidoc
@@ -295,6 +295,8 @@ separately.
   `indexing_data`, and `false`. If unset, the global `transport.compress` is
   used as the fallback setting.
 
+NOTE: The `indexing_data` option is designed for indirect use by Elasticsearch Service. Direct use is not supported. Elastic reserves the right to change or remove this feature in future releases without prior notice.
+
 `cluster.remote.<cluster_alias>.transport.compression_scheme`::
 
   Per cluster setting that enables you to configure compression scheme for
@@ -306,6 +308,8 @@ separately.
   to `deflate`. If unset, and `cluster.remote.<cluster_alias>.transport.compress`
   is not explicitly set, `transport.compression_scheme` is used as the fallback
   setting.
+
+NOTE: The `lz4` option is designed for indirect use by Elasticsearch Service. Direct use is not supported. Elastic reserves the right to change or remove this feature in future releases without prior notice.
 
 [discrete]
 [[remote-cluster-sniff-settings]]

--- a/docs/reference/modules/transport.asciidoc
+++ b/docs/reference/modules/transport.asciidoc
@@ -55,12 +55,16 @@ between nodes. The option `true` will compress all data. The option
 ingest, ccr following (excluding bootstrap), and operations based shard recovery
 (excluding transferring lucene files). Defaults to `false`.
 
+NOTE: The `indexing_data` option is designed for indirect use by Elasticsearch Service. Direct use is not supported. Elastic reserves the right to change or remove this feature in future releases without prior notice.
+
 `transport.compression_scheme`::
 (<<static-cluster-setting,Static>>)
 Configures the compression scheme for `transport.compress`. The options are
 `deflate` or `lz4`. If `lz4` is configured and the remote node has not been
 upgraded to a version supporting `lz4`, the traffic will be sent uncompressed.
 Defaults to `deflate`.
+
+NOTE: The `lz4` option is designed for indirect use by Elasticsearch Service. Direct use is not supported. Elastic reserves the right to change or remove this feature in future releases without prior notice.
 
 `transport.ping_schedule`::
 (<<static-cluster-setting,Static>>)


### PR DESCRIPTION
Compression using indexing_data or lz4 as well as recovery from snapshot
are primarily intended for ESS and is therefore marked ESS only in docs.

Relates #76237 and #74587