### PR TITLE
Add note in breaking changes for nameid_format

### DIFF
--- a/docs/reference/migration/migrate_8_0/security.asciidoc
+++ b/docs/reference/migration/migrate_8_0/security.asciidoc
@@ -113,6 +113,37 @@ result in an error on startup.
 ====
 
 [discrete]
+[[saml-realm-nameid-changes]]
+.The `nameid_format` SAML realm setting has no default value.
+[%collapsible]
+====
+*Details* +
+In SAML, Identity Providers (IdPs) can either be explicitly configured to
+release a `NameID` with a specific format, or configured to attempt to conform 
+with the requirements of a Service Provider (SP). The SP declares its
+requirements in the `NameIDPolicy` element of a SAML Authentication Request.
+In {es}, the `nameid_format` SAML realm setting controls the `NameIDPolicy`
+value.
+
+Previously, the default value for `nameid_format` was
+`urn:oasis:names:tc:SAML:2.0:nameid-format:transient`. This setting created
+authentication requests that required the IdP to release `NameID` with a
+`transient` format.
+
+The default value has been removed, which means that {es} will create SAML Authentication Requests by default that don't put this requirement on the
+IdP. If you want to retain the previous behavior, set `nameid_format` to
+`urn:oasis:names:tc:SAML:2.0:nameid-format:transient`.
+
+*Impact* +
+If you currently don't configure `nameid_format` explicitly, it's possible
+that your configuration won't match the `NameID` format that your IdP expects.
+This mismatch can result in a broken SAML configuration. If you're unsure which 
+name format your IdP uses to generate a value for `NameID`, try setting
+`nameid_format` to `urn:oasis:names:tc:SAML:2.0:nameid-format:transient` 
+explicitly.
+====
+
+[discrete]
 [[ssl-validation-changes]]
 ===== SSL/TLS configuration validation
 
@@ -308,37 +339,6 @@ Assign users with the `kibana_user` role to the `kibana_admin` role.
 Discontinue use of the `kibana_user` role.
 ====
 
-[discrete]
-[[saml-realm-nameid-changes]]
-===== The default value of `nameid_format` setting has been removed.
-
-.The `nameid_format` SAML realm setting has no default value.
-[%collapsible]
-====
-*Details* +
-In SAML, Identity Providers (IdPs) either release a `NameID` or attempt to
-conform with the requirements of a Service Provider (SP). The SP declares its
-requirements in the `NameIDPolicy` of an authentication request. In {es}, the
-`nameid_format` SAML realm setting controls the `NameIDPolicy`.
-
-Previously, the default value for `nameid_format` was
-`urn:oasis:names:tc:SAML:2.0:nameid-format:transient`. This default created
-authentication requests that would require the IdP to release `NameID` with a
-transient format.
-The default value has now been removed. This means that {es} will be default
-create SAML Authentication Requests that do not put forward such requirements
-to the Identity Provider.
-
-If you want to retain the previous behavior, you can set `nameid_format`
-to `urn:oasis:names:tc:SAML:2.0:nameid-format:transient`.
-
-*Impact* +
-To avoid issues, explicitly configure `nameid_format`. If you don't configure
-`nameid_format`, some SAML setups may no longer work. If you don't know
-how your IdP generates a value for `NameID`, explicitly set `nameid_format` to
-`urn:oasis:names:tc:SAML:2.0:nameid-format:transient`.
-
-====
 // end::notable-breaking-changes[]
 
 // These are non-notable changes

--- a/docs/reference/migration/migrate_8_0/security.asciidoc
+++ b/docs/reference/migration/migrate_8_0/security.asciidoc
@@ -320,7 +320,7 @@ with a specific format, or they can be configured to try to conform with the
 requirements of the SP. The SP declares its requirements as part of the
 Authentication Request, using an element which is called the `NameIDPolicy`
 For the {es} SAML realm, `NameIDPolicy` is controlled by `nameid_format` in
-<<saml-settings, SAML realm settings>>.
+SAML realm settings.
 
 Previously, the default value for this setting was
 `urn:oasis:names:tc:SAML:2.0:nameid-format:transient` which meant that {es}
@@ -330,15 +330,15 @@ The default value has now been removed. This means that {es} will be default
 create SAML Authentication Requests that do not put forward such requirements
 to the Identity Provider.
 
-If you want to retain the previous behavior, you can set <<saml-settings, `nameid_format`>>
+If you want to retain the previous behavior, you can set `nameid_format`
 to `urn:oasis:names:tc:SAML:2.0:nameid-format:transient`.
 
 *Impact* +
