### PR TITLE
[Test] Replace size checks with size Matchers

### DIFF
--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/action/oidc/OpenIdConnectAuthenticateRequestTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/action/oidc/OpenIdConnectAuthenticateRequestTests.java
@@ -16,6 +16,7 @@ import java.io.IOException;
 
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
 
 public class OpenIdConnectAuthenticateRequestTests extends ESTestCase {
 
@@ -40,7 +41,7 @@ public class OpenIdConnectAuthenticateRequestTests extends ESTestCase {
         final OpenIdConnectAuthenticateRequest request = new OpenIdConnectAuthenticateRequest();
         final ActionRequestValidationException validation = request.validate();
         assertNotNull(validation);
-        assertThat(validation.validationErrors().size(), equalTo(3));
+        assertThat(validation.validationErrors(), hasSize(3));
         assertThat(validation.validationErrors().get(0), containsString("state parameter is missing"));
         assertThat(validation.validationErrors().get(1), containsString("nonce parameter is missing"));
         assertThat(validation.validationErrors().get(2), containsString("redirect_uri parameter is missing"));
@@ -50,7 +51,7 @@ public class OpenIdConnectAuthenticateRequestTests extends ESTestCase {
         request2.setState(randomAlphaOfLengthBetween(8, 12));
         final ActionRequestValidationException validation2 = request2.validate();
         assertNotNull(validation2);
-        assertThat(validation2.validationErrors().size(), equalTo(1));
+        assertThat(validation2.validationErrors(), hasSize(1));
         assertThat(validation2.validationErrors().get(0), containsString("nonce parameter is missing"));
     }
 }

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/action/oidc/OpenIdConnectPrepareAuthenticationRequestTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/action/oidc/OpenIdConnectPrepareAuthenticationRequestTests.java
@@ -15,6 +15,7 @@ import java.io.IOException;
 
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
 
 public class OpenIdConnectPrepareAuthenticationRequestTests extends ESTestCase {
 
@@ -59,7 +60,7 @@ public class OpenIdConnectPrepareAuthenticationRequestTests extends ESTestCase {
         final OpenIdConnectPrepareAuthenticationRequest request = new OpenIdConnectPrepareAuthenticationRequest();
         final ActionRequestValidationException validation = request.validate();
         assertNotNull(validation);
-        assertThat(validation.validationErrors().size(), equalTo(1));
+        assertThat(validation.validationErrors(), hasSize(1));
         assertThat(validation.validationErrors().get(0), containsString("one of [realm, issuer] must be provided"));
 
         final OpenIdConnectPrepareAuthenticationRequest request2 = new OpenIdConnectPrepareAuthenticationRequest();
@@ -67,7 +68,7 @@ public class OpenIdConnectPrepareAuthenticationRequestTests extends ESTestCase {
         request2.setIssuer("https://op.company.org/");
         final ActionRequestValidationException validation2 = request2.validate();
         assertNotNull(validation2);
-        assertThat(validation2.validationErrors().size(), equalTo(1));
+        assertThat(validation2.validationErrors(), hasSize(1));
         assertThat(validation2.validationErrors().get(0),
             containsString("only one of [realm, issuer] can be provided in the same request"));
     }

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/action/oidc/TransportOpenIdConnectLogoutActionTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/action/oidc/TransportOpenIdConnectLogoutActionTests.java
@@ -69,7 +69,7 @@ import java.util.function.Consumer;
 import static org.elasticsearch.test.ActionListenerUtils.anyActionListener;
 import static org.elasticsearch.xpack.security.authc.TokenServiceTests.mockGetTokenFromId;
 import static org.hamcrest.Matchers.containsString;
-import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.startsWith;
@@ -230,14 +230,14 @@ public class TransportOpenIdConnectLogoutActionTests extends OpenIdConnectTestCa
         assertNotNull(response);
         assertThat(response.getEndSessionUrl(), notNullValue());
         // One index request to create the token
-        assertThat(indexRequests.size(), equalTo(1));
+        assertThat(indexRequests, hasSize(1));
         final IndexRequest indexRequest = indexRequests.get(0);
         assertThat(indexRequest, notNullValue());
         assertThat(indexRequest.id(), startsWith("token"));
         // One bulk request (containing one update request) to invalidate the token
-        assertThat(bulkRequests.size(), equalTo(1));
+        assertThat(bulkRequests, hasSize(1));
         final BulkRequest bulkRequest = bulkRequests.get(0);
-        assertThat(bulkRequest.requests().size(), equalTo(1));
+        assertThat(bulkRequest.requests(), hasSize(1));
         assertThat(bulkRequest.requests().get(0), instanceOf(UpdateRequest.class));
         assertThat(bulkRequest.requests().get(0).id(), startsWith("token_"));
         assertThat(bulkRequest.requests().get(0).toString(), containsString("\"access_token\":{\"invalidated\":true"));

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/action/rolemapping/TransportPutRoleMappingActionTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/action/rolemapping/TransportPutRoleMappingActionTests.java
@@ -26,6 +26,7 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
 
+import static org.hamcrest.Matchers.aMapWithSize;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
@@ -77,7 +78,7 @@ public class TransportPutRoleMappingActionTests extends ESTestCase {
         assertThat(mapping.getName(), equalTo("anarchy"));
         assertThat(mapping.getRoles(), iterableWithSize(1));
         assertThat(mapping.getRoles(), contains("superuser"));
-        assertThat(mapping.getMetadata().size(), equalTo(1));
+        assertThat(mapping.getMetadata(), aMapWithSize(1));
         assertThat(mapping.getMetadata().get("dumb"), equalTo(true));
     }
 

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/action/saml/TransportSamlInvalidateSessionActionTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/action/saml/TransportSamlInvalidateSessionActionTests.java
@@ -97,6 +97,7 @@ import java.util.stream.Stream;
 import static org.elasticsearch.xpack.core.security.authc.RealmSettings.getFullSettingKey;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.iterableWithSize;
 import static org.hamcrest.Matchers.notNullValue;
@@ -271,7 +272,7 @@ public class TransportSamlInvalidateSessionActionTests extends SamlTestCase {
         storeToken(userTokenId2, refreshToken2, logoutRequest.getNameId(), logoutRequest.getSession());
         storeToken(new SamlNameId(NameID.PERSISTENT, randomAlphaOfLength(16), null, null, null), logoutRequest.getSession());
 
-        assertThat(indexRequests.size(), equalTo(4));
+        assertThat(indexRequests, hasSize(4));
 
         final AtomicInteger counter = new AtomicInteger();
         final SearchHit[] searchHits = indexRequests.stream()
@@ -302,7 +303,7 @@ public class TransportSamlInvalidateSessionActionTests extends SamlTestCase {
 
         // 1 to find the tokens for the realm
         // 2 more to find the UserTokens from the 2 matching refresh tokens
-        assertThat(searchRequests.size(), equalTo(3));
+        assertThat(searchRequests, hasSize(3));
 
         assertThat(searchRequests.get(0).source().query(), instanceOf(BoolQueryBuilder.class));
         final List<QueryBuilder> filter0 = ((BoolQueryBuilder) searchRequests.get(0).source().query()).filter();
@@ -335,7 +336,7 @@ public class TransportSamlInvalidateSessionActionTests extends SamlTestCase {
         assertThat(tokenToInvalidate1.getAuthentication(), equalTo(new Authentication(new User("bob"),
             new RealmRef("native", NativeRealmSettings.TYPE, "node01"), null)));
 
-        assertThat(bulkRequests.size(), equalTo(4)); // 4 updates (refresh-token + access-token)
+        assertThat(bulkRequests, hasSize(4)); // 4 updates (refresh-token + access-token)
         // Invalidate refresh token 1
         assertThat(bulkRequests.get(0).requests().get(0), instanceOf(UpdateRequest.class));
         assertThat(bulkRequests.get(0).requests().get(0).id(), equalTo("token_" + TokenService.hashTokenString(userTokenId1)));

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/action/saml/TransportSamlLogoutActionTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/action/saml/TransportSamlLogoutActionTests.java
@@ -80,7 +80,7 @@ import java.util.function.Consumer;
 import static org.elasticsearch.xpack.core.security.authc.RealmSettings.getFullSettingKey;
 import static org.elasticsearch.xpack.security.authc.TokenServiceTests.mockGetTokenFromId;
 import static org.hamcrest.Matchers.containsString;
-import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.startsWith;
@@ -270,10 +270,10 @@ public class TransportSamlLogoutActionTests extends SamlTestCase {
         assertThat(indexRequest1, notNullValue());
         assertThat(indexRequest1.id(), startsWith("token"));
 
-        assertThat(bulkRequests.size(), equalTo(1));
+        assertThat(bulkRequests, hasSize(1));
 
         final BulkRequest bulkRequest = bulkRequests.get(0);
-        assertThat(bulkRequest.requests().size(), equalTo(1));
+        assertThat(bulkRequest.requests(), hasSize(1));
         assertThat(bulkRequest.requests().get(0), instanceOf(UpdateRequest.class));
         assertThat(bulkRequest.requests().get(0).id(), startsWith("token_"));
         assertThat(bulkRequest.requests().get(0).toString(), containsString("\"access_token\":{\"invalidated\":true"));

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/ldap/support/LdapMetadataResolverTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/ldap/support/LdapMetadataResolverTests.java
@@ -24,6 +24,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
+import static org.hamcrest.Matchers.aMapWithSize;
 import static org.hamcrest.Matchers.arrayContaining;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.equalTo;
@@ -59,7 +60,7 @@ public class LdapMetadataResolverTests extends ESTestCase {
                 new Attribute("memberOf", "cn=staff,ou=groups,dc=example,dc=com", "cn=admin,ou=groups,dc=example,dc=com")
         );
         final Map<String, Object> map = resolve(attributes);
-        assertThat(map.size(), equalTo(2));
+        assertThat(map, aMapWithSize(2));
         assertThat(map.get("cn"), equalTo("Clint Barton"));
         assertThat(map.get("uid"), equalTo("hawkeye"));
     }
@@ -71,7 +72,7 @@ public class LdapMetadataResolverTests extends ESTestCase {
                 new Attribute("uid", "hawkeye")
         );
         final Map<String, Object> map = resolve(attributes);
-        assertThat(map.size(), equalTo(2));
+        assertThat(map, aMapWithSize(2));
         assertThat(map.get("cn"), instanceOf(List.class));
         assertThat((List<?>) map.get("cn"), contains("Clint Barton", "hawkeye"));
         assertThat(map.get("uid"), equalTo("hawkeye"));
@@ -81,7 +82,7 @@ public class LdapMetadataResolverTests extends ESTestCase {
         resolver = new LdapMetadataResolver(Arrays.asList("cn", "uid"), true);
         final Collection<Attribute> attributes = Collections.singletonList(new Attribute("uid", "hawkeye"));
         final Map<String, Object> map = resolve(attributes);
-        assertThat(map.size(), equalTo(1));
+        assertThat(map, aMapWithSize(1));
         assertThat(map.get("cn"), nullValue());
         assertThat(map.get("uid"), equalTo("hawkeye"));
     }

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/oidc/OpenIdConnectRealmTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/oidc/OpenIdConnectRealmTests.java
@@ -49,6 +49,8 @@ import static java.time.Instant.now;
 import static org.elasticsearch.test.ActionListenerUtils.anyActionListener;
 import static org.elasticsearch.xpack.core.security.authc.RealmSettings.getFullSettingKey;
 import static org.elasticsearch.xpack.security.authc.oidc.OpenIdConnectRealm.CONTEXT_TOKEN_DATA;
+import static org.hamcrest.Matchers.aMapWithSize;
+import static org.hamcrest.Matchers.anEmptyMap;
 import static org.hamcrest.Matchers.arrayContainingInAnyOrder;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsString;
@@ -90,7 +92,7 @@ public class OpenIdConnectRealmTests extends OpenIdConnectTestCase {
         assertThat(result.getUser().fullName(), equalTo("Clinton Barton"));
         assertThat(result.getUser().roles(), arrayContainingInAnyOrder("kibana_user", "role1"));
         if (notPopulateMetadata) {
-            assertThat(result.getUser().metadata().size(), equalTo(0));
+            assertThat(result.getUser().metadata(), anEmptyMap());
         } else {
             assertThat(result.getUser().metadata().get("oidc(iss)"), equalTo("https://op.company.org"));
             assertThat(result.getUser().metadata().get("oidc(name)"), equalTo("Clinton Barton"));
@@ -318,7 +320,7 @@ public class OpenIdConnectRealmTests extends OpenIdConnectTestCase {
         final String endSessionUrl = logoutResponse.getEndSessionUrl();
         final Map<String, String> parameters = new HashMap<>();
         RestUtils.decodeQueryString(endSessionUrl, endSessionUrl.indexOf("?") + 1, parameters);
-        assertThat(parameters.size(), equalTo(3));
+        assertThat(parameters, aMapWithSize(3));
         assertThat(parameters, hasKey("id_token_hint"));
         assertThat(parameters, hasKey("post_logout_redirect_uri"));
         assertThat(parameters, hasKey("state"));
@@ -337,7 +339,7 @@ public class OpenIdConnectRealmTests extends OpenIdConnectTestCase {
         final String endSessionUrl = logoutResponse.getEndSessionUrl();
         final Map<String, String> parameters = new HashMap<>();
         RestUtils.decodeQueryString(endSessionUrl, endSessionUrl.indexOf("?") + 1, parameters);
-        assertThat(parameters.size(), equalTo(4));
+        assertThat(parameters, aMapWithSize(4));
         assertThat(parameters, hasKey("parameter"));
         assertThat(parameters, hasKey("post_logout_redirect_uri"));
         assertThat(parameters, hasKey("state"));

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/saml/SamlAuthnRequestBuilderTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/saml/SamlAuthnRequestBuilderTests.java
@@ -20,6 +20,7 @@ import org.opensaml.saml.saml2.metadata.EntityDescriptor;
 
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 import static org.opensaml.saml.saml2.core.AuthnContext.KERBEROS_AUTHN_CTX;
@@ -115,7 +116,7 @@ public class SamlAuthnRequestBuilderTests extends SamlTestCase {
         assertThat(request.getNameIDPolicy().getAllowCreate(), equalTo(Boolean.FALSE));
 
         assertThat(request.isForceAuthn(), equalTo(Boolean.FALSE));
-        assertThat(request.getRequestedAuthnContext().getAuthnContextClassRefs().size(), equalTo(1));
+        assertThat(request.getRequestedAuthnContext().getAuthnContextClassRefs(), hasSize(1));
         assertThat(request.getRequestedAuthnContext().getAuthnContextClassRefs().get(0).getAuthnContextClassRef(),
             equalTo(KERBEROS_AUTHN_CTX));
     }
@@ -144,7 +145,7 @@ public class SamlAuthnRequestBuilderTests extends SamlTestCase {
         assertThat(request.getNameIDPolicy().getAllowCreate(), equalTo(Boolean.FALSE));
 
         assertThat(request.isForceAuthn(), equalTo(Boolean.FALSE));
-        assertThat(request.getRequestedAuthnContext().getAuthnContextClassRefs().size(), equalTo(3));
+        assertThat(request.getRequestedAuthnContext().getAuthnContextClassRefs(), hasSize(3));
         assertThat(request.getRequestedAuthnContext().getAuthnContextClassRefs().get(0).getAuthnContextClassRef(),
             equalTo(KERBEROS_AUTHN_CTX));
         assertThat(request.getRequestedAuthnContext().getAuthnContextClassRefs().get(1).getAuthnContextClassRef(),

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/saml/SamlRealmTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/saml/SamlRealmTests.java
@@ -81,9 +81,11 @@ import static org.hamcrest.Matchers.arrayContainingInAnyOrder;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.iterableWithSize;
 import static org.hamcrest.Matchers.notNullValue;
@@ -690,15 +692,15 @@ public class SamlRealmTests extends SamlTestCase {
         when(realms.realm(REALM_NAME)).thenReturn(realm);
         when(realms.stream()).thenAnswer(i -> Stream.of(realm));
         final String emptyRealmName = randomBoolean() ? null : "";
-        assertThat(SamlRealm.findSamlRealms(realms, emptyRealmName, acsUrl).size(), equalTo(1));
+        assertThat(SamlRealm.findSamlRealms(realms, emptyRealmName, acsUrl), hasSize(1));
         assertThat(SamlRealm.findSamlRealms(realms, emptyRealmName, acsUrl).get(0), equalTo(realm));
-        assertThat(SamlRealm.findSamlRealms(realms, "my-saml", acsUrl).size(), equalTo(1));
+        assertThat(SamlRealm.findSamlRealms(realms, "my-saml", acsUrl), hasSize(1));
         assertThat(SamlRealm.findSamlRealms(realms, "my-saml", acsUrl).get(0), equalTo(realm));
-        assertThat(SamlRealm.findSamlRealms(realms, "my-saml", null).size(), equalTo(1));
+        assertThat(SamlRealm.findSamlRealms(realms, "my-saml", null), hasSize(1));
         assertThat(SamlRealm.findSamlRealms(realms, "my-saml", null).get(0), equalTo(realm));
-        assertThat(SamlRealm.findSamlRealms(realms, "my-saml", "https://idp.test:443/saml/login").size(), equalTo(0));
-        assertThat(SamlRealm.findSamlRealms(realms, "incorrect", acsUrl).size(), equalTo(0));
-        assertThat(SamlRealm.findSamlRealms(realms, "incorrect", "https://idp.test:443/saml/login").size(), equalTo(0));
+        assertThat(SamlRealm.findSamlRealms(realms, "my-saml", "https://idp.test:443/saml/login"), empty());
+        assertThat(SamlRealm.findSamlRealms(realms, "incorrect", acsUrl), empty());
+        assertThat(SamlRealm.findSamlRealms(realms, "incorrect", "https://idp.test:443/saml/login"), empty());
     }
 
     private EntityDescriptor mockIdp() {

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/service/FileServiceAccountTokenStoreTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/service/FileServiceAccountTokenStoreTests.java
@@ -44,6 +44,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
@@ -107,7 +108,7 @@ public class FileServiceAccountTokenStoreTests extends ESTestCase {
         final Map<String, char[]> tokenHashes =
             FileServiceAccountTokenStore.parseFile(getDataPath("service_tokens").getParent().resolve("does-not-exist"), logger);
         assertThat(tokenHashes.isEmpty(), is(true));
-        assertThat(events.size(), equalTo(2));
+        assertThat(events, hasSize(2));
         assertThat(events.get(1), containsString("does not exist"));
     }
 
@@ -213,7 +214,7 @@ public class FileServiceAccountTokenStoreTests extends ESTestCase {
 
         final ServiceAccountId accountId = new ServiceAccountId("elastic", "fleet-server");
         final List<TokenInfo> tokenInfos = store.findTokensFor(accountId);
-        assertThat(tokenInfos.size(), equalTo(5));
+        assertThat(tokenInfos, hasSize(5));
         assertThat(tokenInfos.stream().map(TokenInfo::getName).collect(Collectors.toSet()),
             equalTo(org.elasticsearch.core.Set.of("pbkdf2", "bcrypt10", "pbkdf2_stretch", "pbkdf2_50000", "bcrypt")));
         assertThat(tokenInfos.stream().map(TokenInfo::getSource).collect(Collectors.toSet()),

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/service/IndexServiceAccountTokenStoreTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/service/IndexServiceAccountTokenStoreTests.java
@@ -85,6 +85,7 @@ import static org.elasticsearch.index.seqno.SequenceNumbers.UNASSIGNED_SEQ_NO;
 import static org.elasticsearch.xpack.security.authc.service.IndexServiceAccountTokenStore.SERVICE_ACCOUNT_TOKEN_DOC_TYPE;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.mockito.Matchers.any;
@@ -191,7 +192,7 @@ public class IndexServiceAccountTokenStoreTests extends ESTestCase {
         final PlainActionFuture<CreateServiceAccountTokenResponse> future1 = new PlainActionFuture<>();
         store.createToken(authentication, request, future1);
         final BulkRequest bulkRequest = (BulkRequest) requestHolder.get();
-        assertThat(bulkRequest.requests().size(), equalTo(1));
+        assertThat(bulkRequest.requests(), hasSize(1));
         final IndexRequest indexRequest = (IndexRequest) bulkRequest.requests().get(0);
         final Map<String, Object> sourceMap = indexRequest.sourceAsMap();
         assertThat(sourceMap.get("username"), equalTo("elastic/fleet-server"));

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/IndicesAndAliasesResolverTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/IndicesAndAliasesResolverTests.java
@@ -103,6 +103,7 @@ import static org.hamcrest.Matchers.emptyIterable;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.hasItems;
+import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.oneOf;
 import static org.mockito.Matchers.any;
@@ -303,7 +304,7 @@ public class IndicesAndAliasesResolverTests extends ESTestCase {
         List<String> indices = resolveIndices(request, buildAuthorizedIndices(userDashIndices, SearchAction.NAME))
                 .getLocal();
         String[] expectedIndices = new String[]{"-index10", "-index20", "+index30"};
-        assertThat(indices.size(), equalTo(expectedIndices.length));
+        assertThat(indices, hasSize(expectedIndices.length));
         assertThat(indices, hasItems(expectedIndices));
     }
 
@@ -356,7 +357,7 @@ public class IndicesAndAliasesResolverTests extends ESTestCase {
         List<String> indices =
                 resolveIndices(request, buildAuthorizedIndices(userDashIndices, SearchAction.NAME)).getLocal();
         String[] expectedIndices = new String[]{"-index10", "-index20"};
-        assertThat(indices.size(), equalTo(expectedIndices.length));
+        assertThat(indices, hasSize(expectedIndices.length));
         assertThat(request.indices().length, equalTo(expectedIndices.length));
         assertThat(indices, hasItems(expectedIndices));
         assertThat(request.indices(), arrayContainingInAnyOrder(expectedIndices));
@@ -372,7 +373,7 @@ public class IndicesAndAliasesResolverTests extends ESTestCase {
         List<String> indices =
                 resolveIndices(request, buildAuthorizedIndices(userDashIndices, SearchAction.NAME)).getLocal();
         String[] expectedIndices = new String[]{"-index10", "-index11", "-index21"};
-        assertThat(indices.size(), equalTo(expectedIndices.length));
+        assertThat(indices, hasSize(expectedIndices.length));
         assertThat(request.indices().length, equalTo(expectedIndices.length));
         assertThat(indices, hasItems(expectedIndices));
         assertThat(request.indices(), arrayContainingInAnyOrder(expectedIndices));
@@ -383,7 +384,7 @@ public class IndicesAndAliasesResolverTests extends ESTestCase {
         List<String> indices =
                 resolveIndices(request, buildAuthorizedIndices(userDashIndices, SearchAction.NAME)).getLocal();
         String[] expectedIndices = new String[]{"-index10", "-index21", "-does_not_exist"};
-        assertThat(indices.size(), equalTo(expectedIndices.length));
+        assertThat(indices, hasSize(expectedIndices.length));
         assertThat(request.indices().length, equalTo(expectedIndices.length));
         assertThat(indices, hasItems(expectedIndices));
         assertThat(request.indices(), arrayContainingInAnyOrder(expectedIndices));
@@ -395,7 +396,7 @@ public class IndicesAndAliasesResolverTests extends ESTestCase {
         List<String> indices =
                 resolveIndices(request, buildAuthorizedIndices(userDashIndices, SearchAction.NAME)).getLocal();
         String[] expectedIndices = new String[]{"-index1*", "--index11"};
-        assertThat(indices.size(), equalTo(expectedIndices.length));
+        assertThat(indices, hasSize(expectedIndices.length));
         assertThat(request.indices().length, equalTo(expectedIndices.length));
         assertThat(indices, hasItems(expectedIndices));
         assertThat(request.indices(), arrayContainingInAnyOrder(expectedIndices));
@@ -407,7 +408,7 @@ public class IndicesAndAliasesResolverTests extends ESTestCase {
         List<String> indices =
                 resolveIndices(request, buildAuthorizedIndices(userDashIndices, SearchAction.NAME)).getLocal();
         String[] expectedIndices = new String[]{"-index10", "-index11", "--index11", "-index20"};
-        assertThat(indices.size(), equalTo(expectedIndices.length));
+        assertThat(indices, hasSize(expectedIndices.length));
         assertThat(request.indices().length, equalTo(expectedIndices.length));
         assertThat(indices, hasItems(expectedIndices));
         assertThat(request.indices(), arrayContainingInAnyOrder(expectedIndices));
@@ -425,7 +426,7 @@ public class IndicesAndAliasesResolverTests extends ESTestCase {
         request.indicesOptions(IndicesOptions.fromOptions(false, randomBoolean(), randomBoolean(), randomBoolean()));
         List<String> indices = resolveIndices(request, buildAuthorizedIndices(userDashIndices, SearchAction.NAME)).getLocal();
         String[] expectedIndices = new String[]{"-does_not_exist"};
-        assertThat(indices.size(), equalTo(expectedIndices.length));
+        assertThat(indices, hasSize(expectedIndices.length));
         assertThat(request.indices().length, equalTo(expectedIndices.length));
         assertThat(indices, hasItems(expectedIndices));
         assertThat(request.indices(), arrayContainingInAnyOrder(expectedIndices));
@@ -436,7 +437,7 @@ public class IndicesAndAliasesResolverTests extends ESTestCase {
         request.indicesOptions(IndicesOptions.fromOptions(randomBoolean(), randomBoolean(), true, true));
         List<String> indices = resolveIndices(request, buildAuthorizedIndices(user, SearchAction.NAME)).getLocal();
         String[] replacedIndices = new String[]{"bar", "bar-closed", "foofoobar", "foobarfoo", "foofoo", "foofoo-closed"};
-        assertThat(indices.size(), equalTo(replacedIndices.length));
+        assertThat(indices, hasSize(replacedIndices.length));
         assertThat(request.indices().length, equalTo(replacedIndices.length));
         assertThat(indices, hasItems(replacedIndices));
         assertThat(request.indices(), arrayContainingInAnyOrder(replacedIndices));
@@ -456,7 +457,7 @@ public class IndicesAndAliasesResolverTests extends ESTestCase {
         request.indicesOptions(IndicesOptions.fromOptions(randomBoolean(), randomBoolean(), true, true));
         List<String> indices = resolveIndices(request, buildAuthorizedIndices(user, SearchAction.NAME)).getLocal();
         String[] replacedIndices = new String[]{"bar", "bar-closed", "foofoobar", "foobarfoo", "foofoo", "foofoo-closed"};
-        assertThat(indices.size(), equalTo(replacedIndices.length));
+        assertThat(indices, hasSize(replacedIndices.length));
         assertThat(request.indices().length, equalTo(replacedIndices.length));
         assertThat(indices, hasItems(replacedIndices));
         assertThat(request.indices(), arrayContainingInAnyOrder(replacedIndices));
@@ -467,7 +468,7 @@ public class IndicesAndAliasesResolverTests extends ESTestCase {
         request.indicesOptions(IndicesOptions.fromOptions(randomBoolean(), randomBoolean(), true, false));
         List<String> indices = resolveIndices(request, buildAuthorizedIndices(user, SearchAction.NAME)).getLocal();
         String[] replacedIndices = new String[]{"bar", "foofoobar", "foobarfoo", "foofoo"};
-        assertThat(indices.size(), equalTo(replacedIndices.length));
+        assertThat(indices, hasSize(replacedIndices.length));
         assertThat(request.indices().length, equalTo(replacedIndices.length));
         assertThat(indices, hasItems(replacedIndices));
         assertThat(request.indices(), arrayContainingInAnyOrder(replacedIndices));
@@ -478,7 +479,7 @@ public class IndicesAndAliasesResolverTests extends ESTestCase {
         request.indicesOptions(IndicesOptions.fromOptions(false, randomBoolean(), true, true));
         List<String> indices = resolveIndices(request, buildAuthorizedIndices(user, SearchAction.NAME)).getLocal();
         String[] replacedIndices = new String[]{"barbaz", "foofoobar", "foofoo", "foofoo-closed"};
-        assertThat(indices.size(), equalTo(replacedIndices.length));
+        assertThat(indices, hasSize(replacedIndices.length));
         assertThat(request.indices().length, equalTo(replacedIndices.length));
         assertThat(indices, hasItems(replacedIndices));
         assertThat(request.indices(), arrayContainingInAnyOrder(replacedIndices));
@@ -489,7 +490,7 @@ public class IndicesAndAliasesResolverTests extends ESTestCase {
         request.indicesOptions(IndicesOptions.fromOptions(true, randomBoolean(), true, true));
         List<String> indices = resolveIndices(request, buildAuthorizedIndices(user, SearchAction.NAME)).getLocal();
         String[] replacedIndices = new String[]{"foofoobar", "foofoo", "foofoo-closed"};
-        assertThat(indices.size(), equalTo(replacedIndices.length));
+        assertThat(indices, hasSize(replacedIndices.length));
         assertThat(request.indices().length, equalTo(replacedIndices.length));
         assertThat(indices, hasItems(replacedIndices));
         assertThat(request.indices(), arrayContainingInAnyOrder(replacedIndices));
@@ -500,7 +501,7 @@ public class IndicesAndAliasesResolverTests extends ESTestCase {
         request.indicesOptions(IndicesOptions.fromOptions(false, randomBoolean(), true, false));
         List<String> indices = resolveIndices(request, buildAuthorizedIndices(user, SearchAction.NAME)).getLocal();
         String[] replacedIndices = new String[]{"barbaz", "foofoobar", "foofoo"};
-        assertThat(indices.size(), equalTo(replacedIndices.length));
+        assertThat(indices, hasSize(replacedIndices.length));
         assertThat(request.indices().length, equalTo(replacedIndices.length));
         assertThat(indices, hasItems(replacedIndices));
         assertThat(request.indices(), arrayContainingInAnyOrder(replacedIndices));
@@ -511,7 +512,7 @@ public class IndicesAndAliasesResolverTests extends ESTestCase {
         request.indicesOptions(IndicesOptions.fromOptions(true, randomBoolean(), true, false));
         List<String> indices = resolveIndices(request, buildAuthorizedIndices(user, SearchAction.NAME)).getLocal();
         String[] replacedIndices = new String[]{"foofoobar", "foofoo"};
-        assertThat(indices.size(), equalTo(replacedIndices.length));
+        assertThat(indices, hasSize(replacedIndices.length));
         assertThat(request.indices().length, equalTo(replacedIndices.length));
         assertThat(indices, hasItems(replacedIndices));
         assertThat(request.indices(), arrayContainingInAnyOrder(replacedIndices));
@@ -522,7 +523,7 @@ public class IndicesAndAliasesResolverTests extends ESTestCase {
         request.indicesOptions(IndicesOptions.fromOptions(randomBoolean(), randomBoolean(), true, false));
         List<String> indices = resolveIndices(request, buildAuthorizedIndices(user, SearchAction.NAME)).getLocal();
         String[] replacedIndices = new String[]{"bar", "foobarfoo"};
-        assertThat(indices.size(), equalTo(replacedIndices.length));
+        assertThat(indices, hasSize(replacedIndices.length));
         assertThat(request.indices().length, equalTo(replacedIndices.length));
         assertThat(indices, hasItems(replacedIndices));
         assertThat(request.indices(), arrayContainingInAnyOrder(replacedIndices));
@@ -533,7 +534,7 @@ public class IndicesAndAliasesResolverTests extends ESTestCase {
         request.indicesOptions(IndicesOptions.fromOptions(randomBoolean(), randomBoolean(), true, true));
         List<String> indices = resolveIndices(request, buildAuthorizedIndices(user, SearchAction.NAME)).getLocal();
         String[] replacedIndices = new String[]{"bar", "foobarfoo", "bar-closed"};
-        assertThat(indices.size(), equalTo(replacedIndices.length));
+        assertThat(indices, hasSize(replacedIndices.length));
         assertThat(request.indices().length, equalTo(replacedIndices.length));
         assertThat(indices, hasItems(replacedIndices));
         assertThat(request.indices(), arrayContainingInAnyOrder(replacedIndices));
@@ -553,7 +554,7 @@ public class IndicesAndAliasesResolverTests extends ESTestCase {
         request.indicesOptions(IndicesOptions.fromOptions(true, true, true, false));
         List<String> indices = resolveIndices(request, buildAuthorizedIndices(user, SearchAction.NAME)).getLocal();
         String[] replacedIndices = new String[]{"bar", "foobarfoo"};
-        assertThat(indices.size(), equalTo(replacedIndices.length));
+        assertThat(indices, hasSize(replacedIndices.length));
         assertThat(request.indices().length, equalTo(replacedIndices.length));
         assertThat(indices, hasItems(replacedIndices));
         assertThat(request.indices(), arrayContainingInAnyOrder(replacedIndices));
@@ -573,7 +574,7 @@ public class IndicesAndAliasesResolverTests extends ESTestCase {
         request.indicesOptions(IndicesOptions.fromOptions(true, randomBoolean(), true, true));
         List<String> indices = resolveIndices(request, buildAuthorizedIndices(user, SearchAction.NAME)).getLocal();
         String[] replacedIndices = new String[]{"bar", "bar-closed", "foobarfoo"};
-        assertThat(indices.size(), equalTo(replacedIndices.length));
+        assertThat(indices, hasSize(replacedIndices.length));
         assertThat(indices, hasItems(replacedIndices));
         assertThat(request.indices(), arrayContainingInAnyOrder(replacedIndices));
     }
@@ -597,7 +598,7 @@ public class IndicesAndAliasesResolverTests extends ESTestCase {
         request.indicesOptions(IndicesOptions.fromOptions(false, randomBoolean(), randomBoolean(), randomBoolean()));
         List<String> indices = resolveIndices(request, buildAuthorizedIndices(user, SearchAction.NAME)).getLocal();
         String[] replacedIndices = new String[]{"missing", "bar", "barbaz"};
-        assertThat(indices.size(), equalTo(replacedIndices.length));
+        assertThat(indices, hasSize(replacedIndices.length));
         assertThat(request.indices().length, equalTo(replacedIndices.length));
         assertThat(indices, hasItems(replacedIndices));
         assertThat(request.indices(), arrayContainingInAnyOrder(replacedIndices));
@@ -608,7 +609,7 @@ public class IndicesAndAliasesResolverTests extends ESTestCase {
         request.indicesOptions(IndicesOptions.fromOptions(true, randomBoolean(), randomBoolean(), randomBoolean()));
         List<String> indices = resolveIndices(request, buildAuthorizedIndices(user, SearchAction.NAME)).getLocal();
         String[] replacedIndices = new String[]{"bar"};
-        assertThat(indices.size(), equalTo(replacedIndices.length));
+        assertThat(indices, hasSize(replacedIndices.length));
         assertThat(request.indices().length, equalTo(replacedIndices.length));
         assertThat(indices, hasItems(replacedIndices));
         assertThat(request.indices(), arrayContainingInAnyOrder(replacedIndices));
@@ -634,7 +635,7 @@ public class IndicesAndAliasesResolverTests extends ESTestCase {
         request.indicesOptions(IndicesOptions.fromOptions(false, true, true, false));
         List<String> indices = resolveIndices(request, buildAuthorizedIndices(user, SearchAction.NAME)).getLocal();
         String[] expectedIndices = new String[]{"bar", "missing"};
-        assertThat(indices.size(), equalTo(expectedIndices.length));
+        assertThat(indices, hasSize(expectedIndices.length));
         assertThat(request.indices().length, equalTo(expectedIndices.length));
         assertThat(indices, hasItems(expectedIndices));
         assertThat(request.indices(), equalTo(expectedIndices));
@@ -645,7 +646,7 @@ public class IndicesAndAliasesResolverTests extends ESTestCase {
         request.indicesOptions(IndicesOptions.fromOptions(true, randomBoolean(), true, false));
         List<String> indices = resolveIndices(request, buildAuthorizedIndices(user, SearchAction.NAME)).getLocal();
         String[] expectedIndices = new String[]{"bar"};
-        assertThat(indices.size(), equalTo(expectedIndices.length));
+        assertThat(indices, hasSize(expectedIndices.length));
         assertThat(request.indices().length, equalTo(expectedIndices.length));
         assertThat(indices, hasItems(expectedIndices));
         assertThat(request.indices(), equalTo(expectedIndices));
@@ -742,7 +743,7 @@ public class IndicesAndAliasesResolverTests extends ESTestCase {
                 resolveIndices(request, buildAuthorizedIndices(user, IndicesAliasesAction.NAME)).getLocal();
         //the union of all indices and aliases gets returned, missing is not an existing index/alias but that doesn't make any difference
         String[] expectedIndices = new String[]{"alias1", "alias2", "foo", "foofoo", "missing"};
-        assertThat(indices.size(), equalTo(expectedIndices.length));
+        assertThat(indices, hasSize(expectedIndices.length));
         assertThat(indices, hasItems(expectedIndices));
         assertThat(request.getAliasActions().get(0).indices(), arrayContainingInAnyOrder("foo", "foofoo"));
         assertThat(request.getAliasActions().get(0).aliases(), arrayContainingInAnyOrder("alias1"));
@@ -758,7 +759,7 @@ public class IndicesAndAliasesResolverTests extends ESTestCase {
                 resolveIndices(request, buildAuthorizedIndices(user, IndicesAliasesAction.NAME)).getLocal();
         //the union of all resolved indices and aliases gets returned, based on indices and aliases that user is authorized for
         String[] expectedIndices = new String[]{"foo-alias", "alias2", "foofoo", "bar"};
-        assertThat(indices.size(), equalTo(expectedIndices.length));
+        assertThat(indices, hasSize(expectedIndices.length));
         assertThat(indices, hasItems(expectedIndices));
         //wildcards get replaced on each single action
         assertThat(request.getAliasActions().get(0).indices(), arrayContainingInAnyOrder("foofoo"));
@@ -818,7 +819,7 @@ public class IndicesAndAliasesResolverTests extends ESTestCase {
         List<String> indices = resolveIndices(request, authorizedIndices).getLocal();
         //the union of all indices and aliases gets returned
         String[] expectedIndices = new String[]{"foo", "foofoobar", "foofoo", "barbaz"};
-        assertThat(indices.size(), equalTo(expectedIndices.length));
+        assertThat(indices, hasSize(expectedIndices.length));
         assertThat(indices, hasItems(expectedIndices));
         assertThat(request.getAliasActions().get(0).indices(), arrayContainingInAnyOrder("foo"));
         assertThat(request.getAliasActions().get(0).aliases(), arrayContainingInAnyOrder("foofoobar"));
@@ -834,7 +835,7 @@ public class IndicesAndAliasesResolverTests extends ESTestCase {
         List<String> indices = resolveIndices(request, authorizedIndices).getLocal();
         //the union of all indices and aliases gets returned, doesn't matter is some of them don't exist
         String[] expectedIndices = new String[]{"foo", "foofoobar", "missing_index", "missing_alias"};
-        assertThat(indices.size(), equalTo(expectedIndices.length));
+        assertThat(indices, hasSize(expectedIndices.length));
         assertThat(indices, hasItems(expectedIndices));
         assertThat(request.getAliasActions().get(0).indices(), arrayContainingInAnyOrder("foo"));
         assertThat(request.getAliasActions().get(0).aliases(), arrayContainingInAnyOrder("foofoobar"));
@@ -850,7 +851,7 @@ public class IndicesAndAliasesResolverTests extends ESTestCase {
         List<String> indices = resolveIndices(request, authorizedIndices).getLocal();
         //union of all resolved indices and aliases gets returned, based on what user is authorized for
         String[] expectedIndices = new String[]{"foofoobar", "foofoo", "bar", "barbaz"};
-        assertThat(indices.size(), equalTo(expectedIndices.length));
+        assertThat(indices, hasSize(expectedIndices.length));
         assertThat(indices, hasItems(expectedIndices));
         //wildcards get replaced within each single action
         assertThat(request.getAliasActions().get(0).indices(), arrayContainingInAnyOrder("foofoo"));
@@ -938,7 +939,7 @@ public class IndicesAndAliasesResolverTests extends ESTestCase {
         List<String> indices = resolveIndices(request, authorizedIndices).getLocal();
         //the union of all indices and aliases gets returned
         String[] expectedIndices = new String[]{"alias1", "foo", "foofoo"};
-        assertThat(indices.size(), equalTo(expectedIndices.length));
+        assertThat(indices, hasSize(expectedIndices.length));
         assertThat(indices, hasItems(expectedIndices));
         assertThat(request.indices(), arrayContainingInAnyOrder("foo", "foofoo"));
         assertThat(request.aliases(), arrayContainingInAnyOrder("alias1"));
@@ -950,7 +951,7 @@ public class IndicesAndAliasesResolverTests extends ESTestCase {
         final Set<String> authorizedIndices = buildAuthorizedIndices(user, GetAliasesAction.NAME);
         List<String> indices = resolveIndices(request, authorizedIndices).getLocal();
         String[] expectedIndices = new String[]{"alias1", "foofoo"};
-        assertThat(indices.size(), equalTo(expectedIndices.length));
+        assertThat(indices, hasSize(expectedIndices.length));
         assertThat(indices, hasItems(expectedIndices));
         assertThat(request.indices(), arrayContainingInAnyOrder("foofoo"));
         assertThat(request.aliases(), arrayContainingInAnyOrder("alias1"));
@@ -965,7 +966,7 @@ public class IndicesAndAliasesResolverTests extends ESTestCase {
         List<String> indices = resolveIndices(request, authorizedIndices).getLocal();
         //the union of all indices and aliases gets returned, missing is not an existing index/alias but that doesn't make any difference
         String[] expectedIndices = new String[]{"alias2", "missing"};
-        assertThat(indices.size(), equalTo(expectedIndices.length));
+        assertThat(indices, hasSize(expectedIndices.length));
         assertThat(indices, hasItems(expectedIndices));
         assertThat(request.indices(), arrayContainingInAnyOrder("missing"));
         assertThat(request.aliases(), arrayContainingInAnyOrder("alias2"));
@@ -997,7 +998,7 @@ public class IndicesAndAliasesResolverTests extends ESTestCase {
         final Set<String> authorizedIndices = buildAuthorizedIndices(user, GetAliasesAction.NAME);
         List<String> indices = resolveIndices(request, authorizedIndices).getLocal();
         String[] expectedIndices = new String[]{"alias2", "missing"};
-        assertThat(indices.size(), equalTo(expectedIndices.length));
+        assertThat(indices, hasSize(expectedIndices.length));
         assertThat(indices, hasItems(expectedIndices));
         assertThat(request.indices(), arrayContainingInAnyOrder("missing"));
         assertThat(request.aliases(), arrayContainingInAnyOrder("alias2"));
@@ -1012,7 +1013,7 @@ public class IndicesAndAliasesResolverTests extends ESTestCase {
         List<String> indices = resolveIndices(request, authorizedIndices).getLocal();
         //the union of all resolved indices and aliases gets returned, based on indices and aliases that user is authorized for
         String[] expectedIndices = new String[]{"alias1", "foofoo", "foofoo-closed", "foofoobar", "foobarfoo"};
-        assertThat(indices.size(), equalTo(expectedIndices.length));
+        assertThat(indices, hasSize(expectedIndices.length));
         assertThat(indices, hasItems(expectedIndices));
         //wildcards get replaced on each single action
         assertThat(request.indices(), arrayContainingInAnyOrder("foofoobar", "foobarfoo", "foofoo", "foofoo-closed"));
@@ -1028,7 +1029,7 @@ public class IndicesAndAliasesResolverTests extends ESTestCase {
         List<String> indices = resolveIndices(request, authorizedIndices).getLocal();
         //the union of all resolved indices and aliases gets returned, based on indices and aliases that user is authorized for
         String[] expectedIndices = new String[]{"alias1", "foofoo", "foofoobar", "foobarfoo"};
-        assertThat(indices.size(), equalTo(expectedIndices.length));
+        assertThat(indices, hasSize(expectedIndices.length));
         assertThat(indices, hasItems(expectedIndices));
         //wildcards get replaced on each single action
         assertThat(request.indices(), arrayContainingInAnyOrder("foofoobar", "foobarfoo", "foofoo"));
@@ -1044,7 +1045,7 @@ public class IndicesAndAliasesResolverTests extends ESTestCase {
         List<String> indices = resolveIndices(request, authorizedIndices).getLocal();
         //the union of all resolved indices and aliases gets returned, based on indices and aliases that user is authorized for
         String[] expectedIndices = new String[]{"alias1", "foofoo", "foofoobar", "foobarfoo", "bar"};
-        assertThat(indices.size(), equalTo(expectedIndices.length));
+        assertThat(indices, hasSize(expectedIndices.length));
         assertThat(indices, hasItems(expectedIndices));
         //wildcards get replaced on each single action
         assertThat(request.indices(), arrayContainingInAnyOrder("foofoobar", "foobarfoo", "foofoo", "bar"));
@@ -1103,7 +1104,7 @@ public class IndicesAndAliasesResolverTests extends ESTestCase {
         List<String> indices = resolveIndices(request, authorizedIndices).getLocal();
         //the union of all resolved indices and aliases gets returned
         String[] expectedIndices = new String[]{"bar", "foofoobar", "foobarfoo", "foofoo", "alias1"};
-        assertThat(indices.size(), equalTo(expectedIndices.length));
+        assertThat(indices, hasSize(expectedIndices.length));
         assertThat(indices, hasItems(expectedIndices));
         String[] replacedIndices = new String[]{"bar", "foofoobar", "foobarfoo", "foofoo"};
         //_all gets replaced with all indices that user is authorized for
@@ -1321,7 +1322,7 @@ public class IndicesAndAliasesResolverTests extends ESTestCase {
             RefreshRequest request = new RefreshRequest("*");
             List<String> indices = resolveIndices(request, authorizedIndices).getLocal();
             String[] expectedIndices = new String[]{"bar", "foofoobar", "foobarfoo", "foofoo"};
-            assertThat(indices.size(), equalTo(expectedIndices.length));
+            assertThat(indices, hasSize(expectedIndices.length));
             assertThat(indices, hasItems(expectedIndices));
             assertThat(request.indices(), arrayContainingInAnyOrder(expectedIndices));
         }
@@ -1329,7 +1330,7 @@ public class IndicesAndAliasesResolverTests extends ESTestCase {
             DeleteIndexRequest request = new DeleteIndexRequest("*");
             List<String> indices = resolveIndices(request, authorizedIndices).getLocal();
             String[] expectedIndices = new String[]{"bar", "bar-closed", "foofoo", "foofoo-closed"};
-            assertThat(indices.size(), equalTo(expectedIndices.length));
+            assertThat(indices, hasSize(expectedIndices.length));
             assertThat(indices, hasItems(expectedIndices));
             assertThat(request.indices(), arrayContainingInAnyOrder(expectedIndices));
         }
@@ -1439,7 +1440,7 @@ public class IndicesAndAliasesResolverTests extends ESTestCase {
             request.indicesOptions(IndicesOptions.fromOptions(randomBoolean(), randomBoolean(), expandIndicesOpen, randomBoolean()));
         }
         List<String> indices = resolveIndices(request, buildAuthorizedIndices(user, SearchAction.NAME)).getLocal();
-        assertThat(indices.size(), equalTo(1));
+        assertThat(indices, hasSize(1));
         assertThat(request.indices()[0], equalTo(dateTimeIndex));
     }
 
@@ -1478,7 +1479,7 @@ public class IndicesAndAliasesResolverTests extends ESTestCase {
                 resolveIndices(request, buildAuthorizedIndices(user, GetAliasesAction.NAME)).getLocal();
         //the union of all indices and aliases gets returned
         String[] expectedIndices = new String[]{"<datetime-{now/M}>", "foo", "foofoo"};
-        assertThat(indices.size(), equalTo(expectedIndices.length));
+        assertThat(indices, hasSize(expectedIndices.length));
         assertThat(indices, hasItems(expectedIndices));
         assertThat(request.indices(), arrayContainingInAnyOrder("foo", "foofoo"));
         assertThat(request.aliases(), arrayContainingInAnyOrder("<datetime-{now/M}>"));

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/RBACEngineTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/RBACEngineTests.java
@@ -84,6 +84,7 @@ import java.util.stream.Collectors;
 import static java.util.Collections.emptyMap;
 import static org.elasticsearch.common.util.set.Sets.newHashSet;
 import static org.elasticsearch.xpack.security.authz.AuthorizedIndicesTests.getRequestInfo;
+import static org.hamcrest.Matchers.aMapWithSize;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.emptyIterable;
 import static org.hamcrest.Matchers.equalTo;
@@ -378,13 +379,13 @@ public class RBACEngineTests extends ESTestCase {
         assertThat(response.getUsername(), is(user.principal()));
         assertThat(response.isCompleteMatch(), is(true));
 
-        assertThat(response.getClusterPrivileges().size(), equalTo(1));
+        assertThat(response.getClusterPrivileges(), aMapWithSize(1));
         assertThat(response.getClusterPrivileges().get(ClusterHealthAction.NAME), equalTo(true));
 
         assertThat(response.getIndexPrivileges(), Matchers.iterableWithSize(1));
         final ResourcePrivileges result = response.getIndexPrivileges().iterator().next();
         assertThat(result.getResource(), equalTo("academy"));
-        assertThat(result.getPrivileges().size(), equalTo(2));
+        assertThat(result.getPrivileges(), aMapWithSize(2));
         assertThat(result.getPrivileges().get(DeleteAction.NAME), equalTo(true));
         assertThat(result.getPrivileges().get(IndexAction.NAME), equalTo(true));
     }
@@ -419,7 +420,7 @@ public class RBACEngineTests extends ESTestCase {
         assertThat(response, notNullValue());
         assertThat(response.getUsername(), is(user.principal()));
         assertThat(response.isCompleteMatch(), is(false));
-        assertThat(response.getClusterPrivileges().size(), equalTo(2));
+        assertThat(response.getClusterPrivileges(), aMapWithSize(2));
         assertThat(response.getClusterPrivileges().get("monitor"), equalTo(true));
         assertThat(response.getClusterPrivileges().get("manage"), equalTo(false));
         assertThat(response.getIndexPrivileges(), Matchers.iterableWithSize(3));
@@ -430,19 +431,19 @@ public class RBACEngineTests extends ESTestCase {
         final ResourcePrivileges school = indexPrivilegesIterator.next();
 
         assertThat(academy.getResource(), equalTo("academy"));
-        assertThat(academy.getPrivileges().size(), equalTo(3));
+        assertThat(academy.getPrivileges(), aMapWithSize(3));
         assertThat(academy.getPrivileges().get("index"), equalTo(true)); // explicit
         assertThat(academy.getPrivileges().get("delete"), equalTo(false));
         assertThat(academy.getPrivileges().get("manage"), equalTo(false));
 
         assertThat(initiative.getResource(), equalTo("initiative"));
-        assertThat(initiative.getPrivileges().size(), equalTo(3));
+        assertThat(initiative.getPrivileges(), aMapWithSize(3));
         assertThat(initiative.getPrivileges().get("index"), equalTo(true)); // implied by write
         assertThat(initiative.getPrivileges().get("delete"), equalTo(true)); // implied by write
         assertThat(initiative.getPrivileges().get("manage"), equalTo(false));
 
         assertThat(school.getResource(), equalTo("school"));
-        assertThat(school.getPrivileges().size(), equalTo(3));
+        assertThat(school.getPrivileges(), aMapWithSize(3));
         assertThat(school.getPrivileges().get("index"), equalTo(false));
         assertThat(school.getPrivileges().get("delete"), equalTo(false));
         assertThat(school.getPrivileges().get("manage"), equalTo(false));
@@ -471,7 +472,7 @@ public class RBACEngineTests extends ESTestCase {
         assertThat(response.getIndexPrivileges(), Matchers.iterableWithSize(1));
         final ResourcePrivileges result = response.getIndexPrivileges().iterator().next();
         assertThat(result.getResource(), equalTo("academy"));
-        assertThat(result.getPrivileges().size(), equalTo(2));
+        assertThat(result.getPrivileges(), aMapWithSize(2));
         assertThat(result.getPrivileges().get("read"), equalTo(false));
         assertThat(result.getPrivileges().get("write"), equalTo(false));
     }

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/accesscontrol/IndicesPermissionTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/accesscontrol/IndicesPermissionTests.java
@@ -46,6 +46,7 @@ import java.util.stream.Collectors;
 import static org.elasticsearch.cluster.metadata.DataStreamTestHelper.createTimestampField;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
@@ -76,7 +77,7 @@ public class IndicesPermissionTests extends ESTestCase {
         assertTrue(permissions.getIndexPermissions("_index").getFieldPermissions().grantsAccessTo("_field"));
         assertTrue(permissions.getIndexPermissions("_index").getFieldPermissions().hasFieldLevelSecurity());
         assertThat(permissions.getIndexPermissions("_index").getDocumentPermissions().hasDocumentLevelPermissions(), is(true));
-        assertThat(permissions.getIndexPermissions("_index").getDocumentPermissions().getQueries().size(), equalTo(1));
+        assertThat(permissions.getIndexPermissions("_index").getDocumentPermissions().getQueries(), hasSize(1));
         assertThat(permissions.getIndexPermissions("_index").getDocumentPermissions().getQueries(), equalTo(query));
 
         // no document level security:
@@ -96,7 +97,7 @@ public class IndicesPermissionTests extends ESTestCase {
         assertThat(permissions.getIndexPermissions("_index"), notNullValue());
         assertFalse(permissions.getIndexPermissions("_index").getFieldPermissions().hasFieldLevelSecurity());
         assertThat(permissions.getIndexPermissions("_index").getDocumentPermissions().hasDocumentLevelPermissions(), is(true));
-        assertThat(permissions.getIndexPermissions("_index").getDocumentPermissions().getQueries().size(), equalTo(1));
+        assertThat(permissions.getIndexPermissions("_index").getDocumentPermissions().getQueries(), hasSize(1));
         assertThat(permissions.getIndexPermissions("_index").getDocumentPermissions().getQueries(), equalTo(query));
 
         // index group associated with an alias:
@@ -108,14 +109,14 @@ public class IndicesPermissionTests extends ESTestCase {
         assertTrue(permissions.getIndexPermissions("_index").getFieldPermissions().grantsAccessTo("_field"));
         assertTrue(permissions.getIndexPermissions("_index").getFieldPermissions().hasFieldLevelSecurity());
         assertThat(permissions.getIndexPermissions("_index").getDocumentPermissions().hasDocumentLevelPermissions(), is(true));
-        assertThat(permissions.getIndexPermissions("_index").getDocumentPermissions().getQueries().size(), equalTo(1));
+        assertThat(permissions.getIndexPermissions("_index").getDocumentPermissions().getQueries(), hasSize(1));
         assertThat(permissions.getIndexPermissions("_index").getDocumentPermissions().getQueries(), equalTo(query));
 
         assertThat(permissions.getIndexPermissions("_alias"), notNullValue());
         assertTrue(permissions.getIndexPermissions("_alias").getFieldPermissions().grantsAccessTo("_field"));
         assertTrue(permissions.getIndexPermissions("_alias").getFieldPermissions().hasFieldLevelSecurity());
         assertThat(permissions.getIndexPermissions("_alias").getDocumentPermissions().hasDocumentLevelPermissions(), is(true));
-        assertThat(permissions.getIndexPermissions("_alias").getDocumentPermissions().getQueries().size(), equalTo(1));
+        assertThat(permissions.getIndexPermissions("_alias").getDocumentPermissions().getQueries(), hasSize(1));
         assertThat(permissions.getIndexPermissions("_alias").getDocumentPermissions().getQueries(), equalTo(query));
 
         // match all fields
@@ -128,13 +129,13 @@ public class IndicesPermissionTests extends ESTestCase {
         assertThat(permissions.getIndexPermissions("_index"), notNullValue());
         assertFalse(permissions.getIndexPermissions("_index").getFieldPermissions().hasFieldLevelSecurity());
         assertThat(permissions.getIndexPermissions("_index").getDocumentPermissions().hasDocumentLevelPermissions(), is(true));
-        assertThat(permissions.getIndexPermissions("_index").getDocumentPermissions().getQueries().size(), equalTo(1));
+        assertThat(permissions.getIndexPermissions("_index").getDocumentPermissions().getQueries(), hasSize(1));
         assertThat(permissions.getIndexPermissions("_index").getDocumentPermissions().getQueries(), equalTo(query));
 
         assertThat(permissions.getIndexPermissions("_alias"), notNullValue());
         assertFalse(permissions.getIndexPermissions("_alias").getFieldPermissions().hasFieldLevelSecurity());
         assertThat(permissions.getIndexPermissions("_alias").getDocumentPermissions().hasDocumentLevelPermissions(), is(true));
-        assertThat(permissions.getIndexPermissions("_alias").getDocumentPermissions().getQueries().size(), equalTo(1));
+        assertThat(permissions.getIndexPermissions("_alias").getDocumentPermissions().getQueries(), hasSize(1));
         assertThat(permissions.getIndexPermissions("_alias").getDocumentPermissions().getQueries(), equalTo(query));
 
         IndexMetadata.Builder imbBuilder1 = IndexMetadata.builder("_index_1")
@@ -160,19 +161,19 @@ public class IndicesPermissionTests extends ESTestCase {
         assertThat(permissions.getIndexPermissions("_index"), notNullValue());
         assertFalse(permissions.getIndexPermissions("_index").getFieldPermissions().hasFieldLevelSecurity());
         assertThat(permissions.getIndexPermissions("_index").getDocumentPermissions().hasDocumentLevelPermissions(), is(true));
-        assertThat(permissions.getIndexPermissions("_index").getDocumentPermissions().getQueries().size(), equalTo(2));
+        assertThat(permissions.getIndexPermissions("_index").getDocumentPermissions().getQueries(), hasSize(2));
         assertThat(permissions.getIndexPermissions("_index").getDocumentPermissions().getQueries(), equalTo(bothQueries));
 
         assertThat(permissions.getIndexPermissions("_index_1"), notNullValue());
         assertFalse(permissions.getIndexPermissions("_index_1").getFieldPermissions().hasFieldLevelSecurity());
         assertThat(permissions.getIndexPermissions("_index_1").getDocumentPermissions().hasDocumentLevelPermissions(), is(true));
-        assertThat(permissions.getIndexPermissions("_index_1").getDocumentPermissions().getQueries().size(), equalTo(2));
+        assertThat(permissions.getIndexPermissions("_index_1").getDocumentPermissions().getQueries(), hasSize(2));
         assertThat(permissions.getIndexPermissions("_index_1").getDocumentPermissions().getQueries(), equalTo(bothQueries));
 
         assertThat(permissions.getIndexPermissions("_alias"), notNullValue());
         assertFalse(permissions.getIndexPermissions("_alias").getFieldPermissions().hasFieldLevelSecurity());
         assertThat(permissions.getIndexPermissions("_alias").getDocumentPermissions().hasDocumentLevelPermissions(), is(true));
-        assertThat(permissions.getIndexPermissions("_alias").getDocumentPermissions().getQueries().size(), equalTo(2));
+        assertThat(permissions.getIndexPermissions("_alias").getDocumentPermissions().getQueries(), hasSize(2));
         assertThat(permissions.getIndexPermissions("_alias").getDocumentPermissions().getQueries(), equalTo(bothQueries));
 
     }

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/store/NativePrivilegeStoreTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/store/NativePrivilegeStoreTests.java
@@ -73,6 +73,7 @@ import static org.hamcrest.Matchers.arrayContaining;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.everyItem;
 import static org.hamcrest.Matchers.instanceOf;
@@ -165,7 +166,7 @@ public class NativePrivilegeStoreTests extends ESTestCase {
             "_scrollId1", 1, 1, 0, 1, null, null));
 
         final Collection<ApplicationPrivilegeDescriptor> applicationPrivilegeDescriptors = future.get(1, TimeUnit.SECONDS);
-        assertThat(applicationPrivilegeDescriptors.size(), equalTo(0));
+        assertThat(applicationPrivilegeDescriptors, empty());
     }
 
     public void testGetPrivilegesByApplicationName() throws Exception {

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/ingest/SetSecurityUserProcessorTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/ingest/SetSecurityUserProcessorTests.java
@@ -36,6 +36,7 @@ import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
 
+import static org.hamcrest.Matchers.aMapWithSize;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.not;
@@ -108,7 +109,7 @@ public class SetSecurityUserProcessorTests extends ESTestCase {
         processor.execute(ingestDocument);
         Map<String, Object> result = ingestDocument.getFieldValue("_field", Map.class);
         // Still holds data for realm and authentication type
-        assertThat(result.size(), equalTo(2));
+        assertThat(result, aMapWithSize(2));
         assertThat(((Map) result.get("realm")).get("name"), equalTo("_name"));
         assertThat(((Map) result.get("realm")).get("type"), equalTo("_type"));
         assertThat(result.get("authentication_type"), equalTo("REALM"));
@@ -144,7 +145,7 @@ public class SetSecurityUserProcessorTests extends ESTestCase {
 
         @SuppressWarnings("unchecked")
         Map<String, Object> result = ingestDocument.getFieldValue("_field", Map.class);
-        assertThat(result.size(), equalTo(1));
+        assertThat(result, aMapWithSize(1));
         assertThat(result.get("username"), equalTo(authentication.getUser().principal()));
     }
 
@@ -162,7 +163,7 @@ public class SetSecurityUserProcessorTests extends ESTestCase {
         if (authentication.getUser().roles().length == 0) {
             assertThat(result, not(hasKey("roles")));
         } else {
-            assertThat(result.size(), equalTo(1));
+            assertThat(result, aMapWithSize(1));
             assertThat(result.get("roles"), equalTo(Arrays.asList(authentication.getUser().roles())));
         }
     }
@@ -178,7 +179,7 @@ public class SetSecurityUserProcessorTests extends ESTestCase {
 
         @SuppressWarnings("unchecked")
         Map<String, Object> result = ingestDocument.getFieldValue("_field", Map.class);
-        assertThat(result.size(), equalTo(1));
+        assertThat(result, aMapWithSize(1));
         assertThat(result.get("full_name"), equalTo(authentication.getUser().fullName()));
     }
 
@@ -194,7 +195,7 @@ public class SetSecurityUserProcessorTests extends ESTestCase {
         @SuppressWarnings("unchecked")
         Map<String, Object> result = ingestDocument.getFieldValue("_field", Map.class);
         if (authentication.getUser().email() != null) {
-            assertThat(result.size(), equalTo(1));
+            assertThat(result, aMapWithSize(1));
             assertThat(result.get("email"), equalTo(authentication.getUser().email()));
         } else {
             assertThat(result, not(hasKey("email")));
@@ -215,7 +216,7 @@ public class SetSecurityUserProcessorTests extends ESTestCase {
         if (authentication.getUser().metadata().isEmpty()) {
             assertThat(result, not(hasKey("metadata")));
         } else {
-            assertThat(result.size(), equalTo(1));
+            assertThat(result, aMapWithSize(1));
             assertThat(result.get("metadata"), equalTo(authentication.getUser().metadata()));
         }
     }
@@ -233,7 +234,7 @@ public class SetSecurityUserProcessorTests extends ESTestCase {
 
         @SuppressWarnings("unchecked")
         Map<String, Object> result = ingestDocument.getFieldValue("_field", Map.class);
-        assertThat(result.size(), equalTo(1));
+        assertThat(result, aMapWithSize(1));
         assertThat(result.get("username"), equalTo(authentication.getUser().principal()));
 
         ingestDocument = new IngestDocument(new HashMap<>(), new HashMap<>());
@@ -243,7 +244,7 @@ public class SetSecurityUserProcessorTests extends ESTestCase {
 
         @SuppressWarnings("unchecked")
         Map<String, Object> result2 = ingestDocument.getFieldValue("_field", Map.class);
-        assertThat(result2.size(), equalTo(2));
+        assertThat(result2, aMapWithSize(2));
         assertThat(result2.get("username"), equalTo(authentication.getUser().principal()));
         assertThat(result2.get("other"), equalTo("test"));
     }
@@ -275,7 +276,7 @@ public class SetSecurityUserProcessorTests extends ESTestCase {
         processor.execute(ingestDocument);
 
         Map<String, Object> result = ingestDocument.getFieldValue("_field", Map.class);
-        assertThat(result.size(), equalTo(4));
+        assertThat(result, aMapWithSize(4));
         final Map<String, Object> apiKeyMap = (Map<String, Object>) result.get("api_key");
         assertThat(apiKeyMap.get("name"), equalTo("api_key_name"));
         assertThat(apiKeyMap.get("id"), equalTo("api_key_id"));
@@ -321,7 +322,7 @@ public class SetSecurityUserProcessorTests extends ESTestCase {
         processor.execute(ingestDocument);
 
         Map<String, Object> result = ingestDocument.getFieldValue("_field", Map.class);
-        assertThat(result.size(), equalTo(4));
+        assertThat(result, aMapWithSize(4));
         assertThat(((Map<String, Integer>) result.get("api_key")).get("version"), equalTo(42));
         assertThat(((Map<String, Integer>) result.get("realm")).get("id"), equalTo(7));
     }
@@ -344,7 +345,7 @@ public class SetSecurityUserProcessorTests extends ESTestCase {
         processor.execute(ingestDocument);
 
         Map<String, Object> result = ingestDocument.getFieldValue("_field", Map.class);
-        assertThat(result.size(), equalTo(3));
+        assertThat(result, aMapWithSize(3));
         assertThat(((Map<String, String>) result.get("realm")).get("name"), equalTo(lookedUpRealmRef.getName()));
         assertThat(((Map<String, String>) result.get("realm")).get("type"), equalTo(lookedUpRealmRef.getType()));
     }

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/rest/action/apikey/RestQueryApiKeyActionTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/rest/action/apikey/RestQueryApiKeyActionTests.java
@@ -40,6 +40,7 @@ import org.elasticsearch.xpack.core.security.action.apikey.QueryApiKeyResponse;
 import java.util.List;
 
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -98,11 +99,11 @@ public class RestQueryApiKeyActionTests extends ESTestCase {
                 final BoolQueryBuilder boolQueryBuilder = (BoolQueryBuilder) queryBuilder;
                 assertTrue(boolQueryBuilder.filter().isEmpty());
                 assertTrue(boolQueryBuilder.mustNot().isEmpty());
-                assertThat(boolQueryBuilder.must().size(), equalTo(1));
+                assertThat(boolQueryBuilder.must(), hasSize(1));
                 final QueryBuilder mustQueryBuilder = boolQueryBuilder.must().get(0);
                 assertThat(mustQueryBuilder.getClass(), is(TermsQueryBuilder.class));
                 assertThat(((TermsQueryBuilder) mustQueryBuilder).fieldName(), equalTo("name"));
-                assertThat(boolQueryBuilder.should().size(), equalTo(1));
+                assertThat(boolQueryBuilder.should(), hasSize(1));
                 final QueryBuilder shouldQueryBuilder = boolQueryBuilder.should().get(0);
                 assertThat(shouldQueryBuilder.getClass(), is(PrefixQueryBuilder.class));
                 assertThat(((PrefixQueryBuilder) shouldQueryBuilder).fieldName(), equalTo("metadata.environ"));
@@ -146,7 +147,7 @@ public class RestQueryApiKeyActionTests extends ESTestCase {
                 assertThat(queryApiKeyRequest.getFrom(), equalTo(42));
                 assertThat(queryApiKeyRequest.getSize(), equalTo(20));
                 final List<FieldSortBuilder> fieldSortBuilders = queryApiKeyRequest.getFieldSortBuilders();
-                assertThat(fieldSortBuilders.size(), equalTo(3));
+                assertThat(fieldSortBuilders, hasSize(3));
 
                 assertThat(fieldSortBuilders.get(0), equalTo(new FieldSortBuilder("name")));
                 assertThat(

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/support/ApiKeyBoolQueryBuilderTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/support/ApiKeyBoolQueryBuilderTests.java
@@ -56,7 +56,7 @@ public class ApiKeyBoolQueryBuilderTests extends ESTestCase {
         final ApiKeyBoolQueryBuilder apiKeyQb1 = ApiKeyBoolQueryBuilder.build(q1, authentication);
         assertCommonFilterQueries(apiKeyQb1, authentication);
         final List<QueryBuilder> mustQueries = apiKeyQb1.must();
-        assertThat(mustQueries.size(), equalTo(1));
+        assertThat(mustQueries, hasSize(1));
         assertThat(mustQueries.get(0), equalTo(q1));
         assertTrue(apiKeyQb1.should().isEmpty());
         assertTrue(apiKeyQb1.mustNot().isEmpty());


### PR DESCRIPTION
This commit replaces occurences of

    assertThat(foo.size(), equalTo(0));
    assertThat(foo.size(), equalTo(n));

with

    assertThat(foo, empty());
    assertThat(foo, hasSize(n));

(or equivalent Map based matchers) within the security project.

The assertion failure messages that are generated when using the
explicit size based matchers are significantly more informative than a
simple 1 != 0 failure.

Backport of: #78051
