### PR TITLE
[7.14] Note S3 plugin uses JVM-wide truststore (#77676)

### DIFF
--- a/docs/plugins/repository-s3.asciidoc
+++ b/docs/plugins/repository-s3.asciidoc
@@ -125,7 +125,10 @@ settings belong in the `elasticsearch.yml` file.
 `protocol`::
 
     The protocol to use to connect to S3. Valid values are either `http` or
-    `https`. Defaults to `https`.
+    `https`. Defaults to `https`. When using HTTPS, this plugin validates the
+    repository's certificate chain using the JVM-wide truststore. Ensure that
+    the root certificate authority is in this truststore using the JVM's
+    `keytool` tool.
 
 `proxy.host`::
 


### PR DESCRIPTION
Backports the following commits to 7.14:
 - Note S3 plugin uses JVM-wide truststore (#77676)