### PR TITLE
[DOCS] Amend 7.13 deprecation for MDP support

### DIFF
--- a/docs/reference/migration/migrate_7_13.asciidoc
+++ b/docs/reference/migration/migrate_7_13.asciidoc
@@ -154,14 +154,15 @@ aggregations are rarely useful and often unintended.
 The `path.data` setting accepts a list of data paths, but if you specify
 multiple paths then the behaviour is unintuitive and usually does not give the
 desired outcomes. Support for multiple data paths is now deprecated and will be
-removed in 8.0.0.
+removed in a future release.
 
 *Impact* +
-Specify a single path in `path.data`. If needed, you can create a filesystem
-which spans multiple disks with a hardware virtualisation layer such as RAID,
-or a software virtualisation layer such as Logical Volume Manager (LVM) on
-Linux or Storage Spaces on Windows. If you wish to use multiple data paths on a
-single machine then you must run one node for each data path.
+To avoid deprecation warnings, specify a single path in `path.data`. If needed,
+you can create a filesystem which spans multiple disks with a hardware
+virtualisation layer such as RAID, or a software virtualisation layer such as
+Logical Volume Manager (LVM) on Linux or Storage Spaces on Windows. If you wish
+to use multiple data paths on a single machine then you must run one node for
+each data path.
 
 If you currently use multiple data paths in a
 {ref}/high-availability-cluster-design.html[highly available cluster] then you 


### PR DESCRIPTION
We deprecated multiple data paths (MDP) in 7.13. However, we won't be
removing MDP support in 8.0. This amends the related 
deprecation notice in the 7.13 migration guide.

### Preview
https://elasticsearch_78340.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/7.x/migrating-7.13.html#breaking_713_infra_core_deprecations