### PR TITLE
Enforce common dependency configuration setup

### DIFF
--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/ElasticsearchJavaBasePlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/ElasticsearchJavaBasePlugin.java
@@ -99,9 +99,7 @@ public class ElasticsearchJavaBasePlugin implements Plugin<Project> {
                 sourceSet.getImplementationConfigurationName(),
                 sourceSet.getImplementationConfigurationName(),
                 sourceSet.getCompileOnlyConfigurationName(),
-                sourceSet.getRuntimeOnlyConfigurationName(),
-                sourceSet.getCompileClasspathConfigurationName(),
-                sourceSet.getRuntimeClasspathConfigurationName()
+                sourceSet.getRuntimeOnlyConfigurationName()
         );
 
         project.getConfigurations().matching(c -> sourceSetConfigurationNames.contains(c.getName()))

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/ElasticsearchJavaBasePlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/ElasticsearchJavaBasePlugin.java
@@ -32,8 +32,8 @@ import org.gradle.api.tasks.compile.JavaCompile;
 
 import java.util.List;
 import java.util.Objects;
+import java.util.function.Predicate;
 import java.util.stream.Stream;
-
 
 /**
  * A wrapper around Gradle's Java Base plugin that applies our
@@ -50,12 +50,63 @@ public class ElasticsearchJavaBasePlugin implements Plugin<Project> {
         project.getPluginManager().apply(ElasticsearchTestBasePlugin.class);
         project.getPluginManager().apply(PrecommitTaskPlugin.class);
 
+        configureConfigurations(project);
         configureCompile(project);
         configureInputNormalization(project);
 
         // convenience access to common versions used in dependencies
         project.getExtensions().getExtraProperties().set("versions", VersionProperties.getVersions());
     }
+
+    /**
+     * Makes dependencies non-transitive.
+     * <p>
+     * Gradle allows setting all dependencies as non-transitive very easily.
+     * Sadly this mechanism does not translate into maven pom generation. In order
+     * to effectively make the pom act as if it has no transitive dependencies,
+     * we must exclude each transitive dependency of each direct dependency.
+     * <p>
+     * Determining the transitive deps of a dependency which has been resolved as
+     * non-transitive is difficult because the process of resolving removes the
+     * transitive deps. To sidestep this issue, we create a configuration per
+     * direct dependency version. This specially named and unique configuration
+     * will contain all of the transitive dependencies of this particular
+     * dependency. We can then use this configuration during pom generation
+     * to iterate the transitive dependencies and add excludes.
+     */
+    public static void configureConfigurations(Project project) {
+        // we are not shipping these jars, we act like dumb consumers of these things
+        if (project.getPath().startsWith(":test:fixtures") || project.getPath().equals(":build-tools")) {
+            return;
+        }
+        // fail on any conflicting dependency versions
+        project.getConfigurations().all(configuration -> {
+            if (configuration.getName().endsWith("Fixture")) {
+                // just a self contained test-fixture configuration, likely transitive and hellacious
+                return;
+            }
+            configuration.resolutionStrategy(ResolutionStrategy::failOnVersionConflict);
+        });
+
+        // disable transitive dependency management
+        SourceSetContainer sourceSets = project.getExtensions().getByType(SourceSetContainer.class);
+        sourceSets.all(sourceSet -> disableTransitiveDependenciesForSourceSet(project, sourceSet));
+    }
+
+    private static void disableTransitiveDependenciesForSourceSet(Project project, SourceSet sourceSet) {
+        List<String> sourceSetConfigurationNames = List.of(
+                sourceSet.getApiConfigurationName(),
+                sourceSet.getImplementationConfigurationName(),
+                sourceSet.getImplementationConfigurationName(),
+                sourceSet.getCompileOnlyConfigurationName(),
+                sourceSet.getRuntimeOnlyConfigurationName(),
+                sourceSet.getCompileClasspathConfigurationName(),
+                sourceSet.getRuntimeClasspathConfigurationName()
+        );
+
+        project.getConfigurations().matching(c -> sourceSetConfigurationNames.contains(c.getName()))
+                .configureEach(GradleUtils::disableTransitiveDependencies);
+     }
 
     /**
      * Adds compiler settings to the project
@@ -90,12 +141,15 @@ public class ElasticsearchJavaBasePlugin implements Plugin<Project> {
             compileOptions.getRelease().set(releaseVersionProviderFromCompileTask(project, compileTask));
         });
         // also apply release flag to groovy, which is used in build-tools
-        project.getTasks().withType(GroovyCompile.class).configureEach(compileTask -> {
-            // TODO: this probably shouldn't apply to groovy at all?
-            compileTask.getOptions().getRelease().set(releaseVersionProviderFromCompileTask(project, compileTask));
-        });
+        project.getTasks()
+            .withType(GroovyCompile.class)
+            .configureEach(
+                compileTask -> {
+                    // TODO: this probably shouldn't apply to groovy at all?
+                    compileTask.getOptions().getRelease().set(releaseVersionProviderFromCompileTask(project, compileTask));
+                }
+            );
     }
-
 
     /**
      * Apply runtime classpath input normalization so that changes in JAR manifests don't break build cacheability

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/test/rest/InternalYamlRestTestPlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/test/rest/InternalYamlRestTestPlugin.java
@@ -8,7 +8,6 @@
 
 package org.elasticsearch.gradle.internal.test.rest;
 
-import org.elasticsearch.gradle.internal.ElasticsearchJavaPlugin;
 import org.elasticsearch.gradle.internal.test.RestTestBasePlugin;
 import org.elasticsearch.gradle.util.GradleUtils;
 import org.gradle.api.Plugin;
@@ -30,8 +29,6 @@ public class InternalYamlRestTestPlugin implements Plugin<Project> {
     public void apply(Project project) {
         project.getPluginManager().apply(RestTestBasePlugin.class);
         project.getPluginManager().apply(RestResourcesPlugin.class);
-
-        ElasticsearchJavaPlugin.configureConfigurations(project);
 
         // create source set
         SourceSetContainer sourceSets = project.getExtensions().getByType(SourceSetContainer.class);

--- a/build-tools/src/main/java/org/elasticsearch/gradle/util/GradleUtils.java
+++ b/build-tools/src/main/java/org/elasticsearch/gradle/util/GradleUtils.java
@@ -208,7 +208,6 @@ public abstract class GradleUtils {
     }
 
     public static void disableTransitiveDependencies(Configuration config) {
-        System.out.println("GradleUtils.disableTransitiveDependencies " + config.getName());
         config.getDependencies().all(dep -> {
             if (dep instanceof ModuleDependency
                 && dep instanceof ProjectDependency == false

--- a/build-tools/src/main/java/org/elasticsearch/gradle/util/GradleUtils.java
+++ b/build-tools/src/main/java/org/elasticsearch/gradle/util/GradleUtils.java
@@ -208,6 +208,7 @@ public abstract class GradleUtils {
     }
 
     public static void disableTransitiveDependencies(Configuration config) {
+        System.out.println("GradleUtils.disableTransitiveDependencies " + config.getName());
         config.getDependencies().all(dep -> {
             if (dep instanceof ModuleDependency
                 && dep instanceof ProjectDependency == false

--- a/qa/smoke-test-http/build.gradle
+++ b/qa/smoke-test-http/build.gradle
@@ -12,7 +12,7 @@ apply plugin: 'elasticsearch.rest-test'
 apply plugin: 'elasticsearch.test-with-dependencies'
 
 dependencies {
-  testImplementation "com.fasterxml.jackson.core:jackson-databind:2.8.11"
+  testImplementation "com.fasterxml.jackson.core:jackson-databind:2.10.4"
   testImplementation project(':modules:transport-netty4') // for http
   testImplementation project(':plugins:transport-nio') // for http
 }

--- a/x-pack/plugin/sql/qa/server/build.gradle
+++ b/x-pack/plugin/sql/qa/server/build.gradle
@@ -99,6 +99,8 @@ subprojects {
 
     // spatial dependency
     testRuntimeOnly project(path: xpackModule('spatial'))
+
+    testRuntimeOnly "org.slf4j:slf4j-api:1.7.25"
   }
 
   if (project.name != 'security') {

--- a/x-pack/plugin/sql/qa/server/build.gradle
+++ b/x-pack/plugin/sql/qa/server/build.gradle
@@ -74,10 +74,11 @@ subprojects {
     testRuntimeOnly "com.h2database:h2:${h2Version}"
 
     // H2GIS testing dependencies
-    testRuntimeOnly("org.orbisgis:h2gis:${h2gisVersion}") {
-      exclude group: "org.locationtech.jts"
-      exclude group: "com.fasterxml.jackson.core"
-    }
+    testRuntimeOnly("org.orbisgis:h2gis:${h2gisVersion}")
+    testRuntimeOnly("org.orbisgis:h2gis-api:${h2gisVersion}")
+    testRuntimeOnly("org.orbisgis:h2gis-utilities:${h2gisVersion}")
+    testRuntimeOnly("org.orbisgis:cts:1.5.2")
+
 
     testRuntimeOnly project(path: xpackModule('sql:jdbc'))
     testRuntimeOnly xpackProject('plugin:sql:sql-client')

--- a/x-pack/qa/security-tools-tests/build.gradle
+++ b/x-pack/qa/security-tools-tests/build.gradle
@@ -7,6 +7,11 @@ dependencies {
   testRuntimeOnly "com.google.guava:guava:${versions.jimfs_guava}"
 }
 
+configurations.all {
+  resolutionStrategy {
+    forcedModules = ["com.google.guava:guava:${versions.jimfs_guava}"]
+  }
+}
 // add test resources from security, so certificate tool tests can use example certs
 tasks.named("processTestResources").configure {
   from(project(xpackModule('security')).sourceSets.test.resources.srcDirs)


### PR DESCRIPTION
This enforces the general dependency configuration setup we apply also on all test configuration. Also this deals with
lazy created configurations within Gradle (e.g. creating dependencies via `configurations.maybeCreate(...)` which caused some transitive deps to sneak in on several test projects otherwise. 