### PR TITLE
Integration test for sample aggragator (backport of #77807)

### DIFF
--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.aggregation/400_sampler.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.aggregation/400_sampler.yml
@@ -1,0 +1,80 @@
+setup:
+  - do:
+      indices.create:
+          index: test
+          body:
+            settings:
+              number_of_shards: 1
+            mappings:
+              properties:
+                tags:
+                  type: text
+                number:
+                  type: integer
+
+  - do:
+      bulk:
+        index: test
+        refresh: true
+        body:
+          - '{"index": {}}'
+          - '{"tags": "kibana", "number": 1}'
+          - '{"index": {}}'
+          - '{"tags": "kibana", "number": 2}'
+          - '{"index": {}}'
+          - '{"tags": "kibana", "number": 3}'
+          - '{"index": {}}'
+          - '{"tags": "javascript", "number": 4}'
+
+---
+small shard_size:
+  - do:
+      search:
+        rest_total_hits_as_int: true
+        body:
+          query:
+            query_string:
+              query: 'tags:kibana OR tags:javascript'
+          aggs:
+            sample:
+              sampler:
+                shard_size: 1
+              aggs:
+                min_number:
+                  min:
+                    field: number
+                max_number:
+                  max:
+                    field: number
+
+  - match: { hits.total: 4 }
+  - match: { aggregations.sample.doc_count: 1 }
+  # The document with 4 has the highest score so we pick that one.
+  - match: { aggregations.sample.min_number.value: 4.0 }
+  - match: { aggregations.sample.max_number.value: 4.0 }
+
+---
+default shard size:
+  - do:
+      search:
+        rest_total_hits_as_int: true
+        body:
+          query:
+            query_string:
+              query: 'tags:kibana OR tags:javascript'
+          aggs:
+            sample:
+              sampler: {}
+              aggs:
+                min_number:
+                  min:
+                    field: number
+                max_number:
+                  max:
+                    field: number
+
+  - match: { hits.total: 4 }
+  # The default shard size is much larger than the four test documents we are working with
+  - match: { aggregations.sample.doc_count: 4 }
+  - match: { aggregations.sample.min_number.value: 1.0 }
+  - match: { aggregations.sample.max_number.value: 4.0 }


### PR DESCRIPTION
Adds and integration test for the sample aggregator. It's a fairly
simple aggregator - you can only chose how many documents it samples.
