### PR TITLE
[7.15] [ML] Relocating job should not fail if blocked on revert (#77207)

### DIFF
--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportRevertModelSnapshotAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportRevertModelSnapshotAction.java
@@ -120,7 +120,7 @@ public class TransportRevertModelSnapshotAction extends TransportMasterNodeActio
                             ));
                             return;
                         }
-                        isBlocked(job, ActionListener.wrap(
+                        isBlocked(job, request, ActionListener.wrap(
                             isBlocked -> {
                                 if (isBlocked) {
                                     listener.onFailure(ExceptionsHelper.conflictStatusException(
@@ -170,7 +170,7 @@ public class TransportRevertModelSnapshotAction extends TransportMasterNodeActio
             createStateIndexListener);
     }
 
-    private void isBlocked(Job job, ActionListener<Boolean> listener) {
+    private void isBlocked(Job job, RevertModelSnapshotAction.Request request, ActionListener<Boolean> listener) {
         if (job.getBlocked().getReason() == Blocked.Reason.NONE) {
             listener.onResponse(false);
             return;
@@ -183,6 +183,13 @@ public class TransportRevertModelSnapshotAction extends TransportMasterNodeActio
             // in order to complete and eventually unblock the job.
             GetTaskRequest getTaskRequest = new GetTaskRequest();
             getTaskRequest.setTaskId(job.getBlocked().getTaskId());
+
+            // If the request is forced, we will also wait for the existing task to finish
+            // to give a chance to this request to be executed without returning an error.
+            // This is particularly useful when a relocating job is calling revert.
+            getTaskRequest.setWaitForCompletion(request.isForce());
+            getTaskRequest.setTimeout(request.timeout());
+
             executeAsyncWithOrigin(client, ML_ORIGIN, GetTaskAction.INSTANCE, getTaskRequest, ActionListener.wrap(
                 r -> listener.onResponse(r.getTask().isCompleted() == false),
                 e -> {

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/task/OpenJobPersistentTasksExecutor.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/task/OpenJobPersistentTasksExecutor.java
@@ -347,6 +347,7 @@ public class OpenJobPersistentTasksExecutor extends AbstractJobPersistentTasksEx
                     request.setForce(true);
                     request.setDeleteInterveningResults(true);
                     request.masterNodeTimeout(PERSISTENT_TASK_MASTER_NODE_TIMEOUT);
+                    request.timeout(PERSISTENT_TASK_MASTER_NODE_TIMEOUT);
                     executeAsyncWithOrigin(client, ML_ORIGIN, RevertModelSnapshotAction.INSTANCE, request, ActionListener.wrap(
                         response -> listener.onResponse(true),
                         listener::onFailure


### PR DESCRIPTION
Backports the following commits to 7.15:
 - [ML] Relocating job should not fail if blocked on revert (#77207)