### PR TITLE
[7.x] Resolve aliases from IndexAbstraction (#78372)

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/metadata/Metadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/Metadata.java
@@ -65,6 +65,7 @@ import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -1653,24 +1654,14 @@ public class Metadata implements Iterable<IndexMetadata>, Diffable<Metadata>, To
             DataStreamMetadata dataStreamMetadata = (DataStreamMetadata) this.customs.get(DataStreamMetadata.TYPE);
             // If there are no indices, then skip data streams. This happens only when metadata is read from disk
             if (dataStreamMetadata != null && indices.size() > 0) {
-                for (DataStream dataStream : dataStreamMetadata.dataStreams().values()) {
-                    List<IndexMetadata> backingIndices = dataStream.getIndices().stream()
-                        .map(index -> indices.get(index.getName()))
-                        .collect(Collectors.toList());
-                    assert backingIndices.isEmpty() == false;
-                    assert backingIndices.contains(null) == false;
-
-                    IndexAbstraction existing = indicesLookup.put(dataStream.getName(),
-                        new IndexAbstraction.DataStream(dataStream, backingIndices));
-                    assert existing == null : "duplicate data stream for " + dataStream.getName();
-
-                    for (Index i : dataStream.getIndices()) {
-                        indexToDataStreamLookup.put(i.getName(), dataStream);
-                    }
-                }
+                Map<String, List<String>> dataStreamToAliasLookup = new HashMap<>();
                 for (DataStreamAlias alias : dataStreamMetadata.getDataStreamAliases().values()) {
                     List<IndexMetadata> allIndicesOfAllDataStreams = alias.getDataStreams().stream()
-                        .map(name -> dataStreamMetadata.dataStreams().get(name))
+                        .map(name -> {
+                            List<String> aliases = dataStreamToAliasLookup.computeIfAbsent(name, k -> new LinkedList<>());
+                            aliases.add(alias.getName());
+                            return dataStreamMetadata.dataStreams().get(name);
+                        })
                         .flatMap(ds -> ds.getIndices().stream())
                         .map(index -> indices.get(index.getName()))
                         .collect(Collectors.toList());
@@ -1682,6 +1673,22 @@ public class Metadata implements Iterable<IndexMetadata>, Diffable<Metadata>, To
                     IndexAbstraction existing = indicesLookup.put(alias.getName(),
                         new IndexAbstraction.Alias(alias, allIndicesOfAllDataStreams, writeIndexOfWriteDataStream));
                     assert existing == null : "duplicate data stream alias for " + alias.getName();
+                }
+                for (DataStream dataStream : dataStreamMetadata.dataStreams().values()) {
+                    List<IndexMetadata> backingIndices = dataStream.getIndices().stream()
+                        .map(index -> indices.get(index.getName()))
+                        .collect(Collectors.toList());
+                    assert backingIndices.isEmpty() == false;
+                    assert backingIndices.contains(null) == false;
+
+                    List<String> aliases = dataStreamToAliasLookup.getOrDefault(dataStream.getName(), Collections.emptyList());
+                    IndexAbstraction existing = indicesLookup.put(dataStream.getName(),
+                        new IndexAbstraction.DataStream(dataStream, backingIndices, aliases));
+                    assert existing == null : "duplicate data stream for " + dataStream.getName();
+
+                    for (Index i : dataStream.getIndices()) {
+                        indexToDataStreamLookup.put(i.getName(), dataStream);
+                    }
                 }
             }
 

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataTests.java
@@ -54,6 +54,7 @@ import static org.elasticsearch.cluster.metadata.Metadata.Builder.validateDataSt
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.is;
@@ -1090,14 +1091,7 @@ public class MetadataTests extends ESTestCase {
         int numDataStreams = randomIntBetween(2, 8);
         for (int i = 0; i < numDataStreams; i++) {
             String name = "data-stream-" + i;
-            int numBackingIndices = randomIntBetween(1, 4);
-            List<Index> indices = new ArrayList<>(numBackingIndices);
-            for (int j = 1; j <= numBackingIndices; j++) {
-                IndexMetadata idx = createBackingIndex(name, j).build();
-                indices.add(idx.getIndex());
-                b.put(idx, true);
-            }
-            b.put(new DataStream(name, createTimestampField("@timestamp"), indices));
+            addDataStream(name, b);
         }
 
         Metadata metadata = b.build();
@@ -1115,6 +1109,68 @@ public class MetadataTests extends ESTestCase {
             assertThat(value.getWriteIndex().getIndex().getName(),
                 equalTo(DataStream.getDefaultBackingIndexName(name, ds.getGeneration())));
         }
+    }
+
+    public void testBuildIndicesLookupForDataStreamAliases() {
+        Metadata.Builder b = Metadata.builder();
+
+        addDataStream("d1", b);
+        addDataStream("d2", b);
+        addDataStream("d3", b);
+        addDataStream("d4", b);
+
+        b.put("a1", "d1", null, null);
+        b.put("a1", "d2", null, null);
+        b.put("a2", "d3", null, null);
+        b.put("a3", "d1", null, null);
+
+        Metadata metadata = b.build();
+        assertThat(metadata.dataStreams().size(), equalTo(4));
+        IndexAbstraction value = metadata.getIndicesLookup().get("d1");
+        assertThat(value, notNullValue());
+        assertThat(value.getType(), equalTo(IndexAbstraction.Type.DATA_STREAM));
+        assertThat(value.getAliases(), containsInAnyOrder("a1", "a3"));
+
+        value = metadata.getIndicesLookup().get("d2");
+        assertThat(value, notNullValue());
+        assertThat(value.getType(), equalTo(IndexAbstraction.Type.DATA_STREAM));
+        assertThat(value.getAliases(), contains("a1"));
+
+        value = metadata.getIndicesLookup().get("d3");
+        assertThat(value, notNullValue());
+        assertThat(value.getType(), equalTo(IndexAbstraction.Type.DATA_STREAM));
+        assertThat(value.getAliases(), contains("a2"));
+
+        value = metadata.getIndicesLookup().get("d4");
+        assertThat(value, notNullValue());
+        assertThat(value.getType(), equalTo(IndexAbstraction.Type.DATA_STREAM));
+        assertThat(value.getAliases(), empty());
+
+        value = metadata.getIndicesLookup().get("a1");
+        assertThat(value, notNullValue());
+        assertThat(value.getType(), equalTo(IndexAbstraction.Type.ALIAS));
+        assertThat(value.getAliases(), nullValue());
+
+        value = metadata.getIndicesLookup().get("a2");
+        assertThat(value, notNullValue());
+        assertThat(value.getType(), equalTo(IndexAbstraction.Type.ALIAS));
+        assertThat(value.getAliases(), nullValue());
+
+        value = metadata.getIndicesLookup().get("a3");
+        assertThat(value, notNullValue());
+        assertThat(value.getType(), equalTo(IndexAbstraction.Type.ALIAS));
+        assertThat(value.getAliases(), nullValue());
+    }
+
+    private void addDataStream(String name, Metadata.Builder b) {
+        int numBackingIndices = randomIntBetween(1, 4);
+        List<Index> indices = new ArrayList<>(numBackingIndices);
+        for (int j = 1; j <= numBackingIndices; j++) {
+            IndexMetadata idx = createBackingIndex(name, j).build();
+            indices.add(idx.getIndex());
+            b.put(idx, true);
+        }
+        b.put(new DataStream(name, createTimestampField("@timestamp"), indices));
     }
 
     public void testIndicesLookupRecordsDataStreamForBackingIndices() {
@@ -1218,7 +1274,7 @@ public class MetadataTests extends ESTestCase {
             backingIndices.stream().map(IndexMetadata::getIndex).collect(Collectors.toList())
         );
 
-        IndexAbstraction.DataStream dataStreamAbstraction = new IndexAbstraction.DataStream(dataStream, backingIndices);
+        IndexAbstraction.DataStream dataStreamAbstraction = new IndexAbstraction.DataStream(dataStream, backingIndices, Arrays.asList());
         // manually building the indices lookup as going through Metadata.Builder#build would trigger the validate method already
         SortedMap<String, IndexAbstraction> indicesLookup = new TreeMap<>();
         for (IndexMetadata indexMeta : backingIndices) {

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/RBACEngineTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/RBACEngineTests.java
@@ -81,6 +81,7 @@ import java.util.Set;
 import java.util.TreeMap;
 import java.util.stream.Collectors;
 
+import static java.util.Collections.emptyList;
 import static java.util.Collections.emptyMap;
 import static org.elasticsearch.common.util.set.Sets.newHashSet;
 import static org.elasticsearch.xpack.security.authz.AuthorizedIndicesTests.getRequestInfo;
@@ -1066,7 +1067,7 @@ public class RBACEngineTests extends ESTestCase {
         }
         DataStream ds = new DataStream(dataStreamName, null,
             backingIndices.stream().map(IndexMetadata::getIndex).collect(Collectors.toList()));
-        IndexAbstraction.DataStream iads = new IndexAbstraction.DataStream(ds, backingIndices);
+        IndexAbstraction.DataStream iads = new IndexAbstraction.DataStream(ds, backingIndices, emptyList());
         lookup.put(ds.getName(), iads);
         for (IndexMetadata im : backingIndices) {
             lookup.put(im.getIndex().getName(), new IndexAbstraction.Index(im, iads));
@@ -1099,7 +1100,7 @@ public class RBACEngineTests extends ESTestCase {
         }
         DataStream ds = new DataStream(dataStreamName, null,
                 backingIndices.stream().map(IndexMetadata::getIndex).collect(Collectors.toList()));
-        IndexAbstraction.DataStream iads = new IndexAbstraction.DataStream(ds, backingIndices);
+        IndexAbstraction.DataStream iads = new IndexAbstraction.DataStream(ds, backingIndices, emptyList());
         lookup.put(ds.getName(), iads);
         for (IndexMetadata im : backingIndices) {
             lookup.put(im.getIndex().getName(), new IndexAbstraction.Index(im, iads));


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Resolve aliases from IndexAbstraction (#78372)