### PR TITLE
[7.x] Use Objects.equals() instead of == to compare strings (#77840)

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/lucene/search/MultiPhrasePrefixQuery.java
+++ b/server/src/main/java/org/elasticsearch/common/lucene/search/MultiPhrasePrefixQuery.java
@@ -97,7 +97,7 @@ public class MultiPhrasePrefixQuery extends Query {
      */
     public void add(Term[] terms, int position) {
         for (int i = 0; i < terms.length; i++) {
-            if (terms[i].field() != field) {
+            if (Objects.equals(terms[i].field(), field) == false) {
                 throw new IllegalArgumentException(
                         "All phrase terms must be in the same field (" + field + "): "
                                 + terms[i]);

--- a/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/index/IndexResolver.java
+++ b/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/index/IndexResolver.java
@@ -710,7 +710,7 @@ public class IndexResolver {
         // iterate over each type
         for (Entry<String, FieldCapabilities> type : types.entrySet()) {
             String esFieldType = type.getKey();
-            if (esFieldType == UNMAPPED) {
+            if (Objects.equals(esFieldType, UNMAPPED)) {
                 continue;
             }
             String[] indices = type.getValue().indices();
@@ -749,7 +749,7 @@ public class IndexResolver {
             } else {
                 // if the field type is the same across all this alias' indices, check the field's capabilities (searchable/aggregatable)
                 for (Entry<String, FieldCapabilities> type : types.entrySet()) {
-                    if (type.getKey() == UNMAPPED) {
+                    if (Objects.equals(type.getKey(), UNMAPPED)) {
                         continue;
                     }
                     FieldCapabilities f = type.getValue();


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Use Objects.equals() instead of == to compare strings (#77840)