### PR TITLE
[doc] Remove external herokuapp website link

### DIFF
--- a/docs/reference/migration/migrate_8_0/migrate_to_java_time.asciidoc
+++ b/docs/reference/migration/migrate_8_0/migrate_to_java_time.asciidoc
@@ -210,9 +210,6 @@ In java time, `z` outputs 'Z' for Zulu when given a UTC timezone.
 We strongly recommend you test any date format changes using real data before
 deploying in production.
 
-For help with date debugging, consider using
-https://esddd.herokuapp.com/[https://esddd.herokuapp.com/.]
-
 [discrete]
 [[java-time-migrate-update-mappings]]
 === Update index mappings


### PR DESCRIPTION
The website is no longer live and is external to elastic domain. It was used as help for testing migration