### PR TITLE
Add sort optimization with after from Lucene

### DIFF
--- a/server/src/main/java/org/elasticsearch/search/internal/ContextIndexSearcher.java
+++ b/server/src/main/java/org/elasticsearch/search/internal/ContextIndexSearcher.java
@@ -154,7 +154,6 @@ public class ContextIndexSearcher extends IndexSearcher implements Releasable {
         }
     }
 
-    @Override
     public void search(List<LeafReaderContext> leaves, Weight weight, Collector collector) throws IOException {
         for (LeafReaderContext ctx : leaves) { // search each subreader
             searchLeaf(ctx, weight, collector);

--- a/server/src/main/java/org/elasticsearch/search/query/QueryPhase.java
+++ b/server/src/main/java/org/elasticsearch/search/query/QueryPhase.java
@@ -302,7 +302,6 @@ public class QueryPhase {
     }
 
 
-    // TODO: remove this after Lucene 9.0, as sort optimization is enabled by default there
     private static void optimizeNumericSort(SearchContext searchContext, IndexReader reader) {
         if (searchContext.sort() == null) return;
         // disable this optimization if index sorting matches the query sort since it's already optimized by index searcher
@@ -310,8 +309,6 @@ public class QueryPhase {
 
         SortField sortField = searchContext.sort().sort.getSort()[0];
         SortField.Type sortType = IndexSortConfig.getSortFieldType(sortField);
-        //if (SortField.Type.LONG.equals(IndexSortConfig.getSortFieldType(sortField)) == false) return null;
-
         if (sortType != SortField.Type.LONG) return; // for now restrict sort optimization only to long sort
         String fieldName = sortField.getField();
         if (fieldName == null) return; // happens when _score or _doc is the 1st sort field

--- a/server/src/main/java/org/elasticsearch/search/query/QueryPhase.java
+++ b/server/src/main/java/org/elasticsearch/search/query/QueryPhase.java
@@ -10,39 +10,29 @@ package org.elasticsearch.search.query;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.apache.lucene.document.LongPoint;
 import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.LeafReaderContext;
-import org.apache.lucene.index.PointValues;
 import org.apache.lucene.queries.MinDocQuery;
 import org.apache.lucene.queries.SearchAfterSortedDocQuery;
 import org.apache.lucene.search.BooleanClause;
 import org.apache.lucene.search.BooleanQuery;
 import org.apache.lucene.search.Collector;
-import org.apache.lucene.search.CollectorManager;
 import org.apache.lucene.search.ConstantScoreQuery;
-import org.apache.lucene.search.DocValuesFieldExistsQuery;
 import org.apache.lucene.search.FieldDoc;
 import org.apache.lucene.search.MatchAllDocsQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.ScoreDoc;
-import org.apache.lucene.search.ScoreMode;
 import org.apache.lucene.search.Sort;
 import org.apache.lucene.search.SortField;
 import org.apache.lucene.search.TopDocs;
-import org.apache.lucene.search.TopFieldCollector;
-import org.apache.lucene.search.TopFieldDocs;
 import org.apache.lucene.search.TotalHits;
-import org.apache.lucene.search.Weight;
-import org.apache.lucene.util.FutureArrays;
 import org.elasticsearch.action.search.SearchShardTask;
 import org.elasticsearch.common.lucene.Lucene;
 import org.elasticsearch.common.lucene.search.TopDocsAndMaxScore;
 import org.elasticsearch.common.util.concurrent.QueueResizingEsThreadPoolExecutor;
 import org.elasticsearch.core.Booleans;
-import org.elasticsearch.core.CheckedConsumer;
 import org.elasticsearch.index.IndexSortConfig;
-import org.elasticsearch.index.mapper.DateFieldMapper.DateFieldType;
+import org.elasticsearch.index.mapper.DateFieldMapper;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.search.DocValueFormat;
@@ -56,18 +46,12 @@ import org.elasticsearch.search.profile.SearchProfileQueryPhaseResult;
 import org.elasticsearch.search.profile.SearchProfileResults;
 import org.elasticsearch.search.profile.query.InternalProfileCollector;
 import org.elasticsearch.search.rescore.RescorePhase;
-import org.elasticsearch.search.sort.FieldSortBuilder;
 import org.elasticsearch.search.sort.SortAndFormats;
 import org.elasticsearch.search.suggest.SuggestPhase;
 import org.elasticsearch.threadpool.ThreadPool;
 
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.Comparator;
 import java.util.LinkedList;
-import java.util.List;
 import java.util.concurrent.ExecutorService;
 
 import static org.elasticsearch.search.query.QueryCollectorContext.createEarlyTerminationCollectorContext;
@@ -75,7 +59,6 @@ import static org.elasticsearch.search.query.QueryCollectorContext.createFiltere
 import static org.elasticsearch.search.query.QueryCollectorContext.createMinScoreCollectorContext;
 import static org.elasticsearch.search.query.QueryCollectorContext.createMultiCollectorContext;
 import static org.elasticsearch.search.query.TopDocsCollectorContext.createTopDocsCollectorContext;
-import static org.elasticsearch.search.query.TopDocsCollectorContext.shortcutTotalHitCount;
 
 
 /**
@@ -157,7 +140,6 @@ public class QueryPhase {
      */
     static boolean executeInternal(SearchContext searchContext) throws QueryPhaseExecutionException {
         final ContextIndexSearcher searcher = searchContext.searcher();
-        SortAndFormats sortAndFormatsForRewrittenNumericSort = null;
         final IndexReader reader = searcher.getIndexReader();
         QuerySearchResult queryResult = searchContext.queryResult();
         queryResult.searchTimedOut(false);
@@ -229,25 +211,9 @@ public class QueryPhase {
                 hasFilterCollector = true;
             }
 
-            CheckedConsumer<List<LeafReaderContext>, IOException> leafSorter = l -> {};
-            // try to rewrite numeric or date sort to the optimized distanceFeatureQuery
-            if ((searchContext.sort() != null) && SYS_PROP_REWRITE_SORT) {
-                Query rewrittenQuery = tryRewriteLongSort(searchContext, searcher.getIndexReader(), query, hasFilterCollector);
-                if (rewrittenQuery != null) {
-                    query = rewrittenQuery;
-                    // modify sorts: add sort on _score as 1st sort, and move the sort on the original field as the 2nd sort
-                    SortField[] oldSortFields = searchContext.sort().sort.getSort();
-                    DocValueFormat[] oldFormats = searchContext.sort().formats;
-                    SortField[] newSortFields = new SortField[oldSortFields.length + 1];
-                    DocValueFormat[] newFormats = new DocValueFormat[oldSortFields.length + 1];
-                    newSortFields[0] = SortField.FIELD_SCORE;
-                    newFormats[0] = DocValueFormat.RAW;
-                    System.arraycopy(oldSortFields, 0, newSortFields, 1, oldSortFields.length);
-                    System.arraycopy(oldFormats, 0, newFormats, 1, oldFormats.length);
-                    sortAndFormatsForRewrittenNumericSort = searchContext.sort(); // stash SortAndFormats to restore it later
-                    searchContext.sort(new SortAndFormats(new Sort(newSortFields), newFormats));
-                    leafSorter = createLeafSorter(oldSortFields[0]);
-                }
+            if (SYS_PROP_REWRITE_SORT) {
+                optimizeNumericSort(searchContext, searcher.getIndexReader());
+                // TODO: sort leaves according to search sort when Lucene supports sharing bottom sort value between collectors
             }
 
             boolean timeoutSet = scrollContext == null && searchContext.timeout() != null &&
@@ -278,20 +244,7 @@ public class QueryPhase {
             }
 
             try {
-                boolean shouldRescore;
-                // if we are optimizing sort and there are no other collectors
-                if (sortAndFormatsForRewrittenNumericSort!=null && collectors.size()==0 && searchContext.getProfilers()==null) {
-                    shouldRescore = searchWithCollectorManager(searchContext, searcher, query, leafSorter, timeoutSet);
-                } else {
-                    shouldRescore = searchWithCollector(searchContext, searcher, query, collectors, hasFilterCollector, timeoutSet);
-                }
-
-                // if we rewrote numeric long or date sort, restore fieldDocs based on the original sort
-                if (sortAndFormatsForRewrittenNumericSort!=null) {
-                    searchContext.sort(sortAndFormatsForRewrittenNumericSort); // restore SortAndFormats
-                    restoreTopFieldDocs(queryResult, sortAndFormatsForRewrittenNumericSort);
-                }
-
+                boolean shouldRescore = searchWithCollector(searchContext, searcher, query, collectors, hasFilterCollector, timeoutSet);
                 ExecutorService executor = searchContext.indexShard().getThreadPool().executor(ThreadPool.Names.SEARCH);
                 if (executor instanceof QueueResizingEsThreadPoolExecutor) {
                     QueueResizingEsThreadPoolExecutor rExecutor = (QueueResizingEsThreadPoolExecutor) executor;
@@ -349,203 +302,32 @@ public class QueryPhase {
     }
 
 
-    /*
-     * We use collectorManager during sort optimization, where
-     * we have already checked that there are no other collectors, no filters,
-     * no search after, no scroll, no collapse, no track scores.
-     * Absence of all other collectors and parameters allows us to use TopFieldCollector directly.
-     */
-    private static boolean searchWithCollectorManager(SearchContext searchContext,
-                                                      ContextIndexSearcher searcher,
-                                                      Query query,
-                                                      CheckedConsumer<List<LeafReaderContext>, IOException> leafSorter,
-                                                      boolean timeoutSet) throws IOException {
-        final QuerySearchResult queryResult = searchContext.queryResult();
-        final IndexReader reader = searchContext.searcher().getIndexReader();
-        final int numHits = Math.min(searchContext.from() + searchContext.size(), Math.max(1, reader.numDocs()));
-        final SortAndFormats sortAndFormats = searchContext.sort();
+    // TODO: remove this after Lucene 9.0, as sort optimization is enabled by default there
+    private static void optimizeNumericSort(SearchContext searchContext, IndexReader reader) {
+        if (searchContext.sort() == null) return;
+        // disable this optimization if index sorting matches the query sort since it's already optimized by index searcher
+        if (canEarlyTerminate(reader, searchContext.sort())) return;
 
-        int totalHitsThreshold;
-        final TotalHits totalHits;
-        if (searchContext.trackTotalHitsUpTo() == SearchContext.TRACK_TOTAL_HITS_DISABLED) {
-            totalHitsThreshold = 1;
-            totalHits = new TotalHits(0, TotalHits.Relation.GREATER_THAN_OR_EQUAL_TO);
-        } else {
-            int hitCount = shortcutTotalHitCount(reader, query);
-            if (hitCount == -1) {
-                totalHitsThreshold = searchContext.trackTotalHitsUpTo();
-                totalHits = null; // will be computed via the collector
-            } else {
-                totalHitsThreshold = 1;
-                totalHits = new TotalHits(hitCount, TotalHits.Relation.EQUAL_TO); // don't compute hit counts via the collector
-            }
-        }
+        SortField sortField = searchContext.sort().sort.getSort()[0];
+        SortField.Type sortType = IndexSortConfig.getSortFieldType(sortField);
+        //if (SortField.Type.LONG.equals(IndexSortConfig.getSortFieldType(sortField)) == false) return null;
 
-        CollectorManager<TopFieldCollector, TopFieldDocs> sharedManager = TopFieldCollector.createSharedManager(
-            sortAndFormats.sort, numHits, null, totalHitsThreshold);
-
-        List<LeafReaderContext> leaves = new ArrayList<>(searcher.getIndexReader().leaves());
-        leafSorter.accept(leaves);
-
-        final Weight weight = searcher.createWeight(searcher.rewrite(query), ScoreMode.TOP_SCORES, 1f);
-        final List<TopFieldCollector> collectors = new ArrayList<>(leaves.size());
-
-        try {
-            for (LeafReaderContext ctx : leaves) {
-                final TopFieldCollector collector = sharedManager.newCollector();
-                collectors.add(collector);
-                searcher.search(Collections.singletonList(ctx), weight, collector);
-            }
-        } catch (EarlyTerminatingCollector.EarlyTerminationException e) {
-            queryResult.terminatedEarly(true);
-        } catch (TimeExceededException e) {
-            assert timeoutSet : "TimeExceededException thrown even though timeout wasn't set";
-            if (searchContext.request().allowPartialSearchResults() == false) {
-                // Can't rethrow TimeExceededException because not serializable
-                throw new QueryPhaseExecutionException(searchContext.shardTarget(), "Time exceeded");
-            }
-            queryResult.searchTimedOut(true);
-        }
-
-        TopFieldDocs mergedTopDocs = sharedManager.reduce(collectors);
-        // Lucene sets shards indexes during merging of topDocs from different collectors
-        // We need to reset shard index; ES will set shard index later during reduce stage
-        for (ScoreDoc scoreDoc : mergedTopDocs.scoreDocs) {
-            scoreDoc.shardIndex = -1;
-        }
-        if (totalHits != null) { // we have already precalculated totalHits for the whole index
-            mergedTopDocs = new TopFieldDocs(totalHits, mergedTopDocs.scoreDocs, mergedTopDocs.fields);
-        }
-        queryResult.topDocs(new TopDocsAndMaxScore(mergedTopDocs, Float.NaN), sortAndFormats.formats);
-        return false; // no rescoring when sorting by field
-    }
-
-    private static Query tryRewriteLongSort(SearchContext searchContext, IndexReader reader,
-                                            Query query, boolean hasFilterCollector) throws IOException {
-        if ((searchContext.from() + searchContext.size()) <= 0) return null;
-        if (searchContext.searchAfter() != null) return null; //TODO: handle sort optimization with search after
-        if (searchContext.scrollContext() != null) return null;
-        if (searchContext.collapse() != null) return null;
-        if (searchContext.trackScores()) return null;
-        if (searchContext.aggregations() != null) return null;
-        if (canEarlyTerminate(reader, searchContext.sort())) {
-            // disable this optimization if index sorting matches the query sort since it's already optimized by index searcher
-            return null;
-        }
-        Sort sort = searchContext.sort().sort;
-        SortField sortField = sort.getSort()[0];
-        if (SortField.Type.LONG.equals(IndexSortConfig.getSortFieldType(sortField)) == false) return null;
-
-        // check if this is a field of type Long or Date, that is indexed and has doc values
+        if (sortType != SortField.Type.LONG) return; // for now restrict sort optimization only to long sort
         String fieldName = sortField.getField();
+        if (fieldName == null) return; // happens when _score or _doc is the 1st sort field
         SearchExecutionContext searchExecutionContext = searchContext.getSearchExecutionContext();
-        if (fieldName == null) return null; // happens when _score or _doc is the 1st sort field
         final MappedFieldType fieldType = searchExecutionContext.getFieldType(fieldName);
-        if (fieldType == null) return null; // for unmapped fields, default behaviour depending on "unmapped_type" flag
-        if ((fieldType.typeName().equals("long") == false) && (fieldType instanceof DateFieldType == false)) return null;
-        if (fieldType.isSearchable() == false) return null;
-        if (fieldType.hasDocValues() == false) return null;
+        if (fieldType == null) return; // for unmapped fields, default behaviour depending on "unmapped_type" flag
+        if (fieldType.isSearchable() == false) return;
+        if (fieldType.hasDocValues() == false) return;
 
+        // For now restrict sort optimization only to long and date fields
+        // For sort optimization SortField.Type must match with the type of indexed points (Type.LONG and LongPoint)
+        // Some fields there is no match (e.g. integer field uses SortField.Type.LONG, but indexed as IntegerPoint)
+        if ((fieldType.typeName().equals("long") == false) && (fieldType instanceof DateFieldMapper.DateFieldType == false)) return;
 
-        // check that all sorts are actual document fields or _doc
-        for (int i = 1; i < sort.getSort().length; i++) {
-            SortField sField = sort.getSort()[i];
-            String sFieldName = sField.getField();
-            if (sFieldName == null) {
-                if (SortField.FIELD_DOC.equals(sField) == false) {
-                    return null;
-                }
-            } else if (FieldSortBuilder.SHARD_DOC_FIELD_NAME.equals(sFieldName) == false) {
-                //TODO: find out how to cover _script sort that don't use _score
-                if (searchExecutionContext.getFieldType(sFieldName) == null) {
-                    return null; // could be _script sort that uses _score
-                }
-            }
-        }
-
-        // check that setting of missing values allows optimization
-        if (sortField.getMissingValue() == null) return null;
-        Long missingValue = (Long) sortField.getMissingValue();
-        boolean missingValuesAccordingToSort = (sortField.getReverse() && (missingValue == Long.MIN_VALUE)) ||
-            ((sortField.getReverse() == false) && (missingValue == Long.MAX_VALUE));
-        if (missingValuesAccordingToSort == false) return null;
-
-        int docCount = PointValues.getDocCount(reader, fieldName);
-        // is not worth to run optimization on small index
-        if (docCount <= 512) return null;
-
-        // check for multiple values
-        if (PointValues.size(reader, fieldName) != docCount) return null; //TODO: handle multiple values
-
-        // check if the optimization makes sense with the track_total_hits setting
-        if (searchContext.trackTotalHitsUpTo() == Integer.MAX_VALUE) {
-            // with filter, we can't pre-calculate hitsCount, we need to explicitly calculate them => optimization does't make sense
-            if (hasFilterCollector) return null;
-            // if we can't pre-calculate hitsCount based on the query type, optimization does't make sense
-            if (shortcutTotalHitCount(reader, query) == -1) return null;
-        }
-
-        byte[] minValueBytes = PointValues.getMinPackedValue(reader, fieldName);
-        byte[] maxValueBytes = PointValues.getMaxPackedValue(reader, fieldName);
-        if ((maxValueBytes == null) || (minValueBytes == null)) return null;
-        long minValue = LongPoint.decodeDimension(minValueBytes, 0);
-        long maxValue = LongPoint.decodeDimension(maxValueBytes, 0);
-
-        Query rewrittenQuery;
-        if (minValue == maxValue) {
-            rewrittenQuery = new DocValuesFieldExistsQuery(fieldName);
-        } else {
-            if (indexFieldHasDuplicateData(reader, fieldName)) return null;
-            long origin = (sortField.getReverse()) ? maxValue : minValue;
-            long pivotDistance = (maxValue - minValue) >>> 1; // division by 2 on the unsigned representation to avoid overflow
-            if (pivotDistance == 0) { // 0 if maxValue = (minValue + 1)
-                pivotDistance = 1;
-            }
-            rewrittenQuery = LongPoint.newDistanceFeatureQuery(sortField.getField(), 1, origin, pivotDistance);
-        }
-        rewrittenQuery = new BooleanQuery.Builder()
-            .add(query, BooleanClause.Occur.FILTER) // filter for original query
-            .add(rewrittenQuery, BooleanClause.Occur.SHOULD) //should for rewrittenQuery
-            .build();
-        return rewrittenQuery;
-    }
-
-    /**
-     * Creates a sorter of {@link LeafReaderContext} that orders leaves depending on the minimum
-     * value and the sort order of the provided <code>sortField</code>.
-     */
-    static CheckedConsumer<List<LeafReaderContext>, IOException> createLeafSorter(SortField sortField) {
-        return leaves -> {
-            long[] sortValues = new long[leaves.size()];
-            long missingValue = (long) sortField.getMissingValue();
-            for (LeafReaderContext ctx : leaves) {
-                PointValues values = ctx.reader().getPointValues(sortField.getField());
-                if (values == null) {
-                    sortValues[ctx.ord] = missingValue;
-                } else {
-                    byte[] sortValue = sortField.getReverse() ? values.getMaxPackedValue(): values.getMinPackedValue();
-                    sortValues[ctx.ord] = sortValue == null ? missingValue : LongPoint.decodeDimension(sortValue, 0);
-                }
-            }
-            Comparator<LeafReaderContext> comparator = Comparator.comparingLong(l -> sortValues[l.ord]);
-            if (sortField.getReverse()) {
-                comparator = comparator.reversed();
-            }
-            Collections.sort(leaves, comparator);
-        };
-    }
-
-    /**
-     * Restore fieldsDocs to remove the first _score
-     */
-    private static void restoreTopFieldDocs(QuerySearchResult result, SortAndFormats originalSortAndFormats) {
-        TopDocs topDocs = result.topDocs().topDocs;
-        for (ScoreDoc scoreDoc : topDocs.scoreDocs) {
-            FieldDoc fieldDoc = (FieldDoc) scoreDoc;
-            fieldDoc.fields = Arrays.copyOfRange(fieldDoc.fields, 1, fieldDoc.fields.length);
-        }
-        TopFieldDocs newTopDocs = new TopFieldDocs(topDocs.totalHits, topDocs.scoreDocs, originalSortAndFormats.sort.getSort());
-        result.topDocs(new TopDocsAndMaxScore(newTopDocs, Float.NaN), originalSortAndFormats.formats);
+        sortField.setCanUsePoints();
+        return;
     }
 
     /**
@@ -581,83 +363,6 @@ public class QueryPhase {
             }
         }
         return true;
-    }
-
-    /**
-     * Returns true if more than 50% of data in the index have the same value
-     * The evaluation is approximation based on finding the median value and estimating its count
-     */
-    private static boolean indexFieldHasDuplicateData(IndexReader reader, String field) throws IOException {
-        long docsNoDupl = 0; // number of docs in segments with NO duplicate data that would benefit optimization
-        long docsDupl = 0; // number of docs in segments with duplicate data that would NOT benefit optimization
-        for (LeafReaderContext lrc : reader.leaves()) {
-            PointValues pointValues = lrc.reader().getPointValues(field);
-            if (pointValues == null) continue;
-            int docCount = pointValues.getDocCount();
-            if (docCount <= 512) { // skipping small segments as estimateMedianCount doesn't work well on them
-                continue;
-            }
-            assert(pointValues.size() == docCount); // TODO: modify the code to handle multiple values
-            int duplDocCount = docCount/2; // expected doc count of duplicate data
-            if (pointsHaveDuplicateData(pointValues, duplDocCount)) {
-                docsDupl += docCount;
-            } else {
-                docsNoDupl += docCount;
-            }
-        }
-        return (docsDupl > docsNoDupl);
-    }
-
-    static boolean pointsHaveDuplicateData(PointValues pointValues, int duplDocCount) throws IOException {
-        long minValue = LongPoint.decodeDimension(pointValues.getMinPackedValue(), 0);
-        long maxValue = LongPoint.decodeDimension(pointValues.getMaxPackedValue(), 0);
-        boolean hasDuplicateData = true;
-        while ((minValue < maxValue) && hasDuplicateData) {
-            long midValue = Math.floorDiv(minValue, 2) + Math.floorDiv(maxValue, 2); // to avoid overflow first divide each value by 2
-            long countLeft = estimatePointCount(pointValues, minValue, midValue);
-            long countRight = estimatePointCount(pointValues, midValue + 1, maxValue);
-            if ((countLeft >= countRight) && (countLeft > duplDocCount) ) {
-                maxValue = midValue;
-            } else if ((countRight > countLeft) && (countRight > duplDocCount)) {
-                minValue = midValue + 1;
-            } else {
-                hasDuplicateData = false;
-            }
-        }
-        return hasDuplicateData;
-    }
-
-
-    private static long estimatePointCount(PointValues pointValues, long minValue, long maxValue) {
-        final byte[] minValueAsBytes = new byte[Long.BYTES];
-        LongPoint.encodeDimension(minValue, minValueAsBytes, 0);
-        final byte[] maxValueAsBytes = new byte[Long.BYTES];
-        LongPoint.encodeDimension(maxValue, maxValueAsBytes, 0);
-
-        PointValues.IntersectVisitor visitor = new PointValues.IntersectVisitor() {
-            @Override
-            public void grow(int count) {}
-
-            @Override
-            public void visit(int docID) {}
-
-            @Override
-            public void visit(int docID, byte[] packedValue) {}
-
-            @Override
-            public PointValues.Relation compare(byte[] minPackedValue, byte[] maxPackedValue) {
-                if (FutureArrays.compareUnsigned(minPackedValue, 0, Long.BYTES, maxValueAsBytes, 0, Long.BYTES) > 0 ||
-                    FutureArrays.compareUnsigned(maxPackedValue, 0, Long.BYTES, minValueAsBytes, 0, Long.BYTES) < 0) {
-                    return PointValues.Relation.CELL_OUTSIDE_QUERY;
-                }
-                if (FutureArrays.compareUnsigned(minPackedValue, 0, Long.BYTES, minValueAsBytes, 0, Long.BYTES) < 0 ||
-                    FutureArrays.compareUnsigned(maxPackedValue, 0, Long.BYTES, maxValueAsBytes, 0, Long.BYTES) > 0) {
-                    return PointValues.Relation.CELL_CROSSES_QUERY;
-                }
-                return PointValues.Relation.CELL_INSIDE_QUERY;
-            }
-        };
-        return pointValues.estimatePointCount(visitor);
     }
 
     static class TimeExceededException extends RuntimeException {}

--- a/server/src/main/java/org/elasticsearch/search/query/TopDocsCollectorContext.java
+++ b/server/src/main/java/org/elasticsearch/search/query/TopDocsCollectorContext.java
@@ -113,7 +113,7 @@ abstract class TopDocsCollectorContext extends QueryCollectorContext {
             } else {
                 TotalHitCountCollector hitCountCollector = new TotalHitCountCollector();
                 // implicit total hit counts are valid only when there is no filter collector in the chain
-                int hitCount =  hasFilterCollector ? -1 : shortcutTotalHitCount(reader, query);
+                int hitCount = hasFilterCollector ? -1 : shortcutTotalHitCount(reader, query);
                 if (hitCount == -1) {
                     if (trackTotalHitsUpTo == SearchContext.TRACK_TOTAL_HITS_ACCURATE) {
                         this.collector = hitCountCollector;

--- a/server/src/test/java/org/elasticsearch/search/query/QueryPhaseTests.java
+++ b/server/src/test/java/org/elasticsearch/search/query/QueryPhaseTests.java
@@ -27,7 +27,6 @@ import org.apache.lucene.index.NoMergePolicy;
 import org.apache.lucene.index.RandomIndexWriter;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.queries.MinDocQuery;
-import org.apache.lucene.search.BooleanClause;
 import org.apache.lucene.search.BooleanClause.Occur;
 import org.apache.lucene.search.BooleanQuery;
 import org.apache.lucene.search.Collector;
@@ -57,14 +56,8 @@ import org.apache.lucene.search.join.ScoreMode;
 import org.apache.lucene.search.spans.SpanNearQuery;
 import org.apache.lucene.search.spans.SpanTermQuery;
 import org.apache.lucene.store.Directory;
-import org.apache.lucene.store.IOContext;
-import org.apache.lucene.store.IndexInput;
-import org.apache.lucene.store.IndexOutput;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.FixedBitSet;
-import org.apache.lucene.util.bkd.BKDConfig;
-import org.apache.lucene.util.bkd.BKDReader;
-import org.apache.lucene.util.bkd.BKDWriter;
 import org.elasticsearch.action.search.SearchShardTask;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.mapper.DateFieldMapper;
@@ -90,13 +83,13 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-import static org.elasticsearch.search.query.QueryPhase.pointsHaveDuplicateData;
 import static org.elasticsearch.search.query.TopDocsCollectorContext.hasInfMaxScore;
 import static org.hamcrest.Matchers.anyOf;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.instanceOf;
-import static org.hamcrest.Matchers.lessThanOrEqualTo;
+import static org.hamcrest.Matchers.lessThan;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.spy;
@@ -669,7 +662,7 @@ public class QueryPhaseTests extends IndexShardTestCase {
         dir.close();
     }
 
-    public void testNumericLongOrDateSortOptimization() throws Exception {
+    public void testNumericSortOptimization() throws Exception {
         final String fieldNameLong = "long-field";
         final String fieldNameDate = "date-field";
         MappedFieldType fieldTypeLong = new NumberFieldMapper.NumberFieldType(fieldNameLong, NumberFieldMapper.NumberType.LONG);
@@ -678,176 +671,151 @@ public class QueryPhaseTests extends IndexShardTestCase {
         when(searchExecutionContext.getFieldType(fieldNameLong)).thenReturn(fieldTypeLong);
         when(searchExecutionContext.getFieldType(fieldNameDate)).thenReturn(fieldTypeDate);
         // enough docs to have a tree with several leaf nodes
-        final int numDocs = 3500 * 20;
+        final int numDocs = atLeast(3500 * 2);
         Directory dir = newDirectory();
         IndexWriter writer = new IndexWriter(dir, new IndexWriterConfig(null));
+        long startLongValue = randomLongBetween(-10000000L, 10000000L);
+        long longValue = startLongValue;
+        long dateValue = randomLongBetween(0, 3000000000000L);
+
         for (int i = 1; i <= numDocs; ++i) {
             Document doc = new Document();
-            long longValue = randomLongBetween(-10000000L, 10000000L);
             doc.add(new LongPoint(fieldNameLong, longValue));
             doc.add(new NumericDocValuesField(fieldNameLong, longValue));
-            longValue = randomLongBetween(0, 3000000000000L);
-            doc.add(new LongPoint(fieldNameDate, longValue));
-            doc.add(new NumericDocValuesField(fieldNameDate, longValue));
+            doc.add(new LongPoint(fieldNameDate, dateValue));
+            doc.add(new NumericDocValuesField(fieldNameDate, dateValue));
             writer.addDocument(doc);
-            if (i % 3500 == 0) writer.commit();
+            longValue++;
+            dateValue++;
+            if (i % 3500 == 0) writer.flush();
         }
         writer.close();
+
         final IndexReader reader = DirectoryReader.open(dir);
 
-        TestSearchContext searchContext = spy(new TestSearchContext(
-            searchExecutionContext, indexShard, newOptimizedContextSearcher(reader, 0, true)));
-
-        // 1. Test a sort on long field
         final SortField sortFieldLong = new SortField(fieldNameLong, SortField.Type.LONG);
-        sortFieldLong.setMissingValue(Long.MAX_VALUE);
-        final Sort longSort = new Sort(sortFieldLong);
-        SortAndFormats sortAndFormats = new SortAndFormats(longSort, new DocValueFormat[]{DocValueFormat.RAW});
-        searchContext.sort(sortAndFormats);
-        searchContext.parsedQuery(new ParsedQuery(new MatchAllDocsQuery()));
-        searchContext.setTask(new SearchShardTask(123L, "", "", "", null, Collections.emptyMap()));
-        searchContext.setSize(10);
-        QueryPhase.executeInternal(searchContext);
-        assertSortResults(searchContext.queryResult().topDocs().topDocs, (long) numDocs, false);
-
-        // 2. Test a sort on long field + date field
         final SortField sortFieldDate = new SortField(fieldNameDate, SortField.Type.LONG);
-        DocValueFormat dateFormat = fieldTypeDate.docValueFormat(null, null);
-        final Sort longDateSort = new Sort(sortFieldLong, sortFieldDate);
-        sortAndFormats = new SortAndFormats(longDateSort, new DocValueFormat[]{DocValueFormat.RAW, dateFormat});
-        searchContext.sort(sortAndFormats);
-        QueryPhase.executeInternal(searchContext);
-        assertSortResults(searchContext.queryResult().topDocs().topDocs, (long) numDocs, true);
-
-        // 3. Test a sort on date field
+        sortFieldLong.setMissingValue(Long.MAX_VALUE);
         sortFieldDate.setMissingValue(Long.MAX_VALUE);
-        final Sort dateSort = new Sort(sortFieldDate);
-        sortAndFormats = new SortAndFormats(dateSort, new DocValueFormat[]{dateFormat});
-        searchContext.sort(sortAndFormats);
-        QueryPhase.executeInternal(searchContext);
-        assertSortResults(searchContext.queryResult().topDocs().topDocs, (long) numDocs, false);
+        final Sort sortLong = new Sort(sortFieldLong);
+        final Sort sortDate = new Sort(sortFieldDate);
+        final Sort sortLongDate = new Sort(sortFieldLong, sortFieldDate);
+        final Sort sortDateLong = new Sort(sortFieldDate, sortFieldLong);
+        final DocValueFormat dvFormatDate = fieldTypeDate.docValueFormat(null, null);
+        final SortAndFormats formatsLong = new SortAndFormats(sortLong, new DocValueFormat[]{DocValueFormat.RAW});
+        final SortAndFormats formatsDate = new SortAndFormats(sortDate, new DocValueFormat[]{dvFormatDate});
+        final SortAndFormats formatsLongDate = new SortAndFormats(sortLongDate, new DocValueFormat[]{DocValueFormat.RAW, dvFormatDate});
+        final SortAndFormats formatsDateLong = new SortAndFormats(sortDateLong, new DocValueFormat[]{dvFormatDate, DocValueFormat.RAW});
 
-        // 4. Test a sort on date field + long field
-        final Sort dateLongSort = new Sort(sortFieldDate, sortFieldLong);
-        sortAndFormats = new SortAndFormats(dateLongSort, new DocValueFormat[]{dateFormat, DocValueFormat.RAW});
-        searchContext.sort(sortAndFormats);
-        QueryPhase.executeInternal(searchContext);
-        assertSortResults(searchContext.queryResult().topDocs().topDocs, (long) numDocs, true);
+        Query q = LongPoint.newRangeQuery(fieldNameLong, startLongValue, startLongValue + numDocs);
+        final ParsedQuery query = new ParsedQuery(q);
+        final SearchShardTask task = new SearchShardTask(123L, "", "", "", null, Collections.emptyMap());
 
-        // 5. Test that sort optimization is run when from > 0 and size = 0
+        // 1. Test sort optimization on long field
         {
-            sortAndFormats = new SortAndFormats(longSort, new DocValueFormat[]{DocValueFormat.RAW});
-            searchContext.sort(sortAndFormats);
+            TestSearchContext searchContext = new TestSearchContext(
+                searchExecutionContext, indexShard, newContextSearcher(reader));
+            searchContext.sort(formatsLong);
+            searchContext.parsedQuery(query);
+            searchContext.setTask(task);
+            searchContext.trackTotalHitsUpTo(10);
+            searchContext.setSize(10);
+            QueryPhase.executeInternal(searchContext);
+            assertTrue(searchContext.sort().sort.getSort()[0].getCanUsePoints());
+            assertSortResults(searchContext.queryResult().topDocs().topDocs, numDocs, false);
+        }
+
+        // 2. Test sort optimization on long field with after
+        {
+            TestSearchContext searchContext = new TestSearchContext(
+                searchExecutionContext, indexShard, newContextSearcher(reader));
+            int afterDoc = (int) randomLongBetween(0, 30);
+            long afterValue = startLongValue + afterDoc;
+            FieldDoc after = new FieldDoc(afterDoc, Float.NaN, new Long[] {afterValue});
+            searchContext.searchAfter(after);
+            searchContext.sort(formatsLong);
+            searchContext.parsedQuery(query);
+            searchContext.setTask(task);
+            searchContext.trackTotalHitsUpTo(10);
+            searchContext.setSize(10);
+            QueryPhase.executeInternal(searchContext);
+            assertTrue(searchContext.sort().sort.getSort()[0].getCanUsePoints());
+            final TopDocs topDocs = searchContext.queryResult().topDocs().topDocs;
+            long firstResult = (long) ((FieldDoc) topDocs.scoreDocs[0]).fields[0];
+            assertThat(firstResult, greaterThan(afterValue));
+            assertSortResults(topDocs, numDocs, false);
+        }
+
+        // 3. Test sort optimization on long field + date field
+        {
+            TestSearchContext searchContext = new TestSearchContext(
+                searchExecutionContext, indexShard, newContextSearcher(reader));
+            searchContext.sort(formatsLongDate);
+            searchContext.parsedQuery(query);
+            searchContext.setTask(task);
+            searchContext.trackTotalHitsUpTo(10);
+            searchContext.setSize(10);
+            QueryPhase.executeInternal(searchContext);
+            assertTrue(searchContext.sort().sort.getSort()[0].getCanUsePoints());
+            assertSortResults(searchContext.queryResult().topDocs().topDocs, numDocs, true);
+        }
+
+        // 4. Test sort optimization on date field
+        {
+            TestSearchContext searchContext = new TestSearchContext(
+                searchExecutionContext, indexShard, newContextSearcher(reader));
+            searchContext.sort(formatsDate);
+            searchContext.parsedQuery(query);
+            searchContext.setTask(task);
+            searchContext.trackTotalHitsUpTo(10);
+            searchContext.setSize(10);
+            QueryPhase.executeInternal(searchContext);
+            assertTrue(searchContext.sort().sort.getSort()[0].getCanUsePoints());
+            assertSortResults(searchContext.queryResult().topDocs().topDocs, numDocs, false);
+        }
+
+        // 5. Test sort optimization on date field + long field
+        {
+            TestSearchContext searchContext = new TestSearchContext(
+                searchExecutionContext, indexShard, newContextSearcher(reader));
+            searchContext.sort(formatsDateLong);
+            searchContext.parsedQuery(query);
+            searchContext.setTask(task);
+            searchContext.trackTotalHitsUpTo(10);
+            searchContext.setSize(10);
+            QueryPhase.executeInternal(searchContext);
+            assertTrue(searchContext.sort().sort.getSort()[0].getCanUsePoints());
+            assertSortResults(searchContext.queryResult().topDocs().topDocs, (long) numDocs, true);
+        }
+
+        // 6. Test sort optimization on when from > 0 and size = 0
+        {
+            TestSearchContext searchContext = new TestSearchContext(
+                searchExecutionContext, indexShard, newContextSearcher(reader));
+            searchContext.sort(formatsLong);
+            searchContext.parsedQuery(query);
+            searchContext.setTask(task);
+            searchContext.trackTotalHitsUpTo(10);
             searchContext.from(5);
             searchContext.setSize(0);
             QueryPhase.executeInternal(searchContext);
+            assertTrue(searchContext.sort().sort.getSort()[0].getCanUsePoints());
             assertSortResults(searchContext.queryResult().topDocs().topDocs, (long) numDocs, false);
         }
 
-        // 6. Test that sort optimization is NOT run with from = 0 and size= 0
+        // 7. Test that sort optimization doesn't break a case where from = 0 and size= 0
         {
-            sortAndFormats = new SortAndFormats(longSort, new DocValueFormat[]{DocValueFormat.RAW});
-            searchContext = spy(new TestSearchContext(null, indexShard, newContextSearcher(reader)));
-            searchContext.sort(sortAndFormats);
-            searchContext.parsedQuery(new ParsedQuery(new MatchAllDocsQuery()));
-            searchContext.setTask(new SearchShardTask(123L, "", "", "", null, Collections.emptyMap()));
+            TestSearchContext searchContext = new TestSearchContext(
+                searchExecutionContext, indexShard, newContextSearcher(reader));
+            searchContext.sort(formatsLong);
+            searchContext.parsedQuery(query);
+            searchContext.setTask(task);
             searchContext.setSize(0);
-
             QueryPhase.executeInternal(searchContext);
-            TotalHits totalHits = searchContext.queryResult().topDocs().topDocs.totalHits;
-            assertEquals(TotalHits.Relation.EQUAL_TO, totalHits.relation);
-            assertEquals(numDocs, totalHits.value);
-        }
-
-        {
-            // 7. Test a sort with terminate after
-            sortAndFormats = new SortAndFormats(dateSort, new DocValueFormat[]{dateFormat});
-            TestSearchContext newSearchContext = spy(new TestSearchContext(
-                searchExecutionContext, indexShard, newOptimizedContextSearcher(reader, 0, true)));
-            newSearchContext.sort(sortAndFormats);
-            newSearchContext.parsedQuery(new ParsedQuery(new MatchAllDocsQuery()));
-            newSearchContext.setTask(new SearchShardTask(123L, "", "", "", null, Collections.emptyMap()));
-            newSearchContext.setSize(10);
-            int terminateAfter = randomIntBetween(1, numDocs/2);
-            newSearchContext.terminateAfter(terminateAfter);
-            QueryPhase.executeInternal(newSearchContext);
-            assertSortResults(newSearchContext.queryResult().topDocs().topDocs, terminateAfter, false);
-            assertTrue(newSearchContext.queryResult().terminatedEarly());
-        }
-
-        {
-            // 8. Test a sort with timeout
-            sortAndFormats = new SortAndFormats(dateSort, new DocValueFormat[]{dateFormat});
-            TestSearchContext newSearchContext = spy(new TestSearchContext(
-                searchExecutionContext, indexShard, newOptimizedContextSearcher(reader, 0, false)));
-            newSearchContext.sort(sortAndFormats);
-            newSearchContext.parsedQuery(new ParsedQuery(new MatchAllDocsQuery()));
-            newSearchContext.setTask(new SearchShardTask(123L, "", "", "", null, Collections.emptyMap()));
-            newSearchContext.setSize(10);
-            newSearchContext.searcher().addQueryCancellation(() -> { throw new QueryPhase.TimeExceededException(); });
-            QueryPhase.executeInternal(newSearchContext);
-            assertSortResults(newSearchContext.queryResult().topDocs().topDocs, 0, false);
-            assertTrue(newSearchContext.queryResult().searchTimedOut());
         }
 
         reader.close();
         dir.close();
-    }
-
-    public void testIndexHasDuplicateData() throws IOException {
-        int docsCount = 5000;
-        int maxPointsInLeafNode = 40;
-        float duplicateRatio = 0.7f;
-        long duplicateValue = randomLongBetween(-10000000L, 10000000L);
-        BKDConfig config = new BKDConfig(1, 1, 8, maxPointsInLeafNode);
-        try (Directory dir = newDirectory()) {
-            BKDWriter w = new BKDWriter(docsCount, dir, "tmp", config, 1, docsCount);
-            byte[] longBytes = new byte[8];
-            for (int docId = 0; docId < docsCount; docId++) {
-                long value = randomFloat() < duplicateRatio ? duplicateValue : randomLongBetween(-10000000L, 10000000L);
-                LongPoint.encodeDimension(value, longBytes, 0);
-                w.add(longBytes, docId);
-            }
-            try (IndexOutput metaout = dir.createOutput("bkdmeta", IOContext.DEFAULT);
-                 IndexOutput indexout = dir.createOutput("bkdindex", IOContext.DEFAULT);
-                 IndexOutput dataout = dir.createOutput("bkddata", IOContext.DEFAULT)) {
-                w.finish(metaout, indexout, dataout).run();
-            }
-            try (IndexInput metain = dir.openInput("bkdmeta", IOContext.DEFAULT);
-                 IndexInput indexin = dir.openInput("bkdindex", IOContext.DEFAULT);
-                 IndexInput datain = dir.openInput("bkddata", IOContext.DEFAULT)) {
-                BKDReader r = new BKDReader(metain, indexin, datain);
-                assertTrue(pointsHaveDuplicateData(r, r.getDocCount() / 2));
-            }
-        }
-    }
-
-    public void testIndexHasNoDuplicateData() throws IOException {
-        int docsCount = 5000;
-        int maxPointsInLeafNode = 40;
-        float duplicateRatio = 0.3f;
-        long duplicateValue = randomLongBetween(-10000000L, 10000000L);
-        BKDConfig config = new BKDConfig(1, 1, 8, maxPointsInLeafNode);
-        try (Directory dir = newDirectory()) {
-            BKDWriter w = new BKDWriter(docsCount, dir, "tmp", config, 1, docsCount);
-            byte[] longBytes = new byte[8];
-            for (int docId = 0; docId < docsCount; docId++) {
-                long value = randomFloat() < duplicateRatio ? duplicateValue : randomLongBetween(-10000000L, 10000000L);
-                LongPoint.encodeDimension(value, longBytes, 0);
-                w.add(longBytes, docId);
-            }
-            long indexFP;
-            try (IndexOutput out = dir.createOutput("bkd", IOContext.DEFAULT)) {
-                Runnable finalizer = w.finish(out, out, out);
-                indexFP = out.getFilePointer();
-                finalizer.run();;
-            }
-            try (IndexInput in = dir.openInput("bkd", IOContext.DEFAULT)) {
-                in.seek(indexFP);
-                BKDReader r = new BKDReader(in, in, in);
-                assertFalse(pointsHaveDuplicateData(r, r.getDocCount() / 2));
-            }
-        }
     }
 
     public void testMaxScoreQueryVisitor() {
@@ -902,22 +870,19 @@ public class QueryPhaseTests extends IndexShardTestCase {
     }
 
     // assert score docs are in order and their number is as expected
-    private void assertSortResults(TopDocs topDocs, long expectedNumDocs, boolean isDoubleSort) {
-        if (topDocs.totalHits.relation == TotalHits.Relation.GREATER_THAN_OR_EQUAL_TO) {
-            assertThat(topDocs.totalHits.value, lessThanOrEqualTo(expectedNumDocs));
-        } else {
-            assertEquals(topDocs.totalHits.value, expectedNumDocs);
-        }
+    private void assertSortResults(TopDocs topDocs, long totalNumDocs, boolean isDoubleSort) {
+        assertEquals(TotalHits.Relation.GREATER_THAN_OR_EQUAL_TO, topDocs.totalHits.relation);
+        assertThat(topDocs.totalHits.value, lessThan(totalNumDocs)); // we collected less docs than total number
         long cur1, cur2;
         long prev1 = Long.MIN_VALUE;
         long prev2 = Long.MIN_VALUE;
         for (ScoreDoc scoreDoc : topDocs.scoreDocs) {
             cur1 = (long) ((FieldDoc) scoreDoc).fields[0];
-            assertThat(cur1, greaterThanOrEqualTo(prev1)); // test that docs are properly sorted on the first sort
+            assertThat(cur1, greaterThan(prev1)); // test that docs are properly sorted on the first sort
             if (isDoubleSort) {
                 cur2 = (long) ((FieldDoc) scoreDoc).fields[1];
                 if (cur1 == prev1) {
-                    assertThat(cur2, greaterThanOrEqualTo(prev2)); // test that docs are properly sorted on the secondary sort
+                    assertThat(cur2, greaterThan(prev2)); // test that docs are properly sorted on the secondary sort
                 }
                 prev2 = cur2;
             }
@@ -1023,32 +988,6 @@ public class QueryPhaseTests extends IndexShardTestCase {
             public void search(List<LeafReaderContext> leaves, Weight weight, Collector collector) throws IOException {
                 final Collector in = new AssertingEarlyTerminationFilterCollector(collector, size);
                 super.search(leaves, weight, in);
-            }
-        };
-    }
-
-    // used to check that numeric long or date sort optimization was run
-    private static ContextIndexSearcher newOptimizedContextSearcher(IndexReader reader,
-                                                                    int queryType,
-                                                                    boolean wrapExitable) throws IOException {
-        return new ContextIndexSearcher(reader, IndexSearcher.getDefaultSimilarity(),
-            IndexSearcher.getDefaultQueryCache(), IndexSearcher.getDefaultQueryCachingPolicy(), wrapExitable) {
-
-            @Override
-            public void search(List<LeafReaderContext> ctx, Weight weight, Collector collector) throws IOException {
-                final Query query = weight.getQuery();
-                assertTrue(query instanceof BooleanQuery);
-                List<BooleanClause> clauses = ((BooleanQuery) query).clauses();
-                assertTrue(clauses.size() == 2);
-                assertTrue(clauses.get(0).getOccur() == Occur.FILTER);
-                assertTrue(clauses.get(1).getOccur() == Occur.SHOULD);
-                if (queryType == 0) {
-                    assertTrue(clauses.get(1).getQuery().getClass() ==
-                        LongPoint.newDistanceFeatureQuery("random_field", 1, 1, 1).getClass()
-                    );
-                }
-                if (queryType == 1) assertTrue(clauses.get(1).getQuery() instanceof DocValuesFieldExistsQuery);
-                super.search(ctx, weight, collector);
             }
         };
     }

--- a/server/src/test/java/org/elasticsearch/search/query/QueryPhaseTests.java
+++ b/server/src/test/java/org/elasticsearch/search/query/QueryPhaseTests.java
@@ -92,7 +92,6 @@ import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.lessThan;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-import static org.mockito.Mockito.spy;
 
 public class QueryPhaseTests extends IndexShardTestCase {
 

--- a/test/framework/src/main/java/org/elasticsearch/test/TestSearchContext.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/TestSearchContext.java
@@ -78,6 +78,7 @@ public class TestSearchContext extends SearchContext {
     private int terminateAfter = DEFAULT_TERMINATE_AFTER;
     private SearchContextAggregations aggregations;
     private ScrollContext scrollContext;
+    private FieldDoc searchAfter;
     private final ShardSearchRequest request;
 
     private final Map<String, SearchExtBuilder> searchExtBuilders = new HashMap<>();
@@ -337,12 +338,13 @@ public class TestSearchContext extends SearchContext {
 
     @Override
     public SearchContext searchAfter(FieldDoc searchAfter) {
-        return null;
+        this.searchAfter = searchAfter;
+        return this;
     }
 
     @Override
     public FieldDoc searchAfter() {
-        return null;
+        return searchAfter;
     }
 
     @Override


### PR DESCRIPTION
Lucene 8.7 introduces numeric sort optimization directly in comparators.
This means we don't need to have it in ES.
This removes the sort optimization code in ES, and
the only thing that is needed is setCanUsePoints on sortField.

This also will introduce sort optimization with search_after,
as Lucene directly supports sort optimization with search_after.

As previously, we enable sort optimization only when there is 
Long sort on Long or Date fields.

There could be a regression on desc sort, for example on 
@timestamp desc field. In this case, we suggest to 
convert these indices to data stream indices, as 
datatastream indices have their desc sort on 
@timestamp field optimized

Backport for #64292