### PR TITLE
Release notes for 6.8.19

### DIFF
--- a/docs/reference/release-notes/6.8.asciidoc
+++ b/docs/reference/release-notes/6.8.asciidoc
@@ -1,7 +1,7 @@
 [[release-notes-6.8.19]]
 == {es} version 6.8.19
 
-coming::[6.8.19]
+No significant changes.
 
 [[release-notes-6.8.18]]
 == {es} version 6.8.18


### PR DESCRIPTION
Nothing changed in Elasticsearch for 6.8.19 (at least in terms of the shipped software).