### PR TITLE
[DOCS] Adds machine learning release notes

### DIFF
--- a/docs/reference/release-notes.asciidoc
+++ b/docs/reference/release-notes.asciidoc
@@ -6,6 +6,7 @@
 
 This section summarizes the changes in each release.
 
+* <<release-notes-7.15.0>>
 * <<release-notes-7.14.1>>
 * <<release-notes-7.14.0>>
 * <<release-notes-7.13.2>>
@@ -52,6 +53,7 @@ This section summarizes the changes in each release.
 
 --
 
+include::release-notes/7.15.asciidoc[]
 include::release-notes/7.14.asciidoc[]
 include::release-notes/7.13.asciidoc[]
 include::release-notes/7.12.asciidoc[]

--- a/docs/reference/release-notes/7.15.asciidoc
+++ b/docs/reference/release-notes/7.15.asciidoc
@@ -1,0 +1,22 @@
+[[release-notes-7.15.0]]
+== {es} version 7.15.0
+
+//Also see <<breaking-changes-7.15,Breaking changes in 7.15>>.
+
+[discrete]
+[[enhancement-7.15.0]]
+=== Enhancements
+
+Machine Learning::
+* Speed up training of regression and classification models on very large data sets {ml-pull}1941[#1941]
+* Improve regression and classification training accuracy for small data sets {ml-pull}1960[#1960]
+* Prune models for split fields (by, partition) that haven't seen data updates for
+a given period of time {ml-pull}1962[#1962]
+
+[discrete]
+[[bug-7.15.0]]
+=== Bug fixes
+
+Machine Learning::
+* Fix potential "process stopped unexpectedly: Fatal error" for training regression
+and classification models  {ml-pull}1997[#1997] (issue: {ml-issue}1956[#1956])


### PR DESCRIPTION
This PR adds the ml-cpp PRs from https://github.com/elastic/ml-cpp/blob/7.15/docs/CHANGELOG.asciidoc to the 7.15 release notes.