### PR TITLE
HotThreads refactor - Part 1

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/action/admin/HotThreadsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/action/admin/HotThreadsIT.java
@@ -13,6 +13,7 @@ import org.elasticsearch.action.admin.cluster.node.hotthreads.NodeHotThreads;
 import org.elasticsearch.action.admin.cluster.node.hotthreads.NodesHotThreadsRequestBuilder;
 import org.elasticsearch.action.admin.cluster.node.hotthreads.NodesHotThreadsResponse;
 import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.monitor.jvm.HotThreads;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.hamcrest.Matcher;
 
@@ -66,7 +67,7 @@ public class HotThreadsIT extends ESIntegTestCase {
                         break;
                 }
                 assertThat(type, notNullValue());
-                nodesHotThreadsRequestBuilder.setType(type);
+                nodesHotThreadsRequestBuilder.setType(HotThreads.ReportType.of(type));
             } else {
                 type = null;
             }

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/node/hotthreads/NodesHotThreadsRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/node/hotthreads/NodesHotThreadsRequest.java
@@ -12,6 +12,7 @@ import org.elasticsearch.action.support.nodes.BaseNodesRequest;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.monitor.jvm.HotThreads;
 
 import java.io.IOException;
 import java.util.concurrent.TimeUnit;
@@ -19,7 +20,7 @@ import java.util.concurrent.TimeUnit;
 public class NodesHotThreadsRequest extends BaseNodesRequest<NodesHotThreadsRequest> {
 
     int threads = 3;
-    String type = "cpu";
+    HotThreads.ReportType type = HotThreads.ReportType.CPU;
     TimeValue interval = new TimeValue(500, TimeUnit.MILLISECONDS);
     int snapshots = 10;
     boolean ignoreIdleThreads = true;
@@ -29,7 +30,7 @@ public class NodesHotThreadsRequest extends BaseNodesRequest<NodesHotThreadsRequ
         super(in);
         threads = in.readInt();
         ignoreIdleThreads = in.readBoolean();
-        type = in.readString();
+        type = in.readEnum(HotThreads.ReportType.class);
         interval = in.readTimeValue();
         snapshots = in.readInt();
     }
@@ -60,12 +61,12 @@ public class NodesHotThreadsRequest extends BaseNodesRequest<NodesHotThreadsRequ
         return this;
     }
 
