### PR TITLE
[7.x] Add track_total_hits support in mvt API (#78074)

### DIFF
--- a/docs/reference/search/search-vector-tile-api.asciidoc
+++ b/docs/reference/search/search-vector-tile-api.asciidoc
@@ -233,6 +233,15 @@ Accepts `0`-`10000`. Defaults to `10000`. If `0`, results don't include the
 `hits` layer.
 // end::size[]
 
+// tag::track_total_hits[]
+`track_total_hits`::
+(Optional, integer or Boolean)
+Number of hits matching the query to count accurately. Defaults to `10000`.
++
+If `true`, the exact number of hits is returned at the cost of some performance.
+If `false`, the response does not include the total number of hits matching the query.
+// end::track_total_hits[]
+
 [role="child_attributes"]
 [[search-vector-tile-api-request-body]]
 ==== {api-request-body-title}
@@ -285,6 +294,8 @@ include::search-vector-tile-api.asciidoc[tag=size]
 +
 By default, the API calculates a bounding box for each feature. It sorts
 features based on this box's diagonal length, from longest to shortest.
+
+include::search-vector-tile-api.asciidoc[tag=track_total_hits]
 
 [role="child_attributes"]
 [[search-vector-tile-api-response]]

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/search_mvt.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/search_mvt.json
@@ -76,6 +76,10 @@
         "type":"int",
         "description":"Maximum number of features to return in the hits layer. Accepts 0-10000.",
         "default":10000
+      },
+      "track_total_hits":{
+        "type":"boolean|long",
+        "description":"Indicate if the number of documents that match the query should be tracked. A number can also be specified, to accurately track the total hit count up to the number."
       }
     },
     "body":{

--- a/x-pack/plugin/vector-tile/src/javaRestTest/java/org/elasticsearch/xpack/vectortile/VectorTileRestIT.java
+++ b/x-pack/plugin/vector-tile/src/javaRestTest/java/org/elasticsearch/xpack/vectortile/VectorTileRestIT.java
@@ -379,6 +379,58 @@ public class VectorTileRestIT extends ESRestTestCase {
         }
     }
 
