### PR TITLE
[7.15] [DOCS] Modifies aggregations title abbreviation to follow convention. (#78252)

### DIFF
--- a/docs/reference/aggregations/pipeline/bucket-correlation-aggregation.asciidoc
+++ b/docs/reference/aggregations/pipeline/bucket-correlation-aggregation.asciidoc
@@ -3,7 +3,7 @@
 [[search-aggregations-bucket-correlation-aggregation]]
 === Bucket correlation aggregation
 ++++
-<titleabbrev>Bucket correlation aggregation</titleabbrev>
+<titleabbrev>Bucket correlation</titleabbrev>
 ++++
 
 experimental::[]

--- a/docs/reference/aggregations/pipeline/bucket-count-ks-test-aggregation.asciidoc
+++ b/docs/reference/aggregations/pipeline/bucket-count-ks-test-aggregation.asciidoc
@@ -3,7 +3,7 @@
 [[search-aggregations-bucket-count-ks-test-aggregation]]
 === Bucket count K-S test correlation aggregation
 ++++
-<titleabbrev>Bucket count K-S test aggregation</titleabbrev>
+<titleabbrev>Bucket count K-S test</titleabbrev>
 ++++
 
 experimental::[]


### PR DESCRIPTION
Backports the following commits to 7.15:
 - [DOCS] Modifies aggregations title abbreviation to follow convention. (#78252)