### PR TITLE
[7.15] Match IPv6 addresses without compressed id from settings (#77404)

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/node/DiscoveryNodeFilters.java
+++ b/server/src/main/java/org/elasticsearch/cluster/node/DiscoveryNodeFilters.java
@@ -8,13 +8,13 @@
 
 package org.elasticsearch.cluster.node;
 
-import org.elasticsearch.core.Nullable;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.network.InetAddresses;
 import org.elasticsearch.common.network.NetworkAddress;
 import org.elasticsearch.common.regex.Regex;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.transport.TransportAddress;
+import org.elasticsearch.core.Nullable;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -73,7 +73,8 @@ public class DiscoveryNodeFilters {
     }
 
     private boolean matchByIP(String[] values, @Nullable String hostIp, @Nullable String publishIp) {
-        for (String value : values) {
+        for (String ipOrHost : values) {
+            String value = InetAddresses.isInetAddress(ipOrHost) ? NetworkAddress.format(InetAddresses.forString(ipOrHost)) : ipOrHost;
             boolean matchIp = Regex.simpleMatch(value, hostIp) || Regex.simpleMatch(value, publishIp);
             if (matchIp) {
                 return matchIp;


### PR DESCRIPTION
Backports the following commits to 7.15:
 - Match IPv6 addresses without compressed id from settings (#77404)