### PR TITLE
Updating deprecation info API to use shortened URLs

### DIFF
--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/ClusterDeprecationChecks.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/ClusterDeprecationChecks.java
@@ -69,7 +69,7 @@ public class ClusterDeprecationChecks {
         if (pipelinesWithDeprecatedEcsConfig.isEmpty() == false) {
             return new DeprecationIssue(DeprecationIssue.Level.WARNING,
                 "User-Agent ingest plugin will always use ECS-formatted output",
-                "https://www.elastic.co/guide/en/elasticsearch/reference/7.15/user-agent-processor.html#user-agent-processor",
+                "https://ela.st/es-deprecation-7-ingest-pipeline-ecs-option",
                 "Ingest pipelines " + pipelinesWithDeprecatedEcsConfig +
                     " uses the [ecs] option which needs to be removed to work in 8.0", false, null);
         }
@@ -97,8 +97,7 @@ public class ClusterDeprecationChecks {
         if (templatesOverLimit.isEmpty() == false) {
             return new DeprecationIssue(DeprecationIssue.Level.WARNING,
                 "Fields in index template exceed automatic field expansion limit",
-                "https://www.elastic.co/guide/en/elasticsearch/reference/7.0/breaking-changes-7.0.html" +
-                    "#_limiting_the_number_of_auto_expanded_fields",
+                "https://ela.st/es-deprecation-7-number-of-auto-expanded-fields",
                 "Index templates " + templatesOverLimit + " have a number of fields which exceeds the automatic field expansion " +
                     "limit of [" + maxClauseCount + "] and does not have [" + IndexSettings.DEFAULT_FIELD_SETTING.getKey() + "] set, " +
                     "which may cause queries which use automatic field expansion, such as query_string, simple_query_string, and " +
@@ -133,7 +132,7 @@ public class ClusterDeprecationChecks {
 
         if (templatesContainingFieldNames.isEmpty() == false) {
             return new DeprecationIssue(DeprecationIssue.Level.WARNING, "Index templates contain _field_names settings.",
-                    "https://www.elastic.co/guide/en/elasticsearch/reference/7.15/mapping-field-names-field.html#disable-field-names",
+                    "https://ela.st/es-deprecation-7-field_names-settings",
                     "Index templates " + templatesContainingFieldNames + " use the deprecated `enable` setting for the `"
                             + FieldNamesFieldMapper.NAME + "` field. Using this setting in new index mappings will throw an error "
                                     + "in the next major version and needs to be removed from existing mappings and templates.",
@@ -172,8 +171,7 @@ public class ClusterDeprecationChecks {
         if (pollInterval.compareTo(TimeValue.timeValueSeconds(1)) < 0) {
             return new DeprecationIssue(DeprecationIssue.Level.CRITICAL,
                 "Index Lifecycle Management poll interval is set too low",
-                "https://www.elastic.co/guide/en/elasticsearch/reference/master/breaking-changes-8.0.html" +
-                    "#ilm-poll-interval-limit",
+                "https://ela.st/es-deprecation-7-indices-lifecycle-poll-interval-setting",
                 "The Index Lifecycle Management poll interval setting [" + LIFECYCLE_POLL_INTERVAL_SETTING.getKey() + "] is " +
                     "currently set to [" + pollIntervalString + "], but must be 1s or greater", false, null);
         }
@@ -194,7 +192,7 @@ public class ClusterDeprecationChecks {
         }
         return new DeprecationIssue(DeprecationIssue.Level.CRITICAL,
             "Some index templates contain multiple mapping types",
-            "https://www.elastic.co/guide/en/elasticsearch/reference/7.15/removal-of-types.html",
+            "https://ela.st/es-deprecation-7-multiple-types",
             "Index templates " + templatesWithMultipleTypes
             + " define multiple types and so will cause errors when used in index creation",
             false,
@@ -204,7 +202,7 @@ public class ClusterDeprecationChecks {
     static DeprecationIssue checkClusterRoutingAllocationIncludeRelocationsSetting(final ClusterState clusterState) {
         return checkRemovedSetting(clusterState.metadata().settings(),
             CLUSTER_ROUTING_ALLOCATION_INCLUDE_RELOCATIONS_SETTING,
-            "https://www.elastic.co/guide/en/elasticsearch/reference/7.15/modules-cluster.html#disk-based-shard-allocation",
+            "https://ela.st/es-deprecation-7-cluster-routing-allocation-disk-include-relocations-setting",
             DeprecationIssue.Level.WARNING
         );
     }
@@ -273,8 +271,7 @@ public class ClusterDeprecationChecks {
         String detailsForIndexTemplates = getDetailsMessageForGeoShapeIndexTemplates(clusterState.getMetadata().getTemplates());
         boolean deprecationInComponentTemplates = Strings.isEmpty(detailsForComponentTemplates) == false;
         boolean deprecationInIndexTemplates = Strings.isEmpty(detailsForIndexTemplates) == false;
-        String url = "https://www.elastic.co/guide/en/elasticsearch/reference/6.6/breaking-changes-6.6.html" +
-            "#_deprecated_literal_geo_shape_literal_parameters";
+        String url = "https://ela.st/es-deprecation-7-geo-shape-settings";
         if (deprecationInComponentTemplates && deprecationInIndexTemplates) {
             String message = "component templates and index templates contain deprecated geo_shape properties that must be removed";
             String details = detailsForComponentTemplates + "; " + detailsForIndexTemplates;
@@ -365,7 +362,7 @@ public class ClusterDeprecationChecks {
         String detailsForIndexTemplates = getDetailsMessageForSparseVectorIndexTemplates(clusterState.getMetadata().getTemplates());
         boolean deprecationInComponentTemplates = Strings.isEmpty(detailsForComponentTemplates) == false;
         boolean deprecationInIndexTemplates = Strings.isEmpty(detailsForIndexTemplates) == false;
-        String url = "https://www.elastic.co/guide/en/elasticsearch/reference/master/migrating-8.0.html#breaking_80_search_changes";
+        String url = "https://ela.st/es-deprecation-7-sparse-vector";
         if (deprecationInComponentTemplates && deprecationInIndexTemplates) {
             String message = "component templates and index templates contain deprecated sparse_vector fields that must be removed";
             String details = detailsForComponentTemplates + "; " + detailsForIndexTemplates;

--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/ClusterDeprecationChecks.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/ClusterDeprecationChecks.java
@@ -271,7 +271,7 @@ public class ClusterDeprecationChecks {
         String detailsForIndexTemplates = getDetailsMessageForGeoShapeIndexTemplates(clusterState.getMetadata().getTemplates());
         boolean deprecationInComponentTemplates = Strings.isEmpty(detailsForComponentTemplates) == false;
         boolean deprecationInIndexTemplates = Strings.isEmpty(detailsForIndexTemplates) == false;
-        String url = "https://ela.st/es-deprecation-7-geo-shape-settings";
+        String url = "https://ela.st/es-deprecation-7-geo-shape-mappings";
         if (deprecationInComponentTemplates && deprecationInIndexTemplates) {
             String message = "component templates and index templates contain deprecated geo_shape properties that must be removed";
             String details = detailsForComponentTemplates + "; " + detailsForIndexTemplates;

--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/IndexDeprecationChecks.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/IndexDeprecationChecks.java
@@ -339,7 +339,7 @@ public class IndexDeprecationChecks {
     static DeprecationIssue checkIndexRoutingRequireSetting(IndexMetadata indexMetadata) {
         return checkRemovedSetting(indexMetadata.getSettings(),
             INDEX_ROUTING_REQUIRE_SETTING,
-            "https://ela.st/es-deprecation-7-index-routing-settings",
+            "https://ela.st/es-deprecation-7-tier-filtering-settings",
             DeprecationIssue.Level.CRITICAL
         );
     }
@@ -347,7 +347,7 @@ public class IndexDeprecationChecks {
     static DeprecationIssue checkIndexRoutingIncludeSetting(IndexMetadata indexMetadata) {
         return checkRemovedSetting(indexMetadata.getSettings(),
             INDEX_ROUTING_INCLUDE_SETTING,
-            "https://ela.st/es-deprecation-7-index-routing-settings",
+            "https://ela.st/es-deprecation-7-tier-filtering-settings",
             DeprecationIssue.Level.CRITICAL
         );
     }
@@ -355,7 +355,7 @@ public class IndexDeprecationChecks {
     static DeprecationIssue checkIndexRoutingExcludeSetting(IndexMetadata indexMetadata) {
         return checkRemovedSetting(indexMetadata.getSettings(),
             INDEX_ROUTING_EXCLUDE_SETTING,
-            "https://ela.st/es-deprecation-7-index-routing-settings",
+            "https://ela.st/es-deprecation-7-tier-filtering-settings",
             DeprecationIssue.Level.CRITICAL
         );
     }
@@ -393,7 +393,7 @@ public class IndexDeprecationChecks {
             String details = String.format(Locale.ROOT,
                 "The following geo_shape parameters must be removed from %s: [%s]", indexMetadata.getIndex().getName(),
                 messages.stream().collect(Collectors.joining("; ")));
-            String url = "https://ela.st/es-deprecation-7-geo-shape-settings";
+            String url = "https://ela.st/es-deprecation-7-geo-shape-mappings";
             return new DeprecationIssue(DeprecationIssue.Level.CRITICAL, message, url, details, false, null);
         }
     }

--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/IndexDeprecationChecks.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/IndexDeprecationChecks.java
@@ -113,8 +113,7 @@ public class IndexDeprecationChecks {
         if (createdWith.before(Version.V_7_0_0)) {
                 return new DeprecationIssue(DeprecationIssue.Level.CRITICAL,
                     "Index created before 7.0",
-                    "https://www.elastic.co/guide/en/elasticsearch/reference/master/" +
-                        "breaking-changes-8.0.html",
+                    "https://ela.st/es-deprecation-7-reindex",
                     "This index was created using version: " + createdWith,
                     false, null);
         }
@@ -135,8 +134,7 @@ public class IndexDeprecationChecks {
             if (fieldCount.get() > 1024) {
                 return new DeprecationIssue(DeprecationIssue.Level.WARNING,
                     "Number of fields exceeds automatic field expansion limit",
-                    "https://www.elastic.co/guide/en/elasticsearch/reference/7.0/breaking-changes-7.0.html" +
-                        "#_limiting_the_number_of_auto_expanded_fields",
+                    "https://ela.st/es-deprecation-7-number-of-auto-expanded-fields",
                     "This index has [" + fieldCount.get() + "] fields, which exceeds the automatic field expansion limit of 1024 " +
                         "and does not have [" + IndexSettings.DEFAULT_FIELD_SETTING.getKey() + "] set, which may cause queries which use " +
                         "automatic field expansion, such as query_string, simple_query_string, and multi_match to fail if fields are not " +
@@ -159,7 +157,7 @@ public class IndexDeprecationChecks {
             if (fields.size() > 0) {
                 return new DeprecationIssue(DeprecationIssue.Level.WARNING,
                     "Date field format uses patterns which has changed meaning in 7.0",
-                    "https://www.elastic.co/guide/en/elasticsearch/reference/7.0/breaking-changes-7.0.html#breaking_70_java_time_changes",
+                    "https://ela.st/es-deprecation-7-java-time",
                     "This index has date fields with deprecated formats: " + fields + ". "
                         + JodaDeprecationPatterns.USE_NEW_FORMAT_SPECIFIERS, false, null);
             }
@@ -181,8 +179,7 @@ public class IndexDeprecationChecks {
         if (issues.size() > 0) {
             return new DeprecationIssue(DeprecationIssue.Level.WARNING,
                 "Multi-fields within multi-fields",
-                "https://www.elastic.co/guide/en/elasticsearch/reference/7.x/breaking-changes-7.3.html" +
-                    "#_defining_multi_fields_within_multi_fields",
+                "https://ela.st/es-deprecation-7-chained-multi-fields",
                 "The names of fields that contain chained multi-fields: " + issues, false, null);
         }
         return null;
@@ -209,7 +206,7 @@ public class IndexDeprecationChecks {
         if ((mapping != null) && ClusterDeprecationChecks.mapContainsFieldNamesDisabled(mapping.getSourceAsMap())) {
             return new DeprecationIssue(DeprecationIssue.Level.WARNING,
                     "Index mapping contains explicit `_field_names` enabling settings.",
-                    "https://www.elastic.co/guide/en/elasticsearch/reference/7.15/mapping-field-names-field.html#disable-field-names",
+                    "https://ela.st/es-deprecation-7-field_names-settings",
                     "The index mapping contains a deprecated `enabled` setting for `_field_names` that should be removed moving foward.",
                 false, null);
         }
@@ -270,8 +267,7 @@ public class IndexDeprecationChecks {
                 || IndexSettings.INDEX_TRANSLOG_RETENTION_AGE_SETTING.exists(indexMetadata.getSettings())) {
                 return new DeprecationIssue(DeprecationIssue.Level.WARNING,
                     "translog retention settings are ignored",
-                    "https://www.elastic.co/guide/en/elasticsearch/reference/7.15/index-modules-translog.html" +
-                        "#index-modules-translog-retention",
+                    "https://ela.st/es-deprecation-7-translog-settings",
                     "translog retention settings [index.translog.retention.size] and [index.translog.retention.age] are ignored " +
                         "because translog is no longer used in peer recoveries with soft-deletes enabled (default in 7.0 or later)",
                     false, null);
@@ -284,8 +280,7 @@ public class IndexDeprecationChecks {
         if (IndexMetadata.INDEX_DATA_PATH_SETTING.exists(indexMetadata.getSettings())) {
             final String message = String.format(Locale.ROOT,
                 "setting [%s] is deprecated and will be removed in a future version", IndexMetadata.INDEX_DATA_PATH_SETTING.getKey());
-            final String url = "https://www.elastic.co/guide/en/elasticsearch/reference/7.13/" +
-                "breaking-changes-7.13.html#deprecate-shared-data-path-setting";
+            final String url = "https://ela.st/es-deprecation-7-shared-path-settings";
             final String details = "Found index data path configured. Discontinue use of this setting.";
             return new DeprecationIssue(DeprecationIssue.Level.CRITICAL, message, url, details, false, null);
         }
@@ -303,8 +298,7 @@ public class IndexDeprecationChecks {
         if (setting.exists(indexMetadata.getSettings())) {
             final String message = String.format(Locale.ROOT,
                 "setting [%s] is deprecated and will be removed in a future version", setting.getKey());
-            final String url = "https://www.elastic.co/guide/en/elasticsearch/reference/7.15/migrating-7.13.html" +
-                "#breaking_713_infra_core_deprecations";
+            final String url = "https://ela.st/es-deprecation-7-slowlog-settings";
 
             final String details = String.format(Locale.ROOT, "Found [%s] configured. Discontinue use of this setting. Use thresholds.",
                 setting.getKey());
@@ -318,7 +312,7 @@ public class IndexDeprecationChecks {
         if (IndexModule.Type.SIMPLEFS.match(storeType)) {
             return new DeprecationIssue(DeprecationIssue.Level.WARNING,
                 "[simplefs] is deprecated and will be removed in future versions",
-                "https://www.elastic.co/guide/en/elasticsearch/reference/7.15/index-modules-store.html#file-system",
+                "https://ela.st/es-deprecation-7-simplefs-store-type",
                 "[simplefs] is deprecated and will be removed in 8.0. Use [niofs] or other file systems instead. " +
                     "Elasticsearch 7.15 or later uses [niofs] for the [simplefs] store type " +
                     "as it offers superior or equivalent performance to [simplefs].", false, null);
@@ -345,7 +339,7 @@ public class IndexDeprecationChecks {
     static DeprecationIssue checkIndexRoutingRequireSetting(IndexMetadata indexMetadata) {
         return checkRemovedSetting(indexMetadata.getSettings(),
             INDEX_ROUTING_REQUIRE_SETTING,
-            "https://www.elastic.co/guide/en/elasticsearch/reference/7.14/data-tier-shard-filtering.html#data-tier-allocation-filters",
+            "https://ela.st/es-deprecation-7-index-routing-settings",
             DeprecationIssue.Level.CRITICAL
         );
     }
@@ -353,7 +347,7 @@ public class IndexDeprecationChecks {
     static DeprecationIssue checkIndexRoutingIncludeSetting(IndexMetadata indexMetadata) {
         return checkRemovedSetting(indexMetadata.getSettings(),
             INDEX_ROUTING_INCLUDE_SETTING,
-            "https://www.elastic.co/guide/en/elasticsearch/reference/7.14/data-tier-shard-filtering.html#data-tier-allocation-filters",
+            "https://ela.st/es-deprecation-7-index-routing-settings",
             DeprecationIssue.Level.CRITICAL
         );
     }
@@ -361,7 +355,7 @@ public class IndexDeprecationChecks {
     static DeprecationIssue checkIndexRoutingExcludeSetting(IndexMetadata indexMetadata) {
         return checkRemovedSetting(indexMetadata.getSettings(),
             INDEX_ROUTING_EXCLUDE_SETTING,
-            "https://www.elastic.co/guide/en/elasticsearch/reference/7.14/data-tier-shard-filtering.html#data-tier-allocation-filters",
+            "https://ela.st/es-deprecation-7-index-routing-settings",
             DeprecationIssue.Level.CRITICAL
         );
     }
@@ -399,8 +393,7 @@ public class IndexDeprecationChecks {
             String details = String.format(Locale.ROOT,
                 "The following geo_shape parameters must be removed from %s: [%s]", indexMetadata.getIndex().getName(),
                 messages.stream().collect(Collectors.joining("; ")));
-            String url = "https://www.elastic.co/guide/en/elasticsearch/reference/6.6/breaking-changes-6.6.html" +
-                "#_deprecated_literal_geo_shape_literal_parameters";
+            String url = "https://ela.st/es-deprecation-7-geo-shape-settings";
             return new DeprecationIssue(DeprecationIssue.Level.CRITICAL, message, url, details, false, null);
         }
     }

--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/NodeDeprecationChecks.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/NodeDeprecationChecks.java
@@ -76,7 +76,7 @@ class NodeDeprecationChecks {
             pluginsAndModules,
             Environment.PIDFILE_SETTING,
             Environment.NODE_PIDFILE_SETTING,
-            "https://www.elastic.co/guide/en/elasticsearch/reference/7.4/breaking-changes-7.4.html#deprecate-pidfile");
+            "https://ela.st/es-deprecation-7-pidfile-setting");
     }
 
     static DeprecationIssue checkProcessors(final Settings settings , final PluginsAndModules pluginsAndModules,
@@ -86,7 +86,7 @@ class NodeDeprecationChecks {
             pluginsAndModules,
             EsExecutors.PROCESSORS_SETTING,
             EsExecutors.NODE_PROCESSORS_SETTING,
-            "https://www.elastic.co/guide/en/elasticsearch/reference/7.4/breaking-changes-7.4.html#deprecate-processors");
+            "https://ela.st/es-deprecation-7-processors-setting");
     }
 
     static DeprecationIssue checkMissingRealmOrders(final Settings settings, final PluginsAndModules pluginsAndModules,
@@ -109,7 +109,7 @@ class NodeDeprecationChecks {
         return new DeprecationIssue(
             DeprecationIssue.Level.CRITICAL,
             "Realm order will be required in next major release.",
-            "https://www.elastic.co/guide/en/elasticsearch/reference/7.7/breaking-changes-7.7.html#deprecate-missing-realm-order",
+            "https://ela.st/es-deprecation-7-realm-orders-required",
             details,
             false,
             null
@@ -145,7 +145,7 @@ class NodeDeprecationChecks {
         return new DeprecationIssue(
             DeprecationIssue.Level.CRITICAL,
             "Realm orders must be unique in next major release.",
-            "https://www.elastic.co/guide/en/elasticsearch/reference/7.7/breaking-changes-7.7.html#deprecate-duplicated-realm-orders",
+            "https://ela.st/es-deprecation-7-realm-orders-unique",
             details,
            false, null
         );
@@ -167,7 +167,7 @@ class NodeDeprecationChecks {
             return new DeprecationIssue(
                 DeprecationIssue.Level.CRITICAL,
                 "Security is enabled by default for all licenses in the next major version.",
-                "https://www.elastic.co/guide/en/elasticsearch/reference/7.14/migrating-7.14.html#implicitly-disabled-security",
+                "https://ela.st/es-deprecation-7-implicitly-disabled-security",
                 details,
                false, null);
         }
@@ -220,7 +220,7 @@ class NodeDeprecationChecks {
         return new DeprecationIssue(
             DeprecationIssue.Level.WARNING,
             "File and/or native realms are enabled by default in next major release.",
-            "https://www.elastic.co/guide/en/elasticsearch/reference/7.15/migrating-7.13.html#breaking_713_security_changes",
+            "https://ela.st/es-deprecation-7-implicitly-disabled-basic-realms",
             details,
             false,
             null
@@ -246,7 +246,7 @@ class NodeDeprecationChecks {
             return new DeprecationIssue(
                 DeprecationIssue.Level.WARNING,
                 "Realm names cannot start with [" + RESERVED_REALM_NAME_PREFIX + "] in a future major release.",
-                "https://www.elastic.co/guide/en/elastic-stack/7.14/elasticsearch-breaking-changes.html#breaking_714_security_changes",
+                "https://ela.st/es-deprecation-7-realm-names",
                 String.format(Locale.ROOT, "Found realm " + (reservedPrefixedRealmIdentifiers.size() == 1 ? "name" : "names")
                         + " with reserved prefix [%s]: [%s]. "
                         + "In a future major release, node will fail to start if any realm names start with reserved prefix.",
@@ -276,7 +276,7 @@ class NodeDeprecationChecks {
         return checkRemovedSetting(
             settings,
             setting.get(),
-            "https://www.elastic.co/guide/en/elasticsearch/reference/7.x/breaking-changes-7.7.html#deprecate-listener-thread-pool");
+            "https://ela.st/es-deprecation-7-thread-pool-listener-settings");
     }
 
     public static DeprecationIssue checkClusterRemoteConnectSetting(final Settings settings, final PluginsAndModules pluginsAndModules,
@@ -290,7 +290,7 @@ class NodeDeprecationChecks {
                 RemoteClusterService.ENABLE_REMOTE_CLUSTERS,
                 Property.Deprecated,
                 Property.NodeScope),
-            "https://www.elastic.co/guide/en/elasticsearch/reference/7.7/breaking-changes-7.7.html#deprecate-cluster-remote-connect"
+            "https://ela.st/es-deprecation-7-cluster-remote-connect-setting"
         );
     }
 
@@ -299,7 +299,7 @@ class NodeDeprecationChecks {
         return checkRemovedSetting(
             settings,
             Node.NODE_LOCAL_STORAGE_SETTING,
-            "https://www.elastic.co/guide/en/elasticsearch/reference/7.8/breaking-changes-7.8.html#deprecate-node-local-storage"
+            "https://ela.st/es-deprecation-7-node-local-storage-setting"
         );
     }
 
@@ -307,7 +307,7 @@ class NodeDeprecationChecks {
         return checkRemovedSetting(
             settings,
             setting,
-            "https://www.elastic.co/guide/en/elasticsearch/reference/7.8/breaking-changes-7.8.html#deprecate-basic-license-feature-enabled"
+            "https://ela.st/es-deprecation-7-xpack-basic-feature-settings"
         );
     }
 
@@ -319,7 +319,7 @@ class NodeDeprecationChecks {
             ScriptService.SCRIPT_GENERAL_CACHE_SIZE_SETTING,
             ScriptService.SCRIPT_CACHE_SIZE_SETTING,
             "a script context",
-            "https://www.elastic.co/guide/en/elasticsearch/reference/7.9/breaking-changes-7.9.html#deprecate_general_script_cache_size"
+            "https://ela.st/es-deprecation-7-script-cache-size-setting"
         );
     }
 
@@ -331,7 +331,7 @@ class NodeDeprecationChecks {
             ScriptService.SCRIPT_GENERAL_CACHE_EXPIRE_SETTING,
             ScriptService.SCRIPT_CACHE_EXPIRE_SETTING,
             "a script context",
-            "https://www.elastic.co/guide/en/elasticsearch/reference/7.9/breaking-changes-7.9.html#deprecate_general_script_expire"
+            "https://ela.st/es-deprecation-7-script-cache-expire-setting"
         );
     }
 
@@ -343,7 +343,7 @@ class NodeDeprecationChecks {
             ScriptService.SCRIPT_GENERAL_MAX_COMPILATIONS_RATE_SETTING,
             ScriptService.SCRIPT_MAX_COMPILATIONS_RATE_SETTING,
             "a script context",
-            "https://www.elastic.co/guide/en/elasticsearch/reference/7.9/breaking-changes-7.9.html#deprecate_general_script_compile_rate"
+            "https://ela.st/es-deprecation-7-script-max-compilations-rate-setting"
         );
     }
 
@@ -364,7 +364,7 @@ class NodeDeprecationChecks {
                     .map(DiscoveryNodeRole::roleName)
                     .collect(Collectors.joining(","));
             },
-            "https://www.elastic.co/guide/en/elasticsearch/reference/master/breaking-changes-8.0.html#breaking_80_settings_changes"
+            "https://ela.st/es-deprecation-7-node-roles"
         );
     }
 
@@ -373,7 +373,7 @@ class NodeDeprecationChecks {
         return checkRemovedSetting(
             settings,
             BootstrapSettings.SYSTEM_CALL_FILTER_SETTING,
-            "https://www.elastic.co/guide/en/elasticsearch/reference/7.13/breaking-changes-7.13.html#deprecate-system-call-filter-setting"
+            "https://ela.st/es-deprecation-7-system-call-filter-setting"
         );
     }
 
@@ -493,7 +493,7 @@ class NodeDeprecationChecks {
         if (javaVersion.compareTo(JavaVersion.parse("11")) < 0) {
             return new DeprecationIssue(DeprecationIssue.Level.CRITICAL,
                 "Java 11 is required",
-                "https://www.elastic.co/guide/en/elasticsearch/reference/master/breaking-changes-8.0.html#breaking_80_packaging_changes",
+                "https://ela.st/es-deprecation-7-java-version",
                 "Java 11 will be required for future versions of Elasticsearch, this node is running version ["
                     + javaVersion.toString() + "]. Consider switching to a distribution of Elasticsearch with a bundled JDK. "
                     + "If you are already using a distribution with a bundled JDK, ensure the JAVA_HOME environment variable is not set.",
@@ -508,7 +508,7 @@ class NodeDeprecationChecks {
         if (dataPaths.size() > 1) {
             return new DeprecationIssue(DeprecationIssue.Level.CRITICAL,
                 "multiple [path.data] entries are deprecated, use a single data directory",
-                "https://www.elastic.co/guide/en/elasticsearch/reference/7.15/modules-node.html#max-local-storage-nodes",
+                "https://ela.st/es-deprecation-7-multiple-paths",
                 "Multiple data paths are deprecated. Instead, use RAID or other system level features to utilize multiple disks.",
             false, null);
         }
@@ -520,7 +520,7 @@ class NodeDeprecationChecks {
         if (Environment.dataPathUsesList(nodeSettings)) {
             return new DeprecationIssue(DeprecationIssue.Level.CRITICAL,
                 "[path.data] in a list is deprecated, use a string value",
-                "https://www.elastic.co/guide/en/elasticsearch/reference/7.15/modules-node.html#max-local-storage-nodes",
+                "https://ela.st/es-deprecation-7-multiple-paths",
                 "Configuring [path.data] with a list is deprecated. Instead specify as a string value.", false, null);
         }
         return null;
@@ -545,7 +545,7 @@ class NodeDeprecationChecks {
             String key = DiskThresholdDecider.ENABLE_FOR_SINGLE_DATA_NODE.getKey();
             return new DeprecationIssue(DeprecationIssue.Level.CRITICAL,
                 String.format(Locale.ROOT, "setting [%s=false] is deprecated and will not be available in a future version", key),
-                "https://www.elastic.co/guide/en/elasticsearch/reference/7.15/modules-cluster.html#disk-based-shard-allocation",
+                "https://ela.st/es-deprecation-7-disk-watermark-enable-for-single-node-setting",
                 String.format(Locale.ROOT, "found [%s] configured to false. Discontinue use of this setting or set it to true.", key),
                     false, null
             );
@@ -558,7 +558,7 @@ class NodeDeprecationChecks {
             return new DeprecationIssue(DeprecationIssue.Level.WARNING,
                 String.format(Locale.ROOT, "the default value [false] of setting [%s] is deprecated and will be changed to true" +
                     " in a future version. This cluster has only one data node and behavior will therefore change when upgrading", key),
-                "https://www.elastic.co/guide/en/elasticsearch/reference/7.15/modules-cluster.html#disk-based-shard-allocation",
+                "https://ela.st/es-deprecation-7-disk-watermark-enable-for-single-node-setting",
                 String.format(Locale.ROOT, "found [%s] defaulting to false on a single data node cluster." +
                         " Set it to true to avoid this warning." +
                         " Consider using [%s] to disable disk based allocation", key,
@@ -568,7 +568,6 @@ class NodeDeprecationChecks {
             );
 
         }
-
 
         return null;
     }
@@ -601,7 +600,7 @@ class NodeDeprecationChecks {
             "replace the non-secure monitoring exporter password setting(s) [%s] with their secure 'auth.secure_password' replacement",
             passwordSettings
         );
-        final String url = "https://www.elastic.co/guide/en/elasticsearch/reference/7.7/monitoring-settings.html#http-exporter-settings";
+        final String url = "https://ela.st/es-deprecation-7-monitoring-exporter-passwords";
         return new DeprecationIssue(DeprecationIssue.Level.CRITICAL, message, url, details, false, null);
     }
 
@@ -611,7 +610,7 @@ class NodeDeprecationChecks {
                                                     final XPackLicenseState licenseState) {
         return checkRemovedSetting(settings,
             JoinHelper.JOIN_TIMEOUT_SETTING,
-            "https://www.elastic.co/guide/en/elasticsearch/reference/7.x/modules-discovery-settings.html",
+            "https://ela.st/es-deprecation-7-cluster-join-timeout-setting",
             DeprecationIssue.Level.CRITICAL
         );
     }
@@ -655,8 +654,7 @@ class NodeDeprecationChecks {
             "replace search.remote settings [%s] with their secure 'cluster.remote' replacements",
             remoteClusterSeedSettings
         );
-        final String url =
-            "https://www.elastic.co/guide/en/elasticsearch/reference/master/migrating-8.0.html#breaking_80_settings_changes";
+        final String url = "https://ela.st/es-deprecation-7-search-remote-settings";
         return new DeprecationIssue(DeprecationIssue.Level.CRITICAL, message, url, details, false, null);
     }
 
@@ -690,7 +688,7 @@ class NodeDeprecationChecks {
         if (fractionalByteSettings.isEmpty()) {
             return null;
         }
-        String url = "https://www.elastic.co/guide/en/elasticsearch/reference/master/logging.html#deprecation-logging";
+        String url = "https://ela.st/es-deprecation-7-fractional-byte-settings";
         String message = "support for fractional byte size values is deprecated and will be removed in a future release";
         String details = "change the following settings to non-fractional values: [" +
             fractionalByteSettings.entrySet().stream().map(fractionalByteSetting -> fractionalByteSetting.getKey() + "->" +
@@ -711,8 +709,7 @@ class NodeDeprecationChecks {
                 if (DataTier.isFrozenNode(new HashSet<>(roles)) == false) {
                     String message = String.format(Locale.ROOT, "setting [%s] cannot be greater than zero on non-frozen nodes",
                         cacheSizeSettingKey);
-                    String url =
-                        "https://www.elastic.co/guide/en/elasticsearch/reference/master/migrating-8.0.html#breaking_80_settings_changes";
+                    String url = "https://ela.st/es-deprecation-7-searchable-snapshot-shared-cache-setting";
                     String details = String.format(Locale.ROOT, "setting [%s] cannot be greater than zero on non-frozen nodes, and is " +
                         "currently set to [%s]", cacheSizeSettingKey, settings.get(cacheSizeSettingKey));
                     return new DeprecationIssue(DeprecationIssue.Level.CRITICAL, message, url, details, false, null);
@@ -741,7 +738,7 @@ class NodeDeprecationChecks {
         if (details.isEmpty()) {
             return null;
         } else {
-            String url = "https://www.elastic.co/guide/en/elasticsearch/reference/master/migrating-8.0.html#breaking_80_security_changes";
+            String url = "https://ela.st/es-deprecation-7-explicit-ssl-required";
             String message = "cannot set ssl properties without explicitly enabling or disabling ssl";
             String detailsString = details.stream().collect(Collectors.joining("; "));
             return new DeprecationIssue(DeprecationIssue.Level.CRITICAL, message, url, detailsString, false, null);
@@ -792,7 +789,7 @@ class NodeDeprecationChecks {
         if (details.isEmpty()) {
             return null;
         } else {
-            String url = "https://www.elastic.co/guide/en/elasticsearch/reference/master/migrating-8.0.html#breaking_80_security_changes";
+            String url = "https://ela.st/es-deprecation-7-ssl-settings";
             String message = "if ssl is enabled either keystore must be set, or key path and certificate path must be set";
             String detailsString = details.stream().collect(Collectors.joining("; "));
             return new DeprecationIssue(DeprecationIssue.Level.CRITICAL, message, url, detailsString, false, null);
@@ -816,7 +813,7 @@ class NodeDeprecationChecks {
                     "system property must be removed",
                 TransportService.PERMIT_HANDSHAKES_FROM_INCOMPATIBLE_BUILDS_KEY
             );
-            String url = "https://www.elastic.co/guide/en/elasticsearch/reference/master/migrating-8.0.html#breaking_80_transport_changes";
+            String url = "https://ela.st/es-deprecation-7-permit-handshake-from-incompatible-builds-setting";
             return new DeprecationIssue(DeprecationIssue.Level.CRITICAL, message, url, details, false, null);
         }
         return null;
@@ -849,7 +846,7 @@ class NodeDeprecationChecks {
             transportProfilesSettings
         );
 
-        final String url = "https://www.elastic.co/guide/en/elasticsearch/client/java-api/7.x/transport-client.html";
+        final String url = "https://ela.st/es-deprecation-7-transport-profiles-settings";
         return new DeprecationIssue(DeprecationIssue.Level.CRITICAL, message, url, details, false, null);
     }
 
@@ -879,7 +876,7 @@ class NodeDeprecationChecks {
             "cannot use properties [%s] because they have been deprecated and will be removed in the next major version",
             settingNames
         );
-        final String url = "https://www.elastic.co/guide/en/elasticsearch/reference/7.x/modules-gateway.html";
+        final String url = "https://ela.st/es-deprecation-7-deferred-cluster-state-recovery";
         return new DeprecationIssue(DeprecationIssue.Level.CRITICAL, message, url, details, false, null);
     }
 
@@ -914,7 +911,7 @@ class NodeDeprecationChecks {
                 " major version",
             settingNames
         );
-        final String url = "https://www.elastic.co/guide/en/elasticsearch/reference/7.x/modules-threadpool.html";
+        final String url = "https://ela.st/es-deprecation-7-fixed-auto-queue-size-settings";
         return new DeprecationIssue(DeprecationIssue.Level.CRITICAL, message, url, details, false, null);
     }
 
@@ -924,7 +921,7 @@ class NodeDeprecationChecks {
                                                               final XPackLicenseState licenseState) {
         return checkRemovedSetting(settings,
             CLUSTER_ROUTING_REQUIRE_SETTING,
-            "https://www.elastic.co/guide/en/elasticsearch/reference/master/migrating-8.0.html#breaking_80_settings_changes",
+            "https://ela.st/es-deprecation-7-tier-filtering-settings",
             DeprecationIssue.Level.CRITICAL
         );
     }
@@ -935,7 +932,7 @@ class NodeDeprecationChecks {
                                                               final XPackLicenseState licenseState) {
         return checkRemovedSetting(settings,
             CLUSTER_ROUTING_INCLUDE_SETTING,
-            "https://www.elastic.co/guide/en/elasticsearch/reference/master/migrating-8.0.html#breaking_80_settings_changes",
+            "https://ela.st/es-deprecation-7-tier-filtering-settings",
             DeprecationIssue.Level.CRITICAL
         );
     }
@@ -946,7 +943,7 @@ class NodeDeprecationChecks {
                                                               final XPackLicenseState licenseState) {
         return checkRemovedSetting(settings,
             CLUSTER_ROUTING_EXCLUDE_SETTING,
-            "https://www.elastic.co/guide/en/elasticsearch/reference/master/migrating-8.0.html#breaking_80_settings_changes",
+            "https://ela.st/es-deprecation-7-tier-filtering-settings",
             DeprecationIssue.Level.CRITICAL
         );
     }
@@ -957,7 +954,7 @@ class NodeDeprecationChecks {
                                                               final XPackLicenseState licenseState) {
         return checkRemovedSetting(settings,
             Setting.boolSetting(SecurityField.setting("authc.accept_default_password"),true, Setting.Property.Deprecated),
-            "https://www.elastic.co/guide/en/elasticsearch/reference/master/migrating-8.0.html#breaking_80_security_changes",
+            "https://ela.st/es-deprecation-7-accept-default-password-setting",
             DeprecationIssue.Level.CRITICAL
         );
     }
@@ -968,7 +965,7 @@ class NodeDeprecationChecks {
                                                                 final XPackLicenseState licenseState) {
         return checkRemovedSetting(settings,
             Setting.intSetting(SecurityField.setting("authz.store.roles.index.cache.max_size"), 10000, Setting.Property.Deprecated),
-            "https://www.elastic.co/guide/en/elasticsearch/reference/master/migrating-8.0.html#breaking_80_security_changes",
+            "https://ela.st/es-deprecation-7-roles-index-cache-settings",
             DeprecationIssue.Level.CRITICAL
         );
     }
@@ -980,7 +977,7 @@ class NodeDeprecationChecks {
         return checkRemovedSetting(settings,
             Setting.timeSetting(SecurityField.setting("authz.store.roles.index.cache.ttl"), TimeValue.timeValueMinutes(20),
                 Setting.Property.Deprecated),
-            "https://www.elastic.co/guide/en/elasticsearch/reference/master/migrating-8.0.html#breaking_80_security_changes",
+            "https://ela.st/es-deprecation-7-roles-index-cache-settings",
             DeprecationIssue.Level.CRITICAL
         );
     }
@@ -991,7 +988,7 @@ class NodeDeprecationChecks {
                                                              final XPackLicenseState licenseState) {
         return checkRemovedSetting(settings,
             NodeEnvironment.MAX_LOCAL_STORAGE_NODES_SETTING,
-            "https://www.elastic.co/guide/en/elasticsearch/reference/7.14/modules-node.html#max-local-storage-nodes",
+            "https://ela.st/es-deprecation-7-node-local-storage-setting",
             DeprecationIssue.Level.CRITICAL
         );
     }
@@ -1022,7 +1019,7 @@ class NodeDeprecationChecks {
         } else {
             String message = "if nameid_format is not explicitly set, the previous default of " +
                 "'urn:oasis:names:tc:SAML:2.0:nameid-format:transient' is no longer used";
-            String url = "https://www.elastic.co/guide/en/elasticsearch/reference/master/saml-guide.html";
+            String url = "https://ela.st/es-deprecation-7-saml-nameid-format";
             String details = detailsList.stream().collect(Collectors.joining(","));
             return new DeprecationIssue(DeprecationIssue.Level.WARNING, message, url, details, false, null);
         }

--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/NodeDeprecationChecks.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/NodeDeprecationChecks.java
@@ -531,8 +531,7 @@ class NodeDeprecationChecks {
         if (Environment.PATH_SHARED_DATA_SETTING.exists(settings)) {
             final String message = String.format(Locale.ROOT,
                 "setting [%s] is deprecated and will be removed in a future version", Environment.PATH_SHARED_DATA_SETTING.getKey());
-            final String url = "https://www.elastic.co/guide/en/elasticsearch/reference/7.13/" +
-                "breaking-changes-7.13.html#deprecate-shared-data-path-setting";
+            final String url = "https://ela.st/es-deprecation-7-shared-path-settings";
             final String details = "Found shared data path configured. Discontinue use of this setting.";
             return new DeprecationIssue(DeprecationIssue.Level.CRITICAL, message, url, details, false, null);
         }
@@ -667,7 +666,7 @@ class NodeDeprecationChecks {
                                                                                    final XPackLicenseState licenseState) {
         return checkRemovedSetting(settings,
             CLUSTER_ROUTING_ALLOCATION_INCLUDE_RELOCATIONS_SETTING,
-            "https://www.elastic.co/guide/en/elasticsearch/reference/7.15/modules-cluster.html#disk-based-shard-allocation",
+            "https://ela.st/es-deprecation-7-cluster-routing-allocation-disk-include-relocations-setting",
             DeprecationIssue.Level.CRITICAL
         );
     }

--- a/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/ClusterDeprecationChecksTests.java
+++ b/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/ClusterDeprecationChecksTests.java
@@ -392,7 +392,7 @@ public class ClusterDeprecationChecksTests extends ESTestCase {
         assertThat(issue, equalTo(
             new DeprecationIssue(DeprecationIssue.Level.CRITICAL,
                 "index templates contain deprecated geo_shape properties that must be removed",
-                "https://ela.st/es-deprecation-7-geo-shape-settings",
+                "https://ela.st/es-deprecation-7-geo-shape-mappings",
                 "mappings in index template single-type contains deprecated geo_shape properties. [parameter [points_only] in field " +
                     "[location]; parameter [strategy] in field [location]]", false, null)
         ));
@@ -414,7 +414,7 @@ public class ClusterDeprecationChecksTests extends ESTestCase {
         assertThat(issue, equalTo(
             new DeprecationIssue(DeprecationIssue.Level.CRITICAL,
                 "component templates contain deprecated geo_shape properties that must be removed",
-                "https://ela.st/es-deprecation-7-geo-shape-settings",
+                "https://ela.st/es-deprecation-7-geo-shape-mappings",
                 "mappings in component template my-template contains deprecated geo_shape properties. [parameter [points_only] in field " +
                     "[location]; parameter [strategy] in field [location]]", false, null)
         ));
@@ -430,7 +430,7 @@ public class ClusterDeprecationChecksTests extends ESTestCase {
         assertThat(issue, equalTo(
             new DeprecationIssue(DeprecationIssue.Level.CRITICAL,
                 "component templates and index templates contain deprecated geo_shape properties that must be removed",
-                "https://ela.st/es-deprecation-7-geo-shape-settings",
+                "https://ela.st/es-deprecation-7-geo-shape-mappings",
                 "mappings in component template my-template contains deprecated geo_shape properties. [parameter [points_only] in field " +
                     "[location]; parameter [strategy] in field [location]]; mappings in index template single-type contains " +
                     "deprecated geo_shape properties. [parameter [points_only] in field [location]; parameter [strategy] in field " +

--- a/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/ClusterDeprecationChecksTests.java
+++ b/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/ClusterDeprecationChecksTests.java
@@ -91,7 +91,7 @@ public class ClusterDeprecationChecksTests extends ESTestCase {
 
         DeprecationIssue expected = new DeprecationIssue(DeprecationIssue.Level.WARNING,
             "User-Agent ingest plugin will always use ECS-formatted output",
-            "https://www.elastic.co/guide/en/elasticsearch/reference/7.15/user-agent-processor.html#user-agent-processor",
+            "https://ela.st/es-deprecation-7-ingest-pipeline-ecs-option",
             "Ingest pipelines [ecs_false, ecs_true] uses the [ecs] option which needs to be removed to work in 8.0", false, null);
         assertEquals(singletonList(expected), issues);
     }
@@ -159,8 +159,7 @@ public class ClusterDeprecationChecksTests extends ESTestCase {
 
         DeprecationIssue expected = new DeprecationIssue(DeprecationIssue.Level.WARNING,
             "Fields in index template exceed automatic field expansion limit",
-            "https://www.elastic.co/guide/en/elasticsearch/reference/7.0/breaking-changes-7.0.html" +
-                "#_limiting_the_number_of_auto_expanded_fields",
+            "https://ela.st/es-deprecation-7-number-of-auto-expanded-fields",
             "Index templates " + Collections.singletonList(tooManyFieldsTemplate) + " have a number of fields which exceeds the " +
                 "automatic field expansion limit of [1024] and does not have [" + IndexSettings.DEFAULT_FIELD_SETTING.getKey() + "] set, " +
                 "which may cause queries which use automatic field expansion, such as query_string, simple_query_string, and multi_match " +
@@ -234,7 +233,7 @@ public class ClusterDeprecationChecksTests extends ESTestCase {
             assertEquals(1, issues.size());
             DeprecationIssue issue = issues.get(0);
             assertEquals(DeprecationIssue.Level.WARNING, issue.getLevel());
-            assertEquals("https://www.elastic.co/guide/en/elasticsearch/reference/7.15/mapping-field-names-field.html#disable-field-names"
+            assertEquals("https://ela.st/es-deprecation-7-field_names-settings"
                     , issue.getUrl());
             assertEquals("Index templates contain _field_names settings.", issue.getMessage());
             assertEquals("Index templates [" + badTemplateName + "] "
@@ -260,8 +259,7 @@ public class ClusterDeprecationChecksTests extends ESTestCase {
 
             DeprecationIssue expected = new DeprecationIssue(DeprecationIssue.Level.CRITICAL,
                 "Index Lifecycle Management poll interval is set too low",
-                "https://www.elastic.co/guide/en/elasticsearch/reference/master/breaking-changes-8.0.html" +
-                    "#ilm-poll-interval-limit",
+                "https://ela.st/es-deprecation-7-indices-lifecycle-poll-interval-setting",
                 "The Index Lifecycle Management poll interval setting [" + LIFECYCLE_POLL_INTERVAL_SETTING.getKey() + "] is " +
                     "currently set to [" + tooLowInterval + "], but must be 1s or greater", false, null);
             List<DeprecationIssue> issues = DeprecationChecks.filterChecks(CLUSTER_SETTINGS_CHECKS, c -> c.apply(badState));
@@ -340,7 +338,7 @@ public class ClusterDeprecationChecksTests extends ESTestCase {
             String.format(Locale.ROOT,
                 "setting [%s] is deprecated and will be removed in the next major version",
                 settingKey),
-            "https://www.elastic.co/guide/en/elasticsearch/reference/7.15/modules-cluster.html#disk-based-shard-allocation",
+            "https://ela.st/es-deprecation-7-cluster-routing-allocation-disk-include-relocations-setting",
             String.format(Locale.ROOT,
                 "the setting [%s] is currently set to [%b], remove this setting",
                 settingKey,
@@ -394,8 +392,7 @@ public class ClusterDeprecationChecksTests extends ESTestCase {
         assertThat(issue, equalTo(
             new DeprecationIssue(DeprecationIssue.Level.CRITICAL,
                 "index templates contain deprecated geo_shape properties that must be removed",
-                "https://www.elastic.co/guide/en/elasticsearch/reference/6.6/breaking-changes-6.6.html" +
-                    "#_deprecated_literal_geo_shape_literal_parameters",
+                "https://ela.st/es-deprecation-7-geo-shape-settings",
                 "mappings in index template single-type contains deprecated geo_shape properties. [parameter [points_only] in field " +
                     "[location]; parameter [strategy] in field [location]]", false, null)
         ));
@@ -417,8 +414,7 @@ public class ClusterDeprecationChecksTests extends ESTestCase {
         assertThat(issue, equalTo(
             new DeprecationIssue(DeprecationIssue.Level.CRITICAL,
                 "component templates contain deprecated geo_shape properties that must be removed",
-                "https://www.elastic.co/guide/en/elasticsearch/reference/6.6/breaking-changes-6.6.html" +
-                    "#_deprecated_literal_geo_shape_literal_parameters",
+                "https://ela.st/es-deprecation-7-geo-shape-settings",
                 "mappings in component template my-template contains deprecated geo_shape properties. [parameter [points_only] in field " +
                     "[location]; parameter [strategy] in field [location]]", false, null)
         ));
@@ -434,8 +430,7 @@ public class ClusterDeprecationChecksTests extends ESTestCase {
         assertThat(issue, equalTo(
             new DeprecationIssue(DeprecationIssue.Level.CRITICAL,
                 "component templates and index templates contain deprecated geo_shape properties that must be removed",
-                "https://www.elastic.co/guide/en/elasticsearch/reference/6.6/breaking-changes-6.6.html" +
-                    "#_deprecated_literal_geo_shape_literal_parameters",
+                "https://ela.st/es-deprecation-7-geo-shape-settings",
                 "mappings in component template my-template contains deprecated geo_shape properties. [parameter [points_only] in field " +
                     "[location]; parameter [strategy] in field [location]]; mappings in index template single-type contains " +
                     "deprecated geo_shape properties. [parameter [points_only] in field [location]; parameter [strategy] in field " +
@@ -477,7 +472,7 @@ public class ClusterDeprecationChecksTests extends ESTestCase {
         assertThat(issue, equalTo(
             new DeprecationIssue(DeprecationIssue.Level.CRITICAL,
                 "index templates contain deprecated sparse_vector fields that must be removed",
-                "https://www.elastic.co/guide/en/elasticsearch/reference/master/migrating-8.0.html#breaking_80_search_changes",
+                "https://ela.st/es-deprecation-7-sparse-vector",
                 "mappings in index template single-type contains deprecated sparse_vector fields: [my_sparse_vector], " +
                     "[my_nested_sparse_vector]", false, null)
         ));
@@ -498,7 +493,7 @@ public class ClusterDeprecationChecksTests extends ESTestCase {
         assertThat(issue, equalTo(
             new DeprecationIssue(DeprecationIssue.Level.CRITICAL,
                 "component templates contain deprecated sparse_vector fields that must be removed",
-                "https://www.elastic.co/guide/en/elasticsearch/reference/master/migrating-8.0.html#breaking_80_search_changes",
+                "https://ela.st/es-deprecation-7-sparse-vector",
                 "mappings in component template [my-template] contains deprecated sparse_vector fields: [my_sparse_vector]", false, null)
         ));
 
@@ -513,7 +508,7 @@ public class ClusterDeprecationChecksTests extends ESTestCase {
         assertThat(issue, equalTo(
             new DeprecationIssue(DeprecationIssue.Level.CRITICAL,
                 "component templates and index templates contain deprecated sparse_vector fields that must be removed",
-                "https://www.elastic.co/guide/en/elasticsearch/reference/master/migrating-8.0.html#breaking_80_search_changes",
+                "https://ela.st/es-deprecation-7-sparse-vector",
                 "mappings in component template [my-template] contains deprecated sparse_vector fields: [my_sparse_vector]; " +
                     "mappings in index template single-type contains deprecated sparse_vector fields: " +
                     "[my_sparse_vector], [my_nested_sparse_vector]", false, null)

--- a/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/IndexDeprecationChecksTests.java
+++ b/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/IndexDeprecationChecksTests.java
@@ -515,7 +515,7 @@ public class IndexDeprecationChecksTests extends ESTestCase {
             String.format(Locale.ROOT,
                 "setting [%s] is deprecated and will be removed in the next major version",
                 INDEX_ROUTING_REQUIRE_SETTING.getKey()),
-            "https://ela.st/es-deprecation-7-index-routing-settings",
+            "https://ela.st/es-deprecation-7-tier-filtering-settings",
             String.format(Locale.ROOT,
                 "the setting [%s] is currently set to [%s], remove this setting",
                 INDEX_ROUTING_REQUIRE_SETTING.getKey(),
@@ -526,7 +526,7 @@ public class IndexDeprecationChecksTests extends ESTestCase {
             String.format(Locale.ROOT,
                 "setting [%s] is deprecated and will be removed in the next major version",
                 INDEX_ROUTING_INCLUDE_SETTING.getKey()),
-            "https://ela.st/es-deprecation-7-index-routing-settings",
+            "https://ela.st/es-deprecation-7-tier-filtering-settings",
             String.format(Locale.ROOT,
                 "the setting [%s] is currently set to [%s], remove this setting",
                 INDEX_ROUTING_INCLUDE_SETTING.getKey(),
@@ -537,7 +537,7 @@ public class IndexDeprecationChecksTests extends ESTestCase {
             String.format(Locale.ROOT,
                 "setting [%s] is deprecated and will be removed in the next major version",
                 INDEX_ROUTING_EXCLUDE_SETTING.getKey()),
-            "https://ela.st/es-deprecation-7-index-routing-settings",
+            "https://ela.st/es-deprecation-7-tier-filtering-settings",
             String.format(Locale.ROOT,
                 "the setting [%s] is currently set to [%s], remove this setting",
                 INDEX_ROUTING_EXCLUDE_SETTING.getKey(),
@@ -602,7 +602,7 @@ public class IndexDeprecationChecksTests extends ESTestCase {
         assertThat(issues, contains(
             new DeprecationIssue(DeprecationIssue.Level.CRITICAL,
                 "mappings for index test contains deprecated geo_shape properties that must be removed",
-                "https://ela.st/es-deprecation-7-geo-shape-settings",
+                "https://ela.st/es-deprecation-7-geo-shape-mappings",
                 "The following geo_shape parameters must be removed from test: [[parameter [points_only] in field [location]; parameter " +
                     "[strategy] in field [location]]]", false, null)
         ));
@@ -621,7 +621,7 @@ public class IndexDeprecationChecksTests extends ESTestCase {
         assertThat(issues, contains(
             new DeprecationIssue(DeprecationIssue.Level.CRITICAL,
                 "mappings for index test contains deprecated geo_shape properties that must be removed",
-                "https://ela.st/es-deprecation-7-geo-shape-settings",
+                "https://ela.st/es-deprecation-7-geo-shape-mappings",
                 "The following geo_shape parameters must be removed from test: [[parameter [points_only] in field [location]; parameter " +
                     "[strategy] in field [location]]]", false, null)
         ));

--- a/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/IndexDeprecationChecksTests.java
+++ b/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/IndexDeprecationChecksTests.java
@@ -60,8 +60,7 @@ public class IndexDeprecationChecksTests extends ESTestCase {
             .build();
         DeprecationIssue expected = new DeprecationIssue(DeprecationIssue.Level.CRITICAL,
             "Index created before 7.0",
-            "https://www.elastic.co/guide/en/elasticsearch/reference/master/" +
-                "breaking-changes-8.0.html",
+            "https://ela.st/es-deprecation-7-reindex",
             "This index was created using version: " + createdWith, false, null);
         List<DeprecationIssue> issues = DeprecationChecks.filterChecks(INDEX_SETTINGS_CHECKS, c -> c.apply(indexMetadata));
         assertEquals(singletonList(expected), issues);
@@ -113,8 +112,7 @@ public class IndexDeprecationChecksTests extends ESTestCase {
             .build();
         DeprecationIssue expected = new DeprecationIssue(DeprecationIssue.Level.WARNING,
             "Number of fields exceeds automatic field expansion limit",
-            "https://www.elastic.co/guide/en/elasticsearch/reference/7.0/breaking-changes-7.0.html" +
-                "#_limiting_the_number_of_auto_expanded_fields",
+            "https://ela.st/es-deprecation-7-number-of-auto-expanded-fields",
             "This index has [" + fieldCount + "] fields, which exceeds the automatic field expansion limit of 1024 " +
                 "and does not have [" + IndexSettings.DEFAULT_FIELD_SETTING.getKey() + "] set, which may cause queries which use " +
                 "automatic field expansion, such as query_string, simple_query_string, and multi_match to fail if fields are not " +
@@ -174,8 +172,7 @@ public class IndexDeprecationChecksTests extends ESTestCase {
 
         DeprecationIssue expected = new DeprecationIssue(DeprecationIssue.Level.WARNING,
             "Multi-fields within multi-fields",
-            "https://www.elastic.co/guide/en/elasticsearch/reference/7.x/breaking-changes-7.3.html" +
-                "#_defining_multi_fields_within_multi_fields",
+            "https://ela.st/es-deprecation-7-chained-multi-fields",
             "The names of fields that contain chained multi-fields: [[type: _doc, field: invalid-field]]", false, null);
         assertEquals(singletonList(expected), issues);
     }
@@ -223,7 +220,7 @@ public class IndexDeprecationChecksTests extends ESTestCase {
 
         DeprecationIssue expected = new DeprecationIssue(DeprecationIssue.Level.WARNING,
             "Date field format uses patterns which has changed meaning in 7.0",
-            "https://www.elastic.co/guide/en/elasticsearch/reference/7.0/breaking-changes-7.0.html#breaking_70_java_time_changes",
+            "https://ela.st/es-deprecation-7-java-time",
             "This index has date fields with deprecated formats: ["+
                 "[type: _doc, field: date_time_field_Y, format: dd-CC||MM-YYYY, " +
                 "suggestion: 'C' century of era is no longer supported." +
@@ -247,7 +244,7 @@ public class IndexDeprecationChecksTests extends ESTestCase {
 
         DeprecationIssue expected = new DeprecationIssue(DeprecationIssue.Level.WARNING,
             "Date field format uses patterns which has changed meaning in 7.0",
-            "https://www.elastic.co/guide/en/elasticsearch/reference/7.0/breaking-changes-7.0.html#breaking_70_java_time_changes",
+            "https://ela.st/es-deprecation-7-java-time",
             "This index has date fields with deprecated formats: ["+
                 "[type: _doc, field: date_time_field_Y, format: dd-YYYY||MM-YYYY, " +
                 "suggestion: 'Y' year-of-era should be replaced with 'y'. Use 'Y' for week-based-year.]"+
@@ -269,7 +266,7 @@ public class IndexDeprecationChecksTests extends ESTestCase {
 
         DeprecationIssue expected = new DeprecationIssue(DeprecationIssue.Level.WARNING,
             "Date field format uses patterns which has changed meaning in 7.0",
-            "https://www.elastic.co/guide/en/elasticsearch/reference/7.0/breaking-changes-7.0.html#breaking_70_java_time_changes",
+            "https://ela.st/es-deprecation-7-java-time",
             "This index has date fields with deprecated formats: ["+
                 "[type: _doc, field: date_time_field_Y, format: strictWeekyearWeek||MM-YYYY, " +
                 "suggestion: 'Y' year-of-era should be replaced with 'y'. Use 'Y' for week-based-year.]"+
@@ -312,7 +309,7 @@ public class IndexDeprecationChecksTests extends ESTestCase {
 
         DeprecationIssue expected = new DeprecationIssue(DeprecationIssue.Level.WARNING,
             "Date field format uses patterns which has changed meaning in 7.0",
-            "https://www.elastic.co/guide/en/elasticsearch/reference/7.0/breaking-changes-7.0.html#breaking_70_java_time_changes",
+            "https://ela.st/es-deprecation-7-java-time",
             "This index has date fields with deprecated formats: ["+
                 "[type: _doc, field: date_time_field_Y, format: MM-YYYY, " +
                 "suggestion: 'Y' year-of-era should be replaced with 'y'. Use 'Y' for week-based-year.], "+
@@ -346,7 +343,7 @@ public class IndexDeprecationChecksTests extends ESTestCase {
 
         DeprecationIssue expected = new DeprecationIssue(DeprecationIssue.Level.WARNING,
             "Date field format uses patterns which has changed meaning in 7.0",
-            "https://www.elastic.co/guide/en/elasticsearch/reference/7.0/breaking-changes-7.0.html#breaking_70_java_time_changes",
+            "https://ela.st/es-deprecation-7-java-time",
             "This index has date fields with deprecated formats: ["+
                 "[type: _doc, field: date_time_field, format: Y-C-x-y, " +
                 "suggestion: 'Y' year-of-era should be replaced with 'y'. Use 'Y' for week-based-year.; " +
@@ -414,7 +411,7 @@ public class IndexDeprecationChecksTests extends ESTestCase {
         assertThat(issues, contains(
             new DeprecationIssue(DeprecationIssue.Level.WARNING,
                 "translog retention settings are ignored",
-                "https://www.elastic.co/guide/en/elasticsearch/reference/7.15/index-modules-translog.html#index-modules-translog-retention",
+                "https://ela.st/es-deprecation-7-translog-settings",
                 "translog retention settings [index.translog.retention.size] and [index.translog.retention.age] are ignored " +
                     "because translog is no longer used in peer recoveries with soft-deletes enabled (default in 7.0 or later)",
                 false, null)
@@ -452,8 +449,7 @@ public class IndexDeprecationChecksTests extends ESTestCase {
 
         DeprecationIssue issue = issues.get(0);
         assertEquals(DeprecationIssue.Level.WARNING, issue.getLevel());
-        assertEquals("https://www.elastic.co/guide/en/elasticsearch/reference/7.15/mapping-field-names-field.html#disable-field-names"
-                , issue.getUrl());
+        assertEquals("https://ela.st/es-deprecation-7-field_names-settings", issue.getUrl());
         assertEquals("Index mapping contains explicit `_field_names` enabling settings.", issue.getMessage());
         assertEquals("The index mapping contains a deprecated `enabled` setting for `_field_names` that should be removed moving foward.",
                 issue.getDetails());
@@ -464,8 +460,7 @@ public class IndexDeprecationChecksTests extends ESTestCase {
         settings.put(IndexMetadata.INDEX_DATA_PATH_SETTING.getKey(), createTempDir());
         IndexMetadata indexMetadata = IndexMetadata.builder("test").settings(settings).numberOfShards(1).numberOfReplicas(0).build();
         List<DeprecationIssue> issues = DeprecationChecks.filterChecks(INDEX_SETTINGS_CHECKS, c -> c.apply(indexMetadata));
-        final String expectedUrl =
-            "https://www.elastic.co/guide/en/elasticsearch/reference/7.13/breaking-changes-7.13.html#deprecate-shared-data-path-setting";
+        final String expectedUrl = "https://ela.st/es-deprecation-7-shared-path-settings";
         assertThat(issues, contains(
             new DeprecationIssue(DeprecationIssue.Level.CRITICAL,
                 "setting [index.data_path] is deprecated and will be removed in a future version",
@@ -480,8 +475,7 @@ public class IndexDeprecationChecksTests extends ESTestCase {
         settings.put(IndexingSlowLog.INDEX_INDEXING_SLOWLOG_LEVEL_SETTING.getKey(), SlowLogLevel.DEBUG);
         IndexMetadata indexMetadata = IndexMetadata.builder("test").settings(settings).numberOfShards(1).numberOfReplicas(0).build();
         List<DeprecationIssue> issues = DeprecationChecks.filterChecks(INDEX_SETTINGS_CHECKS, c -> c.apply(indexMetadata));
-        final String expectedUrl =
-            "https://www.elastic.co/guide/en/elasticsearch/reference/7.15/migrating-7.13.html#breaking_713_infra_core_deprecations";
+        final String expectedUrl = "https://ela.st/es-deprecation-7-slowlog-settings";
         assertThat(issues, containsInAnyOrder(
             new DeprecationIssue(DeprecationIssue.Level.WARNING,
                 "setting [index.search.slowlog.level] is deprecated and will be removed in a future version",
@@ -503,7 +497,7 @@ public class IndexDeprecationChecksTests extends ESTestCase {
         assertThat(issues, contains(
             new DeprecationIssue(DeprecationIssue.Level.WARNING,
                 "[simplefs] is deprecated and will be removed in future versions",
-                "https://www.elastic.co/guide/en/elasticsearch/reference/7.15/index-modules-store.html#file-system",
+                "https://ela.st/es-deprecation-7-simplefs-store-type",
                 "[simplefs] is deprecated and will be removed in 8.0. Use [niofs] or other file systems instead. " +
                     "Elasticsearch 7.15 or later uses [niofs] for the [simplefs] store type " +
                     "as it offers superior or equivalent performance to [simplefs].", false, null)
@@ -521,7 +515,7 @@ public class IndexDeprecationChecksTests extends ESTestCase {
             String.format(Locale.ROOT,
                 "setting [%s] is deprecated and will be removed in the next major version",
                 INDEX_ROUTING_REQUIRE_SETTING.getKey()),
-            "https://www.elastic.co/guide/en/elasticsearch/reference/7.14/data-tier-shard-filtering.html#data-tier-allocation-filters",
+            "https://ela.st/es-deprecation-7-index-routing-settings",
             String.format(Locale.ROOT,
                 "the setting [%s] is currently set to [%s], remove this setting",
                 INDEX_ROUTING_REQUIRE_SETTING.getKey(),
@@ -532,7 +526,7 @@ public class IndexDeprecationChecksTests extends ESTestCase {
             String.format(Locale.ROOT,
                 "setting [%s] is deprecated and will be removed in the next major version",
                 INDEX_ROUTING_INCLUDE_SETTING.getKey()),
-            "https://www.elastic.co/guide/en/elasticsearch/reference/7.14/data-tier-shard-filtering.html#data-tier-allocation-filters",
+            "https://ela.st/es-deprecation-7-index-routing-settings",
             String.format(Locale.ROOT,
                 "the setting [%s] is currently set to [%s], remove this setting",
                 INDEX_ROUTING_INCLUDE_SETTING.getKey(),
@@ -543,7 +537,7 @@ public class IndexDeprecationChecksTests extends ESTestCase {
             String.format(Locale.ROOT,
                 "setting [%s] is deprecated and will be removed in the next major version",
                 INDEX_ROUTING_EXCLUDE_SETTING.getKey()),
-            "https://www.elastic.co/guide/en/elasticsearch/reference/7.14/data-tier-shard-filtering.html#data-tier-allocation-filters",
+            "https://ela.st/es-deprecation-7-index-routing-settings",
             String.format(Locale.ROOT,
                 "the setting [%s] is currently set to [%s], remove this setting",
                 INDEX_ROUTING_EXCLUDE_SETTING.getKey(),
@@ -608,8 +602,7 @@ public class IndexDeprecationChecksTests extends ESTestCase {
         assertThat(issues, contains(
             new DeprecationIssue(DeprecationIssue.Level.CRITICAL,
                 "mappings for index test contains deprecated geo_shape properties that must be removed",
-                "https://www.elastic.co/guide/en/elasticsearch/reference/6.6/breaking-changes-6.6.html" +
-                    "#_deprecated_literal_geo_shape_literal_parameters",
+                "https://ela.st/es-deprecation-7-geo-shape-settings",
                 "The following geo_shape parameters must be removed from test: [[parameter [points_only] in field [location]; parameter " +
                     "[strategy] in field [location]]]", false, null)
         ));
@@ -628,8 +621,7 @@ public class IndexDeprecationChecksTests extends ESTestCase {
         assertThat(issues, contains(
             new DeprecationIssue(DeprecationIssue.Level.CRITICAL,
                 "mappings for index test contains deprecated geo_shape properties that must be removed",
-                "https://www.elastic.co/guide/en/elasticsearch/reference/6.6/breaking-changes-6.6.html" +
-                    "#_deprecated_literal_geo_shape_literal_parameters",
+                "https://ela.st/es-deprecation-7-geo-shape-settings",
                 "The following geo_shape parameters must be removed from test: [[parameter [points_only] in field [location]; parameter " +
                     "[strategy] in field [location]]]", false, null)
         ));

--- a/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/NodeDeprecationChecksTests.java
+++ b/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/NodeDeprecationChecksTests.java
@@ -695,8 +695,7 @@ public class NodeDeprecationChecksTests extends ESTestCase {
             .put(Environment.PATH_SHARED_DATA_SETTING.getKey(), createTempDir()).build();
         final XPackLicenseState licenseState = new XPackLicenseState(Settings.EMPTY, () -> 0);
         DeprecationIssue issue = NodeDeprecationChecks.checkSharedDataPathSetting(settings, null, null, licenseState);
-        final String expectedUrl =
-            "https://www.elastic.co/guide/en/elasticsearch/reference/7.13/breaking-changes-7.13.html#deprecate-shared-data-path-setting";
+        final String expectedUrl = "https://ela.st/es-deprecation-7-shared-path-settings";
         assertThat(issue, equalTo(
             new DeprecationIssue(DeprecationIssue.Level.CRITICAL,
                 "setting [path.shared_data] is deprecated and will be removed in a future version",
@@ -905,7 +904,7 @@ public class NodeDeprecationChecksTests extends ESTestCase {
             String.format(Locale.ROOT,
                 "setting [%s] is deprecated and will be removed in the next major version",
                 settingKey),
-            "https://www.elastic.co/guide/en/elasticsearch/reference/7.15/modules-cluster.html#disk-based-shard-allocation",
+            "https://ela.st/es-deprecation-7-cluster-routing-allocation-disk-include-relocations-setting",
             String.format(Locale.ROOT,
                 "the setting [%s] is currently set to [%b], remove this setting",
                 settingKey,

--- a/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/NodeDeprecationChecksTests.java
+++ b/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/NodeDeprecationChecksTests.java
@@ -86,7 +86,7 @@ public class NodeDeprecationChecksTests extends ESTestCase {
         final DeprecationIssue expected = new DeprecationIssue(
             DeprecationIssue.Level.CRITICAL,
             "Java 11 is required",
-            "https://www.elastic.co/guide/en/elasticsearch/reference/master/breaking-changes-8.0.html#breaking_80_packaging_changes",
+            "https://ela.st/es-deprecation-7-java-version",
             "Java 11 will be required for future versions of Elasticsearch, this node is running version ["
                 + JavaVersion.current().toString() + "]. Consider switching to a distribution of Elasticsearch with a bundled JDK. "
                 + "If you are already using a distribution with a bundled JDK, ensure the JAVA_HOME environment variable is not set.",
@@ -109,7 +109,7 @@ public class NodeDeprecationChecksTests extends ESTestCase {
         final DeprecationIssue expected = new DeprecationIssue(
             DeprecationIssue.Level.CRITICAL,
             "setting [pidfile] is deprecated in favor of setting [node.pidfile]",
-            "https://www.elastic.co/guide/en/elasticsearch/reference/7.4/breaking-changes-7.4.html#deprecate-pidfile",
+            "https://ela.st/es-deprecation-7-pidfile-setting",
             "the setting [pidfile] is currently set to [" + pidfile + "], instead set [node.pidfile] to [" + pidfile + "]", false, null);
         assertThat(issues, hasItem(expected));
         assertSettingDeprecationsAndWarnings(new Setting<?>[]{Environment.PIDFILE_SETTING});
@@ -124,7 +124,7 @@ public class NodeDeprecationChecksTests extends ESTestCase {
         final DeprecationIssue expected = new DeprecationIssue(
             DeprecationIssue.Level.CRITICAL,
             "setting [processors] is deprecated in favor of setting [node.processors]",
-            "https://www.elastic.co/guide/en/elasticsearch/reference/7.4/breaking-changes-7.4.html#deprecate-processors",
+            "https://ela.st/es-deprecation-7-processors-setting",
             "the setting [processors] is currently set to [" + processors + "], instead set [node.processors] to [" + processors + "]",
             false, null);
         assertThat(issues, hasItem(expected));
@@ -153,7 +153,7 @@ public class NodeDeprecationChecksTests extends ESTestCase {
         assertEquals(new DeprecationIssue(
             DeprecationIssue.Level.CRITICAL,
             "Realm order will be required in next major release.",
-            "https://www.elastic.co/guide/en/elasticsearch/reference/7.7/breaking-changes-7.7.html#deprecate-missing-realm-order",
+            "https://ela.st/es-deprecation-7-realm-orders-required",
             String.format(
                 Locale.ROOT,
                 "Found realms without order config: [%s]. In next major release, node will fail to start with missing realm order.",
@@ -207,7 +207,7 @@ public class NodeDeprecationChecksTests extends ESTestCase {
         assertEquals(1, deprecationIssues.size());
         assertEquals(DeprecationIssue.Level.CRITICAL, deprecationIssues.get(0).getLevel());
         assertEquals(
-            "https://www.elastic.co/guide/en/elasticsearch/reference/7.7/breaking-changes-7.7.html#deprecate-duplicated-realm-orders",
+            "https://ela.st/es-deprecation-7-realm-orders-unique",
             deprecationIssues.get(0).getUrl());
         assertEquals("Realm orders must be unique in next major release.", deprecationIssues.get(0).getMessage());
         assertThat(deprecationIssues.get(0).getDetails(), startsWith("Found multiple realms configured with the same order:"));
@@ -384,8 +384,7 @@ public class NodeDeprecationChecksTests extends ESTestCase {
         final DeprecationIssue deprecationIssue = deprecationIssues.get(0);
         assertEquals(DeprecationIssue.Level.WARNING, deprecationIssue.getLevel());
         assertEquals("Realm names cannot start with [_] in a future major release.", deprecationIssue.getMessage());
-        assertEquals("https://www.elastic.co/guide/en/elastic-stack" +
-            "/7.14/elasticsearch-breaking-changes.html#breaking_714_security_changes", deprecationIssue.getUrl());
+        assertEquals("https://ela.st/es-deprecation-7-realm-names", deprecationIssue.getUrl());
         assertEquals("Found realm " + (invalidRealmNames.size() == 1 ? "name" : "names")
                 + " with reserved prefix [_]: ["
                 + Strings.collectionToDelimitedString(invalidRealmNames.stream().sorted().collect(Collectors.toList()), "; ") + "]. "
@@ -402,7 +401,7 @@ public class NodeDeprecationChecksTests extends ESTestCase {
         final DeprecationIssue expected = new DeprecationIssue(
             DeprecationIssue.Level.CRITICAL,
             "setting [thread_pool.listener.queue_size] is deprecated and will be removed in the next major version",
-            "https://www.elastic.co/guide/en/elasticsearch/reference/7.x/breaking-changes-7.7.html#deprecate-listener-thread-pool",
+            "https://ela.st/es-deprecation-7-thread-pool-listener-settings",
             "the setting [thread_pool.listener.queue_size] is currently set to [" + size + "], remove this setting", false, null);
         assertThat(issues, hasItem(expected));
         assertSettingDeprecationsAndWarnings(new String[]{"thread_pool.listener.queue_size"});
@@ -417,7 +416,7 @@ public class NodeDeprecationChecksTests extends ESTestCase {
         final DeprecationIssue expected = new DeprecationIssue(
             DeprecationIssue.Level.CRITICAL,
             "setting [thread_pool.listener.size] is deprecated and will be removed in the next major version",
-            "https://www.elastic.co/guide/en/elasticsearch/reference/7.x/breaking-changes-7.7.html#deprecate-listener-thread-pool",
+            "https://ela.st/es-deprecation-7-thread-pool-listener-settings",
             "the setting [thread_pool.listener.size] is currently set to [" + size + "], remove this setting", false, null);
         assertThat(issues, hasItem(expected));
         assertSettingDeprecationsAndWarnings(new String[]{"thread_pool.listener.size"});
@@ -432,7 +431,7 @@ public class NodeDeprecationChecksTests extends ESTestCase {
         final DeprecationIssue expected = new DeprecationIssue(
             DeprecationIssue.Level.CRITICAL,
             "setting [script.cache.max_size] is deprecated in favor of grouped setting [script.context.*.cache_max_size]",
-            "https://www.elastic.co/guide/en/elasticsearch/reference/7.9/breaking-changes-7.9.html#deprecate_general_script_cache_size",
+            "https://ela.st/es-deprecation-7-script-cache-size-setting",
             "the setting [script.cache.max_size] is currently set to [" + size + "], instead set [script.context.*.cache_max_size] " +
                 "to [" + size + "] where * is a script context", false, null);
         assertThat(issues, hasItem(expected));
@@ -448,7 +447,7 @@ public class NodeDeprecationChecksTests extends ESTestCase {
         final DeprecationIssue expected = new DeprecationIssue(
             DeprecationIssue.Level.CRITICAL,
             "setting [script.cache.expire] is deprecated in favor of grouped setting [script.context.*.cache_expire]",
-            "https://www.elastic.co/guide/en/elasticsearch/reference/7.9/breaking-changes-7.9.html#deprecate_general_script_expire",
+            "https://ela.st/es-deprecation-7-script-cache-expire-setting",
             "the setting [script.cache.expire] is currently set to [" + expire + "], instead set [script.context.*.cache_expire] to " +
                 "[" + expire + "] where * is a script context", false, null);
         assertThat(issues, hasItem(expected));
@@ -464,7 +463,7 @@ public class NodeDeprecationChecksTests extends ESTestCase {
         final DeprecationIssue expected = new DeprecationIssue(
             DeprecationIssue.Level.CRITICAL,
             "setting [script.max_compilations_rate] is deprecated in favor of grouped setting [script.context.*.max_compilations_rate]",
-            "https://www.elastic.co/guide/en/elasticsearch/reference/7.9/breaking-changes-7.9.html#deprecate_general_script_compile_rate",
+            "https://ela.st/es-deprecation-7-script-max-compilations-rate-setting",
             "the setting [script.max_compilations_rate] is currently set to [" + rate +
                 "], instead set [script.context.*.max_compilations_rate] to [" + rate + "] where * is a script context", false, null);
         assertThat(issues, hasItem(expected));
@@ -480,7 +479,7 @@ public class NodeDeprecationChecksTests extends ESTestCase {
         final DeprecationIssue expected = new DeprecationIssue(
             DeprecationIssue.Level.CRITICAL,
             "setting [cluster.remote.connect] is deprecated in favor of setting [node.remote_cluster_client]",
-            "https://www.elastic.co/guide/en/elasticsearch/reference/7.7/breaking-changes-7.7.html#deprecate-cluster-remote-connect",
+            "https://ela.st/es-deprecation-7-cluster-remote-connect-setting",
             String.format(
                 Locale.ROOT,
                 "the setting [%s] is currently set to [%b], instead set [%s] to [%2$b]",
@@ -501,7 +500,7 @@ public class NodeDeprecationChecksTests extends ESTestCase {
         final DeprecationIssue expected = new DeprecationIssue(
             DeprecationIssue.Level.CRITICAL,
             "setting [node.local_storage] is deprecated and will be removed in the next major version",
-            "https://www.elastic.co/guide/en/elasticsearch/reference/7.8/breaking-changes-7.8.html#deprecate-node-local-storage",
+            "https://ela.st/es-deprecation-7-node-local-storage-setting",
             "the setting [node.local_storage] is currently set to [" + value + "], remove this setting", false, null
         );
         assertThat(issues, hasItem(expected));
@@ -530,8 +529,7 @@ public class NodeDeprecationChecksTests extends ESTestCase {
             final DeprecationIssue expected = new DeprecationIssue(
                 DeprecationIssue.Level.CRITICAL,
                 "setting [" + deprecatedSetting.getKey() + "] is deprecated and will be removed in the next major version",
-                "https://www.elastic.co/guide/en/elasticsearch/reference/7.8/breaking-changes-7.8.html" +
-                    "#deprecate-basic-license-feature-enabled",
+                "https://ela.st/es-deprecation-7-xpack-basic-feature-settings",
                 "the setting [" + deprecatedSetting.getKey() + "] is currently set to [" + value + "], remove this setting", false, null
             );
             assertThat(issues, hasItem(expected));
@@ -557,7 +555,7 @@ public class NodeDeprecationChecksTests extends ESTestCase {
             final DeprecationIssue expected = new DeprecationIssue(
                 DeprecationIssue.Level.CRITICAL,
                 "setting [" + legacyRoleSetting.getKey() + "] is deprecated in favor of setting [node.roles]",
-                "https://www.elastic.co/guide/en/elasticsearch/reference/master/breaking-changes-8.0.html#breaking_80_settings_changes",
+                "https://ela.st/es-deprecation-7-node-roles",
                 "the setting [" + legacyRoleSetting.getKey() + "] is currently set to ["
                     + value + "], instead set [node.roles] to [" + roles + "]", false, null
             );
@@ -579,7 +577,7 @@ public class NodeDeprecationChecksTests extends ESTestCase {
         final DeprecationIssue expected = new DeprecationIssue(
             DeprecationIssue.Level.CRITICAL,
             "setting [bootstrap.system_call_filter] is deprecated and will be removed in the next major version",
-            "https://www.elastic.co/guide/en/elasticsearch/reference/7.13/breaking-changes-7.13.html#deprecate-system-call-filter-setting",
+            "https://ela.st/es-deprecation-7-system-call-filter-setting",
             "the setting [bootstrap.system_call_filter] is currently set to [" + boostrapSystemCallFilter + "], remove this setting",
             false, null);
         assertThat(issues, hasItem(expected));
@@ -632,7 +630,7 @@ public class NodeDeprecationChecksTests extends ESTestCase {
         assertEquals(1, deprecationIssues.size());
         assertEquals("File and/or native realms are enabled by default in next major release.",
             deprecationIssues.get(0).getMessage());
-        assertEquals("https://www.elastic.co/guide/en/elasticsearch/reference/7.15/migrating-7.13.html#breaking_713_security_changes",
+        assertEquals("https://ela.st/es-deprecation-7-implicitly-disabled-basic-realms",
             deprecationIssues.get(0).getUrl());
     }
 
@@ -654,7 +652,7 @@ public class NodeDeprecationChecksTests extends ESTestCase {
             issue.getDetails(),
             equalTo("Multiple data paths are deprecated. Instead, use RAID or other system level features to utilize multiple disks."));
         String url =
-            "https://www.elastic.co/guide/en/elasticsearch/reference/7.15/modules-node.html#max-local-storage-nodes";
+            "https://ela.st/es-deprecation-7-multiple-paths";
         assertThat(issue.getUrl(), equalTo(url));
     }
 
@@ -677,8 +675,7 @@ public class NodeDeprecationChecksTests extends ESTestCase {
         assertThat(
             issue.getDetails(),
             equalTo("Configuring [path.data] with a list is deprecated. Instead specify as a string value."));
-        String url =
-            "https://www.elastic.co/guide/en/elasticsearch/reference/7.15/modules-node.html#max-local-storage-nodes";
+        String url = "https://ela.st/es-deprecation-7-multiple-paths";
         assertThat(issue.getUrl(), equalTo(url));
     }
 
@@ -712,7 +709,7 @@ public class NodeDeprecationChecksTests extends ESTestCase {
             null, ClusterState.EMPTY_STATE, new XPackLicenseState(Settings.EMPTY, () -> 0)));
 
         final String expectedUrl =
-            "https://www.elastic.co/guide/en/elasticsearch/reference/7.15/modules-cluster.html#disk-based-shard-allocation";
+            "https://ela.st/es-deprecation-7-disk-watermark-enable-for-single-node-setting";
         assertThat(issues, hasItem(
             new DeprecationIssue(DeprecationIssue.Level.CRITICAL,
                 "setting [cluster.routing.allocation.disk.watermark.enable_for_single_data_node=false] is deprecated and" +
@@ -741,7 +738,7 @@ public class NodeDeprecationChecksTests extends ESTestCase {
                 null, ClusterStateCreationUtils.state(node1, node1, node1), licenseState));
 
         final String expectedUrl =
-            "https://www.elastic.co/guide/en/elasticsearch/reference/7.15/modules-cluster.html#disk-based-shard-allocation";
+            "https://ela.st/es-deprecation-7-disk-watermark-enable-for-single-node-setting";
         DeprecationIssue deprecationIssue = new DeprecationIssue(DeprecationIssue.Level.WARNING,
             "the default value [false] of setting [cluster.routing.allocation.disk.watermark.enable_for_single_data_node]" +
                 " is deprecated and will be changed to true in a future version." +
@@ -778,8 +775,7 @@ public class NodeDeprecationChecksTests extends ESTestCase {
         final Settings settings = b.build();
         final XPackLicenseState licenseState = new XPackLicenseState(Settings.EMPTY, () -> 0);
         DeprecationIssue issue = NodeDeprecationChecks.checkMonitoringExporterPassword(settings, null, null , licenseState);
-        final String expectedUrl =
-            "https://www.elastic.co/guide/en/elasticsearch/reference/7.7/monitoring-settings.html#http-exporter-settings";
+        final String expectedUrl = "https://ela.st/es-deprecation-7-monitoring-exporter-passwords";
         final String joinedNames = Arrays
             .stream(exporterNames)
             .map(s -> "xpack.monitoring.exporters." + s + ".auth.password")
@@ -815,7 +811,7 @@ public class NodeDeprecationChecksTests extends ESTestCase {
             String.format(Locale.ROOT,
                 "setting [%s] is deprecated and will be removed in the next major version",
                 settingKey),
-            "https://www.elastic.co/guide/en/elasticsearch/reference/7.x/modules-discovery-settings.html",
+            "https://ela.st/es-deprecation-7-cluster-join-timeout-setting",
             String.format(Locale.ROOT,
                 "the setting [%s] is currently set to [%s], remove this setting",
                 settingKey,
@@ -854,8 +850,7 @@ public class NodeDeprecationChecksTests extends ESTestCase {
         final XPackLicenseState licenseState = new XPackLicenseState(Settings.EMPTY, () -> 0);
         DeprecationIssue issue = NodeDeprecationChecks.checkSearchRemoteSettings(settings, null, null , licenseState);
 
-        final String expectedUrl =
-            "https://www.elastic.co/guide/en/elasticsearch/reference/master/migrating-8.0.html#breaking_80_settings_changes";
+        final String expectedUrl = "https://ela.st/es-deprecation-7-search-remote-settings";
         String joinedNames = Arrays
             .stream(clusterNames)
             .map(s -> "search.remote." + s + ".seeds")
@@ -935,7 +930,7 @@ public class NodeDeprecationChecksTests extends ESTestCase {
         assertNotNull(issue.getDetails());
         assertThat(issue.getDetails(), containsString("The default behavior of disabling security on "));
         assertThat(issue.getUrl(),
-            equalTo("https://www.elastic.co/guide/en/elasticsearch/reference/7.14/migrating-7.14.html#implicitly-disabled-security"));
+            equalTo("https://ela.st/es-deprecation-7-implicitly-disabled-security"));
     }
 
     public void testExplicitlyConfiguredSecurityOnBasicAndTrial() {
@@ -973,7 +968,7 @@ public class NodeDeprecationChecksTests extends ESTestCase {
         final ClusterState clusterState = ClusterState.EMPTY_STATE;
         final DeprecationIssue expectedIssue = new DeprecationIssue(DeprecationIssue.Level.WARNING,
             "support for fractional byte size values is deprecated and will be removed in a future release",
-            "https://www.elastic.co/guide/en/elasticsearch/reference/master/logging.html#deprecation-logging",
+            "https://ela.st/es-deprecation-7-fractional-byte-settings",
             String.format(Locale.ROOT,
                 "change the following settings to non-fractional values: [%s->%s]",
                 settingKey,
@@ -1001,7 +996,7 @@ public class NodeDeprecationChecksTests extends ESTestCase {
             String.format(Locale.ROOT,
                 "setting [%s] cannot be greater than zero on non-frozen nodes",
                 cacheSizeSettingKey),
-            "https://www.elastic.co/guide/en/elasticsearch/reference/master/migrating-8.0.html#breaking_80_settings_changes",
+            "https://ela.st/es-deprecation-7-searchable-snapshot-shared-cache-setting",
             String.format(Locale.ROOT,
                 "setting [%s] cannot be greater than zero on non-frozen nodes, and is currently set to [%s]",
                 cacheSizeSettingKey,
@@ -1068,7 +1063,7 @@ public class NodeDeprecationChecksTests extends ESTestCase {
         final ClusterState clusterState = ClusterState.EMPTY_STATE;
         final DeprecationIssue expectedIssue = new DeprecationIssue(DeprecationIssue.Level.CRITICAL,
             "cannot set ssl properties without explicitly enabling or disabling ssl",
-            "https://www.elastic.co/guide/en/elasticsearch/reference/master/migrating-8.0.html#breaking_80_security_changes",
+            "https://ela.st/es-deprecation-7-explicit-ssl-required",
             String.format(Locale.ROOT,
                 "setting [%s] is unset but the following settings exist: [%s,%s]",
                 httpSslEnabledKey,
@@ -1092,7 +1087,7 @@ public class NodeDeprecationChecksTests extends ESTestCase {
         final ClusterState clusterState = ClusterState.EMPTY_STATE;
         DeprecationIssue expectedIssue = new DeprecationIssue(DeprecationIssue.Level.CRITICAL,
             "if ssl is enabled either keystore must be set, or key path and certificate path must be set",
-            "https://www.elastic.co/guide/en/elasticsearch/reference/master/migrating-8.0.html#breaking_80_security_changes",
+            "https://ela.st/es-deprecation-7-ssl-settings",
             "none of [xpack.security.transport.ssl.keystore.path], [xpack.security.transport.ssl.key], or [xpack.security.transport" +
                 ".ssl.certificate] are set. If [xpack.security.transport.ssl.enabled] is true either [xpack.security.transport.ssl" +
                 ".keystore.path] must be set, or [xpack.security.transport.ssl.key] and [xpack.security.transport.ssl.certificate] " +
@@ -1134,7 +1129,7 @@ public class NodeDeprecationChecksTests extends ESTestCase {
             .build();
         expectedIssue = new DeprecationIssue(DeprecationIssue.Level.CRITICAL,
             "if ssl is enabled either keystore must be set, or key path and certificate path must be set",
-            "https://www.elastic.co/guide/en/elasticsearch/reference/master/migrating-8.0.html#breaking_80_security_changes",
+            "https://ela.st/es-deprecation-7-ssl-settings",
             "all of [xpack.security.transport.ssl.keystore.path], [xpack.security.transport.ssl.key], and [xpack.security.transport.ssl" +
                 ".certificate] are set. Either [xpack.security.transport.ssl.keystore.path] must be set, or [xpack.security.transport.ssl" +
                 ".key] and [xpack.security.transport.ssl.certificate] must be set",
@@ -1153,7 +1148,7 @@ public class NodeDeprecationChecksTests extends ESTestCase {
             .build();
         expectedIssue = new DeprecationIssue(DeprecationIssue.Level.CRITICAL,
             "if ssl is enabled either keystore must be set, or key path and certificate path must be set",
-            "https://www.elastic.co/guide/en/elasticsearch/reference/master/migrating-8.0.html#breaking_80_security_changes",
+            "https://ela.st/es-deprecation-7-ssl-settings",
             "[xpack.security.transport.ssl.keystore.path] and [xpack.security.transport.ssl.key] are set. Either [xpack.security" +
                 ".transport.ssl.keystore.path] must be set, or [xpack.security.transport.ssl.key] and [xpack.security.transport.ssl" +
                 ".certificate] must be set",
@@ -1170,7 +1165,7 @@ public class NodeDeprecationChecksTests extends ESTestCase {
             .build();
         expectedIssue = new DeprecationIssue(DeprecationIssue.Level.CRITICAL,
             "if ssl is enabled either keystore must be set, or key path and certificate path must be set",
-            "https://www.elastic.co/guide/en/elasticsearch/reference/master/migrating-8.0.html#breaking_80_security_changes",
+            "https://ela.st/es-deprecation-7-ssl-settings",
             "none of [xpack.security.http.ssl.keystore.path], [xpack.security.http.ssl.key], or [xpack.security.http.ssl.certificate] are" +
                 " set. If [xpack.security.http.ssl.enabled] is true either [xpack.security.http.ssl.keystore.path] must be set, or [xpack" +
                 ".security.http.ssl.key] and [xpack.security.http.ssl.certificate] must be set",
@@ -1200,7 +1195,7 @@ public class NodeDeprecationChecksTests extends ESTestCase {
         assertNotNull(issue.getDetails());
         assertThat(issue.getDetails(), containsString("system property must be removed"));
         assertThat(issue.getUrl(),
-            equalTo("https://www.elastic.co/guide/en/elasticsearch/reference/master/migrating-8.0.html#breaking_80_transport_changes"));
+            equalTo("https://ela.st/es-deprecation-7-permit-handshake-from-incompatible-builds-setting"));
     }
 
     public void testCheckTransportClientProfilesFilterSetting() {
@@ -1214,8 +1209,7 @@ public class NodeDeprecationChecksTests extends ESTestCase {
         final Settings settings = b.build();
         final XPackLicenseState licenseState = new XPackLicenseState(Settings.EMPTY, () -> 0);
         DeprecationIssue issue = NodeDeprecationChecks.checkTransportClientProfilesFilterSetting(settings, null, null, licenseState);
-        final String expectedUrl =
-            "https://www.elastic.co/guide/en/elasticsearch/client/java-api/7.x/transport-client.html";
+        final String expectedUrl = "https://ela.st/es-deprecation-7-transport-profiles-settings";
         final String joinedNames = Arrays
             .stream(profileNames)
             .map(s -> "transport.profiles." + s + ".xpack.security.type")
@@ -1252,7 +1246,7 @@ public class NodeDeprecationChecksTests extends ESTestCase {
         final DeprecationIssue expectedIssue = new DeprecationIssue(DeprecationIssue.Level.CRITICAL,
             "cannot use properties related to delaying cluster state recovery after a majority of master nodes have joined because they " +
                 "have been deprecated and will be removed in the next major version",
-            "https://www.elastic.co/guide/en/elasticsearch/reference/7.x/modules-gateway.html",
+            "https://ela.st/es-deprecation-7-deferred-cluster-state-recovery",
             "cannot use properties [gateway.expected_nodes,gateway.expected_master_nodes,gateway.recover_after_nodes,gateway" +
                 ".recover_after_master_nodes] because they have been deprecated and will be removed in the next major version",
             false, null
@@ -1285,7 +1279,7 @@ public class NodeDeprecationChecksTests extends ESTestCase {
                 "thread_pool.search_throttled.max_queue_size,thread_pool.search_throttled.auto_queue_frame_size,thread_pool" +
                 ".search_throttled.target_response_time] because fixed_auto_queue_size threadpool type has been deprecated" +
                 " and will be removed in the next major version",
-            "https://www.elastic.co/guide/en/elasticsearch/reference/7.x/modules-threadpool.html",
+            "https://ela.st/es-deprecation-7-fixed-auto-queue-size-settings",
             "cannot use properties [thread_pool.search.min_queue_size,thread_pool.search.max_queue_size,thread_pool.search" +
                 ".auto_queue_frame_size,thread_pool.search.target_response_time,thread_pool.search_throttled.min_queue_size," +
                 "thread_pool.search_throttled.max_queue_size,thread_pool.search_throttled.auto_queue_frame_size,thread_pool" +
@@ -1314,7 +1308,7 @@ public class NodeDeprecationChecksTests extends ESTestCase {
             String.format(Locale.ROOT,
                 "setting [%s] is deprecated and will be removed in the next major version",
                 INDEX_ROUTING_REQUIRE_SETTING.getKey()),
-            "https://www.elastic.co/guide/en/elasticsearch/reference/7.14/data-tier-shard-filtering.html#data-tier-allocation-filters",
+            "https://ela.st/es-deprecation-7-tier-filtering-settings",
             String.format(Locale.ROOT,
                 "the setting [%s] is currently set to [%s], remove this setting",
                 INDEX_ROUTING_REQUIRE_SETTING.getKey(),
@@ -1325,7 +1319,7 @@ public class NodeDeprecationChecksTests extends ESTestCase {
             String.format(Locale.ROOT,
                 "setting [%s] is deprecated and will be removed in the next major version",
                 INDEX_ROUTING_INCLUDE_SETTING.getKey()),
-            "https://www.elastic.co/guide/en/elasticsearch/reference/7.14/data-tier-shard-filtering.html#data-tier-allocation-filters",
+            "https://ela.st/es-deprecation-7-tier-filtering-settings",
             String.format(Locale.ROOT,
                 "the setting [%s] is currently set to [%s], remove this setting",
                 INDEX_ROUTING_INCLUDE_SETTING.getKey(),
@@ -1336,7 +1330,7 @@ public class NodeDeprecationChecksTests extends ESTestCase {
             String.format(Locale.ROOT,
                 "setting [%s] is deprecated and will be removed in the next major version",
                 INDEX_ROUTING_EXCLUDE_SETTING.getKey()),
-            "https://www.elastic.co/guide/en/elasticsearch/reference/7.14/data-tier-shard-filtering.html#data-tier-allocation-filters",
+            "https://ela.st/es-deprecation-7-tier-filtering-settings",
             String.format(Locale.ROOT,
                 "the setting [%s] is currently set to [%s], remove this setting",
                 INDEX_ROUTING_EXCLUDE_SETTING.getKey(),
@@ -1403,28 +1397,28 @@ public class NodeDeprecationChecksTests extends ESTestCase {
     public void testCheckAcceptDefaultPasswordSetting() {
         String settingKey = "xpack.security.authc.accept_default_password";
         String settingValue = String.valueOf(randomBoolean());
-        String url = "https://www.elastic.co/guide/en/elasticsearch/reference/master/migrating-8.0.html#breaking_80_security_changes";
+        String url = "https://ela.st/es-deprecation-7-accept-default-password-setting";
         checkSimpleSetting(settingKey, settingValue, url, NodeDeprecationChecks::checkAcceptDefaultPasswordSetting);
     }
 
     public void testCheckAcceptRolesCacheMaxSizeSetting() {
         String settingKey = "xpack.security.authz.store.roles.index.cache.max_size";
         String settingValue = String.valueOf(randomIntBetween(1, 10000));
-        String url = "https://www.elastic.co/guide/en/elasticsearch/reference/master/migrating-8.0.html#breaking_80_security_changes";
+        String url = "https://ela.st/es-deprecation-7-roles-index-cache-settings";
         checkSimpleSetting(settingKey, settingValue, url, NodeDeprecationChecks::checkAcceptRolesCacheMaxSizeSetting);
     }
 
     public void testCheckRolesCacheTTLSizeSetting() {
         String settingKey = "xpack.security.authz.store.roles.index.cache.ttl";
         String settingValue = randomPositiveTimeValue();
-        String url = "https://www.elastic.co/guide/en/elasticsearch/reference/master/migrating-8.0.html#breaking_80_security_changes";
+        String url = "https://ela.st/es-deprecation-7-roles-index-cache-settings";
         checkSimpleSetting(settingKey, settingValue, url, NodeDeprecationChecks::checkRolesCacheTTLSizeSetting);
     }
 
     public void testCheckMaxLocalStorageNodesSetting() {
         String settingKey = NodeEnvironment.MAX_LOCAL_STORAGE_NODES_SETTING.getKey();
         String settingValue = Integer.toString(randomIntBetween(1, 100));
-        String url = "https://www.elastic.co/guide/en/elasticsearch/reference/7.14/modules-node.html#max-local-storage-nodes";
+        String url = "https://ela.st/es-deprecation-7-node-local-storage-setting";
         checkSimpleSetting(settingKey, settingValue, url, NodeDeprecationChecks::checkMaxLocalStorageNodesSetting);
     }
 
@@ -1449,7 +1443,7 @@ public class NodeDeprecationChecksTests extends ESTestCase {
         DeprecationIssue expectedIssue = new DeprecationIssue(DeprecationIssue.Level.WARNING,
             "if nameid_format is not explicitly set, the previous default of 'urn:oasis:names:tc:SAML:2.0:nameid-format:transient' is no " +
                 "longer used",
-            "https://www.elastic.co/guide/en/elasticsearch/reference/master/saml-guide.html",
+            "https://ela.st/es-deprecation-7-saml-nameid-format",
             "no value for [xpack.security.authc.realms.saml.saml1.nameid_format] set in realm [xpack.security.authc.realms.saml.saml1]",
             false, null
         );
@@ -1466,7 +1460,7 @@ public class NodeDeprecationChecksTests extends ESTestCase {
         expectedIssue = new DeprecationIssue(DeprecationIssue.Level.WARNING,
             "if nameid_format is not explicitly set, the previous default of 'urn:oasis:names:tc:SAML:2.0:nameid-format:transient' is no " +
                 "longer used",
-            "https://www.elastic.co/guide/en/elasticsearch/reference/master/saml-guide.html",
+            "https://ela.st/es-deprecation-7-saml-nameid-format",
             "no value for [xpack.security.authc.realms.saml.saml1.nameid_format] set in realm [xpack.security.authc.realms.saml.saml1]",
             false, null
         );
@@ -1482,7 +1476,7 @@ public class NodeDeprecationChecksTests extends ESTestCase {
         expectedIssue = new DeprecationIssue(DeprecationIssue.Level.WARNING,
             "if nameid_format is not explicitly set, the previous default of 'urn:oasis:names:tc:SAML:2.0:nameid-format:transient' is no " +
                 "longer used",
-            "https://www.elastic.co/guide/en/elasticsearch/reference/master/saml-guide.html",
+            "https://ela.st/es-deprecation-7-saml-nameid-format",
             "no value for [xpack.security.authc.realms.saml.saml1.nameid_format] set in realm [xpack.security.authc.realms.saml.saml1]," +
                 "no value for [xpack.security.authc.realms.saml.saml2.nameid_format] set in realm [xpack.security.authc.realms.saml.saml2]",
             false, null


### PR DESCRIPTION
This commit updates the deprecation info API to use shortened https://ela.st URLs that can be adjusted to point to
different documentation URLs without having to modify the source code.
Relates #42404