### PR TITLE
Add die-with-dignity test debugging

### DIFF
--- a/test/external-modules/die-with-dignity/src/javaRestTest/java/org/elasticsearch/qa/die_with_dignity/DieWithDignityIT.java
+++ b/test/external-modules/die-with-dignity/src/javaRestTest/java/org/elasticsearch/qa/die_with_dignity/DieWithDignityIT.java
@@ -8,7 +8,6 @@
 
 package org.elasticsearch.qa.die_with_dignity;
 
-import org.apache.lucene.util.Constants;
 import org.elasticsearch.client.Request;
 import org.elasticsearch.core.PathUtils;
 import org.elasticsearch.test.rest.ESRestTestCase;
@@ -29,7 +28,6 @@ import java.util.Map;
 public class DieWithDignityIT extends ESRestTestCase {
 
     public void testDieWithDignity() throws Exception {
-        assumeFalse("Mute on Windows, see https://github.com/elastic/elasticsearch/issues/77282", Constants.WINDOWS);
         // there should be an Elasticsearch process running with the die.with.dignity.test system property
         {
             final Map<String, String> esCommandLines = getElasticsearchCommandLines();
@@ -106,10 +104,14 @@ public class DieWithDignityIT extends ESRestTestCase {
                 InputStream is = jcmdProcess.getInputStream();
                 BufferedReader in = new BufferedReader(new InputStreamReader(is, StandardCharsets.UTF_8))
             ) {
+                logger.info("Inspecting java pid " + pid);
                 boolean isElasticsearch = false;
                 String jvmArgs = null;
                 String line;
                 while ((line = in.readLine()) != null) {
+                    if (line.startsWith("java_command")) {
+                        logger.info("  -> " + line.trim());
+                    }
                     if (line.equals("java_command: org.elasticsearch.bootstrap.Elasticsearch")) {
                         isElasticsearch = true;
                     }


### PR DESCRIPTION
This commit adds debugging info to the die with dignity test to figure
out why no ES command lines are found on Windows.

relates #77282