### PR TITLE
[DOCS] Fixes description of index_total property for GET Transforms stats API docs

### DIFF
--- a/docs/reference/rest-api/common-parms.asciidoc
+++ b/docs/reference/rest-api/common-parms.asciidoc
@@ -432,7 +432,7 @@ The amount of time spent indexing, in milliseconds.
 end::index-time-ms[]
 
 tag::index-total[]
-The number of indices created.
+The number of index operations.
 end::index-total[]
 
 tag::bulk-index[]


### PR DESCRIPTION
## Overview

As title states.

### Preview

[GET Transform stats](https://elasticsearch_77354.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/get-transform-stats.html#get-transform-stats-response)