### PR TITLE
Only depend on beats when necessary

### DIFF
--- a/distribution/docker/build.gradle
+++ b/distribution/docker/build.gradle
@@ -18,6 +18,11 @@ apply plugin: 'elasticsearch.rest-resources'
 String buildId = providers.systemProperty('build.id').forUseAtConfigurationTime().getOrNull()
 boolean useLocalArtifacts = buildId != null && buildId.isBlank() == false
 
+// If we're performing a release build, but `build.id` hasn't been set, we can
+// infer that we're not at the Docker building stage of the build, and therefore
+// we should skip the beats part of the build.
+boolean includeBeats = VersionProperties.isElasticsearchSnapshot() == true || buildId != null
+
 repositories {
   // Define a repository that allows Gradle to fetch a resource from GitHub. This
   // is only used to fetch the `tini` binary, when building the Iron Bank docker image
@@ -74,8 +79,11 @@ dependencies {
   tini "krallin:tini:0.19.0:${tiniArch}"
   repositoryPlugins project(path: ':plugins', configuration: 'repositoryPlugins')
   nonRepositoryPlugins project(path: ':plugins', configuration: 'nonRepositoryPlugins')
-  filebeat "beats:filebeat:${VersionProperties.elasticsearch}:${beatsArch}@tar.gz"
-  metricbeat "beats:metricbeat:${VersionProperties.elasticsearch}:${beatsArch}@tar.gz"
+
+  if (includeBeats) {
+    filebeat "beats:filebeat:${VersionProperties.elasticsearch}:${beatsArch}@tar.gz"
+    metricbeat "beats:metricbeat:${VersionProperties.elasticsearch}:${beatsArch}@tar.gz"
+  }
 }
 
 ext.expansions = { Architecture architecture, DockerBase base ->

--- a/distribution/docker/build.gradle
+++ b/distribution/docker/build.gradle
@@ -18,11 +18,6 @@ apply plugin: 'elasticsearch.rest-resources'
 String buildId = providers.systemProperty('build.id').forUseAtConfigurationTime().getOrNull()
 boolean useLocalArtifacts = buildId != null && buildId.isBlank() == false
 
-// If we're performing a release build, but `build.id` hasn't been set, we can
-// infer that we're not at the Docker building stage of the build, and therefore
-// we should skip the beats part of the build.
-boolean includeBeats = VersionProperties.isElasticsearchSnapshot() == true || buildId != null
-
 repositories {
   // Define a repository that allows Gradle to fetch a resource from GitHub. This
   // is only used to fetch the `tini` binary, when building the Iron Bank docker image
@@ -79,11 +74,8 @@ dependencies {
   tini "krallin:tini:0.19.0:${tiniArch}"
   repositoryPlugins project(path: ':plugins', configuration: 'repositoryPlugins')
   nonRepositoryPlugins project(path: ':plugins', configuration: 'nonRepositoryPlugins')
-
-  if (includeBeats) {
-    filebeat "beats:filebeat:${VersionProperties.elasticsearch}:${beatsArch}@tar.gz"
-    metricbeat "beats:metricbeat:${VersionProperties.elasticsearch}:${beatsArch}@tar.gz"
-  }
+  filebeat "beats:filebeat:${VersionProperties.elasticsearch}:${beatsArch}@tar.gz"
+  metricbeat "beats:metricbeat:${VersionProperties.elasticsearch}:${beatsArch}@tar.gz"
 }
 
 ext.expansions = { Architecture architecture, DockerBase base ->
@@ -248,9 +240,17 @@ void addBuildDockerContextTask(Architecture architecture, DockerBase base) {
       }
 
       if (base == DockerBase.CLOUD) {
+        // If we're performing a release build, but `build.id` hasn't been set, we can
+        // infer that we're not at the Docker building stage of the build, and therefore
+        // we should skip the beats part of the build.
+        String buildId = providers.systemProperty('build.id').forUseAtConfigurationTime().getOrNull()
+        boolean includeBeats = VersionProperties.isElasticsearchSnapshot() == true || buildId != null
+
         from configurations.repositoryPlugins
-        from configurations.filebeat
-        from configurations.metricbeat
+        if (includeBeats) {
+          from configurations.filebeat
+          from configurations.metricbeat
+        }
         // For some reason, the artifact name can differ depending on what repository we used.
         rename ~/((?:file|metric)beat)-.*\.tar\.gz$/, "\$1-${VersionProperties.elasticsearch}.tar.gz"
 


### PR DESCRIPTION
The unified build happens in stages, and for release builds the main
part of Elasticsearch will be built before the Beats distributions are
available. To work around this, infer in the Docker part of the build
whether to include beats as a dependency.  In the future, we should find
a more robust mechanism.