### PR TITLE
Update usage of retrieving _size

### DIFF
--- a/docs/plugins/mapper-size.asciidoc
+++ b/docs/plugins/mapper-size.asciidoc
@@ -65,7 +65,7 @@ GET my-index-000001/_search
       }
     }
   ],
-  "fields": ["_size"],                <4>
+  "docvalue_fields": ["_size"],                <4>
   "script_fields": {
     "size": {
       "script": "doc['_size']"        <5>


### PR DESCRIPTION
`fields` doesn't work anymore. `docvalue_fields` does work, though.