### PR TITLE
TSDB: Automatically map timestamp

### DIFF
--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/tsdb/15_timestamp_mapping.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/tsdb/15_timestamp_mapping.yml
@@ -1,0 +1,151 @@
+
+---
+date:
+  - skip:
+      version: " - 7.99.99"
+      reason: introduced in 8.0.0 to be backported to 7.16.0
+
+  - do:
+      indices.create:
+          index: test
+          body:
+            settings:
+              index:
+                mode: time_series
+                number_of_replicas: 0
+                number_of_shards: 2
+            mappings:
+              properties:
+                "@timestamp":
+                  type: date
+                metricset:
+                  type: keyword
+                  dimension: true
+
+  - do:
+      indices.get_mapping:
+        index: test
+  - match: { "test.mappings.properties.@timestamp.type": date }
+
+  - do:
+      bulk:
+        refresh: true
+        index: test_index
+        body:
+          - '{"index": {}}'
+          - '{"@timestamp": "2021-04-28T18:50:04.467Z", "metricset": "pod"}'
+
+  - do:
+      search:
+        index: test_index
+        body:
+          docvalue_fields: [ '@timestamp' ]
+  - match: {hits.total.value: 1}
+  - match: { "hits.hits.0.fields.@timestamp": ["2021-04-28T18:50:04.467Z"] }
+
+---
+date_nanos:
+  - skip:
+      version: " - 7.99.99"
+      reason: introduced in 8.0.0 to be backported to 7.16.0
+
+  - do:
+      indices.create:
+          index: test
+          body:
+            settings:
+              index:
+                mode: time_series
+                number_of_replicas: 0
+                number_of_shards: 2
+            mappings:
+              properties:
+                "@timestamp":
+                  type: date_nanos
+                metricset:
+                  type: keyword
+                  dimension: true
+
+  - do:
+      indices.get_mapping:
+        index: test
+  - match: { "test.mappings.properties.@timestamp.type": date_nanos }
+
+  - do:
+      bulk:
+        refresh: true
+        index: test_index
+        body:
+          - '{"index": {}}'
+          - '{"@timestamp": "2021-04-28T18:50:04.467Z", "metricset": "pod"}'
+
+  - do:
+      search:
+        index: test_index
+        body:
+          docvalue_fields: [ '@timestamp' ]
+  - match: {hits.total.value: 1}
+  - match: { "hits.hits.0.fields.@timestamp": ["2021-04-28T18:50:04.467Z"] }
+
+---
+automatically add with date:
+  - skip:
+      version: " - 7.99.99"
+      reason: introduced in 8.0.0 to be backported to 7.16.0
+
+  - do:
+      indices.create:
+          index: test
+          body:
+            settings:
+              index:
+                mode: time_series
+                number_of_replicas: 0
+                number_of_shards: 2
+            mappings:
+              properties:
+                metricset:
+                  type: keyword
+                  dimension: true
+
+  - do:
+      indices.get_mapping:
+        index: test
+  - match: { 'test.mappings.properties.@timestamp': { "type": date } }
+
+  - do:
+      bulk:
+        refresh: true
+        index: test_index
+        body:
+          - '{"index": {}}'
+          - '{"@timestamp": "2021-04-28T18:50:04.467Z", "metricset": "pod"}'
+
+  - do:
+      search:
+        index: test_index
+        body:
+          docvalue_fields: [ '@timestamp' ]
+  - match: {hits.total.value: 1}
+  - match: { "hits.hits.0.fields.@timestamp": ["2021-04-28T18:50:04.467Z"] }
+
+---
+reject @timestamp with wrong type:
+  - skip:
+      version: " - 7.99.99"
+      reason: introduced in 8.0.0 to be backported to 7.16.0
+
+  - do:
+      catch: /@timestamp must be \[date\] or \[date_nanos\]/
+      indices.create:
+          index: test
+          body:
+            settings:
+              index:
+                mode: time_series
+                number_of_replicas: 0
+                number_of_shards: 2
+            mappings:
+              properties:
+                "@timestamp":
+                  type: keyword

