### PR TITLE
Use epoch_millis in can_match date range tests (#77464)

### DIFF
--- a/server/src/test/java/org/elasticsearch/action/search/CanMatchPreFilterSearchPhaseTests.java
+++ b/server/src/test/java/org/elasticsearch/action/search/CanMatchPreFilterSearchPhaseTests.java
@@ -451,7 +451,7 @@ public class CanMatchPreFilterSearchPhaseTests extends ESTestCase {
         List<Index> regularIndices =
             randomList(0, 2, () -> new Index(randomAlphaOfLength(10), UUIDs.base64UUID()));
 
-        long indexMinTimestamp = randomLongBetween(0, 5000);
+        long indexMinTimestamp = randomLongBetween(1000, 5000);
         long indexMaxTimestamp = randomLongBetween(indexMinTimestamp, 5000 * 2);
         StaticCoordinatorRewriteContextProviderBuilder contextProviderBuilder = new StaticCoordinatorRewriteContextProviderBuilder();
         String timestampFieldName = dataStream.getTimeStampField().getName();
@@ -463,7 +463,8 @@ public class CanMatchPreFilterSearchPhaseTests extends ESTestCase {
         // We query a range outside of the timestamp range covered by both datastream indices
         rangeQueryBuilder
             .from(indexMaxTimestamp + 1)
-            .to(indexMaxTimestamp + 2);
+            .to(indexMaxTimestamp + 2)
+            .format("epoch_millis");
 
         BoolQueryBuilder queryBuilder = new BoolQueryBuilder()
             .filter(rangeQueryBuilder);
@@ -519,7 +520,7 @@ public class CanMatchPreFilterSearchPhaseTests extends ESTestCase {
         List<Index> regularIndices =
             randomList(0, 2, () -> new Index(randomAlphaOfLength(10), UUIDs.base64UUID()));
 
-        long indexMinTimestamp = randomLongBetween(0, 5000);
+        long indexMinTimestamp = randomLongBetween(1000, 5000);
         long indexMaxTimestamp = randomLongBetween(indexMinTimestamp, 5000 * 2);
         StaticCoordinatorRewriteContextProviderBuilder contextProviderBuilder = new StaticCoordinatorRewriteContextProviderBuilder();
         String timestampFieldName = dataStream.getTimeStampField().getName();
@@ -577,7 +578,8 @@ public class CanMatchPreFilterSearchPhaseTests extends ESTestCase {
             // We query a range within the timestamp range covered by both datastream indices
             rangeQueryBuilder
                 .from(indexMinTimestamp)
-                .to(indexMaxTimestamp);
+                .to(indexMaxTimestamp)
+                .format("epoch_millis");
 
             queryBuilder.filter(rangeQueryBuilder);
 
@@ -590,7 +592,8 @@ public class CanMatchPreFilterSearchPhaseTests extends ESTestCase {
             // We query a range outside of the timestamp range covered by both datastream indices
             RangeQueryBuilder rangeQueryBuilder = new RangeQueryBuilder(timestampFieldName)
                 .from(indexMaxTimestamp + 1)
-                .to(indexMaxTimestamp + 2);
+                .to(indexMaxTimestamp + 2)
+                .format("epoch_millis");
 
             TermQueryBuilder termQueryBuilder = new TermQueryBuilder("fake", "value");
 


### PR DESCRIPTION
There is a known issue in 7.x where a date parameter of a range query 
can be interpreted as the number of years if no format is provided.
This commit always uses epoch_millis format to avoid this issue in
CanMatchPreFilterSearchPhaseTests.

Relates #63692
Closes #77122