### PR TITLE
[DOCS] Update saml acs with new URL

### DIFF
--- a/x-pack/docs/build.gradle
+++ b/x-pack/docs/build.gradle
@@ -60,7 +60,7 @@ testClusters.matching { it.name == "integTest" }.configureEach {
   setting 'xpack.security.authc.realms.saml.saml1.idp.entity_id', 'https://my-idp.org'
   setting 'xpack.security.authc.realms.saml.saml1.idp.metadata.path', 'idp-docs-metadata.xml'
   setting 'xpack.security.authc.realms.saml.saml1.sp.entity_id', 'https://kibana.org'
-  setting 'xpack.security.authc.realms.saml.saml1.sp.acs', 'https://kibana.org/api/security/v1/saml'
+  setting 'xpack.security.authc.realms.saml.saml1.sp.acs', 'https://kibana.org/api/security/saml/callback'
   setting 'xpack.security.authc.realms.saml.saml1.attributes.principal', 'uid'
   setting 'xpack.security.authc.realms.saml.saml1.attributes.name', 'urn:oid:2.5.4.3'
   user username: 'test_admin'

--- a/x-pack/docs/en/rest-api/security/saml-prepare-authentication-api.asciidoc
+++ b/x-pack/docs/en/rest-api/security/saml-prepare-authentication-api.asciidoc
@@ -77,7 +77,6 @@ POST /_security/saml/prepare
   "realm" : "saml1"
 }
 --------------------------------------------------
-// TEST[skip:Additional configuration needed in yml files]
 
 The following example generates a SAML authentication request for the SAML realm with an Assertion
 Consuming Service URL matching `https://kibana.org/api/security/saml/callback`
@@ -89,7 +88,6 @@ POST /_security/saml/prepare
   "acs" : "https://kibana.org/api/security/saml/callback"
 }
 --------------------------------------------------
-// TEST[skip:Additional configuration needed in yml files]
 
 This API returns the following response:
 

--- a/x-pack/docs/en/rest-api/security/saml-sp-metadata.asciidoc
+++ b/x-pack/docs/en/rest-api/security/saml-sp-metadata.asciidoc
@@ -42,7 +42,6 @@ SAML realm `saml1`:
 --------------------------------------------------
 GET /_security/saml/metadata/saml1
 --------------------------------------------------
-// TEST[skip:Additional configuration needed in yml files]
 
 The API returns the following response containing the SAML metadata as an XML string:
 
@@ -52,4 +51,3 @@ The API returns the following response containing the SAML metadata as an XML st
     "metadata" : "<?xml version=\"1.0\" encoding=\"UTF-8\"?><md:EntityDescriptor xmlns:md=\"urn:oasis:names:tc:SAML:2.0:metadata\" entityID=\"https://kibana.org\"><md:SPSSODescriptor AuthnRequestsSigned=\"false\" WantAssertionsSigned=\"true\" protocolSupportEnumeration=\"urn:oasis:names:tc:SAML:2.0:protocol\"><md:SingleLogoutService Binding=\"urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect\" Location=\"https://kibana.org/logout\"/><md:NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:transient</md:NameIDFormat><md:AssertionConsumerService Binding=\"urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST\" Location=\"https://kibana.org/api/security/saml/callback\" index=\"1\" isDefault=\"true\"/></md:SPSSODescriptor></md:EntityDescriptor>"
 }
 --------------------------------------------------
-// TESTRESPONSE[skip:Additional configuration needed in yml files]


### PR DESCRIPTION
Removes the skipped tests from #77038 and updates `build.gradle` with the new 'xpack.security.authc.realms.saml.saml1.sp.acs' URL. 