### PR TITLE
[DOCS] Add deprecation docs for `cluster.routing.allocation.disk.include_relocations`

### DIFF
--- a/docs/reference/migration/migrate_7_5.asciidoc
+++ b/docs/reference/migration/migrate_7_5.asciidoc
@@ -26,13 +26,13 @@ See also <<release-highlights>> and <<es-release-notes>>.
 ==== The `cluster.routing.allocation.disk.include_relocations` setting is deprecated.
 
 The `cluster.routing.allocation.disk.include_relocations` cluster setting is now
-deprecated. You can currently set
-`cluster.routing.allocation.disk.include_relocations` to `false` to disable this
-accounting. This can result in poor allocation decisions that might overshoot
-watermarks and require significant work to correct.
+deprecated. In future versions, {es} will account for the sizes of relocating
+shards when making allocation decisions based on the disk usage of nodes in the
+cluster.
 
-In 8.0, {es} will account for the sizes of relocating shards when making
-allocation decisions based on the disk usage of nodes in the cluster.
+Currently, you can set `cluster.routing.allocation.disk.include_relocations` to
+`false` to disable this accounting. This can result in poor allocation decisions
+that might overshoot watermarks and require significant work to correct.
 
 To avoid deprecation warnings, discontinue use of the setting.
 

--- a/docs/reference/migration/migrate_7_5.asciidoc
+++ b/docs/reference/migration/migrate_7_5.asciidoc
@@ -14,7 +14,24 @@ See also <<release-highlights>> and <<es-release-notes>>.
 
 //tag::notable-breaking-changes[]
 
-//end::notable-breaking-changes[]
+[discrete]
+[[breaking_75_allocation_deprecations]]
+=== Allocation deprecations
+
+[discrete]
+[[deprecate-cluster-routing-allocation-disk-include-relocations-setting]]
+==== The `cluster.routing.allocation.disk.include_relocations` setting is deprecated.
+
+The `cluster.routing.allocation.disk.include_relocations` cluster setting is now
+deprecated. In future versions, {es} will account for the sizes of relocating
+shards when making allocation decisions based on the disk usage of nodes in the
+cluster.
+
+Currently, you can set `cluster.routing.allocation.disk.include_relocations` to
+`false` to disable this accounting. This can result in poor allocation decisions
+that might overshoot watermarks and require significant work to correct.
+
+To avoid deprecation warnings, discontinue use of the setting.
 
 [discrete]
 [[breaking_75_search_changes]]
@@ -26,3 +43,5 @@ Previously, a wildcard query on the `_index` field matched directly against the
 fully-qualified index name. Now, in order to match against remote indices like
 `cluster:index`, the query must contain a colon, as in `cl*ster:inde*`. This
 behavior aligns with the way indices are matched in the search endpoint.
+
+//end::notable-breaking-changes[]

--- a/docs/reference/migration/migrate_7_5.asciidoc
+++ b/docs/reference/migration/migrate_7_5.asciidoc
@@ -26,13 +26,13 @@ See also <<release-highlights>> and <<es-release-notes>>.
 ==== The `cluster.routing.allocation.disk.include_relocations` setting is deprecated.
 
 The `cluster.routing.allocation.disk.include_relocations` cluster setting is now
-deprecated. In future versions, {es} will account for the sizes of relocating
-shards when making allocation decisions based on the disk usage of nodes in the
-cluster.
+deprecated. You can currently set
+`cluster.routing.allocation.disk.include_relocations` to `false` to disable this
+accounting. This can result in poor allocation decisions that might overshoot
+watermarks and require significant work to correct.
 
-Currently, you can set `cluster.routing.allocation.disk.include_relocations` to
-`false` to disable this accounting. This can result in poor allocation decisions
-that might overshoot watermarks and require significant work to correct.
+In 8.0, {es} will account for the sizes of relocating shards when making
+allocation decisions based on the disk usage of nodes in the cluster.
 
 To avoid deprecation warnings, discontinue use of the setting.
 

--- a/docs/reference/migration/migrate_7_5.asciidoc
+++ b/docs/reference/migration/migrate_7_5.asciidoc
@@ -9,6 +9,9 @@ your application to Elasticsearch 7.5.
 
 See also <<release-highlights>> and <<es-release-notes>>.
 
+* <<breaking_75_allocation_deprecations>>
+* <<breaking_75_search_changes>>
+
 //NOTE: The notable-breaking-changes tagged regions are re-used in the
 //Installation and Upgrade Guide
 


### PR DESCRIPTION
We deprecated the `cluster.routing.allocation.disk.include_relocations` setting in 7.5 with PR #47443.
However, we didn't add a related item to the 7.5 deprecation docs. This adds
the missing item.

Relates to #47717.

### Preview
https://elasticsearch_77726.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/7.x/breaking-changes-7.5.html#deprecate-cluster-routing-allocation-disk-include-relocations-setting