### PR TITLE
[7.x] Fix split packages in external test modules (#78136)

### DIFF
--- a/test/external-modules/delayed-aggs/build.gradle
+++ b/test/external-modules/delayed-aggs/build.gradle
@@ -8,17 +8,11 @@
 
 esplugin {
   description 'A test module that allows to delay aggregations on shards with a configurable time'
-  classname 'org.elasticsearch.search.aggregations.DelayedShardAggregationPlugin'
+  classname 'org.elasticsearch.test.delayedshard.DelayedShardAggregationPlugin'
 }
 
 restResources {
   restApi {
     include '_common', 'indices', 'index', 'cluster', 'search'
   }
-}
-
-tasks.named('splitPackagesAudit').configure {
-  // aggs is owned by server, these should be moved to delayedaggs
-  ignoreClasses 'org.elasticsearch.search.aggregations.DelayedShardAggregationBuilder',
-    'org.elasticsearch.search.aggregations.DelayedShardAggregationPlugin'
 }

--- a/test/external-modules/delayed-aggs/src/main/java/org/elasticsearch/test/delayedshard/DelayedShardAggregationBuilder.java
+++ b/test/external-modules/delayed-aggs/src/main/java/org/elasticsearch/test/delayedshard/DelayedShardAggregationBuilder.java
@@ -6,7 +6,7 @@
  * Side Public License, v 1.
  */
 
-package org.elasticsearch.search.aggregations;
+package org.elasticsearch.test.delayedshard;
 
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -15,6 +15,12 @@ import org.elasticsearch.common.xcontent.ParseField;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.index.query.QueryBuilders;
+import org.elasticsearch.search.aggregations.AbstractAggregationBuilder;
+import org.elasticsearch.search.aggregations.AggregationBuilder;
+import org.elasticsearch.search.aggregations.Aggregator;
+import org.elasticsearch.search.aggregations.AggregatorFactories;
+import org.elasticsearch.search.aggregations.AggregatorFactory;
+import org.elasticsearch.search.aggregations.CardinalityUpperBound;
 import org.elasticsearch.search.aggregations.bucket.filter.FilterAggregationBuilder;
 import org.elasticsearch.search.aggregations.support.AggregationContext;
 

--- a/test/external-modules/delayed-aggs/src/main/java/org/elasticsearch/test/delayedshard/DelayedShardAggregationPlugin.java
+++ b/test/external-modules/delayed-aggs/src/main/java/org/elasticsearch/test/delayedshard/DelayedShardAggregationPlugin.java
@@ -6,7 +6,7 @@
  * Side Public License, v 1.
  */
 
-package org.elasticsearch.search.aggregations;
+package org.elasticsearch.test.delayedshard;
 
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.plugins.SearchPlugin;

--- a/test/external-modules/delayed-aggs/src/test/java/org/elasticsearch/test/delayedshard/DelayedShardAggregationBuilderTests.java
+++ b/test/external-modules/delayed-aggs/src/test/java/org/elasticsearch/test/delayedshard/DelayedShardAggregationBuilderTests.java
@@ -5,10 +5,11 @@
  * in compliance with, at your election, the Elastic License 2.0 or the Server
  * Side Public License, v 1.
  */
-package org.elasticsearch.search.aggregations;
+package org.elasticsearch.test.delayedshard;
 
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.search.aggregations.BaseAggregationTestCase;
 import org.elasticsearch.test.TestGeoShapeFieldMapperPlugin;
 
 import java.util.Arrays;

--- a/test/external-modules/die-with-dignity/build.gradle
+++ b/test/external-modules/die-with-dignity/build.gradle
@@ -6,7 +6,7 @@ apply plugin: 'elasticsearch.internal-es-plugin'
 
 esplugin {
   description 'Die with dignity plugin'
-  classname 'org.elasticsearch.DieWithDignityPlugin'
+  classname 'org.elasticsearch.test.diewithdignity.DieWithDignityPlugin'
 }
 
 // let the javaRestTest see the classpath of main
@@ -30,10 +30,4 @@ tasks.named("test").configure {
 
 tasks.named("yamlRestTest").configure {
   enabled = false
-}
-
-tasks.named('splitPackagesAudit').configure {
-  // these should be moved to an actual package, not the root package
-  ignoreClasses 'org.elasticsearch.DieWithDignityPlugin',
-    'org.elasticsearch.RestDieWithDignityAction'
 }

--- a/test/external-modules/die-with-dignity/src/main/java/org/elasticsearch/test/diewithdignity/DieWithDignityPlugin.java
+++ b/test/external-modules/die-with-dignity/src/main/java/org/elasticsearch/test/diewithdignity/DieWithDignityPlugin.java
@@ -6,7 +6,7 @@
  * Side Public License, v 1.
  */
 
-package org.elasticsearch;
+package org.elasticsearch.test.diewithdignity;
 
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.node.DiscoveryNodes;

--- a/test/external-modules/die-with-dignity/src/main/java/org/elasticsearch/test/diewithdignity/RestDieWithDignityAction.java
+++ b/test/external-modules/die-with-dignity/src/main/java/org/elasticsearch/test/diewithdignity/RestDieWithDignityAction.java
@@ -6,7 +6,7 @@
  * Side Public License, v 1.
  */
 
-package org.elasticsearch;
+package org.elasticsearch.test.diewithdignity;
 
 import org.elasticsearch.client.node.NodeClient;
 import org.elasticsearch.common.Randomness;

--- a/test/external-modules/error-query/build.gradle
+++ b/test/external-modules/error-query/build.gradle
@@ -8,18 +8,11 @@
 
 esplugin {
   description 'A test module that exposes a way to simulate search shard failures and warnings'
-  classname 'org.elasticsearch.search.query.ErrorQueryPlugin'
+  classname 'org.elasticsearch.test.errorquery.ErrorQueryPlugin'
 }
 
 restResources {
   restApi {
     include '_common', 'indices', 'index', 'cluster', 'search'
   }
-}
-
-tasks.named('splitPackagesAudit').configure {
-  // search.query is owned by server, these should be moved to errorquery
-  ignoreClasses 'org.elasticsearch.search.query.ErrorQueryBuilder',
-    'org.elasticsearch.search.query.ErrorQueryPlugin',
-    'org.elasticsearch.search.query.IndexError'
 }

--- a/test/external-modules/error-query/src/main/java/org/elasticsearch/test/errorquery/ErrorQueryBuilder.java
+++ b/test/external-modules/error-query/src/main/java/org/elasticsearch/test/errorquery/ErrorQueryBuilder.java
@@ -6,7 +6,7 @@
  * Side Public License, v 1.
  */
 
-package org.elasticsearch.search.query;
+package org.elasticsearch.test.errorquery;
 
 import org.apache.lucene.search.MatchAllDocsQuery;
 import org.apache.lucene.search.Query;

--- a/test/external-modules/error-query/src/main/java/org/elasticsearch/test/errorquery/ErrorQueryPlugin.java
+++ b/test/external-modules/error-query/src/main/java/org/elasticsearch/test/errorquery/ErrorQueryPlugin.java
@@ -6,7 +6,7 @@
  * Side Public License, v 1.
  */
 
-package org.elasticsearch.search.query;
+package org.elasticsearch.test.errorquery;
 
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.plugins.SearchPlugin;

--- a/test/external-modules/error-query/src/main/java/org/elasticsearch/test/errorquery/IndexError.java
+++ b/test/external-modules/error-query/src/main/java/org/elasticsearch/test/errorquery/IndexError.java
@@ -6,7 +6,7 @@
  * Side Public License, v 1.
  */
 
-package org.elasticsearch.search.query;
+package org.elasticsearch.test.errorquery;
 
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;

--- a/test/external-modules/error-query/src/test/java/org/elasticsearch/test/errorquery/ErrorQueryBuilderTests.java
+++ b/test/external-modules/error-query/src/test/java/org/elasticsearch/test/errorquery/ErrorQueryBuilderTests.java
@@ -5,7 +5,7 @@
  * in compliance with, at your election, the Elastic License 2.0 or the Server
  * Side Public License, v 1.
  */
-package org.elasticsearch.search.query;
+package org.elasticsearch.test.errorquery;
 
 import org.apache.lucene.search.MatchAllDocsQuery;
 import org.apache.lucene.search.Query;


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Fix split packages in external test modules (#78136)