### PR TITLE
[Test] Relax node name match for service account yml test

### DIFF
--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/service_accounts/10_basic.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/service_accounts/10_basic.yml
@@ -108,7 +108,7 @@ teardown:
   - match: { "nodes_credentials._nodes.failed": 0 }
   - is_true: nodes_credentials.file_tokens.token1
   - is_true: nodes_credentials.file_tokens.token1.nodes
-  - match: { "nodes_credentials.file_tokens.token1.nodes.0" : "/(yamlRestTest-0|yamlRestCompatTest-0)/" }
+  - match: { "nodes_credentials.file_tokens.token1.nodes.0" : "/yamlRestTest.*-0/" }
 
   - do:
       security.clear_cached_service_tokens:


### PR DESCRIPTION
The yaml rest compat test was renamed to yaml rest v7 compat test and
this broken the node name matching. This PR relaxed the matching rule so
that it allows arbitrary string after the yamlRestTest to accomodate
possible future changes.

Relates: #77673