### PR TITLE
[7.x] Move `index.hidden` from Static to Dynamic settings (#77218)

### DIFF
--- a/docs/reference/index-modules.asciidoc
+++ b/docs/reference/index-modules.asciidoc
@@ -112,13 +112,6 @@ to incomplete history on the leader. Defaults to `12h`.
     Indicates whether <<query-filter-context, cached filters>> are pre-loaded for
     nested queries. Possible values are `true` (default) and `false`.
 
-[[index-hidden]] `index.hidden`::
-
-    Indicates whether the index should be hidden by default. Hidden indices are not
-    returned by default when using a wildcard expression. This behavior is controlled
-    per request through the use of the `expand_wildcards` parameter. Possible values are
-    `true` and `false` (default).
-
 [[index-shard-check-on-startup]] `index.shard.check_on_startup`::
 +
 ====
@@ -339,6 +332,13 @@ For internal use by Elastic only. Maximum number of time series dimensions for
 the index. Defaults to `16`.
 +
 You can mark a field as a dimension using the `dimension` mapping parameter.
+
+[[index-hidden]] `index.hidden`::
+
+    Indicates whether the index should be hidden by default. Hidden indices are not
+    returned by default when using a wildcard expression. This behavior is controlled
+    per request through the use of the `expand_wildcards` parameter. Possible values are
+    `true` and `false` (default).
 
 [discrete]
 === Settings in other index modules


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Move `index.hidden` from Static to Dynamic settings (#77218)