### PR TITLE
[DOCS] Added missing backtick for code snippet

### DIFF
--- a/docs/reference/indices/field-usage-stats.asciidoc
+++ b/docs/reference/indices/field-usage-stats.asciidoc
@@ -22,7 +22,7 @@ GET /my-index-000001/_field_usage_stats
 [[field-usage-stats-api-request]]
 ==== {api-request-title}
 
-`GET /<index>/_field_usage_stats
+`GET /<index>/_field_usage_stats`
 
 [[field-usage-stats-api-request-prereqs]]
 ==== {api-prereq-title}


### PR DESCRIPTION
Fixed so that the code snippet on [this page](https://www.elastic.co/guide/en/elasticsearch/reference/current/field-usage-stats.html#field-usage-stats-api-request) is displayed correctly (added a missing backtick).