### PR TITLE
Fix test50VerifyAutogeneratedCredentials

### DIFF
--- a/qa/os/src/test/java/org/elasticsearch/packaging/test/ArchiveGenerateInitialPasswordTests.java
+++ b/qa/os/src/test/java/org/elasticsearch/packaging/test/ArchiveGenerateInitialPasswordTests.java
@@ -84,7 +84,7 @@ public class ArchiveGenerateInitialPasswordTests extends PackagingTestCase {
         assumeTrue("expect command isn't on Windows", distribution.platform != Distribution.Platform.WINDOWS);
         stopElasticsearch();
         ServerUtils.enableSecurityAutoConfiguration(installation);
-        Shell.Result result = awaitElasticsearchStartupWithResult(runElasticsearchStartCommand(null, false, true));
+        Shell.Result result = awaitElasticsearchStartupWithResult(runElasticsearchStartCommand(null, false, true), 10000);
         Map<String, String> usersAndPasswords = parseUsersAndPasswords(result.stdout);
         assertThat(usersAndPasswords.size(), equalTo(2));
         assertThat(usersAndPasswords.containsKey("elastic"), is(true));

--- a/qa/os/src/test/java/org/elasticsearch/packaging/test/ArchiveGenerateInitialPasswordTests.java
+++ b/qa/os/src/test/java/org/elasticsearch/packaging/test/ArchiveGenerateInitialPasswordTests.java
@@ -50,7 +50,7 @@ public class ArchiveGenerateInitialPasswordTests extends PackagingTestCase {
         assumeTrue("expect command isn't on Windows", distribution.platform != Distribution.Platform.WINDOWS);
         installation.executables().keystoreTool.run("create");
         installation.executables().keystoreTool.run("add --stdin bootstrap.password", "some-password-here");
-        Shell.Result result = awaitElasticsearchStartupWithResult(runElasticsearchStartCommand(null, false, true));
+        Shell.Result result = awaitElasticsearchStartupWithResult(runElasticsearchStartCommand(null, false, true), 10000);
         Map<String, String> usersAndPasswords = parseUsersAndPasswords(result.stdout);
         assertThat(usersAndPasswords.isEmpty(), is(true));
         String response = ServerUtils.makeRequest(Request.Get("http://localhost:9200"), "elastic", "some-password-here", null);
@@ -63,7 +63,7 @@ public class ArchiveGenerateInitialPasswordTests extends PackagingTestCase {
         stopElasticsearch();
         installation.executables().keystoreTool.run("remove bootstrap.password");
         ServerUtils.disableSecurityAutoConfiguration(installation);
-        Shell.Result result = awaitElasticsearchStartupWithResult(runElasticsearchStartCommand(null, false, true));
+        Shell.Result result = awaitElasticsearchStartupWithResult(runElasticsearchStartCommand(null, false, true), 10000);
         Map<String, String> usersAndPasswords = parseUsersAndPasswords(result.stdout);
         assertThat(usersAndPasswords.isEmpty(), is(true));
     }
@@ -99,7 +99,7 @@ public class ArchiveGenerateInitialPasswordTests extends PackagingTestCase {
         /* Windows issue awaits fix: https://github.com/elastic/elasticsearch/issues/49340 */
         assumeTrue("expect command isn't on Windows", distribution.platform != Distribution.Platform.WINDOWS);
         stopElasticsearch();
-        Shell.Result result = awaitElasticsearchStartupWithResult(runElasticsearchStartCommand(null, false, true));
+        Shell.Result result = awaitElasticsearchStartupWithResult(runElasticsearchStartCommand(null, false, true), 10000);
         Map<String, String> usersAndPasswords = parseUsersAndPasswords(result.stdout);
         assertThat(usersAndPasswords.isEmpty(), is(true));
     }

--- a/qa/os/src/test/java/org/elasticsearch/packaging/test/PackagingTestCase.java
+++ b/qa/os/src/test/java/org/elasticsearch/packaging/test/PackagingTestCase.java
@@ -360,8 +360,24 @@ public abstract class PackagingTestCase extends Assert {
         }
     }
 
+    /**
+     * Call {@link PackagingTestCase#awaitElasticsearchStartup} and return a reference to the Shell.Result from
+     * starting elasticsearch
+     */
     public Shell.Result awaitElasticsearchStartupWithResult(Shell.Result result) throws Exception {
+        awaitElasticsearchStartupWithResult(result, 0);
+        return result;
+    }
+
+    /**
+     * Call {@link PackagingTestCase#awaitElasticsearchStartup} but wait {@code additionalDelay} milliseconds more before
+     * returning the result. Useful in order to capture more from the stdout after ES has has successfully started
+     */
+    public Shell.Result awaitElasticsearchStartupWithResult(Shell.Result result, int additionalDelay) throws Exception {
         awaitElasticsearchStartup(result);
+        if (additionalDelay > 0) {
+            Thread.sleep(additionalDelay);
+        }
         return result;
     }
 


### PR DESCRIPTION
Give Elasticsearch the chance to fully start up and print the
auto-generated credentials in the stdout in all cases before
trying to parse stdout to capture them.

Resolves #77621 