### PR TITLE
[7.x] [DOCS] Remove 7.14.2 coming tag (#78079)

### DIFF
--- a/docs/reference/release-notes/7.14.asciidoc
+++ b/docs/reference/release-notes/7.14.asciidoc
@@ -1,6 +1,6 @@
 [[release-notes-7.14.2]]
 == {es} version 7.14.2
-coming::[7.14.2]
+
 Also see <<breaking-changes-7.14,Breaking changes in 7.14>>.
 
 [[enhancement-7.14.2]]


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [DOCS] Remove 7.14.2 coming tag (#78079)