### PR TITLE
WIP -Remove use of Lucene's SPIClassIterator, and replace with Java's ServiceLoader for plugin extensions

### DIFF
--- a/modules/lang-painless/spi/src/main/java/org/elasticsearch/painless/spi/PainlessExtensionProvider.java
+++ b/modules/lang-painless/spi/src/main/java/org/elasticsearch/painless/spi/PainlessExtensionProvider.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.painless.spi;
+
+import org.elasticsearch.plugins.AbstractPluginExtensionProvider;
+
+/** Service provider for painless extensions. */
+public abstract class PainlessExtensionProvider extends AbstractPluginExtensionProvider {
+
+    public PainlessExtensionProvider(Class<?> extensionType, Class<?> argType) {
+        super(extensionType, argType);
+    }
+
+}

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/PainlessPlugin.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/PainlessPlugin.java
@@ -28,9 +28,11 @@ import org.elasticsearch.env.NodeEnvironment;
 import org.elasticsearch.painless.action.PainlessContextAction;
 import org.elasticsearch.painless.action.PainlessExecuteAction;
 import org.elasticsearch.painless.spi.PainlessExtension;
+import org.elasticsearch.painless.spi.PainlessExtensionProvider;
 import org.elasticsearch.painless.spi.Whitelist;
 import org.elasticsearch.painless.spi.WhitelistLoader;
 import org.elasticsearch.painless.spi.annotation.WhitelistAnnotationParser;
+import org.elasticsearch.plugins.AbstractPluginExtensionProvider;
 import org.elasticsearch.plugins.ActionPlugin;
 import org.elasticsearch.plugins.ExtensiblePlugin;
 import org.elasticsearch.plugins.Plugin;
@@ -145,6 +147,11 @@ public final class PainlessPlugin extends Plugin implements ScriptPlugin, Extens
     @Override
     public List<Setting<?>> getSettings() {
         return Arrays.asList(CompilerSettings.REGEX_ENABLED, CompilerSettings.REGEX_LIMIT_FACTOR);
+    }
+
+    @Override
+    public Class<? extends AbstractPluginExtensionProvider> providerType() {
+        return PainlessExtensionProvider.class;
     }
 
     @Override

--- a/modules/runtime-fields-common/src/main/java/org/elasticsearch/runtimefields/RuntimeFieldsPainlessExtensionProvider.java
+++ b/modules/runtime-fields-common/src/main/java/org/elasticsearch/runtimefields/RuntimeFieldsPainlessExtensionProvider.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.runtimefields;
+
+import org.elasticsearch.painless.spi.PainlessExtensionProvider;
+
+/** Runtime fields provider for painless extensions. */
+public class RuntimeFieldsPainlessExtensionProvider extends PainlessExtensionProvider {
+
+    public RuntimeFieldsPainlessExtensionProvider() {  // explicit no-args ctr, for ServiceLoader
+        super(
+            RuntimeFieldsPainlessExtension.class,      // painless extension type
+            RuntimeFieldsCommonPlugin.class            // ctr arg type
+        );
+    }
+}

--- a/modules/runtime-fields-common/src/main/resources/META-INF/services/org.elasticsearch.painless.spi.PainlessExtension
+++ b/modules/runtime-fields-common/src/main/resources/META-INF/services/org.elasticsearch.painless.spi.PainlessExtension
@@ -1,1 +1,0 @@
-org.elasticsearch.runtimefields.RuntimeFieldsPainlessExtension

--- a/modules/runtime-fields-common/src/main/resources/META-INF/services/org.elasticsearch.painless.spi.PainlessExtensionProvider
+++ b/modules/runtime-fields-common/src/main/resources/META-INF/services/org.elasticsearch.painless.spi.PainlessExtensionProvider
@@ -1,0 +1,1 @@
+org.elasticsearch.runtimefields.RuntimeFieldsPainlessExtensionProvider

