### PR TITLE
[7.x] SQL: fix NULLS FIRST/LAST for aggregations (#77750)

### DIFF
--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/execution/search/SourceGenerator.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/execution/search/SourceGenerator.java
@@ -103,12 +103,12 @@ public abstract class SourceGenerator {
                     FieldAttribute fa = ((FieldAttribute) attr).exactAttribute();
 
                     sortBuilder = fieldSort(fa.name())
-                            .missing(as.missing().position())
+                            .missing(as.missing().searchOrder(as.direction()))
                             .unmappedType(fa.dataType().esType());
 
                     if (fa.isNested()) {
                         FieldSortBuilder fieldSort = fieldSort(fa.name())
-                                .missing(as.missing().position())
+                                .missing(as.missing().searchOrder(as.direction()))
                                 .unmappedType(fa.dataType().esType());
 
                         NestedSortBuilder newSort = new NestedSortBuilder(fa.nestedParent().name());

--- a/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/execution/search/QlSourceBuilder.java
+++ b/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/execution/search/QlSourceBuilder.java
@@ -23,6 +23,7 @@ import java.util.Set;
  */
 public class QlSourceBuilder {
     public static final Version SWITCH_TO_FIELDS_API_VERSION = Version.V_7_10_0;
+    public static final Version INTRODUCING_MISSING_ORDER_IN_COMPOSITE_AGGS_VERSION = Version.V_7_16_0;
     // The LinkedHashMaps preserve the order of the fields in the response
     private final Set<FieldAndFormat> fetchFields = new LinkedHashSet<>();
     private final Map<String, Script> scriptFields = new LinkedHashMap<>();

--- a/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/expression/Order.java
+++ b/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/expression/Order.java
@@ -23,7 +23,14 @@ public class Order extends Expression {
     }
 
     public enum NullsPosition {
-        FIRST, LAST;
+        FIRST, LAST,
+        /**
+         * Nulls position has not been specified by the user and an appropriate default will be used.
+         *
+         * The default values are chosen such that it stays compatible with previous behavior. Unfortunately, this results in
+         * inconsistencies across different types of queries (see https://github.com/elastic/elasticsearch/issues/77068).
+         */
+        ANY;
     }
 
     private final Expression child;
@@ -34,7 +41,7 @@ public class Order extends Expression {
         super(source, singletonList(child));
         this.child = child;
         this.direction = direction;
-        this.nulls = nulls == null ? (direction == OrderDirection.DESC ? NullsPosition.FIRST : NullsPosition.LAST) : nulls;
+        this.nulls = nulls == null ? NullsPosition.ANY : nulls;
     }
 
     @Override

--- a/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/querydsl/container/Sort.java
+++ b/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/querydsl/container/Sort.java
@@ -6,6 +6,7 @@
  */
 package org.elasticsearch.xpack.ql.querydsl.container;
 
+import org.elasticsearch.search.aggregations.bucket.composite.MissingOrder;
 import org.elasticsearch.search.sort.SortOrder;
 import org.elasticsearch.xpack.ql.expression.Order.NullsPosition;
 import org.elasticsearch.xpack.ql.expression.Order.OrderDirection;
@@ -25,20 +26,61 @@ public abstract class Sort {
     }
 
     public enum Missing {
-        FIRST("_first"), LAST("_last");
+        FIRST("_first", MissingOrder.FIRST),
+        LAST("_last", MissingOrder.LAST),
+        /**
+         * Nulls position has not been specified by the user and an appropriate default will be used.
+         *
+         * The default values are chosen such that it stays compatible with previous behavior. Unfortunately, this results in
+         * inconsistencies across different types of queries (see https://github.com/elastic/elasticsearch/issues/77068).
+         */
+        ANY(null, null);
 
-        private final String position;
+        private final String searchOrder;
+        private final MissingOrder aggregationOrder;
 
-        Missing(String position) {
-            this.position = position;
+        Missing(String searchOrder, MissingOrder aggregationOrder) {
+            this.searchOrder = searchOrder;
+            this.aggregationOrder = aggregationOrder;
         }
 
         public static Missing from(NullsPosition pos) {
-            return pos == null || pos == NullsPosition.FIRST ? FIRST : LAST;
+            switch (pos) {
+                case FIRST:
+                    return FIRST;
+                case LAST:
+                    return LAST;
+                default:
+                    return ANY;
+            }
         }
 
-        public String position() {
-            return position;
+        public String searchOrder() {
+            return searchOrder(null);
+        }
+
+        /**
+         * Preferred order of null values in non-aggregation queries.
+         */
+        public String searchOrder(Direction direction) {
+            if (searchOrder != null) {
+                return searchOrder;
+            } else {
+                switch (direction) {
+                    case ASC:
+                        return LAST.searchOrder;
+                    case DESC:
+                        return FIRST.searchOrder;
+                    default:
+                        throw new IllegalArgumentException("Unknown direction [" + direction + "]");
+                }
+            }
+        }
+        /**
+         * Preferred order of null values in aggregation queries.
+         */
+        public MissingOrder aggregationOrder() {
+            return aggregationOrder;
         }
     }
 

--- a/x-pack/plugin/sql/qa/mixed-node/build.gradle
+++ b/x-pack/plugin/sql/qa/mixed-node/build.gradle
@@ -12,6 +12,7 @@ dependencies {
   testImplementation project(':x-pack:qa')
   testImplementation(project(xpackModule('ql:test-fixtures')))
   testImplementation project(xpackModule('sql'))
+  testImplementation project(xpackModule('sql:qa:server'))
 }
 
 testClusters.configureEach {

--- a/x-pack/plugin/sql/qa/mixed-node/src/test/java/org/elasticsearch/xpack/sql/qa/mixed_node/SqlCompatIT.java
+++ b/x-pack/plugin/sql/qa/mixed-node/src/test/java/org/elasticsearch/xpack/sql/qa/mixed_node/SqlCompatIT.java
@@ -64,36 +64,48 @@ public class SqlCompatIT extends BaseRestSqlTestCase {
         });
     }
 
-    public void testNullsOrderBeforeMissingOrderSupport() throws IOException {
+    public void testNullsOrderBeforeMissingOrderSupportQueryingNewNode() throws IOException {
+        testNullsOrderBeforeMissingOrderSupport(newNodesClient);
+    }
+
+    public void testNullsOrderBeforeMissingOrderSupportQueryingOldNode() throws IOException {
+        testNullsOrderBeforeMissingOrderSupport(oldNodesClient);
+    }
+
+    private void testNullsOrderBeforeMissingOrderSupport(RestClient client) throws IOException {
         assumeTrue(
             "expected some nodes without support for missing_order but got none",
             bwcVersion.before(INTRODUCING_MISSING_ORDER_IN_COMPOSITE_AGGS_VERSION)
         );
 
-        for (RestClient bwcClient : Arrays.asList(newNodesClient, oldNodesClient)) {
-            List<Integer> result = runOrderByNullsLastQuery(bwcClient);
+        List<Integer> result = runOrderByNullsLastQuery(client);
 
-            assertEquals(3, result.size());
-            assertNull(result.get(0));
-            assertEquals(Integer.valueOf(1), result.get(1));
-            assertEquals(Integer.valueOf(2), result.get(2));
-        }
+        assertEquals(3, result.size());
+        assertNull(result.get(0));
+        assertEquals(Integer.valueOf(1), result.get(1));
+        assertEquals(Integer.valueOf(2), result.get(2));
     }
 
-    public void testNullsOrderWithMissingOrderSupport() throws IOException {
+    public void testNullsOrderWithMissingOrderSupportQueryingNewNode() throws IOException {
+        testNullsOrderWithMissingOrderSupport(newNodesClient);
+    }
+
+    public void testNullsOrderWithMissingOrderSupportQueryingOldNode() throws IOException {
+        testNullsOrderWithMissingOrderSupport(oldNodesClient);
+    }
+
+    private void testNullsOrderWithMissingOrderSupport(RestClient client) throws IOException {
         assumeTrue(
             "expected all nodes with support for missing_order but got some without",
             bwcVersion.onOrAfter(INTRODUCING_MISSING_ORDER_IN_COMPOSITE_AGGS_VERSION)
         );
 
-        for (RestClient bwcClient : Arrays.asList(newNodesClient, oldNodesClient)) {
-            List<Integer> result = runOrderByNullsLastQuery(bwcClient);
+        List<Integer> result = runOrderByNullsLastQuery(client);
 
-            assertEquals(3, result.size());
-            assertEquals(Integer.valueOf(1), result.get(0));
-            assertEquals(Integer.valueOf(2), result.get(1));
-            assertNull(result.get(2));
-        }
+        assertEquals(3, result.size());
+        assertEquals(Integer.valueOf(1), result.get(0));
+        assertEquals(Integer.valueOf(2), result.get(1));
+        assertNull(result.get(2));
     }
 
     @SuppressWarnings("unchecked")

--- a/x-pack/plugin/sql/qa/mixed-node/src/test/java/org/elasticsearch/xpack/sql/qa/mixed_node/SqlCompatIT.java
+++ b/x-pack/plugin/sql/qa/mixed-node/src/test/java/org/elasticsearch/xpack/sql/qa/mixed_node/SqlCompatIT.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.sql.qa.mixed_node;
+
+import org.apache.http.HttpHost;
+import org.elasticsearch.Version;
+import org.elasticsearch.client.Request;
+import org.elasticsearch.client.Response;
+import org.elasticsearch.client.RestClient;
+import org.elasticsearch.common.xcontent.XContentHelper;
+import org.elasticsearch.common.xcontent.json.JsonXContent;
+import org.elasticsearch.core.internal.io.IOUtils;
+import org.elasticsearch.xpack.ql.TestNode;
+import org.elasticsearch.xpack.ql.TestNodes;
+import org.elasticsearch.xpack.sql.qa.rest.BaseRestSqlTestCase;
+import org.junit.AfterClass;
+import org.junit.Before;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static org.elasticsearch.xpack.ql.TestUtils.buildNodeAndVersions;
+import static org.elasticsearch.xpack.ql.execution.search.QlSourceBuilder.INTRODUCING_MISSING_ORDER_IN_COMPOSITE_AGGS_VERSION;
+
+public class SqlCompatIT extends BaseRestSqlTestCase {
+
+    private static RestClient newNodesClient;
+    private static RestClient oldNodesClient;
+    private static Version bwcVersion;
+
+    @Before
+    public void initBwcClients() throws IOException {
+        if (newNodesClient == null) {
+            assertNull(oldNodesClient);
+
+            TestNodes nodes = buildNodeAndVersions(client());
+            bwcVersion = nodes.getBWCVersion();
+            newNodesClient = buildClient(
+                restClientSettings(),
+                nodes.getNewNodes().stream().map(TestNode::getPublishAddress).toArray(HttpHost[]::new)
+            );
+            oldNodesClient = buildClient(
+                restClientSettings(),
+                nodes.getBWCNodes().stream().map(TestNode::getPublishAddress).toArray(HttpHost[]::new)
+            );
+        }
+    }
+
+    @AfterClass
+    public static void cleanUpClients() throws IOException {
+        IOUtils.close(newNodesClient, oldNodesClient, () -> {
+            newNodesClient = null;
+            oldNodesClient = null;
+            bwcVersion = null;
+        });
+    }
+
+    public void testNullsOrderBeforeMissingOrderSupport() throws IOException {
+        assumeTrue(
+            "expected some nodes without support for missing_order but got none",
+            bwcVersion.before(INTRODUCING_MISSING_ORDER_IN_COMPOSITE_AGGS_VERSION)
+        );
+
+        for (RestClient bwcClient : Arrays.asList(newNodesClient, oldNodesClient)) {
+            List<Integer> result = runOrderByNullsLastQuery(bwcClient);
+
+            assertEquals(3, result.size());
+            assertNull(result.get(0));
+            assertEquals(Integer.valueOf(1), result.get(1));
+            assertEquals(Integer.valueOf(2), result.get(2));
+        }
+    }
+
+    public void testNullsOrderWithMissingOrderSupport() throws IOException {
+        assumeTrue(
+            "expected all nodes with support for missing_order but got some without",
+            bwcVersion.onOrAfter(INTRODUCING_MISSING_ORDER_IN_COMPOSITE_AGGS_VERSION)
+        );
+
+        for (RestClient bwcClient : Arrays.asList(newNodesClient, oldNodesClient)) {
+            List<Integer> result = runOrderByNullsLastQuery(bwcClient);
+
+            assertEquals(3, result.size());
+            assertEquals(Integer.valueOf(1), result.get(0));
+            assertEquals(Integer.valueOf(2), result.get(1));
+            assertNull(result.get(2));
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private List<Integer> runOrderByNullsLastQuery(RestClient queryClient) throws IOException {
+        Request putIndex = new Request("PUT", "/test");
+        putIndex.setJsonEntity("{\"settings\":{\"index\":{\"number_of_shards\":3}}}");
+        client().performRequest(putIndex);
+
+        Request indexDocs = new Request("POST", "/test/_bulk");
+        indexDocs.addParameter("refresh", "true");
+        StringBuilder bulk = new StringBuilder();
+        for (String doc : Arrays.asList("{\"int\":1,\"kw\":\"foo\"}", "{\"int\":2,\"kw\":\"bar\"}", "{\"kw\":\"bar\"}")) {
+            bulk.append("{\"index\":{}\n").append(doc).append("\n");
+        }
+        indexDocs.setJsonEntity(bulk.toString());
+        client().performRequest(indexDocs);
+
+        Request query = new Request("GET", "_sql");
+        query.setJsonEntity("{\"query\":\"SELECT int FROM test GROUP BY 1 ORDER BY 1 NULLS LAST\"}");
+        Response queryResponse = queryClient.performRequest(query);
+
+        assertEquals(200, queryResponse.getStatusLine().getStatusCode());
+
+        InputStream content = queryResponse.getEntity().getContent();
+        Map<String, Object> result = XContentHelper.convertToMap(JsonXContent.jsonXContent, content, false);
+        List<List<Object>> rows = (List<List<Object>>) result.get("rows");
+        return rows.stream().map(row -> (Integer) row.get(0)).collect(Collectors.toList());
+    }
+
+}

--- a/x-pack/plugin/sql/qa/server/src/main/resources/agg-ordering.csv-spec
+++ b/x-pack/plugin/sql/qa/server/src/main/resources/agg-ordering.csv-spec
@@ -70,3 +70,68 @@ null                    |10
 1964-01-01T00:00:00.000Z|4
 1965-01-01T00:00:00.000Z|1
 ;
+
+aggGroupAndOrderByDerivedFieldAsc
+SELECT languages - 2 l, SUM(salary) s FROM test_emp GROUP BY l ORDER BY l;
+
+       l:i     |       s:l
+---------------+---------------
+null           |525196
+-1             |758650
+0              |915398
+1              |891121
+2              |859194
+3              |875296
+;
+
+aggGroupAndOrderByDerivedFieldDesc
+SELECT languages - 2 l, SUM(salary) s FROM test_emp GROUP BY l ORDER BY l DESC;
+       l:i     |       s:l
+---------------+---------------
+3              |875296
+2              |859194
+1              |891121
+0              |915398
+-1             |758650
+null           |525196
+;
+
+orderByHistogramNullsLast
+SELECT HISTOGRAM(languages, 3) l, COUNT(*) c FROM test_emp GROUP BY l ORDER BY l NULLS LAST;
+
+       l:bt    |       c:l
+---------------+---------------
+0              |34
+3              |56
+null           |10
+;
+
+orderByHistogramDescNullsFirst
+SELECT HISTOGRAM(languages, 3) l, COUNT(*) c FROM test_emp GROUP BY l ORDER BY l DESC NULLS FIRST;
+
+       l:bt    |       c:l
+---------------+---------------
+null           |10
+3              |56
+0              |34
+;
+
+orderByDateHistogramNullsLast
+SELECT HISTOGRAM(birth_date, INTERVAL 10 YEARS) b, COUNT(*) c FROM test_emp GROUP BY b ORDER BY b NULLS LAST;
+
+           b:ts         |       c:l
+------------------------+---------------
+1950-04-16T00:00:00.000Z|57
+1960-02-23T00:00:00.000Z|33
+null                    |10
+;
+
+orderByDateHistogramDescNullsFirst
+SELECT HISTOGRAM(birth_date, INTERVAL 10 YEARS) b, COUNT(*) c FROM test_emp GROUP BY b ORDER BY b DESC NULLS FIRST;
+
+           b:ts         |       c:l
+------------------------+---------------
+null                    |10
+1960-02-23T00:00:00.000Z|33
+1950-04-16T00:00:00.000Z|57
+;

--- a/x-pack/plugin/sql/qa/server/src/main/resources/agg-ordering.sql-spec
+++ b/x-pack/plugin/sql/qa/server/src/main/resources/agg-ordering.sql-spec
@@ -159,3 +159,32 @@ SELECT CONCAT('foo', gender) g, MAX(salary) AS max, MIN(salary) AS min FROM test
 
 multipleGroupingsAndOrderingByGroupsAndAggregatesWithFunctions_4
 SELECT CONCAT('foo', gender) g, MAX(salary) AS max, MIN(salary) AS min FROM test_emp GROUP BY g ORDER BY 3 DESC, 1 NULLS FIRST, 2;
+
+aggWithNullsFirst
+SELECT gender FROM test_emp GROUP BY gender ORDER BY gender NULLS FIRST;
+aggWithNullsLast
+SELECT gender FROM test_emp GROUP BY gender ORDER BY gender NULLS LAST;
+aggWithMultipleNullsLast
+SELECT gender, languages FROM test_emp GROUP BY gender, languages ORDER BY gender NULLS LAST, languages NULLS LAST;
+aggWithNullsLastDerivedField
+SELECT languages - 2 l FROM test_emp GROUP BY l ORDER BY l NULLS LAST;
+aggWithNullsFirstDerivedField
+SELECT languages - 2 l FROM test_emp GROUP BY l ORDER BY l NULLS FIRST;
+aggWithMultipleDerivedNullsLast
+SELECT CONCAT(gender, 'A') g, languages - 2 l FROM test_emp GROUP BY g, l ORDER BY g NULLS LAST, l NULLS LAST;
+aggWithMultipleDerivedNullsFirst
+SELECT CONCAT(gender, 'A') g, languages - 2 l FROM test_emp GROUP BY g, l ORDER BY g NULLS FIRST, l NULLS FIRST;
+aggWithDescNullsFirst
+SELECT gender FROM test_emp GROUP BY gender ORDER BY gender DESC NULLS FIRST;
+aggWithDescNullsLast
+SELECT gender FROM test_emp GROUP BY gender ORDER BY gender DESC NULLS LAST;
+aggWithMultipleDescNullsFirst
+SELECT gender, languages FROM test_emp GROUP BY gender, languages ORDER BY gender DESC NULLS FIRST, languages DESC NULLS FIRST;
+aggWithDescNullsFirstDerivedField
+SELECT languages - 2 l FROM test_emp GROUP BY l ORDER BY l DESC NULLS FIRST;
+aggWithDescNullsLastDerivedField
+SELECT languages - 2 l FROM test_emp GROUP BY l ORDER BY l DESC NULLS LAST;
+aggWithMultipleDerivedDescNullsLast
+SELECT CONCAT(gender, 'A') g, languages - 2 l FROM test_emp GROUP BY g, l ORDER BY g DESC NULLS LAST, l DESC NULLS LAST;
+aggWithMultipleDerivedDescNullsFirst
+SELECT CONCAT(gender, 'A') g, languages - 2 l FROM test_emp GROUP BY g, l ORDER BY g DESC NULLS FIRST, l DESC NULLS FIRST;

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/execution/search/Querier.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/execution/search/Querier.java
@@ -14,12 +14,12 @@ import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.search.ShardSearchFailure;
 import org.elasticsearch.client.Client;
-import org.elasticsearch.core.Nullable;
 import org.elasticsearch.common.Strings;
-import org.elasticsearch.core.Tuple;
-import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.common.util.CollectionUtils;
 import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.core.Nullable;
+import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.core.Tuple;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.search.aggregations.Aggregation;
 import org.elasticsearch.search.aggregations.Aggregations;
@@ -85,7 +85,7 @@ import java.util.function.Supplier;
 
 import static java.util.Collections.singletonList;
 import static org.elasticsearch.action.ActionListener.wrap;
-import static org.elasticsearch.xpack.ql.execution.search.QlSourceBuilder.SWITCH_TO_FIELDS_API_VERSION;
+import static org.elasticsearch.xpack.ql.execution.search.QlSourceBuilder.INTRODUCING_MISSING_ORDER_IN_COMPOSITE_AGGS_VERSION;
 
 // TODO: add retry/back-off
 public class Querier {
@@ -156,7 +156,7 @@ public class Querier {
             String... indices) {
         source.timeout(timeout);
 
-        SearchRequest searchRequest = new SearchRequest(SWITCH_TO_FIELDS_API_VERSION);
+        SearchRequest searchRequest = new SearchRequest(INTRODUCING_MISSING_ORDER_IN_COMPOSITE_AGGS_VERSION);
         searchRequest.indices(indices);
         searchRequest.source(source);
         searchRequest.allowPartialSearchResults(false);

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/execution/search/SourceGenerator.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/execution/search/SourceGenerator.java
@@ -116,12 +116,12 @@ public abstract class SourceGenerator {
                     FieldAttribute fa = ((FieldAttribute) attr).exactAttribute();
 
                     sortBuilder = fieldSort(fa.name())
-                            .missing(as.missing().position())
+                            .missing(as.missing().searchOrder(as.direction()))
                             .unmappedType(fa.dataType().esType());
 
                     if (fa.isNested()) {
                         FieldSortBuilder fieldSort = fieldSort(fa.name())
-                                .missing(as.missing().position())
+                                .missing(as.missing().searchOrder(as.direction()))
                                 .unmappedType(fa.dataType().esType());
 
                         NestedSortBuilder newSort = new NestedSortBuilder(fa.nestedParent().name());

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/planner/QueryFolder.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/planner/QueryFolder.java
@@ -724,7 +724,7 @@ class QueryFolder extends RuleExecutor<PhysicalPlan> {
 
                     // TODO: might need to validate whether the target field or group actually exist
                     if (group != null && group != Aggs.IMPLICIT_GROUP_KEY) {
-                        qContainer = qContainer.updateGroup(group.with(direction));
+                        qContainer = qContainer.updateGroup(group.with(direction, missing));
                     }
 
                     // field

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/querydsl/agg/Aggs.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/querydsl/agg/Aggs.java
@@ -11,6 +11,7 @@ import org.elasticsearch.search.aggregations.bucket.composite.CompositeAggregati
 import org.elasticsearch.search.aggregations.bucket.composite.CompositeValuesSourceBuilder;
 import org.elasticsearch.search.aggregations.bucket.filter.FiltersAggregationBuilder;
 import org.elasticsearch.xpack.ql.querydsl.container.Sort.Direction;
+import org.elasticsearch.xpack.ql.querydsl.container.Sort.Missing;
 import org.elasticsearch.xpack.ql.util.StringUtils;
 import org.elasticsearch.xpack.sql.SqlIllegalArgumentException;
 
@@ -40,7 +41,7 @@ public class Aggs {
 
     public static final String ROOT_GROUP_NAME = "groupby";
 
-    public static final GroupByKey IMPLICIT_GROUP_KEY = new GroupByKey(ROOT_GROUP_NAME, AggSource.of(StringUtils.EMPTY), null) {
+    public static final GroupByKey IMPLICIT_GROUP_KEY = new GroupByKey(ROOT_GROUP_NAME, AggSource.of(StringUtils.EMPTY), null, null) {
 
         @Override
         public CompositeValuesSourceBuilder<?> createSourceBuilder() {
@@ -48,7 +49,7 @@ public class Aggs {
         }
 
         @Override
-        protected GroupByKey copy(String id, AggSource source, Direction direction) {
+        protected GroupByKey copy(String id, AggSource source, Direction direction, Missing missing) {
             return this;
         }
     };

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/querydsl/agg/GroupByDateHistogram.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/querydsl/agg/GroupByDateHistogram.java
@@ -10,6 +10,7 @@ import org.elasticsearch.search.aggregations.bucket.composite.CompositeValuesSou
 import org.elasticsearch.search.aggregations.bucket.composite.DateHistogramValuesSourceBuilder;
 import org.elasticsearch.search.aggregations.bucket.histogram.DateHistogramInterval;
 import org.elasticsearch.xpack.ql.expression.gen.script.ScriptTemplate;
+import org.elasticsearch.xpack.ql.querydsl.container.Sort.Missing;
 import org.elasticsearch.xpack.ql.querydsl.container.Sort.Direction;
 import org.elasticsearch.xpack.sql.SqlIllegalArgumentException;
 
@@ -26,24 +27,24 @@ public class GroupByDateHistogram extends GroupByKey {
     private final ZoneId zoneId;
 
     public GroupByDateHistogram(String id, String fieldName, long fixedInterval, ZoneId zoneId) {
-        this(id, AggSource.of(fieldName), null, fixedInterval, null, zoneId);
+        this(id, AggSource.of(fieldName), null, null, fixedInterval, null, zoneId);
     }
 
     public GroupByDateHistogram(String id, ScriptTemplate script, long fixedInterval, ZoneId zoneId) {
-        this(id, AggSource.of(script), null, fixedInterval, null, zoneId);
+        this(id, AggSource.of(script), null, null, fixedInterval, null, zoneId);
     }
 
     public GroupByDateHistogram(String id, String fieldName, String calendarInterval, ZoneId zoneId) {
-        this(id, AggSource.of(fieldName), null, -1L, calendarInterval, zoneId);
+        this(id, AggSource.of(fieldName), null, null, -1L, calendarInterval, zoneId);
     }
 
     public GroupByDateHistogram(String id, ScriptTemplate script, String calendarInterval, ZoneId zoneId) {
-        this(id, AggSource.of(script), null, -1L, calendarInterval, zoneId);
+        this(id, AggSource.of(script), null, null, -1L, calendarInterval, zoneId);
     }
 
-    private GroupByDateHistogram(String id, AggSource source, Direction direction, long fixedInterval,
+    private GroupByDateHistogram(String id, AggSource source, Direction direction, Missing missing, long fixedInterval,
                                  String calendarInterval, ZoneId zoneId) {
-        super(id, source, direction);
+        super(id, source, direction, missing);
         if (fixedInterval <= 0 && (calendarInterval == null || calendarInterval.trim().isEmpty())) {
             throw new SqlIllegalArgumentException("Either fixed interval or calendar interval needs to be specified");
         }
@@ -65,8 +66,8 @@ public class GroupByDateHistogram extends GroupByKey {
     }
 
     @Override
-    protected GroupByKey copy(String id, AggSource source, Direction direction) {
-        return new GroupByDateHistogram(id, source(), direction, fixedInterval, calendarInterval, zoneId);
+    protected GroupByKey copy(String id, AggSource source, Direction direction, Missing missing) {
+        return new GroupByDateHistogram(id, source(), direction, missing, fixedInterval, calendarInterval, zoneId);
     }
 
     @Override

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/querydsl/agg/GroupByNumericHistogram.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/querydsl/agg/GroupByNumericHistogram.java
@@ -10,6 +10,7 @@ import org.elasticsearch.search.aggregations.bucket.composite.CompositeValuesSou
 import org.elasticsearch.search.aggregations.bucket.composite.HistogramValuesSourceBuilder;
 import org.elasticsearch.xpack.ql.expression.gen.script.ScriptTemplate;
 import org.elasticsearch.xpack.ql.querydsl.container.Sort.Direction;
+import org.elasticsearch.xpack.ql.querydsl.container.Sort.Missing;
 
 import java.util.Objects;
 
@@ -21,15 +22,15 @@ public class GroupByNumericHistogram extends GroupByKey {
     private final double interval;
 
     public GroupByNumericHistogram(String id, String fieldName, double interval) {
-        this(id, AggSource.of(fieldName), null, interval);
+        this(id, AggSource.of(fieldName), null, null, interval);
     }
 
     public GroupByNumericHistogram(String id, ScriptTemplate script, double interval) {
-        this(id, AggSource.of(script), null, interval);
+        this(id, AggSource.of(script), null, null, interval);
     }
 
-    private GroupByNumericHistogram(String id, AggSource aggSource, Direction direction, double interval) {
-        super(id, aggSource, direction);
+    private GroupByNumericHistogram(String id, AggSource aggSource, Direction direction, Missing missing, double interval) {
+        super(id, aggSource, direction, missing);
         this.interval = interval;
     }
 
@@ -40,8 +41,8 @@ public class GroupByNumericHistogram extends GroupByKey {
     }
 
     @Override
-    protected GroupByKey copy(String id, AggSource source, Direction direction) {
-        return new GroupByNumericHistogram(id, source(), direction, interval);
+    protected GroupByKey copy(String id, AggSource source, Direction direction, Missing missing) {
+        return new GroupByNumericHistogram(id, source(), direction, missing, interval);
     }
 
     @Override

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/querydsl/agg/GroupByValue.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/querydsl/agg/GroupByValue.java
@@ -10,6 +10,7 @@ import org.elasticsearch.search.aggregations.bucket.composite.CompositeValuesSou
 import org.elasticsearch.search.aggregations.bucket.composite.TermsValuesSourceBuilder;
 import org.elasticsearch.xpack.ql.expression.gen.script.ScriptTemplate;
 import org.elasticsearch.xpack.ql.querydsl.container.Sort.Direction;
+import org.elasticsearch.xpack.ql.querydsl.container.Sort.Missing;
 
 /**
  * GROUP BY key for fields or scripts.
@@ -17,15 +18,15 @@ import org.elasticsearch.xpack.ql.querydsl.container.Sort.Direction;
 public class GroupByValue extends GroupByKey {
 
     public GroupByValue(String id, String fieldName) {
-        this(id, AggSource.of(fieldName), null);
+        this(id, AggSource.of(fieldName), null, null);
     }
 
     public GroupByValue(String id, ScriptTemplate script) {
-        this(id, AggSource.of(script), null);
+        this(id, AggSource.of(script), null, null);
     }
 
-    private GroupByValue(String id, AggSource source, Direction direction) {
-        super(id, source, direction);
+    private GroupByValue(String id, AggSource source, Direction direction, Missing missing) {
+        super(id, source, direction, missing);
     }
 
     @Override
@@ -34,7 +35,7 @@ public class GroupByValue extends GroupByKey {
     }
 
     @Override
-    protected GroupByKey copy(String id, AggSource source, Direction direction) {
-        return new GroupByValue(id, source(), direction);
+    protected GroupByKey copy(String id, AggSource source, Direction direction, Missing missing) {
+        return new GroupByValue(id, source(), direction, missing);
     }
 }

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/querydsl/agg/TopHitsAgg.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/querydsl/agg/TopHitsAgg.java
@@ -53,7 +53,7 @@ public class TopHitsAgg extends LeafAgg {
             if (sortSource.fieldName() != null) {
                 sortBuilderList.add(
                     new FieldSortBuilder(sortSource.fieldName()).order(sortOrder)
-                        .missing(LAST.position())
+                        .missing(LAST.searchOrder())
                         .unmappedType(sortFieldDataType.esType())
                 );
             } else if (sortSource.script() != null) {
@@ -70,7 +70,7 @@ public class TopHitsAgg extends LeafAgg {
 
         if (source().fieldName() != null) {
             sortBuilderList.add(
-                new FieldSortBuilder(source().fieldName()).order(sortOrder).missing(LAST.position()).unmappedType(fieldDataType.esType())
+                new FieldSortBuilder(source().fieldName()).order(sortOrder).missing(LAST.searchOrder()).unmappedType(fieldDataType.esType())
             );
         } else {
             sortBuilderList.add(

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/planner/QueryFolderTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/planner/QueryFolderTests.java
@@ -6,6 +6,8 @@
  */
 package org.elasticsearch.xpack.sql.planner;
 
+import org.elasticsearch.core.Tuple;
+import org.elasticsearch.search.aggregations.bucket.composite.MissingOrder;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.ql.expression.Expressions;
 import org.elasticsearch.xpack.ql.expression.ReferenceAttribute;
@@ -32,6 +34,7 @@ import org.elasticsearch.xpack.sql.types.SqlTypesTests;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 
+import java.util.Arrays;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -553,6 +556,56 @@ public class QueryFolderTests extends ESTestCase {
         AttributeSort as2 = (AttributeSort) sort[1];
         assertEquals("test.int", as2.attribute().qualifiedName());
         assertEquals(Sort.Direction.DESC, as2.direction());
+    }
+
+    public void testFoldGroupByWithNullsOrdering() {
+        for (Tuple<String, MissingOrder> orderDirectiveWithExpectedMissing : Arrays.asList(
+            Tuple.tuple("", MissingOrder.DEFAULT),
+            Tuple.tuple("ASC", MissingOrder.DEFAULT),
+            Tuple.tuple("ASC NULLS FIRST", MissingOrder.FIRST),
+            Tuple.tuple("ASC NULLS LAST", MissingOrder.LAST),
+            Tuple.tuple("DESC", MissingOrder.DEFAULT),
+            Tuple.tuple("DESC NULLS FIRST", MissingOrder.FIRST),
+            Tuple.tuple("DESC NULLS LAST", MissingOrder.LAST)
+        )) {
+            PhysicalPlan p = plan(
+                "SELECT MAX(int), keyword FROM test GROUP BY keyword ORDER BY keyword " + orderDirectiveWithExpectedMissing.v1()
+            );
+
+            assertEquals(EsQueryExec.class, p.getClass());
+            EsQueryExec ee = (EsQueryExec) p;
+
+            assertEquals(
+                "Order directive [" + orderDirectiveWithExpectedMissing.v1() + "]",
+                orderDirectiveWithExpectedMissing.v2(),
+                ee.queryContainer().aggs().groups().get(0).asValueSource().missingOrder()
+            );
+        }
+    }
+
+    public void testFoldGroupByHistogramWithNullsOrdering() {
+        for (Tuple<String, MissingOrder> orderDirectiveWithExpectedMissing : Arrays.asList(
+            Tuple.tuple("", MissingOrder.DEFAULT),
+            Tuple.tuple("ASC", MissingOrder.DEFAULT),
+            Tuple.tuple("ASC NULLS FIRST", MissingOrder.FIRST),
+            Tuple.tuple("ASC NULLS LAST", MissingOrder.LAST),
+            Tuple.tuple("DESC", MissingOrder.DEFAULT),
+            Tuple.tuple("DESC NULLS FIRST", MissingOrder.FIRST),
+            Tuple.tuple("DESC NULLS LAST", MissingOrder.LAST)
+        )) {
+            PhysicalPlan p = plan(
+                "SELECT HISTOGRAM(int, 100) h FROM test GROUP BY h ORDER BY h " + orderDirectiveWithExpectedMissing.v1()
+            );
+
+            assertEquals(EsQueryExec.class, p.getClass());
+            EsQueryExec ee = (EsQueryExec) p;
+
+            assertEquals(
+                "Order directive [" + orderDirectiveWithExpectedMissing.v1() + "]",
+                orderDirectiveWithExpectedMissing.v2(),
+                ee.queryContainer().aggs().groups().get(0).asValueSource().missingOrder()
+            );
+        }
     }
 
     private static String randomOrderByAndLimit(int noOfSelectArgs) {

--- a/x-pack/plugin/sql/src/test/resources/org/elasticsearch/xpack/sql/planner/querytranslator_tests.txt
+++ b/x-pack/plugin/sql/src/test/resources/org/elasticsearch/xpack/sql/planner/querytranslator_tests.txt
@@ -265,6 +265,11 @@ SELECT MAX(int) FROM test GROUP BY HISTOGRAM(date, INTERVAL 2 YEARS);
 "date_histogram":{"field":"date","missing_bucket":true,"order":"asc","fixed_interval":"62208000000ms","time_zone":"Z"}}}]}
 ;
 
+GroupByHistogramNullsLast
+SELECT MAX(int) FROM test GROUP BY HISTOGRAM(date, INTERVAL 2 YEARS) ORDER BY HISTOGRAM(date, INTERVAL 2 YEARS) NULLS LAST;
+"date_histogram":{"field":"date","missing_bucket":true,"missing_order":"last","order":"asc","fixed_interval":"62208000000ms","time_zone":"Z"}}}]}
+;
+
 GroupByHistogramWithScalars
 SELECT MAX(int), HISTOGRAM(date, INTERVAL 5 YEARS - INTERVAL 6 MONTHS) AS h
 FROM test
@@ -363,7 +368,7 @@ GROUP BY CAST(ABS(EXTRACT(YEAR FROM date)) AS BIGINT)
 ORDER BY CAST(ABS(EXTRACT(YEAR FROM date)) AS BIGINT) NULLS FIRST;
 InternalSqlScriptUtils.cast(InternalSqlScriptUtils.abs(InternalSqlScriptUtils.dateTimeExtract(InternalQlScriptUtils.docValue(doc,params.v0),params.v1,params.v2)),params.v3)
 "params":{"v0":"date","v1":"Z","v2":"YEAR","v3":"LONG"
-"missing_bucket":true
+"missing_bucket":true,"missing_order":"first"
 "value_type":"long","order":"asc"
 ;
 
@@ -374,7 +379,7 @@ GROUP BY "cast"
 ORDER BY "cast" NULLS FIRST;
 "InternalSqlScriptUtils.cast(InternalSqlScriptUtils.abs(InternalSqlScriptUtils.dateTimeExtract(InternalQlScriptUtils.docValue(doc,params.v0),params.v1,params.v2)),params.v3)
 "params":{"v0":"date","v1":"Z","v2":"YEAR","v3":"LONG"}
-"missing_bucket":true
+"missing_bucket":true,"missing_order":"first"
 "value_type":"long","order":"asc"
 ;
 
@@ -385,7 +390,7 @@ GROUP BY 1
 ORDER BY 1 NULLS FIRST;
 InternalSqlScriptUtils.cast(InternalSqlScriptUtils.abs(InternalSqlScriptUtils.dateTimeExtract(InternalQlScriptUtils.docValue(doc,params.v0),params.v1,params.v2)),params.v3)
 "params":{"v0":"date","v1":"Z","v2":"YEAR","v3":"LONG"}
-"missing_bucket":true
+"missing_bucket":true,"missing_order":"first"
 "value_type":"long","order":"asc"
 ;
 
@@ -407,7 +412,7 @@ GROUP BY CONVERT(ABS(EXTRACT(YEAR FROM date)), SQL_BIGINT)
 ORDER BY CONVERT(ABS(EXTRACT(YEAR FROM date)), SQL_BIGINT) NULLS FIRST;
 InternalSqlScriptUtils.cast(InternalSqlScriptUtils.abs(InternalSqlScriptUtils.dateTimeExtract(InternalQlScriptUtils.docValue(doc,params.v0),params.v1,params.v2)),params.v3)
 "params":{"v0":"date","v1":"Z","v2":"YEAR","v3":"LONG"}
-"missing_bucket":true
+"missing_bucket":true,"missing_order":"first"
 "value_type":"long","order":"asc"
 ;
 
@@ -428,7 +433,7 @@ GROUP BY "convert"
 ORDER BY "convert" NULLS FIRST;
 InternalSqlScriptUtils.cast(InternalSqlScriptUtils.abs(InternalSqlScriptUtils.dateTimeExtract(InternalQlScriptUtils.docValue(doc,params.v0),params.v1,params.v2)),params.v3)
 "params":{"v0":"date","v1":"Z","v2":"YEAR","v3":"LONG"}
-"missing_bucket":true
+"missing_bucket":true,"missing_order":"first"
 "value_type":"long","order":"asc"
 ;
 
@@ -449,7 +454,7 @@ GROUP BY 1
 ORDER BY 1 NULLS FIRST;
 InternalSqlScriptUtils.cast(InternalSqlScriptUtils.abs(InternalSqlScriptUtils.dateTimeExtract(InternalQlScriptUtils.docValue(doc,params.v0),params.v1,params.v2)),params.v3)
 "params":{"v0":"date","v1":"Z","v2":"YEAR","v3":"LONG"}
-"missing_bucket":true
+"missing_bucket":true,"missing_order":"first"
 "value_type":"long","order":"asc"
 ;
 


### PR DESCRIPTION
Backports the following commits to 7.x:
 - SQL: fix NULLS FIRST/LAST for aggregations (#77750)