### PR TITLE
Changing deprecation info message to warning for path.shared_data property

### DIFF
--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/NodeDeprecationChecks.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/NodeDeprecationChecks.java
@@ -511,7 +511,7 @@ class NodeDeprecationChecks {
             final String url = "https://www.elastic.co/guide/en/elasticsearch/reference/7.13/" +
                 "breaking-changes-7.13.html#deprecate-shared-data-path-setting";
             final String details = "Found shared data path configured. Discontinue use of this setting.";
-            return new DeprecationIssue(DeprecationIssue.Level.CRITICAL, message, url, details, false, null);
+            return new DeprecationIssue(DeprecationIssue.Level.WARNING, message, url, details, false, null);
         }
         return null;
     }

--- a/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/NodeDeprecationChecksTests.java
+++ b/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/NodeDeprecationChecksTests.java
@@ -688,7 +688,7 @@ public class NodeDeprecationChecksTests extends ESTestCase {
         final String expectedUrl =
             "https://www.elastic.co/guide/en/elasticsearch/reference/7.13/breaking-changes-7.13.html#deprecate-shared-data-path-setting";
         assertThat(issue, equalTo(
-            new DeprecationIssue(DeprecationIssue.Level.CRITICAL,
+            new DeprecationIssue(DeprecationIssue.Level.WARNING,
                 "setting [path.shared_data] is deprecated and will be removed in a future version",
                 expectedUrl,
                 "Found shared data path configured. Discontinue use of this setting.",


### PR DESCRIPTION
The deprecation info API currently outputs a critical message if the path.shared_data property exists.
However, that property is not going away until 9.0 according to
https://github.com/elastic/elasticsearch/issues/73168. An 8.0 server will start up fine with this property.
This commit changes the level to "warning" instead.