### PR TITLE
Resolve aliases from IndexAbstraction

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/metadata/IndexAbstraction.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/IndexAbstraction.java
@@ -75,6 +75,13 @@ public interface IndexAbstraction {
     }
 
     /**
+     * @return the names of aliases referring to this instance.
+     *         Returns <code>null</code> if aliases can't point to this instance.
+     */
+    @Nullable
+    List<String> getAliases();
+
+    /**
      * An index abstraction type.
      */
     enum Type {
@@ -160,6 +167,11 @@ public interface IndexAbstraction {
         @Override
         public boolean isSystem() {
             return concreteIndex.isSystem();
+        }
+
+        @Override
+        public List<String> getAliases() {
+            return List.of(concreteIndex.getAliases().keys().toArray(String.class));
         }
     }
 
@@ -253,6 +265,11 @@ public interface IndexAbstraction {
             return dataStreamAlias;
         }
 
+        @Override
+        public List<String> getAliases() {
+            return null;
+        }
+
         private void validateAliasProperties() {
             // Validate hidden status
             final Map<Boolean, List<IndexMetadata>> groupedByHiddenStatus = referenceIndexMetadatas.stream()
@@ -302,11 +319,15 @@ public interface IndexAbstraction {
         private final org.elasticsearch.cluster.metadata.DataStream dataStream;
         private final List<IndexMetadata> dataStreamIndices;
         private final IndexMetadata writeIndex;
+        private final List<String> referencedByDataStreamAliases;
 
-        public DataStream(org.elasticsearch.cluster.metadata.DataStream dataStream, List<IndexMetadata> dataStreamIndices) {
+        public DataStream(org.elasticsearch.cluster.metadata.DataStream dataStream,
+                          List<IndexMetadata> dataStreamIndices,
+                          List<String> aliases) {
             this.dataStream = dataStream;
             this.dataStreamIndices = List.copyOf(dataStreamIndices);
             this.writeIndex =  dataStreamIndices.get(dataStreamIndices.size() - 1);
+            this.referencedByDataStreamAliases = aliases;
         }
 
         @Override
@@ -347,6 +368,11 @@ public interface IndexAbstraction {
         @Override
         public boolean isDataStreamRelated() {
             return true;
+        }
+
+        @Override
+        public List<String> getAliases() {
+            return referencedByDataStreamAliases;
         }
 
         public org.elasticsearch.cluster.metadata.DataStream getDataStream() {

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/RBACEngineTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/RBACEngineTests.java
@@ -1067,7 +1067,7 @@ public class RBACEngineTests extends ESTestCase {
         }
         DataStream ds = new DataStream(dataStreamName, null,
             backingIndices.stream().map(IndexMetadata::getIndex).collect(Collectors.toList()));
-        IndexAbstraction.DataStream iads = new IndexAbstraction.DataStream(ds, backingIndices);
+        IndexAbstraction.DataStream iads = new IndexAbstraction.DataStream(ds, backingIndices, List.of());
         lookup.put(ds.getName(), iads);
         for (IndexMetadata im : backingIndices) {
             lookup.put(im.getIndex().getName(), new IndexAbstraction.Index(im, iads));
@@ -1100,7 +1100,7 @@ public class RBACEngineTests extends ESTestCase {
         }
         DataStream ds = new DataStream(dataStreamName, null,
                 backingIndices.stream().map(IndexMetadata::getIndex).collect(Collectors.toList()));
-        IndexAbstraction.DataStream iads = new IndexAbstraction.DataStream(ds, backingIndices);
+        IndexAbstraction.DataStream iads = new IndexAbstraction.DataStream(ds, backingIndices, List.of());
         lookup.put(ds.getName(), iads);
         for (IndexMetadata im : backingIndices) {
             lookup.put(im.getIndex().getName(), new IndexAbstraction.Index(im, iads));


### PR DESCRIPTION
Resolve aliases from IndexAbstraction.DataStream and IndexAbstraction.Index

Helps with this specifically:  https://github.com/elastic/elasticsearch/pull/78327/files#r717141768    
Relates to #78327