### PR TITLE
[7.15] [DOCS] Add deprecation docs for 6.x and earlier indices (#77804)

### DIFF
--- a/docs/reference/migration/migrate_7_15.asciidoc
+++ b/docs/reference/migration/migrate_7_15.asciidoc
@@ -55,6 +55,27 @@ logging>>.
 [[breaking_715_indices_deprecations]]
 ==== Indices deprecations
 
+[[deprecate-6x-indices]]
+.Indices created in Elasticsearch 6.x and earlier versions are deprecated.
+[%collapsible]
+====
+*Details* +
+In 8.x, {es} will only read indices created in version 7.0 or above. An 8.x node
+will not start in the presence of indices created in 6.x or earlier versions of
+{es}.
+
+*Impact* +
+Before upgrading to an 8.x version, reindex any index created in 6.x or earlier
+versions with {es} 7.x. If you no longer need the index, delete it instead.
+You can use the get index API to check the {es} version in which an index
+was created.
+
+[source,console]
+----
+GET *,-.*?human=true&filter_path=**.settings.index.version.created_string
+----
+====
+
 [[deprecate-simpleifs]]
 .The `simpleifs` index store type is deprecated.
 [%collapsible]


### PR DESCRIPTION
Backports the following commits to 7.15:
 - [DOCS] Add deprecation docs for 6.x and earlier indices (#77804)