### PR TITLE
[7.15] Convert 'routing' values in REST API tests to strings (#77144)

### DIFF
--- a/modules/parent-join/src/yamlRestTest/resources/rest-api-spec/test/11_parent_child.yml
+++ b/modules/parent-join/src/yamlRestTest/resources/rest-api-spec/test/11_parent_child.yml
@@ -20,7 +20,7 @@ setup:
       index:
         index: test
         id:    2
-        routing: 1
+        routing: "1"
         body:  {"bar": "baz", "join_field": { "name" : "child", "parent": "1"} }
 
   - do:

--- a/modules/parent-join/src/yamlRestTest/resources/rest-api-spec/test/30_inner_hits.yml
+++ b/modules/parent-join/src/yamlRestTest/resources/rest-api-spec/test/30_inner_hits.yml
@@ -25,7 +25,7 @@ setup:
       index:
         index: test
         id: 2
-        routing: 1
+        routing: "1"
         body: { "join_field": { "name": "answer", "parent": 1} , "entity_type": "answer" }
 
   - do:
@@ -37,7 +37,7 @@ setup:
   - do:
       index:
         index: test
-        routing: 3
+        routing: "3"
         id: 4
         body: { "join_field": { "name": "address", "parent": 3 }, "entity_type": "address" }
 

--- a/modules/reindex/src/yamlRestTest/resources/rest-api-spec/test/reindex/95_parent_join.yml
+++ b/modules/reindex/src/yamlRestTest/resources/rest-api-spec/test/reindex/95_parent_join.yml
@@ -25,14 +25,14 @@ setup:
       index:
         index: source
         id:    2
-        routing: 1
+        routing: "1"
         body:  { "join_field": { "name": "child", "parent": "1" } }
 
   - do:
       index:
         index: source
         id:    3
-        routing: 1
+        routing: "1"
         body:  { "join_field": { "name": "grand_child", "parent": "2" } }
 
   - do:

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/create/40_routing.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/create/40_routing.yml
@@ -21,14 +21,14 @@
       create:
           index:   test_1
           id:      1
-          routing: 5
+          routing: "5"
           body:    { foo: bar }
 
  - do:
       get:
           index:   test_1
           id:      1
-          routing: 5
+          routing: "5"
           stored_fields:  [_routing]
 
  - match:   { _id:              "1"}

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/delete/30_routing.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/delete/30_routing.yml
@@ -15,7 +15,7 @@
       index:
           index:   test_1
           id:      1
-          routing: 5
+          routing: "5"
           body:    { foo: bar }
 
  - do:
@@ -23,11 +23,11 @@
       delete:
           index:   test_1
           id:      1
-          routing: 4
+          routing: "4"
 
  - do:
       delete:
           index:   test_1
           id:      1
-          routing: 5
+          routing: "5"
 

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/exists/40_routing.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/exists/40_routing.yml
@@ -22,14 +22,14 @@
       index:
           index:   test_1
           id:      1
-          routing: 5
+          routing: "5"
           body:    { foo: bar }
 
  - do:
       exists:
           index:   test_1
           id:      1
-          routing: 5
+          routing: "5"
 
  - is_true: ''
 

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/get/40_routing.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/get/40_routing.yml
@@ -23,14 +23,14 @@
       index:
           index:   test_1
           id:      1
-          routing: 5
+          routing: "5"
           body:    { foo: bar }
 
  - do:
       get:
           index:   test_1
           id:      1
-          routing: 5
+          routing: "5"
           stored_fields:  [_routing]
 
  - match:   { _id:              "1"}

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/get_source/40_routing.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/get_source/40_routing.yml
@@ -24,14 +24,14 @@
       index:
           index:   test_1
           id:      1
-          routing: 5
+          routing: "5"
           body:    { foo: bar }
 
  - do:
       get_source:
           index:   test_1
           id:      1
-          routing: 5
+          routing: "5"
 
  - match:   { '': {foo: bar}}
 

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/index/40_routing.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/index/40_routing.yml
@@ -22,14 +22,14 @@
       index:
           index:   test_1
           id:      1
-          routing: 5
+          routing: "5"
           body:    { foo: bar }
 
  - do:
       get:
           index:   test_1
           id:      1
-          routing: 5
+          routing: "5"
           stored_fields:  [_routing]
 
  - match:   { _id:       "1"}

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.update_aliases/20_routing.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.update_aliases/20_routing.yml
@@ -125,7 +125,7 @@ setup:
             - add:
                 index: test_index
                 alias: test_alias
-                routing: 5
+                routing: "5"
 
   - do:
       indices.get_alias:

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/mget/40_routing.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/mget/40_routing.yml
@@ -22,7 +22,7 @@
       index:
           index:   test_1
           id:      1
-          routing: 5
+          routing: "5"
           body:    { foo: bar }
 
  - do:
@@ -32,8 +32,8 @@
           body:
             docs:
               - { _id: 1 }
-              - { _id: 1, routing: 4 }
-              - { _id: 1, routing: 5 }
+              - { _id: 1, routing: "4" }
+              - { _id: 1, routing: "5" }
 
  - is_false:  docs.0.found
  - is_false:  docs.1.found

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.aggregation/20_terms.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.aggregation/20_terms.yml
@@ -719,7 +719,7 @@ setup:
         refresh: true
         index: test_1
         id: 1
-        routing: 1
+        routing: "1"
         body: { "str": "abc" }
 
   - do:
@@ -727,7 +727,7 @@ setup:
         refresh: true
         index: test_1
         id: 2
-        routing: 1
+        routing: "1"
         body: { "str": "abc" }
 
   - do:
@@ -735,7 +735,7 @@ setup:
         refresh: true
         index: test_1
         id: 3
-        routing: 1
+        routing: "1"
         body: { "str": "bcd" }
 
   - do:
@@ -769,7 +769,7 @@ setup:
         refresh: true
         index: test_1
         id: 1
-        routing: 1
+        routing: "1"
         body: { "str": "abc" }
 
   - do:
@@ -777,7 +777,7 @@ setup:
         refresh: true
         index: test_1
         id: 2
-        routing: 1
+        routing: "1"
         body: { "str": "abc" }
 
   - do:
@@ -785,7 +785,7 @@ setup:
         refresh: true
         index: test_1
         id: 3
-        routing: 1
+        routing: "1"
         body: { "str": "bcd" }
 
   - do:

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/update/40_routing.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/update/40_routing.yml
@@ -23,7 +23,7 @@
       update:
           index:   test_1
           id:      1
-          routing: 5
+          routing: "5"
           body:
             doc:        { foo: baz }
             upsert:     { foo: bar }
@@ -32,7 +32,7 @@
       get:
           index:   test_1
           id:      1
-          routing: 5
+          routing: "5"
           stored_fields:  _routing
 
  - match: { _routing:  "5"}
@@ -49,7 +49,7 @@
       update:
           index:   test_1
           id:      1
-          routing: 5
+          routing: "5"
           _source: foo
           body:
             doc:        { foo: baz }


### PR DESCRIPTION
Backports the following commits to 7.15:
 - Convert 'routing' values in REST API tests to strings (#77144)