### PR TITLE
[7.x] Index Autoscaling policy deciders in one go (#77116)

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/util/Maps.java
+++ b/server/src/main/java/org/elasticsearch/common/util/Maps.java
@@ -13,8 +13,11 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Set;
+import java.util.SortedMap;
 import java.util.TreeMap;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collector;
 import java.util.stream.Collectors;
 
 public class Maps {
@@ -128,4 +131,19 @@ public class Maps {
         }
         return flatMap;
     }
+
+    /**
+     * Returns a {@link Collector} that accumulates the input elements into a sorted map and finishes the resulting set into an
+     * unmodifiable sorted map. The resulting read-only view through the unmodifiable sorted map is a sorted map.
+     *
+     * @param <T> the type of the input elements
+     * @return an unmodifiable map where the underlying map is sorted
+     */
+    public static <T, K, V> Collector<T, ?, SortedMap<K, V>> toUnmodifiableSortedMap(Function<T, ? extends K> keyMapper,
+                                                                                     Function<T, ? extends V> valueMapper) {
+        return Collectors.collectingAndThen(Collectors.toMap(keyMapper, valueMapper, (v1, v2) -> {
+            throw new IllegalStateException("Duplicate key (attempted merging values " + v1 + "  and " + v2 + ")");
+        }, () -> new TreeMap<K, V>()), Collections::unmodifiableSortedMap);
+    }
+
 }

--- a/x-pack/plugin/autoscaling/src/main/java/org/elasticsearch/xpack/autoscaling/policy/AutoscalingPolicy.java
+++ b/x-pack/plugin/autoscaling/src/main/java/org/elasticsearch/xpack/autoscaling/policy/AutoscalingPolicy.java
@@ -12,6 +12,7 @@ import org.elasticsearch.cluster.Diffable;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.common.xcontent.ConstructingObjectParser;
 import org.elasticsearch.common.xcontent.ParseField;
 import org.elasticsearch.common.xcontent.ToXContentObject;
@@ -28,7 +29,6 @@ import java.util.SortedMap;
 import java.util.SortedSet;
 import java.util.TreeMap;
 import java.util.TreeSet;
-import java.util.stream.Collectors;
 
 public class AutoscalingPolicy extends AbstractDiffable<AutoscalingPolicy> implements Diffable<AutoscalingPolicy>, ToXContentObject {
 
@@ -48,7 +48,7 @@ public class AutoscalingPolicy extends AbstractDiffable<AutoscalingPolicy> imple
             return new AutoscalingPolicy(
                 name,
                 Collections.unmodifiableSortedSet(new TreeSet<>(roles)),
-                new TreeMap<>(deciders.stream().collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue)))
+                deciders.stream().collect(Maps.toUnmodifiableSortedMap(Map.Entry::getKey, Map.Entry::getValue))
             );
         });
         PARSER.declareStringArray(ConstructingObjectParser.constructorArg(), ROLES_FIELD);


### PR DESCRIPTION
Backports #77116

`Collectors.toMap` supports collecting results directly to a `TreeMap` which we can wrap with `unmodfiableSortedMap`. In order to reuse this collector, we can extract it to the Maps utility class.