### PR TITLE
[DOCS] Add deprecation docs for `cluster.join.timeout`

### DIFF
--- a/docs/reference/migration/migrate_7_10.asciidoc
+++ b/docs/reference/migration/migrate_7_10.asciidoc
@@ -155,7 +155,7 @@ enable <<deprecation-logging, deprecation logging>>.
 ====
 *Details* +
 The `cluster.join.timeout` node setting is deprecated and will be removed in
-8.0. In 7.x and later clusters, join attempts no longer time out.
+8.0. In 7.x clusters, join attempts no longer time out.
 
 *Impact* +
 To avoid deprecation warnings, discontinue use of the setting.

--- a/docs/reference/migration/migrate_7_10.asciidoc
+++ b/docs/reference/migration/migrate_7_10.asciidoc
@@ -145,6 +145,22 @@ To find out if you are using any deprecated functionality,
 enable <<deprecation-logging, deprecation logging>>.
 
 [discrete]
+[[breaking_710_cluster_deprecations]]
+==== Cluster deprecations
+
+[[deprecate-cluster-join-timeout]]
+.The `cluster.join.timeout` setting is deprecated.
+[%collapsible]
+====
+*Details* +
+The `cluster.join.timeout` node setting is setting is now deprecated. In 7.x
+clusters, join attempts no longer time out.
+
+*Impact* +
+To avoid deprecation warnings, discontinue use of the setting.
+====
+
+[discrete]
 [[breaking_710_indices_changes]]
 ==== Indices deprecations
 

--- a/docs/reference/migration/migrate_7_10.asciidoc
+++ b/docs/reference/migration/migrate_7_10.asciidoc
@@ -154,7 +154,7 @@ enable <<deprecation-logging, deprecation logging>>.
 [%collapsible]
 ====
 *Details* +
-The `cluster.join.timeout` node setting is now deprecated and will be removed in
+The `cluster.join.timeout` node setting is deprecated and will be removed in
 8.0. In 7.x and later clusters, join attempts no longer time out.
 
 *Impact* +

--- a/docs/reference/migration/migrate_7_10.asciidoc
+++ b/docs/reference/migration/migrate_7_10.asciidoc
@@ -154,8 +154,8 @@ enable <<deprecation-logging, deprecation logging>>.
 [%collapsible]
 ====
 *Details* +
-The `cluster.join.timeout` node setting is now deprecated. In 7.x clusters, join
-attempts no longer time out.
+The `cluster.join.timeout` node setting is now deprecated and will be removed in
+8.0. In 7.x and later clusters, join attempts no longer time out.
 
 *Impact* +
 To avoid deprecation warnings, discontinue use of the setting.

--- a/docs/reference/migration/migrate_7_10.asciidoc
+++ b/docs/reference/migration/migrate_7_10.asciidoc
@@ -13,6 +13,7 @@ See also <<release-highlights>> and <<es-release-notes>>.
 * <<breaking_710_java_changes>>
 * <<breaking_710_networking_changes>>
 * <<breaking_710_search_changes>>
+* <<breaking_710_cluster_deprecations>>
 * <<breaking_710_indices_changes>>
 * <<breaking_710_ml_changes>>
 * <<breaking_710_mapping_changes>>

--- a/docs/reference/migration/migrate_7_10.asciidoc
+++ b/docs/reference/migration/migrate_7_10.asciidoc
@@ -153,8 +153,8 @@ enable <<deprecation-logging, deprecation logging>>.
 [%collapsible]
 ====
 *Details* +
-The `cluster.join.timeout` node setting is setting is now deprecated. In 7.x
-clusters, join attempts no longer time out.
+The `cluster.join.timeout` node setting is now deprecated. In 7.x clusters, join
+attempts no longer time out.
 
 *Impact* +
 To avoid deprecation warnings, discontinue use of the setting.


### PR DESCRIPTION
We deprecated the `cluster.join.timeout` setting in 7.10 with PR #60872.
However, we didn't add a related item to the 7.10 deprecation docs. This adds
the missing item.

Relates to #60873.

### Preview
https://elasticsearch_77725.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/7.x/migrating-7.10.html#deprecate-cluster-join-timeout