### PR TITLE
[DOCS] Watcher history now writes to a data stream

### DIFF
--- a/docs/reference/migration/migrate_8_0.asciidoc
+++ b/docs/reference/migration/migrate_8_0.asciidoc
@@ -37,6 +37,7 @@ coming[8.0.0]
 * <<breaking_80_snapshots_changes>>
 * <<breaking_80_threadpool_changes>>
 * <<breaking_80_transport_changes>>
+* <<breaking_80_watcher_changes>>
 
 [discrete]
 [[breaking-changes-8.0]]
@@ -137,6 +138,7 @@ include::migrate_8_0/settings.asciidoc[]
 include::migrate_8_0/snapshots.asciidoc[]
 include::migrate_8_0/threadpool.asciidoc[]
 include::migrate_8_0/transport.asciidoc[]
+include::migrate_8_0/watcher.asciidoc[]
 include::migrate_8_0/migrate_to_java_time.asciidoc[]
 
 ////

--- a/docs/reference/migration/migrate_8_0/watcher.asciidoc
+++ b/docs/reference/migration/migrate_8_0/watcher.asciidoc
@@ -1,0 +1,23 @@
+[discrete]
+[[breaking_80_watcher_changes]]
+==== Watcher changes
+
+//NOTE: The notable-breaking-changes tagged regions are re-used in the
+//Installation and Upgrade Guide
+
+//tag::notable-breaking-changes[]
+.Watcher history now writes to a hidden data stream.
+[%collapsible]
+====
+*Details* +
+In 8.x, {es} writes Watcher history to a hidden
+`.watcher-history-<index-template-version>` data stream. Previously, {es} wrote
+Watcher history to hidden
+`.watcher-history-<index-template-version>-<yyyy-MM-dd>` indices.
+
+*Impact* +
+Update your requests to target the Watcher history data stream. For example, use
+the `.watcher-history-*` wildcard expression. Requests that specifically target
+non-existent Watcher history indices may return an error.
+====
+// end::notable-breaking-changes[]


### PR DESCRIPTION
Adds an 8.0 breaking change for PR #64252.

### Preview
https://elasticsearch_78277.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/migrating-8.0.html#breaking_80_watcher_changes