### PR TITLE
Fixing breaking test

### DIFF
--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/TimeseriesLifecycleTypeTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/TimeseriesLifecycleTypeTests.java
@@ -166,6 +166,9 @@ public class TimeseriesLifecycleTypeTests extends ESTestCase {
         } else {
             TimeseriesLifecycleType.INSTANCE.validate(coldPhase.values());
         }
+        if (actions.containsKey(FreezeAction.NAME)) {
+            assertSettingDeprecationsAndWarnings(new String[0], TimeseriesLifecycleType.FREEZE_ACTION_DEPRECATION_WARNING);
+        }
     }
 
     public void testFreezeActionDeprecationLog() {


### PR DESCRIPTION
Fixing.a random test failure where the deprecated freeze action is sometimes used when creating an ILM phase
Relates #77969