### PR TITLE
Mute NodeShutdownIT#testShardsMoveOffRemovingNode and testStalledSharddMigrationProperlyDetected

### DIFF
--- a/x-pack/plugin/shutdown/qa/multi-node/src/javaRestTest/java/org/elasticsearch/xpack/shutdown/NodeShutdownIT.java
+++ b/x-pack/plugin/shutdown/qa/multi-node/src/javaRestTest/java/org/elasticsearch/xpack/shutdown/NodeShutdownIT.java
@@ -202,6 +202,7 @@ public class NodeShutdownIT extends ESRestTestCase {
      * 2) Ensures the status properly comes to rest at COMPLETE after the shards have moved.
      */
     @SuppressWarnings("unchecked")
+    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/77488")
     public void testShardsMoveOffRemovingNode() throws Exception {
         String nodeIdToShutdown = getRandomNodeId();
 
@@ -275,6 +276,7 @@ public class NodeShutdownIT extends ESRestTestCase {
         ensureGreen(indexName);
     }
 
+    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/77456")
     public void testStalledShardMigrationProperlyDetected() throws Exception {
         String nodeIdToShutdown = getRandomNodeId();
         int numberOfShards = randomIntBetween(1,5);


### PR DESCRIPTION
See https://github.com/elastic/elasticsearch/issues/77456 for `testStalledShardMigrationProperlyDetected`.
See https://github.com/elastic/elasticsearch/issues/77488 for `testShardsMoveOffRemovingNode`.