### PR TITLE
[7.x] [DOCS] Removes new HLRC section from Java REST Client book. (#78368)

### DIFF
--- a/docs/java-rest/index.asciidoc
+++ b/docs/java-rest/index.asciidoc
@@ -11,6 +11,4 @@ include::low-level/index.asciidoc[]
 
 include::high-level/index.asciidoc[]
 
-include::{elasticsearch-java-root}/docs/index.asciidoc[]
-
 include::redirects.asciidoc[]


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [DOCS] Removes new HLRC section from Java REST Client book. (#78368)