### PR TITLE
[DOCS] Fix bullet list layout for indices.recovery.use_snapshots

### DIFF
--- a/docs/reference/modules/indices/recovery.asciidoc
+++ b/docs/reference/modules/indices/recovery.asciidoc
@@ -77,14 +77,14 @@ the resources available to handle the extra load that will result.
 (<<cluster-update-settings,Dynamic>>, Expert) Enables snapshot-based peer recoveries.
 +
 NOTE: This feature is designed for indirect use by Elasticsearch Service. Direct use is not supported. Elastic reserves the right to change or remove this feature in future releases without prior notice.
-
++
 {es} recovers replicas and relocates primary shards using the _peer recovery_
 process, which involves constructing a new copy of a shard on the target node.
 When `indices.recovery.use_snapshots` is `false` {es} will construct this new
 copy by transferring the index data from the current primary. When this setting
 is `true` {es} will attempt to copy the index data from a recent snapshot
 first, and will only copy data from the primary if it cannot identify a
-suitable snapshot. Defaults to `true`.
+suitable snapshot. Defaults to `true`. 
 +
 Setting this option to `true` reduces your operating costs if your cluster runs
 in an environment where the node-to-node data transfer costs are higher than

--- a/docs/reference/modules/indices/recovery.asciidoc
+++ b/docs/reference/modules/indices/recovery.asciidoc
@@ -84,7 +84,7 @@ When `indices.recovery.use_snapshots` is `false` {es} will construct this new
 copy by transferring the index data from the current primary. When this setting
 is `true` {es} will attempt to copy the index data from a recent snapshot
 first, and will only copy data from the primary if it cannot identify a
-suitable snapshot. Defaults to `true`. 
+suitable snapshot. Defaults to `true`.
 +
 Setting this option to `true` reduces your operating costs if your cluster runs
 in an environment where the node-to-node data transfer costs are higher than


### PR DESCRIPTION
Add a missed `+` which got lost during backporting.

Before:
![indices-before](https://user-images.githubusercontent.com/1717632/132179834-16a079dd-a7d2-4bf6-9050-5a2b7886b272.png)

After:
![indices-after](https://user-images.githubusercontent.com/1717632/132179852-807837ff-827a-4f6f-887e-2bef24986aef.png)
