### PR TITLE
[DOCS] Remove the `listener` thread pool

### DIFF
--- a/docs/reference/migration/migrate_8_0/threadpool.asciidoc
+++ b/docs/reference/migration/migrate_8_0/threadpool.asciidoc
@@ -6,6 +6,21 @@
 //Installation and Upgrade Guide
 
 //tag::notable-breaking-changes[]
+
+.The `listener` thread pool has been removed.
+[%collapsible]
+====
+*Details* +
+Previously, the transport client used the thread pool to ensure listeners aren't
+called back on network threads. The transport client has been removed
+in 8.0, and the thread pool is no longer needed.
+
+*Impact* +
+Remove `listener` thread pool settings from `elasticsearch.yml` for any nodes.
+Specifying `listener` thread pool settings in `elasticsearch.yml` will result in
+an error on startup.
+====
+
 .The `fixed_auto_queue_size` thread pool type has been removed.
 [%collapsible]
 ====
@@ -17,4 +32,5 @@ The `search` and `search_throttled` thread pools have the `fixed` type now.
 *Impact* +
 No action needed.
 ====
+
 //end::notable-breaking-changes[]

--- a/docs/reference/modules/threadpool.asciidoc
+++ b/docs/reference/modules/threadpool.asciidoc
@@ -56,11 +56,6 @@ There are several thread pools, but the important ones include:
     keep-alive of `5m` and a max of `min(10, (`<<node.processors,
     `# of allocated processors`>>`) / 2)`.
 
-`listener`::
-    Mainly for java client executing of action when listener threaded is set to
-    `true`. Thread pool type is `scaling` with a default max of
-    `min(10, (`<<node.processors, `# of allocated processors`>>`) / 2)`.
-
 `fetch_shard_started`::
     For listing shard states.
     Thread pool type is `scaling` with keep-alive of `5m` and a default maximum


### PR DESCRIPTION
Changes:
* Removes docs for the `listener` thread pool
* Adds an 8.0 breaking change for the thread pool removal

Relates to #53314 and #53049

### Preview
https://elasticsearch_78194.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/migrating-8.0.html#breaking_80_threadpool_changes