### PR TITLE
[7.x] [Transform] disable index call optimization (#77341)

### DIFF
--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/TransformIndexer.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/TransformIndexer.java
@@ -1112,7 +1112,8 @@ public abstract class TransformIndexer extends AsyncTwoPhaseIndexer<TransformInd
 
         // reduce the indexes to query to the ones that have changes
         SearchRequest request = new SearchRequest(
-            TransformCheckpoint.getChangedIndices(getLastCheckpoint(), getNextCheckpoint()).toArray(new String[0])
+            // gh#77329 optimization turned off
+            TransformCheckpoint.getChangedIndices(TransformCheckpoint.EMPTY, getNextCheckpoint()).toArray(new String[0])
         );
 
         request.allowPartialSearchResults(false) // shard failures should fail the request

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/latest/LatestChangeCollector.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/latest/LatestChangeCollector.java
@@ -54,7 +54,8 @@ class LatestChangeCollector implements Function.ChangeCollector {
     @Override
     public Collection<String> getIndicesToQuery(TransformCheckpoint lastCheckpoint, TransformCheckpoint nextCheckpoint) {
         // we can shortcut here, only the changed indices are of interest
-        return TransformCheckpoint.getChangedIndices(lastCheckpoint, nextCheckpoint);
+        // gh#77329 optimization turned off
+        return TransformCheckpoint.getChangedIndices(TransformCheckpoint.EMPTY, nextCheckpoint);
     }
 
     @Override

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/latest/LatestChangeCollectorTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/latest/LatestChangeCollectorTests.java
@@ -38,6 +38,7 @@ public class LatestChangeCollectorTests extends ESTestCase {
         );
     }
 
+    @AwaitsFix(bugUrl="https://github.com/elastic/elasticsearch/issues/77329")
     public void testGetIndicesToQuery() {
         LatestChangeCollector changeCollector = new LatestChangeCollector("timestamp");
 


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [Transform] disable index call optimization (#77341)