### PR TITLE
[7.15] [DOCS] Fixes description of index_total property for GET Transforms stats API docs. (#77354)

### DIFF
--- a/docs/reference/rest-api/common-parms.asciidoc
+++ b/docs/reference/rest-api/common-parms.asciidoc
@@ -446,7 +446,7 @@ The amount of time spent indexing, in milliseconds.
 end::index-time-ms[]
 
 tag::index-total[]
-The number of indices created.
+The number of index operations.
 end::index-total[]
 
 tag::bulk-index[]


### PR DESCRIPTION
Backports the following commits to 7.15:
 - [DOCS] Fixes description of index_total property for GET Transforms stats API docs. (#77354)