### PR TITLE
Add rest-api-spec yaml test for vector tile

### DIFF
--- a/x-pack/plugin/vector-tile/build.gradle
+++ b/x-pack/plugin/vector-tile/build.gradle
@@ -17,6 +17,8 @@ import org.elasticsearch.gradle.internal.info.BuildParams
 
 apply plugin: 'elasticsearch.internal-es-plugin'
 apply plugin: 'elasticsearch.java-rest-test'
+apply plugin: 'elasticsearch.internal-yaml-rest-test'
+apply plugin: 'elasticsearch.yaml-rest-compat-test'
 
 esplugin {
   name 'vector-tile'
@@ -35,6 +37,7 @@ dependencies {
   runtimeOnly("org.apache.logging.log4j:log4j-slf4j-impl:${versions.log4j}")
   javaRestTestImplementation("com.wdtinc:mapbox-vector-tile:3.1.0")
   javaRestTestImplementation("com.google.protobuf:protobuf-java:3.14.0")
+  yamlRestTestImplementation(testArtifact(project(xpackModule('core'))))
 }
 
 testClusters.all {

--- a/x-pack/plugin/vector-tile/src/yamlRestTest/java/org/elasticsearch/xpack/vectortile/VectorTileClientYamlTestSuiteIT.java
+++ b/x-pack/plugin/vector-tile/src/yamlRestTest/java/org/elasticsearch/xpack/vectortile/VectorTileClientYamlTestSuiteIT.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.xpack.vectortile;
+
+import com.carrotsearch.randomizedtesting.annotations.Name;
+import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
+import org.elasticsearch.test.rest.yaml.ClientYamlTestCandidate;
+import org.elasticsearch.test.rest.yaml.ESClientYamlSuiteTestCase;
+
+/** Runs yaml rest tests */
+public class VectorTileClientYamlTestSuiteIT extends ESClientYamlSuiteTestCase {
+
+    public VectorTileClientYamlTestSuiteIT(@Name("yaml") ClientYamlTestCandidate testCandidate) {
+        super(testCandidate);
+    }
+
+    @ParametersFactory
+    public static Iterable<Object[]> parameters() throws Exception {
+        return ESClientYamlSuiteTestCase.createParameters();
+    }
+}

--- a/x-pack/plugin/vector-tile/src/yamlRestTest/java/org/elasticsearch/xpack/vectortile/VectorTileClientYamlTestSuiteIT.java
+++ b/x-pack/plugin/vector-tile/src/yamlRestTest/java/org/elasticsearch/xpack/vectortile/VectorTileClientYamlTestSuiteIT.java
@@ -17,6 +17,7 @@ package org.elasticsearch.xpack.vectortile;
 
 import com.carrotsearch.randomizedtesting.annotations.Name;
 import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
+
 import org.elasticsearch.test.rest.yaml.ClientYamlTestCandidate;
 import org.elasticsearch.test.rest.yaml.ESClientYamlSuiteTestCase;
 

--- a/x-pack/plugin/vector-tile/src/yamlRestTest/resources/rest-api-spec/test/10_basic.yml
+++ b/x-pack/plugin/vector-tile/src/yamlRestTest/resources/rest-api-spec/test/10_basic.yml
@@ -1,0 +1,169 @@
+---
+setup:
+
+  - do:
+      indices.create:
+        index: locations
+        body:
+          mappings:
+            properties:
+              location:
+                type: geo_point
+
+  - do:
+      index:
+        index:  locations
+        body:
+          location: POINT(34.25 -21.76)
+          value: 1
+
+  - do:
+      indices.refresh: {}
+---
+"no body":
+  - do:
+      search_mvt:
+        index: locations
+        field: location
+        x: 0
+        y: 0
+        zoom: 0
+
+---
+"size param":
+  - do:
+      search_mvt:
+        index: locations
+        field: location
+        x: 0
+        y: 0
+        zoom: 0
+        body:
+         size: 0
+---
+"extent param":
+  - do:
+      search_mvt:
+        index: locations
+        field: location
+        x: 0
+        y: 0
+        zoom: 0
+        body:
+          extent: 256
+
+---
+"exact bounds":
+  - do:
+      search_mvt:
+        index: locations
+        field: location
+        x: 0
+        y: 0
+        zoom: 0
+        body:
+          exact_bounds: true
+
+---
+"grid precision":
+  - do:
+      search_mvt:
+        index: locations
+        field: location
+        x: 0
+        y: 0
+        zoom: 0
+        body:
+          grid_precision: 3
+
+---
+"grid type point":
+  - do:
+      search_mvt:
+        index: locations
+        field: location
+        x: 0
+        y: 0
+        zoom: 0
+        body:
+          grid_type: point
+
+---
+"grid type grid":
+  - do:
+      search_mvt:
+        index: locations
+        field: location
+        x: 0
+        y: 0
+        zoom: 0
+        body:
+          grid_type: grid
+---
+"field field":
+  - do:
+      search_mvt:
+        index: locations
+        field: location
+        x: 0
+        y: 0
+        zoom: 0
+        body:
+          fields: [value]
+
+---
+"runtime_fields field":
+  - do:
+      search_mvt:
+        index: locations
+        field: location
+        x: 0
+        y: 0
+        zoom: 0
+        body:
+          runtime_mappings:
+            lon:
+              script: emit(doc['location'].lon)
+              type: double
+          fields: [lon]
+
+---
+"query field":
+  - do:
+      search_mvt:
+        index: locations
+        field: location
+        x: 0
+        y: 0
+        zoom: 0
+        body:
+          query:
+            term:
+              value: 1
+
+---
+"aggs field":
+  - do:
+      search_mvt:
+        index: locations
+        field: location
+        x: 0
+        y: 0
+        zoom: 0
+        body:
+          aggs:
+            min_value:
+              min:
+                field: value
+
+---
+"sort field":
+  - do:
+      search_mvt:
+        index: locations
+        field: location
+        x: 0
+        y: 0
+        zoom: 0
+        body:
+          sort: []


### PR DESCRIPTION
This PR adds yaml test for vector tile module so the api spec can be tested. 