### PR TITLE
[ML] fixing minor autoscaling edge case check

### DIFF
--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/autoscaling/MlAutoscalingDeciderService.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/autoscaling/MlAutoscalingDeciderService.java
@@ -516,7 +516,7 @@ public class MlAutoscalingDeciderService implements AutoscalingDeciderService,
 
         // This is an exceptionally weird state
         // Our view of the memory is stale or we have tasks where the required job memory is 0, which should be impossible
-        if (largestJob == 0L && ((dataframeAnalyticsTasks.isEmpty() || anomalyDetectionTasks.isEmpty()) == false)) {
+        if (largestJob == 0L && (dataframeAnalyticsTasks.size() + anomalyDetectionTasks.size() > 0)) {
             logger.warn(
                 "The calculated minimum required node size was unexpectedly [0] as there are "
                     + "[{}] anomaly job tasks and [{}] data frame analytics tasks",


### PR DESCRIPTION
The ML autoscaling decider should exit if the largest calculated ML job has a size of `0` and there is at least 
one job task in the cluster.

Previously, this was not done. It exited if we calculated a size of `0` and if BOTH of the task sets were non-empty. It should have exited if either were non-empty