### PR TITLE
Optimize DataTierAllocationDecider Further (#78235)

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/cluster/routing/allocation/DataTierAllocationDecider.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/cluster/routing/allocation/DataTierAllocationDecider.java
@@ -28,14 +28,12 @@ import org.elasticsearch.snapshots.SearchableSnapshotsSettings;
 import org.elasticsearch.xpack.core.DataTier;
 import org.elasticsearch.xpack.core.searchablesnapshots.SearchableSnapshotsConstants;
 
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
-import java.util.stream.Collectors;
 
 import static org.elasticsearch.xpack.core.DataTier.DATA_FROZEN;
 
@@ -87,11 +85,11 @@ public class DataTierAllocationDecider extends AllocationDecider {
 
     private static void validateTierSetting(String setting) {
         if (Strings.hasText(setting)) {
-            Set<String> invalidTiers = Arrays.stream(setting.split(","))
-                .filter(tier -> DataTier.validTierName(tier) == false)
-                .collect(Collectors.toSet());
-            if (invalidTiers.size() > 0) {
-                throw new IllegalArgumentException("invalid tier names: " + invalidTiers);
+            for (String s : setting.split(",")) {
+                if (DataTier.validTierName(s) == false) {
+                    throw new IllegalArgumentException(
+                            "invalid tier names found in [" + setting + "] allowed values are " + DataTier.ALL_DATA_TIERS);
+                }
             }
         }
     }
@@ -123,8 +121,7 @@ public class DataTierAllocationDecider extends AllocationDecider {
                             "] tier preference may be used for partial searchable snapshots (got: [" + value + "])");
                     }
                 } else {
-                    String[] split = value.split(",");
-                    if (Arrays.stream(split).anyMatch(DATA_FROZEN::equals)) {
+                    if (value.contains(DATA_FROZEN)) {
                         throw new IllegalArgumentException("[" + DATA_FROZEN + "] tier can only be used for partial searchable snapshots");
                     }
                 }
@@ -289,8 +286,12 @@ public class DataTierAllocationDecider extends AllocationDecider {
      * {@code Optional<String>}.
      */
     public static Optional<String> preferredAvailableTier(String prioritizedTiers, DiscoveryNodes nodes) {
-        String[] tiers = parseTierList(prioritizedTiers);
-        return Arrays.stream(tiers).filter(tier -> tierNodesPresent(tier, nodes)).findFirst();
+        for (String tier : parseTierList(prioritizedTiers)) {
+            if (tierNodesPresent(tier, nodes)) {
+                return Optional.of(tier);
+            }
+        }
+        return Optional.empty();
     }
 
     public static String[] parseTierList(String tiers) {
@@ -298,7 +299,7 @@ public class DataTierAllocationDecider extends AllocationDecider {
             // avoid parsing overhead in the null/empty string case
             return Strings.EMPTY_ARRAY;
         } else {
-            return Strings.tokenizeToStringArray(tiers, ",");
+            return tiers.split(",");
         }
     }
 
@@ -306,10 +307,11 @@ public class DataTierAllocationDecider extends AllocationDecider {
         assert singleTier.equals(DiscoveryNodeRole.DATA_ROLE.roleName()) || DataTier.validTierName(singleTier) :
             "tier " + singleTier + " is an invalid tier name";
         for (ObjectCursor<DiscoveryNode> node : nodes.getNodes().values()) {
-            if (node.value.getRoles().stream()
-                .map(DiscoveryNodeRole::roleName)
-                .anyMatch(s -> s.equals(DiscoveryNodeRole.DATA_ROLE.roleName()) || s.equals(singleTier))) {
-                return true;
+            for (DiscoveryNodeRole discoveryNodeRole : node.value.getRoles()) {
+                String s = discoveryNodeRole.roleName();
+                if (s.equals(DiscoveryNodeRole.DATA_ROLE.roleName()) || s.equals(singleTier)) {
+                    return true;
+                }
             }
         }
         return false;

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/DataTier.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/DataTier.java
@@ -16,8 +16,6 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.shard.IndexSettingProvider;
 import org.elasticsearch.xpack.cluster.routing.allocation.DataTierAllocationDecider;
 
-import java.util.Arrays;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -40,7 +38,15 @@ public class DataTier {
     public static final String DATA_FROZEN = "data_frozen";
 
     public static final Set<String> ALL_DATA_TIERS =
-        new HashSet<>(Arrays.asList(DATA_CONTENT, DATA_HOT, DATA_WARM, DATA_COLD, DATA_FROZEN));
+        org.elasticsearch.core.Set.of(DATA_CONTENT, DATA_HOT, DATA_WARM, DATA_COLD, DATA_FROZEN);
+
+    static {
+        for (String tier : ALL_DATA_TIERS) {
+            assert tier.equals(DATA_FROZEN) || tier.contains(DATA_FROZEN) == false
+                : "can't have two tier names containing [" + DATA_FROZEN + "] because it would break setting validation optimizations" +
+                    " in the data tier allocation decider";
+        }
+    }
 
     // Represents an ordered list of data tiers from frozen to hot (or slow to fast)
     private static final List<String> ORDERED_FROZEN_TO_HOT_TIERS =
@@ -50,11 +56,7 @@ public class DataTier {
      * Returns true if the given tier name is a valid tier
      */
     public static boolean validTierName(String tierName) {
-        return DATA_CONTENT.equals(tierName) ||
-            DATA_HOT.equals(tierName) ||
-            DATA_WARM.equals(tierName) ||
-            DATA_COLD.equals(tierName) ||
-            DATA_FROZEN.equals(tierName);
+        return ALL_DATA_TIERS.contains(tierName);
     }
 
     /**


### PR DESCRIPTION
This decider is still by far the most expensive component of reroute operations.
Optimizing away some more costly allocations and slow stream loops.

backport of #78235 