### PR TITLE
[DOCS] Add deprecation docs for cluster recovery defer settings

### DIFF
--- a/docs/reference/migration/migrate_7_7.asciidoc
+++ b/docs/reference/migration/migrate_7_7.asciidoc
@@ -9,12 +9,6 @@ your application to Elasticsearch 7.7.
 
 See also <<release-highlights>> and <<es-release-notes>>.
 
-* <<breaking_77_logging_changes>>
-* <<breaking_77_mapping_changes>>
-* <<breaking_77_settings_changes>>
-* <<breaking_77_search_changes>>
-* <<breaking_77_highlighters_changes>>
-
 //NOTE: The notable-breaking-changes tagged regions are re-used in the
 //Installation and Upgrade Guide
 

--- a/docs/reference/migration/migrate_7_7.asciidoc
+++ b/docs/reference/migration/migrate_7_7.asciidoc
@@ -9,6 +9,12 @@ your application to Elasticsearch 7.7.
 
 See also <<release-highlights>> and <<es-release-notes>>.
 
+* <<breaking_77_logging_changes>>
+* <<breaking_77_mapping_changes>>
+* <<breaking_77_settings_changes>>
+* <<breaking_77_search_changes>>
+* <<breaking_77_highlighters_changes>>
+
 //NOTE: The notable-breaking-changes tagged regions are re-used in the
 //Installation and Upgrade Guide
 
@@ -83,6 +89,25 @@ If you configure more than one realm of any type with the same order, the node w
 
 The `auth.password` setting for the monitoring HTTP exporter has been deprecated and will be
 removed in version 8.0.0. Please use the `auth.secure_password` setting instead.
+
+[discrete]
+[[deprecate-defer-cluster-recovery-settings]]
+==== Settings used to defer cluster recovery pending a certain number of master nodes are deprecated.
+
+The following cluster settings are now deprecated:
+
+* `gateway.expected_nodes`
+* `gateway.expected_master_nodes`
+* `gateway.recover_after_nodes`
+* `gateway.recover_after_master_nodes`
+
+It is safe to recover the cluster as soon as a majority of master-eligible nodes
+have joined. There is no benefit in waiting for any additional master-eligible
+nodes to start.
+
+To avoid deprecation warnings, discontinue use of the deprecated settings. If
+needed, use `gateway.expected_data_nodes` or `gateway.recover_after_data_nodes`
+to defer cluster recovery pending a certain number of data nodes.
 
 [discrete]
 [[breaking_77_search_changes]]


### PR DESCRIPTION
We deprecated the following settings in 7.7 with PR #53646:

* `gateway.expected_nodes`
* `gateway.expected_master_nodes`
* `gateway.recover_after_nodes`
* `gateway.recover_after_master_nodes`

However, we didn't add a related item to the 7.7 deprecation docs. This adds the
missing item.

Relates to #53845.

### Preview
https://elasticsearch_77786.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/7.x/breaking-changes-7.7.html#deprecate-defer-cluster-recovery-settings