### PR TITLE
Vector tile end point support for source param

### DIFF
--- a/x-pack/plugin/vector-tile/src/main/java/org/elasticsearch/xpack/vectortile/rest/VectorTileRequest.java
+++ b/x-pack/plugin/vector-tile/src/main/java/org/elasticsearch/xpack/vectortile/rest/VectorTileRequest.java
@@ -136,8 +136,8 @@ class VectorTileRequest {
             Integer.parseInt(restRequest.param(X_PARAM)),
             Integer.parseInt(restRequest.param(Y_PARAM))
         );
-        if (restRequest.hasContent()) {
-            try (XContentParser contentParser = restRequest.contentParser()) {
+        if (restRequest.hasContentOrSourceParam()) {
+            try (XContentParser contentParser = restRequest.contentOrSourceParamParser()) {
                 PARSER.parse(contentParser, request, restRequest);
             }
         }


### PR DESCRIPTION
Tests added in #77264 shows that the API should support source params for the body of the requests. This PR adds that support.

fixes #77365