### PR TITLE
[7.x] Take into account the latest valid snapshot index metadata id (#77412)

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/repositories/IndexSnapshotsServiceIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/repositories/IndexSnapshotsServiceIT.java
@@ -129,6 +129,8 @@ public class IndexSnapshotsServiceIT extends AbstractSnapshotIntegTestCase {
         List<String> indices = org.elasticsearch.core.List.of(indexName, indexName2);
         createIndex(indexName, indexName2);
         SnapshotInfo lastSnapshot = null;
+        String expectedIndexMetadataId = null;
+
         int numSnapshots = randomIntBetween(5, 25);
         for (int i = 0; i < numSnapshots; i++) {
             if (randomBoolean()) {
@@ -139,6 +141,9 @@ public class IndexSnapshotsServiceIT extends AbstractSnapshotIntegTestCase {
             final SnapshotInfo snapshotInfo = createSnapshot(repoName, String.format(Locale.ROOT, "snap-%03d", i), snapshotIndices);
             if (snapshotInfo.indices().contains(indexName)) {
                 lastSnapshot = snapshotInfo;
+                ClusterStateResponse clusterStateResponse = admin().cluster().prepareState().execute().actionGet();
+                IndexMetadata indexMetadata = clusterStateResponse.getState().metadata().index(indexName);
+                expectedIndexMetadataId = IndexMetaDataGenerations.buildUniqueIdentifier(indexMetadata);
             }
         }
 
@@ -156,10 +161,7 @@ public class IndexSnapshotsServiceIT extends AbstractSnapshotIntegTestCase {
 
             final ShardSnapshotInfo shardSnapshotInfo = indexShardSnapshotInfoOpt.get();
 
-            final ClusterStateResponse clusterStateResponse = admin().cluster().prepareState().execute().actionGet();
-            final IndexMetadata indexMetadata = clusterStateResponse.getState().metadata().index(indexName);
-            final String indexMetadataId = IndexMetaDataGenerations.buildUniqueIdentifier(indexMetadata);
-            assertThat(shardSnapshotInfo.getIndexMetadataIdentifier(), equalTo(indexMetadataId));
+            assertThat(shardSnapshotInfo.getIndexMetadataIdentifier(), equalTo(expectedIndexMetadataId));
 
             final Snapshot snapshot = shardSnapshotInfo.getSnapshot();
             assertThat(snapshot, equalTo(lastSnapshot.snapshot()));


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Take into account the latest valid snapshot index metadata id (#77412)