### PR TITLE
Fix testConcurrentConnectsAndDisconnects

### DIFF
--- a/server/src/test/java/org/elasticsearch/transport/ClusterConnectionManagerTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/ClusterConnectionManagerTests.java
@@ -42,6 +42,8 @@ import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.function.Supplier;
 
 import static org.elasticsearch.test.ActionListenerUtils.anyActionListener;
@@ -314,7 +316,6 @@ public class ClusterConnectionManagerTests extends ESTestCase {
         }
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/77728")
     public void testConcurrentConnectsAndDisconnects() throws Exception {
         final DiscoveryNode node = new DiscoveryNode("", new TransportAddress(InetAddress.getLoopbackAddress(), 0), Version.CURRENT);
         doAnswer(invocationOnMock -> {
@@ -335,11 +336,13 @@ public class ClusterConnectionManagerTests extends ESTestCase {
         final Semaphore pendingConnections = new Semaphore(1000);
         final int threadCount = between(1, 10);
         final CountDownLatch countDownLatch = new CountDownLatch(threadCount);
+        final ReadWriteLock connectCompletionLock = new ReentrantReadWriteLock();
 
         final Runnable action = new Runnable() {
             @Override
             public void run() {
                 if (pendingConnections.tryAcquire()) {
+                    assertTrue(connectCompletionLock.readLock().tryLock());
                     connectionManager.connectToNode(node, null, validator, new ActionListener<>() {
                         @Override
                         public void onResponse(Releasable releasable) {
@@ -362,6 +365,7 @@ public class ClusterConnectionManagerTests extends ESTestCase {
                             }
                         }
                     });
+                    connectCompletionLock.readLock().unlock();
                 } else {
                     countDownLatch.countDown();
                 }
@@ -373,6 +377,7 @@ public class ClusterConnectionManagerTests extends ESTestCase {
         }
 
         assertTrue(countDownLatch.await(10, TimeUnit.SECONDS));
+        assertTrue(connectCompletionLock.writeLock().tryLock(10, TimeUnit.SECONDS));
         assertFalse(connectionManager.nodeConnected(node));
         connectionManager.close();
     }


### PR DESCRIPTION
Each call to `connectToNode` temporarily holds a reference to the
connection it just opened, so we must wait for all the `connectToNode`
calls to complete before we can assert that the node is no longer
connected.

Closes #77728