### PR TITLE
Fix mixed-cluster tests when built in release mode

### DIFF
--- a/qa/mixed-cluster/build.gradle
+++ b/qa/mixed-cluster/build.gradle
@@ -39,9 +39,6 @@ for (Version bwcVersion : BuildParams.bwcVersions.wireCompatible) {
 
       setting 'path.repo', "${buildDir}/cluster/shared/repo/${baseName}"
       setting 'xpack.security.enabled', 'false'
-      if (BuildParams.isSnapshotBuild() == false) {
-        systemProperty 'es.index_mode_feature_flag_registered', 'true'
-      }
     }
   }
 
@@ -53,10 +50,16 @@ for (Version bwcVersion : BuildParams.bwcVersions.wireCompatible) {
       // Getting the endpoints causes a wait for the cluster
       println "Test cluster endpoints are: ${-> testClusters."${baseName}".allHttpSocketURI.join(",")}"
       println "Upgrading one node to create a mixed cluster"
+      if (BuildParams.isSnapshotBuild() == false) {
+        testClusters."${baseName}".nodes."${baseName}-0".systemProperty 'es.index_mode_feature_flag_registered', 'true'
+      }
       testClusters."${baseName}".nextNodeToNextVersion()
       // Getting the endpoints causes a wait for the cluster
       println "Upgrade complete, endpoints are: ${-> testClusters."${baseName}".allHttpSocketURI.join(",")}"
       println "Upgrading another node to create a mixed cluster"
+      if (BuildParams.isSnapshotBuild() == false) {
+        testClusters."${baseName}".nodes."${baseName}-1".systemProperty 'es.index_mode_feature_flag_registered', 'true'
+      }
       testClusters."${baseName}".nextNodeToNextVersion()
 
       nonInputProperties.systemProperty('tests.rest.cluster', "${-> testClusters."${baseName}".allHttpSocketURI.join(",")}")


### PR DESCRIPTION
We're fixing our release tests by only enabling this feature flag on the `master` nodes, that is, those built with `-Dbuild.snapshot=false`.

Closes #78219