### PR TITLE
[7.x] Resolve thirdparty gradle plugin artifacts from mavencentral (#77865)

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -1,3 +1,10 @@
+pluginManagement {
+  repositories {
+    mavenCentral()
+    gradlePluginPortal()
+  }
+}
+
 plugins {
   id "com.gradle.enterprise" version "3.6.4"
 }


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Resolve thirdparty gradle plugin artifacts from mavencentral (#77865)