### PR TITLE
Fix ShowKeyStoreCommand test on FIPS

### DIFF
--- a/distribution/tools/keystore-cli/src/test/java/org/elasticsearch/cli/keystore/ShowKeyStoreCommandTests.java
+++ b/distribution/tools/keystore-cli/src/test/java/org/elasticsearch/cli/keystore/ShowKeyStoreCommandTests.java
@@ -39,7 +39,9 @@ public class ShowKeyStoreCommandTests extends KeyStoreCommandTestCase {
     }
 
     public void testErrorOnMissingParameter() throws Exception {
-        createKeystore("");
+        final String password = getPossibleKeystorePassword();
+        createKeystore(password);
+        terminal.addSecretInput(password);
         final UserException e = expectThrows(UserException.class, this::execute);
         assertEquals(ExitCodes.USAGE, e.exitCode);
         assertThat(e.getMessage(), containsString("Must provide a single setting name to show"));


### PR DESCRIPTION
When running under FIPS a keystore must have a password
