### PR TITLE
Use ActionListener for joins and state application

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/indices/store/IndicesStoreIntegrationIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/indices/store/IndicesStoreIntegrationIT.java
@@ -9,6 +9,7 @@
 package org.elasticsearch.indices.store;
 
 import org.apache.logging.log4j.Logger;
+import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthResponse;
 import org.elasticsearch.action.admin.cluster.state.ClusterStateResponse;
 import org.elasticsearch.cluster.ClusterState;
@@ -23,7 +24,6 @@ import org.elasticsearch.cluster.routing.ShardRoutingState;
 import org.elasticsearch.cluster.routing.TestShardRouting;
 import org.elasticsearch.cluster.routing.allocation.command.MoveAllocationCommand;
 import org.elasticsearch.cluster.routing.allocation.decider.EnableAllocationDecider;
-import org.elasticsearch.cluster.service.ClusterApplier.ClusterApplyListener;
 import org.elasticsearch.cluster.service.ClusterApplierService;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.settings.Settings;
@@ -430,9 +430,9 @@ public class IndicesStoreIntegrationIT extends ESIntegTestCase {
             .routingTable(RoutingTable.builder().add(indexRoutingTableBuilder).build())
             .build();
         CountDownLatch latch = new CountDownLatch(1);
-        clusterApplierService.onNewClusterState("test", () -> newState, new ClusterApplyListener() {
+        clusterApplierService.onNewClusterState("test", () -> newState, new ActionListener<>() {
             @Override
-            public void onSuccess() {
+            public void onResponse(Void ignored) {
                 latch.countDown();
             }
 

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/Coordinator.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/Coordinator.java
@@ -32,7 +32,6 @@ import org.elasticsearch.cluster.node.DiscoveryNodes;
 import org.elasticsearch.cluster.routing.RerouteService;
 import org.elasticsearch.cluster.routing.allocation.AllocationService;
 import org.elasticsearch.cluster.service.ClusterApplier;
-import org.elasticsearch.cluster.service.ClusterApplier.ClusterApplyListener;
 import org.elasticsearch.cluster.service.ClusterApplierService;
 import org.elasticsearch.cluster.service.MasterService;
 import org.elasticsearch.common.util.BigArrays;
@@ -175,8 +174,17 @@ public class Coordinator extends AbstractLifecycleComponent implements Discovery
         this.onJoinValidators = JoinTaskExecutor.addBuiltInJoinValidators(onJoinValidators);
         this.singleNodeDiscovery = DiscoveryModule.isSingleNodeDiscovery(settings);
         this.electionStrategy = electionStrategy;
-        this.joinHelper = new JoinHelper(settings, allocationService, masterService, transportService, this::getCurrentTerm,
-            this::getStateForMasterService, this::handleJoinRequest, this::joinLeaderInTerm, this.onJoinValidators, rerouteService,
+        this.joinHelper = new JoinHelper(
+            settings,
+            allocationService,
+            masterService,
+            transportService,
+            this::getCurrentTerm,
+            this::getStateForMasterService,
+            this::handleJoinRequest,
+            this::joinLeaderInTerm,
+            this.onJoinValidators,
+            rerouteService,
             nodeHealthService);
         this.persistedStateSupplier = persistedStateSupplier;
         this.noMasterBlockService = new NoMasterBlockService(settings, clusterSettings);
@@ -282,20 +290,13 @@ public class Coordinator extends AbstractLifecycleComponent implements Discovery
                 // master node applies the committed state at the end of the publication process, not here.
                 applyListener.onResponse(null);
             } else {
-                clusterApplier.onNewClusterState(applyCommitRequest.toString(), () -> applierState,
-                    new ClusterApplyListener() {
-
-                        @Override
-                        public void onFailure(Exception e) {
-                            applyListener.onFailure(e);
-                        }
-
-                        @Override
-                        public void onSuccess() {
-                            onClusterStateApplied();
-                            applyListener.onResponse(null);
-                        }
-                    });
+                clusterApplier.onNewClusterState(
+                    applyCommitRequest.toString(),
+                    () -> applierState,
+                    applyListener.map(r -> {
+                        onClusterStateApplied();
+                        return r;
+                    }));
             }
         }
     }
@@ -467,13 +468,13 @@ public class Coordinator extends AbstractLifecycleComponent implements Discovery
     }
 
 
-    private void handleJoinRequest(JoinRequest joinRequest, JoinHelper.JoinCallback joinCallback) {
+    private void handleJoinRequest(JoinRequest joinRequest, ActionListener<Void> joinListener) {
         assert Thread.holdsLock(mutex) == false;
         assert getLocalNode().isMasterNode() : getLocalNode() + " received a join but is not master-eligible";
         logger.trace("handleJoinRequest: as {}, handling {}", mode, joinRequest);
 
         if (singleNodeDiscovery && joinRequest.getSourceNode().equals(getLocalNode()) == false) {
-            joinCallback.onFailure(new IllegalStateException("cannot join node with [" + DiscoveryModule.DISCOVERY_TYPE_SETTING.getKey() +
+            joinListener.onFailure(new IllegalStateException("cannot join node with [" + DiscoveryModule.DISCOVERY_TYPE_SETTING.getKey() +
                 "] set to [" + DiscoveryModule.SINGLE_NODE_DISCOVERY_TYPE  + "] discovery"));
             return;
         }
@@ -481,19 +482,9 @@ public class Coordinator extends AbstractLifecycleComponent implements Discovery
         transportService.connectToNode(joinRequest.getSourceNode(), ActionListener.wrap(connectionReference -> {
             boolean retainConnection = false;
             try {
-                final JoinHelper.JoinCallback wrappedJoinCallback = new JoinHelper.JoinCallback() {
-                    @Override
-                    public void onSuccess() {
-                        Releasables.close(connectionReference);
-                        joinCallback.onSuccess();
-                    }
-
-                    @Override
-                    public void onFailure(Exception e) {
-                        Releasables.close(connectionReference);
-                        joinCallback.onFailure(e);
-                    }
-                };
+                final ActionListener<Void> wrappedJoinCallback = ActionListener.runBefore(
+                    joinListener,
+                    () -> Releasables.close(connectionReference));
 
                 final ClusterState stateForJoinValidation = getStateForMasterService();
 
@@ -517,20 +508,19 @@ public class Coordinator extends AbstractLifecycleComponent implements Discovery
                     Releasables.close(connectionReference);
                 }
             }
-        }, joinCallback::onFailure));
+        }, joinListener::onFailure));
     }
 
     // package private for tests
-    void sendValidateJoinRequest(ClusterState stateForJoinValidation, JoinRequest joinRequest,
-                                 JoinHelper.JoinCallback joinCallback) {
+    void sendValidateJoinRequest(ClusterState stateForJoinValidation, JoinRequest joinRequest, ActionListener<Void> joinListener) {
         // validate the join on the joining node, will throw a failure if it fails the validation
         joinHelper.sendValidateJoinRequest(joinRequest.getSourceNode(), stateForJoinValidation, new ActionListener<Empty>() {
             @Override
             public void onResponse(Empty empty) {
                 try {
-                    processJoinRequest(joinRequest, joinCallback);
+                    processJoinRequest(joinRequest, joinListener);
                 } catch (Exception e) {
-                    joinCallback.onFailure(e);
+                    joinListener.onFailure(e);
                 }
             }
 
@@ -538,12 +528,12 @@ public class Coordinator extends AbstractLifecycleComponent implements Discovery
             public void onFailure(Exception e) {
                 logger.warn(() -> new ParameterizedMessage("failed to validate incoming join request from node [{}]",
                     joinRequest.getSourceNode()), e);
-                joinCallback.onFailure(new IllegalStateException("failure when sending a validation request to node", e));
+                joinListener.onFailure(new IllegalStateException("failure when sending a validation request to node", e));
             }
         });
     }
 
-    private void processJoinRequest(JoinRequest joinRequest, JoinHelper.JoinCallback joinCallback) {
+    private void processJoinRequest(JoinRequest joinRequest, ActionListener<Void> joinListener) {
         final Optional<Join> optionalJoin = joinRequest.getOptionalJoin();
         synchronized (mutex) {
             updateMaxTermSeen(joinRequest.getTerm());
@@ -552,7 +542,7 @@ public class Coordinator extends AbstractLifecycleComponent implements Discovery
             final boolean prevElectionWon = coordState.electionWon();
 
             optionalJoin.ifPresent(this::handleJoin);
-            joinAccumulator.handleJoinRequest(joinRequest.getSourceNode(), joinCallback);
+            joinAccumulator.handleJoinRequest(joinRequest.getSourceNode(), joinListener);
 
             if (prevElectionWon == false && coordState.electionWon()) {
                 becomeLeader("handleJoinRequest");
@@ -588,8 +578,10 @@ public class Coordinator extends AbstractLifecycleComponent implements Discovery
 
             if (applierState.nodes().getMasterNodeId() != null) {
                 applierState = clusterStateWithNoMasterBlock(applierState);
-                clusterApplier.onNewClusterState("becoming candidate: " + method, () -> applierState, e -> {
-                });
+                clusterApplier.onNewClusterState(
+                    "becoming candidate: " + method,
+                    () -> applierState,
+                    ActionListener.wrap(() -> {}));
             }
         }
 
@@ -1429,7 +1421,7 @@ public class Coordinator extends AbstractLifecycleComponent implements Discovery
             final long completionTimeMillis = transportService.getThreadPool().rawRelativeTimeInMillis();
             clusterStatePublicationEvent.setPublicationCompletionElapsedMillis(completionTimeMillis - getStartTime());
 
-            localNodeAckEvent.addListener(new ActionListener<Void>() {
+            localNodeAckEvent.addListener(new ActionListener<>() {
                 @Override
                 public void onResponse(Void ignore) {
                     assert Thread.holdsLock(mutex) : "Coordinator mutex not held";
@@ -1440,7 +1432,7 @@ public class Coordinator extends AbstractLifecycleComponent implements Discovery
                     receivedJoinsProcessed = true;
 
                     clusterApplier.onNewClusterState(CoordinatorPublication.this.toString(), () -> applierState,
-                        new ClusterApplyListener() {
+                        new ActionListener<Void>() {
                             @Override
                             public void onFailure(Exception e) {
                                 synchronized (mutex) {
@@ -1452,7 +1444,7 @@ public class Coordinator extends AbstractLifecycleComponent implements Discovery
                             }
 
                             @Override
-                            public void onSuccess() {
+                            public void onResponse(Void ignored) {
                                 onClusterStateApplied();
                                 clusterStatePublicationEvent.setMasterApplyElapsedMillis(
                                     transportService.getThreadPool().rawRelativeTimeInMillis() - completionTimeMillis);

--- a/server/src/main/java/org/elasticsearch/cluster/service/ClusterApplier.java
+++ b/server/src/main/java/org/elasticsearch/cluster/service/ClusterApplier.java
@@ -8,6 +8,7 @@
 
 package org.elasticsearch.cluster.service;
 
+import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.cluster.ClusterState;
 
 import java.util.function.Supplier;
@@ -21,38 +22,12 @@ public interface ClusterApplier {
 
     /**
      * Method to invoke when a new cluster state is available to be applied
-     *
-     * @param source information where the cluster state came from
+     *  @param source information where the cluster state came from
      * @param clusterStateSupplier the cluster state supplier which provides the latest cluster state to apply
-     * @param listener callback that is invoked after cluster state is applied
+     * @param listener notified after cluster state is applied. The implementation must not throw exceptions: an exception thrown by this
+     *                 listener is logged by the cluster applier service at {@code ERROR} level and otherwise ignored, except in tests where
+     *                 it raises an {@link AssertionError}. If log-and-ignore is the right behaviour then implementations must do so
+     *                 themselves, typically using a more specific logger and at a less dramatic log level.
      */
-    void onNewClusterState(String source, Supplier<ClusterState> clusterStateSupplier, ClusterApplyListener listener);
-
-    /**
-     * Listener for results of cluster state application
-     */
-    interface ClusterApplyListener {
-        /**
-         * Called on successful cluster state application.
-         *
-         * Implementations of this callback must not throw exceptions: an exception thrown here is logged by the cluster applier service at
-         * {@code ERROR} level and otherwise ignored, except in tests where it raises an {@link AssertionError}. If log-and-ignore is the
-         * right behaviour then implementations must do so themselves, typically using a more specific logger and at a less dramatic log
-         * level.
-         */
-        default void onSuccess() {
-        }
-
-        /**
-         * Called on failure during cluster state application.
-         *
-         * Implementations of this callback must not throw exceptions: an exception thrown here is logged by the cluster applier service at
-         * {@code ERROR} level and otherwise ignored, except in tests where it raises an {@link AssertionError}. If log-and-ignore is the
-         * right behaviour then implementations must do so themselves, typically using a more specific logger and at a less dramatic log
-         * level.
-         *
-         * @param e exception that occurred
-         */
-        void onFailure(Exception e);
-    }
+    void onNewClusterState(String source, Supplier<ClusterState> clusterStateSupplier, ActionListener<Void> listener);
 }

--- a/server/src/main/java/org/elasticsearch/cluster/service/ClusterApplierService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/service/ClusterApplierService.java
@@ -290,7 +290,7 @@ public class ClusterApplierService extends AbstractLifecycleComponent implements
         String source,
         Priority priority,
         Consumer<ClusterState> clusterStateConsumer,
-        ClusterApplyListener listener
+        ActionListener<Void> listener
     ) {
         submitStateUpdateTask(
             source,
@@ -310,7 +310,7 @@ public class ClusterApplierService extends AbstractLifecycleComponent implements
     public void onNewClusterState(
         final String source,
         final Supplier<ClusterState> clusterStateSupplier,
-        final ClusterApplyListener listener
+        final ActionListener<Void> listener
     ) {
         submitStateUpdateTask(
             source,
@@ -329,7 +329,7 @@ public class ClusterApplierService extends AbstractLifecycleComponent implements
         final String source,
         final Priority priority,
         final Function<ClusterState, ClusterState> clusterStateUpdate,
-        final ClusterApplyListener listener
+        final ActionListener<Void> listener
     ) {
         if (lifecycle.started() == false) {
             return;
@@ -542,12 +542,12 @@ public class ClusterApplierService extends AbstractLifecycleComponent implements
 
     private static class ClusterApplyActionListener implements ActionListener<Void> {
         private final String source;
-        private final ClusterApplyListener listener;
+        private final ActionListener<Void> listener;
         private final Supplier<ThreadContext.StoredContext> storedContextSupplier;
 
         ClusterApplyActionListener(
             String source,
-            ClusterApplyListener listener,
+            ActionListener<Void> listener,
             Supplier<ThreadContext.StoredContext> storedContextSupplier
         ) {
             this.source = source;
@@ -570,7 +570,7 @@ public class ClusterApplierService extends AbstractLifecycleComponent implements
         @Override
         public void onResponse(Void unused) {
             try (ThreadContext.StoredContext ignored = storedContextSupplier.get()) {
-                listener.onSuccess();
+                listener.onResponse(null);
             } catch (Exception e) {
                 assert false : e;
                 logger.error(new ParameterizedMessage(

--- a/server/src/main/java/org/elasticsearch/indices/store/IndicesStore.java
+++ b/server/src/main/java/org/elasticsearch/indices/store/IndicesStore.java
@@ -11,6 +11,7 @@ package org.elasticsearch.indices.store;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.message.ParameterizedMessage;
+import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.cluster.ClusterChangedEvent;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.ClusterState;
@@ -279,11 +280,20 @@ public class IndicesStore implements ClusterStateListener, Closeable {
                         logger.debug(() -> new ParameterizedMessage("{} failed to delete unallocated shard, ignoring", shardId), ex);
                     }
                 },
-                e -> logger.error(
-                    () -> new ParameterizedMessage(
-                        "{} unexpected error during deletion of unallocated shard",
-                        shardId),
-                    e));
+                new ActionListener<>() {
+                    @Override
+                    public void onResponse(Void unused) {
+                    }
+
+                    @Override
+                    public void onFailure(Exception e) {
+                        logger.error(
+                            () -> new ParameterizedMessage(
+                                "{} unexpected error during deletion of unallocated shard",
+                                shardId),
+                            e);
+                    }
+                });
         }
 
     }

--- a/server/src/test/java/org/elasticsearch/cluster/InternalClusterInfoServiceSchedulingTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/InternalClusterInfoServiceSchedulingTests.java
@@ -16,18 +16,17 @@ import org.elasticsearch.action.ActionType;
 import org.elasticsearch.action.admin.cluster.node.stats.NodesStatsRequest;
 import org.elasticsearch.action.admin.indices.stats.IndicesStatsRequest;
 import org.elasticsearch.cluster.block.ClusterBlockException;
-import org.elasticsearch.common.util.concurrent.DeterministicTaskQueue;
 import org.elasticsearch.cluster.coordination.MockSinglePrioritizingExecutor;
 import org.elasticsearch.cluster.coordination.NoMasterBlockService;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
-import org.elasticsearch.cluster.service.ClusterApplier;
 import org.elasticsearch.cluster.service.ClusterApplierService;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.cluster.service.FakeThreadPoolMasterService;
 import org.elasticsearch.cluster.service.MasterService;
 import org.elasticsearch.common.settings.ClusterSettings;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.concurrent.DeterministicTaskQueue;
 import org.elasticsearch.common.util.concurrent.PrioritizedEsThreadPoolExecutor;
 import org.elasticsearch.node.Node;
 import org.elasticsearch.test.ClusterServiceUtils;
@@ -137,11 +136,11 @@ public class InternalClusterInfoServiceSchedulingTests extends ESTestCase {
         }
     }
 
-    private static ClusterApplier.ClusterApplyListener setFlagOnSuccess(AtomicBoolean flag) {
-        return new ClusterApplier.ClusterApplyListener() {
+    private static ActionListener<Void> setFlagOnSuccess(AtomicBoolean flag) {
+        return new ActionListener<>() {
 
             @Override
-            public void onSuccess() {
+            public void onResponse(Void ignored) {
                 assertTrue(flag.compareAndSet(false, true));
             }
 

--- a/server/src/test/java/org/elasticsearch/cluster/coordination/NoOpClusterApplier.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/NoOpClusterApplier.java
@@ -7,6 +7,7 @@
  */
 package org.elasticsearch.cluster.coordination;
 
+import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.service.ClusterApplier;
 
@@ -19,7 +20,7 @@ public class NoOpClusterApplier implements ClusterApplier {
     }
 
     @Override
-    public void onNewClusterState(String source, Supplier<ClusterState> clusterStateSupplier, ClusterApplyListener listener) {
-        listener.onSuccess();
+    public void onNewClusterState(String source, Supplier<ClusterState> clusterStateSupplier, ActionListener<Void> listener) {
+        listener.onResponse(null);
     }
 }

--- a/server/src/test/java/org/elasticsearch/cluster/health/ClusterStateHealthTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/health/ClusterStateHealthTests.java
@@ -10,6 +10,7 @@ package org.elasticsearch.cluster.health;
 import com.carrotsearch.hppc.cursors.IntObjectCursor;
 import com.carrotsearch.hppc.cursors.ObjectCursor;
 import org.elasticsearch.Version;
+import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthRequest;
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthResponse;
 import org.elasticsearch.action.admin.cluster.health.TransportClusterHealthAction;
@@ -127,7 +128,7 @@ public class ClusterStateHealthTests extends ESTestCase {
         clusterService.getClusterApplierService().onNewClusterState("restore master",
             () -> ClusterState.builder(currentState)
                 .nodes(DiscoveryNodes.builder(currentState.nodes()).masterNodeId(currentState.nodes().getLocalNodeId())).build(),
-            e -> {});
+            ActionListener.wrap(() -> {}));
 
         logger.info("--> waiting for listener to be called and cluster state being blocked");
         listenerCalled.await();

--- a/server/src/test/java/org/elasticsearch/cluster/routing/BatchedRerouteServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/BatchedRerouteServiceTests.java
@@ -68,7 +68,7 @@ public class BatchedRerouteServiceTests extends ESTestCase {
             batchedRerouteService.reroute("iteration " + i, randomFrom(EnumSet.allOf(Priority.class)),
                 ActionListener.wrap(countDownLatch::countDown));
         }
-        countDownLatch.await(10, TimeUnit.SECONDS);
+        assertTrue(countDownLatch.await(10, TimeUnit.SECONDS));
         assertThat(rerouteCountBeforeReroute, lessThan(rerouteCount.get()));
     }
 
@@ -211,7 +211,7 @@ public class BatchedRerouteServiceTests extends ESTestCase {
                         return ClusterState.builder(state).nodes(DiscoveryNodes.builder(state.nodes())
                             .masterNodeId(randomBoolean() ? null : state.nodes().getLocalNodeId())).build();
                     },
-                    e -> { });
+                    ActionListener.wrap(() -> {}));
             }
         }
 

--- a/server/src/test/java/org/elasticsearch/cluster/service/ClusterApplierServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/service/ClusterApplierServiceTests.java
@@ -8,11 +8,11 @@
 
 package org.elasticsearch.cluster.service;
 
-
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.Version;
+import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.ClusterStateObserver;
@@ -23,7 +23,6 @@ import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
 import org.elasticsearch.cluster.routing.allocation.decider.EnableAllocationDecider;
-import org.elasticsearch.cluster.service.ClusterApplier.ClusterApplyListener;
 import org.elasticsearch.common.Priority;
 import org.elasticsearch.common.logging.Loggers;
 import org.elasticsearch.common.settings.ClusterSettings;
@@ -146,9 +145,9 @@ public class ClusterApplierServiceTests extends ESTestCase {
                 "test1",
                 Priority.HIGH,
                 currentState -> advanceTime(TimeValue.timeValueSeconds(1).millis()),
-                new ClusterApplyListener() {
+                new ActionListener<>() {
                     @Override
-                    public void onSuccess() {
+                    public void onResponse(Void ignored) {
                     }
 
                     @Override
@@ -164,9 +163,9 @@ public class ClusterApplierServiceTests extends ESTestCase {
                     advanceTime(TimeValue.timeValueSeconds(2).millis());
                     throw new IllegalArgumentException("Testing handling of exceptions in the cluster state task");
                 },
-                new ClusterApplyListener() {
+                new ActionListener<>() {
                     @Override
-                    public void onSuccess() {
+                    public void onResponse(Void ignored) {
                         fail();
                     }
 
@@ -179,9 +178,9 @@ public class ClusterApplierServiceTests extends ESTestCase {
                 "test3",
                 Priority.HIGH,
                 currentState -> {},
-                new ClusterApplyListener() {
+                new ActionListener<>() {
                     @Override
-                    public void onSuccess() { }
+                    public void onResponse(Void ignored) { }
 
                     @Override
                     public void onFailure(Exception e) {
@@ -231,9 +230,9 @@ public class ClusterApplierServiceTests extends ESTestCase {
                 "test1",
                 Priority.HIGH,
                 currentState -> advanceTime(TimeValue.timeValueSeconds(1).millis()),
-                new ClusterApplyListener() {
+                new ActionListener<>() {
                     @Override
-                    public void onSuccess() {
+                    public void onResponse(Void ignored) {
                         latch.countDown();
                         processedFirstTask.countDown();
                     }
@@ -252,9 +251,9 @@ public class ClusterApplierServiceTests extends ESTestCase {
                     advanceTime(TimeValue.timeValueSeconds(32).millis());
                     throw new IllegalArgumentException("Testing handling of exceptions in the cluster state task");
                 },
-                new ClusterApplyListener() {
+                new ActionListener<>() {
                     @Override
-                    public void onSuccess() {
+                    public void onResponse(Void ignored) {
                         fail();
                     }
 
@@ -268,9 +267,9 @@ public class ClusterApplierServiceTests extends ESTestCase {
                 "test3",
                 Priority.HIGH,
                 currentState -> advanceTime(TimeValue.timeValueSeconds(34).millis()),
-                new ClusterApplyListener() {
+                new ActionListener<>() {
                     @Override
-                    public void onSuccess() {
+                    public void onResponse(Void ignored) {
                         latch.countDown();
                     }
 
@@ -286,9 +285,9 @@ public class ClusterApplierServiceTests extends ESTestCase {
                 "test4",
                 Priority.HIGH,
                 currentState -> {},
-                new ClusterApplyListener() {
+                new ActionListener<>() {
                     @Override
-                    public void onSuccess() {
+                    public void onResponse(Void ignored) {
                         latch.countDown();
                     }
 
@@ -360,10 +359,10 @@ public class ClusterApplierServiceTests extends ESTestCase {
 
         CountDownLatch latch = new CountDownLatch(1);
         clusterApplierService.onNewClusterState("test", () -> ClusterState.builder(clusterApplierService.state()).build(),
-            new ClusterApplyListener() {
+            new ActionListener<>() {
 
                 @Override
-                public void onSuccess() {
+                public void onResponse(Void ignored) {
                     latch.countDown();
                 }
 
@@ -388,10 +387,10 @@ public class ClusterApplierServiceTests extends ESTestCase {
 
         CountDownLatch latch = new CountDownLatch(1);
         clusterApplierService.onNewClusterState("test", () -> ClusterState.builder(clusterApplierService.state()).build(),
-            new ClusterApplyListener() {
+            new ActionListener<>() {
 
                 @Override
-                public void onSuccess() {
+                public void onResponse(Void ignored) {
                     latch.countDown();
                     fail("should not be called");
                 }
@@ -421,10 +420,10 @@ public class ClusterApplierServiceTests extends ESTestCase {
                         Settings.builder().put(EnableAllocationDecider.CLUSTER_ROUTING_ALLOCATION_ENABLE_SETTING.getKey(), false).build())
                     .build())
                 .build(),
-            new ClusterApplyListener() {
+            new ActionListener<>() {
 
                 @Override
-                public void onSuccess() {
+                public void onResponse(Void ignored) {
                     latch.countDown();
                     fail("should not be called");
                 }
@@ -452,10 +451,10 @@ public class ClusterApplierServiceTests extends ESTestCase {
 
         CountDownLatch latch = new CountDownLatch(1);
         clusterApplierService.onNewClusterState("test", () -> ClusterState.builder(clusterApplierService.state()).build(),
-            new ClusterApplyListener() {
+            new ActionListener<>() {
 
                 @Override
-                public void onSuccess() {
+                public void onResponse(Void ignored) {
                     latch.countDown();
                 }
 
@@ -502,9 +501,9 @@ public class ClusterApplierServiceTests extends ESTestCase {
 
         CountDownLatch latch = new CountDownLatch(1);
         clusterApplierService.onNewClusterState("test", () -> ClusterState.builder(clusterApplierService.state()).build(),
-            new ClusterApplyListener() {
+            new ActionListener<>() {
                 @Override
-                public void onSuccess() {
+                public void onResponse(Void ignored) {
                     latch.countDown();
                 }
 
@@ -538,10 +537,10 @@ public class ClusterApplierServiceTests extends ESTestCase {
                 } else {
                     throw new IllegalArgumentException("mock failure");
                 }
-            }, new ClusterApplyListener() {
+            }, new ActionListener<>() {
 
                 @Override
-                public void onSuccess() {
+                public void onResponse(Void ignored) {
                     assertFalse(threadPool.getThreadContext().isSystemContext());
                     assertEquals(expectedHeaders, threadPool.getThreadContext().getHeaders());
                     assertEquals(expectedResponseHeaders, threadPool.getThreadContext().getResponseHeaders());

--- a/server/src/test/java/org/elasticsearch/snapshots/InternalSnapshotsInfoServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/snapshots/InternalSnapshotsInfoServiceTests.java
@@ -28,7 +28,6 @@ import org.elasticsearch.cluster.routing.RoutingTable;
 import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.cluster.routing.ShardRoutingState;
 import org.elasticsearch.cluster.routing.allocation.AllocationService;
-import org.elasticsearch.cluster.service.ClusterApplier;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.UUIDs;
 import org.elasticsearch.common.collect.ImmutableOpenMap;
@@ -382,19 +381,9 @@ public class InternalSnapshotsInfoServiceTests extends ESTestCase {
     }
 
     private void applyClusterState(final String reason, final Function<ClusterState, ClusterState> applier) {
-        PlainActionFuture.get(
+        PlainActionFuture.<Void, RuntimeException>get(
             future -> clusterService.getClusterApplierService()
-                .onNewClusterState(reason, () -> applier.apply(clusterService.state()), new ClusterApplier.ClusterApplyListener() {
-                    @Override
-                    public void onSuccess() {
-                        future.onResponse(null);
-                    }
-
-                    @Override
-                    public void onFailure(Exception e) {
-                        future.onFailure(e);
-                    }
-                })
+                .onNewClusterState(reason, () -> applier.apply(clusterService.state()), future)
         );
     }
 

--- a/test/framework/src/main/java/org/elasticsearch/cluster/coordination/AbstractCoordinatorTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/cluster/coordination/AbstractCoordinatorTestCase.java
@@ -14,6 +14,7 @@ import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.Version;
+import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.cluster.ClusterModule;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.ClusterStateTaskListener;
@@ -1415,13 +1416,16 @@ public class AbstractCoordinatorTestCase extends ESTestCase {
         }
 
         @Override
-        public void onNewClusterState(String source, Supplier<ClusterState> clusterStateSupplier, ClusterApplyListener listener) {
+        public void onNewClusterState(String source, Supplier<ClusterState> clusterStateSupplier, ActionListener<Void> listener) {
             if (clusterStateApplyResponse == ClusterStateApplyResponse.HANG) {
                 if (randomBoolean()) {
                     // apply cluster state, but don't notify listener
-                    super.onNewClusterState(source, clusterStateSupplier, e -> {
-                        // ignore result
-                    });
+                    super.onNewClusterState(
+                        source,
+                        clusterStateSupplier,
+                        ActionListener.wrap(() -> {
+                            // ignore result
+                        }));
                 }
             } else {
                 super.onNewClusterState(source, clusterStateSupplier, listener);

--- a/test/framework/src/main/java/org/elasticsearch/test/ClusterServiceUtils.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/ClusterServiceUtils.java
@@ -11,6 +11,7 @@ import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.core.util.Throwables;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.Version;
+import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.ClusterState;
@@ -24,7 +25,6 @@ import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodeRole;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
 import org.elasticsearch.cluster.service.ClusterApplier;
-import org.elasticsearch.cluster.service.ClusterApplier.ClusterApplyListener;
 import org.elasticsearch.cluster.service.ClusterApplierService;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.cluster.service.MasterService;
@@ -48,9 +48,9 @@ public class ClusterServiceUtils {
         CountDownLatch latch = new CountDownLatch(1);
         AtomicReference<Exception> exception = new AtomicReference<>();
         executor.onNewClusterState("test setting state",
-            () -> ClusterState.builder(clusterState).version(clusterState.version() + 1).build(), new ClusterApplyListener() {
+            () -> ClusterState.builder(clusterState).version(clusterState.version() + 1).build(), new ActionListener<>() {
                 @Override
-                public void onSuccess() {
+                public void onResponse(Void ignored) {
                     latch.countDown();
                 }
 
@@ -148,17 +148,7 @@ public class ClusterServiceUtils {
             clusterApplier.onNewClusterState(
                 "mock_publish_to_self[" + clusterStatePublicationEvent.getSummary() + "]",
                 clusterStatePublicationEvent::getNewState,
-                new ClusterApplyListener() {
-                    @Override
-                    public void onSuccess() {
-                        publishListener.onResponse(null);
-                    }
-
-                    @Override
-                    public void onFailure(Exception e) {
-                        publishListener.onFailure(e);
-                    }
-                });
+                publishListener);
         };
     }
 

--- a/test/framework/src/main/java/org/elasticsearch/test/disruption/BlockClusterStateProcessing.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/disruption/BlockClusterStateProcessing.java
@@ -8,6 +8,7 @@
 package org.elasticsearch.test.disruption;
 
 import org.apache.logging.log4j.core.util.Throwables;
+import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.Priority;
 import org.elasticsearch.core.TimeValue;
@@ -55,8 +56,16 @@ public class BlockClusterStateProcessing extends SingleNodeDisruption {
                     }
                 }
             },
-            e -> logger.error("unexpected error during disruption", e)
-        );
+            new ActionListener<>() {
+                @Override
+                public void onResponse(Void unused) {
+                }
+
+                @Override
+                public void onFailure(Exception e) {
+                    logger.error("unexpected error during disruption", e);
+                }
+            });
         try {
             started.await();
         } catch (InterruptedException e) {

--- a/test/framework/src/main/java/org/elasticsearch/test/disruption/SlowClusterStateProcessing.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/disruption/SlowClusterStateProcessing.java
@@ -8,6 +8,7 @@
 package org.elasticsearch.test.disruption;
 
 import org.elasticsearch.ExceptionsHelper;
+import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.Priority;
 import org.elasticsearch.core.TimeValue;
@@ -108,8 +109,16 @@ public class SlowClusterStateProcessing extends SingleNodeDisruption {
                     ExceptionsHelper.reThrowIfNotNull(e);
                 }
             },
-            e -> countDownLatch.countDown()
-        );
+            new ActionListener<>() {
+                @Override
+                public void onResponse(Void unused) {
+                }
+
+                @Override
+                public void onFailure(Exception e) {
+                    countDownLatch.countDown();
+                }
+            });
         try {
             countDownLatch.await();
         } catch (InterruptedException e) {


### PR DESCRIPTION
Today we have dedicated `JoinCallback` and `ClusterApplyListener`
interfaces for receiving the result of a join and a cluster state
application respectively. This commit replaces these two dedicated
interfaces with `ActionListener<Void>`, reducing the need for adapter
code when interfacing with the rest of the system and simplifying the
construction of some of the listeners used.