### PR TITLE
Break out searchable snapshots licensed feature object (#77395)

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/license/XPackLicenseState.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/license/XPackLicenseState.java
@@ -78,8 +78,6 @@ public class XPackLicenseState {
 
         SPATIAL_GEO_LINE(OperationMode.GOLD, true),
 
-        SEARCHABLE_SNAPSHOTS(OperationMode.ENTERPRISE, true),
-
         OPERATOR_PRIVILEGES(OperationMode.ENTERPRISE, true),
 
         AUTOSCALING(OperationMode.ENTERPRISE, true);

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/SearchableSnapshotAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/SearchableSnapshotAction.java
@@ -32,6 +32,7 @@ import java.util.Objects;
 
 import static org.elasticsearch.snapshots.SearchableSnapshotsSettings.SEARCHABLE_SNAPSHOTS_REPOSITORY_NAME_SETTING_KEY;
 import static org.elasticsearch.snapshots.SearchableSnapshotsSettings.SEARCHABLE_SNAPSHOT_PARTIAL_SETTING_KEY;
+import static org.elasticsearch.xpack.core.searchablesnapshots.SearchableSnapshotsConstants.SEARCHABLE_SNAPSHOT_FEATURE;
 
 /**
  * A {@link LifecycleAction} that will convert the index into a searchable snapshot, by taking a snapshot of the index, creating a
@@ -130,7 +131,7 @@ public class SearchableSnapshotAction implements LifecycleAction {
         // here before generating snapshots that can't be used if the user doesn't have the right license level.
         BranchingStep conditionalSkipActionStep = new BranchingStep(preActionBranchingKey, checkNoWriteIndex, nextStepKey,
             (index, clusterState) -> {
-                if (licenseState.isAllowed(XPackLicenseState.Feature.SEARCHABLE_SNAPSHOTS) == false) {
+                if (SEARCHABLE_SNAPSHOT_FEATURE.checkWithoutTracking(licenseState) == false) {
                     logger.error("[{}] action is not available in the current license", SearchableSnapshotAction.NAME);
                     throw LicenseUtils.newComplianceException("searchable-snapshots");
                 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/searchablesnapshots/SearchableSnapshotsConstants.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/searchablesnapshots/SearchableSnapshotsConstants.java
@@ -7,6 +7,8 @@
 package org.elasticsearch.xpack.core.searchablesnapshots;
 
 import org.elasticsearch.common.settings.Setting;
+import org.elasticsearch.license.License;
+import org.elasticsearch.license.LicensedFeature;
 import org.elasticsearch.snapshots.SearchableSnapshotsSettings;
 
 import java.util.Map;
@@ -15,6 +17,12 @@ import static org.elasticsearch.index.IndexModule.INDEX_STORE_TYPE_SETTING;
 import static org.elasticsearch.snapshots.SearchableSnapshotsSettings.SEARCHABLE_SNAPSHOT_PARTIAL_SETTING_KEY;
 
 public class SearchableSnapshotsConstants {
+
+    // This should really be in the searchable-snapshots module, but ILM needs access to it
+    // to short-circuit if not allowed. We should consider making the coupling looser,
+    // perhaps through SPI.
+    public static final LicensedFeature.Momentary SEARCHABLE_SNAPSHOT_FEATURE =
+        LicensedFeature.momentary(null, "searchable-snapshots", License.OperationMode.PLATINUM);
 
     public static final Setting<Boolean> SNAPSHOT_PARTIAL_SETTING = Setting.boolSetting(
         SEARCHABLE_SNAPSHOT_PARTIAL_SETTING_KEY,

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/searchablesnapshots/SearchableSnapshotsFeatureSet.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/searchablesnapshots/SearchableSnapshotsFeatureSet.java
@@ -39,7 +39,7 @@ public class SearchableSnapshotsFeatureSet implements XPackFeatureSet {
 
     @Override
     public boolean available() {
-        return licenseState.isAllowed(XPackLicenseState.Feature.SEARCHABLE_SNAPSHOTS);
+        return SearchableSnapshotsConstants.SEARCHABLE_SNAPSHOT_FEATURE.checkWithoutTracking(licenseState);
     }
 
     @Override

--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/action/TransportPutLifecycleAction.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/action/TransportPutLifecycleAction.java
@@ -44,6 +44,7 @@ import java.util.TreeMap;
 import java.util.stream.Collectors;
 
 import static org.elasticsearch.xpack.core.ilm.PhaseCacheManagement.updateIndicesForPolicy;
+import static org.elasticsearch.xpack.core.searchablesnapshots.SearchableSnapshotsConstants.SEARCHABLE_SNAPSHOT_FEATURE;
 
 /**
  * This class is responsible for bootstrapping {@link IndexLifecycleMetadata} into the cluster-state, as well
@@ -79,7 +80,7 @@ public class TransportPutLifecycleAction extends TransportMasterNodeAction<Reque
             .filter(phase -> phase.getActions().containsKey(SearchableSnapshotAction.NAME))
             .collect(Collectors.toList());
         if (phasesDefiningSearchableSnapshot.isEmpty() == false) {
-            if (licenseState.isAllowed(XPackLicenseState.Feature.SEARCHABLE_SNAPSHOTS) == false) {
+            if (SEARCHABLE_SNAPSHOT_FEATURE.checkWithoutTracking(licenseState) == false) {
                 throw new IllegalArgumentException("policy [" + request.getPolicy().getName() + "] defines the [" +
                     SearchableSnapshotAction.NAME + "] action but the current license is non-compliant for [searchable-snapshots]");
             }

--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/SearchableSnapshots.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/SearchableSnapshots.java
@@ -136,6 +136,7 @@ import static org.elasticsearch.snapshots.SearchableSnapshotsSettings.SEARCHABLE
 import static org.elasticsearch.snapshots.SearchableSnapshotsSettings.isPartialSearchableSnapshotIndex;
 import static org.elasticsearch.snapshots.SearchableSnapshotsSettings.isSearchableSnapshotStore;
 import static org.elasticsearch.xpack.core.ClientHelper.SEARCHABLE_SNAPSHOTS_ORIGIN;
+import static org.elasticsearch.xpack.core.searchablesnapshots.SearchableSnapshotsConstants.SEARCHABLE_SNAPSHOT_FEATURE;
 import static org.elasticsearch.xpack.searchablesnapshots.SearchableSnapshotsUtils.emptyIndexCommit;
 
 /**
@@ -259,7 +260,7 @@ public class SearchableSnapshots extends Plugin implements IndexStorePlugin, Eng
     }
 
     public static void ensureValidLicense(XPackLicenseState licenseState) {
-        if (licenseState.isAllowed(XPackLicenseState.Feature.SEARCHABLE_SNAPSHOTS) == false) {
+        if (SEARCHABLE_SNAPSHOT_FEATURE.checkWithoutTracking(licenseState) == false) {
             throw LicenseUtils.newComplianceException("searchable-snapshots");
         }
     }
@@ -532,7 +533,7 @@ public class SearchableSnapshots extends Plugin implements IndexStorePlugin, Eng
     @Override
     public Collection<AllocationDecider> createAllocationDeciders(Settings settings, ClusterSettings clusterSettings) {
         return org.elasticsearch.core.List.of(
-            new SearchableSnapshotAllocationDecider(() -> getLicenseState().isAllowed(XPackLicenseState.Feature.SEARCHABLE_SNAPSHOTS)),
+            new SearchableSnapshotAllocationDecider(() -> SEARCHABLE_SNAPSHOT_FEATURE.checkWithoutTracking(getLicenseState())),
             new SearchableSnapshotRepositoryExistsAllocationDecider(),
             new SearchableSnapshotEnableAllocationDecider(settings, clusterSettings),
             new HasFrozenCacheAllocationDecider(frozenCacheInfoService),

--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/allocation/FailShardsOnInvalidLicenseClusterListener.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/allocation/FailShardsOnInvalidLicenseClusterListener.java
@@ -26,6 +26,8 @@ import org.elasticsearch.license.XPackLicenseState;
 import java.util.HashSet;
 import java.util.Set;
 
+import static org.elasticsearch.xpack.core.searchablesnapshots.SearchableSnapshotsConstants.SEARCHABLE_SNAPSHOT_FEATURE;
+
 public class FailShardsOnInvalidLicenseClusterListener implements LicenseStateListener, IndexEventListener {
 
     private static final Logger logger = LogManager.getLogger(FailShardsOnInvalidLicenseClusterListener.class);
@@ -41,7 +43,7 @@ public class FailShardsOnInvalidLicenseClusterListener implements LicenseStateLi
     public FailShardsOnInvalidLicenseClusterListener(XPackLicenseState xPackLicenseState, RerouteService rerouteService) {
         this.xPackLicenseState = xPackLicenseState;
         this.rerouteService = rerouteService;
-        this.allowed = xPackLicenseState.isAllowed(XPackLicenseState.Feature.SEARCHABLE_SNAPSHOTS);
+        this.allowed = SEARCHABLE_SNAPSHOT_FEATURE.checkWithoutTracking(xPackLicenseState);
         xPackLicenseState.addListener(this);
     }
 
@@ -60,7 +62,7 @@ public class FailShardsOnInvalidLicenseClusterListener implements LicenseStateLi
 
     @Override
     public synchronized void licenseStateChanged() {
-        final boolean allowed = xPackLicenseState.isAllowed(XPackLicenseState.Feature.SEARCHABLE_SNAPSHOTS);
+        final boolean allowed = SEARCHABLE_SNAPSHOT_FEATURE.checkWithoutTracking(xPackLicenseState);
         if (allowed && this.allowed == false) {
             rerouteService.reroute("reroute after license activation", Priority.NORMAL, new ActionListener<ClusterState>() {
                 @Override


### PR DESCRIPTION
This commit moves the uses of Feature.SEARCHABLE_SNAPSHOTS to a new
LicensedFeature instance. Note it does not yet fix any license checks
for searchable snapshots to be tracked, that will be in a separate
followup.