### PR TITLE
Fix Gradle integration with Intellij IDEA

### DIFF
--- a/build-tools-internal/src/main/groovy/elasticsearch.ide.gradle
+++ b/build-tools-internal/src/main/groovy/elasticsearch.ide.gradle
@@ -88,7 +88,7 @@ if (providers.systemProperty('idea.active').forUseAtConfigurationTime().getOrNul
   tasks.register('buildDependencyArtifacts') {
     group = 'ide'
     description = 'Builds artifacts needed as dependency for IDE modules'
-    dependsOn ':client:rest-high-level:shadowJar', ':plugins:repository-hdfs:hadoop-common:shadowJar', ':plugins:repository-azure:azure-storage-blob:shadowJar'
+    dependsOn ':client:rest-high-level:shadowJar', ':plugins:repository-hdfs:hadoop-client-api:shadowJar', ':plugins:repository-azure:azure-storage-blob:shadowJar'
   }
 
   idea {


### PR DESCRIPTION
In #76897 the `hadoop-common` module was renamed to `hadoop-client-ide`, but the change wasn't reflected in `elasticsearch.ide.gradle` script. Because of that an IDE import started failing with the `Task with path ':plugins:repository-hdfs:hadoop-common:shadowJar" not found` error.

Fix the import by setting the correct module name in the `buildDependencyArtifacts` task.
