### PR TITLE
Improve control of outgoing connection lifecycles

### DIFF
--- a/libs/core/src/main/java/org/elasticsearch/core/AbstractRefCounted.java
+++ b/libs/core/src/main/java/org/elasticsearch/core/AbstractRefCounted.java
@@ -58,6 +58,11 @@ public abstract class AbstractRefCounted implements RefCounted {
         return false;
     }
 
+    @Override
+    public final boolean hasReferences() {
+        return refCount.get() > 0;
+    }
+
     /**
      * Called whenever the ref count is incremented or decremented. Can be overridden to record access to the instance for debugging
      * purposes.
@@ -74,7 +79,7 @@ public abstract class AbstractRefCounted implements RefCounted {
     /**
      * Returns the current reference count.
      */
-    public int refCount() {
+    public final int refCount() {
         return this.refCount.get();
     }
 

--- a/libs/core/src/main/java/org/elasticsearch/core/RefCounted.java
+++ b/libs/core/src/main/java/org/elasticsearch/core/RefCounted.java
@@ -54,4 +54,12 @@ public interface RefCounted {
      * @return returns {@code true} if the ref count dropped to 0 as a result of calling this method
      */
     boolean decRef();
+
+    /**
+     * Returns {@code true} only if there was at least one active reference when the method was called; if it returns {@code false} then the
+     * object is closed; future attempts to acquire references will fail.
+     *
+     * @return whether there are currently any active references to this object.
+     */
+    boolean hasReferences();
 }

--- a/server/src/internalClusterTest/java/org/elasticsearch/action/admin/cluster/node/tasks/CancellableTasksIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/action/admin/cluster/node/tasks/CancellableTasksIT.java
@@ -331,7 +331,9 @@ public class CancellableTasksIT extends ESIntegTestCase {
                     if (bannedParent.getNodeId().equals(node.getId()) && randomBoolean()) {
                         Collection<Transport.Connection> childConns = taskManager.startBanOnChildTasks(bannedParent.getId(), "", () -> {});
                         for (Transport.Connection connection : randomSubsetOf(childConns)) {
-                            connection.close();
+                            if (connection.getNode().equals(node) == false) {
+                                connection.close();
+                            }
                         }
                     }
                 }

--- a/server/src/internalClusterTest/java/org/elasticsearch/discovery/ClusterDisruptionIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/discovery/ClusterDisruptionIT.java
@@ -16,19 +16,22 @@ import org.elasticsearch.action.NoShardAvailableActionException;
 import org.elasticsearch.action.get.GetResponse;
 import org.elasticsearch.action.index.IndexRequestBuilder;
 import org.elasticsearch.action.index.IndexResponse;
+import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.action.shard.ShardStateAction;
 import org.elasticsearch.cluster.coordination.ClusterBootstrapService;
+import org.elasticsearch.cluster.coordination.FollowersChecker;
 import org.elasticsearch.cluster.coordination.LagDetector;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.routing.Murmur3HashFunction;
 import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.cluster.routing.ShardRoutingState;
+import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.common.util.concurrent.ConcurrentCollections;
 import org.elasticsearch.common.xcontent.XContentType;
+import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.index.VersionType;
 import org.elasticsearch.index.shard.IndexShard;
 import org.elasticsearch.index.shard.IndexShardTestCase;
@@ -40,6 +43,8 @@ import org.elasticsearch.test.disruption.NetworkDisruption.Bridge;
 import org.elasticsearch.test.disruption.NetworkDisruption.TwoPartitions;
 import org.elasticsearch.test.disruption.ServiceDisruptionScheme;
 import org.elasticsearch.test.junit.annotations.TestIssueLogging;
+import org.elasticsearch.test.transport.MockTransportService;
+import org.elasticsearch.transport.TransportService;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -58,6 +63,11 @@ import java.util.stream.IntStream;
 
 import static org.elasticsearch.action.DocWriteResponse.Result.CREATED;
 import static org.elasticsearch.action.DocWriteResponse.Result.UPDATED;
+import static org.elasticsearch.cluster.coordination.FollowersChecker.FOLLOWER_CHECK_INTERVAL_SETTING;
+import static org.elasticsearch.cluster.coordination.FollowersChecker.FOLLOWER_CHECK_RETRY_COUNT_SETTING;
+import static org.elasticsearch.cluster.coordination.LeaderChecker.LEADER_CHECK_INTERVAL_SETTING;
+import static org.elasticsearch.cluster.coordination.LeaderChecker.LEADER_CHECK_RETRY_COUNT_SETTING;
+import static org.elasticsearch.discovery.PeerFinder.DISCOVERY_FIND_PEERS_INTERVAL_SETTING;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.everyItem;
@@ -494,4 +504,63 @@ public class ClusterDisruptionIT extends AbstractDisruptionTestCase {
         }
     }
 
+    public void testRejoinWhileBeingRemoved() {
+        final String masterNode = internalCluster().startMasterOnlyNode(Settings.builder()
+            .put(FOLLOWER_CHECK_INTERVAL_SETTING.getKey(), "100ms")
+            .put(FOLLOWER_CHECK_RETRY_COUNT_SETTING.getKey(), "1")
+            .build());
+        final String dataNode = internalCluster().startDataOnlyNode(Settings.builder()
+            .put(DISCOVERY_FIND_PEERS_INTERVAL_SETTING.getKey(), "100ms")
+            .put(LEADER_CHECK_INTERVAL_SETTING.getKey(), "100ms")
+            .put(LEADER_CHECK_RETRY_COUNT_SETTING.getKey(), "1")
+            .build());
+
+        final ClusterService masterClusterService = internalCluster().getInstance(ClusterService.class, masterNode);
+        final PlainActionFuture<Void> removedNode = new PlainActionFuture<>();
+        masterClusterService.addListener(clusterChangedEvent -> {
+            if (removedNode.isDone() == false && clusterChangedEvent.state().nodes().getDataNodes().isEmpty()) {
+                removedNode.onResponse(null);
+            }
+        });
+
+        final ClusterService dataClusterService = internalCluster().getInstance(ClusterService.class, dataNode);
+        final PlainActionFuture<Void> failedLeader = new PlainActionFuture<Void>() {
+            @Override
+            protected boolean blockingAllowed() {
+                // we're deliberately blocking the cluster applier on the master until the data node starts to rejoin
+                return true;
+            }
+        };
+        final AtomicBoolean dataNodeHasMaster = new AtomicBoolean(true);
+        dataClusterService.addListener(clusterChangedEvent -> {
+            dataNodeHasMaster.set(clusterChangedEvent.state().nodes().getMasterNode() != null);
+            if (failedLeader.isDone() == false && dataNodeHasMaster.get() == false) {
+                failedLeader.onResponse(null);
+            }
+        });
+
+        masterClusterService.addHighPriorityApplier(event -> {
+            failedLeader.actionGet();
+            if (dataNodeHasMaster.get() == false) {
+                try {
+                    Thread.sleep(100);
+                } catch (InterruptedException e) {
+                    throw new AssertionError("unexpected", e);
+                }
+            }
+        });
+
+        final MockTransportService dataTransportService
+            = (MockTransportService) internalCluster().getInstance(TransportService.class, dataNode);
+        dataTransportService.addRequestHandlingBehavior(FollowersChecker.FOLLOWER_CHECK_ACTION_NAME, (handler, request, channel, task) -> {
+            if (removedNode.isDone() == false) {
+                channel.sendResponse(new ElasticsearchException("simulated check failure"));
+            } else {
+                handler.messageReceived(request, channel, task);
+            }
+        });
+
+        removedNode.actionGet(10, TimeUnit.SECONDS);
+        ensureStableCluster(2);
+    }
 }

--- a/server/src/main/java/org/elasticsearch/cluster/NodeConnectionsService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/NodeConnectionsService.java
@@ -11,21 +11,20 @@ import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.message.ParameterizedMessage;
-import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.GroupedActionListener;
-import org.elasticsearch.action.support.ListenableActionFuture;
 import org.elasticsearch.cluster.coordination.FollowersChecker;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
 import org.elasticsearch.cluster.service.ClusterApplier;
-import org.elasticsearch.core.Nullable;
 import org.elasticsearch.common.component.AbstractLifecycleComponent;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.common.util.concurrent.AbstractRunnable;
+import org.elasticsearch.core.Releasable;
+import org.elasticsearch.core.Releasables;
+import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 
@@ -37,6 +36,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static org.elasticsearch.common.settings.Setting.Property;
 import static org.elasticsearch.common.settings.Setting.positiveTimeSetting;
