### PR TITLE
Short circuit authorization for child actions (#77221)

### DIFF
--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/BulkProcessorIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/BulkProcessorIT.java
@@ -51,10 +51,12 @@ import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.hasType;
 import static org.hamcrest.Matchers.both;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.either;
+import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.everyItem;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
 
@@ -89,7 +91,7 @@ public class BulkProcessorIT extends ESRestHighLevelClientTestCase {
 
             assertThat(listener.beforeCounts.get(), equalTo(1));
             assertThat(listener.afterCounts.get(), equalTo(1));
-            assertThat(listener.bulkFailures.size(), equalTo(0));
+            assertThat(listener.bulkFailures, empty());
             assertResponseItems(listener.bulkItems, numDocs);
             assertMultiGetResponse(highLevelClient().mget(multiGetRequest, RequestOptions.DEFAULT), numDocs);
         }
@@ -115,7 +117,7 @@ public class BulkProcessorIT extends ESRestHighLevelClientTestCase {
 
             assertThat(listener.beforeCounts.get(), equalTo(1));
             assertThat(listener.afterCounts.get(), equalTo(1));
-            assertThat(listener.bulkFailures.size(), equalTo(0));
+            assertThat(listener.bulkFailures, empty());
             assertResponseItems(listener.bulkItems, numDocs);
             assertMultiGetResponse(highLevelClient().mget(multiGetRequest, RequestOptions.DEFAULT), numDocs);
         }
@@ -147,16 +149,16 @@ public class BulkProcessorIT extends ESRestHighLevelClientTestCase {
 
             assertThat(listener.beforeCounts.get(), equalTo(expectedBulkActions));
             assertThat(listener.afterCounts.get(), equalTo(expectedBulkActions));
-            assertThat(listener.bulkFailures.size(), equalTo(0));
-            assertThat(listener.bulkItems.size(), equalTo(numDocs - numDocs % bulkActions));
+            assertThat(listener.bulkFailures, empty());
+            assertThat(listener.bulkItems, hasSize(numDocs - numDocs % bulkActions));
         }
 
         closeLatch.await();
 
         assertThat(listener.beforeCounts.get(), equalTo(totalExpectedBulkActions));
         assertThat(listener.afterCounts.get(), equalTo(totalExpectedBulkActions));
-        assertThat(listener.bulkFailures.size(), equalTo(0));
-        assertThat(listener.bulkItems.size(), equalTo(numDocs));
+        assertThat(listener.bulkFailures, empty());
+        assertThat(listener.bulkItems, hasSize(numDocs));
 
         Set<String> ids = new HashSet<>();
         for (BulkItemResponse bulkItemResponse : listener.bulkItems) {
@@ -198,7 +200,7 @@ public class BulkProcessorIT extends ESRestHighLevelClientTestCase {
         for (Throwable bulkFailure : listener.bulkFailures) {
             logger.error("bulk failure", bulkFailure);
         }
-        assertThat(listener.bulkFailures.size(), equalTo(0));
+        assertThat(listener.bulkFailures, empty());
         assertResponseItems(listener.bulkItems, numDocs);
         assertMultiGetResponse(highLevelClient().mget(multiGetRequest, RequestOptions.DEFAULT), numDocs);
     }
@@ -255,8 +257,8 @@ public class BulkProcessorIT extends ESRestHighLevelClientTestCase {
 
         assertThat(listener.beforeCounts.get(), equalTo(totalExpectedBulkActions));
         assertThat(listener.afterCounts.get(), equalTo(totalExpectedBulkActions));
-        assertThat(listener.bulkFailures.size(), equalTo(0));
-        assertThat(listener.bulkItems.size(), equalTo(testDocs + testReadOnlyDocs));
+        assertThat(listener.bulkFailures, empty());
+        assertThat(listener.bulkItems, hasSize(testDocs + testReadOnlyDocs));
 
         Set<String> ids = new HashSet<>();
         Set<String> readOnlyIds = new HashSet<>();

--- a/plugins/examples/security-authorization-engine/src/javaRestTest/java/org/elasticsearch/example/CustomAuthorizationEngineTests.java
+++ b/plugins/examples/security-authorization-engine/src/javaRestTest/java/org/elasticsearch/example/CustomAuthorizationEngineTests.java
@@ -55,7 +55,7 @@ public class CustomAuthorizationEngineTests extends ESTestCase {
             Authentication authentication =
                 new Authentication(new User("joe", new String[]{"custom_superuser"}, new User("bar", "not_superuser")),
                     new RealmRef("test", "test", "node"), new RealmRef("test", "test", "node"));
-            RequestInfo info = new RequestInfo(authentication, request, action);
+            RequestInfo info = new RequestInfo(authentication, request, action, null);
             PlainActionFuture<AuthorizationInfo> future = new PlainActionFuture<>();
             engine.resolveAuthorizationInfo(info, future);
             AuthorizationInfo authzInfo = future.actionGet();
@@ -72,7 +72,7 @@ public class CustomAuthorizationEngineTests extends ESTestCase {
             Authentication authentication =
                 new Authentication(new User("joe", new String[]{"not_superuser"}, new User("bar", "custom_superuser")),
                     new RealmRef("test", "test", "node"), new RealmRef("test", "test", "node"));
-            RequestInfo info = new RequestInfo(authentication, request, action);
+            RequestInfo info = new RequestInfo(authentication, request, action, null);
             PlainActionFuture<AuthorizationInfo> future = new PlainActionFuture<>();
             engine.resolveAuthorizationInfo(info, future);
             AuthorizationInfo authzInfo = future.actionGet();
@@ -104,7 +104,7 @@ public class CustomAuthorizationEngineTests extends ESTestCase {
         {
             RequestInfo unauthReqInfo =
                 new RequestInfo(new Authentication(new User("joe", "not_superuser"), new RealmRef("test", "test", "node"), null),
-                    requestInfo.getRequest(), requestInfo.getAction());
+                    requestInfo.getRequest(), requestInfo.getAction(), null);
             PlainActionFuture<AuthorizationInfo> future = new PlainActionFuture<>();
             engine.resolveAuthorizationInfo(unauthReqInfo, future);
             AuthorizationInfo authzInfo = future.actionGet();
@@ -129,7 +129,7 @@ public class CustomAuthorizationEngineTests extends ESTestCase {
         {
             RequestInfo requestInfo =
                 new RequestInfo(new Authentication(new User("joe", "custom_superuser"), new RealmRef("test", "test", "node"), null),
-                    new SearchRequest(), "indices:data/read/search");
+                    new SearchRequest(), "indices:data/read/search", null);
             PlainActionFuture<AuthorizationInfo> future = new PlainActionFuture<>();
             engine.resolveAuthorizationInfo(requestInfo, future);
             AuthorizationInfo authzInfo = future.actionGet();
@@ -150,7 +150,7 @@ public class CustomAuthorizationEngineTests extends ESTestCase {
         {
             RequestInfo requestInfo =
                 new RequestInfo(new Authentication(new User("joe", "not_superuser"), new RealmRef("test", "test", "node"), null),
-                    new SearchRequest(), "indices:data/read/search");
+                    new SearchRequest(), "indices:data/read/search", null);
             PlainActionFuture<AuthorizationInfo> future = new PlainActionFuture<>();
             engine.resolveAuthorizationInfo(requestInfo, future);
             AuthorizationInfo authzInfo = future.actionGet();
@@ -172,6 +172,6 @@ public class CustomAuthorizationEngineTests extends ESTestCase {
         final TransportRequest request = new TransportRequest() {};
         final Authentication authentication =
             new Authentication(new User("joe", "custom_superuser"), new RealmRef("test", "test", "node"), null);
-        return new RequestInfo(authentication, request, action);
+        return new RequestInfo(authentication, request, action, null);
     }
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/AuthorizationEngine.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/AuthorizationEngine.java
@@ -25,6 +25,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 
 /**
@@ -247,11 +248,19 @@ public interface AuthorizationEngine {
         private final Authentication authentication;
         private final TransportRequest request;
         private final String action;
+        @Nullable
+        private final AuthorizationContext originatingAuthorizationContext;
 
-        public RequestInfo(Authentication authentication, TransportRequest request, String action) {
-            this.authentication = authentication;
-            this.request = request;
-            this.action = action;
+        public RequestInfo(
+            Authentication authentication,
+            TransportRequest request,
+            String action,
+            AuthorizationContext originatingContext
+        ) {
+            this.authentication = Objects.requireNonNull(authentication);
+            this.request = Objects.requireNonNull(request);
+            this.action = Objects.requireNonNull(action);
+            this.originatingAuthorizationContext = originatingContext;
         }
 
         public String getAction() {
@@ -264,6 +273,27 @@ public interface AuthorizationEngine {
 
         public TransportRequest getRequest() {
             return request;
+        }
+
+        @Nullable
+        public AuthorizationContext getOriginatingAuthorizationContext() {
+            return originatingAuthorizationContext;
+        }
+
+        @Override
+        public String toString() {
+            return getClass().getSimpleName()
+                + '{'
+                + "authentication=["
+                + authentication
+                + "], request=["
+                + request
+                + "], action=["
+                + action
+                + ']'
+                + ", parent=["
+                + originatingAuthorizationContext
+                + "]}";
         }
     }
 
@@ -347,6 +377,31 @@ public interface AuthorizationEngine {
                 return null;
             }
             return "on indices [" + Strings.collectionToCommaDelimitedString(deniedIndices) + "]";
+        }
+
+        public IndicesAccessControl getIndicesAccessControl() {
+            return indicesAccessControl;
+        }
+    }
+
+
+    final class AuthorizationContext {
+        private final String action;
+        private final AuthorizationInfo authorizationInfo;
+        private final IndicesAccessControl indicesAccessControl;
+
+        public AuthorizationContext(String action, AuthorizationInfo authorizationInfo, IndicesAccessControl accessControl) {
+            this.action = action;
+            this.authorizationInfo = authorizationInfo;
+            this.indicesAccessControl = accessControl;
+        }
+
+        public String getAction() {
+            return action;
+        }
+
+        public AuthorizationInfo getAuthorizationInfo() {
+            return authorizationInfo;
         }
 
         public IndicesAccessControl getIndicesAccessControl() {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/permission/LimitedRole.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/permission/LimitedRole.java
@@ -57,6 +57,26 @@ public final class LimitedRole extends Role {
     }
 
     @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        if (super.equals(o) == false) {
+            return false;
+        }
+        LimitedRole that = (LimitedRole) o;
+        return this.limitedBy.equals(that.limitedBy);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), limitedBy);
+    }
+
+    @Override
     public IndicesAccessControl authorize(String action, Set<String> requestedIndicesOrAliases,
                                           Map<String, IndexAbstraction> aliasAndIndexLookup,
                                           FieldPermissionsCache fieldPermissionsCache) {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/permission/Role.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/permission/Role.java
@@ -186,6 +186,29 @@ public class Role {
         return new IndicesAccessControl(granted, indexPermissions);
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        Role that = (Role) o;
+        return Arrays.equals(this.names, that.names)
+            && this.cluster.equals(that.cluster)
+            && this.indices.equals(that.indices)
+            && this.application.equals(that.application)
+            && this.runAs.equals(that.runAs);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = Objects.hash(cluster, indices, application, runAs);
+        result = 31 * result + Arrays.hashCode(names);
+        return result;
+    }
+
     public static class Builder {
 
         private final String[] names;

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/RBACEngine.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/RBACEngine.java
@@ -22,6 +22,7 @@ import org.elasticsearch.action.delete.DeleteAction;
 import org.elasticsearch.action.get.MultiGetAction;
 import org.elasticsearch.action.index.IndexAction;
 import org.elasticsearch.action.search.ClearScrollAction;
+import org.elasticsearch.action.search.ClosePointInTimeAction;
 import org.elasticsearch.action.search.MultiSearchAction;
 import org.elasticsearch.action.search.SearchScrollAction;
 import org.elasticsearch.action.search.SearchScrollRequest;
@@ -31,13 +32,13 @@ import org.elasticsearch.cluster.metadata.IndexAbstraction;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.regex.Regex;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.set.Sets;
 import org.elasticsearch.transport.TransportActionProxy;
 import org.elasticsearch.transport.TransportRequest;
 import org.elasticsearch.xpack.core.async.DeleteAsyncResultAction;
 import org.elasticsearch.xpack.core.eql.EqlAsyncActionNames;
-import org.elasticsearch.action.search.ClosePointInTimeAction;
 import org.elasticsearch.xpack.core.search.action.GetAsyncSearchAction;
 import org.elasticsearch.xpack.core.search.action.SubmitAsyncSearchAction;
 import org.elasticsearch.xpack.core.security.action.GetApiKeyAction;
@@ -87,6 +88,7 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Objects;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.function.Predicate;
@@ -307,6 +309,10 @@ public class RBACEngine implements AuthorizationEngine {
                 listener.onFailure(new IllegalStateException("only scroll and async-search related requests are known indices " +
                     "api that don't support retrieving the indices they relate to"));
             }
+        } else if (isChildActionAuthorizedByParent(requestInfo, authorizationInfo)) {
+            listener.onResponse(
+                new IndexAuthorizationResult(true, requestInfo.getOriginatingAuthorizationContext().getIndicesAccessControl())
+            );
         } else if (((IndicesRequest) request).allowsRemoteIndices()) {
             // remote indices are allowed
             indicesAsyncSupplier.getAsync(ActionListener.wrap(resolvedIndices -> {
@@ -346,6 +352,69 @@ public class RBACEngine implements AuthorizationEngine {
                 listener.onFailure(e);
             }
         }
+    }
+
+    private boolean isChildActionAuthorizedByParent(RequestInfo requestInfo, AuthorizationInfo authorizationInfo) {
+        final AuthorizationContext parent = requestInfo.getOriginatingAuthorizationContext();
+        if (parent == null) {
+            return false;
+        }
+
+        final IndicesAccessControl indicesAccessControl = parent.getIndicesAccessControl();
+        if (indicesAccessControl == null) {
+            // This can happen for is the parent request was authorized by index name only - e.g. bulk request
+            // A missing IAC is not an error, but it means we can't safely tie authz of the child action to the parent authz
+            return false;
+        }
+
+        if (requestInfo.getAction().startsWith(parent.getAction()) == false) {
+            // Parent action is not a true parent
+            // We want to treat shard level actions (those that append '[s]' and/or '[p]' & '[r]')
+            // or similar (e.g. search phases) as children, but not every action that is triggered
+            // within another action should be authorized this way
+            return false;
+        }
+
+        if (authorizationInfo.equals(parent.getAuthorizationInfo()) == false) {
+            // Authorization changed
+            // This should only happen if the user's list of roles changed between requests
+            // Take the safe option and perform full authorization
+            return false;
+        }
+
+        final IndicesRequest indicesRequest;
+        if (requestInfo.getRequest() instanceof IndicesRequest) {
+            indicesRequest = (IndicesRequest) requestInfo.getRequest();
+        } else {
+            // Can only handle indices request here
+            return false;
+        }
+
+        final String[] indices = indicesRequest.indices();
+        if (indices == null || indices.length == 0) {
+            // No indices to check
+            return false;
+        }
+
+        if (Arrays.equals(IndicesAndAliasesResolver.NO_INDICES_OR_ALIASES_ARRAY, indices)) {
+            // Special placeholder for no indices.
+            // We probably can short circuit this, but it's safer not to and just fall through to the regular authorization
+            return false;
+        }
+
+        for (String idx : indices) {
+            assert Regex.isSimpleMatchPattern(idx) == false : "Wildcards should already be expanded but action ["
+                + requestInfo.getAction()
+                + "] has index ["
+                + idx
+                + "]";
+            IndicesAccessControl.IndexAccessControl iac = indicesAccessControl.getIndexPermissions(idx);
+            // The parent context has already successfully authorized access to this index (by name)
+            if (iac == null || iac.isGranted() == false) {
+                return false;
+            }
+        }
+        return true;
     }
 
     private static IndexAuthorizationResult authorizeIndexActionName(String action,
@@ -600,7 +669,7 @@ public class RBACEngine implements AuthorizationEngine {
         private final RBACAuthorizationInfo authenticatedUserAuthorizationInfo;
 
         RBACAuthorizationInfo(Role role, Role authenticatedUserRole) {
-            this.role = role;
+            this.role = Objects.requireNonNull(role);
             this.info = Collections.singletonMap(PRINCIPAL_ROLES_FIELD_NAME, role.names());
             this.authenticatedUserAuthorizationInfo =
                 authenticatedUserRole == null ? this : new RBACAuthorizationInfo(authenticatedUserRole, null);
@@ -618,6 +687,32 @@ public class RBACEngine implements AuthorizationEngine {
         @Override
         public RBACAuthorizationInfo getAuthenticatedUserAuthorizationInfo() {
             return authenticatedUserAuthorizationInfo;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            RBACAuthorizationInfo that = (RBACAuthorizationInfo) o;
+            if (this.role.equals(that.role) == false) {
+                return false;
+            }
+            // Because authenticatedUserAuthorizationInfo can be reference to this, calling `equals` can result in infinite recursion.
+            // But if both user-authz-info objects are references to their containing object, then they must be equal.
+            if (this.authenticatedUserAuthorizationInfo == this) {
+                return that.authenticatedUserAuthorizationInfo == that;
+            } else {
+                return this.authenticatedUserAuthorizationInfo.equals(that.authenticatedUserAuthorizationInfo);
+            }
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(role, authenticatedUserAuthorizationInfo);
         }
     }
 

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/AuthorizationServiceTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/AuthorizationServiceTests.java
@@ -16,6 +16,7 @@ import org.elasticsearch.action.CompositeIndicesRequest;
 import org.elasticsearch.action.DocWriteRequest;
 import org.elasticsearch.action.LatchedActionListener;
 import org.elasticsearch.action.MockIndicesRequest;
+import org.elasticsearch.action.OriginalIndices;
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthAction;
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthRequest;
 import org.elasticsearch.action.admin.indices.alias.Alias;
@@ -106,6 +107,8 @@ import org.elasticsearch.indices.TestIndexNameExpressionResolver;
 import org.elasticsearch.license.XPackLicenseState;
 import org.elasticsearch.license.XPackLicenseState.Feature;
 import org.elasticsearch.script.ScriptService;
+import org.elasticsearch.search.internal.AliasFilter;
+import org.elasticsearch.search.internal.ShardSearchRequest;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.MockLogAppender;
 import org.elasticsearch.threadpool.ThreadPool;
@@ -162,6 +165,7 @@ import org.elasticsearch.xpack.security.authz.store.NativePrivilegeStore;
 import org.elasticsearch.xpack.security.operator.OperatorPrivileges;
 import org.elasticsearch.xpack.sql.action.SqlQueryAction;
 import org.elasticsearch.xpack.sql.action.SqlQueryRequest;
+import org.hamcrest.Description;
 import org.junit.Before;
 import org.mockito.ArgumentMatcher;
 import org.mockito.Matchers;
@@ -232,6 +236,7 @@ public class AuthorizationServiceTests extends ESTestCase {
     private CompositeRolesStore rolesStore;
     private OperatorPrivileges.OperatorPrivilegesService operatorPrivilegesService;
     private boolean shouldFailOperatorPrivilegesCheck = false;
+    private boolean setFakeOriginatingAction = true;
 
     @SuppressWarnings("unchecked")
     @Before
@@ -265,27 +270,12 @@ public class AuthorizationServiceTests extends ESTestCase {
             }
         ).when(privilegesStore).getPrivileges(any(Collection.class), any(Collection.class), anyActionListener());
 
+        final Map<Set<String>, Role> roleCache = new HashMap<>();
         doAnswer((i) -> {
             ActionListener<Role> callback = (ActionListener<Role>) i.getArguments()[2];
             User user = (User) i.getArguments()[0];
-            Set<String> names = new HashSet<>(Arrays.asList(user.roles()));
-            assertNotNull(names);
-            Set<RoleDescriptor> roleDescriptors = new HashSet<>();
-            for (String name : names) {
-                RoleDescriptor descriptor = roleMap.get(name);
-                if (descriptor != null) {
-                    roleDescriptors.add(descriptor);
-                }
-            }
-
-            if (roleDescriptors.isEmpty()) {
-                callback.onResponse(Role.EMPTY);
-            } else {
-                CompositeRolesStore.buildRoleFromDescriptors(roleDescriptors, fieldPermissionsCache, privilegesStore,
-                    ActionListener.wrap(r -> callback.onResponse(r), callback::onFailure)
-                );
-            }
-            return Void.TYPE;
+            buildRole(user, privilegesStore, fieldPermissionsCache, roleCache, callback);
+            return null;
         }).when(rolesStore).getRoles(any(User.class), any(Authentication.class), anyActionListener());
         roleMap.put(ReservedRolesStore.SUPERUSER_ROLE_DESCRIPTOR.getName(), ReservedRolesStore.SUPERUSER_ROLE_DESCRIPTOR);
         operatorPrivilegesService = mock(OperatorPrivileges.OperatorPrivilegesService.class);
@@ -294,7 +284,55 @@ public class AuthorizationServiceTests extends ESTestCase {
             null, Collections.emptySet(), licenseState, TestIndexNameExpressionResolver.newInstance(), operatorPrivilegesService);
     }
 
+    private void buildRole(
+        User user,
+        NativePrivilegeStore privilegesStore,
+        FieldPermissionsCache fieldPermissionsCache,
+        Map<Set<String>, Role> roleCache,
+        ActionListener<Role> listener
+    ) {
+        final Set<String> names = org.elasticsearch.core.Set.of(user.roles());
+        assertNotNull(names);
+
+        // We need a cache here because CompositeRoleStore has one, and our tests rely on it
+        // (to check that nested calls use the same object)
+        final Role cachedRole = roleCache.get(names);
+        if (cachedRole != null) {
+            listener.onResponse(cachedRole);
+            return;
+        }
+
+        Set<RoleDescriptor> roleDescriptors = new HashSet<>();
+        for (String name : names) {
+            RoleDescriptor descriptor = roleMap.get(name);
+            if (descriptor != null) {
+                roleDescriptors.add(descriptor);
+            }
+        }
+
+        if (roleDescriptors.isEmpty()) {
+            listener.onResponse(Role.EMPTY);
+        } else {
+            CompositeRolesStore.buildRoleFromDescriptors(roleDescriptors, fieldPermissionsCache, privilegesStore,
+                ActionListener.wrap(r -> {
+                    roleCache.put(names, r);
+                    listener.onResponse(r);
+                }, listener::onFailure)
+            );
+        }
+    }
+
     private void authorize(Authentication authentication, String action, TransportRequest request) {
+        authorize(authentication, action, request, true, null);
+    }
+
+    private void authorize(
+        Authentication authentication,
+        String action,
+        TransportRequest request,
+        boolean expectCleanThreadContext,
+        Runnable listenerBody
+    ) {
         PlainActionFuture<Object> done = new PlainActionFuture<>();
         PlainActionFuture<IndicesAccessControl> indicesPermissions = new PlainActionFuture<>();
         PlainActionFuture<Object> originatingAction = new PlainActionFuture<>();
@@ -309,15 +347,19 @@ public class AuthorizationServiceTests extends ESTestCase {
             threadContext.putTransient(INDICES_PERMISSIONS_KEY, mockAccessControlHeader);
         }
         String originatingActionHeader = threadContext.getTransient(ORIGINATING_ACTION_KEY);
-        if (originatingActionHeader == null && randomBoolean()) {
-            originatingActionHeader = randomAlphaOfLength(8);
-            threadContext.putTransient(ORIGINATING_ACTION_KEY, originatingActionHeader);
+        if (this.setFakeOriginatingAction) {
+            if (originatingActionHeader == null && randomBoolean()) {
+                originatingActionHeader = randomAlphaOfLength(8);
+                threadContext.putTransient(ORIGINATING_ACTION_KEY, originatingActionHeader);
+            }
         }
         AuthorizationInfo authorizationInfoHeader = threadContext.getTransient(AUTHORIZATION_INFO_KEY);
-        if (authorizationInfoHeader == null && randomBoolean()) {
-            authorizationInfoHeader = mock(AuthorizationInfo.class);
-            threadContext.putTransient(AUTHORIZATION_INFO_KEY, authorizationInfoHeader);
-        }
+        if (authorizationInfoHeader == null)
+            // If we have an originating action, we must also have origination authz info
+            if (originatingActionHeader != null || randomBoolean()) {
+                authorizationInfoHeader = mock(AuthorizationInfo.class);
+                threadContext.putTransient(AUTHORIZATION_INFO_KEY, authorizationInfoHeader);
+            }
         Mockito.reset(operatorPrivilegesService);
         final AtomicBoolean operatorPrivilegesChecked = new AtomicBoolean(false);
         final ElasticsearchSecurityException operatorPrivilegesException =
@@ -334,8 +376,13 @@ public class AuthorizationServiceTests extends ESTestCase {
             originatingAction.onResponse(threadContext.getTransient(ORIGINATING_ACTION_KEY));
             authorizationInfo.onResponse(threadContext.getTransient(AUTHORIZATION_INFO_KEY));
             indicesPermissions.onResponse(threadContext.getTransient(INDICES_PERMISSIONS_KEY));
-            done.onResponse(threadContext.getTransient(someRandomHeader));
+
             assertNull(verify(operatorPrivilegesService).check(action, request, threadContext));
+
+            if (listenerBody != null) {
+                listenerBody.run();
+            }
+            done.onResponse(threadContext.getTransient(someRandomHeader));
         }, e -> {
             if (shouldFailOperatorPrivilegesCheck && operatorPrivilegesChecked.get()) {
                 assertSame(operatorPrivilegesException, e.getCause());
@@ -362,12 +409,14 @@ public class AuthorizationServiceTests extends ESTestCase {
         } else {
             assertThat(threadContext.getTransient(AUTHORIZATION_INFO_KEY), nullValue());
         }
-        // but the authorization listener observes the authorization-resulting headers, which are different
-        if (mockAccessControlHeader != null) {
-            assertThat(indicesPermissions.actionGet(), not(sameInstance(mockAccessControlHeader)));
-        }
-        if (authorizationInfoHeader != null) {
-            assertThat(authorizationInfo.actionGet(), not(sameInstance(authorizationInfoHeader)));
+        if (expectCleanThreadContext) {
+            // but the authorization listener observes the authorization-resulting headers, which are different
+            if (mockAccessControlHeader != null) {
+                assertThat(indicesPermissions.actionGet(), not(sameInstance(mockAccessControlHeader)));
+            }
+            if (authorizationInfoHeader != null) {
+                assertThat(authorizationInfo.actionGet(), not(sameInstance(authorizationInfoHeader)));
+            }
         }
         // except originating action, which is not overwritten
         if (originatingActionHeader != null) {
@@ -829,6 +878,70 @@ public class AuthorizationServiceTests extends ESTestCase {
         }
     }
 
+    public void testSearchAgainstIndex() throws Exception {
+        RoleDescriptor role = new RoleDescriptor(
+            "search_index",
+            null,
+            new IndicesPrivileges[] { IndicesPrivileges.builder().indices("index-*").privileges("read").build() },
+            null
+        );
+        roleMap.put(role.getName(), role);
+        final User user = new User("test search user", role.getName());
+        final Authentication authentication = createAuthentication(user);
+
+        final String requestId = AuditUtil.getOrGenerateRequestId(threadContext);
+        final String indexName = "index-" + randomAlphaOfLengthBetween(1, 5);
+
+        final ClusterState clusterState = mockMetadataWithIndex(indexName);
+        final IndexMetadata indexMetadata = clusterState.metadata().index(indexName);
+
+        SearchRequest searchRequest = new SearchRequest(indexName).allowPartialSearchResults(false);
+        final ShardSearchRequest shardRequest = new ShardSearchRequest(
+            new OriginalIndices(searchRequest),
+            searchRequest,
+            new ShardId(indexMetadata.getIndex(), 0),
+            0,
+            1,
+            AliasFilter.EMPTY,
+            1.0f,
+            System.currentTimeMillis(),
+            null
+        );
+        this.setFakeOriginatingAction = false;
+        authorize(authentication, SearchAction.NAME, searchRequest, true, () -> {
+            verify(rolesStore).getRoles(Mockito.same(user), Mockito.same(authentication), Mockito.any());
+            IndicesAccessControl iac = threadContext.getTransient(AuthorizationServiceField.INDICES_PERMISSIONS_KEY);
+            // Within the action handler, execute a child action (the query phase of search)
+            authorize(
+                authentication,
+                SearchTransportService.QUERY_ACTION_NAME,
+                shardRequest,
+                false,
+                () -> {
+                    // This child action triggers a second interaction with the role store (which is cached)
+                    verify(rolesStore, times(2)).getRoles(Mockito.same(user), Mockito.same(authentication), Mockito.any());
+                    // But it does not create a new IndicesAccessControl
+                    assertThat(threadContext.getTransient(AuthorizationServiceField.INDICES_PERMISSIONS_KEY), sameInstance(iac));
+                }
+            );
+        });
+        verify(auditTrail).accessGranted(
+            eq(requestId),
+            eq(authentication),
+            eq(SearchAction.NAME),
+            eq(searchRequest),
+            authzInfoRoles(new String[] { role.getName() })
+        );
+        verify(auditTrail).accessGranted(
+            eq(requestId),
+            eq(authentication),
+            eq(SearchTransportService.QUERY_ACTION_NAME),
+            eq(shardRequest),
+            authzInfoRoles(new String[] { role.getName() })
+        );
+        verifyNoMoreInteractions(auditTrail);
+    }
+
     public void testScrollRelatedRequestsAllowed() {
         RoleDescriptor role = new RoleDescriptor("a_all", null,
             new IndicesPrivileges[]{IndicesPrivileges.builder().indices("a").privileges("all").build()}, null);
@@ -1228,13 +1341,7 @@ public class AuthorizationServiceTests extends ESTestCase {
             new IndicesPrivileges[]{IndicesPrivileges.builder().indices("b").privileges("all").build()}, null);
         boolean indexExists = randomBoolean();
         if (indexExists) {
-            ClusterState state = mock(ClusterState.class);
-            when(clusterService.state()).thenReturn(state);
-            when(state.metadata()).thenReturn(Metadata.builder()
-                .put(new IndexMetadata.Builder("a")
-                    .settings(Settings.builder().put("index.version.created", Version.CURRENT).build())
-                    .numberOfShards(1).numberOfReplicas(0).build(), true)
-                .build());
+            mockMetadataWithIndex("a");
             roleMap.put("b", bRole);
         } else {
             mockEmptyMetadata();
@@ -1266,13 +1373,7 @@ public class AuthorizationServiceTests extends ESTestCase {
             new IndicesPrivileges[]{IndicesPrivileges.builder().indices("a").privileges("all").build()},
             new String[]{"run as me"});
         roleMap.put("can run as", runAsRole);
-        ClusterState state = mock(ClusterState.class);
-        when(clusterService.state()).thenReturn(state);
-        when(state.metadata()).thenReturn(Metadata.builder()
-            .put(new IndexMetadata.Builder("b")
-                .settings(Settings.builder().put("index.version.created", Version.CURRENT).build())
-                .numberOfShards(1).numberOfReplicas(0).build(), true)
-            .build());
+        mockMetadataWithIndex("b");
         RoleDescriptor bRole = new RoleDescriptor("b", null,
             new IndicesPrivileges[]{IndicesPrivileges.builder().indices("b").privileges("all").build()}, null);
         roleMap.put("b", bRole);
@@ -1291,9 +1392,7 @@ public class AuthorizationServiceTests extends ESTestCase {
             new IndicesPrivileges[]{IndicesPrivileges.builder().indices("*").privileges("all").build()}, null);
         final Authentication authentication = createAuthentication(new User("all_access_user", "all_access"));
         roleMap.put("all_access", role);
-        ClusterState state = mock(ClusterState.class);
-        when(clusterService.state()).thenReturn(state);
-        when(state.metadata()).thenReturn(Metadata.builder()
+        ClusterState state = mockClusterState(Metadata.builder()
             .put(new IndexMetadata.Builder(INTERNAL_SECURITY_MAIN_INDEX_7)
                 .putAlias(new AliasMetadata.Builder(SECURITY_MAIN_ALIAS).build())
                 .settings(Settings.builder().put("index.version.created", Version.CURRENT).build())
@@ -1369,9 +1468,7 @@ public class AuthorizationServiceTests extends ESTestCase {
             IndicesPrivileges.builder().indices("*").privileges("monitor").allowRestrictedIndices(true).build()}, null);
         roleMap.put("restricted_monitor", restrictedMonitorRole);
         roleMap.put("unrestricted_monitor", unrestrictedMonitorRole);
-        ClusterState state = mock(ClusterState.class);
-        when(clusterService.state()).thenReturn(state);
-        when(state.metadata()).thenReturn(Metadata.builder()
+        ClusterState state = mockClusterState(Metadata.builder()
             .put(new IndexMetadata.Builder(INTERNAL_SECURITY_MAIN_INDEX_7)
                 .putAlias(new AliasMetadata.Builder(SECURITY_MAIN_ALIAS).build())
                 .settings(Settings.builder().put("index.version.created", Version.CURRENT).build())
@@ -1413,9 +1510,7 @@ public class AuthorizationServiceTests extends ESTestCase {
     public void testSuperusersCanExecuteOperationAgainstSecurityIndex() throws IOException {
         final User superuser = new User("custom_admin", ReservedRolesStore.SUPERUSER_ROLE_DESCRIPTOR.getName());
         roleMap.put(ReservedRolesStore.SUPERUSER_ROLE_DESCRIPTOR.getName(), ReservedRolesStore.SUPERUSER_ROLE_DESCRIPTOR);
-        ClusterState state = mock(ClusterState.class);
-        when(clusterService.state()).thenReturn(state);
-        when(state.metadata()).thenReturn(Metadata.builder()
+        ClusterState state = mockClusterState(Metadata.builder()
             .put(new IndexMetadata.Builder(INTERNAL_SECURITY_MAIN_INDEX_7)
                 .putAlias(new AliasMetadata.Builder(SECURITY_MAIN_ALIAS).build())
                 .settings(Settings.builder().put("index.version.created", Version.CURRENT).build())
@@ -1465,9 +1560,7 @@ public class AuthorizationServiceTests extends ESTestCase {
         final User superuser = new User("custom_admin", ReservedRolesStore.SUPERUSER_ROLE_DESCRIPTOR.getName());
         final Authentication authentication = createAuthentication(superuser);
         roleMap.put(ReservedRolesStore.SUPERUSER_ROLE_DESCRIPTOR.getName(), ReservedRolesStore.SUPERUSER_ROLE_DESCRIPTOR);
-        ClusterState state = mock(ClusterState.class);
-        when(clusterService.state()).thenReturn(state);
-        when(state.metadata()).thenReturn(Metadata.builder()
+        ClusterState state = mockClusterState(Metadata.builder()
             .put(new IndexMetadata.Builder(INTERNAL_SECURITY_MAIN_INDEX_7)
                 .putAlias(new AliasMetadata.Builder(SECURITY_MAIN_ALIAS).build())
                 .settings(Settings.builder().put("index.version.created", Version.CURRENT).build())
@@ -1705,9 +1798,21 @@ public class AuthorizationServiceTests extends ESTestCase {
     }
 
     private ClusterState mockEmptyMetadata() {
+        return mockClusterState(Metadata.EMPTY_METADATA);
+    }
+
+    private ClusterState mockMetadataWithIndex(String indexName) {
+        final IndexMetadata indexMetadata = new IndexMetadata.Builder(indexName).settings(
+            Settings.builder().put("index.version.created", Version.CURRENT).build()
+        ).numberOfShards(1).numberOfReplicas(0).build();
+        final Metadata metadata = Metadata.builder().put(indexMetadata, true).build();
+        return mockClusterState(metadata);
+    }
+
+    private ClusterState mockClusterState(Metadata metadata) {
         ClusterState state = mock(ClusterState.class);
         when(clusterService.state()).thenReturn(state);
-        when(state.metadata()).thenReturn(Metadata.EMPTY_METADATA);
+        when(state.metadata()).thenReturn(metadata);
         return state;
     }
 
@@ -1952,7 +2057,8 @@ public class AuthorizationServiceTests extends ESTestCase {
         final AuthorizationEngine.RequestInfo requestInfo = new AuthorizationEngine.RequestInfo(
             authentication,
             new SearchRequest(),
-            SearchAction.NAME
+            SearchAction.NAME,
+            null
         );
         final AuthorizationService.LoadAuthorizedIndiciesTimeChecker checker = new AuthorizationService.LoadAuthorizedIndiciesTimeChecker(
             now - TimeUnit.MILLISECONDS.toNanos(210),
@@ -2004,6 +2110,11 @@ public class AuthorizationServiceTests extends ESTestCase {
                 return Arrays.equals(wanted, found);
             }
             return false;
+        }
+
+        @Override
+        public void describeTo(Description description) {
+            description.appendText("RBAC AuthorizationInfo Roles[").appendText(Strings.arrayToCommaDelimitedString(wanted)).appendText("]");
         }
     }
 

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/interceptor/IndicesAliasesRequestInterceptorTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/interceptor/IndicesAliasesRequestInterceptorTests.java
@@ -89,7 +89,7 @@ public class IndicesAliasesRequestInterceptorTests extends ESTestCase {
             indicesAliasesRequest.addAliasAction(IndicesAliasesRequest.AliasActions.removeIndex().index("foofoo"));
         }
         PlainActionFuture<Void> plainActionFuture = new PlainActionFuture<>();
-        RequestInfo requestInfo = new RequestInfo(authentication, indicesAliasesRequest, action);
+        RequestInfo requestInfo = new RequestInfo(authentication, indicesAliasesRequest, action, null);
         AuthorizationEngine mockEngine = mock(AuthorizationEngine.class);
         doAnswer(invocationOnMock -> {
             ActionListener<AuthorizationResult> listener = (ActionListener<AuthorizationResult>) invocationOnMock.getArguments()[3];
@@ -135,7 +135,7 @@ public class IndicesAliasesRequestInterceptorTests extends ESTestCase {
         AuthorizationEngine mockEngine = mock(AuthorizationEngine.class);
         {
             PlainActionFuture<Void> plainActionFuture = new PlainActionFuture<>();
-            RequestInfo requestInfo = new RequestInfo(authentication, indicesAliasesRequest, action);
+            RequestInfo requestInfo = new RequestInfo(authentication, indicesAliasesRequest, action, null);
             doAnswer(invocationOnMock -> {
                 ActionListener<AuthorizationResult> listener = (ActionListener<AuthorizationResult>) invocationOnMock.getArguments()[3];
                 listener.onResponse(AuthorizationResult.deny());
@@ -163,7 +163,7 @@ public class IndicesAliasesRequestInterceptorTests extends ESTestCase {
 
         {
             PlainActionFuture<Void> plainActionFuture = new PlainActionFuture<>();
-            RequestInfo requestInfo = new RequestInfo(authentication, successRequest, action);
+            RequestInfo requestInfo = new RequestInfo(authentication, successRequest, action, null);
             doAnswer(invocationOnMock -> {
                 ActionListener<AuthorizationResult> listener = (ActionListener<AuthorizationResult>) invocationOnMock.getArguments()[3];
                 listener.onResponse(AuthorizationResult.granted());

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/interceptor/ResizeRequestInterceptorTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/interceptor/ResizeRequestInterceptorTests.java
@@ -86,7 +86,7 @@ public class ResizeRequestInterceptorTests extends ESTestCase {
                 new ResizeRequestInterceptor(threadPool, licenseState, auditTrailService);
 
         PlainActionFuture<Void> plainActionFuture = new PlainActionFuture<>();
-        RequestInfo requestInfo = new RequestInfo(authentication, new ResizeRequest("bar", "foo"), action);
+        RequestInfo requestInfo = new RequestInfo(authentication, new ResizeRequest("bar", "foo"), action, null);
         AuthorizationEngine mockEngine = mock(AuthorizationEngine.class);
         doAnswer(invocationOnMock -> {
             ActionListener<AuthorizationResult> listener = (ActionListener<AuthorizationResult>) invocationOnMock.getArguments()[3];
@@ -128,7 +128,7 @@ public class ResizeRequestInterceptorTests extends ESTestCase {
         AuthorizationEngine mockEngine = mock(AuthorizationEngine.class);
         {
             PlainActionFuture<Void> plainActionFuture = new PlainActionFuture<>();
-            RequestInfo requestInfo = new RequestInfo(authentication, new ResizeRequest("target", "source"), action);
+            RequestInfo requestInfo = new RequestInfo(authentication, new ResizeRequest("target", "source"), action, null);
             doAnswer(invocationOnMock -> {
                 ActionListener<AuthorizationResult> listener = (ActionListener<AuthorizationResult>) invocationOnMock.getArguments()[3];
                 listener.onResponse(AuthorizationResult.deny());
@@ -147,7 +147,7 @@ public class ResizeRequestInterceptorTests extends ESTestCase {
         // swap target and source for success
         {
             PlainActionFuture<Void> plainActionFuture = new PlainActionFuture<>();
-            RequestInfo requestInfo = new RequestInfo(authentication, new ResizeRequest("source", "target"), action);
+            RequestInfo requestInfo = new RequestInfo(authentication, new ResizeRequest("source", "target"), action, null);
             doAnswer(invocationOnMock -> {
                 ActionListener<AuthorizationResult> listener = (ActionListener<AuthorizationResult>) invocationOnMock.getArguments()[3];
                 listener.onResponse(AuthorizationResult.granted());


### PR DESCRIPTION
This commit detects a specific case when a child action (e.g. a shard
level action, or a phased action) acts on the same indices (or a
subset of the indices) or that parent request, and we can retain the
original authorization result.

The optimization is only effective for the invocation of the child
action on the same node as the parent - if the transport action needs
to be executed on a remote node then that authorization will not be
optimized and will perform the full check as existed before this
change.

This change is primarily benefitial for actions where a single parent
action on a coordinating node triggers the execution of multiple
children (e.g. a child action per shard) as it allows the
coordinating node to trigger those action and allow the load
to be passed to the remote nodes as quickly as possible rather than
having authorization on the coordinating node become a bottleneck.

Backport: #77221 