### PR TITLE
[DOCS] Searches on the `_type` field are no longer supported

### DIFF
--- a/docs/reference/migration/migrate_8_0/search.asciidoc
+++ b/docs/reference/migration/migrate_8_0/search.asciidoc
@@ -7,13 +7,16 @@
 
 //tag::notable-breaking-changes[]
 [[_type-search-matches-no-docs]]
-.A search on the `_type` field now matches no documents.
+.Searches on the `_type` field are no longer supported.
 [%collapsible]
 ====
 *Details* +
-A search on the `_type` metadata field now matches no documents, regardless of
-the query string. In 7.x, a search for `_doc` in the `_type` field would match
-the same documents as a `match_all` query.
+The `_type` metadata field has been removed. {es} now handles a search on the
+`_type` field as a search on a non-existent field. A search on a non-existent
+field matches no documents, regardless of the query string.
+
+In 7.x, a search for `_doc` in the `_type` field would match the same documents
+as a `match_all` query.
 
 *Impact* +
 Remove queries on the `_type` field from your search requests and search

--- a/docs/reference/migration/migrate_8_0/search.asciidoc
+++ b/docs/reference/migration/migrate_8_0/search.asciidoc
@@ -6,6 +6,20 @@
 //Installation and Upgrade Guide
 
 //tag::notable-breaking-changes[]
+[[_type-search-matches-no-docs]]
+.A search on the `_type` field now matches no documents.
+[%collapsible]
+====
+*Details* +
+A search on the `_type` metadata field now matches no documents, regardless of
+the query string. In 7.x, a search for `_doc` in the `_type` field would match
+the same documents as a `match_all` query.
+
+*Impact* +
+Remove queries on the `_type` field from your search requests and search
+templates. Searches that include these queries may return no results.
+====
+
 [[msearch-empty-line-support]]
 .The multi search API now parses an empty first line as action metadata in text files.
 [%collapsible]

--- a/docs/reference/migration/migrate_8_0/search.asciidoc
+++ b/docs/reference/migration/migrate_8_0/search.asciidoc
@@ -11,9 +11,9 @@
 [%collapsible]
 ====
 *Details* +
-The `_type` metadata field has been removed. {es} now handles a search on the
-`_type` field as a search on a non-existent field. A search on a non-existent
-field matches no documents, regardless of the query string.
+In 8.x, the `_type` metadata field has been removed. {es} now handles a search
+on the `_type` field as a search on a non-existent field. A search on a
+non-existent field matches no documents, regardless of the query string.
 
 In 7.x, a search for `_doc` in the `_type` field would match the same documents
 as a `match_all` query.


### PR DESCRIPTION
Adds an 8.0 breaking change for PR #68564


### Preview
https://elasticsearch_78400.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/migrating-8.0.html#breaking_80_search_changes