### PR TITLE
[7.x] Fleet: Add actions timeout mapping (#75628)

### DIFF
--- a/x-pack/plugin/core/src/main/resources/fleet-actions.json
+++ b/x-pack/plugin/core/src/main/resources/fleet-actions.json
@@ -25,6 +25,9 @@
         "input_type": {
           "type": "keyword"
         },
+        "timeout": {
+          "type": "integer"
+        },
         "@timestamp": {
           "type": "date"
         },


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Fleet: Add actions timeout mapping (#75628)