### PR TITLE
[Transform] fix version check for beta transforms

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/transforms/TransformConfig.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/transforms/TransformConfig.java
@@ -371,14 +371,14 @@ public class TransformConfig extends AbstractDiffable<TransformConfig> implement
 
         List<DeprecationIssue> deprecations = new ArrayList<>();
 
-        // V_8_0_0 deprecate beta transforms
-        if (getVersion() == null || getVersion().before(Version.V_7_15_0)) {
+        // deprecate beta transforms
+        if (getVersion() == null || getVersion().before(Version.V_7_5_0)) {
             deprecations.add(
                 new DeprecationIssue(
-                    Level.CRITICAL, // change to WARNING for 7.x
+                    Level.CRITICAL,
                     "Transform [" + id + "] is too old",
                     TransformDeprecations.BREAKING_CHANGES_BASE_URL,
-                    "The configuration uses an old format, you can use [_update] or [_upgrade] to update to configuration",
+                    "The configuration uses an old format, you can use [_update] or [_upgrade] to update",
                     false,
                     null
                 )

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/transform/transforms/TransformConfigTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/transform/transforms/TransformConfigTests.java
@@ -724,6 +724,28 @@ public class TransformConfigTests extends AbstractSerializingTransformTestCase<T
             )
         );
 
+        deprecatedConfig = randomTransformConfigWithDeprecatedFields(id, Version.V_7_10_0);
+
+        // check _and_ clear warnings
+        assertWarnings("[max_page_search_size] is deprecated inside pivot please use settings instead");
+
+        // important: checkForDeprecations does _not_ create new deprecation warnings
+        assertThat(
+            deprecatedConfig.checkForDeprecations(xContentRegistry()),
+            equalTo(
+                List.of(
+                    new DeprecationIssue(
+                        Level.WARNING,
+                        "Transform [" + id + "] uses deprecated max_page_search_size",
+                        "https://www.elastic.co/guide/en/elasticsearch/reference/master/migrating-8.0.html",
+                        "[max_page_search_size] is deprecated inside pivot please use settings instead",
+                        false,
+                        null
+                    )
+                )
+            )
+        );
+
         deprecatedConfig = randomTransformConfigWithDeprecatedFields(id, Version.V_7_4_0);
 
         // check _and_ clear warnings
@@ -738,7 +760,7 @@ public class TransformConfigTests extends AbstractSerializingTransformTestCase<T
                         Level.CRITICAL,
                         "Transform [" + id + "] is too old",
                         "https://www.elastic.co/guide/en/elasticsearch/reference/master/migrating-8.0.html",
-                        "The configuration uses an old format, you can use [_update] or [_upgrade] to update to configuration",
+                        "The configuration uses an old format, you can use [_update] or [_upgrade] to update",
                         false,
                         null
                     ),


### PR DESCRIPTION
fix the version check for deprecated beta transforms, this was introduced in #77565, but
contained a typo (7.15 instead of 7.5)

Note: For 8.x/master we don't need this check, however we will likely deprecate 7.x transforms,
therefore this check will be re-used. Keeping this in both master and 7.x makes merging easier.