### PR TITLE
Remove fixRedundantIncludes calls

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/mapper/MapperService.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/MapperService.java
@@ -291,7 +291,6 @@ public class MapperService extends AbstractIndexComponent implements Closeable {
 
     private DocumentMapper newDocumentMapper(Mapping mapping, MergeReason reason) {
         DocumentMapper newMapper = new DocumentMapper(documentParser, mapping);
-        newMapper.mapping().getRoot().fixRedundantIncludes();
         newMapper.validate(indexSettings, reason != MergeReason.MAPPING_RECOVERY);
         return newMapper;
     }

--- a/server/src/main/java/org/elasticsearch/index/mapper/NestedObjectMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/NestedObjectMapper.java
@@ -129,16 +129,8 @@ public class NestedObjectMapper extends ObjectMapper {
         return this.includeInParent.value();
     }
 
-    public void setIncludeInParent(boolean includeInParent) {
-        this.includeInParent = new Explicit<>(includeInParent, true);
-    }
-
     public boolean isIncludeInRoot() {
         return this.includeInRoot.value();
-    }
-
-    public void setIncludeInRoot(boolean includeInRoot) {
-        this.includeInRoot = new Explicit<>(includeInRoot, true);
     }
 
     public Map<String, Mapper> getChildren() {

--- a/server/src/main/java/org/elasticsearch/index/mapper/RootObjectMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/RootObjectMapper.java
@@ -104,37 +104,6 @@ public class RootObjectMapper extends ObjectMapper {
         }
     }
 
-    /**
-     * Removes redundant root includes in {@link NestedObjectMapper} trees to avoid duplicate
-     * fields on the root mapper when {@code isIncludeInRoot} is {@code true} for a node that is
-     * itself included into a parent node, for which either {@code isIncludeInRoot} is
-     * {@code true} or which is transitively included in root by a chain of nodes with
-     * {@code isIncludeInParent} returning {@code true}.
-     */
-    // TODO it would be really nice to make this an implementation detail of NestedObjectMapper
-    // and run it as part of the builder, but this does not yet work because of the way that
-    // index templates are merged together. If merge() was run on Builder objects rather than
-    // on Mappers then we could move this.
-    public void fixRedundantIncludes() {
-        fixRedundantIncludes(this, true);
-    }
-
-    private static void fixRedundantIncludes(ObjectMapper objectMapper, boolean parentIncluded) {
-        for (Mapper mapper : objectMapper) {
-            if (mapper instanceof NestedObjectMapper) {
-                NestedObjectMapper child = (NestedObjectMapper) mapper;
-                boolean isNested = child.isNested();
-                boolean includeInRootViaParent = parentIncluded && isNested && child.isIncludeInParent();
-                boolean includedInRoot = isNested && child.isIncludeInRoot();
-                if (includeInRootViaParent && includedInRoot) {
-                    child.setIncludeInParent(true);
-                    child.setIncludeInRoot(false);
-                }
-                fixRedundantIncludes(child, includeInRootViaParent || includedInRoot);
-            }
-        }
-    }
-
     static final class TypeParser extends ObjectMapper.TypeParser {
 
         @Override

--- a/server/src/test/java/org/elasticsearch/index/mapper/NestedObjectMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/NestedObjectMapperTests.java
@@ -929,7 +929,7 @@ public class NestedObjectMapperTests extends MapperServiceTestCase {
 
     public void testMergeNestedMappingsFromDynamicUpdate() throws IOException {
 
-        // Check that dynamic mappings have redundant includes removed
+        // Check that dynamic mappings from multiple shards will merge correctly
 
         MapperService mapperService = createMapperService(topMapping(b -> {
             b.startArray("dynamic_templates");
@@ -949,12 +949,14 @@ public class NestedObjectMapperTests extends MapperServiceTestCase {
 
         ParsedDocument doc = mapperService.documentMapper().parse(source(b -> b.startObject("object").endObject()));
 
+        // From shard 1
         merge(mapperService, Strings.toString(doc.dynamicMappingsUpdate()));
+        // From shard 2
         merge(mapperService, Strings.toString(doc.dynamicMappingsUpdate()));
 
         assertThat(
             Strings.toString(mapperService.documentMapper().mapping()),
-            containsString("\"properties\":{\"object\":{\"type\":\"nested\",\"include_in_parent\":true}}")
+            containsString("\"properties\":{\"object\":{\"type\":\"nested\",\"include_in_parent\":true")
         );
     }
 }


### PR DESCRIPTION
Rather than re-writing mappings, we should just detect redundant includes at
document parse time. We already do this for single-level nested documents, and
this commit extends detection to multiply-nested mappings.