### PR TITLE
Add `create_index` permissions to `editor` role

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStore.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStore.java
@@ -330,7 +330,7 @@ public class ReservedRolesStore implements BiConsumer<Set<String>, ActionListene
                 // Observability
                 RoleDescriptor.IndicesPrivileges.builder()
                     .indices("observability-annotations")
-                    .privileges("read", "view_index_metadata", "write").build(),
+                    .privileges("read", "view_index_metadata", "write", "create_index").build(),
                 // Security
                 RoleDescriptor.IndicesPrivileges.builder()
                     .indices(".siem-signals-*", ".lists-*", ".items-*")


### PR DESCRIPTION
This PR adds `create_index` permissions to `editor` role exclusively for the `observability-annotations` index.

This is needed because the Annotations API [lazily creates the annotations index](https://github.com/elastic/kibana/blob/b77ca9392b659eac9836d0e3bbe17f333b95ee68/x-pack/plugins/observability/server/lib/annotations/create_annotations_client.ts#L59-L67) if it doesn't already exist. This happens with the end users credentials.

@bytebilly 
