### PR TITLE
Match IPv6 addresses without compressed id from settings

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/node/DiscoveryNodeFilters.java
+++ b/server/src/main/java/org/elasticsearch/cluster/node/DiscoveryNodeFilters.java
@@ -8,14 +8,15 @@
 
 package org.elasticsearch.cluster.node;
 
-import org.elasticsearch.core.Nullable;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.network.InetAddresses;
 import org.elasticsearch.common.network.NetworkAddress;
 import org.elasticsearch.common.regex.Regex;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.transport.TransportAddress;
+import org.elasticsearch.core.Nullable;
 
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
@@ -53,7 +54,10 @@ public class DiscoveryNodeFilters {
         for (Map.Entry<String, String> entry : filters.entrySet()) {
             String[] values = Strings.tokenizeToStringArray(entry.getValue(), ",");
             if (values.length > 0) {
-                bFilters.put(entry.getKey(), values);
+                bFilters.put(entry.getKey(), Arrays.stream(values)
+                    .map(ipOrHost -> InetAddresses.isInetAddress(ipOrHost) ?
+                        NetworkAddress.format(InetAddresses.forString(ipOrHost)) : ipOrHost)
+                    .toArray(String[]::new));
             }
         }
         if (bFilters.isEmpty()) {

--- a/server/src/main/java/org/elasticsearch/cluster/node/DiscoveryNodeFilters.java
+++ b/server/src/main/java/org/elasticsearch/cluster/node/DiscoveryNodeFilters.java
@@ -16,7 +16,6 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.transport.TransportAddress;
 import org.elasticsearch.core.Nullable;
 
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
@@ -54,10 +53,7 @@ public class DiscoveryNodeFilters {
         for (Map.Entry<String, String> entry : filters.entrySet()) {
             String[] values = Strings.tokenizeToStringArray(entry.getValue(), ",");
             if (values.length > 0) {
-                bFilters.put(entry.getKey(), Arrays.stream(values)
-                    .map(ipOrHost -> InetAddresses.isInetAddress(ipOrHost) ?
-                        NetworkAddress.format(InetAddresses.forString(ipOrHost)) : ipOrHost)
-                    .toArray(String[]::new));
+                bFilters.put(entry.getKey(), values);
             }
         }
         if (bFilters.isEmpty()) {
@@ -76,7 +72,8 @@ public class DiscoveryNodeFilters {
     }
 
     private boolean matchByIP(String[] values, @Nullable String hostIp, @Nullable String publishIp) {
-        for (String value : values) {
+        for (String ipOrHost : values) {
+            String value = InetAddresses.isInetAddress(ipOrHost) ? NetworkAddress.format(InetAddresses.forString(ipOrHost)) : ipOrHost;
             boolean matchIp = Regex.simpleMatch(value, hostIp) || Regex.simpleMatch(value, publishIp);
             if (matchIp) {
                 return matchIp;

--- a/server/src/test/java/org/elasticsearch/cluster/node/DiscoveryNodeFiltersTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/node/DiscoveryNodeFiltersTests.java
@@ -305,6 +305,16 @@ public class DiscoveryNodeFiltersTests extends ESTestCase {
         assertThat(filters.match(node), equalTo(true));
     }
 
+    public void testHostnameWhichLooksLikeIpv6DoesNotGetMatched() {
+        Settings settings = shuffleSettings(Settings.builder()
+            .put("xxx._name", "fdbd:dc00:111:222:0:0:0:333")
+            .build());
+        DiscoveryNodeFilters filters = buildFromSettings(OR, "xxx.", settings);
+
+        DiscoveryNode node = new DiscoveryNode("", "", "", "fdbd:dc00:111:222::333", "", localAddress, emptyMap(), emptySet(), null);
+        assertThat(filters.match(node), equalTo(false));
+    }
+
     public void testHostnameGetMatchedAndNotAffectedByNormalizing() {
         Settings settings = shuffleSettings(Settings.builder()
             .put("xxx._host", "test-host")

--- a/server/src/test/java/org/elasticsearch/cluster/node/DiscoveryNodeFiltersTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/node/DiscoveryNodeFiltersTests.java
@@ -295,7 +295,7 @@ public class DiscoveryNodeFiltersTests extends ESTestCase {
         assertThat(discoveryNodeFilters.isOnlyAttributeValueFilter(), is(discoveryNodeFilters.match(node)));
     }
 
-    public void testIpv6WithScopeIdFromSettingsMatchingIpv6WithCompressedScopeId() {
+    public void testNormalizesIPAddressFilters() {
         Settings settings = shuffleSettings(Settings.builder()
             .put("xxx." + randomFrom("_ip", "_host_ip", "_publish_ip"), "fdbd:dc00:111:222:0:0:0:333")
             .build());
@@ -305,7 +305,7 @@ public class DiscoveryNodeFiltersTests extends ESTestCase {
         assertThat(filters.match(node), equalTo(true));
     }
 
-    public void testHostnameGetMatchedAndNotAffectedByIpFormatting() {
+    public void testHostnameGetMatchedAndNotAffectedByNormalizing() {
         Settings settings = shuffleSettings(Settings.builder()
             .put("xxx._host", "test-host")
             .build());

--- a/server/src/test/java/org/elasticsearch/cluster/node/DiscoveryNodeFiltersTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/node/DiscoveryNodeFiltersTests.java
@@ -305,6 +305,16 @@ public class DiscoveryNodeFiltersTests extends ESTestCase {
         assertThat(filters.match(node), equalTo(true));
     }
 
+    public void testHostnameGetMatchedAndNotAffectedByIpFormatting() {
+        Settings settings = shuffleSettings(Settings.builder()
+            .put("xxx._host", "test-host")
+            .build());
+        DiscoveryNodeFilters filters = buildFromSettings(OR, "xxx.", settings);
+
+        DiscoveryNode node = new DiscoveryNode("", "", "", "test-host", "192.168.0.1", localAddress, emptyMap(), emptySet(), null);
+        assertThat(filters.match(node), equalTo(true));
+    }
+
     private Settings shuffleSettings(Settings source) {
         Settings.Builder settings = Settings.builder();
         List<String> keys = new ArrayList<>(source.keySet());

--- a/server/src/test/java/org/elasticsearch/cluster/node/DiscoveryNodeFiltersTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/node/DiscoveryNodeFiltersTests.java
@@ -295,6 +295,16 @@ public class DiscoveryNodeFiltersTests extends ESTestCase {
         assertThat(discoveryNodeFilters.isOnlyAttributeValueFilter(), is(discoveryNodeFilters.match(node)));
     }
 
+    public void testIpv6WithScopeIdFromSettingsMatchingIpv6WithCompressedScopeId() {
+        Settings settings = shuffleSettings(Settings.builder()
+            .put("xxx." + randomFrom("_ip", "_host_ip", "_publish_ip"), "fdbd:dc00:111:222:0:0:0:333")
+            .build());
+        DiscoveryNodeFilters filters = buildFromSettings(OR, "xxx.", settings);
+
+        DiscoveryNode node = new DiscoveryNode("", "", "", "", "fdbd:dc00:111:222::333", localAddress, emptyMap(), emptySet(), null);
+        assertThat(filters.match(node), equalTo(true));
+    }
+
     private Settings shuffleSettings(Settings source) {
         Settings.Builder settings = Settings.builder();
         List<String> keys = new ArrayList<>(source.keySet());


### PR DESCRIPTION
Make sure we normalize IPv6 addresses from the settings to the compressed form before we
match them with node ips. Node IPv6 addresses are all represented with the scope id
in the compressed form.

Closes #72091
