### PR TITLE
EQL: Filter out null join keys in sequence queries

### DIFF
--- a/x-pack/plugin/eql/qa/common/src/main/resources/additional_test_queries.toml
+++ b/x-pack/plugin/eql/qa/common/src/main/resources/additional_test_queries.toml
@@ -414,3 +414,30 @@ query = '''
 process where substring(command_line, 5) regex (".*?net[1]?  localgroup.*?", ".*? myappserver.py .*?")
 '''
 
+
+[[queries]]
+name = "sequenceOnOneNullKey"
+query = '''
+sequence
+  [process where parent_process_path == null] by parent_process_path
+  [any where true] by parent_process_path
+'''
+expected_event_ids = []
+
+[[queries]]
+name = "sequenceOnTwoNullKeys"
+query = '''
+sequence by ppid 
+  [process where parent_process_path == null] by parent_process_path
+  [any where true] by parent_process_path
+'''
+expected_event_ids = []
+
+[[queries]]
+name = "sequenceOnImplicitNullKeys"
+query = '''
+sequence by ppid, parent_process_path
+  [process where parent_process_path == null]
+  [any where true]
+'''
+expected_event_ids = []

--- a/x-pack/plugin/eql/qa/correctness/src/javaRestTest/resources/queries.toml
+++ b/x-pack/plugin/eql/qa/correctness/src/javaRestTest/resources/queries.toml
@@ -385,8 +385,8 @@ type = "sequence"
 
 [[queries]]
 queryNo = 24
-count = 1
-expected_event_ids = [2860083, 2860090, 2860098]
+count = 0
+expected_event_ids = []
 filter_counts = [6, 6, 6]
 filters = [
   'security where hostname != "newyork" and event_id == 4625',

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/execution/assembler/BoxedQueryRequest.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/execution/assembler/BoxedQueryRequest.java
@@ -7,7 +7,6 @@
 
 package org.elasticsearch.xpack.eql.execution.assembler;
 
-import org.elasticsearch.index.query.BoolQueryBuilder;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.index.query.RangeQueryBuilder;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
@@ -22,7 +21,6 @@ import java.util.List;
 import java.util.Set;
 
 import static java.util.Collections.emptyList;
-import static org.elasticsearch.index.query.QueryBuilders.boolQuery;
 import static org.elasticsearch.index.query.QueryBuilders.existsQuery;
 import static org.elasticsearch.index.query.QueryBuilders.rangeQuery;
 import static org.elasticsearch.index.query.QueryBuilders.termQuery;
@@ -60,12 +58,10 @@ public class BoxedQueryRequest implements QueryRequest {
         RuntimeUtils.addFilter(timestampRange, searchSource);
         // do not join on null values
         if (keyNames.isEmpty() == false) {
-            BoolQueryBuilder nullValuesFilter = boolQuery();
-            for (int keyIndex = 0; keyIndex < keyNames.size(); keyIndex++) {
+            for (String keyName : keyNames) {
                 // add an "exists" query for each join key to filter out any non-existent values
-                nullValuesFilter.must(existsQuery(keyNames.get(keyIndex)));
+                RuntimeUtils.addFilter(existsQuery(keyName), searchSource);
             }
-            RuntimeUtils.addFilter(nullValuesFilter, searchSource);
         }
     }
 


### PR DESCRIPTION
Joining on `null` keys in sequences can lead to a high amount of queries and matches in a cluster or CCS multi-cluster scenario where some indices have mappings with existent fields while others don't. This change removes support for joining on `null` values by filtering them out pro-actively with an `exists` filter.