### PR TITLE
Fix eager task creation fips plugin

### DIFF
--- a/build-tools-internal/src/main/groovy/elasticsearch.fips.gradle
+++ b/build-tools-internal/src/main/groovy/elasticsearch.fips.gradle
@@ -46,16 +46,16 @@ if (BuildParams.inFipsJvm) {
           // This afterEvaluate hooks is required to avoid deprecated configuration resolution
           // This configuration can be removed once system modules are available
           def extraFipsJars = configurations.detachedConfiguration(bcFips, bcTlsFips)
-          testClusters.all {
+          testClusters.configureEach {
             extraFipsJars.files.each {
               extraJarFile it
             }
           }
         }
-        tasks.withType(TestClustersAware) {
+        tasks.withType(TestClustersAware).configureEach {
           dependsOn 'fipsResources'
         }
-        testClusters.all {
+        testClusters.configureEach {
           setTestDistribution(TestDistribution.DEFAULT)
           extraConfigFile "fips_java.security", fipsSecurity
           extraConfigFile "fips_java.policy", fipsPolicy


### PR DESCRIPTION
This fixes eager task creation when FIPS is enabled to reduce overall configuration overhead.

Before:


<img width="619" alt="Screenshot 2021-09-20 at 18 25 52" src="https://user-images.githubusercontent.com/77300/134038762-40fbb1b6-c0d8-4c14-814f-de54014f0311.png">

After
<img width="643" alt="Screenshot 2021-09-20 at 18 26 53" src="https://user-images.githubusercontent.com/77300/134038797-bec193e3-f97a-417f-80b3-fe730e6ee762.png">
:
