### PR TITLE
Update API stabilities in specs with documentation

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/autoscaling.delete_autoscaling_policy.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/autoscaling.delete_autoscaling_policy.json
@@ -5,7 +5,7 @@
       "description":"Deletes an autoscaling policy. Designed for indirect use by ECE/ESS and ECK. Direct use is not supported."
     },
     "stability":"stable",
-    "visibility":"public",
+    "visibility":"private",
     "headers":{
       "accept": [ "application/json"]
     },

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/autoscaling.get_autoscaling_capacity.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/autoscaling.get_autoscaling_capacity.json
@@ -5,7 +5,7 @@
       "description": "Gets the current autoscaling capacity based on the configured autoscaling policy. Designed for indirect use by ECE/ESS and ECK. Direct use is not supported."
     },
     "stability":"stable",
-    "visibility":"public",
+    "visibility":"private",
     "headers":{
       "accept": [ "application/json"]
     },

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/autoscaling.get_autoscaling_policy.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/autoscaling.get_autoscaling_policy.json
@@ -5,7 +5,7 @@
       "description": "Retrieves an autoscaling policy. Designed for indirect use by ECE/ESS and ECK. Direct use is not supported."
     },
     "stability":"stable",
-    "visibility":"public",
+    "visibility":"private",
     "headers":{
       "accept": [ "application/json"]
     },

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/autoscaling.put_autoscaling_policy.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/autoscaling.put_autoscaling_policy.json
@@ -5,7 +5,7 @@
       "description": "Creates a new autoscaling policy. Designed for indirect use by ECE/ESS and ECK. Direct use is not supported."
     },
     "stability":"stable",
-    "visibility":"public",
+    "visibility":"private",
     "headers":{
       "accept": [ "application/json"],
       "content_type": ["application/json"]

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/fleet.global_checkpoints.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/fleet.global_checkpoints.json
@@ -4,7 +4,7 @@
       "url": null,
       "description": "Returns the current global checkpoints for an index. This API is design for internal use by the fleet server project."
     },
-    "stability":"experimental",
+    "stability":"stable",
     "visibility":"public",
     "headers":{
       "accept": [ "application/json"],

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/fleet.global_checkpoints.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/fleet.global_checkpoints.json
@@ -1,7 +1,7 @@
 {
   "fleet.global_checkpoints":{
     "documentation":{
-      "url": null,
+      "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/get-global-checkpoints.html",
       "description": "Returns the current global checkpoints for an index. This API is design for internal use by the fleet server project."
     },
     "stability":"stable",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/get_script_context.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/get_script_context.json
@@ -4,7 +4,7 @@
       "url": "https://www.elastic.co/guide/en/elasticsearch/painless/master/painless-contexts.html",
       "description":"Returns all script contexts."
     },
-    "stability":"experimental",
+    "stability":"stable",
     "visibility":"public",
     "headers":{
       "accept": [ "application/json"]

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/get_script_languages.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/get_script_languages.json
@@ -4,7 +4,7 @@
       "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-scripting.html",
       "description":"Returns available script types, languages and contexts"
     },
-    "stability":"experimental",
+    "stability":"stable",
     "visibility":"public",
     "headers":{
       "accept": [ "application/json"]

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.resolve_index.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.resolve_index.json
@@ -4,7 +4,7 @@
       "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-resolve-index-api.html",
       "description":"Returns information about any matching indices, aliases, and data streams"
     },
-    "stability":"experimental",
+    "stability":"stable",
     "visibility":"public",
     "headers":{
       "accept": [ "application/json"]

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/ml.get_trained_model_deployment_stats.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/ml.get_trained_model_deployment_stats.json
@@ -4,7 +4,7 @@
       "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-trained-model-deployment-stats.html",
       "description":"Get information about trained model deployments."
     },
-    "stability":"experimental",
+    "stability":"stable",
     "visibility":"public",
     "headers":{
       "accept": [ "application/json"],

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/monitoring.bulk.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/monitoring.bulk.json
@@ -4,7 +4,7 @@
       "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/monitor-elasticsearch-cluster.html",
       "description":"Used by the monitoring features to send monitoring data."
     },
-    "stability":"experimental",
+    "stability":"stable",
     "visibility":"public",
     "headers":{
       "accept": [ "application/json"],

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/monitoring.bulk.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/monitoring.bulk.json
@@ -5,7 +5,7 @@
       "description":"Used by the monitoring features to send monitoring data."
     },
     "stability":"stable",
-    "visibility":"public",
+    "visibility":"private",
     "headers":{
       "accept": [ "application/json"],
       "content_type": ["application/x-ndjson"]

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/rank_eval.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/rank_eval.json
@@ -4,7 +4,7 @@
       "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/search-rank-eval.html",
       "description":"Allows to evaluate the quality of ranked search results over a set of typical search queries"
     },
-    "stability":"experimental",
+    "stability":"stable",
     "visibility":"public",
     "headers":{
       "accept": [ "application/json"],

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/searchable_snapshots.mount.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/searchable_snapshots.mount.json
@@ -4,7 +4,7 @@
       "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/searchable-snapshots-api-mount-snapshot.html",
       "description": "Mount a snapshot as a searchable index."
     },
-    "stability": "experimental",
+    "stability": "stable",
     "visibility":"public",
     "headers":{
       "accept": [ "application/json"],

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/searchable_snapshots.stats.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/searchable_snapshots.stats.json
@@ -4,7 +4,7 @@
       "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/searchable-snapshots-apis.html",
       "description": "Retrieve shard-level statistics about searchable snapshots."
     },
-    "stability": "experimental",
+    "stability": "stable",
     "visibility":"public",
     "headers":{
       "accept": [ "application/json"]

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/security.clear_cached_service_tokens.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/security.clear_cached_service_tokens.json
@@ -4,7 +4,7 @@
       "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-clear-service-token-caches.html",
       "description":"Evicts tokens from the service account token caches."
     },
-    "stability":"beta",
+    "stability":"stable",
     "visibility":"public",
     "headers":{
       "accept": [ "application/json"]

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/security.create_service_token.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/security.create_service_token.json
@@ -4,7 +4,7 @@
       "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-create-service-token.html",
       "description":"Creates a service account token for access without requiring basic authentication."
     },
-    "stability":"beta",
+    "stability":"stable",
     "visibility":"public",
     "headers":{
       "accept": [ "application/json"]

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/security.delete_service_token.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/security.delete_service_token.json
@@ -4,7 +4,7 @@
       "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-delete-service-token.html",
       "description":"Deletes a service account token."
     },
-    "stability":"beta",
+    "stability":"stable",
     "visibility":"public",
     "headers":{
       "accept": [ "application/json"]

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/security.get_service_accounts.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/security.get_service_accounts.json
@@ -4,7 +4,7 @@
       "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-get-service-accounts.html",
       "description":"Retrieves information about service accounts."
     },
-    "stability":"beta",
+    "stability":"stable",
     "visibility":"public",
     "headers":{
       "accept": [ "application/json"]

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/security.get_service_credentials.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/security.get_service_credentials.json
@@ -4,7 +4,7 @@
       "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-get-service-credentials.html",
       "description":"Retrieves information of all service credentials for a service account."
     },
-    "stability":"beta",
+    "stability":"stable",
     "visibility":"public",
     "headers":{
       "accept": [ "application/json"]

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/shutdown.delete_node.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/shutdown.delete_node.json
@@ -5,7 +5,7 @@
       "description":"Removes a node from the shutdown list. Designed for indirect use by ECE/ESS and ECK. Direct use is not supported."
     },
     "stability":"stable",
-    "visibility":"public",
+    "visibility":"private",
     "headers":{
       "accept": [ "application/json"],
       "content_type": ["application/json"]

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/shutdown.delete_node.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/shutdown.delete_node.json
@@ -2,9 +2,9 @@
   "shutdown.delete_node":{
     "documentation":{
       "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current",
-      "description":"Removes a node from the shutdown list"
+      "description":"Removes a node from the shutdown list. Designed for indirect use by ECE/ESS and ECK. Direct use is not supported."
     },
-    "stability":"experimental",
+    "stability":"stable",
     "visibility":"public",
     "headers":{
       "accept": [ "application/json"],

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/shutdown.get_node.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/shutdown.get_node.json
@@ -2,9 +2,9 @@
   "shutdown.get_node":{
     "documentation":{
       "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current",
-      "description":"Retrieve status of a node or nodes that are currently marked as shutting down"
+      "description":"Retrieve status of a node or nodes that are currently marked as shutting down. Designed for indirect use by ECE/ESS and ECK. Direct use is not supported."
     },
-    "stability":"experimental",
+    "stability":"stable",
     "visibility":"public",
     "headers":{
       "accept": [ "application/json"],

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/shutdown.get_node.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/shutdown.get_node.json
@@ -5,7 +5,7 @@
       "description":"Retrieve status of a node or nodes that are currently marked as shutting down. Designed for indirect use by ECE/ESS and ECK. Direct use is not supported."
     },
     "stability":"stable",
-    "visibility":"public",
+    "visibility":"private",
     "headers":{
       "accept": [ "application/json"],
       "content_type": ["application/json"]

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/shutdown.put_node.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/shutdown.put_node.json
@@ -2,9 +2,9 @@
   "shutdown.put_node":{
     "documentation":{
       "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current",
-      "description":"Adds a node to be shut down"
+      "description":"Adds a node to be shut down. Designed for indirect use by ECE/ESS and ECK. Direct use is not supported."
     },
-    "stability":"experimental",
+    "stability":"stable",
     "visibility":"public",
     "headers":{
       "accept": [ "application/json"],

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/shutdown.put_node.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/shutdown.put_node.json
@@ -5,7 +5,7 @@
       "description":"Adds a node to be shut down. Designed for indirect use by ECE/ESS and ECK. Direct use is not supported."
     },
     "stability":"stable",
-    "visibility":"public",
+    "visibility":"private",
     "headers":{
       "accept": [ "application/json"],
       "content_type": ["application/json"]

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/terms_enum.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/terms_enum.json
@@ -4,7 +4,7 @@
       "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/search-terms-enum.html",
       "description": "The terms enum API  can be used to discover terms in the index that begin with the provided string. It is designed for low-latency look-ups used in auto-complete scenarios."
     },
-    "stability":"beta",
+    "stability":"stable",
     "visibility":"public",
     "headers":{
       "accept": [ "application/json"],


### PR DESCRIPTION
Noticed that many of the APIs that are marked as experimental or beta within the API specification aren't documented as such or were perhaps not updated when moving to GA. Looked through all the non-stable APIs and tried to match them up with their documentation, this is the result.

Few things:
- Not sure about `monitoring.bulk` as I couldn't find a documentation page for this API.
- The node shutdown APIs aren't documented as experimental but are internal? Should we mark them as stable?
- Some of these APIs are 8.x-only, will backport manually.