### PR TITLE
Move each field to its own class file

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/fielddata/ScriptDocValues.java
+++ b/server/src/main/java/org/elasticsearch/index/fielddata/ScriptDocValues.java
@@ -17,11 +17,19 @@ import org.elasticsearch.common.geo.GeoPoint;
 import org.elasticsearch.common.geo.GeoUtils;
 import org.elasticsearch.common.time.DateUtils;
 import org.elasticsearch.geometry.utils.Geohash;
+import org.elasticsearch.script.field.BooleanField;
+import org.elasticsearch.script.field.BytesRefField;
 import org.elasticsearch.script.field.Converters;
+import org.elasticsearch.script.field.DateMillisField;
+import org.elasticsearch.script.field.DateNanosField;
+import org.elasticsearch.script.field.DoubleField;
 import org.elasticsearch.script.field.Field;
 import org.elasticsearch.script.field.FieldValues;
+import org.elasticsearch.script.field.GeoPointField;
 import org.elasticsearch.script.field.InvalidConversion;
 import org.elasticsearch.script.JodaCompatibleZonedDateTime;
+import org.elasticsearch.script.field.LongField;
+import org.elasticsearch.script.field.StringField;
 
 import java.io.IOException;
 import java.time.Instant;
@@ -160,7 +168,7 @@ public abstract class ScriptDocValues<T> extends AbstractList<T> implements Fiel
 
         @Override
         public Field<Long> toField(String fieldName) {
-            return new Field.LongField(fieldName, this);
+            return new LongField(fieldName, this);
         }
     }
 
@@ -254,9 +262,9 @@ public abstract class ScriptDocValues<T> extends AbstractList<T> implements Fiel
         @Override
         public Field<JodaCompatibleZonedDateTime> toField(String fieldName) {
             if (isNanos) {
-                return new Field.DateNanosField(fieldName, this);
+                return new DateNanosField(fieldName, this);
             }
-            return new Field.DateMillisField(fieldName, this);
+            return new DateMillisField(fieldName, this);
         }
     }
 
@@ -326,7 +334,7 @@ public abstract class ScriptDocValues<T> extends AbstractList<T> implements Fiel
 
         @Override
         public Field<Double> toField(String fieldName) {
-            return new Field.DoubleField(fieldName, this);
+            return new DoubleField(fieldName, this);
         }
     }
 
@@ -521,7 +529,7 @@ public abstract class ScriptDocValues<T> extends AbstractList<T> implements Fiel
 
         @Override
         public Field<GeoPoint> toField(String fieldName) {
-            return new Field.GeoPointField(fieldName, this);
+            return new GeoPointField(fieldName, this);
         }
     }
 
@@ -597,7 +605,7 @@ public abstract class ScriptDocValues<T> extends AbstractList<T> implements Fiel
 
         @Override
         public Field<Boolean> toField(String fieldName) {
-            return new Field.BooleanField(fieldName, this);
+            return new BooleanField(fieldName, this);
         }
     }
 
@@ -684,7 +692,7 @@ public abstract class ScriptDocValues<T> extends AbstractList<T> implements Fiel
 
         @Override
         public Field<String> toField(String fieldName) {
-            return new Field.StringField(fieldName, this);
+            return new StringField(fieldName, this);
         }
     }
 
@@ -714,7 +722,7 @@ public abstract class ScriptDocValues<T> extends AbstractList<T> implements Fiel
 
         @Override
         public Field<BytesRef> toField(String fieldName) {
-            return new Field.BytesRefField(fieldName, this);
+            return new BytesRefField(fieldName, this);
         }
     }
 }

--- a/server/src/main/java/org/elasticsearch/index/mapper/IpFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/IpFieldMapper.java
@@ -32,6 +32,7 @@ import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.script.IpFieldScript;
 import org.elasticsearch.script.Script;
 import org.elasticsearch.script.ScriptCompiler;
+import org.elasticsearch.script.field.IpField;
 import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.aggregations.support.CoreValuesSourceType;
 import org.elasticsearch.search.lookup.FieldValues;
@@ -358,7 +359,7 @@ public class IpFieldMapper extends FieldMapper {
 
             @Override
             public org.elasticsearch.script.field.Field<String> toField(String fieldName) {
-                return new org.elasticsearch.script.field.Field.IpField(fieldName, this);
+                return new IpField(fieldName, this);
             }
         }
 

