### PR TITLE
Clean up null handling a little to avoid a stacktrace in the logs

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/PhaseCacheManagement.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/PhaseCacheManagement.java
@@ -226,6 +226,10 @@ public final class PhaseCacheManagement {
     @Nullable
     public static Set<Step.StepKey> readStepKeys(final NamedXContentRegistry xContentRegistry, final Client client,
                                                  final String phaseDef, final String currentPhase, final XPackLicenseState licenseState) {
+        if (phaseDef == null) {
+            return null;
+        }
+
         final PhaseExecutionInfo phaseExecutionInfo;
         try (XContentParser parser = JsonXContent.jsonXContent.createParser(xContentRegistry,
             DeprecationHandler.THROW_UNSUPPORTED_OPERATION, phaseDef)) {

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/PhaseCacheManagementTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/PhaseCacheManagementTests.java
@@ -188,6 +188,7 @@ public class PhaseCacheManagementTests extends ESTestCase {
     }
 
     public void testReadStepKeys() {
+        assertNull(readStepKeys(REGISTRY, client, null, "phase", null));
         assertNull(readStepKeys(REGISTRY, client, "{}", "phase", null));
         assertNull(readStepKeys(REGISTRY, client, "aoeu", "phase", null));
         assertNull(readStepKeys(REGISTRY, client, "", "phase", null));


### PR DESCRIPTION
Running ILM with trace logging on as follows (see snippet), I was seeing stacktraces logged that I didn't expect to see. Since this isn't actually an exceptional case, I added a shortcut to skip the logging.

```
PUT _cluster/settings
{
  "transient": {
    "indices.lifecycle.poll_interval": "15s",
    "logger.org.elasticsearch.xpack.ilm": "DEBUG",
    "logger.org.elasticsearch.xpack.core.ilm": "TRACE"
  }
}
```

Example log output:

```
[2021-09-09T10:30:26,276][TRACE][o.e.x.c.i.PhaseCacheManagement] [runTask-0] exception reading step keys checking for refreshability, phase definition: null
java.lang.NullPointerException: Cannot invoke "String.length()" because "content" is null
        at com.fasterxml.jackson.core.JsonFactory.createParser(JsonFactory.java:1045) ~[jackson-core-2.10.4.jar:2.10.4]
        at org.elasticsearch.common.xcontent.json.JsonXContent.createParser(JsonXContent.java:74) ~[elasticsearch-x-content-7.16.0-SNAPSHOT.jar:7.16.0-SNAPSHOT]
        at org.elasticsearch.xpack.core.ilm.PhaseCacheManagement.readStepKeys(PhaseCacheManagement.java:230) [x-pack-core-7.16.0-SNAPSHOT.jar:7.16.0-SNAPSHOT]
        at org.elasticsearch.xpack.ilm.PolicyStepsRegistry.parseStepKeysFromPhase(PolicyStepsRegistry.java:202) [x-pack-ilm-7.16.0-SNAPSHOT.jar:7.16.0-SNAPSHOT]
        at org.elasticsearch.xpack.ilm.IndexLifecycleTransition.validateTransition(IndexLifecycleTransition.java:89) [x-pack-ilm-7.16.0-SNAPSHOT.jar:7.16.0-SNAPSHOT]
        at org.elasticsearch.xpack.ilm.IndexLifecycleTransition.moveClusterStateToStep(IndexLifecycleTransition.java:116) [x-pack-ilm-7.16.0-SNAPSHOT.jar:7.16.0-SNAPSHOT]
        at org.elasticsearch.xpack.ilm.ExecuteStepsUpdateTask.execute(ExecuteStepsUpdateTask.java:109) [x-pack-ilm-7.16.0-SNAPSHOT.jar:7.16.0-SNAPSHOT]
        at org.elasticsearch.cluster.ClusterStateUpdateTask.execute(ClusterStateUpdateTask.java:48) [elasticsearch-7.16.0-SNAPSHOT.jar:7.16.0-SNAPSHOT]
        at org.elasticsearch.cluster.service.MasterService.executeTasks(MasterService.java:750) [elasticsearch-7.16.0-SNAPSHOT.jar:7.16.0-SNAPSHOT]
        at org.elasticsearch.cluster.service.MasterService.calculateTaskOutputs(MasterService.java:366) [elasticsearch-7.16.0-SNAPSHOT.jar:7.16.0-SNAPSHOT]
        at org.elasticsearch.cluster.service.MasterService.runTasks(MasterService.java:229) [elasticsearch-7.16.0-SNAPSHOT.jar:7.16.0-SNAPSHOT]
        at org.elasticsearch.cluster.service.MasterService.access$100(MasterService.java:63) [elasticsearch-7.16.0-SNAPSHOT.jar:7.16.0-SNAPSHOT]
        at org.elasticsearch.cluster.service.MasterService$Batcher.run(MasterService.java:161) [elasticsearch-7.16.0-SNAPSHOT.jar:7.16.0-SNAPSHOT]
        at org.elasticsearch.cluster.service.TaskBatcher.runIfNotProcessed(TaskBatcher.java:139) [elasticsearch-7.16.0-SNAPSHOT.jar:7.16.0-SNAPSHOT]
        at org.elasticsearch.cluster.service.TaskBatcher$BatchedTask.run(TaskBatcher.java:177) [elasticsearch-7.16.0-SNAPSHOT.jar:7.16.0-SNAPSHOT]
        at org.elasticsearch.common.util.concurrent.ThreadContext$ContextPreservingRunnable.run(ThreadContext.java:678) [elasticsearch-7.16.0-SNAPSHOT.jar:7.16.0-SNAPSHOT]
        at org.elasticsearch.common.util.concurrent.PrioritizedEsThreadPoolExecutor$TieBreakingPrioritizedRunnable.runAndClean(PrioritizedEsThreadPoolExecutor.java:259) [elasticsearch-7.16.0-SNAPSHOT.jar:7.16.0-SNAPSHOT]
        at org.elasticsearch.common.util.concurrent.PrioritizedEsThreadPoolExecutor$TieBreakingPrioritizedRunnable.run(PrioritizedEsThreadPoolExecutor.java:222) [elasticsearch-7.16.0-SNAPSHOT.jar:7.16.0-SNAPSHOT]
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1130) [?:?]
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:630) [?:?]
        at java.lang.Thread.run(Thread.java:831) [?:?]
[2021-09-09T10:30:26,290][INFO ][o.e.x.i.IndexLifecycleTransition] [runTask-0] moving index [test-index-1] from [null] to [{"phase":"new","action":"complete","name":"complete"}] in policy [test-policy]
```