### PR TITLE
Fix split package org.apache.lucene.index.ShuffleForcedMergePolicy

### DIFF
--- a/server/build.gradle
+++ b/server/build.gradle
@@ -282,7 +282,6 @@ tasks.named('splitPackagesAudit').configure {
     // but this should be fixed in Lucene 9
     'org.apache.lucene.index.LazySoftDeletesDirectoryReaderWrapper',
     'org.apache.lucene.index.OneMergeHelper',
-    'org.apache.lucene.index.ShuffleForcedMergePolicy',
 
     // Joda should own its own packages! This should be a simple move.
     'org.joda.time.format.StrictISODateTimeFormat',

--- a/server/src/main/java/org/elasticsearch/index/engine/InternalEngine.java
+++ b/server/src/main/java/org/elasticsearch/index/engine/InternalEngine.java
@@ -22,7 +22,6 @@ import org.apache.lucene.index.LiveIndexWriterConfig;
 import org.apache.lucene.index.MergePolicy;
 import org.apache.lucene.index.SegmentCommitInfo;
 import org.apache.lucene.index.SegmentInfos;
-import org.apache.lucene.index.ShuffleForcedMergePolicy;
 import org.apache.lucene.index.SoftDeletesRetentionMergePolicy;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.search.BooleanClause;

--- a/server/src/test/java/org/elasticsearch/index/engine/PrunePostingsMergePolicyTests.java
+++ b/server/src/test/java/org/elasticsearch/index/engine/PrunePostingsMergePolicyTests.java
@@ -18,7 +18,6 @@ import org.apache.lucene.index.IndexWriterConfig;
 import org.apache.lucene.index.LeafReader;
 import org.apache.lucene.index.MergePolicy;
 import org.apache.lucene.index.NumericDocValues;
-import org.apache.lucene.index.ShuffleForcedMergePolicy;
 import org.apache.lucene.index.SoftDeletesRetentionMergePolicy;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.index.Terms;

--- a/server/src/test/java/org/elasticsearch/index/engine/RecoverySourcePruneMergePolicyTests.java
+++ b/server/src/test/java/org/elasticsearch/index/engine/RecoverySourcePruneMergePolicyTests.java
@@ -23,7 +23,6 @@ import org.apache.lucene.index.MergePolicy;
 import org.apache.lucene.index.NumericDocValues;
 import org.apache.lucene.index.SegmentCommitInfo;
 import org.apache.lucene.index.SegmentInfos;
-import org.apache.lucene.index.ShuffleForcedMergePolicy;
 import org.apache.lucene.index.StandardDirectoryReader;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.search.DocIdSetIterator;

--- a/server/src/test/java/org/elasticsearch/index/engine/ShuffleForcedMergePolicyTests.java
+++ b/server/src/test/java/org/elasticsearch/index/engine/ShuffleForcedMergePolicyTests.java
@@ -6,7 +6,7 @@
  * Side Public License, v 1.
  */
 
-package org.elasticsearch.lucene.index;
+package org.elasticsearch.index.engine;
 
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.Field;
@@ -19,13 +19,16 @@ import org.apache.lucene.index.IndexWriterConfig;
 import org.apache.lucene.index.LeafReader;
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.MergePolicy;
+import org.apache.lucene.index.SegmentCommitInfo;
 import org.apache.lucene.index.SegmentInfos;
-import org.apache.lucene.index.ShuffleForcedMergePolicy;
+import org.elasticsearch.index.engine.ShuffleForcedMergePolicy;
 import org.apache.lucene.search.Sort;
 import org.apache.lucene.search.SortField;
 import org.apache.lucene.store.Directory;
 
 import java.io.IOException;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Consumer;
 
 import static org.hamcrest.Matchers.equalTo;
@@ -83,5 +86,13 @@ public class ShuffleForcedMergePolicyTests extends BaseMergePolicyTestCase {
 
     @Override
     protected void assertMerge(MergePolicy policy, MergePolicy.MergeSpecification merge) throws IOException {
+    }
+
+    public void testCopySegmentCommitInfo() {
+        SegmentCommitInfo sci1 = makeSegmentCommitInfo("_testseg", 3, 5, 7, IndexWriter.SOURCE_FLUSH);
+        SegmentCommitInfo sci2 = ShuffleForcedMergePolicy.copySegmentCommitInfo(sci1, Map.of());
+        assertThat(sci2, equalTo(sci1));
+        SegmentCommitInfo sci3 = ShuffleForcedMergePolicy.copySegmentCommitInfo(sci1, Map.of("Foo", "Bar", "Baz", ""));
+        assertThat(sci3.info.getDiagnostics(), equalTo(Map.of("Foo", "Bar", "Baz", "")));
     }
 }


### PR DESCRIPTION
To allow for the future modularization of Elasticsearch with Java Modules, there are a number preparatory tasks that need be completed. This is one part of one such task: eliminate split packages.

Since recent Lucene upgrades, `ShuffleForcedMergePolicy` has but a single package-private dependency on lucene, namely `SegmentInfo::setDiagnostics`. SetDiagnostics is being used by SFMP to set a single additional ES specific diagnostic key. It is possible to recreate the whole SegmentCommitInfo ( and the SI within, along with the additional diagnostic key ), by using just the accessible parts of the lucene API.  But this clearly results in little more object allocation.

If this object allocation is unacceptable, then we can raise this issue with Lucene, with a view to improving the Lucene API to allow for such use case that ES has - to add an additional diagnostic.

relates #78166