### PR TITLE
Script: compile/cache eviction history metric placeholders (#78257)

### DIFF
--- a/server/src/main/java/org/elasticsearch/script/ScriptContextStats.java
+++ b/server/src/main/java/org/elasticsearch/script/ScriptContextStats.java
@@ -20,14 +20,19 @@ import java.util.Objects;
 public class ScriptContextStats implements Writeable, ToXContentFragment, Comparable<ScriptContextStats> {
     private final String context;
     private final long compilations;
+    private final TimeSeries compilationsHistory;
     private final long cacheEvictions;
+    private final TimeSeries cacheEvictionsHistory;
     private final long compilationLimitTriggered;
 
-    public ScriptContextStats(String context, long compilations, long cacheEvictions, long compilationLimitTriggered) {
+    public ScriptContextStats(String context, long compilations, long cacheEvictions, long compilationLimitTriggered,
+                              TimeSeries compilationsHistory, TimeSeries cacheEvictionsHistory) {
         this.context = Objects.requireNonNull(context);
         this.compilations = compilations;
         this.cacheEvictions = cacheEvictions;
         this.compilationLimitTriggered = compilationLimitTriggered;
+        this.compilationsHistory = compilationsHistory;
+        this.cacheEvictionsHistory = cacheEvictionsHistory;
     }
 
     public ScriptContextStats(StreamInput in) throws IOException {
@@ -35,6 +40,8 @@ public class ScriptContextStats implements Writeable, ToXContentFragment, Compar
         compilations = in.readVLong();
         cacheEvictions = in.readVLong();
         compilationLimitTriggered = in.readVLong();
+        compilationsHistory = null;
+        cacheEvictionsHistory = null;
     }
 
     @Override
@@ -45,6 +52,65 @@ public class ScriptContextStats implements Writeable, ToXContentFragment, Compar
         out.writeVLong(compilationLimitTriggered);
     }
 
+    public static class TimeSeries implements Writeable, ToXContentFragment {
+        public final long fiveMinutes;
+        public final long fifteenMinutes;
+        public final long twentyFourHours;
+
+        public TimeSeries() {
+            this.fiveMinutes = 0;
+            this.fifteenMinutes = 0;
+            this.twentyFourHours = 0;
+        }
+
+        public TimeSeries(long fiveMinutes, long fifteenMinutes, long twentyFourHours) {
+            assert fiveMinutes >= 0;
+            this.fiveMinutes = fiveMinutes;
+            assert fifteenMinutes >= fiveMinutes;
+            this.fifteenMinutes = fifteenMinutes;
+            assert twentyFourHours >= fifteenMinutes;
+            this.twentyFourHours = twentyFourHours;
+        }
+
+        public TimeSeries(StreamInput in) throws IOException {
+            fiveMinutes = in.readVLong();
+            fifteenMinutes = in.readVLong();
+            twentyFourHours = in.readVLong();
+        }
+
+        @Override
+        public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+            builder.field(Fields.FIVE_MINUTES, fiveMinutes);
+            builder.field(Fields.FIFTEEN_MINUTES, fifteenMinutes);
+            builder.field(Fields.TWENTY_FOUR_HOURS, twentyFourHours);
+            return builder;
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            out.writeVLong(fiveMinutes);
+            out.writeVLong(fifteenMinutes);
+            out.writeVLong(twentyFourHours);
+        }
+
+        public boolean isEmpty() {
+            return twentyFourHours == 0;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            TimeSeries that = (TimeSeries) o;
+            return fiveMinutes == that.fiveMinutes && fifteenMinutes == that.fifteenMinutes && twentyFourHours == that.twentyFourHours;
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(fiveMinutes, fifteenMinutes, twentyFourHours);
+        }
+    }
+
     public String getContext() {
         return context;
     }
@@ -53,8 +119,16 @@ public class ScriptContextStats implements Writeable, ToXContentFragment, Compar
         return compilations;
     }
 
