### PR TITLE
[7.x][DOCS] Renames deprecated Java API to Java Transport Client

### DIFF
--- a/docs/java-api/index.asciidoc
+++ b/docs/java-api/index.asciidoc
@@ -1,4 +1,4 @@
-= Java API (deprecated)
+= Java Transport Client (deprecated)
 
 include::{elasticsearch-root}/docs/Versions.asciidoc[]
 
@@ -8,8 +8,8 @@ include::{elasticsearch-root}/docs/Versions.asciidoc[]
 
 deprecated[7.0.0, The `TransportClient` is deprecated in favour of the {java-rest}/java-rest-high.html[Java High Level REST Client] and will be removed in Elasticsearch 8.0. The {java-rest}/java-rest-high-level-migration.html[migration guide] describes all the steps needed to migrate.]
 
-This section describes the Java API that Elasticsearch provides. All
-Elasticsearch operations are executed using a
+This section describes the Java Transport Client that Elasticsearch provides. 
+All Elasticsearch operations are executed using a
 <<client,Client>> object. All
 operations are completely asynchronous in nature (either accepts a
 listener, or returns a future).


### PR DESCRIPTION
## Overview

This PR renames the deprecated Java API to Java Transport Client. This book no longer exists in `master`.

Related to: https://github.com/elastic/docs/pull/2220