### PR TITLE
[Test] Fix test for api_key enabled

### DIFF
--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/SecurityInfoTransportActionTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/SecurityInfoTransportActionTests.java
@@ -117,7 +117,7 @@ public class SecurityInfoTransportActionTests extends ESTestCase {
             apiKeyServiceEnabled = randomBoolean();
             settings.put("xpack.security.authc.api_key.enabled", apiKeyServiceEnabled);
         } else {
-            apiKeyServiceEnabled = httpSSLEnabled;
+            apiKeyServiceEnabled = true; // this is the default
         }
 
         final boolean auditingEnabled = randomBoolean();


### PR DESCRIPTION
Since #76801, the API Key feature is enabled by default and no longer
ties to HTTPS setting. This PR fixes the test to reflect the new
default.

Resolves: #78162
