### PR TITLE
[ML] prevent opening anomaly detection jobs with a current model snapshot before 7.0.0

### DIFF
--- a/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/AnomalyJobCRUDIT.java
+++ b/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/AnomalyJobCRUDIT.java
@@ -178,7 +178,8 @@ public class AnomalyJobCRUDIT extends MlSingleNodeTestCase {
                 .actionGet());
         assertThat(ex.getMessage(),
             containsString(
-                "[open-job-with-old-model-snapshot] job snapshot [snap_1] has min version before [7.0.0], please upgrade the model snapshot"
+                "[open-job-with-old-model-snapshot] job snapshot [snap_1] has min version before [7.0.0], " +
+                    "please revert to a newer model snapshot or reset the job"
             )
         );
     }

--- a/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/AnomalyJobCRUDIT.java
+++ b/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/AnomalyJobCRUDIT.java
@@ -8,6 +8,7 @@ package org.elasticsearch.xpack.ml.integration;
 
 import static org.elasticsearch.xpack.core.ClientHelper.ML_ORIGIN;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.hasSize;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -28,7 +29,10 @@ import org.elasticsearch.common.settings.ClusterSettings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.xpack.core.ml.action.GetModelSnapshotsAction;
+import org.elasticsearch.xpack.core.ml.action.OpenJobAction;
 import org.elasticsearch.xpack.core.ml.action.PutJobAction;
+import org.elasticsearch.xpack.core.ml.action.RevertModelSnapshotAction;
 import org.elasticsearch.xpack.core.ml.action.UpdateJobAction;
 import org.elasticsearch.xpack.core.ml.job.config.AnalysisConfig;
 import org.elasticsearch.xpack.core.ml.job.config.AnalysisLimits;
@@ -38,6 +42,8 @@ import org.elasticsearch.xpack.core.ml.job.config.Detector;
 import org.elasticsearch.xpack.core.ml.job.config.Job;
 import org.elasticsearch.xpack.core.ml.job.config.JobUpdate;
 import org.elasticsearch.xpack.core.ml.job.process.autodetect.state.ModelSizeStats;
+import org.elasticsearch.xpack.core.ml.job.process.autodetect.state.ModelSnapshot;
+import org.elasticsearch.xpack.core.ml.job.process.autodetect.state.Quantiles;
 import org.elasticsearch.xpack.ml.MlSingleNodeTestCase;
 import org.elasticsearch.xpack.ml.inference.ingest.InferenceProcessor;
 import org.elasticsearch.xpack.ml.job.persistence.JobResultsPersister;
