### PR TITLE
Avoid compiler error when running `rewrite` task

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/io/stream/ByteBufferStreamInput.java
+++ b/server/src/main/java/org/elasticsearch/common/io/stream/ByteBufferStreamInput.java
@@ -16,6 +16,7 @@ public class ByteBufferStreamInput extends StreamInput {
 
     private final ByteBuffer buffer;
 
+    @SuppressWarnings("cast")
     public ByteBufferStreamInput(ByteBuffer buffer) {
         this.buffer = (ByteBuffer) buffer.mark();
     }


### PR DESCRIPTION
Follow up https://github.com/elastic/elasticsearch/pull/76038 which fixes a compiler error in the `:server` project due to an unnecessary cast warning that only manifests when targeting Java 11.

https://gradle-enterprise.elastic.co/s/wtlx5e37xiu7s