### PR TITLE
[DOCS] Add deprecation docs for translog retention settings

### DIFF
--- a/docs/reference/migration/migrate_7_7.asciidoc
+++ b/docs/reference/migration/migrate_7_7.asciidoc
@@ -14,6 +14,19 @@ See also <<release-highlights>> and <<es-release-notes>>.
 
 //tag::notable-breaking-changes[]
 [discrete]
+[[breaking_77_indices_deprecations]]
+=== Indices deprecations
+
+[discrete]
+==== Translog retention settings are deprecated.
+
+The `index.translog.retention.age` and `index.translog.retention.size` index
+settings are now deprecated. These settings have been ignored since 7.4 in favor
+of {ref}/index-modules-history-retention.html[soft deletes].
+
+To avoid deprecation warnings, discontinue use of the settings.
+
+[discrete]
 [[breaking_77_logging_changes]]
 === Logging changes
 


### PR DESCRIPTION
We deprecated the translog retention settings in 7.7 with PR #45473.
However, we didn't add a related item to the 7.7 breaking changes docs. This adds
the missing item.

Relates to #51697.

### Preview
https://elasticsearch_77814.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/7.x/breaking-changes-7.7.html#_translog_retention_settings_are_deprecated