### PR TITLE
Detecting when a deserialized Map is immutable before changing it in IndexDiskUsageStats (#77219)

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/admin/indices/diskusage/IndexDiskUsageStats.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/diskusage/IndexDiskUsageStats.java
@@ -53,7 +53,7 @@ public final class IndexDiskUsageStats implements ToXContentFragment, Writeable 
     }
 
     public IndexDiskUsageStats(StreamInput in) throws IOException {
-        this.fields = in.readMap(StreamInput::readString, PerFieldDiskUsage::new);
+        this.fields = new HashMap<>(in.readMap(StreamInput::readString, PerFieldDiskUsage::new));
         this.indexSizeInBytes = in.readVLong();
     }
 

--- a/server/src/test/java/org/elasticsearch/action/admin/indices/diskusage/IndexDiskUsageStatsTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/diskusage/IndexDiskUsageStatsTests.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.action.admin.indices.diskusage;
+
+import org.elasticsearch.common.io.stream.BytesStreamOutput;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.test.ESTestCase;
+
+import java.io.IOException;
+
+public class IndexDiskUsageStatsTests extends ESTestCase {
+
+    public void testEmptySerialization() throws IOException {
+        IndexDiskUsageStats emptyDndexDiskUsageStats = createEmptyDiskUsageStats();
+        try (BytesStreamOutput out = new BytesStreamOutput()) {
+            emptyDndexDiskUsageStats.writeTo(out);
+            try (StreamInput in = out.bytes().streamInput()) {
+                IndexDiskUsageStats deserializedNodeStats = new IndexDiskUsageStats(in);
+                assertEquals(emptyDndexDiskUsageStats.getIndexSizeInBytes(), deserializedNodeStats.getIndexSizeInBytes());
+                assertEquals(emptyDndexDiskUsageStats.getFields(), deserializedNodeStats.getFields());
+                // Now just making sure that an exception doesn't get thrown here:
+                deserializedNodeStats.addStoredField(randomAlphaOfLength(10), randomNonNegativeLong());
+            }
+        }
+    }
+
+    private IndexDiskUsageStats createEmptyDiskUsageStats() {
+        return new IndexDiskUsageStats(randomNonNegativeLong());
+    }
+
+}


### PR DESCRIPTION
This commit prevents errors that can happen if an empty fields map is serialized and deserialized
in IndexDiskUsageStats.
Relates #77219 #77327