### PR TITLE
Use mavencentral instead of jcenter in 6.8

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -109,7 +109,10 @@ jar {
  *****************************************************************************/
 
 repositories {
-  jcenter()
+  mavenCentral()
+  maven {
+    url "https://plugins.gradle.org/m2/"
+  }
 }
 
 dependencies {

--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/BuildPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/BuildPlugin.groovy
@@ -605,7 +605,7 @@ class BuildPlugin implements Plugin<Project> {
             name "elastic"
             url "https://artifacts-no-kpi.elastic.co/maven"
         }
-        repos.jcenter()
+        repos.mavenCentral()
         String luceneVersion = VersionProperties.lucene
         if (luceneVersion.contains('-snapshot')) {
             // extract the revision number from the version with a regex matcher

--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/vagrant/VagrantTestPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/vagrant/VagrantTestPlugin.groovy
@@ -158,7 +158,7 @@ class VagrantTestPlugin implements Plugin<Project> {
     private static void configurePackagingArchiveRepositories(Project project) {
         RepositoryHandler repos = project.repositories
 
-        repos.jcenter() // will have releases before 5.0.0
+        repos.mavenCentral() // will have releases before 5.0.0
 
         /* Setup a repository that tries to download from
           https://artifacts.elastic.co/downloads/elasticsearch/[module]-[revision].[ext]

--- a/buildSrc/src/testKit/elasticsearch.build/build.gradle
+++ b/buildSrc/src/testKit/elasticsearch.build/build.gradle
@@ -13,7 +13,7 @@ dependencies {
 }
 
 repositories {
-    jcenter()
+    mavenCentral()
     repositories {
         maven {
             name "local-repo"

--- a/buildSrc/src/testKit/jarHell/build.gradle
+++ b/buildSrc/src/testKit/jarHell/build.gradle
@@ -12,7 +12,7 @@ ext.licenseFile = file("$buildDir/dummy/license")
 ext.noticeFile = file("$buildDir/dummy/notice")
 
 repositories {
-    jcenter()
+    mavenCentral()
     repositories {
         maven {
             name "local"

--- a/buildSrc/src/testKit/testclusters/build.gradle
+++ b/buildSrc/src/testKit/testclusters/build.gradle
@@ -16,7 +16,7 @@ allprojects { all ->
                 url "https://s3.amazonaws.com/download.elasticsearch.org/lucenesnapshots/" + luceneSnapshotRevision
             }
         }
-        jcenter()
+        mavenCentral()
     }
 
     if (project == rootProject || project.name == "alpha" || project.name == "bravo") {

--- a/buildSrc/src/testKit/testingConventions/build.gradle
+++ b/buildSrc/src/testKit/testingConventions/build.gradle
@@ -7,7 +7,7 @@ allprojects {
     apply plugin: 'elasticsearch.build'
 
     repositories {
-        jcenter()
+        mavenCentral()
     }
     dependencies {
         testCompile "junit:junit:4.12"

--- a/buildSrc/src/testKit/thirdPartyAudit/build.gradle
+++ b/buildSrc/src/testKit/thirdPartyAudit/build.gradle
@@ -17,7 +17,7 @@ repositories {
         name = "local-test"
         url = file("sample_jars/build/testrepo")
     }
-    jcenter()
+    mavenCentral()
 }
 
 configurations.create("forbiddenApisCliJar")


### PR DESCRIPTION
jcenter is sunset and regular having stability issues. This should
fix our 6.8 branch. We also change our public available plugins
to use mavencentral instead of jcenter.

This is strictly speaking a breaking change in our gradle plugins that we also ship for external developers. 
Not sure how big of a deal that is in this case, but given JCenter has ben deprecated I think it's the right way
to go to keep our build more stable. Alternatively we could rewrite the repository definition for our internal build and keep
JCenter In the plugins itself, but I don't think it's worth the hassle to go down that route 
