### PR TITLE
[7.x] [ML] Job updates in tests should not update blocked on deleting jobs (#78169)

### DIFF
--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/job/config/JobUpdateTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/job/config/JobUpdateTests.java
@@ -129,7 +129,7 @@ public class JobUpdateTests extends AbstractSerializingTestCase<JobUpdate> {
         if (randomBoolean()) {
             update.setAllowLazyOpen(randomBoolean());
         }
-        if (useInternalParser && randomBoolean()) {
+        if (useInternalParser && randomBoolean() && (job == null || job.isDeleting() == false)) {
             update.setBlocked(BlockedTests.createRandom());
         }
         if (randomBoolean() && job != null) {


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [ML] Job updates in tests should not update blocked on deleting jobs (#78169)