### PR TITLE
[7.x] [DOCS] Document `time_series_metric` mapping parameter (#78013)

### DIFF
--- a/docs/reference/index-modules.asciidoc
+++ b/docs/reference/index-modules.asciidoc
@@ -331,7 +331,8 @@ Defaults to `*`, which matches all fields eligible for
 For internal use by Elastic only. Maximum number of time series dimensions for
 the index. Defaults to `16`.
 +
-You can mark a field as a dimension using the `dimension` mapping parameter.
+You can mark a field as a dimension using the `time_series_dimension` mapping
+parameter.
 
 [[index-hidden]] `index.hidden`::
 

--- a/docs/reference/mapping/types/aggregate-metric-double.asciidoc
+++ b/docs/reference/mapping/types/aggregate-metric-double.asciidoc
@@ -57,6 +57,11 @@ specify at least one value.
 Default metric sub-field to use for queries, scripts, and aggregations that
 don't use a sub-field. Must be a value from the `metrics` array.
 
+include::numeric.asciidoc[tag=time_series_metric]
++
+For `aggregate_metric_double` fields, this parameter accepts `counter`, `gauge`,
+and `summary`. You can't update this parameter for existing fields.
+
 [[aggregate-metric-double-uses]]
 ==== Uses
 

--- a/docs/reference/mapping/types/histogram.asciidoc
+++ b/docs/reference/mapping/types/histogram.asciidoc
@@ -24,6 +24,14 @@ per document. Nested arrays are not supported.
 * `histogram` fields do not support sorting.
 ========
 
+[[histogram-params]]
+==== Parameters
+
+include::numeric.asciidoc[tag=time_series_metric]
++
+For `histogram` fields, this parameter accepts `histogram`. You can't update
+this parameter for existing fields.
+
 [[histogram-uses]]
 ==== Uses
 

--- a/docs/reference/mapping/types/ip.asciidoc
+++ b/docs/reference/mapping/types/ip.asciidoc
@@ -43,14 +43,10 @@ NOTE: You can also store ip ranges in a single field using an <<range,ip_range d
 
 The following parameters are accepted by `ip` fields:
 
-[horizontal]
-
 <<mapping-boost,`boost`>>::
 
     Mapping field-level query time boosting. Accepts a floating point number, defaults
     to `1.0`.
-
-include::keyword.asciidoc[tag=dimension]
 
 <<doc-values,`doc_values`>>::
 
@@ -99,6 +95,8 @@ include::keyword.asciidoc[tag=dimension]
     Whether the field value should be stored and retrievable separately from
     the <<mapping-source-field,`_source`>> field. Accepts `true` or `false`
     (default).
+
+include::keyword.asciidoc[tag=dimension]
 
 [[query-ip-fields]]
 ==== Querying `ip` fields

--- a/docs/reference/mapping/types/keyword.asciidoc
+++ b/docs/reference/mapping/types/keyword.asciidoc
@@ -54,28 +54,10 @@ include::numeric.asciidoc[tag=map-ids-as-keyword]
 
 The following parameters are accepted by `keyword` fields:
 
-[horizontal]
-
 <<mapping-boost,`boost`>>::
 
     Mapping field-level query time boosting. Accepts a floating point number, defaults
     to `1.0`.
-
-// tag::dimension[]
-`dimension`::
-For internal use by Elastic only. Marks the field as a time series dimension.
-Accepts `true` or `false` (default).
-+
-The <<index-mapping-dimension-fields-limit,`index.mapping.dimension_fields.limit`>>
-index setting limits the number of dimensions in an index.
-+
-Dimension fields have the following constraints:
-+
-* The `doc_values` and `index` mapping parameters must be `true`.
-* Field values cannot be an <<array,array or multi-value>>.
-// end::dimension[]
-* Field values cannot be larger than 1024 bytes.
-* The field cannot use a <<normalizer,`normalizer`>>.
 
 <<doc-values,`doc_values`>>::
 
@@ -111,6 +93,10 @@ Dimension fields have the following constraints:
     What information should be stored in the index, for scoring purposes.
     Defaults to `docs` but can also be set to `freqs` to take term frequency into account
     when computing scores.
+
+<<mapping-field-meta,`meta`>>::
+
+    Metadata about the field.
 
 <<norms,`norms`>>::
 
@@ -166,9 +152,21 @@ Dimension fields have the following constraints:
     when building a query for this field.
     Accepts `true` or `false` (default).
 
-<<mapping-field-meta,`meta`>>::
-
-    Metadata about the field.
+// tag::dimension[]
+`time_series_dimension`::
+(Optional, Boolean) For internal use by Elastic only. Marks the field as a time
+series dimension. Defaults to `false`.
++
+The <<index-mapping-dimension-fields-limit,`index.mapping.dimension_fields.limit`>>
+index setting limits the number of dimensions in an index.
++
+Dimension fields have the following constraints:
++
+* The `doc_values` and `index` mapping parameters must be `true`.
+* Field values cannot be an <<array,array or multi-value>>.
+// end::dimension[]
+* Field values cannot be larger than 1024 bytes.
+* The field cannot use a <<normalizer,`normalizer`>>.
 
 include::constant-keyword.asciidoc[]
 

--- a/docs/reference/mapping/types/numeric.asciidoc
+++ b/docs/reference/mapping/types/numeric.asciidoc
@@ -111,23 +111,16 @@ the data as both a `keyword` _and_ a numeric data type.
 
 The following parameters are accepted by numeric types:
 
-[horizontal]
+<<mapping-boost,`boost`>>::
+
+    Mapping field-level query time boosting. Accepts a floating point number, defaults
+    to `1.0`.
 
 <<coerce,`coerce`>>::
 
     Try to convert strings to numbers and truncate fractions for integers.
     Accepts `true` (default) and `false`. Not applicable for `unsigned_long`.
     Note that this cannot be set if the `script` parameter is used.
-
-<<mapping-boost,`boost`>>::
-
-    Mapping field-level query time boosting. Accepts a floating point number, defaults
-    to `1.0`.
-
-include::keyword.asciidoc[tag=dimension]
-+
-Of the numeric field types, only `byte`, `short`, `integer`, and `long` fields
-support this parameter.
 
 <<doc-values,`doc_values`>>::
 
@@ -144,6 +137,10 @@ support this parameter.
 <<mapping-index,`index`>>::
 
     Should the field be searchable? Accepts `true` (default) and `false`.
+
+<<mapping-field-meta,`meta`>>::
+
+    Metadata about the field.
 
 <<null-value,`null_value`>>::
 
@@ -178,9 +175,25 @@ support this parameter.
     the <<mapping-source-field,`_source`>> field. Accepts `true` or `false`
     (default).
 
-<<mapping-field-meta,`meta`>>::
+include::keyword.asciidoc[tag=dimension]
++
+Of the numeric field types, only `byte`, `short`, `integer`, `long`, and
+`unsigned_long` fields support this parameter.
++
+A numeric field can't be both a time series dimension and a time series metric.
 
-    Metadata about the field.
+// tag::time_series_metric[]
+`time_series_metric`::
+(Optional, string) For internal use by Elastic only. Marks the field as a time
+series metric. The value is the metric type. Defaults to `null` (Not a time
+series metric).
+// end::time_series_metric[]
++
+For numeric fields, this parameter accepts `gauge` and `counter`. You can't
+update this parameter for existing fields.
++
+For a numeric time series metric, the `doc_values` parameter must be `true`. A
+numeric field can't be both a time series dimension and a time series metric.
 
 [[scaled-float-params]]
 ==== Parameters for `scaled_float`


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [DOCS] Document `time_series_metric` mapping parameter (#78013)