### PR TITLE
Support for aggregation names with dots in vector tiles (#77477)

### DIFF
--- a/x-pack/plugin/vector-tile/src/javaRestTest/java/org/elasticsearch/xpack/vectortile/VectorTileRestIT.java
+++ b/x-pack/plugin/vector-tile/src/javaRestTest/java/org/elasticsearch/xpack/vectortile/VectorTileRestIT.java
@@ -576,6 +576,10 @@ public class VectorTileRestIT extends ESRestTestCase {
         assertLayer(tile, HITS_LAYER, 4096, 1, 1);
         assertLayer(tile, AGGS_LAYER, 4096, 256 * 256, 2);
         assertLayer(tile, META_LAYER, 4096, 1, 18);
+        // check pipeline aggregation values
+        final VectorTile.Tile.Layer metaLayer = getLayer(tile, META_LAYER);
+        assertTag(metaLayer, metaLayer.getFeatures(0), "aggregations.minVal.min", 1.0);
+        assertTag(metaLayer, metaLayer.getFeatures(0), "aggregations.minVal.max", 1.0);
     }
 
     public void testOverlappingMultipolygon() throws Exception {
@@ -611,6 +615,18 @@ public class VectorTileRestIT extends ESRestTestCase {
         assertThat(layer.getExtent(), Matchers.equalTo(extent));
         assertThat(layer.getFeaturesCount(), Matchers.equalTo(numFeatures));
         assertThat(layer.getKeysCount(), Matchers.equalTo(numTags));
+    }
+
+    private void assertTag(VectorTile.Tile.Layer layer, VectorTile.Tile.Feature feature, String tag, double value) {
+        for (int i = 0; i < feature.getTagsCount(); i += 2) {
+            String thisTag = layer.getKeys(feature.getTags(i));
+            if (tag.equals(thisTag)) {
+                VectorTile.Tile.Value thisValue = layer.getValues(feature.getTags(i + 1));
+                assertThat(value, Matchers.equalTo(thisValue.getDoubleValue()));
+                return;
+            }
+        }
+        fail("Could not find tag [" + tag + " ]");
     }
 
     private VectorTile.Tile execute(Request mvtRequest) throws IOException {

--- a/x-pack/plugin/vector-tile/src/main/java/org/elasticsearch/xpack/vectortile/rest/RestVectorTileAction.java
+++ b/x-pack/plugin/vector-tile/src/main/java/org/elasticsearch/xpack/vectortile/rest/RestVectorTileAction.java
@@ -208,9 +208,9 @@ public class RestVectorTileAction extends BaseRestHandler {
                 tileAggBuilder.subAggregations(request.getAggBuilder());
                 final Collection<AggregationBuilder> aggregations = otherAggBuilder.getAggregatorFactories();
                 for (AggregationBuilder aggregation : aggregations) {
-                    searchRequestBuilder.addAggregation(
-                        new StatsBucketPipelineAggregationBuilder(aggregation.getName(), GRID_FIELD + ">" + aggregation.getName())
-                    );
+                    // we add the metric (.value) to the path in order to support aggregation names with '.'
+                    final String bucketPath = GRID_FIELD + ">" + aggregation.getName() + ".value";
+                    searchRequestBuilder.addAggregation(new StatsBucketPipelineAggregationBuilder(aggregation.getName(), bucketPath));
                 }
             }
         }

--- a/x-pack/plugin/vector-tile/src/yamlRestTest/resources/rest-api-spec/test/20_aggregations.yml
+++ b/x-pack/plugin/vector-tile/src/yamlRestTest/resources/rest-api-spec/test/20_aggregations.yml
@@ -1,0 +1,95 @@
+---
+setup:
+
+  - do:
+      indices.create:
+        index: locations
+        body:
+          mappings:
+            properties:
+              location:
+                type: geo_point
+
+  - do:
+      index:
+        index:  locations
+        body:
+          location: POINT(34.25 -21.76)
+          value: 1
+
+  - do:
+      indices.refresh: {}
+
+---
+"min agg":
+  - do:
+      search_mvt:
+        index: locations
+        field: location
+        x: 0
+        y: 0
+        zoom: 0
+        body:
+          aggs:
+            test.min_value:
+              min:
+                field: value
+
+---
+"max agg":
+  - do:
+      search_mvt:
+        index: locations
+        field: location
+        x: 0
+        y: 0
+        zoom: 0
+        body:
+          aggs:
+            test.max_value:
+              max:
+                field: value
+---
+"avg agg":
+  - do:
+      search_mvt:
+        index: locations
+        field: location
+        x: 0
+        y: 0
+        zoom: 0
+        body:
+          aggs:
+            test.avg_value:
+              avg:
+                field: value
+
+---
+"sum agg":
+  - do:
+      search_mvt:
+        index: locations
+        field: location
+        x: 0
+        y: 0
+        zoom: 0
+        body:
+          aggs:
+            test.sum_value:
+              sum:
+                field: value
+
+---
+"cardinality agg":
+  - do:
+      search_mvt:
+        index: locations
+        field: location
+        x: 0
+        y: 0
+        zoom: 0
+        body:
+          aggs:
+            test.cardinality_value:
+              cardinality:
+                field: value


### PR DESCRIPTION
Vector tiles generate a stats_bucket pipeline aggregation for each aggregation provided by the user. Currently pipeline aggregation fail if the last element of the bucket path contains no metric but the aggregation name contains a dot. On the other hand if the last bucket provided a metric it works.

Therefore as we only support metrc aggregations, we change the way we generate the pipeline aggregation by adding the metric ( in our case '.value') so we don't fail in aggregations with names containing dots.

backport #77477