### PR TITLE
[7.14] [DOCS] Reformat frozen tier breaking change (#73350)

### DIFF
--- a/docs/reference/migration/migrate_7_13.asciidoc
+++ b/docs/reference/migration/migrate_7_13.asciidoc
@@ -88,9 +88,14 @@ SSL/TLS versions on your JDK].
 ====
 
 [discrete]
-[[breaking_713_frozen_multiple_data_paths_changes]]
-==== Frozen tier and multiple data paths changes
+[[breaking_713_settings_changes]]
+==== Settings changes
 
+[[breaking_713_frozen_multiple_data_paths_changes]]
+.Changes to the frozen tier and multiple data paths
+[%collapsible]
+====
+*Details* +
 {es} 7.12 included a technical preview of the frozen tier, being able to use
 partially mounted indices (searchable snapshots mounted with the shared cache
 option). Trying out this feature required configuring a shared cache using the
@@ -103,6 +108,7 @@ you do not utilize multiple data paths this will not affect you. Likewise, if
 you have not set `xpack.searchable.snapshot.shared_cache.size` and have not
 configured dedicated frozen nodes (nodes with the `data_frozen` role and no
 other data roles) this will not affect you.
+====
 // end::notable-breaking-changes[]
 
 [discrete]

--- a/docs/reference/migration/migrate_7_13.asciidoc
+++ b/docs/reference/migration/migrate_7_13.asciidoc
@@ -11,12 +11,12 @@ See also <<release-highlights>> and <<es-release-notes>>.
 
 * <<breaking_713_mapping_changes>>
 * <<breaking_713_ssl_changes>>
-* <<breaking_713_frozen_multiple_data_paths_changes>>
+* <<breaking_713_settings_changes>>
 * <<breaking_713_agg_deprecations>>
 * <<breaking_713_infra_core_deprecations>>
 * <<breaking_713_eql_deprecations>>
-* <<breaking_713_security_changes>>
-* <<breaking_713_setting_changes>>
+* <<breaking_713_security_deprecations>>
+* <<breaking_713_settings_deprecations>>
 
 //NOTE: The notable-breaking-changes tagged regions are re-used in the
 //Installation and Upgrade Guide
@@ -291,7 +291,7 @@ instead.
 ====
 
 [discrete]
-[[breaking_713_security_changes]]
+[[breaking_713_security_deprecations]]
 ==== Security deprecations
 
 [[implicitly-disabled-basic-realms]]
@@ -331,8 +331,8 @@ configuration will result in an error on startup.
 ====
 
 [discrete]
-[[breaking_713_setting_changes]]
-==== Setting deprecations
+[[breaking_713_settings_deprecations]]
+==== Settings deprecations
 
 [[deprecate-shared-data-path-settings]]
 .The `path.shared_data` and `index.data_path` settings are deprecated.


### PR DESCRIPTION
Backports the following commits to 7.14:
 - [DOCS] Reformat frozen tier breaking change (#73350)