### PR TITLE
Adding config so that some tests will break if over-the-wire encryption fails

### DIFF
--- a/plugins/repository-hdfs/src/test/resources/rest-api-spec/test/secure_hdfs_repository/20_repository_create.yml
+++ b/plugins/repository-hdfs/src/test/resources/rest-api-spec/test/secure_hdfs_repository/20_repository_create.yml
@@ -14,6 +14,7 @@
               path: "/user/elasticsearch/test/repository_create"
               security:
                 principal: "elasticsearch@BUILD.ELASTIC.CO"
+              conf.dfs.encrypt.data.transfer.cipher.suites: "AES/CTR/NoPadding"
 
     # Get repository
     - do:

--- a/plugins/repository-hdfs/src/test/resources/rest-api-spec/test/secure_hdfs_repository/30_snapshot.yml
+++ b/plugins/repository-hdfs/src/test/resources/rest-api-spec/test/secure_hdfs_repository/30_snapshot.yml
@@ -15,6 +15,7 @@
             path: "/user/elasticsearch/test/snapshot"
             security:
               principal: "elasticsearch@BUILD.ELASTIC.CO"
+            conf.dfs.encrypt.data.transfer.cipher.suites: "AES/CTR/NoPadding"
 
   # Create index
   - do:

--- a/test/fixtures/hdfs2-fixture/src/main/java/hdfs/MiniHDFS.java
+++ b/test/fixtures/hdfs2-fixture/src/main/java/hdfs/MiniHDFS.java
@@ -84,6 +84,7 @@ public class MiniHDFS {
             cfg.set(DFSConfigKeys.DFS_BLOCK_ACCESS_TOKEN_ENABLE_KEY, "true");
             cfg.set(DFSConfigKeys.IGNORE_SECURE_PORTS_FOR_TESTING_KEY, "true");
             cfg.set(DFSConfigKeys.DFS_ENCRYPT_DATA_TRANSFER_KEY, "true");
+            cfg.set(DFSConfigKeys.DFS_ENCRYPT_DATA_TRANSFER_CIPHER_SUITES_KEY, "AES/CTR/NoPadding");
         }
 
         UserGroupInformation.setConfiguration(cfg);


### PR DESCRIPTION
Until recently, if a user configured over-the-wire encryption for repository-hdfs they would get an exception. That was fixed in an upgraded ticket in two ways: (1) jvm permissions were opened up for haddop2, and (2) support for the hadoop 3 hdfs client was added. This commit adds configuration to a couple of integration tests so that they fail if over-the-wire encryption is not working.
Relates #76897 #76734