### PR TITLE
Script: UnsignedLong field type converter (#77271)

### DIFF
--- a/x-pack/plugin/mapper-unsigned-long/src/main/java/org/elasticsearch/xpack/unsignedlong/DocValuesWhitelistExtension.java
+++ b/x-pack/plugin/mapper-unsigned-long/src/main/java/org/elasticsearch/xpack/unsignedlong/DocValuesWhitelistExtension.java
@@ -26,7 +26,10 @@ import static java.util.Collections.singletonList;
 
 public class DocValuesWhitelistExtension implements PainlessExtension {
 
-    private static final Whitelist WHITELIST = WhitelistLoader.loadFromResourceFiles(DocValuesWhitelistExtension.class, "whitelist.txt");
+    private static final Whitelist WHITELIST = WhitelistLoader.loadFromResourceFiles(
+        DocValuesWhitelistExtension.class,
+        "org.elasticsearch.xpack.unsignedlong.txt"
+    );
 
     @Override
     public Map<ScriptContext<?>, List<Whitelist>> getContextWhitelists() {

--- a/x-pack/plugin/mapper-unsigned-long/src/main/java/org/elasticsearch/xpack/unsignedlong/UnsignedLongField.java
+++ b/x-pack/plugin/mapper-unsigned-long/src/main/java/org/elasticsearch/xpack/unsignedlong/UnsignedLongField.java
@@ -11,6 +11,7 @@ import org.elasticsearch.script.Converter;
 import org.elasticsearch.script.Converters;
 import org.elasticsearch.script.Field;
 import org.elasticsearch.script.FieldValues;
+import org.elasticsearch.script.InvalidConversion;
 
 import java.math.BigInteger;
 import java.util.List;
@@ -19,6 +20,81 @@ import java.util.stream.Collectors;
 import static org.elasticsearch.xpack.unsignedlong.UnsignedLongFieldMapper.BIGINTEGER_2_64_MINUS_ONE;
 
 public class UnsignedLongField extends Field.LongField {
+    public static final Converter<Long, UnsignedLongField> UnsignedLong = new Converter<Long, UnsignedLongField>() {
+        @Override
+        public UnsignedLongField convert(Field<?> sourceField) {
+            if (sourceField instanceof BigIntegerField) {
+                return BigIntegerToUnsignedLong((BigIntegerField) sourceField);
+            }
+            if (sourceField instanceof LongField) {
+                return LongToUnsignedLong((LongField) sourceField);
+            }
+
+            throw new InvalidConversion(sourceField.getClass(), UnsignedLongField.class);
+        }
+
+        @Override
+        public Class<UnsignedLongField> getFieldClass() {
+            return UnsignedLongField.class;
+        }
+
+        @Override
+        public Class<Long> getTargetClass() {
+            return Long.class;
+        }
+    };
+
+    static UnsignedLongField BigIntegerToUnsignedLong(BigIntegerField sourceField) {
+        FieldValues<BigInteger> fv = sourceField.getFieldValues();
+        return new UnsignedLongField(sourceField.getName(), new Converters.DelegatingFieldValues<Long, BigInteger>(fv) {
+            @Override
+            public List<Long> getValues() {
+                return values.getValues().stream().map(java.math.BigInteger::longValue).collect(Collectors.toList());
+            }
+
+            @Override
+            public Long getNonPrimitiveValue() {
+                return values.getNonPrimitiveValue().longValue();
+            }
+
+            @Override
+            public long getLongValue() {
+                return values.getNonPrimitiveValue().longValue();
+            }
+
+            @Override
+            public double getDoubleValue() {
+                return values.getNonPrimitiveValue().doubleValue();
+            }
+        });
+    }
+
+    public static UnsignedLongField LongToUnsignedLong(LongField sourceField) {
+        FieldValues<Long> fv = sourceField.getFieldValues();
+        return new UnsignedLongField(sourceField.getName(), new Converters.DelegatingFieldValues<Long, Long>(fv) {
+            @Override
+            public List<Long> getValues() {
+                // Takes longs in raw format
+                return values.getValues().stream().map(UnsignedLongScriptDocValues::shiftedLong).collect(Collectors.toList());
+            }
+
+            @Override
+            public Long getNonPrimitiveValue() {
+                return getLongValue();
+            }
+
+            @Override
+            public long getLongValue() {
+                return UnsignedLongScriptDocValues.shiftedLong(values.getLongValue());
+            }
+
+            @Override
+            public double getDoubleValue() {
+                return getLongValue();
+            }
+        });
+    }
+
     public UnsignedLongField(String name, FieldValues<Long> values) {
         super(name, values);
     }
@@ -37,7 +113,7 @@ public class UnsignedLongField extends Field.LongField {
     static BigIntegerField UnsignedLongToBigInteger(UnsignedLongField sourceField) {
         FieldValues<Long> fv = sourceField.getFieldValues();
         return new BigIntegerField(sourceField.getName(), new Converters.DelegatingFieldValues<java.math.BigInteger, Long>(fv) {
-            protected BigInteger toBigInteger(long formatted) {
+            private BigInteger toBigInteger(long formatted) {
                 return java.math.BigInteger.valueOf(formatted).and(BIGINTEGER_2_64_MINUS_ONE);
             }
 
@@ -51,5 +127,26 @@ public class UnsignedLongField extends Field.LongField {
                 return toBigInteger(values.getLongValue());
             }
         });
+    }
+
+    public static class UnsignedLongConverter implements Converter<Long, UnsignedLongField> {
+        @Override
+        public UnsignedLongField convert(Field<?> sourceField) {
+            if (sourceField instanceof BigIntegerField) {
+                return BigIntegerToUnsignedLong((BigIntegerField) sourceField);
+            }
+
+            throw new InvalidConversion(sourceField.getClass(), getFieldClass());
+        }
+
+        @Override
+        public Class<UnsignedLongField> getFieldClass() {
+            return UnsignedLongField.class;
+        }
+
+        @Override
+        public Class<Long> getTargetClass() {
+            return Long.class;
+        }
     }
 }

--- a/x-pack/plugin/mapper-unsigned-long/src/main/resources/org/elasticsearch/xpack/unsignedlong/org.elasticsearch.xpack.unsignedlong.txt
+++ b/x-pack/plugin/mapper-unsigned-long/src/main/resources/org/elasticsearch/xpack/unsignedlong/org.elasticsearch.xpack.unsignedlong.txt
@@ -10,3 +10,11 @@ class org.elasticsearch.xpack.unsignedlong.UnsignedLongScriptDocValues {
   Long get(int)
   long getValue()
 }
+
+
+class org.elasticsearch.script.Field {
+    org.elasticsearch.script.Converter UnsignedLong @augmented[augmented_canonical_class_name="org.elasticsearch.xpack.unsignedlong.UnsignedLongField"]
+}
+
+class org.elasticsearch.xpack.unsignedlong.UnsignedLongField @no_import {
+}

--- a/x-pack/plugin/mapper-unsigned-long/src/test/java/org/elasticsearch/xpack/unsignedlong/UnsignedLongFieldTests.java
+++ b/x-pack/plugin/mapper-unsigned-long/src/test/java/org/elasticsearch/xpack/unsignedlong/UnsignedLongFieldTests.java
@@ -15,53 +15,128 @@ import java.math.BigInteger;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
+import java.util.stream.LongStream;
+
+import static org.elasticsearch.search.DocValueFormat.MASK_2_63;
 
 public class UnsignedLongFieldTests extends ESTestCase {
-    static final BigInteger[] VALUES = {
-        BigInteger.valueOf(0L),
-        new BigInteger("18446744073709551615"), // 2^64 - 1
-        new BigInteger("9223372036854775807"),  // 2^63 - 1
-        new BigInteger("9223372036854775808"),  // 2^63
-        new BigInteger("9223372036854775809"),  // 2^63 + 1
-    };
+    static List<BigInteger> VALUES;
 
-    UnsignedLongField FIELD = new UnsignedLongField("test", new FieldValues<Long>() {
-        protected long[] values = Arrays.stream(UnsignedLongFieldTests.VALUES).mapToLong(BigInteger::longValue).toArray();
+    static List<Long> LONG_VALUES;
 
-        @Override
-        public boolean isEmpty() {
-            return values.length == 0;
-        }
+    protected static UnsignedLongField makeField(List<BigInteger> biValues) {
+        return new UnsignedLongField("test", new FieldValues<Long>() {
+            protected long[] values = biValues.stream().mapToLong(BigInteger::longValue).toArray();
 
-        @Override
-        public int size() {
-            return values.length;
-        }
+            @Override
+            public boolean isEmpty() {
+                return values.length == 0;
+            }
 
-        @Override
-        public List<Long> getValues() {
-            return Arrays.stream(values).boxed().collect(Collectors.toList());
-        }
+            @Override
+            public int size() {
+                return values.length;
+            }
 
-        @Override
-        public Long getNonPrimitiveValue() {
-            return UnsignedLongScriptDocValues.shiftedLong(values[0]);
-        }
+            @Override
+            public List<Long> getValues() {
+                return Arrays.stream(values).boxed().collect(Collectors.toList());
+            }
 
-        @Override
-        public long getLongValue() {
-            return UnsignedLongScriptDocValues.shiftedLong(values[0]);
-        }
+            @Override
+            public Long getNonPrimitiveValue() {
+                return UnsignedLongScriptDocValues.shiftedLong(values[0]);
+            }
 
-        @Override
-        public double getDoubleValue() {
-            return UnsignedLongScriptDocValues.shiftedLong(values[0]);
-        }
-    });
+            @Override
+            public long getLongValue() {
+                return UnsignedLongScriptDocValues.shiftedLong(values[0]);
+            }
+
+            @Override
+            public double getDoubleValue() {
+                return UnsignedLongScriptDocValues.shiftedLong(values[0]);
+            }
+        });
+    }
 
     public void testLongValues() {
-        long[] expected = { 0L, -1L, 9223372036854775807L, -9223372036854775808L, -9223372036854775807L };
-        List<Long> asLong = Arrays.stream(expected).boxed().collect(Collectors.toList());
-        assertEquals(asLong, FIELD.convert(Field.Long).getValues());
+        assertEquals(LONG_VALUES, makeField(VALUES).convert(Field.Long).getValues());
+    }
+
+    public void testUnsignedConverter() {
+        Field<Long> thereAndBackAgain = makeField(VALUES).as(Field.BigInteger).as(UnsignedLongField.UnsignedLong);
+        assertEquals(LONG_VALUES, thereAndBackAgain.getValues());
+    }
+
+    public void testLongToUnsignedLong() {
+        long[] raw = { Long.MIN_VALUE, Long.MAX_VALUE, ((long) Integer.MIN_VALUE - 1), ((long) Integer.MAX_VALUE + 1), -1L, 0L, 1L };
+        Field<Long> src = new Field.LongField("", new FieldValues<Long>() {
+            @Override
+            public boolean isEmpty() {
+                return false;
+            }
+
+            @Override
+            public int size() {
+                return raw.length;
+            }
+
+            @Override
+            public List<Long> getValues() {
+                return LongStream.of(raw).boxed().collect(Collectors.toList());
+            }
+
+            @Override
+            public Long getNonPrimitiveValue() {
+                return raw[0];
+            }
+
+            @Override
+            public long getLongValue() {
+                return raw[0];
+            }
+
+            @Override
+            public double getDoubleValue() {
+                return raw[0];
+            }
+        });
+
+        Field<Long> dst = src.as(UnsignedLongField.UnsignedLong);
+        assertEquals(LongStream.of(raw).map(l -> l ^ MASK_2_63).boxed().collect(Collectors.toList()), dst.getValues());
+        assertEquals(Long.valueOf(raw[0] ^ MASK_2_63), dst.getValue(null));
+        assertEquals(raw[0] ^ MASK_2_63, dst.getLong(10));
+        assertEquals((double) (raw[0] ^ MASK_2_63), dst.getDouble(10.0d), 0.1d);
+    }
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        long rawRandom = randomLongBetween(0, Long.MAX_VALUE);
+        BigInteger rawBigIntegerRandom = BigInteger.valueOf(rawRandom);
+
+        if (randomBoolean()) {
+            rawRandom = rawRandom | MASK_2_63;
+            rawBigIntegerRandom = rawBigIntegerRandom.add(BigInteger.valueOf(2).pow(63));
+        }
+
+        VALUES = org.elasticsearch.core.List.of(
+            rawBigIntegerRandom,
+            new BigInteger("18446744073709551615"), // 2^64 - 1
+            BigInteger.valueOf(0L),
+            new BigInteger("9223372036854775807"),  // 2^63 - 1
+            new BigInteger("9223372036854775808"),  // 2^63
+            new BigInteger("9223372036854775809")  // 2^63 + 1
+        );
+
+        LONG_VALUES = org.elasticsearch.core.List.of(
+            rawRandom,
+            -1L,
+            0L,
+            9223372036854775807L,
+            -9223372036854775808L,
+            -9223372036854775807L
+        );
     }
 }

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/unsigned_long/50_script_values.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/unsigned_long/50_script_values.yml
@@ -172,6 +172,33 @@ setup:
                     source: "doc['ul'].value.doubleValue() > 9E18"
   - match: { hits.total.value: 1 }
   - match: { hits.hits.0._id: "2" }
+  - do:
+      search:
+        index: test1
+        body:
+          query:
+            bool:
+              filter:
+                script:
+                  script:
+                    source: "field('ul').as(Field.BigInteger).as(Field.UnsignedLong).getDouble(-2.2d) > 9E18"
+  - match: { hits.total.value: 4 }
+  - match: { hits.hits.0._id: "2" }
+  - match: { hits.hits.1._id: "3" }
+  - match: { hits.hits.2._id: "4" }
+  - match: { hits.hits.3._id: "5" }
+  - do:
+      search:
+        index: test1
+        body:
+          query:
+            bool:
+              filter:
+                script:
+                  script:
+                    source: "field('ul').as(Field.BigInteger).as(Field.UnsignedLong).getLong(-2L) > 9E18"
+  - match: { hits.total.value: 1 }
+  - match: { hits.hits.0._id: "2" }
 
   - do:
       search:


### PR DESCRIPTION
Scripting field API converter for the UnsignedLong format.

```
field('biginteger').as(Field.UnsignedLong)
```

Backport: 2ee1308