+    public TimeSeries getCompilationsHistory() {
+        return compilationsHistory;
+    }
+
     public long getCacheEvictions() {
         return cacheEvictions;
+    }
+
+    public TimeSeries getCacheEvictionsHistory() {
+        return cacheEvictionsHistory;
     }
 
     public long getCompilationLimitTriggered() {
@@ -66,7 +140,22 @@ public class ScriptContextStats implements Writeable, ToXContentFragment, Compar
         builder.startObject();
         builder.field(Fields.CONTEXT, getContext());
         builder.field(Fields.COMPILATIONS, getCompilations());
+
+        TimeSeries series = getCompilationsHistory();
+        if (series != null && series.isEmpty() == false) {
+            builder.startObject(Fields.COMPILATIONS_HISTORY);
+            series.toXContent(builder, params);
+            builder.endObject();
+        }
+
         builder.field(Fields.CACHE_EVICTIONS, getCacheEvictions());
+        series = getCacheEvictionsHistory();
+        if (series != null && series.isEmpty() == false) {
+            builder.startObject(Fields.CACHE_EVICTIONS_HISTORY);
+            series.toXContent(builder, params);
+            builder.endObject();
+        }
+
         builder.field(Fields.COMPILATION_LIMIT_TRIGGERED, getCompilationLimitTriggered());
         builder.endObject();
         return builder;
@@ -80,7 +169,12 @@ public class ScriptContextStats implements Writeable, ToXContentFragment, Compar
     static final class Fields {
         static final String CONTEXT = "context";
         static final String COMPILATIONS = "compilations";
+        static final String COMPILATIONS_HISTORY = "compilations_history";
         static final String CACHE_EVICTIONS = "cache_evictions";
+        static final String CACHE_EVICTIONS_HISTORY = "cache_evictions_history";
         static final String COMPILATION_LIMIT_TRIGGERED = "compilation_limit_triggered";
+        static final String FIVE_MINUTES = "5m";
+        static final String FIFTEEN_MINUTES = "15m";
+        static final String TWENTY_FOUR_HOURS = "24h";
     }
 }

--- a/server/src/main/java/org/elasticsearch/script/ScriptMetrics.java
+++ b/server/src/main/java/org/elasticsearch/script/ScriptMetrics.java
@@ -36,7 +36,9 @@ public class ScriptMetrics {
             context,
             compilationsMetric.count(),
             cacheEvictionsMetric.count(),
-            compilationLimitTriggered.count()
+            compilationLimitTriggered.count(),
+            new ScriptContextStats.TimeSeries(),
+            new ScriptContextStats.TimeSeries()
         );
     }
 }

