### PR TITLE
Limit count of HTTP channels with tracked stats

### DIFF
--- a/docs/reference/modules/http.asciidoc
+++ b/docs/reference/modules/http.asciidoc
@@ -190,3 +190,14 @@ Defaults to `network.tcp.receive_buffer_size`.
 `http.client_stats.enabled`::
 (<<dynamic-cluster-setting,Dynamic>>)
 Enable or disable collection of HTTP client stats. Defaults to `true`.
+
+`http.client_stats.closed_channels.max_count`::
+(<<static-cluster-setting,Static>>)
+When `http.client_stats.enabled` is `true`, sets the maximum number of closed
+HTTP channels for which {es} reports statistics. Defaults to `10000`.
+
+`http.client_stats.closed_channels.max_age`::
+(<<static-cluster-setting,Static>>)
+When `http.client_stats.enabled` is `true`, sets the maximum length of time
+after closing a HTTP channel that {es} will report that channel's statistics.
+Defaults to `5m`.

--- a/modules/transport-netty4/src/main/java/org/elasticsearch/http/netty4/Netty4HttpChannel.java
+++ b/modules/transport-netty4/src/main/java/org/elasticsearch/http/netty4/Netty4HttpChannel.java
@@ -16,6 +16,7 @@ import org.elasticsearch.http.HttpResponse;
 import org.elasticsearch.transport.netty4.Netty4TcpChannel;
 
 import java.net.InetSocketAddress;
