### PR TITLE
Resolve thirdparty gradle plugin artifacts from mavencentral

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -1,3 +1,10 @@
+pluginManagement {
+  repositories {
+    mavenCentral()
+    gradlePluginPortal()
+  }
+}
+
 plugins {
   id "com.gradle.enterprise" version "3.6.4"
 }


### PR DESCRIPTION
This should give us a little more decoupling from jcenter as the
gradle plugin portal tries resolving thirdparty plugin dependencies from
jcenter by default.
This should shield us a bit better from jcenter outtakes that transiently
cause issues resolving from the gradle plugin portal