### PR TITLE
Adding support for source param parsing to avoid intermittent test failures

### DIFF
--- a/x-pack/plugin/vector-tile/src/main/java/org/elasticsearch/xpack/vectortile/rest/VectorTileRequest.java
+++ b/x-pack/plugin/vector-tile/src/main/java/org/elasticsearch/xpack/vectortile/rest/VectorTileRequest.java
@@ -136,8 +136,8 @@ class VectorTileRequest {
             Integer.parseInt(restRequest.param(X_PARAM)),
             Integer.parseInt(restRequest.param(Y_PARAM))
         );
-        if (restRequest.hasContent()) {
-            try (XContentParser contentParser = restRequest.contentParser()) {
+        if (restRequest.hasContentOrSourceParam()) {
+            try (XContentParser contentParser = restRequest.contentOrSourceParamParser()) {
                 PARSER.parse(contentParser, request, restRequest);
             }
         }


### PR DESCRIPTION
It looks like about 10% of the time, ClientYamlTestClient sends the request parameters in the "source" field.
If you run with the seed in this command (grabbed from one of my recent failed builds), you'll get the failure:
`./gradlew ':x-pack:plugin:vector-tile:yamlRestTest' --tests "org.elasticsearch.xpack.vectortile.VectorTileClientYamlTestSuiteIT.test {yaml=/10_basic/grid precision}" -Dtests.seed=E5FA75ABBB16CB80 -Dtests.locale=hr-HR -Dtests.timezone=America/Blanc-Sablon -Druntime.java=11`