### PR TITLE
Batch cluster state updates in ILM

### DIFF
--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/MoveToErrorStepUpdateTask.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/MoveToErrorStepUpdateTask.java
@@ -73,16 +73,21 @@ public class MoveToErrorStepUpdateTask extends ClusterStateUpdateTask {
 
     @Override
     public void clusterStateProcessed(String source, ClusterState oldState, ClusterState newState) {
-        if (newState.equals(oldState) == false) {
-            stateChangeConsumer.accept(newState);
+        IndexMetadata indexMetadata = newState.metadata().index(index);
+        if (indexMetadata != null) {
+            LifecycleExecutionState lifecycleState = LifecycleExecutionState.fromIndexMetadata(indexMetadata);
+            Step.StepKey newStepKey = LifecycleExecutionState.getCurrentStepKey(lifecycleState);
+            if (currentStepKey.equals(newStepKey) == false) {
+                stateChangeConsumer.accept(newState);
+            }
         }
     }
 
     @Override
     public void onFailure(String source, Exception e) {
         final MessageSupplier messageSupplier = () -> new ParameterizedMessage(
-                "policy [{}] for index [{}] failed trying to move from step [{}] to the ERROR step.", policy, index.getName(),
-                currentStepKey);
+            "policy [{}] for index [{}] failed trying to move from step [{}] to the ERROR step.", policy, index.getName(),
+            currentStepKey);
         if (ExceptionsHelper.unwrap(e, NotMasterException.class, FailedToCommitClusterStateException.class) != null) {
             logger.debug(messageSupplier, e);
         } else {

--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/TaskExecutor.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/TaskExecutor.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.ilm;
+
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.ClusterStateTaskExecutor;
+import org.elasticsearch.cluster.ClusterStateUpdateTask;
+
+import java.util.List;
+
+class TaskExecutor implements ClusterStateTaskExecutor<ClusterStateUpdateTask> {
+
+    @Override
+    public ClusterTasksResult<ClusterStateUpdateTask> execute(ClusterState currentState, List<ClusterStateUpdateTask> tasks)
+        throws Exception {
+        ClusterTasksResult.Builder<ClusterStateUpdateTask> builder = ClusterTasksResult.builder();
+        ClusterState state = currentState;
+        for (ClusterStateUpdateTask task : tasks) {
+            state = task.execute(state);
+            builder.success(task);
+        }
+        return builder.build(state);
+    }
+
+    @Override
+    public String describeTasks(List<ClusterStateUpdateTask> tasks) {
+        return "";
+    }
+}


### PR DESCRIPTION
Switch `clusterService.submitStateUpdateTask` used by `IndexLifecycleRunner` to batching version.

Closes https://github.com/elastic/elasticsearch/issues/75853