### PR TITLE
[7.x] Make Maps.toUnmodifiableSortedMap return NavigableMap (#77585)

### DIFF
--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/ccr/AutoFollowStats.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/ccr/AutoFollowStats.java
@@ -9,16 +9,15 @@
 package org.elasticsearch.client.ccr;
 
 import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.common.util.Maps;
+import org.elasticsearch.common.xcontent.ConstructingObjectParser;
 import org.elasticsearch.common.xcontent.ParseField;
 import org.elasticsearch.core.Tuple;
-import org.elasticsearch.common.xcontent.ConstructingObjectParser;
 
 import java.util.AbstractMap;
 import java.util.List;
 import java.util.Map;
 import java.util.NavigableMap;
-import java.util.TreeMap;
-import java.util.stream.Collectors;
 
 public final class AutoFollowStats {
 
@@ -43,14 +42,12 @@ public final class AutoFollowStats {
             (Long) args[0],
             (Long) args[1],
             (Long) args[2],
-            new TreeMap<>(
-                ((List<Map.Entry<String, Tuple<Long, ElasticsearchException>>>) args[3])
-                    .stream()
-                    .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue))),
-            new TreeMap<>(
-                ((List<Map.Entry<String, AutoFollowedCluster>>) args[4])
-                    .stream()
-                    .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue)))
+            ((List<Map.Entry<String, Tuple<Long, ElasticsearchException>>>) args[3])
+                .stream()
+                .collect(Maps.toUnmodifiableSortedMap(Map.Entry::getKey, Map.Entry::getValue)),
+            ((List<Map.Entry<String, AutoFollowedCluster>>) args[4])
+                .stream()
+                .collect(Maps.toUnmodifiableSortedMap(Map.Entry::getKey, Map.Entry::getValue))
         ));
 
     static final ConstructingObjectParser<Map.Entry<String, Tuple<Long, ElasticsearchException>>, Void> AUTO_FOLLOW_EXCEPTIONS_PARSER =

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/ccr/GetAutoFollowPatternResponse.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/ccr/GetAutoFollowPatternResponse.java
@@ -8,13 +8,14 @@
 
 package org.elasticsearch.client.ccr;
 
-import org.elasticsearch.common.xcontent.ParseField;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.ByteSizeValue;
-import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.common.xcontent.ConstructingObjectParser;
 import org.elasticsearch.common.xcontent.ObjectParser;
+import org.elasticsearch.common.xcontent.ParseField;
 import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.core.TimeValue;
 
 import java.util.AbstractMap;
 import java.util.Collections;
@@ -22,8 +23,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.NavigableMap;
 import java.util.Objects;
-import java.util.TreeMap;
-import java.util.stream.Collectors;
 
 public final class GetAutoFollowPatternResponse {
 
@@ -43,8 +42,8 @@ public final class GetAutoFollowPatternResponse {
         "get_auto_follow_pattern_response", true, args -> {
             @SuppressWarnings("unchecked")
             List<Map.Entry<String, Pattern>> entries = (List<Map.Entry<String, Pattern>>) args[0];
-            return new GetAutoFollowPatternResponse(new TreeMap<>(entries.stream()
-                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue))));
+            return new GetAutoFollowPatternResponse(entries.stream()
+                .collect(Maps.toUnmodifiableSortedMap(Map.Entry::getKey, Map.Entry::getValue)));
     });
 
     static {

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/ccr/IndicesFollowStats.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/ccr/IndicesFollowStats.java
@@ -9,9 +9,10 @@
 package org.elasticsearch.client.ccr;
 
 import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.common.util.Maps;
+import org.elasticsearch.common.xcontent.ConstructingObjectParser;
 import org.elasticsearch.common.xcontent.ParseField;
 import org.elasticsearch.core.Tuple;
-import org.elasticsearch.common.xcontent.ConstructingObjectParser;
 
 import java.util.AbstractMap;
 import java.util.Collections;
@@ -138,10 +139,9 @@ public final class IndicesFollowStats {
                                 (long) args[24],
                                 (long) args[25],
                                 (long) args[26],
-                                new TreeMap<>(
-                                        ((List<Map.Entry<Long, Tuple<Integer, ElasticsearchException>>>) args[27])
-                                                .stream()
-                                                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue))),
+                                ((List<Map.Entry<Long, Tuple<Integer, ElasticsearchException>>>) args[27])
+                                    .stream()
+                                    .collect(Maps.toUnmodifiableSortedMap(Map.Entry::getKey, Map.Entry::getValue)),
                                 (ElasticsearchException) args[28]));
 
         static final ConstructingObjectParser<Map.Entry<Long, Tuple<Integer, ElasticsearchException>>, Void> READ_EXCEPTIONS_ENTRY_PARSER =