--- a/server/src/main/java/org/elasticsearch/plugins/AbstractPluginExtensionProvider.java
+++ b/server/src/main/java/org/elasticsearch/plugins/AbstractPluginExtensionProvider.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.plugins;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+import java.util.Objects;
+
+/**
+ * An abstract provider of plugin extensions.
+ *
+ * This class allows customization of the creation of plugin extensions.
+ *
+ * If a plugin extension has a public no-arg constructor, then this mechanism is
+ * not required ( but can still be used ). Otherwise, the plugin extension must
+ * have a constructor with a single argument whose type is the extensible
+ * plugin to which this extension applies.
+ *
+ * An {@link ExtensiblePlugin}, say FooPlugin, wanting to extend its
+ * functionality with a FooPluginExtension, can use this facility as follows:
+ *
+ * 1. Declare its own subtype, say FooPluginExtensionProvider, which will be
+ *    used as the service-type, when locating extensions for the FooPlugin.
+ * 2. Override the {@link ExtensiblePlugin#providerType()} method to return the
+ *    provider type, e.g. FooExtensionProvider.
+ *
+ * The extending Plugin should declare a concrete subtype for the aforementioned
+ * extensible plugin's provider, say FooExtensionProvider (FEP). FEP, should
+ * pass the type of actual plugin extension, FooPluginExtension, as well as the
+ * type of the single constructor parameter, the extending plugin type.
+ *
+ */
+public abstract class AbstractPluginExtensionProvider {
+
+    private final Class<?> extensionType;
+    private final Class<?> argType;  //TODO: We can make this more general, if desired
+
+    public AbstractPluginExtensionProvider(Class<?> extensionType, Class<?> argType) {
+        this.extensionType = Objects.requireNonNull(extensionType);
+        this.argType = argType; // optional, may be null
+    }
+
+    /** The type of the plugin extension. */
+    public Class<?> extensionType() {
+        return extensionType;
+    }
+
+    /** The method type of the creator handle. */
+    public MethodType methodType() {
+        return MethodType.methodType(void.class, argType);
+    }
+
+    /** The <i>creator handle</i> that, when invoked, creates the plugin extension. */
+    public MethodHandle creatorHandle() {
+        try {
+            return MethodHandles.lookup().findConstructor(extensionType(), methodType());
+        } catch (Throwable t) {
+            throw new AssertionError(t);  // TODO: update exception type and message
+        }
+    }
+
+    // TODO: Consider adding a SelfPluginExtensionProvider. Is this useful ?
+}

