### PR TITLE
[ML] Adding more logging for issue #76075

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/datafeed/DatafeedUpdate.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/datafeed/DatafeedUpdate.java
@@ -29,6 +29,7 @@ import org.elasticsearch.xpack.core.ml.utils.QueryProvider;
 import org.elasticsearch.xpack.core.ml.utils.XContentObjectTransformer;
 
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
@@ -516,6 +517,16 @@ public class DatafeedUpdate implements Writeable, ToXContentObject {
 
         public Builder setAggregations(AggProvider aggProvider) {
             this.aggProvider = aggProvider;
+            return this;
+        }
+
+        // Used only in testing
+        public Builder setParsedAggregations(AggregatorFactories.Builder aggregations) {
+            try {
+                this.aggProvider = AggProvider.fromParsedAggs(aggregations);
+            } catch (IOException exception) {
+                throw new UncheckedIOException(exception);
+            }
             return this;
         }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/results/Bucket.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/results/Bucket.java
@@ -6,6 +6,7 @@
  */
 package org.elasticsearch.xpack.core.ml.job.results;
 
+import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.xcontent.ParseField;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -220,6 +221,11 @@ public class Bucket implements ToXContentObject, Writeable {
 
     public void setInitialAnomalyScore(double initialAnomalyScore) {
         this.initialAnomalyScore = initialAnomalyScore;
+    }
+
+    @Override
+    public String toString() {
+        return Strings.toString(this);
     }
 
     /**

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/DatafeedJobsIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/DatafeedJobsIT.java
@@ -368,7 +368,8 @@ public class DatafeedJobsIT extends MlNativeAutodetectIntegTestCase {
                         .fixedInterval(new DateHistogramInterval("1h"))
                         .field("time")
                 )
-            ).subAggregation(AggregationBuilders.max("time").field("time"))
+            // Set size to 1 so that start stop actually doesn't page through all the results too quickly
+            ).subAggregation(AggregationBuilders.max("time").field("time")).size(1)
         );
         DatafeedConfig compositeDatafeedConfig = createDatafeedBuilder(
             compositeJobId + "-datafeed",
@@ -376,8 +377,6 @@ public class DatafeedJobsIT extends MlNativeAutodetectIntegTestCase {
             Collections.singletonList(indexName))
             .setParsedAggregations(aggs)
             .setFrequency(TimeValue.timeValueHours(1))
-            // Start off chunking at an hour so that it runs more slowly and the test has time to stop it in the middle of processing
-            .setChunkingConfig(ChunkingConfig.newManual(TimeValue.timeValueHours(1)))
             .build();
         putDatafeed(compositeDatafeedConfig);
         startDatafeed(compositeDatafeedConfig.getId(), 0L, null);
@@ -390,10 +389,21 @@ public class DatafeedJobsIT extends MlNativeAutodetectIntegTestCase {
         );
         // If we are not OPENED, then we are closed and shouldn't restart as the datafeed finished running through the data
         if (getJobStats(compositeJobId).get(0).getState().equals(JobState.OPENED)) {
+            aggs = new AggregatorFactories.Builder();
+            aggs.addAggregator(
+                AggregationBuilders.composite(
+                    "buckets",
+                    Collections.singletonList(
+                        new DateHistogramValuesSourceBuilder("timebucket")
+                            .fixedInterval(new DateHistogramInterval("1h"))
+                            .field("time")
+                    )
+                ).subAggregation(AggregationBuilders.max("time").field("time")).size(100)
+            );
             updateDatafeed(new DatafeedUpdate.Builder()
                 .setId(compositeDatafeedConfig.getId())
                 // Set to auto to speed up and finish the job
-                .setChunkingConfig(ChunkingConfig.newAuto())
+                .setParsedAggregations(aggs)
                 .build());
             startDatafeed(
                 compositeDatafeedConfig.getId(),
@@ -405,10 +415,16 @@ public class DatafeedJobsIT extends MlNativeAutodetectIntegTestCase {
 
         List<Bucket> scrollBuckets = getBuckets(scrollJobId);
         List<Bucket> compositeBuckets = getBuckets(compositeJobId);
+        assertThat(
+            "composite bucket size " + scrollBuckets + " does not equal scroll bucket size" + compositeBuckets,
+            compositeBuckets.size(),
+            equalTo(scrollBuckets.size())
+        );
         for (int i = 0; i < scrollBuckets.size(); i++) {
             Bucket scrollBucket = scrollBuckets.get(i);
             Bucket compositeBucket = compositeBuckets.get(i);
             try {
+                assertThat(compositeBucket.getTimestamp(), equalTo(scrollBucket.getTimestamp()));
                 assertThat(
                     "composite bucket [" + compositeBucket.getTimestamp() + "] [" + compositeBucket.getEventCount() + "] does not equal"
                         + " scroll bucket [" + scrollBucket.getTimestamp() + "] [" + scrollBucket.getEventCount() + "]",

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/DatafeedJobsIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/DatafeedJobsIT.java
@@ -402,7 +402,6 @@ public class DatafeedJobsIT extends MlNativeAutodetectIntegTestCase {
             );
             updateDatafeed(new DatafeedUpdate.Builder()
                 .setId(compositeDatafeedConfig.getId())
-                // Set to auto to speed up and finish the job
                 .setParsedAggregations(aggs)
                 .build());
             startDatafeed(
@@ -416,7 +415,7 @@ public class DatafeedJobsIT extends MlNativeAutodetectIntegTestCase {
         List<Bucket> scrollBuckets = getBuckets(scrollJobId);
         List<Bucket> compositeBuckets = getBuckets(compositeJobId);
         assertThat(
-            "composite bucket size " + scrollBuckets + " does not equal scroll bucket size" + compositeBuckets,
+            "scroll bucket size " + scrollBuckets + " does not equal composite bucket size" + compositeBuckets,
             compositeBuckets.size(),
             equalTo(scrollBuckets.size())
         );


### PR DESCRIPTION
While investigating test failure #76075, it became evident that there is one completed bucket missing in the composite agg results. 

This commit adds logging to print out all the buckets (and their counts) whenever the finalized bucket count doesn't match up.

Additionally, instead of using chunking, this simply adjusts the composite aggregation paging size.

related: https://github.com/elastic/elasticsearch/issues/76075