### PR TITLE
Label thread names with tracing info

### DIFF
--- a/docs/changelog/77791.yaml
+++ b/docs/changelog/77791.yaml
@@ -1,0 +1,6 @@
+pr: 77791
+summary: Label thread names with tracing info
+area: Infra/Core
+type: enhancement
+issues:
+ - 74580

--- a/server/src/main/java/org/elasticsearch/monitor/jvm/HotThreads.java
+++ b/server/src/main/java/org/elasticsearch/monitor/jvm/HotThreads.java
@@ -12,6 +12,7 @@ import org.apache.lucene.util.CollectionUtil;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.common.time.DateFormatter;
 import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.tasks.Task;
 
 import java.lang.management.ManagementFactory;
 import java.lang.management.ThreadInfo;
@@ -278,6 +279,17 @@ public class HotThreads {
                 }
             }
         }
+
+        // Short-lived requests are in general not tracked accurately in HotThreads. The thread pools
+        // will reuse the thread-ids across multiple short requests, so the reported stacks and in this case
+        // tracing-ids are on best effort basis. For true performance bottlenecks the information will be accurate.
+        sb.append('\n')
+            .append("Note: Any reported tracing IDs (e.g. ")
+            .append(Task.X_OPAQUE_ID)
+            .append(',')
+            .append(Task.TRACE_ID)
+            .append(") may not be accurate for short-lived requests.");
+
         return sb.toString();
     }
 

--- a/server/src/test/java/org/elasticsearch/common/util/concurrent/ThreadContextTests.java
+++ b/server/src/test/java/org/elasticsearch/common/util/concurrent/ThreadContextTests.java
@@ -10,6 +10,7 @@ package org.elasticsearch.common.util.concurrent;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.logging.HeaderWarning;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.tasks.Task;
 import org.elasticsearch.test.ESTestCase;
 
 import java.io.IOException;
@@ -694,5 +695,173 @@ public class ThreadContextTests extends ESTestCase {
                 r.run();
             }
         };
