### PR TITLE
Rename 'policy' path parameter for 'ilm.*_policy' APIs to 'policy_name'

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/ilm.delete_lifecycle.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/ilm.delete_lifecycle.json
@@ -12,12 +12,12 @@
     "url":{
       "paths":[
         {
-          "path":"/_ilm/policy/{policy}",
+          "path":"/_ilm/policy/{policy_name}",
           "methods":[
             "DELETE"
           ],
           "parts":{
-            "policy":{
+            "policy_name":{
               "type":"string",
               "description":"The name of the index lifecycle policy"
             }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/ilm.get_lifecycle.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/ilm.get_lifecycle.json
@@ -12,12 +12,12 @@
     "url":{
       "paths":[
         {
-          "path":"/_ilm/policy/{policy}",
+          "path":"/_ilm/policy/{policy_name}",
           "methods":[
             "GET"
           ],
           "parts":{
-            "policy":{
+            "policy_name":{
               "type":"string",
               "description":"The name of the index lifecycle policy"
             }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/ilm.put_lifecycle.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/ilm.put_lifecycle.json
@@ -13,12 +13,12 @@
     "url":{
       "paths":[
         {
-          "path":"/_ilm/policy/{policy}",
+          "path":"/_ilm/policy/{policy_name}",
           "methods":[
             "PUT"
           ],
           "parts":{
-            "policy":{
+            "policy_name":{
               "type":"string",
               "description":"The name of the index lifecycle policy"
             }

--- a/x-pack/plugin/ilm/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/ilm/10_basic.yml
+++ b/x-pack/plugin/ilm/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/ilm/10_basic.yml
@@ -9,16 +9,16 @@ setup:
   - do:
       catch: missing
       ilm.get_lifecycle:
-        policy: "my_timeseries_lifecycle"
+        policy_name: "my_timeseries_lifecycle"
 
   - do:
       catch: missing
       ilm.delete_lifecycle:
-        policy: "my_timeseries_lifecycle"
+        policy_name: "my_timeseries_lifecycle"
 
   - do:
       ilm.put_lifecycle:
-        policy: "my_timeseries_lifecycle"
+        policy_name: "my_timeseries_lifecycle"
         body: |
            {
              "policy": {
@@ -43,7 +43,7 @@ setup:
 
   - do:
       ilm.get_lifecycle:
-        policy: "my_timeseries_lifecycle"
+        policy_name: "my_timeseries_lifecycle"
   - match: { my_timeseries_lifecycle.version: 1 }
   - is_true: my_timeseries_lifecycle.modified_date
   - match: { my_timeseries_lifecycle.policy.phases.warm.min_age: "10s" }
@@ -51,18 +51,18 @@ setup:
 
   - do:
       ilm.delete_lifecycle:
-        policy: "my_timeseries_lifecycle"
+        policy_name: "my_timeseries_lifecycle"
 
   - do:
       catch: missing
       ilm.get_lifecycle:
-        policy: "my_timeseries_lifecycle"
+        policy_name: "my_timeseries_lifecycle"
 
 ---
 "Test Policy Update":
   - do:
       ilm.put_lifecycle:
-        policy: "my_timeseries_lifecycle"
+        policy_name: "my_timeseries_lifecycle"
         body: |
            {
              "policy": {
@@ -87,7 +87,7 @@ setup:
 
   - do:
       ilm.get_lifecycle:
-        policy: "my_timeseries_lifecycle"
+        policy_name: "my_timeseries_lifecycle"
   - match: { my_timeseries_lifecycle.version: 1 }
   - is_true: my_timeseries_lifecycle.modified_date
   - match: { my_timeseries_lifecycle.policy.phases.warm.min_age: "10s" }
@@ -110,7 +110,7 @@ setup:
 
   - do:
       ilm.put_lifecycle:
-        policy: "my_timeseries_lifecycle"
+        policy_name: "my_timeseries_lifecycle"
         body: |
            {
              "policy": {
@@ -135,7 +135,7 @@ setup:
 
   - do:
       ilm.get_lifecycle:
-        policy: "my_timeseries_lifecycle"
+        policy_name: "my_timeseries_lifecycle"
   - match: { my_timeseries_lifecycle.version: 2 }
   - is_true: my_timeseries_lifecycle.modified_date
   - match: { my_timeseries_lifecycle.policy.phases.warm.min_age: "300s" }
@@ -150,18 +150,18 @@ setup:
 
   - do:
       ilm.delete_lifecycle:
-        policy: "my_timeseries_lifecycle"
+        policy_name: "my_timeseries_lifecycle"
 
   - do:
       catch: missing
       ilm.get_lifecycle:
-        policy: "my_timeseries_lifecycle"
+        policy_name: "my_timeseries_lifecycle"
 
 ---
 "Test Undeletable Policy In Use":
   - do:
       ilm.put_lifecycle:
-        policy: "my_timeseries_lifecycle"
+        policy_name: "my_timeseries_lifecycle"
         body: |
            {
              "policy": {
@@ -186,7 +186,7 @@ setup:
 
   - do:
       ilm.get_lifecycle:
-        policy: "my_timeseries_lifecycle"
+        policy_name: "my_timeseries_lifecycle"
   - match: { my_timeseries_lifecycle.policy.phases.warm.min_age: "10s" }
   - match: { my_timeseries_lifecycle.policy.phases.delete.min_age: "30s" }
 
@@ -200,7 +200,7 @@ setup:
   - do:
       catch: bad_request
       ilm.delete_lifecycle:
-        policy: "my_timeseries_lifecycle"
+        policy_name: "my_timeseries_lifecycle"
   - match: { error.root_cause.0.type: "illegal_argument_exception" }
   - match: { error.root_cause.0.reason: "Cannot delete policy [my_timeseries_lifecycle]. It is in use by one or more indices: [my_timeseries_index]" }
 
@@ -210,19 +210,19 @@ setup:
 
   - do:
       ilm.delete_lifecycle:
-        policy: "my_timeseries_lifecycle"
+        policy_name: "my_timeseries_lifecycle"
 
   - do:
       catch: missing
       ilm.get_lifecycle:
-        policy: "my_timeseries_lifecycle"
+        policy_name: "my_timeseries_lifecycle"
 
 ---
 "Test Invalid Policy":
   - do:
       catch: bad_request
       ilm.put_lifecycle:
-        policy: "my_invalid_lifecycle"
+        policy_name: "my_invalid_lifecycle"
         body: |
            {
              "policy": {
@@ -242,7 +242,7 @@ setup:
   - do:
       catch: bad_request
       ilm.put_lifecycle:
-        policy: "my_invalid_lifecycle"
+        policy_name: "my_invalid_lifecycle"
         body: |
            {
              "policy": {
@@ -262,7 +262,7 @@ setup:
   - do:
       catch: bad_request
       ilm.put_lifecycle:
-        policy: "my_invalid_lifecycle"
+        policy_name: "my_invalid_lifecycle"
         body: |
            {
              "policy": {
@@ -283,7 +283,7 @@ setup:
   - do:
       catch: /Your policy is configured to run the delete phase \(min_age\:\ 5s\) before the warm phase \(min_age\:\ 10s\). You should change the phase timing so that the phases will execute in the order of hot, warm, then cold./
       ilm.put_lifecycle:
-        policy: "bad_policy"
+        policy_name: "bad_policy"
         body: |
            {
              "policy": {

--- a/x-pack/plugin/ilm/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/ilm/11_basic_slm.yml
+++ b/x-pack/plugin/ilm/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/ilm/11_basic_slm.yml
@@ -9,12 +9,12 @@ setup:
   - do:
       catch: missing
       slm.get_lifecycle:
-        policy_id: "daily-snapshots"
+        policy_name: "daily-snapshots"
 
   - do:
       catch: missing
       slm.delete_lifecycle:
-        policy_id: "daily-snapshots"
+        policy_name: "daily-snapshots"
 
   - do:
       snapshot.create_repository:
@@ -27,7 +27,7 @@ setup:
   - do:
       catch: /invalid schedule \[0 \* \* \* \* \?\][:] schedule would be too frequent, executing more than every \[15m\]/
       slm.put_lifecycle:
-        policy_id: "daily-snapshots"
+        policy_name: "daily-snapshots"
         body: |
           {
             "schedule": "0 * * * * ?",
@@ -40,7 +40,7 @@ setup:
 
   - do:
       slm.put_lifecycle:
-        policy_id: "daily-snapshots"
+        policy_name: "daily-snapshots"
         body: |
           {
             "schedule": "0 1 2 3 4 ?",
@@ -60,7 +60,7 @@ setup:
 
   - do:
       slm.get_lifecycle:
-        policy_id: "daily-snapshots"
+        policy_name: "daily-snapshots"
   - match: { daily-snapshots.version: 1 }
   - match: { daily-snapshots.policy.name: "<production-snap-{now/d}>" }
   - is_true: daily-snapshots.next_execution_millis
@@ -69,7 +69,7 @@ setup:
 
   - do:
       slm.put_lifecycle:
-        policy_id: "daily-snapshots"
+        policy_name: "daily-snapshots"
         body: |
           {
             "schedule": "1 1 1 1 1 ?",
@@ -90,11 +90,11 @@ setup:
   - do:
       catch: missing
       slm.get_lifecycle:
-        policy_id: "doesnt-exist"
+        policy_name: "doesnt-exist"
 
   - do:
       slm.get_lifecycle:
-        policy_id: "daily-snapshots"
+        policy_name: "daily-snapshots"
   - match: { daily-snapshots.version: 2 }
   - match: { daily-snapshots.policy.schedule: "1 1 1 1 1 ?" }
   - is_true: daily-snapshots.next_execution_millis

--- a/x-pack/plugin/ilm/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/ilm/20_move_to_step.yml
+++ b/x-pack/plugin/ilm/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/ilm/20_move_to_step.yml
@@ -5,7 +5,7 @@ setup:
           wait_for_status: yellow
   - do:
       ilm.put_lifecycle:
-        policy: "my_moveable_timeseries_lifecycle"
+        policy_name: "my_moveable_timeseries_lifecycle"
         body: |
            {
              "policy": {
@@ -28,7 +28,7 @@ setup:
 
   - do:
       ilm.get_lifecycle:
-        policy: "my_moveable_timeseries_lifecycle"
+        policy_name: "my_moveable_timeseries_lifecycle"
 
   - do:
       indices.create:
@@ -54,12 +54,12 @@ teardown:
 
   - do:
       ilm.delete_lifecycle:
-        policy: "my_moveable_timeseries_lifecycle"
+        policy_name: "my_moveable_timeseries_lifecycle"
 
   - do:
       catch: missing
       ilm.get_lifecycle:
-        policy: "my_moveable_timeseries_lifecycle"
+        policy_name: "my_moveable_timeseries_lifecycle"
 
 ---
 "Test Invalid Move To Step With Incorrect Current Step":

--- a/x-pack/plugin/ilm/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/ilm/30_retry.yml
+++ b/x-pack/plugin/ilm/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/ilm/30_retry.yml
@@ -6,7 +6,7 @@ setup:
 
   - do:
       ilm.put_lifecycle:
-        policy: "my_lifecycle"
+        policy_name: "my_lifecycle"
         body: |
            {
              "policy": {
@@ -29,7 +29,7 @@ setup:
 
   - do:
       ilm.get_lifecycle:
-        policy: "my_lifecycle"
+        policy_name: "my_lifecycle"
 
 ---
 teardown:
@@ -40,12 +40,12 @@ teardown:
 
   - do:
       ilm.delete_lifecycle:
-        policy: "my_lifecycle"
+        policy_name: "my_lifecycle"
 
   - do:
       catch: missing
       ilm.get_lifecycle:
-        policy: "my_lifecycle"
+        policy_name: "my_lifecycle"
 
 ---
 "Test Invalid Retry With Non-errored Policy":

--- a/x-pack/plugin/ilm/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/ilm/40_explain_lifecycle.yml
+++ b/x-pack/plugin/ilm/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/ilm/40_explain_lifecycle.yml
@@ -5,7 +5,7 @@ setup:
           wait_for_status: yellow
   - do:
       ilm.put_lifecycle:
-        policy: "my_moveable_timeseries_lifecycle"
+        policy_name: "my_moveable_timeseries_lifecycle"
         body: |
            {
              "policy": {
@@ -28,7 +28,7 @@ setup:
 
   - do:
       ilm.get_lifecycle:
-        policy: "my_moveable_timeseries_lifecycle"
+        policy_name: "my_moveable_timeseries_lifecycle"
 
   - do:
       indices.create:
@@ -93,12 +93,12 @@ teardown:
 
   - do:
       ilm.delete_lifecycle:
-        policy: "my_moveable_timeseries_lifecycle"
+        policy_name: "my_moveable_timeseries_lifecycle"
 
   - do:
       catch: missing
       ilm.get_lifecycle:
-        policy: "my_moveable_timeseries_lifecycle"
+        policy_name: "my_moveable_timeseries_lifecycle"
 
 ---
 "Test Unmanaged Index Lifecycle Explain":

--- a/x-pack/plugin/ilm/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/ilm/60_operation_mode.yml
+++ b/x-pack/plugin/ilm/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/ilm/60_operation_mode.yml
@@ -12,7 +12,7 @@ setup:
 
   - do:
       ilm.put_lifecycle:
-        policy: "my_timeseries_lifecycle"
+        policy_name: "my_timeseries_lifecycle"
         body: |
            {
              "policy": {
@@ -55,9 +55,9 @@ setup:
 
   - do:
       ilm.delete_lifecycle:
-        policy: "my_timeseries_lifecycle"
+        policy_name: "my_timeseries_lifecycle"
 
   - do:
       catch: missing
       ilm.get_lifecycle:
-        policy: "my_timeseries_lifecycle"
+        policy_name: "my_timeseries_lifecycle"

--- a/x-pack/plugin/ilm/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/ilm/60_remove_policy_for_index.yml
+++ b/x-pack/plugin/ilm/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/ilm/60_remove_policy_for_index.yml
@@ -5,7 +5,7 @@ setup:
           wait_for_status: yellow
   - do:
       ilm.put_lifecycle:
-        policy: "my_moveable_timeseries_lifecycle"
+        policy_name: "my_moveable_timeseries_lifecycle"
         body: |
            {
              "policy": {
@@ -28,11 +28,11 @@ setup:
 
   - do:
       ilm.get_lifecycle:
-        policy: "my_moveable_timeseries_lifecycle"
+        policy_name: "my_moveable_timeseries_lifecycle"
         
   - do:
       ilm.put_lifecycle:
-        policy: "my_alternative_timeseries_lifecycle"
+        policy_name: "my_alternative_timeseries_lifecycle"
         body: |
            {
              "policy": {
@@ -55,7 +55,7 @@ setup:
 
   - do:
       ilm.get_lifecycle:
-        policy: "my_alternative_timeseries_lifecycle"
+        policy_name: "my_alternative_timeseries_lifecycle"
 
   - do:
       indices.create:
@@ -110,21 +110,21 @@ teardown:
 
   - do:
       ilm.delete_lifecycle:
-        policy: "my_moveable_timeseries_lifecycle"
+        policy_name: "my_moveable_timeseries_lifecycle"
 
   - do:
       catch: missing
       ilm.get_lifecycle:
-        policy: "my_moveable_timeseries_lifecycle"
+        policy_name: "my_moveable_timeseries_lifecycle"
 
   - do:
       ilm.delete_lifecycle:
-        policy: "my_alternative_timeseries_lifecycle"
+        policy_name: "my_alternative_timeseries_lifecycle"
 
   - do:
       catch: missing
       ilm.get_lifecycle:
-        policy: "my_alternative_timeseries_lifecycle"
+        policy_name: "my_alternative_timeseries_lifecycle"
 
 ---
 "Test Remove Policy Single Index":

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/data_stream/10_data_stream_resolvability.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/data_stream/10_data_stream_resolvability.yml
@@ -59,7 +59,7 @@
 
   - do:
       ilm.put_lifecycle:
-        policy: "my_lifecycle"
+        policy_name: "my_lifecycle"
         body: |
           {
             "policy": {
@@ -164,7 +164,7 @@
 
   - do:
       ilm.put_lifecycle:
-        policy: "my_moveable_timeseries_lifecycle"
+        policy_name: "my_moveable_timeseries_lifecycle"
         body: |
           {
             "policy": {

--- a/x-pack/plugin/stack/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/stack/10_basic.yml
+++ b/x-pack/plugin/stack/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/stack/10_basic.yml
@@ -8,11 +8,11 @@ setup:
 "Test stack template installation":
   - do:
       ilm.get_lifecycle:
-        policy: "logs"
+        policy_name: "logs"
 
   - do:
       ilm.get_lifecycle:
-        policy: "metrics"
+        policy_name: "metrics"
 
   - do:
       cluster.get_component_template:

--- a/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/mixed_cluster/70_ilm.yml
+++ b/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/mixed_cluster/70_ilm.yml
@@ -2,7 +2,7 @@
 "Test Set Policy On Index":
   - do:
       ilm.get_lifecycle:
-        policy: "my_lifecycle"
+        policy_name: "my_lifecycle"
   - match: { my_lifecycle.policy.phases.warm.min_age: "1000d" }
 
   - do:

--- a/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/old_cluster/70_ilm.yml
+++ b/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/old_cluster/70_ilm.yml
@@ -3,16 +3,16 @@
   - do:
       catch: missing
       ilm.get_lifecycle:
-        policy: "my_lifecycle"
+        policy_name: "my_lifecycle"
 
   - do:
       catch: missing
       ilm.delete_lifecycle:
-        policy: "my_lifecycle"
+        policy_name: "my_lifecycle"
 
   - do:
       ilm.put_lifecycle:
-        policy: "my_lifecycle"
+        policy_name: "my_lifecycle"
         body: |
            {
              "policy": {
@@ -31,7 +31,7 @@
 
   - do:
       ilm.get_lifecycle:
-        policy: "my_lifecycle"
+        policy_name: "my_lifecycle"
   - match: { my_lifecycle.policy.phases.warm.min_age: "1000d" }
 
   - do:

--- a/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/upgraded_cluster/70_ilm.yml
+++ b/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/upgraded_cluster/70_ilm.yml
@@ -2,7 +2,7 @@
 "Test Lifecycle Still There And Indices Are Still Managed":
   - do:
       ilm.get_lifecycle:
-        policy: "my_lifecycle"
+        policy_name: "my_lifecycle"
   - match: { my_lifecycle.policy.phases.warm.min_age: "1000d" }
 
   - do:
@@ -18,4 +18,4 @@
 
   - do:
       ilm.delete_lifecycle:
-        policy: "my_lifecycle"
+        policy_name: "my_lifecycle"


### PR DESCRIPTION
This is done so there isn't a conflict between path parameters and top-level object `policy` within the `ilm.put_lifecycle` request body. Over at the [Elasticsearch specification](https://github.com/elastic/elasticsearch-specification) we're trying to have all top-level entrypoints into an API (path, query, and body) that refer to different components of the API be unique in an effort to remove the need to specify which parameters are a part of the HTTP body and which aren't in the HTTP body.

Keep the APIs as-is in the 7.x branches to avoid breaking language clients.