### PR TITLE
Script: sort unsigned long yml test

### DIFF
--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/unsigned_long/50_script_values.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/unsigned_long/50_script_values.yml
@@ -182,6 +182,7 @@ setup:
                 script:
                   script:
                     source: "field('ul').as(Field.BigInteger).as(Field.UnsignedLong).getDouble(-2.2d) > 9E18"
+          sort: [ { ul: asc } ]
   - match: { hits.total.value: 4 }
   - match: { hits.hits.0._id: "2" }
   - match: { hits.hits.1._id: "3" }


### PR DESCRIPTION
Sorts a test that checks IDs.

Fixes: #77397

