### PR TITLE
[7.15] Introduce external build-tools JavaRestTestPlugin (#77603)

### DIFF
--- a/build-tools-internal/build.gradle
+++ b/build-tools-internal/build.gradle
@@ -103,9 +103,9 @@ gradlePlugin {
       id = 'elasticsearch.java'
       implementationClass = 'org.elasticsearch.gradle.internal.ElasticsearchJavaPlugin'
     }
-    javaRestTest {
-      id = 'elasticsearch.java-rest-test'
-      implementationClass = 'org.elasticsearch.gradle.internal.test.rest.JavaRestTestPlugin'
+    internalJavaRestTest {
+      id = 'elasticsearch.internal-java-rest-test'
+      implementationClass = 'org.elasticsearch.gradle.internal.test.rest.InternalJavaRestTestPlugin'
     }
     releaseTools {
       id = 'elasticsearch.release-tools'

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/test/rest/InternalJavaRestTestPlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/test/rest/InternalJavaRestTestPlugin.java
@@ -21,7 +21,7 @@ import static org.elasticsearch.gradle.internal.test.rest.RestTestUtil.setupTest
 /**
  * Apply this plugin to run the Java based REST tests.
  */
-public class JavaRestTestPlugin implements Plugin<Project> {
+public class InternalJavaRestTestPlugin implements Plugin<Project> {
 
     public static final String SOURCE_SET_NAME = "javaRestTest";
 

--- a/build-tools/build.gradle
+++ b/build-tools/build.gradle
@@ -49,6 +49,10 @@ gradlePlugin {
             id = 'elasticsearch.esplugin'
             implementationClass = 'org.elasticsearch.gradle.plugin.PluginBuildPlugin'
         }
+        javaRestTest {
+            id = 'elasticsearch.java-rest-test'
+            implementationClass = 'org.elasticsearch.gradle.test.JavaRestTestPlugin'
+        }
         testclusters {
             id = 'elasticsearch.testclusters'
             implementationClass = 'org.elasticsearch.gradle.testclusters.TestClustersPlugin'

--- a/build-tools/src/integTest/groovy/org/elasticsearch/gradle/test/JavaRestTestPluginFuncTest.groovy
+++ b/build-tools/src/integTest/groovy/org/elasticsearch/gradle/test/JavaRestTestPluginFuncTest.groovy
@@ -1,0 +1,57 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.gradle.test
+
+import org.elasticsearch.gradle.VersionProperties
+import org.elasticsearch.gradle.fixtures.AbstractGradleFuncTest
+import org.gradle.testkit.runner.TaskOutcome
+
+class JavaRestTestPluginFuncTest extends AbstractGradleFuncTest {
+
+    def "declares default dependencies"() {
+        given:
+        buildFile << """
+        plugins {
+          id 'elasticsearch.java-rest-test'
+        }
+        """
+
+        when:
+        def result = gradleRunner("dependencies").build()
+        def output = normalized(result.output)
+        then:
+        output.contains(normalized("""
+javaRestTestImplementation - Implementation only dependencies for source set 'java rest test'. (n)
+/--- org.elasticsearch.test:framework:${VersionProperties.elasticsearch} (n)"""))
+    }
+
+    def "javaRestTest does nothing when there are no tests"() {
+        given:
+        buildFile << """
+        plugins {
+          id 'elasticsearch.java-rest-test'
+        }
+
+        repositories {
+            mavenCentral()
+        }
+
+        dependencies {
+            javaRestTestImplementation "org.elasticsearch.test:framework:7.14.0"
+        }
+        """
+
+        when:
+        def result = gradleRunner("javaRestTest").build()
+        then:
+        result.task(':compileJavaRestTestJava').outcome == TaskOutcome.NO_SOURCE
+        result.task(':javaRestTest').outcome == TaskOutcome.NO_SOURCE
+    }
+
+}

--- a/build-tools/src/main/java/org/elasticsearch/gradle/test/JavaRestTestPlugin.java
+++ b/build-tools/src/main/java/org/elasticsearch/gradle/test/JavaRestTestPlugin.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.gradle.test;
+
+import org.elasticsearch.gradle.VersionProperties;
+import org.elasticsearch.gradle.plugin.PluginBuildPlugin;
+import org.elasticsearch.gradle.testclusters.ElasticsearchCluster;
+import org.elasticsearch.gradle.testclusters.StandaloneRestIntegTestTask;
+import org.elasticsearch.gradle.testclusters.TestClustersPlugin;
+import org.gradle.api.NamedDomainObjectContainer;
+import org.gradle.api.Plugin;
+import org.gradle.api.Project;
+import org.gradle.api.plugins.JavaBasePlugin;
+import org.gradle.api.tasks.SourceSetContainer;
+import org.gradle.api.tasks.TaskProvider;
+import org.gradle.api.tasks.bundling.Zip;
+import org.gradle.language.base.plugins.LifecycleBasePlugin;
+
+import static org.elasticsearch.gradle.plugin.PluginBuildPlugin.BUNDLE_PLUGIN_TASK_NAME;
+
+public class JavaRestTestPlugin implements Plugin<Project> {
+
+    public static final String JAVA_REST_TEST = "javaRestTest";
+
+    @Override
+    public void apply(Project project) {
+        project.getPluginManager().apply(GradleTestPolicySetupPlugin.class);
+        project.getPluginManager().apply(TestClustersPlugin.class);
+        project.getPluginManager().apply(JavaBasePlugin.class);
+
+        // Setup source set and dependencies
+        var sourceSets = project.getExtensions().getByType(SourceSetContainer.class);
+        var testSourceSet = sourceSets.maybeCreate(JAVA_REST_TEST);
+        var javaRestTestImplementation = project.getConfigurations().getByName(testSourceSet.getImplementationConfigurationName());
+
+        String elasticsearchVersion = VersionProperties.getElasticsearch();
+        javaRestTestImplementation.defaultDependencies(
+            deps -> deps.add(project.getDependencies().create("org.elasticsearch.test:framework:" + elasticsearchVersion))
+        );
+
+        // Register test cluster
+        NamedDomainObjectContainer<ElasticsearchCluster> testClusters = (NamedDomainObjectContainer<ElasticsearchCluster>) project
+            .getExtensions()
+            .getByName(TestClustersPlugin.EXTENSION_NAME);
+        var cluster = testClusters.maybeCreate(JAVA_REST_TEST);
+
+        // Register test task
+        TaskProvider<StandaloneRestIntegTestTask> javaRestTestTask = project.getTasks()
+            .register(JAVA_REST_TEST, StandaloneRestIntegTestTask.class, task -> {
+                task.useCluster(cluster);
+                task.setTestClassesDirs(testSourceSet.getOutput().getClassesDirs());
+                task.setClasspath(testSourceSet.getRuntimeClasspath());
+
+                var nonInputProperties = new SystemPropertyCommandLineArgumentProvider();
+                nonInputProperties.systemProperty("tests.rest.cluster", () -> String.join(",", cluster.getAllHttpSocketURI()));
+                nonInputProperties.systemProperty("tests.cluster", () -> String.join(",", cluster.getAllTransportPortURI()));
+                nonInputProperties.systemProperty("tests.clustername", () -> cluster.getName());
+                task.getJvmArgumentProviders().add(nonInputProperties);
+            });
+
+        // Register plugin bundle with test cluster
+        project.getPlugins().withType(PluginBuildPlugin.class, p -> {
+            TaskProvider<Zip> bundle = project.getTasks().withType(Zip.class).named(BUNDLE_PLUGIN_TASK_NAME);
+            cluster.plugin(bundle.flatMap(Zip::getArchiveFile));
+            javaRestTestTask.configure(t -> t.dependsOn(bundle));
+        });
+
+        // Wire up to check task
+        project.getTasks().named(LifecycleBasePlugin.CHECK_TASK_NAME).configure(check -> check.dependsOn(javaRestTestTask));
+    }
+}

--- a/build-tools/src/main/java/org/elasticsearch/gradle/test/YamlRestTestPlugin.java
+++ b/build-tools/src/main/java/org/elasticsearch/gradle/test/YamlRestTestPlugin.java
@@ -25,12 +25,15 @@ import org.gradle.api.artifacts.dsl.DependencyHandler;
 import org.gradle.api.artifacts.type.ArtifactTypeDefinition;
 import org.gradle.api.attributes.Attribute;
 import org.gradle.api.internal.artifacts.ArtifactAttributes;
+import org.gradle.api.plugins.BasePlugin;
 import org.gradle.api.plugins.JavaBasePlugin;
+import org.gradle.api.plugins.JavaPlugin;
 import org.gradle.api.tasks.Copy;
 import org.gradle.api.tasks.SourceSet;
 import org.gradle.api.tasks.SourceSetContainer;
 import org.gradle.api.tasks.TaskProvider;
 import org.gradle.api.tasks.bundling.Zip;
+import org.gradle.language.base.plugins.LifecycleBasePlugin;
 
 import java.io.File;
 
@@ -85,6 +88,9 @@ public class YamlRestTestPlugin implements Plugin<Project> {
             cluster.plugin(bundle.flatMap(Zip::getArchiveFile));
             yamlRestTestTask.configure(t -> t.dependsOn(bundle));
         });
+
+        // Wire up to check task
+        project.getTasks().named(LifecycleBasePlugin.CHECK_TASK_NAME).configure(check -> check.dependsOn(yamlRestTestTask));
     }
 
     private static void setupDefaultDependencies(
@@ -107,7 +113,7 @@ public class YamlRestTestPlugin implements Plugin<Project> {
         SourceSet testSourceSet,
         ElasticsearchCluster cluster
     ) {
-        return project.getTasks().register("yamlRestTest", StandaloneRestIntegTestTask.class, task -> {
+        return project.getTasks().register(YAML_REST_TEST, StandaloneRestIntegTestTask.class, task -> {
             task.useCluster(cluster);
             task.setTestClassesDirs(testSourceSet.getOutput().getClassesDirs());
             task.setClasspath(testSourceSet.getRuntimeClasspath());

--- a/modules/kibana/build.gradle
+++ b/modules/kibana/build.gradle
@@ -5,7 +5,7 @@
  * in compliance with, at your election, the Elastic License 2.0 or the Server
  * Side Public License, v 1.
  */
-apply plugin: 'elasticsearch.java-rest-test'
+apply plugin: 'elasticsearch.internal-java-rest-test'
 
 esplugin {
   description 'Plugin exposing APIs for Kibana system indices'

--- a/modules/lang-mustache/build.gradle
+++ b/modules/lang-mustache/build.gradle
@@ -6,7 +6,7 @@
  * Side Public License, v 1.
  */
 apply plugin: 'elasticsearch.internal-yaml-rest-test'
-apply plugin: 'elasticsearch.java-rest-test'
+apply plugin: 'elasticsearch.internal-java-rest-test'
 apply plugin: 'elasticsearch.internal-cluster-test'
 
 esplugin {

--- a/modules/reindex/build.gradle
+++ b/modules/reindex/build.gradle
@@ -15,7 +15,7 @@ import org.elasticsearch.gradle.internal.test.AntFixture
 apply plugin: 'elasticsearch.test-with-dependencies'
 apply plugin: 'elasticsearch.jdk-download'
 apply plugin: 'elasticsearch.internal-yaml-rest-test'
-apply plugin: 'elasticsearch.java-rest-test'
+apply plugin: 'elasticsearch.internal-java-rest-test'
 apply plugin: 'elasticsearch.internal-cluster-test'
 
 esplugin {

--- a/modules/transport-netty4/build.gradle
+++ b/modules/transport-netty4/build.gradle
@@ -6,14 +6,12 @@
  * Side Public License, v 1.
  */
 
-
-import org.elasticsearch.gradle.internal.info.BuildParams
 import org.elasticsearch.gradle.internal.test.RestIntegTestTask
-import org.elasticsearch.gradle.internal.test.rest.JavaRestTestPlugin
+import org.elasticsearch.gradle.internal.test.rest.InternalJavaRestTestPlugin
 import org.elasticsearch.gradle.internal.test.InternalClusterTestPlugin
 
 apply plugin: 'elasticsearch.internal-yaml-rest-test'
-apply plugin: 'elasticsearch.java-rest-test'
+apply plugin: 'elasticsearch.internal-java-rest-test'
 apply plugin: 'elasticsearch.internal-cluster-test'
 
 /*
@@ -65,7 +63,7 @@ TaskProvider<Test> pooledInternalClusterTest = tasks.register("pooledInternalClu
 
 TaskProvider<RestIntegTestTask> pooledJavaRestTest = tasks.register("pooledJavaRestTest", RestIntegTestTask) {
     SourceSetContainer sourceSets = project.getExtensions().getByType(SourceSetContainer.class);
-    SourceSet javaRestTestSourceSet = sourceSets.getByName(JavaRestTestPlugin.SOURCE_SET_NAME)
+    SourceSet javaRestTestSourceSet = sourceSets.getByName(InternalJavaRestTestPlugin.SOURCE_SET_NAME)
     setTestClassesDirs(javaRestTestSourceSet.getOutput().getClassesDirs())
     setClasspath(javaRestTestSourceSet.getRuntimeClasspath())
 

--- a/plugins/examples/build.gradle
+++ b/plugins/examples/build.gradle
@@ -20,6 +20,15 @@ subprojects { p ->
         p.dependencies.add("restTestSpecs", p.dependencies.project(path:':rest-api-spec', configuration:'basicRestSpecs'))
     }
   })
+
+  // configure project dependencies for java rest test plugin.
+  // plugin defaults to external available artifacts
+  p.getPluginManager().withPlugin("elasticsearch.java-rest-test", new Action<AppliedPlugin>() {
+    @Override
+    void execute(AppliedPlugin appliedPlugin) {
+      p.dependencies.add("javaRestTestImplementation", project(":test:framework"))
+    }
+  })
 }
 
 configure(project('painless-whitelist')) {

--- a/plugins/examples/security-authorization-engine/build.gradle
+++ b/plugins/examples/security-authorization-engine/build.gradle
@@ -1,5 +1,5 @@
 apply plugin: 'elasticsearch.internal-es-plugin'
-apply plugin: 'elasticsearch.java-rest-test'
+apply plugin: 'elasticsearch.internal-java-rest-test'
 
 esplugin {
   name 'security-authorization-engine'

--- a/qa/die-with-dignity/build.gradle
+++ b/qa/die-with-dignity/build.gradle
@@ -1,7 +1,7 @@
 import org.elasticsearch.gradle.internal.info.BuildParams
 import org.elasticsearch.gradle.util.GradleUtils
 
-apply plugin: 'elasticsearch.java-rest-test'
+apply plugin: 'elasticsearch.internal-java-rest-test'
 apply plugin: 'elasticsearch.internal-es-plugin'
 
 esplugin {

--- a/qa/system-indices/build.gradle
+++ b/qa/system-indices/build.gradle
@@ -7,7 +7,7 @@
  */
 
 apply plugin: 'elasticsearch.internal-es-plugin'
-apply plugin: 'elasticsearch.java-rest-test'
+apply plugin: 'elasticsearch.internal-java-rest-test'
 
 esplugin {
   name 'system-indices-qa'

--- a/x-pack/plugin/async-search/qa/security/build.gradle
+++ b/x-pack/plugin/async-search/qa/security/build.gradle
@@ -1,4 +1,4 @@
-apply plugin: 'elasticsearch.java-rest-test'
+apply plugin: 'elasticsearch.internal-java-rest-test'
 
 dependencies {
   javaRestTestImplementation(testArtifact(project(xpackModule('core'))))

--- a/x-pack/plugin/data-streams/qa/multi-node/build.gradle
+++ b/x-pack/plugin/data-streams/qa/multi-node/build.gradle
@@ -1,6 +1,6 @@
 import org.elasticsearch.gradle.internal.info.BuildParams
 
-apply plugin: 'elasticsearch.java-rest-test'
+apply plugin: 'elasticsearch.internal-java-rest-test'
 
 File repoDir = file("$buildDir/testclusters/repo")
 

--- a/x-pack/plugin/data-streams/qa/rest/build.gradle
+++ b/x-pack/plugin/data-streams/qa/rest/build.gradle
@@ -1,6 +1,6 @@
 import org.elasticsearch.gradle.internal.info.BuildParams
 
-apply plugin: 'elasticsearch.java-rest-test'
+apply plugin: 'elasticsearch.internal-java-rest-test'
 apply plugin: 'elasticsearch.internal-yaml-rest-test'
 
 restResources {

--- a/x-pack/plugin/deprecation/qa/rest/build.gradle
+++ b/x-pack/plugin/deprecation/qa/rest/build.gradle
@@ -2,7 +2,7 @@ import org.elasticsearch.gradle.util.GradleUtils
 import org.elasticsearch.gradle.internal.info.BuildParams
 
 apply plugin: 'elasticsearch.internal-es-plugin'
-apply plugin: 'elasticsearch.java-rest-test'
+apply plugin: 'elasticsearch.internal-java-rest-test'
 
 esplugin {
   description 'Deprecated query plugin'

--- a/x-pack/plugin/enrich/qa/rest-with-advanced-security/build.gradle
+++ b/x-pack/plugin/enrich/qa/rest-with-advanced-security/build.gradle
@@ -1,4 +1,4 @@
-apply plugin: 'elasticsearch.java-rest-test'
+apply plugin: 'elasticsearch.internal-java-rest-test'
 
 import org.elasticsearch.gradle.internal.info.BuildParams
 

--- a/x-pack/plugin/enrich/qa/rest-with-security/build.gradle
+++ b/x-pack/plugin/enrich/qa/rest-with-security/build.gradle
@@ -1,4 +1,4 @@
-apply plugin: 'elasticsearch.java-rest-test'
+apply plugin: 'elasticsearch.internal-java-rest-test'
 
 import org.elasticsearch.gradle.internal.info.BuildParams
 

--- a/x-pack/plugin/enrich/qa/rest/build.gradle
+++ b/x-pack/plugin/enrich/qa/rest/build.gradle
@@ -1,4 +1,4 @@
-apply plugin: 'elasticsearch.java-rest-test'
+apply plugin: 'elasticsearch.internal-java-rest-test'
 apply plugin: 'elasticsearch.internal-yaml-rest-test'
 
 import org.elasticsearch.gradle.internal.info.BuildParams

--- a/x-pack/plugin/eql/qa/correctness/build.gradle
+++ b/x-pack/plugin/eql/qa/correctness/build.gradle
@@ -1,4 +1,4 @@
-apply plugin: 'elasticsearch.java-rest-test'
+apply plugin: 'elasticsearch.internal-java-rest-test'
 apply plugin: 'elasticsearch.build'
 apply plugin: 'elasticsearch.internal-testclusters'
 tasks.named("test").configure { enabled = false }

--- a/x-pack/plugin/eql/qa/rest/build.gradle
+++ b/x-pack/plugin/eql/qa/rest/build.gradle
@@ -1,4 +1,4 @@
-apply plugin: 'elasticsearch.java-rest-test'
+apply plugin: 'elasticsearch.internal-java-rest-test'
 apply plugin: 'elasticsearch.internal-yaml-rest-test'
 
 import org.elasticsearch.gradle.internal.info.BuildParams

--- a/x-pack/plugin/eql/qa/security/build.gradle
+++ b/x-pack/plugin/eql/qa/security/build.gradle
@@ -1,4 +1,4 @@
-apply plugin: 'elasticsearch.java-rest-test'
+apply plugin: 'elasticsearch.internal-java-rest-test'
 
 import org.elasticsearch.gradle.internal.info.BuildParams
 

--- a/x-pack/plugin/fleet/build.gradle
+++ b/x-pack/plugin/fleet/build.gradle
@@ -7,7 +7,7 @@
 
 apply plugin: 'elasticsearch.internal-es-plugin'
 apply plugin: 'elasticsearch.internal-cluster-test'
-apply plugin: 'elasticsearch.java-rest-test'
+apply plugin: 'elasticsearch.internal-java-rest-test'
 
 esplugin {
   name 'x-pack-fleet'

--- a/x-pack/plugin/identity-provider/qa/idp-rest-tests/build.gradle
+++ b/x-pack/plugin/identity-provider/qa/idp-rest-tests/build.gradle
@@ -1,5 +1,5 @@
 import org.elasticsearch.gradle.internal.info.BuildParams
-apply plugin: 'elasticsearch.java-rest-test'
+apply plugin: 'elasticsearch.internal-java-rest-test'
 
 dependencies {
   javaRestTestImplementation(testArtifact(project(xpackModule('core'))))

--- a/x-pack/plugin/ilm/qa/multi-node/build.gradle
+++ b/x-pack/plugin/ilm/qa/multi-node/build.gradle
@@ -1,7 +1,7 @@
 import org.elasticsearch.gradle.util.GradleUtils
 import org.elasticsearch.gradle.internal.info.BuildParams
 
-apply plugin: 'elasticsearch.java-rest-test'
+apply plugin: 'elasticsearch.internal-java-rest-test'
 
 dependencies {
   javaRestTestImplementation(testArtifact(project(xpackModule('core'))))

--- a/x-pack/plugin/ilm/qa/with-security/build.gradle
+++ b/x-pack/plugin/ilm/qa/with-security/build.gradle
@@ -1,4 +1,4 @@
-apply plugin: 'elasticsearch.java-rest-test'
+apply plugin: 'elasticsearch.internal-java-rest-test'
 
 dependencies {
   javaRestTestImplementation project(path: xpackModule('core'))

--- a/x-pack/plugin/logstash/build.gradle
+++ b/x-pack/plugin/logstash/build.gradle
@@ -1,5 +1,5 @@
 apply plugin: 'elasticsearch.internal-es-plugin'
-apply plugin: 'elasticsearch.java-rest-test'
+apply plugin: 'elasticsearch.internal-java-rest-test'
 
 esplugin {
   name 'x-pack-logstash'

--- a/x-pack/plugin/ml/qa/basic-multi-node/build.gradle
+++ b/x-pack/plugin/ml/qa/basic-multi-node/build.gradle
@@ -1,6 +1,6 @@
 import org.elasticsearch.gradle.internal.info.BuildParams
 
-apply plugin: 'elasticsearch.java-rest-test'
+apply plugin: 'elasticsearch.internal-java-rest-test'
 
 testClusters.all {
   testDistribution = 'DEFAULT'

--- a/x-pack/plugin/ml/qa/disabled/build.gradle
+++ b/x-pack/plugin/ml/qa/disabled/build.gradle
@@ -1,6 +1,6 @@
 import org.elasticsearch.gradle.internal.info.BuildParams
 
-apply plugin: 'elasticsearch.java-rest-test'
+apply plugin: 'elasticsearch.internal-java-rest-test'
 
 //dependencies {
 //  testImplementation project(":x-pack:plugin:core")

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/build.gradle
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/build.gradle
@@ -1,5 +1,5 @@
 import org.elasticsearch.gradle.internal.info.BuildParams
-apply plugin: 'elasticsearch.java-rest-test'
+apply plugin: 'elasticsearch.internal-java-rest-test'
 
 dependencies {
   javaRestTestImplementation(testArtifact(project(xpackModule('core'))))

--- a/x-pack/plugin/ml/qa/single-node-tests/build.gradle
+++ b/x-pack/plugin/ml/qa/single-node-tests/build.gradle
@@ -1,6 +1,6 @@
 import org.elasticsearch.gradle.internal.info.BuildParams
 
-apply plugin: 'elasticsearch.java-rest-test'
+apply plugin: 'elasticsearch.internal-java-rest-test'
 
 testClusters.all {
   testDistribution = 'DEFAULT'

--- a/x-pack/plugin/searchable-snapshots/qa/rest/build.gradle
+++ b/x-pack/plugin/searchable-snapshots/qa/rest/build.gradle
@@ -1,4 +1,4 @@
-apply plugin: 'elasticsearch.java-rest-test'
+apply plugin: 'elasticsearch.internal-java-rest-test'
 apply plugin: 'elasticsearch.internal-yaml-rest-test'
 
 dependencies {

--- a/x-pack/plugin/security/qa/basic-enable-security/build.gradle
+++ b/x-pack/plugin/security/qa/basic-enable-security/build.gradle
@@ -1,8 +1,7 @@
 import org.elasticsearch.gradle.testclusters.StandaloneRestIntegTestTask
-import org.elasticsearch.gradle.internal.test.rest.JavaRestTestPlugin
 import org.elasticsearch.gradle.internal.info.BuildParams
 
-apply plugin: 'elasticsearch.java-rest-test'
+apply plugin: 'elasticsearch.internal-java-rest-test'
 
 //randomise between implicitly and explicitly disabled security
 boolean implicitlyDisabledSecurity = (new Random(Long.parseUnsignedLong(BuildParams.testSeed.tokenize(':').get(0), 16))).nextBoolean()

--- a/x-pack/plugin/security/qa/operator-privileges-tests/build.gradle
+++ b/x-pack/plugin/security/qa/operator-privileges-tests/build.gradle
@@ -1,5 +1,5 @@
 apply plugin: 'elasticsearch.internal-es-plugin'
-apply plugin: 'elasticsearch.java-rest-test'
+apply plugin: 'elasticsearch.internal-java-rest-test'
 
 esplugin {
   name 'operator-privileges-test'

--- a/x-pack/plugin/security/qa/security-basic/build.gradle
+++ b/x-pack/plugin/security/qa/security-basic/build.gradle
@@ -1,5 +1,5 @@
 
-apply plugin: 'elasticsearch.java-rest-test'
+apply plugin: 'elasticsearch.internal-java-rest-test'
 
 import org.elasticsearch.gradle.internal.info.BuildParams
 

--- a/x-pack/plugin/security/qa/security-disabled/build.gradle
+++ b/x-pack/plugin/security/qa/security-disabled/build.gradle
@@ -7,7 +7,7 @@
  */
 import org.elasticsearch.gradle.internal.info.BuildParams
 
-apply plugin: 'elasticsearch.java-rest-test'
+apply plugin: 'elasticsearch.internal-java-rest-test'
 
 dependencies {
   javaRestTestImplementation(testArtifact(project(xpackModule('security'))))

--- a/x-pack/plugin/security/qa/security-not-enabled/build.gradle
+++ b/x-pack/plugin/security/qa/security-not-enabled/build.gradle
@@ -6,7 +6,7 @@
  *              defined, it should be not fail
  */
 
-apply plugin: 'elasticsearch.java-rest-test'
+apply plugin: 'elasticsearch.internal-java-rest-test'
 
 dependencies {
   javaRestTestImplementation(testArtifact(project(xpackModule('security'))))

--- a/x-pack/plugin/security/qa/security-trial/build.gradle
+++ b/x-pack/plugin/security/qa/security-trial/build.gradle
@@ -1,4 +1,4 @@
-apply plugin: 'elasticsearch.java-rest-test'
+apply plugin: 'elasticsearch.internal-java-rest-test'
 
 dependencies {
   javaRestTestImplementation project(path: xpackModule('core'))

--- a/x-pack/plugin/security/qa/service-account/build.gradle
+++ b/x-pack/plugin/security/qa/service-account/build.gradle
@@ -1,4 +1,4 @@
-apply plugin: 'elasticsearch.java-rest-test'
+apply plugin: 'elasticsearch.internal-java-rest-test'
 
 dependencies {
   javaRestTestImplementation project(':x-pack:plugin:core')

--- a/x-pack/plugin/security/qa/smoke-test-all-realms/build.gradle
+++ b/x-pack/plugin/security/qa/smoke-test-all-realms/build.gradle
@@ -6,7 +6,7 @@
  * This test is also intended to work correctly on FIPS mode because we also want to know if a realm breaks on FIPS.
  */
 
-apply plugin: 'elasticsearch.java-rest-test'
+apply plugin: 'elasticsearch.internal-java-rest-test'
 
 dependencies {
   javaRestTestImplementation(testArtifact(project(xpackModule('security'))))

--- a/x-pack/plugin/security/qa/tls-basic/build.gradle
+++ b/x-pack/plugin/security/qa/tls-basic/build.gradle
@@ -1,4 +1,4 @@
-apply plugin: 'elasticsearch.java-rest-test'
+apply plugin: 'elasticsearch.internal-java-rest-test'
 
 import org.elasticsearch.gradle.internal.info.BuildParams
 

--- a/x-pack/plugin/shutdown/qa/multi-node/build.gradle
+++ b/x-pack/plugin/shutdown/qa/multi-node/build.gradle
@@ -1,6 +1,6 @@
 import org.elasticsearch.gradle.VersionProperties
 
-apply plugin: 'elasticsearch.java-rest-test'
+apply plugin: 'elasticsearch.internal-java-rest-test'
 
 dependencies {
   javaRestTestImplementation(testArtifact(project(xpackModule('core'))))

--- a/x-pack/plugin/transform/qa/multi-node-tests/build.gradle
+++ b/x-pack/plugin/transform/qa/multi-node-tests/build.gradle
@@ -1,4 +1,4 @@
-apply plugin: 'elasticsearch.java-rest-test'
+apply plugin: 'elasticsearch.internal-java-rest-test'
 
 dependencies {
   javaRestTestImplementation(testArtifact(project(xpackModule('core'))))

--- a/x-pack/plugin/transform/qa/single-node-tests/build.gradle
+++ b/x-pack/plugin/transform/qa/single-node-tests/build.gradle
@@ -1,5 +1,5 @@
 
-apply plugin: 'elasticsearch.java-rest-test'
+apply plugin: 'elasticsearch.internal-java-rest-test'
 
 dependencies {
   javaRestTestImplementation(testArtifact(project(xpackModule('core'))))

--- a/x-pack/plugin/vector-tile/build.gradle
+++ b/x-pack/plugin/vector-tile/build.gradle
@@ -16,7 +16,7 @@
 import org.elasticsearch.gradle.internal.info.BuildParams
 
 apply plugin: 'elasticsearch.internal-es-plugin'
-apply plugin: 'elasticsearch.java-rest-test'
+apply plugin: 'elasticsearch.internal-java-rest-test'
 apply plugin: 'elasticsearch.internal-yaml-rest-test'
 
 esplugin {

--- a/x-pack/plugin/watcher/qa/rest/build.gradle
+++ b/x-pack/plugin/watcher/qa/rest/build.gradle
@@ -1,6 +1,6 @@
 import org.elasticsearch.gradle.internal.info.BuildParams
 
-apply plugin: 'elasticsearch.java-rest-test'
+apply plugin: 'elasticsearch.internal-java-rest-test'
 apply plugin: 'elasticsearch.internal-yaml-rest-test'
 
 dependencies {

--- a/x-pack/plugin/watcher/qa/with-monitoring/build.gradle
+++ b/x-pack/plugin/watcher/qa/with-monitoring/build.gradle
@@ -1,6 +1,6 @@
 import org.elasticsearch.gradle.internal.info.BuildParams
 
-apply plugin: 'elasticsearch.java-rest-test'
+apply plugin: 'elasticsearch.internal-java-rest-test'
 
 dependencies {
   javaRestTestImplementation project(':x-pack:qa')

--- a/x-pack/plugin/watcher/qa/with-security/build.gradle
+++ b/x-pack/plugin/watcher/qa/with-security/build.gradle
@@ -1,4 +1,4 @@
-apply plugin: 'elasticsearch.java-rest-test'
+apply plugin: 'elasticsearch.internal-java-rest-test'
 apply plugin: 'elasticsearch.internal-yaml-rest-test'
 
 dependencies {

--- a/x-pack/qa/runtime-fields/with-security/build.gradle
+++ b/x-pack/qa/runtime-fields/with-security/build.gradle
@@ -1,4 +1,4 @@
-apply plugin: 'elasticsearch.java-rest-test'
+apply plugin: 'elasticsearch.internal-java-rest-test'
 
 dependencies {
   javaRestTestImplementation(testArtifact(project(xpackModule('core'))))

--- a/x-pack/qa/security-example-spi-extension/build.gradle
+++ b/x-pack/qa/security-example-spi-extension/build.gradle
@@ -1,6 +1,6 @@
 import org.elasticsearch.gradle.util.GradleUtils
 
-apply plugin: 'elasticsearch.java-rest-test'
+apply plugin: 'elasticsearch.internal-java-rest-test'
 apply plugin: 'elasticsearch.internal-es-plugin'
 
 esplugin {


### PR DESCRIPTION
Backports the following commits to 7.15:
 - Introduce external build-tools JavaRestTestPlugin (#77603)