### PR TITLE
[DOCS] Add breaking change for `moving_avg`

### DIFF
--- a/docs/reference/migration/migrate_8_0/aggregations.asciidoc
+++ b/docs/reference/migration/migrate_8_0/aggregations.asciidoc
@@ -6,6 +6,20 @@
 //Installation and Upgrade Guide
 
 //tag::notable-breaking-changes[]
+[[remove-moving-avg-agg]]
+.The `moving_avg` aggregation has been removed.
+====
+*Details* +
+The `moving_avg` aggregation was deprecated in 6.4 and has been removed. To
+calculate moving averages, use the
+{ref}/search-aggregations-pipeline-movfn-aggregation.html[`moving_fn`
+aggregation] instead.
+
+*Impact* +
+Discontinue use of the `moving_avg` aggregation. Requests that include the
+`moving_avg` aggregation will return an error.
+====
+
 [[percentile-duplication]]
 .The `percentiles` aggregation's `percents` parameter no longer supports duplicate values.
 [%collapsible]
@@ -20,6 +34,7 @@ Use unique values in the `percents` parameter of the `percentiles` aggregation.
 Requests containing duplicate values in the `percents` parameter will return
 an error.
 ====
+
 [[date-histogram-interval]]
 .The `date_histogram` aggregation's `interval` parameter is no longer valid.
 [%collapsible]

--- a/docs/reference/migration/migrate_8_0/aggregations.asciidoc
+++ b/docs/reference/migration/migrate_8_0/aggregations.asciidoc
@@ -6,8 +6,10 @@
 //Installation and Upgrade Guide
 
 //tag::notable-breaking-changes[]
+
 [[remove-moving-avg-agg]]
 .The `moving_avg` aggregation has been removed.
+[%collapsible]
 ====
 *Details* +
 The `moving_avg` aggregation was deprecated in 6.4 and has been removed. To


### PR DESCRIPTION
Documents the removal of the `moving_avg` aggregation in the 8.0 breaking changes.

Relates to #29594.

### Preview
https://elasticsearch_78018.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/migrating-8.0.html#remove-moving-avg-agg