### PR TITLE
Enable the `get_user_privileges` REST API test

### DIFF
--- a/x-pack/plugin/build.gradle
+++ b/x-pack/plugin/build.gradle
@@ -202,8 +202,7 @@ tasks.named("yamlRestTestV7CompatTest").configure {
 
       // a type field was added to cat.ml_trained_models #73660, this is a backwards compatible change.
       // still this is a cat api, and we don't support them with rest api compatibility. (the test would be very hard to transform too)
-      'ml/trained_model_cat_apis/Test cat trained models',
-      'privileges/40_get_user_privs/Test get_user_privileges for merged roles' // https://github.com/elastic/elasticsearch/pull/77553
+      'ml/trained_model_cat_apis/Test cat trained models'
   ].join(',')
   dependsOn "copyExtraResources"
 }


### PR DESCRIPTION
It was muted in #77553, but can be enabled again after #77777 was merged to 7.x

#77797 will make sure that this test will pass regardless of the internal details of `HashSet` in the JDK