### PR TITLE
   geo_shape mapping created before version 6.6.0 should be using the legacy mapper 

### DIFF
--- a/server/src/test/java/org/elasticsearch/index/query/GeoBoundingBoxQueryBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/GeoBoundingBoxQueryBuilderTests.java
@@ -13,6 +13,7 @@ import org.apache.lucene.document.LatLonPoint;
 import org.apache.lucene.search.IndexOrDocValuesQuery;
 import org.apache.lucene.search.MatchNoDocsQuery;
 import org.apache.lucene.search.Query;
+import org.apache.lucene.util.LuceneTestCase;
 import org.elasticsearch.ElasticsearchParseException;
 import org.elasticsearch.Version;
 import org.elasticsearch.common.geo.GeoPoint;
@@ -32,6 +33,7 @@ import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.notNullValue;
 
+@LuceneTestCase.AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/77857")
 public class GeoBoundingBoxQueryBuilderTests extends AbstractQueryTestCase<GeoBoundingBoxQueryBuilder> {
     /** Randomly generate either NaN or one of the two infinity values. */
     private static Double[] brokenDoubles = {Double.NaN, Double.POSITIVE_INFINITY, Double.NEGATIVE_INFINITY};

--- a/server/src/test/java/org/elasticsearch/index/query/GeoBoundingBoxQueryBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/GeoBoundingBoxQueryBuilderTests.java
@@ -13,9 +13,7 @@ import org.apache.lucene.document.LatLonPoint;
 import org.apache.lucene.search.IndexOrDocValuesQuery;
 import org.apache.lucene.search.MatchNoDocsQuery;
 import org.apache.lucene.search.Query;
-import org.apache.lucene.util.LuceneTestCase;
 import org.elasticsearch.ElasticsearchParseException;
-import org.elasticsearch.Version;
 import org.elasticsearch.common.geo.GeoPoint;
 import org.elasticsearch.common.geo.GeoUtils;
 import org.elasticsearch.geo.GeometryTestUtils;
@@ -23,7 +21,6 @@ import org.elasticsearch.geometry.Rectangle;
 import org.elasticsearch.geometry.utils.Geohash;
 import org.elasticsearch.index.mapper.GeoPointFieldMapper;
 import org.elasticsearch.index.mapper.GeoShapeFieldMapper;
-import org.elasticsearch.index.mapper.LegacyGeoShapeFieldMapper;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.test.AbstractQueryTestCase;
 
@@ -33,7 +30,6 @@ import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.notNullValue;
 
-@LuceneTestCase.AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/77857")
 public class GeoBoundingBoxQueryBuilderTests extends AbstractQueryTestCase<GeoBoundingBoxQueryBuilder> {
     /** Randomly generate either NaN or one of the two infinity values. */
     private static Double[] brokenDoubles = {Double.NaN, Double.POSITIVE_INFINITY, Double.NEGATIVE_INFINITY};
@@ -222,11 +218,7 @@ public class GeoBoundingBoxQueryBuilderTests extends AbstractQueryTestCase<GeoBo
                     queryBuilder.topLeft().lon(),
                     queryBuilder.bottomRight().lon()), dvQuery);
         } else {
-            if (context.indexVersionCreated().before(Version.V_6_6_0)) {
-                assertEquals(LegacyGeoShapeFieldMapper.GeoShapeFieldType.class, fieldType.getClass());
-            } else {
-                assertEquals(GeoShapeFieldMapper.GeoShapeFieldType.class, fieldType.getClass());
-            }
+            assertEquals(GeoShapeFieldMapper.GeoShapeFieldType.class, fieldType.getClass());
         }
     }
 

--- a/server/src/test/java/org/elasticsearch/index/query/GeoDistanceQueryBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/GeoDistanceQueryBuilderTests.java
@@ -13,8 +13,6 @@ import org.apache.lucene.document.LatLonPoint;
 import org.apache.lucene.search.IndexOrDocValuesQuery;
 import org.apache.lucene.search.MatchNoDocsQuery;
 import org.apache.lucene.search.Query;
