### PR TITLE
Fix PruneChangelogsTaskTests to work on Windows

### DIFF
--- a/build-tools-internal/src/test/java/org/elasticsearch/gradle/internal/release/PruneChangelogsTaskTests.java
+++ b/build-tools-internal/src/test/java/org/elasticsearch/gradle/internal/release/PruneChangelogsTaskTests.java
@@ -205,7 +205,9 @@ public class PruneChangelogsTaskTests extends GradleUnitTestCase {
             )
         );
 
-        assertThat(e.getMessage(), equalTo("Failed to delete some files:\n\n\tdocs/changelog/1234.yml\n"));
+        // Use a `Path` so that the test works across platforms
+        final Path failedPath = Path.of("docs", "changelog", "1234.yml");
+        assertThat(e.getMessage(), equalTo("Failed to delete some files:\n\n\t" + failedPath + "\n"));
     }
 
     /**


### PR DESCRIPTION
Closes #78318. The test `findAndDeleteFiles_withFilesToDeleteButDeleteFails_throwsException`
in `PruneChangelogsTaskTests` was failing because the path in the expected error output
changes on Windows. Fix this by using a `Path`.