### PR TITLE
Fix version error in cardinalit profile tests

### DIFF
--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.aggregation/170_cardinality_metric.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.aggregation/170_cardinality_metric.yml
@@ -216,8 +216,8 @@ setup:
 ---
 "profiler int":
   - skip:
-      version: " - 7.9.99"
-      reason:  new info added in 7.10.0
+      version: " - 7.11.99"
+      reason:  new info added in 7.10.0 but post_collection didn't exist in 7.11
   - do:
       search:
         body:
@@ -242,8 +242,8 @@ setup:
 ---
 "profiler double":
   - skip:
-      version: " - 7.9.99"
-      reason:  new info added in 7.10.0
+      version: " - 7.11.99"
+      reason:  new info added in 7.10.0 but post_collection didn't exist in 7.11
   - do:
       search:
         body:
@@ -268,8 +268,8 @@ setup:
 ---
 "profiler string":
   - skip:
-      version: " - 7.9.99"
-      reason:  new info added in 7.10.0
+      version: " - 7.11.99"
+      reason:  new info added in 7.10.0 but post_collection didn't exist in 7.11
   - do:
       search:
         body:


### PR DESCRIPTION
I fixed an incorrect `skip` in the cardinality profiling tests
yesterday. But! I fixed them incorrectly. Sadness. The new profiling was
indeed added in 7.10, but an element of the profiling `post_collect`
didn't exist until 7.12`. This updates the skip to be after 7.12 - we
don't get any tests for the rest of the profiling, but those versions
are pretty old now anyways.

Closes #77708, #77709, #77710
