### PR TITLE
[DOCS] Add deprecation docs for `simpleifs` store type

### DIFF
--- a/docs/reference/index-modules/store.asciidoc
+++ b/docs/reference/index-modules/store.asciidoc
@@ -47,13 +47,16 @@ depending on the operating environment, which is currently `hybridfs` on all
 supported systems but is subject to change.
 
 [[simplefs]]`simplefs`::
-
+{blank}
++
+--
 deprecated::[7.15,"simplefs is deprecated and will be removed in 8.0. Use niofs or other file systems instead. Elasticsearch 7.15 or later uses niofs for the simplefs store type as it offers superior or equivalent performance to simplefs."]
 
 The Simple FS type is a straightforward implementation of file system
 storage (maps to Lucene `SimpleFsDirectory`) using a random access file.
 This implementation has poor concurrent performance (multiple threads
 will bottleneck) and disables some optimizations for heap memory usage.
+--
 
 [[niofs]]`niofs`::
 

--- a/docs/reference/migration/index.asciidoc
+++ b/docs/reference/migration/index.asciidoc
@@ -28,7 +28,7 @@ For more information about {minor-version},
 see the <<release-highlights>> and <<es-release-notes>>.
 For information about how to upgrade your cluster, see <<setup-upgrade>>.
 
-* <<breaking-changes-7.15,Migrating to 7.15>>
+* <<migrating-7.14,Migrating to 7.15>>
 * <<breaking-changes-7.14,Migrating to 7.14>>
 * <<breaking-changes-7.13,Migrating to 7.13>>
 * <<breaking-changes-7.12,Migrating to 7.12>>

--- a/docs/reference/migration/index.asciidoc
+++ b/docs/reference/migration/index.asciidoc
@@ -28,6 +28,7 @@ For more information about {minor-version},
 see the <<release-highlights>> and <<es-release-notes>>.
 For information about how to upgrade your cluster, see <<setup-upgrade>>.
 
+* <<breaking-changes-7.15,Migrating to 7.15>>
 * <<breaking-changes-7.14,Migrating to 7.14>>
 * <<breaking-changes-7.13,Migrating to 7.13>>
 * <<breaking-changes-7.12,Migrating to 7.12>>
@@ -46,6 +47,7 @@ For information about how to upgrade your cluster, see <<setup-upgrade>>.
 
 --
 
+include::migrate_7_15.asciidoc[]
 include::migrate_7_14.asciidoc[]
 include::migrate_7_13.asciidoc[]
 include::migrate_7_12.asciidoc[]

--- a/docs/reference/migration/index.asciidoc
+++ b/docs/reference/migration/index.asciidoc
@@ -28,7 +28,7 @@ For more information about {minor-version},
 see the <<release-highlights>> and <<es-release-notes>>.
 For information about how to upgrade your cluster, see <<setup-upgrade>>.
 
-* <<migrating-7.14,Migrating to 7.15>>
+* <<migrating-7.15,Migrating to 7.15>>
 * <<breaking-changes-7.14,Migrating to 7.14>>
 * <<breaking-changes-7.13,Migrating to 7.13>>
 * <<breaking-changes-7.12,Migrating to 7.12>>

--- a/docs/reference/migration/migrate_7_15.asciidoc
+++ b/docs/reference/migration/migrate_7_15.asciidoc
@@ -48,7 +48,7 @@ using any deprecated functionality, enable <<deprecation-logging, deprecation
 logging>>.
 
 // tag::notable-breaking-changes[]
-[[deprecate-6x-indices]]
+[[deprecate-simpleifs]]
 .The `simpleifs` index store type is deprecated.
 [%collapsible]
 ====

--- a/docs/reference/migration/migrate_7_15.asciidoc
+++ b/docs/reference/migration/migrate_7_15.asciidoc
@@ -1,0 +1,65 @@
+[[breaking-changes-7.15]]
+== Migrating to 7.15
+++++
+<titleabbrev>7.15</titleabbrev>
+++++
+
+This section discusses the changes that you need to be aware of when migrating
+your application to {es} 7.15.
+
+See also <<release-highlights>> and <<es-release-notes>>.
+
+////
+//NOTE: The notable-breaking-changes tagged regions are re-used in the
+//Installation and Upgrade Guide
+
+[discrete]
+[[breaking-changes-7.15]]
+=== Breaking changes
+
+The following changes in {es} 7.15 might affect your applications
+and prevent them from operating normally.
+Before upgrading to 7.15, review these changes and take the described steps
+to mitigate the impact.
+
+NOTE: Breaking changes introduced in minor versions are
+normally limited to security and bug fixes.
+Significant changes in behavior are deprecated in a minor release and
+the old behavior is supported until the next major release.
+To find out if you are using any deprecated functionality,
+enable <<deprecation-logging, deprecation logging>>.
+
+// tag::notable-breaking-changes[]
+// end::notable-breaking-changes[]
+////
+
+[discrete]
+[[deprecated-7.15]]
+=== Deprecations
+
+The following functionality has been deprecated in {es} 7.15 and will be removed
+in 8.0. While this won't have an immediate impact on your applications, we
+strongly encourage you take the described steps to update your code after
+upgrading to 7.15.
+
+NOTE: Significant changes in behavior are deprecated in a minor release and the
+old behavior is supported until the next major release. To find out if you are
+using any deprecated functionality, enable <<deprecation-logging, deprecation
+logging>>.
+
+// tag::notable-breaking-changes[]
+[[deprecate-6x-indices]]
+.The `simpleifs` index store type is deprecated.
+[%collapsible]
+====
+*Details* +
+The `simplefs` value for the {ref}/index-modules-store.html[`index.store.type`]
+index setting is now deprecated. Use the `niofs` value for superior or
+equivalent performance instead.
+
+*Impact* +
+To avoid deprecation warnings, discontinue use of the `simpleifs` store type in
+new indices or index templates. Reindex any index using `simplefs` into one with
+another store type.
+====
+// end::notable-breaking-changes[]

--- a/docs/reference/migration/migrate_7_15.asciidoc
+++ b/docs/reference/migration/migrate_7_15.asciidoc
@@ -1,4 +1,4 @@
-[[breaking-changes-7.15]]
+[[migrating-7.15]]
 == Migrating to 7.15
 ++++
 <titleabbrev>7.15</titleabbrev>


### PR DESCRIPTION
Adds a deprecation notice to the breaking changes docs for #75156.

Also fixes a related deprecation admon.

### Previews
https://elasticsearch_77817.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/7.x/migrating-7.15.html#deprecated-7.15
https://elasticsearch_77817.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/7.x/index-modules-store.html#file-system