### PR TITLE
[7.15] [DOCS] Deleting an index doesn't delete Kibana components (#77286) (#77512)

### DIFF
--- a/docs/reference/indices/delete-index.asciidoc
+++ b/docs/reference/indices/delete-index.asciidoc
@@ -4,14 +4,13 @@
 <titleabbrev>Delete index</titleabbrev>
 ++++
 
-Deletes an existing index.
+Deletes one or more indices.
 
 [source,console]
---------------------------------------------------
+----
 DELETE /my-index-000001
---------------------------------------------------
+----
 // TEST[setup:my_index]
-
 
 [[delete-index-api-request]]
 ==== {api-request-title}
@@ -24,27 +23,29 @@ DELETE /my-index-000001
 * If the {es} {security-features} are enabled, you must have the `delete_index`
 or `manage` <<privileges-list-indices,index privilege>> for the target index.
 
+[[delete-index-api-desc]]
+==== {api-description-title}
+
+Deleting an index deletes its documents, shards, and metadata. It does not
+delete related {kib} components, such as index patterns, visualizations, or
+dashboards.
+
+You cannot delete the current write index of a data stream. To delete the
+index, you must <<data-streams-rollover,roll over>> the data stream so a new
+write index is created. You can then use the delete index API to delete the
+previous write index.
+
 [[delete-index-api-path-params]]
 ==== {api-path-parms-title}
 
 `<index>`::
-+
---
 (Required, string) Comma-separated list of indices to delete. You cannot specify
 <<aliases,index aliases>>.
-
++
 To delete all indices, use `_all` or `*` . To disallow the deletion of indices
-with `_all` or wildcard expressions, change the
-`action.destructive_requires_name` cluster setting to `true`. You can update
-this setting in the `elasticsearch.yml` file or using the
-<<cluster-update-settings,cluster update settings>> API.
-
-NOTE: You cannot delete the current write index of a data stream. To delete the
-index, you must <<data-streams-rollover,roll over>> the data stream so a new
-write index is created. You can then use the delete index API to delete the
-previous write index.
---
-
+with `_all` or wildcard expressions, set the
+<<action-destructive-requires-name,`action.destructive_requires_name`>> cluster
+setting to `true`.
 
 [[delete-index-api-query-params]]
 ==== {api-query-parms-title}
@@ -55,7 +56,7 @@ Defaults to `true`.
 
 include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=expand-wildcards]
 +
-Defaults to `open`.
+Defaults to `open,closed`.
 
 include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=index-ignore-unavailable]
 

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.delete.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.delete.json
@@ -51,8 +51,8 @@
           "none",
           "all"
         ],
-        "default":"open",
-        "description":"Whether wildcard expressions should get expanded to open or closed indices (default: open)"
+        "default":"open,closed",
+        "description":"Whether wildcard expressions should get expanded to open, closed, or hidden indices"
       }
     }
   }


### PR DESCRIPTION
Backports the following commits to 7.15:
 - [DOCS] Deleting an index doesn't delete Kibana components (#77286) (#77512)