### PR TITLE
[DOCS] Modifies aggregations title abbreviation to follow convention

### DIFF
--- a/docs/reference/aggregations/pipeline/bucket-correlation-aggregation.asciidoc
+++ b/docs/reference/aggregations/pipeline/bucket-correlation-aggregation.asciidoc
@@ -3,7 +3,7 @@
 [[search-aggregations-bucket-correlation-aggregation]]
 === Bucket correlation aggregation
 ++++
-<titleabbrev>Bucket correlation aggregation</titleabbrev>
+<titleabbrev>Bucket correlation</titleabbrev>
 ++++
 
 experimental::[]

--- a/docs/reference/aggregations/pipeline/bucket-count-ks-test-aggregation.asciidoc
+++ b/docs/reference/aggregations/pipeline/bucket-count-ks-test-aggregation.asciidoc
@@ -3,7 +3,7 @@
 [[search-aggregations-bucket-count-ks-test-aggregation]]
 === Bucket count K-S test correlation aggregation
 ++++
-<titleabbrev>Bucket count K-S test aggregation</titleabbrev>
+<titleabbrev>Bucket count K-S test</titleabbrev>
 ++++
 
 experimental::[]


### PR DESCRIPTION
## Overview

This PR changes the title abbreviation of the `Bucket count K-S test` and the `Bucket correlation` aggregations to follow the naming conventions.

### Preview

[TOC](https://elasticsearch_78252.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/index.html)