--- a/server/src/test/java/org/elasticsearch/script/ScriptStatsTests.java
+++ b/server/src/test/java/org/elasticsearch/script/ScriptStatsTests.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.script;
+
+import org.elasticsearch.Version;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.io.stream.BytesStreamOutput;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.xcontent.ToXContent;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentFactory;
+import org.elasticsearch.test.ESTestCase;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.function.Function;
+
+import static org.hamcrest.Matchers.equalTo;
+
+public class ScriptStatsTests extends ESTestCase {
+    public void testXContent() throws IOException {
+        List<ScriptContextStats> contextStats = org.elasticsearch.core.List.of(
+            new ScriptContextStats("contextB", 100, 201, 302,
+                    new ScriptContextStats.TimeSeries(1000, 1001, 1002),
+                    new ScriptContextStats.TimeSeries(2000, 2001, 2002)
+            ),
+            new ScriptContextStats("contextA", 1000, 2010, 3020, null, new ScriptContextStats.TimeSeries(0, 0, 0))
+        );
+        ScriptStats stats = new ScriptStats(contextStats);
+        final XContentBuilder builder = XContentFactory.jsonBuilder().prettyPrint();
+        builder.startObject();
+        stats.toXContent(builder, ToXContent.EMPTY_PARAMS);
+        builder.endObject();
+
+        String expected = "{\n" +
+            "  \"script\" : {\n" +
+            "    \"compilations\" : 1100,\n" +
+            "    \"cache_evictions\" : 2211,\n" +
+            "    \"compilation_limit_triggered\" : 3322\n" +
+            "  }\n" +
+            "}";
+        assertThat(Strings.toString(builder), equalTo(expected));
+    }
+
+    public void testSerializeEmptyTimeSeries() throws IOException {
+        ScriptContextStats.TimeSeries empty = new ScriptContextStats.TimeSeries();
+        ScriptContextStats stats = new ScriptContextStats("c", 1111, 2222, 3333, null, empty);
+
+        XContentBuilder builder = XContentFactory.jsonBuilder().prettyPrint();
+        stats.toXContent(builder, ToXContent.EMPTY_PARAMS);
+
+        String expected  =
+                "{\n" +
+                "  \"context\" : \"c\",\n" +
+                "  \"compilations\" : 1111,\n" +
+                "  \"cache_evictions\" : 2222,\n" +
+                "  \"compilation_limit_triggered\" : 3333\n" +
+                "}";
+
+        assertThat(Strings.toString(builder), equalTo(expected));
+    }
+
+    public void testSerializeTimeSeries() throws IOException {
+        Function<ScriptContextStats.TimeSeries, ScriptContextStats> mkContextStats =
+            (ts) -> new ScriptContextStats("c", 1111, 2222, 3333, null, ts);
+
+        ScriptContextStats.TimeSeries series = new ScriptContextStats.TimeSeries(0, 0, 5);
+        String format =
+                "{\n" +
+                "  \"context\" : \"c\",\n" +
+                "  \"compilations\" : 1111,\n" +
+                "  \"cache_evictions\" : 2222,\n" +
+                "  \"cache_evictions_history\" : {\n" +
+                "    \"5m\" : %d,\n" +
+                "    \"15m\" : %d,\n" +
+                "    \"24h\" : %d\n" +
+                "  },\n" +
+                "  \"compilation_limit_triggered\" : 3333\n" +
+                "}";
+
+        XContentBuilder builder = XContentFactory.jsonBuilder().prettyPrint();
+        mkContextStats.apply(series).toXContent(builder, ToXContent.EMPTY_PARAMS);
+
+        assertThat(Strings.toString(builder), equalTo(String.format(Locale.ROOT, format, 0, 0, 5)));
+
+        series = new ScriptContextStats.TimeSeries(0, 7, 1234);
+        builder = XContentFactory.jsonBuilder().prettyPrint();
+        mkContextStats.apply(series).toXContent(builder, ToXContent.EMPTY_PARAMS);
+        assertThat(Strings.toString(builder), equalTo(String.format(Locale.ROOT, format, 0, 7, 1234)));
+
+        series = new ScriptContextStats.TimeSeries(123, 456, 789);
+        builder = XContentFactory.jsonBuilder().prettyPrint();
+        mkContextStats.apply(series).toXContent(builder, ToXContent.EMPTY_PARAMS);
+        assertThat(Strings.toString(builder), equalTo(String.format(Locale.ROOT, format, 123, 456, 789)));
+    }
+
+    public void testTimeSeriesAssertions() {
+        expectThrows(AssertionError.class, () -> new ScriptContextStats.TimeSeries(-1, 1, 2));
+        expectThrows(AssertionError.class, () -> new ScriptContextStats.TimeSeries(1, 0, 2));
+        expectThrows(AssertionError.class, () -> new ScriptContextStats.TimeSeries(1, 3, 2));
+    }
+
+    public void testTimeSeriesIsEmpty() {
+        assertTrue((new ScriptContextStats.TimeSeries(0, 0, 0)).isEmpty());
+        long day = randomLongBetween(1, 1024);
+        long fifteen = day >= 1 ? randomLongBetween(0, day) : 0;
+        long five = fifteen >= 1 ? randomLongBetween(0, fifteen) : 0;
+        assertFalse((new ScriptContextStats.TimeSeries(five, fifteen, day)).isEmpty());
+    }
+
+    public void testTimeSeriesSerialization() throws IOException {
+        ScriptContextStats stats = randomStats();
+
+        ScriptContextStats deserStats = serDeser(Version.V_7_16_0, Version.V_7_16_0, stats);
+        assertEquals(stats.getCompilations(), deserStats.getCompilations());
+        assertEquals(stats.getCacheEvictions(), deserStats.getCacheEvictions());
+        assertEquals(stats.getCompilationLimitTriggered(), deserStats.getCompilationLimitTriggered());
+        assertNull(deserStats.getCompilationsHistory());
+        assertNull(deserStats.getCacheEvictionsHistory());
+    }
+
+    public ScriptContextStats serDeser(Version outVersion, Version inVersion, ScriptContextStats stats) throws IOException {
+        try (BytesStreamOutput out = new BytesStreamOutput()) {
+            out.setVersion(outVersion);
+            stats.writeTo(out);
+            try (StreamInput in = out.bytes().streamInput()) {
+                in.setVersion(inVersion);
+                return new ScriptContextStats(in);
+            }
+        }
+    }
+
+    public ScriptContextStats randomStats() {
+        long[] histStats = {randomLongBetween(0, 2048), randomLongBetween(0, 2048)};
+        List<ScriptContextStats.TimeSeries> timeSeries = new ArrayList<>();
+        for (int j = 0; j < 2; j++) {
+            if (randomBoolean() && histStats[j] > 0) {
+                long day = randomLongBetween(0, histStats[j]);
+                long fifteen = day >= 1 ? randomLongBetween(0, day) : 0;
+                long five = fifteen >= 1 ? randomLongBetween(0, fifteen) : 0;
+                timeSeries.add(new ScriptContextStats.TimeSeries(five, fifteen, day));
+            } else {
+                timeSeries.add(new ScriptContextStats.TimeSeries());
+            }
+        }
+        return new ScriptContextStats(
+            randomAlphaOfLength(15),
+            histStats[0],
+            histStats[1],
+            randomLongBetween(0, 1024),
+            timeSeries.get(0),
+            timeSeries.get(1)
+        );
+    }
+}


### PR DESCRIPTION
Adds 5m/15m/24h metrics to _nodes/stats when those metrics
are non-zero.  Those metrics are not yet populated.

BWC: history metrics are only sent between v8.0.0+ nodes,
v7.16.0 nodes will not send those metrics until they are populated.

Refs: #62899
Backport: db75c4b
