### PR TITLE
[7.x] Correctly size HashSet when creating one from an array (#77553)

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/util/set/Sets.java
+++ b/server/src/main/java/org/elasticsearch/common/util/set/Sets.java
@@ -8,6 +8,7 @@
 
 package org.elasticsearch.common.util.set;
 
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.EnumSet;
@@ -47,9 +48,7 @@ public final class Sets {
     @SuppressWarnings("varargs")
     public static <T> HashSet<T> newHashSet(T... elements) {
         Objects.requireNonNull(elements);
-        HashSet<T> set = new HashSet<>(elements.length);
-        Collections.addAll(set, elements);
-        return set;
+        return new HashSet<>(Arrays.asList(elements));
     }
 
     public static <T> Set<T> newConcurrentHashSet() {

--- a/server/src/test/java/org/elasticsearch/common/xcontent/support/filtering/FilterPathTests.java
+++ b/server/src/test/java/org/elasticsearch/common/xcontent/support/filtering/FilterPathTests.java
@@ -8,9 +8,10 @@
 
 package org.elasticsearch.common.xcontent.support.filtering;
 
-import org.elasticsearch.common.util.set.Sets;
 import org.elasticsearch.test.ESTestCase;
 
+import java.util.Arrays;
+import java.util.LinkedHashSet;
 import java.util.Set;
 
 import static java.util.Collections.singleton;
@@ -295,7 +296,7 @@ public class FilterPathTests extends ESTestCase {
     }
 
     public void testMultipleFilterPaths() {
-        Set<String> inputs = Sets.newHashSet("foo.**.bar.*", "test.dot\\.ted");
+        Set<String> inputs = new LinkedHashSet<>(Arrays.asList("foo.**.bar.*", "test.dot\\.ted"));
 
         FilterPath[] filterPaths = FilterPath.compile(inputs);
         assertNotNull(filterPaths);

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/TimeseriesLifecycleType.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/TimeseriesLifecycleType.java
@@ -20,6 +20,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -62,9 +63,10 @@ public class TimeseriesLifecycleType implements LifecycleType {
 
     static final Set<String> HOT_ACTIONS_THAT_REQUIRE_ROLLOVER = Sets.newHashSet(ReadOnlyAction.NAME, ShrinkAction.NAME,
         ForceMergeAction.NAME, RollupILMAction.NAME, SearchableSnapshotAction.NAME);
-    // a set of actions that cannot be defined (executed) after the managed index has been mounted as searchable snapshot
-    static final Set<String> ACTIONS_CANNOT_FOLLOW_SEARCHABLE_SNAPSHOT = Sets.newHashSet(ShrinkAction.NAME, ForceMergeAction.NAME,
-        FreezeAction.NAME, RollupILMAction.NAME);
+    // Set of actions that cannot be defined (executed) after the managed index has been mounted as searchable snapshot.
+    // It's ordered to produce consistent error messages which can be unit tested.
+    static final Set<String> ACTIONS_CANNOT_FOLLOW_SEARCHABLE_SNAPSHOT = new LinkedHashSet<>(Arrays.asList(
+        ForceMergeAction.NAME, FreezeAction.NAME, ShrinkAction.NAME, RollupILMAction.NAME));
 
     static {
         if (RollupV2.isEnabled()) {

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/job/config/RuleScopeTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/job/config/RuleScopeTests.java
@@ -11,7 +11,9 @@ import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.util.set.Sets;
 import org.elasticsearch.test.AbstractWireSerializingTestCase;
 
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.LinkedHashSet;
 
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.equalTo;
@@ -76,7 +78,7 @@ public class RuleScopeTests extends AbstractWireSerializingTestCase<RuleScope> {
         assertThat(scope.isEmpty(), is(false));
 
         ElasticsearchStatusException e = expectThrows(ElasticsearchStatusException.class,
-                () -> scope.validate(Sets.newHashSet("foo", "foobar")));
+                () -> scope.validate(new LinkedHashSet<>(Arrays.asList("foo", "foobar"))));
         assertThat(e.getMessage(), equalTo("Invalid detector rule: scope field 'bar' is invalid; select from [foo, foobar]"));
     }
 

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/privileges/40_get_user_privs.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/privileges/40_get_user_privs.yml
@@ -303,7 +303,7 @@ teardown:
 
   - length: { "applications" : 3 }
   - contains: { "applications" : { "application" : "app-dne", "privileges" : [ "all" ], "resources" : [ "*" ] } }
-  - contains: { "applications" : { "application" : "test-app", "privileges" : [ "user", "dne" ], "resources" : [ "*" ] } }
+  - contains: { "applications" : { "application" : "test-app", "privileges" : [ "dne", "user" ], "resources" : [ "*" ] } }
   - contains: { "applications" : { "application" : "test-app", "privileges" : [ "read" ], "resources" : [ "object/1", "object/2" ] } }
 
   - match: { "run_as" : [ "app-*", "test-*" ] }


### PR DESCRIPTION
Backports the following commits to 7.x:

- Correctly size HashSet when creating one from an array (#77553)

