### PR TITLE
Allow range types to be used for enrich matching 

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/enrich/EnrichPolicy.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/enrich/EnrichPolicy.java
@@ -38,9 +38,11 @@ public final class EnrichPolicy implements Writeable, ToXContentFragment {
 
     public static final String MATCH_TYPE = "match";
     public static final String GEO_MATCH_TYPE = "geo_match";
+    public static final String RANGE_TYPE = "range";
     public static final String[] SUPPORTED_POLICY_TYPES = new String[]{
         MATCH_TYPE,
-        GEO_MATCH_TYPE
+        GEO_MATCH_TYPE,
+        RANGE_TYPE
     };
 
     private static final ParseField QUERY = new ParseField("query");

--- a/x-pack/plugin/enrich/qa/common/src/main/java/org/elasticsearch/test/enrich/CommonEnrichRestTestCase.java
+++ b/x-pack/plugin/enrich/qa/common/src/main/java/org/elasticsearch/test/enrich/CommonEnrichRestTestCase.java
@@ -70,33 +70,35 @@ public abstract class CommonEnrichRestTestCase extends ESRestTestCase {
 
         // Add entry to source index and then refresh:
         Request indexRequest = new Request("PUT", "/my-source-index/_doc/elastic.co");
-        indexRequest.setJsonEntity("{" +
-            "\"host\": \"elastic.co\"," +
-            "\"globalRank\": 25," +
-            "\"tldRank\": 7," +
-            "\"tld\": \"co\", " +
-            "\"date\": {" +
-                "\"gte\" : \"2021-09-05\"," +
-                "\"lt\" : \"2021-09-07\"" +
-            "}, " +
-            "\"integer\": {" +
-                "\"gte\" : 40," +
-                "\"lt\" : 42" +
-            "}, " +
-            "\"long\": {" +
-                "\"gte\" : 8000000," +
-                "\"lt\" : 9000000" +
-            "}, " +
-            "\"double\": {" +
-                "\"gte\" : 10.10," +
-                "\"lt\" : 20.20" +
-            "}, " +
-            "\"float\": {" +
-                "\"gte\" : 10000.5," +
-                "\"lt\" : 10000.7" +
-            "}, " +
-            "\"ip\": \"100.0.0.0/4\"" +
-            "}");
+        indexRequest.setJsonEntity(
+            "{"
+                + "\"host\": \"elastic.co\","
+                + "\"globalRank\": 25,"
+                + "\"tldRank\": 7,"
+                + "\"tld\": \"co\", "
+                + "\"date\": {"
+                + "\"gte\" : \"2021-09-05\","
+                + "\"lt\" : \"2021-09-07\""
+                + "}, "
+                + "\"integer\": {"
+                + "\"gte\" : 40,"
+                + "\"lt\" : 42"
+                + "}, "
+                + "\"long\": {"
+                + "\"gte\" : 8000000,"
+                + "\"lt\" : 9000000"
+                + "}, "
+                + "\"double\": {"
+                + "\"gte\" : 10.10,"
+                + "\"lt\" : 20.20"
+                + "}, "
+                + "\"float\": {"
+                + "\"gte\" : 10000.5,"
+                + "\"lt\" : 10000.7"
+                + "}, "
+                + "\"ip\": \"100.0.0.0/4\""
+                + "}"
+        );
         assertOK(client().performRequest(indexRequest));
         Request refreshRequest = new Request("POST", "/my-source-index/_refresh");
         assertOK(client().performRequest(refreshRequest));
@@ -108,14 +110,18 @@ public abstract class CommonEnrichRestTestCase extends ESRestTestCase {
         // Create pipeline
         Request putPipelineRequest = new Request("PUT", "/_ingest/pipeline/my_pipeline");
         putPipelineRequest.setJsonEntity(
-            "{\"processors\":[" + "{\"enrich\":{\"policy_name\":\"my_policy\",\"field\":\""+field+"\",\"target_field\":\"entry\"}}" + "]}"
+            "{\"processors\":["
+                + "{\"enrich\":{\"policy_name\":\"my_policy\",\"field\":\""
+                + field
+                + "\",\"target_field\":\"entry\"}}"
+                + "]}"
         );
         assertOK(client().performRequest(putPipelineRequest));
 
         // Index document using pipeline with enrich processor:
         indexRequest = new Request("PUT", "/my-index/_doc/1");
         indexRequest.addParameter("pipeline", "my_pipeline");
-        indexRequest.setJsonEntity("{\""+field+"\": \""+value+"\"}");
+        indexRequest.setJsonEntity("{\"" + field + "\": \"" + value + "\"}");
         assertOK(client().performRequest(indexRequest));
 
         // Check if document has been enriched
@@ -234,7 +240,7 @@ public abstract class CommonEnrichRestTestCase extends ESRestTestCase {
                 source.field("query", QueryBuilders.matchAllQuery());
             }
             source.field("match_field", field);
-            source.field("enrich_fields", new String[]{"globalRank", "tldRank", "tld"});
+            source.field("enrich_fields", new String[] { "globalRank", "tldRank", "tld" });
         }
         source.endObject().endObject();
         return Strings.toString(source);
@@ -251,7 +257,9 @@ public abstract class CommonEnrichRestTestCase extends ESRestTestCase {
             + "\"globalRank\":{\"type\":\"keyword\"},"
             + "\"tldRank\":{\"type\":\"keyword\"},"
             + "\"tld\":{\"type\":\"keyword\"},"
-            + "\"date\":{\"type\":\"date_range\"" + (randomBoolean() ? "" : ", \"format\": \"yyyy-MM-dd\"") + "},"
+            + "\"date\":{\"type\":\"date_range\""
+            + (randomBoolean() ? "" : ", \"format\": \"yyyy-MM-dd\"")
+            + "},"
             + "\"integer\":{\"type\":\"integer_range\"},"
             + "\"long\":{\"type\":\"long_range\"},"
             + "\"double\":{\"type\":\"double_range\"},"

--- a/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/EnrichPolicyRunner.java
+++ b/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/EnrichPolicyRunner.java
@@ -134,6 +134,8 @@ public class EnrichPolicyRunner implements Runnable {
     private List<Map<String, Object>> toMappings(GetIndexResponse response) {
         return StreamSupport.stream(response.mappings().values().spliterator(), false)
             .map(cursor -> cursor.value)
+            .flatMap(k -> StreamSupport.stream(k.values().spliterator(), false))
+            .map(cursor -> cursor.value)
             .map(MappingMetadata::getSourceAsMap)
             .collect(Collectors.toList());
     }

--- a/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/EnrichPolicyRunner.java
+++ b/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/EnrichPolicyRunner.java
@@ -37,6 +37,7 @@ import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.collect.ImmutableOpenMap;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.xcontent.ObjectPath;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.common.xcontent.json.JsonXContent;
@@ -56,8 +57,11 @@ import java.io.UncheckedIOException;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.function.LongSupplier;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
 
 import static org.elasticsearch.xpack.core.ClientHelper.ENRICH_ORIGIN;
 
@@ -123,8 +127,15 @@ public class EnrichPolicyRunner implements Runnable {
                 l.onFailure(e);
                 return;
             }
-            prepareAndCreateEnrichIndex();
+            prepareAndCreateEnrichIndex(toMappings(getIndexResponse));
         }));
+    }
+
+    private List<Map<String, Object>> toMappings(GetIndexResponse response) {
+        return StreamSupport.stream(response.mappings().values().spliterator(), false)
+            .map(cursor -> cursor.value)
+            .map(MappingMetadata::getSourceAsMap)
+            .collect(Collectors.toList());
     }
 
     private Map<String, Object> getMappings(final GetIndexResponse getIndexResponse, final String sourceIndexName) {
@@ -234,19 +245,84 @@ public class EnrichPolicyRunner implements Runnable {
         }
     }
 
