### PR TITLE
[7.x] Report shard counts for ongoing snapshots (#77622)

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/snapshots/GetSnapshotsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/snapshots/GetSnapshotsIT.java
@@ -14,6 +14,7 @@ import org.elasticsearch.action.admin.cluster.snapshots.create.CreateSnapshotRes
 import org.elasticsearch.action.admin.cluster.snapshots.get.GetSnapshotsRequest;
 import org.elasticsearch.action.admin.cluster.snapshots.get.GetSnapshotsRequestBuilder;
 import org.elasticsearch.action.admin.cluster.snapshots.get.GetSnapshotsResponse;
+import org.elasticsearch.cluster.SnapshotsInProgress;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.search.sort.SortOrder;
 import org.elasticsearch.threadpool.ThreadPool;
@@ -178,6 +179,17 @@ public class GetSnapshotsIT extends AbstractSnapshotIntegTestCase {
         for (ActionFuture<CreateSnapshotResponse> inProgressSnapshot : inProgressSnapshots) {
             assertSuccessful(inProgressSnapshot);
         }
+
+        awaitClusterState(
+            state -> state.custom(SnapshotsInProgress.TYPE, SnapshotsInProgress.EMPTY)
+                .entries()
+                .stream()
+                .flatMap(s -> s.shards().stream())
+                .allMatch(
+                    e -> e.getKey().getIndexName().equals("test-index-1") == false
+                        || e.getValue().state() == SnapshotsInProgress.ShardState.SUCCESS
+                )
+        );
 
         assertStablePagination(repoName, allSnapshotNames, GetSnapshotsRequest.SortBy.START_TIME);
         assertStablePagination(repoName, allSnapshotNames, GetSnapshotsRequest.SortBy.NAME);

--- a/server/src/internalClusterTest/java/org/elasticsearch/snapshots/SharedClusterSnapshotRestoreIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/snapshots/SharedClusterSnapshotRestoreIT.java
@@ -1226,6 +1226,10 @@ public class SharedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTestCas
         assertThat(getResponse.getSnapshots().size(), equalTo(1));
         SnapshotInfo snapshotInfo = getResponse.getSnapshots().get(0);
         assertThat(snapshotInfo.state(), equalTo(SnapshotState.IN_PROGRESS));
+        snapshotStatus = client.admin().cluster().prepareSnapshotStatus().execute().actionGet().getSnapshots().get(0);
+        assertThat(snapshotInfo.totalShards(), equalTo(snapshotStatus.getIndices().get("test-idx").getShardsStats().getTotalShards()));
+        assertThat(snapshotInfo.successfulShards(), equalTo(snapshotStatus.getIndices().get("test-idx").getShardsStats().getDoneShards()));
+        assertThat(snapshotInfo.shardFailures().size(), equalTo(0));
 
         logger.info("--> unblocking blocked node");
         unblockNode("test-repo", blockedNode);

--- a/server/src/internalClusterTest/java/org/elasticsearch/snapshots/SnapshotStatusApisIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/snapshots/SnapshotStatusApisIT.java
@@ -409,7 +409,8 @@ public class SnapshotStatusApisIT extends AbstractSnapshotIntegTestCase {
     public void testGetSnapshotsWithSnapshotInProgress() throws Exception {
         createRepository("test-repo", "mock", Settings.builder().put("location", randomRepoPath()).put("block_on_data", true));
 
-        createIndexWithContent("test-idx-1");
+        String indexName = "test-idx-1";
+        createIndexWithContent(indexName, indexSettingsNoReplicas(randomIntBetween(1, 10)).build());
         ensureGreen();
 
         ActionFuture<CreateSnapshotResponse> createSnapshotResponseActionFuture = startFullSnapshot("test-repo", "test-snap");
@@ -426,7 +427,13 @@ public class SnapshotStatusApisIT extends AbstractSnapshotIntegTestCase {
             .get();
         List<SnapshotInfo> snapshotInfoList = response1.getSnapshots();
         assertEquals(1, snapshotInfoList.size());
-        assertEquals(SnapshotState.IN_PROGRESS, snapshotInfoList.get(0).state());
+        SnapshotInfo snapshotInfo = snapshotInfoList.get(0);
+        assertEquals(SnapshotState.IN_PROGRESS, snapshotInfo.state());
+
+        SnapshotStatus snapshotStatus = client().admin().cluster().prepareSnapshotStatus().execute().actionGet().getSnapshots().get(0);
+        assertThat(snapshotInfo.totalShards(), equalTo(snapshotStatus.getIndices().get(indexName).getShardsStats().getTotalShards()));
+        assertThat(snapshotInfo.successfulShards(), equalTo(snapshotStatus.getIndices().get(indexName).getShardsStats().getDoneShards()));
+        assertThat(snapshotInfo.shardFailures().size(), equalTo(0));
 
         String notExistedSnapshotName = "snapshot_not_exist";
         GetSnapshotsResponse response2 = client().admin()

--- a/server/src/main/java/org/elasticsearch/snapshots/SnapshotInfo.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/SnapshotInfo.java
@@ -7,6 +7,8 @@
  */
 package org.elasticsearch.snapshots;
 
+import com.carrotsearch.hppc.cursors.ObjectObjectCursor;
+
 import org.elasticsearch.Version;
 import org.elasticsearch.action.ShardOperationFailedException;
 import org.elasticsearch.action.admin.cluster.snapshots.get.GetSnapshotsRequest;
@@ -28,6 +30,7 @@ import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.XContentParserUtils;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.rest.RestStatus;
 
 import java.io.IOException;
@@ -376,23 +379,30 @@ public final class SnapshotInfo implements Comparable<SnapshotInfo>, ToXContentF
     }
 
     public SnapshotInfo(SnapshotsInProgress.Entry entry) {
-        this(
-            entry.snapshot(),
-            org.elasticsearch.core.List.copyOf(entry.indices().keySet()),
-            entry.dataStreams(),
-            entry.featureStates(),
-            null,
-            Version.CURRENT,
-            entry.startTime(),
-            0L,
-            0,
-            0,
-            Collections.emptyList(),
-            entry.includeGlobalState(),
-            entry.userMetadata(),
-            SnapshotState.IN_PROGRESS,
-            Collections.emptyMap()
-        );
+        int successfulShards = 0;
+        List<SnapshotShardFailure> shardFailures = new ArrayList<>();
+        for (ObjectObjectCursor<ShardId, SnapshotsInProgress.ShardSnapshotStatus> c : entry.shards()) {
+            if (c.value.state() == SnapshotsInProgress.ShardState.SUCCESS) {
+                successfulShards++;
+            } else if (c.value.state() == SnapshotsInProgress.ShardState.FAILED) {
+                shardFailures.add(new SnapshotShardFailure(c.value.nodeId(), c.key, c.value.reason()));
+            }
+        }
+        this.snapshot = Objects.requireNonNull(entry.snapshot());
+        this.indices = org.elasticsearch.core.List.copyOf(entry.indices().keySet());
+        this.dataStreams = org.elasticsearch.core.List.copyOf(entry.dataStreams());
+        this.featureStates = org.elasticsearch.core.List.copyOf(entry.featureStates());
+        this.state = SnapshotState.IN_PROGRESS;
+        this.reason = null;
+        this.version = Version.CURRENT;
+        this.startTime = entry.startTime();
+        this.endTime = 0L;
+        this.totalShards = entry.shards().size();
+        this.successfulShards = successfulShards;
+        this.shardFailures = Collections.unmodifiableList(shardFailures);
+        this.includeGlobalState = entry.includeGlobalState();
+        this.userMetadata = entry.userMetadata() == null ? null : org.elasticsearch.core.Map.copyOf(entry.userMetadata());
+        this.indexSnapshotDetails = Collections.emptyMap();
     }
 
     public SnapshotInfo(


### PR DESCRIPTION
Backports #77622

For in-progress snapshots we can try to calculate the amount of successful shards based on the shard state. We can use a similar approach for failures.