-import org.apache.lucene.util.LuceneTestCase;
-import org.elasticsearch.Version;
 import org.elasticsearch.common.ParsingException;
 import org.elasticsearch.common.geo.GeoDistance;
 import org.elasticsearch.common.geo.GeoPoint;
@@ -22,7 +20,6 @@ import org.elasticsearch.common.unit.DistanceUnit;
 import org.elasticsearch.geo.GeometryTestUtils;
 import org.elasticsearch.index.mapper.GeoPointFieldMapper;
 import org.elasticsearch.index.mapper.GeoShapeFieldMapper;
-import org.elasticsearch.index.mapper.LegacyGeoShapeFieldMapper;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.test.AbstractQueryTestCase;
 
@@ -32,7 +29,6 @@ import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.notNullValue;
 
-@LuceneTestCase.AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/77857")
 public class GeoDistanceQueryBuilderTests extends AbstractQueryTestCase<GeoDistanceQueryBuilder> {
 
     @Override
@@ -140,11 +136,7 @@ public class GeoDistanceQueryBuilderTests extends AbstractQueryTestCase<GeoDista
                     queryBuilder.distance()),
                     dvQuery);
         } else {
-            if (context.indexVersionCreated().before(Version.V_6_6_0)) {
-                assertEquals(LegacyGeoShapeFieldMapper.GeoShapeFieldType.class, fieldType.getClass());
-            } else {
-                assertEquals(GeoShapeFieldMapper.GeoShapeFieldType.class, fieldType.getClass());
-            }
+            assertEquals(GeoShapeFieldMapper.GeoShapeFieldType.class, fieldType.getClass());
         }
     }
 

--- a/server/src/test/java/org/elasticsearch/index/query/GeoDistanceQueryBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/GeoDistanceQueryBuilderTests.java
@@ -13,6 +13,7 @@ import org.apache.lucene.document.LatLonPoint;
 import org.apache.lucene.search.IndexOrDocValuesQuery;
 import org.apache.lucene.search.MatchNoDocsQuery;
 import org.apache.lucene.search.Query;
+import org.apache.lucene.util.LuceneTestCase;
 import org.elasticsearch.Version;
 import org.elasticsearch.common.ParsingException;
 import org.elasticsearch.common.geo.GeoDistance;
@@ -31,6 +32,7 @@ import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.notNullValue;
 
+@LuceneTestCase.AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/77857")
 public class GeoDistanceQueryBuilderTests extends AbstractQueryTestCase<GeoDistanceQueryBuilder> {
 
     @Override

--- a/server/src/test/java/org/elasticsearch/index/query/GeoDistanceQueryBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/GeoDistanceQueryBuilderTests.java
@@ -92,7 +92,7 @@ public class GeoDistanceQueryBuilderTests extends AbstractQueryTestCase<GeoDista
         assertEquals("distance unit must not be null", e.getMessage());
 
         e = expectThrows(IllegalArgumentException.class, () -> query.distance(
-            randomIntBetween(Integer.MIN_VALUE, 0), DistanceUnit.DEFAULT));
+                randomIntBetween(Integer.MIN_VALUE, 0), DistanceUnit.DEFAULT));
         assertEquals("distance must be greater than zero", e.getMessage());
 
         e = expectThrows(IllegalArgumentException.class, () -> query.geohash(null));
@@ -128,13 +128,13 @@ public class GeoDistanceQueryBuilderTests extends AbstractQueryTestCase<GeoDista
                     queryBuilder.point().lat(),
                     queryBuilder.point().lon(),
                     queryBuilder.distance()),
-                indexQuery);
+                    indexQuery);
             Query dvQuery = ((IndexOrDocValuesQuery) query).getRandomAccessQuery();
             assertEquals(LatLonDocValuesField.newSlowDistanceQuery(expectedFieldName,
                     queryBuilder.point().lat(),
                     queryBuilder.point().lon(),
                     queryBuilder.distance()),
-                dvQuery);
+                    dvQuery);
         } else {
             assertEquals(GeoShapeFieldMapper.GeoShapeFieldType.class, fieldType.getClass());
         }
