### PR TITLE
[DOCS] Add java client link

### DIFF
--- a/x-pack/docs/en/security/ccs-clients-integrations/index.asciidoc
+++ b/x-pack/docs/en/security/ccs-clients-integrations/index.asciidoc
@@ -24,6 +24,8 @@ be secured as well, or at least communicate with the cluster in a secured way:
 
 include::http.asciidoc[]
 
+include::java.asciidoc[]
+
 include::hadoop.asciidoc[]
 
 include::monitoring.asciidoc[]


### PR DESCRIPTION
Adds the java link to 7.x from this commit in 7.15: https://github.com/elastic/elasticsearch/pull/78245/commits/af3a9743326e1410b2a20bb95a090174eff09cb8