### PR TITLE
[DOCS] Add breaking change for unsupported `script` fields

### DIFF
--- a/docs/reference/migration/migrate_8_0/reindex.asciidoc
+++ b/docs/reference/migration/migrate_8_0/reindex.asciidoc
@@ -50,4 +50,17 @@ Similarly, the `size` parameter has been renamed to `max_docs` for
 Use the replacement parameters. Requests containing the `size` parameter will
 return an error.
 ====
+
+.The update by query API now rejects unsupported `script` fields.
+[%collapsible]
+====
+*Details* +
+An update by query API request that includes an unsupported field in the
+`script` object now returns an error. Previously, the API would silently ignore
+these unsupported fields.
+
+*Impact* +
+To avoid errors, remove unsupported fields from the `script` object.
+====
+
 //end::notable-breaking-changes[]


### PR DESCRIPTION
Adds an 8.0 breaking change for PR #59507.

### Preview
https://elasticsearch_78217.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/migrating-8.0.html#breaking_80_reindex_changes