### PR TITLE
[7.x] [DOCS] Removes deprecated word from HLRC title. (#77851)

### DIFF
--- a/docs/java-rest/high-level/index.asciidoc
+++ b/docs/java-rest/high-level/index.asciidoc
@@ -1,7 +1,7 @@
 :mainid: java-rest-high
 
 [id="{mainid}"]
-= Java High Level REST Client (deprecated)
+= Java High Level REST Client
 
 [partintro]
 --


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [DOCS] Removes deprecated word from HLRC title. (#77851)