### PR TITLE
Remove invalid path from Open PIT rest spec

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/open_point_in_time.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/open_point_in_time.json
@@ -12,12 +12,6 @@
     "url":{
       "paths":[
         {
-          "path":"/_pit",
-          "methods":[
-            "POST"
-          ]
-        },
-        {
           "path":"/{index}/_pit",
           "methods":[
             "POST"


### PR DESCRIPTION
The rest API spec includes an invalid path for open point in time which if used, results in a server error due to a missing index value. This PR fixes the spec to ensure downstream clients no longer generate methods that attempt to use this path.