### PR TITLE
Add oracle jdk 8 as part of 7.x fips tests

### DIFF
--- a/.ci/matrix-runtime-javas-fips.yml
+++ b/.ci/matrix-runtime-javas-fips.yml
@@ -8,5 +8,6 @@
 # openjdk16
 
 ES_RUNTIME_JAVA:
+  - java8
   - java11
   - openjdk16


### PR DESCRIPTION
This PR is a follow-up based on the discussion in https://github.com/elastic/elasticsearch/pull/77123#discussion_r702614900

Currently 7.x periodic FIPS CI jobs use `Java11` and `openjdk16` same as the master branch. But since `java8` is still supported for 7.x. It seems reasonable that we should run FIPS tests for 7.x with `java8` as well. 

Previously, vendors who backport changes to jdk 8 more frequently caused an issue that SunJSSE cannot be used in FIPS mode with TLS 1.3 (#64379, https://github.com/elastic/elasticsearch/issues/61316#issuecomment-685482708). This made the FIPS CI setup difficult because we need to test different JDK 8 flavours with different configuration. This does not seem to be an issue anymore since Oracle JDK 8 also got the same backport. Plus we have decided to only test a single distribution of jdk 8. Overall, it seems enabling `java8` for 7.x FIPS CI is reasonable.