### PR TITLE
Adjust versions after backporting 76740 to 7.x

### DIFF
--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.aggregation/230_composite.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.aggregation/230_composite.yml
@@ -1305,8 +1305,7 @@ setup:
 ---
 "Simple Composite aggregation with missing_order":
   - skip:
-      # TODO: replace with 7.15.99 once PR is backported to 7.16
-      version: " - 7.99.0"
+      version: " - 7.15.99"
       reason: "`missing_order` has been introduced in 7.16"
   - do:
       search:
@@ -1333,8 +1332,7 @@ setup:
 ---
 "missing_order with missing_bucket = false":
   - skip:
-      # TODO: replace with 7.15.99 once PR is backported to 7.16
-      version: " - 7.99.0"
+      version: " - 7.15.99"
       reason: "`missing_order` has been introduced in 7.16"
   - do:
       catch: /missingOrder can only be set if missingBucket is true/
@@ -1358,8 +1356,7 @@ setup:
 ---
 "missing_order without missing_bucket":
   - skip:
-      # TODO: replace with 7.15.99 once PR is backported to 7.16
-      version: " - 7.99.0"
+      version: " - 7.15.99"
       reason: "`missing_order` has been introduced in 7.16"
   - do:
       catch: /missingOrder can only be set if missingBucket is true/
@@ -1382,8 +1379,7 @@ setup:
 ---
 "Nested Composite aggregation with missing_order":
   - skip:
-      # TODO: replace with 7.15.99 once PR is backported to 7.16
-      version: " - 7.99.0"
+      version: " - 7.15.99"
       reason: "`missing_order` has been introduced in 7.16"
   - do:
       search:

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/composite/CompositeValuesSourceBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/composite/CompositeValuesSourceBuilder.java
@@ -55,8 +55,7 @@ public abstract class CompositeValuesSourceBuilder<AB extends CompositeValuesSou
             this.userValueTypeHint = ValueType.readFromStream(in);
         }
         this.missingBucket = in.readBoolean();
-        // TODO: use V_7_16_0 once PR is backported to 7.x
-        if (in.getVersion().onOrAfter(Version.V_8_0_0)) {
+        if (in.getVersion().onOrAfter(Version.V_7_16_0)) {
             this.missingOrder = MissingOrder.readFromStream(in);
         }
         this.order = SortOrder.readFromStream(in);
@@ -78,8 +77,7 @@ public abstract class CompositeValuesSourceBuilder<AB extends CompositeValuesSou
             userValueTypeHint.writeTo(out);
         }
         out.writeBoolean(missingBucket);
-        // TODO: use V_7_16_0 once PR is backported to 7.x
-        if (out.getVersion().onOrAfter(Version.V_8_0_0)) {
+        if (out.getVersion().onOrAfter(Version.V_7_16_0)) {
             missingOrder.writeTo(out);
         }
         order.writeTo(out);


### PR DESCRIPTION
`missing_order` (see #76740) is now available in 7.x (#77620).