### PR TITLE
geo_shape mapping created before version 6.6.0 should be using the legacy mapper (#77881)

### DIFF
--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/mapper/GeoShapeWithDocValuesFieldMapper.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/mapper/GeoShapeWithDocValuesFieldMapper.java
@@ -201,7 +201,8 @@ public class GeoShapeWithDocValuesFieldMapper extends AbstractShapeGeometryField
             FieldMapper.Builder builder;
             boolean ignoreMalformedByDefault = IGNORE_MALFORMED_SETTING.get(parserContext.getSettings());
             boolean coerceByDefault = COERCE_SETTING.get(parserContext.getSettings());
-            if (LegacyGeoShapeFieldMapper.containsDeprecatedParameter(node.keySet())) {
+            if (parserContext.indexVersionCreated().before(Version.V_6_6_0) ||
+                LegacyGeoShapeFieldMapper.containsDeprecatedParameter(node.keySet())) {
                 builder = new LegacyGeoShapeFieldMapper.Builder(
                     name,
                     parserContext.indexVersionCreated(),

--- a/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/index/mapper/GeoShapeWithDocValuesFieldMapperTests.java
+++ b/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/index/mapper/GeoShapeWithDocValuesFieldMapperTests.java
@@ -24,6 +24,7 @@ import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.index.mapper.DocumentMapper;
+import org.elasticsearch.index.mapper.LegacyGeoShapeFieldMapper;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.Mapper;
 import org.elasticsearch.index.mapper.MapperParsingException;
@@ -364,6 +365,17 @@ public class GeoShapeWithDocValuesFieldMapperTests extends MapperTestCase {
             b.endObject();
         }));
         assertWarnings("Adding multifields to [geo_shape] mappers has no effect and will be forbidden in future");
+    }
+
+    public void testRandomVersionMapping() throws Exception {
+        Version version = VersionUtils.randomIndexCompatibleVersion(random());
+        DocumentMapper defaultMapper = createDocumentMapper(version, fieldMapping(this::minimalMapping));
+        Mapper fieldMapper = defaultMapper.mappers().getMapper("field");
+        if (version.before(Version.V_6_6_0)) {
+            assertThat(fieldMapper, instanceOf(LegacyGeoShapeFieldMapper.class));
+        } else {
+            assertThat(fieldMapper, instanceOf(GeoShapeWithDocValuesFieldMapper.class));
+        }
     }
 
     public String toXContentString(GeoShapeWithDocValuesFieldMapper mapper, boolean includeDefaults) {

--- a/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/index/query/GeoShapeWithDocValuesQueryBuilderTests.java
+++ b/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/index/query/GeoShapeWithDocValuesQueryBuilderTests.java
@@ -10,6 +10,7 @@ package org.elasticsearch.xpack.spatial.index.query;
 import org.apache.lucene.search.ConstantScoreQuery;
 import org.apache.lucene.search.IndexOrDocValuesQuery;
 import org.apache.lucene.search.Query;
+import org.elasticsearch.Version;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.compress.CompressedXContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
@@ -41,7 +42,8 @@ public class GeoShapeWithDocValuesQueryBuilderTests extends AbstractQueryTestCas
 
     @Override
     protected void initializeAdditionalMappings(MapperService mapperService) throws IOException {
-        if (randomBoolean()) {
+
+        if (mapperService.parserContext().indexVersionCreated().before(Version.V_6_6_0) || randomBoolean()) {
             XContentBuilder mapping = jsonBuilder().startObject().startObject("_doc").startObject("properties")
                 .startObject("test").field("type", "geo_shape").endObject().endObject().endObject().endObject();
             mapperService.merge("_doc",


### PR DESCRIPTION
It seems that the mapper on the spatial module would only create legacy mappers when they use a deprecated parameters. Still old mappings previous to version 6.6 should always be using the legacy mapper.

backport #77881