### PR TITLE
[DOCS] Fix typo in setting custom attributes when starting a node

### DIFF
--- a/docs/reference/modules/cluster/allocation_awareness.asciidoc
+++ b/docs/reference/modules/cluster/allocation_awareness.asciidoc
@@ -45,7 +45,7 @@ You can also set custom attributes when you start a node:
 +
 [source,sh]
 --------------------------------------------------------
-`./bin/elasticsearch -Enode.attr.rack_id=rack_one`
+./bin/elasticsearch -Enode.attr.rack_id=rack_one
 --------------------------------------------------------
 
 . Tell {es} to take one or more awareness attributes into account when


### PR DESCRIPTION
remove excess "`" in the cmdline:

Before:
```
`./bin/elasticsearch -Enode.attr.rack_id=rack_one`
```

After:
```
./bin/elasticsearch -Enode.attr.rack_id=rack_one
```


