### PR TITLE
Add a script.field package for fields api specific classes

### DIFF
--- a/modules/lang-painless/src/main/resources/org/elasticsearch/painless/org.elasticsearch.script.fields.txt
+++ b/modules/lang-painless/src/main/resources/org/elasticsearch/painless/org.elasticsearch.script.fields.txt
@@ -9,21 +9,21 @@
 # The whitelist for the fields api
 
 # API
-class org.elasticsearch.script.Field {
-  org.elasticsearch.script.Converter BigInteger
-  org.elasticsearch.script.Converter Long
+class org.elasticsearch.script.field.Field {
+  org.elasticsearch.script.field.Converter BigInteger
+  org.elasticsearch.script.field.Converter Long
   String getName()
   boolean isEmpty()
   List getValues()
   def getValue(def)
   double getDouble(double)
   long getLong(long)
-  org.elasticsearch.script.Field as(org.elasticsearch.script.Converter)
+  org.elasticsearch.script.field.Field as(org.elasticsearch.script.field.Converter)
 }
 
-class org.elasticsearch.script.Converter {
+class org.elasticsearch.script.field.Converter {
 }
 
 class org.elasticsearch.script.DocBasedScript {
-    org.elasticsearch.script.Field field(String)
+    org.elasticsearch.script.field.Field field(String)
 }

--- a/server/src/main/java/org/elasticsearch/index/fielddata/ScriptDocValues.java
+++ b/server/src/main/java/org/elasticsearch/index/fielddata/ScriptDocValues.java
@@ -17,10 +17,10 @@ import org.elasticsearch.common.geo.GeoPoint;
 import org.elasticsearch.common.geo.GeoUtils;
 import org.elasticsearch.common.time.DateUtils;
 import org.elasticsearch.geometry.utils.Geohash;
-import org.elasticsearch.script.Converters;
-import org.elasticsearch.script.Field;
-import org.elasticsearch.script.FieldValues;
-import org.elasticsearch.script.InvalidConversion;
+import org.elasticsearch.script.field.Converters;
+import org.elasticsearch.script.field.Field;
+import org.elasticsearch.script.field.FieldValues;
+import org.elasticsearch.script.field.InvalidConversion;
 import org.elasticsearch.script.JodaCompatibleZonedDateTime;
 
 import java.io.IOException;

--- a/server/src/main/java/org/elasticsearch/index/mapper/IpFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/IpFieldMapper.java
@@ -357,8 +357,8 @@ public class IpFieldMapper extends FieldMapper {
             }
 
             @Override
-            public org.elasticsearch.script.Field<String> toField(String fieldName) {
-                return new org.elasticsearch.script.Field.IpField(fieldName, this);
+            public org.elasticsearch.script.field.Field<String> toField(String fieldName) {
+                return new org.elasticsearch.script.field.Field.IpField(fieldName, this);
             }
         }
 

--- a/server/src/main/java/org/elasticsearch/script/DocBasedScript.java
+++ b/server/src/main/java/org/elasticsearch/script/DocBasedScript.java
@@ -9,6 +9,8 @@
 package org.elasticsearch.script;
 
 import org.elasticsearch.index.fielddata.ScriptDocValues;
+import org.elasticsearch.script.field.EmptyField;
+import org.elasticsearch.script.field.Field;
 
 import java.util.Collections;
 import java.util.Map;

--- a/server/src/main/java/org/elasticsearch/script/DocReader.java
+++ b/server/src/main/java/org/elasticsearch/script/DocReader.java
@@ -9,6 +9,7 @@
 package org.elasticsearch.script;
 
 import org.elasticsearch.index.fielddata.ScriptDocValues;
+import org.elasticsearch.script.field.Field;
 
 import java.util.Map;
 import java.util.stream.Stream;

--- a/server/src/main/java/org/elasticsearch/script/DocValuesDocReader.java
+++ b/server/src/main/java/org/elasticsearch/script/DocValuesDocReader.java
@@ -10,6 +10,8 @@ package org.elasticsearch.script;
 
 import org.apache.lucene.index.LeafReaderContext;
 import org.elasticsearch.index.fielddata.ScriptDocValues;
+import org.elasticsearch.script.field.EmptyField;
+import org.elasticsearch.script.field.Field;
 import org.elasticsearch.search.lookup.LeafSearchLookup;
 import org.elasticsearch.search.lookup.SearchLookup;
 

--- a/server/src/main/java/org/elasticsearch/script/field/Converter.java
+++ b/server/src/main/java/org/elasticsearch/script/field/Converter.java
@@ -6,7 +6,7 @@
  * Side Public License, v 1.
  */
 
-package org.elasticsearch.script;
+package org.elasticsearch.script.field;
 
 /**
  * Converts between one scripting {@link Field} type and another, {@code FC}, with a different underlying

--- a/server/src/main/java/org/elasticsearch/script/field/Converters.java
+++ b/server/src/main/java/org/elasticsearch/script/field/Converters.java
@@ -6,23 +6,24 @@
  * Side Public License, v 1.
  */
 
-package org.elasticsearch.script;
+package org.elasticsearch.script.field;
+
+import org.elasticsearch.script.JodaCompatibleZonedDateTime;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
-
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import static org.elasticsearch.script.Field.BigIntegerField;
-import static org.elasticsearch.script.Field.BooleanField;
-import static org.elasticsearch.script.Field.DoubleField;
-import static org.elasticsearch.script.Field.DateMillisField;
-import static org.elasticsearch.script.Field.DateNanosField;
-import static org.elasticsearch.script.Field.LongField;
-import static org.elasticsearch.script.Field.StringField;
+import static org.elasticsearch.script.field.Field.BigIntegerField;
+import static org.elasticsearch.script.field.Field.BooleanField;
+import static org.elasticsearch.script.field.Field.DateMillisField;
+import static org.elasticsearch.script.field.Field.DateNanosField;
+import static org.elasticsearch.script.field.Field.DoubleField;
+import static org.elasticsearch.script.field.Field.LongField;
+import static org.elasticsearch.script.field.Field.StringField;
 
 /**
  * {@link Converters} for scripting fields.  These constants are exposed as static fields on {@link Field} to

--- a/server/src/main/java/org/elasticsearch/script/field/EmptyField.java
+++ b/server/src/main/java/org/elasticsearch/script/field/EmptyField.java
@@ -6,7 +6,7 @@
  * Side Public License, v 1.
  */
 
-package org.elasticsearch.script;
+package org.elasticsearch.script.field;
 
 import java.util.Collections;
 import java.util.List;

--- a/server/src/main/java/org/elasticsearch/script/field/Field.java
+++ b/server/src/main/java/org/elasticsearch/script/field/Field.java
@@ -7,10 +7,11 @@
  */
 
 
-package org.elasticsearch.script;
+package org.elasticsearch.script.field;
 
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.geo.GeoPoint;
+import org.elasticsearch.script.JodaCompatibleZonedDateTime;
 
 import java.math.BigInteger;
 import java.util.List;

--- a/server/src/main/java/org/elasticsearch/script/field/FieldValues.java
+++ b/server/src/main/java/org/elasticsearch/script/field/FieldValues.java
@@ -6,7 +6,7 @@
  * Side Public License, v 1.
  */
 
-package org.elasticsearch.script;
+package org.elasticsearch.script.field;
 
 import java.util.List;
 

--- a/server/src/main/java/org/elasticsearch/script/field/InvalidConversion.java
+++ b/server/src/main/java/org/elasticsearch/script/field/InvalidConversion.java
@@ -6,7 +6,7 @@
  * Side Public License, v 1.
  */
 
-package org.elasticsearch.script;
+package org.elasticsearch.script.field;
 
 /**
  * A failed conversion of a script {@link Field}.  Thrown by {@link Converter}s and

--- a/server/src/test/java/org/elasticsearch/index/query/SearchExecutionContextTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/SearchExecutionContextTests.java
@@ -515,8 +515,8 @@ public class SearchExecutionContextTests extends ESTestCase {
                                     }
 
                                     @Override
-                                    public org.elasticsearch.script.Field<String> toField(String fieldName) {
-                                        return new org.elasticsearch.script.Field.StringField(fieldName, this);
+                                    public org.elasticsearch.script.field.Field<String> toField(String fieldName) {
+                                        return new org.elasticsearch.script.field.Field.StringField(fieldName, this);
                                     }
                                 };
                             }

--- a/server/src/test/java/org/elasticsearch/script/field/ConvertersTests.java
+++ b/server/src/test/java/org/elasticsearch/script/field/ConvertersTests.java
@@ -6,9 +6,10 @@
  * Side Public License, v 1.
  */
 
-package org.elasticsearch.script;
+package org.elasticsearch.script.field;
 
 import org.elasticsearch.common.geo.GeoPoint;
+import org.elasticsearch.script.JodaCompatibleZonedDateTime;
 import org.elasticsearch.test.ESTestCase;
 
 import java.math.BigInteger;

--- a/x-pack/plugin/mapper-unsigned-long/src/main/java/org/elasticsearch/xpack/unsignedlong/UnsignedLongField.java
+++ b/x-pack/plugin/mapper-unsigned-long/src/main/java/org/elasticsearch/xpack/unsignedlong/UnsignedLongField.java
@@ -7,11 +7,11 @@
 
 package org.elasticsearch.xpack.unsignedlong;
 
-import org.elasticsearch.script.Converter;
-import org.elasticsearch.script.Converters;
-import org.elasticsearch.script.Field;
-import org.elasticsearch.script.FieldValues;
-import org.elasticsearch.script.InvalidConversion;
+import org.elasticsearch.script.field.Converter;
+import org.elasticsearch.script.field.Converters;
+import org.elasticsearch.script.field.Field;
+import org.elasticsearch.script.field.FieldValues;
+import org.elasticsearch.script.field.InvalidConversion;
 
 import java.math.BigInteger;
 import java.util.List;

--- a/x-pack/plugin/mapper-unsigned-long/src/main/java/org/elasticsearch/xpack/unsignedlong/UnsignedLongScriptDocValues.java
+++ b/x-pack/plugin/mapper-unsigned-long/src/main/java/org/elasticsearch/xpack/unsignedlong/UnsignedLongScriptDocValues.java
@@ -10,7 +10,7 @@ package org.elasticsearch.xpack.unsignedlong;
 import org.apache.lucene.index.SortedNumericDocValues;
 import org.apache.lucene.util.ArrayUtil;
 import org.elasticsearch.index.fielddata.ScriptDocValues;
-import org.elasticsearch.script.Field;
+import org.elasticsearch.script.field.Field;
 
 import java.io.IOException;
 

--- a/x-pack/plugin/mapper-unsigned-long/src/main/resources/org/elasticsearch/xpack/unsignedlong/org.elasticsearch.xpack.unsignedlong.txt
+++ b/x-pack/plugin/mapper-unsigned-long/src/main/resources/org/elasticsearch/xpack/unsignedlong/org.elasticsearch.xpack.unsignedlong.txt
@@ -12,8 +12,8 @@ class org.elasticsearch.xpack.unsignedlong.UnsignedLongScriptDocValues {
 }
 
 
-class org.elasticsearch.script.Field {
-    org.elasticsearch.script.Converter UnsignedLong @augmented[augmented_canonical_class_name="org.elasticsearch.xpack.unsignedlong.UnsignedLongField"]
+class org.elasticsearch.script.field.Field {
+    org.elasticsearch.script.field.Converter UnsignedLong @augmented[augmented_canonical_class_name="org.elasticsearch.xpack.unsignedlong.UnsignedLongField"]
 }
 
 class org.elasticsearch.xpack.unsignedlong.UnsignedLongField @no_import {

--- a/x-pack/plugin/mapper-unsigned-long/src/test/java/org/elasticsearch/xpack/unsignedlong/UnsignedLongFieldTests.java
+++ b/x-pack/plugin/mapper-unsigned-long/src/test/java/org/elasticsearch/xpack/unsignedlong/UnsignedLongFieldTests.java
@@ -7,8 +7,8 @@
 
 package org.elasticsearch.xpack.unsignedlong;
 
-import org.elasticsearch.script.Field;
-import org.elasticsearch.script.FieldValues;
+import org.elasticsearch.script.field.Field;
+import org.elasticsearch.script.field.FieldValues;
 import org.elasticsearch.test.ESTestCase;
 
 import java.math.BigInteger;

--- a/x-pack/plugin/mapper-version/src/main/java/org/elasticsearch/xpack/versionfield/VersionScriptDocValues.java
+++ b/x-pack/plugin/mapper-version/src/main/java/org/elasticsearch/xpack/versionfield/VersionScriptDocValues.java
@@ -10,7 +10,7 @@ package org.elasticsearch.xpack.versionfield;
 import org.apache.lucene.index.SortedSetDocValues;
 import org.apache.lucene.util.ArrayUtil;
 import org.elasticsearch.index.fielddata.ScriptDocValues;
-import org.elasticsearch.script.Field;
+import org.elasticsearch.script.field.Field;
 
 import java.io.IOException;
 

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/fielddata/plain/AbstractAtomicGeoShapeShapeFieldData.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/fielddata/plain/AbstractAtomicGeoShapeShapeFieldData.java
@@ -12,8 +12,8 @@ import org.elasticsearch.common.geo.GeoBoundingBox;
 import org.elasticsearch.common.geo.GeoPoint;
 import org.elasticsearch.index.fielddata.ScriptDocValues;
 import org.elasticsearch.index.fielddata.SortedBinaryDocValues;
-import org.elasticsearch.script.Field;
-import org.elasticsearch.script.FieldValues;
+import org.elasticsearch.script.field.Field;
+import org.elasticsearch.script.field.FieldValues;
 import org.elasticsearch.xpack.spatial.index.fielddata.GeoShapeValues;
 import org.elasticsearch.xpack.spatial.index.fielddata.LeafGeoShapeFieldData;
 

--- a/x-pack/plugin/vectors/src/main/java/org/elasticsearch/xpack/vectors/query/DenseVectorScriptDocValues.java
+++ b/x-pack/plugin/vectors/src/main/java/org/elasticsearch/xpack/vectors/query/DenseVectorScriptDocValues.java
@@ -12,7 +12,7 @@ import org.apache.lucene.index.BinaryDocValues;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.Version;
 import org.elasticsearch.index.fielddata.ScriptDocValues;
-import org.elasticsearch.script.Field;
+import org.elasticsearch.script.field.Field;
 import org.elasticsearch.xpack.vectors.mapper.VectorEncoderDecoder;
 
 import java.io.IOException;


### PR DESCRIPTION
This adds a script.field package so that we can start to separate the different types of converters into their own class files without polluting the script package as we add more of them. This change is purely mechanical.