### PR TITLE
Update versions after backporting #77064

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -140,9 +140,9 @@ tasks.register("verifyVersions") {
  * after the backport of the backcompat code is complete.
  */
 
-boolean bwc_tests_enabled = false
+boolean bwc_tests_enabled = true
 // place a PR link here when committing bwc changes:
-String bwc_tests_disabled_issue = "https://github.com/elastic/elasticsearch/pull/77633"
+String bwc_tests_disabled_issue = ""
 /*
  * FIPS 140-2 behavior was fixed in 7.11.0. Before that there is no way to run elasticsearch in a
  * JVM that is properly configured to be in fips mode with BCFIPS. For now we need to disable

--- a/modules/parent-join/src/yamlRestTest/resources/rest-api-spec/test/30_inner_hits.yml
+++ b/modules/parent-join/src/yamlRestTest/resources/rest-api-spec/test/30_inner_hits.yml
@@ -120,8 +120,8 @@ teardown:
 ---
 profile fetch:
   - skip:
-      version: ' - 7.99.99'
-      reason:  fetch profiling implemented in 8.0.0 to be backported to 7.16.0
+      version: ' - 7.15.99'
+      reason:  fetch profiling implemented in 7.16.0
 
   - do:
       search:

--- a/modules/runtime-fields-common/src/yamlRestTest/resources/rest-api-spec/test/runtime_fields/40_runtime_mappings.yml
+++ b/modules/runtime-fields-common/src/yamlRestTest/resources/rest-api-spec/test/runtime_fields/40_runtime_mappings.yml
@@ -50,8 +50,8 @@ setup:
 "Field caps with runtime mappings section overwriting existing mapping":
 
   - skip:
-      version: " - 7.99.99"
-      reason: Runtime mappings support was added in 8.0
+      version: " - 7.9.99"
+      reason: Runtime mappings support was added in 7.10
 
   - do:
       index:

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.aggregation/20_terms.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.aggregation/20_terms.yml
@@ -1328,8 +1328,8 @@ precise size:
 ---
 huge size:
   - skip:
-        version: " - 7.99.99"
-        reason: "Fixed in 8.0.0 to be backported to 7.14.1"
+        version: " - 7.14.0"
+        reason: "Fixed in 7.14.1"
 
   - do:
       bulk:

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.aggregation/350_variable_width_histogram.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.aggregation/350_variable_width_histogram.yml
@@ -28,7 +28,7 @@ setup:
 ---
 "basic":
   - skip:
-      version: " - 7.9.99"
+      version: " - 7.8.99"
       reason: added in 7.9.0
   - do:
       search:

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search/370_profile.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search/370_profile.yml
@@ -22,8 +22,8 @@ setup:
 ---
 fetch fields:
   - skip:
-      version: ' - 7.99.99'
-      reason:  fetch profiling implemented in 8.0.0 to be backported to 7.16.0
+      version: ' - 7.15.99'
+      reason:  fetch profiling implemented in 7.16.0
 
   - do:
       search:
@@ -81,8 +81,8 @@ fetch source:
 ---
 fetch nested source:
   - skip:
-      version: ' - 7.99.99'
-      reason:  fetch profiling implemented in 8.0.0 to be backported to 7.16.0
+      version: ' - 7.15.99'
+      reason:  fetch profiling implemented in 7.16.0
 
   - do:
       indices.create:

--- a/server/src/main/java/org/elasticsearch/search/fetch/FetchSearchResult.java
+++ b/server/src/main/java/org/elasticsearch/search/fetch/FetchSearchResult.java
@@ -41,7 +41,7 @@ public final class FetchSearchResult extends SearchPhaseResult {
         super(in);
         contextId = new ShardSearchContextId(in);
         hits = new SearchHits(in);
-        if (in.getVersion().onOrAfter(Version.V_8_0_0)) {
+        if (in.getVersion().onOrAfter(Version.V_7_16_0)) {
             profileResult = in.readOptionalWriteable(ProfileResult::new);
         } else {
             profileResult = null;
@@ -52,7 +52,7 @@ public final class FetchSearchResult extends SearchPhaseResult {
     public void writeTo(StreamOutput out) throws IOException {
         contextId.writeTo(out);
         hits.writeTo(out);
-        if (out.getVersion().onOrAfter(Version.V_8_0_0)) {
+        if (out.getVersion().onOrAfter(Version.V_7_16_0)) {
             out.writeOptionalWriteable(profileResult);
         }
     }

--- a/server/src/main/java/org/elasticsearch/search/profile/SearchProfileResults.java
+++ b/server/src/main/java/org/elasticsearch/search/profile/SearchProfileResults.java
@@ -46,7 +46,7 @@ public final class SearchProfileResults implements Writeable, ToXContentFragment
     }
 
     public SearchProfileResults(StreamInput in) throws IOException {
-        if (in.getVersion().onOrAfter(Version.V_8_0_0)) {
+        if (in.getVersion().onOrAfter(Version.V_7_16_0)) {
             shardResults = in.readMap(StreamInput::readString, SearchProfileShardResult::new);
         } else {
             // Before 8.0.0 we only send the query phase result
@@ -59,7 +59,7 @@ public final class SearchProfileResults implements Writeable, ToXContentFragment
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        if (out.getVersion().onOrAfter(Version.V_8_0_0)) {
+        if (out.getVersion().onOrAfter(Version.V_7_16_0)) {
             out.writeMap(shardResults, StreamOutput::writeString, (o, r) -> r.writeTo(o));
         } else {
             // Before 8.0.0 we only send the query phase

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/unsigned_long/10_basic.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/unsigned_long/10_basic.yml
@@ -303,8 +303,8 @@ setup:
 ---
 "Composite aggregations":
   - skip:
-      version: " - 7.99.99"
-      reason: "TODO: unsigned_long support for composite aggs was fixed in 7.11"
+      version: " - 7.10.99"
+      reason: "unsigned_long support for composite aggs was fixed in 7.11"
 
   - do:
       search:


### PR DESCRIPTION
Now that #77064 is backported we can run the bwc tests against it. And
we can speak to 7.16 nodes using the wire protocol addedin #77064.