@@ -145,6 +151,40 @@ public class AnomalyJobCRUDIT extends MlSingleNodeTestCase {
         assertThat(ex.getMessage(),
             containsString("Cannot create job [job-with-closed-results-index] as it requires closed index [.ml-state*]"));
         client().admin().indices().prepareDelete(".ml-state-000001").get();
+    }
+
+    public void testOpenJobWithOldSnapshot() {
+        String jobId = "open-job-with-old-model-snapshot";
+        Date timestamp = new Date();
+        createJob(jobId);
+        ModelSnapshot snapshot = new ModelSnapshot
+            .Builder(jobId)
+            .setMinVersion("6.0.0")
+            .setSnapshotId("snap_1")
+            .setQuantiles(new Quantiles(jobId, timestamp, "quantiles-1"))
+            .setSnapshotDocCount(1)
+            .setModelSizeStats(new ModelSizeStats.Builder(jobId).setTimestamp(timestamp).setLogTime(timestamp))
+            .build();
+        indexModelSnapshot(snapshot);
+        GetModelSnapshotsAction.Response getResponse =
+            client().execute(GetModelSnapshotsAction.INSTANCE, new GetModelSnapshotsAction.Request(jobId, "snap_1")).actionGet();
+        assertThat(getResponse.getResources().results(), hasSize(1));
+        client().execute(RevertModelSnapshotAction.INSTANCE, new RevertModelSnapshotAction.Request(jobId, "snap_1")).actionGet();
+
+        // should fail?
+        Exception ex = expectThrows(Exception.class,
+            () -> client()
+                .execute(OpenJobAction.INSTANCE, new OpenJobAction.Request(jobId))
+                .actionGet());
+        assertThat(ex.getMessage(),
+            containsString(
+                "[open-job-with-old-model-snapshot] job snapshot [snap_1] has min version before [7.0.0], please upgrade the model snapshot"
+            )
+        );
+    }
+
+    private void indexModelSnapshot(ModelSnapshot snapshot) {
+        jobResultsPersister.persistModelSnapshot(snapshot, WriteRequest.RefreshPolicy.IMMEDIATE, () -> true);
     }
 
     private void testCreateWithExistingDocs(IndexRequest indexRequest, String jobId) {

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportOpenJobAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportOpenJobAction.java
@@ -12,10 +12,12 @@ import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.ElasticsearchStatusException;
 import org.elasticsearch.ResourceAlreadyExistsException;
+import org.elasticsearch.ResourceNotFoundException;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.master.TransportMasterNodeAction;
 import org.elasticsearch.client.Client;
+import org.elasticsearch.client.OriginSettingClient;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.block.ClusterBlockException;
 import org.elasticsearch.cluster.block.ClusterBlockLevel;
@@ -35,6 +37,7 @@ import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.xpack.core.XPackField;
 import org.elasticsearch.xpack.core.ml.MlConfigIndex;
 import org.elasticsearch.xpack.core.ml.MlTasks;
+import org.elasticsearch.xpack.core.ml.action.GetModelSnapshotsAction;
 import org.elasticsearch.xpack.core.ml.action.NodeAcknowledgedResponse;
 import org.elasticsearch.xpack.core.ml.action.OpenJobAction;
 import org.elasticsearch.xpack.core.ml.job.config.Job;
@@ -51,6 +54,8 @@ import org.elasticsearch.xpack.ml.process.MlMemoryTracker;
 import java.util.Optional;
 import java.util.function.Predicate;
 
+import static org.elasticsearch.xpack.core.ClientHelper.ML_ORIGIN;
+import static org.elasticsearch.xpack.ml.job.task.OpenJobPersistentTasksExecutor.MIN_SUPPORTED_SNAPSHOT_VERSION;
 import static org.elasticsearch.xpack.ml.job.task.OpenJobPersistentTasksExecutor.checkAssignmentState;
 
 /*
@@ -86,7 +91,7 @@ public class TransportOpenJobAction extends TransportMasterNodeAction<OpenJobAct
         this.jobConfigProvider = jobConfigProvider;
         this.memoryTracker = memoryTracker;
         this.migrationEligibilityCheck = new MlConfigMigrationEligibilityCheck(settings, clusterService);
-        this.client = client;
+        this.client = new OriginSettingClient(client, ML_ORIGIN);
     }
 
     @Override
@@ -149,9 +154,52 @@ public class TransportOpenJobAction extends TransportMasterNodeAction<OpenJobAct
             );
 
             // Tell the job tracker to refresh the memory requirement for this job and all other jobs that have persistent tasks
-            ActionListener<Boolean> getJobHandler = ActionListener.wrap(
+            ActionListener<Boolean> modelSnapshotValidationListener = ActionListener.wrap(
                 response -> memoryTracker.refreshAnomalyDetectorJobMemoryAndAllOthers(jobParams.getJobId(),
                     memoryRequirementRefreshListener),
+                listener::onFailure
+            );
+
+            // Validate the model snapshot is supported
+            ActionListener<Boolean> getJobHandler = ActionListener.wrap(
+                response -> {
+                    if (jobParams.getJob().getModelSnapshotId() == null) {
+                        modelSnapshotValidationListener.onResponse(true);
+                        return;
+                    }
+                    client.execute(
+                        GetModelSnapshotsAction.INSTANCE,
+                        new GetModelSnapshotsAction.Request(jobParams.getJobId(), jobParams.getJob().getModelSnapshotId()),
+                        ActionListener.wrap(
+                            modelSnapshot -> {
+                                if (modelSnapshot.getPage().results().isEmpty()) {
+                                    modelSnapshotValidationListener.onResponse(true);
+                                    return;
+                                }
+                                assert modelSnapshot.getPage().results().size() == 1;
+                                if (modelSnapshot.getPage().results().get(0).getMinVersion().onOrAfter(MIN_SUPPORTED_SNAPSHOT_VERSION)) {
+                                    modelSnapshotValidationListener.onResponse(true);
+                                    return;
+                                }
+                                listener.onFailure(
+                                    ExceptionsHelper.serverError(
+                                        "[{}] job snapshot [{}] has min version before [{}], please upgrade the model snapshot",
+                                        jobParams.getJobId(),
+                                        jobParams.getJob().getModelSnapshotId(),
+                                        MIN_SUPPORTED_SNAPSHOT_VERSION.toString()
+                                    )
+                                );
+                            },
+                            failure -> {
+                                if (ExceptionsHelper.unwrapCause(failure) instanceof ResourceNotFoundException) {
+                                    modelSnapshotValidationListener.onResponse(true);
+                                    return;
+                                }
+                                listener.onFailure(ExceptionsHelper.serverError("Unable to validate model snapshot", failure));
+                            }
+                        )
+                    );
+                },
                 listener::onFailure
             );
 

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportOpenJobAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportOpenJobAction.java
@@ -183,7 +183,8 @@ public class TransportOpenJobAction extends TransportMasterNodeAction<OpenJobAct
                                 }
                                 listener.onFailure(
                                     ExceptionsHelper.serverError(
-                                        "[{}] job snapshot [{}] has min version before [{}], please upgrade the model snapshot",
+                                        "[{}] job snapshot [{}] has min version before [{}], " +
+                                            "please revert to a newer model snapshot or reset the job",
                                         jobParams.getJobId(),
                                         jobParams.getJob().getModelSnapshotId(),
                                         MIN_SUPPORTED_SNAPSHOT_VERSION.toString()

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/task/OpenJobPersistentTasksExecutor.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/task/OpenJobPersistentTasksExecutor.java
@@ -35,6 +35,7 @@ import org.elasticsearch.xpack.core.ml.MlMetaIndex;
 import org.elasticsearch.xpack.core.ml.MlTasks;
 import org.elasticsearch.xpack.core.ml.action.FinalizeJobExecutionAction;
 import org.elasticsearch.xpack.core.ml.action.GetJobsAction;
+import org.elasticsearch.xpack.core.ml.action.GetModelSnapshotsAction;
 import org.elasticsearch.xpack.core.ml.action.OpenJobAction;
 import org.elasticsearch.xpack.core.ml.action.ResetJobAction;
 import org.elasticsearch.xpack.core.ml.action.RevertModelSnapshotAction;
@@ -72,6 +73,7 @@ import static org.elasticsearch.xpack.ml.job.JobNodeSelector.AWAITING_LAZY_ASSIG
 public class OpenJobPersistentTasksExecutor extends AbstractJobPersistentTasksExecutor<OpenJobAction.JobParams> {
 
     private static final Logger logger = LogManager.getLogger(OpenJobPersistentTasksExecutor.class);
+    public static final Version MIN_SUPPORTED_SNAPSHOT_VERSION = Version.V_7_0_0;
 
     // Resuming a job with a running datafeed from its current snapshot was added in 7.11 and
     // can only be done if the master node is on or after that version.
@@ -208,7 +210,7 @@ public class OpenJobPersistentTasksExecutor extends AbstractJobPersistentTasksEx
         jobTask.setAutodetectProcessManager(autodetectProcessManager);
         JobTaskState jobTaskState = (JobTaskState) state;
         JobState jobState = jobTaskState == null ? null : jobTaskState.getState();
-        ActionListener<Boolean> resultsMappingUpdateHandler = ActionListener.wrap(
+        ActionListener<Boolean> checkSnapshotVersionListener = ActionListener.wrap(
             mappingsUpdate -> jobResultsProvider.setRunningForecastsToFailed(params.getJobId(), ActionListener.wrap(
                 r -> runJob(jobTask, jobState, params),
                 e -> {
@@ -220,11 +222,22 @@ public class OpenJobPersistentTasksExecutor extends AbstractJobPersistentTasksEx
             )),
             e -> {
                 if (autodetectProcessManager.isNodeDying() == false) {
-                    logger.error(new ParameterizedMessage("[{}] Failed to update results mapping", params.getJobId()), e);
-                    failTask(jobTask, "failed to update results mapping");
+                    logger.error(new ParameterizedMessage("[{}] Failed verifying snapshot version", params.getJobId()), e);
+                    failTask(jobTask, "failed snapshot verification; cause: " + e.getMessage());
                 }
             }
         );
+
+        ActionListener<Boolean> resultsMappingUpdateHandler = ActionListener.wrap(
+            mappingsUpdate -> verifyCurrentSnapshotVersion(params.getJobId(), checkSnapshotVersionListener),
+            e -> {
+                if (autodetectProcessManager.isNodeDying() == false) {
+                    logger.error(new ParameterizedMessage("[{}] Failed to update results mapping", params.getJobId()), e);
+                    failTask(jobTask, "failed to update results mapping; cause: " + e.getMessage());
+                }
+            }
+        );
+
         // We need to update the results index as we MAY update the current forecast results, setting the running forcasts to failed
         // This writes to the results index, which might need updating
         ElasticsearchMappings.addDocMappingIfMissing(
@@ -324,6 +337,61 @@ public class OpenJobPersistentTasksExecutor extends AbstractJobPersistentTasksEx
         );
 
         datafeedConfigProvider.findDatafeedIdsForJobIds(Collections.singleton(jobId), datafeedListener);
+    }
+
+    private void verifyCurrentSnapshotVersion(String jobId, ActionListener<Boolean> listener) {
+        ActionListener<GetJobsAction.Response> jobListener = ActionListener.wrap(
+            jobResponse -> {
+                List<Job> jobPage = jobResponse.getResponse().results();
+                // We requested a single concrete job so if it didn't exist we would get an error
+                assert jobPage.size() == 1;
+                String jobSnapshotId = jobPage.get(0).getModelSnapshotId();
+                if (jobSnapshotId == null) {
+                    listener.onResponse(true);
+                    return;
+                }
+                executeAsyncWithOrigin(
+                    client,
+                    ML_ORIGIN,
+                    GetModelSnapshotsAction.INSTANCE,
+                    new GetModelSnapshotsAction.Request(),
+                    ActionListener.wrap(
+                        snapshot -> {
+                            if (snapshot.getPage().count() == 0) {
+                                listener.onResponse(true);
+                                return;
+                            }
+                            assert snapshot.getPage().results().size() == 1;
+                            ModelSnapshot snapshotObj = snapshot.getPage().results().get(0);
+                            if (snapshotObj.getMinVersion().onOrAfter(MIN_SUPPORTED_SNAPSHOT_VERSION)) {
+                                listener.onResponse(true);
+                                return;
+                            }
+                            listener.onFailure(
+                                ExceptionsHelper.serverError(
+                                    "[{}] job snapshot [{}] has min version before [{}], please upgrade the model snapshot",
+                                    jobId,
+                                    jobSnapshotId,
+                                    MIN_SUPPORTED_SNAPSHOT_VERSION.toString()
+                                )
+                            );
+                        },
+                        snapshotFailure -> {
+                            if (ExceptionsHelper.unwrapCause(snapshotFailure) instanceof ResourceNotFoundException) {
+                                listener.onResponse(true);
+                                return;
+                            }
+                            listener.onFailure(
+                                ExceptionsHelper.serverError("[{}] failed finding snapshot [{}]", snapshotFailure, jobId, jobSnapshotId)
+                            );
+                        }
+                    )
+                );
+            },
+            error -> listener.onFailure(ExceptionsHelper.serverError("[{}] error getting job", error, jobId))
+        );
+        GetJobsAction.Request request = new GetJobsAction.Request(jobId).masterNodeTimeout(PERSISTENT_TASK_MASTER_NODE_TIMEOUT);
+        executeAsyncWithOrigin(client, ML_ORIGIN, GetJobsAction.INSTANCE, request, jobListener);
     }
 
     private void revertToCurrentSnapshot(String jobId, ActionListener<Boolean> listener) {

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/task/OpenJobPersistentTasksExecutor.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/task/OpenJobPersistentTasksExecutor.java
@@ -354,7 +354,7 @@ public class OpenJobPersistentTasksExecutor extends AbstractJobPersistentTasksEx
                     client,
                     ML_ORIGIN,
                     GetModelSnapshotsAction.INSTANCE,
-                    new GetModelSnapshotsAction.Request(),
+                    new GetModelSnapshotsAction.Request(jobId, jobSnapshotId),
                     ActionListener.wrap(
                         snapshot -> {
                             if (snapshot.getPage().count() == 0) {
@@ -369,7 +369,8 @@ public class OpenJobPersistentTasksExecutor extends AbstractJobPersistentTasksEx
                             }
                             listener.onFailure(
                                 ExceptionsHelper.serverError(
-                                    "[{}] job snapshot [{}] has min version before [{}], please upgrade the model snapshot",
+                                    "[{}] job snapshot [{}] has min version before [{}], " +
+                                        "please revert to a newer model snapshot or reset the job",
                                     jobId,
                                     jobSnapshotId,
                                     MIN_SUPPORTED_SNAPSHOT_VERSION.toString()


### PR DESCRIPTION
Anomaly detection jobs with current model snapshot's where the min_version is before 7.0.0 shouldn't open.

To remediate, the user should do one of the following _before_ upgrading to 8.0.0:

- Delete the model snapshot
- Revert to a separate snapshot with a later minimum version
- Reset the job to empty
- Call the upgrade model snapshot: https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-upgrade-job-model-snapshot.html

The only remediations _after_ upgrading to 8.0.0 are:

- Revert to a separate snapshot with a later minimum version
- Reset the job to empty

closes https://github.com/elastic/elasticsearch/issues/78382