### PR TITLE
[7.x] Added more tests for time_series mapping params (#78332)

### DIFF
--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/tsdb/20_mappings.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/tsdb/20_mappings.yml
@@ -1,11 +1,11 @@
 add time series mappings:
   - skip:
-      version: " - 7.99.99"
-      reason: introduced in 8.0.0 to be backported to 7.16.0
+      version: " - 7.15.99"
+      reason: introduced in 7.16.0
 
   - do:
       indices.create:
-          index: test_index
+          index: tsdb_index
           body:
             settings:
               index:

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/aggregate-metrics/90_tsdb_mappings.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/aggregate-metrics/90_tsdb_mappings.yml
@@ -1,0 +1,97 @@
+aggregate_double_metric with time series mappings:
+  - skip:
+      version: " - 7.15.99"
+      reason: introduced in 7.16.0
+
+  - do:
+      indices.create:
+          index: test_index
+          body:
+            settings:
+              index:
+                mode: time_series
+                number_of_replicas: 0
+                number_of_shards: 2
+            mappings:
+              properties:
+                "@timestamp":
+                  type: date
+                metricset:
+                  type: keyword
+                  time_series_dimension: true
+                k8s:
+                  properties:
+                    pod:
+                      properties:
+                        uid:
+                          type: keyword
+                          time_series_dimension: true
+                        name:
+                          type: keyword
+                        network:
+                          properties:
+                            tx:
+                              type: aggregate_metric_double
+                              metrics: [min, max, sum, value_count]
+                              default_metric: max
+                              time_series_metric: counter
+                            rx:
+                              type: aggregate_metric_double
+                              metrics: [min, max, sum, value_count]
+                              default_metric: max
+                              time_series_metric: gauge
+                            packets_dropped:
+                              type: aggregate_metric_double
+                              metrics: [min, max, sum, value_count]
+                              default_metric: max
+                              time_series_metric: summary
+
+
+---
+aggregate_double_metric with wrong time series mappings:
+  - skip:
+      version: " - 7.15.99"
+      reason: introduced in 7.16.0
+  - do:
+      catch: /Unknown value \[histogram\] for field \[time_series_metric\] \- accepted values are \[gauge, counter, summary\]/
+      indices.create:
+        index: tsdb_index
+        body:
+          settings:
+            index:
+              mode: time_series
+              number_of_replicas: 0
+              number_of_shards: 2
+          mappings:
+            properties:
+              "@timestamp":
+                type: date
+              metricset:
+                type: keyword
+                time_series_dimension: true
+              k8s:
+                properties:
+                  pod:
+                    properties:
+                      uid:
+                        type: keyword
+                        time_series_dimension: true
+                      name:
+                        type: keyword
+                      network:
+                        properties:
+                          packets_dropped:
+                            type: aggregate_metric_double
+                            metrics: [ min, max, sum, value_count ]
+                            default_metric: max
+                            time_series_metric: summary
+                          tx:
+                            type: aggregate_metric_double
+                            metrics: [min, max, sum, value_count]
+                            default_metric: max
+                            time_series_metric: counter
+                          rx:
+                            type: aggregate_metric_double
+                            metrics: [min, max, sum, value_count]
+                            default_metric: max
+                            time_series_metric: histogram

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/analytics/histogram.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/analytics/histogram.yml
@@ -171,3 +171,78 @@ setup:
   - match: { aggregations.ranges.buckets.2.doc_count: 37 }
   - match: { aggregations.ranges.buckets.3.key: "0.5-*" }
   - match: { aggregations.ranges.buckets.3.doc_count: 11 }
+
+---
+histogram with time series mappings:
+  - skip:
+      version: " - 7.15.99"
+      reason: introduced in 7.16.0
+
+  - do:
+
+      indices.create:
+        index: tsdb_index
+        body:
+          settings:
+            index:
+              mode: time_series
+              number_of_replicas: 0
+              number_of_shards: 2
+          mappings:
+            properties:
+              "@timestamp":
+                type: date
+              metricset:
+                type: keyword
+                time_series_dimension: true
+              k8s:
+                properties:
+                  pod:
+                    properties:
+                      uid:
+                        type: keyword
+                        time_series_dimension: true
+                      name:
+                        type: keyword
+                      network:
+                        properties:
+                          latency:
+                            type: histogram
+                            time_series_metric: histogram
+
+---
+histogram with wrong time series mappings:
+  - skip:
+      version: " - 7.15.99"
+      reason: introduced in 7.16.0
+  - do:
+      catch: /Unknown value \[counter\] for field \[time_series_metric\] \- accepted values are \[histogram\]/
+      indices.create:
+        index: tsdb_index
+        body:
+          settings:
+            index:
+              mode: time_series
+              number_of_replicas: 0
+              number_of_shards: 2
+          mappings:
+            properties:
+              "@timestamp":
+                type: date
+              metricset:
+                type: keyword
+                time_series_dimension: true
+              k8s:
+                properties:
+                  pod:
+                    properties:
+                      uid:
+                        type: keyword
+                        time_series_dimension: true
+                      name:
+                        type: keyword
+                      network:
+                        properties:
+                          latency:
+                            type: histogram
+                            time_series_metric: counter


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Added more tests for time_series mapping params (#78332)