+    public void testTrackTotalHitsAsBoolean() throws Exception {
+        {
+            final Request mvtRequest = new Request(
+                getHttpMethod(),
+                INDEX_POINTS + "/_mvt/location/" + z + "/" + x + "/" + y + "?track_total_hits=true"
+            );
+            final VectorTile.Tile tile = execute(mvtRequest);
+            assertThat(tile.getLayersCount(), Matchers.equalTo(3));
+            assertLayer(tile, HITS_LAYER, 4096, 33, 2);
+            assertLayer(tile, AGGS_LAYER, 4096, 1, 1);
+            assertLayer(tile, META_LAYER, 4096, 1, 13);
+            assertStringTag(getLayer(tile, META_LAYER), getLayer(tile, META_LAYER).getFeatures(0), "hits.total.relation", "eq");
+            assertSintTag(getLayer(tile, META_LAYER), getLayer(tile, META_LAYER).getFeatures(0), "hits.total.value", 33);
+        }
+        {
+            final Request mvtRequest = new Request(getHttpMethod(), INDEX_POINTS + "/_mvt/location/" + z + "/" + x + "/" + y);
+            mvtRequest.setJsonEntity("{\"track_total_hits\": false }");
+            final VectorTile.Tile tile = execute(mvtRequest);
+            assertThat(tile.getLayersCount(), Matchers.equalTo(3));
+            assertLayer(tile, HITS_LAYER, 4096, 33, 2);
+            assertLayer(tile, AGGS_LAYER, 4096, 1, 1);
+            assertLayer(tile, META_LAYER, 4096, 1, 11);
+        }
+    }
+
+    public void testTrackTotalHitsAsInt() throws Exception {
+        {
+            final Request mvtRequest = new Request(
+                getHttpMethod(),
+                INDEX_POINTS + "/_mvt/location/" + z + "/" + x + "/" + y + "?track_total_hits=100"
+            );
+            final VectorTile.Tile tile = execute(mvtRequest);
+            assertThat(tile.getLayersCount(), Matchers.equalTo(3));
+            assertLayer(tile, HITS_LAYER, 4096, 33, 2);
+            assertLayer(tile, AGGS_LAYER, 4096, 1, 1);
+            assertLayer(tile, META_LAYER, 4096, 1, 13);
+            assertStringTag(getLayer(tile, META_LAYER), getLayer(tile, META_LAYER).getFeatures(0), "hits.total.relation", "eq");
+            assertSintTag(getLayer(tile, META_LAYER), getLayer(tile, META_LAYER).getFeatures(0), "hits.total.value", 33);
+        }
+        {
+            final Request mvtRequest = new Request(getHttpMethod(), INDEX_POINTS + "/_mvt/location/" + z + "/" + x + "/" + y);
+            mvtRequest.setJsonEntity("{\"track_total_hits\": 1 }");
+            final VectorTile.Tile tile = execute(mvtRequest);
+            assertThat(tile.getLayersCount(), Matchers.equalTo(3));
+            assertLayer(tile, HITS_LAYER, 4096, 33, 2);
+            assertLayer(tile, AGGS_LAYER, 4096, 1, 1);
+            assertLayer(tile, META_LAYER, 4096, 1, 13);
+            assertStringTag(getLayer(tile, META_LAYER), getLayer(tile, META_LAYER).getFeatures(0), "hits.total.relation", "gte");
+            assertSintTag(getLayer(tile, META_LAYER), getLayer(tile, META_LAYER).getFeatures(0), "hits.total.value", 1);
+        }
+    }
+
     public void testGridTypeURL() throws Exception {
         final Request mvtRequest = new Request(
             getHttpMethod(),
@@ -620,6 +672,18 @@ public class VectorTileRestIT extends ESRestTestCase {
         assertThat(layer.getKeysCount(), Matchers.equalTo(numTags));
     }
 
+    private void assertSintTag(VectorTile.Tile.Layer layer, VectorTile.Tile.Feature feature, String tag, long value) {
+        for (int i = 0; i < feature.getTagsCount(); i += 2) {
+            String thisTag = layer.getKeys(feature.getTags(i));
+            if (tag.equals(thisTag)) {
+                VectorTile.Tile.Value thisValue = layer.getValues(feature.getTags(i + 1));
+                assertThat(value, Matchers.equalTo(thisValue.getSintValue()));
+                return;
+            }
+        }
+        fail("Could not find tag [" + tag + " ]");
+    }
+
     private void assertDoubleTag(VectorTile.Tile.Layer layer, VectorTile.Tile.Feature feature, String tag, double value) {
         for (int i = 0; i < feature.getTagsCount(); i += 2) {
             String thisTag = layer.getKeys(feature.getTags(i));
@@ -638,8 +702,10 @@ public class VectorTileRestIT extends ESRestTestCase {
             if (tag.equals(thisTag)) {
                 VectorTile.Tile.Value thisValue = layer.getValues(feature.getTags(i + 1));
                 assertEquals(thisValue.getStringValue(), value);
+                return;
             }
         }
+        fail("Could not find tag [" + tag + " ]");
     }
 
     private VectorTile.Tile execute(Request mvtRequest) throws IOException {

--- a/x-pack/plugin/vector-tile/src/main/java/org/elasticsearch/xpack/vectortile/rest/RestVectorTileAction.java
+++ b/x-pack/plugin/vector-tile/src/main/java/org/elasticsearch/xpack/vectortile/rest/RestVectorTileAction.java
@@ -173,6 +173,7 @@ public class RestVectorTileAction extends BaseRestHandler {
         final SearchRequestBuilder searchRequestBuilder = client.prepareSearch(request.getIndexes());
         searchRequestBuilder.setSize(request.getSize());
         searchRequestBuilder.setFetchSource(false);
+        searchRequestBuilder.setTrackTotalHitsUpTo(request.getTrackTotalHitsUpTo());
         searchRequestBuilder.addFetchField(
             new FieldAndFormat(
                 request.getField(),

--- a/x-pack/plugin/vector-tile/src/main/java/org/elasticsearch/xpack/vectortile/rest/VectorTileRequest.java
+++ b/x-pack/plugin/vector-tile/src/main/java/org/elasticsearch/xpack/vectortile/rest/VectorTileRequest.java
@@ -11,6 +11,7 @@ import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.xcontent.ObjectParser;
 import org.elasticsearch.common.xcontent.ParseField;
 import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.core.Booleans;
 import org.elasticsearch.core.CheckedFunction;
 import org.elasticsearch.geometry.Rectangle;
 import org.elasticsearch.index.query.AbstractQueryBuilder;
@@ -40,6 +41,9 @@ import java.util.Map;
 
 import static java.util.Collections.emptyList;
 import static java.util.Collections.emptyMap;
+import static org.elasticsearch.search.internal.SearchContext.DEFAULT_TRACK_TOTAL_HITS_UP_TO;
+import static org.elasticsearch.search.internal.SearchContext.TRACK_TOTAL_HITS_ACCURATE;
+import static org.elasticsearch.search.internal.SearchContext.TRACK_TOTAL_HITS_DISABLED;
 
 /**
  * Transforms a rest request in a vector tile request
@@ -83,6 +87,7 @@ class VectorTileRequest {
         public static final GRID_TYPE GRID_TYPE = VectorTileRequest.GRID_TYPE.GRID;
         public static final int EXTENT = 4096;
         public static final boolean EXACT_BOUNDS = false;
+        public static final int TRACK_TOTAL_HITS_UP_TO = DEFAULT_TRACK_TOTAL_HITS_UP_TO;
     }
 
     private static final ObjectParser<VectorTileRequest, RestRequest> PARSER;
@@ -126,6 +131,15 @@ class VectorTileRequest {
         PARSER.declareString(VectorTileRequest::setGridType, GRID_TYPE_FIELD);
         PARSER.declareInt(VectorTileRequest::setExtent, EXTENT_FIELD);
         PARSER.declareBoolean(VectorTileRequest::setExactBounds, EXACT_BOUNDS_FIELD);
+        PARSER.declareField(VectorTileRequest::setTrackTotalHitsUpTo, (p) -> {
+            XContentParser.Token token = p.currentToken();
+            if (token == XContentParser.Token.VALUE_BOOLEAN
+                || (token == XContentParser.Token.VALUE_STRING && Booleans.isBoolean(p.text()))) {
+                return p.booleanValue() ? TRACK_TOTAL_HITS_ACCURATE : TRACK_TOTAL_HITS_DISABLED;
+            } else {
+                return p.intValue();
+            }
+        }, SearchSourceBuilder.TRACK_TOTAL_HITS_FIELD, ObjectParser.ValueType.VALUE);
     }
 
     static VectorTileRequest parseRestRequest(RestRequest restRequest) throws IOException {
@@ -158,6 +172,19 @@ class VectorTileRequest {
         if (restRequest.hasParam(EXACT_BOUNDS_FIELD.getPreferredName())) {
             request.setExactBounds(restRequest.paramAsBoolean(EXACT_BOUNDS_FIELD.getPreferredName(), Defaults.EXACT_BOUNDS));
         }
+        if (restRequest.hasParam(SearchSourceBuilder.TRACK_TOTAL_HITS_FIELD.getPreferredName())) {
+            if (Booleans.isBoolean(restRequest.param(SearchSourceBuilder.TRACK_TOTAL_HITS_FIELD.getPreferredName()))) {
+                if (restRequest.paramAsBoolean(SearchSourceBuilder.TRACK_TOTAL_HITS_FIELD.getPreferredName(), true)) {
+                    request.setTrackTotalHitsUpTo(TRACK_TOTAL_HITS_ACCURATE);
+                } else {
+                    request.setTrackTotalHitsUpTo(TRACK_TOTAL_HITS_DISABLED);
+                }
+            } else {
+                request.setTrackTotalHitsUpTo(
+                    restRequest.paramAsInt(SearchSourceBuilder.TRACK_TOTAL_HITS_FIELD.getPreferredName(), DEFAULT_TRACK_TOTAL_HITS_UP_TO)
+                );
+            }
+        }
         return request;
     }
 
@@ -185,6 +212,7 @@ class VectorTileRequest {
     private List<FieldAndFormat> fields = Defaults.FETCH;
     private List<SortBuilder<?>> sortBuilders;
     private boolean exact_bounds = Defaults.EXACT_BOUNDS;
+    private int trackTotalHitsUpTo = Defaults.TRACK_TOTAL_HITS_UP_TO;
 
     private VectorTileRequest(String[] indexes, String field, int z, int x, int y) {
         this.indexes = indexes;
@@ -348,5 +376,13 @@ class VectorTileRequest {
 
     private void setSortBuilders(List<SortBuilder<?>> sortBuilders) {
         this.sortBuilders = sortBuilders;
+    }
+
+    public int getTrackTotalHitsUpTo() {
+        return trackTotalHitsUpTo;
+    }
+
+    private void setTrackTotalHitsUpTo(int trackTotalHitsUpTo) {
+        this.trackTotalHitsUpTo = trackTotalHitsUpTo;
     }
 }

--- a/x-pack/plugin/vector-tile/src/test/java/org/elasticsearch/xpack/vectortile/rest/VectorTileRequestTests.java
+++ b/x-pack/plugin/vector-tile/src/test/java/org/elasticsearch/xpack/vectortile/rest/VectorTileRequestTests.java
@@ -24,6 +24,7 @@ import org.elasticsearch.search.aggregations.AggregationBuilder;
 import org.elasticsearch.search.aggregations.bucket.geogrid.GeoTileUtils;
 import org.elasticsearch.search.aggregations.metrics.AvgAggregationBuilder;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
+import org.elasticsearch.search.internal.SearchContext;
 import org.elasticsearch.search.sort.FieldSortBuilder;
 import org.elasticsearch.search.sort.ScriptSortBuilder;
 import org.elasticsearch.search.sort.SortOrder;
@@ -55,6 +56,7 @@ public class VectorTileRequestTests extends ESTestCase {
             assertThat(vectorTileRequest.getExactBounds(), Matchers.equalTo(VectorTileRequest.Defaults.EXACT_BOUNDS));
             assertThat(vectorTileRequest.getRuntimeMappings(), Matchers.equalTo(VectorTileRequest.Defaults.RUNTIME_MAPPINGS));
             assertThat(vectorTileRequest.getQueryBuilder(), Matchers.equalTo(VectorTileRequest.Defaults.QUERY));
+            assertThat(vectorTileRequest.getTrackTotalHitsUpTo(), Matchers.equalTo(VectorTileRequest.Defaults.TRACK_TOTAL_HITS_UP_TO));
         });
     }
 
@@ -63,6 +65,29 @@ public class VectorTileRequestTests extends ESTestCase {
         assertRestRequest(
             (builder) -> { builder.field(SearchSourceBuilder.SIZE_FIELD.getPreferredName(), size); },
             (vectorTileRequest) -> { assertThat(vectorTileRequest.getSize(), Matchers.equalTo(size)); }
+        );
+    }
+
+    public void testFieldTrackTotalHitsAsBoolean() throws IOException {
+        assertRestRequest(
+            (builder) -> { builder.field(SearchSourceBuilder.TRACK_TOTAL_HITS_FIELD.getPreferredName(), true); },
+            (vectorTileRequest) -> {
+                assertThat(vectorTileRequest.getTrackTotalHitsUpTo(), Matchers.equalTo(SearchContext.TRACK_TOTAL_HITS_ACCURATE));
+            }
+        );
+        assertRestRequest(
+            (builder) -> { builder.field(SearchSourceBuilder.TRACK_TOTAL_HITS_FIELD.getPreferredName(), false); },
+            (vectorTileRequest) -> {
+                assertThat(vectorTileRequest.getTrackTotalHitsUpTo(), Matchers.equalTo(SearchContext.TRACK_TOTAL_HITS_DISABLED));
+            }
+        );
+    }
+
+    public void testFieldTrackTotalHitsAsInt() throws IOException {
+        final int trackTotalHits = randomIntBetween(1, 10000);
+        assertRestRequest(
+            (builder) -> { builder.field(SearchSourceBuilder.TRACK_TOTAL_HITS_FIELD.getPreferredName(), trackTotalHits); },
+            (vectorTileRequest) -> { assertThat(vectorTileRequest.getTrackTotalHitsUpTo(), Matchers.equalTo(trackTotalHits)); }
         );
     }
 

--- a/x-pack/plugin/vector-tile/src/yamlRestTest/resources/rest-api-spec/test/10_basic.yml
+++ b/x-pack/plugin/vector-tile/src/yamlRestTest/resources/rest-api-spec/test/10_basic.yml
@@ -167,3 +167,27 @@ setup:
         zoom: 0
         body:
           sort: []
+
+---
+"track_total_hits as integer":
+  - do:
+      search_mvt:
+        index: locations
+        field: location
+        x: 0
+        y: 0
+        zoom: 0
+        body:
+          track_total_hits: 10
+
+---
+"track_total_hits as boolean":
+  - do:
+      search_mvt:
+        index: locations
+        field: location
+        x: 0
+        y: 0
+        zoom: 0
+        body:
+          track_total_hits: true


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Add track_total_hits support in mvt API (#78074)