### PR TITLE
Add ignoreFailure in SearchRequestBuilder#addScriptField

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/search/SearchRequestBuilder.java
+++ b/server/src/main/java/org/elasticsearch/action/search/SearchRequestBuilder.java
@@ -336,6 +336,20 @@ public class SearchRequestBuilder extends ActionRequestBuilder<SearchRequest, Se
     }
 
     /**
+     * Adds a script based field to load and return. The field does not have to be stored,
+     * but its recommended to use non analyzed or numeric fields.
+     *
+     * @param name   The name that will represent this value in the return hit
+     * @param script The script to use
+     * @param ignoreFailure If during runtime we should ignore script failures.
+     *
+     */
+    public SearchRequestBuilder addScriptField(String name, Script script, boolean ignoreFailure) {
+        sourceBuilder().scriptField(name, script, ignoreFailure);
+        return this;
+    }
+
+    /**
      * Adds a sort against the given field name and the sort ordering.
      *
      * @param field The name of the field


### PR DESCRIPTION
It is currently not possible to add a scripted field with ignoreFailure set to true using the SearchRequestBuilder. This commit adds this possibility by adding the methods #addScriptField(String name, Script script, boolean ignoreFailure).