### PR TITLE
[DOCS] Fix ESS install lead-in

### DIFF
--- a/docs/reference/setup/install.asciidoc
+++ b/docs/reference/setup/install.asciidoc
@@ -4,11 +4,7 @@
 [discrete]
 === Hosted Elasticsearch
 
-You can run Elasticsearch on your own hardware, or use our
-https://www.elastic.co/cloud/elasticsearch-service[hosted Elasticsearch Service]
-on Elastic Cloud. The Elasticsearch Service is available on both AWS and GCP.
-{ess-trial}[Try out the
-Elasticsearch Service for free].
+{ess-leadin}
 
 [discrete]
 === Installing Elasticsearch Yourself


### PR DESCRIPTION
Replaces the hard-coded ESS lead-in with the docs attribute.

Previously, this copy omitted Microsoft Azure. This ensures these docs are better maintained.

### Before

<img width="767" alt="Screen Shot 2021-09-16 at 11 54 11 AM" src="https://user-images.githubusercontent.com/40268737/133645020-20ecc8be-6bbd-4b62-8e4e-5937db2ea1ae.PNG">

### After

Note that one of the links has been removed. I think this is fine tho.

<img width="753" alt="Screen Shot 2021-09-16 at 11 54 00 AM" src="https://user-images.githubusercontent.com/40268737/133645044-3baddcfd-0e45-4565-a9e1-1d4767b94840.PNG">

### Preview

https://elasticsearch_77887.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/install-elasticsearch.html#install-elasticsearch
