### PR TITLE
[7.x] [DOCS] Fix typo in setting custom attributes when starting a node (#77617)

### DIFF
--- a/docs/reference/modules/cluster/allocation_awareness.asciidoc
+++ b/docs/reference/modules/cluster/allocation_awareness.asciidoc
@@ -45,7 +45,7 @@ You can also set custom attributes when you start a node:
 +
 [source,sh]
 --------------------------------------------------------
-`./bin/elasticsearch -Enode.attr.rack_id=rack_one`
+./bin/elasticsearch -Enode.attr.rack_id=rack_one
 --------------------------------------------------------
 
 . Tell {es} to take one or more awareness attributes into account when


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [DOCS] Fix typo in setting custom attributes when starting a node (#77617)