### PR TITLE
Ensure example plugin projects don't use stale artifacts

### DIFF
--- a/plugins/examples/build.gradle
+++ b/plugins/examples/build.gradle
@@ -19,16 +19,18 @@ subprojects {
   targetCompatibility = 11
 
   repositories {
-    // Only necessary when building plugins against SNAPSHOT versions of Elasticsearch
-    maven {
-      url = 'https://snapshots.elastic.co/maven/'
+    if (gradle.includedBuilds == false) {
+      // Only necessary when building plugins against SNAPSHOT versions of Elasticsearch
+      maven {
+        url = 'https://snapshots.elastic.co/maven/'
+      }
     }
 
     // Same for Lucene, add the snapshot repo based on the currently used Lucene version
     def luceneVersion = VersionProperties.getLucene()
     if (luceneVersion.contains('-snapshot')) {
       def matcher = luceneVersion =~ /[0-9\.]+-snapshot-([a-z0-9]+)/
-      assert matcher.matches() : "Invalid Lucene snapshot version '${luceneVersion}'"
+      assert matcher.matches(): "Invalid Lucene snapshot version '${luceneVersion}'"
       maven {
         url = "https://s3.amazonaws.com/download.elasticsearch.org/lucenesnapshots/${matcher.group(1)}"
       }

--- a/plugins/examples/settings.gradle
+++ b/plugins/examples/settings.gradle
@@ -36,8 +36,16 @@ gradle.projectsEvaluated {
         resolutionStrategy.dependencySubstitution {
           // When using composite builds we need to tell Gradle to use the project names since we rename the published artifacts
           substitute module('org.elasticsearch:elasticsearch') using module("org.elasticsearch:server:${elasticsearchVersion}")
+          substitute module('org.elasticsearch.client:elasticsearch-rest-high-level-client') using module("org.elasticsearch.client:rest-high-level:${elasticsearchVersion}")
           substitute module('org.elasticsearch.client:elasticsearch-rest-client') using module("org.elasticsearch.client:rest:${elasticsearchVersion}")
+          substitute module('org.elasticsearch.plugin:x-pack-core') with module("org.elasticsearch.plugin:core:${elasticsearchVersion}")
+          substitute module('org.elasticsearch.plugin:elasticsearch-scripting-painless-spi') with module("org.elasticsearch.plugin:spi:${elasticsearchVersion}")
           substitute module('org.elasticsearch.distribution.integ-test-zip:elasticsearch') using variant(module("org.elasticsearch.distribution.integ-test-zip:integ-test-zip:${elasticsearchVersion}")) {
+            attributes {
+              attribute(Attribute.of("composite", Boolean.class), true)
+            }
+          }
+          substitute module('elasticsearch-distribution-snapshot:elasticsearch') using variant(module("org.elasticsearch.distribution.default:${getDefaultDistroProjectName()}:${elasticsearchVersion}")) {
             attributes {
               attribute(Attribute.of("composite", Boolean.class), true)
             }
@@ -45,5 +53,24 @@ gradle.projectsEvaluated {
         }
       }
     }
+  }
+}
+
+/*
+ * Determine which :distribution:archives project to use when resolving as part of a composite build.
+ * We have to duplicate this somewhat, since the example plugins can't use InternalDistributionDownloadPlugin (this is intentional) which is where
+ * that resolution logic lives.
+ */
+static def getDefaultDistroProjectName() {
+  String os = System.getProperty("os.name", "")
+  boolean isArm = System.getProperty("os.arch", "") == 'aarch64'
+  if (os.startsWith("Windows")) {
+    return 'windows-zip'
+  } else if (os.startsWith("Linux") || os.startsWith("LINUX")) {
+    return isArm ? 'linux-aarch64-tar' : 'linux-tar'
+  } else if (os.startsWith("Mac")) {
+    return isArm ? 'darwing-aarch64-tar' : 'darwin-tar'
+  } else {
+    throw new GradleException("Unable to determine system platform type.")
   }
 }


### PR DESCRIPTION
This is a follow up to #78140 and fixes a few instances where the build
was resolving artifacts from our snapshot Maven repository insteady of
using project dependency substitutions from the included build. To
ensure we don't miss these going forward, when building in a composite
we omit the snapshot repo definition altogether, which would instead
result in an error during dependency resolution.