### PR TITLE
Make Empty Map Diffs more Efficient (#78058)

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/metadata/DiffableStringMap.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/DiffableStringMap.java
@@ -65,11 +65,39 @@ public class DiffableStringMap extends AbstractMap<String, String> implements Di
 
     @Override
     public Diff<DiffableStringMap> diff(DiffableStringMap previousState) {
-        return new DiffableStringMapDiff(previousState, this);
+        if (equals(previousState)) {
+            return DiffableStringMapDiff.EMPTY;
+        }
+        final List<String> tempDeletes = new ArrayList<>();
+        for (String key : previousState.keySet()) {
+            if (containsKey(key) == false) {
+                tempDeletes.add(key);
+            }
+        }
+
+        final Map<String, String> tempUpserts = new HashMap<>();
+        for (Map.Entry<String, String> partIter : entrySet()) {
+            String beforePart = previousState.get(partIter.getKey());
+            if (beforePart == null) {
+                tempUpserts.put(partIter.getKey(), partIter.getValue());
+            } else if (partIter.getValue().equals(beforePart) == false) {
+                tempUpserts.put(partIter.getKey(), partIter.getValue());
+            }
+        }
+        return getDiff(tempDeletes, tempUpserts);
     }
 
     public static Diff<DiffableStringMap> readDiffFrom(StreamInput in) throws IOException {
-        return new DiffableStringMapDiff(in);
+        final List<String> deletes = in.readStringList();
+        final Map<String, String> upserts = in.readMap(StreamInput::readString, StreamInput::readString);
+        return getDiff(deletes, upserts);
+    }
+
+    private static Diff<DiffableStringMap> getDiff(List<String> deletes, Map<String, String> upserts) {
+        if (deletes.isEmpty() && upserts.isEmpty()) {
+            return DiffableStringMapDiff.EMPTY;
+        }
+        return new DiffableStringMapDiff(deletes, upserts);
     }
 
     /**
@@ -77,35 +105,19 @@ public class DiffableStringMap extends AbstractMap<String, String> implements Di
      */
     public static class DiffableStringMapDiff implements Diff<DiffableStringMap> {
 
-        public static final DiffableStringMapDiff EMPTY = new DiffableStringMapDiff(DiffableStringMap.EMPTY, DiffableStringMap.EMPTY);
+        public static final DiffableStringMapDiff EMPTY = new DiffableStringMapDiff(Collections.emptyList(), Collections.emptyMap()) {
+            @Override
+            public DiffableStringMap apply(DiffableStringMap part) {
+                return part;
+            }
+        };
 
         private final List<String> deletes;
         private final Map<String, String> upserts; // diffs also become upserts
 
-        private DiffableStringMapDiff(DiffableStringMap before, DiffableStringMap after) {
-            final List<String> tempDeletes = new ArrayList<>();
-            final Map<String, String> tempUpserts = new HashMap<>();
-            for (String key : before.keySet()) {
-                if (after.containsKey(key) == false) {
-                    tempDeletes.add(key);
-                }
-            }
-
-            for (Map.Entry<String, String> partIter : after.entrySet()) {
-                String beforePart = before.get(partIter.getKey());
-                if (beforePart == null) {
-                    tempUpserts.put(partIter.getKey(), partIter.getValue());
-                } else if (partIter.getValue().equals(beforePart) == false) {
-                    tempUpserts.put(partIter.getKey(), partIter.getValue());
-                }
-            }
-            deletes = tempDeletes;
-            upserts = tempUpserts;
-        }
-
-        private DiffableStringMapDiff(StreamInput in) throws IOException {
-            deletes = in.readStringList();
-            upserts = in.readMap(StreamInput::readString, StreamInput::readString);
+        private DiffableStringMapDiff(List<String> deletes, Map<String, String> upserts) {
+            this.deletes = deletes;
+            this.upserts = upserts;
         }
 
         public List<String> getDeletes() {
@@ -135,9 +147,7 @@ public class DiffableStringMap extends AbstractMap<String, String> implements Di
             }
             assert getDiffs().size() == 0 : "there should never be diffs for DiffableStringMap";
 
-            for (Map.Entry<String, String> upsert : upserts.entrySet()) {
-                builder.put(upsert.getKey(), upsert.getValue());
-            }
+            builder.putAll(upserts);
             return new DiffableStringMap(builder);
         }
     }

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/Metadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/Metadata.java
@@ -1134,7 +1134,7 @@ public class Metadata implements Iterable<IndexMetadata>, Diffable<Metadata>, To
         private CoordinationMetadata coordinationMetadata = CoordinationMetadata.EMPTY_METADATA;
         private Settings transientSettings = Settings.Builder.EMPTY_SETTINGS;
         private Settings persistentSettings = Settings.Builder.EMPTY_SETTINGS;
-        private DiffableStringMap hashesOfConsistentSettings = new DiffableStringMap(Collections.emptyMap());
+        private DiffableStringMap hashesOfConsistentSettings = DiffableStringMap.EMPTY;
 
         private final ImmutableOpenMap.Builder<String, IndexMetadata> indices;
         private final ImmutableOpenMap.Builder<String, IndexTemplateMetadata> templates;


### PR DESCRIPTION
Use empty singletons in a few more places and make empty diffs noops so that
diff application does not result in redundant map copying.

backport of #78058 