### PR TITLE
[7.14] [DOCS] Use dedicated hosts for ES (#77582)

### DIFF
--- a/docs/reference/how-to/general.asciidoc
+++ b/docs/reference/how-to/general.asciidoc
@@ -39,4 +39,3 @@ avoid the issues with large documents, it also makes the search experience
 better. For instance if a user searches for two words `foo` and `bar`, a match
 across different chapters is probably very poor, while a match within the same
 paragraph is likely good.
-

--- a/docs/reference/setup.asciidoc
+++ b/docs/reference/setup.asciidoc
@@ -1,8 +1,6 @@
 [[setup]]
 = Set up {es}
 
-[partintro]
---
 This section includes information on how to setup Elasticsearch and get it
 running, including:
 
@@ -35,7 +33,15 @@ https://www.oracle.com/technetwork/java/eol-135779.html[LTS version of Java].
 Elasticsearch will refuse to start if a known-bad version of Java is used.
 The bundled JVM directory may be removed when using your own JVM.
 
---
+[discrete]
+[[dedicated-host]]
+== Use dedicated hosts
+
+In production, we recommend you run {es} on a dedicated host or as a primary
+service. Several {es} features, such as automatic JVM heap sizing, assume it's
+the only resource-intensive application on the host or container. For example,
+you might run {metricbeat} alongside {es} for cluster statistics, but a
+resource-heavy {ls} deployment should be on its own host.
 
 include::setup/install.asciidoc[]
 


### PR DESCRIPTION
Backports the following commits to 7.14:
 - [DOCS] Use dedicated hosts for ES (#77582)