### PR TITLE
Fix ClusterRerouteIT Often Sleeping 30s Needlessly

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/allocation/ClusterRerouteIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/allocation/ClusterRerouteIT.java
@@ -97,7 +97,7 @@ public class ClusterRerouteIT extends ESIntegTestCase {
                 .execute().actionGet();
 
         if (randomBoolean()) {
-            client().admin().indices().prepareClose("test").get();
+            client().admin().indices().prepareClose("test").setWaitForActiveShards(ActiveShardCount.NONE).get();
         }
 
         ClusterState state = client().admin().cluster().prepareState().execute().actionGet().getState();
@@ -232,7 +232,7 @@ public class ClusterRerouteIT extends ESIntegTestCase {
 
         final boolean closed = randomBoolean();
         if (closed) {
-            client().admin().indices().prepareClose("test").get();
+            client().admin().indices().prepareClose("test").setWaitForActiveShards(ActiveShardCount.NONE).get();
         }
 
         ClusterState state = client().admin().cluster().prepareState().execute().actionGet().getState();


### PR DESCRIPTION
We run the close requests while allocation is disabled. This means, we would
always run down the clock on the request timeout only to find that no shards
are active still.
