### PR TITLE
[DOCS] Document empty first line support for msearch API

### DIFF
--- a/docs/reference/migration/migrate_8_0/search.asciidoc
+++ b/docs/reference/migration/migrate_8_0/search.asciidoc
@@ -12,7 +12,7 @@
 ====
 *Details* +
 The multi search API now parses an empty first line as empty action metadata
-when you provide the request body as a text file, such as when using curl's
+when you provide a text file as the request body, such as when using curl's
 `--data-binary` flag.
 
 The API no longer supports text files that contain:
@@ -21,8 +21,8 @@ The API no longer supports text files that contain:
 * An empty first line followed by another empty line.
 
 *Impact* +
-Discontinue use of unsupported text files with the multi search API. Requests
-that include an unsupported file will return an error.
+Don't provide an unsupported text file to the multi search API. Requests that
+include an unsupported file will return an error.
 ====
 
 [[remove-unmapped-type-string]]

--- a/docs/reference/migration/migrate_8_0/search.asciidoc
+++ b/docs/reference/migration/migrate_8_0/search.asciidoc
@@ -11,9 +11,9 @@
 [%collapsible]
 ====
 *Details* +
-The multi search API now supports an empty first line when you provide the
-request body as a text file, such as when using curl's `--data-binary` flag. The
-API parses an empty first line as empty action metadata.
+The multi search API now parses an empty first line as empty action metadata
+when you provide the request body as a text file, such as when using curl's
+`--data-binary` flag.
 
 The API no longer supports text files that contain:
 

--- a/docs/reference/migration/migrate_8_0/search.asciidoc
+++ b/docs/reference/migration/migrate_8_0/search.asciidoc
@@ -6,6 +6,56 @@
 //Installation and Upgrade Guide
 
 //tag::notable-breaking-changes[]
+[[msearch-empty-line-support]]
+.The multi search API now parses an empty first line as action metadata in text files.
+[%collapsible]
+====
+*Details* +
+The multi search API now supports an empty first line when you provide the
+request body as a text file, such as when using curl's `--data-binary` flag. The
+API parses an empty first line as empty action metadata. For example, the API
+now supports a file with the following contents:
+
+[source,js]
+----
+
+{ "query": {"match": { "my-field": "foo" }}}
+
+{ "query": {"match_all": {}}}
+----
+// NOTCONSOLE
+
+The API no longer supports text files that contain:
+
+* An empty first line followed by a line containing only `{}`. For example:
++
+[source,js]
+----
+
+{}
+{ "query": {"match": { "my-field": "foo" }}}
+
+{ "query": {"match_all": {}}}
+----
+// NOTCONSOLE
+
+* An empty first line followed by another empty line. For example:
++
+[source,js]
+----
+
+
+{ "query": {"match": { "my-field": "foo" }}}
+
+{ "query": {"match_all": {}}}
+----
+// NOTCONSOLE
+
+*Impact* +
+Discontinue use of unsupported files with the multi search API. Requests
+that include an unsupported file will return an error.
+====
+
 [[remove-unmapped-type-string]]
 .The `unmapped_type: string` sort option has been removed.
 [%collapsible]

--- a/docs/reference/migration/migrate_8_0/search.asciidoc
+++ b/docs/reference/migration/migrate_8_0/search.asciidoc
@@ -21,7 +21,7 @@ The API no longer supports text files that contain:
 * An empty first line followed by another empty line.
 
 *Impact* +
-Discontinue use of unsupported files with the multi search API. Requests
+Discontinue use of unsupported text files with the multi search API. Requests
 that include an unsupported file will return an error.
 ====
 

--- a/docs/reference/migration/migrate_8_0/search.asciidoc
+++ b/docs/reference/migration/migrate_8_0/search.asciidoc
@@ -13,43 +13,12 @@
 *Details* +
 The multi search API now supports an empty first line when you provide the
 request body as a text file, such as when using curl's `--data-binary` flag. The
-API parses an empty first line as empty action metadata. For example, the API
-now supports a file with the following contents:
-
-[source,js]
-----
-
-{ "query": {"match": { "my-field": "foo" }}}
-
-{ "query": {"match_all": {}}}
-----
-// NOTCONSOLE
+API parses an empty first line as empty action metadata.
 
 The API no longer supports text files that contain:
 
-* An empty first line followed by a line containing only `{}`. For example:
-+
-[source,js]
-----
-
-{}
-{ "query": {"match": { "my-field": "foo" }}}
-
-{ "query": {"match_all": {}}}
-----
-// NOTCONSOLE
-
-* An empty first line followed by another empty line. For example:
-+
-[source,js]
-----
-
-
-{ "query": {"match": { "my-field": "foo" }}}
-
-{ "query": {"match_all": {}}}
-----
-// NOTCONSOLE
+* An empty first line followed by a line containing only `{}`.
+* An empty first line followed by another empty line.
 
 *Impact* +
 Discontinue use of unsupported files with the multi search API. Requests


### PR DESCRIPTION
Adds an 8.0 breaking change for PR #41011

### Preview
https://elasticsearch_78284.docs-preview.app.elstc.co/guide/en/elastic-stack/master/elasticsearch-breaking-changes.html#_search_changes