### PR TITLE
Fix RecoverySourceHandlerTests testHandleCorruptedIndexOnSendSendFiles

### DIFF
--- a/server/src/test/java/org/elasticsearch/indices/recovery/RecoverySourceHandlerTests.java
+++ b/server/src/test/java/org/elasticsearch/indices/recovery/RecoverySourceHandlerTests.java
@@ -421,9 +421,10 @@ public class RecoverySourceHandlerTests extends ESTestCase {
             metas.add(md);
         }
 
+        // only corrupt files that belong to the lucene index and use one that we don't cache on heap so the corruption on disk has an
+        // effect
         CorruptionUtils.corruptFile(random(), FileSystemUtils.files(tempDir, (p) ->
-            (p.getFileName().toString().equals("write.lock") ||
-                p.getFileName().toString().startsWith("extra")) == false));
+            metas.stream().anyMatch(m -> m.name().equals(p.getFileName().toString()) && m.hashEqualsContents() == false)));
         Store targetStore = newStore(createTempDir(), false);
         MultiFileWriter multiFileWriter = new MultiFileWriter(targetStore, mock(RecoveryState.Index.class), "", logger, () -> {});
         RecoveryTargetHandler target = new TestRecoveryTargetHandler() {


### PR DESCRIPTION
This was caused by reading some more bytes from heap in #72621.

closes #77437