+import java.net.SocketAddress;
 
 public class Netty4HttpChannel implements HttpChannel {
 
@@ -34,12 +35,20 @@ public class Netty4HttpChannel implements HttpChannel {
 
     @Override
     public InetSocketAddress getLocalAddress() {
-        return (InetSocketAddress) channel.localAddress();
+        return castAddressOrNull(channel.localAddress());
     }
 
     @Override
     public InetSocketAddress getRemoteAddress() {
-        return (InetSocketAddress) channel.remoteAddress();
+        return castAddressOrNull(channel.remoteAddress());
+    }
+
+    private static InetSocketAddress castAddressOrNull(SocketAddress socketAddress) {
+        if (socketAddress instanceof InetSocketAddress) {
+            return (InetSocketAddress) socketAddress;
+        } else {
+            return null;
+        }
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/common/settings/ClusterSettings.java
+++ b/server/src/main/java/org/elasticsearch/common/settings/ClusterSettings.java
@@ -275,6 +275,8 @@ public final class ClusterSettings extends AbstractScopedSettings {
             HttpTransportSettings.SETTING_HTTP_TRACE_LOG_INCLUDE,
             HttpTransportSettings.SETTING_HTTP_TRACE_LOG_EXCLUDE,
             HttpTransportSettings.SETTING_HTTP_CLIENT_STATS_ENABLED,
+            HttpTransportSettings.SETTING_HTTP_CLIENT_STATS_MAX_CLOSED_CHANNEL_AGE,
+            HttpTransportSettings.SETTING_HTTP_CLIENT_STATS_MAX_CLOSED_CHANNEL_COUNT,
             HierarchyCircuitBreakerService.USE_REAL_MEMORY_USAGE_SETTING,
             HierarchyCircuitBreakerService.TOTAL_CIRCUIT_BREAKER_LIMIT_SETTING,
             HierarchyCircuitBreakerService.FIELDDATA_CIRCUIT_BREAKER_LIMIT_SETTING,

--- a/server/src/main/java/org/elasticsearch/http/HttpTransportSettings.java
+++ b/server/src/main/java/org/elasticsearch/http/HttpTransportSettings.java
@@ -114,6 +114,10 @@ public final class HttpTransportSettings {
 
     public static final Setting<Boolean> SETTING_HTTP_CLIENT_STATS_ENABLED =
         boolSetting("http.client_stats.enabled", true, Property.Dynamic, Property.NodeScope);
+    public static final Setting<Integer> SETTING_HTTP_CLIENT_STATS_MAX_CLOSED_CHANNEL_COUNT =
+        intSetting("http.client_stats.closed_channels.max_count", 10000, Property.NodeScope);
+    public static final Setting<TimeValue> SETTING_HTTP_CLIENT_STATS_MAX_CLOSED_CHANNEL_AGE =
+        Setting.timeSetting("http.client_stats.closed_channels.max_age", TimeValue.timeValueMinutes(5), Property.NodeScope);
 
     private HttpTransportSettings() {
     }

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/node/stats/NodeStatsTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/node/stats/NodeStatsTests.java
@@ -522,6 +522,7 @@ public class NodeStatsTests extends ESTestCase {
             List<HttpStats.ClientStats> clientStats = new ArrayList<>(numClients);
             for (int k = 0; k < numClients; k++) {
                 var cs = new HttpStats.ClientStats(
+                    randomInt(),
                     randomAlphaOfLength(6),
                     randomAlphaOfLength(6),
                     randomAlphaOfLength(6),

--- a/server/src/test/java/org/elasticsearch/http/AbstractHttpServerTransportTests.java
+++ b/server/src/test/java/org/elasticsearch/http/AbstractHttpServerTransportTests.java
@@ -462,6 +462,7 @@ public class AbstractHttpServerTransportTests extends ESTestCase {
                 .withPath("/internal/stats_test")
                 .withHeaders(Map.of(Task.X_OPAQUE_ID, Collections.singletonList(opaqueId)))
                 .build();
+            transport.serverAcceptedChannel(fakeRestRequest.getHttpChannel());
             transport.incomingRequest(fakeRestRequest.getHttpRequest(), fakeRestRequest.getHttpChannel());
 
             HttpStats httpStats = transport.stats();
@@ -478,6 +479,7 @@ public class AbstractHttpServerTransportTests extends ESTestCase {
                 .withPath("/internal/stats_test2")
                 .withHeaders(Map.of(Task.X_OPAQUE_ID.toUpperCase(Locale.ROOT), Collections.singletonList(opaqueId)))
                 .build();
+            transport.serverAcceptedChannel(fakeRestRequest.getHttpChannel());
             transport.incomingRequest(fakeRestRequest.getHttpRequest(), fakeRestRequest.getHttpChannel());
             httpStats = transport.stats();
             assertThat(httpStats.getClientStats().size(), equalTo(2));
@@ -532,6 +534,7 @@ public class AbstractHttpServerTransportTests extends ESTestCase {
                     .withPath("/internal/stats_test")
                     .withHeaders(Map.of(Task.X_OPAQUE_ID, Collections.singletonList(opaqueId)))
                     .build();
+            transport.serverAcceptedChannel(fakeRestRequest.getHttpChannel());
             transport.incomingRequest(fakeRestRequest.getHttpRequest(), fakeRestRequest.getHttpChannel());
 
             // HTTP client stats should default to enabled
@@ -556,6 +559,7 @@ public class AbstractHttpServerTransportTests extends ESTestCase {
                     .withPath("/internal/stats_test")
                     .withHeaders(Map.of(Task.X_OPAQUE_ID, Collections.singletonList(opaqueId)))
                     .build();
+            transport.serverAcceptedChannel(fakeRestRequest.getHttpChannel());
             transport.incomingRequest(fakeRestRequest.getHttpRequest(), fakeRestRequest.getHttpChannel());
             httpStats = transport.stats();
             assertThat(httpStats.getClientStats().size(), equalTo(0));
@@ -573,6 +577,7 @@ public class AbstractHttpServerTransportTests extends ESTestCase {
                     .withPath("/internal/stats_test")
                     .withHeaders(Map.of(Task.X_OPAQUE_ID, Collections.singletonList(opaqueId)))
                     .build();
+            transport.serverAcceptedChannel(fakeRestRequest.getHttpChannel());
             transport.incomingRequest(fakeRestRequest.getHttpRequest(), fakeRestRequest.getHttpChannel());
             httpStats = transport.stats();
             assertThat(httpStats.getClientStats().size(), equalTo(1));

--- a/server/src/test/java/org/elasticsearch/http/HttpClientStatsTrackerTests.java
+++ b/server/src/test/java/org/elasticsearch/http/HttpClientStatsTrackerTests.java
@@ -1,0 +1,430 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.http;
+
+import org.elasticsearch.common.bytes.BytesArray;
+import org.elasticsearch.common.network.NetworkAddress;
+import org.elasticsearch.common.settings.ClusterSettings;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.node.Node;
+import org.elasticsearch.rest.RestRequest;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.rest.FakeRestRequest;
+import org.elasticsearch.threadpool.ThreadPool;
+
+import java.net.InetSocketAddress;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.BrokenBarrierException;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+import java.util.function.Consumer;
+
+import static org.elasticsearch.http.HttpTransportSettings.SETTING_HTTP_CLIENT_STATS_ENABLED;
+import static org.elasticsearch.http.HttpTransportSettings.SETTING_HTTP_CLIENT_STATS_MAX_CLOSED_CHANNEL_AGE;
+import static org.elasticsearch.http.HttpTransportSettings.SETTING_HTTP_CLIENT_STATS_MAX_CLOSED_CHANNEL_COUNT;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.lessThanOrEqualTo;
+
+public class HttpClientStatsTrackerTests extends ESTestCase {
+
+    public void testCollectsNoStatsIfDisabled() {
+        final Settings settings = Settings.builder().put(SETTING_HTTP_CLIENT_STATS_ENABLED.getKey(), false).build();
+        final HttpClientStatsTracker httpClientStatsTracker = new HttpClientStatsTracker(
+            settings,
+            new ClusterSettings(settings, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS),
+            new FakeTimeThreadPool());
+
+        final HttpChannel httpChannel = randomHttpChannel();
+        httpClientStatsTracker.addClientStats(httpChannel);
+        assertThat(httpClientStatsTracker.getClientStats(), empty());
+
+        httpClientStatsTracker.updateClientStats(randomHttpRequest(), httpChannel);
+        assertThat(httpClientStatsTracker.getClientStats(), empty());
+
+        httpChannel.close();
+        assertThat(httpClientStatsTracker.getClientStats(), empty());
+
+        httpClientStatsTracker.updateClientStats(randomHttpRequest(), randomHttpChannel());
+        assertThat(httpClientStatsTracker.getClientStats(), empty());
+    }
+
+    public void testStatsCollection() {
+        final Settings.Builder settings = Settings.builder();
+        if (randomBoolean()) {
+            settings.put(SETTING_HTTP_CLIENT_STATS_ENABLED.getKey(), true);
+        }
+        final long maxAgeMillis;
+        if (randomBoolean()) {
+            maxAgeMillis = randomLongBetween(1L, 1000000L);
+            settings.put(SETTING_HTTP_CLIENT_STATS_MAX_CLOSED_CHANNEL_AGE.getKey(), TimeValue.timeValueMillis(maxAgeMillis));
+        } else {
+            maxAgeMillis = SETTING_HTTP_CLIENT_STATS_MAX_CLOSED_CHANNEL_AGE.get(Settings.EMPTY).millis();
+        }
+
+        final FakeTimeThreadPool threadPool = new FakeTimeThreadPool();
+
+        final HttpClientStatsTracker httpClientStatsTracker = new HttpClientStatsTracker(
+            settings.build(),
+            new ClusterSettings(settings.build(), ClusterSettings.BUILT_IN_CLUSTER_SETTINGS),
+            threadPool);
+
+        threadPool.setRandomTime();
+        final long openTimeMillis = threadPool.absoluteTimeInMillis();
+        long requestLength = 0L;
+        final HttpChannel httpChannel = randomHttpChannel();
+        httpClientStatsTracker.addClientStats(httpChannel);
+        {
+            final List<HttpStats.ClientStats> clientsStats = httpClientStatsTracker.getClientStats();
+            assertThat(clientsStats, hasSize(1));
+            final HttpStats.ClientStats clientStats = clientsStats.get(0);
+            assertThat(clientStats.remoteAddress, equalTo(NetworkAddress.format(httpChannel.getRemoteAddress())));
+            assertNull(clientStats.lastUri);
+            assertThat(clientStats.requestCount, equalTo(0L));
+            assertThat(clientStats.requestSizeBytes, equalTo(requestLength));
+            assertThat(clientStats.closedTimeMillis, equalTo(-1L));
+            assertThat(clientStats.openedTimeMillis, equalTo(openTimeMillis));
+
+            assertNull(clientStats.agent);
+            assertNull(clientStats.forwardedFor);
+            assertNull(clientStats.opaqueId);
+        }
+
+        threadPool.setRandomTime();
+        final HttpRequest httpRequest1 = randomHttpRequest();
+        httpClientStatsTracker.updateClientStats(httpRequest1, httpChannel);
+        {
+            final List<HttpStats.ClientStats> clientsStats = httpClientStatsTracker.getClientStats();
+            assertThat(clientsStats, hasSize(1));
+
+            final HttpStats.ClientStats clientStats = clientsStats.get(0);
+            assertThat(clientStats.remoteAddress, equalTo(NetworkAddress.format(httpChannel.getRemoteAddress())));
+            assertThat(clientStats.lastUri, equalTo(httpRequest1.uri()));
+            assertThat(clientStats.requestCount, equalTo(1L));
+            requestLength += httpRequest1.content().length();
+            assertThat(clientStats.requestSizeBytes, equalTo(requestLength));
+            assertThat(clientStats.closedTimeMillis, equalTo(-1L));
+            assertThat(clientStats.openedTimeMillis, equalTo(openTimeMillis));
+
+            final Map<String, String> relevantHeaders = getRelevantHeaders(httpRequest1);
+            assertThat(clientStats.agent, equalTo(Optional.empty()
+                .or(() -> Optional.ofNullable(relevantHeaders.get("x-elastic-product-origin")))
+                .or(() -> Optional.ofNullable(relevantHeaders.get("user-agent")))
+                .orElse(null)));
+            assertThat(clientStats.forwardedFor, equalTo(relevantHeaders.get("x-forwarded-for")));
+            assertThat(clientStats.opaqueId, equalTo(relevantHeaders.get("x-opaque-id")));
+        }
+
+        threadPool.setRandomTime();
+        final HttpRequest httpRequest2 = randomHttpRequest();
+        httpClientStatsTracker.updateClientStats(httpRequest2, httpChannel);
+        {
+            final List<HttpStats.ClientStats> clientsStats = httpClientStatsTracker.getClientStats();
+            assertThat(clientsStats, hasSize(1));
+
+            final HttpStats.ClientStats clientStats = clientsStats.get(0);
+            assertThat(clientStats.remoteAddress, equalTo(NetworkAddress.format(httpChannel.getRemoteAddress())));
+            assertThat(clientStats.lastUri, equalTo(httpRequest2.uri()));
+            assertThat(clientStats.requestCount, equalTo(2L));
+            requestLength += httpRequest2.content().length();
+            assertThat(clientStats.requestSizeBytes, equalTo(requestLength));
+            assertThat(clientStats.closedTimeMillis, equalTo(-1L));
+            assertThat(clientStats.openedTimeMillis, equalTo(openTimeMillis));
+
+            final Map<String, String> relevantHeaders1 = getRelevantHeaders(httpRequest1);
+            final Map<String, String> relevantHeaders2 = getRelevantHeaders(httpRequest2);
+            assertThat(clientStats.agent, equalTo(Optional.empty()
+                .or(() -> Optional.ofNullable(relevantHeaders1.get("x-elastic-product-origin")))
+                .or(() -> Optional.ofNullable(relevantHeaders1.get("user-agent")))
+                .or(() -> Optional.ofNullable(relevantHeaders2.get("x-elastic-product-origin")))
+                .or(() -> Optional.ofNullable(relevantHeaders2.get("user-agent")))
+                .orElse(null)));
+            assertThat(clientStats.forwardedFor, equalTo(Optional.empty()
+                .or(() -> Optional.ofNullable(relevantHeaders1.get("x-forwarded-for")))
+                .or(() -> Optional.ofNullable(relevantHeaders2.get("x-forwarded-for")))
+                .orElse(null)));
+            assertThat(clientStats.opaqueId, equalTo(Optional.empty()
+                .or(() -> Optional.ofNullable(relevantHeaders1.get("x-opaque-id")))
+                .or(() -> Optional.ofNullable(relevantHeaders2.get("x-opaque-id")))
+                .orElse(null)));
+        }
+
+        threadPool.setRandomTime();
+        final long closeTimeMillis = threadPool.absoluteTimeInMillis();
+        httpChannel.close();
+        {
+            final List<HttpStats.ClientStats> clientsStats = httpClientStatsTracker.getClientStats();
+            assertThat(clientsStats, hasSize(1));
+
+            final HttpStats.ClientStats clientStats = clientsStats.get(0);
+            assertThat(clientStats.remoteAddress, equalTo(NetworkAddress.format(httpChannel.getRemoteAddress())));
+            assertThat(clientStats.lastUri, equalTo(httpRequest2.uri()));
+            assertThat(clientStats.requestCount, equalTo(2L));
+            assertThat(clientStats.requestSizeBytes, equalTo(requestLength));
+            assertThat(clientStats.closedTimeMillis, equalTo(closeTimeMillis));
+            assertThat(clientStats.openedTimeMillis, equalTo(openTimeMillis));
+
+            final Map<String, String> relevantHeaders1 = getRelevantHeaders(httpRequest1);
+            final Map<String, String> relevantHeaders2 = getRelevantHeaders(httpRequest2);
+            assertThat(clientStats.agent, equalTo(Optional.empty()
+                .or(() -> Optional.ofNullable(relevantHeaders1.get("x-elastic-product-origin")))
+                .or(() -> Optional.ofNullable(relevantHeaders1.get("user-agent")))
+                .or(() -> Optional.ofNullable(relevantHeaders2.get("x-elastic-product-origin")))
+                .or(() -> Optional.ofNullable(relevantHeaders2.get("user-agent")))
+                .orElse(null)));
+            assertThat(clientStats.forwardedFor, equalTo(Optional.empty()
+                .or(() -> Optional.ofNullable(relevantHeaders1.get("x-forwarded-for")))
+                .or(() -> Optional.ofNullable(relevantHeaders2.get("x-forwarded-for")))
+                .orElse(null)));
+            assertThat(clientStats.opaqueId, equalTo(Optional.empty()
+                .or(() -> Optional.ofNullable(relevantHeaders1.get("x-opaque-id")))
+                .or(() -> Optional.ofNullable(relevantHeaders2.get("x-opaque-id")))
+                .orElse(null)));
+        }
+
+        threadPool.setCurrentTimeInMillis(
+            threadPool.relativeTimeInMillis()
+                + maxAgeMillis
+                + 1
+                + (randomBoolean() ? 0L : randomLongBetween(0L, 1L << 60)));
+        assertThat(httpClientStatsTracker.getClientStats(), empty());
+    }
+
+    public void testLimitsNumberOfClosedClients() throws InterruptedException {
+
+        final Settings settings;
+        final int closedClientLimit;
+        {
+            final Settings.Builder builder = Settings.builder();
+            if (usually()) {
+                closedClientLimit = scaledRandomIntBetween(1, 10000);
+                builder.put(SETTING_HTTP_CLIENT_STATS_MAX_CLOSED_CHANNEL_COUNT.getKey(), closedClientLimit);
+            } else {
+                closedClientLimit = SETTING_HTTP_CLIENT_STATS_MAX_CLOSED_CHANNEL_COUNT.get(Settings.EMPTY);
+            }
+            settings = builder.build();
+        }
+
+        final FakeTimeThreadPool threadPool = new FakeTimeThreadPool();
+        final ClusterSettings clusterSettings = new ClusterSettings(settings, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
+        final HttpClientStatsTracker httpClientStatsTracker = new HttpClientStatsTracker(settings, clusterSettings, threadPool);
+
+        final Thread[] clientThreads = new Thread[between(1, 5)];
+        final CyclicBarrier startBarrier = new CyclicBarrier(clientThreads.length + 1);
+        final Semaphore operationPermits = new Semaphore(closedClientLimit * 2);
+
+        // If we get stats while a channel is concurrently closed then the iteration through the list of closed channels may see more
+        // stats than expected, even though it was never in a state that had too many channels, so we block closing while retrieving stats
+        final ReadWriteLock closeLock = new ReentrantReadWriteLock(true);
+        final Consumer<HttpChannel> closeUnderLock = httpChannel -> {
+            closeLock.readLock().lock();
+            httpChannel.close();
+            closeLock.readLock().unlock();
+        };
+
+        for (int i = 0; i < clientThreads.length; i++) {
+            clientThreads[i] = new Thread(() -> {
+                try {
+                    startBarrier.await(10, TimeUnit.SECONDS);
+                } catch (InterruptedException | BrokenBarrierException | TimeoutException e) {
+                    throw new AssertionError("unexpected", e);
+                }
+
+                HttpChannel httpChannel = randomHttpChannel();
+                httpClientStatsTracker.addClientStats(httpChannel);
+                while (operationPermits.tryAcquire()) {
+                    if (usually()) {
+                        closeUnderLock.accept(httpChannel);
+                        httpChannel = randomHttpChannel();
+                        httpClientStatsTracker.addClientStats(httpChannel);
+                    }
+
+                    httpClientStatsTracker.updateClientStats(randomHttpRequest(), httpChannel);
+                }
+                closeUnderLock.accept(httpChannel);
+
+            }, "client-thread-" + i);
+            clientThreads[i].start();
+        }
+
+        final AtomicBoolean keepGoing = new AtomicBoolean(true);
+        final Thread statsThread = new Thread(() -> {
+            try {
+                startBarrier.await(10, TimeUnit.SECONDS);
+            } catch (InterruptedException | BrokenBarrierException | TimeoutException e) {
+                throw new AssertionError("unexpected", e);
+            }
+
+            while (keepGoing.get()) {
+                closeLock.writeLock().lock();
+                final List<HttpStats.ClientStats> clientStats = httpClientStatsTracker.getClientStats();
+                closeLock.writeLock().unlock();
+                assertThat(
+                    clientStats.stream().filter(c -> c.closedTimeMillis >= 0L).count(),
+                    lessThanOrEqualTo((long) closedClientLimit));
+            }
+
+        }, "stats-thread");
+        statsThread.start();
+
+        for (Thread clientThread : clientThreads) {
+            clientThread.join();
+        }
+        keepGoing.set(false);
+        statsThread.join();
+    }
+
+    public void testClearsStatsIfDisabledConcurrently() throws InterruptedException {
+        final FakeTimeThreadPool threadPool = new FakeTimeThreadPool();
+        final ClusterSettings clusterSettings = new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
+        final HttpClientStatsTracker httpClientStatsTracker = new HttpClientStatsTracker(Settings.EMPTY, clusterSettings, threadPool);
+
+        final Thread[] clientThreads = new Thread[between(1, 5)];
+        final CyclicBarrier startBarrier = new CyclicBarrier(clientThreads.length + 1);
+        final Semaphore operationPermits = new Semaphore(1000);
+        for (int i = 0; i < clientThreads.length; i++) {
+            clientThreads[i] = new Thread(() -> {
+                try {
+                    startBarrier.await(10, TimeUnit.SECONDS);
+                } catch (InterruptedException | BrokenBarrierException | TimeoutException e) {
+                    throw new AssertionError("unexpected", e);
+                }
+
+                HttpChannel httpChannel = randomHttpChannel();
+                httpClientStatsTracker.addClientStats(httpChannel);
+                while (operationPermits.tryAcquire()) {
+                    if (randomBoolean()) {
+                        httpChannel.close();
+                        httpChannel = randomHttpChannel();
+                        httpClientStatsTracker.addClientStats(httpChannel);
+                    }
+
+                    httpClientStatsTracker.updateClientStats(randomHttpRequest(), httpChannel);
+                }
+                httpChannel.close();
+
+            }, "client-thread-" + i);
+            clientThreads[i].start();
+        }
+
+        try {
+            startBarrier.await(10, TimeUnit.SECONDS);
+        } catch (InterruptedException | BrokenBarrierException | TimeoutException e) {
+            throw new AssertionError("unexpected", e);
+        }
+        clusterSettings.applySettings(
+            Settings.builder().put(SETTING_HTTP_CLIENT_STATS_ENABLED.getKey(), false).build());
+
+        try {
+            assertThat(httpClientStatsTracker.getClientStats(), empty());
+        } finally {
+            for (Thread clientThread : clientThreads) {
+                clientThread.join();
+            }
+        }
+    }
+
+    private Map<String, String> getRelevantHeaders(HttpRequest httpRequest) {
+        final Map<String, String> headers = new HashMap<>(4);
+        final String[] relevantHeaderNames = new String[]{"user-agent", "x-elastic-product-origin", "x-forwarded-for", "x-opaque-id"};
+        for (Map.Entry<String, List<String>> header : httpRequest.getHeaders().entrySet()) {
+            if (header.getValue().size() > 0) {
+                for (String relevantHeaderName : relevantHeaderNames) {
+                    if (header.getKey().equalsIgnoreCase(relevantHeaderName)) {
+                        headers.putIfAbsent(relevantHeaderName, header.getValue().get(0));
+                    }
+                }
+            }
+        }
+        return headers;
+    }
+
+    private HttpRequest randomHttpRequest() {
+        final Map<String, List<String>> headers = new HashMap<>();
+        putRandomHeader("user-agent", headers);
+        putRandomHeader("x-elastic-product-origin", headers);
+        putRandomHeader("x-forwarded-for", headers);
+        putRandomHeader("x-opaque-id", headers);
+        return new FakeRestRequest.FakeHttpRequest(
+            randomFrom(RestRequest.Method.values()),
+            randomAlphaOfLength(10),
+            new BytesArray(randomByteArrayOfLength(between(0, 20))),
+            headers);
+    }
+
+    private static void putRandomHeader(String key, Map<String, List<String>> headers) {
+        if (randomBoolean()) {
+            headers.put(randomizeCase(key), randomList(1, 5, () -> randomAlphaOfLengthBetween(5, 15)));
+        }
+    }
+
+    private static String randomizeCase(String s) {
+        final char[] chars = s.toCharArray();
+        for (int i = 0; i < chars.length; i++) {
+            chars[i] = randomizeCase(chars[i]);
+        }
+        return new String(chars);
+    }
+
+    private static char randomizeCase(char c) {
+        switch (between(1, 3)) {
+            case 1:
+                return Character.toUpperCase(c);
+            case 2:
+                return Character.toLowerCase(c);
+            default:
+                return c;
+        }
+    }
+
+    private HttpChannel randomHttpChannel() {
+        return new FakeRestRequest.FakeHttpChannel(new InetSocketAddress(randomIp(randomBoolean()), randomIntBetween(1, 65535)));
+    }
+
+    private static class FakeTimeThreadPool extends ThreadPool {
+
+        private long currentTimeInMillis;
+        private final long absoluteTimeOffset = randomLong();
+
+        FakeTimeThreadPool() {
+            super(Settings.builder().put(Node.NODE_NAME_SETTING.getKey(), "test").build());
+            stopCachedTimeThread();
+            setRandomTime();
+        }
+
+        @Override
+        public long relativeTimeInMillis() {
+            return currentTimeInMillis;
+        }
+
+        @Override
+        public long absoluteTimeInMillis() {
+            return currentTimeInMillis + absoluteTimeOffset;
+        }
+
+        void setCurrentTimeInMillis(long currentTimeInMillis) {
+            this.currentTimeInMillis = currentTimeInMillis;
+        }
+
+        void setRandomTime() {
+            // absolute time needs to be nonnegative
+            currentTimeInMillis = randomNonNegativeLong() - absoluteTimeOffset;
+        }
+    }
+}

--- a/test/framework/src/main/java/org/elasticsearch/test/rest/FakeRestRequest.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/FakeRestRequest.java
@@ -126,12 +126,12 @@ public class FakeRestRequest extends RestRequest {
         }
     }
 
-    private static class FakeHttpChannel implements HttpChannel {
+    public static class FakeHttpChannel implements HttpChannel {
 
         private final InetSocketAddress remoteAddress;
         private final ListenableActionFuture<Void> closeFuture = new ListenableActionFuture<>();
 
-        private FakeHttpChannel(InetSocketAddress remoteAddress) {
+        public FakeHttpChannel(InetSocketAddress remoteAddress) {
             this.remoteAddress = remoteAddress;
         }
 


### PR DESCRIPTION
Today we expire the client stats for HTTP channels 5 minutes after they
close. It's possible to open a very large number of HTTP channels in 5
minutes, possibly inadvertently, and the stats for those channels can be
overwhelming.

This commit introduces a limit on the number of channels tracked by each
node which applies in addition to the age limit, and makes these limits
configurable via static settings. It drops the pruning of old stats when
starting to track a new channel and instead uses a queue to expire the
oldest stats when each channel closes if necessary to respect the count
limit; it only performs age-based expiry when retrieving the stats,
since the count limit now bounds the memory needed. Finally, it
tightents up some missing synchronization and makes sure that we expose
only immutable objects to the stats subsystem.