--- a/server/src/main/java/org/elasticsearch/plugins/ExtensiblePlugin.java
+++ b/server/src/main/java/org/elasticsearch/plugins/ExtensiblePlugin.java
@@ -30,6 +30,15 @@ public interface ExtensiblePlugin {
     }
 
     /**
+     * The type of the plugin extension provider.
+     *
+     * @return the type of the plugin extension provider, or null if none
+     */
+    default Class<? extends AbstractPluginExtensionProvider> providerType() {
+        return null;  // null allows things to operate without a provider, when there is a no-args ctr
+    }
+
+    /**
      * Allow this plugin to load extensions from other plugins.
      *
      * This method is called once only, after initializing this plugin and all plugins extending this plugin. It is called before

--- a/server/src/main/java/org/elasticsearch/plugins/PluginsService.java
+++ b/server/src/main/java/org/elasticsearch/plugins/PluginsService.java
@@ -538,41 +538,41 @@ public class PluginsService implements ReportingService<PluginsAndModules> {
         }
     }
 
-    // REMOVE - no longer needed
-//    // package-private for test visibility
-//    static <T> T createExtension(Class<? extends T> extensionClass, Class<T> extensionPointType, Plugin plugin) {
-//        @SuppressWarnings("unchecked")
-//        Constructor<T>[] constructors = (Constructor<T>[]) extensionClass.getConstructors();
-//        if (constructors.length == 0) {
-//            throw new IllegalStateException("no public " + extensionConstructorMessage(extensionClass, extensionPointType));
-//        }
-//
-//        if (constructors.length > 1) {
-//            throw new IllegalStateException("no unique public " + extensionConstructorMessage(extensionClass, extensionPointType));
-//        }
-//
-//        final Constructor<T> constructor = constructors[0];
-//        if (constructor.getParameterCount() > 1) {
-//            throw new IllegalStateException(extensionSignatureMessage(extensionClass, extensionPointType, plugin));
-//        }
-//
-//        if (constructor.getParameterCount() == 1 && constructor.getParameterTypes()[0] != plugin.getClass()) {
-//            throw new IllegalStateException(extensionSignatureMessage(extensionClass, extensionPointType, plugin) +
-//                ", not (" + constructor.getParameterTypes()[0].getName() + ")");
-//        }
-//
-//        try {
-//            if (constructor.getParameterCount() == 0) {
-//                return constructor.newInstance();
-//            } else {
-//                return constructor.newInstance(plugin);
-//            }
-//        } catch (ReflectiveOperationException e) {
-//            throw new IllegalStateException(
-//                "failed to create extension [" + extensionClass.getName() + "] of type [" + extensionPointType.getName() + "]", e
-//            );
-//        }
-//    }
+    // REMOVE - no longer needed - retain for now until tests are updated
+    // package-private for test visibility
+    static <T> T createExtension(Class<? extends T> extensionClass, Class<T> extensionPointType, Plugin plugin) {
+        @SuppressWarnings("unchecked")
+        Constructor<T>[] constructors = (Constructor<T>[]) extensionClass.getConstructors();
+        if (constructors.length == 0) {
+            throw new IllegalStateException("no public " + extensionConstructorMessage(extensionClass, extensionPointType));
+        }
+
+        if (constructors.length > 1) {
+            throw new IllegalStateException("no unique public " + extensionConstructorMessage(extensionClass, extensionPointType));
+        }
+
+        final Constructor<T> constructor = constructors[0];
+        if (constructor.getParameterCount() > 1) {
+            throw new IllegalStateException(extensionSignatureMessage(extensionClass, extensionPointType, plugin));
+        }
+
+        if (constructor.getParameterCount() == 1 && constructor.getParameterTypes()[0] != plugin.getClass()) {
+            throw new IllegalStateException(extensionSignatureMessage(extensionClass, extensionPointType, plugin) +
+                ", not (" + constructor.getParameterTypes()[0].getName() + ")");
+        }
+
+        try {
+            if (constructor.getParameterCount() == 0) {
+                return constructor.newInstance();
+            } else {
+                return constructor.newInstance(plugin);
+            }
+        } catch (ReflectiveOperationException e) {
+            throw new IllegalStateException(
+                "failed to create extension [" + extensionClass.getName() + "] of type [" + extensionPointType.getName() + "]", e
+            );
+        }
+    }
 
     private static <T> String extensionSignatureMessage(Class<? extends T> extensionClass, Class<T> extensionPointType, Plugin plugin) {
         return "signature of " + extensionConstructorMessage(extensionClass, extensionPointType) +

--- a/server/src/main/java/org/elasticsearch/plugins/PluginsService.java
+++ b/server/src/main/java/org/elasticsearch/plugins/PluginsService.java
@@ -529,9 +529,10 @@ public class PluginsService implements ReportingService<PluginsAndModules> {
         if (mt.parameterType(0) != plugin.getClass()) {
             throw new IllegalStateException("expected param type:" + plugin.getClass() + ", in: " + mt);
         }
-        MethodHandle mh = provider.creatorHandle();
+        mt = mt.changeParameterType(0, Plugin.class).changeReturnType(Object.class);
+        MethodHandle mh = provider.creatorHandle().asType(mt);
         try {
-            return (T)mh.invoke(plugin);
+            return (T)mh.invokeExact(plugin);
         } catch (Throwable t) {
             throw new IllegalStateException(
                 "provider [" + provider +" ] failed to create extension type [" + extensionPointType.getName() + "]", t);

--- a/server/src/test/resources/META-INF/services/org.elasticsearch.plugins.PluginsServiceTests$TestExtensiblePluginProvider
+++ b/server/src/test/resources/META-INF/services/org.elasticsearch.plugins.PluginsServiceTests$TestExtensiblePluginProvider
@@ -6,4 +6,4 @@
 # Side Public License, v 1.
 #
 
-org.elasticsearch.plugins.PluginsServiceTests$TestExtension1
+org.elasticsearch.plugins.PluginsServiceTests$TestExtension2Provider

--- a/x-pack/plugin/autoscaling/src/main/java/org/elasticsearch/xpack/autoscaling/Autoscaling.java
+++ b/x-pack/plugin/autoscaling/src/main/java/org/elasticsearch/xpack/autoscaling/Autoscaling.java
@@ -27,6 +27,7 @@ import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 import org.elasticsearch.common.xcontent.ParseField;
 import org.elasticsearch.env.Environment;
 import org.elasticsearch.env.NodeEnvironment;
+import org.elasticsearch.plugins.AbstractPluginExtensionProvider;
 import org.elasticsearch.plugins.ActionPlugin;
 import org.elasticsearch.plugins.ExtensiblePlugin;
 import org.elasticsearch.plugins.Plugin;
@@ -191,6 +192,11 @@ public class Autoscaling extends Plugin implements ActionPlugin, ExtensiblePlugi
         return List.of(
             new NamedXContentRegistry.Entry(Metadata.Custom.class, new ParseField(AutoscalingMetadata.NAME), AutoscalingMetadata::parse)
         );
+    }
+
+    @Override
+    public Class<? extends AbstractPluginExtensionProvider> providerType() {
+        return AutoscalingExtensionProvider.class;
     }
 
     @Override

--- a/x-pack/plugin/autoscaling/src/main/java/org/elasticsearch/xpack/autoscaling/AutoscalingExtensionProvider.java
+++ b/x-pack/plugin/autoscaling/src/main/java/org/elasticsearch/xpack/autoscaling/AutoscalingExtensionProvider.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.autoscaling;
+
+import org.elasticsearch.plugins.AbstractPluginExtensionProvider;
+
+/** Service provider for autoscaling extensions. */
+public abstract class AutoscalingExtensionProvider extends AbstractPluginExtensionProvider {
+
+    public AutoscalingExtensionProvider(Class<?> extensionType, Class<?> argType) {
+        super(extensionType, argType);
+    }
+}

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/autoscaling/MlAutoscalingExtensionProvider.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/autoscaling/MlAutoscalingExtensionProvider.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.ml.autoscaling;
+
+import org.elasticsearch.xpack.autoscaling.AutoscalingExtensionProvider;
+import org.elasticsearch.xpack.ml.MachineLearning;
+
+/** ML autoscaling provider for painless extensions. */
+public class MlAutoscalingExtensionProvider extends AutoscalingExtensionProvider {
+
+    public MlAutoscalingExtensionProvider() {  // explicit no-args ctr, for SL
+        super(MlAutoscalingExtension.class,    // Autoscaling extension type
+              MachineLearning.class);          // ctr arg type
+    }
+}

--- a/x-pack/plugin/ml/src/main/resources/META-INF/services/org.elasticsearch.xpack.autoscaling.AutoscalingExtensionProvider
+++ b/x-pack/plugin/ml/src/main/resources/META-INF/services/org.elasticsearch.xpack.autoscaling.AutoscalingExtensionProvider
@@ -5,4 +5,4 @@
 # 2.0.
 #
 
-org.elasticsearch.xpack.ml.autoscaling.MlAutoscalingExtension
+org.elasticsearch.xpack.ml.autoscaling.MlAutoscalingExtensionProvider


### PR DESCRIPTION
Remove use of Lucene's SPIClassIterator, and replace with Java's ServiceLoader. An additional provider interface and mechanism is defined for extensions that require construction through an invocation of a constructor with a single argument.