-If you are not configuring <<saml-settings, `nameid_format`>> explicitly in
+If you are not configuring `nameid_format` explicitly in
 your current configuration, there might be cases where the combination of this
 configuration and the configuration of your SAML Identity Provider will result
 in a non-working setup. If you are uncertain of how your Identity Provider is
-configured to generate a value for `NameID`, you can set <<saml-settings, `nameid_format`>>
+configured to generate a value for `NameID`, you can set `nameid_format`
 to `urn:oasis:names:tc:SAML:2.0:nameid-format:transient` explicitly.
 
 ====

--- a/docs/reference/migration/migrate_8_0/security.asciidoc
+++ b/docs/reference/migration/migrate_8_0/security.asciidoc
@@ -312,21 +312,19 @@ Discontinue use of the `kibana_user` role.
 [[saml-realm-nameid-changes]]
 ===== The default value of `nameid_format` setting has been removed.
 
-.The `nameid_format` setting of SAML realms has no default value.
+.The `nameid_format` SAML realm setting has no default value.
 [%collapsible]
 ====
 *Details* +
-Identity Providers can be either statically configured to release a `NameID`
-with a specific format, or they can be configured to try to conform with the
-requirements of the SP. The SP declares its requirements as part of the
-Authentication Request, using an element which is called the `NameIDPolicy`
-For the {es} SAML realm, `NameIDPolicy` is controlled by `nameid_format` in
-SAML realm settings.
+In SAML, Identity Providers (IdPs) either release a `NameID` or attempt to
+conform with the requirements of a Service Provider (SP). The SP declares its
+requirements in the `NameIDPolicy` of an authentication request. In {es}, the
+`nameid_format` SAML realm setting controls the `NameIDPolicy`.
 
-Previously, the default value for this setting was
-`urn:oasis:names:tc:SAML:2.0:nameid-format:transient` which meant that {es}
-would create SAML Authentication Requests that would require from the Identity
-Provider to release `NameID` with a transient format.
+Previously, the default value for `nameid_format` was
+`urn:oasis:names:tc:SAML:2.0:nameid-format:transient`. This default created
+authentication requests that would require the IdP to release `NameID` with a
+transient format.
 The default value has now been removed. This means that {es} will be default
 create SAML Authentication Requests that do not put forward such requirements
 to the Identity Provider.
@@ -335,12 +333,10 @@ If you want to retain the previous behavior, you can set `nameid_format`
 to `urn:oasis:names:tc:SAML:2.0:nameid-format:transient`.
 
 *Impact* +
-If you are not configuring `nameid_format` explicitly in
-your current configuration, there might be cases where the combination of this
-configuration and the configuration of your SAML Identity Provider will result
-in a non-working setup. If you are uncertain of how your Identity Provider is
-configured to generate a value for `NameID`, you can set `nameid_format`
-to `urn:oasis:names:tc:SAML:2.0:nameid-format:transient` explicitly.
+To avoid issues, explicitly configure `nameid_format`. If you don't configure
+`nameid_format`, some SAML setups may no longer work. If you don't know
+how your IdP generates a value for `NameID`, explicitly set `nameid_format` to
+`urn:oasis:names:tc:SAML:2.0:nameid-format:transient`.
 
 ====
 // end::notable-breaking-changes[]

--- a/docs/reference/migration/migrate_8_0/security.asciidoc
+++ b/docs/reference/migration/migrate_8_0/security.asciidoc
@@ -306,6 +306,7 @@ renamed to better reflect its intended use.
 *Impact* +
 Assign users with the `kibana_user` role to the `kibana_admin` role.
 Discontinue use of the `kibana_user` role.
+====
 
 [discrete]
 [[saml-realm-nameid-changes]]

--- a/docs/reference/migration/migrate_8_0/security.asciidoc
+++ b/docs/reference/migration/migrate_8_0/security.asciidoc
@@ -114,7 +114,7 @@ result in an error on startup.
 
 [discrete]
 [[saml-realm-nameid-changes]]
-.The `nameid_format` SAML realm setting has no default value.
+.The `nameid_format` SAML realm setting no longer has a default value.
 [%collapsible]
 ====
 *Details* +
@@ -136,7 +136,8 @@ IdP. If you want to retain the previous behavior, set `nameid_format` to
 
 *Impact* +
 If you currently don't configure `nameid_format` explicitly, it's possible
-that your configuration won't match the `NameID` format that your IdP expects.
+that your IdP will reject authentication request from {es} because the requests 
+do not specify a `NameID` format (and your IdP is configured to expect one).
 This mismatch can result in a broken SAML configuration. If you're unsure which 
 name format your IdP uses to generate a value for `NameID`, try setting
 `nameid_format` to `urn:oasis:names:tc:SAML:2.0:nameid-format:transient` 

