### PR TITLE
[7.x] Improve handling of corrupt index.latest blob (#77339)

### DIFF
--- a/server/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
+++ b/server/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
@@ -54,6 +54,7 @@ import org.elasticsearch.common.blobstore.BlobStore;
 import org.elasticsearch.common.blobstore.DeleteResult;
 import org.elasticsearch.common.blobstore.fs.FsBlobContainer;
 import org.elasticsearch.common.bytes.BytesArray;
+import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.component.AbstractLifecycleComponent;
 import org.elasticsearch.common.compress.NotXContentException;
 import org.elasticsearch.common.io.Streams;
@@ -2573,7 +2574,17 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
 
     // package private for testing
     long readSnapshotIndexLatestBlob() throws IOException {
-        return Numbers.bytesToLong(Streams.readFully(blobContainer().readBlob(INDEX_LATEST_BLOB)).toBytesRef());
+        final BytesReference content = Streams.readFully(Streams.limitStream(blobContainer().readBlob(INDEX_LATEST_BLOB), Long.BYTES + 1));
+        if (content.length() != Long.BYTES) {
+            throw new RepositoryException(
+                metadata.name(),
+                "exception reading blob ["
+                    + INDEX_LATEST_BLOB
+                    + "]: expected 8 bytes but blob was "
+                    + (content.length() < Long.BYTES ? content.length() + " bytes" : "longer")
+            );
+        }
+        return Numbers.bytesToLong(content.toBytesRef());
     }
 
     private long listBlobsToGetLatestIndexId() throws IOException {

--- a/server/src/test/java/org/elasticsearch/repositories/blobstore/BlobStoreRepositoryTests.java
+++ b/server/src/test/java/org/elasticsearch/repositories/blobstore/BlobStoreRepositoryTests.java
@@ -16,7 +16,9 @@ import org.elasticsearch.client.Client;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.RepositoryMetadata;
 import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.Numbers;
 import org.elasticsearch.common.UUIDs;
+import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.ByteSizeUnit;
 import org.elasticsearch.common.util.BigArrays;
@@ -53,6 +55,7 @@ import java.util.stream.Collectors;
 import static org.elasticsearch.repositories.RepositoryDataTests.generateRandomRepoData;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
@@ -200,6 +203,31 @@ public class BlobStoreRepositoryTests extends ESSingleNodeTestCase {
         assertEquals(ESBlobStoreRepositoryIntegTestCase.getRepositoryData(repository), repositoryData);
         assertThat(repository.latestIndexBlobId(), equalTo(expectedGeneration + 2L));
         assertThat(repository.readSnapshotIndexLatestBlob(), equalTo(expectedGeneration + 2L));
+    }
+
+    public void testCorruptIndexLatestFile() throws Exception {
+        final BlobStoreRepository repository = setupRepo();
+
+        final long generation = randomLong();
+        final byte[] generationBytes = Numbers.longToBytes(generation);
+
+        final byte[] buffer = new byte[16];
+        System.arraycopy(generationBytes, 0, buffer, 0, 8);
+
+        for (int i = 0; i < 16; i++) {
+            repository.blobContainer().writeBlob(BlobStoreRepository.INDEX_LATEST_BLOB, new BytesArray(buffer, 0, i), false);
+            if (i == 8) {
+                assertThat(repository.readSnapshotIndexLatestBlob(), equalTo(generation));
+            } else {
+                assertThat(
+                    expectThrows(RepositoryException.class, repository::readSnapshotIndexLatestBlob).getMessage(),
+                    allOf(
+                        containsString("exception reading blob [index.latest]: expected 8 bytes"),
+                        i < 8 ? containsString("blob was " + i + " bytes") : containsString("blob was longer")
+                    )
+                );
+            }
+        }
     }
 
     public void testRepositoryDataConcurrentModificationNotAllowed() throws Exception {


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Improve handling of corrupt index.latest blob (#77339)