### PR TITLE
Honour max segment size when setting only_expunge_deletes on force merge

### DIFF
--- a/docs/reference/indices/forcemerge.asciidoc
+++ b/docs/reference/indices/forcemerge.asciidoc
@@ -123,7 +123,8 @@ If so, executes it.
 --
 (Optional, Boolean)
 If `true`,
-only expunge segments containing document deletions.
+expunge all segments containing more than `index.merge.policy.expunge_deletes_allowed`
+ (default to 10) percents of deleted documents.
 Defaults to `false`.
 
 In Lucene,
@@ -133,8 +134,6 @@ During a merge,
 a new segment is created
 that does not contain those document deletions.
 
-NOTE: This parameter does *not* override the
-`index.merge.policy.expunge_deletes_allowed` setting.
 --
 
 

--- a/server/src/main/java/org/elasticsearch/index/EsTieredMergePolicy.java
+++ b/server/src/main/java/org/elasticsearch/index/EsTieredMergePolicy.java
@@ -41,7 +41,9 @@ final class EsTieredMergePolicy extends FilterMergePolicy {
 
     @Override
     public MergeSpecification findForcedDeletesMerges(SegmentInfos infos, MergeContext mergeContext) throws IOException {
-        return forcedMergePolicy.findForcedDeletesMerges(infos, mergeContext);
+        // we apply the max segment size through the regular merge policy in
+        // order to avoid giant segments when expunging deletes on a read/write index
+        return regularMergePolicy.findForcedDeletesMerges(infos, mergeContext);
     }
 
     public void setForceMergeDeletesPctAllowed(double forceMergeDeletesPctAllowed) {

--- a/server/src/test/java/org/elasticsearch/index/EsTieredMergePolicyTests.java
+++ b/server/src/test/java/org/elasticsearch/index/EsTieredMergePolicyTests.java
@@ -32,6 +32,7 @@ public class EsTieredMergePolicyTests extends ESTestCase {
         EsTieredMergePolicy policy = new EsTieredMergePolicy();
         policy.setForceMergeDeletesPctAllowed(42);
         assertEquals(42, policy.forcedMergePolicy.getForceMergeDeletesPctAllowed(), 0);
+        assertEquals(42, policy.regularMergePolicy.getForceMergeDeletesPctAllowed(), 0);
     }
 
     public void testSetFloorSegmentMB() {


### PR DESCRIPTION
Backport of #77478