### PR TITLE
Unwrap this Optional for the log message

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/DataTierMigrationRoutedStep.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/DataTierMigrationRoutedStep.java
@@ -98,7 +98,7 @@ public class DataTierMigrationRoutedStep extends ClusterStateWaitStep {
             return new Result(false, new AllocationInfo(idxMeta.getNumberOfReplicas(), allocationPendingAllShards, true, statusMessage));
         } else {
             logger.debug("[{}] migration of index [{}] to tier [{}] (preference [{}]) complete",
-                getKey().getAction(), index, availableDestinationTier, preferredTierConfiguration);
+                getKey().getAction(), index, availableDestinationTier.orElse(""), preferredTierConfiguration);
             return new Result(true, null);
         }
     }


### PR DESCRIPTION
Follow up from #77657

I spent a lot of time looking at log messages during that one, and I noticed this:

```
[2021-09-10T14:13:01,471][DEBUG][o.e.x.c.i.DataTierMigrationRoutedStep] [runTask-0] [migrate] migration of index [[test-index-1/jtlrre5LQ2eGyKSyztn6Zw]] to tier [Optional[data_warm]] (preference [data_warm,data_hot]) complete
```

The `to tier [Optional[data_warm]]` seemed inelegant to me, so here's a PR to tidy that up into:

```
[2021-09-13T15:36:21,981][DEBUG][o.e.x.c.i.DataTierMigrationRoutedStep] [runTask-0] [migrate] migration of index [[test-index-1/5nkxGfarTGGAvxwV0mAuFw]] to tier [data_warm] (preference [data_warm,data_hot]) complete
```