### PR TITLE
API keys with DLS/FLS no longer allowed with incompatible license

### DIFF
--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/Security.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/Security.java
@@ -543,7 +543,7 @@ public class Security extends Plugin implements SystemIndexPlugin, IngestPlugin,
         }
 
         final ApiKeyService apiKeyService = new ApiKeyService(settings, Clock.systemUTC(), client, securityIndex.get(),
-            clusterService, cacheInvalidatorRegistry, threadPool);
+            clusterService, cacheInvalidatorRegistry, threadPool, getLicenseState());
         components.add(apiKeyService);
 
         final HttpTlsRuntimeCheck httpTlsRuntimeCheck = new HttpTlsRuntimeCheck(settings, transportReference);

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/ApiKeyService.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/ApiKeyService.java
@@ -278,16 +278,14 @@ public class ApiKeyService {
         if (authentication == null) {
             listener.onFailure(new IllegalArgumentException("authentication must be provided"));
         } else {
-            if (request.getRoleDescriptors().stream().anyMatch(RoleDescriptor::isUsingDocumentOrFieldLevelSecurity)) {
+            final boolean requestHasDlsFls =
+                request.getRoleDescriptors().stream().anyMatch(RoleDescriptor::isUsingDocumentOrFieldLevelSecurity);
+            final boolean userHasDlsFls = userRoles.stream().anyMatch(RoleDescriptor::isUsingDocumentOrFieldLevelSecurity);
+            if (requestHasDlsFls || userHasDlsFls) {
                 if (false == licenseState.checkFeature(XPackLicenseState.Feature.SECURITY_DLS_FLS)) {
                     listener.onFailure(
-                        LicenseUtils.newComplianceException("field and document level security in API key role descriptors"));
-                    return;
-                }
-            } else if (userRoles.stream().anyMatch(RoleDescriptor::isUsingDocumentOrFieldLevelSecurity)) {
-                if (false == licenseState.checkFeature(XPackLicenseState.Feature.SECURITY_DLS_FLS)) {
-                    listener.onFailure(
-                        LicenseUtils.newComplianceException("field and document level security in user roles"));
+                        LicenseUtils.newComplianceException("field and document level security in "
+                            + (requestHasDlsFls ? "API key role descriptors": "user roles")));
                     return;
                 }
             }

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/audit/logfile/LoggingAuditTrailFilterTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/audit/logfile/LoggingAuditTrailFilterTests.java
@@ -19,6 +19,7 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 import org.elasticsearch.common.xcontent.XContentType;
+import org.elasticsearch.license.XPackLicenseState;
 import org.elasticsearch.mock.orig.Mockito;
 import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.test.ESTestCase;
@@ -93,7 +94,7 @@ public class LoggingAuditTrailFilterTests extends ESTestCase {
             return null;
         }).when(clusterService).addListener(Mockito.isA(LoggingAuditTrail.class));
         apiKeyService = new ApiKeyService(settings, Clock.systemUTC(), mock(Client.class), mock(SecurityIndexManager.class), clusterService,
-                                          mock(CacheInvalidatorRegistry.class), mock(ThreadPool.class));
+                                          mock(CacheInvalidatorRegistry.class), mock(ThreadPool.class), mock(XPackLicenseState.class));
     }
 
     public void testPolicyDoesNotMatchNullValuesInEvent() throws Exception {

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/audit/logfile/LoggingAuditTrailTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/audit/logfile/LoggingAuditTrailTests.java
@@ -35,6 +35,7 @@ import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentType;
+import org.elasticsearch.license.XPackLicenseState;
 import org.elasticsearch.mock.orig.Mockito;
 import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.tasks.Task;
@@ -298,7 +299,7 @@ public class LoggingAuditTrailTests extends ESTestCase {
         logger = CapturingLogger.newCapturingLogger(randomFrom(Level.OFF, Level.FATAL, Level.ERROR, Level.WARN, Level.INFO), patternLayout);
         auditTrail = new LoggingAuditTrail(settings, clusterService, logger, threadContext);
         apiKeyService = new ApiKeyService(settings, Clock.systemUTC(), client, securityIndexManager, clusterService,
-                                          mock(CacheInvalidatorRegistry.class), mock(ThreadPool.class));
+                                          mock(CacheInvalidatorRegistry.class), mock(ThreadPool.class), mock(XPackLicenseState.class));
     }
 
     @After

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/ApiKeyServiceTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/ApiKeyServiceTests.java
@@ -68,7 +68,6 @@ import org.elasticsearch.xpack.core.security.authc.AuthenticationResult;
 import org.elasticsearch.xpack.core.security.authc.support.AuthenticationContextSerializer;
 import org.elasticsearch.xpack.core.security.authc.support.Hasher;
 import org.elasticsearch.xpack.core.security.authz.RoleDescriptor;
