### PR TITLE
Include _index property for each hit in _mvt response

### DIFF
--- a/x-pack/plugin/vector-tile/src/javaRestTest/java/org/elasticsearch/xpack/vectortile/VectorTileRestIT.java
+++ b/x-pack/plugin/vector-tile/src/javaRestTest/java/org/elasticsearch/xpack/vectortile/VectorTileRestIT.java
@@ -88,7 +88,7 @@ public class VectorTileRestIT extends ESRestTestCase {
         double y = (r.getMaxY() + r.getMinY()) / 2;
         for (int i = 0; i < 30; i += 10) {
             for (int j = 0; j <= i; j++) {
-                final Request putRequest = new Request(HttpPost.METHOD_NAME, INDEX_POINTS + "/_doc");
+                final Request putRequest = new Request(HttpPost.METHOD_NAME, INDEX_POINTS + "/_doc/");
                 putRequest.setJsonEntity(
                     "{\n"
                         + "  \"location\": \"POINT("
@@ -117,10 +117,10 @@ public class VectorTileRestIT extends ESRestTestCase {
 
     private void indexShapes() throws IOException {
         final Rectangle r = GeoTileUtils.toBoundingBox(x, y, z);
-        createIndexAndPutGeometry(INDEX_POLYGON, toPolygon(r));
+        createIndexAndPutGeometry(INDEX_POLYGON, toPolygon(r), "polygon");
     }
 
-    private void createIndexAndPutGeometry(String indexName, Geometry geometry) throws IOException {
+    private void createIndexAndPutGeometry(String indexName, Geometry geometry, String id) throws IOException {
         final Request createRequest = new Request(HttpPut.METHOD_NAME, indexName);
         Response response = client().performRequest(createRequest);
         assertThat(response.getStatusLine().getStatusCode(), Matchers.equalTo(HttpStatus.SC_OK));
@@ -140,7 +140,7 @@ public class VectorTileRestIT extends ESRestTestCase {
         response = client().performRequest(mappingRequest);
         assertThat(response.getStatusLine().getStatusCode(), Matchers.equalTo(HttpStatus.SC_OK));
 
-        final Request putRequest = new Request(HttpPost.METHOD_NAME, indexName + "/_doc");
+        final Request putRequest = new Request(HttpPost.METHOD_NAME, indexName + "/_doc/" + id);
         putRequest.setJsonEntity(
             "{\n"
                 + "  \"location\": \""
@@ -249,7 +249,7 @@ public class VectorTileRestIT extends ESRestTestCase {
         mvtRequest.setJsonEntity("{\"size\" : 100}");
         final VectorTile.Tile tile = execute(mvtRequest);
         assertThat(tile.getLayersCount(), Matchers.equalTo(3));
-        assertLayer(tile, HITS_LAYER, 4096, 33, 1);
+        assertLayer(tile, HITS_LAYER, 4096, 33, 2);
         assertLayer(tile, AGGS_LAYER, 4096, 1, 1);
         assertLayer(tile, META_LAYER, 4096, 1, 13);
     }
@@ -260,7 +260,7 @@ public class VectorTileRestIT extends ESRestTestCase {
         final VectorTile.Tile tile = execute(mvtRequest);
         assertThat(tile.getLayersCount(), Matchers.equalTo(3));
         // 33 points, 1 polygon and two from geometry collection
-        assertLayer(tile, HITS_LAYER, 4096, 36, 1);
+        assertLayer(tile, HITS_LAYER, 4096, 36, 2);
         assertLayer(tile, AGGS_LAYER, 4096, 256 * 256, 1);
         assertLayer(tile, META_LAYER, 4096, 1, 13);
     }
@@ -270,7 +270,7 @@ public class VectorTileRestIT extends ESRestTestCase {
         mvtRequest.setJsonEntity("{\"size\" : 100, \"extent\" : 256}");
         final VectorTile.Tile tile = execute(mvtRequest);
         assertThat(tile.getLayersCount(), Matchers.equalTo(3));
-        assertLayer(tile, HITS_LAYER, 256, 33, 1);
+        assertLayer(tile, HITS_LAYER, 256, 33, 2);
         assertLayer(tile, AGGS_LAYER, 256, 1, 1);
         assertLayer(tile, META_LAYER, 256, 1, 13);
     }
@@ -283,7 +283,7 @@ public class VectorTileRestIT extends ESRestTestCase {
         mvtRequest.setJsonEntity("{\"size\" : 100, \"extent\" : 256}");
         final VectorTile.Tile tile = execute(mvtRequest);
         assertThat(tile.getLayersCount(), Matchers.equalTo(3));
-        assertLayer(tile, HITS_LAYER, 512, 33, 1);
+        assertLayer(tile, HITS_LAYER, 512, 33, 2);
         assertLayer(tile, AGGS_LAYER, 512, 1, 1);
         assertLayer(tile, META_LAYER, 512, 1, 13);
     }
@@ -339,7 +339,7 @@ public class VectorTileRestIT extends ESRestTestCase {
             mvtRequest.setJsonEntity("{\"size\" : 100, \"grid_precision\": 7 }");
             final VectorTile.Tile tile = execute(mvtRequest);
             assertThat(tile.getLayersCount(), Matchers.equalTo(3));
-            assertLayer(tile, HITS_LAYER, 4096, 33, 1);
+            assertLayer(tile, HITS_LAYER, 4096, 33, 2);
             assertLayer(tile, AGGS_LAYER, 4096, 1, 1);
             assertLayer(tile, META_LAYER, 4096, 1, 13);
         }
@@ -357,7 +357,7 @@ public class VectorTileRestIT extends ESRestTestCase {
             mvtRequest.setJsonEntity("{\"size\" : 100, \"grid_type\": \"point\" }");
             final VectorTile.Tile tile = execute(mvtRequest);
             assertThat(tile.getLayersCount(), Matchers.equalTo(3));
-            assertLayer(tile, HITS_LAYER, 4096, 33, 1);
+            assertLayer(tile, HITS_LAYER, 4096, 33, 2);
             assertLayer(tile, AGGS_LAYER, 4096, 1, 1);
             assertLayer(tile, META_LAYER, 4096, 1, 13);
             assertFeatureType(tile, AGGS_LAYER, VectorTile.Tile.GeomType.POINT);
@@ -367,7 +367,7 @@ public class VectorTileRestIT extends ESRestTestCase {
             mvtRequest.setJsonEntity("{\"size\" : 100, \"grid_type\": \"grid\" }");
             final VectorTile.Tile tile = execute(mvtRequest);
             assertThat(tile.getLayersCount(), Matchers.equalTo(3));
-            assertLayer(tile, HITS_LAYER, 4096, 33, 1);
+            assertLayer(tile, HITS_LAYER, 4096, 33, 2);
             assertLayer(tile, AGGS_LAYER, 4096, 1, 1);
             assertLayer(tile, META_LAYER, 4096, 1, 13);
             assertFeatureType(tile, AGGS_LAYER, VectorTile.Tile.GeomType.POLYGON);
@@ -388,7 +388,7 @@ public class VectorTileRestIT extends ESRestTestCase {
         mvtRequest.setJsonEntity("{\"size\" : 100, \"grid_type\": \"point\" }");
         final VectorTile.Tile tile = execute(mvtRequest);
         assertThat(tile.getLayersCount(), Matchers.equalTo(3));
-        assertLayer(tile, HITS_LAYER, 4096, 33, 1);
+        assertLayer(tile, HITS_LAYER, 4096, 33, 2);
         assertLayer(tile, AGGS_LAYER, 4096, 1, 1);
         assertLayer(tile, META_LAYER, 4096, 1, 13);
         assertFeatureType(tile, AGGS_LAYER, VectorTile.Tile.GeomType.POLYGON);
@@ -399,7 +399,7 @@ public class VectorTileRestIT extends ESRestTestCase {
         mvtRequest.setJsonEntity("{\"size\" : 100, \"grid_precision\": 0 }");
         final VectorTile.Tile tile = execute(mvtRequest);
         assertThat(tile.getLayersCount(), Matchers.equalTo(2));
-        assertLayer(tile, HITS_LAYER, 4096, 33, 1);
+        assertLayer(tile, HITS_LAYER, 4096, 33, 2);
         assertLayer(tile, META_LAYER, 4096, 1, 8);
     }
 
@@ -411,7 +411,7 @@ public class VectorTileRestIT extends ESRestTestCase {
         mvtRequest.setJsonEntity("{\"size\" : 100, \"grid_precision\": 4 }");
         final VectorTile.Tile tile = execute(mvtRequest);
         assertThat(tile.getLayersCount(), Matchers.equalTo(2));
-        assertLayer(tile, HITS_LAYER, 4096, 33, 1);
+        assertLayer(tile, HITS_LAYER, 4096, 33, 2);
         assertLayer(tile, META_LAYER, 4096, 1, 8);
     }
 
@@ -439,7 +439,7 @@ public class VectorTileRestIT extends ESRestTestCase {
             mvtRequest.setJsonEntity("{\"size\": 100 }");
             final VectorTile.Tile tile = execute(mvtRequest);
             assertThat(tile.getLayersCount(), Matchers.equalTo(3));
-            assertLayer(tile, HITS_LAYER, 4096, 34, 1);
+            assertLayer(tile, HITS_LAYER, 4096, 34, 2);
             final VectorTile.Tile.Layer layer = getLayer(tile, HITS_LAYER);
             assertThat(layer.getFeatures(0).getType(), Matchers.equalTo(VectorTile.Tile.GeomType.POLYGON));
             assertLayer(tile, AGGS_LAYER, 4096, 256 * 256, 1);
@@ -450,7 +450,7 @@ public class VectorTileRestIT extends ESRestTestCase {
             mvtRequest.setJsonEntity("{\"size\": 100, \"sort\" : []}"); // override default sort
             final VectorTile.Tile tile = execute(mvtRequest);
             assertThat(tile.getLayersCount(), Matchers.equalTo(3));
-            assertLayer(tile, HITS_LAYER, 4096, 34, 1);
+            assertLayer(tile, HITS_LAYER, 4096, 34, 2);
             final VectorTile.Tile.Layer layer = getLayer(tile, HITS_LAYER);
             assertThat(layer.getFeatures(0).getType(), Matchers.equalTo(VectorTile.Tile.GeomType.POINT));
             assertLayer(tile, AGGS_LAYER, 4096, 256 * 256, 1);
@@ -487,7 +487,7 @@ public class VectorTileRestIT extends ESRestTestCase {
 
             final VectorTile.Tile tile = execute(mvtRequest);
             assertThat(tile.getLayersCount(), Matchers.equalTo(2));
-            assertLayer(tile, HITS_LAYER, 4096, 34, 1);
+            assertLayer(tile, HITS_LAYER, 4096, 34, 2);
             final VectorTile.Tile.Layer layer = getLayer(tile, HITS_LAYER);
             assertThat(layer.getFeatures(0).getType(), Matchers.equalTo(VectorTile.Tile.GeomType.POLYGON));
             assertLayer(tile, META_LAYER, 4096, 1, 8);
@@ -513,7 +513,7 @@ public class VectorTileRestIT extends ESRestTestCase {
 
             final VectorTile.Tile tile = execute(mvtRequest);
             assertThat(tile.getLayersCount(), Matchers.equalTo(2));
-            assertLayer(tile, HITS_LAYER, 4096, 34, 1);
+            assertLayer(tile, HITS_LAYER, 4096, 34, 2);
             final VectorTile.Tile.Layer layer = getLayer(tile, HITS_LAYER);
             assertThat(layer.getFeatures(33).getType(), Matchers.equalTo(VectorTile.Tile.GeomType.POLYGON));
             assertLayer(tile, META_LAYER, 4096, 1, 8);
@@ -535,18 +535,21 @@ public class VectorTileRestIT extends ESRestTestCase {
         );
         final VectorTile.Tile tile = execute(mvtRequest);
         assertThat(tile.getLayersCount(), Matchers.equalTo(3));
-        assertLayer(tile, HITS_LAYER, 4096, 1, 1);
+        assertLayer(tile, HITS_LAYER, 4096, 1, 2);
         assertLayer(tile, AGGS_LAYER, 4096, 1, 1);
         assertLayer(tile, META_LAYER, 4096, 1, 13);
+        assertStringTag(getLayer(tile, HITS_LAYER), getLayer(tile, HITS_LAYER).getFeatures(0), "_index", INDEX_POINTS);
     }
 
     public void testBasicShape() throws Exception {
         final Request mvtRequest = new Request(getHttpMethod(), INDEX_POLYGON + "/_mvt/location/" + z + "/" + x + "/" + y);
         final VectorTile.Tile tile = execute(mvtRequest);
         assertThat(tile.getLayersCount(), Matchers.equalTo(3));
-        assertLayer(tile, HITS_LAYER, 4096, 1, 1);
+        assertLayer(tile, HITS_LAYER, 4096, 1, 2);
         assertLayer(tile, AGGS_LAYER, 4096, 256 * 256, 1);
         assertLayer(tile, META_LAYER, 4096, 1, 13);
+        assertStringTag(getLayer(tile, HITS_LAYER), getLayer(tile, HITS_LAYER).getFeatures(0), "_index", INDEX_POLYGON);
+        assertStringTag(getLayer(tile, HITS_LAYER), getLayer(tile, HITS_LAYER).getFeatures(0), "_id", "polygon");
     }
 
     public void testWithFields() throws Exception {
@@ -554,7 +557,7 @@ public class VectorTileRestIT extends ESRestTestCase {
         mvtRequest.setJsonEntity("{\"fields\": [\"name\", \"value1\"] }");
         final VectorTile.Tile tile = execute(mvtRequest);
         assertThat(tile.getLayersCount(), Matchers.equalTo(3));
-        assertLayer(tile, HITS_LAYER, 4096, 1, 3);
+        assertLayer(tile, HITS_LAYER, 4096, 1, 4);
         assertLayer(tile, AGGS_LAYER, 4096, 256 * 256, 1);
         assertLayer(tile, META_LAYER, 4096, 1, 13);
     }
@@ -574,13 +577,13 @@ public class VectorTileRestIT extends ESRestTestCase {
         );
         final VectorTile.Tile tile = execute(mvtRequest);
         assertThat(tile.getLayersCount(), Matchers.equalTo(3));
-        assertLayer(tile, HITS_LAYER, 4096, 1, 1);
+        assertLayer(tile, HITS_LAYER, 4096, 1, 2);
         assertLayer(tile, AGGS_LAYER, 4096, 256 * 256, 2);
         assertLayer(tile, META_LAYER, 4096, 1, 18);
         // check pipeline aggregation values
         final VectorTile.Tile.Layer metaLayer = getLayer(tile, META_LAYER);
-        assertTag(metaLayer, metaLayer.getFeatures(0), "aggregations.minVal.min", 1.0);
-        assertTag(metaLayer, metaLayer.getFeatures(0), "aggregations.minVal.max", 1.0);
+        assertDoubleTag(metaLayer, metaLayer.getFeatures(0), "aggregations.minVal.min", 1.0);
+        assertDoubleTag(metaLayer, metaLayer.getFeatures(0), "aggregations.minVal.max", 1.0);
     }
 
     public void testOverlappingMultipolygon() throws Exception {
@@ -589,7 +592,7 @@ public class VectorTileRestIT extends ESRestTestCase {
         final String index = "overlapping_multipolygon";
         final Rectangle r1 = new Rectangle(-160, 160, 80, -80);
         final Rectangle r2 = new Rectangle(-159, 161, 79, -81);
-        createIndexAndPutGeometry(index, new MultiPolygon(List.of(toPolygon(r1), toPolygon(r2))));
+        createIndexAndPutGeometry(index, new MultiPolygon(List.of(toPolygon(r1), toPolygon(r2))), "multi_polygon");
         final Request mvtRequest = new Request(getHttpMethod(), index + "/_mvt/location/0/0/0?grid_precision=0");
         final VectorTile.Tile tile = execute(mvtRequest);
         assertThat(tile.getLayersCount(), Matchers.equalTo(2));
@@ -618,7 +621,7 @@ public class VectorTileRestIT extends ESRestTestCase {
         assertThat(layer.getKeysCount(), Matchers.equalTo(numTags));
     }
 
-    private void assertTag(VectorTile.Tile.Layer layer, VectorTile.Tile.Feature feature, String tag, double value) {
+    private void assertDoubleTag(VectorTile.Tile.Layer layer, VectorTile.Tile.Feature feature, String tag, double value) {
         for (int i = 0; i < feature.getTagsCount(); i += 2) {
             String thisTag = layer.getKeys(feature.getTags(i));
             if (tag.equals(thisTag)) {
@@ -628,6 +631,16 @@ public class VectorTileRestIT extends ESRestTestCase {
             }
         }
         fail("Could not find tag [" + tag + " ]");
+    }
+
+    private void assertStringTag(VectorTile.Tile.Layer layer, VectorTile.Tile.Feature feature, String tag, String value) {
+        for (int i = 0; i < feature.getTagsCount(); i += 2) {
+            String thisTag = layer.getKeys(feature.getTags(i));
+            if (tag.equals(thisTag)) {
+                VectorTile.Tile.Value thisValue = layer.getValues(feature.getTags(i + 1));
+                assertEquals(thisValue.getStringValue(), value);
+            }
+        }
     }
 
     private VectorTile.Tile execute(Request mvtRequest) throws IOException {

--- a/x-pack/plugin/vector-tile/src/main/java/org/elasticsearch/xpack/vectortile/rest/RestVectorTileAction.java
+++ b/x-pack/plugin/vector-tile/src/main/java/org/elasticsearch/xpack/vectortile/rest/RestVectorTileAction.java
@@ -70,6 +70,7 @@ public class RestVectorTileAction extends BaseRestHandler {
 
     private static final String COUNT_TAG = "_count";
     private static final String ID_TAG = "_id";
+    private static final String INDEX_TAG = "_index";
 
     // mime type as defined by the mapbox vector tile specification
     private static final String MIME_TYPE = "application/vnd.mapbox-vector-tile";
@@ -237,6 +238,7 @@ public class RestVectorTileAction extends BaseRestHandler {
                 featureBuilder.clear();
                 featureBuilder.mergeFrom((byte[]) feature);
                 VectorTileUtils.addPropertyToFeature(featureBuilder, layerProps, ID_TAG, searchHit.getId());
+                VectorTileUtils.addPropertyToFeature(featureBuilder, layerProps, INDEX_TAG, searchHit.getIndex());
                 if (fields != null) {
                     for (FieldAndFormat field : fields) {
                         final DocumentField documentField = searchHit.field(field.field);


### PR DESCRIPTION
Adds an _index tag for each feature in the hit layer. This allows to identify uniquely the document that is generating the feature.

closes #77205