--- a/docs/reference/migration/migrate_8_0/security.asciidoc
+++ b/docs/reference/migration/migrate_8_0/security.asciidoc
@@ -234,7 +234,7 @@ on startup.
 
 [discrete]
 [[ssl-misc-changes]]
-===== Other SSL/TLS changes 
+===== Other SSL/TLS changes
 
 .PKCS#11 keystores and trustores cannot be configured in `elasticsearch.yml`
 [%collapsible]
@@ -254,7 +254,7 @@ Use of a PKCS#11 keystore or truststore as the JRE's default store is not affect
 
 *Impact* +
 If you have a PKCS#11 keystore configured within your `elasticsearch.yml` file, you must remove that
-configuration and switch to a supported keystore type, or configure your PKCS#11 keystore as the 
+configuration and switch to a supported keystore type, or configure your PKCS#11 keystore as the
 JRE default store.
 ====
 
@@ -306,6 +306,41 @@ renamed to better reflect its intended use.
 *Impact* +
 Assign users with the `kibana_user` role to the `kibana_admin` role.
 Discontinue use of the `kibana_user` role.
+
+[discrete]
+[[saml-realm-nameid-changes]]
+===== The default value of `nameid_format` setting has been removed.
+
+.The `nameid_format` setting of SAML realms has no default value.
+[%collapsible]
+====
+*Details* +
+Identity Providers can be either statically configured to release a `NameID`
+with a specific format, or they can be configured to try to conform with the
+requirements of the SP. The SP declares its requirements as part of the
+Authentication Request, using an element which is called the `NameIDPolicy`
+For the {es} SAML realm, `NameIDPolicy` is controlled by `nameid_format` in
+<<saml-settings, SAML realm settings>>.
+
+Previously, the default value for this setting was
+`urn:oasis:names:tc:SAML:2.0:nameid-format:transient` which meant that {es}
+would create SAML Authentication Requests that would require from the Identity
+Provider to release `NameID` with a transient format.
+The default value has now been removed. This means that {es} will be default
+create SAML Authentication Requests that do not put forward such requirements
+to the Identity Provider.
+
+If you want to retain the previous behavior, you can set <<saml-settings, `nameid_format`>>
+to `urn:oasis:names:tc:SAML:2.0:nameid-format:transient`.
+
+*Impact* +
+If you are not configuring <<saml-settings, `nameid_format`>> explicitly in
+your current configuration, there might be cases where the combination of this
+configuration and the configuration of your SAML Identity Provider will result
+in a non-working setup. If you are uncertain of how your Identity Provider is
+configured to generate a value for `NameID`, you can set <<saml-settings, `nameid_format`>>
+to `urn:oasis:names:tc:SAML:2.0:nameid-format:transient` explicitly.
+
 ====
 // end::notable-breaking-changes[]
 
@@ -320,7 +355,7 @@ Discontinue use of the `kibana_user` role.
 [%collapsible]
 ====
 *Details* +
-If `xpack.security.fips_mode.enabled` is true (see <<fips-140-compliance>>), 
+If `xpack.security.fips_mode.enabled` is true (see <<fips-140-compliance>>),
 the value of `xpack.security.authc.password_hashing.algorithm` now defaults to
 `pbkdf2_stretch`.
 

--- a/docs/reference/migration/migrate_8_0/security.asciidoc
+++ b/docs/reference/migration/migrate_8_0/security.asciidoc
@@ -136,12 +136,11 @@ IdP. If you want to retain the previous behavior, set `nameid_format` to
 
 *Impact* +
 If you currently don't configure `nameid_format` explicitly, it's possible
-that your IdP will reject authentication request from {es} because the requests 
+that your IdP will reject authentication requests from {es} because the requests 
 do not specify a `NameID` format (and your IdP is configured to expect one).
-This mismatch can result in a broken SAML configuration. If you're unsure which 
-name format your IdP uses to generate a value for `NameID`, try setting
-`nameid_format` to `urn:oasis:names:tc:SAML:2.0:nameid-format:transient` 
-explicitly.
+This mismatch can result in a broken SAML configuration. If you're unsure whether 
+your IdP is explicitly configured to use a certain `NameID` format and you want to retain current behavior
+, try setting `nameid_format` to `urn:oasis:names:tc:SAML:2.0:nameid-format:transient` explicitly.
 ====
 
 [discrete]


### PR DESCRIPTION
We changed the default for `nameid_format` in 8.0 in #44090 but
did not add anything to the breaking changes in the release notes.
This change amends that.

Preview link: https://elasticsearch_77785.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/migrating-8.0.html#breaking_80_security_changes