### PR TITLE
EQL: Use the document fields only, excluding the metadata fields (#77203)

### DIFF
--- a/x-pack/plugin/eql/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/eql/10_basic.yml
+++ b/x-pack/plugin/eql/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/eql/10_basic.yml
@@ -5,6 +5,10 @@ setup:
           index:  eql_test
           body:
             mappings:
+              properties:
+                some_keyword:
+                  type: keyword
+                  ignore_above: 5 # see https://github.com/elastic/elasticsearch/issues/77152
               runtime:
                 day_of_week:
                   type: keyword
@@ -23,6 +27,7 @@ setup:
             user: SYSTEM
             id: 123
             valid: false
+            some_keyword: longer than normal
           - index:
               _index: eql_test
               _id:    2

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/execution/payload/EventPayload.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/execution/payload/EventPayload.java
@@ -27,7 +27,7 @@ public class EventPayload extends AbstractPayload {
         List<SearchHit> hits = RuntimeUtils.searchHits(response);
         values = new ArrayList<>(hits.size());
         for (SearchHit hit : hits) {
-            values.add(new Event(qualifiedIndex(hit), hit.getId(), hit.getSourceRef(), hit.getFields()));
+            values.add(new Event(qualifiedIndex(hit), hit.getId(), hit.getSourceRef(), hit.getDocumentFields()));
         }
     }
 

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/execution/sequence/SequencePayload.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/execution/sequence/SequencePayload.java
@@ -30,7 +30,7 @@ class SequencePayload extends AbstractPayload {
             List<SearchHit> hits = docs.get(i);
             List<Event> events = new ArrayList<>(hits.size());
             for (SearchHit hit : hits) {
-                events.add(new Event(qualifiedIndex(hit), hit.getId(), hit.getSourceRef(), hit.getFields()));
+                events.add(new Event(qualifiedIndex(hit), hit.getId(), hit.getSourceRef(), hit.getDocumentFields()));
             }
             values.add(new org.elasticsearch.xpack.eql.action.EqlSearchResponse.Sequence(s.key().asList(), events));
         }


### PR DESCRIPTION
Backports the following commits to 7.14:
* Use the document fields only, excluding the metadata fields (EQL: Use the document fields only excluding the metadata fields #77203)
(cherry picked from commit 44b8c96b3fa55609e94c77658c7f2fb94160d5ad)