### PR TITLE
[7.x] Fold blob store cache path into BlobStoreCacheService

### DIFF
--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/cache/blob/BlobStoreCacheService.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/cache/blob/BlobStoreCacheService.java
@@ -35,8 +35,11 @@ import org.elasticsearch.common.util.concurrent.RunOnce;
 import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.index.store.LuceneFilesExtensions;
 import org.elasticsearch.node.NodeClosedException;
+import org.elasticsearch.repositories.IndexId;
+import org.elasticsearch.snapshots.SnapshotId;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.ConnectTransportException;
 import org.elasticsearch.xpack.searchablesnapshots.cache.common.ByteRange;
@@ -118,12 +121,19 @@ public class BlobStoreCacheService extends AbstractLifecycleComponent {
     @Override
     protected void doClose() {}
 
-    public CachedBlob get(String repository, String name, String path, long offset) {
+    public CachedBlob get(
+        final String repository,
+        final SnapshotId snapshotId,
+        final IndexId indexId,
+        final ShardId shardId,
+        final String name,
+        final ByteRange range
+    ) {
         assert Thread.currentThread().getName().contains('[' + ThreadPool.Names.SYSTEM_READ + ']') == false
             : "must not block [" + Thread.currentThread().getName() + "] for a cache read";
 
         final PlainActionFuture<CachedBlob> future = PlainActionFuture.newFuture();
-        getAsync(repository, name, path, offset, future);
+        getAsync(repository, snapshotId, indexId, shardId, name, range, future);
         try {
             return future.actionGet(5, TimeUnit.SECONDS);
         } catch (ElasticsearchTimeoutException e) {
@@ -131,7 +141,7 @@ public class BlobStoreCacheService extends AbstractLifecycleComponent {
                 logger.debug(
                     () -> new ParameterizedMessage(
                         "get from cache index timed out after [5s], retrieving from blob store instead [id={}]",
-                        CachedBlob.generateId(repository, name, path, offset)
+                        generateId(repository, snapshotId, indexId, shardId, name, range)
                     ),
                     e
                 );
@@ -142,13 +152,21 @@ public class BlobStoreCacheService extends AbstractLifecycleComponent {
         }
     }
 
-    protected void getAsync(String repository, String name, String path, long offset, ActionListener<CachedBlob> listener) {
+    protected void getAsync(
+        final String repository,
+        final SnapshotId snapshotId,
+        final IndexId indexId,
+        final ShardId shardId,
+        final String name,
+        final ByteRange range,
+        final ActionListener<CachedBlob> listener
+    ) {
         if (closed.get()) {
             logger.debug("failed to retrieve cached blob from system index [{}], service is closed", index);
             listener.onResponse(CachedBlob.CACHE_NOT_READY);
             return;
         }
-        final GetRequest request = new GetRequest(index).id(CachedBlob.generateId(repository, name, path, offset));
+        final GetRequest request = new GetRequest(index).id(generateId(repository, snapshotId, indexId, shardId, name, range));
         client.get(request, new ActionListener<GetResponse>() {
             @Override
             public void onResponse(GetResponse response) {
@@ -157,8 +175,15 @@ public class BlobStoreCacheService extends AbstractLifecycleComponent {
                     assert response.isSourceEmpty() == false;
 
                     final CachedBlob cachedBlob = CachedBlob.fromSource(response.getSource());
-                    assert response.getId().equals(cachedBlob.generatedId());
-                    listener.onResponse(cachedBlob);
+                    assert assertDocId(response, repository, snapshotId, indexId, shardId, name, range);
+                    if (cachedBlob.from() != range.start() || cachedBlob.to() != range.end()) {
+                        // expected range in cache might differ with the returned cached blob; this can happen if the range to put in cache
+                        // is changed between versions or through the index setting. In this case we assume it is a cache miss to force the
+                        // blob to be cached again
+                        listener.onResponse(CachedBlob.CACHE_MISS);
+                    } else {
+                        listener.onResponse(cachedBlob);
+                    }
                 } else {
                     logger.debug("cache miss: [{}]", request.id());
                     listener.onResponse(CachedBlob.CACHE_MISS);
@@ -180,6 +205,21 @@ public class BlobStoreCacheService extends AbstractLifecycleComponent {
         });
     }
 
+    private static boolean assertDocId(
+        final GetResponse response,
+        final String repository,
+        final SnapshotId snapshotId,
+        final IndexId indexId,
+        final ShardId shardId,
+        final String name,
+        final ByteRange range
+    ) {
+        final String expectedId = generateId(repository, snapshotId, indexId, shardId, name, range);
+        assert response.getId().equals(expectedId)
+            : "Expected a cached blob document with id [" + expectedId + "] but got [" + response.getId() + ']';
+        return true;
+    }
+
     private static boolean isExpectedCacheGetException(Exception e) {
         if (TransportActions.isShardNotAvailableException(e)
             || e instanceof ConnectTransportException
@@ -190,18 +230,28 @@ public class BlobStoreCacheService extends AbstractLifecycleComponent {
         return cause instanceof NodeClosedException || cause instanceof ConnectTransportException;
     }
 
-    public void putAsync(String repository, String name, String path, long offset, BytesReference content, ActionListener<Void> listener) {
+    public void putAsync(
+        final String repository,
+        final SnapshotId snapshotId,
+        final IndexId indexId,
+        final ShardId shardId,
+        final String name,
+        final ByteRange range,
+        final BytesReference bytes,
+        final ActionListener<Void> listener
+    ) {
+        final String id = generateId(repository, snapshotId, indexId, shardId, name, range);
         try {
             final CachedBlob cachedBlob = new CachedBlob(
                 Instant.ofEpochMilli(timeSupplier.get()),
                 Version.CURRENT,
                 repository,
                 name,
-                path,
-                content,
-                offset
+                generatePath(snapshotId, indexId, shardId),
+                bytes,
+                range.start()
             );
-            final IndexRequest request = new IndexRequest(index).id(cachedBlob.generatedId());
+            final IndexRequest request = new IndexRequest(index).id(id);
             try (XContentBuilder builder = jsonBuilder()) {
                 request.source(cachedBlob.toXContent(builder, ToXContent.EMPTY_PARAMS));
             }
@@ -240,9 +290,24 @@ public class BlobStoreCacheService extends AbstractLifecycleComponent {
                 }
             }
         } catch (Exception e) {
-            logger.warn(new ParameterizedMessage("cache fill failure: [{}]", CachedBlob.generateId(repository, name, path, offset)), e);
+            logger.warn(() -> new ParameterizedMessage("cache fill failure: [{}]", id), e);
             listener.onFailure(e);
         }
+    }
+
+    protected static String generateId(
+        final String repository,
+        final SnapshotId snapshotId,
+        final IndexId indexId,
+        final ShardId shardId,
+        final String name,
+        final ByteRange range
+    ) {
+        return String.join("/", repository, snapshotId.getUUID(), indexId.getId(), String.valueOf(shardId.id()), name, "@" + range.start());
+    }
+
+    protected static String generatePath(final SnapshotId snapshotId, final IndexId indexId, final ShardId shardId) {
+        return String.join("/", snapshotId.getUUID(), indexId.getId(), String.valueOf(shardId.id()));
     }
 
     /**

--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/cache/blob/CachedBlob.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/cache/blob/CachedBlob.java
@@ -101,10 +101,6 @@ public class CachedBlob implements ToXContent {
         return builder.endObject();
     }
 
-    public String generatedId() {
-        return generateId(repository, name, path, from);
-    }
-
     public long from() {
         return from;
     }
@@ -119,10 +115,6 @@ public class CachedBlob implements ToXContent {
 
     public BytesReference bytes() {
         return bytes;
-    }
-
-    public static String generateId(String repository, String name, String path, long offset) {
-        return String.join("/", repository, path, name, "@" + offset);
     }
 
     @SuppressWarnings("unchecked")

--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/store/SearchableSnapshotDirectory.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/store/SearchableSnapshotDirectory.java
@@ -120,7 +120,6 @@ public class SearchableSnapshotDirectory extends BaseDirectory {
     private final Supplier<BlobContainer> blobContainerSupplier;
     private final Supplier<BlobStoreIndexShardSnapshot> snapshotSupplier;
     private final BlobStoreCacheService blobStoreCacheService;
-    private final String blobStoreCachePath;
     private final String repository;
     private final SnapshotId snapshotId;
     private final IndexId indexId;
@@ -181,7 +180,6 @@ public class SearchableSnapshotDirectory extends BaseDirectory {
         this.prewarmCache = partial == false && useCache ? SNAPSHOT_CACHE_PREWARM_ENABLED_SETTING.get(indexSettings) : false;
         this.excludedFileTypes = new HashSet<>(SNAPSHOT_CACHE_EXCLUDED_FILE_TYPES_SETTING.get(indexSettings));
         this.uncachedChunkSize = SNAPSHOT_UNCACHED_CHUNK_SIZE_SETTING.get(indexSettings).getBytes();
-        this.blobStoreCachePath = String.join("/", snapshotId.getUUID(), indexId.getId(), String.valueOf(shardId.id()));
         this.blobStoreCacheMaxLength = SNAPSHOT_BLOB_CACHE_METADATA_FILES_MAX_LENGTH_SETTING.get(indexSettings);
         this.threadPool = threadPool;
         this.loaded = false;
@@ -706,19 +704,11 @@ public class SearchableSnapshotDirectory extends BaseDirectory {
     }
 
     public CachedBlob getCachedBlob(String name, ByteRange range) {
-        final CachedBlob cachedBlob = blobStoreCacheService.get(repository, name, blobStoreCachePath, range.start());
-        if (cachedBlob == CachedBlob.CACHE_MISS || cachedBlob == CachedBlob.CACHE_NOT_READY) {
-            return cachedBlob;
-        } else if (cachedBlob.from() != range.start() || cachedBlob.to() != range.end()) {
-            // expected range in cache might differ with the returned cached blob; this can happen if the range to put in cache is changed
-            // between versions or through the index setting. In this case we assume it is a cache miss to force the blob to be cached again
-            return CachedBlob.CACHE_MISS;
-        }
-        return cachedBlob;
+        return blobStoreCacheService.get(repository, snapshotId, indexId, shardId, name, range);
     }
 
-    public void putCachedBlob(String name, long offset, BytesReference content, ActionListener<Void> listener) {
-        blobStoreCacheService.putAsync(repository, name, blobStoreCachePath, offset, content, listener);
+    public void putCachedBlob(String name, ByteRange range, BytesReference content, ActionListener<Void> listener) {
+        blobStoreCacheService.putAsync(repository, snapshotId, indexId, shardId, name, range, content, listener);
     }
 
     public FrozenCacheFile getFrozenCacheFile(String fileName, long length) {

--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/store/input/MetadataCachingIndexInput.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/store/input/MetadataCachingIndexInput.java
@@ -287,7 +287,7 @@ public abstract class MetadataCachingIndexInput extends BaseSearchableSnapshotIn
             // NB use Channels.readFromFileChannelWithEofException not readCacheFile() to avoid counting this in the stats
             byteBuffer.flip();
             final BytesReference content = BytesReference.fromByteBuffer(byteBuffer);
-            directory.putCachedBlob(fileInfo.physicalName(), indexCacheMiss.start(), content, new ActionListener<Void>() {
+            directory.putCachedBlob(fileInfo.physicalName(), indexCacheMiss, content, new ActionListener<Void>() {
                 @Override
                 public void onResponse(Void response) {
                     onCacheFillComplete.close();

--- a/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/cache/blob/BlobStoreCacheServiceTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/cache/blob/BlobStoreCacheServiceTests.java
@@ -16,17 +16,22 @@ import org.elasticsearch.action.index.IndexRequest;
 import org.elasticsearch.action.index.IndexResponse;
 import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.client.Client;
+import org.elasticsearch.common.UUIDs;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.get.GetResult;
 import org.elasticsearch.index.shard.ShardId;
+import org.elasticsearch.repositories.IndexId;
+import org.elasticsearch.snapshots.SnapshotId;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.threadpool.TestThreadPool;
+import org.elasticsearch.xpack.searchablesnapshots.cache.common.ByteRange;
 import org.junit.After;
 import org.junit.Before;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
@@ -49,6 +54,12 @@ public class BlobStoreCacheServiceTests extends ESTestCase {
 
     private TestThreadPool threadPool;
     private Client mockClient;
+    private String repository;
+    private SnapshotId snapshotId;
+    private IndexId indexId;
+    private ShardId shardId;
+    private String fileName;
+    private ByteRange range;
 
     @Before
     public void createThreadPool() {
@@ -56,6 +67,12 @@ public class BlobStoreCacheServiceTests extends ESTestCase {
         threadPool = new TestThreadPool(getClass().getSimpleName());
         when(mockClient.threadPool()).thenReturn(threadPool);
         when(mockClient.settings()).thenReturn(Settings.EMPTY);
+        repository = randomAlphaOfLength(5).toLowerCase(Locale.ROOT);
+        snapshotId = new SnapshotId(randomAlphaOfLength(5).toLowerCase(Locale.ROOT), UUIDs.randomBase64UUID());
+        indexId = new IndexId(randomAlphaOfLength(5).toLowerCase(Locale.ROOT), UUIDs.randomBase64UUID());
+        shardId = new ShardId(randomAlphaOfLength(5).toLowerCase(Locale.ROOT), UUIDs.randomBase64UUID(), randomInt(5));
+        fileName = randomAlphaOfLength(5).toLowerCase(Locale.ROOT);
+        range = ByteRange.of(randomLongBetween(0L, 1024L), randomLongBetween(2048L, 4096L));
     }
 
     @After
@@ -91,13 +108,13 @@ public class BlobStoreCacheServiceTests extends ESTestCase {
         blobCacheService.start();
 
         PlainActionFuture<CachedBlob> future = PlainActionFuture.newFuture();
-        blobCacheService.getAsync("_repository", "_file", "/path", 0L, future);
+        blobCacheService.getAsync(repository, snapshotId, indexId, shardId, fileName, range, future);
         assertThat(future.actionGet(), equalTo(CachedBlob.CACHE_MISS));
 
         blobCacheService.stop();
 
         future = PlainActionFuture.newFuture();
-        blobCacheService.getAsync("_repository", "_file", "/path", 0L, future);
+        blobCacheService.getAsync(repository, snapshotId, indexId, shardId, fileName, range, future);
         assertThat(future.actionGet(), equalTo(CachedBlob.CACHE_NOT_READY));
     }
 
@@ -124,13 +141,13 @@ public class BlobStoreCacheServiceTests extends ESTestCase {
         blobCacheService.start();
 
         PlainActionFuture<Void> future = PlainActionFuture.newFuture();
-        blobCacheService.putAsync("_repository", "_file", "/path", 0L, BytesArray.EMPTY, future);
+        blobCacheService.putAsync(repository, snapshotId, indexId, shardId, fileName, range, BytesArray.EMPTY, future);
         assertThat(future.actionGet(), nullValue());
 
         blobCacheService.stop();
 
         future = PlainActionFuture.newFuture();
-        blobCacheService.putAsync("_repository", "_file", "/path", 0L, BytesArray.EMPTY, future);
+        blobCacheService.putAsync(repository, snapshotId, indexId, shardId, fileName, range, BytesArray.EMPTY, future);
         IllegalStateException exception = expectThrows(IllegalStateException.class, future::actionGet);
         assertThat(exception.getMessage(), containsString("Blob cache service is closed"));
     }
@@ -169,7 +186,7 @@ public class BlobStoreCacheServiceTests extends ESTestCase {
             final PlainActionFuture<Void> future = PlainActionFuture.newFuture();
             threadPool.generic()
                 .execute(
-                    () -> { blobCacheService.putAsync("_repository", randomAlphaOfLength(3), "/path", 0L, BytesArray.EMPTY, future); }
+                    () -> blobCacheService.putAsync(repository, snapshotId, indexId, shardId, fileName, range, BytesArray.EMPTY, future)
                 );
             futures.add(future);
         }

--- a/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/cache/common/TestUtils.java
+++ b/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/cache/common/TestUtils.java
@@ -26,6 +26,9 @@ import org.elasticsearch.common.util.concurrent.DeterministicTaskQueue;
 import org.elasticsearch.core.CheckedConsumer;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.PathUtilsForTesting;
+import org.elasticsearch.index.shard.ShardId;
+import org.elasticsearch.repositories.IndexId;
+import org.elasticsearch.snapshots.SnapshotId;
 import org.elasticsearch.xpack.searchablesnapshots.cache.blob.BlobStoreCacheService;
 import org.elasticsearch.xpack.searchablesnapshots.cache.blob.CachedBlob;
 import org.elasticsearch.xpack.searchablesnapshots.store.IndexInputStats;
@@ -326,7 +329,15 @@ public final class TestUtils {
         }
 
         @Override
-        protected void getAsync(String repository, String name, String path, long offset, ActionListener<CachedBlob> listener) {
+        protected void getAsync(
+            String repository,
+            SnapshotId snapshotId,
+            IndexId indexId,
+            ShardId shardId,
+            String name,
+            ByteRange range,
+            ActionListener<CachedBlob> listener
+        ) {
             listener.onResponse(CachedBlob.CACHE_NOT_READY);
         }
 
@@ -338,10 +349,12 @@ public final class TestUtils {
         @Override
         public void putAsync(
             String repository,
+            SnapshotId snapshotId,
+            IndexId indexId,
+            ShardId shardId,
             String name,
-            String path,
-            long offset,
-            BytesReference content,
+            ByteRange range,
+            BytesReference bytes,
             ActionListener<Void> listener
         ) {
             listener.onResponse(null);
@@ -362,8 +375,16 @@ public final class TestUtils {
         }
 
         @Override
-        protected void getAsync(String repository, String name, String path, long offset, ActionListener<CachedBlob> listener) {
-            CachedBlob blob = blobs.get(CachedBlob.generateId(repository, name, path, offset));
+        protected void getAsync(
+            String repository,
+            SnapshotId snapshotId,
+            IndexId indexId,
+            ShardId shardId,
+            String name,
+            ByteRange range,
+            ActionListener<CachedBlob> listener
+        ) {
+            CachedBlob blob = blobs.get(generateId(repository, snapshotId, indexId, shardId, name, range));
             if (blob != null) {
                 listener.onResponse(blob);
             } else {
@@ -374,10 +395,12 @@ public final class TestUtils {
         @Override
         public void putAsync(
             String repository,
+            SnapshotId snapshotId,
+            IndexId indexId,
+            ShardId shardId,
             String name,
-            String path,
-            long offset,
-            BytesReference content,
+            ByteRange range,
+            BytesReference bytes,
             ActionListener<Void> listener
         ) {
             final CachedBlob cachedBlob = new CachedBlob(
@@ -385,11 +408,11 @@ public final class TestUtils {
                 Version.CURRENT,
                 repository,
                 name,
-                path,
-                new BytesArray(content.toBytesRef(), true),
-                offset
+                generatePath(snapshotId, indexId, shardId),
+                new BytesArray(bytes.toBytesRef(), true),
+                range.start()
             );
-            blobs.put(cachedBlob.generatedId(), cachedBlob);
+            blobs.put(generateId(repository, snapshotId, indexId, shardId, name, range), cachedBlob);
             listener.onResponse(null);
         }
     }


### PR DESCRIPTION
Today a SearchableSnapshotDirectory instance computes the
path where blobs are located in the repository and passes this
path to the blob store cache service every time it tries to get
or to put a document in the .snapshot-blob-cache system index.

This path is indexed in cached blob documents and is used as
 ids of cached documents, but this is an implementation detail
so it makes more sense IMO to compute the path in the
BlobStoreCacheService itself and compute doc ids in the
same service. Same thing when detecting that the cached
blob document has a different length than expected; this
should be handled at the BlobStoreCacheService and not
in the Lucene directory itself.

Backport of #77611