-    public NodesHotThreadsRequest type(String type) {
+    public NodesHotThreadsRequest type(HotThreads.ReportType type) {
         this.type = type;
         return this;
     }
 
-    public String type() {
+    public HotThreads.ReportType type() {
         return this.type;
     }
 
@@ -92,7 +93,7 @@ public class NodesHotThreadsRequest extends BaseNodesRequest<NodesHotThreadsRequ
         super.writeTo(out);
         out.writeInt(threads);
         out.writeBoolean(ignoreIdleThreads);
-        out.writeString(type);
+        out.writeEnum(type);
         out.writeTimeValue(interval);
         out.writeInt(snapshots);
     }

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/node/hotthreads/NodesHotThreadsRequestBuilder.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/node/hotthreads/NodesHotThreadsRequestBuilder.java
@@ -11,6 +11,7 @@ package org.elasticsearch.action.admin.cluster.node.hotthreads;
 import org.elasticsearch.action.support.nodes.NodesOperationRequestBuilder;
 import org.elasticsearch.client.ElasticsearchClient;
 import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.monitor.jvm.HotThreads;
 
 public class NodesHotThreadsRequestBuilder
         extends NodesOperationRequestBuilder<NodesHotThreadsRequest, NodesHotThreadsResponse, NodesHotThreadsRequestBuilder> {
@@ -29,7 +30,7 @@ public class NodesHotThreadsRequestBuilder
         return this;
     }
 
-    public NodesHotThreadsRequestBuilder setType(String type) {
+    public NodesHotThreadsRequestBuilder setType(HotThreads.ReportType type) {
         request.type(type);
         return this;
     }

--- a/server/src/main/java/org/elasticsearch/monitor/jvm/HotThreads.java
+++ b/server/src/main/java/org/elasticsearch/monitor/jvm/HotThreads.java
@@ -112,17 +112,20 @@ public class HotThreads {
             switch (type) {
                 case CPU:
                     return o -> {
-                        assert o.cpuTime >= -1 : "cpu time should not be negative, but was " + o.cpuTime + ", thread id: " + o.threadId;
+                        assert o.cpuTime >=
+                            -1 : "cpu time should not be negative, but was " + o.cpuTime + ", thread id: " + o.threadId;
                         return o.cpuTime;
                     };
                 case WAIT:
                     return o -> {
-                        assert o.waitedTime >= -1 : "waited time should not be negative, but was " + o.waitedTime + ", thread id: " + o.threadId;
+                        assert o.waitedTime >=
+                            -1 : "waited time should not be negative, but was " + o.waitedTime + ", thread id: " + o.threadId;
                         return o.waitedTime;
                     };
                 case BLOCK:
                     return o -> {
-                        assert o.blockedTime >= -1 : "blocked time should not be negative, but was " + o.blockedTime + ", thread id: " + o.threadId;
+                        assert o.blockedTime >=
+                            -1 : "blocked time should not be negative, but was " + o.blockedTime + ", thread id: " + o.threadId;
                         return o.blockedTime;
                     };
             }
@@ -310,8 +313,8 @@ public class HotThreads {
                         final StackTraceElement[] show = allInfos[i][t].getStackTrace();
                         if (count == 1) {
                             sb.append(String.format(Locale.ROOT, "  unique snapshot%n"));
-                            for (int l = 0; l < show.length; l++) {
-                                sb.append(String.format(Locale.ROOT, "    %s%n", show[l]));
+                            for (StackTraceElement frame : show) {
+                                sb.append(String.format(Locale.ROOT, "    %s%n", frame));
                             }
                         } else {
                             sb.append(String.format(Locale.ROOT, "  %d/%d snapshots sharing following %d elements%n",

--- a/server/src/main/java/org/elasticsearch/rest/action/admin/cluster/RestNodesHotThreadsAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/admin/cluster/RestNodesHotThreadsAction.java
@@ -15,6 +15,7 @@ import org.elasticsearch.client.node.NodeClient;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.core.RestApiVersion;
 import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.monitor.jvm.HotThreads;
 import org.elasticsearch.rest.BaseRestHandler;
 import org.elasticsearch.rest.BytesRestResponse;
 import org.elasticsearch.rest.RestRequest;
@@ -91,7 +92,7 @@ public class RestNodesHotThreadsAction extends BaseRestHandler {
         NodesHotThreadsRequest nodesHotThreadsRequest = new NodesHotThreadsRequest(nodesIds);
         nodesHotThreadsRequest.threads(request.paramAsInt("threads", nodesHotThreadsRequest.threads()));
         nodesHotThreadsRequest.ignoreIdleThreads(request.paramAsBoolean("ignore_idle_threads", nodesHotThreadsRequest.ignoreIdleThreads()));
-        nodesHotThreadsRequest.type(request.param("type", nodesHotThreadsRequest.type()));
+        nodesHotThreadsRequest.type(HotThreads.ReportType.of(request.param("type", nodesHotThreadsRequest.type().getTypeValue())));
         nodesHotThreadsRequest.interval(TimeValue.parseTimeValue(request.param("interval"), nodesHotThreadsRequest.interval(), "interval"));
         nodesHotThreadsRequest.snapshots(request.paramAsInt("snapshots", nodesHotThreadsRequest.snapshots()));
         nodesHotThreadsRequest.timeout(request.param("timeout"));

--- a/server/src/main/resources/org/elasticsearch/bootstrap/security.policy
+++ b/server/src/main/resources/org/elasticsearch/bootstrap/security.policy
@@ -22,6 +22,8 @@ grant codeBase "${codebase.elasticsearch-secure-sm}" {
 grant codeBase "${codebase.elasticsearch}" {
   // needed for loading plugins which may expect the context class loader to be set
   permission java.lang.RuntimePermission "setContextClassLoader";
+  // needed by HotThreads to enable wait/block time accounting on demand
+  permission java.lang.management.ManagementPermission "control";
 };
 
 //// Very special jar permissions:

--- a/server/src/test/java/org/elasticsearch/monitor/jvm/HotThreadsTests.java
+++ b/server/src/test/java/org/elasticsearch/monitor/jvm/HotThreadsTests.java
@@ -21,7 +21,6 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 import static org.hamcrest.Matchers.containsString;
-import static org.hamcrest.Matchers.matchesPattern;
 import static org.mockito.Matchers.anyInt;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
@@ -479,7 +478,6 @@ public class HotThreadsTests extends ESTestCase {
         when(mockedMXBean.isThreadCpuTimeSupported()).thenReturn(true);
 
         long[] threadIds = new long[] { 1, 2, 3, 4 }; // Adds up to 10, the intervalNanos for calculating time percentages
-        long mockCurrentThreadId = 0L;
         when(mockedMXBean.getAllThreadIds()).thenReturn(threadIds);
 
         HotThreads hotThreads = new HotThreads()

--- a/server/src/test/java/org/elasticsearch/monitor/jvm/HotThreadsTests.java
+++ b/server/src/test/java/org/elasticsearch/monitor/jvm/HotThreadsTests.java
@@ -17,6 +17,7 @@ import java.lang.management.ThreadMXBean;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 import static org.hamcrest.Matchers.containsString;
@@ -28,11 +29,11 @@ import static org.mockito.Mockito.when;
 public class HotThreadsTests extends ESTestCase {
 
     public void testSupportedThreadsReportType() {
-        for (var type: new String[] {"unsupported", "", null, "CPU", "WAIT", "BLOCK" }) {
+        for (String type: new String[] {"unsupported", "", null, "CPU", "WAIT", "BLOCK" }) {
             expectThrows(IllegalArgumentException.class, () -> new HotThreads().type(HotThreads.ReportType.of(type)));
         }
 
-        for (var type : new String[] { "cpu", "wait", "block" }) {
+        for (String type : new String[] { "cpu", "wait", "block" }) {
             try {
                 new HotThreads().type(HotThreads.ReportType.of(type));
             } catch (IllegalArgumentException e) {
@@ -54,18 +55,20 @@ public class HotThreadsTests extends ESTestCase {
     }
 
     public void testIdleThreadsDetection() {
-        for (var threadName : new String[] {
+        for (String threadName : new String[] {
             "Signal Dispatcher", "Finalizer", "Reference Handler", "Notification Thread", "Common-Cleaner" }) {
             ThreadInfo mockedThreadInfo = mock(ThreadInfo.class);
             when(mockedThreadInfo.getThreadName()).thenReturn(threadName);
             assertTrue(HotThreads.isIdleThread(mockedThreadInfo));
+            assertTrue(HotThreads.isKnownJvmThread(mockedThreadInfo));
         }
 
-        for (var threadName : new String[] { "Text", "", null, "Finalizer".toLowerCase(Locale.ROOT) }) {
+        for (String threadName : new String[] { "Text", "", null, "Finalizer".toLowerCase(Locale.ROOT) }) {
             ThreadInfo mockedThreadInfo = mock(ThreadInfo.class);
             when(mockedThreadInfo.getThreadName()).thenReturn(threadName);
             when(mockedThreadInfo.getStackTrace()).thenReturn(new StackTraceElement[0]);
             assertFalse(HotThreads.isIdleThread(mockedThreadInfo));
+            assertFalse(HotThreads.isKnownJvmThread(mockedThreadInfo));
         }
 
         List<StackTraceElement> testJvmStack = makeThreadStackHelper(
@@ -75,6 +78,10 @@ public class HotThreadsTests extends ESTestCase {
                 new String[]{"org.elasticsearch.monitor.test", "methodThree"},
                 new String[]{"org.elasticsearch.monitor.testOther", "methodFour"}
             ));
+
+        for (StackTraceElement stackFrame : testJvmStack) {
+            assertFalse(HotThreads.isKnownElasticStackFrame(stackFrame.getClassName(), stackFrame.getMethodName()));
+        }
 
         ThreadInfo notIdleThread = mock(ThreadInfo.class);
         when(notIdleThread.getThreadName()).thenReturn("Not Idle Thread");
@@ -91,22 +98,23 @@ public class HotThreadsTests extends ESTestCase {
                 new String[]{"java.util.concurrent.LinkedTransferQueue", "poll"}
             ));
 
-        for (var extraFrame : idleThreadStackElements) {
+        for (StackTraceElement extraFrame : idleThreadStackElements) {
             ThreadInfo idleThread = mock(ThreadInfo.class);
             when(idleThread.getThreadName()).thenReturn("Idle Thread");
             when(idleThread.getStackTrace()).thenReturn(new StackTraceElement[] {extraFrame});
             assertTrue(HotThreads.isIdleThread(idleThread));
+            assertTrue(HotThreads.isKnownElasticStackFrame(extraFrame.getClassName(), extraFrame.getMethodName()));
 
-            var topOfStack = new ArrayList<>(testJvmStack);
+            List<StackTraceElement> topOfStack = new ArrayList<>(testJvmStack);
             topOfStack.add(0, extraFrame);
             assertIdleThreadHelper(idleThread, topOfStack);
 
-            var bottomOfStack = new ArrayList<>(testJvmStack);
+            List<StackTraceElement> bottomOfStack = new ArrayList<>(testJvmStack);
             bottomOfStack.add(extraFrame);
             assertIdleThreadHelper(idleThread, bottomOfStack);
 
             if (testJvmStack.size() > 1) {
-                var middleOfStack = new ArrayList<>(testJvmStack);
+                List<StackTraceElement> middleOfStack = new ArrayList<>(testJvmStack);
                 middleOfStack.add(between(Math.min(1, testJvmStack.size()), Math.max(0, testJvmStack.size() - 1)), extraFrame);
                 assertIdleThreadHelper(idleThread, middleOfStack);
             }
@@ -114,32 +122,30 @@ public class HotThreadsTests extends ESTestCase {
     }
 
     public void testSimilarity() {
-        var stackOne = makeThreadStackHelper(
+        StackTraceElement[] stackOne = makeThreadStackHelper(
             List.of(
                 new String[]{"org.elasticsearch.monitor.test", "methodOne"},
                 new String[]{"org.elasticsearch.monitor.testOther", "methodTwo"}
             )).toArray(new StackTraceElement[0]);
 
-        var stackTwo = makeThreadStackHelper(
+        StackTraceElement[] stackTwo = makeThreadStackHelper(
             List.of(
                 new String[]{"org.elasticsearch.monitor.test1", "methodOne"},
                 new String[]{"org.elasticsearch.monitor.testOther", "methodTwo"}
             )).toArray(new StackTraceElement[0]);
 
-        var stackThree = makeThreadStackHelper(
+        StackTraceElement[] stackThree = makeThreadStackHelper(
             List.of(
                 new String[]{"org.elasticsearch.monitor.testOther", "methodTwo"},
                 new String[]{"org.elasticsearch.monitor.test", "methodOne"}
             )).toArray(new StackTraceElement[0]);
 
-        var stackFour = makeThreadStackHelper(
+        StackTraceElement[] stackFour = makeThreadStackHelper(
             List.of(
                 new String[]{"org.elasticsearch.monitor.testPrior", "methodOther"},
                 new String[]{"org.elasticsearch.monitor.test", "methodOne"},
                 new String[]{"org.elasticsearch.monitor.testOther", "methodTwo"}
             )).toArray(new StackTraceElement[0]);
-
-        HotThreads hotThreads = new HotThreads();
 
         // We can simplify this with records when the toolchain is upgraded
         class SimilarityTestCase {
@@ -154,7 +160,7 @@ public class HotThreadsTests extends ESTestCase {
             }
         }
 
-        var testCases = new SimilarityTestCase[] {
+        SimilarityTestCase[] testCases = new SimilarityTestCase[] {
             new SimilarityTestCase(stackOne, stackOne, 2),
             new SimilarityTestCase(stackOne, stackTwo, 1),
             new SimilarityTestCase(stackOne, stackThree, 0),
@@ -163,7 +169,7 @@ public class HotThreadsTests extends ESTestCase {
             new SimilarityTestCase(stackOne, new StackTraceElement[0], 0),
         };
 
-        for (var testCase : testCases) {
+        for (SimilarityTestCase testCase : testCases) {
             ThreadInfo threadOne = mock(ThreadInfo.class);
             when(threadOne.getThreadName()).thenReturn("Thread One");
             when(threadOne.getStackTrace()).thenReturn(testCase.one);
@@ -172,14 +178,17 @@ public class HotThreadsTests extends ESTestCase {
             when(threadTwo.getThreadName()).thenReturn("Thread Two");
             when(threadTwo.getStackTrace()).thenReturn(testCase.two);
 
-            assertEquals(testCase.similarityScore, hotThreads.similarity(threadOne, threadTwo));
+            assertEquals(testCase.similarityScore, HotThreads.similarity(threadOne, threadTwo));
         }
 
         ThreadInfo threadOne = mock(ThreadInfo.class);
         when(threadOne.getThreadName()).thenReturn("Thread One");
         when(threadOne.getStackTrace()).thenReturn(testCases[0].one);
 
-        assertEquals(0, hotThreads.similarity(threadOne, null));
+        assertEquals(0, HotThreads.similarity(threadOne, null));
+
+        assertEquals(0, HotThreads.getStackTrace(null).length);
+        assertEquals(2, HotThreads.getStackTrace(threadOne).length);
     }
 
     // We call this helper for each different mode to reset the before and after timings.
@@ -204,7 +213,7 @@ public class HotThreadsTests extends ESTestCase {
 
             when(mockedThreadInfo.getThreadId()).thenReturn(threadId);
 
-            var stack = makeThreadStackHelper(
+            StackTraceElement[] stack = makeThreadStackHelper(
                 List.of(
                     new String[]{"org.elasticsearch.monitor.test", String.format(Locale.ROOT, "method_%d", (threadId) % 2)},
                     new String[]{"org.elasticsearch.monitor.testOther", "methodFinal"}
@@ -224,7 +233,7 @@ public class HotThreadsTests extends ESTestCase {
         ThreadMXBean mockedMXBean = mock(ThreadMXBean.class);
         when(mockedMXBean.isThreadCpuTimeSupported()).thenReturn(true);
 
-        var threadIds = new long[] { 1, 2, 3, 4 }; // Adds up to 10, the intervalNanos for calculating time percentages
+        long[] threadIds = new long[] { 1, 2, 3, 4 }; // Adds up to 10, the intervalNanos for calculating time percentages
         long mockCurrentThreadId = 0L;
         when(mockedMXBean.getAllThreadIds()).thenReturn(threadIds);
 
@@ -302,7 +311,7 @@ public class HotThreadsTests extends ESTestCase {
         when(mockedMXBean.isThreadCpuTimeSupported()).thenReturn(true);
 
         long mockCurrentThreadId = 5L;
-        var threadIds = new long[] { mockCurrentThreadId }; // Matches half the intervalNanos for calculating time percentages
+        long[] threadIds = new long[] { mockCurrentThreadId }; // Matches half the intervalNanos for calculating time percentages
 
         when(mockedMXBean.getAllThreadIds()).thenReturn(threadIds);
 
@@ -332,5 +341,144 @@ public class HotThreadsTests extends ESTestCase {
         assertEquals(1L, HotThreads.ThreadTimeAccumulator.valueGetterForReportType(HotThreads.ReportType.CPU).applyAsLong(info));
         assertEquals(3L, HotThreads.ThreadTimeAccumulator.valueGetterForReportType(HotThreads.ReportType.WAIT).applyAsLong(info));
         assertEquals(2L, HotThreads.ThreadTimeAccumulator.valueGetterForReportType(HotThreads.ReportType.BLOCK).applyAsLong(info));
+    }
+
+    public void testGetAllValidThreadInfos() {
+        ThreadMXBean mockedMXBean = mock(ThreadMXBean.class);
+        when(mockedMXBean.isThreadCpuTimeSupported()).thenReturn(true);
+
+        long[] threadIds = new long[] { 1, 2, 3, 4 }; // Adds up to 10, the intervalNanos for calculating time percentages
+        long mockCurrentThreadId = 0L;
+        when(mockedMXBean.getAllThreadIds()).thenReturn(threadIds);
+
+        HotThreads hotThreads = new HotThreads()
+            .busiestThreads(4)
+            .type(HotThreads.ReportType.CPU)
+            .interval(TimeValue.timeValueNanos(10))
+            .threadElementsSnapshotCount(11)
+            .ignoreIdleThreads(false);
+
+        // Test the case when all threads exist before and after sleep
+        List<ThreadInfo> allInfos = makeThreadInfoMocksHelper(mockedMXBean, threadIds);
+
+        Map<Long, HotThreads.ThreadTimeAccumulator> validInfos = hotThreads.getAllValidThreadInfos(mockedMXBean, mockCurrentThreadId);
+        assertEquals(allInfos.size(), validInfos.size());
+
+        for (long threadId : threadIds) {
+            HotThreads.ThreadTimeAccumulator accumulator = validInfos.get(threadId);
+            assertNotNull(accumulator);
+            assertEquals(0, accumulator.cpuTime);
+            assertEquals(0, accumulator.blockedTime);
+            assertEquals(0, accumulator.waitedTime);
+        }
+
+        // Fake sleep, e.g don't sleep call the mock again
+
+        Map<Long, HotThreads.ThreadTimeAccumulator> afterValidInfos = hotThreads.getAllValidThreadInfos(mockedMXBean, mockCurrentThreadId);
+        assertEquals(allInfos.size(), afterValidInfos.size());
+        for (long threadId : threadIds) {
+            HotThreads.ThreadTimeAccumulator accumulator = afterValidInfos.get(threadId);
+            assertNotNull(accumulator);
+            boolean evenThreadId = ((threadId % 2) == 0);
+
+            assertEquals(threadId, accumulator.cpuTime);
+            assertEquals((evenThreadId) ? 0 : threadId, accumulator.blockedTime);
+            assertEquals((evenThreadId) ? threadId : 0, accumulator.waitedTime);
+        }
+
+        // Test when a thread has terminated during sleep, we don't report that thread
+        allInfos = makeThreadInfoMocksHelper(mockedMXBean, threadIds);
+
+        validInfos = hotThreads.getAllValidThreadInfos(mockedMXBean, mockCurrentThreadId);
+        assertEquals(allInfos.size(), validInfos.size());
+
+        ThreadInfo removedInfo = allInfos.remove(0);
+        long[] reducedThreadIds = new long[] { 2, 3, 4 };
+        when(mockedMXBean.getAllThreadIds()).thenReturn(reducedThreadIds);
+        when(mockedMXBean.getThreadInfo(Matchers.any(), anyInt())).thenReturn(allInfos.toArray(new ThreadInfo[0]));
+        when(mockedMXBean.getThreadInfo(Matchers.any(long[].class))).thenReturn(allInfos.toArray(new ThreadInfo[0]));
+
+        // Fake sleep
+
+        afterValidInfos = hotThreads.getAllValidThreadInfos(mockedMXBean, mockCurrentThreadId);
+        assertEquals(reducedThreadIds.length, afterValidInfos.size());
+
+        for (long threadId : reducedThreadIds) {
+            HotThreads.ThreadTimeAccumulator accumulator = afterValidInfos.get(threadId);
+            assertNotNull(accumulator);
+            boolean evenThreadId = ((threadId % 2) == 0);
+
+            assertEquals(threadId, accumulator.cpuTime);
+            assertEquals((evenThreadId) ? 0 : threadId, accumulator.blockedTime);
+            assertEquals((evenThreadId) ? threadId : 0, accumulator.waitedTime);
+        }
+
+        // Test capturing timings for thread that launched while we were sleeping
+        allInfos.add(0, removedInfo); // We called getInfo on this once, so second time should be with cpu/wait > 0
+        when(mockedMXBean.getAllThreadIds()).thenReturn(threadIds);
+        when(mockedMXBean.getThreadInfo(Matchers.any(), anyInt())).thenReturn(allInfos.toArray(new ThreadInfo[0]));
+        when(mockedMXBean.getThreadInfo(Matchers.any(long[].class))).thenReturn(allInfos.toArray(new ThreadInfo[0]));
+
+        // Fake sleep
+
+        afterValidInfos = hotThreads.getAllValidThreadInfos(mockedMXBean, mockCurrentThreadId);
+        assertEquals(threadIds.length, afterValidInfos.size());
+
+        HotThreads.ThreadTimeAccumulator firstAccumulator = afterValidInfos.get(removedInfo.getThreadId());
+        assertEquals(1, firstAccumulator.cpuTime);
+        assertEquals(0, firstAccumulator.waitedTime);
+        assertEquals(1, firstAccumulator.blockedTime);
+
+        // Test skipping of current thread
+        validInfos = hotThreads.getAllValidThreadInfos(mockedMXBean, threadIds[threadIds.length - 1]);
+        assertEquals(threadIds.length - 1, validInfos.size());
+        assertFalse(validInfos.containsKey(threadIds[threadIds.length - 1]));
+
+        // Test skipping threads with CPU time of -1
+        when(mockedMXBean.getThreadCpuTime(threadIds[0])).thenReturn(-1L);
+        validInfos = hotThreads.getAllValidThreadInfos(mockedMXBean, mockCurrentThreadId);
+        assertEquals(threadIds.length - 1, validInfos.size());
+        assertFalse(validInfos.containsKey(threadIds[0]));
+
+        // Test skipping null thread infos
+        when(mockedMXBean.getThreadInfo(eq(threadIds[0]), anyInt())).thenReturn(null);
+        validInfos = hotThreads.getAllValidThreadInfos(mockedMXBean, mockCurrentThreadId);
+        assertEquals(threadIds.length - 1, validInfos.size());
+        assertFalse(validInfos.containsKey(threadIds[0]));
+    }
+
+    public void testCaptureThreadStacks() throws InterruptedException {
+        ThreadMXBean mockedMXBean = mock(ThreadMXBean.class);
+        when(mockedMXBean.isThreadCpuTimeSupported()).thenReturn(true);
+
+        long[] threadIds = new long[] { 1, 2, 3, 4 }; // Adds up to 10, the intervalNanos for calculating time percentages
+        long mockCurrentThreadId = 0L;
+        when(mockedMXBean.getAllThreadIds()).thenReturn(threadIds);
+
+        HotThreads hotThreads = new HotThreads()
+            .busiestThreads(4)
+            .type(HotThreads.ReportType.CPU)
+            .interval(TimeValue.timeValueNanos(1))
+            .threadElementsSnapshotCount(3)
+            .ignoreIdleThreads(false);
+
+        // Setup the mocks
+        List<ThreadInfo> allInfos = makeThreadInfoMocksHelper(mockedMXBean, threadIds);
+
+        long[] topThreadIds = new long[] { threadIds[threadIds.length - 1], threadIds[threadIds.length - 2] };
+        List<ThreadInfo> topThreads = List.of(
+            allInfos.get(threadIds.length - 1),
+            allInfos.get(threadIds.length - 2));
+
+        when(mockedMXBean.getThreadInfo(Matchers.any(long[].class), anyInt())).thenReturn(topThreads.toArray(new ThreadInfo[0]));
+
+        ThreadInfo[][] infosWithStacks = hotThreads.captureThreadStacks(mockedMXBean, topThreadIds);
+
+        assertEquals(3, infosWithStacks.length);
+        for (ThreadInfo[] infos : infosWithStacks) {
+            assertEquals(2, infos.length);
+            assertEquals(threadIds[threadIds.length - 1], infos[0].getThreadId());
+            assertEquals(threadIds[threadIds.length - 2], infos[1].getThreadId());
+        }
     }
 }


### PR DESCRIPTION
This PR does few things:

- It refactors about half of the code inside HotThreads.innerDetect into separate methods for unit testing.
- Adds unit tests for the newly created methods and few other tests for the remaining functionality.
- It fixes the wait/blocked time reporting by enabling `Thread Contention Monitoring` in the JVM. With this change wait/blocked times will be accurately reported.
- It changes the report type from String into an Enum type. This change introduces slight behaviour difference. Previously when the HotThreads API was called with an incorrect report type, e.g. `/_nodes/hot_threads?type=gpu` we'd crash with InvalidArgumentException, but after argument validation, therefore producing an empty 400 response. After this change we get a 400 with response: `"reason": "type not supported [gpu]"` 