### PR TITLE
Disable bwc tests before backporting #77633

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -140,9 +140,9 @@ tasks.register("verifyVersions") {
  * after the backport of the backcompat code is complete.
  */
 
-boolean bwc_tests_enabled = true
+boolean bwc_tests_enabled = false
 // place a PR link here when committing bwc changes:
-String bwc_tests_disabled_issue = ""
+String bwc_tests_disabled_issue = "https://github.com/elastic/elasticsearch/pull/77633"
 /*
  * FIPS 140-2 behavior was fixed in 7.11.0. Before that there is no way to run elasticsearch in a
  * JVM that is properly configured to be in fips mode with BCFIPS. For now we need to disable

--- a/docs/reference/search/profile.asciidoc
+++ b/docs/reference/search/profile.asciidoc
@@ -17,8 +17,8 @@ The Profile API gives the user insight into how search requests are executed at
 a low level so that the user can understand why certain requests are slow, and 
 take steps to improve them. Note that the Profile API, 
 <<profile-limitations, amongst other things>>, doesn't measure network latency, 
-time spent in the search fetch phase, time spent while the requests spends in 
-queues or while merging shard responses on the coordinating node.
+time spent while the requests spends in queues, or while merging shard
+responses on the coordinating node.
 
 The output from the Profile API is *very* verbose, especially for complicated 
 requests executed across many shards. Pretty-printing the response is 


### PR DESCRIPTION
We make wire changes in #77633 so we need to disable the backwards
compatibility tests in master before merging the wire changes. We'll
re-enable them after the backport is merged.