@@ -70,8 +70,7 @@ public class NodeConnectionsService extends AbstractLifecycleComponent {
     // Crucially there are no blocking calls under this mutex: it is not held while connecting or disconnecting.
     private final Object mutex = new Object();
 
-    // contains an entry for every node in the latest cluster state, as well as for nodes from which we are in the process of
-    // disconnecting
+    // contains an entry for every node in the latest cluster state
     private final Map<DiscoveryNode, ConnectionTarget> targetsByNode = new HashMap<>();
 
     private final TimeValue reconnectInterval;
@@ -86,7 +85,7 @@ public class NodeConnectionsService extends AbstractLifecycleComponent {
 
     /**
      * Connect to all the given nodes, but do not disconnect from any extra nodes. Calls the completion handler on completion of all
-     * connection attempts to _new_ nodes, but not on attempts to re-establish connections to nodes that are already known.
+     * connection attempts to _new_ nodes, without waiting for any attempts to re-establish connections to nodes that were already known.
      */
     public void connectToNodes(DiscoveryNodes discoveryNodes, Runnable onCompletion) {
 
@@ -102,22 +101,20 @@ public class NodeConnectionsService extends AbstractLifecycleComponent {
         synchronized (mutex) {
             for (final DiscoveryNode discoveryNode : discoveryNodes) {
                 ConnectionTarget connectionTarget = targetsByNode.get(discoveryNode);
-                final boolean isNewNode;
-                if (connectionTarget == null) {
-                    // new node, set up target and listener
+                final boolean isNewNode = connectionTarget == null;
+                if (isNewNode) {
                     connectionTarget = new ConnectionTarget(discoveryNode);
                     targetsByNode.put(discoveryNode, connectionTarget);
-                    isNewNode = true;
-                } else {
-                    // existing node, but maybe we're disconnecting from it, in which case it was recently removed from the cluster
-                    // state and has now been re-added so we should wait for the re-connection
-                    isNewNode = connectionTarget.isPendingDisconnection();
                 }
 
                 if (isNewNode) {
-                    runnables.add(connectionTarget.connect(listener));
+                    logger.debug("connecting to {}", discoveryNode);
+                    runnables.add(connectionTarget.connect(ActionListener.runAfter(
+                        listener,
+                        () -> logger.debug("connected to {}", discoveryNode))));
                 } else {
                     // known node, try and ensure it's connected but do not wait
+                    logger.trace("checking connection to existing node [{}]", discoveryNode);
                     runnables.add(connectionTarget.connect(null));
                     runnables.add(() -> listener.onResponse(null));
                 }
@@ -139,33 +136,7 @@ public class NodeConnectionsService extends AbstractLifecycleComponent {
             }
 
             for (final DiscoveryNode discoveryNode : nodesToDisconnect) {
-                runnables.add(targetsByNode.get(discoveryNode).disconnect());
-            }
-        }
-        runnables.forEach(Runnable::run);
-    }
-
-    void ensureConnections(Runnable onCompletion) {
-        // Called by tests after some disruption has concluded. It is possible that one or more targets are currently CONNECTING and have
-        // been since the disruption was active, and that the connection attempt was thwarted by a concurrent disruption to the connection.
-        // If so, we cannot simply add our listener to the queue because it will be notified when this CONNECTING activity completes even
-        // though it was disrupted. We must therefore wait for all the current activity to finish and then go through and reconnect to
-        // any missing nodes.
-        awaitPendingActivity(() -> connectDisconnectedTargets(onCompletion));
-    }
-
-    private void awaitPendingActivity(Runnable onCompletion) {
-        final List<Runnable> runnables = new ArrayList<>();
-        synchronized (mutex) {
-            final Collection<ConnectionTarget> connectionTargets = targetsByNode.values();
-            if (connectionTargets.isEmpty()) {
-                runnables.add(onCompletion);
-            } else {
-                final GroupedActionListener<Void> listener = new GroupedActionListener<>(
-                    ActionListener.wrap(onCompletion), connectionTargets.size());
-                for (final ConnectionTarget connectionTarget : connectionTargets) {
-                    runnables.add(connectionTarget.awaitCurrentActivity(listener));
-                }
+                runnables.add(targetsByNode.remove(discoveryNode)::disconnect);
             }
         }
         runnables.forEach(Runnable::run);
@@ -173,21 +144,20 @@ public class NodeConnectionsService extends AbstractLifecycleComponent {
 
     /**
      * Makes a single attempt to reconnect to any nodes which are disconnected but should be connected. Does not attempt to reconnect any
-     * nodes which are in the process of disconnecting. The onCompletion handler is called after all ongoing connection/disconnection
-     * attempts have completed.
+     * nodes which are in the process of disconnecting. The onCompletion handler is called after all connection attempts have completed.
      */
-    private void connectDisconnectedTargets(Runnable onCompletion) {
+    void ensureConnections(Runnable onCompletion) {
         final List<Runnable> runnables = new ArrayList<>();
         synchronized (mutex) {
             final Collection<ConnectionTarget> connectionTargets = targetsByNode.values();
             if (connectionTargets.isEmpty()) {
                 runnables.add(onCompletion);
             } else {
-                logger.trace("connectDisconnectedTargets: {}", targetsByNode);
+                logger.trace("ensureConnections: {}", targetsByNode);
                 final GroupedActionListener<Void> listener = new GroupedActionListener<>(
                     ActionListener.wrap(onCompletion), connectionTargets.size());
                 for (final ConnectionTarget connectionTarget : connectionTargets) {
-                    runnables.add(connectionTarget.ensureConnected(listener));
+                    runnables.add(connectionTarget.connect(listener));
                 }
             }
         }
@@ -197,7 +167,7 @@ public class NodeConnectionsService extends AbstractLifecycleComponent {
     class ConnectionChecker extends AbstractRunnable {
         protected void doRun() {
             if (connectionChecker == this) {
-                connectDisconnectedTargets(this::scheduleNextCheck);
+                ensureConnections(this::scheduleNextCheck);
             }
         }
 
@@ -243,231 +213,75 @@ public class NodeConnectionsService extends AbstractLifecycleComponent {
         });
     }
 
-    private enum ActivityType {
-        IDLE,
-        CONNECTING,
-        DISCONNECTING
-    }
-
-    /**
-     * {@link ConnectionTarget} ensures that we are never concurrently connecting to and disconnecting from a node, and that we eventually
-     * either connect to or disconnect from it according to whether {@link ConnectionTarget#connect(ActionListener)} or
-     * {@link ConnectionTarget#disconnect()} was called last.
-     * <p>
-     * Each {@link ConnectionTarget} is in one of these states:
-     * <p>
-     * - idle                       ({@link ConnectionTarget#future} has no listeners)
-     * - awaiting connection        ({@link ConnectionTarget#future} may contain listeners awaiting a connection)
-     * - awaiting disconnection     ({@link ConnectionTarget#future} may contain listeners awaiting a disconnection)
-     * <p>
-     * It will be awaiting connection (respectively disconnection) after calling {@code connect()} (respectively {@code disconnect()}). It
-     * will eventually become idle if these methods are not called infinitely often.
-     * <p>
-     * These methods return a {@link Runnable} which starts the connection/disconnection process iff it was idle before the method was
-     * called, and which notifies any failed listeners if the {@code ConnectionTarget} went from {@code CONNECTING} to {@code DISCONNECTING}
-     * or vice versa. The connection/disconnection process continues until all listeners have been removed, at which point it becomes idle
-     * again.
-     * <p>
-     * Additionally if the last step of the process was a disconnection then this target is removed from the current set of targets. Thus
-     * if this {@link ConnectionTarget} is idle and in the current set of targets then it should be connected.
-     * <p>
-     * All of the {@code listeners} are awaiting the completion of the same activity, which is either a connection or a disconnection.  If
-     * we are currently connecting and then {@link ConnectionTarget#disconnect()} is called then all connection listeners are
-     * removed from the list so they can be notified of failure; once the connecting process has finished a disconnection will be started.
-     * Similarly if we are currently disconnecting and then {@link ConnectionTarget#connect(ActionListener)} is called then all
-     * disconnection listeners are immediately removed for failure notification and a connection is started once the disconnection is
-     * complete.
-     */
     private class ConnectionTarget {
         private final DiscoveryNode discoveryNode;
 
-        private ListenableActionFuture<Void> future = new ListenableActionFuture<>();
-        private ActivityType activityType = ActivityType.IDLE; // indicates what any listeners are awaiting
-
         private final AtomicInteger consecutiveFailureCount = new AtomicInteger();
-
-        private final Runnable connectActivity = new AbstractRunnable() {
-
-            final AbstractRunnable abstractRunnable = this;
-
-            @Override
-            protected void doRun() {
-                assert Thread.holdsLock(mutex) == false : "mutex unexpectedly held";
-                if (transportService.nodeConnected(discoveryNode)) {
-                    // transportService.connectToNode is a no-op if already connected, but we don't want any DEBUG logging in this case
-                    // since we run this for every node on every cluster state update.
-                    logger.trace("still connected to {}", discoveryNode);
-                    onConnected();
-                } else {
-                    logger.debug("connecting to {}", discoveryNode);
-                    transportService.connectToNode(discoveryNode, new ActionListener<Void>() {
-                        @Override
-                        public void onResponse(Void aVoid) {
-                            assert Thread.holdsLock(mutex) == false : "mutex unexpectedly held";
-                            logger.debug("connected to {}", discoveryNode);
-                            onConnected();
-                        }
-
-                        @Override
-                        public void onFailure(Exception e) {
-                            abstractRunnable.onFailure(e);
-                        }
-                    });
-                }
-            }
-
-            private void onConnected() {
-                consecutiveFailureCount.set(0);
-                onCompletion(ActivityType.CONNECTING, null, disconnectActivity);
-            }
-
-            @Override
-            public void onFailure(Exception e) {
-                assert Thread.holdsLock(mutex) == false : "mutex unexpectedly held";
-                final int currentFailureCount = consecutiveFailureCount.incrementAndGet();
-                // only warn every 6th failure
-                final Level level = currentFailureCount % 6 == 1 ? Level.WARN : Level.DEBUG;
-                logger.log(level, new ParameterizedMessage("failed to connect to {} (tried [{}] times)",
-                    discoveryNode, currentFailureCount), e);
-                onCompletion(ActivityType.CONNECTING, e, disconnectActivity);
-            }
-
-            @Override
-            public String toString() {
-                return "connect to " + discoveryNode;
-            }
-        };
-
-        private final Runnable disconnectActivity = new AbstractRunnable() {
-            @Override
-            protected void doRun() {
-                assert Thread.holdsLock(mutex) == false : "mutex unexpectedly held";
-                transportService.disconnectFromNode(discoveryNode);
-                consecutiveFailureCount.set(0);
-                logger.debug("disconnected from {}", discoveryNode);
-                onCompletion(ActivityType.DISCONNECTING, null, connectActivity);
-            }
-
-            @Override
-            public void onFailure(Exception e) {
-                assert Thread.holdsLock(mutex) == false : "mutex unexpectedly held";
-                consecutiveFailureCount.incrementAndGet();
-                // we may not have disconnected, but will not retry, so this connection might have leaked
-                logger.warn(new ParameterizedMessage("failed to disconnect from {}, possible connection leak", discoveryNode), e);
-                assert false : "failed to disconnect from " + discoveryNode + ", possible connection leak\n" + e;
-                onCompletion(ActivityType.DISCONNECTING, e, connectActivity);
-            }
-        };
+        private final AtomicReference<Releasable> connectionRef = new AtomicReference<>();
 
         ConnectionTarget(DiscoveryNode discoveryNode) {
             this.discoveryNode = discoveryNode;
         }
 
-        Runnable connect(@Nullable ActionListener<Void> listener) {
-            return addListenerAndStartActivity(listener, ActivityType.CONNECTING, connectActivity,
-                "disconnection cancelled by reconnection");
+        private void setConnectionRef(Releasable connectionReleasable) {
+            Releasables.close(connectionRef.getAndSet(connectionReleasable));
         }
 
-        Runnable disconnect() {
-            return addListenerAndStartActivity(null, ActivityType.DISCONNECTING, disconnectActivity,
-                "connection cancelled by disconnection");
-        }
+        Runnable connect(ActionListener<Void> listener) {
+            return () -> {
+                final boolean alreadyConnected = transportService.nodeConnected(discoveryNode);
 
-        Runnable ensureConnected(@Nullable ActionListener<Void> listener) {
-            assert Thread.holdsLock(mutex) : "mutex not held";
-
-            if (activityType == ActivityType.IDLE) {
-                if (transportService.nodeConnected(discoveryNode)) {
-                    return () -> listener.onResponse(null);
+                if (alreadyConnected) {
+                    logger.trace("refreshing connection to {}", discoveryNode);
                 } else {
-                    // target is disconnected, and we are currently idle, so start a connection process.
-                    activityType = ActivityType.CONNECTING;
-                    addListener(listener);
-                    return connectActivity;
+                    logger.debug("connecting to {}", discoveryNode);
                 }
-            } else {
-                addListener(listener);
-                return () -> {
-                };
-            }
-        }
 
-        Runnable awaitCurrentActivity(ActionListener<Void> listener) {
-            assert Thread.holdsLock(mutex) : "mutex not held";
+                // It's possible that connectionRef is a reference to an older connection that closed out from under us, but that something
+                // else has opened a fresh connection to the node. Therefore we always call connectToNode() and update connectionRef.
+                transportService.connectToNode(discoveryNode, new ActionListener<Releasable>() {
+                    @Override
+                    public void onResponse(Releasable connectionReleasable) {
+                        if (alreadyConnected) {
+                            logger.trace("refreshed connection to {}", discoveryNode);
+                        } else {
+                            logger.debug("connected to {}", discoveryNode);
+                        }
+                        consecutiveFailureCount.set(0);
+                        setConnectionRef(connectionReleasable);
 
-            if (activityType == ActivityType.IDLE) {
-                return () -> listener.onResponse(null);
-            } else {
-                addListener(listener);
-                return () -> {
-                };
-            }
-        }
-
-        private void addListener(@Nullable ActionListener<Void> listener) {
-            assert Thread.holdsLock(mutex) : "mutex not held";
-            assert activityType != ActivityType.IDLE;
-            if (listener != null) {
-                future.addListener(listener);
-            }
-        }
-
-        private ListenableActionFuture<Void> getAndClearFuture() {
-            assert Thread.holdsLock(mutex) : "mutex not held";
-            final ListenableActionFuture<Void> drainedFuture = future;
-            future = new ListenableActionFuture<>();
-            return drainedFuture;
-        }
-
-        private Runnable addListenerAndStartActivity(@Nullable ActionListener<Void> listener, ActivityType newActivityType,
-                                                     Runnable activity, String cancellationMessage) {
-            assert Thread.holdsLock(mutex) : "mutex not held";
-            assert newActivityType.equals(ActivityType.IDLE) == false;
-
-            if (activityType == ActivityType.IDLE) {
-                activityType = newActivityType;
-                addListener(listener);
-                return activity;
-            }
-
-            if (activityType == newActivityType) {
-                addListener(listener);
-                return () -> {
-                };
-            }
-
-            activityType = newActivityType;
-            final ListenableActionFuture<Void> oldFuture = getAndClearFuture();
-            addListener(listener);
-            return () -> oldFuture.onFailure(new ElasticsearchException(cancellationMessage));
-        }
-
-        private void onCompletion(ActivityType completedActivityType, @Nullable Exception e, Runnable oppositeActivity) {
-            assert Thread.holdsLock(mutex) == false : "mutex unexpectedly held";
-
-            final Runnable cleanup;
-            synchronized (mutex) {
-                assert activityType != ActivityType.IDLE;
-                if (activityType == completedActivityType) {
-                    final ListenableActionFuture<Void> oldFuture = getAndClearFuture();
-                    activityType = ActivityType.IDLE;
-
-                    cleanup = e == null ? () -> oldFuture.onResponse(null) : () -> oldFuture.onFailure(e);
-
-                    if (completedActivityType.equals(ActivityType.DISCONNECTING)) {
-                        final ConnectionTarget removedTarget = targetsByNode.remove(discoveryNode);
-                        assert removedTarget == this : removedTarget + " vs " + this;
+                        final boolean isActive;
+                        synchronized (mutex) {
+                            isActive = targetsByNode.get(discoveryNode) == ConnectionTarget.this;
+                        }
+                        if (isActive == false) {
+                            logger.debug("connected to stale {} - releasing stale connection", discoveryNode);
+                            setConnectionRef(null);
+                        }
+                        if (listener != null) {
+                            listener.onResponse(null);
+                        }
                     }
-                } else {
-                    cleanup = oppositeActivity;
-                }
-            }
-            cleanup.run();
+
+                    @Override
+                    public void onFailure(Exception e) {
+                        final int currentFailureCount = consecutiveFailureCount.incrementAndGet();
+                        // only warn every 6th failure
+                        final Level level = currentFailureCount % 6 == 1 ? Level.WARN : Level.DEBUG;
+                        logger.log(level, new ParameterizedMessage("failed to connect to {} (tried [{}] times)",
+                            discoveryNode, currentFailureCount), e);
+                        setConnectionRef(null);
+                        if (listener != null) {
+                            listener.onFailure(e);
+                        }
+                    }
+                });
+            };
         }
 
-        boolean isPendingDisconnection() {
-            assert Thread.holdsLock(mutex) : "mutex not held";
-            return activityType == ActivityType.DISCONNECTING;
+        void disconnect() {
+            setConnectionRef(null);
+            logger.debug("disconnected from {}", discoveryNode);
         }
 
         @Override
@@ -475,7 +289,6 @@ public class NodeConnectionsService extends AbstractLifecycleComponent {
             synchronized (mutex) {
                 return "ConnectionTarget{" +
                     "discoveryNode=" + discoveryNode +
-                    ", activityType=" + activityType +
                     '}';
             }
         }

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/Coordinator.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/Coordinator.java
@@ -34,6 +34,7 @@ import org.elasticsearch.cluster.routing.RerouteService;
 import org.elasticsearch.cluster.routing.allocation.AllocationService;
 import org.elasticsearch.cluster.service.ClusterApplier;
 import org.elasticsearch.cluster.service.ClusterApplier.ClusterApplyListener;
+import org.elasticsearch.cluster.service.ClusterApplierService;
 import org.elasticsearch.cluster.service.MasterService;
 import org.elasticsearch.common.Priority;
 import org.elasticsearch.common.Strings;
@@ -51,6 +52,7 @@ import org.elasticsearch.common.xcontent.json.JsonXContent;
 import org.elasticsearch.core.Booleans;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.Releasable;
+import org.elasticsearch.core.Releasables;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.discovery.ConfiguredHostsResolver;
 import org.elasticsearch.discovery.Discovery;
@@ -298,10 +300,20 @@ public class Coordinator extends AbstractLifecycleComponent implements Discovery
 
                         @Override
                         public void onSuccess() {
+                            onClusterStateApplied();
                             applyListener.onResponse(null);
                         }
                     });
             }
+        }
+    }
+
+    private void onClusterStateApplied() {
+        assert Thread.currentThread().getName().contains('[' + ClusterApplierService.CLUSTER_UPDATE_THREAD_NAME + ']')
+            || Thread.currentThread().getName().startsWith("TEST-")
+            : Thread.currentThread().getName();
+        if (getMode() != Mode.CANDIDATE) {
+            joinHelper.onClusterStateApplied();
         }
     }
 
@@ -490,21 +502,44 @@ public class Coordinator extends AbstractLifecycleComponent implements Discovery
             return;
         }
 
-        transportService.connectToNode(joinRequest.getSourceNode(), ActionListener.wrap(ignore -> {
-            final ClusterState stateForJoinValidation = getStateForMasterService();
+        transportService.connectToNode(joinRequest.getSourceNode(), ActionListener.wrap(connectionReference -> {
+            boolean retainConnection = false;
+            try {
+                final JoinHelper.JoinCallback wrappedJoinCallback = new JoinHelper.JoinCallback() {
+                    @Override
+                    public void onSuccess() {
+                        Releasables.close(connectionReference);
+                        joinCallback.onSuccess();
+                    }
 
-            if (stateForJoinValidation.nodes().isLocalNodeElectedMaster()) {
-                onJoinValidators.forEach(a -> a.accept(joinRequest.getSourceNode(), stateForJoinValidation));
-                if (stateForJoinValidation.getBlocks().hasGlobalBlock(STATE_NOT_RECOVERED_BLOCK) == false) {
-                    // we do this in a couple of places including the cluster update thread. This one here is really just best effort
-                    // to ensure we fail as fast as possible.
-                    JoinTaskExecutor.ensureVersionBarrier(
-                        joinRequest.getSourceNode().getVersion(),
-                        stateForJoinValidation.getNodes().getMinNodeVersion());
+                    @Override
+                    public void onFailure(Exception e) {
+                        Releasables.close(connectionReference);
+                        joinCallback.onFailure(e);
+                    }
+                };
+
+                final ClusterState stateForJoinValidation = getStateForMasterService();
+
+                if (stateForJoinValidation.nodes().isLocalNodeElectedMaster()) {
+                    onJoinValidators.forEach(a -> a.accept(joinRequest.getSourceNode(), stateForJoinValidation));
+                    if (stateForJoinValidation.getBlocks().hasGlobalBlock(STATE_NOT_RECOVERED_BLOCK) == false) {
+                        // we do this in a couple of places including the cluster update thread. This one here is really just best effort
+                        // to ensure we fail as fast as possible.
+                        JoinTaskExecutor.ensureVersionBarrier(
+                            joinRequest.getSourceNode().getVersion(),
+                            stateForJoinValidation.getNodes().getMinNodeVersion());
+                    }
+                    sendValidateJoinRequest(stateForJoinValidation, joinRequest, wrappedJoinCallback);
+                } else {
+                    processJoinRequest(joinRequest, wrappedJoinCallback);
                 }
-                sendValidateJoinRequest(stateForJoinValidation, joinRequest, joinCallback);
-            } else {
-                processJoinRequest(joinRequest, joinCallback);
+
+                retainConnection = true;
+            } finally {
+                if (retainConnection == false) {
+                    Releasables.close(connectionReference);
+                }
             }
         }, joinCallback::onFailure));
     }
@@ -1454,6 +1489,7 @@ public class Coordinator extends AbstractLifecycleComponent implements Discovery
 
                             @Override
                             public void onSuccess() {
+                                onClusterStateApplied();
                                 clusterStatePublicationEvent.setMasterApplyElapsedMillis(
                                     transportService.getThreadPool().rawRelativeTimeInMillis() - completionTimeMillis);
                                 synchronized (mutex) {

--- a/server/src/main/java/org/elasticsearch/cluster/node/DiscoveryNode.java
+++ b/server/src/main/java/org/elasticsearch/cluster/node/DiscoveryNode.java
@@ -517,6 +517,12 @@ public class DiscoveryNode implements Writeable, ToXContentFragment {
         }
     }
 
+    public String descriptionWithoutAttributes() {
+        final StringBuilder stringBuilder = new StringBuilder();
+        appendDescriptionWithoutAttributes(stringBuilder);
+        return stringBuilder.toString();
+    }
+
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startObject(getId());

--- a/server/src/main/java/org/elasticsearch/cluster/service/ClusterApplierService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/service/ClusterApplierService.java
@@ -498,13 +498,17 @@ public class ClusterApplierService extends AbstractLifecycleComponent implements
     protected void connectToNodesAndWait(ClusterState newClusterState) {
         // can't wait for an ActionFuture on the cluster applier thread, but we do want to block the thread here, so use a CountDownLatch.
         final CountDownLatch countDownLatch = new CountDownLatch(1);
-        nodeConnectionsService.connectToNodes(newClusterState.nodes(), countDownLatch::countDown);
+        connectToNodesAsync(newClusterState, countDownLatch::countDown);
         try {
             countDownLatch.await();
         } catch (InterruptedException e) {
             logger.debug("interrupted while connecting to nodes, continuing", e);
             Thread.currentThread().interrupt();
         }
+    }
+
+    protected final void connectToNodesAsync(ClusterState newClusterState, Runnable onCompletion) {
+        nodeConnectionsService.connectToNodes(newClusterState.nodes(), onCompletion);
     }
 
     private void callClusterStateAppliers(ClusterChangedEvent clusterChangedEvent, StopWatch stopWatch) {

--- a/server/src/main/java/org/elasticsearch/common/bytes/ReleasableBytesReference.java
+++ b/server/src/main/java/org/elasticsearch/common/bytes/ReleasableBytesReference.java
@@ -72,6 +72,11 @@ public final class ReleasableBytesReference implements RefCounted, Releasable, B
         return refCounted.decRef();
     }
 
+    @Override
+    public boolean hasReferences() {
+        return refCounted.hasReferences();
+    }
+
     public ReleasableBytesReference retain() {
         refCounted.incRef();
         return this;

--- a/server/src/main/java/org/elasticsearch/discovery/HandshakingTransportAddressConnector.java
+++ b/server/src/main/java/org/elasticsearch/discovery/HandshakingTransportAddressConnector.java
@@ -13,6 +13,7 @@ import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.ActionRunnable;
 import org.elasticsearch.action.NotifyOnceListener;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.common.Randomness;
@@ -20,6 +21,7 @@ import org.elasticsearch.common.UUIDs;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.transport.TransportAddress;
+import org.elasticsearch.core.Releasable;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.common.util.concurrent.AbstractRunnable;
 import org.elasticsearch.core.internal.io.IOUtils;
@@ -55,8 +57,8 @@ public class HandshakingTransportAddressConnector implements TransportAddressCon
     }
 
     @Override
-    public void connectToRemoteMasterNode(TransportAddress transportAddress, ActionListener<DiscoveryNode> listener) {
-        transportService.getThreadPool().generic().execute(new AbstractRunnable() {
+    public void connectToRemoteMasterNode(TransportAddress transportAddress, ActionListener<ProbeConnectionResult> listener) {
+        transportService.getThreadPool().generic().execute(new ActionRunnable<ProbeConnectionResult>(listener) {
             private final AbstractRunnable thisConnectionAttempt = this;
 
             @Override
@@ -91,12 +93,11 @@ public class HandshakingTransportAddressConnector implements TransportAddressCon
                                     } else if (remoteNode.isMasterNode() == false) {
                                         listener.onFailure(new ConnectTransportException(remoteNode, "non-master-eligible node found"));
                                     } else {
-                                        transportService.connectToNode(remoteNode, new ActionListener<Void>() {
+                                        transportService.connectToNode(remoteNode, new ActionListener<Releasable>() {
                                             @Override
-                                            public void onResponse(Void ignored) {
-                                                logger.trace("[{}] completed full connection with [{}]",
-                                                        thisConnectionAttempt, remoteNode);
-                                                listener.onResponse(remoteNode);
+                                            public void onResponse(Releasable connectionReleasable) {
+                                                logger.trace("[{}] completed full connection with [{}]", thisConnectionAttempt, remoteNode);
+                                                listener.onResponse(new ProbeConnectionResult(remoteNode, connectionReleasable));
                                             }
 
                                             @Override

--- a/server/src/main/java/org/elasticsearch/discovery/PeerFinder.java
+++ b/server/src/main/java/org/elasticsearch/discovery/PeerFinder.java
@@ -24,6 +24,8 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.transport.TransportAddress;
+import org.elasticsearch.core.Releasable;
+import org.elasticsearch.core.Releasables;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.common.util.concurrent.AbstractRunnable;
 import org.elasticsearch.discovery.zen.UnicastZenPing;
@@ -132,9 +134,11 @@ public abstract class PeerFinder {
 
     public void deactivate(DiscoveryNode leader) {
         final boolean peersRemoved;
+        final List<Releasable> connectionReferences;
         synchronized (mutex) {
             logger.trace("deactivating and setting leader to {}", leader);
             active = false;
+            connectionReferences = peersByAddress.values().stream().map(Peer::getConnectionReference).collect(Collectors.toList());
             peersRemoved = handleWakeUp();
             this.leader = Optional.of(leader);
             assert assertInactiveWithNoKnownPeers();
@@ -142,6 +146,24 @@ public abstract class PeerFinder {
         if (peersRemoved) {
             onFoundPeersUpdated();
         }
+
+        // Discovery is over, we're joining a cluster, so we can release all the connections that were being used for discovery. We haven't
+        // finished joining/forming the cluster yet, but if we're joining an existing master then the join will hold open the connection
+        // it's using and if we're becoming the master then join validation will hold open the connections to the joining peers; this set of
+        // peers is a quorum so that's good enough.
+        //
+        // Note however that this might still close connections to other master-eligible nodes that we discovered but which aren't currently
+        // involved in joining: either they're not the master we're joining or else we're becoming the master but they didn't try and join
+        // us yet. It's a pretty safe bet that we'll want to have connections to these nodes in the near future: either they're already in
+        // the cluster or else they will discover we're the master and join us straight away. In theory we could keep these discovery
+        // connections open for a while rather than closing them here and then reopening them again, but in practice it's so much simpler to
+        // forget about them for now.
+        //
+        // Note also that the NodeConnectionsService is still maintaining connections to the nodes in the last-applied cluster state, so
+        // this will only close connections to nodes that we didn't know about beforehand. In most cases that's because we only just started
+        // and haven't applied any cluster states at all yet. This won't cause any connection disruption during a typical master failover.
+        assert peersRemoved || connectionReferences.isEmpty() : connectionReferences;
+        Releasables.close(connectionReferences);
     }
 
     // exposed to subclasses for testing
@@ -228,12 +250,6 @@ public abstract class PeerFinder {
             .map(Peer::getDiscoveryNode).filter(Objects::nonNull).distinct().collect(Collectors.toList());
     }
 
-    private Peer createConnectingPeer(TransportAddress transportAddress) {
-        Peer peer = new Peer(transportAddress);
-        peer.establishConnection();
-        return peer;
-    }
-
     /**
      * @return whether any peers were removed due to disconnection
      */
@@ -303,12 +319,16 @@ public abstract class PeerFinder {
             return;
         }
 
-        peersByAddress.computeIfAbsent(transportAddress, this::createConnectingPeer);
+        if (peersByAddress.containsKey(transportAddress) == false) {
+            final Peer peer = new Peer(transportAddress);
+            peersByAddress.put(transportAddress, peer);
+            peer.establishConnection();
+        }
     }
 
     private class Peer {
         private final TransportAddress transportAddress;
-        private final SetOnce<DiscoveryNode> discoveryNode = new SetOnce<>();
+        private final SetOnce<ProbeConnectionResult> probeConnectionResult = new SetOnce<>();
         private volatile boolean peersRequestInFlight;
 
         Peer(TransportAddress transportAddress) {
@@ -317,13 +337,17 @@ public abstract class PeerFinder {
 
         @Nullable
         DiscoveryNode getDiscoveryNode() {
-            return discoveryNode.get();
+            return Optional.ofNullable(probeConnectionResult.get()).map(ProbeConnectionResult::getDiscoveryNode).orElse(null);
+        }
+
+        private boolean isActive() {
+            return active && peersByAddress.get(transportAddress) == this;
         }
 
         boolean handleWakeUp() {
             assert holdsLock() : "PeerFinder mutex not held";
 
-            if (active == false) {
+            if (isActive() == false) {
                 return true;
             }
 
@@ -347,29 +371,41 @@ public abstract class PeerFinder {
         void establishConnection() {
             assert holdsLock() : "PeerFinder mutex not held";
             assert getDiscoveryNode() == null : "unexpectedly connected to " + getDiscoveryNode();
-            assert active;
+            assert isActive();
 
             final boolean verboseFailureLogging
                     = transportService.getThreadPool().relativeTimeInMillis() - activatedAtMillis > verbosityIncreaseTimeout.millis();
 
             logger.trace("{} attempting connection", this);
-            transportAddressConnector.connectToRemoteMasterNode(transportAddress, new ActionListener<DiscoveryNode>() {
+            transportAddressConnector.connectToRemoteMasterNode(transportAddress, new ActionListener<ProbeConnectionResult>() {
                 @Override
-                public void onResponse(DiscoveryNode remoteNode) {
+                public void onResponse(ProbeConnectionResult connectResult) {
+                    assert holdsLock() == false : "PeerFinder mutex is held in error";
+                    final DiscoveryNode remoteNode = connectResult.getDiscoveryNode();
                     assert remoteNode.isMasterNode() : remoteNode + " is not master-eligible";
                     assert remoteNode.equals(getLocalNode()) == false : remoteNode + " is the local node";
-                    synchronized (mutex) {
-                        if (active == false) {
-                            return;
+                    boolean retainConnection = false;
+                    try {
+                        synchronized (mutex) {
+                            if (isActive() == false) {
+                                return;
+                            }
+
+                            assert probeConnectionResult.get() == null :
+                                "connection result unexpectedly already set to " + probeConnectionResult.get();
+                            probeConnectionResult.set(connectResult);
+
+                            requestPeers();
                         }
 
-                        assert discoveryNode.get() == null : "discoveryNode unexpectedly already set to " + discoveryNode.get();
-                        discoveryNode.set(remoteNode);
-                        requestPeers();
-                    }
+                        onFoundPeersUpdated();
 
-                    assert holdsLock() == false : "PeerFinder mutex is held in error";
-                    onFoundPeersUpdated();
+                        retainConnection = true;
+                    } finally {
+                        if (retainConnection == false) {
+                            Releasables.close(connectResult);
+                        }
+                    }
                 }
 
                 @Override
@@ -394,6 +430,8 @@ public abstract class PeerFinder {
                         logger.debug(new ParameterizedMessage("{} connection failed", Peer.this), e);
                     }
                     synchronized (mutex) {
+                        assert probeConnectionResult.get() == null
+                            : "discoveryNode unexpectedly already set to " + probeConnectionResult.get();
                         peersByAddress.remove(transportAddress);
                     }
                 }
@@ -403,7 +441,7 @@ public abstract class PeerFinder {
         private void requestPeers() {
             assert holdsLock() : "PeerFinder mutex not held";
             assert peersRequestInFlight == false : "PeersRequest already in flight";
-            assert active;
+            assert isActive();
 
             final DiscoveryNode discoveryNode = getDiscoveryNode();
             assert discoveryNode != null : "cannot request peers without first connecting";
@@ -429,7 +467,7 @@ public abstract class PeerFinder {
                 public void handleResponse(PeersResponse response) {
                     logger.trace("{} received {}", Peer.this, response);
                     synchronized (mutex) {
-                        if (active == false) {
+                        if (isActive() == false) {
                             return;
                         }
 
@@ -489,9 +527,15 @@ public abstract class PeerFinder {
                 transportResponseHandler);
         }
 
+        @Nullable
+        Releasable getConnectionReference() {
+            assert holdsLock() : "PeerFinder mutex not held";
+            return probeConnectionResult.get();
+        }
+
         @Override
         public String toString() {
-            return "address [" + transportAddress + "], node [" + discoveryNode.get() + "], requesting [" + peersRequestInFlight + "]";
+            return "address [" + transportAddress + "], node [" + getDiscoveryNode() + "], requesting [" + peersRequestInFlight + "]";
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/discovery/ProbeConnectionResult.java
+++ b/server/src/main/java/org/elasticsearch/discovery/ProbeConnectionResult.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.discovery;
+
+import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.core.Releasable;
+
+/**
+ * The result of a "probe" connection to a transport address, if it successfully discovered a valid node and established a full connection
+ * with it.
+ */
+public class ProbeConnectionResult implements Releasable {
+
+    private final DiscoveryNode discoveryNode;
+    private final Releasable releasable;
+
+    public ProbeConnectionResult(DiscoveryNode discoveryNode, Releasable releasable) {
+        this.discoveryNode = discoveryNode;
+        this.releasable = releasable;
+    }
+
+    public DiscoveryNode getDiscoveryNode() {
+        return discoveryNode;
+    }
+
+    @Override
+    public void close() {
+        releasable.close();
+    }
+
+    @Override
+    public String toString() {
+        return "ProbeConnectionResult{" + discoveryNode + "}";
+    }
+}

--- a/server/src/main/java/org/elasticsearch/discovery/TransportAddressConnector.java
+++ b/server/src/main/java/org/elasticsearch/discovery/TransportAddressConnector.java
@@ -9,12 +9,11 @@
 package org.elasticsearch.discovery;
 
 import org.elasticsearch.action.ActionListener;
-import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.common.transport.TransportAddress;
 
 public interface TransportAddressConnector {
     /**
      * Identify the node at the given address and, if it is a master node and not the local node then establish a full connection to it.
      */
-    void connectToRemoteMasterNode(TransportAddress transportAddress, ActionListener<DiscoveryNode> listener);
+    void connectToRemoteMasterNode(TransportAddress transportAddress, ActionListener<ProbeConnectionResult> listener);
 }

--- a/server/src/main/java/org/elasticsearch/index/store/Store.java
+++ b/server/src/main/java/org/elasticsearch/index/store/Store.java
@@ -397,6 +397,11 @@ public class Store extends AbstractIndexShardComponent implements Closeable, Ref
     }
 
     @Override
+    public final boolean hasReferences() {
+        return refCounter.hasReferences();
+    }
+
+    @Override
     public void close() {
         if (isClosed.compareAndSet(false, true)) {
             // only do this once!

--- a/server/src/main/java/org/elasticsearch/indices/recovery/RecoveryFileChunkRequest.java
+++ b/server/src/main/java/org/elasticsearch/indices/recovery/RecoveryFileChunkRequest.java
@@ -138,4 +138,9 @@ public final class RecoveryFileChunkRequest extends RecoveryTransportRequest imp
     public boolean decRef() {
         return content.decRef();
     }
+
+    @Override
+    public boolean hasReferences() {
+        return content.hasReferences();
+    }
 }

--- a/server/src/main/java/org/elasticsearch/transport/BytesTransportRequest.java
+++ b/server/src/main/java/org/elasticsearch/transport/BytesTransportRequest.java
@@ -74,4 +74,9 @@ public class BytesTransportRequest extends TransportRequest implements RefCounte
     public boolean decRef() {
         return bytes.decRef();
     }
+
+    @Override
+    public boolean hasReferences() {
+        return bytes.hasReferences();
+    }
 }

--- a/server/src/main/java/org/elasticsearch/transport/CloseableConnection.java
+++ b/server/src/main/java/org/elasticsearch/transport/CloseableConnection.java
@@ -9,19 +9,26 @@
 package org.elasticsearch.transport;
 
 import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.core.AbstractRefCounted;
 import org.elasticsearch.core.CompletableContext;
 
 
 /**
  * Abstract Transport.Connection that provides common close logic.
  */
-public abstract class CloseableConnection implements Transport.Connection {
+public abstract class CloseableConnection extends AbstractRefCounted implements Transport.Connection {
 
     private final CompletableContext<Void> closeContext = new CompletableContext<>();
+    private final CompletableContext<Void> removeContext = new CompletableContext<>();
 
     @Override
     public void addCloseListener(ActionListener<Void> listener) {
         closeContext.addListener(ActionListener.toBiConsumer(listener));
+    }
+
+    @Override
+    public void addRemovedListener(ActionListener<Void> listener) {
+        removeContext.addListener(ActionListener.toBiConsumer(listener));
     }
 
     @Override
@@ -34,5 +41,15 @@ public abstract class CloseableConnection implements Transport.Connection {
         // This method is safe to call multiple times as the close context will provide concurrency
         // protection and only be completed once. The attached listeners will only be notified once.
         closeContext.complete(null);
+    }
+
+    @Override
+    public void onRemoved() {
+        removeContext.complete(null);
+    }
+
+    @Override
+    protected void closeInternal() {
+        close();
     }
 }

--- a/server/src/main/java/org/elasticsearch/transport/ClusterConnectionManager.java
+++ b/server/src/main/java/org/elasticsearch/transport/ClusterConnectionManager.java
@@ -12,10 +12,13 @@ import org.apache.logging.log4j.Logger;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.core.AbstractRefCounted;
 import org.elasticsearch.common.util.concurrent.ConcurrentCollections;
 import org.elasticsearch.common.util.concurrent.ListenableFuture;
 import org.elasticsearch.common.util.concurrent.RunOnce;
+import org.elasticsearch.core.AbstractRefCounted;
+import org.elasticsearch.core.Nullable;
+import org.elasticsearch.core.Releasable;
+import org.elasticsearch.core.Releasables;
 import org.elasticsearch.core.internal.io.IOUtils;
 
 import java.util.Collections;
@@ -36,7 +39,8 @@ public class ClusterConnectionManager implements ConnectionManager {
     private static final Logger logger = LogManager.getLogger(ClusterConnectionManager.class);
 
     private final ConcurrentMap<DiscoveryNode, Transport.Connection> connectedNodes = ConcurrentCollections.newConcurrentMap();
-    private final ConcurrentMap<DiscoveryNode, ListenableFuture<Void>> pendingConnections = ConcurrentCollections.newConcurrentMap();
+    private final ConcurrentMap<DiscoveryNode, ListenableFuture<Transport.Connection>> pendingConnections
+        = ConcurrentCollections.newConcurrentMap();
     private final AbstractRefCounted connectingRefCounter = AbstractRefCounted.of(this::pendingConnectionsComplete);
 
     private final Transport transport;
@@ -71,14 +75,38 @@ public class ClusterConnectionManager implements ConnectionManager {
     }
 
     /**
-     * Connects to a node with the given connection profile. If the node is already connected this method has no effect.
-     * Once a successful is established, it can be validated before being exposed.
-     * The ActionListener will be called on the calling thread or the generic thread pool.
+     * Connects to the given node, or acquires another reference to an existing connection to the given node if a connection already exists.
+     *
+     * @param connectionProfile   the profile to use if opening a new connection. Only used in tests, this is {@code null} in production.
+     * @param connectionValidator a callback to validate the connection before it is exposed (e.g. to {@link #nodeConnected}).
+     * @param listener            completed on the calling thread or by the {@link ConnectionValidator}; in production the
+     *                            {@link ConnectionValidator} will complete the listener on the generic thread pool (see
+     *                            {@link TransportService#connectionValidator}). If successful, completed with a {@link Releasable} which
+     *                            will release this connection (and close it if no other references to it are held).
      */
     @Override
-    public void connectToNode(DiscoveryNode node, ConnectionProfile connectionProfile,
-                              ConnectionValidator connectionValidator,
-                              ActionListener<Void> listener) throws ConnectTransportException {
+    public void connectToNode(
+        DiscoveryNode node,
+        @Nullable ConnectionProfile connectionProfile,
+        ConnectionValidator connectionValidator,
+        ActionListener<Releasable> listener
+    ) throws ConnectTransportException {
+        connectToNodeOrRetry(node, connectionProfile, connectionValidator, 0, listener);
+    }
+
+    /**
+     * Connects to the given node, or acquires another reference to an existing connection to the given node if a connection already exists.
+     * If a connection already exists but has been completely released (so it's in the process of closing) then this method will wait for
+     * the close to complete and then try again (up to 10 times).
+     */
+    private void connectToNodeOrRetry(
+        DiscoveryNode node,
+        @Nullable ConnectionProfile connectionProfile,
+        ConnectionValidator connectionValidator,
+        int previousFailureCount,
+        ActionListener<Releasable> listener
+    ) throws ConnectTransportException {
+
         ConnectionProfile resolvedProfile = ConnectionProfile.resolveConnectionProfile(connectionProfile, defaultProfile);
         if (node == null) {
             listener.onFailure(new ConnectTransportException(null, "can't connect to a null node"));
@@ -90,75 +118,116 @@ public class ClusterConnectionManager implements ConnectionManager {
             return;
         }
 
-        if (connectedNodes.containsKey(node)) {
+        final ActionListener<Transport.Connection> acquiringListener = listener.delegateFailure((delegate, connection) -> {
+            if (connection.tryIncRef()) {
+                delegate.onResponse(Releasables.releaseOnce(connection::decRef));
+                return;
+            }
+
+            // We found a connection that's registered but already fully released, so it'll be removed soon by its close listener. Bad luck,
+            // let's wait for it to be removed and then try again.
+            final int failureCount = previousFailureCount + 1;
+            if (failureCount < 10) {
+                logger.trace("concurrent connect/disconnect for [{}] ([{}] failures), will try again", node, failureCount);
+                connection.addRemovedListener(listener.delegateFailure((retryDelegate, ignored) -> connectToNodeOrRetry(
+                    node,
+                    connectionProfile,
+                    connectionValidator,
+                    failureCount,
+                    retryDelegate)));
+            } else {
+                // A run of bad luck this long is probably not bad luck after all: something's broken, just give up.
+                logger.warn("failed to connect to [{}] after [{}] attempts, giving up", node.descriptionWithoutAttributes(), failureCount);
+                listener.onFailure(new ConnectTransportException(
+                    node,
+                    "concurrently connecting and disconnecting even after [" + failureCount + "] attempts"));
+            }
+        });
+
+        final Transport.Connection existingConnection = connectedNodes.get(node);
+        if (existingConnection != null) {
             connectingRefCounter.decRef();
-            listener.onResponse(null);
+            acquiringListener.onResponse(existingConnection);
             return;
         }
 
-        final ListenableFuture<Void> currentListener = new ListenableFuture<>();
-        final ListenableFuture<Void> existingListener = pendingConnections.putIfAbsent(node, currentListener);
+        final ListenableFuture<Transport.Connection> currentListener = new ListenableFuture<>();
+        final ListenableFuture<Transport.Connection> existingListener = pendingConnections.putIfAbsent(node, currentListener);
         if (existingListener != null) {
             try {
                 // wait on previous entry to complete connection attempt
-                existingListener.addListener(listener);
+                existingListener.addListener(acquiringListener);
             } finally {
                 connectingRefCounter.decRef();
             }
             return;
         }
 
-        currentListener.addListener(listener);
+        currentListener.addListener(acquiringListener);
 
         // It's possible that a connection completed, and the pendingConnections entry was removed, between the calls to
         // connectedNodes.containsKey and pendingConnections.putIfAbsent above, so we check again to make sure we don't open a redundant
         // extra connection to the node. We could _just_ check here, but checking up front skips the work to mark the connection as pending.
-        if (connectedNodes.containsKey(node)) {
-            ListenableFuture<Void> future = pendingConnections.remove(node);
+        final Transport.Connection existingConnectionRecheck = connectedNodes.get(node);
+        if (existingConnectionRecheck != null) {
+            ListenableFuture<Transport.Connection> future = pendingConnections.remove(node);
             assert future == currentListener : "Listener in pending map is different than the expected listener";
             connectingRefCounter.decRef();
-            future.onResponse(null);
+            future.onResponse(existingConnectionRecheck);
             return;
         }
 
         final RunOnce releaseOnce = new RunOnce(connectingRefCounter::decRef);
-        internalOpenConnection(node, resolvedProfile, ActionListener.wrap(conn -> {
-            connectionValidator.validate(conn, resolvedProfile, ActionListener.wrap(
+        internalOpenConnection(node, resolvedProfile, ActionListener.wrap(
+            conn -> connectionValidator.validate(conn, resolvedProfile, ActionListener.runAfter(ActionListener.wrap(
                 ignored -> {
                     assert Transports.assertNotTransportThread("connection validator success");
                     try {
                         if (connectedNodes.putIfAbsent(node, conn) != null) {
-                            assert false : "redundant conection to " + node;
-                            logger.debug("existing connection to node [{}], closing new redundant connection", node);
+                            assert false : "redundant connection to " + node;
+                            logger.warn("existing connection to node [{}], closing new redundant connection", node);
                             IOUtils.closeWhileHandlingException(conn);
                         } else {
                             logger.debug("connected to node [{}]", node);
                             try {
                                 connectionListener.onNodeConnected(node, conn);
                             } finally {
-                                final Transport.Connection finalConnection = conn;
                                 conn.addCloseListener(ActionListener.wrap(() -> {
-                                    logger.trace("unregistering {} after connection close and marking as disconnected", node);
-                                    connectedNodes.remove(node, finalConnection);
+                                    connectedNodes.remove(node, conn);
                                     connectionListener.onNodeDisconnected(node, conn);
+                                    conn.onRemoved();
+                                }));
+
+                                conn.addCloseListener(ActionListener.wrap(() -> {
+                                    if (connectingRefCounter.hasReferences() == false) {
+                                        logger.trace("connection manager shut down, closing transport connection to [{}]", node);
+                                    } else if (conn.hasReferences()) {
+                                        logger.info("transport connection to [{}] closed by remote", node.descriptionWithoutAttributes());
+                                        // In production code we only close connections via ref-counting, so this message confirms that a
+                                        // 'node-left ... reason: disconnected' event was caused by external factors. Put differently, if a
+                                        // node leaves the cluster with "reason: disconnected" but without this message being logged then
+                                        // that's a bug.
+                                    } else {
+                                        logger.debug("closing unused transport connection to [{}]", node);
+                                    }
                                 }));
                             }
                         }
                     } finally {
-                        ListenableFuture<Void> future = pendingConnections.remove(node);
+                        ListenableFuture<Transport.Connection> future = pendingConnections.remove(node);
                         assert future == currentListener : "Listener in pending map is different than the expected listener";
                         releaseOnce.run();
-                        future.onResponse(null);
+                        future.onResponse(conn);
                     }
                 }, e -> {
                     assert Transports.assertNotTransportThread("connection validator failure");
                     IOUtils.closeWhileHandlingException(conn);
-                    failConnectionListeners(node, releaseOnce, e, currentListener);
-                }));
-        }, e -> {
-            assert Transports.assertNotTransportThread("internalOpenConnection failure");
-            failConnectionListeners(node, releaseOnce, e, currentListener);
-        }));
+                    failConnectionListener(node, releaseOnce, e, currentListener);
+                }), conn::decRef)),
+            e -> {
+                assert Transports.assertNotTransportThread("internalOpenConnection failure");
+                failConnectionListener(node, releaseOnce, e, currentListener);
+            }));
     }
 
     /**
@@ -265,8 +334,13 @@ public class ClusterConnectionManager implements ConnectionManager {
         }));
     }
 
-    private void failConnectionListeners(DiscoveryNode node, RunOnce releaseOnce, Exception e, ListenableFuture<Void> expectedListener) {
-        ListenableFuture<Void> future = pendingConnections.remove(node);
+    private void failConnectionListener(
+        DiscoveryNode node,
+        RunOnce releaseOnce,
+        Exception e,
+        ListenableFuture<Transport.Connection> expectedListener
+    ) {
+        ListenableFuture<Transport.Connection> future = pendingConnections.remove(node);
         releaseOnce.run();
         if (future != null) {
             assert future == expectedListener : "Listener in pending map is different than the expected listener";

--- a/server/src/main/java/org/elasticsearch/transport/ConnectionManager.java
+++ b/server/src/main/java/org/elasticsearch/transport/ConnectionManager.java
@@ -10,6 +10,7 @@ package org.elasticsearch.transport;
 
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.core.Releasable;
 
 import java.io.Closeable;
 import java.util.Set;
@@ -25,7 +26,7 @@ public interface ConnectionManager extends Closeable {
 
     void connectToNode(DiscoveryNode node, ConnectionProfile connectionProfile,
                        ConnectionValidator connectionValidator,
-                       ActionListener<Void> listener) throws ConnectTransportException;
+                       ActionListener<Releasable> listener) throws ConnectTransportException;
 
     Transport.Connection getConnection(DiscoveryNode node);
 

--- a/server/src/main/java/org/elasticsearch/transport/ProxyConnectionStrategy.java
+++ b/server/src/main/java/org/elasticsearch/transport/ProxyConnectionStrategy.java
@@ -209,11 +209,17 @@ public class ProxyConnectionStrategy extends RemoteConnectionStrategy {
                 DiscoveryNode node = new DiscoveryNode(id, resolved, attributes, DiscoveryNodeRole.BUILT_IN_ROLES,
                     Version.CURRENT.minimumCompatibilityVersion());
 
-                connectionManager.connectToNode(node, null, clusterNameValidator, compositeListener.delegateResponse((l, e) -> {
-                    logger.debug(new ParameterizedMessage("failed to open remote connection [remote cluster: {}, address: {}]",
-                            clusterAlias, resolved), e);
-                    l.onFailure(e);
-                }));
+                connectionManager.connectToRemoteClusterNode(
+                    node,
+                    clusterNameValidator,
+                    compositeListener.delegateResponse((l, e) -> {
+                        logger.debug(new ParameterizedMessage(
+                                "failed to open remote connection [remote cluster: {}, address: {}]",
+                                clusterAlias,
+                                resolved),
+                            e);
+                        l.onFailure(e);
+                    }));
             }
         } else {
             int openConnections = connectionManager.size();

--- a/server/src/main/java/org/elasticsearch/transport/SniffConnectionStrategy.java
+++ b/server/src/main/java/org/elasticsearch/transport/SniffConnectionStrategy.java
@@ -314,8 +314,10 @@ public class SniffConnectionStrategy extends RemoteConnectionStrategy {
                     logger.trace("[{}] opening managed connection to seed node: [{}] proxy address: [{}]", clusterAlias, handshakeNode,
                         proxyAddress);
                     final DiscoveryNode handshakeNodeWithProxy = maybeAddProxyAddress(proxyAddress, handshakeNode);
-                    connectionManager.connectToNode(handshakeNodeWithProxy, null,
-                        transportService.connectionValidator(handshakeNodeWithProxy), fullConnectionStep);
+                    connectionManager.connectToRemoteClusterNode(
+                        handshakeNodeWithProxy,
+                        transportService.connectionValidator(handshakeNodeWithProxy),
+                        fullConnectionStep);
                 } else {
                     fullConnectionStep.onResponse(null);
                 }
@@ -396,7 +398,7 @@ public class SniffConnectionStrategy extends RemoteConnectionStrategy {
                 if (nodePredicate.test(node) && shouldOpenMoreConnections()) {
                     logger.trace("[{}] opening managed connection to node: [{}] proxy address: [{}]", clusterAlias, node, proxyAddress);
                     final DiscoveryNode nodeWithProxy = maybeAddProxyAddress(proxyAddress, node);
-                    connectionManager.connectToNode(nodeWithProxy, null,
+                    connectionManager.connectToRemoteClusterNode(nodeWithProxy,
                         transportService.connectionValidator(node), new ActionListener<Void>() {
                             @Override
                             public void onResponse(Void aVoid) {

--- a/server/src/main/java/org/elasticsearch/transport/Transport.java
+++ b/server/src/main/java/org/elasticsearch/transport/Transport.java
@@ -15,6 +15,7 @@ import org.elasticsearch.common.collect.MapBuilder;
 import org.elasticsearch.common.component.LifecycleComponent;
 import org.elasticsearch.common.transport.BoundTransportAddress;
 import org.elasticsearch.common.transport.TransportAddress;
+import org.elasticsearch.core.RefCounted;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.common.util.concurrent.ConcurrentCollections;
 
@@ -82,7 +83,7 @@ public interface Transport extends LifecycleComponent {
     /**
      * A unidirectional connection to a {@link DiscoveryNode}
      */
-    interface Connection extends Closeable {
+    interface Connection extends Closeable, RefCounted {
         /**
          * The node this connection is associated with
          */
@@ -127,6 +128,17 @@ public interface Transport extends LifecycleComponent {
 
         @Override
         void close();
+
+        /**
+         * Called after this connection is removed from the transport service.
+         */
+        void onRemoved();
+
+        /**
+         * Similar to {@link #addCloseListener} except that these listeners are notified once the connection is removed from the transport
+         * service.
+         */
+        void addRemovedListener(ActionListener<Void> listener);
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/transport/TransportMessage.java
+++ b/server/src/main/java/org/elasticsearch/transport/TransportMessage.java
@@ -43,6 +43,7 @@ public abstract class TransportMessage implements Writeable, RefCounted {
 
     @Override
     public boolean tryIncRef() {
+        // noop, override to manage the life-cycle of resources held by a transport message
         return true;
     }
 
@@ -50,5 +51,11 @@ public abstract class TransportMessage implements Writeable, RefCounted {
     public boolean decRef() {
         // noop, override to manage the life-cycle of resources held by a transport message
         return false;
+    }
+
+    @Override
+    public boolean hasReferences() {
+        // noop, override to manage the life-cycle of resources held by a transport message
+        return true;
     }
 }

--- a/server/src/main/java/org/elasticsearch/transport/TransportService.java
+++ b/server/src/main/java/org/elasticsearch/transport/TransportService.java
@@ -143,12 +143,41 @@ public class TransportService extends AbstractLifecycleComponent
         }
 
         @Override
+        public void addRemovedListener(ActionListener<Void> listener) {
+        }
+
+        @Override
         public boolean isClosed() {
             return false;
         }
 
         @Override
         public void close() {
+            assert false : "should not close the local node connection";
+        }
+
+        @Override
+        public void incRef() {
+        }
+
+        @Override
+        public boolean tryIncRef() {
+            return true;
+        }
+
+        @Override
+        public boolean decRef() {
+            return false;
+        }
+
+        @Override
+        public boolean hasReferences() {
+            return true;
+        }
+
+        @Override
+        public void onRemoved() {
+            assert false : "should not remove the local node connection";
         }
 
         @Override
@@ -367,7 +396,7 @@ public class TransportService extends AbstractLifecycleComponent
      * @param node the node to connect to
      * @param listener the action listener to notify
      */
-    public void connectToNode(DiscoveryNode node, ActionListener<Void> listener) throws ConnectTransportException {
+    public void connectToNode(DiscoveryNode node, ActionListener<Releasable> listener) throws ConnectTransportException {
         connectToNode(node, null, listener);
     }
 
@@ -379,7 +408,7 @@ public class TransportService extends AbstractLifecycleComponent
      * @param connectionProfile the connection profile to use when connecting to this node
      * @param listener the action listener to notify
      */
-    public void connectToNode(final DiscoveryNode node, ConnectionProfile connectionProfile, ActionListener<Void> listener) {
+    public void connectToNode(final DiscoveryNode node, ConnectionProfile connectionProfile, ActionListener<Releasable> listener) {
         if (isLocalNode(node)) {
             listener.onResponse(null);
             return;

--- a/server/src/test/java/org/elasticsearch/action/search/SearchAsyncActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/search/SearchAsyncActionTests.java
@@ -710,7 +710,10 @@ public class SearchAsyncActionTests extends ESTestCase {
 
         @Override
         public void addCloseListener(ActionListener<Void> listener) {
+        }
 
+        @Override
+        public void addRemovedListener(ActionListener<Void> listener) {
         }
 
         @Override
@@ -721,6 +724,31 @@ public class SearchAsyncActionTests extends ESTestCase {
         @Override
         public void close() {
             throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void onRemoved() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void incRef() {
+        }
+
+        @Override
+        public boolean tryIncRef() {
+            return true;
+        }
+
+        @Override
+        public boolean decRef() {
+            assert false : "shouldn't release a mock connection";
+            return false;
+        }
+
+        @Override
+        public boolean hasReferences() {
+            return true;
         }
     }
 }

--- a/server/src/test/java/org/elasticsearch/action/search/TransportSearchActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/search/TransportSearchActionTests.java
@@ -317,12 +317,41 @@ public class TransportSearchActionTests extends ESTestCase {
             }
 
             @Override
+            public void addRemovedListener(ActionListener<Void> listener) {
+            }
+
+            @Override
             public boolean isClosed() {
                 return false;
             }
 
             @Override
             public void close() {
+            }
+
+            @Override
+            public void incRef() {
+            }
+
+            @Override
+            public boolean tryIncRef() {
+                return true;
+            }
+
+            @Override
+            public boolean decRef() {
+                assert false : "shouldn't release a mock connection";
+                return false;
+            }
+
+            @Override
+            public boolean hasReferences() {
+                return true;
+            }
+
+            @Override
+            public void onRemoved() {
+                assert false : "shouldn't remove a mock connection";
             }
         };
 

--- a/server/src/test/java/org/elasticsearch/cluster/NodeConnectionsServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/NodeConnectionsServiceTests.java
@@ -11,9 +11,9 @@ package org.elasticsearch.cluster;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.elasticsearch.Build;
-import org.elasticsearch.ElasticsearchTimeoutException;
 import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.support.ListenableActionFuture;
 import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodeRole;
@@ -26,7 +26,9 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.transport.BoundTransportAddress;
 import org.elasticsearch.common.transport.TransportAddress;
 import org.elasticsearch.common.util.concurrent.DeterministicTaskQueue;
+import org.elasticsearch.core.AbstractRefCounted;
 import org.elasticsearch.core.CheckedRunnable;
+import org.elasticsearch.core.RefCounted;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.MockLogAppender;
@@ -35,7 +37,9 @@ import org.elasticsearch.threadpool.TestThreadPool;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.ConnectTransportException;
 import org.elasticsearch.transport.ConnectionProfile;
+import org.elasticsearch.transport.NodeNotConnectedException;
 import org.elasticsearch.transport.Transport;
+import org.elasticsearch.transport.TransportConnectionListener;
 import org.elasticsearch.transport.TransportException;
 import org.elasticsearch.transport.TransportMessageListener;
 import org.elasticsearch.transport.TransportRequest;
@@ -54,12 +58,12 @@ import java.util.Set;
 import java.util.concurrent.CyclicBarrier;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Predicate;
 
 import static java.util.Collections.emptySet;
 import static org.elasticsearch.cluster.NodeConnectionsService.CLUSTER_NODE_RECONNECT_INTERVAL_SETTING;
 import static org.elasticsearch.common.util.concurrent.ConcurrentCollections.newConcurrentMap;
-import static org.elasticsearch.core.TimeValue.timeValueMillis;
 import static org.hamcrest.Matchers.equalTo;
 
 public class NodeConnectionsServiceTests extends ESTestCase {
@@ -86,12 +90,12 @@ public class NodeConnectionsServiceTests extends ESTestCase {
         return builder.build();
     }
 
-    public void testConnectAndDisconnect() throws Exception {
+    public void testEventuallyConnectsOnlyToAppliedNodes() throws Exception {
         final NodeConnectionsService service = new NodeConnectionsService(Settings.EMPTY, threadPool, transportService);
 
-        final AtomicBoolean stopReconnecting = new AtomicBoolean();
+        final AtomicBoolean keepGoing = new AtomicBoolean(true);
         final Thread reconnectionThread = new Thread(() -> {
-            while (stopReconnecting.get() == false) {
+            while (keepGoing.get()) {
                 final PlainActionFuture<Void> future = new PlainActionFuture<>();
                 service.ensureConnections(() -> future.onResponse(null));
                 future.actionGet();
@@ -99,53 +103,52 @@ public class NodeConnectionsServiceTests extends ESTestCase {
         }, "reconnection thread");
         reconnectionThread.start();
 
-        try {
+        final List<DiscoveryNode> allNodes = generateNodes();
 
-            final List<DiscoveryNode> allNodes = generateNodes();
-            for (int iteration = 0; iteration < 3; iteration++) {
-
-                final boolean isDisrupting = randomBoolean();
-                if (isDisrupting == false) {
-                    // if the previous iteration was a disrupting one then there could still be some pending disconnections which would
-                    // prevent us from asserting that all nodes are connected in this iteration without this call.
-                    ensureConnections(service);
+        final boolean isDisrupting = randomBoolean();
+        final Thread disruptionThread = new Thread(() -> {
+            while (isDisrupting && keepGoing.get()) {
+                final Transport.Connection connection;
+                try {
+                    connection = transportService.getConnection(randomFrom(allNodes));
+                } catch (NodeNotConnectedException e) {
+                    continue;
                 }
-                final AtomicBoolean stopDisrupting = new AtomicBoolean();
-                final Thread disruptionThread = new Thread(() -> {
-                    while (isDisrupting && stopDisrupting.get() == false) {
-                        transportService.disconnectFromNode(randomFrom(allNodes));
-                    }
-                }, "disruption thread " + iteration);
-                disruptionThread.start();
 
-                final DiscoveryNodes nodes = discoveryNodesFromList(randomSubsetOf(allNodes));
                 final PlainActionFuture<Void> future = new PlainActionFuture<>();
-                service.connectToNodes(nodes, () -> future.onResponse(null));
-                future.actionGet();
-                if (isDisrupting == false) {
-                    assertConnected(transportService, nodes);
-                }
-                service.disconnectFromNodesExcept(nodes);
-
-                assertTrue(stopDisrupting.compareAndSet(false, true));
-                disruptionThread.join();
-
-                if (randomBoolean()) {
-                    // sometimes do not wait for the disconnections to complete before starting the next connections
-                    if (usually()) {
-                        ensureConnections(service);
-                        assertConnectedExactlyToNodes(nodes);
-                    } else {
-                        assertBusy(() -> assertConnectedExactlyToNodes(nodes));
-                    }
-                }
+                connection.addRemovedListener(future);
+                connection.close();
+                future.actionGet(10, TimeUnit.SECONDS);
             }
-        } finally {
-            assertTrue(stopReconnecting.compareAndSet(false, true));
-            reconnectionThread.join();
+        }, "disruption thread");
+        disruptionThread.start();
+
+        for (int i = 0; i < 10; i++) {
+            final DiscoveryNodes connectNodes = discoveryNodesFromList(randomSubsetOf(allNodes));
+            final PlainActionFuture<Void> future = new PlainActionFuture<>();
+            service.connectToNodes(connectNodes, () -> future.onResponse(null));
+            future.actionGet(10, TimeUnit.SECONDS);
+            final DiscoveryNodes disconnectExceptNodes = discoveryNodesFromList(randomSubsetOf(allNodes));
+            service.disconnectFromNodesExcept(disconnectExceptNodes);
         }
 
-        ensureConnections(service);
+        final DiscoveryNodes nodes = discoveryNodesFromList(randomSubsetOf(allNodes));
+        final PlainActionFuture<Void> connectFuture = new PlainActionFuture<>();
+        service.connectToNodes(nodes, () -> connectFuture.onResponse(null));
+        connectFuture.actionGet(10, TimeUnit.SECONDS);
+        service.disconnectFromNodesExcept(nodes);
+
+        assertTrue(keepGoing.compareAndSet(true, false));
+        reconnectionThread.join();
+        disruptionThread.join();
+
+        if (isDisrupting) {
+            final PlainActionFuture<Void> ensureFuture = new PlainActionFuture<>();
+            service.ensureConnections(() -> ensureFuture.onResponse(null));
+            ensureFuture.actionGet(10, TimeUnit.SECONDS);
+        }
+
+        assertBusy(() -> assertConnectedExactlyToNodes(nodes));
     }
 
     public void testPeriodicReconnection() {
@@ -213,12 +216,23 @@ public class NodeConnectionsServiceTests extends ESTestCase {
     public void testOnlyBlocksOnConnectionsToNewNodes() throws Exception {
         final NodeConnectionsService service = new NodeConnectionsService(Settings.EMPTY, threadPool, transportService);
 
+        final AtomicReference<ActionListener<DiscoveryNode>> disconnectListenerRef = new AtomicReference<>();
+        transportService.addConnectionListener(new TransportConnectionListener() {
+            @Override
+            public void onNodeDisconnected(DiscoveryNode node, Transport.Connection connection) {
+                final ActionListener<DiscoveryNode> disconnectListener = disconnectListenerRef.getAndSet(null);
+                if (disconnectListener != null) {
+                    disconnectListener.onResponse(node);
+                }
+            }
+        });
+
         // connect to one node
         final DiscoveryNode node0 = new DiscoveryNode("node0", buildNewFakeTransportAddress(), Version.CURRENT);
         final DiscoveryNodes nodes0 = DiscoveryNodes.builder().add(node0).build();
         final PlainActionFuture<Void> future0 = new PlainActionFuture<>();
         service.connectToNodes(nodes0, () -> future0.onResponse(null));
-        future0.actionGet();
+        future0.actionGet(10, TimeUnit.SECONDS);
         assertConnectedExactlyToNodes(nodes0);
 
         // connection attempts to node0 block indefinitely
@@ -233,59 +247,55 @@ public class NodeConnectionsServiceTests extends ESTestCase {
             final DiscoveryNodes nodes01 = DiscoveryNodes.builder(nodes0).add(node1).build();
             final PlainActionFuture<Void> future1 = new PlainActionFuture<>();
             service.connectToNodes(nodes01, () -> future1.onResponse(null));
-            future1.actionGet();
+            future1.actionGet(10, TimeUnit.SECONDS);
             assertConnectedExactlyToNodes(nodes1);
 
             // can also disconnect from node0 without blocking
             final PlainActionFuture<Void> future2 = new PlainActionFuture<>();
             service.connectToNodes(nodes1, () -> future2.onResponse(null));
-            future2.actionGet();
+            future2.actionGet(10, TimeUnit.SECONDS);
             service.disconnectFromNodesExcept(nodes1);
             assertConnectedExactlyToNodes(nodes1);
 
             // however, now node0 is considered to be a new node so we will block on a subsequent attempt to connect to it
             final PlainActionFuture<Void> future3 = new PlainActionFuture<>();
             service.connectToNodes(nodes01, () -> future3.onResponse(null));
-            expectThrows(ElasticsearchTimeoutException.class, () -> future3.actionGet(timeValueMillis(scaledRandomIntBetween(1, 1000))));
+            assertFalse(future3.isDone());
 
             // once the connection is unblocked we successfully connect to it.
             connectionBarrier.await(10, TimeUnit.SECONDS);
-            nodeConnectionBlocks.clear();
-            future3.actionGet();
+            future3.actionGet(10, TimeUnit.SECONDS);
             assertConnectedExactlyToNodes(nodes01);
 
-            // if we disconnect from a node while blocked trying to connect to it then we do eventually disconnect from it
-            nodeConnectionBlocks.put(node0, connectionBarrier::await);
+            // the reconnection is also blocked but the connection future doesn't wait, it completes straight away
             transportService.disconnectFromNode(node0);
             final PlainActionFuture<Void> future4 = new PlainActionFuture<>();
             service.connectToNodes(nodes01, () -> future4.onResponse(null));
-            future4.actionGet();
+            future4.actionGet(10, TimeUnit.SECONDS);
             assertConnectedExactlyToNodes(nodes1);
 
+            // a blocked reconnection attempt doesn't also block the node from being deregistered
             service.disconnectFromNodesExcept(nodes1);
+            final PlainActionFuture<DiscoveryNode> disconnectFuture1 = new PlainActionFuture<>();
+            assertTrue(disconnectListenerRef.compareAndSet(null, disconnectFuture1));
             connectionBarrier.await();
-            if (randomBoolean()) {
-                // assertBusy because the connection completes before disconnecting, so we might briefly observe a connection to node0
-                assertBusy(() -> assertConnectedExactlyToNodes(nodes1));
-            }
-
-            // use ensureConnections() to wait until the service is idle
-            ensureConnections(service);
+            assertThat(disconnectFuture1.actionGet(10, TimeUnit.SECONDS), equalTo(node0)); // node0 connects briefly, must wait here
             assertConnectedExactlyToNodes(nodes1);
 
-            // if we disconnect from a node while blocked trying to connect to it then the listener is notified
-            final PlainActionFuture<Void> future6 = new PlainActionFuture<>();
-            service.connectToNodes(nodes01, () -> future6.onResponse(null));
-            expectThrows(ElasticsearchTimeoutException.class, () -> future6.actionGet(timeValueMillis(scaledRandomIntBetween(1, 1000))));
+            // a blocked connection attempt to a new node also doesn't prevent an immediate deregistration
+            final PlainActionFuture<Void> future5 = new PlainActionFuture<>();
+            service.connectToNodes(nodes01, () -> future5.onResponse(null));
+            assertFalse(future5.isDone());
 
             service.disconnectFromNodesExcept(nodes1);
-            future6.actionGet(); // completed even though the connection attempt is still blocked
             assertConnectedExactlyToNodes(nodes1);
 
+            final PlainActionFuture<DiscoveryNode> disconnectFuture2 = new PlainActionFuture<>();
+            assertTrue(disconnectListenerRef.compareAndSet(null, disconnectFuture2));
             connectionBarrier.await(10, TimeUnit.SECONDS);
-            nodeConnectionBlocks.clear();
-            ensureConnections(service);
+            assertThat(disconnectFuture2.actionGet(10, TimeUnit.SECONDS), equalTo(node0)); // node0 connects briefly, must wait here
             assertConnectedExactlyToNodes(nodes1);
+            assertTrue(future5.isDone());
         } finally {
             nodeConnectionBlocks.clear();
             connectionBarrier.reset();
@@ -412,12 +422,6 @@ public class NodeConnectionsServiceTests extends ESTestCase {
         deterministicTaskQueue.runAllRunnableTasks();
     }
 
-    private void ensureConnections(NodeConnectionsService service) {
-        final PlainActionFuture<Void> future = new PlainActionFuture<>();
-        service.ensureConnections(() -> future.onResponse(null));
-        future.actionGet();
-    }
-
     private void assertConnectedExactlyToNodes(DiscoveryNodes discoveryNodes) {
         assertConnectedExactlyToNodes(transportService, discoveryNodes);
     }
@@ -454,7 +458,7 @@ public class NodeConnectionsServiceTests extends ESTestCase {
         super.tearDown();
     }
 
-    private final class TestTransportService extends TransportService {
+    private static final class TestTransportService extends TransportService {
 
         private TestTransportService(Transport transport, ThreadPool threadPool) {
             super(Settings.EMPTY, transport, threadPool, TransportService.NOOP_TRANSPORT_INTERCEPTOR,
@@ -473,25 +477,9 @@ public class NodeConnectionsServiceTests extends ESTestCase {
             throw new AssertionError("no blocking connect");
         }
 
-        @Override
-        public void connectToNode(DiscoveryNode node, ActionListener<Void> listener) throws ConnectTransportException {
-            final CheckedRunnable<Exception> connectionBlock = nodeConnectionBlocks.get(node);
-            if (connectionBlock != null) {
-                getThreadPool().generic().execute(() -> {
-                        try {
-                            connectionBlock.run();
-                            super.connectToNode(node, listener);
-                        } catch (Exception e) {
-                            throw new AssertionError(e);
-                        }
-                    });
-            } else {
-                super.connectToNode(node, listener);
-            }
-        }
     }
 
-    private static final class MockTransport implements Transport {
+    private final class MockTransport implements Transport {
         private final ResponseHandlers responseHandlers = new ResponseHandlers();
         private final RequestHandlers requestHandlers = new RequestHandlers();
         private volatile boolean randomConnectionExceptions = false;
@@ -520,35 +508,90 @@ public class NodeConnectionsServiceTests extends ESTestCase {
             return new TransportAddress[0];
         }
 
+        private void runConnectionBlock(CheckedRunnable<Exception> connectionBlock) {
+            if (connectionBlock == null) {
+                return;
+            }
+            try {
+                connectionBlock.run();
+            } catch (Exception e) {
+                throw new AssertionError(e);
+            }
+        }
+
         @Override
         public void openConnection(DiscoveryNode node, ConnectionProfile profile, ActionListener<Connection> listener) {
+            final CheckedRunnable<Exception> connectionBlock = nodeConnectionBlocks.get(node);
             if (profile == null && randomConnectionExceptions && randomBoolean()) {
-                threadPool.generic().execute(() -> listener.onFailure(new ConnectTransportException(node, "simulated")));
+                threadPool.generic().execute(() -> {
+                    runConnectionBlock(connectionBlock);
+                    listener.onFailure(new ConnectTransportException(node, "simulated"));
+                });
             } else {
-                threadPool.generic().execute(() -> listener.onResponse(new Connection() {
-                    @Override
-                    public DiscoveryNode getNode() {
-                        return node;
-                    }
+                threadPool.generic().execute(() -> {
+                    runConnectionBlock(connectionBlock);
+                    listener.onResponse(new Connection() {
+                        private final ListenableActionFuture<Void> closeListener = new ListenableActionFuture<>();
+                        private final ListenableActionFuture<Void> removedListener = new ListenableActionFuture<>();
 
-                    @Override
-                    public void sendRequest(long requestId, String action, TransportRequest request, TransportRequestOptions options)
-                        throws TransportException {
-                    }
+                        private final RefCounted refCounted = AbstractRefCounted.of(() -> closeListener.onResponse(null));
 
-                    @Override
-                    public void addCloseListener(ActionListener<Void> listener) {
-                    }
+                        @Override
+                        public DiscoveryNode getNode() {
+                            return node;
+                        }
 
-                    @Override
-                    public void close() {
-                    }
+                        @Override
+                        public void sendRequest(long requestId, String action, TransportRequest request, TransportRequestOptions options)
+                            throws TransportException {
+                        }
 
-                    @Override
-                    public boolean isClosed() {
-                        return false;
-                    }
-                }));
+                        @Override
+                        public void addCloseListener(ActionListener<Void> listener1) {
+                            closeListener.addListener(listener1);
+                        }
+
+                        @Override
+                        public void close() {
+                            closeListener.onResponse(null);
+                        }
+
+                        @Override
+                        public boolean isClosed() {
+                            return closeListener.isDone();
+                        }
+
+                        @Override
+                        public void addRemovedListener(ActionListener<Void> listener) {
+                            removedListener.addListener(listener);
+                        }
+
+                        @Override
+                        public void onRemoved() {
+                            removedListener.onResponse(null);
+                        }
+
+                        @Override
+                        public void incRef() {
+                            refCounted.incRef();
+                        }
+
+                        @Override
+                        public boolean tryIncRef() {
+                            return refCounted.tryIncRef();
+                        }
+
+                        @Override
+                        public boolean decRef() {
+                            return refCounted.decRef();
+                        }
+
+                        @Override
+                        public boolean hasReferences() {
+                            return refCounted.hasReferences();
+                        }
+                    });
+                });
             }
         }
 

--- a/server/src/test/java/org/elasticsearch/cluster/coordination/JoinHelperTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/JoinHelperTests.java
@@ -8,6 +8,7 @@
 package org.elasticsearch.cluster.coordination;
 
 import org.apache.logging.log4j.Level;
+import org.elasticsearch.Build;
 import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListenerResponseHandler;
 import org.elasticsearch.action.support.PlainActionFuture;
@@ -25,8 +26,10 @@ import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.transport.CapturingTransport;
 import org.elasticsearch.test.transport.CapturingTransport.CapturedRequest;
 import org.elasticsearch.test.transport.MockTransport;
+import org.elasticsearch.transport.ClusterConnectionManager;
 import org.elasticsearch.transport.RemoteTransportException;
 import org.elasticsearch.transport.TransportException;
+import org.elasticsearch.transport.TransportRequest;
 import org.elasticsearch.transport.TransportResponse;
 import org.elasticsearch.transport.TransportService;
 
@@ -38,6 +41,7 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import static org.elasticsearch.monitor.StatusInfo.Status.HEALTHY;
 import static org.elasticsearch.monitor.StatusInfo.Status.UNHEALTHY;
+import static org.elasticsearch.transport.TransportService.HANDSHAKE_ACTION_NAME;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
@@ -47,11 +51,18 @@ public class JoinHelperTests extends ESTestCase {
 
     public void testJoinDeduplication() {
         DeterministicTaskQueue deterministicTaskQueue = new DeterministicTaskQueue();
-        CapturingTransport capturingTransport = new CapturingTransport();
+        CapturingTransport capturingTransport = new HandshakingCapturingTransport();
         DiscoveryNode localNode = new DiscoveryNode("node0", buildNewFakeTransportAddress(), Version.CURRENT);
-        TransportService transportService = capturingTransport.createTransportService(Settings.EMPTY,
-            deterministicTaskQueue.getThreadPool(), TransportService.NOOP_TRANSPORT_INTERCEPTOR,
-            x -> localNode, null, Collections.emptySet());
+        TransportService transportService = new TransportService(
+            Settings.EMPTY,
+            capturingTransport,
+            deterministicTaskQueue.getThreadPool(),
+            TransportService.NOOP_TRANSPORT_INTERCEPTOR,
+            x -> localNode,
+            null,
+            Collections.emptySet(),
+            new ClusterConnectionManager(Settings.EMPTY, capturingTransport)
+        );
         JoinHelper joinHelper = new JoinHelper(Settings.EMPTY, null, null, transportService, () -> 0L, () -> null,
             (joinRequest, joinCallback) -> { throw new AssertionError(); }, startJoinRequest -> { throw new AssertionError(); },
             Collections.emptyList(), (s, p, r) -> {},
@@ -60,6 +71,7 @@ public class JoinHelperTests extends ESTestCase {
 
         DiscoveryNode node1 = new DiscoveryNode("node1", buildNewFakeTransportAddress(), Version.CURRENT);
         DiscoveryNode node2 = new DiscoveryNode("node2", buildNewFakeTransportAddress(), Version.CURRENT);
+        final boolean mightSucceed = randomBoolean();
 
         assertFalse(joinHelper.isJoinPending());
 
@@ -88,11 +100,7 @@ public class JoinHelperTests extends ESTestCase {
         assertThat(capturingTransport.getCapturedRequestsAndClear().length, equalTo(0));
 
         // complete the previous join to node1
-        if (randomBoolean()) {
-            capturingTransport.handleResponse(capturedRequest1.requestId, TransportResponse.Empty.INSTANCE);
-        } else {
-            capturingTransport.handleRemoteError(capturedRequest1.requestId, new CoordinationStateRejectedException("dummy"));
-        }
+        completeJoinRequest(capturingTransport, capturedRequest1, mightSucceed);
 
         // check that sending another join to node1 now works again
         joinHelper.sendJoinRequest(node1, 0L, optionalJoin1);
@@ -112,10 +120,28 @@ public class JoinHelperTests extends ESTestCase {
 
         // complete all the joins and check that isJoinPending is updated
         assertTrue(joinHelper.isJoinPending());
-        capturingTransport.handleRemoteError(capturedRequest2.requestId, new CoordinationStateRejectedException("dummy"));
-        capturingTransport.handleRemoteError(capturedRequest1a.requestId, new CoordinationStateRejectedException("dummy"));
-        capturingTransport.handleRemoteError(capturedRequest2a.requestId, new CoordinationStateRejectedException("dummy"));
+        assertTrue(transportService.nodeConnected(node1));
+        assertTrue(transportService.nodeConnected(node2));
+
+        completeJoinRequest(capturingTransport, capturedRequest2, mightSucceed);
+        completeJoinRequest(capturingTransport, capturedRequest1a, mightSucceed);
+        completeJoinRequest(capturingTransport, capturedRequest2a, mightSucceed);
         assertFalse(joinHelper.isJoinPending());
+
+        if (mightSucceed) {
+            // successful requests hold the connections open until the cluster state is applied
+            joinHelper.onClusterStateApplied();
+        }
+        assertFalse(transportService.nodeConnected(node1));
+        assertFalse(transportService.nodeConnected(node2));
+    }
+
+    private void completeJoinRequest(CapturingTransport capturingTransport, CapturedRequest request, boolean mightSucceed) {
+        if (mightSucceed && randomBoolean()) {
+            capturingTransport.handleResponse(request.requestId, TransportResponse.Empty.INSTANCE);
+        } else {
+            capturingTransport.handleRemoteError(request.requestId, new CoordinationStateRejectedException("dummy"));
+        }
     }
 
     public void testFailedJoinAttemptLogLevel() {
@@ -209,7 +235,7 @@ public class JoinHelperTests extends ESTestCase {
 
     public void testJoinFailureOnUnhealthyNodes() {
         DeterministicTaskQueue deterministicTaskQueue = new DeterministicTaskQueue();
-        CapturingTransport capturingTransport = new CapturingTransport();
+        CapturingTransport capturingTransport = new HandshakingCapturingTransport();
         DiscoveryNode localNode = new DiscoveryNode("node0", buildNewFakeTransportAddress(), Version.CURRENT);
         TransportService transportService = capturingTransport.createTransportService(Settings.EMPTY,
             deterministicTaskQueue.getThreadPool(), TransportService.NOOP_TRANSPORT_INTERCEPTOR,
@@ -254,5 +280,22 @@ public class JoinHelperTests extends ESTestCase {
         assertThat(capturedRequests1a.length, equalTo(1));
         CapturedRequest capturedRequest1a = capturedRequests1a[0];
         assertEquals(node1, capturedRequest1a.node);
+    }
+
+    private static class HandshakingCapturingTransport extends CapturingTransport {
+
+        @Override
+        protected void onSendRequest(long requestId, String action, TransportRequest request, DiscoveryNode node) {
+            if (action.equals(HANDSHAKE_ACTION_NAME)) {
+                handleResponse(requestId, new TransportService.HandshakeResponse(
+                    node.getVersion(),
+                    Build.CURRENT.hash(),
+                    node,
+                    ClusterName.DEFAULT
+                ));
+            } else {
+                super.onSendRequest(requestId, action, request, node);
+            }
+        }
     }
 }

--- a/server/src/test/java/org/elasticsearch/cluster/node/DiscoveryNodeTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/node/DiscoveryNodeTests.java
@@ -185,6 +185,7 @@ public class DiscoveryNodeTests extends ESTestCase {
         final String descriptionWithoutAttributes = stringBuilder.toString();
         assertThat(node.toString(), allOf(startsWith(descriptionWithoutAttributes), containsString("test-attr=val")));
         assertThat(descriptionWithoutAttributes, not(containsString("test-attr")));
+        assertEquals(descriptionWithoutAttributes, node.descriptionWithoutAttributes());
     }
 
     public void testDiscoveryNodeToXContent() {

--- a/server/src/test/java/org/elasticsearch/discovery/HandshakingTransportAddressConnectorTests.java
+++ b/server/src/test/java/org/elasticsearch/discovery/HandshakingTransportAddressConnectorTests.java
@@ -124,10 +124,10 @@ public class HandshakingTransportAddressConnectorTests extends ESTestCase {
         remoteClusterName = "local-cluster";
         discoveryAddress = getDiscoveryAddress();
 
-        handshakingTransportAddressConnector.connectToRemoteMasterNode(discoveryAddress, new ActionListener<DiscoveryNode>() {
+        handshakingTransportAddressConnector.connectToRemoteMasterNode(discoveryAddress, new ActionListener<ProbeConnectionResult>() {
             @Override
-            public void onResponse(DiscoveryNode discoveryNode) {
-                receivedNode.set(discoveryNode);
+            public void onResponse(ProbeConnectionResult connectResult) {
+                receivedNode.set(connectResult.getDiscoveryNode());
                 completionLatch.countDown();
             }
 
@@ -223,12 +223,12 @@ public class HandshakingTransportAddressConnectorTests extends ESTestCase {
         return randomBoolean() ? remoteNode.getAddress() : buildNewFakeTransportAddress();
     }
 
-    private static class FailureListener implements ActionListener<DiscoveryNode> {
+    private static class FailureListener implements ActionListener<ProbeConnectionResult> {
         final CountDownLatch completionLatch = new CountDownLatch(1);
 
         @Override
-        public void onResponse(DiscoveryNode discoveryNode) {
-            fail(discoveryNode.toString());
+        public void onResponse(ProbeConnectionResult connectResult) {
+            fail(connectResult.getDiscoveryNode().toString());
         }
 
         @Override

--- a/server/src/test/java/org/elasticsearch/snapshots/SnapshotResiliencyTests.java
+++ b/server/src/test/java/org/elasticsearch/snapshots/SnapshotResiliencyTests.java
@@ -1646,7 +1646,10 @@ public class SnapshotResiliencyTests extends ESTestCase {
 
                         @Override
                         protected void connectToNodesAndWait(ClusterState newClusterState) {
-                            // don't do anything, and don't block
+                            connectToNodesAsync(newClusterState, () -> {
+                                // no need to block waiting for handshakes etc. to complete, it's enough to let the NodeConnectionsService
+                                // take charge of these connections
+                            });
                         }
                     }
                 );

--- a/server/src/test/java/org/elasticsearch/transport/ClusterConnectionManagerTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/ClusterConnectionManagerTests.java
@@ -8,14 +8,23 @@
 
 package org.elasticsearch.transport;
 
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.node.DiscoveryNodeRole;
+import org.elasticsearch.common.logging.Loggers;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.transport.TransportAddress;
+import org.elasticsearch.core.Releasable;
+import org.elasticsearch.core.Releasables;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.MockLogAppender;
+import org.elasticsearch.test.junit.annotations.TestLogging;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.junit.After;
 import org.junit.Before;
@@ -29,11 +38,15 @@ import java.util.concurrent.BrokenBarrierException;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
 
 import static org.elasticsearch.test.ActionListenerUtils.anyActionListener;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
@@ -116,6 +129,69 @@ public class ClusterConnectionManagerTests extends ESTestCase {
         assertEquals(1, nodeDisconnectedCount.get());
     }
 
+    @TestLogging(reason="testing log messages emitted on disconnect", value="org.elasticsearch.transport.ClusterConnectionManager:TRACE")
+    public void testDisconnectLogging() throws IllegalAccessException {
+        final Supplier<DiscoveryNode> nodeFactory = () -> new DiscoveryNode(
+            randomAlphaOfLength(10),
+            new TransportAddress(InetAddress.getLoopbackAddress(), 0),
+            Collections.singletonMap("attr", "val"),
+            DiscoveryNodeRole.BUILT_IN_ROLES,
+            Version.CURRENT);
+        final DiscoveryNode remoteClose = nodeFactory.get();
+        final DiscoveryNode localClose = nodeFactory.get();
+        final DiscoveryNode shutdownClose = nodeFactory.get();
+
+        doAnswer(invocationOnMock -> {
+            @SuppressWarnings("unchecked")
+            final ActionListener<Transport.Connection> listener = (ActionListener<Transport.Connection>) invocationOnMock.getArguments()[2];
+            final DiscoveryNode discoveryNode = (DiscoveryNode) invocationOnMock.getArguments()[0];
+            listener.onResponse(new TestConnect(discoveryNode));
+            return null;
+        }).when(transport).openConnection(any(), eq(connectionProfile), anyActionListener());
+
+        final ConnectionManager.ConnectionValidator validator = (c, p, l) -> l.onResponse(null);
+        final AtomicReference<Releasable> toClose = new AtomicReference<>();
+
+        PlainActionFuture.get(f -> connectionManager.connectToNode(remoteClose, connectionProfile, validator, f.map(x -> null)));
+        PlainActionFuture.get(f -> connectionManager.connectToNode(shutdownClose, connectionProfile, validator, f.map(x -> null)));
+        PlainActionFuture.get(f -> connectionManager.connectToNode(localClose, connectionProfile, validator, f.map(toClose::getAndSet)));
+
+        final Releasable localConnectionRef = toClose.getAndSet(null);
+        assertThat(localConnectionRef, notNullValue());
+
+        final String loggerName = "org.elasticsearch.transport.ClusterConnectionManager";
+        final Logger logger = LogManager.getLogger(loggerName);
+        final MockLogAppender appender = new MockLogAppender();
+        try {
+            appender.start();
+            Loggers.addAppender(logger, appender);
+            appender.addExpectation(new MockLogAppender.SeenEventExpectation(
+                "locally-triggered close message",
+                loggerName,
+                Level.DEBUG,
+                "closing unused transport connection to [" + localClose + "]"));
+            appender.addExpectation(new MockLogAppender.SeenEventExpectation(
+                "remotely-triggered close message",
+                loggerName,
+                Level.INFO,
+                "transport connection to [" + remoteClose.descriptionWithoutAttributes() + "] closed by remote"));
+            appender.addExpectation(new MockLogAppender.SeenEventExpectation(
+                "shutdown-triggered close message",
+                loggerName,
+                Level.TRACE,
+                "connection manager shut down, closing transport connection to [" + shutdownClose + "]"));
+
+            Releasables.close(localConnectionRef);
+            connectionManager.disconnectFromNode(remoteClose);
+            connectionManager.close();
+
+            appender.assertAllExpectationsMatched();
+        } finally {
+            Loggers.removeAppender(logger, appender);
+            appender.stop();
+        }
+    }
+
     public void testConcurrentConnects() throws Exception {
         Set<Transport.Connection> connections = Collections.newSetFromMap(new ConcurrentHashMap<>());
 
@@ -156,10 +232,16 @@ public class ClusterConnectionManagerTests extends ESTestCase {
 
         List<Thread> threads = new ArrayList<>();
         AtomicInteger nodeConnectedCount = new AtomicInteger();
+        AtomicInteger nodeClosedCount = new AtomicInteger();
         AtomicInteger nodeFailureCount = new AtomicInteger();
 
-        CyclicBarrier barrier = new CyclicBarrier(11);
-        for (int i = 0; i < 10; i++) {
+        int threadCount = between(1, 10);
+        Releasable[] releasables = new Releasable[threadCount];
+
+        CyclicBarrier barrier = new CyclicBarrier(threadCount + 1);
+        Semaphore pendingCloses = new Semaphore(threadCount);
+        for (int i = 0; i < threadCount; i++) {
+            final int threadIndex = i;
             Thread thread = new Thread(() -> {
                 try {
                     barrier.await();
@@ -169,10 +251,18 @@ public class ClusterConnectionManagerTests extends ESTestCase {
                 CountDownLatch latch = new CountDownLatch(1);
                 connectionManager.connectToNode(node, connectionProfile, validator,
                     ActionListener.wrap(c -> {
-                        nodeConnectedCount.incrementAndGet();
-                        if (connectionManager.nodeConnected(node) == false) {
-                            throw new AssertionError("Expected node to be connected");
+                        assert connectionManager.nodeConnected(node);
+
+                        if (randomBoolean()) {
+                            releasables[threadIndex] = c;
+                            nodeConnectedCount.incrementAndGet();
+                        } else {
+                            assertTrue(pendingCloses.tryAcquire());
+                            connectionManager.getConnection(node).addRemovedListener(ActionListener.wrap(pendingCloses::release));
+                            Releasables.close(c);
+                            nodeClosedCount.incrementAndGet();
                         }
+
                         assert latch.getCount() == 1;
                         latch.countDown();
                     }, e -> {
@@ -199,25 +289,91 @@ public class ClusterConnectionManagerTests extends ESTestCase {
             }
         });
 
-        assertEquals(10, nodeConnectedCount.get() + nodeFailureCount.get());
+        assertEquals(threadCount, nodeConnectedCount.get() + nodeClosedCount.get() + nodeFailureCount.get());
 
-        int managedConnections = connectionManager.size();
-        if (managedConnections != 0) {
-            assertEquals(1, managedConnections);
-
-            // Only a single connection attempt should be open.
-            assertEquals(1, connections.stream().filter(c -> c.isClosed() == false).count());
+        if (nodeConnectedCount.get() == 0) {
+            // Any successful connections were closed
+            assertTrue(pendingCloses.tryAcquire(threadCount, 10, TimeUnit.SECONDS));
+            assertTrue(connections.stream().allMatch(Transport.Connection::isClosed));
+            assertEquals(0, connectionManager.size());
         } else {
-            // No connections succeeded
-            assertEquals(0, connections.stream().filter(c -> c.isClosed() == false).count());
+            assertEquals(1, connectionManager.size());
+            assertEquals(1L, connections.stream().filter(c -> c.isClosed() == false).count());
         }
 
+        if (randomBoolean()) {
+            Releasables.close(releasables);
+            assertEquals(0, connectionManager.size());
+            assertTrue(connections.stream().allMatch(Transport.Connection::isClosed));
+        }
 
         connectionManager.close();
         // The connection manager will close all open connections
         for (Transport.Connection connection : connections) {
             assertTrue(connection.isClosed());
         }
+    }
+
+    public void testConcurrentConnectsAndDisconnects() throws Exception {
+        final DiscoveryNode node = new DiscoveryNode("", new TransportAddress(InetAddress.getLoopbackAddress(), 0), Version.CURRENT);
+        doAnswer(invocationOnMock -> {
+            @SuppressWarnings("unchecked")
+            ActionListener<Transport.Connection> listener = (ActionListener<Transport.Connection>) invocationOnMock.getArguments()[2];
+            listener.onResponse(new TestConnect(node));
+            return null;
+        }).when(transport).openConnection(eq(node), any(), anyActionListener());
+
+        final ConnectionManager.ConnectionValidator validator = (c, p, l) -> {
+            if (randomBoolean()) {
+                l.onResponse(null);
+            } else {
+                threadPool.generic().execute(() -> l.onResponse(null));
+            }
+        };
+
+        final Semaphore pendingConnections = new Semaphore(1000);
+        final int threadCount = between(1, 10);
+        final CountDownLatch countDownLatch = new CountDownLatch(threadCount);
+
+        final Runnable action = new Runnable() {
+            @Override
+            public void run() {
+                if (pendingConnections.tryAcquire()) {
+                    connectionManager.connectToNode(node, null, validator, new ActionListener<Releasable>() {
+                        @Override
+                        public void onResponse(Releasable releasable) {
+                            if (connectionManager.nodeConnected(node) == false) {
+                                final String description = releasable.toString();
+                                fail(description);
+                            }
+                            Releasables.close(releasable);
+                            threadPool.generic().execute(() -> run());
+                        }
+
+                        @Override
+                        public void onFailure(Exception e) {
+                            if (e instanceof ConnectTransportException
+                                && e.getMessage().contains("concurrently connecting and disconnecting")) {
+                                pendingConnections.release();
+                                threadPool.generic().execute(() -> run());
+                            } else {
+                                throw new AssertionError("unexpected", e);
+                            }
+                        }
+                    });
+                } else {
+                    countDownLatch.countDown();
+                }
+            }
+        };
+
+        for (int i = 0; i < threadCount; i++) {
+            threadPool.generic().execute(action);
+        }
+
+        assertTrue(countDownLatch.await(10, TimeUnit.SECONDS));
+        assertFalse(connectionManager.nodeConnected(node));
+        connectionManager.close();
     }
 
     public void testConnectFailsDuringValidation() {
@@ -249,9 +405,9 @@ public class ClusterConnectionManagerTests extends ESTestCase {
 
         ConnectionManager.ConnectionValidator validator = (c, p, l) -> l.onFailure(new ConnectTransportException(node, ""));
 
-        PlainActionFuture<Void> fut = new PlainActionFuture<>();
+        PlainActionFuture<Releasable> fut = new PlainActionFuture<>();
         connectionManager.connectToNode(node, connectionProfile, validator, fut);
-        expectThrows(ConnectTransportException.class, () -> fut.actionGet());
+        expectThrows(ConnectTransportException.class, fut::actionGet);
 
         assertTrue(connection.isClosed());
         assertFalse(connectionManager.nodeConnected(node));
@@ -289,9 +445,9 @@ public class ClusterConnectionManagerTests extends ESTestCase {
 
         ConnectionManager.ConnectionValidator validator = (c, p, l) -> l.onResponse(null);
 
-        PlainActionFuture<Void> fut = new PlainActionFuture<>();
+        PlainActionFuture<Releasable> fut = new PlainActionFuture<>();
         connectionManager.connectToNode(node, connectionProfile, validator, fut);
-        expectThrows(ConnectTransportException.class, () -> fut.actionGet());
+        expectThrows(ConnectTransportException.class, fut::actionGet);
 
         assertFalse(connectionManager.nodeConnected(node));
         expectThrows(NodeNotConnectedException.class, () -> connectionManager.getConnection(node));

--- a/server/src/test/java/org/elasticsearch/transport/RemoteConnectionManagerTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/RemoteConnectionManagerTests.java
@@ -50,15 +50,15 @@ public class RemoteConnectionManagerTests extends ESTestCase {
 
         DiscoveryNode node1 = new DiscoveryNode("node-1", address, Version.CURRENT);
         PlainActionFuture<Void> future1 = PlainActionFuture.newFuture();
-        remoteConnectionManager.connectToNode(node1, null, validator, future1);
+        remoteConnectionManager.connectToRemoteClusterNode(node1, validator, future1);
         assertTrue(future1.isDone());
 
         // Add duplicate connect attempt to ensure that we do not get duplicate connections in the round robin
-        remoteConnectionManager.connectToNode(node1, null, validator, PlainActionFuture.newFuture());
+        remoteConnectionManager.connectToRemoteClusterNode(node1, validator, PlainActionFuture.newFuture());
 
         DiscoveryNode node2 = new DiscoveryNode("node-2", address, Version.CURRENT.minimumCompatibilityVersion());
         PlainActionFuture<Void> future2 = PlainActionFuture.newFuture();
-        remoteConnectionManager.connectToNode(node2, null, validator, future2);
+        remoteConnectionManager.connectToRemoteClusterNode(node2, validator, future2);
         assertTrue(future2.isDone());
 
         assertEquals(node1, remoteConnectionManager.getConnection(node1).getNode());

--- a/server/src/test/java/org/elasticsearch/transport/TransportServiceDeserializationFailureTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/TransportServiceDeserializationFailureTests.java
@@ -16,6 +16,7 @@ import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.DeterministicTaskQueue;
+import org.elasticsearch.core.Releasable;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.tasks.TaskAwareRequest;
 import org.elasticsearch.tasks.TaskId;
@@ -63,7 +64,7 @@ public class TransportServiceDeserializationFailureTests extends ESTestCase {
         transportService.start();
         transportService.acceptIncomingRequests();
 
-        final PlainActionFuture<Void> connectionFuture = new PlainActionFuture<>();
+        final PlainActionFuture<Releasable> connectionFuture = new PlainActionFuture<>();
         transportService.connectToNode(otherNode, connectionFuture);
         assertTrue(connectionFuture.isDone());
 

--- a/test/framework/src/main/java/org/elasticsearch/cluster/coordination/AbstractCoordinatorTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/cluster/coordination/AbstractCoordinatorTestCase.java
@@ -564,6 +564,13 @@ public class AbstractCoordinatorTestCase extends ESTestCase {
                         clusterNode.getLastAppliedClusterState().blocks().hasGlobalBlockWithId(NO_MASTER_BLOCK_ID), equalTo(false));
                     assertThat(nodeId + " has no STATE_NOT_RECOVERED_BLOCK",
                         clusterNode.getLastAppliedClusterState().blocks().hasGlobalBlock(STATE_NOT_RECOVERED_BLOCK), equalTo(false));
+
+                    for (final ClusterNode otherNode : clusterNodes) {
+                        if (isConnectedPair(leader, otherNode) && isConnectedPair(otherNode, clusterNode)) {
+                            assertTrue(otherNode.getId() + " is connected to healthy node " + clusterNode.getId(),
+                                otherNode.transportService.nodeConnected(clusterNode.localNode));
+                        }
+                    }
                 } else {
                     assertThat(nodeId + " is not following " + leaderId, clusterNode.coordinator.getMode(), is(CANDIDATE));
                     assertThat(nodeId + " has no master", clusterNode.getLastAppliedClusterState().nodes().getMasterNode(), nullValue());
@@ -571,6 +578,13 @@ public class AbstractCoordinatorTestCase extends ESTestCase {
                         clusterNode.getLastAppliedClusterState().blocks().hasGlobalBlockWithId(NO_MASTER_BLOCK_ID), equalTo(true));
                     assertFalse(nodeId + " is not in the applied state on " + leaderId,
                         leader.getLastAppliedClusterState().getNodes().nodeExists(nodeId));
+
+                    for (final ClusterNode otherNode : clusterNodes) {
+                        if (isConnectedPair(leader, otherNode)) {
+                            assertFalse(otherNode.getId() + " is not connected to removed node " + clusterNode.getId(),
+                                otherNode.transportService.nodeConnected(clusterNode.localNode));
+                        }
+                    }
                 }
             }
 
@@ -1412,7 +1426,10 @@ public class AbstractCoordinatorTestCase extends ESTestCase {
 
         @Override
         protected void connectToNodesAndWait(ClusterState newClusterState) {
-            // don't do anything, and don't block
+            connectToNodesAsync(newClusterState, () -> {
+                // no need to block waiting for handshakes etc. to complete, it's enough to let the NodeConnectionsService take charge of
+                // these connections
+            });
         }
 
         @Override

--- a/test/framework/src/main/java/org/elasticsearch/test/transport/StubbableConnectionManager.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/transport/StubbableConnectionManager.java
@@ -10,6 +10,7 @@ package org.elasticsearch.test.transport;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.common.transport.TransportAddress;
+import org.elasticsearch.core.Releasable;
 import org.elasticsearch.transport.ConnectTransportException;
 import org.elasticsearch.transport.ConnectionProfile;
 import org.elasticsearch.transport.ConnectionManager;
@@ -86,7 +87,7 @@ public class StubbableConnectionManager implements ConnectionManager {
 
     @Override
     public void connectToNode(DiscoveryNode node, ConnectionProfile connectionProfile,
-                              ConnectionValidator connectionValidator, ActionListener<Void> listener)
+                              ConnectionValidator connectionValidator, ActionListener<Releasable> listener)
         throws ConnectTransportException {
         delegate.connectToNode(node, connectionProfile, connectionValidator, listener);
     }

--- a/test/framework/src/main/java/org/elasticsearch/test/transport/StubbableTransport.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/transport/StubbableTransport.java
@@ -229,6 +229,10 @@ public class StubbableTransport implements Transport {
             connection.addCloseListener(listener);
         }
 
+        @Override
+        public void addRemovedListener(ActionListener<Void> listener) {
+            connection.addRemovedListener(listener);
+        }
 
         @Override
         public boolean isClosed() {
@@ -250,6 +254,11 @@ public class StubbableTransport implements Transport {
             connection.close();
         }
 
+        @Override
+        public void onRemoved() {
+            connection.onRemoved();
+        }
+
         public Transport.Connection getConnection() {
             return connection;
         }
@@ -257,6 +266,26 @@ public class StubbableTransport implements Transport {
         @Override
         public String toString() {
             return "WrappedConnection[" + connection + "]";
+        }
+
+        @Override
+        public void incRef() {
+            connection.incRef();
+        }
+
+        @Override
+        public boolean tryIncRef() {
+            return connection.tryIncRef();
+        }
+
+        @Override
+        public boolean decRef() {
+            return connection.decRef();
+        }
+
+        @Override
+        public boolean hasReferences() {
+            return connection.hasReferences();
         }
     }
 

--- a/test/framework/src/main/java/org/elasticsearch/transport/AbstractSimpleTransportTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/transport/AbstractSimpleTransportTestCase.java
@@ -21,8 +21,6 @@ import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ActionListenerResponseHandler;
 import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.cluster.node.DiscoveryNode;
-import org.elasticsearch.core.Nullable;
-import org.elasticsearch.core.SuppressForbidden;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -35,9 +33,12 @@ import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.transport.BoundTransportAddress;
 import org.elasticsearch.common.transport.TransportAddress;
-import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.common.util.concurrent.AbstractRunnable;
 import org.elasticsearch.common.util.concurrent.ConcurrentCollections;
+import org.elasticsearch.core.Nullable;
+import org.elasticsearch.core.Releasable;
+import org.elasticsearch.core.SuppressForbidden;
+import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.core.internal.io.IOUtils;
 import org.elasticsearch.mocksocket.MockServerSocket;
 import org.elasticsearch.node.Node;
@@ -2831,9 +2832,9 @@ public abstract class AbstractSimpleTransportTestCase extends ESTestCase {
             serviceC.connectToNode(
                 serviceA.getLocalDiscoNode(),
                 ConnectionProfile.buildDefaultConnectionProfile(Settings.EMPTY),
-                new ActionListener<Void>() {
+                new ActionListener<Releasable>() {
                     @Override
-                    public void onResponse(final Void v) {
+                    public void onResponse(final Releasable ignored) {
                         latch.countDown();
                     }
 

--- a/test/framework/src/test/java/org/elasticsearch/test/disruption/DisruptableMockTransportTests.java
+++ b/test/framework/src/test/java/org/elasticsearch/test/disruption/DisruptableMockTransportTests.java
@@ -15,6 +15,7 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.transport.TransportAddress;
 import org.elasticsearch.common.util.concurrent.DeterministicTaskQueue;
+import org.elasticsearch.core.Releasable;
 import org.elasticsearch.core.Tuple;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.disruption.DisruptableMockTransport.ConnectionStatus;
@@ -136,9 +137,9 @@ public class DisruptableMockTransportTests extends ESTestCase {
         service1.start();
         service2.start();
 
-        final PlainActionFuture<Void> fut1 = new PlainActionFuture<>();
+        final PlainActionFuture<Releasable> fut1 = new PlainActionFuture<>();
         service1.connectToNode(node2, fut1);
-        final PlainActionFuture<Void> fut2 = new PlainActionFuture<>();
+        final PlainActionFuture<Releasable> fut2 = new PlainActionFuture<>();
         service2.connectToNode(node1, fut2);
         deterministicTaskQueue.runAllTasksInTimeOrder();
         assertTrue(fut1.isDone());

--- a/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/repositories/GetCcrRestoreFileChunkAction.java
+++ b/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/repositories/GetCcrRestoreFileChunkAction.java
@@ -116,5 +116,10 @@ public class GetCcrRestoreFileChunkAction extends ActionType<GetCcrRestoreFileCh
         public boolean decRef() {
             return chunk.decRef();
         }
+
+        @Override
+        public boolean hasReferences() {
+            return chunk.hasReferences();
+        }
     }
 }


### PR DESCRIPTION
Today we open connections to other nodes in various places and largely
assume that they remain open as needed, only closing them when applying
a cluster state that removes the remote node from the cluster. This
isn't ideal: we might preserve unnecessary connections to remote nodes
that aren't in the cluster if they never manage to join the cluster, and
we might also disconnect from a node that left the cluster while it's in
the process of re-joining too (see #67873).

With this commit we move to a model in which each user of a connection
to a remote node acquires a reference to the connection that must be
released once it's no longer needed. Connections remain open while there
are any live references, but are now actively closed when all references
are released.

Fixes #67873
Backport of #77295