### PR TITLE
Simplify test artifact compile classpath

### DIFF
--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/InternalTestArtifactExtension.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/InternalTestArtifactExtension.java
@@ -39,8 +39,6 @@ public class InternalTestArtifactExtension {
             featureSpec.disablePublication();
         });
 
-        Configuration testApiElements = project.getConfigurations().getByName(sourceSet.getApiElementsConfigurationName());
-        testApiElements.extendsFrom(project.getConfigurations().getByName(sourceSet.getCompileClasspathConfigurationName()));
         DependencyHandler dependencies = project.getDependencies();
         project.getPlugins().withType(JavaPlugin.class, javaPlugin -> {
             Dependency projectDependency = dependencies.create(project);

--- a/x-pack/plugin/analytics/build.gradle
+++ b/x-pack/plugin/analytics/build.gradle
@@ -8,10 +8,10 @@ esplugin {
 archivesBaseName = 'x-pack-analytics'
 
 dependencies {
-  compileOnly project(":server")
-
-  compileOnly project(path: xpackModule('core'))
-  testImplementation(testArtifact(project(xpackModule('core'))))
   api 'org.apache.commons:commons-math3:3.6.1'
+  compileOnly project(path: xpackModule('core'))
+  compileOnly project(":server")
+  testImplementation(testArtifact(project(xpackModule('core'))))
+  testImplementation(project(":client:rest-high-level"))
 }
 

--- a/x-pack/plugin/async-search/build.gradle
+++ b/x-pack/plugin/async-search/build.gradle
@@ -16,6 +16,8 @@ dependencies {
   compileOnly project(path: xpackModule('core'))
   testImplementation(testArtifact(project(xpackModule('core'))))
   testImplementation project(path: xpackModule('async'))
+
+  internalClusterTestImplementation project(":modules:reindex")
 }
 
 

--- a/x-pack/plugin/async-search/qa/security/build.gradle
+++ b/x-pack/plugin/async-search/qa/security/build.gradle
@@ -4,6 +4,7 @@ dependencies {
   javaRestTestImplementation(testArtifact(project(xpackModule('core'))))
   javaRestTestImplementation project(xpackModule('async-search'))
   javaRestTestImplementation project(':test:framework')
+  javaRestTestImplementation project(":client:rest-high-level")
 }
 
 testClusters.configureEach {

--- a/x-pack/plugin/build.gradle
+++ b/x-pack/plugin/build.gradle
@@ -13,6 +13,7 @@ archivesBaseName = 'x-pack'
 dependencies {
   testImplementation project(xpackModule('core'))
   testImplementation(testArtifact(project(xpackModule('core'))))
+  testImplementation project(':test:framework')
 }
 
 // let the yamlRestTests see the classpath of test

--- a/x-pack/plugin/ccr/build.gradle
+++ b/x-pack/plugin/ccr/build.gradle
@@ -33,6 +33,7 @@ dependencies {
   compileOnly project(path: xpackModule('core'))
   testImplementation(testArtifact(project(xpackModule('core'))))
   testImplementation(testArtifact(project(xpackModule('monitoring'))))
+  testImplementation(project(":modules:analysis-common"))
 }
 
 tasks.named("testingConventions").configure {

--- a/x-pack/plugin/eql/build.gradle
+++ b/x-pack/plugin/eql/build.gradle
@@ -31,6 +31,8 @@ dependencies {
   testImplementation project(path: ':plugins:transport-nio') // for http in RestEqlCancellationIT
 
   testImplementation 'io.ous:jtoml:2.0.0'
+
+  internalClusterTestImplementation project(":client:rest-high-level")
 }
 
 

--- a/x-pack/plugin/eql/qa/common/build.gradle
+++ b/x-pack/plugin/eql/qa/common/build.gradle
@@ -6,7 +6,7 @@ dependencies {
   api project(path: xpackModule('core'))
   api(testArtifact(project(xpackModule('core'))))
   api project(xpackModule('ql:test-fixtures'))
-
+  implementation project(":client:rest-high-level")
   // TOML parser for EqlActionIT tests
   api 'io.ous:jtoml:2.0.0'
 }

--- a/x-pack/plugin/eql/qa/correctness/build.gradle
+++ b/x-pack/plugin/eql/qa/correctness/build.gradle
@@ -10,6 +10,7 @@ dependencies {
   javaRestTestImplementation project(':test:framework')
   javaRestTestImplementation(testArtifact(project(xpackModule('core'))))
   javaRestTestImplementation project(xpackModule('ql:test-fixtures'))
+  javaRestTestImplementation project(":client:rest-high-level")
   javaRestTestImplementation 'io.ous:jtoml:2.0.0'
 }
 

--- a/x-pack/plugin/identity-provider/build.gradle
+++ b/x-pack/plugin/identity-provider/build.gradle
@@ -13,9 +13,7 @@ archivesBaseName = 'x-pack-identity-provider'
 
 dependencies {
   compileOnly project(path: xpackModule('core'))
-  testImplementation(testArtifact(project(xpackModule('core'))))
-  // So that we can extend LocalStateCompositeXPackPlugin
-  testImplementation(testArtifact(project(xpackModule('security'))))
+
   // the following are all SAML dependencies - might as well download the whole internet
   api "org.opensaml:opensaml-core:${versions.opensaml}"
   api "org.opensaml:opensaml-saml-api:${versions.opensaml}"
@@ -52,6 +50,12 @@ dependencies {
 
   testImplementation 'org.elasticsearch:securemock:1.2'
   testImplementation "org.elasticsearch:mocksocket:${versions.mocksocket}"
+  testImplementation(testArtifact(project(xpackModule('core'))))
+  // So that we can extend LocalStateCompositeXPackPlugin
+  testImplementation(testArtifact(project(xpackModule('security'))))
+  testImplementation project(':modules:lang-mustache')
+  internalClusterTestImplementation project(":modules:analysis-common")
+
 }
 
 tasks.named("dependencyLicenses").configure {

--- a/x-pack/plugin/identity-provider/qa/idp-rest-tests/build.gradle
+++ b/x-pack/plugin/identity-provider/qa/idp-rest-tests/build.gradle
@@ -5,6 +5,7 @@ dependencies {
   javaRestTestImplementation(testArtifact(project(xpackModule('core'))))
   //TODO: update javaRestTests to not rely on any code that it is testing
   javaRestTestImplementation project(path: xpackModule('identity-provider'))
+  javaRestTestImplementation project(":client:rest-high-level")
 }
 
 testClusters.configureEach {

--- a/x-pack/plugin/ilm/qa/multi-node/build.gradle
+++ b/x-pack/plugin/ilm/qa/multi-node/build.gradle
@@ -5,6 +5,7 @@ apply plugin: 'elasticsearch.internal-java-rest-test'
 
 dependencies {
   javaRestTestImplementation(testArtifact(project(xpackModule('core'))))
+  javaRestTestImplementation project(":client:rest-high-level")
 }
 
 File repoDir = file("$buildDir/testclusters/repo")

--- a/x-pack/plugin/ilm/qa/with-security/build.gradle
+++ b/x-pack/plugin/ilm/qa/with-security/build.gradle
@@ -3,6 +3,7 @@ apply plugin: 'elasticsearch.authenticated-testclusters'
 
 dependencies {
   javaRestTestImplementation(testArtifact(project(xpackModule('core'))))
+  javaRestTestImplementation project(":client:rest-high-level")
 }
 
 testClusters.configureEach {

--- a/x-pack/plugin/ml/build.gradle
+++ b/x-pack/plugin/ml/build.gradle
@@ -62,7 +62,10 @@ dependencies {
   testImplementation project(path: xpackModule('ilm'))
   testImplementation project(path: xpackModule('shutdown'))
   testImplementation project(path: xpackModule('data-streams'))
+  testImplementation project(path: xpackModule('monitoring'))
   testImplementation project(':modules:ingest-common')
+  testImplementation project(':modules:reindex')
+  testImplementation project(':modules:analysis-common')
   // This should not be here
   testImplementation(testArtifact(project(xpackModule('security'))))
   // ml deps

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/build.gradle
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/build.gradle
@@ -4,9 +4,16 @@ apply plugin: 'elasticsearch.internal-java-rest-test'
 dependencies {
   javaRestTestImplementation(testArtifact(project(xpackModule('core'))))
   javaRestTestImplementation(testArtifact(project(xpackModule('ml'))))
+  javaRestTestImplementation(testArtifact(project(xpackModule('security'))))
   javaRestTestImplementation project(path: ':modules:ingest-common')
+  javaRestTestImplementation project(path: ':modules:reindex')
+  javaRestTestImplementation project(path: ':modules:transport-netty4')
+  javaRestTestImplementation project(path: xpackModule('autoscaling'))
   javaRestTestImplementation project(path: xpackModule('data-streams'))
+  javaRestTestImplementation project(path: xpackModule('ilm'))
+  javaRestTestImplementation project(path: xpackModule('monitoring'))
   javaRestTestImplementation project(path: xpackModule('transform'))
+  javaRestTestImplementation project(":client:rest-high-level")
 }
 
 // location for keys and certificates

--- a/x-pack/plugin/monitoring/build.gradle
+++ b/x-pack/plugin/monitoring/build.gradle
@@ -12,17 +12,17 @@ archivesBaseName = 'x-pack-monitoring'
 
 dependencies {
   compileOnly project(path: xpackModule('core'))
-  testImplementation(testArtifact(project(xpackModule('core'))))
 
   // monitoring deps
   api project(':client:rest')
   api project(':client:sniffer')
 
   // baz - this goes away after we separate out the actions #27759
+  testImplementation project(":modules:analysis-common")
   testImplementation project(xpackModule('watcher'))
-
   testImplementation project(xpackModule('ilm'))
   testImplementation project(xpackModule('data-streams'))
+  testImplementation(testArtifact(project(xpackModule('core'))))
 }
 
 tasks.named("dependencyLicenses").configure {

--- a/x-pack/plugin/ql/build.gradle
+++ b/x-pack/plugin/ql/build.gradle
@@ -15,11 +15,11 @@ ext {
 archivesBaseName = 'x-pack-ql'
 
 dependencies {
+  api "org.antlr:antlr4-runtime:${antlrVersion}"
   compileOnly project(path: xpackModule('core'))
-  testImplementation project(':test:framework')
-  testImplementation(testArtifact(project(xpackModule('core'))))
-  testImplementation(project(xpackModule('ql:test-fixtures'))) {
+  testApi(project(xpackModule('ql:test-fixtures'))) {
     exclude group: 'org.elasticsearch.plugin', module: 'ql'
   }
-  api "org.antlr:antlr4-runtime:${antlrVersion}"
+  testImplementation project(':test:framework')
+  testImplementation(testArtifact(project(xpackModule('core'))))
 }

--- a/x-pack/plugin/repository-encrypted/qa/azure/build.gradle
+++ b/x-pack/plugin/repository-encrypted/qa/azure/build.gradle
@@ -4,4 +4,8 @@ apply plugin: 'elasticsearch.java'
 dependencies {
     internalClusterTestImplementation testArtifact(project(':plugins:repository-azure'), 'internalClusterTest')
     internalClusterTestImplementation testArtifact(project(':x-pack:plugin:repository-encrypted'), 'test')
+    internalClusterTestImplementation project(':server')
+    internalClusterTestImplementation project(':test:framework')
+    internalClusterTestImplementation project(':x-pack:plugin:core')
+    internalClusterTestImplementation testArtifact(project(':x-pack:plugin:core'))
 }

--- a/x-pack/plugin/repository-encrypted/qa/gcs/build.gradle
+++ b/x-pack/plugin/repository-encrypted/qa/gcs/build.gradle
@@ -4,4 +4,9 @@ apply plugin: 'elasticsearch.java'
 dependencies {
     internalClusterTestImplementation testArtifact(project(':plugins:repository-gcs'), 'internalClusterTest')
     internalClusterTestImplementation testArtifact(project(':x-pack:plugin:repository-encrypted'), 'test')
+    internalClusterTestImplementation project(':server')
+    internalClusterTestImplementation project(':test:framework')
+    internalClusterTestImplementation project(':x-pack:plugin:core')
+    internalClusterTestImplementation testArtifact(project(':x-pack:plugin:core'))
+
 }

--- a/x-pack/plugin/repository-encrypted/qa/s3/build.gradle
+++ b/x-pack/plugin/repository-encrypted/qa/s3/build.gradle
@@ -4,4 +4,8 @@ apply plugin: 'elasticsearch.java'
 dependencies {
     internalClusterTestImplementation testArtifact(project(':plugins:repository-s3'), 'internalClusterTest')
     internalClusterTestImplementation testArtifact(project(':x-pack:plugin:repository-encrypted'), 'test')
+    internalClusterTestImplementation project(':server')
+    internalClusterTestImplementation project(':test:framework')
+    internalClusterTestImplementation project(':x-pack:plugin:core')
+    internalClusterTestImplementation testArtifact(project(':x-pack:plugin:core'))
 }

--- a/x-pack/plugin/security/build.gradle
+++ b/x-pack/plugin/security/build.gradle
@@ -22,6 +22,9 @@ dependencies {
   testImplementation project(path: xpackModule('spatial'))
   testImplementation project(path: ':modules:percolator')
   testImplementation project(path: xpackModule('sql:sql-action'))
+  testImplementation project(path: ':modules:analysis-common')
+  testImplementation project(path: ':modules:reindex')
+  testImplementation project(":client:rest-high-level")
 
   testImplementation(testArtifact(project(xpackModule('core'))))
   internalClusterTestImplementation(testArtifact(project(xpackModule('core'))))

--- a/x-pack/plugin/security/cli/build.gradle
+++ b/x-pack/plugin/security/cli/build.gradle
@@ -16,7 +16,8 @@ dependencies {
   }
   testRuntimeOnly "com.google.guava:guava:${versions.jimfs_guava}"
   testImplementation project(":test:framework")
-testImplementation(testArtifact(project(xpackModule('core'))))}
+  testImplementation(testArtifact(project(xpackModule('core'))))
+}
 
 tasks.named("dependencyLicenses").configure {
   mapping from: /bc.*/, to: 'bouncycastle'

--- a/x-pack/plugin/security/qa/security-basic/build.gradle
+++ b/x-pack/plugin/security/qa/security-basic/build.gradle
@@ -6,6 +6,7 @@ import org.elasticsearch.gradle.internal.info.BuildParams
 dependencies {
   javaRestTestImplementation(testArtifact(project(xpackModule('security'))))
   javaRestTestImplementation(testArtifact(project(xpackModule('core'))))
+  javaRestTestImplementation project(":client:rest-high-level")
 }
 
 if (BuildParams.inFipsJvm){

--- a/x-pack/plugin/security/qa/security-trial/build.gradle
+++ b/x-pack/plugin/security/qa/security-trial/build.gradle
@@ -3,6 +3,8 @@ apply plugin: 'elasticsearch.internal-java-rest-test'
 dependencies {
   javaRestTestImplementation project(path: xpackModule('core'))
   javaRestTestImplementation(testArtifact(project(xpackModule('security'))))
+  javaRestTestImplementation(testArtifact(project(xpackModule('core'))))
+  javaRestTestImplementation project(":client:rest-high-level")
 }
 
 testClusters.matching { it.name == 'javaRestTest' }.configureEach {

--- a/x-pack/plugin/security/qa/smoke-test-all-realms/build.gradle
+++ b/x-pack/plugin/security/qa/smoke-test-all-realms/build.gradle
@@ -11,6 +11,7 @@ apply plugin: 'elasticsearch.internal-java-rest-test'
 dependencies {
   javaRestTestImplementation(testArtifact(project(xpackModule('security'))))
   javaRestTestImplementation(testArtifact(project(xpackModule('core'))))
+  javaRestTestImplementation(project(":client:rest-high-level"))
 }
 
 testClusters.matching { it.name == 'javaRestTest' }.configureEach {

--- a/x-pack/plugin/transform/build.gradle
+++ b/x-pack/plugin/transform/build.gradle
@@ -9,12 +9,14 @@ esplugin {
 
 dependencies {
   compileOnly project(":server")
-
   compileOnly project(path: xpackModule('core'))
+
   testImplementation(testArtifact(project(xpackModule('core'))))
   testImplementation project(path: xpackModule('analytics'))
   testImplementation project(path: ':modules:aggs-matrix-stats')
   testImplementation project(path: xpackModule('spatial'))
+
+  internalClusterTestImplementation project(":modules:reindex")
 }
 
 addQaCheckDependencies()

--- a/x-pack/plugin/transform/qa/multi-node-tests/build.gradle
+++ b/x-pack/plugin/transform/qa/multi-node-tests/build.gradle
@@ -3,6 +3,7 @@ apply plugin: 'elasticsearch.internal-java-rest-test'
 dependencies {
   javaRestTestImplementation(testArtifact(project(xpackModule('core'))))
   javaRestTestImplementation project(path: xpackModule('transform'))
+  javaRestTestImplementation project(":client:rest-high-level")
 }
 
 // location for keys and certificates

--- a/x-pack/plugin/transform/qa/single-node-tests/build.gradle
+++ b/x-pack/plugin/transform/qa/single-node-tests/build.gradle
@@ -4,6 +4,7 @@ apply plugin: 'elasticsearch.internal-java-rest-test'
 dependencies {
   javaRestTestImplementation(testArtifact(project(xpackModule('core'))))
   javaRestTestImplementation project(path: xpackModule('transform'))
+  javaRestTestImplementation project(":client:rest-high-level")
 }
 
 testClusters.configureEach {

--- a/x-pack/plugin/watcher/build.gradle
+++ b/x-pack/plugin/watcher/build.gradle
@@ -27,6 +27,7 @@ dependencies {
   testImplementation(testArtifact(project(xpackModule('core'))))
   testImplementation project(xpackModule('ilm'))
   testImplementation project(xpackModule('data-streams'))
+  testImplementation project(':modules:lang-mustache')
 
   // watcher deps
   api 'com.googlecode.owasp-java-html-sanitizer:owasp-java-html-sanitizer:20191001.1'
@@ -40,6 +41,8 @@ dependencies {
   testImplementation 'org.subethamail:subethasmtp:3.1.7'
   // needed for subethasmtp, has @GuardedBy annotation
   testImplementation 'com.google.code.findbugs:jsr305:3.0.2'
+
+  internalClusterTestImplementation project(":modules:analysis-common")
 }
 
 // classes are missing, e.g. com.ibm.icu.lang.UCharacter

--- a/x-pack/qa/evil-tests/build.gradle
+++ b/x-pack/qa/evil-tests/build.gradle
@@ -2,12 +2,15 @@ apply plugin: 'elasticsearch.standalone-test'
 
 dependencies {
   testImplementation(project(xpackModule('core')))
+  testImplementation("org.apache.kerby:kerb-admin:1.1.1")
+  testImplementation("org.apache.kerby:kerb-client:1.1.1")
+  testImplementation("org.apache.kerby:kerb-common:1.1.1")
   testImplementation("org.apache.kerby:kerb-core:1.1.1")
   testImplementation("org.apache.kerby:kerb-server:1.1.1")
-  testImplementation("org.apache.kerby:kerb-client:1.1.1") {
-    transitive = false
-  }
   testImplementation("org.apache.kerby:kerb-simplekdc:1.1.1")
+  testImplementation("org.apache.kerby:kerb-util:1.1.1")
+  testImplementation("org.apache.kerby:kerby-config:1.1.1")
+
   testImplementation(testArtifact(project(xpackModule('security'))))
 }
 

--- a/x-pack/qa/evil-tests/build.gradle
+++ b/x-pack/qa/evil-tests/build.gradle
@@ -1,6 +1,13 @@
 apply plugin: 'elasticsearch.standalone-test'
 
 dependencies {
+  testImplementation(project(xpackModule('core')))
+  testImplementation("org.apache.kerby:kerb-core:1.1.1")
+  testImplementation("org.apache.kerby:kerb-server:1.1.1")
+  testImplementation("org.apache.kerby:kerb-client:1.1.1") {
+    transitive = false
+  }
+  testImplementation("org.apache.kerby:kerb-simplekdc:1.1.1")
   testImplementation(testArtifact(project(xpackModule('security'))))
 }
 

--- a/x-pack/qa/reindex-tests-with-security/build.gradle
+++ b/x-pack/qa/reindex-tests-with-security/build.gradle
@@ -8,7 +8,8 @@ apply plugin: 'elasticsearch.rest-resources'
 dependencies {
   testImplementation(testArtifact(project(xpackModule('core'))))
   testImplementation(testArtifact(project(xpackModule('security'))))
-  testImplementation project(path: ':modules:reindex')
+  testImplementation(project(':modules:reindex'))
+  testImplementation(project(":client:rest-high-level"))
 }
 
 tasks.named("forbiddenPatterns").configure {

--- a/x-pack/qa/runtime-fields/with-security/build.gradle
+++ b/x-pack/qa/runtime-fields/with-security/build.gradle
@@ -3,6 +3,7 @@ apply plugin: 'elasticsearch.authenticated-testclusters'
 
 dependencies {
   javaRestTestImplementation(testArtifact(project(xpackModule('core'))))
+  javaRestTestImplementation project(":client:rest-high-level")
 }
 
 testClusters.configureEach {

--- a/x-pack/qa/security-tools-tests/build.gradle
+++ b/x-pack/qa/security-tools-tests/build.gradle
@@ -1,7 +1,9 @@
 apply plugin: 'elasticsearch.standalone-test'
 
 dependencies {
+  testImplementation project(xpackModule('core'))
   testImplementation project(xpackModule('security'))
+  testImplementation(testArtifact(project(xpackModule('core'))))
   testImplementation(testArtifact(project(xpackModule('security'))))
   testImplementation "com.google.jimfs:jimfs:${versions.jimfs}"
   testRuntimeOnly "com.google.guava:guava:${versions.jimfs_guava}"

--- a/x-pack/qa/third-party/active-directory/build.gradle
+++ b/x-pack/qa/third-party/active-directory/build.gradle
@@ -2,6 +2,7 @@ apply plugin: 'elasticsearch.standalone-test'
 apply plugin: 'elasticsearch.test.fixtures'
 
 dependencies {
+  testImplementation project(xpackModule('core'))
   testImplementation project(xpackModule('security'))
   testImplementation(testArtifact(project(xpackModule('security'))))}
 


### PR DESCRIPTION
- This fixes having transitive compile only dependencies on the classpath for consumers of test artifacts
- We remove compile dependencies from the testArtifact configuration dependencies here as this leaks implementation and compile only deps to consuming projects 