### PR TITLE
[DOCS] Removes deprecated word from HLRC title

### DIFF
--- a/docs/java-rest/high-level/index.asciidoc
+++ b/docs/java-rest/high-level/index.asciidoc
@@ -1,7 +1,7 @@
 :mainid: java-rest-high
 
 [id="{mainid}"]
-= Java High Level REST Client (deprecated)
+= Java High Level REST Client
 
 [partintro]
 --


### PR DESCRIPTION
## Overview

This PR removes the word `deprecated` from the title of the HLRC.