### PR TITLE
Validate PING and STATE connections at join time

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/coordination/ZenDiscoveryIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/coordination/ZenDiscoveryIT.java
@@ -10,28 +10,29 @@ package org.elasticsearch.cluster.coordination;
 
 import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.ActionListenerResponseHandler;
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthResponse;
 import org.elasticsearch.action.admin.cluster.node.stats.NodesStatsResponse;
 import org.elasticsearch.action.admin.indices.recovery.RecoveryResponse;
 import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.Metadata;
-import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.Priority;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentFactory;
-import org.elasticsearch.discovery.Discovery;
 import org.elasticsearch.discovery.DiscoveryStats;
 import org.elasticsearch.discovery.zen.FaultDetection;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.elasticsearch.test.TestCustomMetadata;
+import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.RemoteTransportException;
+import org.elasticsearch.transport.TransportResponse;
+import org.elasticsearch.transport.TransportService;
 
 import java.util.EnumSet;
-import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
 import static org.elasticsearch.action.admin.cluster.node.stats.NodesStatsRequest.Metric.DISCOVERY;
@@ -88,33 +89,34 @@ public class ZenDiscoveryIT extends ESIntegTestCase {
         String masterNode = internalCluster().startMasterOnlyNode();
         String node1 = internalCluster().startNode();
         ClusterService clusterService = internalCluster().getInstance(ClusterService.class, node1);
-        Coordinator coordinator = (Coordinator) internalCluster().getInstance(Discovery.class, masterNode);
         final ClusterState state = clusterService.state();
         Metadata.Builder mdBuilder = Metadata.builder(state.metadata());
         mdBuilder.putCustom(CustomMetadata.TYPE, new CustomMetadata("data"));
         ClusterState stateWithCustomMetadata = ClusterState.builder(state).metadata(mdBuilder).build();
 
         final PlainActionFuture<Void> future = new PlainActionFuture<>();
-        final DiscoveryNode node = state.nodes().getLocalNode();
 
-        coordinator.sendValidateJoinRequest(
-            stateWithCustomMetadata,
-            new JoinRequest(node, 0L, Optional.empty()),
-            new ActionListener<Void>() {
-                @Override
-                public void onResponse(Void unused) {
-                    fail("onResponse should not be called");
-                }
+        internalCluster().getInstance(TransportService.class, masterNode).sendRequest(
+            state.nodes().getLocalNode(),
+            JoinHelper.JOIN_VALIDATE_ACTION_NAME,
+            new ValidateJoinRequest(stateWithCustomMetadata),
+            new ActionListenerResponseHandler<>(
+                new ActionListener<TransportResponse.Empty>() {
+                    @Override
+                    public void onResponse(TransportResponse.Empty unused) {
+                        fail("onResponse should not be called");
+                    }
 
-                @Override
-                public void onFailure(Exception t) {
-                    assertThat(t, instanceOf(IllegalStateException.class));
-                    assertThat(t.getCause(), instanceOf(RemoteTransportException.class));
-                    assertThat(t.getCause().getCause(), instanceOf(IllegalArgumentException.class));
-                    assertThat(t.getCause().getCause().getMessage(), containsString("Unknown NamedWriteable"));
-                    future.onResponse(null);
-                }
-            });
+                    @Override
+                    public void onFailure(Exception t) {
+                        assertThat(t, instanceOf(RemoteTransportException.class));
+                        assertThat(t.getCause(), instanceOf(IllegalArgumentException.class));
+                        assertThat(t.getCause().getMessage(), containsString("Unknown NamedWriteable"));
+                        future.onResponse(null);
+                    }
+                },
+                i -> TransportResponse.Empty.INSTANCE,
+                ThreadPool.Names.GENERIC));
 
         future.actionGet(10, TimeUnit.SECONDS);
     }

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/Coordinator.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/Coordinator.java
@@ -14,6 +14,8 @@ import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.apache.lucene.util.SetOnce;
 import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.ActionListenerResponseHandler;
+import org.elasticsearch.action.support.ListenableActionFuture;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.ClusterStatePublicationEvent;
@@ -62,13 +64,17 @@ import org.elasticsearch.discovery.PeerFinder;
 import org.elasticsearch.discovery.SeedHostsProvider;
 import org.elasticsearch.discovery.SeedHostsResolver;
 import org.elasticsearch.discovery.TransportAddressConnector;
+import org.elasticsearch.discovery.zen.MembershipAction;
 import org.elasticsearch.discovery.zen.PendingClusterStateStats;
 import org.elasticsearch.monitor.NodeHealthService;
 import org.elasticsearch.monitor.StatusInfo;
 import org.elasticsearch.threadpool.Scheduler;
 import org.elasticsearch.threadpool.ThreadPool.Names;
