### PR TITLE
[Test] Re-enable rest compat tests for service accounts

### DIFF
--- a/x-pack/plugin/build.gradle
+++ b/x-pack/plugin/build.gradle
@@ -152,12 +152,10 @@ tasks.named("yamlRestTestV7CompatTest").configure {
       'rollup/put_job/Test basic put_job',
       //https://github.com/elastic/elasticsearch/pull/41502
       'rollup/start_job/Test start job twice',
-      'service_accounts/10_basic/Test service account tokens', // https://github.com/elastic/elasticsearch/pull/75200
 
       // a type field was added to cat.ml_trained_models #73660, this is a backwards compatible change.
       // still this is a cat api, and we don't support them with rest api compatibility. (the test would be very hard to transform too)
       'ml/trained_model_cat_apis/Test cat trained models',
-      'service_accounts/10_basic/Test get service accounts', //#76449, will remove upon backport
   ].join(',')
   dependsOn "copyExtraResources"
 }


### PR DESCRIPTION
Tests for Get service accounts and Get service account tokens were
disabled for rest compat before backports. Now the backports are
complete, these tests can be re-enabled.

Relates: #75995, #76502
