### PR TITLE
Update JSON parser and snippets

### DIFF
--- a/docs/reference/aggregations/bucket/missing-aggregation.asciidoc
+++ b/docs/reference/aggregations/bucket/missing-aggregation.asciidoc
@@ -31,7 +31,7 @@ Response:
   ...
   "aggregations": {
     "products_without_a_price": {
-      "doc_count": 00
+      "doc_count": 0
     }
   }
 }

--- a/docs/reference/aggregations/pipeline/bucket-selector-aggregation.asciidoc
+++ b/docs/reference/aggregations/pipeline/bucket-selector-aggregation.asciidoc
@@ -105,7 +105,7 @@ And the following may be the response:
                "doc_count": 2,
                "total_sales": {
                    "value": 375.0
-               },
+               }
             }
          ]
       }

--- a/docs/reference/aggregations/pipeline/bucket-sort-aggregation.asciidoc
+++ b/docs/reference/aggregations/pipeline/bucket-sort-aggregation.asciidoc
@@ -111,7 +111,7 @@ And the following may be the response:
                "doc_count": 2,
                "total_sales": {
                    "value": 375.0
-               },
+               }
             },
             {
                "key_as_string": "2015/02/01 00:00:00",
@@ -119,7 +119,7 @@ And the following may be the response:
                "doc_count": 2,
                "total_sales": {
                    "value": 60.0
-               },
+               }
             }
          ]
       }

--- a/docs/reference/indices/recovery.asciidoc
+++ b/docs/reference/indices/recovery.asciidoc
@@ -303,7 +303,7 @@ The API returns the following response:
         "percent" : "100.0%",
         "total_on_start" : 0,
         "total_time" : "0s",
-        "total_time_in_millis" : 0,
+        "total_time_in_millis" : 0
       },
       "verify_index" : {
         "check_index_time" : "0s",

--- a/docs/reference/ingest/processors/geoip.asciidoc
+++ b/docs/reference/ingest/processors/geoip.asciidoc
@@ -140,7 +140,7 @@ returns this:
     "geo": {
       "continent_name": "North America",
       "country_name": "United States",
-      "country_iso_code": "US",
+      "country_iso_code": "US"
     }
   }
 }

--- a/docs/reference/ingest/processors/pipeline.asciidoc
+++ b/docs/reference/ingest/processors/pipeline.asciidoc
@@ -98,7 +98,7 @@ Response from the index request:
     "failed": 0
   },
   "_seq_no": 66,
-  "_primary_term": 1,
+  "_primary_term": 1
 }
 --------------------------------------------------
 // TESTRESPONSE[s/"_seq_no": \d+/"_seq_no" : $body._seq_no/ s/"_primary_term" : 1/"_primary_term" : $body._primary_term/]

--- a/docs/reference/ingest/processors/user-agent.asciidoc
+++ b/docs/reference/ingest/processors/user-agent.asciidoc
@@ -71,7 +71,7 @@ Which returns
       },
       "device" : {
         "name" : "Mac"
-      },
+      }
     }
   }
 }

--- a/docs/reference/rest-api/info.asciidoc
+++ b/docs/reference/rest-api/info.asciidoc
@@ -152,11 +152,11 @@ Example response:
       },
       "data_streams" : {
          "available" : true,
-         "enabled" : true,
+         "enabled" : true
       },
       "data_tiers" : {
          "available" : true,
-         "enabled" : true,
+         "enabled" : true
       }
    },
    "tagline" : "You know, for X"

--- a/docs/reference/search/profile.asciidoc
+++ b/docs/reference/search/profile.asciidoc
@@ -77,9 +77,9 @@ The API returns the following result:
             "query": [
               {
                 "type": "BooleanQuery",
-                "description": "message:get
-                message:search", "time_in_nanos" : 11972972, "breakdown" :
-                {
+                "description": "message:get message:search",
+                "time_in_nanos" : 11972972,
+                "breakdown" : {
                   "set_min_competitive_score_count": 0,
                   "match_count": 5,
                   "shallow_advance_count": 0,

--- a/docs/reference/search/search-your-data/retrieve-selected-fields.asciidoc
+++ b/docs/reference/search/search-your-data/retrieve-selected-fields.asciidoc
@@ -214,11 +214,11 @@ returning them as a flat list.
         "group" : ["fans"],
         "user": [{
             "first": ["John"],
-            "last": ["Smith"],
+            "last": ["Smith"]
           },
           {
             "first": ["Alice"],
-            "last": ["White"],
+            "last": ["White"]
           }
         ]
       }
@@ -270,10 +270,10 @@ structure of the nested `user` array:
       "_score": 1.0,
       "fields": {
         "user": [{
-            "first": ["John"],
+            "first": ["John"]
           },
           {
-            "first": ["Alice"],
+            "first": ["Alice"]
           }
         ]
       }

--- a/docs/reference/snapshot-restore/apis/get-snapshot-api.asciidoc
+++ b/docs/reference/snapshot-restore/apis/get-snapshot-api.asciidoc
@@ -432,7 +432,7 @@ The API returns the following response:
         "total": 0,
         "failed": 0,
         "successful": 0
-      },
+      }
     }
   ],
   "next": "c25hcHNob3RfMixteV9yZXBvc2l0b3J5LHNuYXBzaG90XzI=",
@@ -613,7 +613,7 @@ The API returns the following response:
         "total": 0,
         "failed": 0,
         "successful": 0
-      },
+      }
     }
   ],
   "total": 2,


### PR DESCRIPTION
Related to issue  #77823 

This does the following:

- Updates several asciidoc files that contained code snippets with invalid Json, most involving unnecessary trailing commas.

- Makes the switch from the groovy Json parser to the Jackson parser, pursuant to the general goal of eliminating groovy  dependence.

- Makes testing of Json validity at build time more strict.

Note that this update still allows backslash escaping for any character.  Currently that matters because of the file "docs/reference/ml/anomaly-detection/apis/get-datafeed-stats.asciidoc", specifically this part:

```json
"attributes" : {
            "ml.machine_memory" : "$body.datafeeds.0.node.attributes.ml\.machine_memory",
            "ml.max_open_jobs" : "512"
          }
```

It's not clear to me what change, if any, is appropriate there. So, I've left in the escaped period and configured the parser to ignore it for the time being.


