### PR TITLE
[7.14] Fix dependency resolution on eclipse for example projects (#77468)

### DIFF
--- a/plugins/examples/build.gradle
+++ b/plugins/examples/build.gradle
@@ -1,27 +1,25 @@
 import org.elasticsearch.gradle.internal.info.BuildParams
 // Subprojects aren't published so do not assemble
-gradle.projectsEvaluated {
-  subprojects { p ->
-    p.tasks.matching { it.name.equals('assemble') }.configureEach {
-      enabled = false
-    }
-    // Disable example project testing with FIPS JVM
-    tasks.withType(Test) {
-      onlyIf {
-        BuildParams.inFipsJvm == false
-      }
-    }
-
-    // configure project dependencies for yaml rest test plugin.
-    // plugin defaults to external available artifacts
-    p.getPluginManager().withPlugin("elasticsearch.yaml-rest-test", new Action<AppliedPlugin>() {
-      @Override
-      void execute(AppliedPlugin appliedPlugin) {
-          p.dependencies.add("yamlRestTestImplementation", project(":test:framework"))
-          p.dependencies.add("restTestSpecs", p.dependencies.project(path:':rest-api-spec', configuration:'basicRestSpecs'))
-      }
-    })
+subprojects { p ->
+  p.tasks.matching { it.name.equals('assemble') }.configureEach {
+    enabled = false
   }
+  // Disable example project testing with FIPS JVM
+  tasks.withType(Test) {
+    onlyIf {
+      BuildParams.inFipsJvm == false
+    }
+  }
+
+  // configure project dependencies for yaml rest test plugin.
+  // plugin defaults to external available artifacts
+  p.getPluginManager().withPlugin("elasticsearch.yaml-rest-test", new Action<AppliedPlugin>() {
+    @Override
+    void execute(AppliedPlugin appliedPlugin) {
+        p.dependencies.add("yamlRestTestImplementation", project(":test:framework"))
+        p.dependencies.add("restTestSpecs", p.dependencies.project(path:':rest-api-spec', configuration:'basicRestSpecs'))
+    }
+  })
 }
 
 configure(project('painless-whitelist')) {


### PR DESCRIPTION
Backports the following commits to 7.14:
 - Fix dependency resolution on eclipse for example projects (#77468)