### PR TITLE
[7.x] Remove superfluous HTML start element at end of body part-2 (#77600)

### DIFF
--- a/libs/x-content/src/main/java/org/elasticsearch/common/xcontent/XContentBuilder.java
+++ b/libs/x-content/src/main/java/org/elasticsearch/common/xcontent/XContentBuilder.java
@@ -61,7 +61,6 @@ public final class XContentBuilder implements Closeable, Flushable {
      * The builder uses an internal {@link ByteArrayOutputStream} output stream to build the content. When both exclusive and
      * inclusive filters are provided, the underlying builder will first use exclusion filters to remove fields and then will check the
      * remaining fields against the inclusive filters.
-     * <p>
      *
      * @param xContent the {@link XContent}
      * @param includes the inclusive filters: only fields and objects that match the inclusive filters will be written to the output.

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/Def.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/Def.java
@@ -169,7 +169,7 @@ public final class Def {
      * This method traverses {@code recieverClass}'s class hierarchy (including interfaces)
      * until it finds a matching whitelisted method. If one is not found, it throws an exception.
      * Otherwise it returns a handle to the matching method.
-     * <p>
+     *
      * @param painlessLookup the whitelist
      * @param functions user defined functions and lambdas
      * @param constants available constants to be used if the method has the {@code InjectConstantAnnotation}
@@ -373,7 +373,7 @@ public final class Def {
      * This method traverses {@code recieverClass}'s class hierarchy (including interfaces)
      * until it finds a matching whitelisted getter. If one is not found, it throws an exception.
      * Otherwise it returns a handle to the matching getter.
-     * <p>
+     *
      * @param painlessLookup the whitelist
      * @param receiverClass Class of the object to retrieve the field from.
      * @param name Name of the field.
@@ -429,7 +429,7 @@ public final class Def {
      * This method traverses {@code recieverClass}'s class hierarchy (including interfaces)
      * until it finds a matching whitelisted setter. If one is not found, it throws an exception.
      * Otherwise it returns a handle to the matching setter.
-     * <p>
+     *
      * @param painlessLookup the whitelist
      * @param receiverClass Class of the object to retrieve the field from.
      * @param name Name of the field.


### PR DESCRIPTION
The 7.x changes in  PR #77600 erroneously missed two files that should have been included in the backport (from v8.0). This PR resolves that.

relates (#77600)