-import org.elasticsearch.xpack.core.security.authz.permission.Role;
 import org.elasticsearch.xpack.core.security.authz.privilege.ApplicationPrivilege;
 import org.elasticsearch.xpack.core.security.user.User;
 import org.elasticsearch.xpack.security.authc.ApiKeyService.ApiKeyCredentials;

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/AuthenticationServiceTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/AuthenticationServiceTests.java
@@ -282,7 +282,7 @@ public class AuthenticationServiceTests extends ESTestCase {
         ClusterService clusterService = ClusterServiceUtils.createClusterService(threadPool);
         final SecurityContext securityContext = new SecurityContext(settings, threadContext);
         apiKeyService = new ApiKeyService(settings, Clock.systemUTC(), client, securityIndex, clusterService,
-                                          mock(CacheInvalidatorRegistry.class), threadPool);
+                                          mock(CacheInvalidatorRegistry.class), threadPool, mock(XPackLicenseState.class));
         tokenService = new TokenService(settings, Clock.systemUTC(), client, licenseState, securityContext, securityIndex, securityIndex,
             clusterService);
         serviceAccountService = mock(ServiceAccountService.class);

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/support/SecondaryAuthenticatorTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/support/SecondaryAuthenticatorTests.java
@@ -21,6 +21,7 @@ import org.elasticsearch.env.Environment;
 import org.elasticsearch.env.TestEnvironment;
 import org.elasticsearch.license.License;
 import org.elasticsearch.license.TestUtils;
+import org.elasticsearch.license.XPackLicenseState;
 import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.TestMatchers;
@@ -127,7 +128,7 @@ public class SecondaryAuthenticatorTests extends ESTestCase {
 
         tokenService = new TokenService(settings, clock, client, licenseState, securityContext, securityIndex, tokensIndex, clusterService);
         final ApiKeyService apiKeyService = new ApiKeyService(settings, clock, client, securityIndex, clusterService,
-                                                              mock(CacheInvalidatorRegistry.class),threadPool);
+            mock(CacheInvalidatorRegistry.class), threadPool, mock(XPackLicenseState.class));
         final ServiceAccountService serviceAccountService = mock(ServiceAccountService.class);
         doAnswer(invocationOnMock -> {
             @SuppressWarnings("unchecked")

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/store/CompositeRolesStoreTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/store/CompositeRolesStoreTests.java
@@ -1087,7 +1087,7 @@ public class CompositeRolesStoreTests extends ESTestCase {
         ThreadContext threadContext = new ThreadContext(SECURITY_ENABLED_SETTINGS);
         ApiKeyService apiKeyService = spy(new ApiKeyService(SECURITY_ENABLED_SETTINGS, Clock.systemUTC(), mock(Client.class),
                 mock(SecurityIndexManager.class), mock(ClusterService.class),
-                mock(CacheInvalidatorRegistry.class), mock(ThreadPool.class)));
+                mock(CacheInvalidatorRegistry.class), mock(ThreadPool.class), mock(XPackLicenseState.class)));
         NativePrivilegeStore nativePrivStore = mock(NativePrivilegeStore.class);
         doAnswer(invocationOnMock -> {
             @SuppressWarnings("unchecked")
@@ -1143,7 +1143,7 @@ public class CompositeRolesStoreTests extends ESTestCase {
 
         ApiKeyService apiKeyService = spy(new ApiKeyService(SECURITY_ENABLED_SETTINGS, Clock.systemUTC(), mock(Client.class),
                 mock(SecurityIndexManager.class), mock(ClusterService.class),
-                mock(CacheInvalidatorRegistry.class), mock(ThreadPool.class)));
+                mock(CacheInvalidatorRegistry.class), mock(ThreadPool.class), mock(XPackLicenseState.class)));
         NativePrivilegeStore nativePrivStore = mock(NativePrivilegeStore.class);
         doAnswer(invocationOnMock -> {
             @SuppressWarnings("unchecked")


### PR DESCRIPTION
This PR adds a license check for DLS/FLS when creating API keys. If any
of the API key role descriptors use DLS/FLS or if any of the user roles
use DLS/FLS, a license compliance will be thrown.

Note this change does not affect any existing API keys that were already
created when the license was still compatible.

Resolves: #77160