--- a/server/src/main/java/org/elasticsearch/script/field/BigIntegerField.java
+++ b/server/src/main/java/org/elasticsearch/script/field/BigIntegerField.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.script.field;
+
+import java.math.BigInteger;
+
+public class BigIntegerField extends Field<java.math.BigInteger> {
+
+    public BigIntegerField(String name, FieldValues<BigInteger> values) {
+        super(name, values);
+    }
+}

--- a/server/src/main/java/org/elasticsearch/script/field/BooleanField.java
+++ b/server/src/main/java/org/elasticsearch/script/field/BooleanField.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.script.field;
+
+public class BooleanField extends Field<Boolean> {
+
+    public BooleanField(String name, FieldValues<Boolean> values) {
+        super(name, values);
+    }
+}

--- a/server/src/main/java/org/elasticsearch/script/field/BytesRefField.java
+++ b/server/src/main/java/org/elasticsearch/script/field/BytesRefField.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.script.field;
+
+import org.apache.lucene.util.BytesRef;
+
+public class BytesRefField extends Field<BytesRef> {
+
+    public BytesRefField(String name, FieldValues<BytesRef> values) {
+        super(name, values);
+    }
+}

--- a/server/src/main/java/org/elasticsearch/script/field/Converters.java
+++ b/server/src/main/java/org/elasticsearch/script/field/Converters.java
@@ -17,14 +17,6 @@ import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import static org.elasticsearch.script.field.Field.BigIntegerField;
-import static org.elasticsearch.script.field.Field.BooleanField;
-import static org.elasticsearch.script.field.Field.DateMillisField;
-import static org.elasticsearch.script.field.Field.DateNanosField;
-import static org.elasticsearch.script.field.Field.DoubleField;
-import static org.elasticsearch.script.field.Field.LongField;
-import static org.elasticsearch.script.field.Field.StringField;
-
 /**
  * {@link Converters} for scripting fields.  These constants are exposed as static fields on {@link Field} to
  * allow a user to convert via {@link Field#as(Converter)}.

--- a/server/src/main/java/org/elasticsearch/script/field/DateMillisField.java
+++ b/server/src/main/java/org/elasticsearch/script/field/DateMillisField.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.script.field;
+
+import org.elasticsearch.script.JodaCompatibleZonedDateTime;
+
+public class DateMillisField extends Field<JodaCompatibleZonedDateTime> {
+
+    public DateMillisField(String name, FieldValues<JodaCompatibleZonedDateTime> values) {
+        super(name, values);
+    }
+}

--- a/server/src/main/java/org/elasticsearch/script/field/DateNanosField.java
+++ b/server/src/main/java/org/elasticsearch/script/field/DateNanosField.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.script.field;
+
+import org.elasticsearch.script.JodaCompatibleZonedDateTime;
+
+public class DateNanosField extends Field<JodaCompatibleZonedDateTime> {
+
+    public DateNanosField(String name, FieldValues<JodaCompatibleZonedDateTime> values) {
+        super(name, values);
+    }
+}

--- a/server/src/main/java/org/elasticsearch/script/field/DoubleField.java
+++ b/server/src/main/java/org/elasticsearch/script/field/DoubleField.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.script.field;
+
+public class DoubleField extends Field<Double> {
+
+    public DoubleField(String name, FieldValues<Double> values) {
+        super(name, values);
+    }
+}

--- a/server/src/main/java/org/elasticsearch/script/field/Field.java
+++ b/server/src/main/java/org/elasticsearch/script/field/Field.java
@@ -9,10 +9,6 @@
 
 package org.elasticsearch.script.field;
 
-import org.apache.lucene.util.BytesRef;
-import org.elasticsearch.common.geo.GeoPoint;
-import org.elasticsearch.script.JodaCompatibleZonedDateTime;
-
 import java.math.BigInteger;
 import java.util.List;
 
@@ -125,72 +121,6 @@ public abstract class Field<T> {
             return values.getLongValue();
         } catch (RuntimeException err) {
             return defaultValue;
-        }
-    }
-
-    public static class BooleanField extends Field<Boolean> {
-        public BooleanField(String name, FieldValues<Boolean> values) {
-            super(name, values);
-        }
-    }
-
-    public static class DoubleField extends Field<Double> {
-        public DoubleField(String name, FieldValues<Double> values) {
-            super(name, values);
-        }
-    }
-
-    public static class LongField extends Field<Long> {
-        public LongField(String name, FieldValues<Long> values) {
-            super(name, values);
-        }
-    }
-
-    public static class DateNanosField extends Field<JodaCompatibleZonedDateTime> {
-        public DateNanosField(String name, FieldValues<JodaCompatibleZonedDateTime> values) {
-            super(name, values);
-        }
-    }
-
-    public static class DateMillisField extends Field<JodaCompatibleZonedDateTime> {
-        public DateMillisField(String name, FieldValues<JodaCompatibleZonedDateTime> values) {
-            super(name, values);
-        }
-    }
-
-    public static class GeoPointField extends Field<GeoPoint> {
-        public GeoPointField(String name, FieldValues<GeoPoint> values) {
-            super(name, values);
-        }
-    }
-
-    public static class StringField extends Field<String> {
-        public StringField(String name, FieldValues<String> values) {
-            super(name, values);
-        }
-    }
-
-    public static class BytesRefField extends Field<BytesRef> {
-        public BytesRefField(String name, FieldValues<BytesRef> values) {
-            super(name, values);
-        }
-    }
-
-    public static class BigIntegerField extends Field<BigInteger> {
-        public BigIntegerField(String name, FieldValues<BigInteger> values) {
-            super(name, values);
-        }
-    }
-
-    public static class VersionField extends Field<String> {
-        public VersionField(String name, FieldValues<String> values) {
-            super(name, values);
-        }
-    }
-
-    public static class IpField extends Field<String> {
-        public IpField(String name, FieldValues<String> values) {
-            super(name, values);
         }
     }
 }

--- a/server/src/main/java/org/elasticsearch/script/field/GeoPointField.java
+++ b/server/src/main/java/org/elasticsearch/script/field/GeoPointField.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.script.field;
+
+import org.elasticsearch.common.geo.GeoPoint;
+
+public class GeoPointField extends Field<GeoPoint> {
+
+    public GeoPointField(String name, FieldValues<GeoPoint> values) {
+        super(name, values);
+    }
+}

--- a/server/src/main/java/org/elasticsearch/script/field/IpField.java
+++ b/server/src/main/java/org/elasticsearch/script/field/IpField.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.script.field;
+
+public class IpField extends Field<String> {
+
+    public IpField(String name, FieldValues<String> values) {
+        super(name, values);
+    }
+}

--- a/server/src/main/java/org/elasticsearch/script/field/LongField.java
+++ b/server/src/main/java/org/elasticsearch/script/field/LongField.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.script.field;
+
+public class LongField extends Field<Long> {
+
+    public LongField(String name, FieldValues<Long> values) {
+        super(name, values);
+    }
+}

--- a/server/src/main/java/org/elasticsearch/script/field/StringField.java
+++ b/server/src/main/java/org/elasticsearch/script/field/StringField.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.script.field;
+
+public class StringField extends Field<String> {
+
+    public StringField(String name, FieldValues<String> values) {
+        super(name, values);
+    }
+}

--- a/server/src/main/java/org/elasticsearch/script/field/VersionField.java
+++ b/server/src/main/java/org/elasticsearch/script/field/VersionField.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.script.field;
+
+public class VersionField extends Field<String> {
+
+    public VersionField(String name, FieldValues<String> values) {
+        super(name, values);
+    }
+}

--- a/server/src/test/java/org/elasticsearch/index/query/SearchExecutionContextTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/SearchExecutionContextTests.java
@@ -516,7 +516,7 @@ public class SearchExecutionContextTests extends ESTestCase {
 
                                     @Override
                                     public org.elasticsearch.script.field.Field<String> toField(String fieldName) {
-                                        return new org.elasticsearch.script.field.Field.StringField(fieldName, this);
+                                        return new org.elasticsearch.script.field.StringField(fieldName, this);
                                     }
                                 };
                             }

--- a/server/src/test/java/org/elasticsearch/script/field/ConvertersTests.java
+++ b/server/src/test/java/org/elasticsearch/script/field/ConvertersTests.java
@@ -24,7 +24,7 @@ public class ConvertersTests extends ESTestCase {
     public void testLongToBigIntegerToLong() {
         long[] raw = { randomLong(), Long.MIN_VALUE, Long.MAX_VALUE, ((long) Integer.MIN_VALUE - 1), ((long) Integer.MAX_VALUE + 1),
                        -1L, 0L, 1L };
-        Field<Long> src = new Field.LongField("", new FieldValues<Long>() {
+        Field<Long> src = new LongField("", new FieldValues<Long>() {
             @Override
             public boolean isEmpty() {
                 return false;
@@ -75,7 +75,7 @@ public class ConvertersTests extends ESTestCase {
     public void testDoubleTo() {
         double[] raw = { Double.MAX_VALUE, Double.MIN_VALUE, ((double) Float.MAX_VALUE) * 10d, ((double) Float.MIN_VALUE), 0.1d,
                          Long.MAX_VALUE, Long.MIN_VALUE };
-        Field<Double> src = new Field.DoubleField("", new FieldValues<Double>() {
+        Field<Double> src = new DoubleField("", new FieldValues<Double>() {
             @Override
             public boolean isEmpty() {
                 return false;
@@ -129,7 +129,7 @@ public class ConvertersTests extends ESTestCase {
     public void testStringToBigInteger() {
         List<String> raw = List.of(Long.MAX_VALUE + "0", randomLong() + "", Long.MIN_VALUE + "0", Double.MAX_VALUE + "",
                                    Double.MIN_VALUE + "");
-        Field<String> src = new Field.StringField("", new ListFieldValues<>(raw));
+        Field<String> src = new StringField("", new ListFieldValues<>(raw));
 
         Field<BigInteger> dst = src.as(Field.BigInteger);
         BigInteger maxDouble = new BigInteger("17976931348623157" + "0".repeat(292));
@@ -144,7 +144,7 @@ public class ConvertersTests extends ESTestCase {
     public void testStringToLong() {
         long rand = randomLong();
         List<String> raw = List.of(rand + "", Long.MAX_VALUE + "", Long.MIN_VALUE + "", "0", "100");
-        Field<String> src = new Field.StringField("", new ListFieldValues<>(raw));
+        Field<String> src = new StringField("", new ListFieldValues<>(raw));
 
         Field<Long> dst = src.as(Field.Long);
         assertEquals(List.of(rand, Long.MAX_VALUE, Long.MIN_VALUE, 0L, 100L), dst.getValues());
@@ -155,7 +155,7 @@ public class ConvertersTests extends ESTestCase {
 
     public void testBooleanTo() {
         List<Boolean> raw = List.of(Boolean.TRUE, Boolean.FALSE);
-        Field<Boolean> src = new Field.BooleanField("", new ListFieldValues<>(raw));
+        Field<Boolean> src = new BooleanField("", new ListFieldValues<>(raw));
 
         Field<BigInteger> dst = src.as(Field.BigInteger);
         assertEquals(List.of(BigInteger.ONE, BigInteger.ZERO), dst.getValues());
@@ -170,7 +170,7 @@ public class ConvertersTests extends ESTestCase {
         assertEquals(1.0d, dstLong.getDouble(1234.0d), 0.1d);
 
         List<Boolean> rawRev = List.of(Boolean.FALSE, Boolean.TRUE);
-        src = new Field.BooleanField("", new ListFieldValues<>(rawRev));
+        src = new BooleanField("", new ListFieldValues<>(rawRev));
         dst = src.as(Field.BigInteger);
 
         assertEquals(List.of(BigInteger.ZERO, BigInteger.ONE), dst.getValues());
@@ -186,7 +186,7 @@ public class ConvertersTests extends ESTestCase {
     }
 
     public void testInvalidFieldConversion() {
-        Field<GeoPoint> src = new Field.GeoPointField("", new ListFieldValues<>(List.of(new GeoPoint(0, 0))));
+        Field<GeoPoint> src = new GeoPointField("", new ListFieldValues<>(List.of(new GeoPoint(0, 0))));
         InvalidConversion ic = expectThrows(InvalidConversion.class, () -> src.as(Field.BigInteger));
         assertEquals("Cannot convert from [GeoPointField] using converter [BigIntegerField]", ic.getMessage());
 
@@ -202,7 +202,7 @@ public class ConvertersTests extends ESTestCase {
             new JodaCompatibleZonedDateTime(Instant.ofEpochMilli(rawMilli[2]), ZoneOffset.ofHours(0)),
             new JodaCompatibleZonedDateTime(Instant.ofEpochMilli(rawMilli[3]), ZoneOffset.ofHours(-5))
         );
-        Field<JodaCompatibleZonedDateTime> src = new Field.DateMillisField("", new ListFieldValues<>(raw));
+        Field<JodaCompatibleZonedDateTime> src = new DateMillisField("", new ListFieldValues<>(raw));
 
         List<BigInteger> expectedBigInteger = LongStream.of(rawMilli).mapToObj(BigInteger::valueOf).collect(Collectors.toList());
         Field<BigInteger> dstBigInteger = src.as(Field.BigInteger);
@@ -227,7 +227,7 @@ public class ConvertersTests extends ESTestCase {
             new JodaCompatibleZonedDateTime(Instant.EPOCH.plusNanos(rawNanos[2]), ZoneOffset.ofHours(0)),
             new JodaCompatibleZonedDateTime(Instant.EPOCH.plusNanos(rawNanos[3]), ZoneOffset.ofHours(-5))
         );
-        Field<JodaCompatibleZonedDateTime> src = new Field.DateNanosField("", new ListFieldValues<>(raw));
+        Field<JodaCompatibleZonedDateTime> src = new DateNanosField("", new ListFieldValues<>(raw));
 
         List<BigInteger> expectedBigInteger = LongStream.of(rawNanos).mapToObj(BigInteger::valueOf).collect(Collectors.toList());
         Field<BigInteger> dstBigInteger = src.as(Field.BigInteger);

--- a/x-pack/plugin/mapper-unsigned-long/src/main/java/org/elasticsearch/xpack/unsignedlong/UnsignedLongField.java
+++ b/x-pack/plugin/mapper-unsigned-long/src/main/java/org/elasticsearch/xpack/unsignedlong/UnsignedLongField.java
@@ -7,11 +7,13 @@
 
 package org.elasticsearch.xpack.unsignedlong;
 
+import org.elasticsearch.script.field.BigIntegerField;
 import org.elasticsearch.script.field.Converter;
 import org.elasticsearch.script.field.Converters;
 import org.elasticsearch.script.field.Field;
 import org.elasticsearch.script.field.FieldValues;
 import org.elasticsearch.script.field.InvalidConversion;
+import org.elasticsearch.script.field.LongField;
 
 import java.math.BigInteger;
 import java.util.List;
@@ -19,7 +21,7 @@ import java.util.stream.Collectors;
 
 import static org.elasticsearch.xpack.unsignedlong.UnsignedLongFieldMapper.BIGINTEGER_2_64_MINUS_ONE;
 
-public class UnsignedLongField extends Field.LongField {
+public class UnsignedLongField extends LongField {
     public static final Converter<Long, UnsignedLongField> UnsignedLong = new Converter<Long, UnsignedLongField>() {
         @Override
         public UnsignedLongField convert(Field<?> sourceField) {

--- a/x-pack/plugin/mapper-unsigned-long/src/test/java/org/elasticsearch/xpack/unsignedlong/UnsignedLongFieldTests.java
+++ b/x-pack/plugin/mapper-unsigned-long/src/test/java/org/elasticsearch/xpack/unsignedlong/UnsignedLongFieldTests.java
@@ -9,6 +9,7 @@ package org.elasticsearch.xpack.unsignedlong;
 
 import org.elasticsearch.script.field.Field;
 import org.elasticsearch.script.field.FieldValues;
+import org.elasticsearch.script.field.LongField;
 import org.elasticsearch.test.ESTestCase;
 
 import java.math.BigInteger;
@@ -71,7 +72,7 @@ public class UnsignedLongFieldTests extends ESTestCase {
 
     public void testLongToUnsignedLong() {
         long[] raw = { Long.MIN_VALUE, Long.MAX_VALUE, ((long) Integer.MIN_VALUE - 1), ((long) Integer.MAX_VALUE + 1), -1L, 0L, 1L };
-        Field<Long> src = new Field.LongField("", new FieldValues<Long>() {
+        Field<Long> src = new LongField("", new FieldValues<Long>() {
             @Override
             public boolean isEmpty() {
                 return false;

--- a/x-pack/plugin/mapper-version/src/main/java/org/elasticsearch/xpack/versionfield/VersionScriptDocValues.java
+++ b/x-pack/plugin/mapper-version/src/main/java/org/elasticsearch/xpack/versionfield/VersionScriptDocValues.java
@@ -11,6 +11,7 @@ import org.apache.lucene.index.SortedSetDocValues;
 import org.apache.lucene.util.ArrayUtil;
 import org.elasticsearch.index.fielddata.ScriptDocValues;
 import org.elasticsearch.script.field.Field;
+import org.elasticsearch.script.field.VersionField;
 
 import java.io.IOException;
 
@@ -60,6 +61,6 @@ public final class VersionScriptDocValues extends ScriptDocValues<String> {
 
     @Override
     public Field<String> toField(String fieldName) {
-        return new Field.VersionField(fieldName, this);
+        return new VersionField(fieldName, this);
     }
 }


### PR DESCRIPTION
This change is a purely mechanical refactor to move each type of field to its own class. This allows for an easy way to separate the converters as well as each converter will require many lines of code.