### PR TITLE
[DOCS] Clarify migration from warm to cold tier for searchable snapshots

### DIFF
--- a/docs/reference/ilm/actions/ilm-searchable-snapshot.asciidoc
+++ b/docs/reference/ilm/actions/ilm-searchable-snapshot.asciidoc
@@ -31,6 +31,10 @@ Using a policy that makes use of the <<ilm-rollover, rollover>> action
 in the hot phase will avoid this situation and the need for a manual rollover for future
 managed indices.
 
+[NOTE]
+Migration from the warm to the cold tier requires snapshotting the data in the repo
+and reading it back to the node which incurs data transfer costs.
+
 By default, this snapshot is deleted by the <<ilm-delete, delete action>> in the delete phase.
 To keep the snapshot, set `delete_searchable_snapshot` to `false` in the delete action.
 


### PR DESCRIPTION
Specify that we can't just reuse the local data as a cold cache and
the migration incurs data transfer costs.

Closes #74385