### PR TITLE
Fix split package in search business rules module

### DIFF
--- a/x-pack/plugin/search-business-rules/build.gradle
+++ b/x-pack/plugin/search-business-rules/build.gradle
@@ -14,10 +14,3 @@ dependencies {
   testImplementation(testArtifact(project(xpackModule('core'))))
   testImplementation project(":test:framework")
 }
-
-tasks.named('splitPackagesAudit').configure {
-  // Lucene classes should be owned by Lucene!
-  ignoreClasses  'org.apache.lucene.search.CappedScoreQuery',
-    'org.apache.lucene.search.CappedScoreWeight',
-    'org.apache.lucene.search.CappedScorer'
-}

--- a/x-pack/plugin/search-business-rules/src/main/java/org/elasticsearch/xpack/searchbusinessrules/CappedScoreQuery.java
+++ b/x-pack/plugin/search-business-rules/src/main/java/org/elasticsearch/xpack/searchbusinessrules/CappedScoreQuery.java
@@ -4,13 +4,29 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-package org.apache.lucene.search;
+package org.elasticsearch.xpack.searchbusinessrules;
 
 import java.io.IOException;
 import java.util.Objects;
 
 import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.search.BooleanClause;
+import org.apache.lucene.search.BoostQuery;
+import org.apache.lucene.search.BulkScorer;
+import org.apache.lucene.search.DocIdSetIterator;
+import org.apache.lucene.search.FilterLeafCollector;
+import org.apache.lucene.search.FilterScorable;
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.LeafCollector;
+import org.apache.lucene.search.Matches;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.QueryVisitor;
+import org.apache.lucene.search.Scorable;
+import org.apache.lucene.search.ScoreMode;
+import org.apache.lucene.search.Scorer;
+import org.apache.lucene.search.ScorerSupplier;
+import org.apache.lucene.search.Weight;
 import org.apache.lucene.util.Bits;
 
 /**

--- a/x-pack/plugin/search-business-rules/src/main/java/org/elasticsearch/xpack/searchbusinessrules/CappedScoreWeight.java
+++ b/x-pack/plugin/search-business-rules/src/main/java/org/elasticsearch/xpack/searchbusinessrules/CappedScoreWeight.java
@@ -5,9 +5,14 @@
  * 2.0.
  */
 
-package org.apache.lucene.search;
+package org.elasticsearch.xpack.searchbusinessrules;
 
 import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.search.Explanation;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.Scorer;
+import org.apache.lucene.search.TwoPhaseIterator;
+import org.apache.lucene.search.Weight;
 
 import java.io.IOException;
 

--- a/x-pack/plugin/search-business-rules/src/main/java/org/elasticsearch/xpack/searchbusinessrules/CappedScorer.java
+++ b/x-pack/plugin/search-business-rules/src/main/java/org/elasticsearch/xpack/searchbusinessrules/CappedScorer.java
@@ -5,7 +5,11 @@
  * 2.0.
  */
 
-package org.apache.lucene.search;
+package org.elasticsearch.xpack.searchbusinessrules;
+
+import org.apache.lucene.search.FilterScorer;
+import org.apache.lucene.search.Scorer;
+import org.apache.lucene.search.Weight;
 
 import java.io.IOException;
 

--- a/x-pack/plugin/search-business-rules/src/main/java/org/elasticsearch/xpack/searchbusinessrules/PinnedQueryBuilder.java
+++ b/x-pack/plugin/search-business-rules/src/main/java/org/elasticsearch/xpack/searchbusinessrules/PinnedQueryBuilder.java
@@ -8,7 +8,6 @@
 package org.elasticsearch.xpack.searchbusinessrules;
 
 import org.apache.lucene.search.BoostQuery;
-import org.apache.lucene.search.CappedScoreQuery;
 import org.apache.lucene.search.ConstantScoreQuery;
 import org.apache.lucene.search.DisjunctionMaxQuery;
 import org.apache.lucene.search.MatchNoDocsQuery;

--- a/x-pack/plugin/search-business-rules/src/test/java/org/elasticsearch/xpack/searchbusinessrules/PinnedQueryBuilderTests.java
+++ b/x-pack/plugin/search-business-rules/src/test/java/org/elasticsearch/xpack/searchbusinessrules/PinnedQueryBuilderTests.java
@@ -9,7 +9,6 @@ package org.elasticsearch.xpack.searchbusinessrules;
 
 import com.fasterxml.jackson.core.io.JsonStringEncoder;
 
-import org.apache.lucene.search.CappedScoreQuery;
 import org.apache.lucene.search.DisjunctionMaxQuery;
 import org.apache.lucene.search.Query;
 import org.elasticsearch.common.ParsingException;


### PR DESCRIPTION
The CappedScore lucene query exists in search-business-rules, but split
the lucene search package. This commit moves the implementation class
into the existing module package name.