### PR TITLE
Deprecate ignore_throttled parameter

### DIFF
--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/AsyncSearchRequestConverters.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/AsyncSearchRequestConverters.java
@@ -11,6 +11,7 @@ package org.elasticsearch.client;
 import org.apache.http.client.methods.HttpDelete;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpPost;
+import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.client.RequestConverters.Params;
 import org.elasticsearch.client.asyncsearch.DeleteAsyncSearchRequest;
 import org.elasticsearch.client.asyncsearch.GetAsyncSearchRequest;
@@ -53,7 +54,9 @@ final class AsyncSearchRequestConverters {
         params.putParam(RestSearchAction.TYPED_KEYS_PARAM, "true");
         params.withRouting(request.getRouting());
         params.withPreference(request.getPreference());
-        params.withIndicesOptions(request.getIndicesOptions());
+        if (SearchRequest.DEFAULT_INDICES_OPTIONS.equals(request.getIndicesOptions()) == false) {
+            params.withIndicesOptions(request.getIndicesOptions());
+        }
         params.withSearchType(request.getSearchType().name().toLowerCase(Locale.ROOT));
         params.withMaxConcurrentShardRequests(request.getMaxConcurrentShardRequests());
         if (request.getRequestCache() != null) {

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/IndicesRequestConverters.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/IndicesRequestConverters.java
@@ -29,6 +29,7 @@ import org.elasticsearch.action.admin.indices.template.delete.DeleteIndexTemplat
 import org.elasticsearch.action.admin.indices.validate.query.ValidateQueryRequest;
 import org.elasticsearch.action.support.broadcast.BroadcastRequest;
 import org.elasticsearch.action.support.ActiveShardCount;
+import org.elasticsearch.action.support.master.info.ClusterInfoRequest;
 import org.elasticsearch.client.indices.AnalyzeRequest;
 import org.elasticsearch.client.indices.CloseIndexRequest;
 import org.elasticsearch.client.indices.CreateDataStreamRequest;
@@ -248,7 +249,9 @@ final class IndicesRequestConverters {
 
         RequestConverters.Params parameters = new RequestConverters.Params();
         parameters.withMasterTimeout(getMappingsRequest.masterNodeTimeout());
-        parameters.withIndicesOptions(getMappingsRequest.indicesOptions());
+        if (ClusterInfoRequest.DEFAULT_INDICES_OPTIONS.equals(getMappingsRequest.indicesOptions()) == false) {
+            parameters.withIndicesOptions(getMappingsRequest.indicesOptions());
+        }
         parameters.withLocal(getMappingsRequest.local());
         parameters.putParam(INCLUDE_TYPE_NAME_PARAMETER, "true");
         request.addParameters(parameters.asMap());
@@ -327,7 +330,9 @@ final class IndicesRequestConverters {
         String[] indices = syncedFlushRequest.indices() == null ? Strings.EMPTY_ARRAY : syncedFlushRequest.indices();
         Request request = new Request(HttpPost.METHOD_NAME, RequestConverters.endpoint(indices, "_flush/synced"));
         RequestConverters.Params parameters = new RequestConverters.Params();
-        parameters.withIndicesOptions(syncedFlushRequest.indicesOptions());
+        if (BroadcastRequest.DEFAULT_INDICES_OPTIONS.equals(syncedFlushRequest.indicesOptions()) == false) {
+            parameters.withIndicesOptions(syncedFlushRequest.indicesOptions());
+        }
         request.addParameters(parameters.asMap());
         return request;
     }
@@ -518,7 +523,9 @@ final class IndicesRequestConverters {
         Request request = new Request(HttpGet.METHOD_NAME, endpoint);
 
         RequestConverters.Params params = new RequestConverters.Params();
-        params.withIndicesOptions(getIndexRequest.indicesOptions());
+        if (ClusterInfoRequest.DEFAULT_INDICES_OPTIONS.equals(getIndexRequest.indicesOptions()) == false) {
+            params.withIndicesOptions(getIndexRequest.indicesOptions());
+        }
         params.withLocal(getIndexRequest.local());
         params.withIncludeDefaults(getIndexRequest.includeDefaults());
         params.withHuman(getIndexRequest.humanReadable());
@@ -562,7 +569,9 @@ final class IndicesRequestConverters {
         RequestConverters.Params params = new RequestConverters.Params();
         params.withLocal(getIndexRequest.local());
         params.withHuman(getIndexRequest.humanReadable());
-        params.withIndicesOptions(getIndexRequest.indicesOptions());
+        if (ClusterInfoRequest.DEFAULT_INDICES_OPTIONS.equals(getIndexRequest.indicesOptions()) == false) {
+            params.withIndicesOptions(getIndexRequest.indicesOptions());
+        }
         params.withIncludeDefaults(getIndexRequest.includeDefaults());
         params.putParam(INCLUDE_TYPE_NAME_PARAMETER, "true");
         request.addParameters(params.asMap());

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/IndicesRequestConverters.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/IndicesRequestConverters.java
@@ -27,6 +27,7 @@ import org.elasticsearch.action.admin.indices.settings.put.UpdateSettingsRequest
 import org.elasticsearch.action.admin.indices.shrink.ResizeType;
 import org.elasticsearch.action.admin.indices.template.delete.DeleteIndexTemplateRequest;
 import org.elasticsearch.action.admin.indices.validate.query.ValidateQueryRequest;
+import org.elasticsearch.action.support.broadcast.BroadcastRequest;
 import org.elasticsearch.action.support.ActiveShardCount;
 import org.elasticsearch.client.indices.AnalyzeRequest;
 import org.elasticsearch.client.indices.CloseIndexRequest;
@@ -104,7 +105,9 @@ final class IndicesRequestConverters {
         RequestConverters.Params parameters = new RequestConverters.Params();
         parameters.withTimeout(deleteIndexRequest.timeout());
         parameters.withMasterTimeout(deleteIndexRequest.masterNodeTimeout());
-        parameters.withIndicesOptions(deleteIndexRequest.indicesOptions());
+        if (DeleteIndexRequest.DEFAULT_INDICES_OPTIONS.equals(deleteIndexRequest.indicesOptions()) == false) {
+            parameters.withIndicesOptions(deleteIndexRequest.indicesOptions());
+        }
         request.addParameters(parameters.asMap());
         return request;
     }
@@ -117,7 +120,9 @@ final class IndicesRequestConverters {
         parameters.withTimeout(openIndexRequest.timeout());
         parameters.withMasterTimeout(openIndexRequest.masterNodeTimeout());
         parameters.withWaitForActiveShards(openIndexRequest.waitForActiveShards());
-        parameters.withIndicesOptions(openIndexRequest.indicesOptions());
+        if (OpenIndexRequest.DEFAULT_INDICES_OPTIONS.equals(openIndexRequest.indicesOptions()) == false) {
+            parameters.withIndicesOptions(openIndexRequest.indicesOptions());
+        }
         request.addParameters(parameters.asMap());
         return request;
     }
@@ -129,7 +134,9 @@ final class IndicesRequestConverters {
         RequestConverters.Params parameters = new RequestConverters.Params();
         parameters.withTimeout(closeIndexRequest.timeout());
         parameters.withMasterTimeout(closeIndexRequest.masterNodeTimeout());
-        parameters.withIndicesOptions(closeIndexRequest.indicesOptions());
+        if (CloseIndexRequest.DEFAULT_INDICES_OPTIONS.equals(closeIndexRequest.indicesOptions()) == false) {
+            parameters.withIndicesOptions(closeIndexRequest.indicesOptions());
+        }
 
         final ActiveShardCount activeShardCount = closeIndexRequest.waitForActiveShards();
         if (activeShardCount == ActiveShardCount.DEFAULT) {
@@ -188,7 +195,9 @@ final class IndicesRequestConverters {
         RequestConverters.Params parameters = new RequestConverters.Params();
         parameters.withTimeout(putMappingRequest.timeout());
         parameters.withMasterTimeout(putMappingRequest.masterNodeTimeout());
-        parameters.withIndicesOptions(putMappingRequest.indicesOptions());
+        if (PutMappingRequest.DEFAULT_INDICES_OPTIONS.equals(putMappingRequest.indicesOptions()) == false) {
+            parameters.withIndicesOptions(putMappingRequest.indicesOptions());
+        }
         request.addParameters(parameters.asMap());
         request.setEntity(RequestConverters.createEntity(putMappingRequest, RequestConverters.REQUEST_BODY_CONTENT_TYPE));
         return request;
@@ -293,7 +302,9 @@ final class IndicesRequestConverters {
         Request request = new Request(HttpPost.METHOD_NAME, RequestConverters.endpoint(indices, "_refresh"));
 
         RequestConverters.Params parameters = new RequestConverters.Params();
-        parameters.withIndicesOptions(refreshRequest.indicesOptions());
+        if (BroadcastRequest.DEFAULT_INDICES_OPTIONS.equals(refreshRequest.indicesOptions()) == false) {
+            parameters.withIndicesOptions(refreshRequest.indicesOptions());
+        }
         request.addParameters(parameters.asMap());
         return request;
     }
@@ -303,7 +314,9 @@ final class IndicesRequestConverters {
         Request request = new Request(HttpPost.METHOD_NAME, RequestConverters.endpoint(indices, "_flush"));
 
         RequestConverters.Params parameters = new RequestConverters.Params();
-        parameters.withIndicesOptions(flushRequest.indicesOptions());
+        if (BroadcastRequest.DEFAULT_INDICES_OPTIONS.equals(flushRequest.indicesOptions()) == false) {
+            parameters.withIndicesOptions(flushRequest.indicesOptions());
+        }
         parameters.putParam("wait_if_ongoing", Boolean.toString(flushRequest.waitIfOngoing()));
         parameters.putParam("force", Boolean.toString(flushRequest.force()));
         request.addParameters(parameters.asMap());
@@ -324,7 +337,9 @@ final class IndicesRequestConverters {
         Request request = new Request(HttpPost.METHOD_NAME, RequestConverters.endpoint(indices, "_forcemerge"));
 
         RequestConverters.Params parameters = new RequestConverters.Params();
-        parameters.withIndicesOptions(forceMergeRequest.indicesOptions());
+        if (BroadcastRequest.DEFAULT_INDICES_OPTIONS.equals(forceMergeRequest.indicesOptions()) == false) {
+            parameters.withIndicesOptions(forceMergeRequest.indicesOptions());
+        }
         parameters.putParam("max_num_segments", Integer.toString(forceMergeRequest.maxNumSegments()));
         parameters.putParam("only_expunge_deletes", Boolean.toString(forceMergeRequest.onlyExpungeDeletes()));
         parameters.putParam("flush", Boolean.toString(forceMergeRequest.flush()));
@@ -337,7 +352,9 @@ final class IndicesRequestConverters {
         Request request = new Request(HttpPost.METHOD_NAME, RequestConverters.endpoint(indices, "_cache/clear"));
 
         RequestConverters.Params parameters = new RequestConverters.Params();
-        parameters.withIndicesOptions(clearIndicesCacheRequest.indicesOptions());
+        if (BroadcastRequest.DEFAULT_INDICES_OPTIONS.equals(clearIndicesCacheRequest.indicesOptions()) == false) {
+            parameters.withIndicesOptions(clearIndicesCacheRequest.indicesOptions());
+        }
         parameters.putParam("query", Boolean.toString(clearIndicesCacheRequest.queryCache()));
         parameters.putParam("fielddata", Boolean.toString(clearIndicesCacheRequest.fieldDataCache()));
         parameters.putParam("request", Boolean.toString(clearIndicesCacheRequest.requestCache()));
@@ -357,7 +374,9 @@ final class IndicesRequestConverters {
         Request request = new Request(HttpHead.METHOD_NAME, RequestConverters.endpoint(indices, "_alias", aliases));
 
         RequestConverters.Params params = new RequestConverters.Params();
-        params.withIndicesOptions(getAliasesRequest.indicesOptions());
+        if (GetAliasesRequest.DEFAULT_INDICES_OPTIONS.equals(getAliasesRequest.indicesOptions()) == false) {
+            params.withIndicesOptions(getAliasesRequest.indicesOptions());
+        }
         params.withLocal(getAliasesRequest.local());
         request.addParameters(params.asMap());
         return request;
@@ -477,7 +496,9 @@ final class IndicesRequestConverters {
         Request request = new Request(HttpGet.METHOD_NAME, endpoint);
 
         RequestConverters.Params params = new RequestConverters.Params();
-        params.withIndicesOptions(getSettingsRequest.indicesOptions());
+        if (GetSettingsRequest.DEFAULT_INDICES_OPTIONS.equals(getSettingsRequest.indicesOptions()) == false) {
+            params.withIndicesOptions(getSettingsRequest.indicesOptions());
+        }
         params.withLocal(getSettingsRequest.local());
         params.withIncludeDefaults(getSettingsRequest.includeDefaults());
         params.withMasterTimeout(getSettingsRequest.masterNodeTimeout());
@@ -514,7 +535,9 @@ final class IndicesRequestConverters {
         Request request = new Request(HttpGet.METHOD_NAME, endpoint);
 
         RequestConverters.Params params = new RequestConverters.Params();
-        params.withIndicesOptions(getIndexRequest.indicesOptions());
+        if (GetIndexRequest.DEFAULT_INDICES_OPTIONS.equals(getIndexRequest.indicesOptions()) == false) {
+            params.withIndicesOptions(getIndexRequest.indicesOptions());
+        }
         params.withLocal(getIndexRequest.local());
         params.withIncludeDefaults(getIndexRequest.includeDefaults());
         params.withHuman(getIndexRequest.humanReadable());
@@ -557,7 +580,9 @@ final class IndicesRequestConverters {
         RequestConverters.Params params = new RequestConverters.Params();
         params.withLocal(getIndexRequest.local());
         params.withHuman(getIndexRequest.humanReadable());
-        params.withIndicesOptions(getIndexRequest.indicesOptions());
+        if (GetIndexRequest.DEFAULT_INDICES_OPTIONS.equals(getIndexRequest.indicesOptions()) == false) {
+            params.withIndicesOptions(getIndexRequest.indicesOptions());
+        }
         params.withIncludeDefaults(getIndexRequest.includeDefaults());
         request.addParameters(params.asMap());
         return request;
@@ -570,7 +595,9 @@ final class IndicesRequestConverters {
         RequestConverters.Params parameters = new RequestConverters.Params();
         parameters.withTimeout(updateSettingsRequest.timeout());
         parameters.withMasterTimeout(updateSettingsRequest.masterNodeTimeout());
-        parameters.withIndicesOptions(updateSettingsRequest.indicesOptions());
+        if (UpdateSettingsRequest.DEFAULT_INDICES_OPTIONS.equals(updateSettingsRequest.indicesOptions()) == false) {
+            parameters.withIndicesOptions(updateSettingsRequest.indicesOptions());
+        }
         parameters.withPreserveExisting(updateSettingsRequest.isPreserveExisting());
         request.addParameters(parameters.asMap());
         request.setEntity(RequestConverters.createEntity(updateSettingsRequest, RequestConverters.REQUEST_BODY_CONTENT_TYPE));
@@ -662,7 +689,9 @@ final class IndicesRequestConverters {
         String endpoint = RequestConverters.endpoint(indices, types, "_validate/query");
         Request request = new Request(HttpGet.METHOD_NAME, endpoint);
         RequestConverters.Params params = new RequestConverters.Params();
-        params.withIndicesOptions(validateQueryRequest.indicesOptions());
+        if (ValidateQueryRequest.DEFAULT_INDICES_OPTIONS.equals(validateQueryRequest.indicesOptions()) == false) {
+            params.withIndicesOptions(validateQueryRequest.indicesOptions());
+        }
         params.putParam("explain", Boolean.toString(validateQueryRequest.explain()));
         params.putParam("all_shards", Boolean.toString(validateQueryRequest.allShards()));
         params.putParam("rewrite", Boolean.toString(validateQueryRequest.rewrite()));
@@ -677,7 +706,9 @@ final class IndicesRequestConverters {
         String endpoint = RequestConverters.endpoint(indices, "_alias", aliases);
         Request request = new Request(HttpGet.METHOD_NAME, endpoint);
         RequestConverters.Params params = new RequestConverters.Params();
-        params.withIndicesOptions(getAliasesRequest.indicesOptions());
+        if (GetAliasesRequest.DEFAULT_INDICES_OPTIONS.equals(getAliasesRequest.indicesOptions()) == false) {
+            params.withIndicesOptions(getAliasesRequest.indicesOptions());
+        }
         params.withLocal(getAliasesRequest.local());
         request.addParameters(params.asMap());
         return request;
@@ -807,7 +838,9 @@ final class IndicesRequestConverters {
         String endpoint = RequestConverters.endpoint(reloadAnalyzersRequest.getIndices(), "_reload_search_analyzers");
         Request request = new Request(HttpPost.METHOD_NAME, endpoint);
         RequestConverters.Params parameters = new RequestConverters.Params();
-        parameters.withIndicesOptions(reloadAnalyzersRequest.indicesOptions());
+        if (ReloadAnalyzersRequest.DEFAULT_INDICES_OPTIONS.equals(reloadAnalyzersRequest.indicesOptions()) == false) {
+            parameters.withIndicesOptions(reloadAnalyzersRequest.indicesOptions());
+        }
         request.addParameters(parameters.asMap());
         return request;
     }

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/IndicesRequestConverters.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/IndicesRequestConverters.java
@@ -292,7 +292,10 @@ final class IndicesRequestConverters {
         Request request = new Request(HttpGet.METHOD_NAME, endpoint);
 
         RequestConverters.Params parameters = new RequestConverters.Params();
-        parameters.withIndicesOptions(getFieldMappingsRequest.indicesOptions());
+        if (org.elasticsearch.action.admin.indices.mapping.get.GetFieldMappingsRequest.DEFAULT_INDICES_OPTIONS.equals(
+            getFieldMappingsRequest.indicesOptions()) == false) {
+            parameters.withIndicesOptions(getFieldMappingsRequest.indicesOptions());
+        }
         parameters.withIncludeDefaults(getFieldMappingsRequest.includeDefaults());
         parameters.withLocal(getFieldMappingsRequest.local());
         parameters.putParam(INCLUDE_TYPE_NAME_PARAMETER, "true");
@@ -330,9 +333,7 @@ final class IndicesRequestConverters {
         String[] indices = syncedFlushRequest.indices() == null ? Strings.EMPTY_ARRAY : syncedFlushRequest.indices();
         Request request = new Request(HttpPost.METHOD_NAME, RequestConverters.endpoint(indices, "_flush/synced"));
         RequestConverters.Params parameters = new RequestConverters.Params();
-        if (BroadcastRequest.DEFAULT_INDICES_OPTIONS.equals(syncedFlushRequest.indicesOptions()) == false) {
-            parameters.withIndicesOptions(syncedFlushRequest.indicesOptions());
-        }
+        parameters.withIndicesOptions(syncedFlushRequest.indicesOptions());
         request.addParameters(parameters.asMap());
         return request;
     }

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/RequestConverters.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/RequestConverters.java
@@ -417,7 +417,9 @@ final class RequestConverters {
         params.putParam(RestSearchAction.TYPED_KEYS_PARAM, "true");
         params.withRouting(searchRequest.routing());
         params.withPreference(searchRequest.preference());
-        params.withIndicesOptions(searchRequest.indicesOptions());
+        if (SearchRequest.DEFAULT_INDICES_OPTIONS.equals(searchRequest.indicesOptions()) == false) {
+            params.withIndicesOptions(searchRequest.indicesOptions());
+        }
         params.withSearchType(searchRequest.searchType().name().toLowerCase(Locale.ROOT));
         if (searchRequest.isCcsMinimizeRoundtrips() != SearchRequest.defaultCcsMinimizeRoundtrips(searchRequest)) {
             params.putParam("ccs_minimize_roundtrips", Boolean.toString(searchRequest.isCcsMinimizeRoundtrips()));
@@ -453,7 +455,9 @@ final class RequestConverters {
     static Request openPointInTime(OpenPointInTimeRequest openRequest) {
         Request request = new Request(HttpPost.METHOD_NAME, endpoint(openRequest.indices(), "_pit"));
         Params params = new Params();
-        params.withIndicesOptions(openRequest.indicesOptions());
+        if (OpenPointInTimeRequest.DEFAULT_INDICES_OPTIONS.equals(openRequest.indicesOptions()) == false) {
+            params.withIndicesOptions(openRequest.indicesOptions());
+        }
         params.withRouting(openRequest.routing());
         params.withPreference(openRequest.preference());
         params.putParam("keep_alive", openRequest.keepAlive());
@@ -557,7 +561,9 @@ final class RequestConverters {
 
         Params params = new Params();
         params.withFields(fieldCapabilitiesRequest.fields());
-        params.withIndicesOptions(fieldCapabilitiesRequest.indicesOptions());
+        if (FieldCapabilitiesRequest.DEFAULT_INDICES_OPTIONS.equals(fieldCapabilitiesRequest.indicesOptions()) == false) {
+            params.withIndicesOptions(fieldCapabilitiesRequest.indicesOptions());
+        }
         request.addParameters(params.asMap());
         if (fieldCapabilitiesRequest.indexFilter() != null) {
             request.setEntity(createEntity(fieldCapabilitiesRequest, REQUEST_BODY_CONTENT_TYPE));
@@ -569,7 +575,9 @@ final class RequestConverters {
         Request request = new Request(HttpGet.METHOD_NAME, endpoint(rankEvalRequest.indices(), Strings.EMPTY_ARRAY, "_rank_eval"));
 
         Params params = new Params();
-        params.withIndicesOptions(rankEvalRequest.indicesOptions());
+        if (SearchRequest.DEFAULT_INDICES_OPTIONS.equals(rankEvalRequest.indicesOptions()) == false) {
+            params.withIndicesOptions(rankEvalRequest.indicesOptions());
+        }
         params.putParam("search_type", rankEvalRequest.searchType().name().toLowerCase(Locale.ROOT));
         request.addParameters(params.asMap());
         request.setEntity(createEntity(rankEvalRequest.getRankEvalSpec(), REQUEST_BODY_CONTENT_TYPE));
@@ -631,9 +639,13 @@ final class RequestConverters {
             .withTimeout(deleteByQueryRequest.getTimeout())
             .withWaitForActiveShards(deleteByQueryRequest.getWaitForActiveShards())
             .withRequestsPerSecond(deleteByQueryRequest.getRequestsPerSecond())
-            .withIndicesOptions(deleteByQueryRequest.indicesOptions())
             .withWaitForCompletion(waitForCompletion)
             .withSlices(deleteByQueryRequest.getSlices());
+
+        if (SearchRequest.DEFAULT_INDICES_OPTIONS.equals(deleteByQueryRequest.indicesOptions()) == false) {
+            params = params.withIndicesOptions(deleteByQueryRequest.indicesOptions());
+        }
+
         if (deleteByQueryRequest.isAbortOnVersionConflict() == false) {
             params.putParam("conflicts", "proceed");
         }
@@ -663,9 +675,11 @@ final class RequestConverters {
             .withTimeout(updateByQueryRequest.getTimeout())
             .withWaitForActiveShards(updateByQueryRequest.getWaitForActiveShards())
             .withRequestsPerSecond(updateByQueryRequest.getRequestsPerSecond())
-            .withIndicesOptions(updateByQueryRequest.indicesOptions())
             .withWaitForCompletion(waitForCompletion)
             .withSlices(updateByQueryRequest.getSlices());
+        if (SearchRequest.DEFAULT_INDICES_OPTIONS.equals(updateByQueryRequest.indicesOptions()) == false) {
+            params = params.withIndicesOptions(updateByQueryRequest.indicesOptions());
+        }
         if (updateByQueryRequest.isAbortOnVersionConflict() == false) {
             params.putParam("conflicts", "proceed");
         }

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/core/CountRequest.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/core/CountRequest.java
@@ -23,8 +23,6 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.Objects;
 
-import static org.elasticsearch.action.search.SearchRequest.DEFAULT_INDICES_OPTIONS;
-
 /**
  * Encapsulates a request to _count API against one, several or all indices.
  */
@@ -35,7 +33,7 @@ public final class CountRequest extends ActionRequest implements IndicesRequest.
     private String routing;
     private String preference;
     private QueryBuilder query;
-    private IndicesOptions indicesOptions = DEFAULT_INDICES_OPTIONS;
+    private IndicesOptions indicesOptions;
     private int terminateAfter = SearchContext.DEFAULT_TERMINATE_AFTER;
     private Float minScore;
 

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/eql/EqlSearchRequest.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/eql/EqlSearchRequest.java
@@ -28,7 +28,7 @@ import static java.util.Collections.emptyMap;
 public class EqlSearchRequest implements Validatable, ToXContentObject {
 
     private String[] indices;
-    private IndicesOptions indicesOptions = IndicesOptions.fromOptions(true, true, true, false);
+    private IndicesOptions indicesOptions;
 
     private QueryBuilder filter = null;
     private String timestampField = "@timestamp";

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/indexlifecycle/ExplainLifecycleRequest.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/indexlifecycle/ExplainLifecycleRequest.java
@@ -22,7 +22,7 @@ import java.util.Optional;
 public class ExplainLifecycleRequest extends TimedRequest {
 
     private final String[] indices;
-    private IndicesOptions indicesOptions = IndicesOptions.strictExpandOpen();
+    private IndicesOptions indicesOptions;
 
     public ExplainLifecycleRequest(String... indices) {
         if (indices.length == 0) {

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/indexlifecycle/RemoveIndexLifecyclePolicyRequest.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/indexlifecycle/RemoveIndexLifecyclePolicyRequest.java
@@ -21,7 +21,8 @@ public class RemoveIndexLifecyclePolicyRequest extends TimedRequest {
     private final IndicesOptions indicesOptions;
 
     public RemoveIndexLifecyclePolicyRequest(List<String> indices) {
-        this(indices, IndicesOptions.strictExpandOpen());
+       this.indices = Objects.requireNonNull(indices);
+       this.indicesOptions = null;
     }
 
     public RemoveIndexLifecyclePolicyRequest(List<String> indices, IndicesOptions indicesOptions) {

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/indices/CloseIndexRequest.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/indices/CloseIndexRequest.java
@@ -21,8 +21,10 @@ import java.util.Optional;
  */
 public class CloseIndexRequest extends TimedRequest implements Validatable {
 
+    public static final IndicesOptions DEFAULT_INDICES_OPTIONS = IndicesOptions.strictExpandOpen();
+
     private String[] indices;
-    private IndicesOptions indicesOptions = IndicesOptions.strictExpandOpen();
+    private IndicesOptions indicesOptions = DEFAULT_INDICES_OPTIONS;
     private ActiveShardCount waitForActiveShards = null;
 
     /**

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/indices/GetFieldMappingsRequest.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/indices/GetFieldMappingsRequest.java
@@ -24,7 +24,7 @@ public class GetFieldMappingsRequest implements Validatable {
 
     private String[] indices = Strings.EMPTY_ARRAY;
 
-    private IndicesOptions indicesOptions = IndicesOptions.strictExpandOpen();
+    private IndicesOptions indicesOptions;
 
     /**
      * Indicate whether the receiving node should operate based on local index information or forward requests,

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/indices/GetIndexRequest.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/indices/GetIndexRequest.java
@@ -23,13 +23,15 @@ public class GetIndexRequest extends TimedRequest {
         SETTINGS;
     }
 
+    public static final IndicesOptions DEFAULT_INDICES_OPTIONS = IndicesOptions.fromOptions(false, false, true, true);
+
     static final Feature[] DEFAULT_FEATURES = new Feature[] { Feature.ALIASES, Feature.MAPPINGS, Feature.SETTINGS };
     private Feature[] features = DEFAULT_FEATURES;
     private boolean humanReadable = false;
     private transient boolean includeDefaults = false;
 
     private final String[] indices;
-    private IndicesOptions indicesOptions = IndicesOptions.fromOptions(false, false, true, true);
+    private IndicesOptions indicesOptions = DEFAULT_INDICES_OPTIONS;
     private boolean local = false;
 
     public GetIndexRequest(String... indices) {

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/indices/GetMappingsRequest.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/indices/GetMappingsRequest.java
@@ -17,7 +17,7 @@ public class GetMappingsRequest extends TimedRequest {
     private boolean local = false;
     private boolean includeDefaults = false;
     private String[] indices = Strings.EMPTY_ARRAY;
-    private IndicesOptions indicesOptions = IndicesOptions.strictExpandOpen();
+    private IndicesOptions indicesOptions;
 
     /**
      * Indicates whether the receiving node should operate based on local index information or

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/indices/PutMappingRequest.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/indices/PutMappingRequest.java
@@ -31,8 +31,10 @@ import java.util.Map;
  */
 public class PutMappingRequest extends TimedRequest implements IndicesRequest, ToXContentObject {
 
+    public static final IndicesOptions DEFAULT_INDICES_OPTIONS = IndicesOptions.fromOptions(false, false, true, true);
+
     private final String[] indices;
-    private IndicesOptions indicesOptions = IndicesOptions.fromOptions(false, false, true, true);
+    private IndicesOptions indicesOptions = DEFAULT_INDICES_OPTIONS;
 
     private BytesReference source;
     private XContentType xContentType;

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/indices/ReloadAnalyzersRequest.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/indices/ReloadAnalyzersRequest.java
@@ -17,8 +17,10 @@ import java.util.Objects;
  */
 public final class ReloadAnalyzersRequest implements Validatable {
 
+    public static final IndicesOptions DEFAULT_INDICES_OPTIONS = IndicesOptions.strictExpandOpen();
+
     private final String[] indices;
-    private IndicesOptions indicesOptions = IndicesOptions.strictExpandOpen();
+    private IndicesOptions indicesOptions = DEFAULT_INDICES_OPTIONS;
 
     /**
      * Creates a new reload analyzers request

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/ESRestHighLevelClientTestCase.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/ESRestHighLevelClientTestCase.java
@@ -63,6 +63,13 @@ import static org.hamcrest.Matchers.notNullValue;
 
 public abstract class ESRestHighLevelClientTestCase extends ESRestTestCase {
 
+    public static final String IGNORE_THROTTLED_DEPRECATION_WARNING = "[ignore_throttled] parameter is deprecated because frozen " +
+        "indices have been deprecated. Consider cold or frozen tiers in place of frozen indices.";
+
+    protected static final RequestOptions IGNORE_THROTTLED_WARNING = RequestOptions.DEFAULT.toBuilder()
+        .setWarningsHandler(
+            warnings -> List.of(IGNORE_THROTTLED_DEPRECATION_WARNING).equals(warnings) == false
+        ).build();
     protected static final String CONFLICT_PIPELINE_ID = "conflict_pipeline";
 
     private static RestHighLevelClient restHighLevelClient;

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/ESRestHighLevelClientTestCase.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/ESRestHighLevelClientTestCase.java
@@ -68,7 +68,7 @@ public abstract class ESRestHighLevelClientTestCase extends ESRestTestCase {
 
     protected static final RequestOptions IGNORE_THROTTLED_WARNING = RequestOptions.DEFAULT.toBuilder()
         .setWarningsHandler(
-            warnings -> List.of(IGNORE_THROTTLED_DEPRECATION_WARNING).equals(warnings) == false
+            warnings -> Collections.singletonList(IGNORE_THROTTLED_DEPRECATION_WARNING).equals(warnings) == false
         ).build();
     protected static final String CONFLICT_PIPELINE_ID = "conflict_pipeline";
 

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/IndicesClientIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/IndicesClientIT.java
@@ -882,13 +882,14 @@ public class IndicesClientIT extends ESRestHighLevelClientTestCase {
         OpenIndexRequest lenientOpenIndexRequest = new OpenIndexRequest(nonExistentIndex);
         lenientOpenIndexRequest.indicesOptions(IndicesOptions.lenientExpandOpen());
         OpenIndexResponse lenientOpenIndexResponse = execute(lenientOpenIndexRequest, highLevelClient().indices()::open,
-                highLevelClient().indices()::openAsync);
+                highLevelClient().indices()::openAsync, IGNORE_THROTTLED_WARNING);
         assertThat(lenientOpenIndexResponse.isAcknowledged(), equalTo(true));
 
         OpenIndexRequest strictOpenIndexRequest = new OpenIndexRequest(nonExistentIndex);
         strictOpenIndexRequest.indicesOptions(IndicesOptions.strictExpandOpen());
         ElasticsearchException strictException = expectThrows(ElasticsearchException.class,
-                () -> execute(openIndexRequest, highLevelClient().indices()::open, highLevelClient().indices()::openAsync));
+                () -> execute(openIndexRequest, highLevelClient().indices()::open,
+                    highLevelClient().indices()::openAsync, IGNORE_THROTTLED_WARNING));
         assertEquals(RestStatus.NOT_FOUND, strictException.status());
     }
 

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/IndicesClientIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/IndicesClientIT.java
@@ -1003,7 +1003,7 @@ public class IndicesClientIT extends ESRestHighLevelClientTestCase {
             SyncedFlushRequest syncedFlushRequest = new SyncedFlushRequest(index);
             SyncedFlushResponse flushResponse =
                     execute(syncedFlushRequest, highLevelClient().indices()::flushSynced, highLevelClient().indices()::flushSyncedAsync,
-                        expectWarnings(SyncedFlushService.SYNCED_FLUSH_DEPRECATION_MESSAGE));
+                        expectWarnings(SyncedFlushService.SYNCED_FLUSH_DEPRECATION_MESSAGE, IGNORE_THROTTLED_DEPRECATION_WARNING));
             assertThat(flushResponse.totalShards(), equalTo(1));
             assertThat(flushResponse.successfulShards(), equalTo(1));
             assertThat(flushResponse.failedShards(), equalTo(0));
@@ -1019,7 +1019,7 @@ public class IndicesClientIT extends ESRestHighLevelClientTestCase {
                         syncedFlushRequest,
                         highLevelClient().indices()::flushSynced,
                         highLevelClient().indices()::flushSyncedAsync,
-                        expectWarnings(SyncedFlushService.SYNCED_FLUSH_DEPRECATION_MESSAGE)
+                        expectWarnings(SyncedFlushService.SYNCED_FLUSH_DEPRECATION_MESSAGE, IGNORE_THROTTLED_DEPRECATION_WARNING)
                     )
             );
             assertEquals(RestStatus.NOT_FOUND, exception.status());

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/IndicesRequestConvertersTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/IndicesRequestConvertersTests.java
@@ -71,6 +71,7 @@ import java.util.stream.Collectors;
 
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
+import static org.elasticsearch.client.RequestConvertersTests.setRandomIndicesOptions;
 import static org.elasticsearch.client.indices.RandomCreateIndexGenerator.randomAliases;
 import static org.elasticsearch.client.indices.RandomCreateIndexGenerator.randomMapping;
 import static org.elasticsearch.index.RandomCreateIndexGenerator.randomAlias;
@@ -722,8 +723,7 @@ public class IndicesRequestConvertersTests extends ESTestCase {
             syncedFlushRequest.indices(indices);
         }
         Map<String, String> expectedParams = new HashMap<>();
-        RequestConvertersTests.setRandomIndicesOptions(syncedFlushRequest::indicesOptions, syncedFlushRequest::indicesOptions,
-            expectedParams);
+        syncedFlushRequest.indicesOptions(setRandomIndicesOptions(syncedFlushRequest.indicesOptions(), expectedParams));
         Request request = IndicesRequestConverters.flushSynced(syncedFlushRequest);
         StringJoiner endpoint = new StringJoiner("/", "/", "");
         if (indices != null && indices.length > 0) {

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/RankEvalIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/RankEvalIT.java
@@ -99,7 +99,7 @@ public class RankEvalIT extends ESRestHighLevelClientTestCase {
         // now try this when test2 is closed
         closeIndex("index2");
         rankEvalRequest.indicesOptions(IndicesOptions.fromParameters(null, "true", null, "false", SearchRequest.DEFAULT_INDICES_OPTIONS));
-        response = execute(rankEvalRequest, highLevelClient()::rankEval, highLevelClient()::rankEvalAsync);
+        response = execute(rankEvalRequest, highLevelClient()::rankEval, highLevelClient()::rankEvalAsync, IGNORE_THROTTLED_WARNING);
     }
 
     private static List<RatedRequest> createTestEvaluationSpec() {

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/RequestConvertersTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/RequestConvertersTests.java
@@ -1602,7 +1602,7 @@ public class RequestConvertersTests extends ESTestCase {
                 openRequest.preference(preference);
                 expectedParams.put("preference", preference);
             }
-            openRequest.indicesOptions(setRandomIndicesOptions(openRequest.indicesOptions(), expectedParams));
+            setRandomIndicesOptions(openRequest::indicesOptions, openRequest::indicesOptions, expectedParams);
             final Request request = RequestConverters.openPointInTime(openRequest);
             assertThat(request.getParameters(), equalTo(expectedParams));
             assertThat(request.getMethod(), equalTo(HttpPost.METHOD_NAME));
@@ -1741,7 +1741,8 @@ public class RequestConvertersTests extends ESTestCase {
         endpoint.add("_field_caps");
 
         assertEquals(endpoint.toString(), request.getEndpoint());
-        assertEquals(5, request.getParameters().size());
+        int expectedSize = FieldCapabilitiesRequest.DEFAULT_INDICES_OPTIONS.equals(fieldCapabilitiesRequest.indicesOptions()) ? 1 : 5;
+        assertEquals(expectedSize, request.getParameters().size());
 
         // Note that we don't check the field param value explicitly, as field names are
         // passed through
@@ -1782,7 +1783,8 @@ public class RequestConvertersTests extends ESTestCase {
         endpoint.add("_field_caps");
 
         assertEquals(endpoint.toString(), request.getEndpoint());
-        assertEquals(5, request.getParameters().size());
+        int expectedSize = FieldCapabilitiesRequest.DEFAULT_INDICES_OPTIONS.equals(fieldCapabilitiesRequest.indicesOptions()) ? 1 : 5;
+        assertEquals(expectedSize, request.getParameters().size());
 
         // Note that we don't check the field param value explicitly, as field names are
         // passed through
@@ -1821,7 +1823,8 @@ public class RequestConvertersTests extends ESTestCase {
         }
         endpoint.add(RestRankEvalAction.ENDPOINT);
         assertEquals(endpoint.toString(), request.getEndpoint());
-        assertEquals(5, request.getParameters().size());
+        int expectedSize = SearchRequest.DEFAULT_INDICES_OPTIONS.equals(rankEvalRequest.indicesOptions()) ? 1 : 5;
+        assertEquals(expectedSize, request.getParameters().size());
         assertEquals(expectedParams, request.getParameters());
         assertToXContentBody(spec, request.getEntity());
     }
@@ -2157,9 +2160,19 @@ public class RequestConvertersTests extends ESTestCase {
                                         Map<String, String> expectedParams) {
 
         if (randomBoolean()) {
-            setter.accept(IndicesOptions.fromOptions(randomBoolean(), randomBoolean(), randomBoolean(), randomBoolean(),
-                true, false, false, randomBoolean()));
+            // randomly not set random indices options.
+            return;
         }
+
+        IndicesOptions defaults = getter.get();
+        IndicesOptions random = IndicesOptions.fromOptions(randomBoolean(), randomBoolean(), randomBoolean(), randomBoolean(), true, false,
+            false, randomBoolean());
+        if (random.equals(defaults)) {
+            // Random indices options is equal to the defaults, we expect no params to be set.
+            return;
+        }
+
+        setter.accept(random);
         expectedParams.put("ignore_unavailable", Boolean.toString(getter.get().ignoreUnavailable()));
         expectedParams.put("allow_no_indices", Boolean.toString(getter.get().allowNoIndices()));
         if (getter.get().expandWildcardsOpen() && getter.get().expandWildcardsClosed()) {

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/core/CountRequestTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/core/CountRequestTests.java
@@ -63,7 +63,7 @@ public class CountRequestTests extends AbstractRequestTestCase<CountRequest, Que
     public void testIllegalArguments() {
         CountRequest countRequest = new CountRequest();
         assertNotNull(countRequest.indices());
-        assertNotNull(countRequest.indicesOptions());
+        assertNull(countRequest.indicesOptions());
         assertNotNull(countRequest.types());
 
         Exception e = expectThrows(NullPointerException.class, () -> countRequest.indices((String[]) null));
@@ -123,7 +123,9 @@ public class CountRequestTests extends AbstractRequestTestCase<CountRequest, Que
     private static CountRequest copyRequest(CountRequest countRequest) {
         CountRequest result = new CountRequest();
         result.indices(countRequest.indices());
-        result.indicesOptions(countRequest.indicesOptions());
+        if (result.indicesOptions() != null) {
+            result.indicesOptions(countRequest.indicesOptions());
+        }
         result.types(countRequest.types());
         result.routing(countRequest.routing());
         result.preference(countRequest.preference());

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/CRUDDocumentationIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/CRUDDocumentationIT.java
@@ -1047,9 +1047,10 @@ public class CRUDDocumentationIT extends ESRestHighLevelClientTestCase {
             request.setIndicesOptions(IndicesOptions.LENIENT_EXPAND_OPEN); // <1>
             // end::update-by-query-request-indicesOptions
 
+            RequestOptions requestOptions = IGNORE_THROTTLED_WARNING;
             // tag::update-by-query-execute
             BulkByScrollResponse bulkResponse =
-                    client.updateByQuery(request, RequestOptions.DEFAULT);
+                    client.updateByQuery(request, requestOptions);
             // end::update-by-query-execute
             assertSame(0, bulkResponse.getSearchFailures().size());
             assertSame(0, bulkResponse.getBulkFailures().size());
@@ -1159,9 +1160,10 @@ public class CRUDDocumentationIT extends ESRestHighLevelClientTestCase {
             request.setIndicesOptions(IndicesOptions.LENIENT_EXPAND_OPEN); // <1>
             // end::delete-by-query-request-indicesOptions
 
+            RequestOptions requestOptions = IGNORE_THROTTLED_WARNING;
             // tag::delete-by-query-execute
             BulkByScrollResponse bulkResponse =
-                    client.deleteByQuery(request, RequestOptions.DEFAULT);
+                    client.deleteByQuery(request, requestOptions);
             // end::delete-by-query-execute
             assertSame(0, bulkResponse.getSearchFailures().size());
             assertSame(0, bulkResponse.getBulkFailures().size());

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/IndicesClientDocumentationIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/IndicesClientDocumentationIT.java
@@ -111,6 +111,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
 import static org.elasticsearch.client.IndicesClientIT.FROZEN_INDICES_DEPRECATION_WARNING;
+import static org.elasticsearch.client.IndicesClientIT.IGNORE_THROTTLED_DEPRECATION_WARNING;
 import static org.elasticsearch.client.IndicesClientIT.LEGACY_TEMPLATE_OPTIONS;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.equalTo;
@@ -161,8 +162,9 @@ public class IndicesClientDocumentationIT extends ESRestHighLevelClientTestCase 
             request.indicesOptions(indicesOptions); // <4>
             // end::indices-exists-request-optionals
 
+            RequestOptions requestOptions = IGNORE_THROTTLED_WARNING;
             // tag::indices-exists-execute
-            boolean exists = client.indices().exists(request, RequestOptions.DEFAULT);
+            boolean exists = client.indices().exists(request, requestOptions);
             // end::indices-exists-execute
             assertTrue(exists);
         }
@@ -229,8 +231,9 @@ public class IndicesClientDocumentationIT extends ESRestHighLevelClientTestCase 
             request.indicesOptions(IndicesOptions.lenientExpandOpen()); // <1>
             // end::delete-index-request-indicesOptions
 
+            RequestOptions requestOptions = IGNORE_THROTTLED_WARNING;
             // tag::delete-index-execute
-            AcknowledgedResponse deleteIndexResponse = client.indices().delete(request, RequestOptions.DEFAULT);
+            AcknowledgedResponse deleteIndexResponse = client.indices().delete(request, requestOptions);
             // end::delete-index-execute
 
             // tag::delete-index-response
@@ -593,8 +596,9 @@ public class IndicesClientDocumentationIT extends ESRestHighLevelClientTestCase 
             request.indicesOptions(IndicesOptions.lenientExpandOpen()); // <1>
             // end::get-mappings-request-indicesOptions
 
+            RequestOptions requestOptions = IGNORE_THROTTLED_WARNING;
             // tag::get-mappings-execute
-            GetMappingsResponse getMappingResponse = client.indices().getMapping(request, RequestOptions.DEFAULT);
+            GetMappingsResponse getMappingResponse = client.indices().getMapping(request, requestOptions);
             // end::get-mappings-execute
 
             // tag::get-mappings-response
@@ -713,10 +717,11 @@ public class IndicesClientDocumentationIT extends ESRestHighLevelClientTestCase 
         request.local(true); // <1>
         // end::get-field-mappings-request-local
 
+        RequestOptions requestOptions = IGNORE_THROTTLED_WARNING;
         {
             // tag::get-field-mappings-execute
             GetFieldMappingsResponse response =
-                client.indices().getFieldMapping(request, RequestOptions.DEFAULT);
+                client.indices().getFieldMapping(request, requestOptions);
             // end::get-field-mappings-execute
 
             // tag::get-field-mappings-response
@@ -767,7 +772,7 @@ public class IndicesClientDocumentationIT extends ESRestHighLevelClientTestCase 
             });
 
             // tag::get-field-mappings-execute-async
-            client.indices().getFieldMappingAsync(request, RequestOptions.DEFAULT, listener); // <1>
+            client.indices().getFieldMappingAsync(request, requestOptions, listener); // <1>
             // end::get-field-mappings-execute-async
 
             assertTrue(latch.await(30L, TimeUnit.SECONDS));
@@ -807,8 +812,9 @@ public class IndicesClientDocumentationIT extends ESRestHighLevelClientTestCase 
             request.indicesOptions(IndicesOptions.strictExpandOpen()); // <1>
             // end::open-index-request-indicesOptions
 
+            RequestOptions requestOptions = IGNORE_THROTTLED_WARNING;
             // tag::open-index-execute
-            OpenIndexResponse openIndexResponse = client.indices().open(request, RequestOptions.DEFAULT);
+            OpenIndexResponse openIndexResponse = client.indices().open(request, requestOptions);
             // end::open-index-execute
 
             // tag::open-index-response
@@ -838,7 +844,7 @@ public class IndicesClientDocumentationIT extends ESRestHighLevelClientTestCase 
             listener = new LatchedActionListener<>(listener, latch);
 
             // tag::open-index-execute-async
-            client.indices().openAsync(request, RequestOptions.DEFAULT, listener); // <1>
+            client.indices().openAsync(request, requestOptions, listener); // <1>
             // end::open-index-execute-async
 
             assertTrue(latch.await(30L, TimeUnit.SECONDS));
@@ -874,7 +880,7 @@ public class IndicesClientDocumentationIT extends ESRestHighLevelClientTestCase 
             // end::refresh-request
 
             // tag::refresh-request-indicesOptions
-            request.indicesOptions(IndicesOptions.lenientExpandOpen()); // <1>
+            request.indicesOptions(IndicesOptions.strictExpandOpenAndForbidClosed()); // <1>
             // end::refresh-request-indicesOptions
 
             // tag::refresh-execute
@@ -954,8 +960,9 @@ public class IndicesClientDocumentationIT extends ESRestHighLevelClientTestCase 
             request.force(true); // <1>
             // end::flush-request-force
 
+            RequestOptions requestOptions = IGNORE_THROTTLED_WARNING;
             // tag::flush-execute
-            FlushResponse flushResponse = client.indices().flush(request, RequestOptions.DEFAULT);
+            FlushResponse flushResponse = client.indices().flush(request, requestOptions);
             // end::flush-execute
 
             // tag::flush-response
@@ -984,7 +991,7 @@ public class IndicesClientDocumentationIT extends ESRestHighLevelClientTestCase 
             listener = new LatchedActionListener<>(listener, latch);
 
             // tag::flush-execute-async
-            client.indices().flushAsync(request, RequestOptions.DEFAULT, listener); // <1>
+            client.indices().flushAsync(request, requestOptions, listener); // <1>
             // end::flush-execute-async
 
             assertTrue(latch.await(30L, TimeUnit.SECONDS));
@@ -1114,8 +1121,9 @@ public class IndicesClientDocumentationIT extends ESRestHighLevelClientTestCase 
         request.indicesOptions(IndicesOptions.lenientExpandOpen()); // <1>
         // end::get-settings-request-indicesOptions
 
+        RequestOptions requestOptions = IGNORE_THROTTLED_WARNING;
         // tag::get-settings-execute
-        GetSettingsResponse getSettingsResponse = client.indices().getSettings(request, RequestOptions.DEFAULT);
+        GetSettingsResponse getSettingsResponse = client.indices().getSettings(request, requestOptions);
         // end::get-settings-execute
 
         // tag::get-settings-response
@@ -1150,7 +1158,7 @@ public class IndicesClientDocumentationIT extends ESRestHighLevelClientTestCase 
         listener = new LatchedActionListener<>(listener, latch);
 
         // tag::get-settings-execute-async
-        client.indices().getSettingsAsync(request, RequestOptions.DEFAULT, listener); // <1>
+        client.indices().getSettingsAsync(request, requestOptions, listener); // <1>
         // end::get-settings-execute-async
 
         assertTrue(latch.await(30L, TimeUnit.SECONDS));
@@ -1167,7 +1175,6 @@ public class IndicesClientDocumentationIT extends ESRestHighLevelClientTestCase 
         }
 
         GetSettingsRequest request = new GetSettingsRequest().indices("index");
-        request.indicesOptions(IndicesOptions.lenientExpandOpen());
 
         // tag::get-settings-request-include-defaults
         request.includeDefaults(true); // <1>
@@ -1233,8 +1240,9 @@ public class IndicesClientDocumentationIT extends ESRestHighLevelClientTestCase 
         request.includeDefaults(true); // <1>
         // end::get-index-request-includeDefaults
 
+        RequestOptions requestOptions = IGNORE_THROTTLED_WARNING;
         // tag::get-index-execute
-        GetIndexResponse getIndexResponse = client.indices().get(request, RequestOptions.DEFAULT);
+        GetIndexResponse getIndexResponse = client.indices().get(request, requestOptions);
         // end::get-index-execute
 
         // tag::get-index-response
@@ -1278,7 +1286,7 @@ public class IndicesClientDocumentationIT extends ESRestHighLevelClientTestCase 
         listener = new LatchedActionListener<>(listener, latch);
 
         // tag::get-index-execute-async
-        client.indices().getAsync(request, RequestOptions.DEFAULT, listener); // <1>
+        client.indices().getAsync(request, requestOptions, listener); // <1>
         // end::get-index-execute-async
 
         assertTrue(latch.await(30L, TimeUnit.SECONDS));
@@ -1319,8 +1327,9 @@ public class IndicesClientDocumentationIT extends ESRestHighLevelClientTestCase 
             request.flush(true); // <1>
             // end::force-merge-request-flush
 
+            RequestOptions requestOptions = IGNORE_THROTTLED_WARNING;
             // tag::force-merge-execute
-            ForceMergeResponse forceMergeResponse = client.indices().forcemerge(request, RequestOptions.DEFAULT);
+            ForceMergeResponse forceMergeResponse = client.indices().forcemerge(request, requestOptions);
             // end::force-merge-execute
 
             // tag::force-merge-response
@@ -1345,7 +1354,7 @@ public class IndicesClientDocumentationIT extends ESRestHighLevelClientTestCase 
             // end::force-merge-execute-listener
 
             // tag::force-merge-execute-async
-            client.indices().forcemergeAsync(request, RequestOptions.DEFAULT, listener); // <1>
+            client.indices().forcemergeAsync(request, requestOptions, listener); // <1>
             // end::force-merge-execute-async
         }
         {
@@ -1397,8 +1406,9 @@ public class IndicesClientDocumentationIT extends ESRestHighLevelClientTestCase 
             request.fields("field1", "field2", "field3"); // <1>
             // end::clear-cache-request-fields
 
+            RequestOptions requestOptions = IGNORE_THROTTLED_WARNING;
             // tag::clear-cache-execute
-            ClearIndicesCacheResponse clearCacheResponse = client.indices().clearCache(request, RequestOptions.DEFAULT);
+            ClearIndicesCacheResponse clearCacheResponse = client.indices().clearCache(request, requestOptions);
             // end::clear-cache-execute
 
             // tag::clear-cache-response
@@ -1473,8 +1483,9 @@ public class IndicesClientDocumentationIT extends ESRestHighLevelClientTestCase 
             request.indicesOptions(IndicesOptions.lenientExpandOpen()); // <1>
             // end::close-index-request-indicesOptions
 
+            RequestOptions requestOptions = IGNORE_THROTTLED_WARNING;
             // tag::close-index-execute
-            AcknowledgedResponse closeIndexResponse = client.indices().close(request, RequestOptions.DEFAULT);
+            AcknowledgedResponse closeIndexResponse = client.indices().close(request, requestOptions);
             // end::close-index-execute
 
             // tag::close-index-response
@@ -1541,8 +1552,9 @@ public class IndicesClientDocumentationIT extends ESRestHighLevelClientTestCase 
             request.local(true); // <1>
             // end::exists-alias-request-local
 
+            RequestOptions requestOptions = IGNORE_THROTTLED_WARNING;
             // tag::exists-alias-execute
-            boolean exists = client.indices().existsAlias(request, RequestOptions.DEFAULT);
+            boolean exists = client.indices().existsAlias(request, requestOptions);
             // end::exists-alias-execute
             assertTrue(exists);
 
@@ -2008,8 +2020,9 @@ public class IndicesClientDocumentationIT extends ESRestHighLevelClientTestCase 
             request.local(true); // <1>
             // end::get-alias-request-local
 
+            RequestOptions requestOptions = IGNORE_THROTTLED_WARNING;
             // tag::get-alias-execute
-            GetAliasesResponse response = client.indices().getAlias(request, RequestOptions.DEFAULT);
+            GetAliasesResponse response = client.indices().getAlias(request, requestOptions);
             // end::get-alias-execute
 
             // tag::get-alias-response
@@ -2048,7 +2061,7 @@ public class IndicesClientDocumentationIT extends ESRestHighLevelClientTestCase 
             listener = new LatchedActionListener<>(listener, latch);
 
             // tag::get-alias-execute-async
-            client.indices().getAliasAsync(request, RequestOptions.DEFAULT, listener); // <1>
+            client.indices().getAliasAsync(request, requestOptions, listener); // <1>
             // end::get-alias-execute-async
 
             assertTrue(latch.await(30L, TimeUnit.SECONDS));
@@ -2121,9 +2134,10 @@ public class IndicesClientDocumentationIT extends ESRestHighLevelClientTestCase 
         request.indicesOptions(IndicesOptions.lenientExpandOpen()); // <1>
         // end::indices-put-settings-request-indicesOptions
 
+        RequestOptions requestOptions = IGNORE_THROTTLED_WARNING;
         // tag::indices-put-settings-execute
         AcknowledgedResponse updateSettingsResponse =
-                client.indices().putSettings(request, RequestOptions.DEFAULT);
+                client.indices().putSettings(request, requestOptions);
         // end::indices-put-settings-execute
 
         // tag::indices-put-settings-response
@@ -2987,7 +3001,7 @@ public class IndicesClientDocumentationIT extends ESRestHighLevelClientTestCase 
 
             final RequestOptions freezeIndexOptions = RequestOptions.DEFAULT.toBuilder()
                 .setWarningsHandler(
-                    warnings -> org.elasticsearch.core.List.of(FROZEN_INDICES_DEPRECATION_WARNING).equals(warnings) == false
+                    warnings -> org.elasticsearch.core.List.of(FROZEN_INDICES_DEPRECATION_WARNING, IGNORE_THROTTLED_DEPRECATION_WARNING).equals(warnings) == false
                 )
                 .build();
 
@@ -3072,7 +3086,7 @@ public class IndicesClientDocumentationIT extends ESRestHighLevelClientTestCase 
             // tag::unfreeze-index-execute
             final RequestOptions unfreezeIndexOptions = RequestOptions.DEFAULT.toBuilder()
                 .setWarningsHandler(
-                    warnings -> org.elasticsearch.core.List.of(FROZEN_INDICES_DEPRECATION_WARNING).equals(warnings) == false
+                    warnings -> org.elasticsearch.core.List.of(FROZEN_INDICES_DEPRECATION_WARNING, IGNORE_THROTTLED_DEPRECATION_WARNING).equals(warnings) == false
                 )
                 .build();
             ShardsAcknowledgedResponse openIndexResponse = client.indices().unfreeze(request, unfreezeIndexOptions);

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/IndicesClientDocumentationIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/IndicesClientDocumentationIT.java
@@ -101,7 +101,6 @@ import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.rest.RestStatus;
 
 import java.io.IOException;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -110,6 +109,7 @@ import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
+import static java.util.Arrays.asList;
 import static org.elasticsearch.client.IndicesClientIT.FROZEN_INDICES_DEPRECATION_WARNING;
 import static org.elasticsearch.client.IndicesClientIT.IGNORE_THROTTLED_DEPRECATION_WARNING;
 import static org.elasticsearch.client.IndicesClientIT.LEGACY_TEMPLATE_OPTIONS;
@@ -2177,7 +2177,7 @@ public class IndicesClientDocumentationIT extends ESRestHighLevelClientTestCase 
 
         // tag::put-template-request
         PutIndexTemplateRequest request = new PutIndexTemplateRequest("my-template"); // <1>
-        request.patterns(Arrays.asList("pattern-1", "log-*")); // <2>
+        request.patterns(asList("pattern-1", "log-*")); // <2>
         // end::put-template-request
 
         // tag::put-template-request-settings
@@ -2325,7 +2325,7 @@ public class IndicesClientDocumentationIT extends ESRestHighLevelClientTestCase 
         RestHighLevelClient client = highLevelClient();
         {
             PutIndexTemplateRequest putRequest = new PutIndexTemplateRequest("my-template");
-            putRequest.patterns(Arrays.asList("pattern-1", "log-*"));
+            putRequest.patterns(asList("pattern-1", "log-*"));
             putRequest.settings(Settings.builder().put("index.number_of_shards", 3).put("index.number_of_replicas", 1));
             putRequest.mapping("{ \"properties\": { \"message\": { \"type\": \"text\" } } }",
                 XContentType.JSON
@@ -2390,7 +2390,7 @@ public class IndicesClientDocumentationIT extends ESRestHighLevelClientTestCase 
             PutComposableIndexTemplateRequest putRequest = new PutComposableIndexTemplateRequest()
                 .name("my-template")
                 .indexTemplate(
-                    new ComposableIndexTemplate(Arrays.asList("pattern-1", "log-*"), template, null, null, null, null)
+                    new ComposableIndexTemplate(asList("pattern-1", "log-*"), template, null, null, null, null)
                 );
             assertTrue(client.indices().putIndexTemplate(putRequest, RequestOptions.DEFAULT).isAcknowledged());
         }
@@ -2450,7 +2450,7 @@ public class IndicesClientDocumentationIT extends ESRestHighLevelClientTestCase 
             PutComposableIndexTemplateRequest request = new PutComposableIndexTemplateRequest()
                 .name("my-template"); // <1>
             ComposableIndexTemplate composableIndexTemplate =
-                new ComposableIndexTemplate(Arrays.asList("pattern-1", "log-*"), null, null, null, null, null); // <2>
+                new ComposableIndexTemplate(asList("pattern-1", "log-*"), null, null, null, null, null); // <2>
             request.indexTemplate(composableIndexTemplate);
             assertTrue(client.indices().putIndexTemplate(request, RequestOptions.DEFAULT).isAcknowledged());
             // end::put-index-template-v2-request
@@ -2465,7 +2465,7 @@ public class IndicesClientDocumentationIT extends ESRestHighLevelClientTestCase 
                 .put("index.number_of_replicas", 1)
                 .build();
             Template template = new Template(settings, null, null); // <2>
-            ComposableIndexTemplate composableIndexTemplate = new ComposableIndexTemplate(Arrays.asList("pattern-1", "log-*"),
+            ComposableIndexTemplate composableIndexTemplate = new ComposableIndexTemplate(asList("pattern-1", "log-*"),
                 template, null, null, null, null); // <3>
             request.indexTemplate(composableIndexTemplate);
 
@@ -2485,7 +2485,7 @@ public class IndicesClientDocumentationIT extends ESRestHighLevelClientTestCase 
             PutComposableIndexTemplateRequest request = new PutComposableIndexTemplateRequest()
                 .name("my-template");
             Template template = new Template(null, new CompressedXContent(mappingJson), null); // <2>
-            ComposableIndexTemplate composableIndexTemplate = new ComposableIndexTemplate(Arrays.asList("pattern-1", "log-*"),
+            ComposableIndexTemplate composableIndexTemplate = new ComposableIndexTemplate(asList("pattern-1", "log-*"),
                 template, null, null, null, null); // <3>
             request.indexTemplate(composableIndexTemplate);
 
@@ -2503,7 +2503,7 @@ public class IndicesClientDocumentationIT extends ESRestHighLevelClientTestCase 
             aliases.put("twitter_alias", twitterAlias);
             aliases.put("{index}_alias", placeholderAlias);
             Template template = new Template(null, null, aliases); // <3>
-            ComposableIndexTemplate composableIndexTemplate = new ComposableIndexTemplate(Arrays.asList("pattern-1", "log-*"),
+            ComposableIndexTemplate composableIndexTemplate = new ComposableIndexTemplate(asList("pattern-1", "log-*"),
                 template, null, null, null, null); // <4>
             request.indexTemplate(composableIndexTemplate);
 
@@ -2521,7 +2521,7 @@ public class IndicesClientDocumentationIT extends ESRestHighLevelClientTestCase 
             PutComposableIndexTemplateRequest request = new PutComposableIndexTemplateRequest()
                 .name("my-template");
             ComposableIndexTemplate composableIndexTemplate =
-                    new ComposableIndexTemplate(Arrays.asList("pattern-1", "log-*"), null,
+                    new ComposableIndexTemplate(asList("pattern-1", "log-*"), null,
                             Collections.singletonList("ct1"), null, null, null); // <1>
             request.indexTemplate(composableIndexTemplate);
 
@@ -2533,7 +2533,7 @@ public class IndicesClientDocumentationIT extends ESRestHighLevelClientTestCase 
             // tag::put-index-template-v2-request-priority
             PutComposableIndexTemplateRequest request = new PutComposableIndexTemplateRequest()
                 .name("my-template");
-            ComposableIndexTemplate composableIndexTemplate = new ComposableIndexTemplate(Arrays.asList("pattern-1", "log-*"),
+            ComposableIndexTemplate composableIndexTemplate = new ComposableIndexTemplate(asList("pattern-1", "log-*"),
                 null, null, 20L, null, null); // <1>
             request.indexTemplate(composableIndexTemplate);
 
@@ -2545,7 +2545,7 @@ public class IndicesClientDocumentationIT extends ESRestHighLevelClientTestCase 
             // tag::put-index-template-v2-request-version
             PutComposableIndexTemplateRequest request = new PutComposableIndexTemplateRequest()
                 .name("my-template");
-            ComposableIndexTemplate composableIndexTemplate = new ComposableIndexTemplate(Arrays.asList("pattern-1", "log-*"),
+            ComposableIndexTemplate composableIndexTemplate = new ComposableIndexTemplate(asList("pattern-1", "log-*"),
                 null, null, null, 3L, null); // <1>
             request.indexTemplate(composableIndexTemplate);
 
@@ -2602,7 +2602,7 @@ public class IndicesClientDocumentationIT extends ESRestHighLevelClientTestCase 
         {
             PutComposableIndexTemplateRequest request = new PutComposableIndexTemplateRequest()
                 .name("my-template");
-            ComposableIndexTemplate composableIndexTemplate = new ComposableIndexTemplate(Arrays.asList("pattern-1", "log-*"),
+            ComposableIndexTemplate composableIndexTemplate = new ComposableIndexTemplate(asList("pattern-1", "log-*"),
                 null, null, null, null, null); // <2>
             request.indexTemplate(composableIndexTemplate);
             assertTrue(client.indices().putIndexTemplate(request, RequestOptions.DEFAULT).isAcknowledged());
@@ -2628,7 +2628,7 @@ public class IndicesClientDocumentationIT extends ESRestHighLevelClientTestCase 
         {
             PutComposableIndexTemplateRequest request = new PutComposableIndexTemplateRequest()
                 .name("my-template");
-            ComposableIndexTemplate composableIndexTemplate = new ComposableIndexTemplate(Arrays.asList("pattern-1", "log-*"),
+            ComposableIndexTemplate composableIndexTemplate = new ComposableIndexTemplate(asList("pattern-1", "log-*"),
                 null, null, null, null, null); // <2>
             request.indexTemplate(composableIndexTemplate);
             assertTrue(client.indices().putIndexTemplate(request, RequestOptions.DEFAULT).isAcknowledged());
@@ -2666,7 +2666,7 @@ public class IndicesClientDocumentationIT extends ESRestHighLevelClientTestCase 
             PutComposableIndexTemplateRequest request = new PutComposableIndexTemplateRequest()
                 .name("my-template"); // <1>
             Template template = new Template(Settings.builder().put("index.number_of_replicas", 3).build(), null, null);
-            ComposableIndexTemplate composableIndexTemplate = new ComposableIndexTemplate(Arrays.asList("pattern-1", "log-*"),
+            ComposableIndexTemplate composableIndexTemplate = new ComposableIndexTemplate(asList("pattern-1", "log-*"),
                 template, null, null, null, null);
             request.indexTemplate(composableIndexTemplate);
             assertTrue(client.indices().putIndexTemplate(request, RequestOptions.DEFAULT).isAcknowledged());
@@ -2678,7 +2678,7 @@ public class IndicesClientDocumentationIT extends ESRestHighLevelClientTestCase 
             .name("used-for-simulation");
         Settings settings = Settings.builder().put("index.number_of_shards", 6).build();
         Template template = new Template(settings, null, null); // <2>
-        ComposableIndexTemplate composableIndexTemplate = new ComposableIndexTemplate(Arrays.asList("log-*"),
+        ComposableIndexTemplate composableIndexTemplate = new ComposableIndexTemplate(asList("log-*"),
             template, null, 90L, null, null);
         newIndexTemplateRequest.indexTemplate(composableIndexTemplate);
 
@@ -3001,7 +3001,7 @@ public class IndicesClientDocumentationIT extends ESRestHighLevelClientTestCase 
 
             final RequestOptions freezeIndexOptions = RequestOptions.DEFAULT.toBuilder()
                 .setWarningsHandler(
-                    warnings -> org.elasticsearch.core.List.of(FROZEN_INDICES_DEPRECATION_WARNING, IGNORE_THROTTLED_DEPRECATION_WARNING).equals(warnings) == false
+                    warnings -> asList(FROZEN_INDICES_DEPRECATION_WARNING, IGNORE_THROTTLED_DEPRECATION_WARNING).equals(warnings) == false
                 )
                 .build();
 
@@ -3086,7 +3086,7 @@ public class IndicesClientDocumentationIT extends ESRestHighLevelClientTestCase 
             // tag::unfreeze-index-execute
             final RequestOptions unfreezeIndexOptions = RequestOptions.DEFAULT.toBuilder()
                 .setWarningsHandler(
-                    warnings -> org.elasticsearch.core.List.of(FROZEN_INDICES_DEPRECATION_WARNING, IGNORE_THROTTLED_DEPRECATION_WARNING).equals(warnings) == false
+                    warnings -> asList(FROZEN_INDICES_DEPRECATION_WARNING, IGNORE_THROTTLED_DEPRECATION_WARNING).equals(warnings) == false
                 )
                 .build();
             ShardsAcknowledgedResponse openIndexResponse = client.indices().unfreeze(request, unfreezeIndexOptions);
@@ -3143,7 +3143,7 @@ public class IndicesClientDocumentationIT extends ESRestHighLevelClientTestCase 
         RestHighLevelClient client = highLevelClient();
         {
             PutIndexTemplateRequest putRequest = new PutIndexTemplateRequest("my-template");
-            putRequest.patterns(Arrays.asList("pattern-1", "log-*"));
+            putRequest.patterns(asList("pattern-1", "log-*"));
             putRequest.settings(Settings.builder().put("index.number_of_shards", 3));
             assertTrue(client.indices().putTemplate(putRequest, LEGACY_TEMPLATE_OPTIONS).isAcknowledged());
         }
@@ -3169,7 +3169,7 @@ public class IndicesClientDocumentationIT extends ESRestHighLevelClientTestCase 
 
         {
             PutIndexTemplateRequest putRequest = new PutIndexTemplateRequest("my-template");
-            putRequest.patterns(Arrays.asList("pattern-1", "log-*"));
+            putRequest.patterns(asList("pattern-1", "log-*"));
             putRequest.settings(Settings.builder().put("index.number_of_shards", 3));
             assertTrue(client.indices().putTemplate(putRequest, LEGACY_TEMPLATE_OPTIONS).isAcknowledged());
         }

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/IndicesClientDocumentationIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/IndicesClientDocumentationIT.java
@@ -1030,10 +1030,12 @@ public class IndicesClientDocumentationIT extends ESRestHighLevelClientTestCase 
             request.indicesOptions(IndicesOptions.lenientExpandOpen()); // <1>
             // end::flush-synced-request-indicesOptions
 
+            RequestOptions requestOptions = expectWarnings(
+                "Synced flush is deprecated and will be removed in 8.0. Use flush at /_flush or /{index}/_flush instead.",
+                IGNORE_THROTTLED_DEPRECATION_WARNING
+            );
             // tag::flush-synced-execute
-            SyncedFlushResponse flushSyncedResponse = client.indices().flushSynced(request, expectWarnings(
-                "Synced flush is deprecated and will be removed in 8.0. Use flush at /_flush or /{index}/_flush instead."
-            ));
+            SyncedFlushResponse flushSyncedResponse = client.indices().flushSynced(request, requestOptions);
             // end::flush-synced-execute
 
             // tag::flush-synced-response

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/SearchDocumentationIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/SearchDocumentationIT.java
@@ -149,7 +149,7 @@ public class SearchDocumentationIT extends ESRestHighLevelClientTestCase {
             // tag::search-request-preference
             searchRequest.preference("_local"); // <1>
             // end::search-request-preference
-            assertNotNull(client.search(searchRequest, RequestOptions.DEFAULT));
+            assertNotNull(client.search(searchRequest, IGNORE_THROTTLED_WARNING));
         }
         {
             // tag::search-source-basics
@@ -777,7 +777,7 @@ public class SearchDocumentationIT extends ESRestHighLevelClientTestCase {
             openRequest.preference("_local"); // <1>
             // end::open-point-in-time-preference
 
-            openResponse = client.openPointInTime(openRequest, RequestOptions.DEFAULT);
+            openResponse = client.openPointInTime(openRequest, IGNORE_THROTTLED_WARNING);
             pitId = openResponse.getPointInTimeId();
             client.closePointInTime(new ClosePointInTimeRequest(pitId), RequestOptions.DEFAULT);
         }
@@ -1119,8 +1119,9 @@ public class SearchDocumentationIT extends ESRestHighLevelClientTestCase {
         request.indicesOptions(IndicesOptions.lenientExpandOpen()); // <1>
         // end::field-caps-request-indicesOptions
 
+        RequestOptions requestOptions = IGNORE_THROTTLED_WARNING;
         // tag::field-caps-execute
-        FieldCapabilitiesResponse response = client.fieldCaps(request, RequestOptions.DEFAULT);
+        FieldCapabilitiesResponse response = client.fieldCaps(request, requestOptions);
         // end::field-caps-execute
 
         // tag::field-caps-response
@@ -1371,7 +1372,7 @@ public class SearchDocumentationIT extends ESRestHighLevelClientTestCase {
                 .indicesOptions(IndicesOptions.lenientExpandOpen()) // <3>
                 .preference("_local"); // <4>
             // end::count-request-args
-            assertNotNull(client.count(countRequest, RequestOptions.DEFAULT));
+            assertNotNull(client.count(countRequest, IGNORE_THROTTLED_WARNING));
         }
         {
             // tag::count-source-basics

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/eql/EqlSearchRequestTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/eql/EqlSearchRequestTests.java
@@ -8,6 +8,7 @@
 
 package org.elasticsearch.client.eql;
 
+import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.client.AbstractRequestTestCase;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
@@ -70,7 +71,9 @@ public class EqlSearchRequestTests extends AbstractRequestTestCase<EqlSearchRequ
         assertThat(serverInstance.tiebreakerField(), equalTo(clientTestInstance.tiebreakerField()));
         assertThat(serverInstance.filter(), equalTo(clientTestInstance.filter()));
         assertThat(serverInstance.query(), equalTo(clientTestInstance.query()));
-        assertThat(serverInstance.indicesOptions(), equalTo(clientTestInstance.indicesOptions()));
+        IndicesOptions actual = clientTestInstance.indicesOptions() == null ?
+            org.elasticsearch.xpack.eql.action.EqlSearchRequest.DEFAULT_INDICES_OPTIONS : clientTestInstance.indicesOptions();
+        assertThat(serverInstance.indicesOptions(), equalTo(actual));
         assertThat(serverInstance.indices(), equalTo(clientTestInstance.indices()));
         assertThat(serverInstance.fetchSize(), equalTo(clientTestInstance.fetchSize()));
         assertThat(serverInstance.size(), equalTo(clientTestInstance.size()));

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/indexlifecycle/RemoveIndexLifecyclePolicyRequestTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/indexlifecycle/RemoveIndexLifecyclePolicyRequestTests.java
@@ -42,11 +42,15 @@ public class RemoveIndexLifecyclePolicyRequestTests extends ESTestCase {
     }
 
     private RemoveIndexLifecyclePolicyRequest copyInstance(RemoveIndexLifecyclePolicyRequest req) {
-        return new RemoveIndexLifecyclePolicyRequest(new ArrayList<>(req.indices()), IndicesOptions.fromOptions(
+        if (req.indicesOptions() != null) {
+            return new RemoveIndexLifecyclePolicyRequest(new ArrayList<>(req.indices()), IndicesOptions.fromOptions(
                 req.indicesOptions().ignoreUnavailable(), req.indicesOptions().allowNoIndices(),
                 req.indicesOptions().expandWildcardsOpen(), req.indicesOptions().expandWildcardsClosed(),
                 req.indicesOptions().allowAliasesToMultipleIndices(), req.indicesOptions().forbidClosedIndices(),
                 req.indicesOptions().ignoreAliases(), req.indicesOptions().ignoreThrottled()));
+        } else {
+            return new RemoveIndexLifecyclePolicyRequest(new ArrayList<>(req.indices()));
+        }
     }
 
     private RemoveIndexLifecyclePolicyRequest mutateInstance(RemoveIndexLifecyclePolicyRequest req) {
@@ -55,9 +59,14 @@ public class RemoveIndexLifecyclePolicyRequestTests extends ESTestCase {
                     randomValueOtherThan(req.indicesOptions(), () -> IndicesOptions.fromOptions(randomBoolean(), randomBoolean(),
                     randomBoolean(), randomBoolean(), randomBoolean(), randomBoolean(), randomBoolean(), randomBoolean())));
         } else {
-            return new RemoveIndexLifecyclePolicyRequest(
+            if (req.indicesOptions() != null) {
+                return new RemoveIndexLifecyclePolicyRequest(
                     randomValueOtherThan(req.indices(), () -> Arrays.asList(generateRandomStringArray(20, 20, false))),
                     req.indicesOptions());
+            } else {
+                return new RemoveIndexLifecyclePolicyRequest(
+                    randomValueOtherThan(req.indices(), () -> Arrays.asList(generateRandomStringArray(20, 20, false))));
+            }
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/alias/get/GetAliasesRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/alias/get/GetAliasesRequest.java
@@ -20,9 +20,11 @@ import java.io.IOException;
 
 public class GetAliasesRequest extends MasterNodeReadRequest<GetAliasesRequest> implements AliasesRequest {
 
+    public static final IndicesOptions DEFAULT_INDICES_OPTIONS = IndicesOptions.strictExpandHidden();
+
     private String[] indices = Strings.EMPTY_ARRAY;
     private String[] aliases = Strings.EMPTY_ARRAY;
-    private IndicesOptions indicesOptions = IndicesOptions.strictExpandHidden();
+    private IndicesOptions indicesOptions = DEFAULT_INDICES_OPTIONS;
     private String[] originalAliases = Strings.EMPTY_ARRAY;
 
     public GetAliasesRequest(String... aliases) {

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/delete/DeleteIndexRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/delete/DeleteIndexRequest.java
@@ -25,9 +25,12 @@ import static org.elasticsearch.action.ValidateActions.addValidationError;
  */
 public class DeleteIndexRequest extends AcknowledgedRequest<DeleteIndexRequest> implements IndicesRequest.Replaceable {
 
+    public static final IndicesOptions DEFAULT_INDICES_OPTIONS =
+        IndicesOptions.fromOptions(false, true, true, true, false, false, true, false);
+
     private String[] indices;
     // Delete index should work by default on both open and closed indices.
-    private IndicesOptions indicesOptions = IndicesOptions.fromOptions(false, true, true, true, false, false, true, false);
+    private IndicesOptions indicesOptions = DEFAULT_INDICES_OPTIONS;
 
     public DeleteIndexRequest(StreamInput in) throws IOException {
         super(in);

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/mapping/get/GetFieldMappingsRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/mapping/get/GetFieldMappingsRequest.java
@@ -26,6 +26,8 @@ import java.io.IOException;
  */
 public class GetFieldMappingsRequest extends ActionRequest implements IndicesRequest.Replaceable {
 
+    public static final IndicesOptions DEFAULT_INDICES_OPTIONS = IndicesOptions.strictExpandOpen();
+
     protected boolean local = false;
 
     private String[] fields = Strings.EMPTY_ARRAY;
@@ -35,7 +37,7 @@ public class GetFieldMappingsRequest extends ActionRequest implements IndicesReq
     private String[] indices = Strings.EMPTY_ARRAY;
     private String[] types = Strings.EMPTY_ARRAY;
 
-    private IndicesOptions indicesOptions = IndicesOptions.strictExpandOpen();
+    private IndicesOptions indicesOptions = DEFAULT_INDICES_OPTIONS;
 
     public GetFieldMappingsRequest() {}
 

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/open/OpenIndexRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/open/OpenIndexRequest.java
@@ -27,8 +27,10 @@ import static org.elasticsearch.action.ValidateActions.addValidationError;
  */
 public class OpenIndexRequest extends AcknowledgedRequest<OpenIndexRequest> implements IndicesRequest.Replaceable {
 
+    public static final IndicesOptions DEFAULT_INDICES_OPTIONS = IndicesOptions.fromOptions(false, true, false, true);
+
     private String[] indices;
-    private IndicesOptions indicesOptions = IndicesOptions.fromOptions(false, true, false, true);
+    private IndicesOptions indicesOptions = DEFAULT_INDICES_OPTIONS;
     private ActiveShardCount waitForActiveShards = ActiveShardCount.DEFAULT;
 
     public OpenIndexRequest(StreamInput in) throws IOException {

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/settings/get/GetSettingsRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/settings/get/GetSettingsRequest.java
@@ -24,8 +24,10 @@ import java.util.Objects;
 
 public class GetSettingsRequest extends MasterNodeReadRequest<GetSettingsRequest> implements IndicesRequest.Replaceable {
 
+    public static final IndicesOptions DEFAULT_INDICES_OPTIONS = IndicesOptions.fromOptions(false, true, true, true);
+
     private String[] indices = Strings.EMPTY_ARRAY;
-    private IndicesOptions indicesOptions = IndicesOptions.fromOptions(false, true, true, true);
+    private IndicesOptions indicesOptions = DEFAULT_INDICES_OPTIONS;
     private String[] names = Strings.EMPTY_ARRAY;
     private boolean humanReadable = false;
     private boolean includeDefaults = false;

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/settings/put/UpdateSettingsRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/settings/put/UpdateSettingsRequest.java
@@ -39,8 +39,10 @@ import static org.elasticsearch.common.settings.Settings.Builder.EMPTY_SETTINGS;
 public class UpdateSettingsRequest extends AcknowledgedRequest<UpdateSettingsRequest>
         implements IndicesRequest.Replaceable, ToXContentObject {
 
+    public static final IndicesOptions DEFAULT_INDICES_OPTIONS = IndicesOptions.fromOptions(false, false, true, true);
+
     private String[] indices;
-    private IndicesOptions indicesOptions = IndicesOptions.fromOptions(false, false, true, true);
+    private IndicesOptions indicesOptions = DEFAULT_INDICES_OPTIONS;
     private Settings settings = EMPTY_SETTINGS;
     private boolean preserveExisting = false;
     private String origin = "";

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/validate/query/ValidateQueryRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/validate/query/ValidateQueryRequest.java
@@ -30,6 +30,8 @@ import java.util.Arrays;
  */
 public class ValidateQueryRequest extends BroadcastRequest<ValidateQueryRequest> implements ToXContentObject {
 
+    public static final IndicesOptions DEFAULT_INDICES_OPTIONS = IndicesOptions.fromOptions(false, false, true, false);
+
     private QueryBuilder query = new MatchAllQueryBuilder();
 
     private boolean explain;
@@ -65,7 +67,7 @@ public class ValidateQueryRequest extends BroadcastRequest<ValidateQueryRequest>
      */
     public ValidateQueryRequest(String... indices) {
         super(indices);
-        indicesOptions(IndicesOptions.fromOptions(false, false, true, false));
+        indicesOptions(DEFAULT_INDICES_OPTIONS);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/action/fieldcaps/FieldCapabilitiesRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/fieldcaps/FieldCapabilitiesRequest.java
@@ -31,9 +31,10 @@ import java.util.Set;
 
 public final class FieldCapabilitiesRequest extends ActionRequest implements IndicesRequest.Replaceable, ToXContentObject {
     public static final String NAME = "field_caps_request";
+    public static final IndicesOptions DEFAULT_INDICES_OPTIONS = IndicesOptions.strictExpandOpen();
 
     private String[] indices = Strings.EMPTY_ARRAY;
-    private IndicesOptions indicesOptions = IndicesOptions.strictExpandOpen();
+    private IndicesOptions indicesOptions = DEFAULT_INDICES_OPTIONS;
     private String[] fields = Strings.EMPTY_ARRAY;
     private boolean includeUnmapped = false;
     // pkg private API mainly for cross cluster search to signal that we do multiple reductions ie. the results should not be merged

--- a/server/src/main/java/org/elasticsearch/action/support/IndicesOptions.java
+++ b/server/src/main/java/org/elasticsearch/action/support/IndicesOptions.java
@@ -9,6 +9,8 @@ package org.elasticsearch.action.support;
 
 import org.elasticsearch.Version;
 import org.elasticsearch.ElasticsearchParseException;
+import org.elasticsearch.common.logging.DeprecationCategory;
+import org.elasticsearch.common.logging.DeprecationLogger;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.common.xcontent.ParseField;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -103,6 +105,10 @@ public class IndicesOptions implements ToXContentFragment {
 
         public static final EnumSet<Option> NONE = EnumSet.noneOf(Option.class);
     }
+
+    private static final DeprecationLogger DEPRECATION_LOGGER = DeprecationLogger.getLogger(IndicesOptions.class);
+    private static final String IGNORE_THROTTLED_DEPRECATION_MESSAGE = "[ignore_throttled] parameter is deprecated " +
+        "because frozen indices have been deprecated. Consider cold or frozen tiers in place of frozen indices.";
 
     public static final IndicesOptions STRICT_EXPAND_OPEN =
         new IndicesOptions(EnumSet.of(Option.ALLOW_NO_INDICES), EnumSet.of(WildcardStates.OPEN));
@@ -317,6 +323,10 @@ public class IndicesOptions implements ToXContentFragment {
     }
 
     public static IndicesOptions fromRequest(RestRequest request, IndicesOptions defaultSettings) {
+        if (request.hasParam("ignore_throttled")) {
+            DEPRECATION_LOGGER.warn(DeprecationCategory.API, "ignore_throttled_param", IGNORE_THROTTLED_DEPRECATION_MESSAGE);
+        }
+
         return fromParameters(
                 request.param("expand_wildcards"),
                 request.param("ignore_unavailable"),
@@ -381,7 +391,7 @@ public class IndicesOptions implements ToXContentFragment {
 
     private static final ParseField EXPAND_WILDCARDS_FIELD = new ParseField("expand_wildcards");
     private static final ParseField IGNORE_UNAVAILABLE_FIELD = new ParseField("ignore_unavailable");
-    private static final ParseField IGNORE_THROTTLED_FIELD = new ParseField("ignore_throttled");
+    private static final ParseField IGNORE_THROTTLED_FIELD = new ParseField("ignore_throttled").withAllDeprecated();
     private static final ParseField ALLOW_NO_INDICES_FIELD = new ParseField("allow_no_indices");
 
     public static IndicesOptions fromXContent(XContentParser parser) throws IOException {

--- a/server/src/main/java/org/elasticsearch/action/support/IndicesOptions.java
+++ b/server/src/main/java/org/elasticsearch/action/support/IndicesOptions.java
@@ -324,7 +324,7 @@ public class IndicesOptions implements ToXContentFragment {
 
     public static IndicesOptions fromRequest(RestRequest request, IndicesOptions defaultSettings) {
         if (request.hasParam("ignore_throttled")) {
-            DEPRECATION_LOGGER.warn(DeprecationCategory.API, "ignore_throttled_param", IGNORE_THROTTLED_DEPRECATION_MESSAGE);
+            DEPRECATION_LOGGER.deprecate(DeprecationCategory.API, "ignore_throttled_param", IGNORE_THROTTLED_DEPRECATION_MESSAGE);
         }
 
         return fromParameters(

--- a/server/src/main/java/org/elasticsearch/action/support/broadcast/BroadcastRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/support/broadcast/BroadcastRequest.java
@@ -22,6 +22,8 @@ import java.io.IOException;
 
 public class BroadcastRequest<Request extends BroadcastRequest<Request>> extends ActionRequest implements IndicesRequest.Replaceable {
 
+    public static final IndicesOptions DEFAULT_INDICES_OPTIONS = IndicesOptions.strictExpandOpenAndForbidClosed();
+
     protected String[] indices;
     private IndicesOptions indicesOptions;
 

--- a/server/src/main/java/org/elasticsearch/action/support/master/info/ClusterInfoRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/support/master/info/ClusterInfoRequest.java
@@ -20,10 +20,12 @@ import java.io.IOException;
 public abstract class ClusterInfoRequest<Request extends ClusterInfoRequest<Request>> extends MasterNodeReadRequest<Request>
         implements IndicesRequest.Replaceable {
 
+    public static final IndicesOptions DEFAULT_INDICES_OPTIONS = IndicesOptions.strictExpandOpen();
+
     private String[] indices = Strings.EMPTY_ARRAY;
     private String[] types = Strings.EMPTY_ARRAY;
 
-    private IndicesOptions indicesOptions = IndicesOptions.strictExpandOpen();
+    private IndicesOptions indicesOptions = DEFAULT_INDICES_OPTIONS;
 
     public ClusterInfoRequest() {
     }

--- a/server/src/test/java/org/elasticsearch/action/support/IndicesOptionsTests.java
+++ b/server/src/test/java/org/elasticsearch/action/support/IndicesOptionsTests.java
@@ -14,6 +14,7 @@ import org.elasticsearch.action.support.IndicesOptions.WildcardStates;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.xcontent.DeprecationHandler;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 import org.elasticsearch.common.xcontent.ToXContent.MapParams;
 import org.elasticsearch.common.xcontent.XContentBuilder;
@@ -352,7 +353,7 @@ public class IndicesOptionsTests extends ESTestCase {
         BytesReference xContentBytes = toXContentBytes(indicesOptions, type);
         IndicesOptions fromXContentOptions;
         try (XContentParser parser = type.xContent().createParser(
-            NamedXContentRegistry.EMPTY, null, xContentBytes.streamInput())) {
+            NamedXContentRegistry.EMPTY, DeprecationHandler.IGNORE_DEPRECATIONS, xContentBytes.streamInput())) {
             fromXContentOptions = IndicesOptions.fromXContent(parser);
         }
 

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/action/EqlSearchRequest.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/action/EqlSearchRequest.java
@@ -46,9 +46,10 @@ public class EqlSearchRequest extends ActionRequest implements IndicesRequest.Re
 
     public static long MIN_KEEP_ALIVE = TimeValue.timeValueMinutes(1).millis();
     public static TimeValue DEFAULT_KEEP_ALIVE = TimeValue.timeValueDays(5);
+    public static final IndicesOptions DEFAULT_INDICES_OPTIONS = IndicesOptions.fromOptions(true, true, true, false);
 
     private String[] indices;
-    private IndicesOptions indicesOptions = IndicesOptions.fromOptions(true, true, true, false);
+    private IndicesOptions indicesOptions = DEFAULT_INDICES_OPTIONS;
 
     private QueryBuilder filter = null;
     private String timestampField = FIELD_TIMESTAMP;

--- a/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/AbstractSearchableSnapshotsRestTestCase.java
+++ b/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/AbstractSearchableSnapshotsRestTestCase.java
@@ -29,6 +29,7 @@ import org.elasticsearch.search.builder.SearchSourceBuilder;
 import org.elasticsearch.test.rest.ESRestTestCase;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -475,7 +476,7 @@ public abstract class AbstractSearchableSnapshotsRestTestCase extends ESRestTest
             request.addParameter("ignore_throttled", ignoreThrottled.toString());
             RequestOptions requestOptions = RequestOptions.DEFAULT.toBuilder()
                 .setWarningsHandler(
-                    warnings -> List.of(
+                    warnings -> Collections.singletonList(
                         "[ignore_throttled] parameter is deprecated because frozen indices have been deprecated. "
                             + "Consider cold or frozen tiers in place of frozen indices."
                     ).equals(warnings) == false

--- a/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/AbstractSearchableSnapshotsRestTestCase.java
+++ b/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/AbstractSearchableSnapshotsRestTestCase.java
@@ -13,6 +13,7 @@ import org.apache.http.client.methods.HttpPut;
 import org.apache.http.entity.ContentType;
 import org.apache.http.entity.StringEntity;
 import org.elasticsearch.client.Request;
+import org.elasticsearch.client.RequestOptions;
 import org.elasticsearch.client.Response;
 import org.elasticsearch.client.ResponseException;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
@@ -472,6 +473,15 @@ public abstract class AbstractSearchableSnapshotsRestTestCase extends ESRestTest
         request.setJsonEntity(new SearchSourceBuilder().trackTotalHits(true).query(query).toString());
         if (ignoreThrottled != null) {
             request.addParameter("ignore_throttled", ignoreThrottled.toString());
+            RequestOptions requestOptions = RequestOptions.DEFAULT.toBuilder()
+                .setWarningsHandler(
+                    warnings -> List.of(
+                        "[ignore_throttled] parameter is deprecated because frozen indices have been deprecated. "
+                            + "Consider cold or frozen tiers in place of frozen indices."
+                    ).equals(warnings) == false
+                )
+                .build();
+            request.setOptions(requestOptions);
         }
 
         final Response response = client().performRequest(request);

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/indices.freeze/10_basic.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/indices.freeze/10_basic.yml
@@ -23,6 +23,8 @@
       index: test
 
 - do:
+    warnings:
+      - "[ignore_throttled] parameter is deprecated because frozen indices have been deprecated. Consider cold or frozen tiers in place of frozen indices."
     search:
       rest_total_hits_as_int: true
       index: test
@@ -66,6 +68,8 @@
       index: test*
 
 - do:
+    warnings:
+      - "[ignore_throttled] parameter is deprecated because frozen indices have been deprecated. Consider cold or frozen tiers in place of frozen indices."
     search:
       rest_total_hits_as_int: true
       index: _all
@@ -90,7 +94,6 @@
 
 ---
 "Test index options":
-
 - skip:
     version: " - 6.99.99"
     reason: types are required in requests before 7.0.0
@@ -133,6 +136,8 @@
 - match: {hits.total: 0}
 
 - do:
+    warnings:
+      - "[ignore_throttled] parameter is deprecated because frozen indices have been deprecated. Consider cold or frozen tiers in place of frozen indices."
     search:
       rest_total_hits_as_int: true
       index: _all

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/ml/datafeeds_crud.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/ml/datafeeds_crud.yml
@@ -440,6 +440,8 @@ setup:
   - match: { acknowledged: true }
 ---
 "Test put and update datafeed with indices options":
+  - skip:
+      features: warnings
   - do:
       ml.put_datafeed:
         datafeed_id: test-datafeed-indices-options-1
@@ -480,7 +482,11 @@ setup:
   - match: { datafeeds.0.indices_options.ignore_throttled: true }
 ---
 "Test put and update datafeed with indices options in params":
+  - skip:
+      features: warnings
   - do:
+      warnings:
+        - "[ignore_throttled] parameter is deprecated because frozen indices have been deprecated. Consider cold or frozen tiers in place of frozen indices."
       ml.put_datafeed:
         datafeed_id: test-datafeed-indices-options-params-1
         ignore_throttled: false
@@ -499,6 +505,8 @@ setup:
 
 
   - do:
+      warnings:
+        - "[ignore_throttled] parameter is deprecated because frozen indices have been deprecated. Consider cold or frozen tiers in place of frozen indices."
       ml.update_datafeed:
         datafeed_id: test-datafeed-indices-options-params-1
         ignore_throttled: false

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/ml/jobs_crud.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/ml/jobs_crud.yml
@@ -1163,7 +1163,11 @@
   - is_false: jobs.0.datafeed_config
 ---
 "Test put job with datafeed with indices options in params":
+  - skip:
+      features: warnings
   - do:
+      warnings:
+        - "[ignore_throttled] parameter is deprecated because frozen indices have been deprecated. Consider cold or frozen tiers in place of frozen indices."
       ml.put_job:
         job_id: jobs-crud-put-with-datafeed-with-indices-options
         ignore_throttled: false

--- a/x-pack/plugin/transform/qa/multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/continuous/DateHistogramGroupByIT.java
+++ b/x-pack/plugin/transform/qa/multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/continuous/DateHistogramGroupByIT.java
@@ -9,7 +9,6 @@ package org.elasticsearch.xpack.transform.integration.continuous;
 
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.search.SearchResponse;
-import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.client.transform.transforms.DestConfig;
 import org.elasticsearch.client.transform.transforms.SettingsConfig;
 import org.elasticsearch.client.transform.transforms.SourceConfig;
@@ -90,8 +89,7 @@ public class DateHistogramGroupByIT extends ContinuousTestCase {
 
     @Override
     public void testIteration(int iteration, Set<String> modifiedEvents) throws IOException {
-        SearchRequest searchRequestSource = new SearchRequest(CONTINUOUS_EVENTS_SOURCE_INDEX).allowPartialSearchResults(false)
-            .indicesOptions(IndicesOptions.LENIENT_EXPAND_OPEN);
+        SearchRequest searchRequestSource = new SearchRequest(CONTINUOUS_EVENTS_SOURCE_INDEX).allowPartialSearchResults(false);
         SearchSourceBuilder sourceBuilderSource = new SearchSourceBuilder().size(0);
         DateHistogramAggregationBuilder bySecond = new DateHistogramAggregationBuilder("second").field(timestampField)
             .fixedInterval(DateHistogramInterval.SECOND)
@@ -104,8 +102,7 @@ public class DateHistogramGroupByIT extends ContinuousTestCase {
         searchRequestSource.source(sourceBuilderSource);
         SearchResponse responseSource = search(searchRequestSource);
 
-        SearchRequest searchRequestDest = new SearchRequest(NAME).allowPartialSearchResults(false)
-            .indicesOptions(IndicesOptions.LENIENT_EXPAND_OPEN);
+        SearchRequest searchRequestDest = new SearchRequest(NAME).allowPartialSearchResults(false);
         SearchSourceBuilder sourceBuilderDest = new SearchSourceBuilder().size(100).sort("second");
         searchRequestDest.source(sourceBuilderDest);
         SearchResponse responseDest = search(searchRequestDest);

--- a/x-pack/plugin/transform/qa/multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/continuous/DateHistogramGroupByOtherTimeFieldIT.java
+++ b/x-pack/plugin/transform/qa/multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/continuous/DateHistogramGroupByOtherTimeFieldIT.java
@@ -91,8 +91,7 @@ public class DateHistogramGroupByOtherTimeFieldIT extends ContinuousTestCase {
 
     @Override
     public void testIteration(int iteration, Set<String> modifiedEvents) throws IOException {
-        SearchRequest searchRequestSource = new SearchRequest(CONTINUOUS_EVENTS_SOURCE_INDEX).allowPartialSearchResults(false)
-            .indicesOptions(IndicesOptions.LENIENT_EXPAND_OPEN);
+        SearchRequest searchRequestSource = new SearchRequest(CONTINUOUS_EVENTS_SOURCE_INDEX).allowPartialSearchResults(false);
         SearchSourceBuilder sourceBuilderSource = new SearchSourceBuilder().size(0);
         DateHistogramAggregationBuilder bySecond = new DateHistogramAggregationBuilder("second").field(metricTimestampField)
             .fixedInterval(DateHistogramInterval.SECOND)
@@ -106,8 +105,7 @@ public class DateHistogramGroupByOtherTimeFieldIT extends ContinuousTestCase {
         searchRequestSource.source(sourceBuilderSource);
         SearchResponse responseSource = search(searchRequestSource);
 
-        SearchRequest searchRequestDest = new SearchRequest(NAME).allowPartialSearchResults(false)
-            .indicesOptions(IndicesOptions.LENIENT_EXPAND_OPEN);
+        SearchRequest searchRequestDest = new SearchRequest(NAME).allowPartialSearchResults(false);
         SearchSourceBuilder sourceBuilderDest = new SearchSourceBuilder().size(10000).sort("second");
         if (addGroupByTerms) {
             sourceBuilderDest.sort("event");

--- a/x-pack/plugin/transform/qa/multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/continuous/HistogramGroupByIT.java
+++ b/x-pack/plugin/transform/qa/multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/continuous/HistogramGroupByIT.java
@@ -2,7 +2,6 @@ package org.elasticsearch.xpack.transform.integration.continuous;
 
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.search.SearchResponse;
-import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.client.transform.transforms.DestConfig;
 import org.elasticsearch.client.transform.transforms.SourceConfig;
 import org.elasticsearch.client.transform.transforms.TransformConfig;
@@ -64,8 +63,7 @@ public class HistogramGroupByIT extends ContinuousTestCase {
 
     @Override
     public void testIteration(int iteration, Set<String> modifiedEvents) throws IOException {
-        SearchRequest searchRequestSource = new SearchRequest(CONTINUOUS_EVENTS_SOURCE_INDEX).allowPartialSearchResults(false)
-            .indicesOptions(IndicesOptions.LENIENT_EXPAND_OPEN);
+        SearchRequest searchRequestSource = new SearchRequest(CONTINUOUS_EVENTS_SOURCE_INDEX).allowPartialSearchResults(false);
         SearchSourceBuilder sourceBuilderSource = new SearchSourceBuilder().size(0);
         HistogramAggregationBuilder metricBuckets = new HistogramAggregationBuilder("metric").field(metricField)
             .interval(50.0)
@@ -74,8 +72,7 @@ public class HistogramGroupByIT extends ContinuousTestCase {
         searchRequestSource.source(sourceBuilderSource);
         SearchResponse responseSource = search(searchRequestSource);
 
-        SearchRequest searchRequestDest = new SearchRequest(NAME).allowPartialSearchResults(false)
-            .indicesOptions(IndicesOptions.LENIENT_EXPAND_OPEN);
+        SearchRequest searchRequestDest = new SearchRequest(NAME).allowPartialSearchResults(false);
         SearchSourceBuilder sourceBuilderDest = new SearchSourceBuilder().size(10000).sort("metric");
         searchRequestDest.source(sourceBuilderDest);
         SearchResponse responseDest = search(searchRequestDest);

--- a/x-pack/plugin/transform/qa/multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/continuous/LatestContinuousIT.java
+++ b/x-pack/plugin/transform/qa/multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/continuous/LatestContinuousIT.java
@@ -10,7 +10,6 @@ package org.elasticsearch.xpack.transform.integration.continuous;
 import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.search.SearchResponse;
-import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.client.transform.transforms.DestConfig;
 import org.elasticsearch.client.transform.transforms.SourceConfig;
 import org.elasticsearch.client.transform.transforms.TransformConfig;
@@ -88,7 +87,6 @@ public class LatestContinuousIT extends ContinuousTestCase {
         SearchRequest searchRequestSource =
             new SearchRequest(CONTINUOUS_EVENTS_SOURCE_INDEX)
                 .allowPartialSearchResults(false)
-                .indicesOptions(IndicesOptions.LENIENT_EXPAND_OPEN)
                 .source(
                     new SearchSourceBuilder()
                         // runtime mappings are needed in case "event-upper-at-search" is selected as the event field in test constructor
@@ -106,7 +104,6 @@ public class LatestContinuousIT extends ContinuousTestCase {
         SearchRequest searchRequestDest =
             new SearchRequest(NAME)
                 .allowPartialSearchResults(false)
-                .indicesOptions(IndicesOptions.LENIENT_EXPAND_OPEN)
                 // In destination index we don't have access to runtime fields from source index, let's use what we have i.e.: event.keyword
                 // and assume the sorting order will be the same (it is true as the runtime field applies "toUpperCase()" which preserves
                 // sorting order)

--- a/x-pack/plugin/transform/qa/multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/continuous/TermsGroupByIT.java
+++ b/x-pack/plugin/transform/qa/multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/continuous/TermsGroupByIT.java
@@ -9,7 +9,6 @@ package org.elasticsearch.xpack.transform.integration.continuous;
 
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.search.SearchResponse;
-import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.client.transform.transforms.DestConfig;
 import org.elasticsearch.client.transform.transforms.SourceConfig;
 import org.elasticsearch.client.transform.transforms.TransformConfig;
@@ -82,8 +81,7 @@ public class TermsGroupByIT extends ContinuousTestCase {
 
     @Override
     public void testIteration(int iteration, Set<String> modifiedEvents) throws IOException {
-        SearchRequest searchRequestSource = new SearchRequest(CONTINUOUS_EVENTS_SOURCE_INDEX).allowPartialSearchResults(false)
-            .indicesOptions(IndicesOptions.LENIENT_EXPAND_OPEN);
+        SearchRequest searchRequestSource = new SearchRequest(CONTINUOUS_EVENTS_SOURCE_INDEX).allowPartialSearchResults(false);
 
         SearchSourceBuilder sourceBuilderSource = new SearchSourceBuilder().size(0);
         TermsAggregationBuilder terms = new TermsAggregationBuilder("event").size(1000).field(termsField).order(BucketOrder.key(true));
@@ -96,8 +94,7 @@ public class TermsGroupByIT extends ContinuousTestCase {
         searchRequestSource.source(sourceBuilderSource);
         SearchResponse responseSource = search(searchRequestSource);
 
-        SearchRequest searchRequestDest = new SearchRequest(NAME).allowPartialSearchResults(false)
-            .indicesOptions(IndicesOptions.LENIENT_EXPAND_OPEN);
+        SearchRequest searchRequestDest = new SearchRequest(NAME).allowPartialSearchResults(false);
         SearchSourceBuilder sourceBuilderDest = new SearchSourceBuilder().size(1000).sort("event");
         searchRequestDest.source(sourceBuilderDest);
         SearchResponse responseDest = search(searchRequestDest);

--- a/x-pack/plugin/transform/qa/multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/continuous/TermsOnDateGroupByIT.java
+++ b/x-pack/plugin/transform/qa/multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/continuous/TermsOnDateGroupByIT.java
@@ -9,7 +9,6 @@ package org.elasticsearch.xpack.transform.integration.continuous;
 
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.search.SearchResponse;
-import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.client.transform.transforms.DestConfig;
 import org.elasticsearch.client.transform.transforms.SourceConfig;
 import org.elasticsearch.client.transform.transforms.TransformConfig;
@@ -90,8 +89,7 @@ public class TermsOnDateGroupByIT extends ContinuousTestCase {
 
     @Override
     public void testIteration(int iteration, Set<String> modifiedEvents) throws IOException {
-        SearchRequest searchRequestSource = new SearchRequest(CONTINUOUS_EVENTS_SOURCE_INDEX).allowPartialSearchResults(false)
-            .indicesOptions(IndicesOptions.LENIENT_EXPAND_OPEN);
+        SearchRequest searchRequestSource = new SearchRequest(CONTINUOUS_EVENTS_SOURCE_INDEX).allowPartialSearchResults(false);
 
         SearchSourceBuilder sourceBuilderSource = new SearchSourceBuilder().size(0);
         TermsAggregationBuilder terms = new TermsAggregationBuilder("some-timestamp").size(1000)
@@ -107,8 +105,7 @@ public class TermsOnDateGroupByIT extends ContinuousTestCase {
         searchRequestSource.source(sourceBuilderSource);
         SearchResponse responseSource = search(searchRequestSource);
 
-        SearchRequest searchRequestDest = new SearchRequest(NAME).allowPartialSearchResults(false)
-            .indicesOptions(IndicesOptions.LENIENT_EXPAND_OPEN);
+        SearchRequest searchRequestDest = new SearchRequest(NAME).allowPartialSearchResults(false);
         SearchSourceBuilder sourceBuilderDest = new SearchSourceBuilder().size(1000).sort("some-timestamp");
         searchRequestDest.source(sourceBuilderDest);
         SearchResponse responseDest = search(searchRequestDest);

--- a/x-pack/plugin/watcher/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/watcher/put_watch/92_put_watch_with_indices_options.yml
+++ b/x-pack/plugin/watcher/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/watcher/put_watch/92_put_watch_with_indices_options.yml
@@ -7,6 +7,7 @@ setup:
 ---
 "Test put watch with allow no indices":
   - skip:
+      features: ["warnings"]
       version: "7.10.1 - 7.10.2"
       reason: "watch parsing with partial indices options was broken in 7.10.1 and 7.10.2"
   - do:
@@ -43,16 +44,27 @@ setup:
           }
   - match: { _id: "my_watch_allow_no_indices" }
 
+# The get watch api, parses the watch, which yields deprecation warning if an indices_options definition is defined.
   - do:
+      warnings:
+        - "Deprecated field [ignore_throttled] used, this field is unused and will be removed entirely"
       watcher.get_watch:
         id: "my_watch_allow_no_indices"
   - match: { found : true}
   - match: { _id: "my_watch_allow_no_indices" }
   - match: { watch.input.search.request.indices_options.allow_no_indices: false }
 
+# During tear down, the list watch api is used to delete all watches. This parses the watches, which causes deprecation
+# warnings for any watch that have any indices_options defined. So manually delete this watch to avoid this.
+  - do:
+      watcher.delete_watch:
+        id: "my_watch_allow_no_indices"
+  - match: { found: true }
+
 ---
 "Test put watch with expand wildcards":
   - skip:
+      features: ["warnings"]
       version: "7.10.1 - 7.10.2"
       reason: "watch parsing with partial indices options was broken in 7.10.1 and 7.10.2"
   - do:
@@ -89,16 +101,27 @@ setup:
           }
   - match: { _id: "my_watch_expand_wildcards" }
 
+# The get watch api parses the watch, which yields deprecation warning if an indices_options definition is defined.
   - do:
+      warnings:
+        - "Deprecated field [ignore_throttled] used, this field is unused and will be removed entirely"
       watcher.get_watch:
         id: "my_watch_expand_wildcards"
   - match: { found : true}
   - match: { _id: "my_watch_expand_wildcards" }
   - match: { watch.input.search.request.indices_options.expand_wildcards: [ "open", "hidden" ] }
 
+# During tear down, the list watch api is used to delete all watches. This parses the watches, which causes deprecation
+# warnings for any watch that have any indices_options defined. So manually delete this watch to avoid this.
+  - do:
+      watcher.delete_watch:
+        id: "my_watch_expand_wildcards"
+  - match: { found: true }
+
 ---
 "Test put watch with ignore unavailable":
   - skip:
+      features: ["warnings"]
       version: "7.10.1 - 7.10.2"
       reason: "watch parsing with partial indices options was broken in 7.10.1 and 7.10.2"
   - do:
@@ -135,9 +158,19 @@ setup:
           }
   - match: { _id: "my_watch_ignore_unavailable" }
 
+# The get watch api parses the watch, which yields deprecation warning if an indices_options definition is defined.
   - do:
+      warnings:
+        - "Deprecated field [ignore_throttled] used, this field is unused and will be removed entirely"
       watcher.get_watch:
         id: "my_watch_ignore_unavailable"
   - match: { found : true}
   - match: { _id: "my_watch_ignore_unavailable" }
   - match: { watch.input.search.request.indices_options.ignore_unavailable: false }
+
+# During tear down, the list watch api is used to delete all watches. This parses the watches, which causes deprecation
+# warnings for any watch that have any indices_options defined. So manually delete this watch to avoid this.
+  - do:
+      watcher.delete_watch:
+        id: "my_watch_ignore_unavailable"
+  - match: { found: true }

--- a/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/support/WatcherUtilsTests.java
+++ b/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/support/WatcherUtilsTests.java
@@ -47,6 +47,10 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 
 public class WatcherUtilsTests extends ESTestCase {
+
+    private static final String IGNORE_THROTTLED_FIELD_WARNING = "Deprecated field [ignore_throttled] used, this field is unused and " +
+        "will be removed entirely";
+
     public void testFlattenModel() throws Exception {
         ZonedDateTime now = ZonedDateTime.now(Clock.systemUTC());
         Map<String, Object> map = new HashMap<>();
@@ -138,6 +142,9 @@ public class WatcherUtilsTests extends ESTestCase {
 
         assertNotNull(result.getTemplate());
         assertThat(result.getTemplate().getLang(), equalTo(stored ? null : "mustache"));
+        if (expectedIndicesOptions.equals(DEFAULT_INDICES_OPTIONS) == false) {
+            assertWarnings(IGNORE_THROTTLED_FIELD_WARNING);
+        }
         if (expectedSource == null) {
             assertThat(result.getTemplate().getIdOrCode(), equalTo(expectedTemplate.getIdOrCode()));
             assertThat(result.getTemplate().getType(), equalTo(expectedTemplate.getType()));
@@ -224,6 +231,9 @@ public class WatcherUtilsTests extends ESTestCase {
         assertThat(parser.nextToken(), equalTo(XContentParser.Token.START_OBJECT));
         WatcherSearchTemplateRequest result = WatcherSearchTemplateRequest.fromXContent(parser, DEFAULT_SEARCH_TYPE);
 
+        if (indicesOptions.equals(DEFAULT_INDICES_OPTIONS) == false) {
+            assertWarnings(IGNORE_THROTTLED_FIELD_WARNING);
+        }
         assertThat(result.getIndices(), arrayContainingInAnyOrder(indices));
         assertThat(result.getIndicesOptions(), equalTo(indicesOptions));
         assertThat(result.getSearchType(), equalTo(searchType));

--- a/x-pack/qa/full-cluster-restart/src/test/java/org/elasticsearch/xpack/restart/FullClusterRestartIT.java
+++ b/x-pack/qa/full-cluster-restart/src/test/java/org/elasticsearch/xpack/restart/FullClusterRestartIT.java
@@ -992,6 +992,8 @@ public class FullClusterRestartIT extends AbstractFullClusterRestartTestCase {
             ensureGreen(index);
             assertNoFileBasedRecovery(index, n -> true);
             final Request request = new Request("GET", "/" + index + "/_search");
+            request.setOptions(expectWarnings("[ignore_throttled] parameter is deprecated because frozen " +
+                "indices have been deprecated. Consider cold or frozen tiers in place of frozen indices."));
             request.addParameter("ignore_throttled", "false");
             assertThat(XContentMapValues.extractValue("hits.total.value", entityAsMap(client().performRequest(request))),
                 equalTo(totalHits));


### PR DESCRIPTION
Backporting #77479 to 7.x branch.

Frozen indices are deprecated, which will make ignore_throttled obsolete.

Some changes to HLRC  HLRC and related tests were required in order to deprecate ignore_throttled parameter:
* Change HLRC request classes to set indices options initial value to null.
    This avoids sending the ignore_throttled parameter (and other indices options parameters)
    and therefore avoids the depracation warning header in the response. All these
    request classes had the indices options set to what is the defaukt in the corresponding
    action request class. So sending these indices options params was a noop, which is the same
    as not sending indices options parameters, which is what this change does.
* For transport action request classes that are reused in the HLRC as request class,
    change the corresponding hlrc request converter to only send indices options params
    if the indices options are different than what the default is.
* For tests that use a non default indices options, allow 'ignore_throttled is deprecated'
    warning.

Other changes:
* A number of tests have been changed to allowed warning header for deprecated ignore_throttled parameter.
* Some rest v7 compat yaml tests are temporary muted, but will be unmuted once this
    change has been backported.

Relates to #70192