### PR TITLE
[7.x] Update spotless plugin to contain race condition fix (#78062)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,7 +43,7 @@ plugins {
   id 'elasticsearch.internal-testclusters'
   id 'elasticsearch.run'
   id 'elasticsearch.release-tools'
-  id "com.diffplug.spotless" version "5.15.0" apply false
+  id "com.diffplug.spotless" version "5.15.1" apply false
 }
 
 String licenseCommit


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Update spotless plugin to contain race condition fix (#78062)