### PR TITLE
Expand fleet-server privileges to include restricted indices

### DIFF
--- a/x-pack/docs/en/rest-api/security/get-service-accounts.asciidoc
+++ b/x-pack/docs/en/rest-api/security/get-service-accounts.asciidoc
@@ -94,7 +94,7 @@ GET /_security/service/elastic/fleet-server
             "create_index",
             "auto_configure"
           ],
-          "allow_restricted_indices": false
+          "allow_restricted_indices": true
         }
       ],
       "applications": [],

--- a/x-pack/plugin/security/qa/service-account/src/javaRestTest/java/org/elasticsearch/xpack/security/authc/service/ServiceAccountIT.java
+++ b/x-pack/plugin/security/qa/service-account/src/javaRestTest/java/org/elasticsearch/xpack/security/authc/service/ServiceAccountIT.java
@@ -110,7 +110,7 @@ public class ServiceAccountIT extends ESRestTestCase {
         + "            \"create_index\",\n"
         + "            \"auto_configure\"\n"
         + "          ],\n"
-        + "          \"allow_restricted_indices\": false\n"
+        + "          \"allow_restricted_indices\": true\n"
         + "        }\n"
         + "      ],\n"
         + "      \"applications\": [],\n"

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/service/ElasticServiceAccounts.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/service/ElasticServiceAccounts.java
@@ -36,6 +36,7 @@ final class ElasticServiceAccounts {
                     .builder()
                     .indices(".fleet-*")
                     .privileges("read", "write", "monitor", "create_index", "auto_configure")
+                    .allowRestrictedIndices(true)
                     .build()
             },
             null,


### PR DESCRIPTION
Since #74212, all system indices are now treated as restricted indices,
which includes the fleet system indices. As a result, the fleet-server
server account needs privileges to access restricted indices under the
fleet-* namespace.

Relates: #74212