--- a/server/src/main/java/org/elasticsearch/index/IndexMode.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexMode.java
@@ -11,10 +11,15 @@ package org.elasticsearch.index;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.index.mapper.DateFieldMapper;
+import org.elasticsearch.index.mapper.Mapper;
+import org.elasticsearch.index.mapper.MappingParserContext;
+import org.elasticsearch.index.mapper.RootObjectMapper;
 
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.stream.Stream;
 
 import static java.util.stream.Collectors.toSet;
@@ -26,6 +31,9 @@ public enum IndexMode {
     STANDARD {
         @Override
         void validateWithOtherSettings(Map<Setting<?>, Object> settings) {}
+
+        @Override
+        public void completeMappings(MappingParserContext context, RootObjectMapper.Builder builder) {}
     },
     TIME_SERIES {
         @Override
@@ -43,6 +51,27 @@ public enum IndexMode {
         private String error(Setting<?> unsupported) {
             return "[" + IndexSettings.MODE.getKey() + "=time_series] is incompatible with [" + unsupported.getKey() + "]";
         }
+
+        @Override
+        public void completeMappings(MappingParserContext context, RootObjectMapper.Builder builder) {
+            Optional<Mapper.Builder> timestamp = builder.getBuilder("@timestamp");
+            if (timestamp.isEmpty()) {
+                builder.add(
+                    new DateFieldMapper.Builder(
+                        "@timestamp",
+                        DateFieldMapper.Resolution.MILLISECONDS,
+                        DateFieldMapper.DEFAULT_DATE_TIME_FORMATTER,
+                        context.scriptCompiler(),
+                        DateFieldMapper.IGNORE_MALFORMED_SETTING.get(context.getSettings()),
+                        context.getIndexSettings().getIndexVersionCreated()
+                    )
+                );
+                return;
+            }
+            if (false == timestamp.get() instanceof DateFieldMapper.Builder) {
+                throw new IllegalArgumentException("@timestamp must be [date] or [date_nanos]");
+            }
+        }
     };
 
     private static final List<Setting<?>> TIME_SERIES_UNSUPPORTED = List.of(
@@ -57,4 +86,9 @@ public enum IndexMode {
     );
 
     abstract void validateWithOtherSettings(Map<Setting<?>, Object> settings);
+
+    /**
+     * Validate and/or modify the mappings after after they've been parsed.
+     */
+    public abstract void completeMappings(MappingParserContext context, RootObjectMapper.Builder builder);
 }

--- a/server/src/main/java/org/elasticsearch/index/mapper/ObjectMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/ObjectMapper.java
@@ -28,6 +28,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Optional;
 
 public class ObjectMapper extends Mapper implements Cloneable {
     private static final DeprecationLogger deprecationLogger = DeprecationLogger.getLogger(ObjectMapper.class);
@@ -84,6 +85,10 @@ public class ObjectMapper extends Mapper implements Cloneable {
         public Builder add(Mapper.Builder builder) {
             mappersBuilders.add(builder);
             return this;
+        }
+
+        public Optional<Mapper.Builder> getBuilder(String name) {
+            return mappersBuilders.stream().filter(b -> b.name().equals(name)).findFirst();
         }
 
         protected final Map<String, Mapper> buildMappers(boolean root, MapperBuilderContext context) {

--- a/server/src/main/java/org/elasticsearch/index/mapper/RootObjectMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/RootObjectMapper.java
@@ -151,6 +151,7 @@ public class RootObjectMapper extends ObjectMapper {
                     iterator.remove();
                 }
             }
+            parserContext.getIndexSettings().getMode().completeMappings(parserContext, builder);
             return builder;
         }
 


### PR DESCRIPTION
If tsdb is enabled we need an `@timestamp` field. This automatically
maps the field if it is missing and fails to create indices in
time_series mode that map `@timestamp` as anything other than `date` and
`date_nanos`.
