### PR TITLE
[DOCS] Fix deprecation version for cluster recovery breaking change

### DIFF
--- a/docs/reference/migration/migrate_8_0/settings.asciidoc
+++ b/docs/reference/migration/migrate_8_0/settings.asciidoc
@@ -147,8 +147,7 @@ Discontinue use of the removed settings. Specifying these settings in
 [%collapsible]
 ====
 *Details* +
-The following settings were deprecated in {es} 7.8.0 and have been removed in
-{es} 8.0.0:
+The following cluster settings have been removed:
 
 * `gateway.expected_nodes`
 * `gateway.expected_master_nodes`


### PR DESCRIPTION
The related settings were deprecated in 7.7, not 7.8. This removes the unneeded reference.