### PR TITLE
Note S3 plugin uses JVM-wide truststore

### DIFF
--- a/docs/plugins/repository-s3.asciidoc
+++ b/docs/plugins/repository-s3.asciidoc
@@ -125,7 +125,10 @@ settings belong in the `elasticsearch.yml` file.
 `protocol`::
 
     The protocol to use to connect to S3. Valid values are either `http` or
-    `https`. Defaults to `https`.
+    `https`. Defaults to `https`. When using HTTPS, this plugin validates the
+    repository's certificate chain using the JVM-wide truststore. Ensure that
+    the root certificate authority is in this truststore using the JVM's
+    `keytool` tool.
 
 `proxy.host`::
 


### PR DESCRIPTION
Today it's not clear how to tell Elasticsearch to trust an S3-compatible
repository that presents a certificate issued by a private or
nonstandard CA. This commit expands the docs to say how.

Supersedes #65034
Relates #77081

Co-authored-by: Joost De Cock <joost@decock.org>