### PR TITLE
[DOCS] Remove support for `unmapped_type:string` sort

### DIFF
--- a/docs/reference/migration/migrate_8_0/mappings.asciidoc
+++ b/docs/reference/migration/migrate_8_0/mappings.asciidoc
@@ -6,6 +6,19 @@
 //Installation and Upgrade Guide
 
 //tag::notable-breaking-changes[]
+.Updating `include_in_parent` or `include_in_root` for a `nested` field now returns an error.
+[%collapsible]
+====
+*Details* +
+Attempts to update the `include_in_parent` or `include_in_root` mapping
+parameter for an existing `nested` field now returns an error. Previously, {es}
+would silently ignore attempts to update these parameters.
+
+*Impact* +
+To avoid errors, do not attempt to update `include_in_parent` or
+`include_in_root` for an existing `nested` field.
+====
+
 .The maximum number of completion contexts per field is now 10.
 [%collapsible]
 ====

--- a/docs/reference/migration/migrate_8_0/mappings.asciidoc
+++ b/docs/reference/migration/migrate_8_0/mappings.asciidoc
@@ -6,19 +6,6 @@
 //Installation and Upgrade Guide
 
 //tag::notable-breaking-changes[]
-.Updating `include_in_parent` or `include_in_root` for a `nested` field now returns an error.
-[%collapsible]
-====
-*Details* +
-Attempts to update the `include_in_parent` or `include_in_root` mapping
-parameter for an existing `nested` field now returns an error. Previously, {es}
-would silently ignore attempts to update these parameters.
-
-*Impact* +
-To avoid errors, do not attempt to update `include_in_parent` or
-`include_in_root` for an existing `nested` field.
-====
-
 .The maximum number of completion contexts per field is now 10.
 [%collapsible]
 ====

--- a/docs/reference/migration/migrate_8_0/search.asciidoc
+++ b/docs/reference/migration/migrate_8_0/search.asciidoc
@@ -16,8 +16,8 @@ Instead, use `unmapped_type: keyword` to handle an unmapped field as if it had
 the `keyword` field type but ignore its values for sorting.
 
 *Impact* +
-Discontinue use of `unmapped_type: string`. Requests that include the
-`unmapped_type: string` sort option will return an error.
+Discontinue use of `unmapped_type: string`. Search requests that include the
+`unmapped_type: string` sort option will return shard failures.
 ====
 
 [[id-field-data]]

--- a/docs/reference/migration/migrate_8_0/search.asciidoc
+++ b/docs/reference/migration/migrate_8_0/search.asciidoc
@@ -6,6 +6,20 @@
 //Installation and Upgrade Guide
 
 //tag::notable-breaking-changes[]
+[[remove-unmapped-type-string]]
+.The `unmapped_type: string` sort option has been removed.
+[%collapsible]
+====
+*Details* +
+Search requests no longer support the `unmapped_type: string` sort option.
+Instead, use `unmapped_type: keyword` to handle an unmapped field as if it had
+the `keyword` field type but ignore its values for sorting.
+
+*Impact* +
+Discontinue use of `unmapped_type: string`. Requests that include the
+`unmapped_type: string` sort option will return an error.
+====
+
 [[id-field-data]]
 .Aggregating and sorting on `_id` is disallowed by default.
 [%collapsible]


### PR DESCRIPTION
Adds an 8.0 breaking change for PR #45675.

### Preview
https://elasticsearch_78272.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/migrating-8.0.html#remove-unmapped-type-string