### PR TITLE
[DOCS] Remove `include_type_name` query parameter

### DIFF
--- a/docs/reference/migration/migrate_8_0/mappings.asciidoc
+++ b/docs/reference/migration/migrate_8_0/mappings.asciidoc
@@ -115,7 +115,7 @@ However, 7.x indices that use these mapping parameters will continue to work.
 The `include_type_name` query parameter has been removed from the index
 creation, index template, and mapping APIs. Previously, you could set
 `include_type_name` to `true` to indicate that requests and responses should
-include a mapping type name. Mapping types have been removed in 8.0.
+include a mapping type name. Mapping types have been removed in 8.x.
 
 *Impact* +
 Discontinue use of the `include_type_name` query parameter. Requests that

--- a/docs/reference/migration/migrate_8_0/mappings.asciidoc
+++ b/docs/reference/migration/migrate_8_0/mappings.asciidoc
@@ -18,7 +18,6 @@ Use a maximum of 10 completion contexts in a completion field. Specifying more
 than 10 completion contexts will return an error.
 ====
 
-
 .Mapping API endpoints containing mapping types have been removed.
 [%collapsible]
 ====
@@ -107,5 +106,19 @@ These parameters have been removed in 8.0.0.
 *Impact* +
 In 8.0, you can no longer create mappings that include these parameters.
 However, 7.x indices that use these mapping parameters will continue to work.
+====
+
+.The `include_type_name` query parameter has been removed.
+[%collapsible]
+====
+*Details* +
+The `include_type_name` query parameter has been removed from the index
+creation, index template, and mapping APIs. Previously, you could set
+`include_type_name` to `true` to indicate that requests and responses should
+include a mapping type name. Mapping types have been removed in 8.0.
+
+*Impact* +
+Discontinue use of the `include_type_name` query parameter. Requests that
+include the parameter will return an error.
 ====
 // end::notable-breaking-changes[]


### PR DESCRIPTION
Adds an 8.0 breaking change for PR #48632.

### Preview
https://elasticsearch_78394.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/migrating-8.0.html#breaking_80_mappings_changes