### PR TITLE
[DOCS] Note exclusive force merge API options

### DIFF
--- a/docs/reference/indices/forcemerge.asciidoc
+++ b/docs/reference/indices/forcemerge.asciidoc
@@ -116,6 +116,8 @@ set it to `1`.
 
 Defaults to checking if a merge needs to execute.
 If so, executes it.
+
+You can't specify this parameter and `only_expunge_deletes` in the same request.
 --
 
 `only_expunge_deletes`::
@@ -134,6 +136,7 @@ During a merge,
 a new segment is created
 that does not contain those document deletions.
 
+You can't specify this parameter and `max_num_segments` in the same request.
 --
 
 


### PR DESCRIPTION
You can't specify `max_num_segments` and `max_num_segments` in the same request.

Relates to PR #44761.