### PR TITLE
Document missing_order param for composite aggregations

### DIFF
--- a/docs/reference/aggregations/bucket/composite-aggregation.asciidoc
+++ b/docs/reference/aggregations/bucket/composite-aggregation.asciidoc
@@ -614,14 +614,15 @@ GET /_search
 }
 --------------------------------------------------
 
-In the example above the source `product_name` will emit an explicit `null` bucket for
-documents without a value for the field `product` and the bucket will be placed last.
+In the above example, the `product_name` source emits an explicit `null` bucket
+for documents without a `product` value. This bucket is placed last.
 
-The position of the `null` bucket can be controlled with the optional `missing_order`
-parameter. If `missing_order` is `first` or last `last`, the `null` bucket will be placed
-at first or last position respectively. If `missing_order` is omitted or `default` the
-`order` specified in the source dictates whether the `null` bucket should rank first
-(ascending order, `asc`) or last (descending order, `desc`).
+You can control the position of the `null` bucket using the optional
+`missing_order` parameter. If `missing_order` is `first` or `last`, the `null`
+bucket is placed in the respective first or last position. If `missing_order` is
+omitted or `default`, the source's `order` determines the bucket's position. If
+`order` is `asc` (ascending), the bucket is in the first position. If `order` is
+`desc` (descending), the bucket is in the last position.
 
 ==== Size
 

--- a/docs/reference/aggregations/bucket/composite-aggregation.asciidoc
+++ b/docs/reference/aggregations/bucket/composite-aggregation.asciidoc
@@ -599,19 +599,29 @@ GET /_search
   "aggs": {
     "my_buckets": {
       "composite": {
-        "sources": [
-          { "product_name": { "terms": { "field": "product", "missing_bucket": true } } }
-        ]
+        "sources": [{
+          "product_name": {
+            "terms": {
+              "field": "product",
+              "missing_bucket": true,
+              "missing_order": "last"
+            }
+          }
+        }]
       }
     }
   }
 }
 --------------------------------------------------
 
-In the example above the source `product_name` will emit an explicit `null` value
-for documents without a value for the field `product`.
-The `order` specified in the source dictates whether the `null` values should rank
-first (ascending order, `asc`) or last (descending order, `desc`).
+In the example above the source `product_name` will emit an explicit `null` bucket for
+documents without a value for the field `product` and the bucket will be placed last.
+
+The position of the `null` bucket can be controlled with the optional `missing_order`
+parameter. If `missing_order` is `first` or last `last`, the `null` bucket will be placed
+at first or last position respectively. If `missing_order` is omitted or `default` the
+`order` specified in the source dictates whether the `null` bucket should rank first
+(ascending order, `asc`) or last (descending order, `desc`).
 
 ==== Size
 


### PR DESCRIPTION
Documents the missing_order parameter for composite aggregations introduced in #76740 