### PR TITLE
[DOCS] Remove `_term` and `_time` agg order keys

### DIFF
--- a/docs/reference/aggregations/bucket/terms-aggregation.asciidoc
+++ b/docs/reference/aggregations/bucket/terms-aggregation.asciidoc
@@ -248,8 +248,6 @@ GET /_search
 }
 --------------------------------------------------
 
-deprecated[6.0.0, Use `_key` instead of `_term` to order buckets by their term]
-
 Ordering the buckets by single value metrics sub-aggregation (identified by the aggregation name):
 
 [source,console,id=terms-aggregation-subaggregation-example]

--- a/docs/reference/migration/migrate_8_0/aggregations.asciidoc
+++ b/docs/reference/migration/migrate_8_0/aggregations.asciidoc
@@ -7,6 +7,32 @@
 
 //tag::notable-breaking-changes[]
 
+[[remove-term-order-key]]
+.The `terms` aggregation no longer supports the `_term` order key.
+[%collapsible]
+====
+*Details* +
+The `terms` aggregation no longer supports the `_term` key in `order` values. To
+sort buckets by their term, use `_key` instead.
+
+*Impact* +
+Discontinue use of the `_term` order key. Requests that include a `_term` order
+key will return an error.
+====
+
+[[remove-time-order-key]]
+.The `date_histogram` aggregation no longer supports the `_time` order key.
+[%collapsible]
+====
+*Details* +
+The `date_histogram` aggregation no longer supports the `_time` key in `order`
+values. To sort buckets by their key, use `_key` instead.
+
+*Impact* +
+Discontinue use of the `_time` order key. Requests that include a `_time` order
+key will return an error.
+====
+
 [[remove-moving-avg-agg]]
 .The `moving_avg` aggregation has been removed.
 [%collapsible]


### PR DESCRIPTION
Adds an 8.0 breaking change for the removal of the `_term` and `_time`
agg `order` keys.

Relates to #39450

### Preview
https://elasticsearch_78209.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/migrating-8.0.html#breaking_80_aggregations_changes