-    private XContentBuilder resolveEnrichMapping(final EnrichPolicy policy) {
-        // Currently the only supported policy type is EnrichPolicy.MATCH_TYPE, which is a keyword type
-        final String keyType;
-        final CheckedFunction<XContentBuilder, XContentBuilder, IOException> matchFieldMapping;
+    private XContentBuilder resolveEnrichMapping(final EnrichPolicy policy, final List<Map<String, Object>> mappings) {
         if (EnrichPolicy.MATCH_TYPE.equals(policy.getType())) {
-            matchFieldMapping = (builder) -> builder.field("type", "keyword").field("doc_values", false);
-            // No need to also configure index_options, because keyword type defaults to 'docs'.
+            return createEnrichMappingBuilder((builder) -> builder.field("type", "keyword").field("doc_values", false));
+        } else if (EnrichPolicy.RANGE_TYPE.equals(policy.getType())) {
+            return createRangeEnrichMappingBuilder(policy, mappings);
         } else if (EnrichPolicy.GEO_MATCH_TYPE.equals(policy.getType())) {
-            matchFieldMapping = (builder) -> builder.field("type", "geo_shape");
+            return createEnrichMappingBuilder((builder) -> builder.field("type", "geo_shape"));
         } else {
             throw new ElasticsearchException("Unrecognized enrich policy type [{}]", policy.getType());
         }
+    }
 
+    private XContentBuilder createRangeEnrichMappingBuilder(EnrichPolicy policy, List<Map<String, Object>> mappings) {
+        String matchFieldPath = "properties." + policy.getMatchField().replace(".", ".properties.");
+        List<Map<String, String>> matchFieldMappings = mappings.stream()
+            .map(map -> ObjectPath.<Map<String, String>>eval(matchFieldPath, map))
+            .filter(Objects::nonNull)
+            .collect(Collectors.toList());
+
+        Set<String> types = matchFieldMappings.stream().map(map -> map.get("type")).collect(Collectors.toSet());
+        if (types.size() == 1) {
+            String type = types.iterator().next();
+            switch (type) {
+                case "integer_range":
+                case "float_range":
+                case "long_range":
+                case "double_range":
+                case "ip_range":
+                    return createEnrichMappingBuilder((builder) -> builder.field("type", type).field("doc_values", false));
+
+                // date_range types mappings allow for the format to be specified, should be preserved in the created index
+                case "date_range":
+                    Set<String> formatEntries = matchFieldMappings.stream().map(map -> map.get("format")).collect(Collectors.toSet());
+                    if (formatEntries.size() == 1) {
+                        return createEnrichMappingBuilder((builder) -> {
+                            builder.field("type", type).field("doc_values", false);
+                            String format = formatEntries.iterator().next();
+                            if (format != null) {
+                                builder.field("format", format);
+                            }
+                            return builder;
+                        });
+                    }
+                    if (formatEntries.isEmpty()) {
+                        // no format specify rely on default
+                        return createEnrichMappingBuilder((builder) -> builder.field("type", type).field("doc_values", false));
+                    }
+                    throw new ElasticsearchException(
+                        "Multiple distinct date format specified for match field '{}' - indices({})  format entries({})",
+                        policy.getMatchField(),
+                        Strings.collectionToCommaDelimitedString(policy.getIndices()),
+                        (formatEntries.contains(null) ? "(DEFAULT), " : "") + Strings.collectionToCommaDelimitedString(formatEntries)
+                    );
+
+                default:
+                    throw new ElasticsearchException(
+                        "Field '{}' has type [{}] which doesn't appear to be a range type",
+                        policy.getMatchField(),
+                        type
+                    );
+            }
+        }
+        if (types.isEmpty()) {
+            throw new ElasticsearchException(
+                "No mapping type found for match field '{}' - indices({})",
+                policy.getMatchField(),
+                Strings.collectionToCommaDelimitedString(policy.getIndices())
+            );
+        }
+        throw new ElasticsearchException(
+            "Multiple distinct mapping types for match field '{}' - indices({})  types({})",
+            policy.getMatchField(),
+            Strings.collectionToCommaDelimitedString(policy.getIndices()),
+            Strings.collectionToCommaDelimitedString(types)
+        );
+    }
+
+    private XContentBuilder createEnrichMappingBuilder(CheckedFunction<XContentBuilder, XContentBuilder, IOException> matchFieldMapping) {
         // Enable _source on enrich index. Explicitly mark key mapping type.
         try {
             XContentBuilder builder = JsonXContent.contentBuilder();
@@ -285,7 +361,7 @@ public class EnrichPolicyRunner implements Runnable {
         }
     }
 
-    private void prepareAndCreateEnrichIndex() {
+    private void prepareAndCreateEnrichIndex(List<Map<String, Object>> mappings) {
         long nowTimestamp = nowSupplier.getAsLong();
         String enrichIndexName = EnrichPolicy.getBaseName(policyName) + "-" + nowTimestamp;
         Settings enrichIndexSettings = Settings.builder()
@@ -297,7 +373,7 @@ public class EnrichPolicyRunner implements Runnable {
             .put("index.warmer.enabled", false)
             .build();
         CreateIndexRequest createEnrichIndexRequest = new CreateIndexRequest(enrichIndexName, enrichIndexSettings);
-        createEnrichIndexRequest.mapping(MapperService.SINGLE_MAPPING_NAME, resolveEnrichMapping(policy));
+        createEnrichIndexRequest.mapping(MapperService.SINGLE_MAPPING_NAME, resolveEnrichMapping(policy, mappings));
         logger.debug("Policy [{}]: Creating new enrich index [{}]", policyName, enrichIndexName);
         enrichOriginClient().admin()
             .indices()

--- a/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/EnrichProcessorFactory.java
+++ b/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/EnrichProcessorFactory.java
@@ -81,6 +81,7 @@ final class EnrichProcessorFactory implements Processor.Factory, Consumer<Cluste
         BiConsumer<SearchRequest, BiConsumer<SearchResponse, Exception>> searchRunner = createSearchRunner(client, enrichCache);
         switch (policyType) {
             case EnrichPolicy.MATCH_TYPE:
+            case EnrichPolicy.RANGE_TYPE:
                 return new MatchProcessor(
                     tag,
                     description,

--- a/x-pack/plugin/enrich/src/test/java/org/elasticsearch/xpack/enrich/EnrichPolicyRunnerTests.java
+++ b/x-pack/plugin/enrich/src/test/java/org/elasticsearch/xpack/enrich/EnrichPolicyRunnerTests.java
@@ -149,12 +149,7 @@ public class EnrichPolicyRunnerTests extends ESSingleNodeTestCase {
 
         // Validate Index definition
         String createdEnrichIndex = ".enrich-test1-" + createTime;
-        GetIndexResponse enrichIndex = client().admin().indices().getIndex(new GetIndexRequest().indices(".enrich-test1")).actionGet();
-        assertThat(enrichIndex.getIndices().length, equalTo(1));
-        assertThat(enrichIndex.getIndices()[0], equalTo(createdEnrichIndex));
-        Settings settings = enrichIndex.getSettings().get(createdEnrichIndex);
-        assertNotNull(settings);
-        assertThat(settings.get("index.auto_expand_replicas"), is(equalTo("0-all")));
+        GetIndexResponse enrichIndex = getGetIndexResponseAndCheck(createdEnrichIndex);
 
         // Validate Mapping
         Map<String, Object> mapping = enrichIndex.getMappings().get(createdEnrichIndex).get("_doc").sourceAsMap();
@@ -226,12 +221,7 @@ public class EnrichPolicyRunnerTests extends ESSingleNodeTestCase {
 
         // Validate Index definition
         String createdEnrichIndex = ".enrich-test1-" + createTime;
-        GetIndexResponse enrichIndex = client().admin().indices().getIndex(new GetIndexRequest().indices(".enrich-test1")).actionGet();
-        assertThat(enrichIndex.getIndices().length, equalTo(1));
-        assertThat(enrichIndex.getIndices()[0], equalTo(createdEnrichIndex));
-        Settings settings = enrichIndex.getSettings().get(createdEnrichIndex);
-        assertNotNull(settings);
-        assertThat(settings.get("index.auto_expand_replicas"), is(equalTo("0-all")));
+        GetIndexResponse enrichIndex = getGetIndexResponseAndCheck(createdEnrichIndex);
 
         // Validate Mapping
         Map<String, Object> mapping = enrichIndex.getMappings().get(createdEnrichIndex).get("_doc").sourceAsMap();
@@ -256,6 +246,186 @@ public class EnrichPolicyRunnerTests extends ESSingleNodeTestCase {
         assertThat(enrichDocument.size(), is(equalTo(2)));
         assertThat(enrichDocument.get("location"), is(equalTo("POINT(10.0 10.0)")));
         assertThat(enrichDocument.get("zipcode"), is(equalTo(90210)));
+
+        // Validate segments
+        validateSegments(createdEnrichIndex, 1);
+
+        // Validate Index is read only
+        ensureEnrichIndexIsReadOnly(createdEnrichIndex);
+    }
+
+    public void testRunnerIntegerRangeMatchType() throws Exception {
+        testNumberRangeMatchType("integer");
+    }
+
+    public void testRunnerLongRangeMatchType() throws Exception {
+        testNumberRangeMatchType("long");
+    }
+
+    public void testRunnerFloatRangeMatchType() throws Exception {
+        testNumberRangeMatchType("float");
+    }
+
+    public void testRunnerDoubleRangeMatchType() throws Exception {
+        testNumberRangeMatchType("double");
+    }
+
+    private void testNumberRangeMatchType(String rangeType) throws Exception {
+        final String sourceIndex = "source-index";
+        createIndex(sourceIndex, Settings.EMPTY, "_doc", "range", "type=" + rangeType + "_range");
+        IndexResponse indexRequest = client().index(
+            new IndexRequest().index(sourceIndex)
+                .id("id")
+                .source("{" + "\"range\":" + "{" + "\"gt\":1," + "\"lt\":10" + "}," + "\"zipcode\":90210" + "}", XContentType.JSON)
+                .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE)
+        ).actionGet();
+        assertEquals(RestStatus.CREATED, indexRequest.status());
+
+        SearchResponse sourceSearchResponse = client().search(
+            new SearchRequest(sourceIndex).source(SearchSourceBuilder.searchSource().query(QueryBuilders.matchAllQuery()))
+        ).actionGet();
+        assertThat(sourceSearchResponse.getHits().getTotalHits().value, equalTo(1L));
+        Map<String, Object> sourceDocMap = sourceSearchResponse.getHits().getAt(0).getSourceAsMap();
+        assertNotNull(sourceDocMap);
+        assertThat(sourceDocMap.get("range"), is(equalTo(Map.of("lt", 10, "gt", 1))));
+        assertThat(sourceDocMap.get("zipcode"), is(equalTo(90210)));
+
+        List<String> enrichFields = List.of("zipcode");
+        EnrichPolicy policy = new EnrichPolicy(EnrichPolicy.RANGE_TYPE, null, List.of(sourceIndex), "range", enrichFields, null);
+        String policyName = "test1";
+
+        final long createTime = randomNonNegativeLong();
+        final AtomicReference<Exception> exception = new AtomicReference<>();
+        final CountDownLatch latch = new CountDownLatch(1);
+        ActionListener<ExecuteEnrichPolicyStatus> listener = createTestListener(latch, exception::set);
+        EnrichPolicyRunner enrichPolicyRunner = createPolicyRunner(policyName, policy, listener, createTime);
+
+        logger.info("Starting policy run");
+        enrichPolicyRunner.run();
+        latch.await();
+        if (exception.get() != null) {
+            throw exception.get();
+        }
+
+        // Validate Index definition
+        String createdEnrichIndex = ".enrich-test1-" + createTime;
+        GetIndexResponse enrichIndex = getGetIndexResponseAndCheck(createdEnrichIndex);
+
+        // Validate Mapping
+        Map<String, Object> mapping = enrichIndex.getMappings().get(createdEnrichIndex).sourceAsMap();
+        validateMappingMetadata(mapping, policyName, policy);
+        assertThat(mapping.get("dynamic"), is("false"));
+        Map<?, ?> properties = (Map<?, ?>) mapping.get("properties");
+        assertNotNull(properties);
+        assertThat(properties.size(), is(equalTo(1)));
+        Map<?, ?> field1 = (Map<?, ?>) properties.get("range");
+        assertNotNull(field1);
+        assertThat(field1.get("type"), is(equalTo(rangeType + "_range")));
+        assertEquals(Boolean.FALSE, field1.get("doc_values"));
+
+        // Validate document structure
+        SearchResponse enrichSearchResponse = client().search(
+            new SearchRequest(".enrich-test1").source(SearchSourceBuilder.searchSource().query(QueryBuilders.matchAllQuery()))
+        ).actionGet();
+
+        assertThat(enrichSearchResponse.getHits().getTotalHits().value, equalTo(1L));
+        Map<String, Object> enrichDocument = enrichSearchResponse.getHits().iterator().next().getSourceAsMap();
+        assertNotNull(enrichDocument);
+        assertThat(enrichDocument.size(), is(equalTo(2)));
+        assertThat(enrichDocument.get("range"), is(equalTo(Map.of("lt", 10, "gt", 1))));
+        assertThat(enrichDocument.get("zipcode"), is(equalTo(90210)));
+
+        // Validate segments
+        validateSegments(createdEnrichIndex, 1);
+
+        // Validate Index is read only
+        ensureEnrichIndexIsReadOnly(createdEnrichIndex);
+    }
+
+    private GetIndexResponse getGetIndexResponseAndCheck(String createdEnrichIndex) {
+        GetIndexResponse enrichIndex = client().admin().indices().getIndex(new GetIndexRequest().indices(".enrich-test1")).actionGet();
+        assertThat(enrichIndex.getIndices().length, equalTo(1));
+        assertThat(enrichIndex.getIndices()[0], equalTo(createdEnrichIndex));
+        Settings settings = enrichIndex.getSettings().get(createdEnrichIndex);
+        assertNotNull(settings);
+        assertThat(settings.get("index.auto_expand_replicas"), is(equalTo("0-all")));
+        return enrichIndex;
+    }
+
+    public void testRunnerRangeTypeWithIpRange() throws Exception {
+        final String sourceIndexName = "source-index";
+        createIndex(sourceIndexName, Settings.EMPTY, "_doc", "subnet", "type=ip_range");
+        IndexResponse indexRequest = client().index(
+            new IndexRequest().index(sourceIndexName)
+                .id("id")
+                .source("{" + "\"subnet\":" + "\"10.0.0.0/8\"," + "\"department\":\"research\"" + "}", XContentType.JSON)
+                .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE)
+        ).actionGet();
+        assertEquals(RestStatus.CREATED, indexRequest.status());
+
+        GetIndexResponse sourceIndex = client().admin().indices().getIndex(new GetIndexRequest().indices(sourceIndexName)).actionGet();
+        // Validate Mapping
+        Map<String, Object> sourceIndexMapping = sourceIndex.getMappings().get(sourceIndexName).sourceAsMap();
+        Map<?, ?> sourceIndexProperties = (Map<?, ?>) sourceIndexMapping.get("properties");
+        Map<?, ?> subnetField = (Map<?, ?>) sourceIndexProperties.get("subnet");
+        assertNotNull(subnetField);
+        assertThat(subnetField.get("type"), is(equalTo("ip_range")));
+
+        SearchResponse sourceSearchResponse = client().search(
+            new SearchRequest(sourceIndexName).source(SearchSourceBuilder.searchSource().query(QueryBuilders.matchAllQuery()))
+        ).actionGet();
+        assertThat(sourceSearchResponse.getHits().getTotalHits().value, equalTo(1L));
+        Map<String, Object> sourceDocMap = sourceSearchResponse.getHits().getAt(0).getSourceAsMap();
+        assertNotNull(sourceDocMap);
+        assertThat(sourceDocMap.get("subnet"), is(equalTo("10.0.0.0/8")));
+        assertThat(sourceDocMap.get("department"), is(equalTo("research")));
+
+        List<String> enrichFields = List.of("department");
+        EnrichPolicy policy = new EnrichPolicy(EnrichPolicy.RANGE_TYPE, null, List.of(sourceIndexName), "subnet", enrichFields);
+        String policyName = "test1";
+
+        final long createTime = randomNonNegativeLong();
+        final AtomicReference<Exception> exception = new AtomicReference<>();
+        final CountDownLatch latch = new CountDownLatch(1);
+        ActionListener<ExecuteEnrichPolicyStatus> listener = createTestListener(latch, exception::set);
+        EnrichPolicyRunner enrichPolicyRunner = createPolicyRunner(policyName, policy, listener, createTime);
+
+        logger.info("Starting policy run");
+        enrichPolicyRunner.run();
+        latch.await();
+        if (exception.get() != null) {
+            throw exception.get();
+        }
+
+        // Validate Index definition
+        String createdEnrichIndex = ".enrich-test1-" + createTime;
+        GetIndexResponse enrichIndex = getGetIndexResponseAndCheck(createdEnrichIndex);
+
+        // Validate Mapping
+        Map<String, Object> mapping = enrichIndex.getMappings().get(createdEnrichIndex).sourceAsMap();
+        validateMappingMetadata(mapping, policyName, policy);
+        assertThat(mapping.get("dynamic"), is("false"));
+        Map<?, ?> properties = (Map<?, ?>) mapping.get("properties");
+        assertNotNull(properties);
+        assertThat(properties.size(), is(equalTo(1)));
+        Map<?, ?> field1 = (Map<?, ?>) properties.get("subnet");
+        assertNotNull(field1);
+        assertThat(field1.get("type"), is(equalTo("ip_range")));
+        assertThat(field1.get("doc_values"), is(false));
+
+        // Validate document structure and lookup of element in range
+        SearchResponse enrichSearchResponse = client().search(
+            new SearchRequest(".enrich-test1").source(
+                SearchSourceBuilder.searchSource().query(QueryBuilders.matchQuery("subnet", "10.0.0.1"))
+            )
+        ).actionGet();
+
+        assertThat(enrichSearchResponse.getHits().getTotalHits().value, equalTo(1L));
+        Map<String, Object> enrichDocument = enrichSearchResponse.getHits().iterator().next().getSourceAsMap();
+        assertNotNull(enrichDocument);
+        assertThat(enrichDocument.size(), is(equalTo(2)));
+        assertThat(enrichDocument.get("subnet"), is(equalTo("10.0.0.0/8")));
+        assertThat(enrichDocument.get("department"), is(equalTo("research")));
 
         // Validate segments
         validateSegments(createdEnrichIndex, 1);
@@ -338,12 +508,7 @@ public class EnrichPolicyRunnerTests extends ESSingleNodeTestCase {
 
         // Validate Index definition
         String createdEnrichIndex = ".enrich-test1-" + createTime;
-        GetIndexResponse enrichIndex = client().admin().indices().getIndex(new GetIndexRequest().indices(".enrich-test1")).actionGet();
-        assertThat(enrichIndex.getIndices().length, equalTo(1));
-        assertThat(enrichIndex.getIndices()[0], equalTo(createdEnrichIndex));
-        Settings settings = enrichIndex.getSettings().get(createdEnrichIndex);
-        assertNotNull(settings);
-        assertThat(settings.get("index.auto_expand_replicas"), is(equalTo("0-all")));
+        GetIndexResponse enrichIndex = getGetIndexResponseAndCheck(createdEnrichIndex);
 
         // Validate Mapping
         Map<String, Object> mapping = enrichIndex.getMappings().get(createdEnrichIndex).get("_doc").sourceAsMap();
@@ -456,12 +621,7 @@ public class EnrichPolicyRunnerTests extends ESSingleNodeTestCase {
 
         // Validate Index definition
         String createdEnrichIndex = ".enrich-test1-" + createTime;
-        GetIndexResponse enrichIndex = client().admin().indices().getIndex(new GetIndexRequest().indices(".enrich-test1")).actionGet();
-        assertThat(enrichIndex.getIndices().length, equalTo(1));
-        assertThat(enrichIndex.getIndices()[0], equalTo(createdEnrichIndex));
-        Settings settings = enrichIndex.getSettings().get(createdEnrichIndex);
-        assertNotNull(settings);
-        assertThat(settings.get("index.auto_expand_replicas"), is(equalTo("0-all")));
+        GetIndexResponse enrichIndex = getGetIndexResponseAndCheck(createdEnrichIndex);
 
         // Validate Mapping
         Map<String, Object> mapping = enrichIndex.getMappings().get(createdEnrichIndex).get("_doc").sourceAsMap();
@@ -572,12 +732,7 @@ public class EnrichPolicyRunnerTests extends ESSingleNodeTestCase {
 
         // Validate Index definition
         String createdEnrichIndex = ".enrich-test1-" + createTime;
-        GetIndexResponse enrichIndex = client().admin().indices().getIndex(new GetIndexRequest().indices(".enrich-test1")).actionGet();
-        assertThat(enrichIndex.getIndices().length, equalTo(1));
-        assertThat(enrichIndex.getIndices()[0], equalTo(createdEnrichIndex));
-        Settings settings = enrichIndex.getSettings().get(createdEnrichIndex);
-        assertNotNull(settings);
-        assertThat(settings.get("index.auto_expand_replicas"), is(equalTo("0-all")));
+        GetIndexResponse enrichIndex = getGetIndexResponseAndCheck(createdEnrichIndex);
 
         // Validate Mapping
         Map<String, Object> mapping = enrichIndex.getMappings().get(createdEnrichIndex).get("_doc").sourceAsMap();
@@ -902,12 +1057,7 @@ public class EnrichPolicyRunnerTests extends ESSingleNodeTestCase {
 
         // Validate Index definition
         String createdEnrichIndex = ".enrich-test1-" + createTime;
-        GetIndexResponse enrichIndex = client().admin().indices().getIndex(new GetIndexRequest().indices(".enrich-test1")).actionGet();
-        assertThat(enrichIndex.getIndices().length, equalTo(1));
-        assertThat(enrichIndex.getIndices()[0], equalTo(createdEnrichIndex));
-        Settings settings = enrichIndex.getSettings().get(createdEnrichIndex);
-        assertNotNull(settings);
-        assertThat(settings.get("index.auto_expand_replicas"), is(equalTo("0-all")));
+        GetIndexResponse enrichIndex = getGetIndexResponseAndCheck(createdEnrichIndex);
 
         // Validate Mapping
         Map<String, Object> mapping = enrichIndex.getMappings().get(createdEnrichIndex).get("_doc").sourceAsMap();
@@ -1028,12 +1178,7 @@ public class EnrichPolicyRunnerTests extends ESSingleNodeTestCase {
 
         // Validate Index definition
         String createdEnrichIndex = ".enrich-test1-" + createTime;
-        GetIndexResponse enrichIndex = client().admin().indices().getIndex(new GetIndexRequest().indices(".enrich-test1")).actionGet();
-        assertThat(enrichIndex.getIndices().length, equalTo(1));
-        assertThat(enrichIndex.getIndices()[0], equalTo(createdEnrichIndex));
-        Settings settings = enrichIndex.getSettings().get(createdEnrichIndex);
-        assertNotNull(settings);
-        assertThat(settings.get("index.auto_expand_replicas"), is(equalTo("0-all")));
+        GetIndexResponse enrichIndex = getGetIndexResponseAndCheck(createdEnrichIndex);
 
         // Validate Mapping
         Map<String, Object> mapping = enrichIndex.getMappings().get(createdEnrichIndex).get("_doc").sourceAsMap();
@@ -1066,6 +1211,127 @@ public class EnrichPolicyRunnerTests extends ESSingleNodeTestCase {
         assertThat(resultDataField.size(), is(equalTo(2)));
         assertThat(resultDataField.get("field1"), is(equalTo("value1")));
         assertThat(resultDataField.get("field2"), is(equalTo(2)));
+        assertNull(resultDataField.get("field3"));
+
+        // Validate segments
+        validateSegments(createdEnrichIndex, 1);
+
+        // Validate Index is read only
+        ensureEnrichIndexIsReadOnly(createdEnrichIndex);
+    }
+
+    public void testRunnerExplicitObjectSourceMappingRangePolicy() throws Exception {
+        final String sourceIndex = "source-index";
+        XContentBuilder mappingBuilder = JsonXContent.contentBuilder();
+        mappingBuilder.startObject()
+            .startObject(MapperService.SINGLE_MAPPING_NAME)
+            .startObject("properties")
+            .startObject("data")
+            .field("type", "object")
+            .startObject("properties")
+            .startObject("subnet")
+            .field("type", "ip_range")
+            .endObject()
+            .startObject("department")
+            .field("type", "keyword")
+            .endObject()
+            .startObject("field3")
+            .field("type", "keyword")
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject();
+        CreateIndexResponse createResponse = client().admin()
+            .indices()
+            .create(new CreateIndexRequest(sourceIndex).mapping(mappingBuilder))
+            .actionGet();
+        assertTrue(createResponse.isAcknowledged());
+
+        IndexResponse indexRequest = client().index(
+            new IndexRequest().index(sourceIndex)
+                .id("id")
+                .source(
+                    "{"
+                        + "\"data\":{"
+                        + "\"subnet\":\"10.0.0.0/8\","
+                        + "\"department\":\"research\","
+                        + "\"field3\":\"ignored\""
+                        + "}"
+                        + "}",
+                    XContentType.JSON
+                )
+                .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE)
+        ).actionGet();
+        assertEquals(RestStatus.CREATED, indexRequest.status());
+
+        SearchResponse sourceSearchResponse = client().search(
+            new SearchRequest(sourceIndex).source(SearchSourceBuilder.searchSource().query(QueryBuilders.matchAllQuery()))
+        ).actionGet();
+        assertThat(sourceSearchResponse.getHits().getTotalHits().value, equalTo(1L));
+        Map<String, Object> sourceDocMap = sourceSearchResponse.getHits().getAt(0).getSourceAsMap();
+        assertNotNull(sourceDocMap);
+        Map<?, ?> dataField = ((Map<?, ?>) sourceDocMap.get("data"));
+        assertNotNull(dataField);
+        assertThat(dataField.get("subnet"), is(equalTo("10.0.0.0/8")));
+        assertThat(dataField.get("department"), is(equalTo("research")));
+        assertThat(dataField.get("field3"), is(equalTo("ignored")));
+
+        String policyName = "test1";
+        List<String> enrichFields = List.of("data.department", "missingField");
+        EnrichPolicy policy = new EnrichPolicy(EnrichPolicy.RANGE_TYPE, null, List.of(sourceIndex), "data.subnet", enrichFields);
+
+        final long createTime = randomNonNegativeLong();
+        final AtomicReference<Exception> exception = new AtomicReference<>();
+        final CountDownLatch latch = new CountDownLatch(1);
+        ActionListener<ExecuteEnrichPolicyStatus> listener = createTestListener(latch, exception::set);
+        EnrichPolicyRunner enrichPolicyRunner = createPolicyRunner(policyName, policy, listener, createTime);
+
+        logger.info("Starting policy run");
+        enrichPolicyRunner.run();
+        latch.await();
+        if (exception.get() != null) {
+            throw exception.get();
+        }
+
+        // Validate Index definition
+        String createdEnrichIndex = ".enrich-test1-" + createTime;
+        GetIndexResponse enrichIndex = getGetIndexResponseAndCheck(createdEnrichIndex);
+
+        // Validate Mapping
+        Map<String, Object> mapping = enrichIndex.getMappings().get(createdEnrichIndex).sourceAsMap();
+        validateMappingMetadata(mapping, policyName, policy);
+        assertThat(mapping.get("dynamic"), is("false"));
+        Map<?, ?> properties = (Map<?, ?>) mapping.get("properties");
+        assertNotNull(properties);
+        assertThat(properties.size(), is(equalTo(1)));
+        Map<?, ?> data = (Map<?, ?>) properties.get("data");
+        assertNotNull(data);
+        assertThat(data.size(), is(equalTo(1)));
+        Map<?, ?> dataProperties = (Map<?, ?>) data.get("properties");
+        assertNotNull(dataProperties);
+        assertThat(dataProperties.size(), is(equalTo(1)));
+        Map<?, ?> field1 = (Map<?, ?>) dataProperties.get("subnet");
+        assertNotNull(field1);
+        assertThat(field1.get("type"), is(equalTo("ip_range")));
+        assertThat(field1.get("doc_values"), is(false));
+
+        SearchResponse enrichSearchResponse = client().search(
+            new SearchRequest(".enrich-test1").source(
+                SearchSourceBuilder.searchSource().query(QueryBuilders.matchQuery("data.subnet", "10.0.0.1"))
+            )
+        ).actionGet();
+
+        assertThat(enrichSearchResponse.getHits().getTotalHits().value, equalTo(1L));
+        Map<String, Object> enrichDocument = enrichSearchResponse.getHits().iterator().next().getSourceAsMap();
+        assertNotNull(enrichDocument);
+        assertThat(enrichDocument.size(), is(equalTo(1)));
+        Map<?, ?> resultDataField = ((Map<?, ?>) enrichDocument.get("data"));
+        assertNotNull(resultDataField);
+        assertThat(resultDataField.size(), is(equalTo(2)));
+        assertThat(resultDataField.get("subnet"), is(equalTo("10.0.0.0/8")));
+        assertThat(resultDataField.get("department"), is(equalTo("research")));
         assertNull(resultDataField.get("field3"));
 
         // Validate segments
@@ -1167,12 +1433,7 @@ public class EnrichPolicyRunnerTests extends ESSingleNodeTestCase {
 
         // Validate Index definition
         String createdEnrichIndex = ".enrich-test1-" + createTime;
-        GetIndexResponse enrichIndex = client().admin().indices().getIndex(new GetIndexRequest().indices(".enrich-test1")).actionGet();
-        assertThat(enrichIndex.getIndices().length, equalTo(1));
-        assertThat(enrichIndex.getIndices()[0], equalTo(createdEnrichIndex));
-        Settings settings = enrichIndex.getSettings().get(createdEnrichIndex);
-        assertNotNull(settings);
-        assertThat(settings.get("index.auto_expand_replicas"), is(equalTo("0-all")));
+        GetIndexResponse enrichIndex = getGetIndexResponseAndCheck(createdEnrichIndex);
 
         // Validate Mapping
         Map<String, Object> mapping = enrichIndex.getMappings().get(createdEnrichIndex).get("_doc").sourceAsMap();
@@ -1214,6 +1475,301 @@ public class EnrichPolicyRunnerTests extends ESSingleNodeTestCase {
         assertThat(resultFieldsField.get("field1"), is(equalTo("value1")));
         assertThat(resultFieldsField.get("field2"), is(equalTo(2)));
         assertNull(resultFieldsField.get("field3"));
+
+        // Validate segments
+        validateSegments(createdEnrichIndex, 1);
+
+        // Validate Index is read only
+        ensureEnrichIndexIsReadOnly(createdEnrichIndex);
+    }
+
+    public void testRunnerTwoObjectLevelsSourceMappingRangePolicy() throws Exception {
+        final String sourceIndex = "source-index";
+        XContentBuilder mappingBuilder = JsonXContent.contentBuilder();
+        mappingBuilder.startObject()
+            .startObject(MapperService.SINGLE_MAPPING_NAME)
+            .startObject("properties")
+            .startObject("data")
+            .startObject("properties")
+            .startObject("fields")
+            .startObject("properties")
+            .startObject("subnet")
+            .field("type", "ip_range")
+            .endObject()
+            .startObject("department")
+            .field("type", "keyword")
+            .endObject()
+            .startObject("field3")
+            .field("type", "keyword")
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject();
+        CreateIndexResponse createResponse = client().admin()
+            .indices()
+            .create(new CreateIndexRequest(sourceIndex).mapping(mappingBuilder))
+            .actionGet();
+        assertTrue(createResponse.isAcknowledged());
+
+        IndexResponse indexRequest = client().index(
+            new IndexRequest().index(sourceIndex)
+                .id("id")
+                .source(
+                    "{"
+                        + "\"data\":{"
+                        + "\"fields\":{"
+                        + "\"subnet\":\"10.0.0.0/8\","
+                        + "\"department\":\"research\","
+                        + "\"field3\":\"ignored\""
+                        + "}"
+                        + "}"
+                        + "}",
+                    XContentType.JSON
+                )
+                .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE)
+        ).actionGet();
+        assertEquals(RestStatus.CREATED, indexRequest.status());
+
+        SearchResponse sourceSearchResponse = client().search(
+            new SearchRequest(sourceIndex).source(SearchSourceBuilder.searchSource().query(QueryBuilders.matchAllQuery()))
+        ).actionGet();
+        assertThat(sourceSearchResponse.getHits().getTotalHits().value, equalTo(1L));
+        Map<String, Object> sourceDocMap = sourceSearchResponse.getHits().getAt(0).getSourceAsMap();
+        assertNotNull(sourceDocMap);
+        Map<?, ?> dataField = ((Map<?, ?>) sourceDocMap.get("data"));
+        assertNotNull(dataField);
+        Map<?, ?> fieldsField = ((Map<?, ?>) dataField.get("fields"));
+        assertNotNull(fieldsField);
+        assertThat(fieldsField.get("subnet"), is(equalTo("10.0.0.0/8")));
+        assertThat(fieldsField.get("department"), is(equalTo("research")));
+        assertThat(fieldsField.get("field3"), is(equalTo("ignored")));
+
+        String policyName = "test1";
+        List<String> enrichFields = List.of("data.fields.department", "missingField");
+        EnrichPolicy policy = new EnrichPolicy(EnrichPolicy.RANGE_TYPE, null, List.of(sourceIndex), "data.fields.subnet", enrichFields);
+
+        final long createTime = randomNonNegativeLong();
+        final AtomicReference<Exception> exception = new AtomicReference<>();
+        final CountDownLatch latch = new CountDownLatch(1);
+        ActionListener<ExecuteEnrichPolicyStatus> listener = createTestListener(latch, exception::set);
+        EnrichPolicyRunner enrichPolicyRunner = createPolicyRunner(policyName, policy, listener, createTime);
+
+        logger.info("Starting policy run");
+        enrichPolicyRunner.run();
+        latch.await();
+        if (exception.get() != null) {
+            throw exception.get();
+        }
+
+        // Validate Index definition
+        String createdEnrichIndex = ".enrich-test1-" + createTime;
+        GetIndexResponse enrichIndex = getGetIndexResponseAndCheck(createdEnrichIndex);
+
+        // Validate Mapping
+        Map<String, Object> mapping = enrichIndex.getMappings().get(createdEnrichIndex).sourceAsMap();
+        validateMappingMetadata(mapping, policyName, policy);
+        assertThat(mapping.get("dynamic"), is("false"));
+        Map<?, ?> properties = (Map<?, ?>) mapping.get("properties");
+        assertNotNull(properties);
+        assertThat(properties.size(), is(equalTo(1)));
+        Map<?, ?> data = (Map<?, ?>) properties.get("data");
+        assertNotNull(data);
+        assertThat(data.size(), is(equalTo(1)));
+        Map<?, ?> dataProperties = (Map<?, ?>) data.get("properties");
+        assertNotNull(dataProperties);
+        assertThat(dataProperties.size(), is(equalTo(1)));
+        Map<?, ?> fields = (Map<?, ?>) dataProperties.get("fields");
+        assertNotNull(fields);
+        assertThat(fields.size(), is(equalTo(1)));
+        Map<?, ?> fieldsProperties = (Map<?, ?>) fields.get("properties");
+        assertNotNull(fieldsProperties);
+        assertThat(fieldsProperties.size(), is(equalTo(1)));
+        Map<?, ?> field1 = (Map<?, ?>) fieldsProperties.get("subnet");
+        assertNotNull(field1);
+        assertThat(field1.get("type"), is(equalTo("ip_range")));
+        assertThat(field1.get("doc_values"), is(false));
+
+        SearchResponse enrichSearchResponse = client().search(
+            new SearchRequest(".enrich-test1").source(SearchSourceBuilder.searchSource().query(QueryBuilders.matchAllQuery()))
+        ).actionGet();
+
+        assertThat(enrichSearchResponse.getHits().getTotalHits().value, equalTo(1L));
+        Map<String, Object> enrichDocument = enrichSearchResponse.getHits().iterator().next().getSourceAsMap();
+        assertNotNull(enrichDocument);
+        assertThat(enrichDocument.size(), is(equalTo(1)));
+        Map<?, ?> resultDataField = ((Map<?, ?>) enrichDocument.get("data"));
+        assertNotNull(resultDataField);
+        Map<?, ?> resultFieldsField = ((Map<?, ?>) resultDataField.get("fields"));
+        assertNotNull(resultFieldsField);
+        assertThat(resultFieldsField.size(), is(equalTo(2)));
+        assertThat(resultFieldsField.get("subnet"), is(equalTo("10.0.0.0/8")));
+        assertThat(resultFieldsField.get("department"), is(equalTo("research")));
+        assertNull(resultFieldsField.get("field3"));
+
+        // Validate segments
+        validateSegments(createdEnrichIndex, 1);
+
+        // Validate Index is read only
+        ensureEnrichIndexIsReadOnly(createdEnrichIndex);
+    }
+
+    public void testRunnerTwoObjectLevelsSourceMappingDateRangeWithFormat() throws Exception {
+        final String sourceIndex = "source-index";
+        XContentBuilder mappingBuilder = JsonXContent.contentBuilder();
+        mappingBuilder.startObject()
+            .startObject(MapperService.SINGLE_MAPPING_NAME)
+            .startObject("properties")
+            .startObject("data")
+            .startObject("properties")
+            .startObject("fields")
+            .startObject("properties")
+            .startObject("period")
+            .field("type", "date_range")
+            .field("format", "yyyy'/'MM'/'dd' at 'HH':'mm||strict_date_time")
+            .endObject()
+            .startObject("status")
+            .field("type", "keyword")
+            .endObject()
+            .startObject("field3")
+            .field("type", "keyword")
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject();
+        CreateIndexResponse createResponse = client().admin()
+            .indices()
+            .create(new CreateIndexRequest(sourceIndex).mapping(mappingBuilder))
+            .actionGet();
+        assertTrue(createResponse.isAcknowledged());
+
+        IndexResponse indexRequest = client().index(
+            new IndexRequest().index(sourceIndex)
+                .id("id")
+                .source(
+                    "{"
+                        + "\"data\":{"
+                        + "\"fields\":{"
+                        + "\"period\": {"
+                        + "    \"gte\" : \"2021/08/20 at 12:00\","
+                        + "    \"lte\" : \"2021/08/28 at 23:00\""
+                        + "},"
+                        + "\"status\":\"enrolled\","
+                        + "\"field3\":\"ignored\""
+                        + "}"
+                        + "}"
+                        + "}",
+                    XContentType.JSON
+                )
+                .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE)
+        ).actionGet();
+        assertEquals(RestStatus.CREATED, indexRequest.status());
+
+        SearchResponse sourceSearchResponse = client().search(
+            new SearchRequest(sourceIndex).source(SearchSourceBuilder.searchSource().query(QueryBuilders.matchAllQuery()))
+        ).actionGet();
+        assertThat(sourceSearchResponse.getHits().getTotalHits().value, equalTo(1L));
+        Map<String, Object> sourceDocMap = sourceSearchResponse.getHits().getAt(0).getSourceAsMap();
+        assertNotNull(sourceDocMap);
+        Map<?, ?> dataField = ((Map<?, ?>) sourceDocMap.get("data"));
+        assertNotNull(dataField);
+        Map<?, ?> fieldsField = ((Map<?, ?>) dataField.get("fields"));
+        assertNotNull(fieldsField);
+        Map<?, ?> periodField = ((Map<?, ?>) fieldsField.get("period"));
+        assertNotNull(periodField);
+        assertThat(periodField.get("gte"), is(equalTo("2021/08/20 at 12:00")));
+        assertThat(periodField.get("lte"), is(equalTo("2021/08/28 at 23:00")));
+        assertThat(fieldsField.get("status"), is(equalTo("enrolled")));
+        assertThat(fieldsField.get("field3"), is(equalTo("ignored")));
+
+        String policyName = "test1";
+        List<String> enrichFields = List.of("data.fields.status", "missingField");
+        EnrichPolicy policy = new EnrichPolicy(EnrichPolicy.RANGE_TYPE, null, List.of(sourceIndex), "data.fields.period", enrichFields);
+
+        final long createTime = randomNonNegativeLong();
+        final AtomicReference<Exception> exception = new AtomicReference<>();
+        final CountDownLatch latch = new CountDownLatch(1);
+        ActionListener<ExecuteEnrichPolicyStatus> listener = createTestListener(latch, exception::set);
+        EnrichPolicyRunner enrichPolicyRunner = createPolicyRunner(policyName, policy, listener, createTime);
+
+        logger.info("Starting policy run");
+        enrichPolicyRunner.run();
+        latch.await();
+        if (exception.get() != null) {
+            throw exception.get();
+        }
+
+        // Validate Index definition
+        String createdEnrichIndex = ".enrich-test1-" + createTime;
+        GetIndexResponse enrichIndex = getGetIndexResponseAndCheck(createdEnrichIndex);
+
+        // Validate Mapping
+        Map<String, Object> mapping = enrichIndex.getMappings().get(createdEnrichIndex).sourceAsMap();
+        validateMappingMetadata(mapping, policyName, policy);
+        assertThat(mapping.get("dynamic"), is("false"));
+        Map<?, ?> properties = (Map<?, ?>) mapping.get("properties");
+        assertNotNull(properties);
+        assertThat(properties.size(), is(equalTo(1)));
+        Map<?, ?> data = (Map<?, ?>) properties.get("data");
+        assertNotNull(data);
+        assertThat(data.size(), is(equalTo(1)));
+        Map<?, ?> dataProperties = (Map<?, ?>) data.get("properties");
+        assertNotNull(dataProperties);
+        assertThat(dataProperties.size(), is(equalTo(1)));
+        Map<?, ?> fields = (Map<?, ?>) dataProperties.get("fields");
+        assertNotNull(fields);
+        assertThat(fields.size(), is(equalTo(1)));
+        Map<?, ?> fieldsProperties = (Map<?, ?>) fields.get("properties");
+        assertNotNull(fieldsProperties);
+        assertThat(fieldsProperties.size(), is(equalTo(1)));
+        Map<?, ?> field1 = (Map<?, ?>) fieldsProperties.get("period");
+        assertNotNull(field1);
+        assertThat(field1.get("type"), is(equalTo("date_range")));
+        assertThat(field1.get("doc_values"), is(false));
+
+        SearchResponse enrichSearchResponse = client().search(
+            new SearchRequest(".enrich-test1").source(
+                SearchSourceBuilder.searchSource().query(QueryBuilders.matchQuery("data.fields.period", "2021-08-19T14:00:00Z"))
+            )
+        ).actionGet();
+
+        assertThat(enrichSearchResponse.getHits().getTotalHits().value, equalTo(0L));
+
+        enrichSearchResponse = client().search(
+            new SearchRequest(".enrich-test1").source(
+                SearchSourceBuilder.searchSource().query(QueryBuilders.matchQuery("data.fields.period", "2021-08-20T14:00:00Z"))
+            )
+        ).actionGet();
+
+        assertThat(enrichSearchResponse.getHits().getTotalHits().value, equalTo(1L));
+        Map<String, Object> enrichDocument = enrichSearchResponse.getHits().iterator().next().getSourceAsMap();
+        assertNotNull(enrichDocument);
+        assertThat(enrichDocument.size(), is(equalTo(1)));
+        Map<?, ?> resultDataField = ((Map<?, ?>) enrichDocument.get("data"));
+        assertNotNull(resultDataField);
+        Map<?, ?> resultFieldsField = ((Map<?, ?>) resultDataField.get("fields"));
+        assertNotNull(resultFieldsField);
+        assertThat(resultFieldsField.size(), is(equalTo(2)));
+        Map<?, ?> resultsPeriodField = ((Map<?, ?>) resultFieldsField.get("period"));
+        assertNotNull(periodField);
+        assertThat(resultsPeriodField.get("gte"), is(equalTo("2021/08/20 at 12:00")));
+        assertThat(resultsPeriodField.get("lte"), is(equalTo("2021/08/28 at 23:00")));
+        assertThat(resultFieldsField.get("status"), is(equalTo("enrolled")));
+        assertNull(resultFieldsField.get("field3"));
+
+        enrichSearchResponse = client().search(
+            new SearchRequest(".enrich-test1").source(
+                SearchSourceBuilder.searchSource().query(QueryBuilders.matchQuery("data.fields.period", "2021/08/20 at 14:00"))
+            )
+        ).actionGet();
+        assertThat(enrichSearchResponse.getHits().getTotalHits().value, equalTo(1L));
 
         // Validate segments
         validateSegments(createdEnrichIndex, 1);
@@ -1291,12 +1847,7 @@ public class EnrichPolicyRunnerTests extends ESSingleNodeTestCase {
 
         // Validate Index definition
         String createdEnrichIndex = ".enrich-test1-" + createTime;
-        GetIndexResponse enrichIndex = client().admin().indices().getIndex(new GetIndexRequest().indices(".enrich-test1")).actionGet();
-        assertThat(enrichIndex.getIndices().length, equalTo(1));
-        assertThat(enrichIndex.getIndices()[0], equalTo(createdEnrichIndex));
-        Settings settings = enrichIndex.getSettings().get(createdEnrichIndex);
-        assertNotNull(settings);
-        assertThat(settings.get("index.auto_expand_replicas"), is(equalTo("0-all")));
+        GetIndexResponse enrichIndex = getGetIndexResponseAndCheck(createdEnrichIndex);
 
         // Validate Mapping
         Map<String, Object> mapping = enrichIndex.getMappings().get(createdEnrichIndex).get("_doc").sourceAsMap();
@@ -1466,12 +2017,7 @@ public class EnrichPolicyRunnerTests extends ESSingleNodeTestCase {
         assertThat(forceMergeAttempts.get(), equalTo(2));
 
         // Validate Index definition
-        GetIndexResponse enrichIndex = client().admin().indices().getIndex(new GetIndexRequest().indices(".enrich-test1")).actionGet();
-        assertThat(enrichIndex.getIndices().length, equalTo(1));
-        assertThat(enrichIndex.getIndices()[0], equalTo(createdEnrichIndex));
-        Settings settings = enrichIndex.getSettings().get(createdEnrichIndex);
-        assertNotNull(settings);
-        assertThat(settings.get("index.auto_expand_replicas"), is(equalTo("0-all")));
+        GetIndexResponse enrichIndex = getGetIndexResponseAndCheck(createdEnrichIndex);
 
         // Validate Mapping
         Map<String, Object> mapping = enrichIndex.getMappings().get(createdEnrichIndex).get("_doc").sourceAsMap();

--- a/x-pack/plugin/enrich/src/test/java/org/elasticsearch/xpack/enrich/EnrichPolicyRunnerTests.java
+++ b/x-pack/plugin/enrich/src/test/java/org/elasticsearch/xpack/enrich/EnrichPolicyRunnerTests.java
@@ -64,6 +64,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 
+import static java.util.Collections.singletonList;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.instanceOf;
@@ -125,13 +126,7 @@ public class EnrichPolicyRunnerTests extends ESSingleNodeTestCase {
         List<String> enrichFields = new ArrayList<>();
         enrichFields.add("field2");
         enrichFields.add("field5");
-        EnrichPolicy policy = new EnrichPolicy(
-            EnrichPolicy.MATCH_TYPE,
-            null,
-            Collections.singletonList(sourceIndex),
-            "field1",
-            enrichFields
-        );
+        EnrichPolicy policy = new EnrichPolicy(EnrichPolicy.MATCH_TYPE, null, singletonList(sourceIndex), "field1", enrichFields);
         String policyName = "test1";
 
         final long createTime = randomNonNegativeLong();
@@ -287,11 +282,11 @@ public class EnrichPolicyRunnerTests extends ESSingleNodeTestCase {
         assertThat(sourceSearchResponse.getHits().getTotalHits().value, equalTo(1L));
         Map<String, Object> sourceDocMap = sourceSearchResponse.getHits().getAt(0).getSourceAsMap();
         assertNotNull(sourceDocMap);
-        assertThat(sourceDocMap.get("range"), is(equalTo(Map.of("lt", 10, "gt", 1))));
+        assertThat(sourceDocMap.get("range"), is(equalTo(org.elasticsearch.core.Map.of("lt", 10, "gt", 1))));
         assertThat(sourceDocMap.get("zipcode"), is(equalTo(90210)));
 
-        List<String> enrichFields = List.of("zipcode");
-        EnrichPolicy policy = new EnrichPolicy(EnrichPolicy.RANGE_TYPE, null, List.of(sourceIndex), "range", enrichFields, null);
+        List<String> enrichFields = singletonList("zipcode");
+        EnrichPolicy policy = new EnrichPolicy(EnrichPolicy.RANGE_TYPE, null, singletonList((sourceIndex)), "range", enrichFields, null);
         String policyName = "test1";
 
         final long createTime = randomNonNegativeLong();
@@ -312,7 +307,7 @@ public class EnrichPolicyRunnerTests extends ESSingleNodeTestCase {
         GetIndexResponse enrichIndex = getGetIndexResponseAndCheck(createdEnrichIndex);
 
         // Validate Mapping
-        Map<String, Object> mapping = enrichIndex.getMappings().get(createdEnrichIndex).sourceAsMap();
+        Map<String, Object> mapping = enrichIndex.getMappings().get(createdEnrichIndex).get("_doc").sourceAsMap();
         validateMappingMetadata(mapping, policyName, policy);
         assertThat(mapping.get("dynamic"), is("false"));
         Map<?, ?> properties = (Map<?, ?>) mapping.get("properties");
@@ -332,7 +327,7 @@ public class EnrichPolicyRunnerTests extends ESSingleNodeTestCase {
         Map<String, Object> enrichDocument = enrichSearchResponse.getHits().iterator().next().getSourceAsMap();
         assertNotNull(enrichDocument);
         assertThat(enrichDocument.size(), is(equalTo(2)));
-        assertThat(enrichDocument.get("range"), is(equalTo(Map.of("lt", 10, "gt", 1))));
+        assertThat(enrichDocument.get("range"), is(equalTo(org.elasticsearch.core.Map.of("lt", 10, "gt", 1))));
         assertThat(enrichDocument.get("zipcode"), is(equalTo(90210)));
 
         // Validate segments
@@ -365,7 +360,7 @@ public class EnrichPolicyRunnerTests extends ESSingleNodeTestCase {
 
         GetIndexResponse sourceIndex = client().admin().indices().getIndex(new GetIndexRequest().indices(sourceIndexName)).actionGet();
         // Validate Mapping
-        Map<String, Object> sourceIndexMapping = sourceIndex.getMappings().get(sourceIndexName).sourceAsMap();
+        Map<String, Object> sourceIndexMapping = sourceIndex.getMappings().get(sourceIndexName).get("_doc").sourceAsMap();
         Map<?, ?> sourceIndexProperties = (Map<?, ?>) sourceIndexMapping.get("properties");
         Map<?, ?> subnetField = (Map<?, ?>) sourceIndexProperties.get("subnet");
         assertNotNull(subnetField);
@@ -380,8 +375,8 @@ public class EnrichPolicyRunnerTests extends ESSingleNodeTestCase {
         assertThat(sourceDocMap.get("subnet"), is(equalTo("10.0.0.0/8")));
         assertThat(sourceDocMap.get("department"), is(equalTo("research")));
 
-        List<String> enrichFields = List.of("department");
-        EnrichPolicy policy = new EnrichPolicy(EnrichPolicy.RANGE_TYPE, null, List.of(sourceIndexName), "subnet", enrichFields);
+        List<String> enrichFields = singletonList("department");
+        EnrichPolicy policy = new EnrichPolicy(EnrichPolicy.RANGE_TYPE, null, singletonList(sourceIndexName), "subnet", enrichFields);
         String policyName = "test1";
 
         final long createTime = randomNonNegativeLong();
@@ -402,7 +397,7 @@ public class EnrichPolicyRunnerTests extends ESSingleNodeTestCase {
         GetIndexResponse enrichIndex = getGetIndexResponseAndCheck(createdEnrichIndex);
 
         // Validate Mapping
-        Map<String, Object> mapping = enrichIndex.getMappings().get(createdEnrichIndex).sourceAsMap();
+        Map<String, Object> mapping = enrichIndex.getMappings().get(createdEnrichIndex).get("_doc").sourceAsMap();
         validateMappingMetadata(mapping, policyName, policy);
         assertThat(mapping.get("dynamic"), is("false"));
         Map<?, ?> properties = (Map<?, ?>) mapping.get("properties");
@@ -484,13 +479,7 @@ public class EnrichPolicyRunnerTests extends ESSingleNodeTestCase {
         enrichFields.add("field1");
         enrichFields.add("field2");
         enrichFields.add("field5");
-        EnrichPolicy policy = new EnrichPolicy(
-            EnrichPolicy.MATCH_TYPE,
-            null,
-            Collections.singletonList(sourceIndexPattern),
-            "key",
-            enrichFields
-        );
+        EnrichPolicy policy = new EnrichPolicy(EnrichPolicy.MATCH_TYPE, null, singletonList(sourceIndexPattern), "key", enrichFields);
         String policyName = "test1";
 
         final long createTime = randomNonNegativeLong();
@@ -597,13 +586,7 @@ public class EnrichPolicyRunnerTests extends ESSingleNodeTestCase {
 
         String sourceIndexPattern = baseSourceName + "*";
         List<String> enrichFields = Arrays.asList("idx", "field1", "field2", "field5");
-        EnrichPolicy policy = new EnrichPolicy(
-            EnrichPolicy.MATCH_TYPE,
-            null,
-            Collections.singletonList(sourceIndexPattern),
-            "key",
-            enrichFields
-        );
+        EnrichPolicy policy = new EnrichPolicy(EnrichPolicy.MATCH_TYPE, null, singletonList(sourceIndexPattern), "key", enrichFields);
         String policyName = "test1";
 
         final long createTime = randomNonNegativeLong();
@@ -708,13 +691,7 @@ public class EnrichPolicyRunnerTests extends ESSingleNodeTestCase {
 
         String sourceIndexPattern = baseSourceName + "*";
         List<String> enrichFields = Arrays.asList("idx", "field1", "field2", "field5");
-        EnrichPolicy policy = new EnrichPolicy(
-            EnrichPolicy.MATCH_TYPE,
-            null,
-            Collections.singletonList(sourceIndexPattern),
-            "key",
-            enrichFields
-        );
+        EnrichPolicy policy = new EnrichPolicy(EnrichPolicy.MATCH_TYPE, null, singletonList(sourceIndexPattern), "key", enrichFields);
         String policyName = "test1";
 
         final long createTime = randomNonNegativeLong();
@@ -771,13 +748,7 @@ public class EnrichPolicyRunnerTests extends ESSingleNodeTestCase {
         List<String> enrichFields = new ArrayList<>();
         enrichFields.add("field2");
         enrichFields.add("field5");
-        EnrichPolicy policy = new EnrichPolicy(
-            EnrichPolicy.MATCH_TYPE,
-            null,
-            Collections.singletonList(sourceIndex),
-            "field1",
-            enrichFields
-        );
+        EnrichPolicy policy = new EnrichPolicy(EnrichPolicy.MATCH_TYPE, null, singletonList(sourceIndex), "field1", enrichFields);
         String policyName = "test1";
 
         final long createTime = randomNonNegativeLong();
@@ -806,13 +777,7 @@ public class EnrichPolicyRunnerTests extends ESSingleNodeTestCase {
         List<String> enrichFields = new ArrayList<>();
         enrichFields.add("field2");
         enrichFields.add("field5");
-        EnrichPolicy policy = new EnrichPolicy(
-            EnrichPolicy.MATCH_TYPE,
-            null,
-            Collections.singletonList(sourceIndex),
-            "field1",
-            enrichFields
-        );
+        EnrichPolicy policy = new EnrichPolicy(EnrichPolicy.MATCH_TYPE, null, singletonList(sourceIndex), "field1", enrichFields);
         String policyName = "test1";
 
         final long createTime = randomNonNegativeLong();
@@ -871,14 +836,8 @@ public class EnrichPolicyRunnerTests extends ESSingleNodeTestCase {
         assertTrue(createResponse.isAcknowledged());
 
         String policyName = "test1";
-        List<String> enrichFields = Collections.singletonList("field2");
-        EnrichPolicy policy = new EnrichPolicy(
-            EnrichPolicy.MATCH_TYPE,
-            null,
-            Collections.singletonList(sourceIndex),
-            "nesting.key",
-            enrichFields
-        );
+        List<String> enrichFields = singletonList("field2");
+        EnrichPolicy policy = new EnrichPolicy(EnrichPolicy.MATCH_TYPE, null, singletonList(sourceIndex), "nesting.key", enrichFields);
 
         final long createTime = randomNonNegativeLong();
         final AtomicReference<Exception> exception = new AtomicReference<>();
@@ -943,7 +902,7 @@ public class EnrichPolicyRunnerTests extends ESSingleNodeTestCase {
         List<String> enrichFields = new ArrayList<>();
         enrichFields.add("nesting.field2");
         enrichFields.add("missingField");
-        EnrichPolicy policy = new EnrichPolicy(EnrichPolicy.MATCH_TYPE, null, Collections.singletonList(sourceIndex), "key", enrichFields);
+        EnrichPolicy policy = new EnrichPolicy(EnrichPolicy.MATCH_TYPE, null, singletonList(sourceIndex), "key", enrichFields);
 
         final long createTime = randomNonNegativeLong();
         final AtomicReference<Exception> exception = new AtomicReference<>();
@@ -1034,13 +993,7 @@ public class EnrichPolicyRunnerTests extends ESSingleNodeTestCase {
         List<String> enrichFields = new ArrayList<>();
         enrichFields.add("data.field2");
         enrichFields.add("missingField");
-        EnrichPolicy policy = new EnrichPolicy(
-            EnrichPolicy.MATCH_TYPE,
-            null,
-            Collections.singletonList(sourceIndex),
-            "data.field1",
-            enrichFields
-        );
+        EnrichPolicy policy = new EnrichPolicy(EnrichPolicy.MATCH_TYPE, null, singletonList(sourceIndex), "data.field1", enrichFields);
 
         final long createTime = randomNonNegativeLong();
         final AtomicReference<Exception> exception = new AtomicReference<>();
@@ -1155,13 +1108,7 @@ public class EnrichPolicyRunnerTests extends ESSingleNodeTestCase {
         List<String> enrichFields = new ArrayList<>();
         enrichFields.add("data.field2");
         enrichFields.add("missingField");
-        EnrichPolicy policy = new EnrichPolicy(
-            EnrichPolicy.MATCH_TYPE,
-            null,
-            Collections.singletonList(sourceIndex),
-            "data.field1",
-            enrichFields
-        );
+        EnrichPolicy policy = new EnrichPolicy(EnrichPolicy.MATCH_TYPE, null, singletonList(sourceIndex), "data.field1", enrichFields);
 
         final long createTime = randomNonNegativeLong();
         final AtomicReference<Exception> exception = new AtomicReference<>();
@@ -1245,7 +1192,7 @@ public class EnrichPolicyRunnerTests extends ESSingleNodeTestCase {
             .endObject();
         CreateIndexResponse createResponse = client().admin()
             .indices()
-            .create(new CreateIndexRequest(sourceIndex).mapping(mappingBuilder))
+            .create(new CreateIndexRequest(sourceIndex).mapping("_doc", mappingBuilder))
             .actionGet();
         assertTrue(createResponse.isAcknowledged());
 
@@ -1279,8 +1226,8 @@ public class EnrichPolicyRunnerTests extends ESSingleNodeTestCase {
         assertThat(dataField.get("field3"), is(equalTo("ignored")));
 
         String policyName = "test1";
-        List<String> enrichFields = List.of("data.department", "missingField");
-        EnrichPolicy policy = new EnrichPolicy(EnrichPolicy.RANGE_TYPE, null, List.of(sourceIndex), "data.subnet", enrichFields);
+        List<String> enrichFields = Arrays.asList("data.department", "missingField");
+        EnrichPolicy policy = new EnrichPolicy(EnrichPolicy.RANGE_TYPE, null, singletonList(sourceIndex), "data.subnet", enrichFields);
 
         final long createTime = randomNonNegativeLong();
         final AtomicReference<Exception> exception = new AtomicReference<>();
@@ -1300,7 +1247,7 @@ public class EnrichPolicyRunnerTests extends ESSingleNodeTestCase {
         GetIndexResponse enrichIndex = getGetIndexResponseAndCheck(createdEnrichIndex);
 
         // Validate Mapping
-        Map<String, Object> mapping = enrichIndex.getMappings().get(createdEnrichIndex).sourceAsMap();
+        Map<String, Object> mapping = enrichIndex.getMappings().get(createdEnrichIndex).get("_doc").sourceAsMap();
         validateMappingMetadata(mapping, policyName, policy);
         assertThat(mapping.get("dynamic"), is("false"));
         Map<?, ?> properties = (Map<?, ?>) mapping.get("properties");
@@ -1413,7 +1360,7 @@ public class EnrichPolicyRunnerTests extends ESSingleNodeTestCase {
         EnrichPolicy policy = new EnrichPolicy(
             EnrichPolicy.MATCH_TYPE,
             null,
-            Collections.singletonList(sourceIndex),
+            singletonList(sourceIndex),
             "data.fields.field1",
             enrichFields
         );
@@ -1511,7 +1458,7 @@ public class EnrichPolicyRunnerTests extends ESSingleNodeTestCase {
             .endObject();
         CreateIndexResponse createResponse = client().admin()
             .indices()
-            .create(new CreateIndexRequest(sourceIndex).mapping(mappingBuilder))
+            .create(new CreateIndexRequest(sourceIndex).mapping("_doc", mappingBuilder))
             .actionGet();
         assertTrue(createResponse.isAcknowledged());
 
@@ -1549,8 +1496,14 @@ public class EnrichPolicyRunnerTests extends ESSingleNodeTestCase {
         assertThat(fieldsField.get("field3"), is(equalTo("ignored")));
 
         String policyName = "test1";
-        List<String> enrichFields = List.of("data.fields.department", "missingField");
-        EnrichPolicy policy = new EnrichPolicy(EnrichPolicy.RANGE_TYPE, null, List.of(sourceIndex), "data.fields.subnet", enrichFields);
+        List<String> enrichFields = Arrays.asList("data.fields.department", "missingField");
+        EnrichPolicy policy = new EnrichPolicy(
+            EnrichPolicy.RANGE_TYPE,
+            null,
+            singletonList(sourceIndex),
+            "data.fields.subnet",
+            enrichFields
+        );
 
         final long createTime = randomNonNegativeLong();
         final AtomicReference<Exception> exception = new AtomicReference<>();
@@ -1570,7 +1523,7 @@ public class EnrichPolicyRunnerTests extends ESSingleNodeTestCase {
         GetIndexResponse enrichIndex = getGetIndexResponseAndCheck(createdEnrichIndex);
 
         // Validate Mapping
-        Map<String, Object> mapping = enrichIndex.getMappings().get(createdEnrichIndex).sourceAsMap();
+        Map<String, Object> mapping = enrichIndex.getMappings().get(createdEnrichIndex).get("_doc").sourceAsMap();
         validateMappingMetadata(mapping, policyName, policy);
         assertThat(mapping.get("dynamic"), is("false"));
         Map<?, ?> properties = (Map<?, ?>) mapping.get("properties");
@@ -1646,7 +1599,7 @@ public class EnrichPolicyRunnerTests extends ESSingleNodeTestCase {
             .endObject();
         CreateIndexResponse createResponse = client().admin()
             .indices()
-            .create(new CreateIndexRequest(sourceIndex).mapping(mappingBuilder))
+            .create(new CreateIndexRequest(sourceIndex).mapping("_doc", mappingBuilder))
             .actionGet();
         assertTrue(createResponse.isAcknowledged());
 
@@ -1690,8 +1643,14 @@ public class EnrichPolicyRunnerTests extends ESSingleNodeTestCase {
         assertThat(fieldsField.get("field3"), is(equalTo("ignored")));
 
         String policyName = "test1";
-        List<String> enrichFields = List.of("data.fields.status", "missingField");
-        EnrichPolicy policy = new EnrichPolicy(EnrichPolicy.RANGE_TYPE, null, List.of(sourceIndex), "data.fields.period", enrichFields);
+        List<String> enrichFields = Arrays.asList("data.fields.status", "missingField");
+        EnrichPolicy policy = new EnrichPolicy(
+            EnrichPolicy.RANGE_TYPE,
+            null,
+            singletonList(sourceIndex),
+            "data.fields.period",
+            enrichFields
+        );
 
         final long createTime = randomNonNegativeLong();
         final AtomicReference<Exception> exception = new AtomicReference<>();
@@ -1711,7 +1670,7 @@ public class EnrichPolicyRunnerTests extends ESSingleNodeTestCase {
         GetIndexResponse enrichIndex = getGetIndexResponseAndCheck(createdEnrichIndex);
 
         // Validate Mapping
-        Map<String, Object> mapping = enrichIndex.getMappings().get(createdEnrichIndex).sourceAsMap();
+        Map<String, Object> mapping = enrichIndex.getMappings().get(createdEnrichIndex).get("_doc").sourceAsMap();
         validateMappingMetadata(mapping, policyName, policy);
         assertThat(mapping.get("dynamic"), is("false"));
         Map<?, ?> properties = (Map<?, ?>) mapping.get("properties");
@@ -1824,13 +1783,7 @@ public class EnrichPolicyRunnerTests extends ESSingleNodeTestCase {
         List<String> enrichFields = new ArrayList<>();
         enrichFields.add("data.field2");
         enrichFields.add("missingField");
-        EnrichPolicy policy = new EnrichPolicy(
-            EnrichPolicy.MATCH_TYPE,
-            null,
-            Collections.singletonList(sourceIndex),
-            "data.field1",
-            enrichFields
-        );
+        EnrichPolicy policy = new EnrichPolicy(EnrichPolicy.MATCH_TYPE, null, singletonList(sourceIndex), "data.field1", enrichFields);
 
         final long createTime = randomNonNegativeLong();
         final AtomicReference<Exception> exception = new AtomicReference<>();
@@ -1918,13 +1871,7 @@ public class EnrichPolicyRunnerTests extends ESSingleNodeTestCase {
         assertThat(sourceDocMap.get("field5"), is(equalTo("value5")));
 
         List<String> enrichFields = Arrays.asList("field2", "field5");
-        EnrichPolicy policy = new EnrichPolicy(
-            EnrichPolicy.MATCH_TYPE,
-            null,
-            Collections.singletonList(sourceIndex),
-            "field1",
-            enrichFields
-        );
+        EnrichPolicy policy = new EnrichPolicy(EnrichPolicy.MATCH_TYPE, null, singletonList(sourceIndex), "field1", enrichFields);
         String policyName = "test1";
 
         final long createTime = randomNonNegativeLong();

--- a/x-pack/plugin/enrich/src/test/java/org/elasticsearch/xpack/enrich/EnrichStoreCrudTests.java
+++ b/x-pack/plugin/enrich/src/test/java/org/elasticsearch/xpack/enrich/EnrichStoreCrudTests.java
@@ -114,7 +114,10 @@ public class EnrichStoreCrudTests extends AbstractEnrichTestCase {
                 IllegalArgumentException.class,
                 () -> saveEnrichPolicy("name", invalidPolicy, clusterService)
             );
-            assertThat(error.getMessage(), equalTo("unsupported policy type [unsupported_type], supported types are [match, geo_match]"));
+            assertThat(
+                error.getMessage(),
+                equalTo("unsupported policy type [unsupported_type], supported types are [match, geo_match, range]")
+            );
         }
     }
 


### PR DESCRIPTION
Backporting #76110 to 7.x

Added RANGE_POLICY, The code expects source indicies, if multiple are specified, to have consistent type and if applicable format across these.

Pulled in https://github.com/elastic/elasticsearch/pull/65781/files#diff-be6652cff75cf1e283570c14fd5dea042ddb586ac5645f7deef6ef3716732906
and  https://github.com/elastic/elasticsearch/pull/65781/files#diff-d893db3430284d2635214c41f0cb66b3ca154d6cd73c29c5c97031ece40d2904 from probakowski