@@ -142,159 +142,159 @@ public class GeoDistanceQueryBuilderTests extends AbstractQueryTestCase<GeoDista
 
     public void testParsingAndToQuery1() throws IOException {
         String query = "{\n" +
-            "    \"geo_distance\":{\n" +
-            "        \"distance\":\"12mi\",\n" +
-            "        \"" + GEO_POINT_FIELD_NAME + "\":{\n" +
-            "            \"lat\":40,\n" +
-            "            \"lon\":-70\n" +
-            "        }\n" +
-            "    }\n" +
-            "}\n";
+                "    \"geo_distance\":{\n" +
+                "        \"distance\":\"12mi\",\n" +
+                "        \"" + GEO_POINT_FIELD_NAME + "\":{\n" +
+                "            \"lat\":40,\n" +
+                "            \"lon\":-70\n" +
+                "        }\n" +
+                "    }\n" +
+                "}\n";
         assertGeoDistanceRangeQuery(query, 40, -70, 12, DistanceUnit.MILES);
     }
 
     public void testParsingAndToQuery2() throws IOException {
         String query = "{\n" +
-            "    \"geo_distance\":{\n" +
-            "        \"distance\":\"12mi\",\n" +
-            "        \"" + GEO_POINT_FIELD_NAME + "\":[-70, 40]\n" +
-            "    }\n" +
-            "}\n";
+                "    \"geo_distance\":{\n" +
+                "        \"distance\":\"12mi\",\n" +
+                "        \"" + GEO_POINT_FIELD_NAME + "\":[-70, 40]\n" +
+                "    }\n" +
+                "}\n";
         assertGeoDistanceRangeQuery(query, 40, -70, 12, DistanceUnit.MILES);
     }
 
     public void testParsingAndToQuery3() throws IOException {
         String query = "{\n" +
-            "    \"geo_distance\":{\n" +
-            "        \"distance\":\"12mi\",\n" +
-            "        \"" + GEO_POINT_FIELD_NAME + "\":\"40, -70\"\n" +
-            "    }\n" +
-            "}\n";
+                "    \"geo_distance\":{\n" +
+                "        \"distance\":\"12mi\",\n" +
+                "        \"" + GEO_POINT_FIELD_NAME + "\":\"40, -70\"\n" +
+                "    }\n" +
+                "}\n";
         assertGeoDistanceRangeQuery(query, 40, -70, 12, DistanceUnit.MILES);
     }
 
     public void testParsingAndToQuery4() throws IOException {
         String query = "{\n" +
-            "    \"geo_distance\":{\n" +
-            "        \"distance\":\"12mi\",\n" +
-            "        \"" + GEO_POINT_FIELD_NAME + "\":\"drn5x1g8cu2y\"\n" +
-            "    }\n" +
-            "}\n";
+                "    \"geo_distance\":{\n" +
+                "        \"distance\":\"12mi\",\n" +
+                "        \"" + GEO_POINT_FIELD_NAME + "\":\"drn5x1g8cu2y\"\n" +
+                "    }\n" +
+                "}\n";
         GeoPoint geoPoint = GeoPoint.fromGeohash("drn5x1g8cu2y");
         assertGeoDistanceRangeQuery(query, geoPoint.getLat(), geoPoint.getLon(), 12, DistanceUnit.MILES);
     }
 
     public void testParsingAndToQuery5() throws IOException {
         String query = "{\n" +
-            "    \"geo_distance\":{\n" +
-            "        \"distance\":12,\n" +
-            "        \"unit\":\"mi\",\n" +
-            "        \"" + GEO_POINT_FIELD_NAME + "\":{\n" +
-            "            \"lat\":40,\n" +
-            "            \"lon\":-70\n" +
-            "        }\n" +
-            "    }\n" +
-            "}\n";
+                "    \"geo_distance\":{\n" +
+                "        \"distance\":12,\n" +
+                "        \"unit\":\"mi\",\n" +
+                "        \"" + GEO_POINT_FIELD_NAME + "\":{\n" +
+                "            \"lat\":40,\n" +
+                "            \"lon\":-70\n" +
+                "        }\n" +
+                "    }\n" +
+                "}\n";
         assertGeoDistanceRangeQuery(query, 40, -70, 12, DistanceUnit.MILES);
     }
 
     public void testParsingAndToQuery6() throws IOException {
         String query = "{\n" +
-            "    \"geo_distance\":{\n" +
-            "        \"distance\":\"12\",\n" +
-            "        \"unit\":\"mi\",\n" +
-            "        \"" + GEO_POINT_FIELD_NAME + "\":{\n" +
-            "            \"lat\":40,\n" +
-            "            \"lon\":-70\n" +
-            "        }\n" +
-            "    }\n" +
-            "}\n";
+                "    \"geo_distance\":{\n" +
+                "        \"distance\":\"12\",\n" +
+                "        \"unit\":\"mi\",\n" +
+                "        \"" + GEO_POINT_FIELD_NAME + "\":{\n" +
+                "            \"lat\":40,\n" +
+                "            \"lon\":-70\n" +
+                "        }\n" +
+                "    }\n" +
+                "}\n";
         assertGeoDistanceRangeQuery(query, 40, -70, 12, DistanceUnit.MILES);
     }
 
     public void testParsingAndToQuery7() throws IOException {
         String query = "{\n" +
-            "  \"geo_distance\":{\n" +
-            "      \"distance\":\"19.312128\",\n" +
-            "      \"" + GEO_POINT_FIELD_NAME + "\":{\n" +
-            "          \"lat\":40,\n" +
-            "          \"lon\":-70\n" +
-            "      }\n" +
-            "  }\n" +
-            "}\n";
+                "  \"geo_distance\":{\n" +
+                "      \"distance\":\"19.312128\",\n" +
+                "      \"" + GEO_POINT_FIELD_NAME + "\":{\n" +
+                "          \"lat\":40,\n" +
+                "          \"lon\":-70\n" +
+                "      }\n" +
+                "  }\n" +
+                "}\n";
         assertGeoDistanceRangeQuery(query, 40, -70, 19.312128, DistanceUnit.DEFAULT);
     }
 
     public void testParsingAndToQuery8() throws IOException {
         String query = "{\n" +
-            "    \"geo_distance\":{\n" +
-            "        \"distance\":19.312128,\n" +
-            "        \"" + GEO_POINT_FIELD_NAME + "\":{\n" +
-            "            \"lat\":40,\n" +
-            "            \"lon\":-70\n" +
-            "        }\n" +
-            "    }\n" +
-            "}\n";
+                "    \"geo_distance\":{\n" +
+                "        \"distance\":19.312128,\n" +
+                "        \"" + GEO_POINT_FIELD_NAME + "\":{\n" +
+                "            \"lat\":40,\n" +
+                "            \"lon\":-70\n" +
+                "        }\n" +
+                "    }\n" +
+                "}\n";
         assertGeoDistanceRangeQuery(query, 40, -70, 19.312128, DistanceUnit.DEFAULT);
     }
 
     public void testParsingAndToQuery9() throws IOException {
         String query = "{\n" +
-            "    \"geo_distance\":{\n" +
-            "        \"distance\":\"19.312128\",\n" +
-            "        \"unit\":\"km\",\n" +
-            "        \"" + GEO_POINT_FIELD_NAME + "\":{\n" +
-            "            \"lat\":40,\n" +
-            "            \"lon\":-70\n" +
-            "        }\n" +
-            "    }\n" +
-            "}\n";
+                "    \"geo_distance\":{\n" +
+                "        \"distance\":\"19.312128\",\n" +
+                "        \"unit\":\"km\",\n" +
+                "        \"" + GEO_POINT_FIELD_NAME + "\":{\n" +
+                "            \"lat\":40,\n" +
+                "            \"lon\":-70\n" +
+                "        }\n" +
+                "    }\n" +
+                "}\n";
         assertGeoDistanceRangeQuery(query, 40, -70, 19.312128, DistanceUnit.KILOMETERS);
     }
 
     public void testParsingAndToQuery10() throws IOException {
         String query = "{\n" +
-            "    \"geo_distance\":{\n" +
-            "        \"distance\":19.312128,\n" +
-            "        \"unit\":\"km\",\n" +
-            "        \"" + GEO_POINT_FIELD_NAME + "\":{\n" +
-            "            \"lat\":40,\n" +
-            "            \"lon\":-70\n" +
-            "        }\n" +
-            "    }\n" +
-            "}\n";
+                "    \"geo_distance\":{\n" +
+                "        \"distance\":19.312128,\n" +
+                "        \"unit\":\"km\",\n" +
+                "        \"" + GEO_POINT_FIELD_NAME + "\":{\n" +
+                "            \"lat\":40,\n" +
+                "            \"lon\":-70\n" +
+                "        }\n" +
+                "    }\n" +
+                "}\n";
         assertGeoDistanceRangeQuery(query, 40, -70, 19.312128, DistanceUnit.KILOMETERS);
     }
 
     public void testParsingAndToQuery11() throws IOException {
         String query = "{\n" +
-            "    \"geo_distance\":{\n" +
-            "        \"distance\":\"19.312128km\",\n" +
-            "        \"" + GEO_POINT_FIELD_NAME + "\":{\n" +
-            "            \"lat\":40,\n" +
-            "            \"lon\":-70\n" +
-            "        }\n" +
-            "    }\n" +
-            "}\n";
+                "    \"geo_distance\":{\n" +
+                "        \"distance\":\"19.312128km\",\n" +
+                "        \"" + GEO_POINT_FIELD_NAME + "\":{\n" +
+                "            \"lat\":40,\n" +
+                "            \"lon\":-70\n" +
+                "        }\n" +
+                "    }\n" +
+                "}\n";
         assertGeoDistanceRangeQuery(query, 40, -70, 19.312128, DistanceUnit.KILOMETERS);
     }
 
     public void testParsingAndToQuery12() throws IOException {
         String query = "{\n" +
-            "    \"geo_distance\":{\n" +
-            "        \"distance\":\"12mi\",\n" +
-            "        \"unit\":\"km\",\n" +
-            "        \"" + GEO_POINT_FIELD_NAME + "\":{\n" +
-            "            \"lat\":40,\n" +
-            "            \"lon\":-70\n" +
-            "        }\n" +
-            "    }\n" +
-            "}\n";
+                "    \"geo_distance\":{\n" +
+                "        \"distance\":\"12mi\",\n" +
+                "        \"unit\":\"km\",\n" +
+                "        \"" + GEO_POINT_FIELD_NAME + "\":{\n" +
+                "            \"lat\":40,\n" +
+                "            \"lon\":-70\n" +
+                "        }\n" +
+                "    }\n" +
+                "}\n";
         assertGeoDistanceRangeQuery(query, 40, -70, 12, DistanceUnit.MILES);
     }
 
     private void assertGeoDistanceRangeQuery(String query, double lat, double lon, double distance, DistanceUnit distanceUnit)
