### PR TITLE
[7.x] Only depend on beats when necessary (#77436)

### DIFF
--- a/distribution/docker/build.gradle
+++ b/distribution/docker/build.gradle
@@ -243,9 +243,17 @@ void addBuildDockerContextTask(Architecture architecture, DockerBase base) {
       }
 
       if (base == DockerBase.CLOUD) {
+        // If we're performing a release build, but `build.id` hasn't been set, we can
+        // infer that we're not at the Docker building stage of the build, and therefore
+        // we should skip the beats part of the build.
+        String buildId = providers.systemProperty('build.id').forUseAtConfigurationTime().getOrNull()
+        boolean includeBeats = VersionProperties.isElasticsearchSnapshot() == true || buildId != null
+
         from configurations.repositoryPlugins
-        from configurations.filebeat
-        from configurations.metricbeat
+        if (includeBeats) {
+          from configurations.filebeat
+          from configurations.metricbeat
+        }
         // For some reason, the artifact name can differ depending on what repository we used.
         rename ~/((?:file|metric)beat)-.*\.tar\.gz$/, "\$1-${VersionProperties.elasticsearch}.tar.gz"
 


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Only depend on beats when necessary (#77436)