### PR TITLE
Fold blob store cache path into BlobStoreCacheService

### DIFF
--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/cache/blob/BlobStoreCacheService.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/cache/blob/BlobStoreCacheService.java
@@ -35,8 +35,11 @@ import org.elasticsearch.common.util.concurrent.RunOnce;
 import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.index.store.LuceneFilesExtensions;
 import org.elasticsearch.node.NodeClosedException;
+import org.elasticsearch.repositories.IndexId;
+import org.elasticsearch.snapshots.SnapshotId;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.ConnectTransportException;
 import org.elasticsearch.xpack.searchablesnapshots.cache.common.ByteRange;
@@ -118,12 +121,19 @@ public class BlobStoreCacheService extends AbstractLifecycleComponent {
     @Override
     protected void doClose() {}
 
-    public CachedBlob get(String repository, String name, String path, long offset) {
+    public CachedBlob get(
+        final String repository,
+        final SnapshotId snapshotId,
+        final IndexId indexId,
+        final ShardId shardId,
+        final String name,
+        final ByteRange range
+    ) {
         assert Thread.currentThread().getName().contains('[' + ThreadPool.Names.SYSTEM_READ + ']') == false
             : "must not block [" + Thread.currentThread().getName() + "] for a cache read";
 
         final PlainActionFuture<CachedBlob> future = PlainActionFuture.newFuture();
-        getAsync(repository, name, path, offset, future);
+        getAsync(repository, snapshotId, indexId, shardId, name, range, future);
         try {
             return future.actionGet(5, TimeUnit.SECONDS);
         } catch (ElasticsearchTimeoutException e) {
@@ -131,7 +141,7 @@ public class BlobStoreCacheService extends AbstractLifecycleComponent {
                 logger.debug(
                     () -> new ParameterizedMessage(
                         "get from cache index timed out after [5s], retrieving from blob store instead [id={}]",
-                        CachedBlob.generateId(repository, name, path, offset)
+                        generateId(repository, snapshotId, indexId, shardId, name, range)
                     ),
                     e
                 );
@@ -142,13 +152,21 @@ public class BlobStoreCacheService extends AbstractLifecycleComponent {
         }
     }
 
-    protected void getAsync(String repository, String name, String path, long offset, ActionListener<CachedBlob> listener) {
+    protected void getAsync(
+        final String repository,
+        final SnapshotId snapshotId,
+        final IndexId indexId,
+        final ShardId shardId,
+        final String name,
+        final ByteRange range,
+        final ActionListener<CachedBlob> listener
+    ) {
         if (closed.get()) {
             logger.debug("failed to retrieve cached blob from system index [{}], service is closed", index);
             listener.onResponse(CachedBlob.CACHE_NOT_READY);
             return;
         }
-        final GetRequest request = new GetRequest(index).id(CachedBlob.generateId(repository, name, path, offset));
+        final GetRequest request = new GetRequest(index).id(generateId(repository, snapshotId, indexId, shardId, name, range));
         client.get(request, new ActionListener<>() {
             @Override
             public void onResponse(GetResponse response) {
@@ -157,7 +175,7 @@ public class BlobStoreCacheService extends AbstractLifecycleComponent {
                     assert response.isSourceEmpty() == false;
 
                     final CachedBlob cachedBlob = CachedBlob.fromSource(response.getSource());
-                    assert response.getId().equals(cachedBlob.generatedId());
+                    assert assertDocId(response, repository, snapshotId, indexId, shardId, name, range);
                     listener.onResponse(cachedBlob);
                 } else {
                     logger.debug("cache miss: [{}]", request.id());
@@ -180,6 +198,21 @@ public class BlobStoreCacheService extends AbstractLifecycleComponent {
         });
     }
 
+    private static boolean assertDocId(
+        final GetResponse response,
+        final String repository,
+        final SnapshotId snapshotId,
+        final IndexId indexId,
+        final ShardId shardId,
+        final String name,
+        final ByteRange range
+    ) {
+        final String expectedId = generateId(repository, snapshotId, indexId, shardId, name, range);
+        assert response.getId().equals(expectedId)
+            : "Expected a cached blob document with id [" + expectedId + "] but got [" + response.getId() + ']';
+        return true;
+    }
+
     private static boolean isExpectedCacheGetException(Exception e) {
         if (TransportActions.isShardNotAvailableException(e)
             || e instanceof ConnectTransportException
@@ -190,18 +223,28 @@ public class BlobStoreCacheService extends AbstractLifecycleComponent {
         return cause instanceof NodeClosedException || cause instanceof ConnectTransportException;
     }
 
-    public void putAsync(String repository, String name, String path, long offset, BytesReference content, ActionListener<Void> listener) {
+    public void putAsync(
+        final String repository,
+        final SnapshotId snapshotId,
+        final IndexId indexId,
+        final ShardId shardId,
+        final String name,
+        final ByteRange range,
+        final BytesReference bytes,
+        final ActionListener<Void> listener
+    ) {
+        final String id = generateId(repository, snapshotId, indexId, shardId, name, range);
         try {
             final CachedBlob cachedBlob = new CachedBlob(
                 Instant.ofEpochMilli(timeSupplier.get()),
                 Version.CURRENT,
                 repository,
                 name,
-                path,
-                content,
-                offset
+                generatePath(snapshotId, indexId, shardId),
+                bytes,
+                range.start()
             );
-            final IndexRequest request = new IndexRequest(index).id(cachedBlob.generatedId());
+            final IndexRequest request = new IndexRequest(index).id(id);
             try (XContentBuilder builder = jsonBuilder()) {
                 request.source(cachedBlob.toXContent(builder, ToXContent.EMPTY_PARAMS));
             }
@@ -240,9 +283,24 @@ public class BlobStoreCacheService extends AbstractLifecycleComponent {
                 }
             }
         } catch (Exception e) {
-            logger.warn(new ParameterizedMessage("cache fill failure: [{}]", CachedBlob.generateId(repository, name, path, offset)), e);
+            logger.warn(() -> new ParameterizedMessage("cache fill failure: [{}]", id), e);
             listener.onFailure(e);
         }
+    }
+
+    protected static String generateId(
+        final String repository,
+        final SnapshotId snapshotId,
+        final IndexId indexId,
+        final ShardId shardId,
+        final String name,
+        final ByteRange range
+    ) {
+        return String.join("/", repository, snapshotId.getUUID(), indexId.getId(), String.valueOf(shardId.id()), name, "@" + range.start());
+    }
+
+    protected static String generatePath(final SnapshotId snapshotId, final IndexId indexId, final ShardId shardId) {
+        return String.join("/", snapshotId.getUUID(), indexId.getId(), String.valueOf(shardId.id()));
     }
 
     /**

--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/cache/blob/CachedBlob.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/cache/blob/CachedBlob.java
@@ -101,10 +101,6 @@ public class CachedBlob implements ToXContent {
         return builder.endObject();
     }
 
-    public String generatedId() {
-        return generateId(repository, name, path, from);
-    }
-
     public long from() {
         return from;
     }
@@ -119,10 +115,6 @@ public class CachedBlob implements ToXContent {
 
     public BytesReference bytes() {
         return bytes;
-    }
-
-    public static String generateId(String repository, String name, String path, long offset) {
-        return String.join("/", repository, path, name, "@" + offset);
     }
 
     @SuppressWarnings("unchecked")

--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/store/SearchableSnapshotDirectory.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/store/SearchableSnapshotDirectory.java
@@ -704,15 +704,7 @@ public class SearchableSnapshotDirectory extends BaseDirectory {
     }
 
     public CachedBlob getCachedBlob(String name, ByteRange range) {
-        final CachedBlob cachedBlob = blobStoreCacheService.get(repository, snapshotId, indexId, shardId, name, range);
-        if (cachedBlob == CachedBlob.CACHE_MISS || cachedBlob == CachedBlob.CACHE_NOT_READY) {
-            return cachedBlob;
-        } else if (cachedBlob.from() != range.start() || cachedBlob.to() != range.end()) {
-            // expected range in cache might differ with the returned cached blob; this can happen if the range to put in cache is changed
-            // between versions or through the index setting. In this case we assume it is a cache miss to force the blob to be cached again
-            return CachedBlob.CACHE_MISS;
-        }
-        return cachedBlob;
+        return blobStoreCacheService.get(repository, snapshotId, indexId, shardId, name, range);
     }
 
     public void putCachedBlob(String name, ByteRange range, BytesReference content, ActionListener<Void> listener) {

--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/store/input/MetadataCachingIndexInput.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/store/input/MetadataCachingIndexInput.java
@@ -287,7 +287,7 @@ public abstract class MetadataCachingIndexInput extends BaseSearchableSnapshotIn
             // NB use Channels.readFromFileChannelWithEofException not readCacheFile() to avoid counting this in the stats
             byteBuffer.flip();
             final BytesReference content = BytesReference.fromByteBuffer(byteBuffer);
-            directory.putCachedBlob(fileInfo.physicalName(), indexCacheMiss.start(), content, new ActionListener<Void>() {
+            directory.putCachedBlob(fileInfo.physicalName(), indexCacheMiss, content, new ActionListener<>() {
                 @Override
                 public void onResponse(Void response) {
                     onCacheFillComplete.close();


### PR DESCRIPTION
Today a `SearchableSnapshotDirectory` instance computes the path where blobs are located in the repository and passes this path to the blob store cache service every time it tries to get or to put a document in the `.snapshot-blob-cache` system index. 

This path is indexed in cached blob documents and is used as ids of cached documents, but this is an implementation detail so it makes more sense IMO to compute the path in the `BlobStoreCacheService` itself and compute doc ids in the same service. Same thing when detecting that the cached blob document has a different length than expected; this should be handled at the BlobStoreCacheService and not in the Lucene directory itself.