### PR TITLE
Fix watcher check that determines when to serialize indices options.

### DIFF
--- a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/support/search/WatcherSearchTemplateRequest.java
+++ b/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/support/search/WatcherSearchTemplateRequest.java
@@ -158,7 +158,7 @@ public class WatcherSearchTemplateRequest implements ToXContentObject {
                 builder.rawField(BODY_FIELD.getPreferredName(), stream);
             }
         }
-        if (indicesOptions != DEFAULT_INDICES_OPTIONS) {
+        if (indicesOptions.equals(DEFAULT_INDICES_OPTIONS) == false) {
             builder.startObject(INDICES_OPTIONS_FIELD.getPreferredName());
             indicesOptions.toXContent(builder, params);
             builder.endObject();

--- a/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/support/WatcherUtilsTests.java
+++ b/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/support/WatcherUtilsTests.java
@@ -150,10 +150,10 @@ public class WatcherUtilsTests extends ESTestCase {
             assertThat(result.getTemplate().getIdOrCode(), equalTo(expectedSource.utf8ToString()));
             assertThat(result.getTemplate().getType(), equalTo(ScriptType.INLINE));
         }
-        if (expectedIndicesOptions != DEFAULT_INDICES_OPTIONS && expectedTypes != null) {
+        if (expectedIndicesOptions.equals(DEFAULT_INDICES_OPTIONS) == false && expectedTypes != null) {
             assertWarnings(IGNORE_THROTTLED_FIELD_WARNING, WatcherSearchTemplateRequest.TYPES_DEPRECATION_MESSAGE);
             assertThat(result.getTypes(), arrayContainingInAnyOrder(expectedTypes));
-        } else if (expectedIndicesOptions != DEFAULT_INDICES_OPTIONS) {
+        } else if (expectedIndicesOptions.equals(DEFAULT_INDICES_OPTIONS) == false) {
             assertWarnings(IGNORE_THROTTLED_FIELD_WARNING);
         } else if (expectedTypes != null) {
             assertWarnings(WatcherSearchTemplateRequest.TYPES_DEPRECATION_MESSAGE);


### PR DESCRIPTION
Backporting #78070 to 7.x branch.

The check was an identity check between the default constant and
the set indices options. This check is incorrect because in many
cases when `IndicesOptions` is parsed or randomly generated in tests,
then this check incorrectly returns false when in fact an `IndicesOptions`
instance is equal to the default constant, but it is just a different
instance/object.

Closes #78035