### PR TITLE
[DOCS] RHEL Security TMP override

### DIFF
--- a/docs/reference/setup/install/rpm.asciidoc
+++ b/docs/reference/setup/install/rpm.asciidoc
@@ -123,6 +123,17 @@ endif::[]
 
 include::skip-set-kernel-parameters.asciidoc[]
 
+[[install-rhel-security]]
+==== Override Red Hat TMP if Security Compliance
+
+If you are applying a security compliance in your RHEL installation 
+you must change the path of the TMP directory that will use elasticsearch as Java.
+
+1. Uncomment `-Djava.io.tmpdir=${ES_TMPDIR}` under `/etc/elasticsearch/jvm.options`
+2. Add `ES_TMPDIR=/usr/share/elasticsearch/tmp` under `/etc/sysconfig/elasticsearch`
+3. Create the /usr/share/elasticsearch/tmp directory and make sure that the owner and group are elasticsearch and the permissions are `0755`
+4. Lastly make sure that `/dev/shm` doesn't have the noexec attribute with command: `mount | grep tmpfs | grep '/dev/shm'`
+
 ifdef::include-xpack[]
 [role="xpack"]
 [[rpm-enable-indices]]


### PR DESCRIPTION
Adding content for [top last 30d Elastic Discuss post](https://discuss.elastic.co/t/elasticsearch-v7-6-2-failed-to-start-killed-by-sigabrt-on-rhel-7-7-urgent/231039) which covers a BlackHat RHEL start-up error with [this solution](https://discuss.elastic.co/t/elasticsearch-v7-6-2-failed-to-start-killed-by-sigabrt-on-rhel-7-7-urgent/231039/11).

Not sure if it makes sense to include "if you don't do this, you'll get [these errors](https://discuss.elastic.co/t/elasticsearch-v7-6-2-failed-to-start-killed-by-sigabrt-on-rhel-7-7-urgent/231039/8)" or some kind of better framing/context. Putting in raw helpful content for review 🙏🏼 