### PR TITLE
Make use of new Get Snapshots Filtering in SLM Retention

### DIFF
--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/slm/SnapshotRetentionTask.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/slm/SnapshotRetentionTask.java
@@ -253,10 +253,7 @@ public class SnapshotRetentionTask implements SchedulerEngine.Listener {
                     Map<String, List<SnapshotInfo>> snapshots = new HashMap<>();
                     for (SnapshotInfo info : resp.getSnapshots()) {
                         if (RETAINABLE_STATES.contains(info.state()) && info.userMetadata() != null) {
-                            final Object policy = info.userMetadata().get(POLICY_ID_METADATA_FIELD);
-                            if (policy instanceof String && policies.contains(policy)) {
-                                snapshots.computeIfAbsent(info.repository(), repo -> new ArrayList<>()).add(info);
-                            }
+                            snapshots.computeIfAbsent(info.repository(), repo -> new ArrayList<>()).add(info);
                         }
                     }
                     listener.onResponse(snapshots);

--- a/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/slm/SnapshotRetentionTaskTests.java
+++ b/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/slm/SnapshotRetentionTaskTests.java
@@ -335,7 +335,7 @@ public class SnapshotRetentionTaskTests extends ESTestCase {
                     (historyItem) -> fail("should never write history")));
 
             AtomicReference<Exception> errHandlerCalled = new AtomicReference<>(null);
-            task.getAllRetainableSnapshots(Collections.singleton(repoId), new ActionListener<>() {
+            task.getAllRetainableSnapshots(Collections.singleton(repoId), Set.of(policyId), new ActionListener<>() {
                 @Override
                 public void onResponse(Map<String, List<SnapshotInfo>> stringListMap) {
                     logger.info("--> forcing failure");
@@ -528,6 +528,7 @@ public class SnapshotRetentionTaskTests extends ESTestCase {
 
         @Override
         void getAllRetainableSnapshots(Collection<String> repositories,
+                                       Set<String> policies,
                                        ActionListener<Map<String, List<SnapshotInfo>>> listener,
                                        Consumer<Exception> errorHandler) {
             listener.onResponse(this.snapshotRetriever.get());


### PR DESCRIPTION
We can save ourselves the trouble of even looking at snapshots that don't have a relevant
policy on the SLM side now.

relates #74350