### PR TITLE
Speed up ordinal lookups in composite aggregation

### DIFF
--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/composite/OrdinalValuesSource.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/composite/OrdinalValuesSource.java
@@ -371,9 +371,6 @@ class OrdinalValuesSource extends SingleDimensionValuesSource<BytesRef> {
             final long index = slot.index;
             final long oldOrd = slot.ord;
             final BytesRef unmapped = slot.unmapped;
-            if (oldOrd == Long.MIN_VALUE) {
-                continue;
-            }
             final long newOrd;
             if (oldOrd >= 0) {
                 if (lastOldOrd == oldOrd) {


### PR DESCRIPTION
This change is an optimization on top of #74559, that sorts ordinals to perform
lookups. The sorting ensures that we don't do the de-compression of
 blocks in the dictionary of terms more than necessary.
 In the worst case today, we can decompress the same block for each lookup
term per segment, while this change requires only one decompression.

This commit also creates the doc values lookup once
per request per segment. This is useful when inverted lists
 are used to shortcut the collection since terms are already sorted
 in the dictionary.