### PR TITLE
Explicitly set illegal-access to deny for tests (#72588)

### DIFF
--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/BuildPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/BuildPlugin.groovy
@@ -962,7 +962,15 @@ class BuildPlugin implements Plugin<Project> {
             heapdumpDir.mkdirs()
             jvmArg '-XX:HeapDumpPath=' + heapdumpDir
             if (project.runtimeJavaVersion >= JavaVersion.VERSION_1_9) {
-                jvmArg '--illegal-access=warn'
+                jvmArg '--illegal-access=deny'
+                jvmArg '--add-opens=java.base/java.security.cert=ALL-UNNAMED'
+                jvmArg '--add-opens=java.base/java.nio.channels=ALL-UNNAMED'
+                jvmArg '--add-opens=java.base/java.net=ALL-UNNAMED'
+                jvmArg '--add-opens=java.base/javax.net.ssl=ALL-UNNAMED'
+                jvmArg '--add-opens=java.base/java.nio.file=ALL-UNNAMED'
+                jvmArg '--add-opens=java.base/java.time=ALL-UNNAMED'
+                jvmArg '--add-opens=java.base/java.lang=ALL-UNNAMED'
+                jvmArg '--add-opens=java.management/java.lang.management=ALL-UNNAMED'
             }
             argLine System.getProperty('tests.jvm.argline')
 


### PR DESCRIPTION
Since Java 16, the default value for illegal-access is deny. This means
the latest release of Elasticsearch, and all current integration tests,
run with deny (since we don't explicitly set it in jvm options). Yet
tests run with illegal-access=warn, for legacy reasons. elastic#71908
proposed to remove the setting from test jvms, but concerns were raised
there about whether this would cause some test failures.

This commit explicitly sets tests to deny. This has the added benefit
that any failures will be caught even when running tests with older
jvms.