### PR TITLE
[DOCS] Add max open shards error to 'Size your shards'

### DIFF
--- a/docs/reference/how-to/size-your-shards.asciidoc
+++ b/docs/reference/how-to/size-your-shards.asciidoc
@@ -219,8 +219,13 @@ PUT my-index-000001/_settings
 [[fix-an-oversharded-cluster]]
 === Fix an oversharded cluster
 
-If your cluster is experiencing stability issues due to oversharded indices,
+If your cluster is experiencing the following error or stability issues due to oversharded indices,
 you can use one or more of the following methods to fix them.
+
+[source,txt]
+----
+Validation Failed: 1: this action would add [#] total shards, but this cluster currently has [#]/[#] maximum shards open;
+----
 
 [discrete]
 [[create-indices-that-cover-longer-time-periods]]
@@ -314,3 +319,14 @@ POST _reindex
   }
 }
 ----
+
+[discrete]
+[[more-info]]
+==== Additional Resources
+
+- https://www.elastic.co/elasticon/conf/2016/sf/quantitative-cluster-sizing
+- https://www.elastic.co/blog/how-many-shards-should-i-have-in-my-elasticsearch-cluster
+- https://www.slideshare.net/dadoonet/managing-your-black-friday-logs-cloudconfit-93309899
+- https://www.youtube.com/watch?v=ilP7tG6tabI
+- https://www.elastic.co/webinars/using-rally-to-get-your-elasticsearch-cluster-size-right
+

--- a/docs/reference/how-to/size-your-shards.asciidoc
+++ b/docs/reference/how-to/size-your-shards.asciidoc
@@ -29,8 +29,8 @@ cluster sizing video]. As you test different shard configurations, use {kib}'s
 cluster's stability and performance.
 
 The following sections provide some reminders and guidelines you should consider
-when designing your sharding strategy. If your cluster has shard-related
-problems, see <<fix-an-oversharded-cluster>>.
+when designing your sharding strategy. If your cluster is already oversharded,
+see <<reduce-cluster-shard-count>>.
 
 [discrete]
 [[shard-sizing-considerations]]
@@ -214,18 +214,12 @@ PUT my-index-000001/_settings
 --------------------------------------------------
 // TEST[setup:my_index]
 
-
 [discrete]
-[[fix-an-oversharded-cluster]]
-=== Fix an oversharded cluster
+[[reduce-cluster-shard-count]]
+=== Reduce a cluster's shard count
 
-If your cluster is experiencing the following error or stability issues due to oversharded indices,
-you can use one or more of the following methods to fix them.
-
-[source,txt]
-----
-Validation Failed: 1: this action would add [#] total shards, but this cluster currently has [#]/[#] maximum shards open;
-----
+If your cluster is already oversharded, you can use one or more of the following
+methods to reduce a cluster's shard count.
 
 [discrete]
 [[create-indices-that-cover-longer-time-periods]]
@@ -321,12 +315,51 @@ POST _reindex
 ----
 
 [discrete]
-[[more-info]]
-==== Additional Resources
+[[troubleshoot-shard-related-errors]]
+=== Troubleshoot shard-related errors
 
-- https://www.elastic.co/elasticon/conf/2016/sf/quantitative-cluster-sizing
-- https://www.elastic.co/blog/how-many-shards-should-i-have-in-my-elasticsearch-cluster
-- https://www.slideshare.net/dadoonet/managing-your-black-friday-logs-cloudconfit-93309899
-- https://www.youtube.com/watch?v=ilP7tG6tabI
-- https://www.elastic.co/webinars/using-rally-to-get-your-elasticsearch-cluster-size-right
+Here’s how to resolve common shard-related errors.
 
+[discrete]
+==== this action would add [x] total shards, but this cluster currently has [y]/[z] maximum shards open;
+
+The <<cluster-max-shards-per-node,`cluster.max_shards_per_node`>> cluster
+setting limits the maximum number of open shards for a cluster. This error
+indicates an action would exceed this limit.
+
+If you're confident your changes won't destabilize the cluster, you can
+temporarily increase the limit using the <<cluster-update-settings,update
+cluster settings API>> and retry the action.
+
+[source,console]
+----
+PUT _cluster/settings
+{
+  "transient" : {
+    "cluster.max_shards_per_node": 1200
+  }
+}
+----
+
+This increase should only be temporary. As a long-term solution, we recommend
+you add non-frozen data notes or <<reduce-cluster-shard-count,reduce your
+cluster's shard count>>. To get a cluster's current shard count after making
+changes, use the <<cluster-stats,cluster stats API>>.
+
+[source,console]
+----
+GET _cluster/stats?filter_path=indices.shards.total
+----
+
+When a long-term solution is in place, we recommend you reset the
+`cluster.max_shards_per_node` limit.
+
+[source,console]
+----
+PUT _cluster/settings
+{
+  "transient" : {
+    "cluster.max_shards_per_node": null
+  }
+}
+----

--- a/docs/reference/how-to/size-your-shards.asciidoc
+++ b/docs/reference/how-to/size-your-shards.asciidoc
@@ -342,9 +342,10 @@ PUT _cluster/settings
 ----
 
 This increase should only be temporary. As a long-term solution, we recommend
-you add non-frozen data notes or <<reduce-cluster-shard-count,reduce your
-cluster's shard count>>. To get a cluster's current shard count after making
-changes, use the <<cluster-stats,cluster stats API>>.
+you add nodes to the oversharded data tier or
+<<reduce-cluster-shard-count,reduce your cluster's shard count>>. To get a
+cluster's current shard count after making changes, use the
+<<cluster-stats,cluster stats API>>.
 
 [source,console]
 ----


### PR DESCRIPTION
Changes:

* Adds a troubleshooting section and documents the `maximum shards open` error.
* Retitles the `Fix an oversharded cluster` to `Reduce a cluster's shard count`.

Relates to this [Elastic Discuss topic](https://discuss.elastic.co/t/how-to-fix-hitting-maximum-shards-open-error/200502/2).