### PR TITLE
[ML] Job updates in tests should not update blocked on deleting jobs

### DIFF
--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/job/config/JobUpdateTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/job/config/JobUpdateTests.java
@@ -130,7 +130,7 @@ public class JobUpdateTests extends AbstractSerializingTestCase<JobUpdate> {
         if (randomBoolean()) {
             update.setAllowLazyOpen(randomBoolean());
         }
-        if (useInternalParser && randomBoolean()) {
+        if (useInternalParser && randomBoolean() && job.isDeleting() == false) {
             update.setBlocked(BlockedTests.createRandom());
         }
         if (randomBoolean() && job != null) {

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/job/config/JobUpdateTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/job/config/JobUpdateTests.java
@@ -130,7 +130,7 @@ public class JobUpdateTests extends AbstractSerializingTestCase<JobUpdate> {
         if (randomBoolean()) {
             update.setAllowLazyOpen(randomBoolean());
         }
-        if (useInternalParser && randomBoolean() && job.isDeleting() == false) {
+        if (useInternalParser && randomBoolean() && (job == null || job.isDeleting() == false)) {
             update.setBlocked(BlockedTests.createRandom());
         }
         if (randomBoolean() && job != null) {


### PR DESCRIPTION
Deleting jobs do not allow for their `blocked` field to be changed
from `delete`. Tests were creating job updates that ignored that
leading to a test failure when a non-noop update made no change to
a job. This commit ensures random job updates do not have a change
to the `blocked` field for deleting jobs.

Closes #78160