--- a/server/src/main/java/org/elasticsearch/common/util/Maps.java
+++ b/server/src/main/java/org/elasticsearch/common/util/Maps.java
@@ -12,10 +12,10 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.NavigableMap;
 import java.util.Objects;
-import java.util.SortedMap;
-import java.util.TreeMap;
 import java.util.Set;
+import java.util.TreeMap;
 import java.util.function.Function;
 import java.util.stream.Collector;
 import java.util.stream.Collectors;
@@ -137,13 +137,13 @@ public class Maps {
      * unmodifiable sorted map. The resulting read-only view through the unmodifiable sorted map is a sorted map.
      *
      * @param <T> the type of the input elements
-     * @return an unmodifiable map where the underlying map is sorted
+     * @return an unmodifiable {@link NavigableMap} where the underlying map is sorted
      */
-    public static <T, K, V> Collector<T, ?, SortedMap<K, V>> toUnmodifiableSortedMap(Function<T, ? extends K> keyMapper,
-                                                                                     Function<T, ? extends V> valueMapper) {
+    public static <T, K, V> Collector<T, ?, NavigableMap<K, V>> toUnmodifiableSortedMap(Function<T, ? extends K> keyMapper,
+                                                                                        Function<T, ? extends V> valueMapper) {
         return Collectors.collectingAndThen(Collectors.toMap(keyMapper, valueMapper, (v1, v2) -> {
             throw new IllegalStateException("Duplicate key (attempted merging values " + v1 + "  and " + v2 + ")");
-        }, () -> new TreeMap<K, V>()), Collections::unmodifiableSortedMap);
+        }, () -> new TreeMap<K, V>()), Collections::unmodifiableNavigableMap);
     }
 
 }

--- a/test/framework/src/main/java/org/elasticsearch/test/junit/listeners/LoggingListener.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/junit/listeners/LoggingListener.java
@@ -11,6 +11,7 @@ package org.elasticsearch.test.junit.listeners;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.common.logging.Loggers;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.test.junit.annotations.TestIssueLogging;
 import org.elasticsearch.test.junit.annotations.TestLogging;
 import org.junit.runner.Description;
@@ -22,7 +23,6 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 /**
@@ -103,8 +103,8 @@ public class LoggingListener extends RunListener {
          * parent setting.
          */
         final Map<String, String> loggingLevels =
-            new TreeMap<>(Stream.concat(testLoggingMap.entrySet().stream(), testIssueLoggingMap.entrySet().stream())
-                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue)));
+            Stream.concat(testLoggingMap.entrySet().stream(), testIssueLoggingMap.entrySet().stream())
+                .collect(Maps.toUnmodifiableSortedMap(Map.Entry::getKey, Map.Entry::getValue));
 
         /*
          * Obtain the existing logging levels so that we can restore them at the end of the test. We have to do this separately from

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ccr/ShardFollowNodeTaskStatus.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ccr/ShardFollowNodeTaskStatus.java
@@ -9,17 +9,18 @@ package org.elasticsearch.xpack.core.ccr;
 
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.Version;
-import org.elasticsearch.common.xcontent.ParseField;
 import org.elasticsearch.common.Strings;
-import org.elasticsearch.core.Tuple;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.unit.ByteSizeUnit;
 import org.elasticsearch.common.unit.ByteSizeValue;
-import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.common.xcontent.ConstructingObjectParser;
+import org.elasticsearch.common.xcontent.ParseField;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.core.Tuple;
 import org.elasticsearch.tasks.Task;
 
 import java.io.IOException;
@@ -97,10 +98,9 @@ public class ShardFollowNodeTaskStatus implements Task.Status {
                             (long) args[23],
                             (long) args[24],
                             (long) args[25],
-                            new TreeMap<>(
-                                    ((List<Map.Entry<Long, Tuple<Integer, ElasticsearchException>>>) args[26])
-                                            .stream()
-                                            .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue))),
+                            ((List<Map.Entry<Long, Tuple<Integer, ElasticsearchException>>>) args[26])
+                                .stream()
+                                .collect(Maps.toUnmodifiableSortedMap(Map.Entry::getKey, Map.Entry::getValue)),
                             (long) args[27],
                             (ElasticsearchException) args[28]));
 


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Make Maps.toUnmodifiableSortedMap return NavigableMap (#77585)