### PR TITLE
[7.x] Eschew leniency when parsing time zones (#77267)

### DIFF
--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.aggregation/49_range_timezone_bug.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.aggregation/49_range_timezone_bug.yml
@@ -1,0 +1,95 @@
+setup:
+    - do:
+        indices.create:
+            index: test
+            body:
+                settings:
+                    number_of_replicas: 0
+                mappings:
+                    properties:
+                        mydate:
+                            type: date
+                            format: "uuuu-MM-dd'T'HH:mm:ss.SSSSSSSSSZZZZZ"
+
+    - do:
+        cluster.health:
+            wait_for_status: green
+
+    - do:
+        index:
+            index: test
+            id: 1
+            body: { "mydate": "2021-08-12T01:00:00.000000000+02:00" }
+
+    - do:
+        indices.refresh: {}
+
+---
+"respect offsets in range bounds":
+    - skip:
+        version: " - 7.99.99"
+        reason: "Fixed in 7.16 (backport pending)"
+    - do:
+        search:
+            rest_total_hits_as_int: true
+            body: {
+                      "query": {
+                        "match_all": {}
+                      },
+                      "aggregations": {
+                        "myagg": {
+                          "date_range": {
+                            "field": "mydate",
+                            "ranges": [
+                              {
+                                "from": "2021-08-12T00:00:00.000000000+02:00",
+                                "to": "2021-08-12T02:00:00.000000000+02:00"
+                              }
+                            ]
+                          }
+                        }
+                      }
+                    }
+    - match: { hits.total: 1 }
+    - length: { aggregations.myagg.buckets: 1 }
+    - match: { aggregations.myagg.buckets.0.from_as_string: "2021-08-11T22:00:00.000000000Z" }
+    - match: { aggregations.myagg.buckets.0.from: 1628719200000 }
+    - match: { aggregations.myagg.buckets.0.to_as_string: "2021-08-12T00:00:00.000000000Z" }
+    - match: { aggregations.myagg.buckets.0.to: 1628726400000 }
+    - match: { aggregations.myagg.buckets.0.doc_count: 1 }
+
+---
+"offsets and timezones play nicely together":
+    - skip:
+        version: " - 7.99.99"
+        reason: "Fixed in 7.16 (backport pending)"
+    - do:
+        search:
+            rest_total_hits_as_int: true
+            body: {
+                      "query": {
+                        "match_all": {}
+                      },
+                      "aggregations": {
+                        "myagg": {
+                          "date_range": {
+                            "time_zone": "America/New_York",
+                            "field": "mydate",
+                            "ranges": [
+                              {
+                                "from": "2021-08-12T00:00:00.000000000+02:00",
+                                "to": "2021-08-12T02:00:00.000000000+02:00"
+                              }
+                            ]
+                          }
+                        }
+                      }
+                    }
+    - match: { hits.total: 1 }
+    - length: { aggregations.myagg.buckets: 1 }
+    - match: { aggregations.myagg.buckets.0.from_as_string: "2021-08-11T18:00:00.000000000-04:00" }
+    - match: { aggregations.myagg.buckets.0.from: 1628719200000 }
+    - match: { aggregations.myagg.buckets.0.to_as_string: "2021-08-11T20:00:00.000000000-04:00" }
+    - match: { aggregations.myagg.buckets.0.to: 1628726400000 }
+    - match: { aggregations.myagg.buckets.0.doc_count: 1 }
+

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.aggregation/49_range_timezone_bug.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.aggregation/49_range_timezone_bug.yml
@@ -27,7 +27,7 @@ setup:
 ---
 "respect offsets in range bounds":
     - skip:
-        version: " - 7.99.99"
+        version: " - 7.15.99"
         reason: "Fixed in 7.16 (backport pending)"
     - do:
         search:
@@ -61,7 +61,7 @@ setup:
 ---
 "offsets and timezones play nicely together":
     - skip:
-        version: " - 7.99.99"
+        version: " - 7.15.99"
         reason: "Fixed in 7.16 (backport pending)"
     - do:
         search:

--- a/server/src/main/java/org/elasticsearch/common/time/JavaDateMathParser.java
+++ b/server/src/main/java/org/elasticsearch/common/time/JavaDateMathParser.java
@@ -210,7 +210,9 @@ public class JavaDateMathParser implements DateMathParser {
                 return DateFormatters.from(formatter.parse(value)).toInstant();
             } else {
                 TemporalAccessor accessor = formatter.parse(value);
-                ZoneId zoneId = TemporalQueries.zone().queryFrom(accessor);
+                // Use the offset if provided, otherwise fall back to the zone, or null.
+                ZoneOffset offset = TemporalQueries.offset().queryFrom(accessor);
+                ZoneId zoneId = offset == null ? TemporalQueries.zoneId().queryFrom(accessor) : ZoneId.ofOffset("", offset);
                 if (zoneId != null) {
                     timeZone = zoneId;
                 }


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Eschew leniency when parsing time zones (#77267)