### PR TITLE
[7.x][DOCS] Fixes broken links

### DIFF
--- a/docs/reference/setup/setup-xclient.asciidoc
+++ b/docs/reference/setup/setup-xclient.asciidoc
@@ -113,4 +113,5 @@ Then in your project's `pom.xml` if using maven, add the following repositories 
 --
 
 . If you are using {stack} {security-features}, there are more configuration
-steps. See {ref}/java-clients.html[Java Client and security].
+steps. Refer to 
+{java-rest}/java-rest-overview.html[the Java Client documentation].

--- a/x-pack/docs/en/security/securing-communications/separating-node-client-traffic.asciidoc
+++ b/x-pack/docs/en/security/securing-communications/separating-node-client-traffic.asciidoc
@@ -67,5 +67,4 @@ transport.profiles.client.xpack.security.ssl.client_authentication: none
 
 This setting keeps certificate authentication active for node-to-node traffic,
 but removes the requirement to distribute a signed certificate to transport
-clients. For more information, see
-{ref}/java-clients.html#transport-client[Configuring the Transport Client to work with a Secured Cluster].
+clients.


### PR DESCRIPTION
## Overview

This PR fixes two broken links that point to non-existing pages.
Related to the docs-ci fail in https://github.com/elastic/elasticsearch/pull/78212