### PR TITLE
[7.x] [Test] Relax node name match for service account yml test (#77675)

### DIFF
--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/service_accounts/10_basic.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/service_accounts/10_basic.yml
@@ -108,7 +108,7 @@ teardown:
   - match: { "nodes_credentials._nodes.failed": 0 }
   - is_true: nodes_credentials.file_tokens.token1
   - is_true: nodes_credentials.file_tokens.token1.nodes
-  - match: { "nodes_credentials.file_tokens.token1.nodes.0" : "/(yamlRestTest-0|yamlRestCompatTest-0)/" }
+  - match: { "nodes_credentials.file_tokens.token1.nodes.0" : "/yamlRestTest.*-0/" }
 
   - do:
       security.clear_cached_service_tokens:


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [Test] Relax node name match for service account yml test (#77675)