### PR TITLE
[ML] Adjust list of platforms that have ML native code

### DIFF
--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MachineLearningFeatureSet.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MachineLearningFeatureSet.java
@@ -76,7 +76,7 @@ public class MachineLearningFeatureSet implements XPackFeatureSet {
      * List of platforms for which the native processes are available
      */
     private static final List<String> mlPlatforms = Collections.unmodifiableList(
-            Arrays.asList("darwin-x86_64", "linux-aarch64", "linux-x86_64", "windows-x86_64"));
+            Arrays.asList("darwin-aarch64", "darwin-x86_64", "linux-aarch64", "linux-x86_64", "windows-x86_64"));
 
     private final boolean enabled;
     private final XPackLicenseState licenseState;

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/MachineLearningFeatureSetTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/MachineLearningFeatureSetTests.java
@@ -125,6 +125,7 @@ public class MachineLearningFeatureSetTests extends ESTestCase {
         assertTrue(MachineLearningFeatureSet.isRunningOnMlPlatform("Linux", "amd64", true));
         assertTrue(MachineLearningFeatureSet.isRunningOnMlPlatform("Linux", "aarch64", true));
         assertTrue(MachineLearningFeatureSet.isRunningOnMlPlatform("Mac OS X", "x86_64", true));
+        assertTrue(MachineLearningFeatureSet.isRunningOnMlPlatform("Mac OS X", "aarch64", true));
         assertTrue(MachineLearningFeatureSet.isRunningOnMlPlatform("Windows 10", "amd64", true));
         assertFalse(MachineLearningFeatureSet.isRunningOnMlPlatform("Windows 10", "arm64", false));
         assertFalse(MachineLearningFeatureSet.isRunningOnMlPlatform("Linux", "i386", false));


### PR DESCRIPTION
Now that our release process will incorporate the ML
binaries for macOS on ARM into Elasticsearch we can
update the list of platforms where we expect the
controller process to be running.

This change is for 7.x only - on master the way the
controller is managed has changed.