### PR TITLE
Use pid to identify die-with-dignity process

### DIFF
--- a/build-tools/src/main/java/org/elasticsearch/gradle/testclusters/ElasticsearchNode.java
+++ b/build-tools/src/main/java/org/elasticsearch/gradle/testclusters/ElasticsearchNode.java
@@ -1409,6 +1409,12 @@ public class ElasticsearchNode implements TestClusterConfiguration {
         return esProcess.isAlive();
     }
 
+    @Internal
+    public long getPid() {
+        requireNonNull(esProcess, "Can't get pid of " + this + " as it's not started. Does the task have `useCluster` ?");
+        return esProcess.pid();
+    }
+
     void waitForAllConditions() {
         waitForConditions(waitConditions, System.currentTimeMillis(), NODE_UP_TIMEOUT_UNIT.toMillis(NODE_UP_TIMEOUT) +
         // Installing plugins at config time and loading them when nods start requires additional time we need to

--- a/test/external-modules/die-with-dignity/build.gradle
+++ b/test/external-modules/die-with-dignity/build.gradle
@@ -17,6 +17,7 @@ tasks.named("javaRestTest").configure {
   systemProperty 'tests.security.manager', 'false'
   systemProperty 'tests.system_call_filter', 'false'
   nonInputProperties.systemProperty 'log', "${-> testClusters.javaRestTest.singleNode().getServerLog()}"
+  nonInputProperties.systemProperty 'es.pid', "${ -> testClusters.javaRestTest.singleNode().getPid() }"
   systemProperty 'runtime.java.home', BuildParams.runtimeJavaHome
 }
 

--- a/test/external-modules/die-with-dignity/src/javaRestTest/java/org/elasticsearch/qa/die_with_dignity/DieWithDignityIT.java
+++ b/test/external-modules/die-with-dignity/src/javaRestTest/java/org/elasticsearch/qa/die_with_dignity/DieWithDignityIT.java
@@ -31,9 +31,7 @@ public class DieWithDignityIT extends ESRestTestCase {
         expectThrows(IOException.class, () -> client().performRequest(new Request("GET", "/_die_with_dignity")));
 
         // the Elasticsearch process should die and disappear from the output of jps
-        assertBusy(() -> {
-            assertFalse(javaPidExists(esPid));
-        });
+        assertBusy(() -> { assertFalse(javaPidExists(esPid)); });
 
         // parse the logs and ensure that Elasticsearch died with the expected cause
         final List<String> lines = Files.readAllLines(PathUtils.get(System.getProperty("log")));


### PR DESCRIPTION
The die-with-dignity test forces an OOM in Elasticsearch and sees that
it dies appropriately. The test first asserts the correct ES process is
running, and that that process no longer exists after forcing the OOM.
Unfortunately the way of identifying the pid through jps args doesn't
always work (see https://bugs.openjdk.java.net/browse/JDK-7091209).

Instead, this commit passes the known pid for the test cluster through
to the die-with-dignity test, so that it can check for the pid instead
of the command line options.

closes #77282