### PR TITLE
Flip http methods in _mvt rest-api-spec

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/search_mvt.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/search_mvt.json
@@ -19,8 +19,8 @@
         {
           "path": "/{index}/_mvt/{field}/{zoom}/{x}/{y}",
           "methods": [
-            "GET",
-            "POST"
+            "POST",
+            "GET"
           ],
           "parts": {
             "index": {


### PR DESCRIPTION
Language clients take per convention the first http method from the rest-api-spec. This PR changes the first method to `POST`, which is the preference for endpoints that expect a body.