### PR TITLE
[7.x] Fix failing non snapshot ci build (#77335)

### DIFF
--- a/test/external-modules/die-with-dignity/build.gradle
+++ b/test/external-modules/die-with-dignity/build.gradle
@@ -13,6 +13,7 @@ esplugin {
 GradleUtils.extendSourceSet(project, "main", "javaRestTest", tasks.named("javaRestTest"))
 
 tasks.named("javaRestTest").configure {
+  it.onlyIf { BuildParams.isSnapshotBuild() }
   systemProperty 'tests.security.manager', 'false'
   systemProperty 'tests.system_call_filter', 'false'
   nonInputProperties.systemProperty 'log', "${-> testClusters.javaRestTest.singleNode().getServerLog()}"


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Fix failing non snapshot ci build (#77335)