### PR TITLE
[7.x] Enable wait/blocked time accounting (#77935)

### DIFF
--- a/server/src/main/java/org/elasticsearch/monitor/jvm/HotThreads.java
+++ b/server/src/main/java/org/elasticsearch/monitor/jvm/HotThreads.java
@@ -16,6 +16,8 @@ import org.elasticsearch.core.TimeValue;
 import java.lang.management.ManagementFactory;
 import java.lang.management.ThreadInfo;
 import java.lang.management.ThreadMXBean;
+import java.security.AccessController;
+import java.security.PrivilegedAction;
 import java.time.Clock;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -34,6 +36,7 @@ public class HotThreads {
 
     private static final StackTraceElement[] EMPTY = new StackTraceElement[0];
     private static final DateFormatter DATE_TIME_FORMATTER = DateFormatter.forPattern("date_optional_time");
+    private static final long INVALID_TIMING = -1L;
 
     private int busiestThreads = 3;
     private TimeValue interval = new TimeValue(500, TimeUnit.MILLISECONDS);
@@ -142,144 +145,150 @@ public class HotThreads {
         return false;
     }
 
+    Map<Long, ThreadTimeAccumulator> getAllValidThreadInfos(ThreadMXBean threadBean, long currentThreadId) {
+        long[] threadIds = threadBean.getAllThreadIds();
+        ThreadInfo[] threadInfos = threadBean.getThreadInfo(threadIds);
+        Map<Long, ThreadTimeAccumulator> result = new HashMap<>(threadIds.length);
+
+        for (int i = 0; i < threadIds.length; i++) {
+            if (threadInfos[i] == null || threadIds[i] == currentThreadId) {
+                continue;
+            }
+            long cpuTime = threadBean.getThreadCpuTime(threadIds[i]);
+            if (cpuTime == INVALID_TIMING) {
+                continue;
+            }
+            result.put(threadIds[i], new ThreadTimeAccumulator(threadInfos[i], cpuTime));
+        }
+
+        return result;
+    }
+
+    ThreadInfo[][] captureThreadStacks(ThreadMXBean threadBean, long[] threadIds) throws InterruptedException {
+        ThreadInfo[][] result = new ThreadInfo[threadElementsSnapshotCount][];
+        for (int j = 0; j < threadElementsSnapshotCount; j++) {
+            // NOTE, javadoc of getThreadInfo says: If a thread of the given ID is not alive or does not exist,
+            // null will be set in the corresponding element in the returned array. A thread is alive if it has
+            // been started and has not yet died.
+            result[j] = threadBean.getThreadInfo(threadIds, Integer.MAX_VALUE);
+            Thread.sleep(threadElementsSnapshotDelay.millis());
+        }
+
+        return result;
+    }
+
+    private void setThreadWaitBlockTimeMonitoringEnabled(ThreadMXBean threadBean, boolean enabled) {
+        if (threadBean.isThreadContentionMonitoringSupported()) {
+            AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
+                threadBean.setThreadContentionMonitoringEnabled(enabled);
+                return null;
+            });
+        }
+    }
+
     String innerDetect(ThreadMXBean threadBean, long currentThreadId) throws Exception {
         if (threadBean.isThreadCpuTimeSupported() == false) {
             throw new ElasticsearchException("thread CPU time is not supported on this JDK");
         }
 
-        StringBuilder sb = new StringBuilder();
-        sb.append("Hot threads at ");
-        sb.append(DATE_TIME_FORMATTER.format(LocalDateTime.now(Clock.systemUTC())));
-        sb.append(", interval=");
-        sb.append(interval);
-        sb.append(", busiestThreads=");
-        sb.append(busiestThreads);
-        sb.append(", ignoreIdleThreads=");
-        sb.append(ignoreIdleThreads);
-        sb.append(":\n");
+        StringBuilder sb = new StringBuilder()
+            .append("Hot threads at ")
+            .append(DATE_TIME_FORMATTER.format(LocalDateTime.now(Clock.systemUTC())))
+            .append(", interval=")
+            .append(interval)
+            .append(", busiestThreads=")
+            .append(busiestThreads)
+            .append(", ignoreIdleThreads=")
+            .append(ignoreIdleThreads)
+            .append(":\n");
 
-        Map<Long, ThreadTimeAccumulator> threadInfos = new HashMap<>();
-        for (long threadId : threadBean.getAllThreadIds()) {
-            // ignore our own thread...
-            if (currentThreadId == threadId) {
-                continue;
-            }
-            long cpu = threadBean.getThreadCpuTime(threadId);
-            if (cpu == -1) {
-                continue;
-            }
-            ThreadInfo info = threadBean.getThreadInfo(threadId, 0);
-            if (info == null) {
-                continue;
-            }
-            threadInfos.put(threadId, new ThreadTimeAccumulator(info, cpu));
-        }
-        Thread.sleep(interval.millis());
-        for (long threadId : threadBean.getAllThreadIds()) {
-            // ignore our own thread...
-            if (currentThreadId == threadId) {
-                continue;
-            }
-            long cpu = threadBean.getThreadCpuTime(threadId);
-            if (cpu == -1) {
-                threadInfos.remove(threadId);
-                continue;
-            }
-            ThreadInfo info = threadBean.getThreadInfo(threadId, 0);
-            if (info == null) {
-                threadInfos.remove(threadId);
-                continue;
-            }
-            ThreadTimeAccumulator data = threadInfos.get(threadId);
-            if (data != null) {
-                data.setDelta(info, cpu);
-            } else {
-                threadInfos.remove(threadId);
-            }
-        }
-        // sort by delta CPU time on thread.
-        List<ThreadTimeAccumulator> hotties = new ArrayList<>(threadInfos.values());
-        final int busiestThreads = Math.min(this.busiestThreads, hotties.size());
-        // skip that for now
-        final ToLongFunction<ThreadTimeAccumulator> getter = ThreadTimeAccumulator.valueGetterForReportType(type);
+        // Enabling thread contention monitoring is required for capturing JVM thread wait/blocked times
+        setThreadWaitBlockTimeMonitoringEnabled(threadBean, true);
 
-        CollectionUtil.introSort(hotties, Comparator.comparingLong(getter).reversed());
+        try {
+            // Capture before and after thread state with timings
+            Map<Long, ThreadTimeAccumulator> previousThreadInfos = getAllValidThreadInfos(threadBean, currentThreadId);
+            Thread.sleep(interval.millis());
+            Map<Long, ThreadTimeAccumulator> latestThreadInfos = getAllValidThreadInfos(threadBean, currentThreadId);
 
-        // analyse N stack traces for M busiest threads
-        long[] ids = new long[busiestThreads];
-        for (int i = 0; i < busiestThreads; i++) {
-            ThreadTimeAccumulator info = hotties.get(i);
-            ids[i] = info.info.getThreadId();
-        }
-        ThreadInfo[][] allInfos = new ThreadInfo[threadElementsSnapshotCount][];
-        for (int j = 0; j < threadElementsSnapshotCount; j++) {
-            // NOTE, javadoc of getThreadInfo says: If a thread of the given ID is not alive or does not exist,
-            // null will be set in the corresponding element in the returned array. A thread is alive if it has
-            // been started and has not yet died.
-            allInfos[j] = threadBean.getThreadInfo(ids, Integer.MAX_VALUE);
-            Thread.sleep(threadElementsSnapshotDelay.millis());
-        }
-        for (int t = 0; t < busiestThreads; t++) {
-            long time = getter.applyAsLong(hotties.get(t));
-            String threadName = null;
-            for (ThreadInfo[] info : allInfos) {
-                if (info != null && info[t] != null) {
-                    if (ignoreIdleThreads && isIdleThread(info[t])) {
-                        info[t] = null;
-                        continue;
-                    }
-                    threadName = info[t].getThreadName();
-                    break;
-                }
-            }
-            if (threadName == null) {
-                continue; // thread is not alive yet or died before the first snapshot - ignore it!
-            }
-            double percent = (((double) time) / interval.nanos()) * 100;
-            sb.append(String.format(Locale.ROOT, "%n%4.1f%% (%s out of %s) %s usage by thread '%s'%n",
-                percent, TimeValue.timeValueNanos(time), interval, type.getTypeValue(), threadName));
-            // for each snapshot (2nd array index) find later snapshot for same thread with max number of
-            // identical StackTraceElements (starting from end of each)
-            boolean[] done = new boolean[threadElementsSnapshotCount];
-            for (int i = 0; i < threadElementsSnapshotCount; i++) {
-                if (done[i]) continue;
-                int maxSim = 1;
-                boolean[] similars = new boolean[threadElementsSnapshotCount];
-                for (int j = i + 1; j < threadElementsSnapshotCount; j++) {
-                    if (done[j]) continue;
-                    int similarity = similarity(allInfos[i][t], allInfos[j][t]);
-                    if (similarity > maxSim) {
-                        maxSim = similarity;
-                        similars = new boolean[threadElementsSnapshotCount];
-                    }
-                    if (similarity == maxSim) similars[j] = true;
-                }
-                // print out trace maxSim levels of i, and mark similar ones as done
-                int count = 1;
-                for (int j = i + 1; j < threadElementsSnapshotCount; j++) {
-                    if (similars[j]) {
-                        done[j] = true;
-                        count++;
-                    }
-                }
-                if (allInfos[i][t] != null) {
-                    final StackTraceElement[] show = allInfos[i][t].getStackTrace();
-                    if (count == 1) {
-                        sb.append(String.format(Locale.ROOT, "  unique snapshot%n"));
-                        for (int l = 0; l < show.length; l++) {
-                            sb.append(String.format(Locale.ROOT, "    %s%n", show[l]));
+            latestThreadInfos.forEach((threadId, accumulator) -> accumulator.subtractPrevious(previousThreadInfos.get(threadId)));
+
+            // Sort by delta CPU time on thread.
+            List<ThreadTimeAccumulator> topThreads = new ArrayList<>(latestThreadInfos.values());
+            final ToLongFunction<ThreadTimeAccumulator> getter = ThreadTimeAccumulator.valueGetterForReportType(type);
+
+            CollectionUtil.introSort(topThreads, Comparator.comparingLong(getter).reversed());
+            topThreads = topThreads.subList(0, Math.min(busiestThreads, topThreads.size()));
+            long[] topThreadIds = topThreads.stream().mapToLong(t -> t.threadId).toArray();
+
+            // analyse N stack traces for the top threads
+            ThreadInfo[][] allInfos = captureThreadStacks(threadBean, topThreadIds);
+
+            for (int t = 0; t < topThreads.size(); t++) {
+                long time = getter.applyAsLong(topThreads.get(t));
+                String threadName = null;
+                for (ThreadInfo[] info : allInfos) {
+                    if (info != null && info[t] != null) {
+                        if (ignoreIdleThreads && isIdleThread(info[t])) {
+                            info[t] = null;
+                            continue;
                         }
-                    } else {
-                        sb.append(String.format(Locale.ROOT, "  %d/%d snapshots sharing following %d elements%n",
-                            count, threadElementsSnapshotCount, maxSim));
-                        for (int l = show.length - maxSim; l < show.length; l++) {
-                            sb.append(String.format(Locale.ROOT, "    %s%n", show[l]));
+                        threadName = info[t].getThreadName();
+                        break;
+                    }
+                }
+                if (threadName == null) {
+                    continue; // thread is not alive yet or died before the first snapshot - ignore it!
+                }
+                double percent = (((double) time) / interval.nanos()) * 100;
+                sb.append(String.format(Locale.ROOT, "%n%4.1f%% (%s out of %s) %s usage by thread '%s'%n",
+                    percent, TimeValue.timeValueNanos(time), interval, type.getTypeValue(), threadName));
+                // for each snapshot (2nd array index) find later snapshot for same thread with max number of
+                // identical StackTraceElements (starting from end of each)
+                boolean[] done = new boolean[threadElementsSnapshotCount];
+                for (int i = 0; i < threadElementsSnapshotCount; i++) {
+                    if (done[i]) continue;
+                    int maxSim = 1;
+                    boolean[] similars = new boolean[threadElementsSnapshotCount];
+                    for (int j = i + 1; j < threadElementsSnapshotCount; j++) {
+                        if (done[j]) continue;
+                        int similarity = similarity(allInfos[i][t], allInfos[j][t]);
+                        if (similarity > maxSim) {
+                            maxSim = similarity;
+                            similars = new boolean[threadElementsSnapshotCount];
+                        }
+                        if (similarity == maxSim) similars[j] = true;
+                    }
+                    // print out trace maxSim levels of i, and mark similar ones as done
+                    int count = 1;
+                    for (int j = i + 1; j < threadElementsSnapshotCount; j++) {
+                        if (similars[j]) {
+                            done[j] = true;
+                            count++;
+                        }
+                    }
+                    if (allInfos[i][t] != null) {
+                        final StackTraceElement[] show = allInfos[i][t].getStackTrace();
+                        if (count == 1) {
+                            sb.append(String.format(Locale.ROOT, "  unique snapshot%n"));
+                            for (StackTraceElement frame : show) {
+                                sb.append(String.format(Locale.ROOT, "    %s%n", frame));
+                            }
+                        } else {
+                            sb.append(String.format(Locale.ROOT, "  %d/%d snapshots sharing following %d elements%n",
+                                count, threadElementsSnapshotCount, maxSim));
+                            for (int l = show.length - maxSim; l < show.length; l++) {
+                                sb.append(String.format(Locale.ROOT, "    %s%n", show[l]));
+                            }
                         }
                     }
                 }
             }
+
+            return sb.toString();
+        } finally {
+            setThreadWaitBlockTimeMonitoringEnabled(threadBean, false);
         }
-        return sb.toString();
     }
 
     int similarity(ThreadInfo threadInfo, ThreadInfo threadInfo0) {
@@ -296,56 +305,59 @@ public class HotThreads {
         return rslt;
     }
 
-
     static class ThreadTimeAccumulator {
-        long cpuTime;
-        long blockedCount;
-        long blockedTime;
-        long waitedCount;
-        long waitedTime;
-        boolean deltaDone;
-        ThreadInfo info;
+        private final long threadId;
+
+        private long cpuTime;
+        private long blockedTime;
+        private long waitedTime;
 
         ThreadTimeAccumulator(ThreadInfo info, long cpuTime) {
-            blockedCount = info.getBlockedCount();
-            blockedTime = info.getBlockedTime();
-            waitedCount = info.getWaitedCount();
-            waitedTime = info.getWaitedTime();
+            this.blockedTime = info.getBlockedTime();
+            this.waitedTime = info.getWaitedTime();
             this.cpuTime = cpuTime;
-            this.info = info;
+            this.threadId = info.getThreadId();
         }
 
-        void setDelta(ThreadInfo info, long cpuTime) {
-            if (deltaDone) throw new IllegalStateException("setDelta already called once");
-            blockedCount = info.getBlockedCount() - blockedCount;
-            blockedTime = info.getBlockedTime() - blockedTime;
-            waitedCount = info.getWaitedCount() - waitedCount;
-            waitedTime = info.getWaitedTime() - waitedTime;
-            this.cpuTime = cpuTime - this.cpuTime;
-            deltaDone = true;
-            this.info = info;
+        void subtractPrevious(ThreadTimeAccumulator previous) {
+            // Previous can be null for threads that had started while we were sleeping.
+            // In that case the absolute thread timings are the delta.
+            if (previous != null) {
+                if (previous.getThreadId() != getThreadId()) {
+                    throw new IllegalStateException("Thread timing accumulation must be done on the same thread");
+                }
+                this.blockedTime -= previous.blockedTime;
+                this.waitedTime -= previous.waitedTime;
+                this.cpuTime -= previous.cpuTime;
+            }
+        }
+
+        // A thread can migrate a CPU while executing, in which case, on certain processors, the
+        // reported timings will be bogus (and likely negative). We cap the reported timings to >= 0 values only.
+        public long getCpuTime() {
+            return Math.max(cpuTime, 0);
+        }
+
+        public long getBlockedTime() {
+            return Math.max(blockedTime, 0);
+        }
+
+        public long getWaitedTime() {
+            return Math.max(waitedTime, 0);
+        }
+
+        public long getThreadId() {
+            return threadId;
         }
 
         static ToLongFunction<ThreadTimeAccumulator> valueGetterForReportType(ReportType type) {
             switch (type) {
                 case CPU:
-                    return o -> {
-                        assert o.cpuTime >= -1 :
-                            "cpu time should not be negative, but was " + o.cpuTime + ", thread info: " + o.info;
-                        return o.cpuTime;
-                    };
+                    return ThreadTimeAccumulator::getCpuTime;
                 case WAIT:
-                    return o -> {
-                        assert o.waitedTime >= -1 :
-                            "waited time should not be negative, but was " + o.waitedTime + ", thread info: " + o.info;
-                        return o.waitedTime;
-                    };
+                    return ThreadTimeAccumulator::getWaitedTime;
                 case BLOCK:
-                    return o -> {
-                        assert o.blockedTime >= -1 :
-                            "blocked time should not be negative, but was " + o.blockedTime + ", thread info: " + o.info;
-                        return o.blockedTime;
-                    };
+                    return ThreadTimeAccumulator::getBlockedTime;
             }
             throw new IllegalArgumentException("expected thread type to be either 'cpu', 'wait', or 'block', but was " + type);
         }

--- a/server/src/main/resources/org/elasticsearch/bootstrap/security.policy
+++ b/server/src/main/resources/org/elasticsearch/bootstrap/security.policy
@@ -22,6 +22,10 @@ grant codeBase "${codebase.elasticsearch-secure-sm}" {
 grant codeBase "${codebase.elasticsearch}" {
   // needed for loading plugins which may expect the context class loader to be set
   permission java.lang.RuntimePermission "setContextClassLoader";
+  // needed for SPI class loading
+  permission java.lang.RuntimePermission "accessDeclaredMembers";
+  // needed by HotThreads to enable wait/block time accounting on demand
+  permission java.lang.management.ManagementPermission "control";
 };
 
 //// Very special jar permissions:

--- a/server/src/test/java/org/elasticsearch/monitor/jvm/HotThreadsTests.java
+++ b/server/src/test/java/org/elasticsearch/monitor/jvm/HotThreadsTests.java
@@ -10,6 +10,7 @@ package org.elasticsearch.monitor.jvm;
 
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.test.ESTestCase;
+import org.mockito.InOrder;
 import org.mockito.Matchers;
 
 import java.lang.management.ThreadInfo;
@@ -17,22 +18,24 @@ import java.lang.management.ThreadMXBean;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 import static org.hamcrest.Matchers.containsString;
 import static org.mockito.Matchers.anyInt;
 import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 public class HotThreadsTests extends ESTestCase {
 
     public void testSupportedThreadsReportType() {
-        for (String type: new String[] {"unsupported", "", null, "CPU", "WAIT", "BLOCK" }) {
+        for (String type : new String[]{"unsupported", "", null, "CPU", "WAIT", "BLOCK"}) {
             expectThrows(IllegalArgumentException.class, () -> new HotThreads().type(HotThreads.ReportType.of(type)));
         }
 
-        for (String type : new String[] { "cpu", "wait", "block" }) {
+        for (String type : new String[]{"cpu", "wait", "block"}) {
             try {
                 new HotThreads().type(HotThreads.ReportType.of(type));
             } catch (IllegalArgumentException e) {
@@ -54,15 +57,15 @@ public class HotThreadsTests extends ESTestCase {
     }
 
     public void testIdleThreadsDetection() {
-        for (String threadName : new String[] {
-            "Signal Dispatcher", "Finalizer", "Reference Handler", "Notification Thread", "Common-Cleaner", "process reaper" }) {
+        for (String threadName : new String[]{
+            "Signal Dispatcher", "Finalizer", "Reference Handler", "Notification Thread", "Common-Cleaner", "process reaper"}) {
             ThreadInfo mockedThreadInfo = mock(ThreadInfo.class);
             when(mockedThreadInfo.getThreadName()).thenReturn(threadName);
             assertTrue(HotThreads.isKnownJDKThread(mockedThreadInfo));
             assertTrue(HotThreads.isIdleThread(mockedThreadInfo));
         }
 
-        for (String threadName : new String[] { "Text", "", null, "Finalizer".toLowerCase(Locale.ROOT) }) {
+        for (String threadName : new String[]{"Text", "", null, "Finalizer".toLowerCase(Locale.ROOT)}) {
             ThreadInfo mockedThreadInfo = mock(ThreadInfo.class);
             when(mockedThreadInfo.getThreadName()).thenReturn(threadName);
             when(mockedThreadInfo.getStackTrace()).thenReturn(new StackTraceElement[0]);
@@ -101,7 +104,7 @@ public class HotThreadsTests extends ESTestCase {
         for (StackTraceElement extraFrame : idleThreadStackElements) {
             ThreadInfo idleThread = mock(ThreadInfo.class);
             when(idleThread.getThreadName()).thenReturn("Idle Thread");
-            when(idleThread.getStackTrace()).thenReturn(new StackTraceElement[] {extraFrame});
+            when(idleThread.getStackTrace()).thenReturn(new StackTraceElement[]{extraFrame});
             assertTrue(HotThreads.isKnownIdleStackFrame(extraFrame.getClassName(), extraFrame.getMethodName()));
             assertTrue(HotThreads.isIdleThread(idleThread));
 
@@ -162,7 +165,7 @@ public class HotThreadsTests extends ESTestCase {
             }
         }
 
-        SimilarityTestCase[] testCases = new SimilarityTestCase[] {
+        SimilarityTestCase[] testCases = new SimilarityTestCase[]{
             new SimilarityTestCase(stackOne, stackOne, 2),
             new SimilarityTestCase(stackOne, stackTwo, 1),
             new SimilarityTestCase(stackOne, stackThree, 0),
@@ -190,27 +193,22 @@ public class HotThreadsTests extends ESTestCase {
         assertEquals(0, hotThreads.similarity(threadOne, null));
     }
 
-    // We call this helper for each different mode to reset the before and after timings.
-    private List<ThreadInfo> makeThreadInfoMocksHelper(ThreadMXBean mockedMXBean, long[] threadIds) {
-        List<ThreadInfo> allInfos = new ArrayList<>(threadIds.length);
+    private ThreadInfo makeThreadInfoMocksHelper(ThreadMXBean mockedMXBean, long threadId) {
+        when(mockedMXBean.getThreadCpuTime(threadId)).thenReturn(0L).thenReturn(threadId);
+        ThreadInfo mockedThreadInfo = mock(ThreadInfo.class);
+        when(mockedMXBean.getThreadInfo(eq(threadId), anyInt())).thenReturn(mockedThreadInfo);
+        when(mockedThreadInfo.getThreadName()).thenReturn(String.format(Locale.ROOT, "Thread %d", threadId));
 
-        for (long threadId : threadIds) {
-            // We first return 0 for all timings, then a true value to create the reporting deltas.
-            when(mockedMXBean.getThreadCpuTime(threadId)).thenReturn(0L).thenReturn(threadId);
-            ThreadInfo mockedThreadInfo = mock(ThreadInfo.class);
-            when(mockedMXBean.getThreadInfo(eq(threadId), anyInt())).thenReturn(mockedThreadInfo);
-            when(mockedThreadInfo.getThreadName()).thenReturn(String.format(Locale.ROOT, "Thread %d", threadId));
+        // We create some variability for the blocked and waited times. Odd and even.
+        when(mockedThreadInfo.getBlockedCount()).thenReturn(0L).thenReturn(threadId % 2);
+        long blockedTime = ((threadId % 2) == 0) ? 0L : threadId;
+        when(mockedThreadInfo.getBlockedTime()).thenReturn(0L).thenReturn(blockedTime);
 
-            // We create some variability for the blocked and waited times. Odd and even.
-            when(mockedThreadInfo.getBlockedCount()).thenReturn(0L).thenReturn(threadId % 2);
-            long blockedTime = ((threadId % 2) == 0) ? 0L : threadId;
-            when(mockedThreadInfo.getBlockedTime()).thenReturn(0L).thenReturn(blockedTime);
+        when(mockedThreadInfo.getWaitedCount()).thenReturn(0L).thenReturn((threadId + 1) % 2);
+        long waitTime = (((threadId + 1) % 2) == 0) ? 0L : threadId;
+        when(mockedThreadInfo.getWaitedTime()).thenReturn(0L).thenReturn(waitTime);
 
-            when(mockedThreadInfo.getWaitedCount()).thenReturn(0L).thenReturn((threadId + 1) % 2);
-            long waitTime = (((threadId + 1) % 2) == 0) ? 0L : threadId;
-            when(mockedThreadInfo.getWaitedTime()).thenReturn(0L).thenReturn(waitTime);
-
-            when(mockedThreadInfo.getThreadId()).thenReturn(threadId);
+        when(mockedThreadInfo.getThreadId()).thenReturn(threadId);
 
             StackTraceElement[] stack = makeThreadStackHelper(
                 org.elasticsearch.core.List.of(
@@ -219,8 +217,19 @@ public class HotThreadsTests extends ESTestCase {
                 )).toArray(new StackTraceElement[0]);
             when(mockedThreadInfo.getStackTrace()).thenReturn(stack);
 
-            allInfos.add(mockedThreadInfo);
+        return mockedThreadInfo;
+    }
+
+    // We call this helper for each different mode to reset the before and after timings.
+    private List<ThreadInfo> makeThreadInfoMocksHelper(ThreadMXBean mockedMXBean, long[] threadIds) {
+        List<ThreadInfo> allInfos = new ArrayList<>(threadIds.length);
+
+        for (long threadId : threadIds) {
+            allInfos.add(makeThreadInfoMocksHelper(mockedMXBean, threadId));
         }
+
+        when(mockedMXBean.getThreadInfo(Matchers.any(), anyInt())).thenReturn(allInfos.toArray(new ThreadInfo[0]));
+        when(mockedMXBean.getThreadInfo(Matchers.any(long[].class))).thenReturn(allInfos.toArray(new ThreadInfo[0]));
 
         return allInfos;
     }
@@ -229,7 +238,7 @@ public class HotThreadsTests extends ESTestCase {
         ThreadMXBean mockedMXBean = mock(ThreadMXBean.class);
         when(mockedMXBean.isThreadCpuTimeSupported()).thenReturn(true);
 
-        long[] threadIds = new long[] { 1, 2, 3, 4 }; // Adds up to 10, the intervalNanos for calculating time percentages
+        long[] threadIds = new long[]{1, 2, 3, 4}; // Adds up to 10, the intervalNanos for calculating time percentages
         long mockCurrentThreadId = 0L;
         when(mockedMXBean.getAllThreadIds()).thenReturn(threadIds);
 
@@ -303,6 +312,31 @@ public class HotThreadsTests extends ESTestCase {
         assertThat(blockInnerResult, containsString("10.0% (1nanos out of 10nanos) block usage by thread 'Thread 1'"));
         assertThat(blockInnerResult, containsString("0.0% (0s out of 10nanos) block usage by thread 'Thread 2'"));
         assertThat(blockInnerResult, containsString("0.0% (0s out of 10nanos) block usage by thread 'Thread 4'"));
+
+        // Test with only one stack to trigger the different print in innerDetect
+
+        allInfos = makeThreadInfoMocksHelper(mockedMXBean, threadIds);
+        cpuOrderedInfos = List.of(allInfos.get(3), allInfos.get(2), allInfos.get(1), allInfos.get(0));
+        when(mockedMXBean.getThreadInfo(Matchers.any(), anyInt())).thenReturn(cpuOrderedInfos.toArray(new ThreadInfo[0]));
+
+        hotThreads = new HotThreads()
+            .busiestThreads(4)
+            .type(HotThreads.ReportType.CPU)
+            .interval(TimeValue.timeValueNanos(10))
+            .threadElementsSnapshotCount(1)
+            .ignoreIdleThreads(false);
+
+        String singleResult = hotThreads.innerDetect(mockedMXBean, mockCurrentThreadId);
+
+        assertThat(singleResult, containsString("  unique snapshot"));
+        assertEquals(5, singleResult.split(" unique snapshot").length);
+        assertThat(singleResult, containsString("40.0% (4nanos out of 10nanos) cpu usage by thread 'Thread 4'"));
+        assertThat(singleResult, containsString("30.0% (3nanos out of 10nanos) cpu usage by thread 'Thread 3'"));
+        assertThat(singleResult, containsString("20.0% (2nanos out of 10nanos) cpu usage by thread 'Thread 2'"));
+        assertThat(singleResult, containsString("10.0% (1nanos out of 10nanos) cpu usage by thread 'Thread 1'"));
+        assertThat(innerResult, containsString("org.elasticsearch.monitor.test.method_0(Some_File:1)"));
+        assertThat(innerResult, containsString("org.elasticsearch.monitor.test.method_1(Some_File:1)"));
+        assertThat(innerResult, containsString("org.elasticsearch.monitor.testOther.methodFinal(Some_File:1)"));
     }
 
     public void testEnsureInnerDetectSkipsCurrentThread() throws Exception {
@@ -310,7 +344,7 @@ public class HotThreadsTests extends ESTestCase {
         when(mockedMXBean.isThreadCpuTimeSupported()).thenReturn(true);
 
         long mockCurrentThreadId = 5L;
-        long[] threadIds = new long[] { mockCurrentThreadId }; // Matches half the intervalNanos for calculating time percentages
+        long[] threadIds = new long[]{mockCurrentThreadId}; // Matches half the intervalNanos for calculating time percentages
 
         when(mockedMXBean.getAllThreadIds()).thenReturn(threadIds);
 
@@ -345,5 +379,234 @@ public class HotThreadsTests extends ESTestCase {
         for (HotThreads.ReportType type : HotThreads.ReportType.values()) {
             assertNotNull(HotThreads.ThreadTimeAccumulator.valueGetterForReportType(type));
         }
+    }
+
+    public void testGetAllValidThreadInfos() {
+        ThreadMXBean mockedMXBean = mock(ThreadMXBean.class);
+        when(mockedMXBean.isThreadCpuTimeSupported()).thenReturn(true);
+
+        long[] threadIds = new long[]{1, 2, 3, 4}; // Adds up to 10, the intervalNanos for calculating time percentages
+        long mockCurrentThreadId = 0L;
+        when(mockedMXBean.getAllThreadIds()).thenReturn(threadIds);
+
+        HotThreads hotThreads = new HotThreads()
+            .busiestThreads(4)
+            .type(HotThreads.ReportType.CPU)
+            .interval(TimeValue.timeValueNanos(10))
+            .threadElementsSnapshotCount(11)
+            .ignoreIdleThreads(false);
+
+        // Test the case when all threads exist before and after sleep
+        List<ThreadInfo> allInfos = makeThreadInfoMocksHelper(mockedMXBean, threadIds);
+
+        Map<Long, HotThreads.ThreadTimeAccumulator> validInfos = hotThreads.getAllValidThreadInfos(mockedMXBean, mockCurrentThreadId);
+        assertEquals(allInfos.size(), validInfos.size());
+
+        for (long threadId : threadIds) {
+            HotThreads.ThreadTimeAccumulator accumulator = validInfos.get(threadId);
+            assertNotNull(accumulator);
+            assertEquals(0, accumulator.getCpuTime());
+            assertEquals(0, accumulator.getBlockedTime());
+            assertEquals(0, accumulator.getWaitedTime());
+        }
+
+        // Fake sleep, e.g don't sleep call the mock again
+
+        Map<Long, HotThreads.ThreadTimeAccumulator> afterValidInfos = hotThreads.getAllValidThreadInfos(mockedMXBean, mockCurrentThreadId);
+        assertEquals(allInfos.size(), afterValidInfos.size());
+        for (long threadId : threadIds) {
+            HotThreads.ThreadTimeAccumulator accumulator = afterValidInfos.get(threadId);
+            assertNotNull(accumulator);
+            boolean evenThreadId = ((threadId % 2) == 0);
+
+            assertEquals(threadId, accumulator.getCpuTime());
+            assertEquals((evenThreadId) ? 0 : threadId, accumulator.getBlockedTime());
+            assertEquals((evenThreadId) ? threadId : 0, accumulator.getWaitedTime());
+        }
+
+        // Test when a thread has terminated during sleep, we don't report that thread
+        allInfos = makeThreadInfoMocksHelper(mockedMXBean, threadIds);
+
+        validInfos = hotThreads.getAllValidThreadInfos(mockedMXBean, mockCurrentThreadId);
+        assertEquals(allInfos.size(), validInfos.size());
+
+        ThreadInfo removedInfo = allInfos.remove(0);
+        long[] reducedThreadIds = new long[]{2, 3, 4};
+        when(mockedMXBean.getAllThreadIds()).thenReturn(reducedThreadIds);
+        when(mockedMXBean.getThreadInfo(Matchers.any(), anyInt())).thenReturn(allInfos.toArray(new ThreadInfo[0]));
+        when(mockedMXBean.getThreadInfo(Matchers.any(long[].class))).thenReturn(allInfos.toArray(new ThreadInfo[0]));
+
+        // Fake sleep
+
+        afterValidInfos = hotThreads.getAllValidThreadInfos(mockedMXBean, mockCurrentThreadId);
+        assertEquals(reducedThreadIds.length, afterValidInfos.size());
+
+        for (long threadId : reducedThreadIds) {
+            HotThreads.ThreadTimeAccumulator accumulator = afterValidInfos.get(threadId);
+            assertNotNull(accumulator);
+            boolean evenThreadId = ((threadId % 2) == 0);
+
+            assertEquals(threadId, accumulator.getCpuTime());
+            assertEquals((evenThreadId) ? 0 : threadId, accumulator.getBlockedTime());
+            assertEquals((evenThreadId) ? threadId : 0, accumulator.getWaitedTime());
+        }
+
+        // Test capturing timings for thread that launched while we were sleeping
+        allInfos.add(0, removedInfo); // We called getInfo on this once, so second time should be with cpu/wait > 0
+        when(mockedMXBean.getAllThreadIds()).thenReturn(threadIds);
+        when(mockedMXBean.getThreadInfo(Matchers.any(), anyInt())).thenReturn(allInfos.toArray(new ThreadInfo[0]));
+        when(mockedMXBean.getThreadInfo(Matchers.any(long[].class))).thenReturn(allInfos.toArray(new ThreadInfo[0]));
+
+        // Fake sleep
+
+        afterValidInfos = hotThreads.getAllValidThreadInfos(mockedMXBean, mockCurrentThreadId);
+        assertEquals(threadIds.length, afterValidInfos.size());
+
+        HotThreads.ThreadTimeAccumulator firstAccumulator = afterValidInfos.get(removedInfo.getThreadId());
+        assertEquals(1, firstAccumulator.getCpuTime());
+        assertEquals(0, firstAccumulator.getWaitedTime());
+        assertEquals(1, firstAccumulator.getBlockedTime());
+
+        // Test skipping of current thread
+        validInfos = hotThreads.getAllValidThreadInfos(mockedMXBean, threadIds[threadIds.length - 1]);
+        assertEquals(threadIds.length - 1, validInfos.size());
+        assertFalse(validInfos.containsKey(threadIds[threadIds.length - 1]));
+
+        // Test skipping threads with CPU time of -1
+        when(mockedMXBean.getThreadCpuTime(threadIds[0])).thenReturn(-1L);
+        validInfos = hotThreads.getAllValidThreadInfos(mockedMXBean, mockCurrentThreadId);
+        assertEquals(threadIds.length - 1, validInfos.size());
+        assertFalse(validInfos.containsKey(threadIds[0]));
+
+        // Test skipping null thread infos
+        when(mockedMXBean.getThreadInfo(eq(threadIds[0]), anyInt())).thenReturn(null);
+        validInfos = hotThreads.getAllValidThreadInfos(mockedMXBean, mockCurrentThreadId);
+        assertEquals(threadIds.length - 1, validInfos.size());
+        assertFalse(validInfos.containsKey(threadIds[0]));
+    }
+
+    public void testCaptureThreadStacks() throws InterruptedException {
+        ThreadMXBean mockedMXBean = mock(ThreadMXBean.class);
+        when(mockedMXBean.isThreadCpuTimeSupported()).thenReturn(true);
+
+        long[] threadIds = new long[]{1, 2, 3, 4}; // Adds up to 10, the intervalNanos for calculating time percentages
+        when(mockedMXBean.getAllThreadIds()).thenReturn(threadIds);
+
+        HotThreads hotThreads = new HotThreads()
+            .busiestThreads(4)
+            .type(HotThreads.ReportType.CPU)
+            .interval(TimeValue.timeValueNanos(1))
+            .threadElementsSnapshotCount(3)
+            .ignoreIdleThreads(false);
+
+        // Setup the mocks
+        List<ThreadInfo> allInfos = makeThreadInfoMocksHelper(mockedMXBean, threadIds);
+
+        long[] topThreadIds = new long[]{threadIds[threadIds.length - 1], threadIds[threadIds.length - 2]};
+        List<ThreadInfo> topThreads = List.of(
+            allInfos.get(threadIds.length - 1),
+            allInfos.get(threadIds.length - 2));
+
+        when(mockedMXBean.getThreadInfo(Matchers.any(long[].class), anyInt())).thenReturn(topThreads.toArray(new ThreadInfo[0]));
+
+        ThreadInfo[][] infosWithStacks = hotThreads.captureThreadStacks(mockedMXBean, topThreadIds);
+
+        assertEquals(3, infosWithStacks.length);
+        for (ThreadInfo[] infos : infosWithStacks) {
+            assertEquals(2, infos.length);
+            assertEquals(threadIds[threadIds.length - 1], infos[0].getThreadId());
+            assertEquals(threadIds[threadIds.length - 2], infos[1].getThreadId());
+        }
+    }
+
+    public void testThreadInfoAccumulator() {
+        ThreadMXBean mockedMXBean = mock(ThreadMXBean.class);
+        when(mockedMXBean.isThreadCpuTimeSupported()).thenReturn(true);
+
+        ThreadInfo threadOne = makeThreadInfoMocksHelper(mockedMXBean, 1L);
+        ThreadInfo threadTwo = makeThreadInfoMocksHelper(mockedMXBean, 2L);
+
+        HotThreads.ThreadTimeAccumulator acc = new HotThreads.ThreadTimeAccumulator(threadOne, 100L);
+        HotThreads.ThreadTimeAccumulator accNext = new HotThreads.ThreadTimeAccumulator(threadOne, 250L);
+        accNext.subtractPrevious(acc);
+
+        assertEquals(150, accNext.getCpuTime());
+        assertEquals(0, accNext.getWaitedTime());
+        assertEquals(1, accNext.getBlockedTime());
+
+        HotThreads.ThreadTimeAccumulator accNotMoving = new HotThreads.ThreadTimeAccumulator(threadOne, 250L);
+        HotThreads.ThreadTimeAccumulator accNotMovingNext = new HotThreads.ThreadTimeAccumulator(threadOne, 250L);
+
+        accNotMovingNext.subtractPrevious(accNotMoving);
+
+        assertEquals(0, accNotMovingNext.getCpuTime());
+        assertEquals(0, accNotMovingNext.getWaitedTime());
+        assertEquals(0, accNotMovingNext.getBlockedTime());
+
+        HotThreads.ThreadTimeAccumulator accOne = new HotThreads.ThreadTimeAccumulator(threadOne, 250L);
+        HotThreads.ThreadTimeAccumulator accTwo = new HotThreads.ThreadTimeAccumulator(threadTwo, 350L);
+
+        expectThrows(IllegalStateException.class, () -> accTwo.subtractPrevious(accOne));
+    }
+
+    public void testWaitBlockTimeMonitoringEnabled() throws Exception {
+        ThreadMXBean mockedMXBean = mock(ThreadMXBean.class);
+        when(mockedMXBean.isThreadCpuTimeSupported()).thenReturn(true);
+        when(mockedMXBean.isThreadContentionMonitoringSupported()).thenReturn(true);
+
+        long[] threadIds = new long[]{1, 2, 3, 4}; // Adds up to 10, the intervalNanos for calculating time percentages
+        long mockCurrentThreadId = 0L;
+        when(mockedMXBean.getAllThreadIds()).thenReturn(threadIds);
+
+        List<ThreadInfo> allInfos = makeThreadInfoMocksHelper(mockedMXBean, threadIds);
+        List<ThreadInfo> cpuOrderedInfos = List.of(allInfos.get(3), allInfos.get(2), allInfos.get(1), allInfos.get(0));
+        when(mockedMXBean.getThreadInfo(Matchers.any(), anyInt())).thenReturn(cpuOrderedInfos.toArray(new ThreadInfo[0]));
+
+        HotThreads hotThreads = new HotThreads()
+            .busiestThreads(4)
+            .type(HotThreads.ReportType.CPU)
+            .interval(TimeValue.timeValueNanos(10))
+            .threadElementsSnapshotCount(11)
+            .ignoreIdleThreads(false);
+
+        String innerResult = hotThreads.innerDetect(mockedMXBean, mockCurrentThreadId);
+
+        assertThat(innerResult, containsString("Hot threads at "));
+        assertThat(innerResult, containsString("interval=10nanos, busiestThreads=4, ignoreIdleThreads=false:"));
+        assertThat(innerResult, containsString("11/11 snapshots sharing following 2 elements"));
+        assertThat(innerResult, containsString("40.0% (4nanos out of 10nanos) cpu usage by thread 'Thread 4'"));
+        assertThat(innerResult, containsString("30.0% (3nanos out of 10nanos) cpu usage by thread 'Thread 3'"));
+        assertThat(innerResult, containsString("20.0% (2nanos out of 10nanos) cpu usage by thread 'Thread 2'"));
+        assertThat(innerResult, containsString("10.0% (1nanos out of 10nanos) cpu usage by thread 'Thread 1'"));
+        assertThat(innerResult, containsString("org.elasticsearch.monitor.test.method_0(Some_File:1)"));
+        assertThat(innerResult, containsString("org.elasticsearch.monitor.test.method_1(Some_File:1)"));
+        assertThat(innerResult, containsString("org.elasticsearch.monitor.testOther.methodFinal(Some_File:1)"));
+
+        // Ensure we called the monitoring enabled with true and then with false
+        InOrder orderVerifier = inOrder(mockedMXBean);
+        orderVerifier.verify(mockedMXBean).setThreadContentionMonitoringEnabled(true);
+        orderVerifier.verify(mockedMXBean).setThreadContentionMonitoringEnabled(false);
+    }
+
+    public void testWaitBlockTimeMonitoringEnabledWithException() {
+        ThreadMXBean mockedMXBean = mock(ThreadMXBean.class);
+        when(mockedMXBean.isThreadCpuTimeSupported()).thenReturn(true);
+        when(mockedMXBean.isThreadContentionMonitoringSupported()).thenReturn(true);
+
+        when(mockedMXBean.getAllThreadIds()).thenThrow(new RuntimeException("Something bad happened"));
+
+        HotThreads hotThreads = new HotThreads()
+            .busiestThreads(4)
+            .type(HotThreads.ReportType.CPU)
+            .interval(TimeValue.timeValueNanos(10))
+            .threadElementsSnapshotCount(11)
+            .ignoreIdleThreads(false);
+
+        expectThrows(RuntimeException.class, () -> hotThreads.innerDetect(mockedMXBean, 0L));
+
+        // Ensure we called the monitoring enabled with true and then with false even with exception thrown
+        InOrder orderVerifier = inOrder(mockedMXBean);
+        orderVerifier.verify(mockedMXBean).setThreadContentionMonitoringEnabled(true);
+        orderVerifier.verify(mockedMXBean).setThreadContentionMonitoringEnabled(false);
     }
 }

--- a/server/src/test/java/org/elasticsearch/monitor/jvm/HotThreadsTests.java
+++ b/server/src/test/java/org/elasticsearch/monitor/jvm/HotThreadsTests.java
@@ -559,7 +559,8 @@ public class HotThreadsTests extends ESTestCase {
         when(mockedMXBean.getAllThreadIds()).thenReturn(threadIds);
 
         List<ThreadInfo> allInfos = makeThreadInfoMocksHelper(mockedMXBean, threadIds);
-        List<ThreadInfo> cpuOrderedInfos = org.elasticsearch.core.List.of(allInfos.get(3), allInfos.get(2), allInfos.get(1), allInfos.get(0));
+        List<ThreadInfo> cpuOrderedInfos = org.elasticsearch.core.List.of(
+            allInfos.get(3), allInfos.get(2), allInfos.get(1), allInfos.get(0));
         when(mockedMXBean.getThreadInfo(Matchers.any(), anyInt())).thenReturn(cpuOrderedInfos.toArray(new ThreadInfo[0]));
 
         HotThreads hotThreads = new HotThreads()

--- a/server/src/test/java/org/elasticsearch/monitor/jvm/HotThreadsTests.java
+++ b/server/src/test/java/org/elasticsearch/monitor/jvm/HotThreadsTests.java
@@ -316,7 +316,7 @@ public class HotThreadsTests extends ESTestCase {
         // Test with only one stack to trigger the different print in innerDetect
 
         allInfos = makeThreadInfoMocksHelper(mockedMXBean, threadIds);
-        cpuOrderedInfos = List.of(allInfos.get(3), allInfos.get(2), allInfos.get(1), allInfos.get(0));
+        cpuOrderedInfos = org.elasticsearch.core.List.of(allInfos.get(3), allInfos.get(2), allInfos.get(1), allInfos.get(0));
         when(mockedMXBean.getThreadInfo(Matchers.any(), anyInt())).thenReturn(cpuOrderedInfos.toArray(new ThreadInfo[0]));
 
         hotThreads = new HotThreads()
@@ -503,7 +503,7 @@ public class HotThreadsTests extends ESTestCase {
         List<ThreadInfo> allInfos = makeThreadInfoMocksHelper(mockedMXBean, threadIds);
 
         long[] topThreadIds = new long[]{threadIds[threadIds.length - 1], threadIds[threadIds.length - 2]};
-        List<ThreadInfo> topThreads = List.of(
+        List<ThreadInfo> topThreads = org.elasticsearch.core.List.of(
             allInfos.get(threadIds.length - 1),
             allInfos.get(threadIds.length - 2));
 
@@ -559,7 +559,7 @@ public class HotThreadsTests extends ESTestCase {
         when(mockedMXBean.getAllThreadIds()).thenReturn(threadIds);
 
         List<ThreadInfo> allInfos = makeThreadInfoMocksHelper(mockedMXBean, threadIds);
-        List<ThreadInfo> cpuOrderedInfos = List.of(allInfos.get(3), allInfos.get(2), allInfos.get(1), allInfos.get(0));
+        List<ThreadInfo> cpuOrderedInfos = org.elasticsearch.core.List.of(allInfos.get(3), allInfos.get(2), allInfos.get(1), allInfos.get(0));
         when(mockedMXBean.getThreadInfo(Matchers.any(), anyInt())).thenReturn(cpuOrderedInfos.toArray(new ThreadInfo[0]));
 
         HotThreads hotThreads = new HotThreads()


### PR DESCRIPTION
Backport of https://github.com/elastic/elasticsearch/pull/77935

HotThreads has wait and blocked time accounting functionality, however the reported timings for the "wait" and "block" reports are always 0, because thread contention monitoring isn't enabled in the JVM. This change fixes that by enabling/disabling thread contention monitoring, while we are running the timing capture logic.

Apart from fixing the wait/block time accounting bug, this PR also restricts the reported thread timings to values >= 0 to fix the test failures reported in #72376, which relate to CPU thread migration.

I did a small refactor to eliminate the code duplication in the timing capture logic, remove unused variables and add more unit tests for the refactored logic.

Closes #72376