### PR TITLE
[DOCS] Remove index stats API's `types` option

### DIFF
--- a/docs/reference/migration/migrate_8_0/indices.asciidoc
+++ b/docs/reference/migration/migrate_8_0/indices.asciidoc
@@ -116,4 +116,17 @@ index setting].
 Accept the new behaviour, or specify `?wait_for_active_shards=0` to preserve
 the old behaviour if needed.
 ====
+
+.The index stats API's `types` query parameter has been removed.
+[%collapsible]
+====
+*Details* +
+The index stats API's `types` query parameter has been removed. Previously, you
+could combine `types` with the `indexing` query parameter to return indexing
+stats for specific mapping types. Mapping types have been removed in 8.0.
+
+*Impact* +
+Discontinue use of the `types` query parameter. Requests that include the
+parameter will return an error.
+====
 //end::notable-breaking-changes[]


### PR DESCRIPTION
Adds an 8.0 breaking change for PR #47203.

### Preview
https://elasticsearch_78335.docs-preview.app.elstc.co/guide/en/elastic-stack/master/elasticsearch-breaking-changes.html#_indices_changes