### PR TITLE
Fix SetupPasswordToolIT

### DIFF
--- a/x-pack/plugin/security/src/main/bin/elasticsearch-reset-elastic-password.bat
+++ b/x-pack/plugin/security/src/main/bin/elasticsearch-reset-elastic-password.bat
@@ -11,7 +11,7 @@ setlocal enableextensions
 set ES_MAIN_CLASS=org.elasticsearch.xpack.security.authc.esnative.tool.ResetBuiltinPasswordTool
 set ES_ADDITIONAL_SOURCES=x-pack-env;x-pack-security-env
 set ES_ADDITIONAL_CLASSPATH_DIRECTORIES=lib/tools/security-cli
-call "%~dp0elasticsearch-cli.bat --elastic" ^
+call "%~dp0elasticsearch-cli.bat" "--elastic" ^
   %%* ^
   || goto exit
 

--- a/x-pack/plugin/security/src/main/bin/elasticsearch-reset-kibana-system-password.bat
+++ b/x-pack/plugin/security/src/main/bin/elasticsearch-reset-kibana-system-password.bat
@@ -11,7 +11,7 @@ setlocal enableextensions
 set ES_MAIN_CLASS=org.elasticsearch.xpack.security.authc.esnative.tool.ResetBuiltinPasswordTool
 set ES_ADDITIONAL_SOURCES=x-pack-env;x-pack-security-env
 set ES_ADDITIONAL_CLASSPATH_DIRECTORIES=lib/tools/security-cli
-call "%~dp0elasticsearch-cli.bat --kibana_system" ^
+call "%~dp0elasticsearch-cli.bat" "--kibana_system" ^
   %%* ^
   || goto exit
 

--- a/x-pack/qa/security-setup-password-tests/build.gradle
+++ b/x-pack/qa/security-setup-password-tests/build.gradle
@@ -17,7 +17,7 @@ testClusters.matching { it.name == "integTest" }.configureEach {
   setting 'xpack.security.enabled', 'true'
   setting 'xpack.license.self_generated.type', 'trial'
   // Setup passwords doesn't work when there is a password auto-configured on first start
-  setting 'xpack.security.autoconfiguration', 'false'
+  setting 'xpack.security.autoconfiguration.enabled', 'false'
 
   user username: "test_admin", password: "x-pack-test-password"
 }

--- a/x-pack/qa/security-setup-password-tests/build.gradle
+++ b/x-pack/qa/security-setup-password-tests/build.gradle
@@ -16,6 +16,8 @@ testClusters.matching { it.name == "integTest" }.configureEach {
   testDistribution = 'DEFAULT'
   setting 'xpack.security.enabled', 'true'
   setting 'xpack.license.self_generated.type', 'trial'
+  // Setup passwords doesn't work when there is a password auto-configured on first start
+  setting 'xpack.security.autoconfiguration', 'false'
 
   user username: "test_admin", password: "x-pack-test-password"
 }

--- a/x-pack/qa/security-setup-password-tests/src/test/java/org/elasticsearch/xpack/security/authc/esnative/tool/SetupPasswordToolIT.java
+++ b/x-pack/qa/security-setup-password-tests/src/test/java/org/elasticsearch/xpack/security/authc/esnative/tool/SetupPasswordToolIT.java
@@ -21,7 +21,6 @@ import java.util.Map;
 
 public class SetupPasswordToolIT extends AbstractPasswordToolTestCase {
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/77408")
     public void testSetupPasswordToolAutoSetup() throws Exception {
 
         MockTerminal mockTerminal = new MockTerminal();


### PR DESCRIPTION
In #77291, we introduced the functionality to auto-generate a
password for the elastic user on startup. This means that the
setup-passwords tool cannot be used ( as it depends on the
password not being set ). This change fixes the QA project
test cluster to start with auto-configuration disabled
