### PR TITLE
Track searchable snapshot usage (#77597)

### DIFF
--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/SearchableSnapshots.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/SearchableSnapshots.java
@@ -348,7 +348,7 @@ public class SearchableSnapshots extends Plugin implements IndexStorePlugin, Eng
             // Instead, we periodically look through the indices and identify if any are searchable snapshots,
             // then marking the feature as used. We do this on each master node so that if one master fails, the
             // continue reporting usage state.
-            var usageTracker = new SearchableSnapshotsUsageTracker(getLicenseState(), clusterService::state);
+            SearchableSnapshotsUsageTracker usageTracker = new SearchableSnapshotsUsageTracker(getLicenseState(), clusterService::state);
             threadPool.scheduleWithFixedDelay(usageTracker, TimeValue.timeValueMinutes(15), ThreadPool.Names.GENERIC);
         }
 

--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/SearchableSnapshots.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/SearchableSnapshots.java
@@ -342,6 +342,16 @@ public class SearchableSnapshots extends Plugin implements IndexStorePlugin, Eng
         } else {
             PersistentCache.cleanUp(settings, nodeEnvironment);
         }
+
+        if (DiscoveryNode.isMasterNode(environment.settings())) {
+            // Tracking usage of searchable snapshots is too costly to do on each individually mounted snapshot.
+            // Instead, we periodically look through the indices and identify if any are searchable snapshots,
+            // then marking the feature as used. We do this on each master node so that if one master fails, the
+            // continue reporting usage state.
+            var usageTracker = new SearchableSnapshotsUsageTracker(getLicenseState(), clusterService::state);
+            threadPool.scheduleWithFixedDelay(usageTracker, TimeValue.timeValueMinutes(15), ThreadPool.Names.GENERIC);
+        }
+
         this.allocator.set(new SearchableSnapshotAllocator(client, clusterService.getRerouteService(), frozenCacheInfoService));
         components.add(new FrozenCacheServiceSupplier(frozenCacheService.get()));
         components.add(new CacheServiceSupplier(cacheService.get()));
@@ -750,4 +760,5 @@ public class SearchableSnapshots extends Plugin implements IndexStorePlugin, Eng
             assert knownUuids.equals(newUuids) : knownUuids + " vs " + newUuids;
         }
     }
+
 }

--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/SearchableSnapshotsUsageTracker.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/SearchableSnapshotsUsageTracker.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.searchablesnapshots;
+
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.metadata.IndexMetadata;
+import org.elasticsearch.license.XPackLicenseState;
+import org.elasticsearch.snapshots.SearchableSnapshotsSettings;
+
+import java.util.function.Supplier;
+
+import static org.elasticsearch.xpack.core.searchablesnapshots.SearchableSnapshotsConstants.SEARCHABLE_SNAPSHOT_FEATURE;
+
+final class SearchableSnapshotsUsageTracker implements Runnable {
+
+    private final XPackLicenseState licenseState;
+    private final Supplier<ClusterState> clusterStateSupplier;
+
+    SearchableSnapshotsUsageTracker(XPackLicenseState licenseState, Supplier<ClusterState> clusterStateSupplier) {
+        this.clusterStateSupplier = clusterStateSupplier;
+        this.licenseState = licenseState;
+    }
+
+    @Override
+    public void run() {
+        if (hasSearchableSnapshotsIndices(clusterStateSupplier.get())) {
+            SEARCHABLE_SNAPSHOT_FEATURE.check(licenseState);
+        }
+    }
+
+    private static boolean hasSearchableSnapshotsIndices(ClusterState state) {
+        for (IndexMetadata indexMetadata : state.metadata()) {
+            if (SearchableSnapshotsSettings.isSearchableSnapshotStore(indexMetadata.getSettings())) {
+                return true;
+            }
+        }
+        return false;
+    }
+}


### PR DESCRIPTION
This commit adds usage tracking to searchable snapshots. It works by
inspecting all indices metadata in cluster state every 15 minutes to see
if any searchable snapshot stores exist, and if any do, then triggering
feature usage tracking on the license state.