### PR TITLE
Improve Settings Performance in a few Spots (#78069)

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/settings/Setting.java
+++ b/server/src/main/java/org/elasticsearch/common/settings/Setting.java
@@ -543,11 +543,16 @@ public class Setting<T> implements ToXContentObject {
      * @return the raw string representation of the setting value
      */
     String innerGetRaw(final Settings settings) {
-        if (this.isSecure(settings)) {
-            throw new IllegalArgumentException("Setting [" + getKey() + "] is a non-secure setting" +
+        final String key = getKey();
+            if (this.isSecure(settings)) {
+            throw new IllegalArgumentException("Setting [" + key + "] is a non-secure setting" +
                 " and must be stored inside elasticsearch.yml, but was found inside the Elasticsearch keystore");
         }
-        return settings.get(getKey(), defaultValue.apply(settings));
+        final String found = settings.get(key);
+        if (found != null) {
+            return found;
+        }
+        return defaultValue.apply(settings);
     }
 
     /** Logs a deprecation warning if the setting is deprecated and used. */
@@ -577,7 +582,7 @@ public class Setting<T> implements ToXContentObject {
     @Override
     public final XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startObject();
-        builder.field("key", key.toString());
+        builder.field("key", getKey());
         builder.field("properties", properties);
         builder.field("is_group_setting", isGroupSetting());
         builder.field("default", defaultValue.apply(Settings.EMPTY));
@@ -1570,6 +1575,9 @@ public class Setting<T> implements ToXContentObject {
     }
 
     private static List<String> parseableStringToList(String parsableString) {
+        if ("[]".equals(parsableString)) {
+            return Collections.emptyList();
+        }
         // fromXContent doesn't use named xcontent or deprecation.
         try (XContentParser xContentParser = XContentType.JSON.xContent()
                 .createParser(NamedXContentRegistry.EMPTY, DeprecationHandler.THROW_UNSUPPORTED_OPERATION, parsableString)) {
@@ -1584,6 +1592,9 @@ public class Setting<T> implements ToXContentObject {
     }
 
     private static String arrayToParsableString(List<String> array) {
+        if (array.isEmpty()) {
+            return "[]";
+        }
         try {
             XContentBuilder builder = XContentBuilder.builder(XContentType.JSON.xContent());
             builder.startArray();
@@ -1909,6 +1920,8 @@ public class Setting<T> implements ToXContentObject {
         private final String prefix;
         private final String suffix;
 
+        private final String keyString;
+
         AffixKey(String prefix) {
             this(prefix, null);
         }
@@ -1927,6 +1940,14 @@ public class Setting<T> implements ToXContentObject {
                 // the last part of this regexp is to support both list and group keys
                 pattern = Pattern.compile("(" + Pattern.quote(prefix) + "([-\\w]+)\\." + Pattern.quote(suffix) + ")(?:\\..*)?");
             }
+            StringBuilder sb = new StringBuilder();
+            sb.append(prefix);
+            if (suffix != null) {
+                sb.append('*');
+                sb.append('.');
+                sb.append(suffix);
+            }
+            keyString = sb.toString();
         }
 
         @Override
@@ -1971,16 +1992,7 @@ public class Setting<T> implements ToXContentObject {
 
         @Override
         public String toString() {
-            StringBuilder sb = new StringBuilder();
-            if (prefix != null) {
-                sb.append(prefix);
-            }
-            if (suffix != null) {
-                sb.append('*');
-                sb.append('.');
-                sb.append(suffix);
-            }
-            return sb.toString();
+            return keyString;
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/common/settings/Settings.java
+++ b/server/src/main/java/org/elasticsearch/common/settings/Settings.java
@@ -80,13 +80,13 @@ public final class Settings implements ToXContentFragment {
     private final SecureSettings secureSettings;
 
     /** The first level of setting names. This is constructed lazily in {@link #names()}. */
-    private final SetOnce<Set<String>> firstLevelNames = new SetOnce<>();
+    private Set<String> firstLevelNames;
 
     /**
      * Setting names found in this Settings for both string and secure settings.
      * This is constructed lazily in {@link #keySet()}.
      */
-    private final SetOnce<Set<String>> keys = new SetOnce<>();
+    private Set<String> keys;
 
     private Settings(Map<String, Object> settings, SecureSettings secureSettings) {
         // we use a sorted map for consistent serialization when using getAsMap()
@@ -477,24 +477,24 @@ public final class Settings implements ToXContentFragment {
      * @return  The direct keys of this settings
      */
     public Set<String> names() {
-        synchronized (firstLevelNames) {
-            if (firstLevelNames.get() == null) {
-                Stream<String> stream = settings.keySet().stream();
-                if (secureSettings != null) {
-                    stream = Stream.concat(stream, secureSettings.getSettingNames().stream());
-                }
-                Set<String> names = stream.map(k -> {
-                    int i = k.indexOf('.');
-                    if (i < 0) {
-                        return k;
-                    } else {
-                        return k.substring(0, i);
-                    }
-                }).collect(Collectors.toSet());
-                firstLevelNames.set(Collections.unmodifiableSet(names));
-            }
+        final Set<String> names = firstLevelNames;
+        if (names != null) {
+            return names;
         }
-        return firstLevelNames.get();
+        Stream<String> stream = settings.keySet().stream();
+        if (secureSettings != null) {
+            stream = Stream.concat(stream, secureSettings.getSettingNames().stream());
+        }
+        final Set<String> newFirstLevelNames = Collections.unmodifiableSet(stream.map(k -> {
+            int i = k.indexOf('.');
+            if (i < 0) {
+                return k;
+            } else {
+                return k.substring(0, i);
+            }
+        }).collect(Collectors.toSet()));
+        firstLevelNames = newFirstLevelNames;
+        return newFirstLevelNames;
     }
 
     /**
@@ -714,21 +714,21 @@ public final class Settings implements ToXContentFragment {
 
     /** Returns the fully qualified setting names contained in this settings object. */
     public Set<String> keySet() {
-        if (keys.get() == null) {
-            synchronized (keys) {
-                // Check that the keys are still null now that we have acquired the lock
-                if (keys.get() == null) {
-                    if (secureSettings == null) {
-                        keys.set(settings.keySet());
-                    } else {
-                        Stream<String> stream = Stream.concat(settings.keySet().stream(), secureSettings.getSettingNames().stream());
-                        // uniquify, since for legacy reasons the same setting name may exist in both
-                        keys.set(Collections.unmodifiableSet(stream.collect(Collectors.toSet())));
-                    }
-                }
-            }
+        final Set<String> keySet = keys;
+        if (keySet != null) {
+            return keySet;
         }
-        return keys.get();
+        final Set<String> newKeySet;
+        if (secureSettings == null) {
+            newKeySet = settings.keySet();
+        } else {
+            // uniquify, since for legacy reasons the same setting name may exist in both
+            final Set<String> merged = new HashSet<>(settings.keySet());
+            merged.addAll(secureSettings.getSettingNames());
+            newKeySet = Collections.unmodifiableSet(merged);
+        }
+        keys = newKeySet;
+        return newKeySet;
     }
 
     /**


### PR DESCRIPTION
Settings show up in a few spots when profiling very large clusters.
This PR fixes a few obvious spots to speed them up a little:
* Remove pointless synchronization on lazy fields as there's never any contention on
building these in the real world anyway and even if there was a rare double execution
wouldn't hurt
* Fix expensive key string building during setting lookup for affix settings
* Fix redundantly running default value method in setting get
* Short circuit common empty list setting parsing + serialization

backport of #78069 