### PR TITLE
[7.7] [DOCS] Add deprecation docs for ECS user agent (#77970)

### DIFF
--- a/docs/reference/ingest/processors/user-agent.asciidoc
+++ b/docs/reference/ingest/processors/user-agent.asciidoc
@@ -19,7 +19,7 @@ The ingest-user-agent module ships by default with the regexes.yaml made availab
 | `regex_file`           | no        | -                                                                                               | The name of the file in the `config/ingest-user-agent` directory containing the regular expressions for parsing the user agent string. Both the directory and the file have to be created before starting Elasticsearch. If not specified, ingest-user-agent will use the regexes.yaml from uap-core it ships with (see below).
 | `properties`           | no        | [`name`, `major`, `minor`, `patch`, `build`, `os`, `os_name`, `os_major`, `os_minor`, `device`] | Controls what properties are added to `target_field`.
 | `ignore_missing`       | no        | `false`                                                                                         | If `true` and `field` does not exist, the processor quietly exits without modifying the document
-| `ecs`                  | no        | `true`                                                                                         | Whether to return the output in Elastic Common Schema format. NOTE: This setting is deprecated and will be removed in a future version.
+| `ecs`                  | no        | `true`                                                                                         | deprecated:[7.2] Whether to return the output in Elastic Common Schema format.
 |======
 
 Here is an example that adds the user agent details to the `user_agent` field based on the `agent` field:

--- a/docs/reference/migration/migrate_7_2.asciidoc
+++ b/docs/reference/migration/migrate_7_2.asciidoc
@@ -31,6 +31,19 @@ unexpectedly ignored the rest.  For instance if you set `discovery.seed_hosts:
 discovery. Seed host addresses containing port ranges are now rejected.
 
 [discrete]
+[[breaking_72_ingest_changes]]
+=== Ingest pipeline changes
+
+[discrete]
+[[deprecate-ecs-parameter]]
+==== The `user_agent` ingest processor's `ecs` parameter is deprecated.
+
+The `ecs` parameter for the `user_agent` ingest processor is deprecated and will
+be removed in 8.0. In 8.x, the `user_agent` ingest processor will only return
+{ecs-ref}[Elastic Common Schema (ECS)] fields.
+
+To avoid deprecation warnings, remove the parameter from your ingest pipelines.
+
 [[breaking_72_ilm_deprecations]]
 === {ilm-cap} ({ilm-init}) deprecations
 


### PR DESCRIPTION
Backports the following commits to 7.7:
 - [DOCS] Add deprecation docs for ECS user agent (#77970)