### PR TITLE
[DOCS] Removes new HLRC section from Java REST Client book

### DIFF
--- a/docs/java-rest/index.asciidoc
+++ b/docs/java-rest/index.asciidoc
@@ -11,6 +11,4 @@ include::low-level/index.asciidoc[]
 
 include::high-level/index.asciidoc[]
 
-include::{elasticsearch-java-root}/docs/index.asciidoc[]
-
 include::redirects.asciidoc[]


### PR DESCRIPTION
## Overview

This PR removes the content generated from the `elasticsearch-java` repo from the Java REST Client book.