### PR TITLE
[7.x] [doc] Improve documentation for deprecation logging (#78326)

### DIFF
--- a/docs/reference/setup/logging-config.asciidoc
+++ b/docs/reference/setup/logging-config.asciidoc
@@ -200,8 +200,14 @@ By default, {es} rolls and compresses deprecation logs at 1GB. The default
 configuration preserves a maximum of five log files: four rolled logs and an
 active log.
 
-{es} emits deprecation log messages at the `CRITICAL` level. To stop writing
-deprecation log messages, set `logger.deprecation.level` to `OFF`:
+{es} emits deprecation log messages at the `CRITICAL` level. Those messages
+are indicating that a used deprecation feature will be removed in a next major
+version. Deprecation log messages at the `WARN` level indicates that a less
+critical feature was used, it won't be removed in next major version, but might
+be removed in the future.
+
+To stop writing deprecation log messages, set `logger.deprecation.level`
+to `OFF`:
 
 [source,properties]
 ----


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [doc] Improve documentation for deprecation logging (#78326)