### PR TITLE
[DOCS] Remove shrink API snippet from 'Size your shards'

### DIFF
--- a/docs/reference/how-to/size-your-shards.asciidoc
+++ b/docs/reference/how-to/size-your-shards.asciidoc
@@ -255,7 +255,7 @@ unneeded indices.
 
 [source,console]
 ----
-DELETE my-index-*
+DELETE my-index-000001
 ----
 // TEST[setup:my_index]
 
@@ -280,12 +280,6 @@ POST my-index-000001/_forcemerge
 
 If you no longer write to an index, you can use the
 <<indices-shrink-index,shrink index API>> to reduce its shard count.
-
-[source,console]
-----
-POST my-index-000001/_shrink/my-shrunken-index-000001
-----
-// TEST[s/^/PUT my-index-000001\n{"settings":{"index.number_of_shards":2,"blocks.write":true}}\n/]
 
 {ilm-init} also has a <<ilm-shrink,shrink action>> for indices in the
 warm phase.


### PR DESCRIPTION
The current shrink API snippet doesn't show you how to remove replicas or reduce primary shards.

Rather than duplicate those instructions from the shrink API docs, this removes the snippet. A link to the shrink API and shrink ILM action docs is already provided.

It also updates a delete index API snippet to avoid wildcards. Wildcard expansion for the delete index API is disabled by default in 8.0.