### PR TITLE
[DOCS] Remove support for EOL OSs and `SysV init`

### DIFF
--- a/docs/reference/migration/migrate_8_0.asciidoc
+++ b/docs/reference/migration/migrate_8_0.asciidoc
@@ -104,9 +104,9 @@ the `SysV init` process.
 
 *Details* +
 Ensure your nodes use a
-https://www.elastic.co/support/matrix#matrix_os[supported operating system] for
-8.0. Running {es} on an unsupported operating system can result in unexpected
-errors or failures.
+https://www.elastic.co/support/matrix#matrix_os[supported operating system].
+Running {es} on an unsupported operating system can result in unexpected errors
+or failures.
 ====
 
 // end::notable-breaking-changes[]

--- a/docs/reference/migration/migrate_8_0.asciidoc
+++ b/docs/reference/migration/migrate_8_0.asciidoc
@@ -85,6 +85,29 @@ Use the replacement REST API endpoints. Requests submitted to the `_xpack`
 API endpoints will return an error.
 ====
 
+.Several EOL operating systems are no longer supported.
+[%collapsible]
+====
+*Details* +
+The following operating systems have reached their end of life and are no longer
+supported by {es}:
+
+* Amazon Linux
+* CentOS 6
+* Debian 8
+* openSUSE Leap 42
+* Oracle Enterprise Linux 6
+* Ubuntu 16.04
+
+We've also removed support for `SysV init`. No supported operating systems use
+the `SysV init` process.
+
+*Details* +
+Ensure your nodes use a
+https://www.elastic.co/support/matrix#matrix_os[supported operating system] for
+8.0. Running {es} on an unsupported operating system can result in unexpected
+errors or failures.
+====
 
 // end::notable-breaking-changes[]
 


### PR DESCRIPTION
Adds an 8.0 breaking change for the removal of support for several EOL operating
systems and `SysV init`.

Relates to #51480 and #51716

### Preview
https://elasticsearch_78199.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/migrating-8.0.html#breaking-changes-8.0