### PR TITLE
Fix calendar interval describe in documentation

### DIFF
--- a/docs/reference/aggregations/pipeline/movavg-aggregation.asciidoc
+++ b/docs/reference/aggregations/pipeline/movavg-aggregation.asciidoc
@@ -80,7 +80,7 @@ POST /_search
 // TEST[setup:sales]
 // TEST[warning:The moving_avg aggregation has been deprecated in favor of the moving_fn aggregation.]
 
-<1> A `date_histogram` named "my_date_histo" is constructed on the "timestamp" field, with one-day intervals
+<1> A `date_histogram` named "my_date_histo" is constructed on the "timestamp" field, with one-month intervals
 <2> A `sum` metric is used to calculate the sum of a field.  This could be any metric (sum, min, max, etc)
 <3> Finally, we specify a `moving_avg` aggregation which uses "the_sum" metric as its input.
 


### PR DESCRIPTION
The query set a `1M` calendar interval whereas the documentation says it is a one day interval. 
In the query result, we can see the one month interval is used.