### PR TITLE
Make Settings.toXContent Much Faster (#77549)

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/Numbers.java
+++ b/server/src/main/java/org/elasticsearch/common/Numbers.java
@@ -189,4 +189,17 @@ public final class Numbers {
         }
         return (byte) l;
     }
+
+    /**
+     * Checks if the given string can be parsed as a positive integer value.
+     */
+    public static boolean isPositiveNumeric(String string) {
+        for (int i = 0; i < string.length(); ++i) {
+            final char c = string.charAt(i);
+            if (c < '0' || c > '9') {
+                return false;
+            }
+        }
+        return true;
+    }
 }

--- a/server/src/main/java/org/elasticsearch/common/settings/Settings.java
+++ b/server/src/main/java/org/elasticsearch/common/settings/Settings.java
@@ -13,6 +13,7 @@ import org.apache.lucene.util.SetOnce;
 import org.elasticsearch.ElasticsearchGenerationException;
 import org.elasticsearch.ElasticsearchParseException;
 import org.elasticsearch.Version;
+import org.elasticsearch.common.Numbers;
 import org.elasticsearch.core.Booleans;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -159,7 +160,10 @@ public final class Settings implements ToXContentFragment {
         for (Map.Entry<String, Object> entry : map.entrySet()) {
             if (isArray) {
                 try {
-                    int index = Integer.parseInt(entry.getKey());
+                    final String key = entry.getKey();
+                    // check whether string may be an integer first (mostly its not) to avoid the slowness of parseInt throwing in a hot
+                    // loop
+                    int index = Numbers.isPositiveNumeric(key) ? Integer.parseInt(key) : -1;
                     if (index >= 0) {
                         maxIndex = Math.max(maxIndex, index);
                     } else {

--- a/server/src/main/java/org/elasticsearch/index/mapper/Uid.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/Uid.java
@@ -10,6 +10,7 @@ package org.elasticsearch.index.mapper;
 
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.UnicodeUtil;
+import org.elasticsearch.common.Numbers;
 
 import java.util.Arrays;
 import java.util.Base64;
@@ -106,16 +107,6 @@ public final class Uid {
         return true;
     }
 
-    static boolean isPositiveNumeric(String id) {
-        for (int i = 0; i < id.length(); ++i) {
-            final char c = id.charAt(i);
-            if (c < '0' || c > '9') {
-                return false;
-            }
-        }
-        return true;
-    }
-
     /** With numeric ids, we just fold two consecutive chars in a single byte
      *  and use 0x0f as an end marker. */
     private static BytesRef encodeNumericId(String id) {
@@ -164,7 +155,7 @@ public final class Uid {
         if (id.isEmpty()) {
             throw new IllegalArgumentException("Ids can't be empty");
         }
-        if (isPositiveNumeric(id)) {
+        if (Numbers.isPositiveNumeric(id)) {
             // common for ids that come from databases with auto-increments
             return encodeNumericId(id);
         } else if (isURLBase64WithoutPadding(id)) {


### PR DESCRIPTION
I found this when trying to reproduce a test failure. We're spending 1%+ of the
test thread runtime on the `convertMapsToArrays` by throwing `NumberFormatException`
in a hot loop for every entry. The production impact of this change is probably
rather limited unless there is a spot where we serialize a lot of settings but
the test speedup is noticeable when trying to reproduce things.

backport of #77549 