### PR TITLE
[7.15] Align REST spec naming to docs for metering APIs (#77499)

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/nodes.clear_repositories_metering_archive.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/nodes.clear_repositories_metering_archive.json
@@ -1,5 +1,5 @@
 {
-  "nodes.clear_metering_archive":{
+  "nodes.clear_repositories_metering_archive":{
     "documentation":{
       "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/clear-repositories-metering-archive-api.html",
       "description":"Removes the archived repositories metering information present in the cluster."

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/nodes.get_repositories_metering_info.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/nodes.get_repositories_metering_info.json
@@ -1,5 +1,5 @@
 {
-  "nodes.get_metering_info":{
+  "nodes.get_repositories_metering_info":{
     "documentation":{
       "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/get-repositories-metering-api.html",
       "description":"Returns cluster repositories metering information."


### PR DESCRIPTION
Backport of #77499