### PR TITLE
[DOCS] Adds deprecation notice to the index file of Java HLRC

### DIFF
--- a/docs/java-rest/high-level/index.asciidoc
+++ b/docs/java-rest/high-level/index.asciidoc
@@ -6,6 +6,8 @@
 [partintro]
 --
 
+deprecated[7.15.0, The High Level REST Client is deprecated in favour of the Java Client.]
+
 The Java High Level REST Client works on top of the Java Low Level REST client.
 Its main goal is to expose API specific methods, that accept request objects as
 an argument and return response objects, so that request marshalling and


### PR DESCRIPTION
## Overview

This PR marks the Java High Level REST Client as deprecated.

### Preview

![Java_High_Level_REST_Client___Java_REST_Client__master____Elastic](https://user-images.githubusercontent.com/22324794/133972828-12bae3b4-b8d6-4981-b44a-6b49cb6da738.png)

[Java HLRC index](https://elasticsearch_77988.docs-preview.app.elstc.co/guide/en/elasticsearch/client/java-rest/master/java-rest-high.html)