### PR TITLE
Fix randomization in MlNodeShutdownIT

### DIFF
--- a/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/MlNodeShutdownIT.java
+++ b/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/MlNodeShutdownIT.java
@@ -74,6 +74,8 @@ public class MlNodeShutdownIT extends BaseMlIntegTestCase {
         });
 
         // Call the shutdown API for the chosen node.
+        final SingleNodeShutdownMetadata.Type type = randomFrom(SingleNodeShutdownMetadata.Type.values());
+        final String targetNodeName = type == SingleNodeShutdownMetadata.Type.REPLACE ? randomAlphaOfLengthBetween(10, 20) : null;
         client().execute(
             PutShutdownNodeAction.INSTANCE,
             new PutShutdownNodeAction.Request(
@@ -81,7 +83,7 @@ public class MlNodeShutdownIT extends BaseMlIntegTestCase {
                 randomFrom(SingleNodeShutdownMetadata.Type.values()),
                 "just testing",
                 null,
-                null)
+                targetNodeName)
         ).actionGet();
 
         // Wait for the desired end state of all 6 jobs running on nodes that are not shutting down.
@@ -144,14 +146,15 @@ public class MlNodeShutdownIT extends BaseMlIntegTestCase {
         });
 
         // Call the shutdown API for the chosen node.
+        final SingleNodeShutdownMetadata.Type type = randomFrom(SingleNodeShutdownMetadata.Type.values());
+        final String targetNodeName = type == SingleNodeShutdownMetadata.Type.REPLACE ? randomAlphaOfLengthBetween(10, 20) : null;
         client().execute(
             PutShutdownNodeAction.INSTANCE,
             new PutShutdownNodeAction.Request(
-                nodeIdToShutdown.get(),
-                randomFrom(SingleNodeShutdownMetadata.Type.values()),
+                nodeIdToShutdown.get(), type,
                 "just testing",
                 null,
-                null)
+                targetNodeName)
         )
             .actionGet();
 


### PR DESCRIPTION
This commit fixes the randomization in MlNodeShutdownIT to ensure that
the required values for the selected shutdown type are all present.

Follow-up to #77151
Backport integrated directly into the backport of the original PR, see #77278