### PR TITLE
Fix randomAuthentication by removing duplicate key

### DIFF
--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authc/AuthenticationTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authc/AuthenticationTests.java
@@ -170,7 +170,7 @@ public class AuthenticationTests extends ESTestCase {
             metadata = Map.of(randomAlphaOfLengthBetween(3, 8), randomAlphaOfLengthBetween(3, 8));
         } else {
             metadata = Arrays.stream(randomArray(1, 5, String[]::new, () -> randomAlphaOfLengthBetween(3, 8)))
-                .collect(Collectors.toMap(s -> s, s -> randomAlphaOfLengthBetween(3, 8)));
+                .distinct().collect(Collectors.toMap(s -> s, s -> randomAlphaOfLengthBetween(3, 8)));
         }
         if (randomBoolean()) { // run-as
             return new Authentication(new User(user.principal(), user.roles(), randomUser()),


### PR DESCRIPTION
randomArray sometimes generates duplicate entries and the subsequent
conversion to a Map hence fails due to the duplicate key. This PR fixes
the failure by ensure array elements are distinct before converting to a
Map. The alternative is to generate distinct array entries from the
beginning. But given how the code is used in the context, a simple
distinct call is easier and sufficient.

Resolves: #77127
