### PR TITLE
Refactor GeoBoundingBoxQuery integration tests (#77103)

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/search/geo/GeoBoundingBoxQueryGeoShapeIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/geo/GeoBoundingBoxQueryGeoShapeIT.java
@@ -13,15 +13,12 @@ import org.elasticsearch.common.xcontent.XContentFactory;
 
 import java.io.IOException;
 
-public class GeoBoundingBoxQueryGeoShapeIT extends AbstractGeoBoundingBoxQueryIT {
+public class GeoBoundingBoxQueryGeoShapeIT extends GeoBoundingBoxQueryIntegTestCase {
 
     @Override
     public XContentBuilder getMapping() throws IOException {
         XContentBuilder xContentBuilder = XContentFactory.jsonBuilder().startObject().startObject("type1")
             .startObject("properties").startObject("location").field("type", "geo_shape");
-        if (randomBoolean()) {
-            xContentBuilder.field("strategy", "recursive");
-        }
         xContentBuilder.endObject().endObject().endObject().endObject();
         return xContentBuilder;
     }

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/geo/GeoBoundingBoxQueryLegacyGeoShapeIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/geo/GeoBoundingBoxQueryLegacyGeoShapeIT.java
@@ -13,14 +13,13 @@ import org.elasticsearch.common.xcontent.XContentFactory;
 
 import java.io.IOException;
 
-public class GeoBoundingBoxQueryGeoPointIT extends GeoBoundingBoxQueryIntegTestCase {
+public class GeoBoundingBoxQueryLegacyGeoShapeIT extends GeoBoundingBoxQueryIntegTestCase {
 
     @Override
     public XContentBuilder getMapping() throws IOException {
-        XContentBuilder xContentBuilder = XContentFactory.jsonBuilder().startObject().startObject("type1")
-            .startObject("properties").startObject("location").field("type", "geo_point");
-        xContentBuilder.endObject().endObject().endObject().endObject();
-        return xContentBuilder;
+        return XContentFactory.jsonBuilder().startObject().startObject("type1")
+            .startObject("properties").startObject("location").field("type", "geo_shape").field("strategy", "recursive")
+            .endObject().endObject().endObject().endObject();
     }
 }
 

--- a/test/framework/src/main/java/org/elasticsearch/search/geo/GeoBoundingBoxQueryIntegTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/search/geo/GeoBoundingBoxQueryIntegTestCase.java
@@ -31,14 +31,18 @@ import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcke
 import static org.hamcrest.Matchers.anyOf;
 import static org.hamcrest.Matchers.equalTo;
 
-abstract class AbstractGeoBoundingBoxQueryIT extends ESIntegTestCase {
+public abstract class GeoBoundingBoxQueryIntegTestCase extends ESIntegTestCase {
+
+    /**
+     * Get the mapping for this test. It should contain a field called `location' that
+     * supports GeoBoundingBox queries.
+     */
+    public abstract XContentBuilder getMapping() throws IOException;
 
     @Override
     protected boolean forbidPrivateIndexSettings() {
         return false;
     }
-
-    public abstract XContentBuilder getMapping() throws IOException;
 
     public void testSimpleBoundingBoxTest() throws Exception {
         Version version = VersionUtils.randomIndexCompatibleVersion(random());


### PR DESCRIPTION
GeoBoundingBoxQuery integration test mixes legacy geo_shape and geo_shape test. This PR breaks that dependency by introducing a GeoBoundingBoxQueryIntegTestCase. This TestCase is then implemented by the different geo fields.

backport #77103