-        throws IOException {
+            throws IOException {
         Query parsedQuery = parseQuery(query).toQuery(createSearchExecutionContext());
         // The parsedQuery contains IndexOrDocValuesQuery, which wraps LatLonPointDistanceQuery which in turn has default visibility,
         // so we cannot access its fields directly to check and have to use toString() here instead.
@@ -304,7 +304,7 @@ public class GeoDistanceQueryBuilderTests extends AbstractQueryTestCase<GeoDista
 
     public void testFromJson() throws IOException {
         String json =
-            "{\n" +
+                "{\n" +
                 "  \"geo_distance\" : {\n" +
                 "    \"pin.location\" : [ -70.0, 40.0 ],\n" +
                 "    \"distance\" : 12000.0,\n" +
@@ -340,15 +340,15 @@ public class GeoDistanceQueryBuilderTests extends AbstractQueryTestCase<GeoDista
 
     public void testParseFailsWithMultipleFields() throws IOException {
         String json = "{\n" +
-            "  \"geo_distance\" : {\n" +
-            "    \"point1\" : {\n" +
-            "      \"lat\" : 30, \"lon\" : 12\n" +
-            "    },\n" +
-            "    \"point2\" : {\n" +
-            "      \"lat\" : 30, \"lon\" : 12\n" +
-            "    }\n" +
-            "  }\n" +
-            "}";
+                "  \"geo_distance\" : {\n" +
+                "    \"point1\" : {\n" +
+                "      \"lat\" : 30, \"lon\" : 12\n" +
+                "    },\n" +
+                "    \"point2\" : {\n" +
+                "      \"lat\" : 30, \"lon\" : 12\n" +
+                "    }\n" +
+                "  }\n" +
+                "}";
         ParsingException e = expectThrows(ParsingException.class, () -> parseQuery(json));
         assertEquals("[geo_distance] query doesn't support multiple fields, found [point1] and [point2]", e.getMessage());
     }

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/mapper/GeoShapeWithDocValuesFieldMapper.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/mapper/GeoShapeWithDocValuesFieldMapper.java
@@ -201,7 +201,8 @@ public class GeoShapeWithDocValuesFieldMapper extends AbstractShapeGeometryField
             FieldMapper.Builder builder;
             boolean ignoreMalformedByDefault = IGNORE_MALFORMED_SETTING.get(parserContext.getSettings());
             boolean coerceByDefault = COERCE_SETTING.get(parserContext.getSettings());
-            if (LegacyGeoShapeFieldMapper.containsDeprecatedParameter(node.keySet())) {
+            if (parserContext.indexVersionCreated().before(Version.V_6_6_0) ||
+                LegacyGeoShapeFieldMapper.containsDeprecatedParameter(node.keySet())) {
                 builder = new LegacyGeoShapeFieldMapper.Builder(
                     name,
                     parserContext.indexVersionCreated(),

--- a/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/index/mapper/GeoShapeWithDocValuesFieldMapperTests.java
+++ b/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/index/mapper/GeoShapeWithDocValuesFieldMapperTests.java
@@ -24,6 +24,7 @@ import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.index.mapper.DocumentMapper;
+import org.elasticsearch.index.mapper.LegacyGeoShapeFieldMapper;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.Mapper;
 import org.elasticsearch.index.mapper.MapperParsingException;
@@ -389,6 +390,17 @@ public class GeoShapeWithDocValuesFieldMapperTests extends MapperTestCase {
             b.endObject();
         }));
         assertWarnings("Adding multifields to [geo_shape] mappers has no effect and will be forbidden in future");
+    }
+
+    public void testRandomVersionMapping() throws Exception {
+        Version version = VersionUtils.randomIndexCompatibleVersion(random());
+        DocumentMapper defaultMapper = createDocumentMapper(version, fieldMapping(this::minimalMapping));
+        Mapper fieldMapper = defaultMapper.mappers().getMapper("field");
+        if (version.before(Version.V_6_6_0)) {
+            assertThat(fieldMapper, instanceOf(LegacyGeoShapeFieldMapper.class));
+        } else {
+            assertThat(fieldMapper, instanceOf(GeoShapeWithDocValuesFieldMapper.class));
+        }
     }
 
     public String toXContentString(GeoShapeWithDocValuesFieldMapper mapper, boolean includeDefaults) {

--- a/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/index/query/GeoShapeWithDocValuesQueryBuilderTests.java
+++ b/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/index/query/GeoShapeWithDocValuesQueryBuilderTests.java
@@ -10,6 +10,7 @@ package org.elasticsearch.xpack.spatial.index.query;
 import org.apache.lucene.search.ConstantScoreQuery;
 import org.apache.lucene.search.IndexOrDocValuesQuery;
 import org.apache.lucene.search.Query;
+import org.elasticsearch.Version;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.compress.CompressedXContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
@@ -41,7 +42,8 @@ public class GeoShapeWithDocValuesQueryBuilderTests extends AbstractQueryTestCas
 
     @Override
     protected void initializeAdditionalMappings(MapperService mapperService) throws IOException {
-        if (randomBoolean()) {
+
+        if (mapperService.parserContext().indexVersionCreated().before(Version.V_6_6_0) || randomBoolean()) {
             XContentBuilder mapping = jsonBuilder().startObject().startObject("_doc").startObject("properties")
                 .startObject("test").field("type", "geo_shape").endObject().endObject().endObject().endObject();
             mapperService.merge("_doc",


### PR DESCRIPTION
It seems that the mapper on the spatial module would only create legacy mappers when they use a deprecated parameters. Still old mappings previous to version 6.6 should always be using the legacy mapper.

Fixes https://github.com/elastic/elasticsearch/issues/77857