### PR TITLE
[DOCS] Always enable file and native realms unless explicitly disabled

### DIFF
--- a/docs/reference/migration/migrate_8_0/security.asciidoc
+++ b/docs/reference/migration/migrate_8_0/security.asciidoc
@@ -6,6 +6,41 @@
 //Installation and Upgrade Guide
 
 //tag::notable-breaking-changes[]
+.The file and native realms are now enabled unless explicitly disabled.
+[%collapsible]
+====
+*Details* +
+The file and native realms are now enabled unless explicitly disabled. If
+explicitly disabled, the file and native realms remain disabled at all times.
+
+Previously, the file and native realms had the following implicit behaviors:
+
+* If the file and native realms were not configured, they were implicitly disabled
+if any other realm was configured.
+
+* If no other realm was available because realms were not configured or
+explicitly disabled, the file and native realms were enabled, even if explicitly
+disabled.
+
+*Impact* +
+To explicilty disable the file or native realm, set the respective
+`file.<realm-name>.enabled` or `native.<realm-name>.enabled` setting to `false`
+under the `xpack.security.authc.realms` namespace in `elasticsearch.yml`.
+
+The following configuration example disables the native realm, named `realm1`,
+and disables the file realm, named `realm2`:
+
+[source,yaml]
+----
+xpack.security.authc.realms:
+  
+  native.realm1.enabled: false
+  file.realm2.enabled: false
+
+  ...
+----
+====
+
 .The realm `order` setting is now required.
 [%collapsible]
 ====

--- a/docs/reference/migration/migrate_8_0/security.asciidoc
+++ b/docs/reference/migration/migrate_8_0/security.asciidoc
@@ -27,8 +27,7 @@ To explicilty disable the file or native realm, set the respective
 `file.<realm-name>.enabled` or `native.<realm-name>.enabled` setting to `false`
 under the `xpack.security.authc.realms` namespace in `elasticsearch.yml`.
 
-The following configuration example disables the native realm, named `realm1`,
-and the file realm, named `realm2`:
+The following configuration example disables the native realm and the file realm.
 
 [source,yaml]
 ----

--- a/docs/reference/migration/migrate_8_0/security.asciidoc
+++ b/docs/reference/migration/migrate_8_0/security.asciidoc
@@ -28,7 +28,7 @@ To explicilty disable the file or native realm, set the respective
 under the `xpack.security.authc.realms` namespace in `elasticsearch.yml`.
 
 The following configuration example disables the native realm, named `realm1`,
-and disables the file realm, named `realm2`:
+and the file realm, named `realm2`:
 
 [source,yaml]
 ----

--- a/docs/reference/migration/migrate_8_0/security.asciidoc
+++ b/docs/reference/migration/migrate_8_0/security.asciidoc
@@ -18,9 +18,9 @@ Previously, the file and native realms had the following implicit behaviors:
 * If the file and native realms were not configured, they were implicitly disabled
 if any other realm was configured.
 
-* If no other realm was available because realms were not configured or
-explicitly disabled, the file and native realms were enabled, even if explicitly
-disabled.
+* If no other realm was available because realms were either not configured,
+not perrmitted by license, or explicitly disabled, the file and native realms 
+were enabled, even if explicitly disabled.
 
 *Impact* +
 To explicilty disable the file or native realm, set the respective


### PR DESCRIPTION
Adds an 8.0 breaking change for PR #69096.

The copy is based on the 7.13 deprecation notice added with PR #69320.

### Preview
https://elasticsearch_78405.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/migrating-8.0.html#breaking_80_security_changes