### PR TITLE
[7.x] Document missing_order param for composite aggregations (#77839)

### DIFF
--- a/docs/reference/aggregations/bucket/composite-aggregation.asciidoc
+++ b/docs/reference/aggregations/bucket/composite-aggregation.asciidoc
@@ -599,19 +599,30 @@ GET /_search
   "aggs": {
     "my_buckets": {
       "composite": {
-        "sources": [
-          { "product_name": { "terms": { "field": "product", "missing_bucket": true } } }
-        ]
+        "sources": [{
+          "product_name": {
+            "terms": {
+              "field": "product",
+              "missing_bucket": true,
+              "missing_order": "last"
+            }
+          }
+        }]
       }
     }
   }
 }
 --------------------------------------------------
 
-In the example above the source `product_name` will emit an explicit `null` value
-for documents without a value for the field `product`.
-The `order` specified in the source dictates whether the `null` values should rank
-first (ascending order, `asc`) or last (descending order, `desc`).
+In the above example, the `product_name` source emits an explicit `null` bucket
+for documents without a `product` value. This bucket is placed last.
+
+You can control the position of the `null` bucket using the optional
+`missing_order` parameter. If `missing_order` is `first` or `last`, the `null`
+bucket is placed in the respective first or last position. If `missing_order` is
+omitted or `default`, the source's `order` determines the bucket's position. If
+`order` is `asc` (ascending), the bucket is in the first position. If `order` is
+`desc` (descending), the bucket is in the last position.
 
 ==== Size
 


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Document missing_order param for composite aggregations (#77839)