### PR TITLE
Deprecate Unused SnapshotCreationException (#48309)

### DIFF
--- a/server/src/main/java/org/elasticsearch/snapshots/SnapshotCreationException.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/SnapshotCreationException.java
@@ -14,7 +14,10 @@ import java.io.IOException;
 
 /**
  * Thrown when snapshot creation fails completely
+ * TODO: Remove this class in 8.0
+ * @deprecated This exception isn't thrown anymore. It's only here for BwC.
  */
+@Deprecated
 public class SnapshotCreationException extends SnapshotException {
 
     public SnapshotCreationException(final String repositoryName, final SnapshotId snapshotId, final Throwable cause) {


### PR DESCRIPTION
This Ex. isn't used anymore. A follow up
to `master`/`8.0` only should remove it
once it's deprecated in `7.x` as well
(where it's still used for BwC during mixed-version
cluster snapshots currently).

backport of #48309 