### PR TITLE
Restore public visibility of methods on RootObjectMapper

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/mapper/RootObjectMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/RootObjectMapper.java
@@ -269,18 +269,30 @@ public class RootObjectMapper extends ObjectMapper {
         return copy;
     }
 
+    /**
+     * Public API
+     */
     public boolean dateDetection() {
         return this.dateDetection.value();
     }
 
+    /**
+     * Public API
+     */
     public boolean numericDetection() {
         return this.numericDetection.value();
     }
 
+    /**
+     * Public API
+     */
     public DateFormatter[] dynamicDateTimeFormatters() {
         return dynamicDateTimeFormatters.value();
     }
 
+    /**
+     * Public API
+     */
     public DynamicTemplate[] dynamicTemplates() {
         return dynamicTemplates.value();
     }

--- a/server/src/main/java/org/elasticsearch/index/mapper/RootObjectMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/RootObjectMapper.java
@@ -269,19 +269,19 @@ public class RootObjectMapper extends ObjectMapper {
         return copy;
     }
 
-    boolean dateDetection() {
+    public boolean dateDetection() {
         return this.dateDetection.value();
     }
 
-    boolean numericDetection() {
+    public boolean numericDetection() {
         return this.numericDetection.value();
     }
 
-    DateFormatter[] dynamicDateTimeFormatters() {
+    public DateFormatter[] dynamicDateTimeFormatters() {
         return dynamicDateTimeFormatters.value();
     }
 
-    DynamicTemplate[] dynamicTemplates() {
+    public DynamicTemplate[] dynamicTemplates() {
         return dynamicTemplates.value();
     }
 


### PR DESCRIPTION
Reset methods on RootObjectMapper to public for external use.