### PR TITLE
SQL: Skip automatically creating the "elastic" user

### DIFF
--- a/x-pack/plugin/sql/qa/server/security/build.gradle
+++ b/x-pack/plugin/sql/qa/server/security/build.gradle
@@ -26,6 +26,8 @@ subprojects {
     setting 'xpack.security.audit.enabled', 'true'
     setting 'xpack.security.enabled', 'true'
     setting 'xpack.license.self_generated.type', 'trial'
+    // skip automatically creating the "elastic" user (and the associated .security index)
+    setting 'xpack.security.autoconfiguration.enabled', 'false'
     // Setup roles used by tests
     extraConfigFile 'roles.yml', mainProject.file('roles.yml')
     /* Setup the one admin user that we run the tests as.


### PR DESCRIPTION
Following recent changes in https://github.com/elastic/elasticsearch/pull/77291, the `elastic` user is created automatically which, in turn, triggers the creation of the `.security` index. With this PR the QA security module is configured to skip this automatic step.
Fixes https://github.com/elastic/elasticsearch/issues/77492.