### PR TITLE
Add explicit lifecycle task for release builds

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,6 +20,8 @@ import org.elasticsearch.gradle.plugin.PluginBuildPlugin
 import org.gradle.plugins.ide.eclipse.model.AccessRule
 import org.gradle.util.DistributionLocator
 import org.gradle.util.GradleVersion
+import org.elasticsearch.gradle.util.GradleUtils
+
 import static org.elasticsearch.gradle.util.GradleUtils.maybeConfigure
 import org.gradle.plugins.ide.eclipse.model.ProjectDependency
 import org.elasticsearch.gradle.internal.InternalPluginBuildPlugin
@@ -426,4 +428,13 @@ tasks.named("eclipse").configure {
   dependsOn gradle.includedBuild('build-conventions').task(':eclipse')
   dependsOn gradle.includedBuild('build-tools').task(':eclipse')
   dependsOn gradle.includedBuild('build-tools-internal').task(':eclipse')
+}
+
+tasks.register("buildReleaseArtifacts").configure {
+  group = 'build'
+  description = 'Builds all artifacts required for release manager'
+
+  dependsOn subprojects.findAll { it.path.startsWith(':distribution:docker') == false && it.path.startsWith(':ml-cpp') == false }
+    .collect { GradleUtils.findByName(it.tasks, 'assemble') }
+    .findAll { it != null }
 }


### PR DESCRIPTION
Our release pipeline is getting increasingly complex. This is leading to lots of issues with tasks "leaking" into those builds causing issues. We rely currently on `assemble` as the task to "build everything", which it is, but we don't necessarily want to build _everything_ in our release pipeline in a single go. 

This pull request introduces an explicit task to be used by our release builds which filters out ML and Docker build as those are doing in separate release stages. As necessary going forward we should tweak the dependencies here, instead of making our release configuration more and more fragile.