### PR TITLE
Improve Settings Performance in a few Spots

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/settings/Setting.java
+++ b/server/src/main/java/org/elasticsearch/common/settings/Setting.java
@@ -431,8 +431,8 @@ public class Setting<T> implements ToXContentObject {
     }
 
     private boolean exists(final Set<String> keys, final SecureSettings secureSettings) {
-        return keys.contains(getKey()) &&
-            (secureSettings == null || secureSettings.getSettingNames().contains(getKey()) == false);
+        final String key = getKey();
+        return keys.contains(key) && (secureSettings == null || secureSettings.getSettingNames().contains(key) == false);
     }
 
     /**
@@ -533,12 +533,17 @@ public class Setting<T> implements ToXContentObject {
      * @return the raw string representation of the setting value
      */
     String innerGetRaw(final Settings settings) {
+        final String key = getKey();
         SecureSettings secureSettings = settings.getSecureSettings();
-        if (secureSettings != null && secureSettings.getSettingNames().contains(getKey())) {
-            throw new IllegalArgumentException("Setting [" + getKey() + "] is a non-secure setting" +
+        if (secureSettings != null && secureSettings.getSettingNames().contains(key)) {
+            throw new IllegalArgumentException("Setting [" + key + "] is a non-secure setting" +
                 " and must be stored inside elasticsearch.yml, but was found inside the Elasticsearch keystore");
         }
-        return settings.get(getKey(), defaultValue.apply(settings));
+        final String found = settings.get(key);
+        if (found != null) {
+            return found;
+        }
+        return defaultValue.apply(settings);
     }
 
     /** Logs a deprecation warning if the setting is deprecated and used. */
@@ -566,7 +571,7 @@ public class Setting<T> implements ToXContentObject {
     @Override
     public final XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startObject();
-        builder.field("key", key.toString());
+        builder.field("key", getKey());
         builder.field("properties", properties);
         builder.field("is_group_setting", isGroupSetting());
         builder.field("default", defaultValue.apply(Settings.EMPTY));
@@ -1555,6 +1560,9 @@ public class Setting<T> implements ToXContentObject {
     }
 
     private static List<String> parseableStringToList(String parsableString) {
+        if ("[]".equals(parsableString)) {
+            return List.of();
+        }
         // fromXContent doesn't use named xcontent or deprecation.
         try (XContentParser xContentParser = XContentType.JSON.xContent()
                 .createParser(NamedXContentRegistry.EMPTY, DeprecationHandler.THROW_UNSUPPORTED_OPERATION, parsableString)) {
@@ -1569,6 +1577,9 @@ public class Setting<T> implements ToXContentObject {
     }
 
     private static String arrayToParsableString(List<String> array) {
+        if (array.isEmpty()) {
+            return "[]";
+        }
         try {
             XContentBuilder builder = XContentBuilder.builder(XContentType.JSON.xContent());
             builder.startArray();
@@ -1894,6 +1905,8 @@ public class Setting<T> implements ToXContentObject {
         private final String prefix;
         private final String suffix;
 
+        private final String keyString;
+
         AffixKey(String prefix) {
             this(prefix, null);
         }
@@ -1912,6 +1925,14 @@ public class Setting<T> implements ToXContentObject {
                 // the last part of this regexp is to support both list and group keys
                 pattern = Pattern.compile("(" + Pattern.quote(prefix) + "([-\\w]+)\\." + Pattern.quote(suffix) + ")(?:\\..*)?");
             }
+            StringBuilder sb = new StringBuilder();
+            sb.append(prefix);
+            if (suffix != null) {
+                sb.append('*');
+                sb.append('.');
+                sb.append(suffix);
+            }
+            keyString = sb.toString();
         }
 
         @Override
@@ -1956,16 +1977,7 @@ public class Setting<T> implements ToXContentObject {
 
         @Override
         public String toString() {
-            StringBuilder sb = new StringBuilder();
-            if (prefix != null) {
-                sb.append(prefix);
-            }
-            if (suffix != null) {
-                sb.append('*');
-                sb.append('.');
-                sb.append(suffix);
-            }
-            return sb.toString();
+            return keyString;
         }
 
         @Override


### PR DESCRIPTION
Settings show up in a few spots when profiling very large clusters.
This PR fixes a few obvious spots to speed them up a little:
* Remove pointless synchronization on lazy fields as there's never any contention on
building these in the real world anyway and even if there was a rare double execution
wouldn't hurt
* Fix expensive key string building during setting lookup for affix settings
* Fix redundantly running default value method in setting get
* Short circuit common empty list setting parsing + serialization
