### PR TITLE
Change deprecation info message level to warning for underscore realms

### DIFF
--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/NodeDeprecationChecks.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/NodeDeprecationChecks.java
@@ -227,7 +227,7 @@ class NodeDeprecationChecks {
             return null;
         } else {
             return new DeprecationIssue(
-                DeprecationIssue.Level.CRITICAL,
+                DeprecationIssue.Level.WARNING,
                 "Realm names cannot start with [" + RESERVED_REALM_NAME_PREFIX + "] in a future major release.",
                 "https://www.elastic.co/guide/en/elasticsearch/reference/7.14/deprecated-7.14.html#reserved-prefixed-realm-names",
                 String.format(Locale.ROOT, "Found realm " + (reservedPrefixedRealmIdentifiers.size() == 1 ? "name" : "names")

--- a/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/NodeDeprecationChecksTests.java
+++ b/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/NodeDeprecationChecksTests.java
@@ -372,6 +372,7 @@ public class NodeDeprecationChecksTests extends ESTestCase {
         assertEquals(1, deprecationIssues.size());
 
         final DeprecationIssue deprecationIssue = deprecationIssues.get(0);
+        assertEquals(DeprecationIssue.Level.WARNING, deprecationIssue.getLevel());
         assertEquals("Realm names cannot start with [_] in a future major release.", deprecationIssue.getMessage());
         assertEquals("https://www.elastic.co/guide/en/elasticsearch/reference" +
             "/7.14/deprecated-7.14.html#reserved-prefixed-realm-names", deprecationIssue.getUrl());


### PR DESCRIPTION
Originally realm names starting with '_' were going to be prohibited in 8.0. However it was later decided
to just leave them deprecated. See https://github.com/elastic/elasticsearch/issues/73250#issuecomment-861463971.
Relates #73250 #73366