### PR TITLE
mute test SSLReloadDuringStartupIntegTests.testReloadDuringStartup

### DIFF
--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/ssl/SSLReloadDuringStartupIntegTests.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/ssl/SSLReloadDuringStartupIntegTests.java
@@ -59,6 +59,7 @@ public class SSLReloadDuringStartupIntegTests extends SecurityIntegTestCase {
         return true;
     }
 
+    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/77490")
     public void testReloadDuringStartup() throws Exception {
         final String node = randomFrom(internalCluster().getNodeNames());
         final Environment env = internalCluster().getInstance(Environment.class, node);


### PR DESCRIPTION
Relates to https://github.com/elastic/elasticsearch/issues/77490