### PR TITLE
Remove unused recent trial license version from license state (#76692)

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/license/LicenseService.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/license/LicenseService.java
@@ -325,7 +325,7 @@ public class LicenseService extends AbstractLifecycleComponent implements Cluste
         if (licensesMetadata != null) {
             final License license = licensesMetadata.getLicense();
             if (event.getJobName().equals(LICENSE_JOB)) {
-                updateLicenseState(license, licensesMetadata.getMostRecentTrialVersion());
+                updateLicenseState(license);
             } else if (event.getJobName().startsWith(ExpirationCallback.EXPIRATION_JOB_PREFIX)) {
                 expirationCallbacks.stream()
                     .filter(expirationCallback -> expirationCallback.getId().equals(event.getJobName()))
@@ -466,14 +466,14 @@ public class LicenseService extends AbstractLifecycleComponent implements Cluste
 
     private void updateLicenseState(LicensesMetadata licensesMetadata) {
         if (licensesMetadata != null) {
-            updateLicenseState(getLicense(licensesMetadata), licensesMetadata.getMostRecentTrialVersion());
+            updateLicenseState(getLicense(licensesMetadata));
         }
     }
 
-    protected void updateLicenseState(final License license, Version mostRecentTrialVersion) {
+    protected void updateLicenseState(final License license) {
         if (license == LicensesMetadata.LICENSE_TOMBSTONE) {
             // implies license has been explicitly deleted
-            licenseState.update(License.OperationMode.MISSING, false, license.expiryDate(), mostRecentTrialVersion);
+            licenseState.update(License.OperationMode.MISSING, false, license.expiryDate());
             return;
         }
         if (license != null) {
@@ -484,7 +484,7 @@ public class LicenseService extends AbstractLifecycleComponent implements Cluste
             } else {
                 active = time >= license.issueDate() && time < license.expiryDate();
             }
-            licenseState.update(license.operationMode(), active, license.expiryDate(), mostRecentTrialVersion);
+            licenseState.update(license.operationMode(), active, license.expiryDate());
 
             if (active) {
                 logger.debug("license [{}] - valid", license.uid());
@@ -522,7 +522,7 @@ public class LicenseService extends AbstractLifecycleComponent implements Cluste
                 logger.info("license [{}] mode [{}] - valid", license.uid(),
                     license.operationMode().name().toLowerCase(Locale.ROOT));
             }
-            updateLicenseState(license, currentLicensesMetadata.getMostRecentTrialVersion());
+            updateLicenseState(license);
         }
     }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/license/LicenseStateListener.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/license/LicenseStateListener.java
@@ -7,8 +7,6 @@
 
 package org.elasticsearch.license;
 
-import org.elasticsearch.Version;
-
 /**
  * Marker interface for callbacks that are invoked when the license state changes.
  */
@@ -16,7 +14,7 @@ import org.elasticsearch.Version;
 public interface LicenseStateListener {
 
     /**
-     * Callback when the license state changes. See {@link XPackLicenseState#update(License.OperationMode, boolean, long, Version)}.
+     * Callback when the license state changes. See {@link XPackLicenseState#update(License.OperationMode, boolean, long)}.
      */
     void licenseStateChanged();
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/license/XPackLicenseState.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/license/XPackLicenseState.java
@@ -6,7 +6,6 @@
  */
 package org.elasticsearch.license;
 
-import org.elasticsearch.Version;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.logging.HeaderWarning;
 import org.elasticsearch.common.logging.LoggerMessageFormat;
@@ -456,11 +455,8 @@ public class XPackLicenseState {
      * @param mode   The mode (type) of the current license.
      * @param active True if the current license exists and is within its allowed usage period; false if it is expired or missing.
      * @param expirationDate Expiration date of the current license.
-     * @param mostRecentTrialVersion If this cluster has, at some point commenced a trial, the most recent version on which they did that.
-     *                               May be {@code null} if they have never generated a trial license on this cluster, or the most recent
-     *                               trial was prior to this metadata being tracked (6.1)
      */
-    protected void update(OperationMode mode, boolean active, long expirationDate, @Nullable Version mostRecentTrialVersion) {
+    protected void update(OperationMode mode, boolean active, long expirationDate) {
         status = new Status(mode, active, expirationDate);
         listeners.forEach(LicenseStateListener::licenseStateChanged);
     }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/license/TestUtils.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/license/TestUtils.java
@@ -7,18 +7,18 @@
 package org.elasticsearch.license;
 
 import com.carrotsearch.randomizedtesting.RandomizedTest;
-import org.elasticsearch.Version;
+
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.time.DateFormatter;
 import org.elasticsearch.common.time.DateMathParser;
-import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.common.xcontent.XContentType;
+import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.license.licensor.LicenseSigner;
 import org.elasticsearch.protocol.xpack.license.LicensesStatus;
 import org.elasticsearch.protocol.xpack.license.PutLicenseResponse;
@@ -363,7 +363,6 @@ public class TestUtils {
     public static class AssertingLicenseState extends XPackLicenseState {
         public final List<License.OperationMode> modeUpdates = new ArrayList<>();
         public final List<Boolean> activeUpdates = new ArrayList<>();
-        public final List<Version> trialVersionUpdates = new ArrayList<>();
         public final List<Long> expirationDateUpdates = new ArrayList<>();
 
         public AssertingLicenseState() {
@@ -371,16 +370,15 @@ public class TestUtils {
         }
 
         @Override
-        protected void update(License.OperationMode mode, boolean active, long expirationDate, Version mostRecentTrialVersion) {
+        protected void update(License.OperationMode mode, boolean active, long expirationDate) {
             modeUpdates.add(mode);
             activeUpdates.add(active);
             expirationDateUpdates.add(expirationDate);
-            trialVersionUpdates.add(mostRecentTrialVersion);
         }
     }
 
     /**
-     * A license state that makes the {@link #update(License.OperationMode, boolean, long, Version)}
+     * A license state that makes the {@link #update(License.OperationMode, boolean, long)}
      * method public for use in tests.
      */
     public static class UpdatableLicenseState extends XPackLicenseState {
@@ -393,8 +391,8 @@ public class TestUtils {
         }
 
         @Override
-        public void update(License.OperationMode mode, boolean active, long expirationDate, Version mostRecentTrialVersion) {
-            super.update(mode, active, expirationDate, mostRecentTrialVersion);
+        public void update(License.OperationMode mode, boolean active, long expirationDate) {
+            super.update(mode, active, expirationDate);
         }
     }
 

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/license/XPackLicenseStateTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/license/XPackLicenseStateTests.java
@@ -45,7 +45,7 @@ public class XPackLicenseStateTests extends ESTestCase {
     /** Creates a license state with the given license type and active state, and checks the given method returns expected. */
     void assertAllowed(OperationMode mode, boolean active, Predicate<XPackLicenseState> predicate, boolean expected) {
         XPackLicenseState licenseState = TestUtils.newTestLicenseState();
-        licenseState.update(mode, active, Long.MAX_VALUE, null);
+        licenseState.update(mode, active, Long.MAX_VALUE);
         assertEquals(expected, predicate.test(licenseState));
     }
 
@@ -106,7 +106,7 @@ public class XPackLicenseStateTests extends ESTestCase {
 
     public void testSecurityBasicWithoutExplicitSecurityEnabled() {
         XPackLicenseState licenseState = TestUtils.newTestLicenseState();
-        licenseState.update(BASIC, true, Long.MAX_VALUE, null);
+        licenseState.update(BASIC, true, Long.MAX_VALUE);
 
         assertThat(licenseState.isSecurityEnabled(), is(false));
         assertThat(licenseState.checkFeature(Feature.SECURITY_AUDITING), is(false));
@@ -120,7 +120,7 @@ public class XPackLicenseStateTests extends ESTestCase {
     public void testSecurityBasicWithExplicitSecurityEnabled() {
         final Settings settings = Settings.builder().put(XPackSettings.SECURITY_ENABLED.getKey(), true).build();
         XPackLicenseState licenseState = new XPackLicenseState(settings, () -> 0);
-        licenseState.update(BASIC, true, Long.MAX_VALUE, null);
+        licenseState.update(BASIC, true, Long.MAX_VALUE);
         assertThat(licenseState.isSecurityEnabled(), is(true));
         assertThat(licenseState.checkFeature(Feature.SECURITY_AUDITING), is(false));
         assertThat(licenseState.checkFeature(Feature.SECURITY_DLS_FLS), is(false));
@@ -134,7 +134,7 @@ public class XPackLicenseStateTests extends ESTestCase {
         Settings settings = randomFrom(Settings.EMPTY,
             Settings.builder().put(XPackSettings.SECURITY_ENABLED.getKey(), true).build());
         XPackLicenseState licenseState = new XPackLicenseState(settings, () -> 0);
-        licenseState.update(STANDARD, true, Long.MAX_VALUE, null);
+        licenseState.update(STANDARD, true, Long.MAX_VALUE);
 
         assertThat(licenseState.isSecurityEnabled(), is(true));
         assertThat(licenseState.checkFeature(Feature.SECURITY_AUDITING), is(false));
@@ -147,7 +147,7 @@ public class XPackLicenseStateTests extends ESTestCase {
         Settings settings = randomFrom(Settings.EMPTY,
             Settings.builder().put(XPackSettings.SECURITY_ENABLED.getKey(), true).build());
         XPackLicenseState licenseState = new XPackLicenseState(settings, () -> 0);
-        licenseState.update(STANDARD, false, Long.MAX_VALUE, null);
+        licenseState.update(STANDARD, false, Long.MAX_VALUE);
 
         assertThat(licenseState.isSecurityEnabled(), is(true));
         assertThat(licenseState.checkFeature(Feature.SECURITY_AUDITING), is(false));
@@ -160,7 +160,7 @@ public class XPackLicenseStateTests extends ESTestCase {
         Settings settings = randomFrom(Settings.EMPTY,
             Settings.builder().put(XPackSettings.SECURITY_ENABLED.getKey(), true).build());
         XPackLicenseState licenseState = new XPackLicenseState(settings, () -> 0);
-        licenseState.update(GOLD, true, Long.MAX_VALUE, null);
+        licenseState.update(GOLD, true, Long.MAX_VALUE);
 
         assertThat(licenseState.isSecurityEnabled(), is(true));
         assertThat(licenseState.checkFeature(Feature.SECURITY_AUDITING), is(true));
@@ -173,7 +173,7 @@ public class XPackLicenseStateTests extends ESTestCase {
         Settings settings = randomFrom(Settings.EMPTY,
             Settings.builder().put(XPackSettings.SECURITY_ENABLED.getKey(), true).build());
         XPackLicenseState licenseState = new XPackLicenseState(settings, () -> 0);
-        licenseState.update(GOLD, false, Long.MAX_VALUE, null);
+        licenseState.update(GOLD, false, Long.MAX_VALUE);
 
         assertThat(licenseState.isSecurityEnabled(), is(true));
         assertThat(licenseState.checkFeature(Feature.SECURITY_AUDITING), is(true));
@@ -186,7 +186,7 @@ public class XPackLicenseStateTests extends ESTestCase {
         Settings settings = randomFrom(Settings.EMPTY,
             Settings.builder().put(XPackSettings.SECURITY_ENABLED.getKey(), true).build());
         XPackLicenseState licenseState = new XPackLicenseState(settings, () -> 0);
-        licenseState.update(PLATINUM, true, Long.MAX_VALUE, null);
+        licenseState.update(PLATINUM, true, Long.MAX_VALUE);
 
         assertThat(licenseState.isSecurityEnabled(), is(true));
         assertThat(licenseState.checkFeature(Feature.SECURITY_AUDITING), is(true));
@@ -199,7 +199,7 @@ public class XPackLicenseStateTests extends ESTestCase {
         Settings settings = randomFrom(Settings.EMPTY,
             Settings.builder().put(XPackSettings.SECURITY_ENABLED.getKey(), true).build());
         XPackLicenseState licenseState = new XPackLicenseState(settings, () -> 0);
-        licenseState.update(PLATINUM, false, Long.MAX_VALUE, null);
+        licenseState.update(PLATINUM, false, Long.MAX_VALUE);
 
         assertThat(licenseState.isSecurityEnabled(), is(true));
         assertThat(licenseState.checkFeature(Feature.SECURITY_AUDITING), is(true));
@@ -210,7 +210,7 @@ public class XPackLicenseStateTests extends ESTestCase {
 
     public void testNewTrialDefaultsSecurityOff() {
         XPackLicenseState licenseState = TestUtils.newTestLicenseState();
-        licenseState.update(TRIAL, true, Long.MAX_VALUE, VersionUtils.randomVersionBetween(random(), Version.V_6_3_0, Version.CURRENT));
+        licenseState.update(TRIAL, true, Long.MAX_VALUE);
 
         assertThat(licenseState.isSecurityEnabled(), is(false));
         assertSecurityNotAllowed(licenseState);
@@ -379,48 +379,48 @@ public class XPackLicenseStateTests extends ESTestCase {
 
     public void testJdbcBasic() {
         XPackLicenseState licenseState = TestUtils.newTestLicenseState();
-        licenseState.update(BASIC, true, Long.MAX_VALUE, null);
+        licenseState.update(BASIC, true, Long.MAX_VALUE);
         assertThat(licenseState.checkFeature(XPackLicenseState.Feature.JDBC), is(false));
     }
 
     public void testJdbcStandard() {
         XPackLicenseState licenseState = TestUtils.newTestLicenseState();
-        licenseState.update(STANDARD, true, Long.MAX_VALUE, null);
+        licenseState.update(STANDARD, true, Long.MAX_VALUE);
 
         assertThat(licenseState.checkFeature(XPackLicenseState.Feature.JDBC), is(false));
     }
 
     public void testJdbcStandardExpired() {
         XPackLicenseState licenseState = TestUtils.newTestLicenseState();
-        licenseState.update(STANDARD, false, Long.MAX_VALUE, null);
+        licenseState.update(STANDARD, false, Long.MAX_VALUE);
 
         assertThat(licenseState.checkFeature(XPackLicenseState.Feature.JDBC), is(false));
     }
 
     public void testJdbcGold() {
         XPackLicenseState licenseState = TestUtils.newTestLicenseState();
-        licenseState.update(GOLD, true, Long.MAX_VALUE, null);
+        licenseState.update(GOLD, true, Long.MAX_VALUE);
 
         assertThat(licenseState.checkFeature(XPackLicenseState.Feature.JDBC), is(false));
     }
 
     public void testJdbcGoldExpired() {
         XPackLicenseState licenseState = TestUtils.newTestLicenseState();
-        licenseState.update(GOLD, false, Long.MAX_VALUE, null);
+        licenseState.update(GOLD, false, Long.MAX_VALUE);
 
         assertThat(licenseState.checkFeature(XPackLicenseState.Feature.JDBC), is(false));
     }
 
     public void testJdbcPlatinum() {
         XPackLicenseState licenseState = TestUtils.newTestLicenseState();
-        licenseState.update(PLATINUM, true, Long.MAX_VALUE, null);
+        licenseState.update(PLATINUM, true, Long.MAX_VALUE);
 
         assertThat(licenseState.checkFeature(XPackLicenseState.Feature.JDBC), is(true));
     }
 
     public void testJdbcPlatinumExpired() {
         XPackLicenseState licenseState = TestUtils.newTestLicenseState();
-        licenseState.update(PLATINUM, false, Long.MAX_VALUE, null);
+        licenseState.update(PLATINUM, false, Long.MAX_VALUE);
 
         assertThat(licenseState.checkFeature(XPackLicenseState.Feature.JDBC), is(false));
     }
@@ -440,56 +440,56 @@ public class XPackLicenseStateTests extends ESTestCase {
 
     public void testCcrBasic() {
         final XPackLicenseState state = TestUtils.newTestLicenseState();
-        state.update(BASIC, true, Long.MAX_VALUE, null);
+        state.update(BASIC, true, Long.MAX_VALUE);
 
         assertThat(state.checkFeature(XPackLicenseState.Feature.CCR), is(false));
     }
 
     public void testCcrBasicExpired() {
         final XPackLicenseState state = TestUtils.newTestLicenseState();
-        state.update(BASIC, false, Long.MAX_VALUE, null);
+        state.update(BASIC, false, Long.MAX_VALUE);
 
         assertThat(state.checkFeature(XPackLicenseState.Feature.CCR), is(false));
     }
 
     public void testCcrStandard() {
         final XPackLicenseState state = TestUtils.newTestLicenseState();
-        state.update(STANDARD, true, Long.MAX_VALUE, null);
+        state.update(STANDARD, true, Long.MAX_VALUE);
 
         assertThat(state.checkFeature(XPackLicenseState.Feature.CCR), is(false));
     }
 
     public void testCcrStandardExpired() {
         final XPackLicenseState state = TestUtils.newTestLicenseState();
-        state.update(STANDARD, false, Long.MAX_VALUE, null);
+        state.update(STANDARD, false, Long.MAX_VALUE);
 
         assertThat(state.checkFeature(XPackLicenseState.Feature.CCR), is(false));
     }
 
     public void testCcrGold() {
         final XPackLicenseState state = TestUtils.newTestLicenseState();
-        state.update(GOLD, true, Long.MAX_VALUE, null);
+        state.update(GOLD, true, Long.MAX_VALUE);
 
         assertThat(state.checkFeature(XPackLicenseState.Feature.CCR), is(false));
     }
 
     public void testCcrGoldExpired() {
         final XPackLicenseState state = TestUtils.newTestLicenseState();
-        state.update(GOLD, false, Long.MAX_VALUE, null);
+        state.update(GOLD, false, Long.MAX_VALUE);
 
         assertThat(state.checkFeature(XPackLicenseState.Feature.CCR), is(false));
     }
 
     public void testCcrPlatinum() {
         final XPackLicenseState state = TestUtils.newTestLicenseState();
-        state.update(PLATINUM, true, Long.MAX_VALUE, null);
+        state.update(PLATINUM, true, Long.MAX_VALUE);
 
         assertTrue(state.checkFeature(XPackLicenseState.Feature.CCR));
     }
 
     public void testCcrPlatinumExpired() {
         final XPackLicenseState state = TestUtils.newTestLicenseState();
-        state.update(PLATINUM, false, Long.MAX_VALUE, null);
+        state.update(PLATINUM, false, Long.MAX_VALUE);
 
         assertFalse(state.checkFeature(XPackLicenseState.Feature.CCR));
     }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/license/XPackLicenseStateTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/license/XPackLicenseStateTests.java
@@ -6,13 +6,11 @@
  */
 package org.elasticsearch.license;
 
-import org.elasticsearch.Version;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.iterable.Iterables;
 import org.elasticsearch.license.License.OperationMode;
 import org.elasticsearch.license.XPackLicenseState.Feature;
 import org.elasticsearch.test.ESTestCase;
-import org.elasticsearch.test.VersionUtils;
 import org.elasticsearch.xpack.core.XPackField;
 import org.elasticsearch.xpack.core.XPackSettings;
 

--- a/x-pack/plugin/identity-provider/src/test/java/org/elasticsearch/xpack/idp/saml/rest/action/IdpBaseRestHandlerTests.java
+++ b/x-pack/plugin/identity-provider/src/test/java/org/elasticsearch/xpack/idp/saml/rest/action/IdpBaseRestHandlerTests.java
@@ -39,7 +39,7 @@ public class IdpBaseRestHandlerTests extends ESTestCase {
             .put("xpack.idp.enabled", true)
             .build();
         final TestUtils.UpdatableLicenseState licenseState = new TestUtils.UpdatableLicenseState(settings);
-        licenseState.update(licenseMode, true, Long.MAX_VALUE, null);
+        licenseState.update(licenseMode, true, Long.MAX_VALUE);
         return new IdpBaseRestHandler(licenseState) {
             @Override
             protected RestChannelConsumer innerPrepareRequest(RestRequest request, NodeClient client) throws IOException {

--- a/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/license/MachineLearningLicensingIT.java
+++ b/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/license/MachineLearningLicensingIT.java
@@ -853,7 +853,7 @@ public class MachineLearningLicensingIT extends BaseMlIntegTestCase {
 
     public static void disableLicensing(License.OperationMode operationMode) {
         for (XPackLicenseState licenseState : internalCluster().getInstances(XPackLicenseState.class)) {
-            licenseState.update(operationMode, false, Long.MAX_VALUE, null);
+            licenseState.update(operationMode, false, Long.MAX_VALUE);
         }
     }
 
@@ -863,7 +863,7 @@ public class MachineLearningLicensingIT extends BaseMlIntegTestCase {
 
     public static void enableLicensing(License.OperationMode operationMode) {
         for (XPackLicenseState licenseState : internalCluster().getInstances(XPackLicenseState.class)) {
-            licenseState.update(operationMode, true, Long.MAX_VALUE, null);
+            licenseState.update(operationMode, true, Long.MAX_VALUE);
         }
     }
 }

--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/license/LicensingTests.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/license/LicensingTests.java
@@ -296,7 +296,7 @@ public class LicensingTests extends SecurityIntegTestCase {
 
             // apply the disabling of the license once the cluster is stable
             for (XPackLicenseState licenseState : internalCluster().getInstances(XPackLicenseState.class)) {
-                licenseState.update(OperationMode.BASIC, false, Long.MAX_VALUE, null);
+                licenseState.update(OperationMode.BASIC, false, Long.MAX_VALUE);
             }
         }, 30L, TimeUnit.SECONDS);
     }
@@ -308,7 +308,7 @@ public class LicensingTests extends SecurityIntegTestCase {
         assertBusy(() -> {
             // first update the license so we can execute monitoring actions
             for (XPackLicenseState licenseState : internalCluster().getInstances(XPackLicenseState.class)) {
-                licenseState.update(operationMode, true, Long.MAX_VALUE, null);
+                licenseState.update(operationMode, true, Long.MAX_VALUE);
             }
 
             ensureGreen();
@@ -318,7 +318,7 @@ public class LicensingTests extends SecurityIntegTestCase {
             // re-apply the update in case any node received an updated cluster state that triggered the license state
             // to change
             for (XPackLicenseState licenseState : internalCluster().getInstances(XPackLicenseState.class)) {
-                licenseState.update(operationMode, true, Long.MAX_VALUE, null);
+                licenseState.update(operationMode, true, Long.MAX_VALUE);
             }
         }, 30L, TimeUnit.SECONDS);
     }
@@ -326,7 +326,7 @@ public class LicensingTests extends SecurityIntegTestCase {
     private void setLicensingExpirationDate(License.OperationMode operationMode, long expirationDate) throws Exception {
         assertBusy(() -> {
             for (XPackLicenseState licenseState : internalCluster().getInstances(XPackLicenseState.class)) {
-                licenseState.update(operationMode, true, expirationDate, null);
+                licenseState.update(operationMode, true, expirationDate);
             }
 
             ensureGreen();

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/SecurityTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/SecurityTests.java
@@ -428,7 +428,7 @@ public class SecurityTests extends ESTestCase {
         assertNotSame(MapperPlugin.NOOP_FIELD_FILTER, fieldFilter);
         licenseState.update(
             randomFrom(License.OperationMode.BASIC, License.OperationMode.STANDARD, License.OperationMode.GOLD),
-            true, Long.MAX_VALUE, null);
+            true, Long.MAX_VALUE);
         assertNotSame(MapperPlugin.NOOP_FIELD_FILTER, fieldFilter);
         assertSame(MapperPlugin.NOOP_FIELD_PREDICATE, fieldFilter.apply(randomAlphaOfLengthBetween(3, 6)));
     }

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/support/SecondaryAuthenticatorTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/support/SecondaryAuthenticatorTests.java
@@ -113,7 +113,7 @@ public class SecondaryAuthenticatorTests extends ESTestCase {
         when(client.threadPool()).thenReturn(threadPool);
 
         final TestUtils.UpdatableLicenseState licenseState = new TestUtils.UpdatableLicenseState();
-        licenseState.update(License.OperationMode.PLATINUM, true, Long.MAX_VALUE, null);
+        licenseState.update(License.OperationMode.PLATINUM, true, Long.MAX_VALUE);
 
         final Clock clock = Clock.systemUTC();
 

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/store/CompositeRolesStoreTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/store/CompositeRolesStoreTests.java
@@ -770,7 +770,7 @@ public class CompositeRolesStoreTests extends ESTestCase {
         UpdatableLicenseState xPackLicenseState = new UpdatableLicenseState(SECURITY_ENABLED_SETTINGS);
         // these licenses don't allow custom role providers
         xPackLicenseState.update(randomFrom(OperationMode.BASIC, OperationMode.GOLD, OperationMode.STANDARD), true,
-            Long.MAX_VALUE, null);
+            Long.MAX_VALUE);
         final AtomicReference<Collection<RoleDescriptor>> effectiveRoleDescriptors = new AtomicReference<Collection<RoleDescriptor>>();
         final DocumentSubsetBitsetCache documentSubsetBitsetCache = buildBitsetCache();
         CompositeRolesStore compositeRolesStore = new CompositeRolesStore(
@@ -796,7 +796,7 @@ public class CompositeRolesStoreTests extends ESTestCase {
             documentSubsetBitsetCache, rds -> effectiveRoleDescriptors.set(rds));
         // these licenses allow custom role providers
         xPackLicenseState.update(randomFrom(OperationMode.PLATINUM, OperationMode.ENTERPRISE, OperationMode.TRIAL), true,
-            Long.MAX_VALUE, null);
+            Long.MAX_VALUE);
         roleNames = Sets.newHashSet("roleA");
         future = new PlainActionFuture<>();
         compositeRolesStore.roles(roleNames, future);
@@ -814,7 +814,7 @@ public class CompositeRolesStoreTests extends ESTestCase {
             mock(ApiKeyService.class), mock(ServiceAccountService.class),
             documentSubsetBitsetCache, rds -> effectiveRoleDescriptors.set(rds));
         xPackLicenseState.update(randomFrom(OperationMode.PLATINUM, OperationMode.ENTERPRISE, OperationMode.TRIAL), false,
-            Long.MAX_VALUE, null);
+            Long.MAX_VALUE);
         roleNames = Sets.newHashSet("roleA");
         future = new PlainActionFuture<>();
         compositeRolesStore.roles(roleNames, future);

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/rest/action/saml/SamlBaseRestHandlerTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/rest/action/saml/SamlBaseRestHandlerTests.java
@@ -46,7 +46,7 @@ public class SamlBaseRestHandlerTests extends ESTestCase {
                 .put(XPackSettings.SECURITY_ENABLED.getKey(), true)
                 .build();
         final TestUtils.UpdatableLicenseState licenseState = new TestUtils.UpdatableLicenseState(settings);
-        licenseState.update(licenseMode, true, Long.MAX_VALUE, null);
+        licenseState.update(licenseMode, true, Long.MAX_VALUE);
 
         return new SamlBaseRestHandler(settings, licenseState) {
 

--- a/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/LocalStateSpatialPlugin.java
+++ b/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/LocalStateSpatialPlugin.java
@@ -7,11 +7,9 @@
 
 package org.elasticsearch.xpack.spatial;
 
-import org.apache.lucene.util.LuceneTestCase;
 import org.elasticsearch.license.License;
 import org.elasticsearch.license.TestUtils;
 import org.elasticsearch.license.XPackLicenseState;
-import org.elasticsearch.test.VersionUtils;
 
 /**
  * This class overrides the {@link SpatialPlugin} in order
@@ -23,7 +21,7 @@ public class LocalStateSpatialPlugin extends SpatialPlugin {
     protected XPackLicenseState getLicenseState() {
         TestUtils.UpdatableLicenseState licenseState = new TestUtils.UpdatableLicenseState();
         License.OperationMode operationMode = License.OperationMode.TRIAL;
-        licenseState.update(operationMode, true, Long.MAX_VALUE, VersionUtils.randomVersion(LuceneTestCase.random()));
+        licenseState.update(operationMode, true, Long.MAX_VALUE);
         return licenseState;
     }
 }

--- a/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/SpatialPluginTests.java
+++ b/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/SpatialPluginTests.java
@@ -19,7 +19,6 @@ import org.elasticsearch.search.aggregations.metrics.MetricAggregatorSupplier;
 import org.elasticsearch.search.aggregations.support.ValuesSourceConfig;
 import org.elasticsearch.search.aggregations.support.ValuesSourceRegistry;
 import org.elasticsearch.test.ESTestCase;
-import org.elasticsearch.test.VersionUtils;
 import org.elasticsearch.xpack.spatial.search.aggregations.support.GeoShapeValuesSourceType;
 
 import java.util.Arrays;
@@ -83,7 +82,7 @@ public class SpatialPluginTests extends ESTestCase {
         return new SpatialPlugin() {
             protected XPackLicenseState getLicenseState() {
                 TestUtils.UpdatableLicenseState licenseState = new TestUtils.UpdatableLicenseState();
-                licenseState.update(operationMode, true, Long.MAX_VALUE, VersionUtils.randomVersion(random()));
+                licenseState.update(operationMode, true, Long.MAX_VALUE);
                 return licenseState;
             }
         };


### PR DESCRIPTION
The license state previously used the most recent trial license version
to determine the default security enabled state. Since that no longer
exists, this can be removed from the license state.