### PR TITLE
Fix Deadlock in TcpTransport#openConnection

### DIFF
--- a/server/src/main/java/org/elasticsearch/transport/TcpTransport.java
+++ b/server/src/main/java/org/elasticsearch/transport/TcpTransport.java
@@ -384,6 +384,7 @@ public abstract class TcpTransport extends AbstractLifecycleComponent implements
         final AtomicReference<Exception> lastException = new AtomicReference<>();
         final AtomicReference<InetSocketAddress> boundSocket = new AtomicReference<>();
         if (closeLock.writeLock().tryLock() == false) {
+            assert false; // can't be concurrently stopping and mustn't be opening any connections yet
             throw new IllegalStateException("failed to acquire close-write-lock");
         }
         try {

--- a/server/src/main/java/org/elasticsearch/transport/TcpTransport.java
+++ b/server/src/main/java/org/elasticsearch/transport/TcpTransport.java
@@ -383,7 +383,9 @@ public abstract class TcpTransport extends AbstractLifecycleComponent implements
         PortsRange portsRange = new PortsRange(port);
         final AtomicReference<Exception> lastException = new AtomicReference<>();
         final AtomicReference<InetSocketAddress> boundSocket = new AtomicReference<>();
-        closeLock.writeLock().lock();
+        if (closeLock.writeLock().tryLock() == false) {
+            throw new IllegalStateException("failed to acquire close-write-lock");
+        }
         try {
             // No need for locking here since Lifecycle objects can't move from STARTED to INITIALIZED
             if (lifecycle.initialized() == false && lifecycle.started() == false) {


### PR DESCRIPTION
This seems to only affect `MockNioTransport` but I think it's a clean fix regardless.
We should not be blockingly locking on the transport thread, otherwise if the close operation
on the transport waits for all io loops to complete (like `MockNioTransport` does)
we will deadlock if closing and opening a connection coincide.
Also, just as a matter of principle I don't think we should have blocking locking on any transport thread to
make reasoning about the code a little easier.

failed here: https://elasticsearch-ci.elastic.co/job/elastic+elasticsearch+pull-request+part-1/5513/consoleText