### PR TITLE
Implement DiffableStringMap's get and containsKey in terms of the wrapped innerMap

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/metadata/DiffableStringMap.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/DiffableStringMap.java
@@ -48,6 +48,16 @@ public class DiffableStringMap extends AbstractMap<String, String> implements Di
     }
 
     @Override
+    public String get(Object key) {
+        return innerMap.get(key);
+    }
+
+    @Override
+    public boolean containsKey(Object key) {
+        return innerMap.containsKey(key);
+    }
+
+    @Override
     @SuppressWarnings("unchecked")
     public void writeTo(StreamOutput out) throws IOException {
         out.writeMap((Map<String, Object>) (Map) innerMap);


### PR DESCRIPTION
In practice, the wrapped `innerMap` is either empty or a `HashMap`, so we can get much better performance here by delegating to it for these methods -- as opposed to using the default implementations from `AbstractMap` ([javadoc link](https://docs.oracle.com/javase/7/docs/api/java/util/AbstractMap.html#get(java.lang.Object))) which do a linear scan through via an `iterator()` of the `entrySet()`.

Totally unscientific (because I'm using it for the first time) JMH results from before:

```
Benchmark                                           Mode  Cnt     Score    Error  Units
LifecycleExecutionStateBenchmark.fromIndexMetadata  avgt   30  1358.084 ± 34.200  ns/op
```

and after:

```
Benchmark                                           Mode  Cnt    Score   Error  Units
LifecycleExecutionStateBenchmark.fromIndexMetadata  avgt   30  332.168 ± 5.678  ns/op
```

This ends up mattering because `LifecycleExecutionState#fromIndexMetadata` ends up loading all the keys it's interested in by way of `LifecycleExecutionState#fromCustomMetadata` and there's [a lot of them](https://github.com/elastic/elasticsearch/blob/f77860de8780f16d30a3ede3745d156e13680b14/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/LifecycleExecutionState.java#L166-L257). The `customData` map there is a `DiffableStringMap`, so we're doing a scan through all the keys in `fromCustomMetadata` invoking `get` each time, and `get` itself was doing a further scan through all the keys (well, half the keys, on average) internally, so `fromIndexMetadata` was accidentally quadratic.