### PR TITLE
[7.11] [DOCS] Add deprecation docs for legacy node role settings (#77719)

### DIFF
--- a/docs/reference/migration/migrate_7_9.asciidoc
+++ b/docs/reference/migration/migrate_7_9.asciidoc
@@ -139,7 +139,6 @@ you dynamically update the index mapping based on the template's mapping configu
 
 [[deprecate_auto_import_dangling_indices]]
 .Automatically importing dangling indices is disabled by default.
-
 [%collapsible]
 ====
 *Details* +
@@ -155,6 +154,30 @@ Alternatively you can enable automatic imports of dangling indices, recovering
 the unsafe behaviour of earlier versions, by setting
 `gateway.auto_import_dangling_indices` to `true`. This setting is deprecated
 and will be removed in {es} 8.0.0. We do not recommend using this setting.
+====
 
+[[deprecate_legacy_node_role_settings]]
+.Several node role settings are deprecated.
+[%collapsible]
+====
+*Details* +
+The following node role settings are now deprecated:
+
+* `node.data`
+* `node.ingest`
+* `node.master`
+* `node.ml`
+* `node.remote_cluster_client`
+* `node.transform`
+* `node.voting_only`
+
+Use the {ref}/modules-node.html#node-roles[`node.roles` setting] instead.
+
+If you used the deprecated node role settings on a 7.13 or later cluster, you
+will have a {ref}/logging.html#deprecation-logging[deprecation log message] on
+each of your nodes indicating the exact replacement value for `node.roles`.
+
+*Impact* +
+To avoid deprecation warnings, discontinue use of the deprecated settings.
 ====
 //end::notable-breaking-changes[]


### PR DESCRIPTION
Backports the following commits to 7.11:
 - [DOCS] Add deprecation docs for legacy node role settings (#77719)