### PR TITLE
Remove `index.mode` setting from time series mappings tests

### DIFF
--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/tsdb/20_mappings.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/tsdb/20_mappings.yml
@@ -9,7 +9,6 @@ add time series mappings:
           body:
             settings:
               index:
-                mode: time_series
                 number_of_replicas: 0
                 number_of_shards: 2
             mappings:

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/aggregate-metrics/90_tsdb_mappings.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/aggregate-metrics/90_tsdb_mappings.yml
@@ -9,7 +9,6 @@ aggregate_double_metric with time series mappings:
           body:
             settings:
               index:
-                mode: time_series
                 number_of_replicas: 0
                 number_of_shards: 2
             mappings:
@@ -59,7 +58,6 @@ aggregate_double_metric with wrong time series mappings:
         body:
           settings:
             index:
-              mode: time_series
               number_of_replicas: 0
               number_of_shards: 2
           mappings:

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/analytics/histogram.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/analytics/histogram.yml
@@ -222,7 +222,6 @@ histogram with wrong time series mappings:
         body:
           settings:
             index:
-              mode: time_series
               number_of_replicas: 0
               number_of_shards: 2
           mappings:


### PR DESCRIPTION
PR removes `index.mode` setting from yaml tests that only test `time_series_*` 
mapping parameters. `index.mode: time_series` is not needed for testing the 
mapping parameters and tests fail when the feature flag is not enabled.

Closes #78361