### PR TITLE
HotThreads refactor idle threads code 

### DIFF
--- a/server/src/main/java/org/elasticsearch/monitor/jvm/HotThreads.java
+++ b/server/src/main/java/org/elasticsearch/monitor/jvm/HotThreads.java
@@ -42,17 +42,18 @@ public class HotThreads {
     private ReportType type = ReportType.CPU;
     private boolean ignoreIdleThreads = true;
 
-    private static final List<String[]> knownElasticIdleFrames = Arrays.asList(
+    private static final List<String[]> knownIdleStackFrames = Arrays.asList(
         new String[] {"java.util.concurrent.ThreadPoolExecutor", "getTask"},
         new String[] {"sun.nio.ch.SelectorImpl", "select"},
         new String[] {"org.elasticsearch.threadpool.ThreadPool$CachedTimeThread", "run"},
         new String[] {"org.elasticsearch.indices.ttl.IndicesTTLService$Notifier", "await"},
-        new String[] {"java.util.concurrent.LinkedTransferQueue", "poll"}
+        new String[] {"java.util.concurrent.LinkedTransferQueue", "poll"},
+        new String[] {"com.sun.jmx.remote.internal.ServerCommunicatorAdmin$Timeout", "run"}
     );
 
     // NOTE: these are JVM dependent and JVM version dependent
-    private static final List<String> knownJvmInternalThreads = Arrays.asList(
-        "Signal Dispatcher", "Finalizer", "Reference Handler", "Notification Thread", "Common-Cleaner"
+    private static final List<String> knownJDKInternalThreads = Arrays.asList(
+        "Signal Dispatcher", "Finalizer", "Reference Handler", "Notification Thread", "Common-Cleaner", "process reaper"
     );
 
     public enum ReportType {
@@ -118,12 +119,12 @@ public class HotThreads {
     }
 
     static boolean isKnownJvmThread(ThreadInfo threadInfo) {
-        return (knownJvmInternalThreads.stream().anyMatch(jvmThread ->
+        return (knownJDKInternalThreads.stream().anyMatch(jvmThread ->
             threadInfo.getThreadName() != null && threadInfo.getThreadName().equals(jvmThread)));
     }
 
     static boolean isKnownElasticStackFrame(String className, String methodName) {
-        return (knownElasticIdleFrames.stream().anyMatch(pair ->
+        return (knownIdleStackFrames.stream().anyMatch(pair ->
             pair[0].equals(className) && pair[1].equals(methodName)));
     }
 

--- a/server/src/main/java/org/elasticsearch/monitor/jvm/HotThreads.java
+++ b/server/src/main/java/org/elasticsearch/monitor/jvm/HotThreads.java
@@ -118,23 +118,23 @@ public class HotThreads {
         }
     }
 
-    static boolean isKnownJvmThread(ThreadInfo threadInfo) {
+    static boolean isKnownJDKThread(ThreadInfo threadInfo) {
         return (knownJDKInternalThreads.stream().anyMatch(jvmThread ->
             threadInfo.getThreadName() != null && threadInfo.getThreadName().equals(jvmThread)));
     }
 
-    static boolean isKnownElasticStackFrame(String className, String methodName) {
+    static boolean isKnownIdleStackFrame(String className, String methodName) {
         return (knownIdleStackFrames.stream().anyMatch(pair ->
             pair[0].equals(className) && pair[1].equals(methodName)));
     }
 
     static boolean isIdleThread(ThreadInfo threadInfo) {
-        if (isKnownJvmThread(threadInfo)) {
+        if (isKnownJDKThread(threadInfo)) {
             return true;
         }
 
         for (StackTraceElement frame : threadInfo.getStackTrace()) {
-            if (isKnownElasticStackFrame(frame.getClassName(), frame.getMethodName())) {
+            if (isKnownIdleStackFrame(frame.getClassName(), frame.getMethodName())) {
                 return true;
             }
         }

--- a/server/src/main/java/org/elasticsearch/monitor/jvm/HotThreads.java
+++ b/server/src/main/java/org/elasticsearch/monitor/jvm/HotThreads.java
@@ -19,6 +19,7 @@ import java.lang.management.ThreadMXBean;
 import java.time.Clock;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
@@ -40,6 +41,19 @@ public class HotThreads {
     private int threadElementsSnapshotCount = 10;
     private ReportType type = ReportType.CPU;
     private boolean ignoreIdleThreads = true;
+
+    private static final List<String[]> knownElasticIdleFrames = Arrays.asList(
+        new String[] {"java.util.concurrent.ThreadPoolExecutor", "getTask"},
+        new String[] {"sun.nio.ch.SelectorImpl", "select"},
+        new String[] {"org.elasticsearch.threadpool.ThreadPool$CachedTimeThread", "run"},
+        new String[] {"org.elasticsearch.indices.ttl.IndicesTTLService$Notifier", "await"},
+        new String[] {"java.util.concurrent.LinkedTransferQueue", "poll"}
+    );
+
+    // NOTE: these are JVM dependent and JVM version dependent
+    private static final List<String> knownJvmInternalThreads = Arrays.asList(
+        "Signal Dispatcher", "Finalizer", "Reference Handler", "Notification Thread", "Common-Cleaner"
+    );
 
     public enum ReportType {
 
@@ -103,37 +117,23 @@ public class HotThreads {
         }
     }
 
-    static boolean isIdleThread(ThreadInfo threadInfo) {
-        String threadName = threadInfo.getThreadName();
+    static boolean isKnownJvmThread(ThreadInfo threadInfo) {
+        return (knownJvmInternalThreads.stream().anyMatch(jvmThread ->
+            threadInfo.getThreadName() != null && threadInfo.getThreadName().equals(jvmThread)));
+    }
 
-        // NOTE: these are likely JVM dependent
-        if (threadName.equals("Signal Dispatcher") ||
-            threadName.equals("Finalizer") ||
-            threadName.equals("Reference Handler")) {
+    static boolean isKnownElasticStackFrame(String className, String methodName) {
+        return (knownElasticIdleFrames.stream().anyMatch(pair ->
+            pair[0].equals(className) && pair[1].equals(methodName)));
+    }
+
+    static boolean isIdleThread(ThreadInfo threadInfo) {
+        if (isKnownJvmThread(threadInfo)) {
             return true;
         }
 
         for (StackTraceElement frame : threadInfo.getStackTrace()) {
-            String className = frame.getClassName();
-            String methodName = frame.getMethodName();
-            if (className.equals("java.util.concurrent.ThreadPoolExecutor") &&
-                methodName.equals("getTask")) {
-                return true;
-            }
-            if (className.equals("sun.nio.ch.SelectorImpl") &&
-                methodName.equals("select")) {
-                return true;
-            }
-            if (className.equals("org.elasticsearch.threadpool.ThreadPool$CachedTimeThread") &&
-                methodName.equals("run")) {
-                return true;
-            }
-            if (className.equals("org.elasticsearch.indices.ttl.IndicesTTLService$Notifier") &&
-                methodName.equals("await")) {
-                return true;
-            }
-            if (className.equals("java.util.concurrent.LinkedTransferQueue") &&
-                methodName.equals("poll")) {
+            if (isKnownElasticStackFrame(frame.getClassName(), frame.getMethodName())) {
                 return true;
             }
         }

--- a/server/src/test/java/org/elasticsearch/monitor/jvm/HotThreadsTests.java
+++ b/server/src/test/java/org/elasticsearch/monitor/jvm/HotThreadsTests.java
@@ -55,7 +55,7 @@ public class HotThreadsTests extends ESTestCase {
 
     public void testIdleThreadsDetection() {
         for (String threadName : new String[] {
-            "Signal Dispatcher", "Finalizer", "Reference Handler", "Notification Thread", "Common-Cleaner" }) {
+            "Signal Dispatcher", "Finalizer", "Reference Handler", "Notification Thread", "Common-Cleaner", "process reaper" }) {
             ThreadInfo mockedThreadInfo = mock(ThreadInfo.class);
             when(mockedThreadInfo.getThreadName()).thenReturn(threadName);
             assertTrue(HotThreads.isKnownJvmThread(mockedThreadInfo));
@@ -94,7 +94,8 @@ public class HotThreadsTests extends ESTestCase {
                 new String[]{"sun.nio.ch.SelectorImpl", "select"},
                 new String[]{"org.elasticsearch.threadpool.ThreadPool$CachedTimeThread", "run"},
                 new String[]{"org.elasticsearch.indices.ttl.IndicesTTLService$Notifier", "await"},
-                new String[]{"java.util.concurrent.LinkedTransferQueue", "poll"}
+                new String[]{"java.util.concurrent.LinkedTransferQueue", "poll"},
+                new String[]{"com.sun.jmx.remote.internal.ServerCommunicatorAdmin$Timeout", "run"}
             ));
 
         for (StackTraceElement extraFrame : idleThreadStackElements) {

--- a/server/src/test/java/org/elasticsearch/monitor/jvm/HotThreadsTests.java
+++ b/server/src/test/java/org/elasticsearch/monitor/jvm/HotThreadsTests.java
@@ -58,7 +58,7 @@ public class HotThreadsTests extends ESTestCase {
             "Signal Dispatcher", "Finalizer", "Reference Handler", "Notification Thread", "Common-Cleaner", "process reaper" }) {
             ThreadInfo mockedThreadInfo = mock(ThreadInfo.class);
             when(mockedThreadInfo.getThreadName()).thenReturn(threadName);
-            assertTrue(HotThreads.isKnownJvmThread(mockedThreadInfo));
+            assertTrue(HotThreads.isKnownJDKThread(mockedThreadInfo));
             assertTrue(HotThreads.isIdleThread(mockedThreadInfo));
         }
 
@@ -66,7 +66,7 @@ public class HotThreadsTests extends ESTestCase {
             ThreadInfo mockedThreadInfo = mock(ThreadInfo.class);
             when(mockedThreadInfo.getThreadName()).thenReturn(threadName);
             when(mockedThreadInfo.getStackTrace()).thenReturn(new StackTraceElement[0]);
-            assertFalse(HotThreads.isKnownJvmThread(mockedThreadInfo));
+            assertFalse(HotThreads.isKnownJDKThread(mockedThreadInfo));
             assertFalse(HotThreads.isIdleThread(mockedThreadInfo));
         }
 
@@ -79,7 +79,7 @@ public class HotThreadsTests extends ESTestCase {
             ));
 
         for (StackTraceElement stackFrame : testJvmStack) {
-            assertFalse(HotThreads.isKnownElasticStackFrame(stackFrame.getClassName(), stackFrame.getMethodName()));
+            assertFalse(HotThreads.isKnownIdleStackFrame(stackFrame.getClassName(), stackFrame.getMethodName()));
         }
 
         ThreadInfo notIdleThread = mock(ThreadInfo.class);
@@ -102,7 +102,7 @@ public class HotThreadsTests extends ESTestCase {
             ThreadInfo idleThread = mock(ThreadInfo.class);
             when(idleThread.getThreadName()).thenReturn("Idle Thread");
             when(idleThread.getStackTrace()).thenReturn(new StackTraceElement[] {extraFrame});
-            assertTrue(HotThreads.isKnownElasticStackFrame(extraFrame.getClassName(), extraFrame.getMethodName()));
+            assertTrue(HotThreads.isKnownIdleStackFrame(extraFrame.getClassName(), extraFrame.getMethodName()));
             assertTrue(HotThreads.isIdleThread(idleThread));
 
             List<StackTraceElement> topOfStack = new ArrayList<>(testJvmStack);


### PR DESCRIPTION
This is a small non-issue PR to remove some code duplication from the existing HotThreads code regarding detecting idle threads. It also contains one small addition to include the two new JVM threads 'Notification Thread' and 'Common-Cleaner' into the list of known JVM threads.