+    }
+
+    public void testThreadNamingWithTracingIds() {
+        ThreadContext threadContext = new ThreadContext(Settings.EMPTY);
+        Runnable withContext;
+
+        // an abstract runnable that has X-Opaque-Id in its header.
+        try (ThreadContext.StoredContext ignored = threadContext.stashContext()) {
+            threadContext.putHeader(Task.X_OPAQUE_ID, "some_id");
+            withContext = threadContext.preserveContext(new AbstractRunnable() {
+
+                @Override
+                public void onAfter() {
+                    assertFalse(Thread.currentThread().getName().contains("some_id"));
+                    assertFalse(Thread.currentThread().getName().contains(Task.X_OPAQUE_ID));
+                    assertFalse(Thread.currentThread().getName().contains(ThreadContext.WithTracingIdsInThreadName.ID_LABEL));
+                }
+
+                @Override
+                public void onFailure(Exception e) {
+                    throw new RuntimeException("from onFailure", e);
+                }
+
+                @Override
+                protected void doRun() {
+                    // Assertions are errors, turn this into exception to make sure we get the error on failure
+                    try {
+                        assertTrue(Thread.currentThread().getName().contains("some_id"));
+                        assertTrue(Thread.currentThread().getName().contains(Task.X_OPAQUE_ID));
+                        assertTrue(Thread.currentThread().getName().contains(ThreadContext.WithTracingIdsInThreadName.ID_LABEL));
+                    } catch (Throwable t) {
+                        throw new RuntimeException("Assertion failed " + t.getMessage());
+                    }
+                }
+            });
+        }
+
+        withContext.run();
+
+        // an abstract runnable that has trace.id in its header
+        try (ThreadContext.StoredContext ignored = threadContext.stashContext()) {
+            threadContext.putHeader(Task.TRACE_ID, "some_trace_id");
+            withContext = threadContext.preserveContext(new AbstractRunnable() {
+
+                @Override
+                public void onAfter() {
+                    assertFalse(Thread.currentThread().getName().contains("some_trace_id"));
+                    assertFalse(Thread.currentThread().getName().contains(Task.TRACE_ID));
+                    assertFalse(Thread.currentThread().getName().contains(ThreadContext.WithTracingIdsInThreadName.ID_LABEL));
+                }
+
+                @Override
+                public void onFailure(Exception e) {
+                    throw new RuntimeException("from onFailure", e);
+                }
+
+                @Override
+                protected void doRun() {
+                    try {
+                        assertTrue(Thread.currentThread().getName().contains("some_trace_id"));
+                        assertTrue(Thread.currentThread().getName().contains(Task.TRACE_ID));
+                        assertTrue(Thread.currentThread().getName().contains(ThreadContext.WithTracingIdsInThreadName.ID_LABEL));
+                    } catch (Throwable t) {
+                        throw new RuntimeException("Assertion failed " + t.getMessage());
+                    }
+                }
+            });
+        }
+
+        withContext.run();
+
+        // an abstract runnable that has both X-Opaque-Id and trace.id in its headers,
+        // but this time they are in the parent caller context
+        ThreadContext outsideContext = new ThreadContext(Settings.EMPTY);
+        outsideContext.putHeader(Task.TRACE_ID, "some_trace_id");
+        outsideContext.putHeader(Task.X_OPAQUE_ID, "some_opaque_id");
+
+        try (ThreadContext.StoredContext ignored = outsideContext.stashContext()) {
+            withContext = outsideContext.preserveContext(new AbstractRunnable() {
+
+                @Override
+                public void onAfter() {
+                    assertFalse(Thread.currentThread().getName().contains("some_trace_id"));
+                    assertFalse(Thread.currentThread().getName().contains("some_opaque_id"));
+                    assertFalse(Thread.currentThread().getName().contains(Task.TRACE_ID));
+                    assertFalse(Thread.currentThread().getName().contains(Task.X_OPAQUE_ID));
+                    assertFalse(Thread.currentThread().getName().contains(ThreadContext.WithTracingIdsInThreadName.ID_LABEL));
+                }
+
+                @Override
+                public void onFailure(Exception e) {
+                    throw new RuntimeException("from onFailure", e);
+                }
+
+                @Override
+                protected void doRun() {
+                    try {
+                        assertTrue(Thread.currentThread().getName().contains("some_trace_id"));
+                        assertTrue(Thread.currentThread().getName().contains("some_opaque_id"));
+                        assertTrue(Thread.currentThread().getName().contains(Task.TRACE_ID));
+                        assertTrue(Thread.currentThread().getName().contains(Task.X_OPAQUE_ID));
+                        assertTrue(Thread.currentThread().getName().contains(ThreadContext.WithTracingIdsInThreadName.ID_LABEL));
+                    } catch (Throwable t) {
+                        throw new RuntimeException("Assertion failed " + t.getMessage());
+                    }
+                }
+            });
+        }
+
+        withContext.run();
+
+        // Make sure naming works with Runnable that's not wrapped in AbstractRunnable
+        try (ThreadContext.StoredContext ignored = threadContext.stashContext()) {
+            threadContext.putHeader(Task.X_OPAQUE_ID, "foo-bar-id");
+            withContext = threadContext.preserveContext(() -> {
+                assertTrue(Thread.currentThread().getName().contains("foo-bar-id"));
+                assertTrue(Thread.currentThread().getName().contains(Task.X_OPAQUE_ID));
+                assertTrue(Thread.currentThread().getName().contains(ThreadContext.WithTracingIdsInThreadName.ID_LABEL));
+            });
+        }
+
+        withContext.run();
+
+        // Ensure we cleaned up the thread name in case of an exception in the runnable
+        try (ThreadContext.StoredContext ignored = threadContext.stashContext()) {
+            threadContext.putHeader(Task.X_OPAQUE_ID, "some_id");
+            withContext = threadContext.preserveContext(new AbstractRunnable() {
+
+                @Override
+                public void onAfter() {
+                    assertFalse(Thread.currentThread().getName().contains("some_id"));
+                    assertFalse(Thread.currentThread().getName().contains(Task.X_OPAQUE_ID));
+                    assertFalse(Thread.currentThread().getName().contains(ThreadContext.WithTracingIdsInThreadName.ID_LABEL));
+                }
+
+                @Override
+                public void onFailure(Exception e) {
+                    assertFalse(Thread.currentThread().getName().contains("some_id"));
+                    assertFalse(Thread.currentThread().getName().contains(Task.X_OPAQUE_ID));
+                    assertFalse(Thread.currentThread().getName().contains(ThreadContext.WithTracingIdsInThreadName.ID_LABEL));
+                    throw new RuntimeException("from onFailure", e);
+                }
+
+                @Override
+                protected void doRun() throws Exception {
+                    assertTrue(Thread.currentThread().getName().contains("some_id"));
+                    assertTrue(Thread.currentThread().getName().contains(Task.X_OPAQUE_ID));
+                    assertTrue(Thread.currentThread().getName().contains(ThreadContext.WithTracingIdsInThreadName.ID_LABEL));
+                    throw new Exception("from doRun");
+                }
+            });
+        }
+
+        RuntimeException e = expectThrows(RuntimeException.class, withContext::run);
+        assertEquals("from onFailure", e.getMessage());
+        assertEquals("from doRun", e.getCause().getMessage());
+
+        // Make sure there's no thread label if no tracing ids were present in the headers
+        try (ThreadContext.StoredContext ignored = threadContext.stashContext()) {
+            threadContext.putHeader("foo", "bar");
+            withContext = threadContext.preserveContext(() -> {
+                assertFalse(Thread.currentThread().getName().contains("bar"));
+                assertFalse(Thread.currentThread().getName().contains(ThreadContext.WithTracingIdsInThreadName.ID_LABEL));
+            });
+        }
+
+        withContext.run();
+
     }
 }

--- a/server/src/test/java/org/elasticsearch/monitor/jvm/HotThreadsTests.java
+++ b/server/src/test/java/org/elasticsearch/monitor/jvm/HotThreadsTests.java
@@ -314,7 +314,7 @@ public class HotThreadsTests extends ESTestCase {
 
         String innerResult = hotThreads.innerDetect(mockedMXBean, mockCurrentThreadId);
 
-        assertEquals(1, innerResult.lines().count());
+        assertEquals(3, innerResult.lines().count());
     }
 
     public void testReportTypeValueGetter() {


### PR DESCRIPTION
This PR is a proposal to solve #74580 by adding the X-Opaque-Id and trace.id header values in the Thread name field while the wrapped Runnable is running.

The mentioned issue above has some discussion on the possible alternatives and their pros/cons.

The change is localized to the private wrapped runnable implementations inside ThreadContext. Looking at usages I think this should be good for all client use cases, but I'm not 100% sure, I might've missed a class of threads or thread pools that can hold the tracing headers and not be handled by the two wrapped runnable implementations.

I also added a disclaimer in HotThreads that the tracing ids reported may not be accurate for short-lived request executions.

Closes #74580