### PR TITLE
[7.x] Add 'headers.content_type' to APIs that accept a body (#77934)

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/close_point_in_time.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/close_point_in_time.json
@@ -7,7 +7,8 @@
     "stability":"stable",
     "visibility":"public",
     "headers":{
-      "accept": [ "application/json"]
+      "accept": [ "application/json"],
+      "content_type": ["application/json"]
     },
     "url":{
       "paths":[

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/field_caps.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/field_caps.json
@@ -7,7 +7,8 @@
     "stability":"stable",
     "visibility":"public",
     "headers":{
-      "accept": [ "application/json"]
+      "accept": [ "application/json"],
+      "content_type": ["application/json"]
     },
     "url":{
       "paths":[

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/ml.delete_expired_data.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/ml.delete_expired_data.json
@@ -7,7 +7,8 @@
     "stability":"stable",
     "visibility":"public",
     "headers":{
-      "accept": [ "application/json"]
+      "accept": [ "application/json"],
+      "content_type": ["application/json"]
     },
     "url":{
       "paths":[

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/ml.preview_datafeed.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/ml.preview_datafeed.json
@@ -7,7 +7,8 @@
     "stability":"stable",
     "visibility":"public",
     "headers":{
-      "accept": [ "application/json"]
+      "accept": [ "application/json"],
+      "content_type": ["application/json"]
     },
     "url":{
       "paths":[

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/ml.stop_datafeed.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/ml.stop_datafeed.json
@@ -7,7 +7,8 @@
     "stability":"stable",
     "visibility":"public",
     "headers":{
-      "accept": [ "application/json"]
+      "accept": [ "application/json"],
+      "content_type": ["application/json"]
     },
     "url":{
       "paths":[


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Add 'headers.content_type' to APIs that accept a body (#77934)