### PR TITLE
[7.x] Script: sort unsigned long yml test (#77444)

### DIFF
--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/unsigned_long/50_script_values.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/unsigned_long/50_script_values.yml
@@ -182,6 +182,7 @@ setup:
                 script:
                   script:
                     source: "field('ul').as(Field.BigInteger).as(Field.UnsignedLong).getDouble(-2.2d) > 9E18"
+          sort: [ { ul: asc } ]
   - match: { hits.total.value: 4 }
   - match: { hits.hits.0._id: "2" }
   - match: { hits.hits.1._id: "3" }


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Script: sort unsigned long yml test (#77444)