### PR TITLE
integrate transform deprecations into deprecation API

### DIFF
--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/DeprecationInfoAction.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/DeprecationInfoAction.java
@@ -211,6 +211,14 @@ public class DeprecationInfoAction extends ActionType<DeprecationInfoAction.Resp
                 }
             }
 
+            // WORKAROUND: move transform deprecation issues into cluster_settings
+            List<DeprecationIssue> transformDeprecations = pluginSettingIssues.remove(
+                TransformDeprecationChecker.TRANSFORM_DEPRECATION_KEY
+            );
+            if (transformDeprecations != null) {
+                clusterSettingsIssues.addAll(transformDeprecations);
+            }
+
             return new DeprecationInfoAction.Response(clusterSettingsIssues, nodeSettingsIssues, indexSettingsIssues, pluginSettingIssues);
         }
     }

--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/TransformDeprecationChecker.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/TransformDeprecationChecker.java
@@ -1,0 +1,68 @@
+package org.elasticsearch.xpack.deprecation;
+
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.cluster.metadata.Metadata;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.xpack.core.action.util.PageParams;
+import org.elasticsearch.xpack.core.deprecation.DeprecationIssue;
+import org.elasticsearch.xpack.core.transform.action.GetTransformAction;
+import org.elasticsearch.xpack.core.transform.transforms.TransformConfig;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class TransformDeprecationChecker implements DeprecationChecker {
+
+    public static final String TRANSFORM_DEPRECATION_KEY = "transform_settings";
+
+    @Override
+    public boolean enabled(Settings settings) {
+        // always enabled
+        return true;
+    }
+
+    @Override
+    public void check(Components components, ActionListener<CheckResult> deprecationIssueListener) {
+
+        PageParams startPage = new PageParams(0, PageParams.DEFAULT_SIZE);
+        List<DeprecationIssue> issues = new ArrayList<>();
+        recursiveGetTransformsAndCollectDeprecations(
+            components,
+            issues,
+            startPage,
+            ActionListener.wrap(
+                allIssues -> { deprecationIssueListener.onResponse(new CheckResult(getName(), allIssues)); },
+                deprecationIssueListener::onFailure
+            )
+        );
+    }
+
+    @Override
+    public String getName() {
+        return TRANSFORM_DEPRECATION_KEY;
+    }
+
+    private void recursiveGetTransformsAndCollectDeprecations(
+        Components components,
+        List<DeprecationIssue> issues,
+        PageParams page,
+        ActionListener<List<DeprecationIssue>> listener
+    ) {
+        final GetTransformAction.Request request = new GetTransformAction.Request(Metadata.ALL);
+        request.setPageParams(page);
+        request.setAllowNoResources(true);
+
+        components.client().execute(GetTransformAction.INSTANCE, request, ActionListener.wrap(getTransformResponse -> {
+            for (TransformConfig config : getTransformResponse.getTransformConfigurations()) {
+                issues.addAll(config.checkForDeprecations(components.xContentRegistry()));
+            }
+            if (getTransformResponse.getCount() >= (page.getFrom() + page.getSize())) {
+                PageParams nextPage = new PageParams(page.getFrom() + page.getSize(), PageParams.DEFAULT_SIZE);
+                recursiveGetTransformsAndCollectDeprecations(components, issues, nextPage, listener);
+            } else {
+                listener.onResponse(issues);
+            }
+
+        }, listener::onFailure));
+    }
+}

--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/TransformDeprecationChecker.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/TransformDeprecationChecker.java
@@ -1,3 +1,10 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
 package org.elasticsearch.xpack.deprecation;
 
 import org.elasticsearch.action.ActionListener;

--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/TransportDeprecationInfoAction.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/TransportDeprecationInfoAction.java
@@ -38,8 +38,8 @@ import static org.elasticsearch.xpack.deprecation.DeprecationChecks.CLUSTER_SETT
 import static org.elasticsearch.xpack.deprecation.DeprecationChecks.INDEX_SETTINGS_CHECKS;
 
 public class TransportDeprecationInfoAction extends TransportMasterNodeReadAction<DeprecationInfoAction.Request,
-        DeprecationInfoAction.Response> {
-    private static final List<DeprecationChecker> PLUGIN_CHECKERS = List.of(new MlDeprecationChecker());
+    DeprecationInfoAction.Response> {
+    private static final List<DeprecationChecker> PLUGIN_CHECKERS = List.of(new MlDeprecationChecker(), new TransformDeprecationChecker());
     private static final Logger logger = LogManager.getLogger(TransportDeprecationInfoAction.class);
 
     private final NodeClient client;


### PR DESCRIPTION
integrates transform deprecation checks into the deprecation API

Note, as transform requires a _client_ and the _namedXContentRegistry_ it was not possible to integrate directly into the cluster checks. I therefore used the plugin API, but move the content into `cluster_settings` as discussed.

Example output:

```
{
  "cluster_settings" : [
    {
      "level" : "critical",
      "message" : "Transform [t2] is too old",
      "url" : "https://www.elastic.co/guide/en/elasticsearch/reference/master/migrating-8.0.html",
      "details" : "The configuration uses an old format, you can use [_update] or [_upgrade] to update to configuration",
      "resolve_during_rolling_upgrade" : false
    },
    {
...
}
```