### PR TITLE
Add integration test for percentile_ranks (backport of #77815)

### DIFF
--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.aggregation/420_percentile_ranks_tdigest_metric.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.aggregation/420_percentile_ranks_tdigest_metric.yml
@@ -1,0 +1,180 @@
+setup:
+  - do:
+      indices.create:
+        index: test
+        body:
+          settings:
+            number_of_replicas: 0
+          mappings:
+            properties:
+              int:
+                type : integer
+              double:
+                type : double
+              keyword:
+                type: keyword
+
+  - do:
+      bulk:
+        refresh: true
+        index: test
+        body:
+          - '{"index": {}}'
+          - '{"int":   1, "double":   1.0, "keyword": "foo"}'
+          - '{"index": {}}'
+          - '{"int":  51, "double":  51.0, "keyword": "foo"}'
+          - '{"index": {}}'
+          - '{"int": 101, "double": 101.0, "keyword": "foo"}'
+          - '{"index": {}}'
+          - '{"int": 151, "double": 151.0, "keyword": "foo"}'
+
+---
+basic:
+  - skip:
+      features: close_to
+
+  - do:
+      search:
+        body:
+          size: 0
+          aggs:
+            percentile_ranks_int:
+              percentile_ranks:
+                field: int
+                values: [50, 99]
+            percentile_ranks_double:
+              percentile_ranks:
+                field: double
+                values: [50, 99]
+
+  - match: { hits.total.value: 4 }
+  - close_to: { aggregations.percentile_ranks_int.values.50\\.0: { value: 37.0, error: 1} }
+  - close_to: { aggregations.percentile_ranks_int.values.99\\.0: { value: 61.5, error: 1} }
+  - close_to: { aggregations.percentile_ranks_double.values.50\\.0: { value: 37.0, error: 1} }
+  - close_to: { aggregations.percentile_ranks_double.values.99\\.0: { value: 61.5, error: 1} }
+
+---
+filtered:
+  - skip:
+      features: close_to
+
+  - do:
+      search:
+        body:
+          size: 0
+          query:
+            range:
+              int:
+                gte: 50
+          aggs:
+            percentile_ranks_int:
+              percentile_ranks:
+                field: int
+                values: [50]
+            percentile_ranks_double:
+              percentile_ranks:
+                field: double
+                values: [50]
+
+  - match: { hits.total.value: 3 }
+  - close_to: { aggregations.percentile_ranks_int.values.50\\.0: { value: 16.0, error: 1} }
+  - close_to: { aggregations.percentile_ranks_double.values.50\\.0: { value: 16.0, error: 1} }
+
+---
+missing field with missing param:
+  - skip:
+      features: close_to
+
+  - do:
+      search:
+        body:
+          size: 0
+          aggs:
+            percentile_ranks_missing:
+              percentile_ranks:
+                field: missing
+                missing: 1.0
+                values: [50, 99]
+
+  - match: { hits.total.value: 4 }
+  - close_to: { aggregations.percentile_ranks_missing.values.50\\.0: { value: 100.0, error: 1} }
+  - close_to: { aggregations.percentile_ranks_missing.values.99\\.0: { value: 100.0, error: 1} }
+ 
+---
+missing field without missing param:
+  - do:
+      search:
+        body:
+          size: 0
+          aggs:
+            percentile_ranks_missing:
+              percentile_ranks:
+                field: missing
+                values: [50, 99]
+
+  - match: { hits.total.value: 4 }
+  - is_false: aggregations.percentile_ranks_missing.value
+
+---
+invalid params:
+  - do:
+      catch: bad_request
+      search:
+        body:
+          aggs:
+            percentile_ranks_int:
+              percentile_ranks:
+                field: int
+                values: []
+
+  - do:
+      catch: bad_request
+      search:
+        body:
+          aggs:
+            percentile_ranks_int:
+              percentile_ranks:
+                field: int
+                values: null
+
+  - do:
+      catch: bad_request
+      search:
+        body:
+          aggs:
+            percentile_ranks_int:
+              percentile_ranks:
+                field: int
+                values: ["foo"]
+
+  - do:
+      catch: bad_request
+      search:
+        body:
+          aggs:
+            percentile_ranks_string:
+              percentile_ranks:
+                field: string
+
+---
+non-keyed test:
+  - skip:
+      features: close_to
+
+  - do:
+      search:
+        body:
+          size: 0
+          aggs:
+            percentile_ranks_int:
+              percentile_ranks:
+                field: int
+                values: [50, 99]
+                keyed: false
+
+  - match: { hits.total.value: 4 }
+  - match: { aggregations.percentile_ranks_int.values.0.key: 50}
+  - close_to: { aggregations.percentile_ranks_int.values.0.value: { value: 37.0, error: 1} }
+  - match: { aggregations.percentile_ranks_int.values.1.key: 99}
+  - close_to: { aggregations.percentile_ranks_int.values.1.value: { value: 61.5, error: 1} }
+

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.aggregation/420_percentile_ranks_tdigest_metric.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.aggregation/420_percentile_ranks_tdigest_metric.yml
@@ -35,6 +35,7 @@ basic:
 
   - do:
       search:
+        rest_total_hits_as_int: true
         body:
           size: 0
           aggs:
@@ -47,7 +48,7 @@ basic:
                 field: double
                 values: [50, 99]
 
-  - match: { hits.total.value: 4 }
+  - match: { hits.total: 4 }
   - close_to: { aggregations.percentile_ranks_int.values.50\\.0: { value: 37.0, error: 1} }
   - close_to: { aggregations.percentile_ranks_int.values.99\\.0: { value: 61.5, error: 1} }
   - close_to: { aggregations.percentile_ranks_double.values.50\\.0: { value: 37.0, error: 1} }
@@ -60,6 +61,7 @@ filtered:
 
   - do:
       search:
+        rest_total_hits_as_int: true
         body:
           size: 0
           query:
@@ -76,7 +78,7 @@ filtered:
                 field: double
                 values: [50]
 
-  - match: { hits.total.value: 3 }
+  - match: { hits.total: 3 }
   - close_to: { aggregations.percentile_ranks_int.values.50\\.0: { value: 16.0, error: 1} }
   - close_to: { aggregations.percentile_ranks_double.values.50\\.0: { value: 16.0, error: 1} }
 
@@ -87,6 +89,7 @@ missing field with missing param:
 
   - do:
       search:
+        rest_total_hits_as_int: true
         body:
           size: 0
           aggs:
@@ -96,7 +99,7 @@ missing field with missing param:
                 missing: 1.0
                 values: [50, 99]
 
-  - match: { hits.total.value: 4 }
+  - match: { hits.total: 4 }
   - close_to: { aggregations.percentile_ranks_missing.values.50\\.0: { value: 100.0, error: 1} }
   - close_to: { aggregations.percentile_ranks_missing.values.99\\.0: { value: 100.0, error: 1} }
  
@@ -104,6 +107,7 @@ missing field with missing param:
 missing field without missing param:
   - do:
       search:
+        rest_total_hits_as_int: true
         body:
           size: 0
           aggs:
@@ -112,7 +116,7 @@ missing field without missing param:
                 field: missing
                 values: [50, 99]
 
-  - match: { hits.total.value: 4 }
+  - match: { hits.total: 4 }
   - is_false: aggregations.percentile_ranks_missing.value
 
 ---
@@ -163,6 +167,7 @@ non-keyed test:
 
   - do:
       search:
+        rest_total_hits_as_int: true
         body:
           size: 0
           aggs:
@@ -172,7 +177,7 @@ non-keyed test:
                 values: [50, 99]
                 keyed: false
 
-  - match: { hits.total.value: 4 }
+  - match: { hits.total: 4 }
   - match: { aggregations.percentile_ranks_int.values.0.key: 50}
   - close_to: { aggregations.percentile_ranks_int.values.0.value: { value: 37.0, error: 1} }
   - match: { aggregations.percentile_ranks_int.values.1.key: 99}

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.aggregation/430_percentile_ranks_hdr_metric.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.aggregation/430_percentile_ranks_hdr_metric.yml
@@ -1,0 +1,229 @@
+setup:
+  - do:
+      indices.create:
+        index: test
+        body:
+          settings:
+            number_of_replicas: 0
+          mappings:
+            properties:
+              int:
+                type : integer
+              double:
+                type : double
+              keyword:
+                type: keyword
+
+  - do:
+      bulk:
+        refresh: true
+        index: test
+        body:
+          - '{"index": {}}'
+          - '{"int":   1, "double":   1.0, "keyword": "foo"}'
+          - '{"index": {}}'
+          - '{"int":  51, "double":  51.0, "keyword": "foo"}'
+          - '{"index": {}}'
+          - '{"int": 101, "double": 101.0, "keyword": "foo"}'
+          - '{"index": {}}'
+          - '{"int": 151, "double": 151.0, "keyword": "foo"}'
+
+---
+basic:
+  - skip:
+      features: close_to
+
+  - do:
+      search:
+        body:
+          size: 0
+          aggs:
+            percentile_ranks_int:
+              percentile_ranks:
+                field: int
+                values: [50, 99]
+                hdr: {}
+            percentile_ranks_double:
+              percentile_ranks:
+                field: double
+                values: [50, 99]
+                hdr: {}
+
+  - match: { hits.total.value: 4 }
+  - close_to: { aggregations.percentile_ranks_int.values.50\\.0: { value: 25.0, error: 1} }
+  - close_to: { aggregations.percentile_ranks_int.values.99\\.0: { value: 50.0, error: 1} }
+  - close_to: { aggregations.percentile_ranks_double.values.50\\.0: { value: 25.0, error: 1} }
+  - close_to: { aggregations.percentile_ranks_double.values.99\\.0: { value: 50.0, error: 1} }
+
+---
+set significant digits:
+  - skip:
+      features: close_to
+
+  - do:
+      search:
+        body:
+          size: 0
+          aggs:
+            percentile_ranks_int:
+              percentile_ranks:
+                field: int
+                values: [50, 99]
+                hdr:
+                  number_of_significant_value_digits: 3
+            percentile_ranks_double:
+              percentile_ranks:
+                field: double
+                values: [50, 99]
+                hdr:
+                  number_of_significant_value_digits: 3
+
+  - match: { hits.total.value: 4 }
+  - close_to: { aggregations.percentile_ranks_int.values.50\\.0: { value: 25.0, error: 1} }
+  - close_to: { aggregations.percentile_ranks_int.values.99\\.0: { value: 50.0, error: 1} }
+  - close_to: { aggregations.percentile_ranks_double.values.50\\.0: { value: 25.0, error: 1} }
+  - close_to: { aggregations.percentile_ranks_double.values.99\\.0: { value: 50.0, error: 1} }
+
+---
+filtered:
+  - skip:
+      features: close_to
+
+  - do:
+      search:
+        body:
+          size: 0
+          query:
+            range:
+              int:
+                gte: 50
+          aggs:
+            percentile_ranks_int:
+              percentile_ranks:
+                field: int
+                values: [50]
+                hdr:
+                  number_of_significant_value_digits: 3
+            percentile_ranks_double:
+              percentile_ranks:
+                field: double
+                values: [50]
+                hdr:
+                  number_of_significant_value_digits: 3
+
+  - match: { hits.total.value: 3 }
+  - close_to: { aggregations.percentile_ranks_int.values.50\\.0: { value: 0.0, error: 1} }
+  - close_to: { aggregations.percentile_ranks_double.values.50\\.0: { value: 0.0, error: 1} }
+
+---
+missing field with missing param:
+  - skip:
+      features: close_to
+
+  - do:
+      search:
+        body:
+          size: 0
+          aggs:
+            percentile_ranks_missing:
+              percentile_ranks:
+                field: missing
+                missing: 1.0
+                values: [50, 99]
+                hdr:
+                  number_of_significant_value_digits: 3
+
+  - match: { hits.total.value: 4 }
+  - close_to: { aggregations.percentile_ranks_missing.values.50\\.0: { value: 100.0, error: 1} }
+  - close_to: { aggregations.percentile_ranks_missing.values.99\\.0: { value: 100.0, error: 1} }
+
+---
+missing field without missing param:
+  - do:
+      search:
+        body:
+          size: 0
+          aggs:
+            percentile_ranks_missing:
+              percentile_ranks:
+                field: missing
+                values: [50, 99]
+                hdr:
+                  number_of_significant_value_digits: 3
+
+  - match: { hits.total.value: 4 }
+  - is_false: aggregations.percentile_ranks_missing.value
+
+---
+invalid params:
+  - do:
+      catch: bad_request
+      search:
+        body:
+          aggs:
+            percentile_ranks_int:
+              percentile_ranks:
+                field: int
+                values: []
+                hdr:
+                  number_of_significant_value_digits: 3
+
+  - do:
+      catch: bad_request
+      search:
+        body:
+          aggs:
+            percentile_ranks_int:
+              percentile_ranks:
+                field: int
+                values: null
+                hdr:
+                  number_of_significant_value_digits: 3
+
+  - do:
+      catch: bad_request
+      search:
+        body:
+          aggs:
+            percentile_ranks_int:
+              percentile_ranks:
+                field: int
+                values: ["foo"]
+                hdr:
+                  number_of_significant_value_digits: 3
+
+  - do:
+      catch: bad_request
+      search:
+        body:
+          aggs:
+            percentile_ranks_string:
+              percentile_ranks:
+                field: string
+                hdr:
+                  number_of_significant_value_digits: 3
+
+
+---
+non-keyed:
+  - skip:
+      features: close_to
+
+  - do:
+      search:
+        body:
+          size: 0
+          aggs:
+            percentile_ranks_int:
+              percentile_ranks:
+                field: int
+                values: [50, 99]
+                keyed: false
+                hdr:
+                  number_of_significant_value_digits: 3
+
+  - match: { hits.total.value: 4 }
+  - match: { aggregations.percentile_ranks_int.values.0.key: 50}
+  - close_to: { aggregations.percentile_ranks_int.values.0.value: { value: 25, error: 1} }
+  - match: { aggregations.percentile_ranks_int.values.1.key: 99}
+  - close_to: { aggregations.percentile_ranks_int.values.1.value: { value: 50, error: 1} }

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.aggregation/430_percentile_ranks_hdr_metric.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.aggregation/430_percentile_ranks_hdr_metric.yml
@@ -35,6 +35,7 @@ basic:
 
   - do:
       search:
+        rest_total_hits_as_int: true
         body:
           size: 0
           aggs:
@@ -49,7 +50,7 @@ basic:
                 values: [50, 99]
                 hdr: {}
 
-  - match: { hits.total.value: 4 }
+  - match: { hits.total: 4 }
   - close_to: { aggregations.percentile_ranks_int.values.50\\.0: { value: 25.0, error: 1} }
   - close_to: { aggregations.percentile_ranks_int.values.99\\.0: { value: 50.0, error: 1} }
   - close_to: { aggregations.percentile_ranks_double.values.50\\.0: { value: 25.0, error: 1} }
@@ -62,6 +63,7 @@ set significant digits:
 
   - do:
       search:
+        rest_total_hits_as_int: true
         body:
           size: 0
           aggs:
@@ -78,7 +80,7 @@ set significant digits:
                 hdr:
                   number_of_significant_value_digits: 3
 
-  - match: { hits.total.value: 4 }
+  - match: { hits.total: 4 }
   - close_to: { aggregations.percentile_ranks_int.values.50\\.0: { value: 25.0, error: 1} }
   - close_to: { aggregations.percentile_ranks_int.values.99\\.0: { value: 50.0, error: 1} }
   - close_to: { aggregations.percentile_ranks_double.values.50\\.0: { value: 25.0, error: 1} }
@@ -91,6 +93,7 @@ filtered:
 
   - do:
       search:
+        rest_total_hits_as_int: true
         body:
           size: 0
           query:
@@ -111,7 +114,7 @@ filtered:
                 hdr:
                   number_of_significant_value_digits: 3
 
-  - match: { hits.total.value: 3 }
+  - match: { hits.total: 3 }
   - close_to: { aggregations.percentile_ranks_int.values.50\\.0: { value: 0.0, error: 1} }
   - close_to: { aggregations.percentile_ranks_double.values.50\\.0: { value: 0.0, error: 1} }
 
@@ -122,6 +125,7 @@ missing field with missing param:
 
   - do:
       search:
+        rest_total_hits_as_int: true
         body:
           size: 0
           aggs:
@@ -133,7 +137,7 @@ missing field with missing param:
                 hdr:
                   number_of_significant_value_digits: 3
 
-  - match: { hits.total.value: 4 }
+  - match: { hits.total: 4 }
   - close_to: { aggregations.percentile_ranks_missing.values.50\\.0: { value: 100.0, error: 1} }
   - close_to: { aggregations.percentile_ranks_missing.values.99\\.0: { value: 100.0, error: 1} }
 
@@ -141,6 +145,7 @@ missing field with missing param:
 missing field without missing param:
   - do:
       search:
+        rest_total_hits_as_int: true
         body:
           size: 0
           aggs:
@@ -151,7 +156,7 @@ missing field without missing param:
                 hdr:
                   number_of_significant_value_digits: 3
 
-  - match: { hits.total.value: 4 }
+  - match: { hits.total: 4 }
   - is_false: aggregations.percentile_ranks_missing.value
 
 ---
@@ -211,6 +216,7 @@ non-keyed:
 
   - do:
       search:
+        rest_total_hits_as_int: true
         body:
           size: 0
           aggs:
@@ -222,7 +228,7 @@ non-keyed:
                 hdr:
                   number_of_significant_value_digits: 3
 
-  - match: { hits.total.value: 4 }
+  - match: { hits.total: 4 }
   - match: { aggregations.percentile_ranks_int.values.0.key: 50}
   - close_to: { aggregations.percentile_ranks_int.values.0.value: { value: 25, error: 1} }
   - match: { aggregations.percentile_ranks_int.values.1.key: 99}


### PR DESCRIPTION
This revives #27127, modernizing it to include stuff like `close_to`.
