### PR TITLE
Fix failing non snapshot ci build

### DIFF
--- a/test/external-modules/die-with-dignity/build.gradle
+++ b/test/external-modules/die-with-dignity/build.gradle
@@ -13,6 +13,7 @@ esplugin {
 GradleUtils.extendSourceSet(project, "main", "javaRestTest", tasks.named("javaRestTest"))
 
 tasks.named("javaRestTest").configure {
+  it.onlyIf { BuildParams.isSnapshotBuild() }
   systemProperty 'tests.security.manager', 'false'
   systemProperty 'tests.system_call_filter', 'false'
   nonInputProperties.systemProperty 'log', "${-> testClusters.javaRestTest.singleNode().getServerLog()}"


### PR DESCRIPTION
After moving test-die-with-dignity to an external test module (see #77136) we need
to ensure the javaRestTests are only triggered in snapshot builds as they fail
on non snapshot builds.

Fixes #77326