### PR TITLE
[ML] Fix typo in ML shutdown test

### DIFF
--- a/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/MlNodeShutdownIT.java
+++ b/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/MlNodeShutdownIT.java
@@ -34,7 +34,6 @@ import static org.hamcrest.Matchers.notNullValue;
 
 public class MlNodeShutdownIT extends BaseMlIntegTestCase {
 
-    @AwaitsFix(bugUrl="https://github.com/elastic/elasticsearch/issues/77297")
     public void testJobsVacateShuttingDownNode() throws Exception {
 
         internalCluster().ensureAtLeastNumDataNodes(3);
@@ -81,7 +80,7 @@ public class MlNodeShutdownIT extends BaseMlIntegTestCase {
             PutShutdownNodeAction.INSTANCE,
             new PutShutdownNodeAction.Request(
                 nodeIdToShutdown.get(),
-                randomFrom(SingleNodeShutdownMetadata.Type.values()),
+                type,
                 "just testing",
                 null,
                 targetNodeName)


### PR DESCRIPTION
There was a small typo in #77281 that made the test fail 2/9ths
of the time.

Fixes #77297