### PR TITLE
[DOCS] Add deprecation docs for transport profile types

### DIFF
--- a/docs/reference/migration/migrate_7_3.asciidoc
+++ b/docs/reference/migration/migrate_7_3.asciidoc
@@ -77,4 +77,21 @@ that the total number of hits is not tracked.
 
 Aliases are now replicated to a follower from its leader, so directly modifying
 aliases on follower indices is no longer allowed.
+
+[discrete]
+[[breaking_73_security_deprecations]]
+=== Security deprecations
+
+[discrete]
+[[deprecate-transport-profile-sec-type]]
+==== The `transport.profiles.*.xpack.security.type` setting is deprecated.
+
+The `transport.profiles.*.xpack.security.type` setting is now deprecated. In
+8.0, the Java transport client will be removed. All client traffic will use the
+HTTP interface instead.
+
+To avoid deprecation warnings,
+{java-rest}/java-rest-high-level-migration.html[migrate any code for the Java
+transport client]. Then remove any transport profiles using the deprecated
+setting.
 // end::notable-breaking-changes[]


### PR DESCRIPTION
We deprecated the `transport.profiles.*.xpack.security.type` setting in 7.3 with PR #43237
However, we didn't add a related item to the 7.3 deprecation docs. This adds the
missing item.

Relates to #43236.

### Preview
https://elasticsearch_77780.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/7.x/breaking-changes-7.3.html#deprecate-transport-profile-sec-type