### PR TITLE
[7.x] Adjust SearchableSnapshotsLicenseIntegTests.testShardAllocationOnInvalidLicense (#77757)

### DIFF
--- a/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/SearchableSnapshotsLicenseIntegTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/SearchableSnapshotsLicenseIntegTests.java
@@ -23,7 +23,6 @@ import org.elasticsearch.action.support.DefaultShardOperationFailedException;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.health.ClusterHealthStatus;
 import org.elasticsearch.cluster.metadata.Metadata;
-import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.license.DeleteLicenseAction;
@@ -36,7 +35,6 @@ import org.elasticsearch.license.PostStartTrialRequest;
 import org.elasticsearch.license.PostStartTrialResponse;
 import org.elasticsearch.protocol.xpack.license.DeleteLicenseRequest;
 import org.elasticsearch.test.ESIntegTestCase;
-import org.elasticsearch.test.junit.annotations.TestLogging;
 import org.elasticsearch.xpack.core.searchablesnapshots.MountSearchableSnapshotAction;
 import org.elasticsearch.xpack.core.searchablesnapshots.MountSearchableSnapshotRequest;
 import org.elasticsearch.xpack.searchablesnapshots.action.ClearSearchableSnapshotsCacheAction;
@@ -56,6 +54,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.oneOf;
 
 @ESIntegTestCase.ClusterScope(scope = ESIntegTestCase.Scope.TEST)
 public class SearchableSnapshotsLicenseIntegTests extends BaseFrozenSearchableSnapshotsIntegTestCase {
@@ -145,7 +144,6 @@ public class SearchableSnapshotsLicenseIntegTests extends BaseFrozenSearchableSn
         }
     }
 
-    @TestLogging(reason = "https://github.com/elastic/elasticsearch/issues/72329", value = "org.elasticsearch.license:DEBUG")
     public void testShardAllocationOnInvalidLicense() throws Exception {
         // check that shards have been failed as part of invalid license
         assertBusy(
@@ -170,23 +168,19 @@ public class SearchableSnapshotsLicenseIntegTests extends BaseFrozenSearchableSn
         waitNoPendingTasksOnAll();
         ensureClusterStateConsistency();
 
-        try {
-            PostStartTrialRequest startTrialRequest = new PostStartTrialRequest().setType(License.LicenseType.TRIAL.getTypeName())
-                .acknowledge(true);
-            PostStartTrialResponse resp = client().execute(PostStartTrialAction.INSTANCE, startTrialRequest).get();
-            assertEquals(PostStartTrialResponse.Status.UPGRADED_TO_TRIAL, resp.getStatus());
-        } catch (AssertionError ae) {
-            try {
-                final ClusterService clusterService = internalCluster().getCurrentMasterNodeInstance(ClusterService.class);
-                logger.error(
-                    "Failed to start trial license again, cluster state on master node is:\n{}",
-                    Strings.toString(clusterService.state(), false, true)
-                );
-            } catch (Exception e) {
-                ae.addSuppressed(e);
-            }
-            throw ae;
-        }
+        PostStartTrialRequest request = new PostStartTrialRequest().setType(License.LicenseType.TRIAL.getTypeName()).acknowledge(true);
+        final PostStartTrialResponse response = client().execute(PostStartTrialAction.INSTANCE, request).get();
+        assertThat(
+            response.getStatus(),
+            oneOf(
+                PostStartTrialResponse.Status.UPGRADED_TO_TRIAL,
+                // The LicenceService automatically generates a license of {@link LicenceService#SELF_GENERATED_LICENSE_TYPE} type
+                // if there is no license found in the cluster state (see {@link LicenceService#registerOrUpdateSelfGeneratedLicense).
+                // Since this test explicitly removes the LicensesMetadata from cluster state it is possible that the self generated
+                // license is created before the PostStartTrialRequest is acked.
+                PostStartTrialResponse.Status.TRIAL_ALREADY_ACTIVATED
+            )
+        );
         // check if cluster goes green again after valid license has been put in place
         ensureGreen(indexName);
     }


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Adjust SearchableSnapshotsLicenseIntegTests.testShardAllocationOnInvalidLicense (#77757)