### PR TITLE
Support for aggregation names with dots in first element path of a pipeline aggregation (#77481)

### DIFF
--- a/server/src/main/java/org/elasticsearch/search/aggregations/pipeline/BucketMetricsPipelineAggregationBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/pipeline/BucketMetricsPipelineAggregationBuilder.java
@@ -14,6 +14,7 @@ import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.aggregations.AggregationBuilder;
 import org.elasticsearch.search.aggregations.pipeline.BucketHelpers.GapPolicy;
+import org.elasticsearch.search.aggregations.support.AggregationPath;
 
 import java.io.IOException;
 import java.util.Map;
@@ -103,11 +104,8 @@ public abstract class BucketMetricsPipelineAggregationBuilder<AF extends BucketM
             context.addBucketPathValidationError("must contain a single entry for aggregation [" + name + "]");
             return;
         }
-        // Need to find the first agg name in the buckets path to check its a
-        // multi bucket agg: aggs are split with '>' and can optionally have a
-        // metric name after them by using '.' so need to split on both to get
-        // just the agg name
-        final String firstAgg = bucketsPaths[0].split("[>\\.]")[0];
+        // find the first agg name in the buckets path to check its a multi bucket agg
+        final String firstAgg = AggregationPath.parse(bucketsPaths[0]).getPathElementsAsStringList().get(0);
         Optional<AggregationBuilder> aggBuilder = context.getSiblingAggregations()
             .stream()
             .filter(builder -> builder.getName().equals(firstAgg))


### PR DESCRIPTION
When the first element on the path of a pipeline aggregation refers to an aggregation with a name containing a dot, the aggregation fails as it does not save properly the aggregation name during validation. This is due that the validation it's own parsing strategy that cannot deal with such names.

This PR changes the strategy during validation is it uses AggregationPath to resolve the name.

backport #77481