### PR TITLE
Add Optional to Configure bind user

### DIFF
--- a/x-pack/docs/en/security/authentication/configuring-active-directory-realm.asciidoc
+++ b/x-pack/docs/en/security/authentication/configuring-active-directory-realm.asciidoc
@@ -97,7 +97,7 @@ operation are supported: failover and load balancing. See <<ref-ad-settings>>.
 
 . Restart {es}.
 
-. Configure a bind user. 
+. (Optional) Configure a bind user. 
 +
 --
 The Active Directory realm authenticates users using an LDAP bind request. By 


### PR DESCRIPTION
To avoid confusion I have added the `(Optional)` label to the item `Configure bind user` which is optional with Active Directory.


I would suggest to backport this to 7.x docs.