### PR TITLE
[7.14] Restore public visibility of methods on RootObjectMapper (#77274)

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/mapper/RootObjectMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/RootObjectMapper.java
@@ -267,19 +267,31 @@ public class RootObjectMapper extends ObjectMapper {
         return copy;
     }
 
-    boolean dateDetection() {
+    /**
+     * Public API
+     */
+    public boolean dateDetection() {
         return this.dateDetection.value();
     }
 
-    boolean numericDetection() {
+    /**
+     * Public API
+     */
+    public boolean numericDetection() {
         return this.numericDetection.value();
     }
 
-    DateFormatter[] dynamicDateTimeFormatters() {
+    /**
+     * Public API
+     */
+    public DateFormatter[] dynamicDateTimeFormatters() {
         return dynamicDateTimeFormatters.value();
     }
 
-    DynamicTemplate[] dynamicTemplates() {
+    /**
+     * Public API
+     */
+    public DynamicTemplate[] dynamicTemplates() {
         return dynamicTemplates.value();
     }
 


### PR DESCRIPTION
Backports the following commits to 7.14:
 - Restore public visibility of methods on RootObjectMapper (#77274)