### PR TITLE
[7.x] Upgrade bundled JDK to Java 17 (#78197)

### DIFF
--- a/build-tools-internal/version.properties
+++ b/build-tools-internal/version.properties
@@ -2,7 +2,7 @@ elasticsearch     = 7.16.0
 lucene            = 8.10.0-snapshot-bf2fcb53079
 
 bundled_jdk_vendor = adoptium
-bundled_jdk = 16.0.2+7
+bundled_jdk = 17+35
 
 checkstyle = 8.39
 

--- a/build-tools/src/main/java/org/elasticsearch/gradle/JdkDownloadPlugin.java
+++ b/build-tools/src/main/java/org/elasticsearch/gradle/JdkDownloadPlugin.java
@@ -132,12 +132,11 @@ public class JdkDownloadPlugin implements Plugin<Project> {
             // The following is an absolute hack until Adoptium provides Apple aarch64 builds
             String zuluPathSuffix = jdk.getPlatform().equals("linux") ? "-embedded" : "";
             switch (jdk.getMajor()) {
+                case "17":
                 case "16":
                     artifactPattern = "zulu"
                         + zuluPathSuffix
-                        + "/bin/zulu"
-                        + jdk.getMajor()
-                        + ".32.15-ca-jdk16.0.2-"
+                        + "/bin/zulu16.32.15-ca-jdk16.0.2-"
                         + azulPlatform(jdk)
                         + "_[classifier].[ext]";
                     break;

--- a/docs/changelog/78197.yaml
+++ b/docs/changelog/78197.yaml
@@ -1,0 +1,6 @@
+pr: 78197
+summary: Upgrade bundled JDK to Java 17
+area: Packaging
+type: upgrade
+issues:
+ - 78168


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Upgrade bundled JDK to Java 17 (#78197)