### PR TITLE
[DOCS] Add deprecation docs for low ILM poll intervals

### DIFF
--- a/docs/reference/migration/migrate_7_2.asciidoc
+++ b/docs/reference/migration/migrate_7_2.asciidoc
@@ -9,6 +9,9 @@ your application to Elasticsearch 7.2.
 
 See also <<release-highlights>> and <<es-release-notes>>.
 
+* <<breaking_72_discovery_changes>>
+* <<breaking_80_ilm_deprecations>>
+
 //NOTE: The notable-breaking-changes tagged regions are re-used in the
 //Installation and Upgrade Guide
 
@@ -27,4 +30,17 @@ unexpectedly ignored the rest.  For instance if you set `discovery.seed_hosts:
 "10.11.12.13:9300-9310"` then {es} would only use `10.11.12.13:9300` for
 discovery. Seed host addresses containing port ranges are now rejected.
 
+[discrete]
+[[breaking_80_ilm_deprecations]]
+=== {ilm-cap} ({ilm-init}) deprecations
+
+[discrete]
+[[deprecate-ilm-poll-interval-1s]]
+==== An {ilm-init} poll interval of less than one second is deprecated.
+
+Setting `indices.lifecycle.poll_interval` to less than one second (`1s`) is now
+deprecated. If the `indices.lifecycle.poll_interval` cluster setting is too low,
+it can cause excessive load on a cluster.
+
+To avoid deprecation warnings, use a setting value of `1s` or greater.
 // end::notable-breaking-changes[]

--- a/docs/reference/migration/migrate_7_2.asciidoc
+++ b/docs/reference/migration/migrate_7_2.asciidoc
@@ -10,7 +10,7 @@ your application to Elasticsearch 7.2.
 See also <<release-highlights>> and <<es-release-notes>>.
 
 * <<breaking_72_discovery_changes>>
-* <<breaking_80_ilm_deprecations>>
+* <<breaking_72_ilm_deprecations>>
 
 //NOTE: The notable-breaking-changes tagged regions are re-used in the
 //Installation and Upgrade Guide
@@ -31,7 +31,7 @@ unexpectedly ignored the rest.  For instance if you set `discovery.seed_hosts:
 discovery. Seed host addresses containing port ranges are now rejected.
 
 [discrete]
-[[breaking_80_ilm_deprecations]]
+[[breaking_72_ilm_deprecations]]
 === {ilm-cap} ({ilm-init}) deprecations
 
 [discrete]


### PR DESCRIPTION
We deprecated ILM poll intervals of less than 1 second in 7.2 with PR #41096
However, we didn't add a related item to the 7.2 deprecation docs.
This adds the missing item.

Relates to #41095.

### Preview
https://elasticsearch_77733.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/7.x/breaking-changes-7.2.html#deprecate-ilm-poll-interval-1s