### PR TITLE
[DOCS] Add breaking change for ECS user agent

### DIFF
--- a/docs/reference/migration/migrate_8_0.asciidoc
+++ b/docs/reference/migration/migrate_8_0.asciidoc
@@ -22,6 +22,7 @@ coming[8.0.0]
 * <<breaking_80_http_changes>>
 * <<breaking_80_ilm_changes>>
 * <<breaking_80_indices_changes>>
+* <<breaking_80_ingest_changes>>
 * <<breaking_80_java_changes>>
 * <<breaking_80_mappings_changes>>
 * <<breaking_80_network_changes>>
@@ -98,6 +99,7 @@ include::migrate_8_0/eql.asciidoc[]
 include::migrate_8_0/http.asciidoc[]
 include::migrate_8_0/ilm.asciidoc[]
 include::migrate_8_0/indices.asciidoc[]
+include::migrate_8_0/ingest.asciidoc[]
 include::migrate_8_0/java.asciidoc[]
 include::migrate_8_0/mappings.asciidoc[]
 include::migrate_8_0/network.asciidoc[]

--- a/docs/reference/migration/migrate_8_0/ingest.asciidoc
+++ b/docs/reference/migration/migrate_8_0/ingest.asciidoc
@@ -12,7 +12,7 @@
 *Details* +
 In 7.2, we deprecated the `ecs` parameter for the `user_agent` ingest processor.
 In 8.x, the `user_agent` ingest processor will only return {ecs-ref}[Elastic
-Common Schema (ECS)] fields, even if `ecs` is `false`.
+Common Schema (ECS)] fields, regardless of the `ecs` value.
 
 *Impact* +
 To avoid deprecation warnings, remove the parameter from your ingest pipelines.

--- a/docs/reference/migration/migrate_8_0/ingest.asciidoc
+++ b/docs/reference/migration/migrate_8_0/ingest.asciidoc
@@ -1,0 +1,21 @@
+[discrete]
+[[breaking_80_ingest_changes]]
+==== Ingest pipeline changes
+
+//NOTE: The notable-breaking-changes tagged regions are re-used in the
+//Installation and Upgrade Guide
+
+//tag::notable-breaking-changes[]
+.The `user_agent` ingest processor's `ecs` parameter has no effect.
+[%collapsible]
+====
+*Details* +
+In 7.2, we deprecated the `ecs` parameter for the `user_agent` ingest processor.
+In 8.x, the `user_agent` ingest processor will only return {ecs-ref}[Elastic
+Common Schema (ECS)] fields.
+
+*Impact* +
+To avoid deprecation warnings, remove the parameter from your ingest pipelines.
+If a pipeline specifies a `ecs` value, the value is ignored.
+====
+//end::notable-breaking-changes[]

--- a/docs/reference/migration/migrate_8_0/ingest.asciidoc
+++ b/docs/reference/migration/migrate_8_0/ingest.asciidoc
@@ -12,7 +12,7 @@
 *Details* +
 In 7.2, we deprecated the `ecs` parameter for the `user_agent` ingest processor.
 In 8.x, the `user_agent` ingest processor will only return {ecs-ref}[Elastic
-Common Schema (ECS)] fields.
+Common Schema (ECS)] fields, even if `ecs` is `false`.
 
 *Impact* +
 To avoid deprecation warnings, remove the parameter from your ingest pipelines.

--- a/docs/reference/migration/migrate_8_0/ingest.asciidoc
+++ b/docs/reference/migration/migrate_8_0/ingest.asciidoc
@@ -16,6 +16,6 @@ Common Schema (ECS)] fields.
 
 *Impact* +
 To avoid deprecation warnings, remove the parameter from your ingest pipelines.
-If a pipeline specifies a `ecs` value, the value is ignored.
+If a pipeline specifies an `ecs` value, the value is ignored.
 ====
 //end::notable-breaking-changes[]


### PR DESCRIPTION
In 8.x, we'll ignore the `ecs` option for the `user_agent` ingest processor.
This adds a related breaking change to the 8.0 migration docs.

Relates to #38828

### Preview
https://elasticsearch_77971.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/migrating-8.0.html#breaking_80_ingest_changes