### PR TITLE
Speed up DiscoveryNodeFilters.trimTier

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/node/DiscoveryNodeFilters.java
+++ b/server/src/main/java/org/elasticsearch/cluster/node/DiscoveryNodeFilters.java
@@ -49,7 +49,10 @@ public class DiscoveryNodeFilters {
     };
 
     public static DiscoveryNodeFilters buildFromKeyValue(OpType opType, Map<String, String> filters) {
-        Map<String, String[]> bFilters = new HashMap<>();
+        if (filters.isEmpty()) {
+            return null;
+        }
+        Map<String, String[]> bFilters = new HashMap<>(filters.size());
         for (Map.Entry<String, String> entry : filters.entrySet()) {
             String[] values = Strings.tokenizeToStringArray(entry.getValue(), ",");
             if (values.length > 0) {
@@ -68,7 +71,7 @@ public class DiscoveryNodeFilters {
 
     DiscoveryNodeFilters(OpType opType, Map<String, String[]> filters) {
         this.opType = opType;
-        this.filters = filters;
+        this.filters = Map.copyOf(filters);
     }
 
     private boolean matchByIP(String[] values, @Nullable String hostIp, @Nullable String publishIp) {

--- a/server/src/main/java/org/elasticsearch/cluster/node/DiscoveryNodeFilters.java
+++ b/server/src/main/java/org/elasticsearch/cluster/node/DiscoveryNodeFilters.java
@@ -95,6 +95,7 @@ public class DiscoveryNodeFilters {
             return null;
         }
         if (original.filters.containsKey(TIER_PREFERENCE)) {
+            // Remove all entries that use "_tier_preference", as these will be handled elsewhere
             if (original.filters.size() == 1) {
                 return null;
             }

--- a/server/src/main/java/org/elasticsearch/common/util/Maps.java
+++ b/server/src/main/java/org/elasticsearch/common/util/Maps.java
@@ -81,12 +81,27 @@ public class Maps {
      * @param <V>   the type of the values in the map
      * @return an immutable map that contains the items from the specified map with the provided key removed
      */
+    @SuppressWarnings("unchecked")
     public static <K, V> Map<K, V> copyMapWithRemovedEntry(final Map<K, V> map, final K key) {
         Objects.requireNonNull(map);
         Objects.requireNonNull(key);
         assert checkIsImmutableMap(map, key, map.get(key));
-        return map.entrySet().stream().filter(k -> key.equals(k.getKey()) == false)
-            .collect(Collectors.toUnmodifiableMap(Map.Entry::getKey, Map.Entry::getValue));
+        if (map.containsKey(key) == false) {
+            return map;
+        }
+        final int size = map.size();
+        if (size == 1) {
+            return Map.of();
+        }
+        @SuppressWarnings("rawtypes")
+        final Map.Entry<K, V>[] entries = new Map.Entry[size - 1];
+        int i = 0;
+        for (Map.Entry<K, V> entry : map.entrySet()) {
+            if (key.equals(entry.getKey()) == false) {
+                entries[i++] = entry;
+            }
+        }
+        return Map.ofEntries(entries);
     }
 
     // map classes that are known to be immutable, used to speed up immutability check in #assertImmutableMap
@@ -154,7 +169,6 @@ public class Maps {
      * @param map - input to be flattened
      * @param flattenArrays - if false, arrays will be ignored
      * @param ordered - if true the resulted map will be sorted
-     * @return
      */
     public static Map<String, Object> flatten(Map<String, Object> map, boolean flattenArrays, boolean ordered) {
         return flatten(map, flattenArrays, ordered, null);

--- a/server/src/test/java/org/elasticsearch/common/util/MapsTests.java
+++ b/server/src/test/java/org/elasticsearch/common/util/MapsTests.java
@@ -28,6 +28,7 @@ import java.util.stream.Stream;
 
 import static java.util.Map.entry;
 import static java.util.stream.Collectors.toMap;
+import static org.hamcrest.Matchers.anEmptyMap;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.hasItem;
@@ -188,6 +189,16 @@ public class MapsTests extends ESTestCase {
         for (Map.Entry<String, Object> entry : flatten.entrySet()) {
             assertThat(entry.getKey(), entry.getValue(), equalTo(deepGet(entry.getKey(), map)));
         }
+    }
+
+    public void testCopyMapWithAddedOrReplacedEntry() {
+        final Map<String, String> start = Map.of("foo", "bar", "blub", "bla");
+        final Map<String, String> removeMissing = Maps.copyMapWithRemovedEntry(start, "missing");
+        assertSame(start, removeMissing);
+        final Map<String, String> removeFoo = Maps.copyMapWithRemovedEntry(start, "foo");
+        assertThat(removeFoo, equalTo(Map.of("blub", "bla")));
+        final Map<String, String> removeBlub = Maps.copyMapWithRemovedEntry(removeFoo, "blub");
+        assertThat(removeBlub, anEmptyMap());
     }
 
     @SuppressWarnings("unchecked")


### PR DESCRIPTION
This shows up as expensive in profiling in at least the data tier allocation decider in 7.x.
Made it more efficient and also made `copyMapWithRemovedEntry` that it uses more
efficient and added tests for it.
