### PR TITLE
[7.15] Flip HTTP methods in _mvt rest-api-spec (#77228)

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/search_mvt.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/search_mvt.json
@@ -19,8 +19,8 @@
         {
           "path": "/{index}/_mvt/{field}/{zoom}/{x}/{y}",
           "methods": [
-            "GET",
-            "POST"
+            "POST",
+            "GET"
           ],
           "parts": {
             "index": {


### PR DESCRIPTION
Backports the following commits to 7.15:
 - Flip HTTP methods in _mvt rest-api-spec (#77228)