+import org.elasticsearch.transport.TransportRequest;
+import org.elasticsearch.transport.TransportRequestOptions;
 import org.elasticsearch.transport.TransportResponse.Empty;
 import org.elasticsearch.transport.TransportService;
+import org.elasticsearch.transport.Transports;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -491,7 +497,6 @@ public class Coordinator extends AbstractLifecycleComponent implements Discovery
         }
     }
 
-
     private void handleJoinRequest(JoinRequest joinRequest, ActionListener<Void> joinListener) {
         assert Thread.holdsLock(mutex) == false;
         assert getLocalNode().isMasterNode() : getLocalNode() + " received a join but is not master-eligible";
@@ -506,26 +511,11 @@ public class Coordinator extends AbstractLifecycleComponent implements Discovery
         transportService.connectToNode(joinRequest.getSourceNode(), ActionListener.wrap(connectionReference -> {
             boolean retainConnection = false;
             try {
-                final ActionListener<Void> wrappedJoinCallback = ActionListener.runBefore(
-                    joinListener,
-                    () -> Releasables.close(connectionReference));
-
-                final ClusterState stateForJoinValidation = getStateForMasterService();
-
-                if (stateForJoinValidation.nodes().isLocalNodeElectedMaster()) {
-                    onJoinValidators.forEach(a -> a.accept(joinRequest.getSourceNode(), stateForJoinValidation));
-                    if (stateForJoinValidation.getBlocks().hasGlobalBlock(STATE_NOT_RECOVERED_BLOCK) == false) {
-                        // we do this in a couple of places including the cluster update thread. This one here is really just best effort
-                        // to ensure we fail as fast as possible.
-                        JoinTaskExecutor.ensureVersionBarrier(
-                            joinRequest.getSourceNode().getVersion(),
-                            stateForJoinValidation.getNodes().getMinNodeVersion());
-                    }
-                    sendValidateJoinRequest(stateForJoinValidation, joinRequest, wrappedJoinCallback);
-                } else {
-                    processJoinRequest(joinRequest, wrappedJoinCallback);
-                }
-
+                validateJoinRequest(
+                    joinRequest,
+                    ActionListener
+                        .runBefore(joinListener, () -> Releasables.close(connectionReference))
+                        .delegateFailure((l, ignored) -> processJoinRequest(joinRequest, l)));
                 retainConnection = true;
             } finally {
                 if (retainConnection == false) {
@@ -535,42 +525,126 @@ public class Coordinator extends AbstractLifecycleComponent implements Discovery
         }, joinListener::onFailure));
     }
 
-    // package private for tests
-    void sendValidateJoinRequest(ClusterState stateForJoinValidation, JoinRequest joinRequest, ActionListener<Void> joinListener) {
-        // validate the join on the joining node, will throw a failure if it fails the validation
-        joinHelper.sendValidateJoinRequest(joinRequest.getSourceNode(), stateForJoinValidation, new ActionListener<Empty>() {
+    private void validateJoinRequest(JoinRequest joinRequest, ActionListener<Void> validateListener) {
+
+        // Before letting the node join the cluster, ensure:
+        // - it's a new enough version to pass the version barrier
+        // - we have a healthy STATE channel to the node
+        // - if we're already master that it can make sense of a the current cluster state.
+        // - we have a healthy PING channel to the node
+
+        final ListenableActionFuture<Empty> validateStateListener = new ListenableActionFuture<>();
+        final ClusterState stateForJoinValidation = getStateForMasterService();
+        if (stateForJoinValidation.nodes().isLocalNodeElectedMaster()) {
+            onJoinValidators.forEach(a -> a.accept(joinRequest.getSourceNode(), stateForJoinValidation));
+            if (stateForJoinValidation.getBlocks().hasGlobalBlock(STATE_NOT_RECOVERED_BLOCK) == false) {
+                // We do this in a couple of places including the cluster update thread. This one here is really just best effort to ensure
+                // we fail as fast as possible.
+                JoinTaskExecutor.ensureVersionBarrier(
+                    joinRequest.getSourceNode().getVersion(),
+                    stateForJoinValidation.getNodes().getMinNodeVersion());
+            }
+            sendJoinValidate(joinRequest.getSourceNode(), stateForJoinValidation, validateStateListener);
+        } else {
+            sendJoinPing(joinRequest.getSourceNode(), TransportRequestOptions.Type.STATE, validateStateListener);
+        }
+
+        sendJoinPing(joinRequest.getSourceNode(), TransportRequestOptions.Type.PING, new ActionListener<Empty>() {
             @Override
             public void onResponse(Empty empty) {
-                try {
-                    processJoinRequest(joinRequest, joinListener);
-                } catch (Exception e) {
-                    joinListener.onFailure(e);
-                }
+                validateStateListener.addListener(validateListener.map(ignored -> null));
             }
 
             @Override
             public void onFailure(Exception e) {
-                logger.warn(() -> new ParameterizedMessage("failed to validate incoming join request from node [{}]",
-                    joinRequest.getSourceNode()), e);
-                joinListener.onFailure(new IllegalStateException("failure when sending a validation request to node", e));
+                // The join will be rejected, but we wait for the state validation to complete as well since the node will retry and we
+                // don't want lots of cluster states in flight.
+                validateStateListener.addListener(
+                    new ActionListener<Empty>() {
+                        @Override
+                        public void onResponse(Empty empty) {
+                            validateListener.onFailure(e);
+                        }
+
+                        @Override
+                        public void onFailure(Exception e2) {
+                            e2.addSuppressed(e);
+                            validateListener.onFailure(e2);
+                        }
+                    });
             }
         });
     }
 
+    private void sendJoinValidate(DiscoveryNode discoveryNode, ClusterState clusterState, ActionListener<Empty> listener) {
+        final String actionName;
+        if (Coordinator.isZen1Node(discoveryNode)) {
+            actionName = MembershipAction.DISCOVERY_JOIN_VALIDATE_ACTION_NAME;
+        } else {
+            actionName = JoinHelper.JOIN_VALIDATE_ACTION_NAME;
+        }
+
+        transportService.sendRequest(
+            discoveryNode,
+            actionName,
+            new ValidateJoinRequest(clusterState),
+            TransportRequestOptions.of(null, TransportRequestOptions.Type.STATE),
+            new ActionListenerResponseHandler<>(
+                listener.delegateResponse((l, e) -> {
+                    logger.warn(
+                        () -> new ParameterizedMessage(
+                            "failed to validate incoming join request from node [{}]",
+                            discoveryNode),
+                        e);
+                    listener.onFailure(new IllegalStateException("failure when sending a validation request to node", e));
+                }),
+                i -> Empty.INSTANCE,
+                Names.GENERIC));
+    }
+
+    private void sendJoinPing(DiscoveryNode discoveryNode, TransportRequestOptions.Type channelType, ActionListener<Empty> listener) {
+        if (discoveryNode.getVersion().onOrAfter(Version.V_7_16_0)) {
+            transportService.sendRequest(
+                discoveryNode,
+                JoinHelper.JOIN_PING_ACTION_NAME,
+                TransportRequest.Empty.INSTANCE,
+                TransportRequestOptions.of(null, channelType),
+                new ActionListenerResponseHandler<>(
+                    listener.delegateResponse((l, e) -> {
+                        logger.warn(
+                            () -> new ParameterizedMessage(
+                                "failed to ping joining node [{}] on channel type [{}]",
+                                discoveryNode,
+                                channelType),
+                            e);
+                        listener.onFailure(new IllegalStateException("failure when sending a join ping request to node", e));
+                    }),
+                    i -> Empty.INSTANCE,
+                    Names.GENERIC));
+        } else {
+            listener.onResponse(Empty.INSTANCE);
+        }
+    }
+
     private void processJoinRequest(JoinRequest joinRequest, ActionListener<Void> joinListener) {
+        assert Transports.assertNotTransportThread("blocking on coordinator mutex and maybe doing IO to increase term");
         final Optional<Join> optionalJoin = joinRequest.getOptionalJoin();
-        synchronized (mutex) {
-            updateMaxTermSeen(joinRequest.getTerm());
+        try {
+            synchronized (mutex) {
+                updateMaxTermSeen(joinRequest.getTerm());
 
-            final CoordinationState coordState = coordinationState.get();
-            final boolean prevElectionWon = coordState.electionWon();
+                final CoordinationState coordState = coordinationState.get();
+                final boolean prevElectionWon = coordState.electionWon();
 
-            optionalJoin.ifPresent(this::handleJoin);
-            joinAccumulator.handleJoinRequest(joinRequest.getSourceNode(), joinListener);
+                optionalJoin.ifPresent(this::handleJoin);
+                joinAccumulator.handleJoinRequest(joinRequest.getSourceNode(), joinListener);
 
-            if (prevElectionWon == false && coordState.electionWon()) {
-                becomeLeader("handleJoinRequest");
+                if (prevElectionWon == false && coordState.electionWon()) {
+                    becomeLeader("handleJoinRequest");
+                }
             }
+        } catch (Exception e) {
+            joinListener.onFailure(e);
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/Coordinator.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/Coordinator.java
@@ -603,7 +603,7 @@ public class Coordinator extends AbstractLifecycleComponent implements Discovery
     }
 
     private void sendJoinPing(DiscoveryNode discoveryNode, TransportRequestOptions.Type channelType, ActionListener<Empty> listener) {
-        if (discoveryNode.getVersion().onOrAfter(Version.V_7_16_0)) {
+        if (discoveryNode.getVersion().onOrAfter(Version.V_7_16_0) && isZen1Node(discoveryNode) == false) {
             transportService.sendRequest(
                 discoveryNode,
                 JoinHelper.JOIN_PING_ACTION_NAME,

--- a/server/src/test/java/org/elasticsearch/cluster/coordination/CoordinatorTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/CoordinatorTests.java
@@ -1359,6 +1359,53 @@ public class CoordinatorTests extends AbstractCoordinatorTestCase {
         }
     }
 
+    public void testNodeCannotJoinIfJoinPingValidationFailsOnMaster() throws IllegalAccessException {
+        try (Cluster cluster = new Cluster(randomIntBetween(1, 3))) {
+            cluster.runRandomly();
+            cluster.stabilise();
+
+            cluster.getAnyLeader().addActionBlock(JoinHelper.JOIN_PING_ACTION_NAME);
+
+            // check that if node ping join validation fails on master, the nodes can't join
+            List<ClusterNode> addedNodes = cluster.addNodes(randomIntBetween(1, 2));
+            final long previousClusterStateVersion = cluster.getAnyLeader().getLastAppliedClusterState().version();
+
+            MockLogAppender mockAppender = new MockLogAppender();
+            mockAppender.start();
+            Logger joinLogger = LogManager.getLogger(JoinHelper.class);
+            Logger coordinatorLogger = LogManager.getLogger(Coordinator.class);
+            Loggers.addAppender(joinLogger, mockAppender);
+            Loggers.addAppender(coordinatorLogger, mockAppender);
+            try {
+                mockAppender.addExpectation(
+                    new MockLogAppender.SeenEventExpectation(
+                        "failed to join",
+                        JoinHelper.class.getCanonicalName(),
+                        Level.INFO,
+                        "*failed to join*"));
+                mockAppender.addExpectation(
+                    new MockLogAppender.SeenEventExpectation(
+                        "failed to ping",
+                        Coordinator.class.getCanonicalName(),
+                        Level.WARN,
+                        "*failed to ping joining node*"));
+                cluster.runFor(10000, "failing joins");
+                mockAppender.assertAllExpectationsMatched();
+            } finally {
+                Loggers.removeAppender(coordinatorLogger, mockAppender);
+                Loggers.removeAppender(joinLogger, mockAppender);
+                mockAppender.stop();
+            }
+
+            assertTrue(addedNodes.stream().allMatch(ClusterNode::isCandidate));
+            final long newClusterStateVersion = cluster.getAnyLeader().getLastAppliedClusterState().version();
+            assertEquals(previousClusterStateVersion, newClusterStateVersion);
+
+            cluster.getAnyLeader().clearActionBlocks();
+            cluster.stabilise();
+        }
+    }
+
     public void testNodeCannotJoinIfJoinValidationFailsOnJoiningNode() {
         try (Cluster cluster = new Cluster(randomIntBetween(1, 3))) {
             cluster.runRandomly();

--- a/server/src/test/java/org/elasticsearch/cluster/coordination/JoinHelperTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/JoinHelperTests.java
@@ -168,7 +168,7 @@ public class JoinHelperTests extends ESTestCase {
     }
 
     public void testJoinValidationRejectsMismatchedClusterUUID() {
-        assertJoinValidationRejectsMismatchedClusterUUID(JoinHelper.VALIDATE_JOIN_ACTION_NAME);
+        assertJoinValidationRejectsMismatchedClusterUUID(JoinHelper.JOIN_VALIDATE_ACTION_NAME);
     }
 
     private void assertJoinValidationRejectsMismatchedClusterUUID(String actionName) {

--- a/server/src/test/java/org/elasticsearch/cluster/coordination/NodeJoinTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/NodeJoinTests.java
@@ -163,7 +163,7 @@ public class NodeJoinTests extends ESTestCase {
                             destination,
                             initialState.getClusterName()
                     ));
-                } else if (action.equals(JoinHelper.VALIDATE_JOIN_ACTION_NAME)) {
+                } else if (action.equals(JoinHelper.JOIN_VALIDATE_ACTION_NAME) || action.equals(JoinHelper.JOIN_PING_ACTION_NAME)) {
                     handleResponse(requestId, new TransportResponse.Empty());
                 } else {
                     super.onSendRequest(requestId, action, request, destination);

--- a/test/framework/src/main/java/org/elasticsearch/cluster/coordination/AbstractCoordinatorTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/cluster/coordination/AbstractCoordinatorTestCase.java
@@ -68,6 +68,8 @@ import org.elasticsearch.test.disruption.DisruptableMockTransport.ConnectionStat
 import org.elasticsearch.threadpool.Scheduler;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportInterceptor;
+import org.elasticsearch.transport.TransportRequest;
+import org.elasticsearch.transport.TransportRequestOptions;
 import org.elasticsearch.transport.TransportService;
 import org.hamcrest.Matcher;
 import org.hamcrest.Matchers;
@@ -134,6 +136,7 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.Matchers.oneOf;
 import static org.hamcrest.Matchers.sameInstance;
 
 public class AbstractCoordinatorTestCase extends ESTestCase {
@@ -980,6 +983,37 @@ public class AbstractCoordinatorTestCase extends ESTestCase {
                         return clusterNodes.stream().map(cn -> cn.mockTransport)
                             .filter(transport -> transport.getLocalNode().getAddress().equals(address)).findAny();
                     }
+
+                    @Override
+                    protected void onSendRequest(
+                        long requestId,
+                        String action,
+                        TransportRequest request,
+                        TransportRequestOptions options,
+                        DisruptableMockTransport destinationTransport
+                    ) {
+                        final TransportRequestOptions.Type chanType = options.type();
+                        switch (action) {
+                            case JoinHelper.JOIN_ACTION_NAME:
+                            case FollowersChecker.FOLLOWER_CHECK_ACTION_NAME:
+                            case LeaderChecker.LEADER_CHECK_ACTION_NAME:
+                                assertThat(action, chanType, equalTo(TransportRequestOptions.Type.PING));
+                                break;
+                            case JoinHelper.JOIN_VALIDATE_ACTION_NAME:
+                            case PublicationTransportHandler.PUBLISH_STATE_ACTION_NAME:
+                            case PublicationTransportHandler.COMMIT_STATE_ACTION_NAME:
+                                assertThat(action, chanType, equalTo(TransportRequestOptions.Type.STATE));
+                                break;
+                            case JoinHelper.JOIN_PING_ACTION_NAME:
+                                assertThat(action, chanType, oneOf(TransportRequestOptions.Type.STATE, TransportRequestOptions.Type.PING));
+                                break;
+                            default:
+                                assertThat(action, chanType, equalTo(TransportRequestOptions.Type.REG));
+                                break;
+                        }
+
+                        super.onSendRequest(requestId, action, request, options, destinationTransport);
+                    }
                 };
                 final Settings settings = nodeSettings.hasValue(DiscoveryModule.DISCOVERY_TYPE_SETTING.getKey()) ?
                     nodeSettings : Settings.builder().put(nodeSettings)
@@ -1254,6 +1288,14 @@ public class AbstractCoordinatorTestCase extends ESTestCase {
 
             ClusterState getLastAppliedClusterState() {
                 return clusterApplierService.state();
+            }
+
+            void addActionBlock(@SuppressWarnings("SameParameterValue") String actionName) {
+                mockTransport.addActionBlock(actionName);
+            }
+
+            void clearActionBlocks() {
+                mockTransport.clearActionBlocks();
             }
 
             void applyInitialConfiguration() {


### PR DESCRIPTION
When a node requests to join the cluster we perform some basic
validation to ensure that it makes sense to process its join request.
Today we verify its version and that it can read a recent cluster state
without errors. This commit adds some extra validation that the
connections needed for the node to join the cluster are not broken (i.e.
silently dropping packets). We notice broken channels eventually but it
might take many minutes, and until we notice the node may be joining and
leaving the cluster repeatedly which is quite disruptive. In more
detail:

- If the established `STATE` channel from the master to the joining node
is broken then today we let the node join and then remove it a couple of
minutes later for lagging.

- If the established `PING` channel from the master to the joining node
is broken then today we let the node join and then remove it 30s later
for ping failures.

- If the established `PING` channel from the joining node to the master
is broken then today the node will join but keep on rejoining
unnecessarily, believing the master to be failing to respond to its
pings.

With this commit we ensure that the joining node has a good `PING`
channel to the master, and that the master has good `STATE` and `PING`
channels back to the joining node, before starting to process its join.
We do this by sending the join request on the `PING` channel, then
sending the validation state back on the `STATE` channel and a new
lightweight message on the `PING` channel in parallel.

Backport of #77741