### PR TITLE
Make Failing Transport Handlers on Node Shutdown More Reliable

### DIFF
--- a/server/src/main/java/org/elasticsearch/indices/recovery/PeerRecoveryTargetService.java
+++ b/server/src/main/java/org/elasticsearch/indices/recovery/PeerRecoveryTargetService.java
@@ -24,6 +24,7 @@ import org.elasticsearch.cluster.ClusterStateObserver;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.component.Lifecycle;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.ByteSizeValue;
@@ -603,6 +604,12 @@ public class PeerRecoveryTargetService implements IndexEventListener {
                     request.shardId().id()), e);
             }
             Throwable cause = ExceptionsHelper.unwrapCause(e);
+            if (transportService.lifecycleState() != Lifecycle.State.STARTED) {
+                // the node is shutting down, we just fail the recovery to release resources
+                onGoingRecoveries.failRecovery(recoveryId, new RecoveryFailedException(request,
+                        "node is shutting down", cause), false);
+                return;
+            }
             if (cause instanceof CancellableThreads.ExecutionCancelledException) {
                 // this can also come from the source wrapped in a RemoteTransportException
                 onGoingRecoveries.failRecovery(recoveryId, new RecoveryFailedException(request,

--- a/server/src/main/java/org/elasticsearch/transport/TransportService.java
+++ b/server/src/main/java/org/elasticsearch/transport/TransportService.java
@@ -1042,9 +1042,12 @@ public class TransportService extends AbstractLifecycleComponent
             return;
         }
 
-        // callback that an exception happened, but on a different thread since we don't
-        // want handlers to worry about stack overflows
-        threadPool.generic().execute(new AbstractRunnable() {
+        // Callback that an exception happened, but on a different thread since we don't
+        // want handlers to worry about stack overflows.
+        // Execute on the current thread in the special case of a node shut down to notify the listener even when the threadpool has
+        // already been shut down.
+        final String executor = lifecycle.stoppedOrClosed() ? ThreadPool.Names.SAME : ThreadPool.Names.GENERIC;
+        threadPool.executor(executor).execute(new AbstractRunnable() {
             @Override
             public void doRun() {
                 for (Transport.ResponseContext<?> holderToNotify : pruned) {


### PR DESCRIPTION
Don't fork when shutting down already as the generic pool may not execute all
tasks queued up on it silently.
Also, when handling exceptions in the peer recovery target service, don't try to
re-schedule recoveries when the node is shutting down already and fail right away
no matter the exception.

closes #77017
