### PR TITLE
[DOCS] Fixes section IDs in start/stop trained model deployment APIs.

### DIFF
--- a/docs/reference/ml/df-analytics/apis/start-trained-model-deployment.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/start-trained-model-deployment.asciidoc
@@ -43,7 +43,7 @@ to 20 seconds.
 
 ////
 ////
-[[ml-get-trained-models-response-codes]]
+[[start-trained-models-response-codes]]
 == {api-response-codes-title}
 
 ////

--- a/docs/reference/ml/df-analytics/apis/stop-trained-model-deployment.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/stop-trained-model-deployment.asciidoc
@@ -39,7 +39,7 @@ include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=model-id]
 == {api-response-body-title}
 ////
 ////
-[[ml-get-trained-models-response-codes]]
+[[stop-trained-models-response-codes]]
 == {api-response-codes-title}
 ////
 


### PR DESCRIPTION
## Overview

This PR fixes two section IDs in the start/stop trained model deployment API documentation.