### PR TITLE
Mute ReleaseNotesIndexGeneratorTest

### DIFF
--- a/build-tools-internal/src/test/java/org/elasticsearch/gradle/internal/release/BreakingChangesGeneratorTest.java
+++ b/build-tools-internal/src/test/java/org/elasticsearch/gradle/internal/release/BreakingChangesGeneratorTest.java
@@ -8,6 +8,7 @@
 
 package org.elasticsearch.gradle.internal.release;
 
+import org.junit.Ignore;
 import org.junit.Test;
 
 import java.nio.charset.StandardCharsets;
@@ -19,6 +20,7 @@ import java.util.Objects;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;
 
+@Ignore("https://github.com/elastic/elasticsearch/issues/77190")
 public class BreakingChangesGeneratorTest {
 
     /**

--- a/build-tools-internal/src/test/java/org/elasticsearch/gradle/internal/release/GenerateReleaseNotesTaskTest.java
+++ b/build-tools-internal/src/test/java/org/elasticsearch/gradle/internal/release/GenerateReleaseNotesTaskTest.java
@@ -10,6 +10,7 @@ package org.elasticsearch.gradle.internal.release;
 
 import org.elasticsearch.gradle.internal.test.GradleUnitTestCase;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import java.io.File;
@@ -33,6 +34,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
 
+@Ignore("https://github.com/elastic/elasticsearch/issues/77190")
 public class GenerateReleaseNotesTaskTest extends GradleUnitTestCase {
     private GitWrapper gitWrapper;
 

--- a/build-tools-internal/src/test/java/org/elasticsearch/gradle/internal/release/ReleaseHighlightsGeneratorTest.java
+++ b/build-tools-internal/src/test/java/org/elasticsearch/gradle/internal/release/ReleaseHighlightsGeneratorTest.java
@@ -8,6 +8,7 @@
 
 package org.elasticsearch.gradle.internal.release;
 
+import org.junit.Ignore;
 import org.junit.Test;
 
 import java.nio.charset.StandardCharsets;
@@ -19,6 +20,7 @@ import java.util.Objects;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;
 
+@Ignore("https://github.com/elastic/elasticsearch/issues/77190")
 public class ReleaseHighlightsGeneratorTest {
 
     /**

--- a/build-tools-internal/src/test/java/org/elasticsearch/gradle/internal/release/ReleaseNotesGeneratorTest.java
+++ b/build-tools-internal/src/test/java/org/elasticsearch/gradle/internal/release/ReleaseNotesGeneratorTest.java
@@ -8,6 +8,7 @@
 
 package org.elasticsearch.gradle.internal.release;
 
+import org.junit.Ignore;
 import org.junit.Test;
 
 import java.nio.charset.StandardCharsets;
@@ -24,6 +25,7 @@ import java.util.Set;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;
 
+@Ignore("https://github.com/elastic/elasticsearch/issues/77190")
 public class ReleaseNotesGeneratorTest {
 
     /**

--- a/build-tools-internal/src/test/java/org/elasticsearch/gradle/internal/release/ReleaseNotesIndexGeneratorTest.java
+++ b/build-tools-internal/src/test/java/org/elasticsearch/gradle/internal/release/ReleaseNotesIndexGeneratorTest.java
@@ -8,6 +8,7 @@
 
 package org.elasticsearch.gradle.internal.release;
 
+import org.junit.Ignore;
 import org.junit.Test;
 
 import java.nio.charset.StandardCharsets;
@@ -21,6 +22,7 @@ import java.util.stream.Stream;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;
 
+@Ignore("https://github.com/elastic/elasticsearch/issues/77190")
 public class ReleaseNotesIndexGeneratorTest {
 
     /**


### PR DESCRIPTION
This is failing constantly on CI https://github.com/elastic/elasticsearch/issues/77190 for `master` so muting.
