### PR TITLE
[7.15] Add methods to retrieve doc and/or metadata fields only from SearchHit (#77192)

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/search/fields/SearchFieldsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/fields/SearchFieldsIT.java
@@ -1194,9 +1194,10 @@ public class SearchFieldsIT extends ESIntegTestCase {
         assertSearchResponse(response);
         assertHitCount(response, 1);
 
-        Map<String, DocumentField> fields = response.getHits().getAt(0).getFields();
+        Map<String, DocumentField> fields = response.getHits().getAt(0).getMetadataFields();
 
         assertThat(fields.get("field1"), nullValue());
         assertThat(fields.get("_routing").getValue().toString(), equalTo("1"));
+        assertThat(response.getHits().getAt(0).getDocumentFields().size(), equalTo(0));
     }
 }

--- a/server/src/main/java/org/elasticsearch/search/SearchHit.java
+++ b/server/src/main/java/org/elasticsearch/search/SearchHit.java
@@ -457,8 +457,22 @@ public final class SearchHit implements Writeable, ToXContentObject, Iterable<Do
     }
 
     /**
+     * @return a map of metadata fields for this hit
+     */
+    public Map<String, DocumentField> getMetadataFields() {
+        return Collections.unmodifiableMap(metaFields);
+    }
+
+    /**
+     * @return a map of non-metadata fields requested for this hit
+     */
+    public Map<String, DocumentField> getDocumentFields() {
+        return Collections.unmodifiableMap(documentFields);
+    }
+
+    /**
      * A map of hit fields (from field name to hit fields) if additional fields
-     * were required to be loaded.
+     * were required to be loaded. Includes both document and metadata fields.
      */
     public Map<String, DocumentField> getFields() {
         if (metaFields.size() > 0 || documentFields.size() > 0) {


### PR DESCRIPTION
Backports the following commits to 7.15:
 - Add methods to retrieve doc and/or metadata fields only from SearchHit (#77192)