### PR TITLE
Proceed with pagination even if we can't get all snapshots to be successful

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/snapshots/GetSnapshotsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/snapshots/GetSnapshotsIT.java
@@ -8,7 +8,6 @@
 
 package org.elasticsearch.snapshots;
 
-import org.apache.lucene.util.LuceneTestCase.AwaitsFix;
 import org.elasticsearch.action.ActionFuture;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.admin.cluster.snapshots.create.CreateSnapshotResponse;

--- a/server/src/internalClusterTest/java/org/elasticsearch/snapshots/GetSnapshotsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/snapshots/GetSnapshotsIT.java
@@ -16,7 +16,6 @@ import org.elasticsearch.action.admin.cluster.snapshots.get.GetSnapshotsRequestB
 import org.elasticsearch.action.admin.cluster.snapshots.get.GetSnapshotsResponse;
 import org.elasticsearch.cluster.SnapshotsInProgress;
 import org.elasticsearch.cluster.service.ClusterService;
-import org.elasticsearch.common.StopWatch;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.search.sort.SortOrder;
 import org.elasticsearch.test.ClusterServiceUtils;
@@ -191,7 +190,7 @@ public class GetSnapshotsIT extends AbstractSnapshotIntegTestCase {
                             || e.getValue().state() == SnapshotsInProgress.ShardState.SUCCESS
                     ),
                 internalCluster().getInstance(ClusterService.class, internalCluster().getMasterName()),
-                3
+                3 // Short time-out is enough, we don't want wait 30 sec if there's no updates
             );
         } catch (Throwable ignore) {
             // Happens when the test-index-1 snapshots weren't all finished successfully, but the snapshots are blocked on the data nodes

--- a/test/framework/src/main/java/org/elasticsearch/test/ClusterServiceUtils.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/ClusterServiceUtils.java
@@ -179,6 +179,13 @@ public class ClusterServiceUtils {
     public static void awaitClusterState(Logger logger,
                                          Predicate<ClusterState> statePredicate,
                                          ClusterService clusterService) throws Exception {
+        awaitClusterState(logger, statePredicate, clusterService, 30);
+    }
+
+    public static void awaitClusterState(Logger logger,
+                                         Predicate<ClusterState> statePredicate,
+                                         ClusterService clusterService,
+                                         int timeoutSeconds) throws Exception {
         final ClusterStateObserver observer = new ClusterStateObserver(
             clusterService,
             null,
@@ -203,7 +210,7 @@ public class ClusterServiceUtils {
                     assert false : "onTimeout called with no timeout set";
                 }
             }, statePredicate);
-            future.get(30L, TimeUnit.SECONDS);
+            future.get(timeoutSeconds, TimeUnit.SECONDS);
         }
     }
 }


### PR DESCRIPTION
For in-progress snapshots it matters only that the state stable, so we can check
that the pagination is stable as well.

Fixes #78348
