### PR TITLE
[7.15] Clarify geoip database loader log message (#77391)

### DIFF
--- a/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/DatabaseRegistry.java
+++ b/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/DatabaseRegistry.java
@@ -308,12 +308,13 @@ public final class DatabaseRegistry implements Closeable {
 
     void updateDatabase(String databaseFileName, String recordedMd5, Path file) {
         try {
-            LOGGER.info("database file changed [{}], reload database...", file);
+            LOGGER.debug("starting reload of changed geoip database file [{}]", file);
             DatabaseReaderLazyLoader loader = new DatabaseReaderLazyLoader(cache, file, recordedMd5);
             DatabaseReaderLazyLoader existing = databases.put(databaseFileName, loader);
             if (existing != null) {
                 existing.close();
             }
+            LOGGER.info("successfully reloaded changed geoip database file [{}]", file);
         } catch (Exception e) {
             LOGGER.error((Supplier<?>) () -> new ParameterizedMessage("failed to update database [{}]", databaseFileName), e);
         }


### PR DESCRIPTION
Moves the log message to the completion of the operation and puts it in the past tense to signal successful completion rather than the initiation of the operation. This does not address the fact that the geoip database loader log entries are frequently after the point that ES reaches a ready state which sometimes leads users to believe that ES is stuck. Completely addressing that issue will likely involve either more prominently documenting the "[o.e.n.Node] [my-node-name] started" message as the point at which ES is up or somehow hooking into the completion of all "initialization" tasks and logging something to that effect.

Relates to #77305

Backport of #77391
