### PR TITLE
Format `AbstractFilteringTestCase` (backport of #77217)

### DIFF
--- a/build-tools-internal/src/main/groovy/elasticsearch.formatting.gradle
+++ b/build-tools-internal/src/main/groovy/elasticsearch.formatting.gradle
@@ -205,6 +205,8 @@ subprojects {
           if (project.path == ':server') {
             target 'src/*/java/org/elasticsearch/action/admin/cluster/repositories/**/*.java',
                    'src/*/java/org/elasticsearch/action/admin/cluster/snapshots/**/*.java',
+                   'src/test/java/org/elasticsearch/common/xcontent/support/AbstractFilteringTestCase.java',
+                   'src/test/java/org/elasticsearch/common/xcontent/support/XContentMapValuesTests.java',
                    'src/*/java/org/elasticsearch/index/snapshots/**/*.java',
                    'src/*/java/org/elasticsearch/repositories/**/*.java',
                    'src/*/java/org/elasticsearch/search/aggregations/**/*.java',

--- a/server/src/test/java/org/elasticsearch/common/xcontent/support/AbstractFilteringTestCase.java
+++ b/server/src/test/java/org/elasticsearch/common/xcontent/support/AbstractFilteringTestCase.java
@@ -8,18 +8,23 @@
 
 package org.elasticsearch.common.xcontent.support;
 
-import org.elasticsearch.core.CheckedFunction;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.util.set.Sets;
+import org.elasticsearch.common.xcontent.DeprecationHandler;
+import org.elasticsearch.common.xcontent.FilterXContentParser;
+import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 import org.elasticsearch.common.xcontent.XContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.common.xcontent.XContentType;
+import org.elasticsearch.core.CheckedFunction;
+import org.elasticsearch.core.PathUtils;
 import org.elasticsearch.test.ESTestCase;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
-import org.elasticsearch.core.PathUtils;
 import java.util.Set;
 
 import static java.util.Collections.emptySet;
@@ -32,85 +37,31 @@ import static java.util.stream.Collectors.toSet;
 public abstract class AbstractFilteringTestCase extends ESTestCase {
 
     @FunctionalInterface
-    protected interface Builder extends CheckedFunction<XContentBuilder, XContentBuilder, IOException> {
-    }
+    protected interface Builder extends CheckedFunction<XContentBuilder, XContentBuilder, IOException> {}
 
     protected abstract void testFilter(Builder expected, Builder actual, Set<String> includes, Set<String> excludes) throws IOException;
 
-    /** Sample test case **/
-    protected static final Builder SAMPLE = builder -> builder.startObject()
-            .field("title", "My awesome book")
-                .field("pages", 456)
-                .field("price", 27.99)
-                .field("timestamp", 1428582942867L)
-                .nullField("default")
-                .startArray("tags")
-                    .value("elasticsearch")
-                    .value("java")
-                .endArray()
-                .startArray("authors")
-                    .startObject()
-                        .field("name", "John Doe")
-                        .field("lastname", "John")
-                        .field("firstname", "Doe")
-                    .endObject()
-                    .startObject()
-                        .field("name", "William Smith")
-                        .field("lastname", "William")
-                        .field("firstname", "Smith")
-                    .endObject()
-                .endArray()
-                .startObject("properties")
-                    .field("weight", 0.8d)
-                    .startObject("language")
-                        .startObject("en")
-                            .field("lang", "English")
-                            .field("available", true)
-                            .startArray("distributors")
-                                .startObject()
-                                    .field("name", "The Book Shop")
-                                    .startArray("addresses")
-                                        .startObject()
-                                            .field("name", "address #1")
-                                            .field("street", "Hampton St")
-                                            .field("city", "London")
-                                        .endObject()
-                                        .startObject()
-                                            .field("name", "address #2")
-                                            .field("street", "Queen St")
-                                            .field("city", "Stornoway")
-                                        .endObject()
-                                    .endArray()
-                                .endObject()
-                                .startObject()
-                                    .field("name", "Sussex Books House")
-                                .endObject()
-                            .endArray()
-                        .endObject()
-                        .startObject("fr")
-                            .field("lang", "French")
-                            .field("available", false)
-                            .startArray("distributors")
-                                .startObject()
-                                    .field("name", "La Maison du Livre")
-                                    .startArray("addresses")
-                                        .startObject()
-                                            .field("name", "address #1")
-                                            .field("street", "Rue Mouffetard")
-                                            .field("city", "Paris")
-                                        .endObject()
-                                    .endArray()
-                                .endObject()
-                                .startObject()
-                                    .field("name", "Thetra")
-                                .endObject()
-                            .endArray()
-                        .endObject()
-                    .endObject()
-                .endObject()
-            .endObject();
+    /** Sample test case */
+    protected static final Builder SAMPLE = builderFor("sample.json");
 
-    public void testNoFiltering() throws Exception {
+    protected static Builder builderFor(String file) {
+        return builder -> {
+            try (
+                XContentParser parser = XContentType.JSON.xContent()
+                    .createParser(
+                        NamedXContentRegistry.EMPTY,
+                        DeprecationHandler.THROW_UNSUPPORTED_OPERATION,
+                        AbstractFilteringTestCase.class.getResourceAsStream(file)
+                    )
+            ) {
+                // copyCurrentStructure does not property handle filters when it is passed a json parser. So we hide it.
+                return builder.copyCurrentStructure(new FilterXContentParser(parser) {
+                });
+            }
+        };
+    }
+
+    public final void testNoFiltering() throws Exception {
         final Builder expected = SAMPLE;
 
         testFilter(expected, SAMPLE, emptySet(), emptySet());
@@ -119,7 +70,7 @@ public abstract class AbstractFilteringTestCase extends ESTestCase {
         testFilter(expected, SAMPLE, emptySet(), singleton("xyz"));
     }
 
-    public void testNoMatch() throws Exception {
+    public final void testNoMatch() throws Exception {
         final Builder expected = builder -> builder.startObject().endObject();
 
         testFilter(expected, SAMPLE, singleton("xyz"), emptySet());
@@ -127,998 +78,165 @@ public abstract class AbstractFilteringTestCase extends ESTestCase {
         testFilter(expected, SAMPLE, emptySet(), singleton("**"));
     }
 
-    public void testSimpleFieldInclusive() throws Exception {
+    public final void testSimpleFieldInclusive() throws Exception {
         final Builder expected = builder -> builder.startObject().field("title", "My awesome book").endObject();
 
         testFilter(expected, SAMPLE, singleton("title"), emptySet());
     }
 
-    public void testSimpleFieldExclusive() throws Exception {
-        final Builder expected = builder -> builder.startObject()
-                                                            .field("pages", 456)
-                                                            .field("price", 27.99)
-                                                            .field("timestamp", 1428582942867L)
-                                                            .nullField("default")
-                                                            .startArray("tags")
-                                                                .value("elasticsearch")
-                                                                .value("java")
-                                                            .endArray()
-                                                            .startArray("authors")
-                                                                .startObject()
-                                                                    .field("name", "John Doe")
-                                                                    .field("lastname", "John")
-                                                                    .field("firstname", "Doe")
-                                                                .endObject()
-                                                                .startObject()
-                                                                    .field("name", "William Smith")
-                                                                    .field("lastname", "William")
-                                                                    .field("firstname", "Smith")
-                                                                .endObject()
-                                                            .endArray()
-                                                            .startObject("properties")
-                                                                .field("weight", 0.8d)
-                                                                .startObject("language")
-                                                                    .startObject("en")
-                                                                        .field("lang", "English")
-                                                                        .field("available", true)
-                                                                        .startArray("distributors")
-                                                                            .startObject()
-                                                                                .field("name", "The Book Shop")
-                                                                                .startArray("addresses")
-                                                                                    .startObject()
-                                                                                        .field("name", "address #1")
-                                                                                        .field("street", "Hampton St")
-                                                                                        .field("city", "London")
-                                                                                    .endObject()
-                                                                                    .startObject()
-                                                                                        .field("name", "address #2")
-                                                                                        .field("street", "Queen St")
-                                                                                        .field("city", "Stornoway")
-                                                                                    .endObject()
-                                                                                .endArray()
-                                                                            .endObject()
-                                                                            .startObject()
-                                                                                .field("name", "Sussex Books House")
-                                                                            .endObject()
-                                                                        .endArray()
-                                                                    .endObject()
-                                                                    .startObject("fr")
-                                                                        .field("lang", "French")
-                                                                        .field("available", false)
-                                                                        .startArray("distributors")
-                                                                            .startObject()
-                                                                                .field("name", "La Maison du Livre")
-                                                                                .startArray("addresses")
-                                                                                    .startObject()
-                                                                                        .field("name", "address #1")
-                                                                                        .field("street", "Rue Mouffetard")
-                                                                                        .field("city", "Paris")
-                                                                                    .endObject()
-                                                                                .endArray()
-                                                                            .endObject()
-                                                                            .startObject()
-                                                                                .field("name", "Thetra")
-                                                                            .endObject()
-                                                                        .endArray()
-                                                                    .endObject()
-                                                                .endObject()
-                                                            .endObject()
-                                                        .endObject();
-
-        testFilter(expected, SAMPLE, emptySet(), singleton("title"));
+    public final void testSimpleFieldExclusive() throws Exception {
+        testFilter(builderFor("sample_no_title.json"), SAMPLE, emptySet(), singleton("title"));
     }
 
-    public void testSimpleFieldWithWildcardInclusive() throws Exception {
-        final Builder expected = builder -> builder.startObject()
-                                                            .field("price", 27.99)
-                                                            .startObject("properties")
-                                                                .field("weight", 0.8d)
-                                                                .startObject("language")
-                                                                    .startObject("en")
-                                                                        .field("lang", "English")
-                                                                        .field("available", true)
-                                                                        .startArray("distributors")
-                                                                            .startObject()
-                                                                                .field("name", "The Book Shop")
-                                                                                .startArray("addresses")
-                                                                                    .startObject()
-                                                                                        .field("name", "address #1")
-                                                                                        .field("street", "Hampton St")
-                                                                                        .field("city", "London")
-                                                                                    .endObject()
-                                                                                    .startObject()
-                                                                                        .field("name", "address #2")
-                                                                                        .field("street", "Queen St")
-                                                                                        .field("city", "Stornoway")
-                                                                                    .endObject()
-                                                                                .endArray()
-                                                                            .endObject()
-                                                                            .startObject()
-                                                                                .field("name", "Sussex Books House")
-                                                                            .endObject()
-                                                                        .endArray()
-                                                                    .endObject()
-                                                                    .startObject("fr")
-                                                                        .field("lang", "French")
-                                                                        .field("available", false)
-                                                                        .startArray("distributors")
-                                                                            .startObject()
-                                                                                .field("name", "La Maison du Livre")
-                                                                                .startArray("addresses")
-                                                                                    .startObject()
-                                                                                        .field("name", "address #1")
-                                                                                        .field("street", "Rue Mouffetard")
-                                                                                        .field("city", "Paris")
-                                                                                    .endObject()
-                                                                                .endArray()
-                                                                            .endObject()
-                                                                            .startObject()
-                                                                                .field("name", "Thetra")
-                                                                            .endObject()
-                                                                        .endArray()
-                                                                    .endObject()
-                                                                .endObject()
-                                                            .endObject()
-                                                        .endObject();
-
-        testFilter(expected, SAMPLE, singleton("pr*"), emptySet());
+    public final void testSimpleFieldWithWildcardInclusive() throws Exception {
+        testFilter(builderFor("sample_just_pr.json"), SAMPLE, singleton("pr*"), emptySet());
     }
 
-    public void testSimpleFieldWithWildcardExclusive() throws Exception {
-        final Builder expected = builder -> builder.startObject()
-                                                            .field("title", "My awesome book")
-                                                            .field("pages", 456)
-                                                            .field("timestamp", 1428582942867L)
-                                                            .nullField("default")
-                                                            .startArray("tags")
-                                                                .value("elasticsearch")
-                                                                .value("java")
-                                                            .endArray()
-                                                            .startArray("authors")
-                                                                .startObject()
-                                                                    .field("name", "John Doe")
-                                                                    .field("lastname", "John")
-                                                                    .field("firstname", "Doe")
-                                                                .endObject()
-                                                                .startObject()
-                                                                    .field("name", "William Smith")
-                                                                    .field("lastname", "William")
-                                                                    .field("firstname", "Smith")
-                                                                .endObject()
-                                                            .endArray()
-                                                        .endObject();
-
-        testFilter(expected, SAMPLE, emptySet(), singleton("pr*"));
+    public final void testSimpleFieldWithWildcardExclusive() throws Exception {
+        testFilter(builderFor("sample_no_pr.json"), SAMPLE, emptySet(), singleton("pr*"));
     }
 
-    public void testMultipleFieldsInclusive() throws Exception {
-        final Builder expected = builder -> builder.startObject()
-                                                            .field("title", "My awesome book")
-                                                            .field("pages", 456)
-                                                        .endObject();
-
+    public final void testMultipleFieldsInclusive() throws Exception {
+        Builder expected = builder -> builder.startObject().field("title", "My awesome book").field("pages", 456).endObject();
         testFilter(expected, SAMPLE, Sets.newHashSet("title", "pages"), emptySet());
     }
 
-    public void testMultipleFieldsExclusive() throws Exception {
-        final Builder expected = builder -> builder.startObject()
-                                                            .field("price", 27.99)
-                                                            .field("timestamp", 1428582942867L)
-                                                            .nullField("default")
-                                                            .startArray("tags")
-                                                                .value("elasticsearch")
-                                                                .value("java")
-                                                            .endArray()
-                                                            .startArray("authors")
-                                                                .startObject()
-                                                                    .field("name", "John Doe")
-                                                                    .field("lastname", "John")
-                                                                    .field("firstname", "Doe")
-                                                                .endObject()
-                                                                .startObject()
-                                                                    .field("name", "William Smith")
-                                                                    .field("lastname", "William")
-                                                                    .field("firstname", "Smith")
-                                                                .endObject()
-                                                            .endArray()
-                                                            .startObject("properties")
-                                                                .field("weight", 0.8d)
-                                                                .startObject("language")
-                                                                    .startObject("en")
-                                                                        .field("lang", "English")
-                                                                        .field("available", true)
-                                                                        .startArray("distributors")
-                                                                            .startObject()
-                                                                                .field("name", "The Book Shop")
-                                                                                .startArray("addresses")
-                                                                                    .startObject()
-                                                                                        .field("name", "address #1")
-                                                                                        .field("street", "Hampton St")
-                                                                                        .field("city", "London")
-                                                                                    .endObject()
-                                                                                    .startObject()
-                                                                                        .field("name", "address #2")
-                                                                                        .field("street", "Queen St")
-                                                                                        .field("city", "Stornoway")
-                                                                                    .endObject()
-                                                                                .endArray()
-                                                                            .endObject()
-                                                                            .startObject()
-                                                                                .field("name", "Sussex Books House")
-                                                                            .endObject()
-                                                                        .endArray()
-                                                                    .endObject()
-                                                                    .startObject("fr")
-                                                                        .field("lang", "French")
-                                                                        .field("available", false)
-                                                                        .startArray("distributors")
-                                                                            .startObject()
-                                                                                .field("name", "La Maison du Livre")
-                                                                                .startArray("addresses")
-                                                                                    .startObject()
-                                                                                        .field("name", "address #1")
-                                                                                        .field("street", "Rue Mouffetard")
-                                                                                        .field("city", "Paris")
-                                                                                    .endObject()
-                                                                                .endArray()
-                                                                            .endObject()
-                                                                            .startObject()
-                                                                                .field("name", "Thetra")
-                                                                            .endObject()
-                                                                        .endArray()
-                                                                    .endObject()
-                                                                .endObject()
-                                                            .endObject()
-                                                        .endObject();
-
-        testFilter(expected, SAMPLE, emptySet(), Sets.newHashSet("title", "pages"));
+    public final void testMultipleFieldsExclusive() throws Exception {
+        testFilter(builderFor("sample_no_title_pages.json"), SAMPLE, emptySet(), Sets.newHashSet("title", "pages"));
     }
 
-    public void testSimpleArrayInclusive() throws Exception {
-        final Builder expected = builder -> builder.startObject()
-                                                            .startArray("tags")
-                                                                .value("elasticsearch")
-                                                                .value("java")
-                                                            .endArray()
-                                                    .endObject();
-
+    public final void testSimpleArrayInclusive() throws Exception {
+        Builder expected = builder -> builder.startObject().startArray("tags").value("elasticsearch").value("java").endArray().endObject();
         testFilter(expected, SAMPLE, singleton("tags"), emptySet());
     }
 
-    public void testSimpleArrayExclusive() throws Exception {
-        final Builder expected = builder -> builder.startObject()
-                                                            .field("title", "My awesome book")
-                                                            .field("pages", 456)
-                                                            .field("price", 27.99)
-                                                            .field("timestamp", 1428582942867L)
-                                                            .nullField("default")
-                                                            .startArray("authors")
-                                                                .startObject()
-                                                                    .field("name", "John Doe")
-                                                                    .field("lastname", "John")
-                                                                    .field("firstname", "Doe")
-                                                                .endObject()
-                                                                .startObject()
-                                                                    .field("name", "William Smith")
-                                                                    .field("lastname", "William")
-                                                                    .field("firstname", "Smith")
-                                                                .endObject()
-                                                            .endArray()
-                                                            .startObject("properties")
-                                                                .field("weight", 0.8d)
-                                                                .startObject("language")
-                                                                    .startObject("en")
-                                                                        .field("lang", "English")
-                                                                        .field("available", true)
-                                                                        .startArray("distributors")
-                                                                            .startObject()
-                                                                                .field("name", "The Book Shop")
-                                                                                .startArray("addresses")
-                                                                                    .startObject()
-                                                                                        .field("name", "address #1")
-                                                                                        .field("street", "Hampton St")
-                                                                                        .field("city", "London")
-                                                                                    .endObject()
-                                                                                    .startObject()
-                                                                                        .field("name", "address #2")
-                                                                                        .field("street", "Queen St")
-                                                                                        .field("city", "Stornoway")
-                                                                                    .endObject()
-                                                                                .endArray()
-                                                                            .endObject()
-                                                                            .startObject()
-                                                                                .field("name", "Sussex Books House")
-                                                                            .endObject()
-                                                                        .endArray()
-                                                                    .endObject()
-                                                                    .startObject("fr")
-                                                                        .field("lang", "French")
-                                                                        .field("available", false)
-                                                                        .startArray("distributors")
-                                                                            .startObject()
-                                                                                .field("name", "La Maison du Livre")
-                                                                                .startArray("addresses")
-                                                                                    .startObject()
-                                                                                        .field("name", "address #1")
-                                                                                        .field("street", "Rue Mouffetard")
-                                                                                        .field("city", "Paris")
-                                                                                    .endObject()
-                                                                                .endArray()
-                                                                            .endObject()
-                                                                            .startObject()
-                                                                                .field("name", "Thetra")
-                                                                            .endObject()
-                                                                        .endArray()
-                                                                    .endObject()
-                                                                .endObject()
-                                                            .endObject()
-                                                        .endObject();
-
-        testFilter(expected, SAMPLE, emptySet(), singleton("tags"));
+    public final void testSimpleArrayExclusive() throws Exception {
+        testFilter(builderFor("sample_no_tags.json"), SAMPLE, emptySet(), singleton("tags"));
     }
 
-    public void testSimpleArrayOfObjectsInclusive() throws Exception {
-        final Builder expected = builder -> builder.startObject()
-                                                            .startArray("authors")
-                                                                .startObject()
-                                                                    .field("name", "John Doe")
-                                                                    .field("lastname", "John")
-                                                                    .field("firstname", "Doe")
-                                                                .endObject()
-                                                                .startObject()
-                                                                    .field("name", "William Smith")
-                                                                    .field("lastname", "William")
-                                                                    .field("firstname", "Smith")
-                                                                .endObject()
-                                                            .endArray()
-                                                        .endObject();
-
+    public final void testSimpleArrayOfObjectsInclusive() throws Exception {
+        Builder expected = builderFor("sample_just_authors.json");
         testFilter(expected, SAMPLE, singleton("authors"), emptySet());
         testFilter(expected, SAMPLE, singleton("authors.*"), emptySet());
         testFilter(expected, SAMPLE, singleton("authors.*name"), emptySet());
     }
 
-    protected static final Builder SIMPLE_ARRAY_OF_OBJECTS_EXCLUSIVE = builder -> builder.startObject()
-                                            .field("title", "My awesome book")
-                                            .field("pages", 456)
-                                            .field("price", 27.99)
-                                            .field("timestamp", 1428582942867L)
-                                            .nullField("default")
-                                            .startArray("tags")
-                                                .value("elasticsearch")
-                                                .value("java")
-                                            .endArray()
-                                            .startObject("properties")
-                                                .field("weight", 0.8d)
-                                                .startObject("language")
-                                                    .startObject("en")
-                                                        .field("lang", "English")
-                                                        .field("available", true)
-                                                        .startArray("distributors")
-                                                            .startObject()
-                                                                .field("name", "The Book Shop")
-                                                                .startArray("addresses")
-                                                                    .startObject()
-                                                                        .field("name", "address #1")
-                                                                        .field("street", "Hampton St")
-                                                                        .field("city", "London")
-                                                                    .endObject()
-                                                                    .startObject()
-                                                                        .field("name", "address #2")
-                                                                        .field("street", "Queen St")
-                                                                        .field("city", "Stornoway")
-                                                                    .endObject()
-                                                                .endArray()
-                                                            .endObject()
-                                                            .startObject()
-                                                                .field("name", "Sussex Books House")
-                                                            .endObject()
-                                                        .endArray()
-                                                    .endObject()
-                                                    .startObject("fr")
-                                                        .field("lang", "French")
-                                                        .field("available", false)
-                                                        .startArray("distributors")
-                                                            .startObject()
-                                                                .field("name", "La Maison du Livre")
-                                                                .startArray("addresses")
-                                                                    .startObject()
-                                                                        .field("name", "address #1")
-                                                                        .field("street", "Rue Mouffetard")
-                                                                        .field("city", "Paris")
-                                                                    .endObject()
-                                                                .endArray()
-                                                            .endObject()
-                                                            .startObject()
-                                                                .field("name", "Thetra")
-                                                            .endObject()
-                                                        .endArray()
-                                                    .endObject()
-                                                .endObject()
-                                            .endObject()
-                                       .endObject();
-
-    public void testSimpleArrayOfObjectsExclusive() throws Exception {
-        testFilter(SIMPLE_ARRAY_OF_OBJECTS_EXCLUSIVE, SAMPLE, emptySet(), singleton("authors"));
-        testFilter(SIMPLE_ARRAY_OF_OBJECTS_EXCLUSIVE, SAMPLE, emptySet(), singleton("authors.*"));
-        testFilter(SIMPLE_ARRAY_OF_OBJECTS_EXCLUSIVE, SAMPLE, emptySet(), singleton("authors.*name"));
+    public final void testSimpleArrayOfObjectsExclusive() throws Exception {
+        Builder expected = builderFor("sample_no_authors.json");
+        testFilter(expected, SAMPLE, emptySet(), singleton("authors"));
+        if (removesEmptyArrays()) {
+            testFilter(expected, SAMPLE, emptySet(), singleton("authors.*"));
+            testFilter(expected, SAMPLE, emptySet(), singleton("authors.*name"));
+        }
     }
 
-    public void testSimpleArrayOfObjectsPropertyInclusive() throws Exception {
-        final Builder expected = builder -> builder.startObject()
-                                                            .startArray("authors")
-                                                                .startObject()
-                                                                    .field("lastname", "John")
-                                                                .endObject()
-                                                                .startObject()
-                                                                    .field("lastname", "William")
-                                                                .endObject()
-                                                            .endArray()
-                                                        .endObject();
+    protected abstract boolean removesEmptyArrays();
 
+    public void testSimpleArrayOfObjectsPropertyInclusive() throws Exception {
+        Builder expected = builderFor("sample_just_authors_lastname.json");
         testFilter(expected, SAMPLE, singleton("authors.lastname"), emptySet());
         testFilter(expected, SAMPLE, singleton("authors.l*"), emptySet());
     }
 
     public void testSimpleArrayOfObjectsPropertyExclusive() throws Exception {
-        final Builder expected = builder -> builder.startObject()
-                                                            .field("title", "My awesome book")
-                                                            .field("pages", 456)
-                                                            .field("price", 27.99)
-                                                            .field("timestamp", 1428582942867L)
-                                                            .nullField("default")
-                                                            .startArray("tags")
-                                                                .value("elasticsearch")
-                                                                .value("java")
-                                                            .endArray()
-                                                            .startArray("authors")
-                                                                .startObject()
-                                                                    .field("name", "John Doe")
-                                                                    .field("firstname", "Doe")
-                                                                .endObject()
-                                                                .startObject()
-                                                                    .field("name", "William Smith")
-                                                                    .field("firstname", "Smith")
-                                                                .endObject()
-                                                            .endArray()
-                                                            .startObject("properties")
-                                                                .field("weight", 0.8d)
-                                                                .startObject("language")
-                                                                    .startObject("en")
-                                                                        .field("lang", "English")
-                                                                        .field("available", true)
-                                                                        .startArray("distributors")
-                                                                            .startObject()
-                                                                                .field("name", "The Book Shop")
-                                                                                .startArray("addresses")
-                                                                                    .startObject()
-                                                                                        .field("name", "address #1")
-                                                                                        .field("street", "Hampton St")
-                                                                                        .field("city", "London")
-                                                                                    .endObject()
-                                                                                    .startObject()
-                                                                                        .field("name", "address #2")
-                                                                                        .field("street", "Queen St")
-                                                                                        .field("city", "Stornoway")
-                                                                                    .endObject()
-                                                                                .endArray()
-                                                                            .endObject()
-                                                                            .startObject()
-                                                                                .field("name", "Sussex Books House")
-                                                                            .endObject()
-                                                                        .endArray()
-                                                                    .endObject()
-                                                                    .startObject("fr")
-                                                                        .field("lang", "French")
-                                                                        .field("available", false)
-                                                                        .startArray("distributors")
-                                                                            .startObject()
-                                                                                .field("name", "La Maison du Livre")
-                                                                                .startArray("addresses")
-                                                                                    .startObject()
-                                                                                        .field("name", "address #1")
-                                                                                        .field("street", "Rue Mouffetard")
-                                                                                        .field("city", "Paris")
-                                                                                    .endObject()
-                                                                                .endArray()
-                                                                            .endObject()
-                                                                            .startObject()
-                                                                                .field("name", "Thetra")
-                                                                            .endObject()
-                                                                        .endArray()
-                                                                    .endObject()
-                                                                .endObject()
-                                                            .endObject()
-                                                       .endObject();
-
+        Builder expected = builderFor("sample_no_authors_lastname.json");
         testFilter(expected, SAMPLE, emptySet(), singleton("authors.lastname"));
         testFilter(expected, SAMPLE, emptySet(), singleton("authors.l*"));
     }
 
     public void testRecurseField1Inclusive() throws Exception {
-        final Builder expected = builder -> builder.startObject()
-                                                            .startArray("authors")
-                                                                .startObject()
-                                                                    .field("name", "John Doe")
-                                                                .endObject()
-                                                                .startObject()
-                                                                    .field("name", "William Smith")
-                                                            .   endObject()
-                                                            .endArray()
-                                                            .startObject("properties")
-                                                                .startObject("language")
-                                                                    .startObject("en")
-                                                                        .startArray("distributors")
-                                                                            .startObject()
-                                                                                .field("name", "The Book Shop")
-                                                                                .startArray("addresses")
-                                                                                    .startObject()
-                                                                                        .field("name", "address #1")
-                                                                                    .endObject()
-                                                                                    .startObject()
-                                                                                        .field("name", "address #2")
-                                                                                    .endObject()
-                                                                                .endArray()
-                                                                            .endObject()
-                                                                            .startObject()
-                                                                                .field("name", "Sussex Books House")
-                                                                            .endObject()
-                                                                        .endArray()
-                                                                    .endObject()
-                                                                    .startObject("fr")
-                                                                        .startArray("distributors")
-                                                                            .startObject()
-                                                                                .field("name", "La Maison du Livre")
-                                                                                .startArray("addresses")
-                                                                                    .startObject()
-                                                                                        .field("name", "address #1")
-                                                                                    .endObject()
-                                                                                .endArray()
-                                                                            .endObject()
-                                                                            .startObject()
-                                                                                .field("name", "Thetra")
-                                                                            .endObject()
-                                                                        .endArray()
-                                                                    .endObject()
-                                                                .endObject()
-                                                            .endObject()
-                                                        .endObject();
-
+        Builder expected = builderFor("sample_just_names.json");
         testFilter(expected, SAMPLE, singleton("**.name"), emptySet());
     }
 
     public void testRecurseField1Exclusive() throws Exception {
-        final Builder expected = builder -> builder.startObject()
-                                                            .field("title", "My awesome book")
-                                                            .field("pages", 456)
-                                                            .field("price", 27.99)
-                                                            .field("timestamp", 1428582942867L)
-                                                            .nullField("default")
-                                                            .startArray("tags")
-                                                                .value("elasticsearch")
-                                                                .value("java")
-                                                            .endArray()
-                                                            .startArray("authors")
-                                                                .startObject()
-                                                                    .field("lastname", "John")
-                                                                    .field("firstname", "Doe")
-                                                                .endObject()
-                                                                .startObject()
-                                                                    .field("lastname", "William")
-                                                                    .field("firstname", "Smith")
-                                                                .endObject()
-                                                            .endArray()
-                                                            .startObject("properties")
-                                                                .field("weight", 0.8d)
-                                                                .startObject("language")
-                                                                    .startObject("en")
-                                                                        .field("lang", "English")
-                                                                        .field("available", true)
-                                                                        .startArray("distributors")
-                                                                            .startObject()
-                                                                                .startArray("addresses")
-                                                                                    .startObject()
-                                                                                        .field("street", "Hampton St")
-                                                                                        .field("city", "London")
-                                                                                    .endObject()
-                                                                                    .startObject()
-                                                                                        .field("street", "Queen St")
-                                                                                        .field("city", "Stornoway")
-                                                                                    .endObject()
-                                                                                .endArray()
-                                                                            .endObject()
-                                                                        .endArray()
-                                                                    .endObject()
-                                                                    .startObject("fr")
-                                                                        .field("lang", "French")
-                                                                        .field("available", false)
-                                                                        .startArray("distributors")
-                                                                            .startObject()
-                                                                                .startArray("addresses")
-                                                                                    .startObject()
-                                                                                        .field("street", "Rue Mouffetard")
-                                                                                        .field("city", "Paris")
-                                                                                    .endObject()
-                                                                                .endArray()
-                                                                            .endObject()
-                                                                        .endArray()
-                                                                    .endObject()
-                                                                .endObject()
-                                                            .endObject()
-                                                       .endObject();
-
+        Builder expected = builderFor("sample_no_names.json");
         testFilter(expected, SAMPLE, emptySet(), singleton("**.name"));
     }
 
     public void testRecurseField2Inclusive() throws Exception {
-        final Builder expected = builder -> builder.startObject()
-                                                            .startObject("properties")
-                                                                .startObject("language")
-                                                                    .startObject("en")
-                                                                        .startArray("distributors")
-                                                                            .startObject()
-                                                                                .field("name", "The Book Shop")
-                                                                                .startArray("addresses")
-                                                                                    .startObject()
-                                                                                        .field("name", "address #1")
-                                                                                    .endObject()
-                                                                                    .startObject()
-                                                                                        .field("name", "address #2")
-                                                                                    .endObject()
-                                                                                .endArray()
-                                                                            .endObject()
-                                                                            .startObject()
-                                                                                .field("name", "Sussex Books House")
-                                                                            .endObject()
-                                                                        .endArray()
-                                                                    .endObject()
-                                                                    .startObject("fr")
-                                                                        .startArray("distributors")
-                                                                            .startObject()
-                                                                                .field("name", "La Maison du Livre")
-                                                                                .startArray("addresses")
-                                                                                    .startObject()
-                                                                                        .field("name", "address #1")
-                                                                                    .endObject()
-                                                                                .endArray()
-                                                                            .endObject()
-                                                                            .startObject()
-                                                                                .field("name", "Thetra")
-                                                                            .endObject()
-                                                                        .endArray()
-                                                                    .endObject()
-                                                                .endObject()
-                                                            .endObject()
-                                                        .endObject();
-
+        Builder expected = builderFor("sample_just_properties_names.json");
         testFilter(expected, SAMPLE, singleton("properties.**.name"), emptySet());
     }
 
     public void testRecurseField2Exclusive() throws Exception {
-        final Builder expected = builder -> builder.startObject()
-                                                            .field("title", "My awesome book")
-                                                            .field("pages", 456)
-                                                            .field("price", 27.99)
-                                                            .field("timestamp", 1428582942867L)
-                                                            .nullField("default")
-                                                            .startArray("tags")
-                                                                .value("elasticsearch")
-                                                                .value("java")
-                                                            .endArray()
-                                                            .startArray("authors")
-                                                                .startObject()
-                                                                    .field("name", "John Doe")
-                                                                    .field("lastname", "John")
-                                                                    .field("firstname", "Doe")
-                                                                .endObject()
-                                                                .startObject()
-                                                                    .field("name", "William Smith")
-                                                                    .field("lastname", "William")
-                                                                    .field("firstname", "Smith")
-                                                                .endObject()
-                                                            .endArray()
-                                                            .startObject("properties")
-                                                                .field("weight", 0.8d)
-                                                                .startObject("language")
-                                                                    .startObject("en")
-                                                                        .field("lang", "English")
-                                                                        .field("available", true)
-                                                                        .startArray("distributors")
-                                                                            .startObject()
-                                                                                .startArray("addresses")
-                                                                                    .startObject()
-                                                                                        .field("street", "Hampton St")
-                                                                                        .field("city", "London")
-                                                                                    .endObject()
-                                                                                    .startObject()
-                                                                                        .field("street", "Queen St")
-                                                                                        .field("city", "Stornoway")
-                                                                                    .endObject()
-                                                                                .endArray()
-                                                                            .endObject()
-                                                                        .endArray()
-                                                                    .endObject()
-                                                                    .startObject("fr")
-                                                                        .field("lang", "French")
-                                                                        .field("available", false)
-                                                                        .startArray("distributors")
-                                                                            .startObject()
-                                                                                .startArray("addresses")
-                                                                                    .startObject()
-                                                                                        .field("street", "Rue Mouffetard")
-                                                                                        .field("city", "Paris")
-                                                                                    .endObject()
-                                                                                .endArray()
-                                                                            .endObject()
-                                                                        .endArray()
-                                                                    .endObject()
-                                                                .endObject()
-                                                            .endObject()
-                                                       .endObject();
-
+        Builder expected = builderFor("sample_no_properties_names.json");
         testFilter(expected, SAMPLE, emptySet(), singleton("properties.**.name"));
     }
 
     public void testRecurseField3Inclusive() throws Exception {
-        final Builder expected = builder -> builder.startObject()
-                                                            .startObject("properties")
-                                                                .startObject("language")
-                                                                    .startObject("en")
-                                                                        .startArray("distributors")
-                                                                            .startObject()
-                                                                                .field("name", "The Book Shop")
-                                                                                .startArray("addresses")
-                                                                                    .startObject()
-                                                                                        .field("name", "address #1")
-                                                                                    .endObject()
-                                                                                    .startObject()
-                                                                                        .field("name", "address #2")
-                                                                                    .endObject()
-                                                                                .endArray()
-                                                                            .endObject()
-                                                                            .startObject()
-                                                                                .field("name", "Sussex Books House")
-                                                                            .endObject()
-                                                                        .endArray()
-                                                                    .endObject()
-                                                                .endObject()
-                                                            .endObject()
-                                                        .endObject();
-
+        Builder expected = builderFor("sample_just_properties_en_names.json");
         testFilter(expected, SAMPLE, singleton("properties.*.en.**.name"), emptySet());
     }
 
     public void testRecurseField3Exclusive() throws Exception {
-        final Builder expected = builder -> builder.startObject()
-                                                            .field("title", "My awesome book")
-                                                            .field("pages", 456)
-                                                            .field("price", 27.99)
-                                                            .field("timestamp", 1428582942867L)
-                                                            .nullField("default")
-                                                            .startArray("tags")
-                                                                .value("elasticsearch")
-                                                                .value("java")
-                                                            .endArray()
-                                                            .startArray("authors")
-                                                                .startObject()
-                                                                    .field("name", "John Doe")
-                                                                    .field("lastname", "John")
-                                                                    .field("firstname", "Doe")
-                                                                .endObject()
-                                                                .startObject()
-                                                                    .field("name", "William Smith")
-                                                                    .field("lastname", "William")
-                                                                    .field("firstname", "Smith")
-                                                                .endObject()
-                                                            .endArray()
-                                                            .startObject("properties")
-                                                                .field("weight", 0.8d)
-                                                                .startObject("language")
-                                                                    .startObject("en")
-                                                                        .field("lang", "English")
-                                                                        .field("available", true)
-                                                                        .startArray("distributors")
-                                                                            .startObject()
-                                                                                .startArray("addresses")
-                                                                                    .startObject()
-                                                                                        .field("street", "Hampton St")
-                                                                                        .field("city", "London")
-                                                                                    .endObject()
-                                                                                    .startObject()
-                                                                                        .field("street", "Queen St")
-                                                                                        .field("city", "Stornoway")
-                                                                                    .endObject()
-                                                                                .endArray()
-                                                                            .endObject()
-                                                                        .endArray()
-                                                                    .endObject()
-                                                                    .startObject("fr")
-                                                                        .field("lang", "French")
-                                                                        .field("available", false)
-                                                                        .startArray("distributors")
-                                                                            .startObject()
-                                                                                .field("name", "La Maison du Livre")
-                                                                                .startArray("addresses")
-                                                                                    .startObject()
-                                                                                        .field("name", "address #1")
-                                                                                        .field("street", "Rue Mouffetard")
-                                                                                        .field("city", "Paris")
-                                                                                    .endObject()
-                                                                                .endArray()
-                                                                            .endObject()
-                                                                            .startObject()
-                                                                                .field("name", "Thetra")
-                                                                            .endObject()
-                                                                        .endArray()
-                                                                    .endObject()
-                                                                .endObject()
-                                                            .endObject()
-                                                       .endObject();
-
+        Builder expected = builderFor("sample_no_properties_en_names.json");
         testFilter(expected, SAMPLE, emptySet(), singleton("properties.*.en.**.name"));
     }
 
     public void testRecurseField4Inclusive() throws Exception {
-        final Builder expected = builder -> builder.startObject()
-                                                            .startObject("properties")
-                                                                .startObject("language")
-                                                                    .startObject("en")
-                                                                        .startArray("distributors")
-                                                                            .startObject()
-                                                                                .field("name", "The Book Shop")
-                                                                            .endObject()
-                                                                            .startObject()
-                                                                                .field("name", "Sussex Books House")
-                                                                            .endObject()
-                                                                        .endArray()
-                                                                    .endObject()
-                                                                    .startObject("fr")
-                                                                        .startArray("distributors")
-                                                                            .startObject()
-                                                                                .field("name", "La Maison du Livre")
-                                                                            .endObject()
-                                                                            .startObject()
-                                                                                .field("name", "Thetra")
-                                                                            .endObject()
-                                                                        .endArray()
-                                                                    .endObject()
-                                                                .endObject()
-                                                            .endObject()
-                                                        .endObject();
-
+        Builder expected = builderFor("sample_just_properties_distributors_names.json");
         testFilter(expected, SAMPLE, singleton("properties.**.distributors.name"), emptySet());
     }
 
     public void testRecurseField4Exclusive() throws Exception {
-        final Builder expected = builder -> builder.startObject()
-                                                            .field("title", "My awesome book")
-                                                            .field("pages", 456)
-                                                            .field("price", 27.99)
-                                                            .field("timestamp", 1428582942867L)
-                                                            .nullField("default")
-                                                            .startArray("tags")
-                                                                .value("elasticsearch")
-                                                                .value("java")
-                                                            .endArray()
-                                                            .startArray("authors")
-                                                                .startObject()
-                                                                    .field("name", "John Doe")
-                                                                    .field("lastname", "John")
-                                                                    .field("firstname", "Doe")
-                                                                .endObject()
-                                                                .startObject()
-                                                                    .field("name", "William Smith")
-                                                                    .field("lastname", "William")
-                                                                    .field("firstname", "Smith")
-                                                                .endObject()
-                                                            .endArray()
-                                                            .startObject("properties")
-                                                                .field("weight", 0.8d)
-                                                                .startObject("language")
-                                                                    .startObject("en")
-                                                                        .field("lang", "English")
-                                                                        .field("available", true)
-                                                                        .startArray("distributors")
-                                                                            .startObject()
-                                                                                .startArray("addresses")
-                                                                                    .startObject()
-                                                                                        .field("name", "address #1")
-                                                                                        .field("street", "Hampton St")
-                                                                                        .field("city", "London")
-                                                                                    .endObject()
-                                                                                    .startObject()
-                                                                                        .field("name", "address #2")
-                                                                                        .field("street", "Queen St")
-                                                                                        .field("city", "Stornoway")
-                                                                                    .endObject()
-                                                                                .endArray()
-                                                                            .endObject()
-                                                                        .endArray()
-                                                                    .endObject()
-                                                                    .startObject("fr")
-                                                                        .field("lang", "French")
-                                                                        .field("available", false)
-                                                                        .startArray("distributors")
-                                                                            .startObject()
-                                                                                .startArray("addresses")
-                                                                                    .startObject()
-                                                                                        .field("name", "address #1")
-                                                                                        .field("street", "Rue Mouffetard")
-                                                                                        .field("city", "Paris")
-                                                                                    .endObject()
-                                                                                .endArray()
-                                                                            .endObject()
-                                                                        .endArray()
-                                                                    .endObject()
-                                                                .endObject()
-                                                            .endObject()
-                                                       .endObject();
-
+        Builder expected = builderFor("sample_no_properties_distributors_names.json");
         testFilter(expected, SAMPLE, emptySet(), singleton("properties.**.distributors.name"));
     }
 
     public void testRawField() throws Exception {
-        final Builder expectedRawField = builder -> builder
-                .startObject()
-                    .field("foo", 0)
-                    .startObject("raw")
-                        .field("content", "hello world!")
-                    .endObject()
-                .endObject();
-
-        final Builder expectedRawFieldFiltered = builder -> builder
-                .startObject()
-                    .field("foo", 0)
-                .endObject();
-
-        final Builder expectedRawFieldNotFiltered = builder -> builder
-                .startObject()
-                    .startObject("raw")
-                        .field("content", "hello world!")
-                    .endObject()
-                .endObject();
-
-        Builder sampleWithRaw = builder -> {
-            BytesReference raw = BytesReference
-                    .bytes(XContentBuilder.builder(builder.contentType().xContent())
-                            .startObject()
-                                .field("content", "hello world!")
-                            .endObject());
-            return builder.startObject().field("foo", 0).rawField("raw", raw.streamInput()).endObject();
+        Builder expectedRawField = builder -> {
+            builder.startObject();
+            builder.field("foo", 0);
+            builder.startObject("raw").field("content", "hello world!").endObject();
+            return builder.endObject();
         };
 
-        // Test method: rawField(String fieldName, BytesReference content)
+        Builder expectedRawFieldRemoved = builder -> {
+            builder.startObject();
+            builder.field("foo", 0);
+            return builder.endObject();
+        };
+
+        Builder expectedRawFieldIncluded = builder -> {
+            builder.startObject();
+            builder.startObject("raw").field("content", "hello world!").endObject();
+            return builder.endObject();
+        };
+
+        @SuppressWarnings("deprecation")  // Tests filtering with a deprecated method
+        Builder sampleWithRaw = builder -> {
+            BytesReference raw = BytesReference.bytes(
+                XContentBuilder.builder(builder.contentType().xContent()).startObject().field("content", "hello world!").endObject()
+            );
+            return builder.startObject().field("foo", 0).rawField("raw", raw.streamInput()).endObject();
+        };
         testFilter(expectedRawField, sampleWithRaw, emptySet(), emptySet());
-        testFilter(expectedRawFieldFiltered, sampleWithRaw, singleton("f*"), emptySet());
-        testFilter(expectedRawFieldFiltered, sampleWithRaw, emptySet(), singleton("r*"));
-        testFilter(expectedRawFieldNotFiltered, sampleWithRaw, singleton("r*"), emptySet());
-        testFilter(expectedRawFieldNotFiltered, sampleWithRaw, emptySet(), singleton("f*"));
+        testFilter(expectedRawFieldRemoved, sampleWithRaw, singleton("f*"), emptySet());
+        testFilter(expectedRawFieldRemoved, sampleWithRaw, emptySet(), singleton("r*"));
+        testFilter(expectedRawFieldIncluded, sampleWithRaw, singleton("r*"), emptySet());
+        testFilter(expectedRawFieldIncluded, sampleWithRaw, emptySet(), singleton("f*"));
 
         sampleWithRaw = builder -> {
-            BytesReference raw = BytesReference
-                    .bytes(XContentBuilder.builder(builder.contentType().xContent())
-                            .startObject()
-                            .   field("content", "hello world!")
-                            .endObject());
-            return builder.startObject().field("foo", 0).rawField("raw", raw.streamInput()).endObject();
+            BytesReference raw = BytesReference.bytes(
+                XContentBuilder.builder(builder.contentType().xContent()).startObject().field("content", "hello world!").endObject()
+            );
+            return builder.startObject().field("foo", 0).rawField("raw", raw.streamInput(), builder.contentType()).endObject();
         };
-
-        // Test method: rawField(String fieldName, InputStream content)
         testFilter(expectedRawField, sampleWithRaw, emptySet(), emptySet());
-        testFilter(expectedRawFieldFiltered, sampleWithRaw, singleton("f*"), emptySet());
-        testFilter(expectedRawFieldFiltered, sampleWithRaw, emptySet(), singleton("r*"));
-        testFilter(expectedRawFieldNotFiltered, sampleWithRaw, singleton("r*"), emptySet());
-        testFilter(expectedRawFieldNotFiltered, sampleWithRaw, emptySet(), singleton("f*"));
+        testFilter(expectedRawFieldRemoved, sampleWithRaw, singleton("f*"), emptySet());
+        testFilter(expectedRawFieldRemoved, sampleWithRaw, emptySet(), singleton("r*"));
+        testFilter(expectedRawFieldIncluded, sampleWithRaw, singleton("r*"), emptySet());
+        testFilter(expectedRawFieldIncluded, sampleWithRaw, emptySet(), singleton("f*"));
     }
 
     public void testArrays() throws Exception {
         // Test: Array of values (no filtering)
-        final Builder sampleArrayOfValues = builder -> builder
-                .startObject()
-                    .startArray("tags")
-                        .value("lorem").value("ipsum").value("dolor")
-                    .endArray()
-                .endObject();
+        Builder sampleArrayOfValues = builder -> {
+            builder.startObject();
+            builder.startArray("tags").value("lorem").value("ipsum").value("dolor").endArray();
+            return builder.endObject();
+        };
         testFilter(sampleArrayOfValues, sampleArrayOfValues, singleton("t*"), emptySet());
         testFilter(sampleArrayOfValues, sampleArrayOfValues, singleton("tags"), emptySet());
         testFilter(sampleArrayOfValues, sampleArrayOfValues, emptySet(), singleton("a"));
@@ -1130,17 +248,16 @@ public abstract class AbstractFilteringTestCase extends ESTestCase {
         testFilter(expected, sampleArrayOfValues, emptySet(), singleton("tags"));
 
         // Test: Array of objects (no filtering)
-        final Builder sampleArrayOfObjects = builder -> builder
-                .startObject()
-                    .startArray("tags")
-                        .startObject()
-                            .field("lastname", "lorem")
-                        .endObject()
-                        .startObject()
-                            .field("firstname", "ipsum")
-                        .endObject()
-                    .endArray()
-                .endObject();
+        Builder sampleArrayOfObjects = builder -> {
+            builder.startObject();
+            builder.startArray("tags");
+            {
+                builder.startObject().field("lastname", "lorem").endObject();
+                builder.startObject().field("firstname", "ipsum").endObject();
+            }
+            builder.endArray();
+            return builder.endObject();
+        };
         testFilter(sampleArrayOfObjects, sampleArrayOfObjects, singleton("t*"), emptySet());
         testFilter(sampleArrayOfObjects, sampleArrayOfObjects, singleton("tags"), emptySet());
         testFilter(sampleArrayOfObjects, sampleArrayOfObjects, emptySet(), singleton("a"));
@@ -1151,14 +268,15 @@ public abstract class AbstractFilteringTestCase extends ESTestCase {
         testFilter(expected, sampleArrayOfObjects, emptySet(), singleton("tags"));
 
         // Test: Array of objects (with partial filtering)
-        expected = builder -> builder
-                .startObject()
-                    .startArray("tags")
-                        .startObject()
-                            .field("firstname", "ipsum")
-                        .endObject()
-                    .endArray()
-                .endObject();
+        expected = builder -> {
+            builder.startObject();
+            builder.startArray("tags");
+            {
+                builder.startObject().field("firstname", "ipsum").endObject();
+            }
+            builder.endArray();
+            return builder.endObject();
+        };
         testFilter(expected, sampleArrayOfObjects, singleton("t*.firstname"), emptySet());
         testFilter(expected, sampleArrayOfObjects, emptySet(), singleton("t*.lastname"));
     }
@@ -1178,62 +296,20 @@ public abstract class AbstractFilteringTestCase extends ESTestCase {
     }
 
     public void testSingleFieldWithBothExcludesIncludes() throws IOException {
-        final Builder expected = builder -> builder
-            .startObject()
-                .field("pages", 456)
-                .field("price", 27.99)
-            .endObject();
-
+        Builder expected = builder -> builder.startObject().field("pages", 456).field("price", 27.99).endObject();
         testFilter(expected, SAMPLE, singleton("p*"), singleton("properties"));
     }
 
     public void testObjectsInArrayWithBothExcludesIncludes() throws IOException {
         Set<String> includes = Sets.newHashSet("tags", "authors");
         Set<String> excludes = singleton("authors.name");
-
-        final Builder expected = builder -> builder
-            .startObject()
-                .startArray("tags")
-                    .value("elasticsearch")
-                    .value("java")
-                .endArray()
-                .startArray("authors")
-                    .startObject()
-                        .field("lastname", "John")
-                        .field("firstname", "Doe")
-                    .endObject()
-                    .startObject()
-                        .field("lastname", "William")
-                        .field("firstname", "Smith")
-                    .endObject()
-                .endArray()
-            .endObject();
-
-        testFilter(expected, SAMPLE, includes, excludes);
+        testFilter(builderFor("sample_just_tags_authors_no_name.json"), SAMPLE, includes, excludes);
     }
 
     public void testRecursiveObjectsInArrayWithBothExcludesIncludes() throws IOException {
         Set<String> includes = Sets.newHashSet("**.language", "properties.weight");
         Set<String> excludes = singleton("**.distributors");
-
-        final Builder expected = builder -> builder
-            .startObject()
-                .startObject("properties")
-                    .field("weight", 0.8d)
-                    .startObject("language")
-                        .startObject("en")
-                            .field("lang", "English")
-                            .field("available", true)
-                        .endObject()
-                        .startObject("fr")
-                            .field("lang", "French")
-                            .field("available", false)
-                        .endObject()
-                    .endObject()
-                .endObject()
-            .endObject();
-
-        testFilter(expected, SAMPLE, includes, excludes);
+        testFilter(builderFor("sample_just_properties_no_distributors.json"), SAMPLE, includes, excludes);
     }
 
     public void testRecursiveSameObjectWithBothExcludesIncludes() throws IOException {
@@ -1247,47 +323,15 @@ public abstract class AbstractFilteringTestCase extends ESTestCase {
     public void testRecursiveObjectsPropertiesWithBothExcludesIncludes() throws IOException {
         Set<String> includes = singleton("**.en.*");
         Set<String> excludes = Sets.newHashSet("**.distributors.*.name", "**.street");
-
-        final Builder expected = builder -> builder
-            .startObject()
-                .startObject("properties")
-                    .startObject("language")
-                        .startObject("en")
-                            .field("lang", "English")
-                            .field("available", true)
-                            .startArray("distributors")
-                                .startObject()
-                                    .field("name", "The Book Shop")
-                                    .startArray("addresses")
-                                        .startObject()
-                                            .field("city", "London")
-                                        .endObject()
-                                        .startObject()
-                                            .field("city", "Stornoway")
-                                        .endObject()
-                                    .endArray()
-                                .endObject()
-                                .startObject()
-                                    .field("name", "Sussex Books House")
-                                .endObject()
-                            .endArray()
-                        .endObject()
-                    .endObject()
-                .endObject()
-            .endObject();
-
-        testFilter(expected, SAMPLE, includes, excludes);
+        testFilter(builderFor("sample_just_properties_en_no_distributors_name_no_street.json"), SAMPLE, includes, excludes);
     }
 
     public void testWithLfAtEnd() throws IOException {
-        final Builder sample = builder -> builder
-                .startObject()
-                    .startObject("foo")
-                        .field("bar", "baz")
-                    .endObject()
-                .endObject()
-                .prettyPrint()
-                .lfAtEnd();
+        final Builder sample = builder -> {
+            builder.startObject();
+            builder.startObject("foo").field("bar", "baz").endObject();
+            return builder.endObject().prettyPrint().lfAtEnd();
+        };
 
         testFilter(sample, sample, singleton("foo"), emptySet());
         testFilter(sample, sample, emptySet(), singleton("bar"));
@@ -1300,62 +344,55 @@ public abstract class AbstractFilteringTestCase extends ESTestCase {
     }
 
     public void testBasics() throws Exception {
-        final Builder sample = builder -> builder
-                .startObject()
-                    .field("test1", "value1")
-                    .field("test2", "value2")
-                    .field("something_else", "value3")
-                .endObject();
+        Builder sample = builder -> {
+            return builder.startObject().field("test1", "value1").field("test2", "value2").field("something_else", "value3").endObject();
+        };
 
-        Builder expected = builder -> builder
-                .startObject()
-                    .field("test1", "value1")
-                .endObject();
+        Builder expected = builder -> builder.startObject().field("test1", "value1").endObject();
         testFilter(expected, sample, singleton("test1"), emptySet());
 
-        expected = builder -> builder
-                .startObject()
-                    .field("test1", "value1")
-                    .field("test2", "value2")
-                .endObject();
+        expected = builder -> builder.startObject().field("test1", "value1").field("test2", "value2").endObject();
         testFilter(expected, sample, singleton("test*"), emptySet());
 
-        expected = builder -> builder
-                .startObject()
-                    .field("test2", "value2")
-                    .field("something_else", "value3")
-                .endObject();
+        expected = builder -> builder.startObject().field("test2", "value2").field("something_else", "value3").endObject();
         testFilter(expected, sample, emptySet(), singleton("test1"));
 
         // more complex object...
-        final Builder complex = builder -> builder
-                .startObject()
-                    .startObject("path1")
-                        .startArray("path2")
-                            .startObject().field("test", "value1").endObject()
-                            .startObject().field("test", "value2").endObject()
-                        .endArray()
-                    .endObject()
-                    .field("test1", "value1")
-                .endObject();
+        Builder complex = builder -> {
+            builder.startObject();
+            builder.startObject("path1");
+            {
+                builder.startArray("path2");
+                {
+                    builder.startObject().field("test", "value1").endObject();
+                    builder.startObject().field("test", "value2").endObject();
+                }
+                builder.endArray();
+            }
+            builder.endObject();
+            builder.field("test1", "value1");
+            return builder.endObject();
+        };
 
-        expected = builder -> builder
-                .startObject()
-                    .startObject("path1")
-                        .startArray("path2")
-                            .startObject().field("test", "value1").endObject()
-                            .startObject().field("test", "value2").endObject()
-                        .endArray()
-                    .endObject()
-                .endObject();
+        expected = builder -> {
+            builder.startObject();
+            builder.startObject("path1");
+            {
+                builder.startArray("path2");
+                {
+                    builder.startObject().field("test", "value1").endObject();
+                    builder.startObject().field("test", "value2").endObject();
+                }
+                builder.endArray();
+            }
+            builder.endObject();
+            return builder.endObject();
+        };
         testFilter(expected, complex, singleton("path1"), emptySet());
         testFilter(expected, complex, singleton("path1*"), emptySet());
         testFilter(expected, complex, singleton("path1.path2.*"), emptySet());
 
-        expected = builder -> builder
-                .startObject()
-                    .field("test1", "value1")
-                .endObject();
+        expected = builder -> builder.startObject().field("test1", "value1").endObject();
         testFilter(expected, complex, singleton("test1*"), emptySet());
     }
 
@@ -1363,22 +400,12 @@ public abstract class AbstractFilteringTestCase extends ESTestCase {
      * Generalization of {@link XContentMapValuesTests#testSupplementaryCharactersInPaths()}
      */
     public void testFilterSupplementaryCharactersInPaths() throws IOException {
-        final Builder sample = builder -> builder
-                .startObject()
-                    .field("搜索", 2)
-                    .field("指数", 3)
-                .endObject();
+        Builder sample = builder -> builder.startObject().field("搜索", 2).field("指数", 3).endObject();
 
-        Builder expected = builder -> builder
-                .startObject()
-                    .field("搜索", 2)
-                .endObject();
+        Builder expected = builder -> builder.startObject().field("搜索", 2).endObject();
         testFilter(expected, sample, singleton("搜索"), emptySet());
 
-        expected = builder -> builder
-                .startObject()
-                    .field("指数", 3)
-                .endObject();
+        expected = builder -> builder.startObject().field("指数", 3).endObject();
         testFilter(expected, sample, emptySet(), singleton("搜索"));
     }
 
@@ -1386,22 +413,12 @@ public abstract class AbstractFilteringTestCase extends ESTestCase {
      * Generalization of {@link XContentMapValuesTests#testSharedPrefixes()}
      */
     public void testFilterSharedPrefixes() throws IOException {
-        final Builder sample = builder -> builder
-                .startObject()
-                    .field("foobar", 2)
-                    .field("foobaz", 3)
-                .endObject();
+        Builder sample = builder -> builder.startObject().field("foobar", 2).field("foobaz", 3).endObject();
 
-        Builder expected = builder -> builder
-                .startObject()
-                    .field("foobar", 2)
-                .endObject();
+        Builder expected = builder -> builder.startObject().field("foobar", 2).endObject();
         testFilter(expected, sample, singleton("foobar"), emptySet());
 
-        expected = builder -> builder
-                .startObject()
-                    .field("foobaz", 3)
-                .endObject();
+        expected = builder -> builder.startObject().field("foobaz", 3).endObject();
         testFilter(expected, sample, emptySet(), singleton("foobar"));
     }
 
@@ -1409,16 +426,8 @@ public abstract class AbstractFilteringTestCase extends ESTestCase {
      * Generalization of {@link XContentMapValuesTests#testPrefix()}
      */
     public void testFilterPrefix() throws IOException {
-        final Builder sample = builder -> builder
-                .startObject()
-                    .array("photos", "foo", "bar")
-                    .field("photosCount", 2)
-                .endObject();
-
-        Builder expected = builder -> builder
-                .startObject()
-                    .field("photosCount", 2)
-                .endObject();
+        Builder sample = builder -> builder.startObject().array("photos", "foo", "bar").field("photosCount", 2).endObject();
+        Builder expected = builder -> builder.startObject().field("photosCount", 2).endObject();
         testFilter(expected, sample, singleton("photosCount"), emptySet());
     }
 

--- a/server/src/test/java/org/elasticsearch/common/xcontent/support/XContentMapValuesTests.java
+++ b/server/src/test/java/org/elasticsearch/common/xcontent/support/XContentMapValuesTests.java
@@ -10,13 +10,13 @@ package org.elasticsearch.common.xcontent.support;
 
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.bytes.BytesReference;
-import org.elasticsearch.core.Tuple;
 import org.elasticsearch.common.xcontent.ToXContentObject;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.common.xcontent.json.JsonXContent;
+import org.elasticsearch.core.Tuple;
 import org.hamcrest.Matchers;
 
 import java.io.IOException;
@@ -28,8 +28,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import static java.util.Collections.emptySet;
-import static java.util.Collections.singleton;
+import static io.github.nik9000.mapmatcher.MapMatcher.assertMap;
+import static io.github.nik9000.mapmatcher.MapMatcher.matchesMap;
 import static org.elasticsearch.common.xcontent.XContentHelper.convertToMap;
 import static org.elasticsearch.common.xcontent.XContentHelper.toXContent;
 import static org.hamcrest.Matchers.contains;
@@ -61,16 +61,15 @@ public class XContentMapValuesTests extends AbstractFilteringTestCase {
             sourceExcludes = excludes.toArray(new String[excludes.size()]);
         }
 
-        assertEquals("Filtered map must be equal to the expected map",
-                toMap(expected, xContentType, humanReadable),
-                XContentMapValues.filter(toMap(actual, xContentType, humanReadable), sourceIncludes, sourceExcludes));
+        assertMap(
+            XContentMapValues.filter(toMap(actual, xContentType, humanReadable), sourceIncludes, sourceExcludes),
+            matchesMap(toMap(expected, xContentType, humanReadable))
+        );
     }
 
-    @SuppressWarnings({"unchecked"})
+    @SuppressWarnings({ "unchecked" })
     public void testExtractValue() throws Exception {
-        XContentBuilder builder = XContentFactory.jsonBuilder().startObject()
-                .field("test", "value")
-                .endObject();
+        XContentBuilder builder = XContentFactory.jsonBuilder().startObject().field("test", "value").endObject();
 
         Map<String, Object> map;
         try (XContentParser parser = createParser(JsonXContent.jsonXContent, Strings.toString(builder))) {
@@ -80,9 +79,9 @@ public class XContentMapValuesTests extends AbstractFilteringTestCase {
         assertThat(XContentMapValues.extractValue("test.me", map), nullValue());
         assertThat(XContentMapValues.extractValue("something.else.2", map), nullValue());
 
-        builder = XContentFactory.jsonBuilder().startObject()
-                .startObject("path1").startObject("path2").field("test", "value").endObject().endObject()
-                .endObject();
+        builder = XContentFactory.jsonBuilder().startObject();
+        builder.startObject("path1").startObject("path2").field("test", "value").endObject().endObject();
+        builder.endObject();
 
         try (XContentParser parser = createParser(JsonXContent.jsonXContent, Strings.toString(builder))) {
             map = parser.map();
@@ -102,9 +101,9 @@ public class XContentMapValuesTests extends AbstractFilteringTestCase {
         assertThat(extMapValue.containsKey("path2"), equalTo(true));
 
         // lists
-        builder = XContentFactory.jsonBuilder().startObject()
-                .startObject("path1").array("test", "value1", "value2").endObject()
-                .endObject();
+        builder = XContentFactory.jsonBuilder().startObject();
+        builder.startObject("path1").array("test", "value1", "value2").endObject();
+        builder.endObject();
 
         try (XContentParser parser = createParser(JsonXContent.jsonXContent, Strings.toString(builder))) {
             map = parser.map();
@@ -116,14 +115,18 @@ public class XContentMapValuesTests extends AbstractFilteringTestCase {
         List<?> extListValue = (List<?>) extValue;
         assertThat(extListValue, hasSize(2));
 
-        builder = XContentFactory.jsonBuilder().startObject()
-                .startObject("path1")
-                .startArray("path2")
-                .startObject().field("test", "value1").endObject()
-                .startObject().field("test", "value2").endObject()
-                .endArray()
-                .endObject()
-                .endObject();
+        builder = XContentFactory.jsonBuilder().startObject();
+        {
+            builder.startObject("path1");
+            {
+                builder.startArray("path2");
+                builder.startObject().field("test", "value1").endObject();
+                builder.startObject().field("test", "value2").endObject();
+                builder.endArray();
+            }
+            builder.endObject();
+        }
+        builder.endObject();
 
         try (XContentParser parser = createParser(JsonXContent.jsonXContent, Strings.toString(builder))) {
             map = parser.map();
@@ -138,17 +141,15 @@ public class XContentMapValuesTests extends AbstractFilteringTestCase {
         assertThat(extListValue.get(1).toString(), equalTo("value2"));
 
         // fields with . in them
-        builder = XContentFactory.jsonBuilder().startObject()
-                .field("xxx.yyy", "value")
-                .endObject();
+        builder = XContentFactory.jsonBuilder().startObject().field("xxx.yyy", "value").endObject();
         try (XContentParser parser = createParser(JsonXContent.jsonXContent, Strings.toString(builder))) {
             map = parser.map();
         }
         assertThat(XContentMapValues.extractValue("xxx.yyy", map).toString(), equalTo("value"));
 
-        builder = XContentFactory.jsonBuilder().startObject()
-                .startObject("path1.xxx").startObject("path2.yyy").field("test", "value").endObject().endObject()
-                .endObject();
+        builder = XContentFactory.jsonBuilder().startObject();
+        builder.startObject("path1.xxx").startObject("path2.yyy").field("test", "value").endObject().endObject();
+        builder.endObject();
 
         try (XContentParser parser = createParser(JsonXContent.jsonXContent, Strings.toString(builder))) {
             map = parser.map();
@@ -157,18 +158,18 @@ public class XContentMapValuesTests extends AbstractFilteringTestCase {
     }
 
     public void testExtractValueWithNullValue() throws Exception {
-        XContentBuilder builder = XContentFactory.jsonBuilder().startObject()
-            .field("field", "value")
-            .nullField("other_field")
-            .array("array", "value1", null, "value2")
-            .startObject("object1")
-                .startObject("object2").nullField("field").endObject()
-            .endObject()
-            .startArray("object_array")
-                .startObject().nullField("field").endObject()
-                .startObject().field("field", "value").endObject()
-            .endArray()
-        .endObject();
+        XContentBuilder builder = XContentFactory.jsonBuilder().startObject();
+        builder.field("field", "value");
+        builder.nullField("other_field");
+        builder.array("array", "value1", null, "value2");
+        builder.startObject("object1").startObject("object2").nullField("field").endObject().endObject();
+        builder.startArray("object_array");
+        {
+            builder.startObject().nullField("field").endObject();
+            builder.startObject().field("field", "value").endObject();
+        }
+        builder.endArray();
+        builder.endObject();
 
         Map<String, Object> map;
         try (XContentParser parser = createParser(JsonXContent.jsonXContent, Strings.toString(builder))) {
@@ -180,18 +181,16 @@ public class XContentMapValuesTests extends AbstractFilteringTestCase {
         assertNull(XContentMapValues.extractValue("object1.missing", map, "NULL"));
 
         assertEquals("NULL", XContentMapValues.extractValue("other_field", map, "NULL"));
-        assertEquals(org.elasticsearch.core.List.of("value1", "NULL", "value2"),
-            XContentMapValues.extractValue("array", map, "NULL"));
-        assertEquals(org.elasticsearch.core.List.of("NULL", "value"),
-            XContentMapValues.extractValue("object_array.field", map, "NULL"));
+        assertEquals(list("value1", "NULL", "value2"), XContentMapValues.extractValue("array", map, "NULL"));
+        assertEquals(list("NULL", "value"), XContentMapValues.extractValue("object_array.field", map, "NULL"));
         assertEquals("NULL", XContentMapValues.extractValue("object1.object2.field", map, "NULL"));
     }
 
     public void testExtractValueMixedObjects() throws IOException {
-        XContentBuilder builder = XContentFactory.jsonBuilder().startObject()
-            .startObject("foo").field("cat", "meow").endObject()
-            .field("foo.bar", "baz")
-            .endObject();
+        XContentBuilder builder = XContentFactory.jsonBuilder().startObject();
+        builder.startObject("foo").field("cat", "meow").endObject();
+        builder.field("foo.bar", "baz");
+        builder.endObject();
         try (XContentParser parser = createParser(JsonXContent.jsonXContent, Strings.toString(builder))) {
             Map<String, Object> map = parser.map();
             assertThat(XContentMapValues.extractValue("foo.bar", map), equalTo("baz"));
@@ -199,10 +198,10 @@ public class XContentMapValuesTests extends AbstractFilteringTestCase {
     }
 
     public void testExtractValueMixedDottedObjectNotation() throws IOException {
-        XContentBuilder builder = XContentFactory.jsonBuilder().startObject()
-            .startObject("foo").field("cat", "meow").endObject()
-            .field("foo.cat", "miau")
-            .endObject();
+        XContentBuilder builder = XContentFactory.jsonBuilder().startObject();
+        builder.startObject("foo").field("cat", "meow").endObject();
+        builder.field("foo.cat", "miau");
+        builder.endObject();
         try (XContentParser parser = createParser(JsonXContent.jsonXContent, Strings.toString(builder))) {
             Map<String, Object> map = parser.map();
             assertThat((List<?>) XContentMapValues.extractValue("foo.cat", map), containsInAnyOrder("meow", "miau"));
@@ -210,59 +209,49 @@ public class XContentMapValuesTests extends AbstractFilteringTestCase {
     }
 
     public void testExtractRawValue() throws Exception {
-        XContentBuilder builder = XContentFactory.jsonBuilder().startObject()
-                .field("test", "value")
-                .endObject();
-
+        XContentBuilder builder = XContentFactory.jsonBuilder().startObject().field("test", "value").endObject();
         Map<String, Object> map;
         try (XContentParser parser = createParser(JsonXContent.jsonXContent, Strings.toString(builder))) {
             map = parser.map();
         }
         assertThat(XContentMapValues.extractRawValues("test", map).get(0).toString(), equalTo("value"));
 
-        builder = XContentFactory.jsonBuilder().startObject()
-                .field("test.me", "value")
-                .endObject();
-
+        builder = XContentFactory.jsonBuilder().startObject().field("test.me", "value").endObject();
         try (XContentParser parser = createParser(JsonXContent.jsonXContent, Strings.toString(builder))) {
             map = parser.map();
         }
         assertThat(XContentMapValues.extractRawValues("test.me", map).get(0).toString(), equalTo("value"));
 
-        builder = XContentFactory.jsonBuilder().startObject()
-                .startObject("path1").startObject("path2").field("test", "value").endObject().endObject()
-                .endObject();
-
+        builder = XContentFactory.jsonBuilder().startObject();
+        builder.startObject("path1").startObject("path2").field("test", "value").endObject().endObject();
+        builder.endObject();
         try (XContentParser parser = createParser(JsonXContent.jsonXContent, Strings.toString(builder))) {
             map = parser.map();
         }
         assertThat(XContentMapValues.extractRawValues("path1.path2.test", map).get(0).toString(), equalTo("value"));
 
-        builder = XContentFactory.jsonBuilder().startObject()
-                .startObject("path1.xxx").startObject("path2.yyy").field("test", "value").endObject().endObject()
-                .endObject();
-
+        builder = XContentFactory.jsonBuilder().startObject();
+        builder.startObject("path1.xxx").startObject("path2.yyy").field("test", "value").endObject().endObject();
+        builder.endObject();
         try (XContentParser parser = createParser(JsonXContent.jsonXContent, Strings.toString(builder))) {
             map = parser.map();
         }
         assertThat(XContentMapValues.extractRawValues("path1.xxx.path2.yyy.test", map).get(0).toString(), equalTo("value"));
 
-        builder = XContentFactory.jsonBuilder().startObject()
-            .startObject("path1").startArray("path2")
-            .startArray()
-            .startObject().startObject("path3").field("field", "value1").endObject().endObject()
-            .startObject().startObject("path3").field("field", "value2").endObject().endObject()
-            .endArray()
-            .endArray()
-            .endObject().endObject();
-
+        builder = XContentFactory.jsonBuilder().startObject().startObject("path1").startArray("path2");
+        builder.startArray();
+        builder.startObject().startObject("path3").field("field", "value1").endObject().endObject();
+        builder.startObject().startObject("path3").field("field", "value2").endObject().endObject();
+        builder.endArray();
+        builder.endArray().endObject().endObject();
         try (XContentParser parser = createParser(JsonXContent.jsonXContent, Strings.toString(builder))) {
             map = parser.map();
         }
         assertThat(XContentMapValues.extractRawValues("path1.path2.path3.field", map), contains("value1", "value2"));
 
-        builder = XContentFactory.jsonBuilder().startObject()
-            .startObject("path1").array("path2", 9, true, "manglewurzle").endObject().endObject();
+        builder = XContentFactory.jsonBuilder().startObject().startObject("path1");
+        builder.array("path2", 9, true, "manglewurzle");
+        builder.endObject().endObject();
         try (XContentParser parser = createParser(JsonXContent.jsonXContent, Strings.toString(builder))) {
             map = parser.map();
         }
@@ -272,9 +261,9 @@ public class XContentMapValuesTests extends AbstractFilteringTestCase {
 
     public void testExtractRawValueLeafOnly() throws IOException {
         Map<String, Object> map;
-        XContentBuilder builder = XContentFactory.jsonBuilder().startObject()
-            .startArray("path1").value(9).startObject().field("path2", "value").endObject().value(7).endArray()
-            .endObject();
+        XContentBuilder builder = XContentFactory.jsonBuilder().startObject();
+        builder.startArray("path1").value(9).startObject().field("path2", "value").endObject().value(7).endArray();
+        builder.endObject();
         try (XContentParser parser = createParser(JsonXContent.jsonXContent, Strings.toString(builder))) {
             map = parser.map();
         }
@@ -284,33 +273,32 @@ public class XContentMapValuesTests extends AbstractFilteringTestCase {
 
     public void testExtractRawValueMixedObjects() throws IOException {
         {
-            XContentBuilder builder = XContentFactory.jsonBuilder().startObject()
-                .startObject("foo").field("cat", "meow").endObject()
-                .field("foo.bar", "baz")
-                .endObject();
+            XContentBuilder builder = XContentFactory.jsonBuilder().startObject();
+            builder.startObject("foo").field("cat", "meow").endObject();
+            builder.field("foo.bar", "baz");
+            builder.endObject();
             try (XContentParser parser = createParser(JsonXContent.jsonXContent, Strings.toString(builder))) {
                 Map<String, Object> map = parser.map();
                 assertThat(XContentMapValues.extractRawValues("foo.bar", map), Matchers.contains("baz"));
             }
         }
         {
-            XContentBuilder builder = XContentFactory.jsonBuilder().startObject()
-                .startObject("foo").field("bar", "meow").endObject()
-                .field("foo.bar", "baz")
-                .endObject();
+            XContentBuilder builder = XContentFactory.jsonBuilder().startObject();
+            builder.startObject("foo").field("bar", "meow").endObject();
+            builder.field("foo.bar", "baz");
+            builder.endObject();
             try (XContentParser parser = createParser(JsonXContent.jsonXContent, Strings.toString(builder))) {
                 Map<String, Object> map = parser.map();
                 assertThat(XContentMapValues.extractRawValues("foo.bar", map), Matchers.containsInAnyOrder("meow", "baz"));
             }
         }
         {
-            XContentBuilder builder = XContentFactory.jsonBuilder().startObject()
-                .field("foo", "bar")
-                .field("foo.subfoo", "baz")
-                .endObject();
+            XContentBuilder builder = XContentFactory.jsonBuilder().startObject();
+            builder.field("foo", "bar");
+            builder.field("foo.subfoo", "baz");
+            builder.endObject();
             try (XContentParser parser = createParser(JsonXContent.jsonXContent, Strings.toString(builder))) {
-                assertThat(XContentMapValues.extractRawValues("foo.subfoo", parser.map()),
-                    containsInAnyOrder("baz"));
+                assertThat(XContentMapValues.extractRawValues("foo.subfoo", parser.map()), containsInAnyOrder("baz"));
             }
         }
     }
@@ -319,48 +307,47 @@ public class XContentMapValuesTests extends AbstractFilteringTestCase {
         Map<String, Object> map = new HashMap<>();
         map.put("obj", "value");
         map.put("obj_name", "value_name");
-        Map<String, Object> filteredMap = XContentMapValues.filter(map, new String[]{"obj_name"}, Strings.EMPTY_ARRAY);
+        Map<String, Object> filteredMap = XContentMapValues.filter(map, new String[] { "obj_name" }, Strings.EMPTY_ARRAY);
         assertThat(filteredMap.size(), equalTo(1));
         assertThat((String) filteredMap.get("obj_name"), equalTo("value_name"));
     }
-
 
     @SuppressWarnings("unchecked")
     public void testNestedFiltering() {
         Map<String, Object> map = new HashMap<>();
         map.put("field", "value");
-        map.put("array",
-                Arrays.asList(
-                        1,
-                        new HashMap<String, Object>() {{
-                            put("nested", 2);
-                            put("nested_2", 3);
-                        }}));
-        Map<String, Object> filteredMap = XContentMapValues.filter(map, new String[]{"array.nested"}, Strings.EMPTY_ARRAY);
+        map.put("array", Arrays.asList(1, new HashMap<String, Object>() {
+            {
+                put("nested", 2);
+                put("nested_2", 3);
+            }
+        }));
+        Map<String, Object> filteredMap = XContentMapValues.filter(map, new String[] { "array.nested" }, Strings.EMPTY_ARRAY);
         assertThat(filteredMap.size(), equalTo(1));
 
         assertThat(((List<?>) filteredMap.get("array")), hasSize(1));
         assertThat(((Map<String, Object>) ((List<?>) filteredMap.get("array")).get(0)).size(), equalTo(1));
         assertThat((Integer) ((Map<String, Object>) ((List<?>) filteredMap.get("array")).get(0)).get("nested"), equalTo(2));
 
-        filteredMap = XContentMapValues.filter(map, new String[]{"array.*"}, Strings.EMPTY_ARRAY);
+        filteredMap = XContentMapValues.filter(map, new String[] { "array.*" }, Strings.EMPTY_ARRAY);
         assertThat(filteredMap.size(), equalTo(1));
         assertThat(((List<?>) filteredMap.get("array")), hasSize(1));
         assertThat(((Map<String, Object>) ((List<?>) filteredMap.get("array")).get(0)).size(), equalTo(2));
 
         map.clear();
         map.put("field", "value");
-        map.put("obj",
-                new HashMap<String, Object>() {{
-                    put("field", "value");
-                    put("field2", "value2");
-                }});
-        filteredMap = XContentMapValues.filter(map, new String[]{"obj.field"}, Strings.EMPTY_ARRAY);
+        map.put("obj", new HashMap<String, Object>() {
+            {
+                put("field", "value");
+                put("field2", "value2");
+            }
+        });
+        filteredMap = XContentMapValues.filter(map, new String[] { "obj.field" }, Strings.EMPTY_ARRAY);
         assertThat(filteredMap.size(), equalTo(1));
         assertThat(((Map<String, Object>) filteredMap.get("obj")).size(), equalTo(1));
         assertThat((String) ((Map<String, Object>) filteredMap.get("obj")).get("field"), equalTo("value"));
 
-        filteredMap = XContentMapValues.filter(map, new String[]{"obj.*"}, Strings.EMPTY_ARRAY);
+        filteredMap = XContentMapValues.filter(map, new String[] { "obj.*" }, Strings.EMPTY_ARRAY);
         assertThat(filteredMap.size(), equalTo(1));
         assertThat(((Map<String, Object>) filteredMap.get("obj")).size(), equalTo(2));
         assertThat((String) ((Map<String, Object>) filteredMap.get("obj")).get("field"), equalTo("value"));
@@ -372,39 +359,37 @@ public class XContentMapValuesTests extends AbstractFilteringTestCase {
     public void testCompleteObjectFiltering() {
         Map<String, Object> map = new HashMap<>();
         map.put("field", "value");
-        map.put("obj",
-                new HashMap<String, Object>() {{
-                    put("field", "value");
-                    put("field2", "value2");
-                }});
-        map.put("array",
-                Arrays.asList(
-                        1,
-                        new HashMap<String, Object>() {{
-                            put("field", "value");
-                            put("field2", "value2");
-                        }}));
+        map.put("obj", new HashMap<String, Object>() {
+            {
+                put("field", "value");
+                put("field2", "value2");
+            }
+        });
+        map.put("array", Arrays.asList(1, new HashMap<String, Object>() {
+            {
+                put("field", "value");
+                put("field2", "value2");
+            }
+        }));
 
-        Map<String, Object> filteredMap = XContentMapValues.filter(map, new String[]{"obj"}, Strings.EMPTY_ARRAY);
+        Map<String, Object> filteredMap = XContentMapValues.filter(map, new String[] { "obj" }, Strings.EMPTY_ARRAY);
         assertThat(filteredMap.size(), equalTo(1));
         assertThat(((Map<String, Object>) filteredMap.get("obj")).size(), equalTo(2));
         assertThat(((Map<String, Object>) filteredMap.get("obj")).get("field").toString(), equalTo("value"));
         assertThat(((Map<String, Object>) filteredMap.get("obj")).get("field2").toString(), equalTo("value2"));
 
-
-        filteredMap = XContentMapValues.filter(map, new String[]{"obj"}, new String[]{"*.field2"});
+        filteredMap = XContentMapValues.filter(map, new String[] { "obj" }, new String[] { "*.field2" });
         assertThat(filteredMap.size(), equalTo(1));
         assertThat(((Map<String, Object>) filteredMap.get("obj")).size(), equalTo(1));
         assertThat(((Map<String, Object>) filteredMap.get("obj")).get("field").toString(), equalTo("value"));
 
-
-        filteredMap = XContentMapValues.filter(map, new String[]{"array"}, new String[]{});
+        filteredMap = XContentMapValues.filter(map, new String[] { "array" }, new String[] {});
         assertThat(filteredMap.size(), equalTo(1));
         assertThat(((List<?>) filteredMap.get("array")).size(), equalTo(2));
         assertThat((Integer) ((List<?>) filteredMap.get("array")).get(0), equalTo(1));
         assertThat(((Map<String, Object>) ((List<?>) filteredMap.get("array")).get(1)).size(), equalTo(2));
 
-        filteredMap = XContentMapValues.filter(map, new String[]{"array"}, new String[]{"*.field2"});
+        filteredMap = XContentMapValues.filter(map, new String[] { "array" }, new String[] { "*.field2" });
         assertThat(filteredMap.size(), equalTo(1));
         assertThat(((List<?>) filteredMap.get("array")), hasSize(2));
         assertThat((Integer) ((List<?>) filteredMap.get("array")).get(0), equalTo(1));
@@ -416,33 +401,34 @@ public class XContentMapValuesTests extends AbstractFilteringTestCase {
     public void testFilterIncludesUsingStarPrefix() {
         Map<String, Object> map = new HashMap<>();
         map.put("field", "value");
-        map.put("obj",
-                new HashMap<String, Object>() {{
-                    put("field", "value");
-                    put("field2", "value2");
-                }});
-        map.put("n_obj",
-                new HashMap<String, Object>() {{
-                    put("n_field", "value");
-                    put("n_field2", "value2");
-                }});
+        map.put("obj", new HashMap<String, Object>() {
+            {
+                put("field", "value");
+                put("field2", "value2");
+            }
+        });
+        map.put("n_obj", new HashMap<String, Object>() {
+            {
+                put("n_field", "value");
+                put("n_field2", "value2");
+            }
+        });
 
-        Map<String, Object> filteredMap = XContentMapValues.filter(map, new String[]{"*.field2"}, Strings.EMPTY_ARRAY);
+        Map<String, Object> filteredMap = XContentMapValues.filter(map, new String[] { "*.field2" }, Strings.EMPTY_ARRAY);
         assertThat(filteredMap.size(), equalTo(1));
         assertThat(filteredMap, hasKey("obj"));
         assertThat(((Map<String, Object>) filteredMap.get("obj")).size(), equalTo(1));
         assertThat(((Map<String, Object>) filteredMap.get("obj")), hasKey("field2"));
 
         // only objects
-        filteredMap = XContentMapValues.filter(map, new String[]{"*.*"}, Strings.EMPTY_ARRAY);
+        filteredMap = XContentMapValues.filter(map, new String[] { "*.*" }, Strings.EMPTY_ARRAY);
         assertThat(filteredMap.size(), equalTo(2));
         assertThat(filteredMap, hasKey("obj"));
         assertThat(((Map<String, Object>) filteredMap.get("obj")).size(), equalTo(2));
         assertThat(filteredMap, hasKey("n_obj"));
         assertThat(((Map<String, Object>) filteredMap.get("n_obj")).size(), equalTo(2));
 
-
-        filteredMap = XContentMapValues.filter(map, new String[]{"*"}, new String[]{"*.*2"});
+        filteredMap = XContentMapValues.filter(map, new String[] { "*" }, new String[] { "*.*2" });
         assertThat(filteredMap.size(), equalTo(3));
         assertThat(filteredMap, hasKey("field"));
         assertThat(filteredMap, hasKey("obj"));
@@ -451,7 +437,6 @@ public class XContentMapValuesTests extends AbstractFilteringTestCase {
         assertThat(filteredMap, hasKey("n_obj"));
         assertThat(((Map<String, Object>) filteredMap.get("n_obj")).size(), equalTo(1));
         assertThat(((Map<String, Object>) filteredMap.get("n_obj")), hasKey("n_field"));
-
     }
 
     public void testFilterWithEmptyIncludesExcludes() {
@@ -463,89 +448,75 @@ public class XContentMapValuesTests extends AbstractFilteringTestCase {
     }
 
     public void testThatFilterIncludesEmptyObjectWhenUsingIncludes() throws Exception {
-        XContentBuilder builder = XContentFactory.jsonBuilder().startObject()
-                .startObject("obj")
-                .endObject()
-                .endObject();
+        XContentBuilder builder = XContentFactory.jsonBuilder().startObject().startObject("obj").endObject().endObject();
 
         Tuple<XContentType, Map<String, Object>> mapTuple = convertToMap(BytesReference.bytes(builder), true, builder.contentType());
-        Map<String, Object> filteredSource = XContentMapValues.filter(mapTuple.v2(), new String[]{"obj"}, Strings.EMPTY_ARRAY);
+        Map<String, Object> filteredSource = XContentMapValues.filter(mapTuple.v2(), new String[] { "obj" }, Strings.EMPTY_ARRAY);
 
         assertThat(mapTuple.v2(), equalTo(filteredSource));
     }
 
     public void testThatFilterIncludesEmptyObjectWhenUsingExcludes() throws Exception {
-        XContentBuilder builder = XContentFactory.jsonBuilder().startObject()
-                .startObject("obj")
-                .endObject()
-                .endObject();
+        XContentBuilder builder = XContentFactory.jsonBuilder().startObject().startObject("obj").endObject().endObject();
 
         Tuple<XContentType, Map<String, Object>> mapTuple = convertToMap(BytesReference.bytes(builder), true, builder.contentType());
-        Map<String, Object> filteredSource = XContentMapValues.filter(mapTuple.v2(), Strings.EMPTY_ARRAY, new String[]{"nonExistingField"});
+        Map<String, Object> filteredSource = XContentMapValues.filter(
+            mapTuple.v2(),
+            Strings.EMPTY_ARRAY,
+            new String[] { "nonExistingField" }
+        );
 
         assertThat(mapTuple.v2(), equalTo(filteredSource));
     }
 
     @SuppressWarnings("unchecked")
     public void testNotOmittingObjectsWithExcludedProperties() throws Exception {
-        XContentBuilder builder = XContentFactory.jsonBuilder().startObject()
-                .startObject("obj")
-                .field("f1", "v1")
-                .endObject()
-                .endObject();
+        XContentBuilder builder = XContentFactory.jsonBuilder().startObject().startObject("obj").field("f1", "v1").endObject().endObject();
 
         Tuple<XContentType, Map<String, Object>> mapTuple = convertToMap(BytesReference.bytes(builder), true, builder.contentType());
-        Map<String, Object> filteredSource = XContentMapValues.filter(mapTuple.v2(), Strings.EMPTY_ARRAY, new String[]{"obj.f1"});
+        Map<String, Object> filteredSource = XContentMapValues.filter(mapTuple.v2(), Strings.EMPTY_ARRAY, new String[] { "obj.f1" });
 
         assertThat(filteredSource.size(), equalTo(1));
         assertThat(filteredSource, hasKey("obj"));
         assertThat(((Map<String, Object>) filteredSource.get("obj")).size(), equalTo(0));
     }
 
-    @SuppressWarnings({"unchecked"})
+    @SuppressWarnings({ "unchecked" })
     public void testNotOmittingObjectWithNestedExcludedObject() throws Exception {
-        XContentBuilder builder = XContentFactory.jsonBuilder().startObject()
-                .startObject("obj1")
-                .startObject("obj2")
-                .startObject("obj3")
-                .endObject()
-                .endObject()
-                .endObject()
-                .endObject();
+        XContentBuilder builder = XContentFactory.jsonBuilder().startObject();
+        builder.startObject("obj1").startObject("obj2").startObject("obj3");
+        builder.endObject().endObject().endObject().endObject();
 
         // implicit include
         Tuple<XContentType, Map<String, Object>> mapTuple = convertToMap(BytesReference.bytes(builder), true, builder.contentType());
-        Map<String, Object> filteredSource = XContentMapValues.filter(mapTuple.v2(), Strings.EMPTY_ARRAY, new String[]{"*.obj2"});
+        Map<String, Object> filteredSource = XContentMapValues.filter(mapTuple.v2(), Strings.EMPTY_ARRAY, new String[] { "*.obj2" });
 
         assertThat(filteredSource.size(), equalTo(1));
         assertThat(filteredSource, hasKey("obj1"));
         assertThat(((Map<String, Object>) filteredSource.get("obj1")).size(), equalTo(0));
 
         // explicit include
-        filteredSource = XContentMapValues.filter(mapTuple.v2(), new String[]{"obj1"}, new String[]{"*.obj2"});
+        filteredSource = XContentMapValues.filter(mapTuple.v2(), new String[] { "obj1" }, new String[] { "*.obj2" });
         assertThat(filteredSource.size(), equalTo(1));
         assertThat(filteredSource, hasKey("obj1"));
         assertThat(((Map<String, Object>) filteredSource.get("obj1")).size(), equalTo(0));
 
         // wild card include
-        filteredSource = XContentMapValues.filter(mapTuple.v2(), new String[]{"*.obj2"}, new String[]{"*.obj3"});
+        filteredSource = XContentMapValues.filter(mapTuple.v2(), new String[] { "*.obj2" }, new String[] { "*.obj3" });
         assertThat(filteredSource.size(), equalTo(1));
         assertThat(filteredSource, hasKey("obj1"));
         assertThat(((Map<String, Object>) filteredSource.get("obj1")), hasKey("obj2"));
         assertThat(((Map<String, Object>) ((Map<String, Object>) filteredSource.get("obj1")).get("obj2")).size(), equalTo(0));
     }
 
-    @SuppressWarnings({"unchecked"})
+    @SuppressWarnings({ "unchecked" })
     public void testIncludingObjectWithNestedIncludedObject() throws Exception {
-        XContentBuilder builder = XContentFactory.jsonBuilder().startObject()
-                .startObject("obj1")
-                .startObject("obj2")
-                .endObject()
-                .endObject()
-                .endObject();
+        XContentBuilder builder = XContentFactory.jsonBuilder().startObject();
+        builder.startObject("obj1").startObject("obj2");
+        builder.endObject().endObject().endObject();
 
         Tuple<XContentType, Map<String, Object>> mapTuple = convertToMap(BytesReference.bytes(builder), true, builder.contentType());
-        Map<String, Object> filteredSource = XContentMapValues.filter(mapTuple.v2(), new String[]{"*.obj2"}, Strings.EMPTY_ARRAY);
+        Map<String, Object> filteredSource = XContentMapValues.filter(mapTuple.v2(), new String[] { "*.obj2" }, Strings.EMPTY_ARRAY);
 
         assertThat(filteredSource.size(), equalTo(1));
         assertThat(filteredSource, hasKey("obj1"));
@@ -553,7 +524,6 @@ public class XContentMapValuesTests extends AbstractFilteringTestCase {
         assertThat(((Map<String, Object>) filteredSource.get("obj1")), hasKey("obj2"));
         assertThat(((Map<String, Object>) ((Map<String, Object>) filteredSource.get("obj1")).get("obj2")).size(), equalTo(0));
     }
-
 
     public void testDotsInFieldNames() {
         Map<String, Object> map = new HashMap<>();
@@ -564,13 +534,13 @@ public class XContentMapValuesTests extends AbstractFilteringTestCase {
         map.put("quux", 5);
 
         // dots in field names in includes
-        Map<String, Object> filtered = XContentMapValues.filter(map, new String[] {"foo"}, new String[0]);
+        Map<String, Object> filtered = XContentMapValues.filter(map, new String[] { "foo" }, new String[0]);
         Map<String, Object> expected = new HashMap<>(map);
         expected.remove("quux");
         assertEquals(expected, filtered);
 
         // dots in field names in excludes
-        filtered = XContentMapValues.filter(map, new String[0], new String[] {"foo"});
+        filtered = XContentMapValues.filter(map, new String[0], new String[] { "foo" });
         expected = new HashMap<>(map);
         expected.keySet().retainAll(Collections.singleton("quux"));
         assertEquals(expected, filtered);
@@ -581,8 +551,8 @@ public class XContentMapValuesTests extends AbstractFilteringTestCase {
         map.put("搜索", 2);
         map.put("指数", 3);
 
-        assertEquals(Collections.singletonMap("搜索", 2), XContentMapValues.filter(map, new String[] {"搜索"}, new String[0]));
-        assertEquals(Collections.singletonMap("指数", 3), XContentMapValues.filter(map, new String[0], new String[] {"搜索"}));
+        assertEquals(Collections.singletonMap("搜索", 2), XContentMapValues.filter(map, new String[] { "搜索" }, new String[0]));
+        assertEquals(Collections.singletonMap("指数", 3), XContentMapValues.filter(map, new String[0], new String[] { "搜索" }));
     }
 
     public void testSharedPrefixes() {
@@ -590,15 +560,13 @@ public class XContentMapValuesTests extends AbstractFilteringTestCase {
         map.put("foobar", 2);
         map.put("foobaz", 3);
 
-        assertEquals(Collections.singletonMap("foobar", 2), XContentMapValues.filter(map, new String[] {"foobar"}, new String[0]));
-        assertEquals(Collections.singletonMap("foobaz", 3), XContentMapValues.filter(map, new String[0], new String[] {"foobar"}));
+        assertEquals(Collections.singletonMap("foobar", 2), XContentMapValues.filter(map, new String[] { "foobar" }, new String[0]));
+        assertEquals(Collections.singletonMap("foobaz", 3), XContentMapValues.filter(map, new String[0], new String[] { "foobar" }));
     }
 
     @Override
-    public void testSimpleArrayOfObjectsExclusive() throws Exception {
-        //Empty arrays are preserved by XContentMapValues, they get removed only if explicitly excluded.
-        //See following tests around this specific behaviour
-        testFilter(SIMPLE_ARRAY_OF_OBJECTS_EXCLUSIVE, SAMPLE, emptySet(), singleton("authors"));
+    protected boolean removesEmptyArrays() {
+        return false;
     }
 
     public void testArraySubFieldExclusion() {
@@ -609,10 +577,10 @@ public class XContentMapValuesTests extends AbstractFilteringTestCase {
         object.put("exclude", "bar");
         array.add(object);
         map.put("array", array);
-        Map<String, Object> filtered = XContentMapValues.filter(map, new String[0], new String[]{"array.exclude"});
+        Map<String, Object> filtered = XContentMapValues.filter(map, new String[0], new String[] { "array.exclude" });
         assertTrue(filtered.containsKey("field"));
         assertTrue(filtered.containsKey("array"));
-        List<?> filteredArray = (List<?>)filtered.get("array");
+        List<?> filteredArray = (List<?>) filtered.get("array");
         assertThat(filteredArray, hasSize(0));
     }
 
@@ -621,10 +589,10 @@ public class XContentMapValuesTests extends AbstractFilteringTestCase {
         map.put("field", "value");
         List<Map<String, String>> array = new ArrayList<>();
         map.put("array", array);
-        Map<String, Object> filtered = XContentMapValues.filter(map, new String[0], new String[]{"array.exclude"});
+        Map<String, Object> filtered = XContentMapValues.filter(map, new String[0], new String[] { "array.exclude" });
         assertTrue(filtered.containsKey("field"));
         assertTrue(filtered.containsKey("array"));
-        List<?> filteredArray = (List<?>)filtered.get("array");
+        List<?> filteredArray = (List<?>) filtered.get("array");
         assertEquals(0, filteredArray.size());
     }
 
@@ -634,16 +602,15 @@ public class XContentMapValuesTests extends AbstractFilteringTestCase {
         List<Map<String, String>> array = new ArrayList<>();
         map.put("array", array);
         {
-            Map<String, Object> filtered = XContentMapValues.filter(map, new String[]{"array.include"}, new String[0]);
+            Map<String, Object> filtered = XContentMapValues.filter(map, new String[] { "array.include" }, new String[0]);
             assertFalse(filtered.containsKey("field"));
             assertFalse(filtered.containsKey("array"));
         }
         {
-            Map<String, Object> filtered = XContentMapValues.filter(map, new String[]{"array", "array.include"},
-                new String[0]);
+            Map<String, Object> filtered = XContentMapValues.filter(map, new String[] { "array", "array.include" }, new String[0]);
             assertFalse(filtered.containsKey("field"));
             assertTrue(filtered.containsKey("array"));
-            List<?> filteredArray = (List<?>)filtered.get("array");
+            List<?> filteredArray = (List<?>) filtered.get("array");
             assertEquals(0, filteredArray.size());
         }
     }
@@ -653,26 +620,25 @@ public class XContentMapValuesTests extends AbstractFilteringTestCase {
         map.put("field", "value");
         map.put("object", new HashMap<>());
         {
-            Map<String, Object> filtered = XContentMapValues.filter(map, new String[]{"object.include"}, new String[0]);
+            Map<String, Object> filtered = XContentMapValues.filter(map, new String[] { "object.include" }, new String[0]);
             assertFalse(filtered.containsKey("field"));
             assertFalse(filtered.containsKey("object"));
         }
         {
-            Map<String, Object> filtered = XContentMapValues.filter(map, new String[]{"object", "object.include"},
-                new String[0]);
+            Map<String, Object> filtered = XContentMapValues.filter(map, new String[] { "object", "object.include" }, new String[0]);
             assertFalse(filtered.containsKey("field"));
             assertTrue(filtered.containsKey("object"));
-            Map<?, ?> filteredMap = (Map<?, ?>)filtered.get("object");
+            Map<?, ?> filteredMap = (Map<?, ?>) filtered.get("object");
             assertEquals(0, filteredMap.size());
         }
     }
 
     public void testPrefix() {
         Map<String, Object> map = new HashMap<>();
-        map.put("photos", Arrays.asList(new String[] {"foo", "bar"}));
+        map.put("photos", Arrays.asList(new String[] { "foo", "bar" }));
         map.put("photosCount", 2);
 
-        Map<String, Object> filtered = XContentMapValues.filter(map, new String[] {"photosCount"}, new String[0]);
+        Map<String, Object> filtered = XContentMapValues.filter(map, new String[] { "photosCount" }, new String[0]);
         Map<String, Object> expected = new HashMap<>();
         expected.put("photosCount", 2);
         assertEquals(expected, filtered);
@@ -690,13 +656,9 @@ public class XContentMapValuesTests extends AbstractFilteringTestCase {
     }
 
     public void testExtractFlatArrayNestedSource() {
-        Map<?, ?> map = map("nested", list(
-            map("field", "nested1"),
-            map("field", "nested2")));
+        Map<?, ?> map = map("nested", list(map("field", "nested1"), map("field", "nested2")));
         List<Map<?, ?>> nestedSources = XContentMapValues.extractNestedSources("nested", map);
-        assertThat(nestedSources, containsInAnyOrder(
-            map("field", "nested1"),
-            map("field", "nested2")));
+        assertThat(nestedSources, containsInAnyOrder(map("field", "nested1"), map("field", "nested2")));
     }
 
     public void testNonExistentNestedSource() {
@@ -704,29 +666,41 @@ public class XContentMapValuesTests extends AbstractFilteringTestCase {
     }
 
     public void testNestedSourceIsBadlyFormed() {
-        Exception e = expectThrows(IllegalStateException.class,
-            () -> XContentMapValues.extractNestedSources("nested", map("nested", "foo")));
+        Exception e = expectThrows(
+            IllegalStateException.class,
+            () -> XContentMapValues.extractNestedSources("nested", map("nested", "foo"))
+        );
         assertThat(e.getMessage(), equalTo("Cannot extract nested source from path [nested]: got [foo]"));
     }
 
     public void testExtractNestedSources() {
         Map<?, ?> map = map(
-            "obj.ect", list(
-                map("nested", list(map("field", "nested1"), map("field", "nested2"))),
-                map("nested", list(map("field", "nested3")))
-            ),
-            "obj", list(map("ect", map("nested", list(
-                map("field", "nested4"), map("field", "nested5"))
-            )))
+            "obj.ect",
+            list(map("nested", list(map("field", "nested1"), map("field", "nested2"))), map("nested", list(map("field", "nested3")))),
+            "obj",
+            list(map("ect", map("nested", list(map("field", "nested4"), map("field", "nested5")))))
         );
         List<Map<?, ?>> nestedSources = XContentMapValues.extractNestedSources("obj.ect.nested", map);
-        assertThat(nestedSources, containsInAnyOrder(
-            map("field", "nested1"),
-            map("field", "nested2"),
-            map("field", "nested3"),
-            map("field", "nested4"),
-            map("field", "nested5")
-        ));
+        assertThat(
+            nestedSources,
+            containsInAnyOrder(
+                map("field", "nested1"),
+                map("field", "nested2"),
+                map("field", "nested3"),
+                map("field", "nested4"),
+                map("field", "nested5")
+            )
+        );
+        assertThat(
+            nestedSources,
+            containsInAnyOrder(
+                map("field", "nested1"),
+                map("field", "nested2"),
+                map("field", "nested3"),
+                map("field", "nested4"),
+                map("field", "nested5")
+            )
+        );
     }
 
     private static Map<?, ?> map(String k1, Object v1) {

--- a/server/src/test/java/org/elasticsearch/common/xcontent/support/filtering/AbstractXContentFilteringTestCase.java
+++ b/server/src/test/java/org/elasticsearch/common/xcontent/support/filtering/AbstractXContentFilteringTestCase.java
@@ -38,6 +38,11 @@ public abstract class AbstractXContentFilteringTestCase extends AbstractFilterin
 
     protected abstract XContentType getXContentType();
 
+    @Override
+    protected boolean removesEmptyArrays() {
+        return true;
+    }
+
     private XContentBuilder createBuilder() throws IOException {
         return XContentBuilder.builder(getXContentType().xContent());
     }

--- a/server/src/test/resources/org/elasticsearch/common/xcontent/support/sample.json
+++ b/server/src/test/resources/org/elasticsearch/common/xcontent/support/sample.json
@@ -1,0 +1,71 @@
+{
+  "title" : "My awesome book",
+  "pages" : 456,
+  "price" : 27.99,
+  "timestamp" : 1428582942867,
+  "default" : null,
+  "tags" : [
+    "elasticsearch",
+    "java"
+  ],
+  "authors" : [
+    {
+      "name" : "John Doe",
+      "lastname" : "John",
+      "firstname" : "Doe"
+    },
+    {
+      "name" : "William Smith",
+      "lastname" : "William",
+      "firstname" : "Smith"
+    }
+  ],
+  "properties" : {
+    "weight" : 0.8,
+    "language" : {
+      "en" : {
+        "lang" : "English",
+        "available" : true,
+        "distributors" : [
+          {
+            "name" : "The Book Shop",
+            "addresses" : [
+              {
+                "name" : "address #1",
+                "street" : "Hampton St",
+                "city" : "London"
+              },
+              {
+                "name" : "address #2",
+                "street" : "Queen St",
+                "city" : "Stornoway"
+              }
+            ]
+          },
+          {
+            "name" : "Sussex Books House"
+          }
+        ]
+      },
+      "fr" : {
+        "lang" : "French",
+        "available" : false,
+        "distributors" : [
+          {
+            "name" : "La Maison du Livre",
+            "addresses" : [
+              {
+                "name" : "address #1",
+                "street" : "Rue Mouffetard",
+                "city" : "Paris"
+              }
+            ]
+          },
+          {
+            "name" : "Thetra"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/server/src/test/resources/org/elasticsearch/common/xcontent/support/sample_just_authors.json
+++ b/server/src/test/resources/org/elasticsearch/common/xcontent/support/sample_just_authors.json
@@ -1,0 +1,14 @@
+{
+  "authors" : [
+    {
+      "name" : "John Doe",
+      "lastname" : "John",
+      "firstname" : "Doe"
+    },
+    {
+      "name" : "William Smith",
+      "lastname" : "William",
+      "firstname" : "Smith"
+    }
+  ]
+}

--- a/server/src/test/resources/org/elasticsearch/common/xcontent/support/sample_just_authors_lastname.json
+++ b/server/src/test/resources/org/elasticsearch/common/xcontent/support/sample_just_authors_lastname.json
@@ -1,0 +1,10 @@
+{
+  "authors" : [
+    {
+      "lastname" : "John"
+    },
+    {
+      "lastname" : "William"
+    }
+  ]
+}

--- a/server/src/test/resources/org/elasticsearch/common/xcontent/support/sample_just_names.json
+++ b/server/src/test/resources/org/elasticsearch/common/xcontent/support/sample_just_names.json
@@ -1,0 +1,47 @@
+{
+  "authors" : [
+    {
+      "name" : "John Doe"
+    },
+    {
+      "name" : "William Smith"
+    }
+  ],
+  "properties" : {
+    "language" : {
+      "en" : {
+        "distributors" : [
+          {
+            "name" : "The Book Shop",
+            "addresses" : [
+              {
+                "name" : "address #1"
+              },
+              {
+                "name" : "address #2"
+              }
+            ]
+          },
+          {
+            "name" : "Sussex Books House"
+          }
+        ]
+      },
+      "fr" : {
+        "distributors" : [
+          {
+            "name" : "La Maison du Livre",
+            "addresses" : [
+              {
+                "name" : "address #1"
+              }
+            ]
+          },
+          {
+            "name" : "Thetra"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/server/src/test/resources/org/elasticsearch/common/xcontent/support/sample_just_pr.json
+++ b/server/src/test/resources/org/elasticsearch/common/xcontent/support/sample_just_pr.json
@@ -1,0 +1,51 @@
+{
+  "price" : 27.99,
+  "properties" : {
+    "weight" : 0.8,
+    "language" : {
+      "en" : {
+        "lang" : "English",
+        "available" : true,
+        "distributors" : [
+          {
+            "name" : "The Book Shop",
+            "addresses" : [
+              {
+                "name" : "address #1",
+                "street" : "Hampton St",
+                "city" : "London"
+              },
+              {
+                "name" : "address #2",
+                "street" : "Queen St",
+                "city" : "Stornoway"
+              }
+            ]
+          },
+          {
+            "name" : "Sussex Books House"
+          }
+        ]
+      },
+      "fr" : {
+        "lang" : "French",
+        "available" : false,
+        "distributors" : [
+          {
+            "name" : "La Maison du Livre",
+            "addresses" : [
+              {
+                "name" : "address #1",
+                "street" : "Rue Mouffetard",
+                "city" : "Paris"
+              }
+            ]
+          },
+          {
+            "name" : "Thetra"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/server/src/test/resources/org/elasticsearch/common/xcontent/support/sample_just_properties_distributors_names.json
+++ b/server/src/test/resources/org/elasticsearch/common/xcontent/support/sample_just_properties_distributors_names.json
@@ -1,0 +1,26 @@
+{
+  "properties" : {
+    "language" : {
+      "en" : {
+        "distributors" : [
+          {
+            "name" : "The Book Shop"
+          },
+          {
+            "name" : "Sussex Books House"
+          }
+        ]
+      },
+      "fr" : {
+        "distributors" : [
+          {
+            "name" : "La Maison du Livre"
+          },
+          {
+            "name" : "Thetra"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/server/src/test/resources/org/elasticsearch/common/xcontent/support/sample_just_properties_en_names.json
+++ b/server/src/test/resources/org/elasticsearch/common/xcontent/support/sample_just_properties_en_names.json
@@ -1,0 +1,24 @@
+{
+  "properties" : {
+    "language" : {
+      "en" : {
+        "distributors" : [
+          {
+            "name" : "The Book Shop",
+            "addresses" : [
+              {
+                "name" : "address #1"
+              },
+              {
+                "name" : "address #2"
+              }
+            ]
+          },
+          {
+            "name" : "Sussex Books House"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/server/src/test/resources/org/elasticsearch/common/xcontent/support/sample_just_properties_en_no_distributors_name_no_street.json
+++ b/server/src/test/resources/org/elasticsearch/common/xcontent/support/sample_just_properties_en_no_distributors_name_no_street.json
@@ -1,0 +1,26 @@
+{
+  "properties" : {
+    "language" : {
+      "en" : {
+        "lang" : "English",
+        "available" : true,
+        "distributors" : [
+          {
+            "name" : "The Book Shop",
+            "addresses" : [
+              {
+                "city" : "London"
+              },
+              {
+                "city" : "Stornoway"
+              }
+            ]
+          },
+          {
+            "name" : "Sussex Books House"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/server/src/test/resources/org/elasticsearch/common/xcontent/support/sample_just_properties_names.json
+++ b/server/src/test/resources/org/elasticsearch/common/xcontent/support/sample_just_properties_names.json
@@ -1,0 +1,39 @@
+{
+  "properties" : {
+    "language" : {
+      "en" : {
+        "distributors" : [
+          {
+            "name" : "The Book Shop",
+            "addresses" : [
+              {
+                "name" : "address #1"
+              },
+              {
+                "name" : "address #2"
+              }
+            ]
+          },
+          {
+            "name" : "Sussex Books House"
+          }
+        ]
+      },
+      "fr" : {
+        "distributors" : [
+          {
+            "name" : "La Maison du Livre",
+            "addresses" : [
+              {
+                "name" : "address #1"
+              }
+            ]
+          },
+          {
+            "name" : "Thetra"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/server/src/test/resources/org/elasticsearch/common/xcontent/support/sample_just_properties_no_distributors.json
+++ b/server/src/test/resources/org/elasticsearch/common/xcontent/support/sample_just_properties_no_distributors.json
@@ -1,0 +1,15 @@
+{
+  "properties" : {
+    "weight" : 0.8,
+    "language" : {
+      "en" : {
+        "lang" : "English",
+        "available" : true
+      },
+      "fr" : {
+        "lang" : "French",
+        "available" : false
+      }
+    }
+  }
+}

--- a/server/src/test/resources/org/elasticsearch/common/xcontent/support/sample_just_tags_authors_no_name.json
+++ b/server/src/test/resources/org/elasticsearch/common/xcontent/support/sample_just_tags_authors_no_name.json
@@ -1,0 +1,16 @@
+{
+  "tags" : [
+    "elasticsearch",
+    "java"
+  ],
+  "authors" : [
+    {
+      "lastname" : "John",
+      "firstname" : "Doe"
+    },
+    {
+      "lastname" : "William",
+      "firstname" : "Smith"
+    }
+  ]
+}

--- a/server/src/test/resources/org/elasticsearch/common/xcontent/support/sample_no_authors.json
+++ b/server/src/test/resources/org/elasticsearch/common/xcontent/support/sample_no_authors.json
@@ -1,0 +1,59 @@
+{
+  "title" : "My awesome book",
+  "pages" : 456,
+  "price" : 27.99,
+  "timestamp" : 1428582942867,
+  "default" : null,
+  "tags" : [
+    "elasticsearch",
+    "java"
+  ],
+  "properties" : {
+    "weight" : 0.8,
+    "language" : {
+      "en" : {
+        "lang" : "English",
+        "available" : true,
+        "distributors" : [
+          {
+            "name" : "The Book Shop",
+            "addresses" : [
+              {
+                "name" : "address #1",
+                "street" : "Hampton St",
+                "city" : "London"
+              },
+              {
+                "name" : "address #2",
+                "street" : "Queen St",
+                "city" : "Stornoway"
+              }
+            ]
+          },
+          {
+            "name" : "Sussex Books House"
+          }
+        ]
+      },
+      "fr" : {
+        "lang" : "French",
+        "available" : false,
+        "distributors" : [
+          {
+            "name" : "La Maison du Livre",
+            "addresses" : [
+              {
+                "name" : "address #1",
+                "street" : "Rue Mouffetard",
+                "city" : "Paris"
+              }
+            ]
+          },
+          {
+            "name" : "Thetra"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/server/src/test/resources/org/elasticsearch/common/xcontent/support/sample_no_authors_lastname.json
+++ b/server/src/test/resources/org/elasticsearch/common/xcontent/support/sample_no_authors_lastname.json
@@ -1,0 +1,69 @@
+{
+  "title" : "My awesome book",
+  "pages" : 456,
+  "price" : 27.99,
+  "timestamp" : 1428582942867,
+  "default" : null,
+  "tags" : [
+    "elasticsearch",
+    "java"
+  ],
+  "authors" : [
+    {
+      "name" : "John Doe",
+      "firstname" : "Doe"
+    },
+    {
+      "name" : "William Smith",
+      "firstname" : "Smith"
+    }
+  ],
+  "properties" : {
+    "weight" : 0.8,
+    "language" : {
+      "en" : {
+        "lang" : "English",
+        "available" : true,
+        "distributors" : [
+          {
+            "name" : "The Book Shop",
+            "addresses" : [
+              {
+                "name" : "address #1",
+                "street" : "Hampton St",
+                "city" : "London"
+              },
+              {
+                "name" : "address #2",
+                "street" : "Queen St",
+                "city" : "Stornoway"
+              }
+            ]
+          },
+          {
+            "name" : "Sussex Books House"
+          }
+        ]
+      },
+      "fr" : {
+        "lang" : "French",
+        "available" : false,
+        "distributors" : [
+          {
+            "name" : "La Maison du Livre",
+            "addresses" : [
+              {
+                "name" : "address #1",
+                "street" : "Rue Mouffetard",
+                "city" : "Paris"
+              }
+            ]
+          },
+          {
+            "name" : "Thetra"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/server/src/test/resources/org/elasticsearch/common/xcontent/support/sample_no_names.json
+++ b/server/src/test/resources/org/elasticsearch/common/xcontent/support/sample_no_names.json
@@ -1,0 +1,58 @@
+{
+  "title" : "My awesome book",
+  "pages" : 456,
+  "price" : 27.99,
+  "timestamp" : 1428582942867,
+  "default" : null,
+  "tags" : [
+    "elasticsearch",
+    "java"
+  ],
+  "authors" : [
+    {
+      "lastname" : "John",
+      "firstname" : "Doe"
+    },
+    {
+      "lastname" : "William",
+      "firstname" : "Smith"
+    }
+  ],
+  "properties" : {
+    "weight" : 0.8,
+    "language" : {
+      "en" : {
+        "lang" : "English",
+        "available" : true,
+        "distributors" : [
+          {
+            "addresses" : [
+              {
+                "street" : "Hampton St",
+                "city" : "London"
+              },
+              {
+                "street" : "Queen St",
+                "city" : "Stornoway"
+              }
+            ]
+          }
+        ]
+      },
+      "fr" : {
+        "lang" : "French",
+        "available" : false,
+        "distributors" : [
+          {
+            "addresses" : [
+              {
+                "street" : "Rue Mouffetard",
+                "city" : "Paris"
+              }
+            ]
+          }
+        ]
+      }
+    }
+  }
+}

--- a/server/src/test/resources/org/elasticsearch/common/xcontent/support/sample_no_pr.json
+++ b/server/src/test/resources/org/elasticsearch/common/xcontent/support/sample_no_pr.json
@@ -1,0 +1,22 @@
+{
+  "title" : "My awesome book",
+  "pages" : 456,
+  "timestamp" : 1428582942867,
+  "default" : null,
+  "tags" : [
+    "elasticsearch",
+    "java"
+  ],
+  "authors" : [
+    {
+      "name" : "John Doe",
+      "lastname" : "John",
+      "firstname" : "Doe"
+    },
+    {
+      "name" : "William Smith",
+      "lastname" : "William",
+      "firstname" : "Smith"
+    }
+  ]
+}

--- a/server/src/test/resources/org/elasticsearch/common/xcontent/support/sample_no_properties_distributors_names.json
+++ b/server/src/test/resources/org/elasticsearch/common/xcontent/support/sample_no_properties_distributors_names.json
@@ -1,0 +1,63 @@
+{
+  "title" : "My awesome book",
+  "pages" : 456,
+  "price" : 27.99,
+  "timestamp" : 1428582942867,
+  "default" : null,
+  "tags" : [
+    "elasticsearch",
+    "java"
+  ],
+  "authors" : [
+    {
+      "name" : "John Doe",
+      "lastname" : "John",
+      "firstname" : "Doe"
+    },
+    {
+      "name" : "William Smith",
+      "lastname" : "William",
+      "firstname" : "Smith"
+    }
+  ],
+  "properties" : {
+    "weight" : 0.8,
+    "language" : {
+      "en" : {
+        "lang" : "English",
+        "available" : true,
+        "distributors" : [
+          {
+            "addresses" : [
+              {
+                "name" : "address #1",
+                "street" : "Hampton St",
+                "city" : "London"
+              },
+              {
+                "name" : "address #2",
+                "street" : "Queen St",
+                "city" : "Stornoway"
+              }
+            ]
+          }
+        ]
+      },
+      "fr" : {
+        "lang" : "French",
+        "available" : false,
+        "distributors" : [
+          {
+            "addresses" : [
+              {
+                "name" : "address #1",
+                "street" : "Rue Mouffetard",
+                "city" : "Paris"
+              }
+            ]
+          }
+        ]
+      }
+    }
+  }
+}

--- a/server/src/test/resources/org/elasticsearch/common/xcontent/support/sample_no_properties_en_names.json
+++ b/server/src/test/resources/org/elasticsearch/common/xcontent/support/sample_no_properties_en_names.json
@@ -1,0 +1,65 @@
+{
+  "title" : "My awesome book",
+  "pages" : 456,
+  "price" : 27.99,
+  "timestamp" : 1428582942867,
+  "default" : null,
+  "tags" : [
+    "elasticsearch",
+    "java"
+  ],
+  "authors" : [
+    {
+      "name" : "John Doe",
+      "lastname" : "John",
+      "firstname" : "Doe"
+    },
+    {
+      "name" : "William Smith",
+      "lastname" : "William",
+      "firstname" : "Smith"
+    }
+  ],
+  "properties" : {
+    "weight" : 0.8,
+    "language" : {
+      "en" : {
+        "lang" : "English",
+        "available" : true,
+        "distributors" : [
+          {
+            "addresses" : [
+              {
+                "street" : "Hampton St",
+                "city" : "London"
+              },
+              {
+                "street" : "Queen St",
+                "city" : "Stornoway"
+              }
+            ]
+          }
+        ]
+      },
+      "fr" : {
+        "lang" : "French",
+        "available" : false,
+        "distributors" : [
+          {
+            "name" : "La Maison du Livre",
+            "addresses" : [
+              {
+                "name" : "address #1",
+                "street" : "Rue Mouffetard",
+                "city" : "Paris"
+              }
+            ]
+          },
+          {
+            "name" : "Thetra"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/server/src/test/resources/org/elasticsearch/common/xcontent/support/sample_no_properties_names.json
+++ b/server/src/test/resources/org/elasticsearch/common/xcontent/support/sample_no_properties_names.json
@@ -1,0 +1,60 @@
+{
+  "title" : "My awesome book",
+  "pages" : 456,
+  "price" : 27.99,
+  "timestamp" : 1428582942867,
+  "default" : null,
+  "tags" : [
+    "elasticsearch",
+    "java"
+  ],
+  "authors" : [
+    {
+      "name" : "John Doe",
+      "lastname" : "John",
+      "firstname" : "Doe"
+    },
+    {
+      "name" : "William Smith",
+      "lastname" : "William",
+      "firstname" : "Smith"
+    }
+  ],
+  "properties" : {
+    "weight" : 0.8,
+    "language" : {
+      "en" : {
+        "lang" : "English",
+        "available" : true,
+        "distributors" : [
+          {
+            "addresses" : [
+              {
+                "street" : "Hampton St",
+                "city" : "London"
+              },
+              {
+                "street" : "Queen St",
+                "city" : "Stornoway"
+              }
+            ]
+          }
+        ]
+      },
+      "fr" : {
+        "lang" : "French",
+        "available" : false,
+        "distributors" : [
+          {
+            "addresses" : [
+              {
+                "street" : "Rue Mouffetard",
+                "city" : "Paris"
+              }
+            ]
+          }
+        ]
+      }
+    }
+  }
+}

--- a/server/src/test/resources/org/elasticsearch/common/xcontent/support/sample_no_tags.json
+++ b/server/src/test/resources/org/elasticsearch/common/xcontent/support/sample_no_tags.json
@@ -1,0 +1,67 @@
+{
+  "title" : "My awesome book",
+  "pages" : 456,
+  "price" : 27.99,
+  "timestamp" : 1428582942867,
+  "default" : null,
+  "authors" : [
+    {
+      "name" : "John Doe",
+      "lastname" : "John",
+      "firstname" : "Doe"
+    },
+    {
+      "name" : "William Smith",
+      "lastname" : "William",
+      "firstname" : "Smith"
+    }
+  ],
+  "properties" : {
+    "weight" : 0.8,
+    "language" : {
+      "en" : {
+        "lang" : "English",
+        "available" : true,
+        "distributors" : [
+          {
+            "name" : "The Book Shop",
+            "addresses" : [
+              {
+                "name" : "address #1",
+                "street" : "Hampton St",
+                "city" : "London"
+              },
+              {
+                "name" : "address #2",
+                "street" : "Queen St",
+                "city" : "Stornoway"
+              }
+            ]
+          },
+          {
+            "name" : "Sussex Books House"
+          }
+        ]
+      },
+      "fr" : {
+        "lang" : "French",
+        "available" : false,
+        "distributors" : [
+          {
+            "name" : "La Maison du Livre",
+            "addresses" : [
+              {
+                "name" : "address #1",
+                "street" : "Rue Mouffetard",
+                "city" : "Paris"
+              }
+            ]
+          },
+          {
+            "name" : "Thetra"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/server/src/test/resources/org/elasticsearch/common/xcontent/support/sample_no_title.json
+++ b/server/src/test/resources/org/elasticsearch/common/xcontent/support/sample_no_title.json
@@ -1,0 +1,70 @@
+{
+  "pages" : 456,
+  "price" : 27.99,
+  "timestamp" : 1428582942867,
+  "default" : null,
+  "tags" : [
+    "elasticsearch",
+    "java"
+  ],
+  "authors" : [
+    {
+      "name" : "John Doe",
+      "lastname" : "John",
+      "firstname" : "Doe"
+    },
+    {
+      "name" : "William Smith",
+      "lastname" : "William",
+      "firstname" : "Smith"
+    }
+  ],
+  "properties" : {
+    "weight" : 0.8,
+    "language" : {
+      "en" : {
+        "lang" : "English",
+        "available" : true,
+        "distributors" : [
+          {
+            "name" : "The Book Shop",
+            "addresses" : [
+              {
+                "name" : "address #1",
+                "street" : "Hampton St",
+                "city" : "London"
+              },
+              {
+                "name" : "address #2",
+                "street" : "Queen St",
+                "city" : "Stornoway"
+              }
+            ]
+          },
+          {
+            "name" : "Sussex Books House"
+          }
+        ]
+      },
+      "fr" : {
+        "lang" : "French",
+        "available" : false,
+        "distributors" : [
+          {
+            "name" : "La Maison du Livre",
+            "addresses" : [
+              {
+                "name" : "address #1",
+                "street" : "Rue Mouffetard",
+                "city" : "Paris"
+              }
+            ]
+          },
+          {
+            "name" : "Thetra"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/server/src/test/resources/org/elasticsearch/common/xcontent/support/sample_no_title_pages.json
+++ b/server/src/test/resources/org/elasticsearch/common/xcontent/support/sample_no_title_pages.json
@@ -1,0 +1,69 @@
+{
+  "price" : 27.99,
+  "timestamp" : 1428582942867,
+  "default" : null,
+  "tags" : [
+    "elasticsearch",
+    "java"
+  ],
+  "authors" : [
+    {
+      "name" : "John Doe",
+      "lastname" : "John",
+      "firstname" : "Doe"
+    },
+    {
+      "name" : "William Smith",
+      "lastname" : "William",
+      "firstname" : "Smith"
+    }
+  ],
+  "properties" : {
+    "weight" : 0.8,
+    "language" : {
+      "en" : {
+        "lang" : "English",
+        "available" : true,
+        "distributors" : [
+          {
+            "name" : "The Book Shop",
+            "addresses" : [
+              {
+                "name" : "address #1",
+                "street" : "Hampton St",
+                "city" : "London"
+              },
+              {
+                "name" : "address #2",
+                "street" : "Queen St",
+                "city" : "Stornoway"
+              }
+            ]
+          },
+          {
+            "name" : "Sussex Books House"
+          }
+        ]
+      },
+      "fr" : {
+        "lang" : "French",
+        "available" : false,
+        "distributors" : [
+          {
+            "name" : "La Maison du Livre",
+            "addresses" : [
+              {
+                "name" : "address #1",
+                "street" : "Rue Mouffetard",
+                "city" : "Paris"
+              }
+            ]
+          },
+          {
+            "name" : "Thetra"
+          }
+        ]
+      }
+    }
+  }
+}


### PR DESCRIPTION
`AbstractFilteringTestCase` had a ton of carefully formatted
`XContentBuilder` calls that would have been totally unreadable after
the formatter worked its magic. So I formatted a bunch of them by hand
and extracted the rest to json files.
