### PR TITLE
[7.x] Remove invalid path from Open PIT rest spec (#77609)

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/open_point_in_time.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/open_point_in_time.json
@@ -12,12 +12,6 @@
     "url":{
       "paths":[
         {
-          "path":"/_pit",
-          "methods":[
-            "POST"
-          ]
-        },
-        {
           "path":"/{index}/_pit",
           "methods":[
             "POST"


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Remove invalid path from Open PIT rest spec (#77609)