### PR TITLE
Add `index.mode: time_series` (backport of #77626)

### DIFF
--- a/qa/mixed-cluster/build.gradle
+++ b/qa/mixed-cluster/build.gradle
@@ -39,6 +39,9 @@ for (Version bwcVersion : BuildParams.bwcVersions.wireCompatible) {
 
       setting 'path.repo', "${buildDir}/cluster/shared/repo/${baseName}"
       setting 'xpack.security.enabled', 'false'
+      if (BuildParams.isSnapshotBuild() == false) {
+        systemProperty 'es.index_mode_feature_flag_registered', 'true'
+      }
     }
   }
 

--- a/qa/smoke-test-multinode/build.gradle
+++ b/qa/smoke-test-multinode/build.gradle
@@ -6,6 +6,8 @@
  * Side Public License, v 1.
  */
 
+import org.elasticsearch.gradle.internal.info.BuildParams
+
 apply plugin: 'elasticsearch.internal-testclusters'
 apply plugin: 'elasticsearch.standalone-rest-test'
 apply plugin: 'elasticsearch.rest-test'
@@ -25,6 +27,9 @@ testClusters.matching { it.name == "integTest" }.configureEach {
 
 testClusters.all {
   setting 'xpack.security.enabled', 'false'
+  if (BuildParams.isSnapshotBuild() == false) {
+    systemProperty 'es.index_mode_feature_flag_registered', 'true'
+  }
 }
 
 tasks.named("integTest").configure {

--- a/rest-api-spec/build.gradle
+++ b/rest-api-spec/build.gradle
@@ -1,3 +1,5 @@
+import org.elasticsearch.gradle.internal.info.BuildParams
+
 apply plugin: 'elasticsearch.build'
 apply plugin: 'elasticsearch.publish'
 apply plugin: 'elasticsearch.rest-resources'
@@ -32,6 +34,9 @@ artifacts {
 
 testClusters.all {
   module ':modules:mapper-extras'
+  if (BuildParams.isSnapshotBuild() == false) {
+    systemProperty 'es.index_mode_feature_flag_registered', 'true'
+  }
 }
 
 tasks.named("test").configure {enabled = false }

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/tsdb/10_settings.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/tsdb/10_settings.yml
@@ -1,0 +1,117 @@
+enable:
+  - skip:
+      version: " - 7.15.99"
+      reason: introduced in 7.16.0
+
+  - do:
+      indices.create:
+          index: test_index
+          body:
+            settings:
+              index:
+                mode: time_series
+                number_of_replicas: 0
+                number_of_shards: 2
+            mappings:
+              properties:
+                "@timestamp":
+                  type: date
+                metricset:
+                  type: keyword
+                k8s:
+                  properties:
+                    pod:
+                      properties:
+                        uid:
+                          type: keyword
+                        name:
+                          type: keyword
+                        ip:
+                          type: ip
+                        network:
+                          properties:
+                            tx:
+                              type: long
+                            rx:
+                              type: long
+
+---
+no sort field:
+  - skip:
+      version: " - 7.15.99"
+      reason: introduced in 7.16.0
+
+  - do:
+      catch: /\[index.mode=time_series\] is incompatible with \[index.sort.field\]/
+      indices.create:
+          index: test_index
+          body:
+            settings:
+              index:
+                mode: time_series
+                sort.field: ['a']
+
+---
+no sort order:
+  - skip:
+      version: " - 7.15.99"
+      reason: introduced in 7.16.0
+
+  - do:
+      catch: /\[index.mode=time_series\] is incompatible with \[index.sort.order\]/
+      indices.create:
+          index: test_index
+          body:
+            settings:
+              index:
+                mode: time_series
+                sort.order: ['DESC']
+
+---
+no sort mode:
+  - skip:
+      version: " - 7.15.99"
+      reason: introduced in 7.16.0
+
+  - do:
+      catch: /\[index.mode=time_series\] is incompatible with \[index.sort.mode\]/
+      indices.create:
+          index: test_index
+          body:
+            settings:
+              index:
+                mode: time_series
+                sort.mode: ['MIN']
+
+---
+no sort missing:
+  - skip:
+      version: " - 7.15.99"
+      reason: introduced in 7.16.0
+
+  - do:
+      catch: /\[index.mode=time_series\] is incompatible with \[index.sort.missing\]/
+      indices.create:
+          index: test_index
+          body:
+            settings:
+              index:
+                mode: time_series
+                sort.missing: ['_last']
+
+---
+no partitioning:
+  - skip:
+      version: " - 7.15.99"
+      reason: introduced in 7.16.0
+
+  - do:
+      catch: /\[index.mode=time_series\] is incompatible with \[index.routing_partition_size\]/
+      indices.create:
+          index: test_index
+          body:
+            settings:
+              index:
+                mode: time_series
+                shards: 5
+                routing_partition_size: 2

--- a/server/src/main/java/org/elasticsearch/common/settings/IndexScopedSettings.java
+++ b/server/src/main/java/org/elasticsearch/common/settings/IndexScopedSettings.java
@@ -35,7 +35,6 @@ import org.elasticsearch.index.store.Store;
 import org.elasticsearch.indices.IndicesRequestCache;
 import org.elasticsearch.indices.ShardLimitValidator;
 
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Map;
@@ -50,7 +49,7 @@ public final class IndexScopedSettings extends AbstractScopedSettings {
 
     public static final Predicate<String> INDEX_SETTINGS_KEY_PREDICATE = (s) -> s.startsWith(IndexMetadata.INDEX_SETTING_PREFIX);
 
-    public static final Set<Setting<?>> BUILT_IN_INDEX_SETTINGS = Collections.unmodifiableSet(new HashSet<>(Arrays.asList(
+    private static final Set<Setting<?>> ALWAYS_ENABLED_BUILT_IN_INDEX_SETTINGS = org.elasticsearch.core.Set.of(
         MaxRetryAllocationDecider.SETTING_ALLOCATION_MAX_RETRY,
         MergeSchedulerConfig.AUTO_THROTTLE_SETTING,
         MergeSchedulerConfig.MAX_MERGE_COUNT_SETTING,
@@ -178,9 +177,18 @@ public final class IndexScopedSettings extends AbstractScopedSettings {
                 }
             }
         }, Property.IndexScope), // this allows similarity settings to be passed
-        Setting.groupSetting("index.analysis.", Property.IndexScope) // this allows analysis settings to be passed
+        Setting.groupSetting("index.analysis.", Property.IndexScope)); // this allows analysis settings to be passed
 
-    )));
+    public static final Set<Setting<?>> BUILT_IN_INDEX_SETTINGS = builtInIndexSettings();
+
+    private static Set<Setting<?>> builtInIndexSettings() {
+        if (false == IndexSettings.isTimeSeriesModeEnabled()) {
+            return ALWAYS_ENABLED_BUILT_IN_INDEX_SETTINGS;
+        }
+        Set<Setting<?>> result = new HashSet<>(ALWAYS_ENABLED_BUILT_IN_INDEX_SETTINGS);
+        result.add(IndexSettings.MODE);
+        return org.elasticsearch.core.Set.copyOf(result);
+    }
 
     public static final IndexScopedSettings DEFAULT_SCOPED_SETTINGS = new IndexScopedSettings(Settings.EMPTY, BUILT_IN_INDEX_SETTINGS);
 

--- a/server/src/main/java/org/elasticsearch/common/settings/Setting.java
+++ b/server/src/main/java/org/elasticsearch/common/settings/Setting.java
@@ -1417,7 +1417,28 @@ public class Setting<T> implements ToXContentObject {
      * @return the setting object
      */
     public static <T extends Enum<T>> Setting<T> enumSetting(Class<T> clazz, String key, T defaultValue, Property... properties) {
-        return new Setting<>(key, defaultValue.toString(), e -> Enum.valueOf(clazz, e.toUpperCase(Locale.ROOT)), properties);
+        return enumSetting(clazz, key, defaultValue, s -> {}, properties);
+    }
+
+    /**
+     * Creates a setting where the allowed values are defined as enum constants. All enum constants must be uppercase.
+     *
+     * @param clazz the enum class
+     * @param key the key for the setting
+     * @param defaultValue the default value for this setting
+     * @param validator validator for this setting
+     * @param properties properties for this setting like scope, filtering...
+     * @param <T> the generics type parameter reflecting the actual type of the enum
+     * @return the setting object
+     */
+    public static <T extends Enum<T>> Setting<T> enumSetting(
+        Class<T> clazz,
+        String key,
+        T defaultValue,
+        Validator<T> validator,
+        Property... properties
+    ) {
+        return new Setting<>(key, defaultValue.toString(), e -> Enum.valueOf(clazz, e.toUpperCase(Locale.ROOT)), validator, properties);
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/index/IndexMode.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexMode.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.index;
+
+import org.elasticsearch.cluster.metadata.IndexMetadata;
+import org.elasticsearch.common.settings.Setting;
+import org.elasticsearch.common.settings.Settings;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Stream;
+
+import static java.util.stream.Collectors.toSet;
+
+/**
+ * "Mode" that controls which behaviors and settings an index supports.
+ */
+public enum IndexMode {
+    STANDARD {
+        @Override
+        void validateWithOtherSettings(Map<Setting<?>, Object> settings) {}
+    },
+    TIME_SERIES {
+        @Override
+        void validateWithOtherSettings(Map<Setting<?>, Object> settings) {
+            if (settings.get(IndexMetadata.INDEX_ROUTING_PARTITION_SIZE_SETTING) != Integer.valueOf(1)) {
+                throw new IllegalArgumentException(error(IndexMetadata.INDEX_ROUTING_PARTITION_SIZE_SETTING));
+            }
+            for (Setting<?> unsupported : TIME_SERIES_UNSUPPORTED) {
+                if (false == Objects.equals(unsupported.getDefault(Settings.EMPTY), settings.get(unsupported))) {
+                    throw new IllegalArgumentException(error(unsupported));
+                }
+            }
+        }
+
+        private String error(Setting<?> unsupported) {
+            return "[" + IndexSettings.MODE.getKey() + "=time_series] is incompatible with [" + unsupported.getKey() + "]";
+        }
+    };
+
+    private static final List<Setting<?>> TIME_SERIES_UNSUPPORTED = org.elasticsearch.core.List.of(
+        IndexSortConfig.INDEX_SORT_FIELD_SETTING,
+        IndexSortConfig.INDEX_SORT_ORDER_SETTING,
+        IndexSortConfig.INDEX_SORT_MODE_SETTING,
+        IndexSortConfig.INDEX_SORT_MISSING_SETTING
+    );
+
+    static final List<Setting<?>> VALIDATE_WITH_SETTINGS = org.elasticsearch.core.List.copyOf(
+        Stream.concat(Stream.of(IndexMetadata.INDEX_ROUTING_PARTITION_SIZE_SETTING), TIME_SERIES_UNSUPPORTED.stream()).collect(toSet())
+    );
+
+    abstract void validateWithOtherSettings(Map<Setting<?>, Object> settings);
+}

--- a/server/src/main/java/org/elasticsearch/index/IndexSettings.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexSettings.java
@@ -10,6 +10,7 @@ package org.elasticsearch.index;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.util.Strings;
 import org.apache.lucene.index.MergePolicy;
+import org.elasticsearch.Build;
 import org.elasticsearch.Version;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.common.logging.Loggers;
@@ -19,13 +20,16 @@ import org.elasticsearch.common.settings.Setting.Property;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.ByteSizeUnit;
 import org.elasticsearch.common.unit.ByteSizeValue;
+import org.elasticsearch.core.Booleans;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.index.translog.Translog;
 import org.elasticsearch.ingest.IngestService;
 import org.elasticsearch.node.Node;
 
 import java.util.Collections;
+import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -335,12 +339,59 @@ public final class IndexSettings {
     public static final Setting<Double> FILE_BASED_RECOVERY_THRESHOLD_SETTING
         = Setting.doubleSetting("index.recovery.file_based_threshold", 0.1d, 0.0d, Setting.Property.IndexScope);
 
+    /**
+     * Is the {@code index.mode} enabled? It should only be enbaled if you
+     * pass a jvm parameter or are running a snapshot build.
+     */
+    private static final Boolean TIME_SERIES_MODE_FEATURE_FLAG_REGISTERED;
+
+    static {
+        final String property = System.getProperty("es.index_mode_feature_flag_registered");
+        if (Build.CURRENT.isSnapshot() && property != null) {
+            throw new IllegalArgumentException("es.index_mode_feature_flag_registered is only supported in non-snapshot builds");
+        }
+        TIME_SERIES_MODE_FEATURE_FLAG_REGISTERED = Booleans.parseBoolean(property, null);
+    }
+
+    public static boolean isTimeSeriesModeEnabled() {
+        return Build.CURRENT.isSnapshot() || (TIME_SERIES_MODE_FEATURE_FLAG_REGISTERED != null && TIME_SERIES_MODE_FEATURE_FLAG_REGISTERED);
+    }
+
+    /**
+     * The {@link IndexMode "mode"} of the index.
+     */
+    public static final Setting<IndexMode> MODE = Setting.enumSetting(IndexMode.class,
+        "index.mode",
+        IndexMode.STANDARD,
+        new Setting.Validator<IndexMode>() {
+            @Override
+            public void validate(IndexMode value) {}
+
+            @Override
+            public void validate(IndexMode value, Map<Setting<?>, Object> settings) {
+                value.validateWithOtherSettings(settings);
+            }
+
+            @Override
+            public Iterator<Setting<?>> settings() {
+                return IndexMode.VALIDATE_WITH_SETTINGS.iterator();
+            }
+        },
+        Property.IndexScope,
+        Property.Final
+    );
+
     private final Index index;
     private final Version version;
     private final Logger logger;
     private final String nodeName;
     private final Settings nodeSettings;
     private final int numberOfShards;
+    /**
+     * The {@link IndexMode "mode"} of the index.
+     */
+    private final IndexMode mode;
+
     // volatile fields are updated via #updateIndexMetadata(IndexMetadata) under lock
     private volatile Settings settings;
     private volatile IndexMetadata indexMetadata;
@@ -483,6 +534,7 @@ public final class IndexSettings {
         nodeName = Node.NODE_NAME_SETTING.get(settings);
         this.indexMetadata = indexMetadata;
         numberOfShards = settings.getAsInt(IndexMetadata.SETTING_NUMBER_OF_SHARDS, null);
+        mode = isTimeSeriesModeEnabled() ? scopedSettings.get(MODE) : IndexMode.STANDARD;
 
         this.searchThrottled = INDEX_SEARCH_THROTTLED.get(settings);
         this.queryStringLenient = QUERY_STRING_LENIENT_SETTING.get(settings);
@@ -692,6 +744,13 @@ public final class IndexSettings {
      * Returns the number of replicas this index has.
      */
     public int getNumberOfReplicas() { return settings.getAsInt(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, null); }
+
+    /**
+     * "Mode" that controls which behaviors and settings an index supports.
+     */
+    public IndexMode getMode() {
+        return mode;
+    }
 
     /**
      * Returns the node settings. The settings returned from {@link #getSettings()} are a merged version of the

--- a/server/src/test/java/org/elasticsearch/index/TimeSeriesModeTests.java
+++ b/server/src/test/java/org/elasticsearch/index/TimeSeriesModeTests.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.index;
+
+import org.elasticsearch.cluster.metadata.IndexMetadata;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.test.ESTestCase;
+
+import static org.hamcrest.Matchers.equalTo;
+
+public class TimeSeriesModeTests extends ESTestCase {
+    public void testPartitioned() {
+        Settings s = Settings.builder()
+            .put(IndexMetadata.INDEX_ROUTING_PARTITION_SIZE_SETTING.getKey(), 2)
+            .put(IndexSettings.MODE.getKey(), "time_series")
+            .build();
+        Exception e = expectThrows(IllegalArgumentException.class, () -> IndexSettings.MODE.get(s));
+        assertThat(e.getMessage(), equalTo("[index.mode=time_series] is incompatible with [index.routing_partition_size]"));
+    }
+
+    public void testSortField() {
+        Settings s = Settings.builder()
+            .put(IndexSortConfig.INDEX_SORT_FIELD_SETTING.getKey(), "a")
+            .put(IndexSettings.MODE.getKey(), "time_series")
+            .build();
+        Exception e = expectThrows(IllegalArgumentException.class, () -> IndexSettings.MODE.get(s));
+        assertThat(e.getMessage(), equalTo("[index.mode=time_series] is incompatible with [index.sort.field]"));
+    }
+
+    public void testSortMode() {
+        Settings s = Settings.builder()
+            .put(IndexSortConfig.INDEX_SORT_MISSING_SETTING.getKey(), "_last")
+            .put(IndexSettings.MODE.getKey(), "time_series")
+            .build();
+        Exception e = expectThrows(IllegalArgumentException.class, () -> IndexSettings.MODE.get(s));
+        assertThat(e.getMessage(), equalTo("[index.mode=time_series] is incompatible with [index.sort.missing]"));
+    }
+
+    public void testSortOrder() {
+        Settings s = Settings.builder()
+            .put(IndexSortConfig.INDEX_SORT_ORDER_SETTING.getKey(), "desc")
+            .put(IndexSettings.MODE.getKey(), "time_series")
+            .build();
+        Exception e = expectThrows(IllegalArgumentException.class, () -> IndexSettings.MODE.get(s));
+        assertThat(e.getMessage(), equalTo("[index.mode=time_series] is incompatible with [index.sort.order]"));
+    }
+}

--- a/x-pack/qa/core-rest-tests-with-security/build.gradle
+++ b/x-pack/qa/core-rest-tests-with-security/build.gradle
@@ -1,3 +1,5 @@
+import org.elasticsearch.gradle.internal.info.BuildParams
+
 apply plugin: 'elasticsearch.internal-testclusters'
 apply plugin: 'elasticsearch.standalone-rest-test'
 apply plugin: 'elasticsearch.rest-test'
@@ -31,6 +33,9 @@ testClusters.matching { it.name == "integTest" }.configureEach {
   setting 'xpack.ml.enabled', 'false'
   setting 'xpack.license.self_generated.type', 'trial'
   setting 'indices.lifecycle.history_index_enabled', 'false'
+  if (BuildParams.isSnapshotBuild() == false) {
+    systemProperty 'es.index_mode_feature_flag_registered', 'true'
+  }
 
   user username: System.getProperty('tests.rest.cluster.username', 'test_user'),
     password: System.getProperty('tests.rest.cluster.password', 'x-pack-test-password')

--- a/x-pack/qa/runtime-fields/build.gradle
+++ b/x-pack/qa/runtime-fields/build.gradle
@@ -1,3 +1,13 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import org.elasticsearch.gradle.internal.info.BuildParams
+
 apply plugin: 'elasticsearch.build'
 
 dependencies {
@@ -30,6 +40,9 @@ subprojects {
       testDistribution = 'DEFAULT'
       setting 'xpack.license.self_generated.type', 'trial'
       setting 'xpack.security.enabled', 'false'
+      if (BuildParams.isSnapshotBuild() == false) {
+        systemProperty 'es.index_mode_feature_flag_registered', 'true'
+      }
     }
 
     tasks.named("yamlRestTest").configure {


### PR DESCRIPTION
This adds a setting to enable time series mode that is hidden by the
`es.index_mode_feature_flag_registered` feature flag. All it does right
now is make sure you haven't configured index sorting and partitioning.
This gives us a place to "hang" all of our further work on time series
mode.

Time series mode will entirely take over index sorting. We don't believe
you'll ever be able to configure sorting yourself when you are in time
series mode. We don't expect time series mode to support index
partitioning when we first build it but we'd like to get there.
