### PR TITLE
[7.13] [DOCS] Add redirect for field aliases (#77349)

### DIFF
--- a/docs/reference/redirects.asciidoc
+++ b/docs/reference/redirects.asciidoc
@@ -3,6 +3,11 @@
 
 The following pages have moved or been deleted.
 
+[role="exclude",id="alias"]
+=== Field aliases
+
+Refer to <<field-alias>>.
+
 [role="exclude",id="grok-basics"]
 === Grok basics
 
@@ -399,7 +404,7 @@ See <<getting-started-index>>.
 See <<indices-delete-index>>.
 
 [role="exclude", id="getting-started-modify-data"]
-== Modifying your data
+=== Modifying your data
 See <<docs-update>>.
 
 [role="exclude", id="indexing-replacing-documents"]


### PR DESCRIPTION
Backports the following commits to 7.13:
 - [DOCS] Update anchor and add redirect for aliases (#77349)