### PR TITLE
[Test] Hardcode java11 for Pull Request FIPS CI

### DIFF
--- a/.ci/jobs.t/elastic+elasticsearch+pull-request+part-1-fips.yml
+++ b/.ci/jobs.t/elastic+elasticsearch+pull-request+part-1-fips.yml
@@ -31,7 +31,7 @@
           properties-file: '.ci/java-versions.properties'
           properties-content: |
             JAVA_HOME=$HOME/.java/$ES_BUILD_JAVA
-            RUNTIME_JAVA_HOME=$HOME/.java/$ES_RUNTIME_JAVA
+            RUNTIME_JAVA_HOME=$HOME/.java/java11
             JAVA15_HOME=$HOME/.java/openjdk15
       - shell: |
           #!/usr/local/bin/runbld --redirect-stderr

--- a/.ci/jobs.t/elastic+elasticsearch+pull-request+part-2-fips.yml
+++ b/.ci/jobs.t/elastic+elasticsearch+pull-request+part-2-fips.yml
@@ -31,7 +31,7 @@
           properties-file: '.ci/java-versions.properties'
           properties-content: |
             JAVA_HOME=$HOME/.java/$ES_BUILD_JAVA
-            RUNTIME_JAVA_HOME=$HOME/.java/$ES_RUNTIME_JAVA
+            RUNTIME_JAVA_HOME=$HOME/.java/java11
             JAVA15_HOME=$HOME/.java/openjdk15
       - shell: |
           #!/usr/local/bin/runbld --redirect-stderr


### PR DESCRIPTION
This PR changes the Pull Request FIPS CI to use Java 11 instead of Java
8 for consistency with Periodic FIPS CI setup and the support matrix.

Supercedes: #77671